### PR TITLE
changelog entry about legacy shreds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Release channels have their own copy of this changelog:
 * Deprecated snapshot archive formats have been removed and are no longer loadable.
 * Using `--snapshot-interval-slots 0` to disable generating snapshots has been removed. Use `--no-snapshots` instead.
 * Validator will now bind all ports within provided `--dynamic-port-range`, including the client ports. A range of at least 25 ports is recommended to avoid failures to bind during startup.
+* Agave can no longer operate with legacy shreds. This may break operations with ledgers that are older than April 2024.
 
 #### Changes
 * `--transaction-structure view` is now the default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Release channels have their own copy of this changelog:
 * Deprecated snapshot archive formats have been removed and are no longer loadable.
 * Using `--snapshot-interval-slots 0` to disable generating snapshots has been removed. Use `--no-snapshots` instead.
 * Validator will now bind all ports within provided `--dynamic-port-range`, including the client ports. A range of at least 25 ports is recommended to avoid failures to bind during startup.
-* Agave can no longer operate with legacy shreds. This may break operations with ledgers that are older than April 2024.
+* Agave and agave-ledger-tool can no longer operate with legacy shreds. Legacy shreds have not been in circulation since the activation of https://explorer.solana.com/address/GV49KKQdBNaiv2pgqhS2Dy3GWYJGXMTVYbYkdk91orRy. This change may break operations with old ledgers that may still contain legacy shreds.
 
 #### Changes
 * `--transaction-structure view` is now the default.


### PR DESCRIPTION
#### Problem

- Legacy shreds have not been in use for a long time (e.g. https://github.com/anza-xyz/agave/pull/677)
- Support for them is completely removed in 3.0, but if someone wants to operate on a very old ledger it could be surprising as per https://github.com/anza-xyz/agave/pull/7360#discussion_r2287008594

#### Summary of Changes

- Add change log entry