### PR TITLE
Remove duplicate if clause from spl github workflow

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   check:
-    if: github.repository == 'anza-xyz/agave'
+    #if: github.repository == 'anza-xyz/agave'
     if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -77,7 +77,7 @@ jobs:
           cargo check
 
   test_cli:
-    if: github.repository == 'anza-xyz/agave'
+    #if: github.repository == 'anza-xyz/agave'
     if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -108,7 +108,7 @@ jobs:
           cargo test --manifest-path clients/cli/Cargo.toml
 
   cargo-test-sbf:
-    if: github.repository == 'anza-xyz/agave'
+    #if: github.repository == 'anza-xyz/agave'
     if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
#### Problem

#6439 was merged with the intention to disable this workflow temporarily. The duplicate if clauses cause the workflow to fail and generates failure emails with no resolution.

#### Summary of Changes

Comment out the duplicate if clause to allow the workflow to exit gracefully.
