### PR TITLE
Avoid duplicate additions of obsolete accounts

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1068,7 +1068,7 @@ fn test_clean_dead_slot_with_obsolete_accounts() {
     let accounts = AccountsDb::new_with_config(
         Vec::new(),
         Some(AccountsDbConfig {
-            mark_obsolete_accounts: true,
+            mark_obsolete_accounts: MarkObsoleteAccounts::Enabled,
             ..ACCOUNTS_DB_CONFIG_FOR_TESTING
         }),
         None,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1083,24 +1083,29 @@ fn test_clean_dead_slot_with_obsolete_accounts() {
     accounts.add_root_and_flush_write_cache(1);
     accounts.add_root_and_flush_write_cache(2);
 
-    // Pubkey1 should be in 3 slots, 0 and 1 and 2
-    accounts.assert_ref_count(&pubkey, 3);
+    // With obsolete accounts disabled, Pubkey1 should exist in three slots: 0, 1, and 2.
+    // Manually marked as obsolete and unreferenced, which allows clean to remove slots 0 and 1.
+    // If obsolete accounts are enabled, slots 0 and 1 were already cleaned during the write cache
+    // flush, leaving the account as a single reference in slot 2.
+    if !accounts.mark_obsolete_accounts {
+        accounts.assert_ref_count(&pubkey, 3);
+        // Mark pubkey in slot 1 as obsolete, simulating obsolete accounts being enabled
+        let old_storage = accounts
+            .storage
+            .get_slot_storage_entry_shrinking_in_progress_ok(1)
+            .unwrap();
+        old_storage.mark_accounts_obsolete(vec![(0, 1)].into_iter(), 2);
 
-    // Mark pubkey in slot 1 as obsolete, simulating obsolete accounts being enabled
-    let old_storage = accounts
-        .storage
-        .get_slot_storage_entry_shrinking_in_progress_ok(1)
-        .unwrap();
-    old_storage.mark_accounts_obsolete(vec![(0, 1)].into_iter(), 2);
+        // Unreference pubkey, which would occur during the normal mark_accounts_obsolete flow
+        accounts.unref_pubkeys([pubkey].iter(), 1, &HashSet::new());
 
-    // Unreference pubkey, which would occur during the normal mark_accounts_obsolete flow
-    accounts.unref_pubkeys([pubkey].iter(), 1, &HashSet::new());
+        // Pubkey1 should now have two references: Slot0 and Slot2.
+        accounts.assert_ref_count(&pubkey, 2);
 
-    // Pubkey1 should now have two references: Slot0 and Slot2.
-    accounts.assert_ref_count(&pubkey, 2);
+        // Clean, remove slot0/1.
+        accounts.clean_accounts_for_tests();
+    }
 
-    // Clean, remove slot0/1.
-    accounts.clean_accounts_for_tests();
     assert!(accounts.storage.get_slot_storage_entry(0).is_none());
     assert!(accounts.storage.get_slot_storage_entry(1).is_none());
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1074,16 +1074,23 @@ fn test_clean_dead_slot_with_obsolete_accounts() {
         None,
         Arc::default(),
     );
+
     let pubkey = solana_pubkey::new_rand();
+    let pubkey2 = solana_pubkey::new_rand();
     let account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
+    let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
+    accounts.set_latest_full_snapshot_slot(2);
 
-    // Store account 1 in slot 0
-    accounts.store_for_tests((0, [(&pubkey, &account)].as_slice()));
+    // Store pubkey1 and pubkey2 in slot 0
+    accounts.store_for_tests((0, [(&pubkey, &account), (&pubkey2, &account)].as_slice()));
 
-    // Update account 1 as in slot 1
-    accounts.store_for_tests((1, [(&pubkey, &account)].as_slice()));
+    // Update pubkey1 and make pubkey2 a zero lamport account in slot 1
+    accounts.store_for_tests((
+        1,
+        [(&pubkey, &account), (&pubkey2, &zero_lamport_account)].as_slice(),
+    ));
 
-    // Update account 1 as in slot 2
+    // Update pubkey1 as in slot 2
     accounts.store_for_tests((2, [(&pubkey, &account)].as_slice()));
 
     // Flush the slots individually to avoid reclaims
@@ -1091,12 +1098,24 @@ fn test_clean_dead_slot_with_obsolete_accounts() {
     accounts.add_root_and_flush_write_cache(1);
     accounts.add_root_and_flush_write_cache(2);
 
+    // Slot 1 should not be removed as it has the zero lamport account
+    assert!(accounts.storage.get_slot_storage_entry(1).is_some());
+    let slot = accounts.storage.get_slot_storage_entry(1).unwrap();
+
+    // Ensure that slot1 also still contains the obsolete account
+    assert!(slot.get_obsolete_accounts(None).len() == 1);
+
+    // Ref count for pubkey1 should be 1 as obsolete accounts are enabled
+    accounts.assert_ref_count(&pubkey, 1);
+
+    // Clean, which will remove slot1
+    accounts.clean_accounts_for_tests();
+
     assert!(accounts.storage.get_slot_storage_entry(0).is_none());
     assert!(accounts.storage.get_slot_storage_entry(1).is_none());
 
-    // Ref count for pubkey should be 1. It was decremented for slot1 and above, and decremented
-    // for slot0 during clean_accounts_for_tests
-    // It was NOT decremented for slot1 during clean_accounts_for_test as it was marked obsolete
+    // Ref count for pubkey should be 1. It was NOT decremented during clean_accounts_for_tests
+    // despite slot 1 being removed, because the account was already obsolete
     accounts.assert_ref_count(&pubkey, 1);
 }
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1103,7 +1103,7 @@ fn test_clean_dead_slot_with_obsolete_accounts() {
     let slot = accounts.storage.get_slot_storage_entry(1).unwrap();
 
     // Ensure that slot1 also still contains the obsolete account
-    assert!(slot.get_obsolete_accounts(None).len() == 1);
+    assert_eq!(slot.get_obsolete_accounts(None).len(), 1);
 
     // Ref count for pubkey1 should be 1 as obsolete accounts are enabled
     accounts.assert_ref_count(&pubkey, 1);

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1008,8 +1008,11 @@ mod tests {
 
         bank1.fill_bank_with_ticks_for_tests();
 
-        // Mark the entry for pubkey1 as obsolete in slot0
-        account_storage_entry.mark_accounts_obsolete(vec![(offset, 0)].into_iter(), slot);
+        // Mark the entry for pubkey1 as obsolete in slot0 if obsolete accounts are not enabled
+        // If obsolete accounts are enabled, the account was marked obsolete during flush
+        if !bank1.accounts().accounts_db.mark_obsolete_accounts {
+            account_storage_entry.mark_accounts_obsolete(vec![(offset, 0)].into_iter(), slot);
+        }
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -832,7 +832,7 @@ mod tests {
             },
             status_cache::Status,
         },
-        solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING,
+        solana_accounts_db::accounts_db::{MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING},
         solana_genesis_config::create_genesis_config,
         solana_keypair::Keypair,
         solana_native_token::LAMPORTS_PER_SOL,
@@ -962,7 +962,7 @@ mod tests {
 
         let bank_test_config = BankTestConfig {
             accounts_db_config: AccountsDbConfig {
-                mark_obsolete_accounts: true,
+                mark_obsolete_accounts: MarkObsoleteAccounts::Enabled,
                 ..ACCOUNTS_DB_CONFIG_FOR_TESTING
             },
         };

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -959,7 +959,17 @@ mod tests {
 
         // Create a few accounts
         let (genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
-        let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+
+        let bank_test_config = BankTestConfig {
+            accounts_db_config: AccountsDbConfig {
+                mark_obsolete_accounts: true,
+                ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+            },
+        };
+
+        let bank = Bank::new_with_config_for_tests(&genesis_config, bank_test_config);
+
+        let (bank0, bank_forks) = Bank::wrap_with_bank_forks_for_tests(bank);
         bank0
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -975,29 +985,6 @@ mod tests {
         bank0.squash();
         bank0.force_flush_accounts_cache();
 
-        // Find the account storage entry for slot 0
-        let target_slot = 0;
-        let account_storage_entry = bank0
-            .accounts()
-            .accounts_db
-            .storage
-            .get_slot_storage_entry(target_slot)
-            .unwrap();
-
-        // Find all the accounts in slot 0
-        let accounts = bank0
-            .accounts()
-            .accounts_db
-            .get_unique_accounts_from_storage(&account_storage_entry);
-
-        // Find the offset of pubkey `key1` in the accounts db slot0 and save the offset.
-        let offset = accounts
-            .stored_accounts
-            .iter()
-            .find(|account| key1.pubkey() == *account.pubkey())
-            .map(|account| account.index_info.offset())
-            .expect("Pubkey1 is present in Slot0");
-
         // Create a new slot, and invalidate the account for key1 in slot0
         let slot = 1;
         let bank1 =
@@ -1007,12 +994,6 @@ mod tests {
             .unwrap();
 
         bank1.fill_bank_with_ticks_for_tests();
-
-        // Mark the entry for pubkey1 as obsolete in slot0 if obsolete accounts are not enabled
-        // If obsolete accounts are enabled, the account was marked obsolete during flush
-        if !bank1.accounts().accounts_db.mark_obsolete_accounts {
-            account_storage_entry.mark_accounts_obsolete(vec![(offset, 0)].into_iter(), slot);
-        }
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
#### Problem
Some tests manually insert obsolete accounts to test the behaviour.

#### Summary of Changes
- Now that the feature is fully supported, enable obsolete accounts for targeted tests and revisit behaviour. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
