### PR TITLE
Clean up store stats

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6533,16 +6533,6 @@ impl AccountsDb {
                     i64
                 ),
                 (
-                    "store_get_slot_store",
-                    self.stats.store_get_slot_store.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "store_find_existing",
-                    self.stats.store_find_existing.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
                     "dropped_stores",
                     self.stats.dropped_stores.swap(0, Ordering::Relaxed),
                     i64

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -19,8 +19,6 @@ pub struct AccountsStats {
     pub store_num_accounts: AtomicU64,
     pub store_total_data: AtomicU64,
     pub create_store_count: AtomicU64,
-    pub store_get_slot_store: AtomicU64,
-    pub store_find_existing: AtomicU64,
     pub dropped_stores: AtomicU64,
     pub handle_dead_keys_us: AtomicU64,
     pub purge_exact_us: AtomicU64,


### PR DESCRIPTION
#### Problem

"get_slot_store" and "find_existing_store" stats are osolete since we no longer do "Append" for ancient appendvec. 


#### Summary of Changes

Remove them.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
