### PR TITLE
agave-validator: add args tests for run (part 6)

### DIFF
--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -122,7 +122,7 @@ struct ProcessTransactionsResult {
     last_sent_time: Option<Instant>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Config {
     pub retry_rate_ms: u64,
     pub leader_forward_count: u64,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -26,7 +26,7 @@ use {
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_runtime::snapshot_utils::{SnapshotVersion, SUPPORTED_ARCHIVE_COMPRESSION},
     solana_send_transaction_service::send_transaction_service::{
-        MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
+        Config as SendTransactionServiceConfig, MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
     },
     solana_signer::Signer,
     solana_streamer::socket::SocketAddrSpace,
@@ -62,6 +62,7 @@ pub mod json_rpc_config;
 pub mod pub_sub_config;
 pub mod rpc_bigtable_config;
 pub mod rpc_bootstrap_config;
+pub mod send_transaction_config;
 
 #[derive(Debug, PartialEq)]
 pub struct RunArgs {
@@ -74,6 +75,7 @@ pub struct RunArgs {
     pub blockstore_options: BlockstoreOptions,
     pub json_rpc_config: JsonRpcConfig,
     pub pub_sub_config: PubSubConfig,
+    pub send_transaction_service_config: SendTransactionServiceConfig,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -123,6 +125,9 @@ impl FromClapArgMatches for RunArgs {
             blockstore_options: BlockstoreOptions::from_clap_arg_match(matches)?,
             json_rpc_config: JsonRpcConfig::from_clap_arg_match(matches)?,
             pub_sub_config: PubSubConfig::from_clap_arg_match(matches)?,
+            send_transaction_service_config: SendTransactionServiceConfig::from_clap_arg_match(
+                matches,
+            )?,
         })
     }
 }
@@ -1752,6 +1757,7 @@ mod tests {
                         solana_rpc::rpc_pubsub_service::DEFAULT_QUEUE_CAPACITY_ITEMS,
                     ..PubSubConfig::default_for_tests()
                 },
+                send_transaction_service_config: SendTransactionServiceConfig::default(),
             }
         }
     }
@@ -1768,6 +1774,7 @@ mod tests {
                 blockstore_options: self.blockstore_options.clone(),
                 json_rpc_config: self.json_rpc_config.clone(),
                 pub_sub_config: self.pub_sub_config.clone(),
+                send_transaction_service_config: self.send_transaction_service_config.clone(),
             }
         }
     }

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -41,6 +41,9 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
         let default_max_retries =
             value_t!(matches, "rpc_send_transaction_default_max_retries", usize).ok();
 
+        let service_max_retries =
+            value_t!(matches, "rpc_send_transaction_service_max_retries", usize)?;
+
         let rpc_send_transaction_also_leader =
             matches.is_present("rpc_send_transaction_also_leader");
         let leader_forward_count = if tpu_peers.is_some() && !rpc_send_transaction_also_leader {
@@ -55,11 +58,7 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
             batch_size,
             batch_send_rate_ms,
             default_max_retries,
-            service_max_retries: value_t!(
-                matches,
-                "rpc_send_transaction_service_max_retries",
-                usize
-            )?,
+            service_max_retries,
             retry_pool_max_size: value_t!(
                 matches,
                 "rpc_send_transaction_retry_pool_max_size",

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -12,8 +12,8 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
         let retry_rate_ms = value_t!(matches, "rpc_send_transaction_retry_ms", u64)?;
         if batch_send_rate_ms > retry_rate_ms {
             return Err(Error::Dynamic(Box::<dyn std::error::Error>::from(format!(
-                "the specified rpc-send-batch-ms ({batch_send_rate_ms}) is invalid, it must \
-                 be <= rpc-send-retry-ms ({retry_rate_ms})"
+                "the specified rpc-send-batch-ms ({batch_send_rate_ms}) is invalid, it must be <= \
+                 rpc-send-retry-ms ({retry_rate_ms})"
             ))));
         }
 
@@ -21,12 +21,11 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
         let millis_per_second = 1000;
         let tps = rpc_send_batch_size as u64 * millis_per_second / batch_send_rate_ms;
         if tps > MAX_TRANSACTION_SENDS_PER_SECOND {
-            return Err(Error::Dynamic(Box::<dyn std::error::Error>::from(
-                format!(
-                    "either the specified rpc-send-batch-size ({rpc_send_batch_size}) or rpc-send-batch-ms ({batch_send_rate_ms}) is invalid, \
-                 'rpc-send-batch-size * 1000 / rpc-send-batch-ms' must be smaller than ({MAX_TRANSACTION_SENDS_PER_SECOND}) .",
-                ),
-            )));
+            return Err(Error::Dynamic(Box::<dyn std::error::Error>::from(format!(
+                "either the specified rpc-send-batch-size ({rpc_send_batch_size}) or \
+                 rpc-send-batch-ms ({batch_send_rate_ms}) is invalid, 'rpc-send-batch-size * 1000 \
+                 / rpc-send-batch-ms' must be smaller than ({MAX_TRANSACTION_SENDS_PER_SECOND}) .",
+            ))));
         }
 
         let tpu_peers = matches

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -17,12 +17,12 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
             ))));
         }
 
