### PR TITLE
[syscalls] Remove logic associated with `fix_alt_bn128_multiplication_input_length`

### DIFF
--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -17,7 +17,7 @@ use {
     solana_big_mod_exp::{big_mod_exp, BigModExpParams},
     solana_blake3_hasher as blake3,
     solana_bn254::prelude::{
-        alt_bn128_addition, alt_bn128_multiplication, alt_bn128_multiplication_128,
+        alt_bn128_addition, alt_bn128_multiplication,
         alt_bn128_pairing, AltBn128Error, ALT_BN128_ADDITION_OUTPUT_LEN,
         ALT_BN128_MULTIPLICATION_OUTPUT_LEN, ALT_BN128_PAIRING_ELEMENT_LEN,
         ALT_BN128_PAIRING_OUTPUT_LEN,
@@ -1685,16 +1685,7 @@ declare_builtin_function!(
 
         let calculation = match group_op {
             ALT_BN128_ADD => alt_bn128_addition,
-            ALT_BN128_MUL => {
-                let fix_alt_bn128_multiplication_input_length = invoke_context
-                    .get_feature_set()
-                    .fix_alt_bn128_multiplication_input_length;
-                if fix_alt_bn128_multiplication_input_length {
-                    alt_bn128_multiplication
-                } else {
-                    alt_bn128_multiplication_128
-                }
-            }
+            ALT_BN128_MUL => alt_bn128_multiplication,
             ALT_BN128_PAIRING => alt_bn128_pairing,
             _ => {
                 return Err(SyscallError::InvalidAttribute.into());

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -17,10 +17,9 @@ use {
     solana_big_mod_exp::{big_mod_exp, BigModExpParams},
     solana_blake3_hasher as blake3,
     solana_bn254::prelude::{
-        alt_bn128_addition, alt_bn128_multiplication,
-        alt_bn128_pairing, AltBn128Error, ALT_BN128_ADDITION_OUTPUT_LEN,
-        ALT_BN128_MULTIPLICATION_OUTPUT_LEN, ALT_BN128_PAIRING_ELEMENT_LEN,
-        ALT_BN128_PAIRING_OUTPUT_LEN,
+        alt_bn128_addition, alt_bn128_multiplication, alt_bn128_pairing, AltBn128Error,
+        ALT_BN128_ADDITION_OUTPUT_LEN, ALT_BN128_MULTIPLICATION_OUTPUT_LEN,
+        ALT_BN128_PAIRING_ELEMENT_LEN, ALT_BN128_PAIRING_OUTPUT_LEN,
     },
     solana_cpi::MAX_RETURN_DATA,
     solana_hash::Hash,


### PR DESCRIPTION
#### Problem
The feature gate `fix_alt_bn128_multiplication_input_length` under key `bn2puAyxUx6JUabAxYdKdJ5QHbNNmKw8dCGuGCyRrFN` has been active on mainnet since epoch 836.

#### Summary of Changes
Remove logic associated with `fix_alt_bn128_multiplication_input_length`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
