### PR TITLE
shred: Address clippy enum_variant_names lint for shred::Error

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -165,9 +165,9 @@ impl ShredFlags {
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(transparent)]
-    BincodeError(#[from] bincode::Error),
+    Bincode(#[from] bincode::Error),
     #[error(transparent)]
-    ErasureError(#[from] reed_solomon_erasure::Error),
+    Erasure(#[from] reed_solomon_erasure::Error),
     #[error("Invalid data size: {size}, payload: {payload}")]
     InvalidDataSize { size: u16, payload: usize },
     #[error("Invalid deshred set")]
@@ -203,7 +203,7 @@ pub enum Error {
     #[error("Invalid packet size, could not get the shred")]
     InvalidPacketSize,
     #[error(transparent)]
-    IoError(#[from] std::io::Error),
+    Io(#[from] std::io::Error),
     #[error("Unknown proof size")]
     UnknownProofSize,
 }

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1590,14 +1590,14 @@ mod test {
             }) {
                 assert_matches!(
                     recover(shreds, reed_solomon_cache).err(),
-                    Some(Error::ErasureError(TooFewParityShards))
+                    Some(Error::Erasure(TooFewParityShards))
                 );
                 continue;
             }
             if shreds.len() < num_data_shreds {
                 assert_matches!(
                     recover(shreds, reed_solomon_cache).err(),
-                    Some(Error::ErasureError(TooFewShardsPresent))
+                    Some(Error::Erasure(TooFewShardsPresent))
                 );
                 continue;
             }


### PR DESCRIPTION
#### Problem
Was looking at other stuff and saw this one come up so figured I'd plug in a fix real quick:
https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names