### PR TITLE
send-tx-service: remove deprecated re-export

### DIFF
--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -1,14 +1,8 @@
-#[deprecated(
-    since = "2.2.0",
-    note = "Please import from `send_transaction_service` directly."
-)]
-pub use crate::{
-    send_transaction_service_stats::SendTransactionServiceStats,
-    transaction_client::{CurrentLeaderInfo, LEADER_INFO_REFRESH_RATE_MS},
-};
 use {
     crate::{
-        send_transaction_service_stats::SendTransactionServiceStatsReport,
+        send_transaction_service_stats::{
+            SendTransactionServiceStats, SendTransactionServiceStatsReport,
+        },
         transaction_client::TransactionClient,
     },
     crossbeam_channel::{Receiver, RecvTimeoutError},


### PR DESCRIPTION
#### Problem
send_transaction_service_stats and transaction_client re-exports in send-transaction-service have been deprecated since Agave v2.2.

#### Summary of Changes
Remove deprecated re-exports.
