### PR TITLE
Moves status cache serde-for-snapshots code into own module

### DIFF
--- a/runtime/benches/status_cache.rs
+++ b/runtime/benches/status_cache.rs
@@ -6,9 +6,7 @@ use {
     rand::{rngs::SmallRng, Rng, SeedableRng},
     solana_accounts_db::ancestors::Ancestors,
     solana_hash::{Hash, HASH_BYTES},
-    solana_runtime::{
-        bank::BankStatusCache, snapshot_bank_utils::serialize_status_cache, status_cache::*,
-    },
+    solana_runtime::{bank::BankStatusCache, status_cache::*},
     solana_sha256_hasher::hash,
     solana_signature::{Signature, SIGNATURE_BYTES},
     test::Bencher,
@@ -46,9 +44,8 @@ fn bench_status_cache_serialize_max(bencher: &mut Bencher) {
     fill_status_cache(&mut status_cache, max_cache_entries, 100_000);
 
     assert!(status_cache.roots().contains(&0));
-    let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
     bencher.iter(|| {
-        let _ = serialize_status_cache(&status_cache.root_slot_deltas(), &path).unwrap();
+        let _ = serialize(&status_cache.root_slot_deltas()).unwrap();
     });
 }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -55,12 +55,16 @@ use {
     types::SerdeAccountsLtHash,
 };
 
+mod status_cache;
 mod storage;
 mod tests;
 mod types;
 mod utils;
 
-pub(crate) use storage::{SerializableAccountStorageEntry, SerializedAccountsFileId};
+pub(crate) use {
+    status_cache::{deserialize_status_cache, serialize_status_cache},
+    storage::{SerializableAccountStorageEntry, SerializedAccountsFileId},
+};
 
 const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;
 

--- a/runtime/src/serde_snapshot/status_cache.rs
+++ b/runtime/src/serde_snapshot/status_cache.rs
@@ -1,0 +1,494 @@
+//! Serialize and deserialize the status cache for snapshots
+
+use {
+    crate::{bank::BankSlotDelta, snapshot_utils, status_cache::KeySlice},
+    bincode::{self, Options as _},
+    solana_clock::Slot,
+    solana_hash::Hash,
+    solana_instruction::error::InstructionError,
+    solana_transaction_error::TransactionError,
+    std::{
+        collections::HashMap,
+        path::Path,
+        sync::{Arc, Mutex},
+    },
+};
+
+#[cfg_attr(
+    feature = "frozen-abi",
+    frozen_abi(digest = "DNMK4ve8crKwuyUWx4ummQfgA3ydmDuptiJTp8G8m18p")
+)]
+type SerdeBankSlotDelta = SerdeSlotDelta<Result<(), SerdeTransactionError>>;
+type SerdeSlotDelta<T> = (Slot, bool, SerdeStatus<T>);
+type SerdeStatus<T> = HashMap<Hash, (usize, Vec<(KeySlice, T)>)>;
+
+/// Serializes the status cache's `slot_deltas` to file at `status_cache_path`
+///
+/// This fn serializes the status cache into the binary format requried by snapshots.
+pub fn serialize_status_cache(
+    slot_deltas: &[BankSlotDelta],
+    status_cache_path: &Path,
+) -> snapshot_utils::Result<u64> {
+    snapshot_utils::serialize_snapshot_data_file(status_cache_path, |stream| {
+        let snapshot_slot_deltas = slot_deltas
+            .iter()
+            .map(|slot_delta| {
+                let status_map = slot_delta.2.lock().unwrap();
+                let snapshot_status_map = status_map
+                    .iter()
+                    .map(|(key, value)| {
+                        (
+                            *key,
+                            (
+                                value.0,
+                                value
+                                    .1
+                                    .iter()
+                                    .map(|(key_slice, result)| {
+                                        (
+                                            *key_slice,
+                                            result.clone().map_err(SerdeTransactionError::from),
+                                        )
+                                    })
+                                    .collect::<Vec<_>>(),
+                            ),
+                        )
+                    })
+                    .collect::<HashMap<_, _>>();
+                (slot_delta.0, slot_delta.1, snapshot_status_map)
+            })
+            .collect::<Vec<_>>();
+        bincode::serialize_into(stream, &snapshot_slot_deltas)?;
+        Ok(())
+    })
+}
+
+/// Deserializes the status cache from file at `status_cache_path`
+///
+/// This fn deserializes the status cache from a snapshot.
+pub fn deserialize_status_cache(
+    status_cache_path: &Path,
+) -> snapshot_utils::Result<Vec<BankSlotDelta>> {
+    snapshot_utils::deserialize_snapshot_data_file(status_cache_path, |stream| {
+        let snapshot_slot_deltas: Vec<SerdeBankSlotDelta> = bincode::options()
+            .with_limit(snapshot_utils::MAX_SNAPSHOT_DATA_FILE_SIZE)
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .deserialize_from(stream)?;
+
+        let slot_deltas = snapshot_slot_deltas
+            .iter()
+            .map(|slot_delta| {
+                let status_map = slot_delta
+                    .2
+                    .iter()
+                    .map(|(key, value)| {
+                        (
+                            *key,
+                            (
+                                value.0,
+                                value
+                                    .1
+                                    .iter()
+                                    .map(|(key_slice, result)| {
+                                        (*key_slice, result.clone().map_err(TransactionError::from))
+                                    })
+                                    .collect::<Vec<_>>(),
+                            ),
+                        )
+                    })
+                    .collect::<HashMap<_, _>>();
+                (slot_delta.0, slot_delta.1, Arc::new(Mutex::new(status_map)))
+            })
+            .collect::<Vec<_>>();
+        Ok(slot_deltas)
+    })
+}
+
+/// Copy of `TransactionError` that uses a different `InstructionError` type to
+/// contain a string in the BorshIoError variant.
+#[cfg_attr(
+    feature = "frozen-abi",
+    frozen_abi(digest = "5pMgydVNgsYbg64Trhjxbftsug5La7fRDmooyrsHd4wy"),
+    derive(AbiExample, AbiEnumVisitor)
+)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+enum SerdeTransactionError {
+    AccountInUse,
+    AccountLoadedTwice,
+    AccountNotFound,
+    ProgramAccountNotFound,
+    InsufficientFundsForFee,
+    InvalidAccountForFee,
+    AlreadyProcessed,
+    BlockhashNotFound,
+    InstructionError(u8, SerdeInstructionError),
+    CallChainTooDeep,
+    MissingSignatureForFee,
+    InvalidAccountIndex,
+    SignatureFailure,
+    InvalidProgramForExecution,
+    SanitizeFailure,
+    ClusterMaintenance,
+    AccountBorrowOutstanding,
+    WouldExceedMaxBlockCostLimit,
+    UnsupportedVersion,
+    InvalidWritableAccount,
+    WouldExceedMaxAccountCostLimit,
+    WouldExceedAccountDataBlockLimit,
+    TooManyAccountLocks,
+    AddressLookupTableNotFound,
+    InvalidAddressLookupTableOwner,
+    InvalidAddressLookupTableData,
+    InvalidAddressLookupTableIndex,
+    InvalidRentPayingAccount,
+    WouldExceedMaxVoteCostLimit,
+    WouldExceedAccountDataTotalLimit,
+    DuplicateInstruction(u8),
+    InsufficientFundsForRent { account_index: u8 },
+    MaxLoadedAccountsDataSizeExceeded,
+    InvalidLoadedAccountsDataSizeLimit,
+    ResanitizationNeeded,
+    ProgramExecutionTemporarilyRestricted { account_index: u8 },
+    UnbalancedTransaction,
+    ProgramCacheHitMaxLimit,
+    CommitCancelled,
+}
+
+impl From<TransactionError> for SerdeTransactionError {
+    fn from(err: TransactionError) -> Self {
+        match err {
+            TransactionError::AccountInUse => Self::AccountInUse,
+            TransactionError::AccountLoadedTwice => Self::AccountLoadedTwice,
+            TransactionError::AccountNotFound => Self::AccountNotFound,
+            TransactionError::ProgramAccountNotFound => Self::ProgramAccountNotFound,
+            TransactionError::InsufficientFundsForFee => Self::InsufficientFundsForFee,
+            TransactionError::InvalidAccountForFee => Self::InvalidAccountForFee,
+            TransactionError::AlreadyProcessed => Self::AlreadyProcessed,
+            TransactionError::BlockhashNotFound => Self::BlockhashNotFound,
+            TransactionError::InstructionError(i, inner) => Self::InstructionError(i, inner.into()),
+            TransactionError::CallChainTooDeep => Self::CallChainTooDeep,
+            TransactionError::MissingSignatureForFee => Self::MissingSignatureForFee,
+            TransactionError::InvalidAccountIndex => Self::InvalidAccountIndex,
+            TransactionError::SignatureFailure => Self::SignatureFailure,
+            TransactionError::InvalidProgramForExecution => Self::InvalidProgramForExecution,
+            TransactionError::SanitizeFailure => Self::SanitizeFailure,
+            TransactionError::ClusterMaintenance => Self::ClusterMaintenance,
+            TransactionError::AccountBorrowOutstanding => Self::AccountBorrowOutstanding,
+            TransactionError::WouldExceedMaxBlockCostLimit => Self::WouldExceedMaxBlockCostLimit,
+            TransactionError::UnsupportedVersion => Self::UnsupportedVersion,
+            TransactionError::InvalidWritableAccount => Self::InvalidWritableAccount,
+            TransactionError::WouldExceedMaxAccountCostLimit => {
+                Self::WouldExceedMaxAccountCostLimit
+            }
+            TransactionError::WouldExceedAccountDataBlockLimit => {
+                Self::WouldExceedAccountDataBlockLimit
+            }
+            TransactionError::TooManyAccountLocks => Self::TooManyAccountLocks,
+            TransactionError::AddressLookupTableNotFound => Self::AddressLookupTableNotFound,
+            TransactionError::InvalidAddressLookupTableOwner => {
+                Self::InvalidAddressLookupTableOwner
+            }
+            TransactionError::InvalidAddressLookupTableData => Self::InvalidAddressLookupTableData,
+            TransactionError::InvalidAddressLookupTableIndex => {
+                Self::InvalidAddressLookupTableIndex
+            }
+            TransactionError::InvalidRentPayingAccount => Self::InvalidRentPayingAccount,
+            TransactionError::WouldExceedMaxVoteCostLimit => Self::WouldExceedMaxVoteCostLimit,
+            TransactionError::WouldExceedAccountDataTotalLimit => {
+                Self::WouldExceedAccountDataTotalLimit
+            }
+            TransactionError::DuplicateInstruction(i) => Self::DuplicateInstruction(i),
+            TransactionError::InsufficientFundsForRent { account_index } => {
+                Self::InsufficientFundsForRent { account_index }
+            }
+            TransactionError::MaxLoadedAccountsDataSizeExceeded => {
+                Self::MaxLoadedAccountsDataSizeExceeded
+            }
+            TransactionError::InvalidLoadedAccountsDataSizeLimit => {
+                Self::InvalidLoadedAccountsDataSizeLimit
+            }
+            TransactionError::ResanitizationNeeded => Self::ResanitizationNeeded,
+            TransactionError::ProgramExecutionTemporarilyRestricted { account_index } => {
+                Self::ProgramExecutionTemporarilyRestricted { account_index }
+            }
+            TransactionError::UnbalancedTransaction => Self::UnbalancedTransaction,
+            TransactionError::ProgramCacheHitMaxLimit => Self::ProgramCacheHitMaxLimit,
+            TransactionError::CommitCancelled => Self::CommitCancelled,
+        }
+    }
+}
+
+impl From<SerdeTransactionError> for TransactionError {
+    fn from(err: SerdeTransactionError) -> Self {
+        match err {
+            SerdeTransactionError::AccountInUse => Self::AccountInUse,
+            SerdeTransactionError::AccountLoadedTwice => Self::AccountLoadedTwice,
+            SerdeTransactionError::AccountNotFound => Self::AccountNotFound,
+            SerdeTransactionError::ProgramAccountNotFound => Self::ProgramAccountNotFound,
+            SerdeTransactionError::InsufficientFundsForFee => Self::InsufficientFundsForFee,
+            SerdeTransactionError::InvalidAccountForFee => Self::InvalidAccountForFee,
+            SerdeTransactionError::AlreadyProcessed => Self::AlreadyProcessed,
+            SerdeTransactionError::BlockhashNotFound => Self::BlockhashNotFound,
+            SerdeTransactionError::InstructionError(i, inner) => {
+                Self::InstructionError(i, inner.into())
+            }
+            SerdeTransactionError::CallChainTooDeep => Self::CallChainTooDeep,
+            SerdeTransactionError::MissingSignatureForFee => Self::MissingSignatureForFee,
+            SerdeTransactionError::InvalidAccountIndex => Self::InvalidAccountIndex,
+            SerdeTransactionError::SignatureFailure => Self::SignatureFailure,
+            SerdeTransactionError::InvalidProgramForExecution => Self::InvalidProgramForExecution,
+            SerdeTransactionError::SanitizeFailure => Self::SanitizeFailure,
+            SerdeTransactionError::ClusterMaintenance => Self::ClusterMaintenance,
+            SerdeTransactionError::AccountBorrowOutstanding => Self::AccountBorrowOutstanding,
+            SerdeTransactionError::WouldExceedMaxBlockCostLimit => {
+                Self::WouldExceedMaxBlockCostLimit
+            }
+            SerdeTransactionError::UnsupportedVersion => Self::UnsupportedVersion,
+            SerdeTransactionError::InvalidWritableAccount => Self::InvalidWritableAccount,
+            SerdeTransactionError::WouldExceedMaxAccountCostLimit => {
+                Self::WouldExceedMaxAccountCostLimit
+            }
+            SerdeTransactionError::WouldExceedAccountDataBlockLimit => {
+                Self::WouldExceedAccountDataBlockLimit
+            }
+            SerdeTransactionError::TooManyAccountLocks => Self::TooManyAccountLocks,
+            SerdeTransactionError::AddressLookupTableNotFound => Self::AddressLookupTableNotFound,
+            SerdeTransactionError::InvalidAddressLookupTableOwner => {
+                Self::InvalidAddressLookupTableOwner
+            }
+            SerdeTransactionError::InvalidAddressLookupTableData => {
+                Self::InvalidAddressLookupTableData
+            }
+            SerdeTransactionError::InvalidAddressLookupTableIndex => {
+                Self::InvalidAddressLookupTableIndex
+            }
+            SerdeTransactionError::InvalidRentPayingAccount => Self::InvalidRentPayingAccount,
+            SerdeTransactionError::WouldExceedMaxVoteCostLimit => Self::WouldExceedMaxVoteCostLimit,
+            SerdeTransactionError::WouldExceedAccountDataTotalLimit => {
+                Self::WouldExceedAccountDataTotalLimit
+            }
+            SerdeTransactionError::DuplicateInstruction(i) => Self::DuplicateInstruction(i),
+            SerdeTransactionError::InsufficientFundsForRent { account_index } => {
+                Self::InsufficientFundsForRent { account_index }
+            }
+            SerdeTransactionError::MaxLoadedAccountsDataSizeExceeded => {
+                Self::MaxLoadedAccountsDataSizeExceeded
+            }
+            SerdeTransactionError::InvalidLoadedAccountsDataSizeLimit => {
+                Self::InvalidLoadedAccountsDataSizeLimit
+            }
+            SerdeTransactionError::ResanitizationNeeded => Self::ResanitizationNeeded,
+            SerdeTransactionError::ProgramExecutionTemporarilyRestricted { account_index } => {
+                Self::ProgramExecutionTemporarilyRestricted { account_index }
+            }
+            SerdeTransactionError::UnbalancedTransaction => Self::UnbalancedTransaction,
+            SerdeTransactionError::ProgramCacheHitMaxLimit => Self::ProgramCacheHitMaxLimit,
+            SerdeTransactionError::CommitCancelled => Self::CommitCancelled,
+        }
+    }
+}
+
+/// Copy of `InstructionError` type in which the `BorshIoError` variant
+/// contains a string.
+#[cfg_attr(test, derive(strum_macros::FromRepr, strum_macros::EnumIter))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+enum SerdeInstructionError {
+    GenericError,
+    InvalidArgument,
+    InvalidInstructionData,
+    InvalidAccountData,
+    AccountDataTooSmall,
+    InsufficientFunds,
+    IncorrectProgramId,
+    MissingRequiredSignature,
+    AccountAlreadyInitialized,
+    UninitializedAccount,
+    UnbalancedInstruction,
+    ModifiedProgramId,
+    ExternalAccountLamportSpend,
+    ExternalAccountDataModified,
+    ReadonlyLamportChange,
+    ReadonlyDataModified,
+    DuplicateAccountIndex,
+    ExecutableModified,
+    RentEpochModified,
+    NotEnoughAccountKeys,
+    AccountDataSizeChanged,
+    AccountNotExecutable,
+    AccountBorrowFailed,
+    AccountBorrowOutstanding,
+    DuplicateAccountOutOfSync,
+    Custom(u32),
+    InvalidError,
+    ExecutableDataModified,
+    ExecutableLamportChange,
+    ExecutableAccountNotRentExempt,
+    UnsupportedProgramId,
+    CallDepth,
+    MissingAccount,
+    ReentrancyNotAllowed,
+    MaxSeedLengthExceeded,
+    InvalidSeeds,
+    InvalidRealloc,
+    ComputationalBudgetExceeded,
+    PrivilegeEscalation,
+    ProgramEnvironmentSetupFailure,
+    ProgramFailedToComplete,
+    ProgramFailedToCompile,
+    Immutable,
+    IncorrectAuthority,
+    BorshIoError(String),
+    AccountNotRentExempt,
+    InvalidAccountOwner,
+    ArithmeticOverflow,
+    UnsupportedSysvar,
+    IllegalOwner,
+    MaxAccountsDataAllocationsExceeded,
+    MaxAccountsExceeded,
+    MaxInstructionTraceLengthExceeded,
+    BuiltinProgramsMustConsumeComputeUnits,
+}
+
+impl From<SerdeInstructionError> for InstructionError {
+    fn from(err: SerdeInstructionError) -> Self {
+        match err {
+            SerdeInstructionError::GenericError => Self::GenericError,
+            SerdeInstructionError::InvalidArgument => Self::InvalidArgument,
+            SerdeInstructionError::InvalidInstructionData => Self::InvalidInstructionData,
+            SerdeInstructionError::InvalidAccountData => Self::InvalidAccountData,
+            SerdeInstructionError::AccountDataTooSmall => Self::AccountDataTooSmall,
+            SerdeInstructionError::InsufficientFunds => Self::InsufficientFunds,
+            SerdeInstructionError::IncorrectProgramId => Self::IncorrectProgramId,
+            SerdeInstructionError::MissingRequiredSignature => Self::MissingRequiredSignature,
+            SerdeInstructionError::AccountAlreadyInitialized => Self::AccountAlreadyInitialized,
+            SerdeInstructionError::UninitializedAccount => Self::UninitializedAccount,
+            SerdeInstructionError::UnbalancedInstruction => Self::UnbalancedInstruction,
+            SerdeInstructionError::ModifiedProgramId => Self::ModifiedProgramId,
+            SerdeInstructionError::ExternalAccountLamportSpend => Self::ExternalAccountLamportSpend,
+            SerdeInstructionError::ExternalAccountDataModified => Self::ExternalAccountDataModified,
+            SerdeInstructionError::ReadonlyLamportChange => Self::ReadonlyLamportChange,
+            SerdeInstructionError::ReadonlyDataModified => Self::ReadonlyDataModified,
+            SerdeInstructionError::DuplicateAccountIndex => Self::DuplicateAccountIndex,
+            SerdeInstructionError::ExecutableModified => Self::ExecutableModified,
+            SerdeInstructionError::RentEpochModified => Self::RentEpochModified,
+            SerdeInstructionError::NotEnoughAccountKeys => Self::NotEnoughAccountKeys,
+            SerdeInstructionError::AccountDataSizeChanged => Self::AccountDataSizeChanged,
+            SerdeInstructionError::AccountNotExecutable => Self::AccountNotExecutable,
+            SerdeInstructionError::AccountBorrowFailed => Self::AccountBorrowFailed,
+            SerdeInstructionError::AccountBorrowOutstanding => Self::AccountBorrowOutstanding,
+            SerdeInstructionError::DuplicateAccountOutOfSync => Self::DuplicateAccountOutOfSync,
+            SerdeInstructionError::Custom(n) => Self::Custom(n),
+            SerdeInstructionError::InvalidError => Self::InvalidError,
+            SerdeInstructionError::ExecutableDataModified => Self::ExecutableDataModified,
+            SerdeInstructionError::ExecutableLamportChange => Self::ExecutableLamportChange,
+            SerdeInstructionError::ExecutableAccountNotRentExempt => {
+                Self::ExecutableAccountNotRentExempt
+            }
+            SerdeInstructionError::UnsupportedProgramId => Self::UnsupportedProgramId,
+            SerdeInstructionError::CallDepth => Self::CallDepth,
+            SerdeInstructionError::MissingAccount => Self::MissingAccount,
+            SerdeInstructionError::ReentrancyNotAllowed => Self::ReentrancyNotAllowed,
+            SerdeInstructionError::MaxSeedLengthExceeded => Self::MaxSeedLengthExceeded,
+            SerdeInstructionError::InvalidSeeds => Self::InvalidSeeds,
+            SerdeInstructionError::InvalidRealloc => Self::InvalidRealloc,
+            SerdeInstructionError::ComputationalBudgetExceeded => Self::ComputationalBudgetExceeded,
+            SerdeInstructionError::PrivilegeEscalation => Self::PrivilegeEscalation,
+            SerdeInstructionError::ProgramEnvironmentSetupFailure => {
+                Self::ProgramEnvironmentSetupFailure
+            }
+            SerdeInstructionError::ProgramFailedToComplete => Self::ProgramFailedToComplete,
+            SerdeInstructionError::ProgramFailedToCompile => Self::ProgramFailedToCompile,
+            SerdeInstructionError::Immutable => Self::Immutable,
+            SerdeInstructionError::IncorrectAuthority => Self::IncorrectAuthority,
+            SerdeInstructionError::BorshIoError(_) => Self::BorshIoError(String::new()),
+            SerdeInstructionError::AccountNotRentExempt => Self::AccountNotRentExempt,
+            SerdeInstructionError::InvalidAccountOwner => Self::InvalidAccountOwner,
+            SerdeInstructionError::ArithmeticOverflow => Self::ArithmeticOverflow,
+            SerdeInstructionError::UnsupportedSysvar => Self::UnsupportedSysvar,
+            SerdeInstructionError::IllegalOwner => Self::IllegalOwner,
+            SerdeInstructionError::MaxAccountsDataAllocationsExceeded => {
+                Self::MaxAccountsDataAllocationsExceeded
+            }
+            SerdeInstructionError::MaxAccountsExceeded => Self::MaxAccountsExceeded,
+            SerdeInstructionError::MaxInstructionTraceLengthExceeded => {
+                Self::MaxInstructionTraceLengthExceeded
+            }
+            SerdeInstructionError::BuiltinProgramsMustConsumeComputeUnits => {
+                Self::BuiltinProgramsMustConsumeComputeUnits
+            }
+        }
+    }
+}
+
+impl From<InstructionError> for SerdeInstructionError {
+    fn from(err: InstructionError) -> Self {
+        match err {
+            InstructionError::GenericError => Self::GenericError,
+            InstructionError::InvalidArgument => Self::InvalidArgument,
+            InstructionError::InvalidInstructionData => Self::InvalidInstructionData,
+            InstructionError::InvalidAccountData => Self::InvalidAccountData,
+            InstructionError::AccountDataTooSmall => Self::AccountDataTooSmall,
+            InstructionError::InsufficientFunds => Self::InsufficientFunds,
+            InstructionError::IncorrectProgramId => Self::IncorrectProgramId,
+            InstructionError::MissingRequiredSignature => Self::MissingRequiredSignature,
+            InstructionError::AccountAlreadyInitialized => Self::AccountAlreadyInitialized,
+            InstructionError::UninitializedAccount => Self::UninitializedAccount,
+            InstructionError::UnbalancedInstruction => Self::UnbalancedInstruction,
+            InstructionError::ModifiedProgramId => Self::ModifiedProgramId,
+            InstructionError::ExternalAccountLamportSpend => Self::ExternalAccountLamportSpend,
+            InstructionError::ExternalAccountDataModified => Self::ExternalAccountDataModified,
+            InstructionError::ReadonlyLamportChange => Self::ReadonlyLamportChange,
+            InstructionError::ReadonlyDataModified => Self::ReadonlyDataModified,
+            InstructionError::DuplicateAccountIndex => Self::DuplicateAccountIndex,
+            InstructionError::ExecutableModified => Self::ExecutableModified,
+            InstructionError::RentEpochModified => Self::RentEpochModified,
+            InstructionError::NotEnoughAccountKeys => Self::NotEnoughAccountKeys,
+            InstructionError::AccountDataSizeChanged => Self::AccountDataSizeChanged,
+            InstructionError::AccountNotExecutable => Self::AccountNotExecutable,
+            InstructionError::AccountBorrowFailed => Self::AccountBorrowFailed,
+            InstructionError::AccountBorrowOutstanding => Self::AccountBorrowOutstanding,
+            InstructionError::DuplicateAccountOutOfSync => Self::DuplicateAccountOutOfSync,
+            InstructionError::Custom(n) => Self::Custom(n),
+            InstructionError::InvalidError => Self::InvalidError,
+            InstructionError::ExecutableDataModified => Self::ExecutableDataModified,
+            InstructionError::ExecutableLamportChange => Self::ExecutableLamportChange,
+            InstructionError::ExecutableAccountNotRentExempt => {
+                Self::ExecutableAccountNotRentExempt
+            }
+            InstructionError::UnsupportedProgramId => Self::UnsupportedProgramId,
+            InstructionError::CallDepth => Self::CallDepth,
+            InstructionError::MissingAccount => Self::MissingAccount,
+            InstructionError::ReentrancyNotAllowed => Self::ReentrancyNotAllowed,
+            InstructionError::MaxSeedLengthExceeded => Self::MaxSeedLengthExceeded,
+            InstructionError::InvalidSeeds => Self::InvalidSeeds,
+            InstructionError::InvalidRealloc => Self::InvalidRealloc,
+            InstructionError::ComputationalBudgetExceeded => Self::ComputationalBudgetExceeded,
+            InstructionError::PrivilegeEscalation => Self::PrivilegeEscalation,
+            InstructionError::ProgramEnvironmentSetupFailure => {
+                Self::ProgramEnvironmentSetupFailure
+            }
+            InstructionError::ProgramFailedToComplete => Self::ProgramFailedToComplete,
+            InstructionError::ProgramFailedToCompile => Self::ProgramFailedToCompile,
+            InstructionError::Immutable => Self::Immutable,
+            InstructionError::IncorrectAuthority => Self::IncorrectAuthority,
+            InstructionError::BorshIoError(_) => Self::BorshIoError(String::new()),
+            InstructionError::AccountNotRentExempt => Self::AccountNotRentExempt,
+            InstructionError::InvalidAccountOwner => Self::InvalidAccountOwner,
+            InstructionError::ArithmeticOverflow => Self::ArithmeticOverflow,
+            InstructionError::UnsupportedSysvar => Self::UnsupportedSysvar,
+            InstructionError::IllegalOwner => Self::IllegalOwner,
+            InstructionError::MaxAccountsDataAllocationsExceeded => {
+                Self::MaxAccountsDataAllocationsExceeded
+            }
+            InstructionError::MaxAccountsExceeded => Self::MaxAccountsExceeded,
+            InstructionError::MaxInstructionTraceLengthExceeded => {
+                Self::MaxInstructionTraceLengthExceeded
+            }
+            InstructionError::BuiltinProgramsMustConsumeComputeUnits => {
+                Self::BuiltinProgramsMustConsumeComputeUnits
+            }
+        }
+    }
+}

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -17,7 +17,7 @@ use {
         epoch_stakes::VersionedEpochStakes,
         runtime_config::RuntimeConfig,
         serde_snapshot::{
-            reconstruct_bank_from_fields, SnapshotAccountsDbFields, SnapshotBankFields,
+            self, reconstruct_bank_from_fields, SnapshotAccountsDbFields, SnapshotBankFields,
         },
         snapshot_archive_info::{
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
@@ -26,16 +26,14 @@ use {
         snapshot_hash::SnapshotHash,
         snapshot_package::{SnapshotKind, SnapshotPackage},
         snapshot_utils::{
-            self, deserialize_snapshot_data_file, get_highest_bank_snapshot_post,
-            get_highest_full_snapshot_archive_info, get_highest_incremental_snapshot_archive_info,
-            rebuild_storages_from_snapshot_dir, serialize_snapshot_data_file,
+            self, get_highest_bank_snapshot_post, get_highest_full_snapshot_archive_info,
+            get_highest_incremental_snapshot_archive_info, rebuild_storages_from_snapshot_dir,
             verify_and_unarchive_snapshots, ArchiveFormat, BankSnapshotInfo, SnapshotError,
             SnapshotVersion, StorageAndNextAccountsFileId, UnarchivedSnapshots,
             VerifyEpochStakesError, VerifySlotDeltasError, VerifySlotHistoryError,
         },
         status_cache,
     },
-    bincode::{config::Options, serialize_into},
     log::*,
     solana_accounts_db::{
         accounts_db::{AccountsDbConfig, AtomicAccountsFileId},
@@ -45,65 +43,16 @@ use {
     solana_builtins::prototype::BuiltinPrototype,
     solana_clock::{Epoch, Slot},
     solana_genesis_config::GenesisConfig,
-    solana_hash::Hash,
-    solana_instruction::error::InstructionError,
     solana_measure::{measure::Measure, measure_time},
     solana_pubkey::Pubkey,
     solana_slot_history::{Check, SlotHistory},
-    solana_transaction_error::TransactionError,
     std::{
         collections::{HashMap, HashSet},
         ops::RangeInclusive,
         path::{Path, PathBuf},
-        sync::{atomic::AtomicBool, Arc, Mutex},
+        sync::{atomic::AtomicBool, Arc},
     },
 };
-
-type SerdeStatus<T> = HashMap<Hash, (usize, Vec<(status_cache::KeySlice, T)>)>;
-type SerdeSlotDelta<T> = (Slot, bool, SerdeStatus<T>);
-#[cfg_attr(
-    feature = "frozen-abi",
-    frozen_abi(digest = "EKEe5eQhdd78XHfWaskKuKbMKqcmnz63jsabK5KUFgxj")
-)]
-type SerdeBankSlotDelta = SerdeSlotDelta<Result<(), SerdeTransactionError>>;
-
-pub fn serialize_status_cache(
-    slot_deltas: &[BankSlotDelta],
-    status_cache_path: &Path,
-) -> snapshot_utils::Result<u64> {
-    serialize_snapshot_data_file(status_cache_path, |stream| {
-        let snapshot_slot_deltas = slot_deltas
-            .iter()
-            .map(|slot_delta| {
-                let status_map = slot_delta.2.lock().unwrap();
-                let snapshot_status_map = status_map
-                    .iter()
-                    .map(|(key, value)| {
-                        (
-                            *key,
-                            (
-                                value.0,
-                                value
-                                    .1
-                                    .iter()
-                                    .map(|(key_slice, result)| {
-                                        (
-                                            *key_slice,
-                                            result.clone().map_err(SerdeTransactionError::from),
-                                        )
-                                    })
-                                    .collect::<Vec<_>>(),
-                            ),
-                        )
-                    })
-                    .collect::<HashMap<_, _>>();
-                (slot_delta.0, slot_delta.1, snapshot_status_map)
-            })
-            .collect::<Vec<_>>();
-        serialize_into(stream, &snapshot_slot_deltas)?;
-        Ok(())
-    })
-}
 
 #[derive(Debug)]
 pub struct BankFromArchivesTimings {
@@ -293,7 +242,11 @@ pub fn bank_from_snapshot_archives(
             },
         )
         .join(snapshot_utils::SNAPSHOT_STATUS_CACHE_FILENAME);
-    let slot_deltas = deserialize_status_cache(&status_cache_path)?;
+    info!(
+        "Rebuilding status cache from {}",
+        status_cache_path.display()
+    );
+    let slot_deltas = serde_snapshot::deserialize_status_cache(&status_cache_path)?;
 
     verify_slot_deltas(slot_deltas.as_slice(), &bank)?;
 
@@ -487,7 +440,11 @@ pub fn bank_from_snapshot_dir(
     let status_cache_path = bank_snapshot
         .snapshot_dir
         .join(snapshot_utils::SNAPSHOT_STATUS_CACHE_FILENAME);
-    let slot_deltas = deserialize_status_cache(&status_cache_path)?;
+    info!(
+        "Rebuilding status cache from {}",
+        status_cache_path.display()
+    );
+    let slot_deltas = serde_snapshot::deserialize_status_cache(&status_cache_path)?;
 
     verify_slot_deltas(slot_deltas.as_slice(), &bank)?;
 
@@ -594,49 +551,6 @@ fn snapshot_version_and_root_paths(
     };
 
     Ok((snapshot_version, snapshot_root_paths))
-}
-
-fn deserialize_status_cache(
-    status_cache_path: &Path,
-) -> snapshot_utils::Result<Vec<BankSlotDelta>> {
-    deserialize_snapshot_data_file(status_cache_path, |stream| {
-        info!(
-            "Rebuilding status cache from {}",
-            status_cache_path.display()
-        );
-        let snapshot_slot_deltas: Vec<SerdeBankSlotDelta> = bincode::options()
-            .with_limit(snapshot_utils::MAX_SNAPSHOT_DATA_FILE_SIZE)
-            .with_fixint_encoding()
-            .allow_trailing_bytes()
-            .deserialize_from(stream)?;
-
-        let slot_deltas = snapshot_slot_deltas
-            .iter()
-            .map(|slot_delta| {
-                let status_map = slot_delta
-                    .2
-                    .iter()
-                    .map(|(key, value)| {
-                        (
-                            *key,
-                            (
-                                value.0,
-                                value
-                                    .1
-                                    .iter()
-                                    .map(|(key_slice, result)| {
-                                        (*key_slice, result.clone().map_err(TransactionError::from))
-                                    })
-                                    .collect::<Vec<_>>(),
-                            ),
-                        )
-                    })
-                    .collect::<HashMap<_, _>>();
-                (slot_delta.0, slot_delta.1, Arc::new(Mutex::new(status_map)))
-            })
-            .collect::<Vec<_>>();
-        Ok(slot_deltas)
-    })
 }
 
 /// Verify that the snapshot's slot deltas are not corrupt/invalid
@@ -934,394 +848,6 @@ pub fn bank_to_incremental_snapshot_archive(
         full_snapshot_slot,
         snapshot_archive_info,
     ))
