### PR TITLE
validator: Add comment to --wait-for-exit deprecation

### DIFF
--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -46,6 +46,7 @@ impl FromClapArgMatches for ExitArgs {
             Some(PostExitAction::Wait)
         };
 
+        // Deprecated in v3.0.0
         if matches.is_present("wait_for_exit") {
             eprintln!(
                 "WARN: The --wait-for-exit flag has been deprecated, waiting for exit is now the \


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/7609 deprecated `--wait-for-exit`, but there is no comment to note which version is was deprecated in. Having the version noted makes it easier to know when we can rip stuff, similar to what we do in this function:
https://github.com/anza-xyz/agave/blob/6d40add2f6e7dbebfb717e57b6751a4264617c8e/validator/src/cli.rs#L104

#### Summary of Changes
Add the comment to make it easier to know when we can rip this out in the future