### PR TITLE
Make SVM crates inherit workspace version

### DIFF
--- a/svm-callback/Cargo.toml
+++ b/svm-callback/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-svm-callback"
-version = "3.1.0"
 description = "Solana SVM callback"
+version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/svm-feature-set/Cargo.toml
+++ b/svm-feature-set/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-svm-feature-set"
-version = "3.1.0"
 description = "Solana SVM Feature Set"
+version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
#### Problem
These items are workspace members so they should inherit the version instead of manually declaring and having to keep up to date

https://github.com/anza-xyz/agave/blob/a9333ff6fd747cd85e8479f5327a38cc7c3a45c7/Cargo.toml#L105-L106

#### Summary of Changes
Inherit the workspace version
