### PR TITLE
Rekey `reenable_zk_elgamal_proof_program` feature gate

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1107,7 +1107,7 @@ pub mod disable_zk_elgamal_proof_program {
 }
 
 pub mod reenable_zk_elgamal_proof_program {
-    solana_pubkey::declare_id!("zkemPXcuM3G4wpMDZ36Cpw34EjUpvm1nuioiSGbGZPR");
+    solana_pubkey::declare_id!("zkeygbBwEGgThKda6nVFVUjJHSYXbwydbmaPUeNQbmK");
 }
 
 pub mod raise_block_limits_to_100m {


### PR DESCRIPTION
#### Problem
the `reenable_zk_elgamal_proof_program` feature gate was never re-keyed after https://github.com/anza-xyz/agave/pull/7126.

#### Summary of Changes
Rekey the feature gate. This is the same key as in https://github.com/anza-xyz/agave/pull/7128. Once https://github.com/anza-xyz/agave/pull/7129 is merged, I will probably need to rekey this again.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
