### PR TITLE
Removes unused snapshot timing return values

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -128,7 +128,7 @@ fn restore_from_snapshot(
     let full_snapshot_archive_info =
         FullSnapshotArchiveInfo::new_from_path(full_snapshot_archive_path).unwrap();
 
-    let (deserialized_bank, _timing) = snapshot_bank_utils::bank_from_snapshot_archives(
+    let deserialized_bank = snapshot_bank_utils::bank_from_snapshot_archives(
         account_paths,
         &snapshot_config.bank_snapshots_dir,
         &full_snapshot_archive_info,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -276,7 +276,7 @@ fn bank_forks_from_snapshot(
     };
 
     let bank = if let Some(fastboot_snapshot) = fastboot_snapshot {
-        let (bank, _) = snapshot_bank_utils::bank_from_snapshot_dir(
+        snapshot_bank_utils::bank_from_snapshot_dir(
             &account_paths,
             &fastboot_snapshot,
             genesis_config,
@@ -292,8 +292,7 @@ fn bank_forks_from_snapshot(
         .map_err(|err| BankForksUtilsError::BankFromSnapshotsDirectory {
             source: err,
             path: fastboot_snapshot.snapshot_path(),
-        })?;
-        bank
+        })?
     } else {
         // Given that we are going to boot from an archive, the append vecs held in the snapshot dirs for fast-boot should
         // be released.  They will be released by the account_background_service anyway.  But in the case of the account_paths
@@ -301,7 +300,7 @@ fn bank_forks_from_snapshot(
         // the archives, causing the out-of-memory problem.  So, purge the snapshot dirs upfront before loading from the archive.
         snapshot_utils::purge_all_bank_snapshots(&snapshot_config.bank_snapshots_dir);
 
-        let (bank, _) = snapshot_bank_utils::bank_from_snapshot_archives(
+        snapshot_bank_utils::bank_from_snapshot_archives(
             &account_paths,
             &snapshot_config.bank_snapshots_dir,
             &full_snapshot_archive_info,
@@ -325,8 +324,7 @@ fn bank_forks_from_snapshot(
                 .as_ref()
                 .map(|archive| archive.path().display().to_string())
                 .unwrap_or("none".to_string()),
-        })?;
-        bank
+        })?
     };
 
     // We must inform accounts-db of the latest full snapshot slot, which is used by the background

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -970,7 +970,7 @@ mod tests {
             index: Some(accounts_index_config),
             ..ACCOUNTS_DB_CONFIG_FOR_TESTING
         };
-        let (roundtrip_bank, _) = snapshot_bank_utils::bank_from_snapshot_archives(
+        let roundtrip_bank = snapshot_bank_utils::bank_from_snapshot_archives(
             &[accounts_dir],
             &bank_snapshots_dir,
             &snapshot,
@@ -1070,7 +1070,7 @@ mod tests {
         )
         .unwrap();
         let (_accounts_tempdir, accounts_dir) = snapshot_utils::create_tmp_accounts_dir_for_tests();
-        let (roundtrip_bank, _) = snapshot_bank_utils::bank_from_snapshot_archives(
+        let roundtrip_bank = snapshot_bank_utils::bank_from_snapshot_archives(
             &[accounts_dir],
             &bank_snapshots_dir,
             &snapshot,

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -294,7 +294,7 @@ mod tests {
         .unwrap();
 
         // Deserialize
-        let (dbank, _) = snapshot_bank_utils::bank_from_snapshot_archives(
+        let dbank = snapshot_bank_utils::bank_from_snapshot_archives(
             &[accounts_dir],
             bank_snapshots_dir.path(),
             &snapshot_archive_info,

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -658,7 +658,7 @@ mod tests {
             skip_initial_hash_calc: !should_recalculate_accounts_lt_hash,
             ..ACCOUNTS_DB_CONFIG_FOR_TESTING
         };
-        let (roundtrip_bank, _) = snapshot_bank_utils::bank_from_snapshot_archives(
+        let roundtrip_bank = snapshot_bank_utils::bank_from_snapshot_archives(
             &[accounts_dir],
             &bank_snapshots_dir,
             &snapshot,


### PR DESCRIPTION
#### Problem

When loading a bank from snapshot archives/local status (e.g. `bank_from_snapshot_archives()`), the functions return timing structs. The timing values are already reported to metrics from within the function, and none of the callers use the returned timing struct. It is unused and can be removed.


#### Summary of Changes

Remove 'em.