-        let rpc_send_batch_size = value_t!(matches, "rpc_send_transaction_batch_size", usize)?;
+        let batch_size = value_t!(matches, "rpc_send_transaction_batch_size", usize)?;
         let millis_per_second = 1000;
-        let tps = rpc_send_batch_size as u64 * millis_per_second / batch_send_rate_ms;
+        let tps = batch_size as u64 * millis_per_second / batch_send_rate_ms;
         if tps > MAX_TRANSACTION_SENDS_PER_SECOND {
             return Err(Error::Dynamic(Box::<dyn std::error::Error>::from(format!(
-                "either the specified rpc-send-batch-size ({rpc_send_batch_size}) or \
+                "either the specified rpc-send-batch-size ({batch_size}) or \
                  rpc-send-batch-ms ({batch_send_rate_ms}) is invalid, 'rpc-send-batch-size * 1000 \
                  / rpc-send-batch-ms' must be smaller than ({MAX_TRANSACTION_SENDS_PER_SECOND}) .",
             ))));
@@ -49,7 +49,7 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
 
         Ok(SendTransactionServiceConfig {
             retry_rate_ms,
-            batch_size: value_t!(matches, "rpc_send_transaction_batch_size", usize)?,
+            batch_size,
             batch_send_rate_ms,
             default_max_retries: value_t!(
                 matches,

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -105,19 +105,43 @@ mod tests {
 
     #[test]
     fn verify_args_struct_by_command_run_with_batch_size() {
-        let default_run_args = RunArgs::default();
-        let expected_args = RunArgs {
-            send_transaction_service_config: SendTransactionServiceConfig {
-                batch_size: 1,
-                ..default_run_args.send_transaction_service_config.clone()
-            },
-            ..default_run_args.clone()
-        };
-        verify_args_struct_by_command_run_with_identity_setup(
-            default_run_args,
-            vec!["--rpc-send-batch-size", "1"],
-            expected_args,
-        );
+        {
+            let default_run_args = RunArgs::default();
+            let expected_args = RunArgs {
+                send_transaction_service_config: SendTransactionServiceConfig {
+                    batch_size: 1,
+                    ..default_run_args.send_transaction_service_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rpc-send-batch-size", "1"],
+                expected_args,
+            );
+        }
+
+        {
+            let default_run_args = RunArgs::default();
+            let expected_args = RunArgs {
+                send_transaction_service_config: SendTransactionServiceConfig {
+                    batch_size: 999,
+                    batch_send_rate_ms: 1000,
+                    ..default_run_args.send_transaction_service_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    "--rpc-send-batch-size",
+                    "999",
+                    "--rpc-send-batch-ms",
+                    "1000",
+                ],
+                expected_args,
+            );
+        }
     }
 
     #[test]

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -10,6 +10,12 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
             retry_rate_ms: value_t!(matches, "rpc_send_transaction_retry_ms", u64)?,
             batch_size: value_t!(matches, "rpc_send_transaction_batch_size", usize)?,
             batch_send_rate_ms: value_t!(matches, "rpc_send_transaction_batch_ms", u64)?,
+            default_max_retries: value_t!(
+                matches,
+                "rpc_send_transaction_default_max_retries",
+                usize
+            )
+            .ok(),
             ..Default::default()
         })
     }
@@ -71,6 +77,23 @@ mod tests {
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
             vec!["--rpc-send-batch-ms", "99999"],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_default_max_retries() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            send_transaction_service_config: SendTransactionServiceConfig {
+                default_max_retries: Some(9999),
+                ..default_run_args.send_transaction_service_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--rpc-send-default-max-retries", "9999"],
             expected_args,
         );
     }

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -38,6 +38,9 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
                 )))
             })?;
 
