### PR TITLE
validator: Make wait for exit the default exit behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Release channels have their own copy of this changelog:
 * `--transaction-structure view` is now the default.
 * The default full snapshot interval is now 100,000 slots.
 * `SOLANA_BANKING_THREADS` environment variable is no longer supported. Use `--block-prouduction-num-workers` instead.
-* By default, `agave-validator exit` will now wait for the validator process to terminate before returning. The `--wait-for-exit` flag has been deprecated, but operators can still opt out with the new `--skip-wait-for-exit` flag.
+* By default, `agave-validator exit` will now wait for the validator process to terminate before returning. The `--wait-for-exit` flag has been deprecated, but operators can still opt out with the new `--no-wait-for-exit` flag.
 
 ## 2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Release channels have their own copy of this changelog:
 * `--transaction-structure view` is now the default.
 * The default full snapshot interval is now 100,000 slots.
 * `SOLANA_BANKING_THREADS` environment variable is no longer supported. Use `--block-prouduction-num-workers` instead.
+* By default, `agave-validator exit` will now wait for the validator process to terminate before returning. The `--wait-for-exit` flag has been deprecated, but operators can still opt out with the new `--skip-wait-for-exit` flag.
 
 ## 2.3.0
 

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -6,7 +6,10 @@ use {
         commands::{monitor, wait_for_restart_window, Error, FromClapArgMatches, Result},
     },
     clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand},
-    solana_clap_utils::input_validators::{is_parsable, is_valid_percentage},
+    solana_clap_utils::{
+        hidden_unless_forced,
+        input_validators::{is_parsable, is_valid_percentage},
+    },
     std::path::Path,
 };
 
@@ -86,6 +89,7 @@ pub fn command<'a>() -> App<'a, 'a> {
             Arg::with_name("wait_for_exit")
                 .long("wait-for-exit")
                 .conflicts_with("monitor")
+                .hidden(hidden_unless_forced())
                 .help("Wait for the validator to terminate after sending the exit request"),
         )
         .arg(

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -97,7 +97,7 @@ pub fn command<'a>() -> App<'a, 'a> {
                 .long("skip-wait-for-exit")
                 .takes_value(false)
                 .conflicts_with("wait_for_exit")
-                .help("Skip waiting for the validator to terminate after sending the exit request"),
+                .help("Do not wait for the validator to terminate after sending the exit request"),
         )
         .arg(
             Arg::with_name("min_idle_time")

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -40,7 +40,7 @@ impl FromClapArgMatches for ExitArgs {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         let post_exit_action = if matches.is_present("monitor") {
             Some(PostExitAction::Monitor)
-        } else if matches.is_present("skip_wait_for_exit") {
+        } else if matches.is_present("no_wait_for_exit") {
             None
         } else {
             Some(PostExitAction::Wait)
@@ -82,7 +82,7 @@ pub fn command<'a>() -> App<'a, 'a> {
                 .short("m")
                 .long("monitor")
                 .takes_value(false)
-                .requires("skip_wait_for_exit")
+                .requires("no_wait_for_exit")
                 .help("Monitor the validator after sending the exit request"),
         )
         .arg(
@@ -93,8 +93,8 @@ pub fn command<'a>() -> App<'a, 'a> {
                 .help("Wait for the validator to terminate after sending the exit request"),
         )
         .arg(
-            Arg::with_name("skip_wait_for_exit")
-                .long("skip-wait-for-exit")
+            Arg::with_name("no_wait_for_exit")
+                .long("no-wait-for-exit")
                 .takes_value(false)
                 .conflicts_with("wait_for_exit")
                 .help("Do not wait for the validator to terminate after sending the exit request"),
@@ -268,7 +268,7 @@ mod tests {
     fn verify_args_struct_by_command_exit_with_post_exit_action() {
         verify_args_struct_by_command(
             command(),
-            vec![COMMAND, "--monitor", "--skip-wait-for-exit"],
+            vec![COMMAND, "--monitor", "--no-wait-for-exit"],
             ExitArgs {
                 post_exit_action: Some(PostExitAction::Monitor),
                 ..ExitArgs::default()
@@ -277,7 +277,7 @@ mod tests {
 
         verify_args_struct_by_command(
             command(),
-            vec![COMMAND, "--skip-wait-for-exit"],
+            vec![COMMAND, "--no-wait-for-exit"],
             ExitArgs {
                 post_exit_action: None,
                 ..ExitArgs::default()


### PR DESCRIPTION
#### Problem
--wait-for-exit was previously introduced to allow operators to opt into waiting for exit. The wait for exit behavior is critical for optimal validator restart

#### Summary of Changes
So change the default behavior to wait for exit and introduce a new --no-wait-for-exit incase operators want to opt out for some reason

#### Flag Behavior
Here is a truth table outlining what will happen with various flags

| monitor ? | wait-for-exit ? | no-wait-for-exit ? | Option<Action> |
|-----------|-----------------|----------------------|--------|
| True | True | True | Illegal (monitor & wait conflict) |
| True | True | False | Illegal (monitor & wait conflict) |
| True | False | True | Some(PostExitAction::Monitor) |
| True | False | False | Illegal (monitor requires no-wait) |
| False | True | True | Illegal (wait and no-wait conflict) |
| False | True | False | Some(PostExitAction::Wait) |
| False | False | True | None |
| False | False | False | Some(PostExitAction::Wait) (default) |