### PR TITLE
Support append to append_vec using file-io

### DIFF
--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -30,7 +30,7 @@ const ACCOUNTS_COUNTS: [usize; 4] = [
 ];
 
 fn bench_write_accounts_file(c: &mut Criterion, storage_access: StorageAccess) {
-    let mut group = c.benchmark_group("write_accounts_file");
+    let mut group = c.benchmark_group(format!("write_accounts_file_{:?}", storage_access));
 
     // most accounts on mnb are 165-200 bytes, so use that here too
     let space = 200;

--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -29,7 +29,7 @@ const ACCOUNTS_COUNTS: [usize; 4] = [
     10_000, // reasonable largest number of accounts written per slot
 ];
 
-fn bench_write_accounts_file(c: &mut Criterion) {
+fn bench_write_accounts_file(c: &mut Criterion, storage_access: StorageAccess) {
     let mut group = c.benchmark_group("write_accounts_file");
 
     // most accounts on mnb are 165-200 bytes, so use that here too
@@ -64,7 +64,7 @@ fn bench_write_accounts_file(c: &mut Criterion) {
                 || {
                     let path = temp_dir.path().join(format!("append_vec_{accounts_count}"));
                     let file_size = accounts.len() * (space + append_vec::STORE_META_OVERHEAD);
-                    AppendVec::new(path, true, file_size, StorageAccess::File)
+                    AppendVec::new(path, true, file_size, storage_access)
                 },
                 |append_vec| {
                     let res = append_vec.append_accounts(&storable_accounts, 0).unwrap();
@@ -96,6 +96,14 @@ fn bench_write_accounts_file(c: &mut Criterion) {
             );
         });
     }
+}
+
+fn bench_write_accounts_file_file_io(c: &mut Criterion) {
+    bench_write_accounts_file(c, StorageAccess::File);
+}
+
+fn bench_write_accounts_file_mmap(c: &mut Criterion) {
+    bench_write_accounts_file(c, StorageAccess::Mmap);
 }
 
 fn bench_scan_pubkeys(c: &mut Criterion) {
@@ -282,7 +290,8 @@ fn bench_get_account_shared_data(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    bench_write_accounts_file,
+    bench_write_accounts_file_file_io,
+    bench_write_accounts_file_mmap,
     bench_scan_pubkeys,
     bench_get_account_shared_data,
 );

--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -64,7 +64,7 @@ fn bench_write_accounts_file(c: &mut Criterion) {
                 || {
                     let path = temp_dir.path().join(format!("append_vec_{accounts_count}"));
                     let file_size = accounts.len() * (space + append_vec::STORE_META_OVERHEAD);
-                    AppendVec::new(path, true, file_size)
+                    AppendVec::new(path, true, file_size, StorageAccess::File)
                 },
                 |append_vec| {
                     let res = append_vec.append_accounts(&storable_accounts, 0).unwrap();
@@ -125,7 +125,7 @@ fn bench_scan_pubkeys(c: &mut Criterion) {
             .iter()
             .map(|(_, account)| append_vec::aligned_stored_size(account.data().len()))
             .sum();
-        let append_vec = AppendVec::new(append_vec_path, true, file_size);
+        let append_vec = AppendVec::new(append_vec_path, true, file_size, StorageAccess::File);
         let stored_accounts_info = append_vec
             .append_accounts(&(Slot::MAX, storable_accounts.as_slice()), 0)
             .unwrap();
@@ -210,7 +210,7 @@ fn bench_get_account_shared_data(c: &mut Criterion) {
             .iter()
             .map(|(_, account)| append_vec::aligned_stored_size(account.data().len()))
             .sum();
-        let append_vec = AppendVec::new(append_vec_path, true, file_size);
+        let append_vec = AppendVec::new(append_vec_path, true, file_size, StorageAccess::File);
         let stored_accounts_info = append_vec
             .append_accounts(&(Slot::MAX, storable_accounts.as_slice()), 0)
             .unwrap();

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -436,12 +436,14 @@ fn select_from_range_with_start_end_rates(
 pub(crate) mod tests {
     use {
         super::*,
-        crate::accounts_file::AccountsFileProvider,
+        crate::accounts_file::{AccountsFileProvider, StorageAccess},
         std::{iter, path::Path},
+        test_case::test_case,
     };
 
-    #[test]
-    fn test_shrink_in_progress() {
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
+    fn test_shrink_in_progress(storage_access: StorageAccess) {
         // test that we check in order map then shrink_in_progress_map
         let storage = AccountStorage::default();
         let slot = 0;
@@ -460,6 +462,7 @@ pub(crate) mod tests {
             id,
             store_file_size,
             AccountsFileProvider::AppendVec,
+            storage_access,
         ));
         let entry2 = Arc::new(AccountStorageEntry::new(
             common_store_path,
@@ -467,6 +470,7 @@ pub(crate) mod tests {
             id,
             store_file_size2,
             AccountsFileProvider::AppendVec,
+            storage_access,
         ));
         storage.map.insert(slot, entry);
 
@@ -509,7 +513,11 @@ pub(crate) mod tests {
     }
 
     impl AccountStorage {
-        fn get_test_storage_with_id(&self, id: AccountsFileId) -> Arc<AccountStorageEntry> {
+        fn get_test_storage_with_id(
+            &self,
+            id: AccountsFileId,
+            storage_access: StorageAccess,
+        ) -> Arc<AccountStorageEntry> {
             let slot = 0;
             // add a map store
             let common_store_path = Path::new("");
@@ -520,80 +528,87 @@ pub(crate) mod tests {
                 id,
                 store_file_size,
                 AccountsFileProvider::AppendVec,
+                storage_access,
             ))
         }
-        fn get_test_storage(&self) -> Arc<AccountStorageEntry> {
-            self.get_test_storage_with_id(0)
+        fn get_test_storage(&self, storage_access: StorageAccess) -> Arc<AccountStorageEntry> {
+            self.get_test_storage_with_id(0, storage_access)
         }
     }
 
-    #[test]
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
     #[should_panic(expected = "self.no_shrink_in_progress()")]
-    fn test_get_slot_storage_entry_fail() {
+    fn test_get_slot_storage_entry_fail(storage_access: StorageAccess) {
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
             .write()
             .unwrap()
-            .insert(0, storage.get_test_storage());
+            .insert(0, storage.get_test_storage(storage_access));
         storage.get_slot_storage_entry(0);
     }
 
-    #[test]
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
     #[should_panic(expected = "self.no_shrink_in_progress()")]
-    fn test_all_slots_fail() {
+    fn test_all_slots_fail(storage_access: StorageAccess) {
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
             .write()
             .unwrap()
-            .insert(0, storage.get_test_storage());
+            .insert(0, storage.get_test_storage(storage_access));
         storage.all_slots();
     }
 
-    #[test]
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
     #[should_panic(expected = "self.no_shrink_in_progress()")]
-    fn test_initialize_fail() {
+    fn test_initialize_fail(storage_access: StorageAccess) {
         let mut storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
             .write()
             .unwrap()
-            .insert(0, storage.get_test_storage());
+            .insert(0, storage.get_test_storage(storage_access));
         storage.initialize(AccountStorageMap::default());
     }
 
-    #[test]
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
     #[should_panic(
         expected = "shrink_can_be_active || self.shrink_in_progress_map.read().unwrap().is_empty()"
     )]
-    fn test_remove_fail() {
+    fn test_remove_fail(storage_access: StorageAccess) {
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
             .write()
             .unwrap()
-            .insert(0, storage.get_test_storage());
+            .insert(0, storage.get_test_storage(storage_access));
         storage.remove(&0, false);
     }
 
-    #[test]
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
     #[should_panic(expected = "self.no_shrink_in_progress()")]
-    fn test_iter_fail() {
+    fn test_iter_fail(storage_access: StorageAccess) {
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
             .write()
             .unwrap()
-            .insert(0, storage.get_test_storage());
+            .insert(0, storage.get_test_storage(storage_access));
         storage.iter();
     }
 
-    #[test]
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
     #[should_panic(expected = "self.no_shrink_in_progress()")]
-    fn test_insert_fail() {
+    fn test_insert_fail(storage_access: StorageAccess) {
         let storage = AccountStorage::default();
-        let sample = storage.get_test_storage();
+        let sample = storage.get_test_storage(storage_access);
         storage
             .shrink_in_progress_map
             .write()
@@ -602,12 +617,13 @@ pub(crate) mod tests {
         storage.insert(0, sample);
     }
 
-    #[test]
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
     #[should_panic(expected = "duplicate call")]
-    fn test_shrinking_in_progress_fail3() {
+    fn test_shrinking_in_progress_fail3(storage_access: StorageAccess) {
         // already entry in shrink_in_progress_map
         let storage = AccountStorage::default();
-        let sample = storage.get_test_storage();
+        let sample = storage.get_test_storage(storage_access);
         storage.map.insert(0, sample.clone());
         storage
             .shrink_in_progress_map
@@ -617,28 +633,30 @@ pub(crate) mod tests {
         storage.shrinking_in_progress(0, sample);
     }
 
-    #[test]
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
     #[should_panic(expected = "duplicate call")]
-    fn test_shrinking_in_progress_fail4() {
+    fn test_shrinking_in_progress_fail4(storage_access: StorageAccess) {
         // already called 'shrink_in_progress' on this slot and it is still active
         let storage = AccountStorage::default();
-        let sample_to_shrink = storage.get_test_storage();
-        let sample = storage.get_test_storage();
+        let sample_to_shrink = storage.get_test_storage(storage_access);
+        let sample = storage.get_test_storage(storage_access);
         storage.map.insert(0, sample_to_shrink);
         let _shrinking_in_progress = storage.shrinking_in_progress(0, sample.clone());
         storage.shrinking_in_progress(0, sample);
     }
 
-    #[test]
-    fn test_shrinking_in_progress_second_call() {
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
+    fn test_shrinking_in_progress_second_call(storage_access: StorageAccess) {
         // already called 'shrink_in_progress' on this slot, but it finished, so we succeed
         // verify data structures during and after shrink and then with subsequent shrink call
         let storage = AccountStorage::default();
         let slot = 0;
         let id_to_shrink = 1;
         let id_shrunk = 0;
-        let sample_to_shrink = storage.get_test_storage_with_id(id_to_shrink);
-        let sample = storage.get_test_storage();
+        let sample_to_shrink = storage.get_test_storage_with_id(id_to_shrink, storage_access);
+        let sample = storage.get_test_storage(storage_access);
         storage.map.insert(slot, sample_to_shrink);
         let shrinking_in_progress = storage.shrinking_in_progress(slot, sample.clone());
         assert!(storage.map.contains_key(&slot));
@@ -661,30 +679,33 @@ pub(crate) mod tests {
         storage.shrinking_in_progress(slot, sample);
     }
 
-    #[test]
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
     #[should_panic(expected = "no pre-existing storage for shrinking slot")]
-    fn test_shrinking_in_progress_fail1() {
+    fn test_shrinking_in_progress_fail1(storage_access: StorageAccess) {
         // nothing in slot currently
         let storage = AccountStorage::default();
-        let sample = storage.get_test_storage();
+        let sample = storage.get_test_storage(storage_access);
         storage.shrinking_in_progress(0, sample);
     }
 
-    #[test]
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
     #[should_panic(expected = "no pre-existing storage for shrinking slot")]
-    fn test_shrinking_in_progress_fail2() {
+    fn test_shrinking_in_progress_fail2(storage_access: StorageAccess) {
         // nothing in slot currently, but there is an empty map entry
         let storage = AccountStorage::default();
-        let sample = storage.get_test_storage();
+        let sample = storage.get_test_storage(storage_access);
         storage.shrinking_in_progress(0, sample);
     }
 
-    #[test]
-    fn test_missing() {
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
+    fn test_missing(storage_access: StorageAccess) {
         // already called 'shrink_in_progress' on this slot, but it finished, so we succeed
         // verify data structures during and after shrink and then with subsequent shrink call
         let storage = AccountStorage::default();
-        let sample = storage.get_test_storage();
+        let sample = storage.get_test_storage(storage_access);
         let id = sample.id();
         let missing_id = 9999;
         let slot = sample.slot();
@@ -718,8 +739,9 @@ pub(crate) mod tests {
         assert!(storage.get_account_storage_entry(slot, id).is_some());
     }
 
-    #[test]
-    fn test_get_if() {
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
+    fn test_get_if(storage_access: StorageAccess) {
         let storage = AccountStorage::default();
         assert!(storage.get_if(|_, _| true).is_empty());
 
@@ -733,6 +755,7 @@ pub(crate) mod tests {
                 id,
                 5000,
                 AccountsFileProvider::AppendVec,
+                storage_access,
             );
             storage.map.insert(slot, entry.into());
         }
@@ -750,15 +773,16 @@ pub(crate) mod tests {
         assert_eq!(storage.get_if(|_, _| true).len(), ids.len());
     }
 
-    #[test]
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
     #[should_panic(expected = "self.no_shrink_in_progress()")]
-    fn test_get_if_fail() {
+    fn test_get_if_fail(storage_access: StorageAccess) {
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
             .write()
             .unwrap()
-            .insert(0, storage.get_test_storage());
+            .insert(0, storage.get_test_storage(storage_access));
         storage.get_if(|_, _| true);
     }
 

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -147,21 +147,25 @@ mod tests {
     fn create_storage_for_storage_reader(
         slot: Slot,
         provider: AccountsFileProvider,
+        storage_access: StorageAccess,
     ) -> (AccountStorageEntry, Vec<tempfile::TempDir>) {
         let id = 0;
         let (temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
         let file_size = 1024 * 1024;
         (
-            AccountStorageEntry::new(&paths[0], slot, id, file_size, provider),
+            AccountStorageEntry::new(&paths[0], slot, id, file_size, provider, storage_access),
             temp_dirs,
         )
     }
 
-    #[test]
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
     #[should_panic(expected = "Obsolete accounts should be empty for TieredStorage")]
-    fn test_account_storage_reader_tiered_storage_one_obsolete_account_should_panic() {
+    fn test_account_storage_reader_tiered_storage_one_obsolete_account_should_panic(
+        storage_access: StorageAccess,
+    ) {
         let (storage, _temp_dirs) =
-            create_storage_for_storage_reader(0, AccountsFileProvider::HotStorage);
+            create_storage_for_storage_reader(0, AccountsFileProvider::HotStorage, storage_access);
 
         let account = AccountSharedData::new(1, 10, &Pubkey::new_unique());
         let account2 = AccountSharedData::new(1, 10, &Pubkey::new_unique());
@@ -182,10 +186,14 @@ mod tests {
         _ = AccountStorageReader::new(&storage, None).unwrap();
     }
 
-    #[test_case(AccountsFileProvider::AppendVec)]
-    #[test_case(AccountsFileProvider::HotStorage)]
-    fn test_account_storage_reader_no_obsolete_accounts(provider: AccountsFileProvider) {
-        let (storage, _temp_dirs) = create_storage_for_storage_reader(0, provider);
+    #[test_case(AccountsFileProvider::AppendVec, StorageAccess::Mmap)]
+    #[test_case(AccountsFileProvider::AppendVec, StorageAccess::File)]
+    #[test_case(AccountsFileProvider::HotStorage, StorageAccess::File)]
+    fn test_account_storage_reader_no_obsolete_accounts(
+        provider: AccountsFileProvider,
+        storage_access: StorageAccess,
+    ) {
+        let (storage, _temp_dirs) = create_storage_for_storage_reader(0, provider, storage_access);
 
         let account = AccountSharedData::new(1, 10, &Pubkey::default());
         let account2 = AccountSharedData::new(1, 10, &Pubkey::default());
@@ -221,7 +229,7 @@ mod tests {
     ) {
         solana_logger::setup();
         let (storage, _temp_dirs) =
-            create_storage_for_storage_reader(0, AccountsFileProvider::AppendVec);
+            create_storage_for_storage_reader(0, AccountsFileProvider::AppendVec, storage_access);
 
         let slot = 0;
 
@@ -306,10 +314,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_account_storage_reader_filter_by_slot() {
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
+    fn test_account_storage_reader_filter_by_slot(storage_access: StorageAccess) {
         let (storage, _temp_dirs) =
-            create_storage_for_storage_reader(10, AccountsFileProvider::AppendVec);
+            create_storage_for_storage_reader(10, AccountsFileProvider::AppendVec, storage_access);
         let total_accounts = 30;
 
         let slot = 0;

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -269,18 +269,6 @@ mod tests {
             .reopen_as_readonly(storage_access)
             .unwrap_or(storage);
 
-        // Assert that storage.accounts was reopened with the specified access type
-        match storage_access {
-            StorageAccess::File => assert!(matches!(
-                storage.accounts.internals_for_archive(),
-                InternalsForArchive::FileIo(_)
-            )),
-            StorageAccess::Mmap => assert!(matches!(
-                storage.accounts.internals_for_archive(),
-                InternalsForArchive::Mmap(_)
-            )),
-        }
-
         // Create the reader and check the length
         let mut reader = AccountStorageReader::new(&storage, None).unwrap();
         let current_len = storage.accounts.len() - storage.get_obsolete_bytes(None);

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -277,6 +277,18 @@ mod tests {
             .reopen_as_readonly(storage_access)
             .unwrap_or(storage);
 
+        // Assert that storage.accounts was reopened with the specified access type
+        match storage_access {
+            StorageAccess::File => assert!(matches!(
+                storage.accounts.internals_for_archive(),
+                InternalsForArchive::FileIo(_)
+            )),
+            StorageAccess::Mmap => assert!(matches!(
+                storage.accounts.internals_for_archive(),
+                InternalsForArchive::Mmap(_)
+            )),
+        }
+
         // Create the reader and check the length
         let mut reader = AccountStorageReader::new(&storage, None).unwrap();
         let current_len = storage.accounts.len() - storage.get_obsolete_bytes(None);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3000,6 +3000,7 @@ impl AccountsDb {
         self.storage_access = storage_access;
     }
 
+    #[cfg(test)]
     pub fn storage_access(&self) -> StorageAccess {
         self.storage_access
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -975,10 +975,11 @@ impl AccountStorageEntry {
         id: AccountsFileId,
         file_size: u64,
         provider: AccountsFileProvider,
+        storage_access: StorageAccess,
     ) -> Self {
         let tail = AccountsFile::file_name(slot, id);
         let path = Path::new(path).join(tail);
-        let accounts = provider.new_writable(path, file_size);
+        let accounts = provider.new_writable(path, file_size, storage_access);
 
         Self {
             id,
@@ -1631,6 +1632,7 @@ impl AccountsDb {
             self.next_id(),
             size,
             self.accounts_file_provider,
+            self.storage_access,
         )
     }
 
@@ -2996,6 +2998,10 @@ impl AccountsDb {
     #[cfg(feature = "dev-context-only-utils")]
     pub fn set_storage_access(&mut self, storage_access: StorageAccess) {
         self.storage_access = storage_access;
+    }
+
+    pub fn storage_access(&self) -> StorageAccess {
+        self.storage_access
     }
 
     /// Sort `accounts` by pubkey and removes all but the *last* of consecutive

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3000,11 +3000,6 @@ impl AccountsDb {
         self.storage_access = storage_access;
     }
 
-    #[cfg(test)]
-    pub fn storage_access(&self) -> StorageAccess {
-        self.storage_access
-    }
-
     /// Sort `accounts` by pubkey and removes all but the *last* of consecutive
     /// accounts in the vector with the same pubkey.
     ///
@@ -7393,6 +7388,11 @@ impl AccountsDb {
     /// This is useful for testing clean algorithms.
     pub fn get_len_of_slots_with_uncleaned_pubkeys(&self) -> usize {
         self.uncleaned_pubkeys.len()
+    }
+
+    #[cfg(test)]
+    pub fn storage_access(&self) -> StorageAccess {
+        self.storage_access
     }
 
     /// useful to adapt tests written prior to introduction of the write cache

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -18,6 +18,7 @@ use {
     },
     solana_lattice_hash::lt_hash::Checksum as LtHashChecksum,
     solana_pubkey::PUBKEY_BYTES,
+    solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     std::{
         iter::{self, FromIterator},
         ops::Range,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -18,7 +18,6 @@ use {
     },
     solana_lattice_hash::lt_hash::Checksum as LtHashChecksum,
     solana_pubkey::PUBKEY_BYTES,
-    solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     std::{
         iter::{self, FromIterator},
         ops::Range,

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -96,18 +96,6 @@ impl AccountsFile {
         Ok(Self::AppendVec(av))
     }
 
-    /// true if this storage can possibly be appended to (independent of capacity check)
-    //
-    // NOTE: Only used by ancient append vecs "append" method, which is test-only now.
-    #[cfg(test)]
-    pub(crate) fn can_append(&self) -> bool {
-        match self {
-            Self::AppendVec(_) => true,
-            // once created, tiered storages cannot be appended to
-            Self::TieredStorage(_) => false,
-        }
-    }
-
     /// if storage is not readonly, reopen another instance that is read only
     pub(crate) fn reopen_as_readonly(&self) -> Option<Self> {
         match self {

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -434,11 +434,19 @@ pub enum AccountsFileProvider {
 }
 
 impl AccountsFileProvider {
-    pub fn new_writable(&self, path: impl Into<PathBuf>, file_size: u64) -> AccountsFile {
+    pub fn new_writable(
+        &self,
+        path: impl Into<PathBuf>,
+        file_size: u64,
+        storage_access: StorageAccess,
+    ) -> AccountsFile {
         match self {
-            Self::AppendVec => {
-                AccountsFile::AppendVec(AppendVec::new(path, true, file_size as usize))
-            }
+            Self::AppendVec => AccountsFile::AppendVec(AppendVec::new(
+                path,
+                true,
+                file_size as usize,
+                storage_access,
+            )),
             Self::HotStorage => AccountsFile::TieredStorage(TieredStorage::new_writable(path)),
         }
     }

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -102,7 +102,7 @@ impl AccountsFile {
     #[cfg(test)]
     pub(crate) fn can_append(&self) -> bool {
         match self {
-            Self::AppendVec(av) => av.can_append(),
+            Self::AppendVec(_) => true,
             // once created, tiered storages cannot be appended to
             Self::TieredStorage(_) => false,
         }

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -99,7 +99,7 @@ impl AccountsFile {
     /// if storage is not readonly, reopen another instance that is read only
     pub(crate) fn reopen_as_readonly(&self) -> Option<Self> {
         match self {
-            Self::AppendVec(av) => av.reopen_as_readonly().map(Self::AppendVec),
+            Self::AppendVec(av) => av.reopen_as_readonly_file_io().map(Self::AppendVec),
             Self::TieredStorage(_) => None,
         }
     }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1595,9 +1595,7 @@ pub mod tests {
                             let storage = db.storage.get_slot_storage_entry(slot);
                             if all_slots_shrunk {
                                 assert!(storage.is_some());
-                                // Here we use can_append() as a proxy to assert the backup storage of the accounts after shrinking.
-                                // When storage is AppendVec, can_append() will return true.
-                                assert!(storage.unwrap().accounts.can_append());
+                                assert!(!storage.unwrap().has_accounts());
                             } else {
                                 assert!(storage.is_none());
                             }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1599,7 +1599,7 @@ pub mod tests {
                                 // When storage_access is set to `File`, after shrinking an ancient slot, the backup storage should be
                                 // open as File, which means can_append() will return false.
                                 // When storage_access is set to `Mmap`, backup storage is still Mmap, and can_append() will return true.
-                                assert_eq!(storage.unwrap().accounts.can_append(), true);
+                                assert!(storage.unwrap().accounts.can_append());
                             } else {
                                 assert!(storage.is_none());
                             }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1599,10 +1599,7 @@ pub mod tests {
                                 // When storage_access is set to `File`, after shrinking an ancient slot, the backup storage should be
                                 // open as File, which means can_append() will return false.
                                 // When storage_access is set to `Mmap`, backup storage is still Mmap, and can_append() will return true.
-                                assert_eq!(
-                                    storage.unwrap().accounts.can_append(),
-                                    storage_access == StorageAccess::Mmap
-                                );
+                                assert_eq!(storage.unwrap().accounts.can_append(), true);
                             } else {
                                 assert!(storage.is_none());
                             }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1596,7 +1596,7 @@ pub mod tests {
                             if all_slots_shrunk {
                                 assert!(storage.is_some());
                                 // Here we use can_append() as a proxy to assert the backup storage of the accounts after shrinking.
-                                // When is AppendVec, can_append() will return true.
+                                // When storage is AppendVec, can_append() will return true.
                                 assert!(storage.unwrap().accounts.can_append());
                             } else {
                                 assert!(storage.is_none());

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1596,9 +1596,7 @@ pub mod tests {
                             if all_slots_shrunk {
                                 assert!(storage.is_some());
                                 // Here we use can_append() as a proxy to assert the backup storage of the accounts after shrinking.
-                                // When storage_access is set to `File`, after shrinking an ancient slot, the backup storage should be
-                                // open as File, which means can_append() will return false.
-                                // When storage_access is set to `Mmap`, backup storage is still Mmap, and can_append() will return true.
+                                // When is AppendVec, can_append() will return true.
                                 assert!(storage.unwrap().accounts.can_append());
                             } else {
                                 assert!(storage.is_none());

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -14,7 +14,6 @@ pub(crate) use meta::StoredAccountMeta;
 pub use meta::{AccountMeta, StoredMeta};
 #[cfg(not(feature = "dev-context-only-utils"))]
 use meta::{AccountMeta, StoredMeta};
-
 use {
     crate::{
         account_info::Offset,

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1897,11 +1897,7 @@ pub mod tests {
         };
         let (av, _) = AppendVec::new_from_file(path, accounts_len, storage_access).unwrap();
         let reopen = av.reopen_as_readonly();
-        if storage_access == StorageAccess::File {
-            assert!(reopen.is_none());
-        } else {
-            assert!(reopen.is_none());
-        }
+        assert!(reopen.is_none());
     }
 
     #[test_case(StorageAccess::Mmap)]

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -167,7 +167,6 @@ struct AccountOffsets {
 #[derive(Debug)]
 enum AppendVecFileBacking {
     /// A file-backed block of memory that is used to store the data for each appended item.
-    #[allow(dead_code)]
     Mmap(MmapMut),
     /// This was opened as a read only file
     File(File),
@@ -340,7 +339,12 @@ impl AppendVec {
                     .fetch_add(1, Ordering::Relaxed);
                 AppendVecFileBacking::Mmap(mmap)
             }
-            StorageAccess::File => AppendVecFileBacking::File(data),
+            StorageAccess::File => {
+                APPEND_VEC_STATS
+                    .open_as_file_io
+                    .fetch_add(1, Ordering::Relaxed);
+                AppendVecFileBacking::File(data)
+            }
         };
         APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
 
@@ -1383,7 +1387,7 @@ pub mod tests {
         solana_account::{Account, AccountSharedData},
         solana_clock::Slot,
         std::{mem::ManuallyDrop, time::Instant},
-        test_case::test_case,
+        test_case::{test_case, test_matrix},
     };
 
     impl AppendVec {
@@ -2346,10 +2350,7 @@ pub mod tests {
     // Test to make sure that `is_dirty` is tracked properly
     // * `reopen_as_readonly()` moves `is_dirty`
     // * `flush()` clears `is_dirty`
-    #[test_case(false, StorageAccess::Mmap)]
-    #[test_case(false, StorageAccess::File)]
-    #[test_case(true, StorageAccess::Mmap)]
-    #[test_case(true, StorageAccess::File)]
+    #[test_matrix([false, true], [StorageAccess::Mmap, StorageAccess::File])]
     fn test_is_dirty(begins_dirty: bool, storage_access: StorageAccess) {
         let file = get_append_vec_path("test_is_dirty");
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1900,7 +1900,7 @@ pub mod tests {
         if storage_access == StorageAccess::File {
             assert!(reopen.is_none());
         } else {
-            assert!(reopen.is_some());
+            assert!(reopen.is_none());
         }
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -40,7 +40,7 @@ use {
         self,
         convert::TryFrom,
         fs::{remove_file, File, OpenOptions},
-        io::{BufRead, Seek, SeekFrom, Write},
+        io::{self, BufRead, Seek, SeekFrom, Write},
         mem::{self, MaybeUninit},
         path::{Path, PathBuf},
         ptr, slice,
@@ -619,7 +619,7 @@ impl AppendVec {
 
     /// Copy `len` bytes from `src` to the first 64-byte boundary after position `offset` of
     /// the internal buffer. Then update `offset` to the first byte after the copied data.
-    fn append_ptr(&self, offset: &mut usize, src: *const u8, len: usize) {
+    fn append_ptr(&self, offset: &mut usize, src: *const u8, len: usize) -> io::Result<()> {
         let pos = u64_align!(*offset);
         match &self.backing {
             AppendVecFileBacking::Mmap(mmap) => {
@@ -635,17 +635,22 @@ impl AppendVec {
             AppendVecFileBacking::File(file) => {
                 // Safety: caller should ensure the passed pointer and length are valid.
                 let data = unsafe { slice::from_raw_parts(src, len) };
-                write_buffer_to_file(file, data, pos as u64).unwrap();
+                write_buffer_to_file(file, data, pos as u64)?;
             }
         }
         *offset = pos + len;
+        Ok(())
     }
 
     /// Copy each value in `vals`, in order, to the first 64-byte boundary after position `offset`.
     /// If there is sufficient space, then update `offset` and the internal `current_len` to the
     /// first byte after the copied data and return the starting position of the copied data.
     /// Otherwise return None and leave `offset` unchanged.
-    fn append_ptrs_locked(&self, offset: &mut usize, vals: &[(*const u8, usize)]) -> Option<usize> {
+    fn append_ptrs_locked(
+        &self,
+        offset: &mut usize,
+        vals: &[(*const u8, usize)],
+    ) -> io::Result<Option<usize>> {
         let mut end = *offset;
         for val in vals {
             end = u64_align!(end);
@@ -653,15 +658,15 @@ impl AppendVec {
         }
 
         if (self.file_size as usize) < end {
-            return None;
+            return Ok(None);
         }
 
         let pos = u64_align!(*offset);
         for val in vals {
-            self.append_ptr(offset, val.0, val.1)
+            self.append_ptr(offset, val.0, val.1)?
         }
         self.current_len.store(*offset, Ordering::Release);
-        Some(pos)
+        Ok(Some(pos))
     }
 
     /// Return a reference to the type at `offset` if its data doesn't overrun the internal buffer.
@@ -1302,7 +1307,10 @@ impl AppendVec {
                     (hash_ptr, mem::size_of::<ObsoleteAccountHash>()),
                     (data_ptr, stored_meta.data_len as usize),
                 ];
-                if let Some(start_offset) = self.append_ptrs_locked(&mut offset, &ptrs) {
+                if let Some(start_offset) = self
+                    .append_ptrs_locked(&mut offset, &ptrs)
+                    .expect("must append data to append_vec")
+                {
                     offsets.push(start_offset)
                 } else {
                     stop = true;
@@ -2334,22 +2342,22 @@ pub mod tests {
             av1.append_account_test(&create_test_account(10)).unwrap();
         }
         assert_eq!(*av1.is_dirty.get_mut(), begins_dirty);
-        // let mut av2 = av1.reopen_as_readonly().unwrap();
-        // // don't delete the file when the AppendVec is dropped (let TempFile do it)
-        // *av2.remove_file_on_drop.get_mut() = false;
+        let mut av2 = av1.reopen_as_readonly();
+        let av2 = av2
+            .as_mut()
+            .inspect(|_|
+                // when av1 was reopened, ensure `is_dirty` is moved
+                assert!(!*av1.is_dirty.get_mut()))
+            .unwrap_or(&mut av1);
+        // don't delete the file when the AppendVec is dropped (let TempFile do it)
+        *av2.remove_file_on_drop.get_mut() = false;
 
-        // // ensure `is_dirty` is moved
-        // assert!(!*av1.is_dirty.get_mut());
-        // assert_eq!(*av2.is_dirty.get_mut(), begins_dirty);
+        // ensure `is_dirty` is moved
+        assert_eq!(*av2.is_dirty.get_mut(), begins_dirty);
 
-        // // ensure we can flush the new append vec
-        // assert!(av2.flush().is_ok());
-        // // and now should not be dirty
-        // assert!(!*av2.is_dirty.get_mut());
-
-        // // ensure we can flush the old append vec too
-        // assert!(av1.flush().is_ok());
-        // // and now should not be dirty
-        // assert!(!*av1.is_dirty.get_mut());
+        // ensure we can flush the new append vec
+        assert!(av2.flush().is_ok());
+        // and now should not be dirty
+        assert!(!*av2.is_dirty.get_mut());
     }
 }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -2364,22 +2364,23 @@ pub mod tests {
             av1.append_account_test(&create_test_account(10)).unwrap();
         }
         assert_eq!(*av1.is_dirty.get_mut(), begins_dirty);
-        let mut av2 = av1.reopen_as_readonly();
-        let av2 = av2
-            .as_mut()
-            .inspect(|_|
-                // when av1 was reopened, ensure `is_dirty` is moved
-                assert!(!*av1.is_dirty.get_mut()))
-            .unwrap_or(&mut av1);
+        let mut av2 = av1.reopen_as_readonly().unwrap();
+
         // don't delete the file when the AppendVec is dropped (let TempFile do it)
         *av2.remove_file_on_drop.get_mut() = false;
 
         // ensure `is_dirty` is moved
+        assert!(!*av1.is_dirty.get_mut());
         assert_eq!(*av2.is_dirty.get_mut(), begins_dirty);
 
         // ensure we can flush the new append vec
         assert!(av2.flush().is_ok());
         // and now should not be dirty
         assert!(!*av2.is_dirty.get_mut());
+
+        // ensure we can flush the old append vec too
+        assert!(av1.flush().is_ok());
+        // and now should not be dirty
+        assert!(!*av1.is_dirty.get_mut());
     }
 }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -406,37 +406,33 @@ impl AppendVec {
         self.current_len.store(0, Ordering::Release);
     }
 
-    /// when we can use file i/o as opposed to mmap, this is the trigger to tell us
-    /// that no more appending will occur and we can close the initial mmap.
+    /// when append_lock isn't set, this is the trigger to tell us
+    /// that no more appending will occur and we can close the initial append_vec.
     pub(crate) fn reopen_as_readonly(&self) -> Option<Self> {
-        match &self.backing {
-            AppendVecFileBacking::File(_file) => {
-                // already a file, so already read-only
-                None
-            }
-            AppendVecFileBacking::Mmap(_mmap) => {
-                // we are an mmap, so re-open as a file
-                // we are re-opening the file, so don't remove the file on disk when the old mmapped one is dropped
-                self.remove_file_on_drop.store(false, Ordering::Release);
+        // Early return if already in read-only mode
+        self.append_lock.as_ref()?;
 
-                // add a memory barrier to ensure the the last mmap writes
-                // happen before the first file-io reads
-                std::sync::atomic::fence(Ordering::AcqRel);
+        // we are an mmap, so re-open as a file
+        // we are re-opening the file, so don't remove the file on disk when the old mmapped one is dropped
+        self.remove_file_on_drop.store(false, Ordering::Release);
 
-                // The file should have already been sanitized. Don't need to check when we open the file again.
-                let mut new = AppendVec::new_from_file_unchecked(
-                    self.path.clone(),
-                    self.len(),
-                    StorageAccess::File,
-                )
-                .ok()?;
-                if self.is_dirty.swap(false, Ordering::AcqRel) {
-                    // *move* the dirty-ness to the new append vec
-                    *new.is_dirty.get_mut() = true;
-                }
-                Some(new)
-            }
+        // add a memory barrier to ensure the the last mmap writes
+        // happen before the first file-io reads
+        std::sync::atomic::fence(Ordering::AcqRel);
+
+        // The file should have already been sanitized. Don't need to check when we open the file again.
+        let mut new = AppendVec::new_from_file_unchecked(
+            self.path.clone(),
+            self.len(),
+            false,
+            StorageAccess::File,
+        )
+        .ok()?;
+        if self.is_dirty.swap(false, Ordering::AcqRel) {
+            // *move* the dirty-ness to the new append vec
+            *new.is_dirty.get_mut() = true;
         }
+        Some(new)
     }
 
     /// how many more bytes can be stored in this append vec
@@ -464,7 +460,7 @@ impl AppendVec {
         storage_access: StorageAccess,
     ) -> Result<(Self, usize)> {
         let path = path.into();
-        let new = Self::new_from_file_unchecked(path, current_len, storage_access)?;
+        let new = Self::new_from_file_unchecked(path, current_len, false, storage_access)?;
 
         let num_accounts = new.sanitize_layout_and_length()?;
         Ok((new, num_accounts))
@@ -480,7 +476,7 @@ impl AppendVec {
         current_len: usize,
         storage_access: StorageAccess,
     ) -> Result<Self> {
-        let new = Self::new_from_file_unchecked(path, current_len, storage_access)?;
+        let new = Self::new_from_file_unchecked(path, current_len, false, storage_access)?;
 
         // The current_len is allowed to be either exactly the same as file_size, or
         // u64-aligned-equivalent to file_size.  This is because `flush` and `shink` compute the
@@ -515,6 +511,7 @@ impl AppendVec {
     pub fn new_from_file_unchecked(
         path: impl Into<PathBuf>,
         current_len: usize,
+        appendable: bool,
         storage_access: StorageAccess,
     ) -> Result<Self> {
         let path = path.into();
@@ -580,7 +577,7 @@ impl AppendVec {
     pub fn new_for_store_tool(path: impl Into<PathBuf>) -> Result<Self> {
         let path = path.into();
         let file_size = std::fs::metadata(&path)?.len();
-        Self::new_from_file_unchecked(path, file_size as usize, StorageAccess::default())
+        Self::new_from_file_unchecked(path, file_size as usize, false, StorageAccess::default())
     }
 
     /// Checks that all accounts layout is correct and returns the number of accounts.
@@ -2052,8 +2049,9 @@ pub mod tests {
 
         // Truncate the AppendVec to PAGESIZE. This will cause get_account* to fail to load the account.
         let truncated_accounts_len: usize = PAGE_SIZE;
-        let av = AppendVec::new_from_file_unchecked(path, truncated_accounts_len, storage_access)
-            .unwrap();
+        let av =
+            AppendVec::new_from_file_unchecked(path, truncated_accounts_len, false, storage_access)
+                .unwrap();
         let account = av.get_account_shared_data(0);
         assert!(account.is_none()); // Expect None to be returned.
 
@@ -2160,8 +2158,13 @@ pub mod tests {
         // now open the append vec with the given storage access method
         // then perform the scan and check it is correct
         let append_vec = ManuallyDrop::new(
-            AppendVec::new_from_file_unchecked(&temp_file.path, total_stored_size, storage_access)
-                .unwrap(),
+            AppendVec::new_from_file_unchecked(
+                &temp_file.path,
+                total_stored_size,
+                false,
+                storage_access,
+            )
+            .unwrap(),
         );
 
         check_fn(&append_vec, &pubkeys, &account_offsets, &accounts);

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -350,7 +350,7 @@ impl AppendVec {
 
         AppendVec {
             path: file,
-            backing: AppendVecFileBacking::Mmap(mmap),
+            backing,
             // writable state's mutex forces append to be single threaded, but concurrent with
             // reads. See UNSAFE usage in `append_ptr`
             read_write_state: ReadWriteState::new(true),
@@ -412,7 +412,7 @@ impl AppendVec {
 
     /// Return AppendVec opened in read-only file-io mode or `None` if it already is such
     pub(crate) fn reopen_as_readonly_file_io(&self) -> Option<Self> {
-        if self.append_lock.as_ref().is_none()
+        if matches!(self.read_write_state, ReadWriteState::ReadOnly)
             && matches!(self.backing, AppendVecFileBacking::File(_))
         {
             // Early return if already in read-only mode *and* already a file-io

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -2364,8 +2364,8 @@ pub mod tests {
             av1.append_account_test(&create_test_account(10)).unwrap();
         }
         assert_eq!(*av1.is_dirty.get_mut(), begins_dirty);
-        let mut av2 = av1.reopen_as_readonly().unwrap();
 
+        let mut av2 = av1.reopen_as_readonly().unwrap();
         // don't delete the file when the AppendVec is dropped (let TempFile do it)
         *av2.remove_file_on_drop.get_mut() = false;
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -412,8 +412,7 @@ impl AppendVec {
         // Early return if already in read-only mode
         self.append_lock.as_ref()?;
 
-        // we are an mmap, so re-open as a file
-        // we are re-opening the file, so don't remove the file on disk when the old mmapped one is dropped
+        // we are re-opening the file, so don't remove the file on disk when the old one is dropped
         self.remove_file_on_drop.store(false, Ordering::Release);
 
         // add a memory barrier to ensure the the last mmap writes
@@ -421,13 +420,9 @@ impl AppendVec {
         std::sync::atomic::fence(Ordering::AcqRel);
 
         // The file should have already been sanitized. Don't need to check when we open the file again.
-        let mut new = AppendVec::new_from_file_unchecked(
-            self.path.clone(),
-            self.len(),
-            false,
-            StorageAccess::File,
-        )
-        .ok()?;
+        let mut new =
+            AppendVec::new_from_file_unchecked(self.path.clone(), self.len(), StorageAccess::File)
+                .ok()?;
         if self.is_dirty.swap(false, Ordering::AcqRel) {
             // *move* the dirty-ness to the new append vec
             *new.is_dirty.get_mut() = true;
@@ -460,7 +455,7 @@ impl AppendVec {
         storage_access: StorageAccess,
     ) -> Result<(Self, usize)> {
         let path = path.into();
-        let new = Self::new_from_file_unchecked(path, current_len, false, storage_access)?;
+        let new = Self::new_from_file_unchecked(path, current_len, storage_access)?;
 
         let num_accounts = new.sanitize_layout_and_length()?;
         Ok((new, num_accounts))
@@ -476,7 +471,7 @@ impl AppendVec {
         current_len: usize,
         storage_access: StorageAccess,
     ) -> Result<Self> {
-        let new = Self::new_from_file_unchecked(path, current_len, false, storage_access)?;
+        let new = Self::new_from_file_unchecked(path, current_len, storage_access)?;
 
         // The current_len is allowed to be either exactly the same as file_size, or
         // u64-aligned-equivalent to file_size.  This is because `flush` and `shink` compute the
@@ -511,7 +506,6 @@ impl AppendVec {
     pub fn new_from_file_unchecked(
         path: impl Into<PathBuf>,
         current_len: usize,
-        appendable: bool,
         storage_access: StorageAccess,
     ) -> Result<Self> {
         let path = path.into();
@@ -525,9 +519,9 @@ impl AppendVec {
             .create(false)
             .open(&path)?;
 
-        if storage_access == StorageAccess::File {
-            APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
+        APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
 
+        if storage_access == StorageAccess::File {
             APPEND_VEC_STATS
                 .open_as_file_io
                 .fetch_add(1, Ordering::Relaxed);
@@ -555,8 +549,6 @@ impl AppendVec {
             result?
         };
 
-        APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
-
         APPEND_VEC_STATS
             .open_as_mmap
             .fetch_add(1, Ordering::Relaxed);
@@ -577,7 +569,7 @@ impl AppendVec {
     pub fn new_for_store_tool(path: impl Into<PathBuf>) -> Result<Self> {
         let path = path.into();
         let file_size = std::fs::metadata(&path)?.len();
-        Self::new_from_file_unchecked(path, file_size as usize, false, StorageAccess::default())
+        Self::new_from_file_unchecked(path, file_size as usize, StorageAccess::default())
     }
 
     /// Checks that all accounts layout is correct and returns the number of accounts.
@@ -2049,9 +2041,8 @@ pub mod tests {
 
         // Truncate the AppendVec to PAGESIZE. This will cause get_account* to fail to load the account.
         let truncated_accounts_len: usize = PAGE_SIZE;
-        let av =
-            AppendVec::new_from_file_unchecked(path, truncated_accounts_len, false, storage_access)
-                .unwrap();
+        let av = AppendVec::new_from_file_unchecked(path, truncated_accounts_len, storage_access)
+            .unwrap();
         let account = av.get_account_shared_data(0);
         assert!(account.is_none()); // Expect None to be returned.
 
@@ -2158,13 +2149,8 @@ pub mod tests {
         // now open the append vec with the given storage access method
         // then perform the scan and check it is correct
         let append_vec = ManuallyDrop::new(
-            AppendVec::new_from_file_unchecked(
-                &temp_file.path,
-                total_stored_size,
-                false,
-                storage_access,
-            )
-            .unwrap(),
+            AppendVec::new_from_file_unchecked(&temp_file.path, total_stored_size, storage_access)
+                .unwrap(),
         );
 
         check_fn(&append_vec, &pubkeys, &account_offsets, &accounts);

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1332,15 +1332,6 @@ impl AppendVec {
         })
     }
 
-    // NOTE: Only used by ancient append vecs "append" method, which is test-only now.
-    #[cfg(test)]
-    pub(crate) fn can_append(&self) -> bool {
-        match &self.backing {
-            AppendVecFileBacking::File(_file) => true,
-            AppendVecFileBacking::Mmap(_mmap) => true,
-        }
-    }
-
     /// Returns the way to access this accounts file when archiving
     pub(crate) fn internals_for_archive(&self) -> InternalsForArchive {
         match &self.backing {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -2347,23 +2347,22 @@ pub mod tests {
             av1.append_account_test(&create_test_account(10)).unwrap();
         }
         assert_eq!(*av1.is_dirty.get_mut(), begins_dirty);
+        // let mut av2 = av1.reopen_as_readonly().unwrap();
+        // // don't delete the file when the AppendVec is dropped (let TempFile do it)
+        // *av2.remove_file_on_drop.get_mut() = false;
 
-        let mut av2 = av1.reopen_as_readonly().unwrap();
-        // don't delete the file when the AppendVec is dropped (let TempFile do it)
-        *av2.remove_file_on_drop.get_mut() = false;
+        // // ensure `is_dirty` is moved
+        // assert!(!*av1.is_dirty.get_mut());
+        // assert_eq!(*av2.is_dirty.get_mut(), begins_dirty);
 
-        // ensure `is_dirty` is moved
-        assert!(!*av1.is_dirty.get_mut());
-        assert_eq!(*av2.is_dirty.get_mut(), begins_dirty);
+        // // ensure we can flush the new append vec
+        // assert!(av2.flush().is_ok());
+        // // and now should not be dirty
+        // assert!(!*av2.is_dirty.get_mut());
 
-        // ensure we can flush the new append vec
-        assert!(av2.flush().is_ok());
-        // and now should not be dirty
-        assert!(!*av2.is_dirty.get_mut());
-
-        // ensure we can flush the old append vec too
-        assert!(av1.flush().is_ok());
-        // and now should not be dirty
-        assert!(!*av1.is_dirty.get_mut());
+        // // ensure we can flush the old append vec too
+        // assert!(av1.flush().is_ok());
+        // // and now should not be dirty
+        // assert!(!*av1.is_dirty.get_mut());
     }
 }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -410,11 +410,14 @@ impl AppendVec {
         self.current_len.store(0, Ordering::Release);
     }
 
-    /// when append_lock isn't set, this is the trigger to tell us
-    /// that no more appending will occur and we can close the initial append_vec.
-    pub(crate) fn reopen_as_readonly(&self) -> Option<Self> {
-        // Early return if already in read-only mode
-        self.append_lock.as_ref()?;
+    /// Return AppendVec opened in read-only file-io mode or `None` if it already is such
+    pub(crate) fn reopen_as_readonly_file_io(&self) -> Option<Self> {
+        if self.append_lock.as_ref().is_none()
+            && matches!(self.backing, AppendVecFileBacking::File(_))
+        {
+            // Early return if already in read-only mode *and* already a file-io
+            return None;
+        }
 
         // we are re-opening the file, so don't remove the file on disk when the old one is dropped
         self.remove_file_on_drop.store(false, Ordering::Release);
@@ -1903,14 +1906,24 @@ pub mod tests {
         let file = get_append_vec_path("test_append_vec_flush");
         let path = &file.path;
         let accounts_len = {
-            // wrap AppendVec in ManuallyDrop to ensure we do not remove the backing file when dropped
-            let av = ManuallyDrop::new(AppendVec::new(path, true, 1024 * 1024, storage_access));
+            let av = AppendVec::new(path, true, 1024 * 1024, storage_access);
             av.append_account_test(&create_test_account(10)).unwrap();
-            av.len()
+            // wrap AppendVec in ManuallyDrop to ensure we do not remove the backing file when dropped
+            let ro_av = ManuallyDrop::new(
+                av.reopen_as_readonly_file_io()
+                    .expect("appendable AppendVec should always re-open as read-only"),
+            );
+            ro_av.len()
         };
+
         let (av, _) = AppendVec::new_from_file(path, accounts_len, storage_access).unwrap();
-        let reopen = av.reopen_as_readonly();
-        assert!(reopen.is_none());
+        let reopen = av.reopen_as_readonly_file_io();
+        // even if AppendVec is already read-only, but uses mmap, it should reopen as file_io
+        if storage_access == StorageAccess::File {
+            assert!(reopen.is_none());
+        } else {
+            assert!(reopen.is_some());
+        }
     }
 
     #[test_case(StorageAccess::Mmap)]
@@ -2366,7 +2379,7 @@ pub mod tests {
         }
         assert_eq!(*av1.is_dirty.get_mut(), begins_dirty);
 
-        let mut av2 = av1.reopen_as_readonly().unwrap();
+        let mut av2 = av1.reopen_as_readonly_file_io().unwrap();
         // don't delete the file when the AppendVec is dropped (let TempFile do it)
         *av2.remove_file_on_drop.get_mut() = false;
 

--- a/accounts-db/src/sorted_storages.rs
+++ b/accounts-db/src/sorted_storages.rs
@@ -196,7 +196,7 @@ mod tests {
         super::*,
         crate::{
             accounts_db::{AccountStorageEntry, AccountsFileId},
-            accounts_file::{AccountsFile, AccountsFileProvider},
+            accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
             append_vec::AppendVec,
         },
         std::sync::Arc,
@@ -448,8 +448,14 @@ mod tests {
             id,
             size as u64,
             AccountsFileProvider::AppendVec,
+            StorageAccess::File,
         );
-        let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, true, 1024 * 1024));
+        let av = AccountsFile::AppendVec(AppendVec::new(
+            &tf.path,
+            true,
+            1024 * 1024,
+            StorageAccess::File,
+        ));
         data.accounts = av;
 
         Arc::new(data)

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -708,6 +708,7 @@ pub mod tests {
             id,
             file_size,
             AccountsFileProvider::AppendVec,
+            db.storage_access(),
         );
         let storage = Arc::new(data);
         db.storage.insert(slot, storage.clone());


### PR DESCRIPTION
#### Problem
AppendVec is using mmap when appending accounts, which makes IO operations poorly controllable and predictable. Read access is already done by default using file-io, but it is not supported during creation of account storages.

#### Summary of Changes
* support writing data to files at arbitrary offset in file-io
* support appending accounts to `AppendVec` opened in `StorageAccess::File`
* always open `AppendVec`  using configured `storage_access` instead of starting with `mmap` and then switching to `file`
* both writing and reading `AppendVec` is now based on `accounts_db_access_storages_method` flag (except for `AppendVec` that goes through writable -> readonly path that is forced to be file-io to preserve current behavior)

##### Performance impact
This change brings a noticeable increase in several metrics:
* accounts_db-flush_accounts_cache.flush_roots_elapsed goes from 401-520ms range to 430-550ms
* accounts_db-flush_accounts_cache.store_accounts_total_us from 78-90ms to 113-146ms
* accounts_db-flush_accounts_cache.store_accounts_elapsed_us from 55-63ms to 90-125ms
* shrink_candidate_slots.shrink_all_us from 21-36ms to 26-46ms
* benchmark write_accounts_file/append_vec/10000 1.12ms -> 8.55ms

This is however explainable by file-io returning only after disk IO is actually made as opposed to copying into mmap which is async.
Benchmark when flush/sync is added get much closer in timing - except that file-io also adds syscall overhead.