### PR TITLE
simple QOS streams/s per peer

### DIFF
--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -23,6 +23,8 @@ use {
     thiserror::Error,
 };
 
+// Convservatively allow 50 TPS per validator.
+pub const MAX_VOTES_PER_SECOND: u64 = 50;
 pub enum VoteOp {
     PushVote {
         tx: Transaction,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -341,13 +341,6 @@ async fn run_server(
     let unstaked_connection_table: Arc<Mutex<ConnectionTable>> = Arc::new(Mutex::new(
         ConnectionTable::new(ConnectionTableType::Unstaked, cancel.clone()),
     ));
-    let stream_load_ema = Arc::new(StakedStreamLoadEMA::new(
-        stats.clone(),
-        quic_server_params.max_unstaked_connections,
-        quic_server_params.max_streams_per_ms,
-    ));
-=======
-        Arc::new(Mutex::new(ConnectionTable::new()));
 
     let qos_tracker = match quic_server_params.qos_mode {
         QosMode::StakeWeighted { max_streams_per_ms } => {
@@ -364,7 +357,6 @@ async fn run_server(
         },
     };
 
->>>>>>> 0d9a02a6a4 (rebase with master)
     stats
         .quic_endpoints_count
         .store(endpoints.len(), Ordering::Relaxed);
@@ -1172,7 +1164,7 @@ async fn handle_connection(
                 max_streams_per_second,
             } => {
                 let interval_ms = STREAM_THROTTLING_INTERVAL.as_millis() as u64;
-                (max_streams_per_second * interval_ms / 1000).max(1)
+                max_streams_per_second * interval_ms / 1000
             }
         };
 

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1754,6 +1754,34 @@ pub mod test {
         }
         s1.finish().unwrap();
 
+        check_received_packets(receiver, num_expected_packets, num_bytes).await;
+    }
+
+    pub async fn check_multiple_packets(
+        receiver: Receiver<PacketBatch>,
+        server_address: SocketAddr,
+        client_keypair: Option<&Keypair>,
+        num_expected_packets: usize,
+    ) {
+        let conn1 = Arc::new(make_client_endpoint(&server_address, client_keypair).await);
+
+        // Send a full size packet with single byte writes.
+        let num_bytes = PACKET_DATA_SIZE;
+        let packet = vec![1u8; num_bytes];
+        for _ in 0..num_expected_packets {
+            let mut s1 = conn1.open_uni().await.unwrap();
+            s1.write_all(&packet).await.unwrap();
+            s1.finish().unwrap();
+        }
+
+        check_received_packets(receiver, num_expected_packets, num_bytes).await;
+    }
+
+    async fn check_received_packets(
+        receiver: Receiver<PacketBatch>,
+        num_expected_packets: usize,
+        num_bytes: usize,
+    ) {
         let mut all_packets = vec![];
         let now = Instant::now();
         let mut total_packets = 0;

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1172,7 +1172,7 @@ async fn handle_connection(
                 max_streams_per_second,
             } => {
                 let interval_ms = STREAM_THROTTLING_INTERVAL.as_millis() as u64;
-                max_streams_per_second * interval_ms / 1000
+                (max_streams_per_second * interval_ms / 1000).max(1)
             }
         };
 

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -31,6 +31,7 @@ pub(crate) struct StakedStreamLoadEMA {
     max_staked_load_in_ema_window: u64,
     // Maximum number of streams for an unstaked connection in stream throttling window
     max_unstaked_load_in_throttling_window: u64,
+    max_streams_per_ms: u64,
 }
 
 impl StakedStreamLoadEMA {
@@ -63,6 +64,7 @@ impl StakedStreamLoadEMA {
             stats,
             max_staked_load_in_ema_window,
             max_unstaked_load_in_throttling_window,
+            max_streams_per_ms,
         }
     }
 
@@ -180,6 +182,10 @@ impl StakedStreamLoadEMA {
                 )
             }
         }
+    }
+
+    pub(crate) fn max_streams_per_ms(&self) -> u64 {
+        self.max_streams_per_ms
     }
 }
 

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -636,7 +636,6 @@ pub struct QuicServerParams {
     pub max_connections_per_peer: usize,
     pub max_staked_connections: usize,
     pub max_unstaked_connections: usize,
-    // pub max_streams_per_ms: u64,
     pub max_connections_per_ipaddr_per_min: u64,
     pub wait_for_chunk_timeout: Duration,
     pub coalesce: Duration,

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -619,17 +619,30 @@ pub fn spawn_server_multi(
     )
 }
 
