### PR TITLE
ledger-tool: Run cargo fmt with format_strings = true

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -35,8 +35,8 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .value_name("PATHS")
             .takes_value(true)
             .help(
-                "Persistent accounts location. May be specified multiple times. \
-                [default: <LEDGER>/accounts]",
+                "Persistent accounts location. May be specified multiple times. [default: \
+                 <LEDGER>/accounts]",
             ),
         Arg::with_name("accounts_index_path")
             .long("accounts-index-path")
@@ -44,8 +44,8 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .takes_value(true)
             .multiple(true)
             .help(
-                "Persistent accounts-index location. May be specified multiple times. \
-                [default: <LEDGER>/accounts_index]",
+                "Persistent accounts-index location. May be specified multiple times. [default: \
+                 <LEDGER>/accounts_index]",
             ),
         Arg::with_name("accounts_index_bins")
             .long("accounts-index-bins")

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -1182,9 +1182,9 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .validator(is_slot)
                                 .default_value("1000")
                                 .help(
-                                    "Number of transaction signatures to query at once. \
-                                     Smaller: more responsive/lower throughput. \
-                                     Larger: less responsive/higher throughput",
+                                    "Number of transaction signatures to query at once. Smaller: \
+                                     more responsive/lower throughput. Larger: less \
+                                     responsive/higher throughput",
                                 ),
                         )
                         .arg(

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -466,8 +466,8 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                     .help("Start slot to purge from (inclusive)"),
             )
             .arg(Arg::with_name("end_slot").index(2).value_name("SLOT").help(
-                "Ending slot to stop purging (inclusive). \
-                 [default: the highest slot in the ledger]",
+                "Ending slot to stop purging (inclusive). [default: the highest slot in the \
+                 ledger]",
             ))
             .arg(
                 Arg::with_name("batch_size")

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1316,8 +1316,8 @@ fn main() {
                         .value_name("DIR")
                         .takes_value(true)
                         .help(
-                            "Output directory for the snapshot \
-                             [default: --snapshot-archive-path if present else --ledger directory]",
+                            "Output directory for the snapshot [default: --snapshot-archive-path \
+                             if present else --ledger directory]",
                         ),
                 )
                 .arg(
@@ -1475,12 +1475,12 @@ fn main() {
                         .takes_value(false)
                         .help("Recalculate the accounts lt hash for minimized snapshots")
                         .long_help(
-                            "Recalculate the accounts lt hash for minimized snapshots. \
-                             Without this flag, loading the minimized snapshot will fail \
-                             startup accounts verification because the accounts lt hash will not \
-                             match due to the pruned account state. If not recalculating the \
-                             accounts lt hash, pass `--accounts-db-skip-initial-hash-calculation` \
-                             to `leder-tool verify` in order to bypass this check.",
+                            "Recalculate the accounts lt hash for minimized snapshots. Without \
+                             this flag, loading the minimized snapshot will fail startup accounts \
+                             verification because the accounts lt hash will not match due to the \
+                             pruned account state. If not recalculating the accounts lt hash, \
+                             pass `--accounts-db-skip-initial-hash-calculation` to `leder-tool \
+                             verify` in order to bypass this check.",
                         )
                         .requires("minimized"),
                 )


### PR DESCRIPTION
#### Problem
We want to get string formatting set and enforced in CI; we need to clean up existing stuff to get there

#### Summary of Changes
Format strings in preparation for the setting being enforced in rustfmt.toml