### PR TITLE
fix: typos in documentation

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2785,7 +2785,7 @@ impl AccountsDb {
     /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts index
     ///    and should not be unref'd. If they exist in the accounts index, they are NEW.
     /// clean_stored_dead_slots - clean_stored_dead_slots iterates through all the pubkeys in the dead
-    ///    slots and unrefs them in the acocunts index if they are not present in
+    ///    slots and unrefs them in the accounts index if they are not present in
     ///    pubkeys_removed_from_accounts_index. Skipping clean is the equivilent to
     ///    pubkeys_removed_from_accounts_index containing all the pubkeys in the dead slots
     fn process_dead_slots(

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -74,7 +74,7 @@ impl std::fmt::Debug for BankNotification {
 
 pub type BankNotificationWithEventSequence = (
     BankNotification,
-    Option<u64>, // dependecy work sequence number
+    Option<u64>, // dependency work sequence number
 );
 
 pub type BankNotificationReceiver = Receiver<BankNotificationWithEventSequence>;

--- a/storage-bigtable/proto/google.bigtable.v2.rs
+++ b/storage-bigtable/proto/google.bigtable.v2.rs
@@ -675,7 +675,7 @@ pub struct RequestLatencyStats {
 pub struct FullReadStatsView {
     /// Iteration stats describe how efficient the read is, e.g. comparing
     /// rows seen vs. rows returned or cells seen vs cells returned can provide an
-    /// indication of read efficiency (the higher the ratio of seen to retuned the
+    /// indication of read efficiency (the higher the ratio of seen to returned the
     /// better).
     #[prost(message, optional, tag = "1")]
     pub read_iteration_stats: ::core::option::Option<ReadIterationStats>,


### PR DESCRIPTION
Corrected `dependecy` to `dependency`
Corrected `acocunts` to `accounts`
Corrected `retuned` to `returned`