+        let default_max_retries =
+            value_t!(matches, "rpc_send_transaction_default_max_retries", usize).ok();
+
         let rpc_send_transaction_also_leader =
             matches.is_present("rpc_send_transaction_also_leader");
         let leader_forward_count = if tpu_peers.is_some() && !rpc_send_transaction_also_leader {
@@ -51,12 +54,7 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
             retry_rate_ms,
             batch_size,
             batch_send_rate_ms,
-            default_max_retries: value_t!(
-                matches,
-                "rpc_send_transaction_default_max_retries",
-                usize
-            )
-            .ok(),
+            default_max_retries,
             service_max_retries: value_t!(
                 matches,
                 "rpc_send_transaction_service_max_retries",

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -8,24 +8,24 @@ use {
 
 impl FromClapArgMatches for SendTransactionServiceConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
-        let rpc_send_batch_send_rate_ms = value_t!(matches, "rpc_send_transaction_batch_ms", u64)?;
+        let batch_send_rate_ms = value_t!(matches, "rpc_send_transaction_batch_ms", u64)?;
         let rpc_send_retry_rate_ms = value_t!(matches, "rpc_send_transaction_retry_ms", u64)?;
-        if rpc_send_batch_send_rate_ms > rpc_send_retry_rate_ms {
-            return Err(crate::commands::Error::Dynamic(Box::<dyn std::error::Error>::from(
-                format!(
-                    "the specified rpc-send-batch-ms ({rpc_send_batch_send_rate_ms}) is invalid, it must \
+        if batch_send_rate_ms > rpc_send_retry_rate_ms {
+            return Err(crate::commands::Error::Dynamic(
+                Box::<dyn std::error::Error>::from(format!(
+                    "the specified rpc-send-batch-ms ({batch_send_rate_ms}) is invalid, it must \
                  be <= rpc-send-retry-ms ({rpc_send_retry_rate_ms})"
-                ),
-            )));
+                )),
+            ));
         }
 
         let rpc_send_batch_size = value_t!(matches, "rpc_send_transaction_batch_size", usize)?;
         let millis_per_second = 1000;
-        let tps = rpc_send_batch_size as u64 * millis_per_second / rpc_send_batch_send_rate_ms;
+        let tps = rpc_send_batch_size as u64 * millis_per_second / batch_send_rate_ms;
         if tps > MAX_TRANSACTION_SENDS_PER_SECOND {
             return Err(crate::commands::Error::Dynamic(Box::<dyn std::error::Error>::from(
                 format!(
-                    "either the specified rpc-send-batch-size ({rpc_send_batch_size}) or rpc-send-batch-ms ({rpc_send_batch_send_rate_ms}) is invalid, \
+                    "either the specified rpc-send-batch-size ({rpc_send_batch_size}) or rpc-send-batch-ms ({batch_send_rate_ms}) is invalid, \
                  'rpc-send-batch-size * 1000 / rpc-send-batch-ms' must be smaller than ({MAX_TRANSACTION_SENDS_PER_SECOND}) .",
                 ),
             )));
@@ -53,7 +53,7 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
         Ok(SendTransactionServiceConfig {
             retry_rate_ms: rpc_send_retry_rate_ms,
             batch_size: value_t!(matches, "rpc_send_transaction_batch_size", usize)?,
-            batch_send_rate_ms: rpc_send_batch_send_rate_ms,
+            batch_send_rate_ms,
             default_max_retries: value_t!(
                 matches,
                 "rpc_send_transaction_default_max_retries",

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -72,7 +72,6 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
             )?,
             tpu_peers,
             leader_forward_count,
-            ..Default::default()
         })
     }
 }

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -9,12 +9,12 @@ use {
 impl FromClapArgMatches for SendTransactionServiceConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         let batch_send_rate_ms = value_t!(matches, "rpc_send_transaction_batch_ms", u64)?;
-        let rpc_send_retry_rate_ms = value_t!(matches, "rpc_send_transaction_retry_ms", u64)?;
-        if batch_send_rate_ms > rpc_send_retry_rate_ms {
+        let retry_rate_ms = value_t!(matches, "rpc_send_transaction_retry_ms", u64)?;
+        if batch_send_rate_ms > retry_rate_ms {
             return Err(crate::commands::Error::Dynamic(
                 Box::<dyn std::error::Error>::from(format!(
                     "the specified rpc-send-batch-ms ({batch_send_rate_ms}) is invalid, it must \
-                 be <= rpc-send-retry-ms ({rpc_send_retry_rate_ms})"
+                 be <= rpc-send-retry-ms ({retry_rate_ms})"
                 )),
             ));
         }
@@ -51,7 +51,7 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
         };
 
         Ok(SendTransactionServiceConfig {
-            retry_rate_ms: rpc_send_retry_rate_ms,
+            retry_rate_ms,
             batch_size: value_t!(matches, "rpc_send_transaction_batch_size", usize)?,
             batch_send_rate_ms,
             default_max_retries: value_t!(

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -1,0 +1,23 @@
+use {
+    crate::commands::{FromClapArgMatches, Result},
+    clap::{value_t, ArgMatches},
+    solana_send_transaction_service::send_transaction_service::Config as SendTransactionServiceConfig,
+};
+
+impl FromClapArgMatches for SendTransactionServiceConfig {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        Ok(SendTransactionServiceConfig {
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::commands::run::args::{
+            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+        },
+    };
+}

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -9,6 +9,7 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
         Ok(SendTransactionServiceConfig {
             retry_rate_ms: value_t!(matches, "rpc_send_transaction_retry_ms", u64)?,
             batch_size: value_t!(matches, "rpc_send_transaction_batch_size", usize)?,
+            batch_send_rate_ms: value_t!(matches, "rpc_send_transaction_batch_ms", u64)?,
             ..Default::default()
         })
     }
@@ -53,6 +54,23 @@ mod tests {
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
             vec!["--rpc-send-batch-size", "9999"],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_batch_send_rate_ms() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            send_transaction_service_config: SendTransactionServiceConfig {
+                batch_send_rate_ms: 99999,
+                ..default_run_args.send_transaction_service_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--rpc-send-batch-ms", "99999"],
             expected_args,
         );
     }

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -7,6 +7,7 @@ use {
 impl FromClapArgMatches for SendTransactionServiceConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         Ok(SendTransactionServiceConfig {
+            retry_rate_ms: value_t!(matches, "rpc_send_transaction_retry_ms", u64)?,
             ..Default::default()
         })
     }
@@ -20,4 +21,21 @@ mod tests {
             tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
         },
     };
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_retry_rate_ms() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            send_transaction_service_config: SendTransactionServiceConfig {
+                retry_rate_ms: 99999,
+                ..default_run_args.send_transaction_service_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--rpc-send-retry-ms", "99999"],
+            expected_args,
+        );
+    }
 }

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -21,6 +21,11 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
                 "rpc_send_transaction_service_max_retries",
                 usize
             )?,
+            retry_pool_max_size: value_t!(
+                matches,
+                "rpc_send_transaction_retry_pool_max_size",
+                usize
+            )?,
             ..Default::default()
         })
     }
