### PR TITLE
BankForks::sharable_banks

### DIFF
--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -55,7 +55,7 @@ pub(crate) fn ensure_banking_stage_setup(
     transaction_recorder: TransactionRecorder,
     num_threads: NonZeroUsize,
 ) {
-    let root_bank = bank_forks.read().unwrap().sharable_root_bank();
+    let sharable_banks = bank_forks.read().unwrap().sharable_banks();
     let unified_receiver = channels.unified_receiver().clone();
 
     let (is_exited, decision_maker) = {
@@ -77,7 +77,7 @@ pub(crate) fn ensure_banking_stage_setup(
                 // by solScCleaner.
                 return;
             }
-            let bank = root_bank.load();
+            let bank = sharable_banks.root();
             for batch in batches.iter() {
                 // over-provision nevertheless some of packets could be invalid.
                 let task_id_base = helper.generate_task_ids(batch.len());

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -605,7 +605,7 @@ impl AncestorHashesService {
         let serve_repair = {
             ServeRepair::new(
                 repair_info.cluster_info.clone(),
-                repair_info.bank_forks.read().unwrap().sharable_root_bank(),
+                repair_info.bank_forks.read().unwrap().sharable_banks(),
                 repair_info.repair_whitelist.clone(),
                 Box::new(StandardRepairHandler::new(blockstore)),
             )
@@ -1271,11 +1271,7 @@ mod test {
             let responder_serve_repair = {
                 ServeRepair::new(
                     Arc::new(cluster_info),
-                    vote_simulator
-                        .bank_forks
-                        .read()
-                        .unwrap()
-                        .sharable_root_bank(),
+                    vote_simulator.bank_forks.read().unwrap().sharable_banks(),
                     Arc::<RwLock<HashSet<_>>>::default(), // repair whitelist
                     Box::new(StandardRepairHandler::new(blockstore.clone())),
                 )
@@ -1382,7 +1378,7 @@ mod test {
             let requester_serve_repair = {
                 ServeRepair::new(
                     requester_cluster_info.clone(),
-                    bank_forks.read().unwrap().sharable_root_bank(),
+                    bank_forks.read().unwrap().sharable_banks(),
                     repair_whitelist.clone(),
                     Box::new(StandardRepairHandler::new(blockstore)),
                 )

--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -18,7 +18,7 @@ use {
     },
     solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
     solana_pubkey::Pubkey,
-    solana_runtime::bank_forks::SharableBank,
+    solana_runtime::bank_forks::SharableBanks,
     std::{
         collections::HashSet,
         net::SocketAddr,
@@ -150,12 +150,12 @@ impl RepairHandlerType {
         &self,
         blockstore: Arc<Blockstore>,
         cluster_info: Arc<ClusterInfo>,
-        sharable_root_bank: SharableBank,
+        sharable_banks: SharableBanks,
         serve_repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
     ) -> ServeRepair {
         ServeRepair::new(
             cluster_info,
-            sharable_root_bank,
+            sharable_banks,
             serve_repair_whitelist,
             self.to_handler(blockstore),
         )

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -41,7 +41,7 @@ use {
         packet::{Packet, PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
     },
     solana_pubkey::{Pubkey, PUBKEY_BYTES},
-    solana_runtime::bank_forks::SharableBank,
+    solana_runtime::bank_forks::SharableBanks,
     solana_signature::{Signature, SIGNATURE_BYTES},
     solana_signer::Signer,
     solana_streamer::{
@@ -338,7 +338,7 @@ impl RepairProtocol {
 
 pub struct ServeRepair {
     cluster_info: Arc<ClusterInfo>,
-    root_bank: SharableBank,
+    sharable_banks: SharableBanks,
     repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
     repair_handler: Box<dyn RepairHandler + Send + Sync>,
 }
@@ -401,13 +401,13 @@ struct RepairRequestWithMeta {
 impl ServeRepair {
     pub fn new(
         cluster_info: Arc<ClusterInfo>,
-        sharable_root_bank: SharableBank,
+        sharable_banks: SharableBanks,
         repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
         repair_handler: Box<dyn RepairHandler + Send + Sync>,
     ) -> Self {
         Self {
             cluster_info,
-            root_bank: sharable_root_bank,
+            sharable_banks,
             repair_whitelist,
             repair_handler,
         }
@@ -424,7 +424,7 @@ impl ServeRepair {
         let repair_handler = Box::new(StandardRepairHandler::new(blockstore));
         Self::new(
             cluster_info,
-            bank_forks.read().unwrap().sharable_root_bank(),
+            bank_forks.read().unwrap().sharable_banks(),
             repair_whitelist,
             repair_handler,
         )
@@ -662,7 +662,7 @@ impl ServeRepair {
         let mut total_requests = requests.len();
 
         let socket_addr_space = *self.cluster_info.socket_addr_space();
-        let root_bank = self.root_bank.load();
+        let root_bank = self.sharable_banks.root();
         let epoch_staked_nodes = root_bank.epoch_staked_nodes(root_bank.epoch());
         let identity_keypair = self.cluster_info.keypair().clone();
         let my_id = identity_keypair.pubkey();

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -342,7 +342,7 @@ impl Tpu {
             forward_stage_receiver,
             client,
             vote_forwarding_client_socket,
-            bank_forks.read().unwrap().sharable_root_bank(),
+            bank_forks.read().unwrap().sharable_banks(),
             ForwardAddressGetter::new(cluster_info.clone(), poh_recorder.clone()),
             DataBudget::default(),
         );

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1312,7 +1312,7 @@ impl Validator {
         let serve_repair = config.repair_handler_type.create_serve_repair(
             blockstore.clone(),
             cluster_info.clone(),
-            bank_forks.read().unwrap().sharable_root_bank(),
+            bank_forks.read().unwrap().sharable_banks(),
             config.repair_whitelist.clone(),
         );
         let (repair_request_quic_sender, repair_request_quic_receiver) = unbounded();

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -44,6 +44,35 @@ impl ReadOnlyAtomicSlot {
     }
 }
 
+/// Convenience type since often root/working banks are fetched together.
+#[derive(Clone)]
+pub struct SharableBanks {
+    root_bank: SharableBank,
+    working_bank: SharableBank,
+}
+
+impl SharableBanks {
+    pub fn root(&self) -> Arc<Bank> {
+        self.root_bank.load()
+    }
+
+    pub fn working(&self) -> Arc<Bank> {
+        self.working_bank.load()
+    }
+
+    pub fn load(&self) -> BankPair {
+        BankPair {
+            root_bank: self.root(),
+            working_bank: self.working(),
+        }
+    }
+}
+
+pub struct BankPair {
+    pub root_bank: Arc<Bank>,
+    pub working_bank: Arc<Bank>,
+}
+
 #[derive(Clone)]
 pub struct SharableBank(Arc<ArcSwap<Bank>>);
 
@@ -225,6 +254,13 @@ impl BankForks {
 
     pub fn sharable_working_bank(&self) -> SharableBank {
         self.working_bank.clone()
+    }
+
+    pub fn sharable_banks(&self) -> SharableBanks {
+        SharableBanks {
+            root_bank: self.sharable_root_bank(),
+            working_bank: self.sharable_working_bank(),
+        }
     }
 
     pub fn root_bank(&self) -> Arc<Bank> {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -47,17 +47,17 @@ impl ReadOnlyAtomicSlot {
 /// Convenience type since often root/working banks are fetched together.
 #[derive(Clone)]
 pub struct SharableBanks {
-    root_bank: SharableBank,
-    working_bank: SharableBank,
+    root_bank: Arc<ArcSwap<Bank>>,
+    working_bank: Arc<ArcSwap<Bank>>,
 }
 
 impl SharableBanks {
     pub fn root(&self) -> Arc<Bank> {
-        self.root_bank.load()
+        self.root_bank.load_full()
     }
 
     pub fn working(&self) -> Arc<Bank> {
-        self.working_bank.load()
+        self.working_bank.load_full()
     }
 
     pub fn load(&self) -> BankPair {
@@ -71,19 +71,6 @@ impl SharableBanks {
 pub struct BankPair {
     pub root_bank: Arc<Bank>,
     pub working_bank: Arc<Bank>,
-}
-
-#[derive(Clone)]
-pub struct SharableBank(Arc<ArcSwap<Bank>>);
-
-impl SharableBank {
-    pub fn load(&self) -> Arc<Bank> {
-        self.0.load_full()
-    }
-
-    fn store(&self, bank: Arc<Bank>) {
-        self.0.store(bank);
-    }
 }
 
 #[derive(Error, Debug)]
@@ -112,9 +99,8 @@ pub struct BankForks {
     banks: HashMap<Slot, BankWithScheduler>,
     descendants: HashMap<Slot, HashSet<Slot>>,
     root: Arc<AtomicSlot>,
-    root_bank: SharableBank,
     working_slot: Slot,
-    working_bank: SharableBank,
+    sharable_banks: SharableBanks,
     in_vote_only_mode: Arc<AtomicBool>,
     highest_slot_at_startup: Slot,
     scheduler_pool: Option<InstalledSchedulerPoolArc>,
@@ -161,9 +147,13 @@ impl BankForks {
 
         let bank_forks = Arc::new(RwLock::new(Self {
             root: Arc::new(AtomicSlot::new(root_slot)),
-            root_bank: SharableBank(Arc::new(ArcSwap::from(Arc::clone(&root_bank)))),
             working_slot: root_slot,
-            working_bank: SharableBank(Arc::new(ArcSwap::from(Arc::clone(&root_bank)))),
+            sharable_banks: SharableBanks {
+                root_bank: Arc::new(ArcSwap::from(root_bank.clone())),
+                // working bank is initially the same as root - all banks are either the root
+                // or its ancestors.
+                working_bank: Arc::new(ArcSwap::from(root_bank.clone())),
+            },
             banks,
             descendants,
             in_vote_only_mode: Arc::new(AtomicBool::new(false)),
@@ -248,23 +238,12 @@ impl BankForks {
         self.get(slot).map(|bank| bank.hash())
     }
 
-    pub fn sharable_root_bank(&self) -> SharableBank {
-        self.root_bank.clone()
-    }
-
-    pub fn sharable_working_bank(&self) -> SharableBank {
-        self.working_bank.clone()
-    }
-
     pub fn sharable_banks(&self) -> SharableBanks {
-        SharableBanks {
-            root_bank: self.sharable_root_bank(),
-            working_bank: self.sharable_working_bank(),
-        }
+        self.sharable_banks.clone()
     }
 
     pub fn root_bank(&self) -> Arc<Bank> {
-        self.root_bank.load()
+        self.sharable_banks.root()
     }
 
     pub fn install_scheduler_pool(&mut self, pool: InstalledSchedulerPoolArc) {
@@ -304,7 +283,7 @@ impl BankForks {
 
         // Update sharable working bank and cached slot.
         self.working_slot = self.find_highest_slot();
-        self.working_bank.store(self.working_bank());
+        self.sharable_banks.working_bank.store(self.working_bank());
 
         bank
     }
@@ -353,7 +332,7 @@ impl BankForks {
         // Update sharable working bank and cached slot.
         // The previous working bank (highest slot) may have been removed.
         self.working_slot = self.find_highest_slot();
-        self.working_bank.store(self.working_bank());
+        self.sharable_banks.working_bank.store(self.working_bank());
 
         Some(bank)
     }
@@ -415,7 +394,7 @@ impl BankForks {
         snapshot_controller: Option<&SnapshotController>,
         highest_super_majority_root: Option<Slot>,
     ) -> Result<(Vec<BankWithScheduler>, SetRootMetrics), SetRootError> {
-        let old_epoch = self.root_bank.load().epoch();
+        let old_epoch = self.sharable_banks.root().epoch();
 
         let root_bank = &self
             .get(root)
@@ -425,7 +404,7 @@ impl BankForks {
         // BankForks first *and* from a different thread, this store *must* be at least Release to
         // ensure atomic ordering correctness.
         self.root.store(root, Ordering::Release);
-        self.root_bank.store(Arc::clone(root_bank));
+        self.sharable_banks.root_bank.store(Arc::clone(root_bank));
 
         let new_epoch = root_bank.epoch();
         if old_epoch != new_epoch {

--- a/runtime/src/bank_hash_cache.rs
+++ b/runtime/src/bank_hash_cache.rs
@@ -10,7 +10,7 @@
 use {
     crate::{
         bank::Bank,
-        bank_forks::{BankForks, SharableBank},
+        bank_forks::{BankForks, SharableBanks},
     },
     solana_clock::Slot,
     solana_hash::Hash,
@@ -26,14 +26,14 @@ pub type DumpedSlotSubscription = Arc<Mutex<bool>>;
 pub struct BankHashCache {
     hashes: BTreeMap<Slot, Hash>,
     bank_forks: Arc<RwLock<BankForks>>,
-    root_bank: SharableBank,
+    sharable_banks: SharableBanks,
     last_root: Slot,
     dumped_slot_subscription: DumpedSlotSubscription,
 }
 
 impl BankHashCache {
     pub fn new(bank_forks: Arc<RwLock<BankForks>>) -> Self {
-        let root_bank = bank_forks.read().unwrap().sharable_root_bank();
+        let sharable_banks = bank_forks.read().unwrap().sharable_banks();
         let dumped_slot_subscription = DumpedSlotSubscription::default();
         bank_forks
             .write()
@@ -42,7 +42,7 @@ impl BankHashCache {
         Self {
             hashes: BTreeMap::default(),
             bank_forks,
-            root_bank,
+            sharable_banks,
             last_root: 0,
             dumped_slot_subscription,
         }
@@ -94,7 +94,7 @@ impl BankHashCache {
 
     /// Returns the root bank and also prunes cache of any slots < root
     pub fn get_root_bank_and_prune_cache(&mut self) -> Arc<Bank> {
-        let root_bank = self.root_bank.load();
+        let root_bank = self.sharable_banks.root();
         if root_bank.slot() != self.last_root {
             self.last_root = root_bank.slot();
             self.hashes = self.hashes.split_off(&self.last_root);


### PR DESCRIPTION
#### Problem
- Many of our threads read lock `BankForks` to get the root and working bank
- Causes unneccessary contention on this widely shared lock

#### Summary of Changes
- SharableBanks to load working and root banks without locking bank forks

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
