### PR TITLE
fix port bind in connection cache

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -33,6 +33,7 @@ solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
 solana-message = { workspace = true }
+solana-net-utils = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-pubsub-client = { workspace = true }
 solana-quic-client = { workspace = true }

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -90,7 +90,11 @@ impl ConnectionCache {
         }
         if let Some(client_socket) = client_socket {
             config.update_client_endpoint(client_socket);
+        } else if cfg!(debug_assertions) {
+            let client_socket = solana_net_utils::sockets::bind_to_localhost_unique().unwrap();
+            config.update_client_endpoint(client_socket);
         }
+
         if let Some(stake_info) = stake_info {
             config.set_staked_nodes(stake_info.0, stake_info.1);
         }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6164,6 +6164,7 @@ dependencies = [
  "solana-keypair",
  "solana-measure",
  "solana-message",
+ "solana-net-utils",
  "solana-pubkey",
  "solana-pubsub-client",
  "solana-quic-client",


### PR DESCRIPTION
#### Problem

- when running unittests connection cache could bind to random ports

#### Summary of Changes

- make it use unique allocations instead
- this should have no material impact on normal operations - but let us think of possible failure possibilities too.
- Probably a better solution would be to always force the maker of connection cache to supply a valid socket, but if we phase out connection cache maybe its too much?