@@ -116,6 +121,23 @@ mod tests {
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
             vec!["--rpc-send-service-max-retries", "9999"],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_retry_pool_max_size() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            send_transaction_service_config: SendTransactionServiceConfig {
+                retry_pool_max_size: 9999,
+                ..default_run_args.send_transaction_service_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--rpc-send-transaction-retry-pool-max-size", "9999"],
             expected_args,
         );
     }

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -22,9 +22,9 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
         let tps = batch_size as u64 * millis_per_second / batch_send_rate_ms;
         if tps > MAX_TRANSACTION_SENDS_PER_SECOND {
             return Err(Error::Dynamic(Box::<dyn std::error::Error>::from(format!(
-                "either the specified rpc-send-batch-size ({batch_size}) or \
-                 rpc-send-batch-ms ({batch_send_rate_ms}) is invalid, 'rpc-send-batch-size * 1000 \
-                 / rpc-send-batch-ms' must be smaller than ({MAX_TRANSACTION_SENDS_PER_SECOND}) .",
+                "either the specified rpc-send-batch-size ({batch_size}) or rpc-send-batch-ms \
+                 ({batch_send_rate_ms}) is invalid, 'rpc-send-batch-size * 1000 / \
+                 rpc-send-batch-ms' must be smaller than ({MAX_TRANSACTION_SENDS_PER_SECOND}) .",
             ))));
         }
 

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -44,6 +44,9 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
         let service_max_retries =
             value_t!(matches, "rpc_send_transaction_service_max_retries", usize)?;
 
