### PR TITLE
gossip: remove deprecated methods

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1035,15 +1035,6 @@ impl ClusterInfo {
             .unwrap_or_default()
     }
 
-    /// all validators that have a valid rpc port regardless of `shred_version`.
-    #[deprecated(
-        since = "3.0.0",
-        note = "use `rpc_peers` instead to ensure shred version is the same"
-    )]
-    pub fn all_rpc_peers(&self) -> Vec<ContactInfo> {
-        self.rpc_peers()
-    }
-
     /// all validators that have a valid rpc port and are on the same `shred_version`.
     pub fn rpc_peers(&self) -> Vec<ContactInfo> {
         let self_pubkey = self.id();

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -144,16 +144,6 @@ impl GossipService {
     }
 }
 
-/// Discover Validators in a cluster
-#[deprecated(since = "3.0.0", note = "use `discover_validators` instead")]
-pub fn discover_cluster(
-    entrypoint: &SocketAddr,
-    num_nodes: usize,
-    socket_addr_space: SocketAddrSpace,
-) -> std::io::Result<Vec<ContactInfo>> {
-    discover_validators(entrypoint, num_nodes, 0, socket_addr_space)
-}
-
 pub fn discover_validators(
     entrypoint: &SocketAddr,
     num_nodes: usize,

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -15,7 +15,6 @@ use {
             localhost_port_range_for_tests, multi_bind_in_range_with_config,
             SocketConfiguration as SocketConfig,
         },
-        PortRange,
     },
     solana_pubkey::Pubkey,
     solana_quic_definitions::QUIC_PORT_OFFSET,
@@ -51,35 +50,6 @@ impl Node {
         let config = NodeConfig {
             bind_ip_addrs: Arc::new(BindIpAddrs::new(vec![bind_ip_addr]).expect("should bind")),
             gossip_port: port_range.0,
-            port_range,
-            advertised_ip: bind_ip_addr,
-            public_tpu_addr: None,
-            public_tpu_forwards_addr: None,
-            num_tvu_receive_sockets: NonZero::new(1).unwrap(),
-            num_tvu_retransmit_sockets: NonZero::new(1).unwrap(),
-            num_quic_endpoints: NonZero::new(DEFAULT_QUIC_ENDPOINTS)
-                .expect("Number of QUIC endpoints can not be zero"),
-            vortexor_receiver_addr: None,
-        };
-        let mut node = Self::new_with_external_ip(pubkey, config);
-        let rpc_ports: [u16; 2] = find_available_ports_in_range(bind_ip_addr, port_range).unwrap();
-        let rpc_addr = SocketAddr::new(bind_ip_addr, rpc_ports[0]);
-        let rpc_pubsub_addr = SocketAddr::new(bind_ip_addr, rpc_ports[1]);
-        node.info.set_rpc(rpc_addr).unwrap();
-        node.info.set_rpc_pubsub(rpc_pubsub_addr).unwrap();
-        node
-    }
-
-    #[deprecated(since = "3.0.0", note = "use new_with_external_ip")]
-    pub fn new_single_bind(
-        pubkey: &Pubkey,
-        gossip_addr: &SocketAddr,
-        port_range: PortRange,
-        bind_ip_addr: IpAddr,
-    ) -> Self {
-        let config = NodeConfig {
-            bind_ip_addrs: Arc::new(BindIpAddrs::new(vec![bind_ip_addr]).expect("should bind")),
-            gossip_port: gossip_addr.port(),
             port_range,
             advertised_ip: bind_ip_addr,
             public_tpu_addr: None,


### PR DESCRIPTION
#### Problem
Some gossip methods have been deprecated since agave v3.0. Master is now v3.1.

#### Summary of Changes
Remove deprecated methods.