+#[derive(Clone, Debug)]
+pub enum QosMode {
+    /// The maximum number of streams per millisecond across all connections
+    StakeWeighted {
+        max_streams_per_ms: u64,
+    },
+    // The maximum number of streams per second allowed for each peer
+    SimpleStreamsPerSecond {
+        max_streams_per_second: u64,
+    },
+}
+
 #[derive(Clone)]
 pub struct QuicServerParams {
     pub max_connections_per_peer: usize,
     pub max_staked_connections: usize,
     pub max_unstaked_connections: usize,
-    pub max_streams_per_ms: u64,
+    // pub max_streams_per_ms: u64,
     pub max_connections_per_ipaddr_per_min: u64,
     pub wait_for_chunk_timeout: Duration,
     pub coalesce: Duration,
     pub coalesce_channel_size: usize,
     pub num_threads: NonZeroUsize,
+    pub qos_mode: QosMode,
 }
 
 impl Default for QuicServerParams {
@@ -638,12 +651,14 @@ impl Default for QuicServerParams {
             max_connections_per_peer: 1,
             max_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS,
             max_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS,
-            max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             coalesce: DEFAULT_TPU_COALESCE,
             coalesce_channel_size: DEFAULT_MAX_COALESCE_CHANNEL_SIZE,
             num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
+            qos_mode: QosMode::StakeWeighted {
+                max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
+            },
         }
     }
 }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -60,7 +60,7 @@ use {
         },
     },
     solana_signer::Signer,
-    solana_streamer::quic::{QuicServerParams, DEFAULT_TPU_COALESCE},
+    solana_streamer::quic::{QosMode, QuicServerParams, DEFAULT_TPU_COALESCE},
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
     solana_turbine::{
         broadcast_stage::BroadcastStageType,
@@ -921,10 +921,10 @@ pub fn execute(
         max_connections_per_peer: tpu_max_connections_per_peer.try_into().unwrap(),
         max_staked_connections: tpu_max_staked_connections.try_into().unwrap(),
         max_unstaked_connections: tpu_max_unstaked_connections.try_into().unwrap(),
-        max_streams_per_ms,
         max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
         coalesce: tpu_coalesce,
         num_threads: tpu_transaction_receive_threads,
+        qos_mode: QosMode::StakeWeighted { max_streams_per_ms },
         ..Default::default()
     };
 
@@ -932,7 +932,7 @@ pub fn execute(
         max_connections_per_peer: tpu_max_connections_per_peer.try_into().unwrap(),
         max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
         max_unstaked_connections: tpu_max_fwd_unstaked_connections.try_into().unwrap(),
-        max_streams_per_ms,
+        qos_mode: QosMode::StakeWeighted { max_streams_per_ms },
         max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
         coalesce: tpu_coalesce,
         num_threads: tpu_transaction_forward_receive_threads,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -35,6 +35,7 @@ use {
             TransactionStructure, Validator, ValidatorConfig, ValidatorError,
             ValidatorStartProgress, ValidatorTpuConfig,
         },
+        voting_service::MAX_VOTES_PER_SECOND,
     },
     solana_gossip::{
         cluster_info::{NodeConfig, DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS},
@@ -939,12 +940,18 @@ pub fn execute(
         ..Default::default()
     };
 
-    // Vote shares TPU forward's characteristics, except that we accept 1 connection
-    // per peer and no unstaked connections are accepted.
-    let mut vote_quic_server_config = tpu_fwd_quic_server_config.clone();
-    vote_quic_server_config.max_connections_per_peer = 1;
-    vote_quic_server_config.max_unstaked_connections = 0;
-    vote_quic_server_config.num_threads = tpu_vote_transaction_receive_threads;
+    let vote_quic_server_config = QuicServerParams {
+        max_connections_per_peer: 1,
+        max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
+        max_unstaked_connections: 0,
+        qos_mode: QosMode::SimpleStreamsPerSecond {
+            max_streams_per_second: MAX_VOTES_PER_SECOND,
+        },
+        max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
+        coalesce: tpu_coalesce,
+        num_threads: tpu_vote_transaction_receive_threads,
+        ..Default::default()
+    };
 
     let validator = match Validator::new(
         node,

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -12,7 +12,7 @@ use {
     solana_quic_definitions::NotifyKeyUpdate,
     solana_streamer::{
         nonblocking::quic::DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-        quic::{spawn_server_with_cancel, EndpointKeyUpdater, QuicServerParams},
+        quic::{spawn_server_with_cancel, EndpointKeyUpdater, QosMode, QuicServerParams},
         streamer::StakedNodes,
     },
     std::{
@@ -122,10 +122,10 @@ impl Vortexor {
             max_connections_per_peer,
             max_staked_connections: max_tpu_staked_connections,
             max_unstaked_connections: max_tpu_unstaked_connections,
-            max_streams_per_ms,
             max_connections_per_ipaddr_per_min,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             coalesce: tpu_coalesce,
+            qos_mode: QosMode::StakeWeighted { max_streams_per_ms },
             ..Default::default()
         };
 


### PR DESCRIPTION
#### Problem

Vote using QUIC requires a simpler QOS instead of stake weighted as we want to allow all staked nodes to be able to vote and there is no need to differentiate the count of votes per vote interval based on stakes.

#### Summary of Changes

Introduced QosMode to differentiate the SWQOS from simple QOS.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