+        let retry_pool_max_size =
+            value_t!(matches, "rpc_send_transaction_retry_pool_max_size", usize)?;
+
         let rpc_send_transaction_also_leader =
             matches.is_present("rpc_send_transaction_also_leader");
         let leader_forward_count = if tpu_peers.is_some() && !rpc_send_transaction_also_leader {
@@ -59,11 +62,7 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
             batch_send_rate_ms,
             default_max_retries,
             service_max_retries,
-            retry_pool_max_size: value_t!(
-                matches,
-                "rpc_send_transaction_retry_pool_max_size",
-                usize
-            )?,
+            retry_pool_max_size,
             tpu_peers,
             leader_forward_count,
         })

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -8,6 +8,7 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         Ok(SendTransactionServiceConfig {
             retry_rate_ms: value_t!(matches, "rpc_send_transaction_retry_ms", u64)?,
+            batch_size: value_t!(matches, "rpc_send_transaction_batch_size", usize)?,
             ..Default::default()
         })
     }
@@ -35,6 +36,23 @@ mod tests {
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
             vec!["--rpc-send-retry-ms", "99999"],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_batch_size() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            send_transaction_service_config: SendTransactionServiceConfig {
+                batch_size: 9999,
+                ..default_run_args.send_transaction_service_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--rpc-send-batch-size", "9999"],
             expected_args,
         );
     }

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -16,6 +16,11 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
                 usize
             )
             .ok(),
+            service_max_retries: value_t!(
+                matches,
+                "rpc_send_transaction_service_max_retries",
+                usize
+            )?,
             ..Default::default()
         })
     }
@@ -94,6 +99,23 @@ mod tests {
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
             vec!["--rpc-send-default-max-retries", "9999"],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_service_max_retries() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            send_transaction_service_config: SendTransactionServiceConfig {
+                service_max_retries: 9999,
+                ..default_run_args.send_transaction_service_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--rpc-send-service-max-retries", "9999"],
             expected_args,
         );
     }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -87,8 +87,6 @@ pub enum Operation {
     Run,
 }
 
