### PR TITLE
Make runtime accounts contiguous in memory

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -24,7 +24,7 @@ use {
         message_address_table_lookup::SVMMessageAddressTableLookup, svm_message::SVMMessage,
     },
     solana_transaction::sanitized::SanitizedTransaction,
-    solana_transaction_context::TransactionAccount,
+    solana_transaction_context::transaction_accounts::TransactionAccount,
     solana_transaction_error::TransactionResult as Result,
     std::{
         cmp::Reverse,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -32,8 +32,8 @@ use {
     solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMMessage},
     solana_svm_type_overrides::sync::Arc,
     solana_transaction_context::{
-        IndexOfAccount, InstructionAccount, TransactionAccount, TransactionContext,
-        MAX_ACCOUNTS_PER_TRANSACTION,
+        transaction_accounts::TransactionAccount, IndexOfAccount, InstructionAccount,
+        TransactionContext, MAX_ACCOUNTS_PER_TRANSACTION,
     },
     std::{
         alloc::Layout,
@@ -1338,7 +1338,7 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(
-            invoke_context.transaction_context.accounts_resize_delta(),
+            invoke_context.transaction_context.accounts().resize_delta(),
             resize_delta
         );
     }

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -13,14 +13,14 @@ use {
     solana_sdk_ids::bpf_loader_deprecated,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     solana_transaction_context::{
-        BorrowedAccount, IndexOfAccount, InstructionContext, MAX_ACCOUNTS_PER_INSTRUCTION,
+        BorrowedInstructionAccount, IndexOfAccount, InstructionContext, MAX_ACCOUNTS_PER_INSTRUCTION,
     },
     std::mem::{self, size_of},
 };
 
 /// Modifies the memory mapping in serialization and CPI return for stricter_abi_and_runtime_constraints
 pub fn modify_memory_region_of_account(
-    account: &mut BorrowedAccount<'_>,
+    account: &mut BorrowedInstructionAccount<'_>,
     region: &mut MemoryRegion,
 ) {
     region.len = account.get_data().len() as u64;
@@ -35,7 +35,7 @@ pub fn modify_memory_region_of_account(
 
 /// Creates the memory mapping in serialization and CPI return for account_data_direct_mapping
 pub fn create_memory_region_of_account(
-    account: &mut BorrowedAccount<'_>,
+    account: &mut BorrowedInstructionAccount<'_>,
     vaddr: u64,
 ) -> Result<MemoryRegion, InstructionError> {
     let can_data_be_changed = account.can_data_be_changed().is_ok();
@@ -52,7 +52,7 @@ pub fn create_memory_region_of_account(
 
 #[allow(dead_code)]
 enum SerializeAccount<'a> {
-    Account(IndexOfAccount, BorrowedAccount<'a>),
+    Account(IndexOfAccount, BorrowedInstructionAccount<'a>),
     Duplicate(IndexOfAccount),
 }
 
@@ -126,7 +126,7 @@ impl Serializer {
 
     fn write_account(
         &mut self,
-        account: &mut BorrowedAccount<'_>,
+        account: &mut BorrowedInstructionAccount<'_>,
     ) -> Result<u64, InstructionError> {
         if !self.stricter_abi_and_runtime_constraints {
             let vm_data_addr = self.vaddr.saturating_add(self.buffer.len() as u64);

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -13,7 +13,8 @@ use {
     solana_sdk_ids::bpf_loader_deprecated,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     solana_transaction_context::{
-        BorrowedInstructionAccount, IndexOfAccount, InstructionContext, MAX_ACCOUNTS_PER_INSTRUCTION,
+        BorrowedInstructionAccount, IndexOfAccount, InstructionContext,
+        MAX_ACCOUNTS_PER_INSTRUCTION,
     },
     std::mem::{self, size_of},
 };
@@ -1611,7 +1612,7 @@ mod tests {
                 .unwrap();
         }
         assert_eq!(
-            transaction_context.accounts_resize_delta(),
+            transaction_context.accounts().resize_delta(),
             MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION
                 - remaining_allowed_growth as i64,
         );

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -20,7 +20,7 @@ use {
     solana_svm_log_collector::{ic_logger_msg, LogCollector},
     solana_svm_measure::measure::Measure,
     solana_svm_type_overrides::sync::Arc,
-    solana_transaction_context::{BorrowedAccount, InstructionContext},
+    solana_transaction_context::{BorrowedInstructionAccount, InstructionContext},
     std::{cell::RefCell, rc::Rc},
 };
 
@@ -58,7 +58,7 @@ fn get_state_mut(data: &mut [u8]) -> Result<&mut LoaderV4State, InstructionError
 fn check_program_account(
     log_collector: &Option<Rc<RefCell<LogCollector>>>,
     instruction_context: &InstructionContext,
-    program: &BorrowedAccount,
+    program: &BorrowedInstructionAccount,
     authority_address: &Pubkey,
 ) -> Result<LoaderV4State, InstructionError> {
     if !loader_v4::check_id(program.get_owner()) {

--- a/programs/stake/src/config.rs
+++ b/programs/stake/src/config.rs
@@ -11,7 +11,7 @@ use {
     solana_config_interface::state::{get_config_data, ConfigKeys},
     solana_genesis_config::GenesisConfig,
     solana_pubkey::Pubkey,
-    solana_transaction_context::BorrowedAccount,
+    solana_transaction_context::BorrowedInstructionAccount,
 };
 
 #[allow(deprecated)]
@@ -31,7 +31,7 @@ fn create_config_account(
 }
 
 #[allow(deprecated)]
-pub fn from(account: &BorrowedAccount) -> Option<Config> {
+pub fn from(account: &BorrowedInstructionAccount) -> Option<Config> {
     get_config_data(account.get_data())
         .ok()
         .and_then(|data| deserialize(data).ok())

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -10,7 +10,7 @@ use {
     solana_svm_log_collector::ic_msg,
     solana_system_interface::error::SystemError,
     solana_sysvar::rent::Rent,
-    solana_transaction_context::{BorrowedAccount, IndexOfAccount, InstructionContext},
+    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContext},
     std::collections::HashSet,
 };
 
@@ -20,7 +20,7 @@ fn checked_add(a: u64, b: u64) -> Result<u64, InstructionError> {
 }
 
 pub fn advance_nonce_account(
-    account: &mut BorrowedAccount,
+    account: &mut BorrowedInstructionAccount,
     signers: &HashSet<Pubkey>,
     invoke_context: &InvokeContext,
 ) -> Result<(), InstructionError> {
@@ -154,7 +154,7 @@ pub(crate) fn withdraw_nonce_account(
 }
 
 pub(crate) fn initialize_nonce_account(
-    account: &mut BorrowedAccount,
+    account: &mut BorrowedInstructionAccount,
     nonce_authority: &Pubkey,
     rent: &Rent,
     invoke_context: &InvokeContext,
@@ -204,7 +204,7 @@ pub(crate) fn initialize_nonce_account(
 }
 
 pub(crate) fn authorize_nonce_account(
-    account: &mut BorrowedAccount,
+    account: &mut BorrowedInstructionAccount,
     nonce_authority: &Pubkey,
     signers: &HashSet<Pubkey>,
     invoke_context: &InvokeContext,

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -17,7 +17,7 @@ use {
     solana_system_interface::{
         error::SystemError, instruction::SystemInstruction, MAX_PERMITTED_DATA_LENGTH,
     },
-    solana_transaction_context::{BorrowedAccount, IndexOfAccount, InstructionContext},
+    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContext},
     std::collections::HashSet,
 };
 
@@ -70,7 +70,7 @@ impl Address {
 }
 
 fn allocate(
-    account: &mut BorrowedAccount,
+    account: &mut BorrowedInstructionAccount,
     address: &Address,
     space: u64,
     signers: &HashSet<Pubkey>,
@@ -112,7 +112,7 @@ fn allocate(
 }
 
 fn assign(
-    account: &mut BorrowedAccount,
+    account: &mut BorrowedInstructionAccount,
     address: &Address,
     owner: &Pubkey,
     signers: &HashSet<Pubkey>,
@@ -132,7 +132,7 @@ fn assign(
 }
 
 fn allocate_and_assign(
-    to: &mut BorrowedAccount,
+    to: &mut BorrowedInstructionAccount,
     to_address: &Address,
     space: u64,
     owner: &Pubkey,

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -14,7 +14,7 @@ use {
     solana_pubkey::Pubkey,
     solana_sdk_ids::sysvar,
     solana_slot_hashes::{SlotHashes, MAX_ENTRIES},
-    solana_transaction_context::TransactionAccount,
+    solana_transaction_context::transaction_accounts::TransactionAccount,
     solana_vote_program::{
         vote_instruction::VoteInstruction,
         vote_state::{

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -14,7 +14,7 @@ use {
     solana_rent::Rent,
     solana_sdk_ids::{sysvar, vote::id},
     solana_slot_hashes::{SlotHashes, MAX_ENTRIES},
-    solana_transaction_context::TransactionAccount,
+    solana_transaction_context::transaction_accounts::TransactionAccount,
     solana_vote_program::{
         vote_instruction::VoteInstruction,
         vote_processor::Entrypoint,

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -10,7 +10,7 @@ use {
         sysvar_cache::get_sysvar_with_account_check,
     },
     solana_pubkey::Pubkey,
-    solana_transaction_context::{BorrowedAccount, InstructionContext},
+    solana_transaction_context::{BorrowedInstructionAccount, InstructionContext},
     solana_vote_interface::{instruction::VoteInstruction, program::id, state::VoteAuthorize},
     std::collections::HashSet,
 };
@@ -18,7 +18,7 @@ use {
 fn process_authorize_with_seed_instruction(
     invoke_context: &InvokeContext,
     instruction_context: &InstructionContext,
-    vote_account: &mut BorrowedAccount,
+    vote_account: &mut BorrowedInstructionAccount,
     new_authority: &Pubkey,
     authorization_type: VoteAuthorize,
     current_authority_derived_key_owner: &Pubkey,

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -11,7 +11,7 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_slot_hashes::SlotHash,
-    solana_transaction_context::{BorrowedAccount, IndexOfAccount, InstructionContext},
+    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContext},
     solana_vote_interface::{error::VoteError, program::id},
     std::{
         cmp::Ordering,
@@ -32,7 +32,7 @@ pub fn to<T: WritableAccount>(versioned: &VoteStateVersions, account: &mut T) ->
 // Updates the vote account state with a new VoteStateV3 instance.  This is required temporarily during the
 // upgrade of vote account state from V1_14_11 to Current.
 fn set_vote_account_state(
-    vote_account: &mut BorrowedAccount,
+    vote_account: &mut BorrowedInstructionAccount,
     vote_state: VoteStateV3,
 ) -> Result<(), InstructionError> {
     // If the account is not large enough to store the vote state, then attempt a realloc to make it large enough.
@@ -681,7 +681,7 @@ pub fn process_slot_vote_unchecked(vote_state: &mut VoteStateV3, slot: Slot) {
 /// but will implicitly withdraw authorization from the previously authorized
 /// key
 pub fn authorize<S: std::hash::BuildHasher>(
-    vote_account: &mut BorrowedAccount,
+    vote_account: &mut BorrowedInstructionAccount,
     authorized: &Pubkey,
     vote_authorize: VoteAuthorize,
     signers: &HashSet<Pubkey, S>,
@@ -725,7 +725,7 @@ pub fn authorize<S: std::hash::BuildHasher>(
 
 /// Update the node_pubkey, requires signature of the authorized voter
 pub fn update_validator_identity<S: std::hash::BuildHasher>(
-    vote_account: &mut BorrowedAccount,
+    vote_account: &mut BorrowedInstructionAccount,
     node_pubkey: &Pubkey,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
@@ -746,7 +746,7 @@ pub fn update_validator_identity<S: std::hash::BuildHasher>(
 
 /// Update the vote account's commission
 pub fn update_commission<S: std::hash::BuildHasher>(
-    vote_account: &mut BorrowedAccount,
+    vote_account: &mut BorrowedInstructionAccount,
     commission: u8,
     signers: &HashSet<Pubkey, S>,
     epoch_schedule: &EpochSchedule,
@@ -867,7 +867,7 @@ pub fn withdraw<S: std::hash::BuildHasher>(
 /// Assumes that the account is being init as part of a account creation or balance transfer and
 /// that the transaction must be signed by the staker's keys
 pub fn initialize_account<S: std::hash::BuildHasher>(
-    vote_account: &mut BorrowedAccount,
+    vote_account: &mut BorrowedInstructionAccount,
     vote_init: &VoteInit,
     signers: &HashSet<Pubkey, S>,
     clock: &Clock,
@@ -888,7 +888,7 @@ pub fn initialize_account<S: std::hash::BuildHasher>(
 }
 
 fn verify_and_get_vote_state<S: std::hash::BuildHasher>(
-    vote_account: &BorrowedAccount,
+    vote_account: &BorrowedInstructionAccount,
     clock: &Clock,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<VoteStateV3, InstructionError> {
@@ -906,7 +906,7 @@ fn verify_and_get_vote_state<S: std::hash::BuildHasher>(
 }
 
 pub fn process_vote_with_account<S: std::hash::BuildHasher>(
-    vote_account: &mut BorrowedAccount,
+    vote_account: &mut BorrowedInstructionAccount,
     slot_hashes: &[SlotHash],
     clock: &Clock,
     vote: &Vote,
@@ -926,7 +926,7 @@ pub fn process_vote_with_account<S: std::hash::BuildHasher>(
 }
 
 pub fn process_vote_state_update<S: std::hash::BuildHasher>(
-    vote_account: &mut BorrowedAccount,
+    vote_account: &mut BorrowedInstructionAccount,
     slot_hashes: &[SlotHash],
     clock: &Clock,
     vote_state_update: VoteStateUpdate,
@@ -972,7 +972,7 @@ pub fn do_process_vote_state_update(
 }
 
 pub fn process_tower_sync<S: std::hash::BuildHasher>(
-    vote_account: &mut BorrowedAccount,
+    vote_account: &mut BorrowedInstructionAccount,
     slot_hashes: &[SlotHash],
     clock: &Clock,
     tower_sync: TowerSync,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -83,7 +83,7 @@ use {
         sanitized::{MessageHash, SanitizedTransaction, MAX_TX_ACCOUNT_LOCKS},
         versioned::VersionedTransaction,
     },
-    solana_transaction_context::TransactionAccount,
+    solana_transaction_context::transaction_accounts::TransactionAccount,
     solana_transaction_error::TransactionError,
     solana_transaction_status::{
         map_inner_instructions, BlockEncodingOptions, ConfirmedBlock,

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -11,7 +11,7 @@ use {
     },
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction::sanitized::SanitizedTransaction,
-    solana_transaction_context::TransactionAccount,
+    solana_transaction_context::transaction_accounts::TransactionAccount,
 };
 
 // Used to approximate how many accounts will be calculated for storage so that

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -157,7 +157,7 @@ use {
         versioned::VersionedTransaction,
         Transaction, TransactionVerificationMode,
     },
-    solana_transaction_context::{TransactionAccount, TransactionReturnData},
+    solana_transaction_context::{transaction_accounts::TransactionAccount, TransactionReturnData},
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     solana_vote::vote_account::{VoteAccount, VoteAccountsHashMap},
     std::{

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5359,7 +5359,7 @@ fn test_same_program_id_uses_unique_executable_accounts() {
         let instruction_context = transaction_context.get_current_instruction_context()?;
         let program_idx = instruction_context.get_index_of_program_account_in_transaction()?;
         let mut acc = transaction_context.accounts().try_borrow_mut(program_idx)?;
-        acc.set_data(vec![1, 2]);
+        acc.set_data_from_slice(&[1, 2]);
         Ok(())
     });
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -35,7 +35,7 @@ use {
     solana_svm_callback::{AccountState, TransactionProcessingCallback},
     solana_svm_feature_set::SVMFeatureSet,
     solana_svm_transaction::svm_message::SVMMessage,
-    solana_transaction_context::{IndexOfAccount, TransactionAccount},
+    solana_transaction_context::{transaction_accounts::TransactionAccount, IndexOfAccount},
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     std::num::{NonZeroU32, Saturating},
 };
@@ -843,7 +843,9 @@ mod tests {
         solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
         solana_system_transaction::transfer,
         solana_transaction::{sanitized::SanitizedTransaction, Transaction},
-        solana_transaction_context::{TransactionAccount, TransactionContext},
+        solana_transaction_context::{
+            transaction_accounts::TransactionAccount, TransactionContext,
+        },
         solana_transaction_error::{TransactionError, TransactionResult as Result},
         std::{
             borrow::Cow,

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -3,7 +3,7 @@ use {
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
-    solana_transaction_context::TransactionAccount,
+    solana_transaction_context::transaction_accounts::TransactionAccount,
 };
 
 /// Captured account state used to rollback account state for nonce and fee

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -1284,7 +1284,9 @@ mod tests {
             ebpf::MM_INPUT_START, memory_region::MemoryRegion, program::SBPFVersion, vm::Config,
         },
         solana_sdk_ids::system_program,
-        solana_transaction_context::{InstructionAccount, TransactionAccount},
+        solana_transaction_context::{
+            transaction_accounts::TransactionAccount, InstructionAccount,
+        },
         std::{
             cell::{Cell, RefCell},
             mem, ptr,

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -11,7 +11,7 @@ use {
     solana_stable_layout::stable_instruction::StableInstruction,
     solana_svm_measure::measure::Measure,
     solana_transaction_context::{
-        BorrowedAccount, MAX_ACCOUNTS_PER_INSTRUCTION, MAX_INSTRUCTION_DATA_LEN,
+        BorrowedInstructionAccount, MAX_ACCOUNTS_PER_INSTRUCTION, MAX_INSTRUCTION_DATA_LEN,
     },
     std::mem,
 };
@@ -1078,7 +1078,7 @@ fn cpi_common<S: SyscallInvokeSigned>(
 fn update_callee_account(
     check_aligned: bool,
     caller_account: &CallerAccount,
-    mut callee_account: BorrowedAccount<'_>,
+    mut callee_account: BorrowedInstructionAccount<'_>,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
 ) -> Result<bool, Error> {
@@ -1135,7 +1135,7 @@ fn update_caller_account_region(
     memory_mapping: &mut MemoryMapping,
     check_aligned: bool,
     caller_account: &CallerAccount,
-    callee_account: &mut BorrowedAccount<'_>,
+    callee_account: &mut BorrowedInstructionAccount<'_>,
     account_data_direct_mapping: bool,
 ) -> Result<(), Error> {
     let is_caller_loader_deprecated = !check_aligned;
@@ -1185,7 +1185,7 @@ fn update_caller_account(
     memory_mapping: &MemoryMapping<'_>,
     check_aligned: bool,
     caller_account: &mut CallerAccount<'_>,
-    callee_account: &mut BorrowedAccount<'_>,
+    callee_account: &mut BorrowedInstructionAccount<'_>,
     stricter_abi_and_runtime_constraints: bool,
 ) -> Result<(), Error> {
     *caller_account.lamports = callee_account.get_lamports();

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -747,7 +747,7 @@ impl<'a> InstructionContext<'a> {
     pub fn try_borrow_instruction_account(
         &self,
         index_in_instruction: IndexOfAccount,
-    ) -> Result<BorrowedAccount, InstructionError> {
+    ) -> Result<BorrowedInstructionAccount, InstructionError> {
         let instruction_account = *self
             .instruction_accounts
             .get(index_in_instruction as usize)
@@ -758,7 +758,7 @@ impl<'a> InstructionContext<'a> {
             .accounts
             .try_borrow_mut(instruction_account.index_in_transaction)?;
 
-        Ok(BorrowedAccount {
+        Ok(BorrowedInstructionAccount {
             transaction_context: self.transaction_context,
             instruction_account,
             account,
@@ -820,14 +820,14 @@ impl<'a> InstructionContext<'a> {
 
 /// Shared account borrowed from the TransactionContext and an InstructionContext.
 #[derive(Debug)]
-pub struct BorrowedAccount<'a> {
+pub struct BorrowedInstructionAccount<'a> {
     transaction_context: &'a TransactionContext,
     account: RefMut<'a, AccountSharedData>,
     instruction_account: InstructionAccount,
     index_in_transaction_of_instruction_program: IndexOfAccount,
 }
 
-impl BorrowedAccount<'_> {
+impl BorrowedInstructionAccount<'_> {
     /// Returns the index of this account (transaction wide)
     #[inline]
     pub fn get_index_in_transaction(&self) -> IndexOfAccount {

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -1,0 +1,127 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
+use {
+    crate::{IndexOfAccount, MAX_ACCOUNT_DATA_GROWTH_PER_TRANSACTION, MAX_ACCOUNT_DATA_LEN},
+    solana_account::AccountSharedData,
+    solana_instruction::error::InstructionError,
+    solana_pubkey::Pubkey,
+    std::cell::{Cell, Ref, RefCell, RefMut},
+};
+
+/// An account key and the matching account
+pub type TransactionAccount = (Pubkey, AccountSharedData);
+pub(crate) type OwnedTransactionAccounts = (
+    Vec<RefCell<AccountSharedData>>,
+    Box<[Cell<bool>]>,
+    Cell<i64>,
+);
+
+#[derive(Debug)]
+pub struct TransactionAccounts {
+    accounts: Vec<RefCell<AccountSharedData>>,
+    touched_flags: Box<[Cell<bool>]>,
+    resize_delta: Cell<i64>,
+    lamports_delta: Cell<i128>,
+}
+
+impl TransactionAccounts {
+    #[cfg(not(target_os = "solana"))]
+    pub(crate) fn new(accounts: Vec<RefCell<AccountSharedData>>) -> TransactionAccounts {
+        let touched_flags = vec![Cell::new(false); accounts.len()].into_boxed_slice();
+        TransactionAccounts {
+            accounts,
+            touched_flags,
+            resize_delta: Cell::new(0),
+            lamports_delta: Cell::new(0),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.accounts.len()
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    pub fn touch(&self, index: IndexOfAccount) -> Result<(), InstructionError> {
+        self.touched_flags
+            .get(index as usize)
+            .ok_or(InstructionError::NotEnoughAccountKeys)?
+            .set(true);
+        Ok(())
+    }
+
+    pub(crate) fn update_accounts_resize_delta(
+        &self,
+        old_len: usize,
+        new_len: usize,
+    ) -> Result<(), InstructionError> {
+        let accounts_resize_delta = self.resize_delta.get();
+        self.resize_delta.set(
+            accounts_resize_delta.saturating_add((new_len as i64).saturating_sub(old_len as i64)),
+        );
+        Ok(())
+    }
+
+    pub(crate) fn can_data_be_resized(
+        &self,
+        old_len: usize,
+        new_len: usize,
+    ) -> Result<(), InstructionError> {
+        // The new length can not exceed the maximum permitted length
+        if new_len > MAX_ACCOUNT_DATA_LEN as usize {
+            return Err(InstructionError::InvalidRealloc);
+        }
+        // The resize can not exceed the per-transaction maximum
+        let length_delta = (new_len as i64).saturating_sub(old_len as i64);
+        if self.resize_delta.get().saturating_add(length_delta)
+            > MAX_ACCOUNT_DATA_GROWTH_PER_TRANSACTION
+        {
+            return Err(InstructionError::MaxAccountsDataAllocationsExceeded);
+        }
+        Ok(())
+    }
+
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    pub(crate) fn try_borrow_mut(
+        &self,
+        index: IndexOfAccount,
+    ) -> Result<RefMut<'_, AccountSharedData>, InstructionError> {
+        self.accounts
+            .get(index as usize)
+            .ok_or(InstructionError::MissingAccount)?
+            .try_borrow_mut()
+            .map_err(|_| InstructionError::AccountBorrowFailed)
+    }
+
+    pub fn try_borrow(
+        &self,
+        index: IndexOfAccount,
+    ) -> Result<Ref<'_, AccountSharedData>, InstructionError> {
+        self.accounts
+            .get(index as usize)
+            .ok_or(InstructionError::MissingAccount)?
+            .try_borrow()
+            .map_err(|_| InstructionError::AccountBorrowFailed)
+    }
+
+    pub(crate) fn add_lamports_delta(&self, balance: i128) -> Result<(), InstructionError> {
+        let delta = self.lamports_delta.get();
+        self.lamports_delta.set(
+            delta
+                .checked_add(balance)
+                .ok_or(InstructionError::ArithmeticOverflow)?,
+        );
+        Ok(())
+    }
+
+    pub(crate) fn get_lamports_delta(&self) -> i128 {
+        self.lamports_delta.get()
+    }
+
+    pub(crate) fn take(self) -> OwnedTransactionAccounts {
+        (self.accounts, self.touched_flags, self.resize_delta)
+    }
+
+    pub fn resize_delta(&self) -> i64 {
+        self.resize_delta.get()
+    }
+}


### PR DESCRIPTION
#### Problem

In [SIMD-0177](https://github.com/solana-foundation/solana-improvement-documents/pull/177), we want the transaction accounts to be contiguous in memory so that they can be shared with programs.

Today, the accounts are not contiguous in a vector, since they are wrapped in a RefCell.

#### Summary of Changes

1. Rename `BorrowedAccount` to `BorrowedInstructionAccount` to clarify we are borrowing an instruction account.
2. Create a new file `transaction_accounts.rs` to hold everything related to transaction accounts.
3. Wrap the whole vector in a single UnsafeCell (this is done in two steps in this PR: First, use an unsafe cell per account. Second, use it only on the vector).
4. Create `AccountRef`, `AccountRefMut` and an internal borrow counter to emulate the behavior of RefCell. The implementation follows what Rust core lib does: https://doc.rust-lang.org/stable/src/core/cell.rs.html#1397-1433 and https://doc.rust-lang.org/stable/src/core/cell.rs.html#1791-1834.

I created both `AccountRef` and `AccountRefMut` to maintain the same existing behavior of permitting multiple immutable borrows, but a single exclusive mutable borrow. Changing that may affect consensus.
