### PR TITLE
validator: Deprecate --monitor flag for exit command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Release channels have their own copy of this changelog:
 #### Changes
 ### Validator
 #### Breaking
+#### Deprecations
+* The `--monitor` flag with `agave-validator exit` is now deprecated. Operators can use the `monitor` command after `exit` instead.
 
 ## 3.0.0
 

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -53,6 +53,13 @@ impl FromClapArgMatches for ExitArgs {
                  default behavior"
             );
         }
+        // Deprecated in v3.1.0
+        if matches.is_present("monitor") {
+            eprintln!(
+                "WARN: The --monitor flag has been deprecated, use \"agave-validator monitor\" \
+                 instead"
+            );
+        }
 
         Ok(ExitArgs {
             force: matches.is_present("force"),
@@ -84,6 +91,7 @@ pub fn command<'a>() -> App<'a, 'a> {
                 .long("monitor")
                 .takes_value(false)
                 .requires("no_wait_for_exit")
+                .hidden(hidden_unless_forced())
                 .help("Monitor the validator after sending the exit request"),
         )
         .arg(


### PR DESCRIPTION
#### Problem
Use of --monitor conflicts with wait-for-exit behavior that is necessary for a graceful shutdown. More so, operators that want the monitor functionality can just call agave-validator monitor immediately after.

#### Summary of Changes
Deprecate `--monitor`, including a CHANGELOG entry
