### PR TITLE
axe SignedData enum (ledger/ shred)

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -275,19 +275,6 @@ pub enum Shred {
     ShredData(ShredData),
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum SignedData {
-    MerkleRoot(Hash),
-}
-
-impl AsRef<[u8]> for SignedData {
-    fn as_ref(&self) -> &[u8] {
-        match self {
-            Self::MerkleRoot(root) => root.as_ref(),
-        }
-    }
-}
-
 /// Tuple which uniquely identifies a shred should it exists.
 #[derive(Clone, Copy, Eq, Debug, Hash, PartialEq)]
 pub struct ShredId(Slot, /*shred index:*/ u32, ShredType);
@@ -394,7 +381,7 @@ impl Shred {
     dispatch!(fn common_header(&self) -> &ShredCommonHeader);
     #[cfg(any(test, feature = "dev-context-only-utils"))]
     dispatch!(fn set_signature(&mut self, signature: Signature));
-    dispatch!(fn signed_data(&self) -> Result<SignedData, Error>);
+    dispatch!(fn signed_data(&self) -> Result<Hash, Error>);
 
     dispatch!(pub fn chained_merkle_root(&self) -> Result<Hash, Error>);
     dispatch!(pub(crate) fn retransmitter_signature(&self) -> Result<Signature, Error>);

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1313,7 +1313,7 @@ fn finish_erasure_batch(
 mod test {
     use {
         super::*,
-        crate::shred::{merkle_tree::get_proof_size, ShredFlags, ShredId, SignedData},
+        crate::shred::{merkle_tree::get_proof_size, ShredFlags, ShredId},
         assert_matches::assert_matches,
         itertools::Itertools,
         rand::{seq::SliceRandom, CryptoRng, Rng},
@@ -1769,7 +1769,7 @@ mod test {
                 chained_merkle_root
             );
             let data = shred::layout::get_signed_data(shred).unwrap();
-            assert_eq!(data, SignedData::MerkleRoot(merkle_root));
+            assert_eq!(data, merkle_root);
             assert!(signature.verify(pubkey.as_ref(), data.as_ref()));
         }
         // Verify common, data and coding headers.

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -4,9 +4,8 @@ use {
         merkle,
         payload::Payload,
         traits::{Shred, ShredCode as ShredCodeTrait},
-        CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
-        DATA_SHREDS_PER_FEC_BLOCK, MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT,
-        SIZE_OF_NONCE,
+        CodingShredHeader, Error, ShredCommonHeader, ShredType, DATA_SHREDS_PER_FEC_BLOCK,
+        MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
     },
     solana_hash::Hash,
     solana_packet::PACKET_DATA_SIZE,
@@ -34,10 +33,9 @@ impl ShredCode {
     #[cfg(any(test, feature = "dev-context-only-utils"))]
     dispatch!(pub(super) fn set_signature(&mut self, signature: Signature));
 
-    pub(super) fn signed_data(&self) -> Result<SignedData, Error> {
-        match self {
-            Self::Merkle(shred) => Ok(SignedData::MerkleRoot(shred.signed_data()?)),
-        }
+    pub(super) fn signed_data(&self) -> Result<Hash, Error> {
+        let Self::Merkle(shred) = self;
+        shred.signed_data()
     }
 
     pub(super) fn chained_merkle_root(&self) -> Result<Hash, Error> {

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -5,7 +5,7 @@ use {
         merkle,
         payload::Payload,
         traits::{Shred as _, ShredData as ShredDataTrait},
-        DataShredHeader, Error, ShredCommonHeader, ShredFlags, ShredType, ShredVariant, SignedData,
+        DataShredHeader, Error, ShredCommonHeader, ShredFlags, ShredType, ShredVariant,
         MAX_DATA_SHREDS_PER_SLOT,
     },
     solana_clock::Slot,
@@ -29,10 +29,9 @@ impl ShredData {
     #[cfg(any(test, feature = "dev-context-only-utils"))]
     dispatch!(pub(super) fn set_signature(&mut self, signature: Signature));
 
-    pub(super) fn signed_data(&self) -> Result<SignedData, Error> {
-        match self {
-            Self::Merkle(shred) => Ok(SignedData::MerkleRoot(shred.signed_data()?)),
-        }
+    pub(super) fn signed_data(&self) -> Result<Hash, Error> {
+        let Self::Merkle(shred) = self;
+        shred.signed_data()
     }
 
     pub(super) fn chained_merkle_root(&self) -> Result<Hash, Error> {

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::implicit_hasher)]
 use {
-    crate::shred::{self, SignedData, SIZE_OF_MERKLE_ROOT},
+    crate::shred::{self, SIZE_OF_MERKLE_ROOT},
     itertools::{izip, Itertools},
     rayon::{prelude::*, ThreadPool},
     solana_clock::Slot,
@@ -67,18 +67,15 @@ pub fn verify_shred_cpu(
     let Some(data) = shred::layout::get_signed_data(shred) else {
         return false;
     };
-    match data {
-        SignedData::MerkleRoot(root) => {
-            let key = (signature, *pubkey, root);
-            if cache.read().unwrap().get(&key).is_some() {
-                true
-            } else if key.0.verify(key.1.as_ref(), key.2.as_ref()) {
-                cache.write().unwrap().put(key, ());
-                true
-            } else {
-                false
-            }
-        }
+
+    let key = (signature, *pubkey, data);
+    if cache.read().unwrap().get(&key).is_some() {
+        true
+    } else if key.0.verify(key.1.as_ref(), key.2.as_ref()) {
+        cache.write().unwrap().put(key, ());
+        true
+    } else {
+        false
     }
 }
 


### PR DESCRIPTION
#### Problem
The SignedData enum isn't needed anymore after https://github.com/anza-xyz/agave/pull/7586 

#### Summary of Changes
As suggested [here](https://github.com/anza-xyz/agave/pull/7586#discussion_r2284828763) the SignedData enum has been removed. 