### PR TITLE
Implement validator.toml config scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,7 @@ dependencies = [
  "console 0.16.0",
  "core_affinity",
  "crossbeam-channel",
+ "dirs-next",
  "fd-lock",
  "indicatif 0.18.0",
  "itertools 0.12.1",
@@ -529,6 +530,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tikv-jemallocator",
  "tokio",
+ "toml 0.8.12",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "console 0.16.0",
  "core_affinity",
  "crossbeam-channel",
+ "dirs-next",
  "fd-lock",
  "indicatif 0.18.0",
  "itertools 0.12.1",
@@ -273,6 +274,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tikv-jemallocator",
  "tokio",
+ "toml 0.8.12",
 ]
 
 [[package]]
@@ -4459,7 +4461,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -4468,7 +4470,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -5382,6 +5384,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
  "serde",
 ]
 
@@ -10874,10 +10885,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.12",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -10887,7 +10913,20 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.10.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.25",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap 2.10.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -11838,6 +11877,15 @@ name = "winnow"
 version = "0.5.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e87b8dfbe3baffbe687eef2e164e32286eff31a5ee16463ce03d991643ec94"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
 dependencies = [
  "memchr",
 ]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -20,6 +20,7 @@ clap = { workspace = true }
 console = { workspace = true }
 core_affinity = { workspace = true }
 crossbeam-channel = { workspace = true }
+dirs-next = { workspace = true }
 fd-lock = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
@@ -86,6 +87,7 @@ solana-vote-program = { workspace = true }
 symlink = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+toml = { workspace = true }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 jemallocator = { workspace = true }

