### PR TITLE
remove gossip ping gate

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -19,7 +19,7 @@ use {
         contact_info::{self, ContactInfo, ContactInfoQuery, Error as ContactInfoError},
         crds::{Crds, Cursor, GossipRoute},
         crds_data::{self, CrdsData, EpochSlotsIndex, LowestSlot, SnapshotHashes, Vote, MAX_VOTES},
-        crds_filter::{should_retain_crds_value, GossipFilterDirection, MIN_STAKE_TO_SKIP_PING},
+        crds_filter::{should_retain_crds_value, GossipFilterDirection},
         crds_gossip::CrdsGossip,
         crds_gossip_error::CrdsGossipError,
         crds_gossip_pull::{
@@ -2012,7 +2012,6 @@ impl ClusterInfo {
                 &mut rng,
                 &keypair,
                 value,
-                stakes,
                 &self.socket_addr_space,
                 &self.ping_cache,
                 &mut pings,
@@ -2496,7 +2495,6 @@ fn verify_gossip_addr<R: Rng + CryptoRng>(
     rng: &mut R,
     keypair: &Keypair,
     value: &CrdsValue,
-    stakes: &HashMap<Pubkey, u64>,
     socket_addr_space: &SocketAddrSpace,
     ping_cache: &Mutex<PingCache>,
     pings: &mut Vec<(SocketAddr, Ping)>,
@@ -2506,10 +2504,6 @@ fn verify_gossip_addr<R: Rng + CryptoRng>(
         CrdsData::LegacyContactInfo(node) => (node.pubkey(), node.gossip()),
         _ => return true, // If not a contact-info, nothing to verify.
     };
-    // For (sufficiently) staked nodes, don't bother with ping/pong.
-    if stakes.get(pubkey).copied() >= Some(MIN_STAKE_TO_SKIP_PING) {
-        return true;
-    }
     // Invalid addresses are not verifiable.
     let Some(addr) = addr.filter(|addr| socket_addr_space.check(addr)) else {
         return false;

--- a/gossip/src/crds_filter.rs
+++ b/gossip/src/crds_filter.rs
@@ -16,8 +16,6 @@ const MIN_NUM_STAKED_NODES: usize = 500;
 /// Minimum stake that a node should have so that all its CRDS values are
 /// propagated through gossip (below this only subset of CRDS is propagated).
 pub(crate) const MIN_STAKE_FOR_GOSSIP: u64 = solana_native_token::LAMPORTS_PER_SOL;
-/// Minimum stake required for a node to bypass the initial ping check when joining gossip.
-pub(crate) const MIN_STAKE_TO_SKIP_PING: u64 = 1000 * solana_native_token::LAMPORTS_PER_SOL;
 
 /// Returns false if the CRDS value should be discarded.
 /// `direction` controls whether we are looking at


### PR DESCRIPTION
#### Problem
gossip ping gate is not necessary. all nodes are pinged regardless of their stake before they receive push messages/pull requests

#### Summary of Changes
Remove ping gate 

NOTE: this does not increase receive pings on staked nodes. See below:
<img width="1658" height="758" alt="Screenshot 2025-08-25 at 1 10 48 PM" src="https://github.com/user-attachments/assets/8b7f7917-c923-47c5-8eaa-49ee62310e64" />
^ data to left of vertical cursor line is w/ ping gate. everything to right of cursor line is w/o ping gate. 
