### PR TITLE
Added v1 spec revision

### DIFF
--- a/docs/src/proposals/off-chain-message-signing.md
+++ b/docs/src/proposals/off-chain-message-signing.md
@@ -52,8 +52,8 @@ This field **SHOULD NOT** be displayed to users
 
 #### Header version
 
-The header version is represented as an 8-bit unsigned integer. Only the version
-0 header format is specified in this document
+The header version is represented as an 8-bit unsigned integer. Only the version 
+1 and earlier of the header format are specified in this document.
 
 This field **SHOULD NOT** be displayed to users
 
@@ -79,7 +79,9 @@ compatibility and composition of messages.
 
 \* Combined length of the [message preamble](#message-preamble) and message body<br/>
 \*\* Those characters for which [`isprint(3)`](https://linux.die.net/man/3/isprint)
-returns true.  That is, `0x20..=0x7e`.
+returns true or the newline - `\n` character.  That is, `0x20..=0x7e` or `0x0a`. 
+The newline character was added as part of the header version 1 specification and is
+not recognised under the previous revision.
 
 Both the message encoding and maximum message length **MUST** be enforced by
 signer and verifier.

--- a/docs/src/proposals/off-chain-message-signing.md
+++ b/docs/src/proposals/off-chain-message-signing.md
@@ -52,9 +52,10 @@ This field **SHOULD NOT** be displayed to users
 
 #### Header version
 
-The header version is represented as an 8-bit unsigned integer. Only the version 
-1 and earlier of the header format are specified in this document.
-
+The header version is represented as an 8-bit unsigned integer. Only the versions 
+1 and 0 of the header format are specified in this document.
+Version 0 and 1 are nearly identical: the only difference between them is treatment of acceptable
+characters for message format 0. See the message format section for more information.
 This field **SHOULD NOT** be displayed to users
 
 #### Application domain
@@ -82,6 +83,7 @@ compatibility and composition of messages.
 returns true or the newline - `\n` character.  That is, `0x20..=0x7e` or `0x0a`. 
 The newline character was added as part of the header version 1 specification and is
 not recognised under the previous revision.
+NOTE: header version 0 does not allow the newline character, only header version 1 allows it.
 
 Both the message encoding and maximum message length **MUST** be enforced by
 signer and verifier.


### PR DESCRIPTION
#### Problem

Out of date OCMS spec

#### Summary of Changes

Added v1 header spec changes according to the [sRFC 24](https://forum.solana.com/t/srfc-0024-extending-off-chain-message-signing-standard/1681)
