### PR TITLE
v2.3: pin spl-token-cli version on stable branch

### DIFF
--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,5 +1,5 @@
 # populate this on the stable branch
-splTokenCliVersion=
+splTokenCliVersion=5.3.0
 
 maybeSplTokenCliVersionArg=
 if [[ -n "$splTokenCliVersion" ]]; then


### PR DESCRIPTION
#### Problem

Release process requires spl-token-cli version pin

#### Summary of Changes

Update the script with the latest `spl-token-cli` release version