### PR TITLE
Remove --entrypoint from default args of bench-tps script

### DIFF
--- a/multinode-demo/bench-tps.sh
+++ b/multinode-demo/bench-tps.sh
@@ -21,7 +21,6 @@ usage() {
 
 args=("$@")
 default_arg --url "http://127.0.0.1:8899"
-default_arg --entrypoint "127.0.0.1:8001"
 default_arg --faucet "127.0.0.1:9900"
 default_arg --duration 90
 default_arg --tx-count 50000


### PR DESCRIPTION
#### Problem
- #7115 broke this script due to removal of `--entrypoint` cli arg on bench-tps

#### Summary of Changes
- Remove --entrypoint default_arg from script

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
