### PR TITLE
svm: Remove deprecated re-export

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -27,7 +27,7 @@ use {
     solana_keypair::Keypair,
     solana_loader_v3_interface::instruction as loader_v3_instruction,
     solana_loader_v4_interface::instruction as loader_v4_instruction,
-    solana_message::{Message, SanitizedMessage},
+    solana_message::{inner_instruction::InnerInstruction, Message, SanitizedMessage},
     solana_program_runtime::invoke_context::mock_process_instruction,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
@@ -55,7 +55,6 @@ use {
     solana_stake_interface as stake,
     solana_svm::{
         transaction_commit_result::{CommittedTransaction, TransactionCommitResult},
-        transaction_execution_result::InnerInstruction,
         transaction_processor::ExecutionRecordingConfig,
     },
     solana_svm_timings::ExecuteTimings,

--- a/svm/src/transaction_execution_result.rs
+++ b/svm/src/transaction_execution_result.rs
@@ -1,11 +1,6 @@
-// Re-exported since these have moved to `solana_message`.
-#[deprecated(
-    since = "1.18.0",
-    note = "Please use `solana_message::inner_instruction` types instead"
-)]
-pub use solana_message::inner_instruction::{InnerInstruction, InnerInstructionsList};
 use {
     crate::account_loader::LoadedTransaction,
+    solana_message::inner_instruction::InnerInstructionsList,
     solana_program_runtime::loaded_programs::ProgramCacheEntry,
     solana_pubkey::Pubkey,
     solana_transaction_context::TransactionReturnData,


### PR DESCRIPTION
#### Summary of Changes
Deprecated since v1.18, rip it out