### PR TITLE
gossip: fix and re-enable service exit unit test

### DIFF
--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -396,16 +396,13 @@ mod tests {
     };
 
     #[test]
-    #[ignore]
     // test that stage will exit when flag is set
     fn test_exit() {
         let exit = Arc::new(AtomicBool::new(false));
-        let tn = Node::new_localhost();
-        let cluster_info = ClusterInfo::new(
-            tn.info.clone(),
-            Arc::new(Keypair::new()),
-            SocketAddrSpace::Unspecified,
-        );
+        let kp = Keypair::new();
+        let tn = Node::new_localhost_with_pubkey(&kp.pubkey());
+        let cluster_info =
+            ClusterInfo::new(tn.info.clone(), Arc::new(kp), SocketAddrSpace::Unspecified);
         let c = Arc::new(cluster_info);
         let d = GossipService::new(
             &c,


### PR DESCRIPTION
#### Problem
Gossip service unit test was disabled and hitting and assert in cluster_info::new() because the entrypoint node's pubkey and the passed in keypair's pubkey don't match.

#### Summary of Changes
Update the test so the entrypoint node and cluster info are initialized with the same keypair.
