### PR TITLE
runtime: Do not `collect()` in `create_commit_results` and its callers

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -311,13 +311,12 @@ pub fn execute_batch<'a>(
 // Get actual transaction execution costs from transaction commit results
 fn get_transaction_costs<'a, Tx: TransactionWithMeta>(
     bank: &Bank,
-    commit_results: &[TransactionCommitResult],
+    commit_results: impl Iterator<Item = TransactionCommitResult>,
     sanitized_transactions: &'a [Tx],
 ) -> Vec<Option<TransactionCost<'a, Tx>>> {
     assert_eq!(sanitized_transactions.len(), commit_results.len());
 
     commit_results
-        .iter()
         .zip(sanitized_transactions)
         .map(|(commit_result, tx)| {
             if let Ok(committed_tx) = commit_result {
@@ -2285,12 +2284,13 @@ impl TransactionStatusSender {
         &self,
         slot: Slot,
         transactions: Vec<SanitizedTransaction>,
-        commit_results: Vec<TransactionCommitResult>,
+        commit_results: impl Iterator<Item = TransactionCommitResult>,
         balances: TransactionBalancesSet,
         token_balances: TransactionTokenBalancesSet,
         costs: Vec<Option<u64>>,
         transaction_indexes: Vec<usize>,
     ) {
+        let commit_results: Vec<_> = commit_results.collect();
         let work_sequence = self
             .dependency_tracker
             .as_ref()

--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -42,13 +42,13 @@ pub fn setup_bank_and_vote_pubkeys_for_tests(
 
 pub fn find_and_send_votes(
     sanitized_txs: &[impl TransactionWithMeta],
-    commit_results: &[TransactionCommitResult],
+    commit_results: impl Iterator<Item = TransactionCommitResult>,
     vote_sender: Option<&ReplayVoteSender>,
 ) {
     if let Some(vote_sender) = vote_sender {
         sanitized_txs
             .iter()
-            .zip(commit_results.iter())
+            .zip(commit_results)
             .for_each(|(tx, commit_result)| {
                 if tx.is_simple_vote_transaction() && commit_result.was_executed_successfully() {
                     if let Some(parsed_vote) = vote_parser::parse_sanitized_vote_transaction(tx) {


### PR DESCRIPTION
#### Problem

`create_commit_results` was calling `collect()`, triggering an additional allocation.

#### Summary of Changes

Given that all the callers of `create_commit_results` only iterate over the `TransactionCommitResult` elements, `create_commit_results` can return an iterator instead of a vector.