-const MILLIS_PER_SECOND: u64 = 1000;
-
 pub fn execute(
     matches: &ArgMatches,
     solana_version: &str,
@@ -463,17 +461,6 @@ pub fn execute(
     let rpc_send_retry_rate_ms = run_args.send_transaction_service_config.retry_rate_ms;
     let rpc_send_batch_size = run_args.send_transaction_service_config.batch_size;
     let rpc_send_batch_send_rate_ms = run_args.send_transaction_service_config.batch_send_rate_ms;
-
-    let tps = rpc_send_batch_size as u64 * MILLIS_PER_SECOND / rpc_send_batch_send_rate_ms;
-    if tps > send_transaction_service::MAX_TRANSACTION_SENDS_PER_SECOND {
-        Err(format!(
-            "either the specified rpc-send-batch-size ({}) or rpc-send-batch-ms ({}) is invalid, \
-             'rpc-send-batch-size * 1000 / rpc-send-batch-ms' must be smaller than ({}) .",
-            rpc_send_batch_size,
-            rpc_send_batch_send_rate_ms,
-            send_transaction_service::MAX_TRANSACTION_SENDS_PER_SECOND
-        ))?;
-    }
     let rpc_send_transaction_tpu_peers = run_args.send_transaction_service_config.tpu_peers;
 
     let xdp_interface = matches.value_of("retransmit_xdp_interface");

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -460,7 +460,7 @@ pub fn execute(
     let starting_with_geyser_plugins: bool = on_start_geyser_plugin_config_files.is_some()
         || matches.is_present("geyser_plugin_always_enabled");
 
-    let rpc_send_retry_rate_ms = value_t_or_exit!(matches, "rpc_send_transaction_retry_ms", u64);
+    let rpc_send_retry_rate_ms = run_args.send_transaction_service_config.retry_rate_ms;
     let rpc_send_batch_size = value_t_or_exit!(matches, "rpc_send_transaction_batch_size", usize);
     let rpc_send_batch_send_rate_ms =
         value_t_or_exit!(matches, "rpc_send_transaction_batch_ms", u64);

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -482,14 +482,6 @@ pub fn execute(
         ))?;
     }
     let rpc_send_transaction_tpu_peers = run_args.send_transaction_service_config.tpu_peers;
-    let rpc_send_transaction_also_leader = matches.is_present("rpc_send_transaction_also_leader");
-    let leader_forward_count =
-        if rpc_send_transaction_tpu_peers.is_some() && !rpc_send_transaction_also_leader {
-            // rpc-sts is configured to send only to specific tpu peers. disable leader forwards
-            0
-        } else {
-            value_t_or_exit!(matches, "rpc_send_transaction_leader_forward_count", u64)
-        };
 
     let xdp_interface = matches.value_of("retransmit_xdp_interface");
     let xdp_zero_copy = matches.is_present("retransmit_xdp_zero_copy");
@@ -598,7 +590,7 @@ pub fn execute(
         contact_save_interval: DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS,
         send_transaction_service_config: send_transaction_service::Config {
             retry_rate_ms: rpc_send_retry_rate_ms,
-            leader_forward_count,
+            leader_forward_count: run_args.send_transaction_service_config.leader_forward_count,
             default_max_retries: run_args.send_transaction_service_config.default_max_retries,
             service_max_retries: run_args.send_transaction_service_config.service_max_retries,
             batch_send_rate_ms: rpc_send_batch_send_rate_ms,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -613,11 +613,7 @@ pub fn execute(
             service_max_retries: run_args.send_transaction_service_config.service_max_retries,
             batch_send_rate_ms: rpc_send_batch_send_rate_ms,
             batch_size: rpc_send_batch_size,
-            retry_pool_max_size: value_t_or_exit!(
-                matches,
-                "rpc_send_transaction_retry_pool_max_size",
-                usize
-            ),
+            retry_pool_max_size: run_args.send_transaction_service_config.retry_pool_max_size,
             tpu_peers: rpc_send_transaction_tpu_peers,
         },
         no_poh_speed_test: matches.is_present("no_poh_speed_test"),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -462,8 +462,7 @@ pub fn execute(
 
     let rpc_send_retry_rate_ms = run_args.send_transaction_service_config.retry_rate_ms;
     let rpc_send_batch_size = run_args.send_transaction_service_config.batch_size;
-    let rpc_send_batch_send_rate_ms =
-        value_t_or_exit!(matches, "rpc_send_transaction_batch_ms", u64);
+    let rpc_send_batch_send_rate_ms = run_args.send_transaction_service_config.batch_send_rate_ms;
 
     if rpc_send_batch_send_rate_ms > rpc_send_retry_rate_ms {
         Err(format!(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -464,13 +464,6 @@ pub fn execute(
     let rpc_send_batch_size = run_args.send_transaction_service_config.batch_size;
     let rpc_send_batch_send_rate_ms = run_args.send_transaction_service_config.batch_send_rate_ms;
 
-    if rpc_send_batch_send_rate_ms > rpc_send_retry_rate_ms {
-        Err(format!(
-            "the specified rpc-send-batch-ms ({rpc_send_batch_send_rate_ms}) is invalid, it must \
-             be <= rpc-send-retry-ms ({rpc_send_retry_rate_ms})"
-        ))?;
-    }
-
     let tps = rpc_send_batch_size as u64 * MILLIS_PER_SECOND / rpc_send_batch_send_rate_ms;
     if tps > send_transaction_service::MAX_TRANSACTION_SENDS_PER_SECOND {
         Err(format!(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -461,7 +461,7 @@ pub fn execute(
         || matches.is_present("geyser_plugin_always_enabled");
 
     let rpc_send_retry_rate_ms = run_args.send_transaction_service_config.retry_rate_ms;
-    let rpc_send_batch_size = value_t_or_exit!(matches, "rpc_send_transaction_batch_size", usize);
+    let rpc_send_batch_size = run_args.send_transaction_service_config.batch_size;
     let rpc_send_batch_send_rate_ms =
         value_t_or_exit!(matches, "rpc_send_transaction_batch_ms", u64);
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -59,7 +59,6 @@ use {
             self, ArchiveFormat, SnapshotInterval, SnapshotVersion, BANK_SNAPSHOTS_DIR,
         },
     },
-    solana_send_transaction_service::send_transaction_service,
     solana_signer::Signer,
     solana_streamer::quic::{QuicServerParams, DEFAULT_TPU_COALESCE},
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
@@ -458,11 +457,6 @@ pub fn execute(
     let starting_with_geyser_plugins: bool = on_start_geyser_plugin_config_files.is_some()
         || matches.is_present("geyser_plugin_always_enabled");
 
-    let rpc_send_retry_rate_ms = run_args.send_transaction_service_config.retry_rate_ms;
-    let rpc_send_batch_size = run_args.send_transaction_service_config.batch_size;
-    let rpc_send_batch_send_rate_ms = run_args.send_transaction_service_config.batch_send_rate_ms;
-    let rpc_send_transaction_tpu_peers = run_args.send_transaction_service_config.tpu_peers;
-
     let xdp_interface = matches.value_of("retransmit_xdp_interface");
     let xdp_zero_copy = matches.is_present("retransmit_xdp_zero_copy");
     let retransmit_xdp = matches.value_of("retransmit_xdp_cpu_cores").map(|cpus| {
@@ -568,16 +562,7 @@ pub fn execute(
         generator_config: None,
         contact_debug_interval,
         contact_save_interval: DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS,
-        send_transaction_service_config: send_transaction_service::Config {
-            retry_rate_ms: rpc_send_retry_rate_ms,
-            leader_forward_count: run_args.send_transaction_service_config.leader_forward_count,
-            default_max_retries: run_args.send_transaction_service_config.default_max_retries,
-            service_max_retries: run_args.send_transaction_service_config.service_max_retries,
-            batch_send_rate_ms: rpc_send_batch_send_rate_ms,
-            batch_size: rpc_send_batch_size,
-            retry_pool_max_size: run_args.send_transaction_service_config.retry_pool_max_size,
-            tpu_peers: rpc_send_transaction_tpu_peers,
-        },
+        send_transaction_service_config: run_args.send_transaction_service_config,
         no_poh_speed_test: matches.is_present("no_poh_speed_test"),
         no_os_memory_stats_reporting: matches.is_present("no_os_memory_stats_reporting"),
         no_os_network_stats_reporting: matches.is_present("no_os_network_stats_reporting"),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -609,12 +609,7 @@ pub fn execute(
         send_transaction_service_config: send_transaction_service::Config {
             retry_rate_ms: rpc_send_retry_rate_ms,
             leader_forward_count,
-            default_max_retries: value_t!(
-                matches,
-                "rpc_send_transaction_default_max_retries",
-                usize
-            )
-            .ok(),
+            default_max_retries: run_args.send_transaction_service_config.default_max_retries,
             service_max_retries: value_t_or_exit!(
                 matches,
                 "rpc_send_transaction_service_max_retries",

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -610,11 +610,7 @@ pub fn execute(
             retry_rate_ms: rpc_send_retry_rate_ms,
             leader_forward_count,
             default_max_retries: run_args.send_transaction_service_config.default_max_retries,
-            service_max_retries: value_t_or_exit!(
-                matches,
-                "rpc_send_transaction_service_max_retries",
-                usize
-            ),
+            service_max_retries: run_args.send_transaction_service_config.service_max_retries,
             batch_send_rate_ms: rpc_send_batch_send_rate_ms,
             batch_size: rpc_send_batch_size,
             retry_pool_max_size: value_t_or_exit!(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -481,17 +481,7 @@ pub fn execute(
             send_transaction_service::MAX_TRANSACTION_SENDS_PER_SECOND
         ))?;
     }
-    let rpc_send_transaction_tpu_peers = matches
-        .values_of("rpc_send_transaction_tpu_peer")
-        .map(|values| {
-            values
-                .map(solana_net_utils::parse_host_port)
-                .collect::<Result<Vec<SocketAddr>, String>>()
-        })
-        .transpose()
-        .map_err(|err| {
-            format!("failed to parse rpc send-transaction-service tpu peer address: {err}")
-        })?;
+    let rpc_send_transaction_tpu_peers = run_args.send_transaction_service_config.tpu_peers;
     let rpc_send_transaction_also_leader = matches.is_present("rpc_send_transaction_also_leader");
     let leader_forward_count =
         if rpc_send_transaction_tpu_peers.is_some() && !rpc_send_transaction_also_leader {


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/issues/4082

#### Summary of Changes

impl FromClapArgMatches for SendTransactionServiceConfig
