### PR TITLE
svm: Remove deprecated TransactionProcessingCallback function

### DIFF
--- a/svm-callback/src/lib.rs
+++ b/svm-callback/src/lib.rs
@@ -39,15 +39,6 @@ pub trait TransactionProcessingCallback: InvokeContextCallback {
 
     fn inspect_account(&self, _address: &Pubkey, _account_state: AccountState, _is_writable: bool) {
     }
-
-    #[deprecated(
-        since = "2.3.0",
-        note = "Use `get_epoch_stake_for_vote_account` on the `InvokeContextCallback` trait \
-                instead"
-    )]
-    fn get_current_epoch_vote_account_stake(&self, vote_address: &Pubkey) -> u64 {
-        Self::get_epoch_stake_for_vote_account(self, vote_address)
-    }
 }
 
 /// The state the account is in initially, before transaction processing

--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -131,8 +131,6 @@ pub trait TransactionProcessingCallback {
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)>;
 
     fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {}
-
-    fn get_current_epoch_vote_account_stake(&self, _vote_address: &Pubkey) -> u64;
 }
 ```
 


### PR DESCRIPTION
#### Problem
The item was deprecated in v2.3.0 so fair game to rip out in v3.0.0 (current master).

As a side note for the SVM team, `spec.md` is missing `inspect_account()`; think that makes sense to address in a follow-on PR tho