### PR TITLE
remove logic associated with `simplify_alt_bn128_syscall_error_codes`

### DIFF
--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1691,10 +1691,7 @@ declare_builtin_function!(
             }
         };
 
-        let result_point = match calculation(input) {
-            Ok(result_point) => result_point,
-            Err(_) => return Ok(1),
-        };
+        let Ok(result_point) = calculation(input) else { return Ok(1) };
 
         call_result.copy_from_slice(&result_point);
         Ok(SUCCESS)

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -17,7 +17,7 @@ use {
     solana_big_mod_exp::{big_mod_exp, BigModExpParams},
     solana_blake3_hasher as blake3,
     solana_bn254::prelude::{
-        alt_bn128_addition, alt_bn128_multiplication, alt_bn128_pairing, AltBn128Error,
+        alt_bn128_addition, alt_bn128_multiplication, alt_bn128_pairing,
         ALT_BN128_ADDITION_OUTPUT_LEN, ALT_BN128_MULTIPLICATION_OUTPUT_LEN,
         ALT_BN128_PAIRING_ELEMENT_LEN, ALT_BN128_PAIRING_OUTPUT_LEN,
     },
@@ -1691,26 +1691,10 @@ declare_builtin_function!(
             }
         };
 
-        let simplify_alt_bn128_syscall_error_codes = invoke_context
-            .get_feature_set()
-            .simplify_alt_bn128_syscall_error_codes;
-
         let result_point = match calculation(input) {
             Ok(result_point) => result_point,
-            Err(e) => {
-                return if simplify_alt_bn128_syscall_error_codes {
-                    Ok(1)
-                } else {
-                    Ok(e.into())
-                };
-            }
+            Err(_) => return Ok(1),
         };
-
-        // This can never happen and should be removed when the
-        // simplify_alt_bn128_syscall_error_codes feature gets activated
-        if result_point.len() != output && !simplify_alt_bn128_syscall_error_codes {
-            return Ok(AltBn128Error::SliceOutOfBounds.into());
-        }
 
         call_result.copy_from_slice(&result_point);
         Ok(SUCCESS)


### PR DESCRIPTION
Problem
The feature gate `simplify_alt_bn128_syscall_error_codes` under key `JDn5q3GBeqzvUa7z67BbmVHVdE3EbUAjvFep3weR3jxX` has been active on mainnet since epoch 635.

Summary of Changes
Remove logic associated with `simplify_alt_bn128_syscall_error_codes`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
