### PR TITLE
Added command to fetch the latest blockhash using the CLI

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -462,6 +462,7 @@ pub enum CliCommand {
         signature: Signature,
         message: OffchainMessage,
     },
+    GetLatestBlockhash
 }
 
 #[derive(Debug, PartialEq)]
@@ -837,6 +838,7 @@ pub fn parse_command(
         ("verify-offchain-signature", Some(matches)) => {
             parse_verify_offchain_signature(matches, default_signer, wallet_manager)
         }
+        ("latest-blockhash", Some(matches)) => parse_get_latest_blockhash(matches),
         //
         ("", None) => {
             eprintln!("{}", matches.usage());
@@ -922,6 +924,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::GetGenesisHash => process_get_genesis_hash(&rpc_client),
         CliCommand::GetSlot => process_get_slot(&rpc_client, config),
         CliCommand::GetBlockHeight => process_get_block_height(&rpc_client, config),
+        CliCommand::GetLatestBlockhash => process_get_latest_blockhash(&rpc_client, config),
         CliCommand::LargestAccounts { filter } => {
             process_largest_accounts(&rpc_client, config, filter.clone())
         }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -507,6 +507,11 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .help("Display rent in lamports instead of SOL"),
                 ),
         )
+        .subcommand(
+            SubCommand::with_name("latest-blockhash")
+                .about("Get latest blockhash")
+                .alias("get-latest-blockhash"),
+        )
     }
 }
 
@@ -610,6 +615,10 @@ pub fn parse_get_slot(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliEr
 
 pub fn parse_get_block_height(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     Ok(CliCommandInfo::without_signers(CliCommand::GetBlockHeight))
+}
+
+pub fn parse_get_latest_blockhash(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
+    Ok(CliCommandInfo::without_signers(CliCommand::GetLatestBlockhash))
 }
 
 pub fn parse_largest_accounts(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
@@ -1192,6 +1201,11 @@ pub fn process_get_slot(rpc_client: &RpcClient, _config: &CliConfig) -> ProcessR
 pub fn process_get_block_height(rpc_client: &RpcClient, _config: &CliConfig) -> ProcessResult {
     let block_height = rpc_client.get_block_height()?;
     Ok(block_height.to_string())
+}
+
+pub fn process_get_latest_blockhash(rpc_client: &RpcClient, _config: &CliConfig) -> ProcessResult {
+    let blockhash = rpc_client.get_latest_blockhash()?;
+    Ok(blockhash.to_string())
 }
 
 pub fn parse_show_block_production(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {


### PR DESCRIPTION
#### Problem

CLI lacks a functional way to fetch the latest blockhash. Having to fetch the entire block (>5MBs) and then filtering for 45 bytes of data is absurd.

#### Summary of Changes

Added a command to get the latest blockhash.

Usage:
`solana latest-blockhash`