--- a/validator/src/clap_ext.rs
+++ b/validator/src/clap_ext.rs
@@ -1,0 +1,82 @@
+use {
+    clap::{Arg, ArgMatches},
+    thiserror::Error,
+};
+
+/// Convenience trait for small types that can be converted to a str (e.g., bool).
+///
+/// Particularly useful when using [`ArgExt::default_value_if_is_some`] with with some type
+/// that can be trivially represented as a str, and may do so often.
+pub trait AsStrExt<'a> {
+    fn as_str(&self) -> &'a str;
+}
+
+impl AsStrExt<'static> for bool {
+    fn as_str(&self) -> &'static str {
+        match self {
+            true => "true",
+            false => "false",
+        }
+    }
+}
+
+/// Extension trait for `Arg` to add additional functionality.
+pub trait ArgExt<'a> {
+    /// Set the default value if the given `default` argument is `Some`.
+    fn default_value_if_is_some(self, default: Option<&'a str>) -> Self;
+}
+
+impl<'a> ArgExt<'a> for Arg<'a, '_> {
+    fn default_value_if_is_some(self, default: Option<&'a str>) -> Self {
+        match default {
+            Some(default) => self.default_value(default),
+            None => self,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ArgMatchesExtError<'a> {
+    #[error("Invalid boolean value for {name}: {value}")]
+    InvalidBool { name: &'a str, value: &'a str },
+}
+
+/// Extension trait for `ArgMatches` to add additional functionality.
+pub trait ArgMatchesExt<'a> {
+    /// Check if the given flag is set.
+    fn check_flag(&'a self, name: &'a str) -> Result<bool, ArgMatchesExtError<'a>>;
+}
+
+impl<'a> ArgMatchesExt<'a> for ArgMatches<'a> {
+    /// Check if the given flag is set.
+    ///
+    /// Useful when providing default values for arguments configured
+    /// as flags, i.e., via `Arg::takes_value(false)`. This will be a common
+    /// occurrence when populating default CLI arguments from a config file.
+    ///
+    /// Clap version 2.x doesn't trivially support default flag values.
+    /// In particular, calling [`Arg::default_value`] implicitly sets `Arg::takes_value(true)`.
+    /// This is problematic for the typical idiom for checking if a flag is present,
+    /// [`ArgMatches::is_present`], as it will always return true if a default is set.
+    ///
+    /// To work around this, we use [`ArgMatches::occurrences_of`] to check if the flag
+    /// was explicitly set on the command line, as this will not be affected by a default value.
+    /// Then, if no occurrences are found, we check the argument value for `"true"` or `"false"`,
+    /// as this _will_ be set by the default value.
+    fn check_flag(&'a self, name: &'a str) -> Result<bool, ArgMatchesExtError<'a>> {
+        // Check if the flag was explicitly set on the command line.
+        if self.occurrences_of(name) > 0 {
+            return Ok(true);
+        }
+
+        // If the flag was not explicitly set, check the argument value, which may have been
+        // provided as a default.
+        match self.value_of(name).map(|s| s.trim()) {
+            Some("true") => Ok(true),
+            Some("false") => Ok(false),
+            Some(value) => Err(ArgMatchesExtError::InvalidBool { name, value }),
+            // Command line flag was not set, and no default was provided.
+            None => Ok(false),
+        }
+    }
+}

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1,5 +1,5 @@
 use {
-    crate::commands,
+    crate::{commands, config_file::ValidatorConfig},
     clap::{crate_description, crate_name, App, AppSettings, Arg, ArgMatches, SubCommand},
     solana_accounts_db::{
         accounts_db::{
@@ -50,7 +50,11 @@ const MAX_SNAPSHOT_DOWNLOAD_ABORT: u32 = 5;
 // with less than 2 ticks per slot.
 const MINIMUM_TICKS_PER_SLOT: u64 = 2;
 
-pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
+pub fn app<'a>(
+    version: &'a str,
+    default_args: &'a DefaultArgs,
+    validator_config: &'a ValidatorConfig,
+) -> App<'a, 'a> {
     let app = App::new(crate_name!())
         .about(crate_description!())
         .version(version)
@@ -75,7 +79,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .subcommand(commands::wait_for_restart_window::command())
         .subcommand(commands::set_public_address::command());
 
-    commands::run::add_args(app, default_args)
+    commands::run::add_args(app, default_args, validator_config)
         .args(&thread_args(&default_args.thread_args))
         .args(&get_deprecated_arguments())
         .after_help("The default subcommand is run")

--- a/validator/src/commands/run/args/account_secondary_indexes.rs
+++ b/validator/src/commands/run/args/account_secondary_indexes.rs
@@ -63,8 +63,11 @@ impl FromClapArgMatches for AccountSecondaryIndexes {
 mod tests {
     use {
         super::*,
-        crate::commands::run::args::{
-            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+        crate::{
+            commands::run::args::{
+                tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+            },
+            config_file::ValidatorConfig,
         },
         solana_rpc::rpc::JsonRpcConfig,
         test_case::test_case,
@@ -88,8 +91,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec!["--account-index", arg_value],
             expected_args,
         );
@@ -112,8 +117,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec![
                 "--account-index",
                 "program-id",
@@ -145,8 +152,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec![
                     "--account-index", // required by --account-index-include-key
                     "program-id",
@@ -180,8 +189,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec![
                     "--account-index", // required by --account-index-include-key
                     "program-id",
@@ -216,8 +227,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec![
                     "--account-index", // required by --account-index-exclude-key
                     "program-id",
@@ -251,8 +264,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec![
                     "--account-index", // required by --account-index-exclude-key
                     "program-id",

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -60,12 +60,15 @@ impl FromClapArgMatches for BlockstoreOptions {
 mod tests {
     use {
         super::*,
-        crate::commands::run::args::{
-            tests::{
-                verify_args_struct_by_command_run_is_error_with_identity_setup,
-                verify_args_struct_by_command_run_with_identity_setup,
+        crate::{
+            commands::run::args::{
+                tests::{
+                    verify_args_struct_by_command_run_is_error_with_identity_setup,
+                    verify_args_struct_by_command_run_with_identity_setup,
+                },
+                RunArgs,
             },
-            RunArgs,
+            config_file::ValidatorConfig,
         },
         test_case::test_case,
     };
@@ -92,8 +95,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec!["--wal-recovery-mode", arg_value],
             expected_args,
         );
@@ -102,8 +107,10 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_run_with_wal_recovery_mode_invalid() {
         let default_run_args = crate::commands::run::args::RunArgs::default();
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_is_error_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec!["--wal-recovery-mode", "invalid"],
         );
     }
@@ -127,8 +134,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec!["--rocksdb-ledger-compression", arg_value],
             expected_args,
         );
@@ -137,8 +146,10 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_run_with_rocksdb_ledger_compression_invalid() {
         let default_run_args = crate::commands::run::args::RunArgs::default();
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_is_error_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec!["--rocksdb-ledger-compression", "invalid"],
         );
     }
@@ -156,8 +167,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec!["--rocksdb-perf-sample-interval", "100"],
             expected_args,
         );
@@ -175,8 +188,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--rocksdb-compaction-threads", "1"],
                 expected_args,
             );
@@ -195,8 +210,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--rocksdb-flush-threads", "1"],
                 expected_args,
             );

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -263,6 +263,7 @@ mod tests {
     fn verify_args_struct_by_command_run_with_rpc_niceness_adj() {
         verify_args_struct_by_command_run_is_error_with_identity_setup(
             crate::commands::run::args::RunArgs::default(),
+            &ValidatorConfig::default(),
             vec!["--rpc-niceness-adjustment", "10"],
         );
     }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -51,8 +51,11 @@ mod tests {
     use crate::commands::run::args::tests::verify_args_struct_by_command_run_is_error_with_identity_setup;
     use {
         super::*,
-        crate::commands::run::args::{
-            tests::verify_args_struct_by_command_run_with_identity_setup, DefaultArgs, RunArgs,
+        crate::{
+            commands::run::args::{
+                tests::verify_args_struct_by_command_run_with_identity_setup, DefaultArgs, RunArgs,
+            },
+            config_file::ValidatorConfig,
         },
         solana_rpc::rpc_pubsub_service::PubSubConfig,
         std::{
@@ -72,8 +75,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--enable-rpc-transaction-history"],
                 expected_args,
             );
@@ -92,8 +97,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec![
                     "--enable-rpc-transaction-history", // required by enable_extended_tx_metadata_storage
                     "--enable-extended-tx-metadata-storage",
@@ -114,8 +121,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--rpc-faucet-address", "127.0.0.1:8000"],
                 expected_args,
             );
@@ -133,8 +142,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--health-check-slot-distance", "100"],
                 expected_args,
             );
@@ -152,8 +163,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--skip-preflight-health-check"],
                 expected_args,
             );
@@ -171,8 +184,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--rpc-max-multiple-accounts", "9999"],
                 expected_args,
             );
@@ -190,8 +205,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--rpc-threads", "10"],
                 expected_args,
             );
@@ -209,8 +226,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--rpc-blocking-threads", "999"],
                 expected_args,
             );
@@ -229,8 +248,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--rpc-niceness-adjustment", "10"],
                 expected_args,
             );
@@ -270,8 +291,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--full-rpc-api"],
                 expected_args,
             );
@@ -290,8 +313,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec![
                     "--enable-rpc-transaction-history", // required by --rpc-scan-and-fix-roots
                     "--rpc-scan-and-fix-roots",
@@ -313,8 +338,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--rpc-max-request-body-size", "999"],
                 expected_args,
             );

--- a/validator/src/commands/run/args/pub_sub_config.rs
+++ b/validator/src/commands/run/args/pub_sub_config.rs
@@ -29,8 +29,11 @@ impl FromClapArgMatches for PubSubConfig {
 mod tests {
     use {
         super::*,
-        crate::commands::run::args::{
-            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+        crate::{
+            commands::run::args::{
+                tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+            },
+            config_file::ValidatorConfig,
         },
         solana_rpc::rpc::JsonRpcConfig,
     };
@@ -49,8 +52,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec![
                 "--enable-rpc-transaction-history", // required by enable-rpc-bigtable-ledger-storage
                 "--rpc-pubsub-enable-block-subscription",
@@ -69,8 +74,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec!["--rpc-pubsub-enable-vote-subscription"],
             expected_args,
         );
@@ -86,8 +93,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec!["--rpc-pubsub-max-active-subscriptions", "1000"],
             expected_args,
         );
@@ -103,8 +112,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec!["--rpc-pubsub-queue-capacity-items", "9999"],
             expected_args,
         );
@@ -120,8 +131,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec!["--rpc-pubsub-queue-capacity-bytes", "9999"],
             expected_args,
         );
@@ -137,8 +150,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec!["--rpc-pubsub-worker-threads", "9999"],
             expected_args,
         );
@@ -158,8 +173,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec![
                 "--full-rpc-api", // required by --rpc-pubsub-notification-threads
                 "--rpc-pubsub-notification-threads",

--- a/validator/src/commands/run/args/rpc_bigtable_config.rs
+++ b/validator/src/commands/run/args/rpc_bigtable_config.rs
@@ -23,8 +23,11 @@ impl FromClapArgMatches for RpcBigtableConfig {
 mod tests {
     use {
         super::*,
-        crate::commands::run::args::{
-            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+        crate::{
+            commands::run::args::{
+                tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+            },
+            config_file::ValidatorConfig,
         },
         solana_rpc::rpc::JsonRpcConfig,
     };
@@ -49,8 +52,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec![
                 "--enable-rpc-transaction-history", // required by enable-rpc-bigtable-ledger-storage
                 "--enable-rpc-bigtable-ledger-storage",
@@ -73,8 +78,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec![
                 "--enable-rpc-transaction-history", // required by enable-bigtable-ledger-upload
                 "--enable-bigtable-ledger-upload",
@@ -98,8 +105,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec![
                 "--enable-rpc-transaction-history", // required by enable-bigtable-ledger-upload
                 "--enable-bigtable-ledger-upload",  // required by all rpc_bigtable_config
@@ -125,8 +134,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec![
                 "--enable-rpc-transaction-history", // required by enable-bigtable-ledger-upload
                 "--enable-bigtable-ledger-upload",  // required by all rpc_bigtable_config
@@ -152,8 +163,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec![
                 "--enable-rpc-transaction-history", // required by enable-bigtable-ledger-upload
                 "--enable-bigtable-ledger-upload",  // required by all rpc_bigtable_config
@@ -179,8 +192,10 @@ mod tests {
             },
             ..default_run_args.clone()
         };
+        let validator_config = ValidatorConfig::default();
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
+            &validator_config,
             vec![
                 "--enable-rpc-transaction-history", // required by enable-bigtable-ledger-upload
                 "--enable-bigtable-ledger-upload",  // required by all rpc_bigtable_config

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -56,8 +56,11 @@ impl FromClapArgMatches for RpcBootstrapConfig {
 mod tests {
     use {
         super::*,
-        crate::commands::run::args::{
-            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+        crate::{
+            commands::run::args::{
+                tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+            },
+            config_file::ValidatorConfig,
         },
         solana_pubkey::Pubkey,
         std::{
@@ -78,8 +81,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args.clone(),
+                &validator_config,
                 vec!["--no-genesis-fetch"],
                 expected_args,
             );
@@ -98,8 +103,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args.clone(),
+                &validator_config,
                 vec!["--no-snapshot-fetch"],
                 expected_args,
             );
@@ -122,8 +129,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec![
                     // required by --check-vote-account
                     "--entrypoint",
@@ -151,8 +160,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec![
                     // required by --only-known-rpc
                     "--known-validator",
@@ -176,8 +187,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec![
                     // required by --no-untrusted-rpc
                     "--known-validator",
@@ -201,8 +214,10 @@ mod tests {
                 },
                 ..default_run_args.clone()
             };
+            let validator_config = ValidatorConfig::default();
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
+                &validator_config,
                 vec!["--no-incremental-snapshots"],
                 expected_args,
             );

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         admin_rpc_service::{self, load_staked_nodes_overrides, StakedNodesOverrides},
         bootstrap,
+        clap_ext::ArgMatchesExt,
         cli::{self},
         commands::{run::args::RunArgs, FromClapArgMatches},
         ledger_lockfile, lock_ledger,
@@ -496,7 +497,7 @@ pub fn execute(
         };
 
     let xdp_interface = matches.value_of("retransmit_xdp_interface");
-    let xdp_zero_copy = matches.is_present("retransmit_xdp_zero_copy");
+    let xdp_zero_copy = matches.check_flag("retransmit_xdp_zero_copy").unwrap();
     let retransmit_xdp = matches.value_of("retransmit_xdp_cpu_cores").map(|cpus| {
         XdpConfig::new(
             xdp_interface,

--- a/validator/src/config_file.rs
+++ b/validator/src/config_file.rs
@@ -1,0 +1,82 @@
+//! Validator configuration file.
+//!
+//! The validator configuration file is a TOML file that can be used to configure CLI argument defaults.
+//! The default path is `~/.config/agave/validator.toml`.
+//!
+//! # Goals
+//!
+//! - Reduce the number of CLI arguments needed when starting the validator.
+//! - Explicitly passed CLI arguments should take precedence over config file values.
+//! - Should be minimally invasive to existing CLI argument code.
+//!     - Config values should plug in directly as default values to CLI arguments.
+//!     - The configuration's rust defintions should generally be `Option`al or provide a sane default.
+
+use {
+    serde::Deserialize,
+    std::{
+        fs::{self},
+        path::{Path, PathBuf},
+    },
+    thiserror::Error,
+};
+
+#[derive(Error, Debug)]
+pub enum ValidatorConfigError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Toml(#[from] toml::de::Error),
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ValidatorConfig {
+    #[serde(default)]
+    pub net: Net,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Net {
+    #[serde(default)]
+    pub xdp: Xdp,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Xdp {
+    pub interface: Option<String>,
+    pub cpus: Option<String>,
+    pub zero_copy: Option<bool>,
+}
+
+impl ValidatorConfig {
+    pub fn default_path() -> Option<PathBuf> {
+        dirs_next::config_dir().map(|mut path| {
+            path.extend(["agave", "validator.toml"]);
+            path
+        })
+    }
+
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, ValidatorConfigError> {
+        let file = fs::read_to_string(path)?;
+        let config: ValidatorConfig = toml::from_str(&file)?;
+        Ok(config)
+    }
+
+    pub fn load_from_default_path() -> ValidatorConfig {
+        match ValidatorConfig::default_path() {
+            Some(config_path) => ValidatorConfig::from_path(config_path)
+                .inspect_err(|e| match e {
+                    ValidatorConfigError::Io(e) => {
+                        log::warn!("Unable to read validator config file: {e}");
+                    }
+                    ValidatorConfigError::Toml(e) => {
+                        log::warn!("Error parsing validator config file: {e}");
+                    }
+                })
+                .unwrap_or_default(),
+            None => {
+                log::warn!("Unable to determine system config path for validator config");
+                ValidatorConfig::default()
+            }
+        }
+    }
+}

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -16,8 +16,10 @@ use {
 
 pub mod admin_rpc_service;
 pub mod bootstrap;
+pub mod clap_ext;
 pub mod cli;
 pub mod commands;
+pub mod config_file;
 pub mod dashboard;
 
 pub fn format_name_value(name: &str, value: &str) -> String {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -5,6 +5,7 @@ use {
     agave_validator::{
         cli::{app, warn_for_deprecated_arguments, DefaultArgs},
         commands,
+        config_file::ValidatorConfig,
     },
     log::error,
     std::{path::PathBuf, process::exit},
@@ -17,7 +18,8 @@ static GLOBAL: Jemalloc = Jemalloc;
 pub fn main() {
     let default_args = DefaultArgs::new();
     let solana_version = solana_version::version!();
-    let cli_app = app(solana_version, &default_args);
+    let validator_config = ValidatorConfig::load_from_default_path();
+    let cli_app = app(solana_version, &default_args, &validator_config);
     let matches = cli_app.get_matches();
     warn_for_deprecated_arguments(&matches);
 


### PR DESCRIPTION
#### Problem

The validator CLI accepts a large, and growing, number of arguments. This can be cumbersome to manage, especially as more functionality is built out (like XDP), which will benefit from simpler configurability.

#### Summary of Changes

This PR sets up the scaffolding for a toml validator config file. A major goal with this scheme is that it should be minimally invasive to the existing existing clap argument configuration. 

Proposed precedence is as follows: explicit CLI arg > config file property > default (e.g., `DefaultArgs`)

The basic scheme is as follows:
- Config file at `~/.config/agave/validator.toml`.
- Incrementally start defining toml config file properties for validator arguments as needed.
- Pass corresponding config file property into clap argument setup via  `default_value_if_is_some`. This will only use this value as the argument default if toml parsing actually got a value for the property (i.e., `Some<T>`). Command line arg still overrides because config value is set as a _default_.
- Leverages existing parsing / validation because config values are passed as default values in argument config.
- Compatible with existing `DefaultArgs` by simply using something like `validator_config.arg_key.unwrap_or(default_args.arg_key)`

Note - I haven't specified all possible CLI argument properties in the config schema here. This is meant to add the scaffolding and a minimal example (XDP). Subsequent work / PRs should be done to come up with a comprehensive mapping of CLI arguments to config schema. It's also perfectly reasonable IMO to do this incrementally. 