-}
-
-/// Copy of `TransactionError` that uses a different `InstructionError` type to
-/// contain a string in the BorshIoError variant.
-#[cfg_attr(
-    feature = "frozen-abi",
-    frozen_abi(digest = "GyjBLQFupLXxDhBYR6mh9ZhFbW1WMHRPg5mGARu3su56"),
-    derive(AbiExample, AbiEnumVisitor)
-)]
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-enum SerdeTransactionError {
-    AccountInUse,
-    AccountLoadedTwice,
-    AccountNotFound,
-    ProgramAccountNotFound,
-    InsufficientFundsForFee,
-    InvalidAccountForFee,
-    AlreadyProcessed,
-    BlockhashNotFound,
-    InstructionError(u8, SerdeInstructionError),
-    CallChainTooDeep,
-    MissingSignatureForFee,
-    InvalidAccountIndex,
-    SignatureFailure,
-    InvalidProgramForExecution,
-    SanitizeFailure,
-    ClusterMaintenance,
-    AccountBorrowOutstanding,
-    WouldExceedMaxBlockCostLimit,
-    UnsupportedVersion,
-    InvalidWritableAccount,
-    WouldExceedMaxAccountCostLimit,
-    WouldExceedAccountDataBlockLimit,
-    TooManyAccountLocks,
-    AddressLookupTableNotFound,
-    InvalidAddressLookupTableOwner,
-    InvalidAddressLookupTableData,
-    InvalidAddressLookupTableIndex,
-    InvalidRentPayingAccount,
-    WouldExceedMaxVoteCostLimit,
-    WouldExceedAccountDataTotalLimit,
-    DuplicateInstruction(u8),
-    InsufficientFundsForRent { account_index: u8 },
-    MaxLoadedAccountsDataSizeExceeded,
-    InvalidLoadedAccountsDataSizeLimit,
-    ResanitizationNeeded,
-    ProgramExecutionTemporarilyRestricted { account_index: u8 },
-    UnbalancedTransaction,
-    ProgramCacheHitMaxLimit,
-    CommitCancelled,
-}
-
-/// Copy of `InstructionError` type in which the `BorshIoError` variant
-/// contains a string.
-#[cfg_attr(test, derive(strum_macros::FromRepr, strum_macros::EnumIter))]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-enum SerdeInstructionError {
-    GenericError,
-    InvalidArgument,
-    InvalidInstructionData,
-    InvalidAccountData,
-    AccountDataTooSmall,
-    InsufficientFunds,
-    IncorrectProgramId,
-    MissingRequiredSignature,
-    AccountAlreadyInitialized,
-    UninitializedAccount,
-    UnbalancedInstruction,
-    ModifiedProgramId,
-    ExternalAccountLamportSpend,
-    ExternalAccountDataModified,
-    ReadonlyLamportChange,
-    ReadonlyDataModified,
-    DuplicateAccountIndex,
-    ExecutableModified,
-    RentEpochModified,
-    NotEnoughAccountKeys,
-    AccountDataSizeChanged,
-    AccountNotExecutable,
-    AccountBorrowFailed,
-    AccountBorrowOutstanding,
-    DuplicateAccountOutOfSync,
-    Custom(u32),
-    InvalidError,
-    ExecutableDataModified,
-    ExecutableLamportChange,
-    ExecutableAccountNotRentExempt,
-    UnsupportedProgramId,
-    CallDepth,
-    MissingAccount,
-    ReentrancyNotAllowed,
-    MaxSeedLengthExceeded,
-    InvalidSeeds,
-    InvalidRealloc,
-    ComputationalBudgetExceeded,
-    PrivilegeEscalation,
-    ProgramEnvironmentSetupFailure,
-    ProgramFailedToComplete,
-    ProgramFailedToCompile,
-    Immutable,
-    IncorrectAuthority,
-    BorshIoError(String),
-    AccountNotRentExempt,
-    InvalidAccountOwner,
-    ArithmeticOverflow,
-    UnsupportedSysvar,
-    IllegalOwner,
-    MaxAccountsDataAllocationsExceeded,
-    MaxAccountsExceeded,
-    MaxInstructionTraceLengthExceeded,
-    BuiltinProgramsMustConsumeComputeUnits,
-}
-
-impl From<SerdeInstructionError> for InstructionError {
-    fn from(err: SerdeInstructionError) -> Self {
-        match err {
-            SerdeInstructionError::GenericError => Self::GenericError,
-            SerdeInstructionError::InvalidArgument => Self::InvalidArgument,
-            SerdeInstructionError::InvalidInstructionData => Self::InvalidInstructionData,
-            SerdeInstructionError::InvalidAccountData => Self::InvalidAccountData,
-            SerdeInstructionError::AccountDataTooSmall => Self::AccountDataTooSmall,
-            SerdeInstructionError::InsufficientFunds => Self::InsufficientFunds,
-            SerdeInstructionError::IncorrectProgramId => Self::IncorrectProgramId,
-            SerdeInstructionError::MissingRequiredSignature => Self::MissingRequiredSignature,
-            SerdeInstructionError::AccountAlreadyInitialized => Self::AccountAlreadyInitialized,
-            SerdeInstructionError::UninitializedAccount => Self::UninitializedAccount,
-            SerdeInstructionError::UnbalancedInstruction => Self::UnbalancedInstruction,
-            SerdeInstructionError::ModifiedProgramId => Self::ModifiedProgramId,
-            SerdeInstructionError::ExternalAccountLamportSpend => Self::ExternalAccountLamportSpend,
-            SerdeInstructionError::ExternalAccountDataModified => Self::ExternalAccountDataModified,
-            SerdeInstructionError::ReadonlyLamportChange => Self::ReadonlyLamportChange,
-            SerdeInstructionError::ReadonlyDataModified => Self::ReadonlyDataModified,
-            SerdeInstructionError::DuplicateAccountIndex => Self::DuplicateAccountIndex,
-            SerdeInstructionError::ExecutableModified => Self::ExecutableModified,
-            SerdeInstructionError::RentEpochModified => Self::RentEpochModified,
-            SerdeInstructionError::NotEnoughAccountKeys => Self::NotEnoughAccountKeys,
-            SerdeInstructionError::AccountDataSizeChanged => Self::AccountDataSizeChanged,
-            SerdeInstructionError::AccountNotExecutable => Self::AccountNotExecutable,
-            SerdeInstructionError::AccountBorrowFailed => Self::AccountBorrowFailed,
-            SerdeInstructionError::AccountBorrowOutstanding => Self::AccountBorrowOutstanding,
-            SerdeInstructionError::DuplicateAccountOutOfSync => Self::DuplicateAccountOutOfSync,
-            SerdeInstructionError::Custom(n) => Self::Custom(n),
-            SerdeInstructionError::InvalidError => Self::InvalidError,
-            SerdeInstructionError::ExecutableDataModified => Self::ExecutableDataModified,
-            SerdeInstructionError::ExecutableLamportChange => Self::ExecutableLamportChange,
-            SerdeInstructionError::ExecutableAccountNotRentExempt => {
-                Self::ExecutableAccountNotRentExempt
-            }
-            SerdeInstructionError::UnsupportedProgramId => Self::UnsupportedProgramId,
-            SerdeInstructionError::CallDepth => Self::CallDepth,
-            SerdeInstructionError::MissingAccount => Self::MissingAccount,
-            SerdeInstructionError::ReentrancyNotAllowed => Self::ReentrancyNotAllowed,
-            SerdeInstructionError::MaxSeedLengthExceeded => Self::MaxSeedLengthExceeded,
-            SerdeInstructionError::InvalidSeeds => Self::InvalidSeeds,
-            SerdeInstructionError::InvalidRealloc => Self::InvalidRealloc,
-            SerdeInstructionError::ComputationalBudgetExceeded => Self::ComputationalBudgetExceeded,
-            SerdeInstructionError::PrivilegeEscalation => Self::PrivilegeEscalation,
-            SerdeInstructionError::ProgramEnvironmentSetupFailure => {
-                Self::ProgramEnvironmentSetupFailure
-            }
-            SerdeInstructionError::ProgramFailedToComplete => Self::ProgramFailedToComplete,
-            SerdeInstructionError::ProgramFailedToCompile => Self::ProgramFailedToCompile,
-            SerdeInstructionError::Immutable => Self::Immutable,
-            SerdeInstructionError::IncorrectAuthority => Self::IncorrectAuthority,
-            SerdeInstructionError::BorshIoError(_) => Self::BorshIoError(String::new()),
-            SerdeInstructionError::AccountNotRentExempt => Self::AccountNotRentExempt,
-            SerdeInstructionError::InvalidAccountOwner => Self::InvalidAccountOwner,
-            SerdeInstructionError::ArithmeticOverflow => Self::ArithmeticOverflow,
-            SerdeInstructionError::UnsupportedSysvar => Self::UnsupportedSysvar,
-            SerdeInstructionError::IllegalOwner => Self::IllegalOwner,
-            SerdeInstructionError::MaxAccountsDataAllocationsExceeded => {
-                Self::MaxAccountsDataAllocationsExceeded
-            }
-            SerdeInstructionError::MaxAccountsExceeded => Self::MaxAccountsExceeded,
-            SerdeInstructionError::MaxInstructionTraceLengthExceeded => {
-                Self::MaxInstructionTraceLengthExceeded
-            }
-            SerdeInstructionError::BuiltinProgramsMustConsumeComputeUnits => {
-                Self::BuiltinProgramsMustConsumeComputeUnits
-            }
-        }
-    }
-}
-
-impl From<InstructionError> for SerdeInstructionError {
-    fn from(err: InstructionError) -> Self {
-        match err {
-            InstructionError::GenericError => Self::GenericError,
-            InstructionError::InvalidArgument => Self::InvalidArgument,
-            InstructionError::InvalidInstructionData => Self::InvalidInstructionData,
-            InstructionError::InvalidAccountData => Self::InvalidAccountData,
-            InstructionError::AccountDataTooSmall => Self::AccountDataTooSmall,
-            InstructionError::InsufficientFunds => Self::InsufficientFunds,
-            InstructionError::IncorrectProgramId => Self::IncorrectProgramId,
-            InstructionError::MissingRequiredSignature => Self::MissingRequiredSignature,
-            InstructionError::AccountAlreadyInitialized => Self::AccountAlreadyInitialized,
-            InstructionError::UninitializedAccount => Self::UninitializedAccount,
-            InstructionError::UnbalancedInstruction => Self::UnbalancedInstruction,
-            InstructionError::ModifiedProgramId => Self::ModifiedProgramId,
-            InstructionError::ExternalAccountLamportSpend => Self::ExternalAccountLamportSpend,
-            InstructionError::ExternalAccountDataModified => Self::ExternalAccountDataModified,
-            InstructionError::ReadonlyLamportChange => Self::ReadonlyLamportChange,
-            InstructionError::ReadonlyDataModified => Self::ReadonlyDataModified,
-            InstructionError::DuplicateAccountIndex => Self::DuplicateAccountIndex,
-            InstructionError::ExecutableModified => Self::ExecutableModified,
-            InstructionError::RentEpochModified => Self::RentEpochModified,
-            InstructionError::NotEnoughAccountKeys => Self::NotEnoughAccountKeys,
-            InstructionError::AccountDataSizeChanged => Self::AccountDataSizeChanged,
-            InstructionError::AccountNotExecutable => Self::AccountNotExecutable,
-            InstructionError::AccountBorrowFailed => Self::AccountBorrowFailed,
-            InstructionError::AccountBorrowOutstanding => Self::AccountBorrowOutstanding,
-            InstructionError::DuplicateAccountOutOfSync => Self::DuplicateAccountOutOfSync,
-            InstructionError::Custom(n) => Self::Custom(n),
-            InstructionError::InvalidError => Self::InvalidError,
-            InstructionError::ExecutableDataModified => Self::ExecutableDataModified,
-            InstructionError::ExecutableLamportChange => Self::ExecutableLamportChange,
-            InstructionError::ExecutableAccountNotRentExempt => {
-                Self::ExecutableAccountNotRentExempt
-            }
-            InstructionError::UnsupportedProgramId => Self::UnsupportedProgramId,
-            InstructionError::CallDepth => Self::CallDepth,
-            InstructionError::MissingAccount => Self::MissingAccount,
-            InstructionError::ReentrancyNotAllowed => Self::ReentrancyNotAllowed,
-            InstructionError::MaxSeedLengthExceeded => Self::MaxSeedLengthExceeded,
-            InstructionError::InvalidSeeds => Self::InvalidSeeds,
-            InstructionError::InvalidRealloc => Self::InvalidRealloc,
-            InstructionError::ComputationalBudgetExceeded => Self::ComputationalBudgetExceeded,
-            InstructionError::PrivilegeEscalation => Self::PrivilegeEscalation,
-            InstructionError::ProgramEnvironmentSetupFailure => {
-                Self::ProgramEnvironmentSetupFailure
-            }
-            InstructionError::ProgramFailedToComplete => Self::ProgramFailedToComplete,
-            InstructionError::ProgramFailedToCompile => Self::ProgramFailedToCompile,
-            InstructionError::Immutable => Self::Immutable,
-            InstructionError::IncorrectAuthority => Self::IncorrectAuthority,
-            InstructionError::BorshIoError(_) => Self::BorshIoError(String::new()),
-            InstructionError::AccountNotRentExempt => Self::AccountNotRentExempt,
-            InstructionError::InvalidAccountOwner => Self::InvalidAccountOwner,
-            InstructionError::ArithmeticOverflow => Self::ArithmeticOverflow,
-            InstructionError::UnsupportedSysvar => Self::UnsupportedSysvar,
-            InstructionError::IllegalOwner => Self::IllegalOwner,
-            InstructionError::MaxAccountsDataAllocationsExceeded => {
-                Self::MaxAccountsDataAllocationsExceeded
-            }
-            InstructionError::MaxAccountsExceeded => Self::MaxAccountsExceeded,
-            InstructionError::MaxInstructionTraceLengthExceeded => {
-                Self::MaxInstructionTraceLengthExceeded
-            }
-            InstructionError::BuiltinProgramsMustConsumeComputeUnits => {
-                Self::BuiltinProgramsMustConsumeComputeUnits
-            }
-        }
-    }
-}
-
-impl From<TransactionError> for SerdeTransactionError {
-    fn from(err: TransactionError) -> Self {
-        match err {
-            TransactionError::AccountInUse => Self::AccountInUse,
-            TransactionError::AccountLoadedTwice => Self::AccountLoadedTwice,
-            TransactionError::AccountNotFound => Self::AccountNotFound,
-            TransactionError::ProgramAccountNotFound => Self::ProgramAccountNotFound,
-            TransactionError::InsufficientFundsForFee => Self::InsufficientFundsForFee,
-            TransactionError::InvalidAccountForFee => Self::InvalidAccountForFee,
-            TransactionError::AlreadyProcessed => Self::AlreadyProcessed,
-            TransactionError::BlockhashNotFound => Self::BlockhashNotFound,
-            TransactionError::InstructionError(i, inner) => Self::InstructionError(i, inner.into()),
-            TransactionError::CallChainTooDeep => Self::CallChainTooDeep,
-            TransactionError::MissingSignatureForFee => Self::MissingSignatureForFee,
-            TransactionError::InvalidAccountIndex => Self::InvalidAccountIndex,
-            TransactionError::SignatureFailure => Self::SignatureFailure,
-            TransactionError::InvalidProgramForExecution => Self::InvalidProgramForExecution,
-            TransactionError::SanitizeFailure => Self::SanitizeFailure,
-            TransactionError::ClusterMaintenance => Self::ClusterMaintenance,
-            TransactionError::AccountBorrowOutstanding => Self::AccountBorrowOutstanding,
-            TransactionError::WouldExceedMaxBlockCostLimit => Self::WouldExceedMaxBlockCostLimit,
-            TransactionError::UnsupportedVersion => Self::UnsupportedVersion,
-            TransactionError::InvalidWritableAccount => Self::InvalidWritableAccount,
-            TransactionError::WouldExceedMaxAccountCostLimit => {
-                Self::WouldExceedMaxAccountCostLimit
-            }
-            TransactionError::WouldExceedAccountDataBlockLimit => {
-                Self::WouldExceedAccountDataBlockLimit
-            }
-            TransactionError::TooManyAccountLocks => Self::TooManyAccountLocks,
-            TransactionError::AddressLookupTableNotFound => Self::AddressLookupTableNotFound,
-            TransactionError::InvalidAddressLookupTableOwner => {
-                Self::InvalidAddressLookupTableOwner
-            }
-            TransactionError::InvalidAddressLookupTableData => Self::InvalidAddressLookupTableData,
-            TransactionError::InvalidAddressLookupTableIndex => {
-                Self::InvalidAddressLookupTableIndex
-            }
-            TransactionError::InvalidRentPayingAccount => Self::InvalidRentPayingAccount,
-            TransactionError::WouldExceedMaxVoteCostLimit => Self::WouldExceedMaxVoteCostLimit,
-            TransactionError::WouldExceedAccountDataTotalLimit => {
-                Self::WouldExceedAccountDataTotalLimit
-            }
-            TransactionError::DuplicateInstruction(i) => Self::DuplicateInstruction(i),
-            TransactionError::InsufficientFundsForRent { account_index } => {
-                Self::InsufficientFundsForRent { account_index }
-            }
-            TransactionError::MaxLoadedAccountsDataSizeExceeded => {
-                Self::MaxLoadedAccountsDataSizeExceeded
-            }
-            TransactionError::InvalidLoadedAccountsDataSizeLimit => {
-                Self::InvalidLoadedAccountsDataSizeLimit
-            }
-            TransactionError::ResanitizationNeeded => Self::ResanitizationNeeded,
-            TransactionError::ProgramExecutionTemporarilyRestricted { account_index } => {
-                Self::ProgramExecutionTemporarilyRestricted { account_index }
-            }
-            TransactionError::UnbalancedTransaction => Self::UnbalancedTransaction,
-            TransactionError::ProgramCacheHitMaxLimit => Self::ProgramCacheHitMaxLimit,
-            TransactionError::CommitCancelled => Self::CommitCancelled,
-        }
-    }
-}
-
-impl From<SerdeTransactionError> for TransactionError {
-    fn from(err: SerdeTransactionError) -> Self {
-        match err {
-            SerdeTransactionError::AccountInUse => Self::AccountInUse,
-            SerdeTransactionError::AccountLoadedTwice => Self::AccountLoadedTwice,
-            SerdeTransactionError::AccountNotFound => Self::AccountNotFound,
-            SerdeTransactionError::ProgramAccountNotFound => Self::ProgramAccountNotFound,
-            SerdeTransactionError::InsufficientFundsForFee => Self::InsufficientFundsForFee,
-            SerdeTransactionError::InvalidAccountForFee => Self::InvalidAccountForFee,
-            SerdeTransactionError::AlreadyProcessed => Self::AlreadyProcessed,
-            SerdeTransactionError::BlockhashNotFound => Self::BlockhashNotFound,
-            SerdeTransactionError::InstructionError(i, inner) => {
-                Self::InstructionError(i, inner.into())
-            }
-            SerdeTransactionError::CallChainTooDeep => Self::CallChainTooDeep,
-            SerdeTransactionError::MissingSignatureForFee => Self::MissingSignatureForFee,
-            SerdeTransactionError::InvalidAccountIndex => Self::InvalidAccountIndex,
-            SerdeTransactionError::SignatureFailure => Self::SignatureFailure,
-            SerdeTransactionError::InvalidProgramForExecution => Self::InvalidProgramForExecution,
-            SerdeTransactionError::SanitizeFailure => Self::SanitizeFailure,
-            SerdeTransactionError::ClusterMaintenance => Self::ClusterMaintenance,
-            SerdeTransactionError::AccountBorrowOutstanding => Self::AccountBorrowOutstanding,
-            SerdeTransactionError::WouldExceedMaxBlockCostLimit => {
-                Self::WouldExceedMaxBlockCostLimit
-            }
-            SerdeTransactionError::UnsupportedVersion => Self::UnsupportedVersion,
-            SerdeTransactionError::InvalidWritableAccount => Self::InvalidWritableAccount,
-            SerdeTransactionError::WouldExceedMaxAccountCostLimit => {
-                Self::WouldExceedMaxAccountCostLimit
-            }
-            SerdeTransactionError::WouldExceedAccountDataBlockLimit => {
-                Self::WouldExceedAccountDataBlockLimit
-            }
-            SerdeTransactionError::TooManyAccountLocks => Self::TooManyAccountLocks,
-            SerdeTransactionError::AddressLookupTableNotFound => Self::AddressLookupTableNotFound,
-            SerdeTransactionError::InvalidAddressLookupTableOwner => {
-                Self::InvalidAddressLookupTableOwner
-            }
-            SerdeTransactionError::InvalidAddressLookupTableData => {
-                Self::InvalidAddressLookupTableData
-            }
-            SerdeTransactionError::InvalidAddressLookupTableIndex => {
-                Self::InvalidAddressLookupTableIndex
-            }
-            SerdeTransactionError::InvalidRentPayingAccount => Self::InvalidRentPayingAccount,
-            SerdeTransactionError::WouldExceedMaxVoteCostLimit => Self::WouldExceedMaxVoteCostLimit,
-            SerdeTransactionError::WouldExceedAccountDataTotalLimit => {
-                Self::WouldExceedAccountDataTotalLimit
-            }
-            SerdeTransactionError::DuplicateInstruction(i) => Self::DuplicateInstruction(i),
-            SerdeTransactionError::InsufficientFundsForRent { account_index } => {
-                Self::InsufficientFundsForRent { account_index }
-            }
-            SerdeTransactionError::MaxLoadedAccountsDataSizeExceeded => {
-                Self::MaxLoadedAccountsDataSizeExceeded
-            }
-            SerdeTransactionError::InvalidLoadedAccountsDataSizeLimit => {
-                Self::InvalidLoadedAccountsDataSizeLimit
-            }
-            SerdeTransactionError::ResanitizationNeeded => Self::ResanitizationNeeded,
-            SerdeTransactionError::ProgramExecutionTemporarilyRestricted { account_index } => {
-                Self::ProgramExecutionTemporarilyRestricted { account_index }
-            }
-            SerdeTransactionError::UnbalancedTransaction => Self::UnbalancedTransaction,
-            SerdeTransactionError::ProgramCacheHitMaxLimit => Self::ProgramCacheHitMaxLimit,
-            SerdeTransactionError::CommitCancelled => Self::CommitCancelled,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -9,7 +9,6 @@ use {
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfo,
             SnapshotArchiveInfoGetter,
         },
-        snapshot_bank_utils,
         snapshot_config::SnapshotConfig,
         snapshot_hash::SnapshotHash,
         snapshot_package::{SnapshotKind, SnapshotPackage},
@@ -998,7 +997,7 @@ fn serialize_snapshot(
 
         let status_cache_path = bank_snapshot_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME);
         let (status_cache_consumed_size, status_cache_serialize_us) = measure_us!(
-            snapshot_bank_utils::serialize_status_cache(slot_deltas, &status_cache_path)
+            serde_snapshot::serialize_status_cache(slot_deltas, &status_cache_path)
                 .map_err(|err| AddBankSnapshotError::SerializeStatusCache(Box::new(err)))?
         );
 


### PR DESCRIPTION
#### Problem

The SDK's TransactionError and InstructionError changed, which caused snapshots to break due to the serialization of the status cache. This was mitigated in #7559 by airgap-ing the TransactionError type, and performing conversions when serializing and deserializing the status cache.

This new code was living in `snapshot_bank_utils.rs`, which was not ideal. For one, it required `snapshot_utils.rs` to import from `snapshot_bank_utils`, and the whole point of these two files being separate was so that `snapshot_utils.rs` did not import from `snapshot_bank_utils.rs` nor anything from Bank.

For two, there is already precedent for putting these "serde" types within the `serde_snapshot` module.


#### Summary of Changes

Move the serde code of the status cache into its own module under `serde_snapshot`.

Note, no functionality was changed in this PR, minus the bench (see comments inline below).