### PR TITLE
Add obsolete account enum

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -297,7 +297,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     partitioned_epoch_rewards_config: DEFAULT_PARTITIONED_EPOCH_REWARDS_CONFIG,
     storage_access: StorageAccess::File,
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalTest,
-    mark_obsolete_accounts: false,
+    mark_obsolete_accounts: MarkObsoleteAccounts::Disabled,
     num_background_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
@@ -319,7 +319,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     partitioned_epoch_rewards_config: DEFAULT_PARTITIONED_EPOCH_REWARDS_CONFIG,
     storage_access: StorageAccess::File,
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormal,
-    mark_obsolete_accounts: false,
+    mark_obsolete_accounts: MarkObsoleteAccounts::Disabled,
     num_background_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
@@ -442,7 +442,7 @@ pub struct AccountsDbConfig {
     pub partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig,
     pub storage_access: StorageAccess,
     pub scan_filter_for_shrinking: ScanFilter,
-    pub mark_obsolete_accounts: bool,
+    pub mark_obsolete_accounts: MarkObsoleteAccounts,
     /// Number of threads for background operations (`thread_pool_background')
     pub num_background_threads: Option<NonZeroUsize>,
     /// Number of threads for foreground operations (`thread_pool_foreground`)
@@ -1208,6 +1208,16 @@ struct CleaningInfo {
     might_contain_zero_lamport_entry: bool,
 }
 
+/// Indicates when to mark accounts obsolete
+/// * Disabled - mark accounts obsolete during write cache flush
+/// * Enabled - do not mark accounts obsolete
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkObsoleteAccounts {
+    #[default]
+    Disabled,
+    Enabled,
+}
+
 /// This is the return type of AccountsDb::construct_candidate_clean_keys.
 /// It's a collection of pubkeys with associated information to
 /// facilitate the decision making about which accounts can be removed
@@ -1366,7 +1376,7 @@ pub struct AccountsDb {
     /// Flag to indicate if the experimental obsolete account tracking feature is enabled.
     /// This feature tracks obsolete accounts in the account storage entry allowing
     /// for earlier cleaning of obsolete accounts in the storages and index.
-    pub mark_obsolete_accounts: bool,
+    pub mark_obsolete_accounts: MarkObsoleteAccounts,
 }
 
 pub fn quarter_thread_count() -> usize {
@@ -5312,7 +5322,9 @@ impl AccountsDb {
             // should_flush_f is set to None when
             // 1) There's an ongoing scan to avoid reclaiming accounts being scanned.
             // 2) The slot is > max_clean_root to prevent unrooted slots from reclaiming rooted versions.
-            let reclaim_method = if self.mark_obsolete_accounts && should_flush_f.is_some() {
+            let reclaim_method = if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled
+                && should_flush_f.is_some()
+            {
                 UpsertReclaim::ReclaimOldSlots
             } else {
                 UpsertReclaim::IgnoreReclaims
@@ -5565,7 +5577,7 @@ impl AccountsDb {
                 })
         });
 
-        if self.mark_obsolete_accounts {
+        if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
             // If `mark_obsolete_accounts` is true, then none if the duplicate accounts were
             // included in the lt_hash, and do not need to be mixed out.
             // The duplicates_lt_hash should be the default value.
@@ -7073,7 +7085,7 @@ impl AccountsDb {
 
                 self.set_storage_count_and_alive_bytes(storage_info, &mut timings);
 
-                if self.mark_obsolete_accounts {
+                if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
                     let mut mark_obsolete_accounts_time =
                         Measure::start("mark_obsolete_accounts_time");
                     // Mark all reclaims at max_slot. This is safe because only the snapshot paths care about
@@ -7229,8 +7241,10 @@ impl AccountsDb {
         let mut num_duplicate_accounts = 0_u64;
         // With obsolete accounts, the duplicates_lt_hash should NOT be created.
         // And skip calculating the lt_hash from accounts too.
-        let mut duplicates_lt_hash =
-            (!self.mark_obsolete_accounts).then(|| Box::new(DuplicatesLtHash::default()));
+        let mut duplicates_lt_hash = match self.mark_obsolete_accounts {
+            MarkObsoleteAccounts::Disabled => Some(Box::new(DuplicatesLtHash::default())),
+            MarkObsoleteAccounts::Enabled => None,
+        };
         let mut lt_hash_time = Duration::default();
         self.accounts_index.scan(
             pubkeys.iter(),
@@ -7553,13 +7567,12 @@ impl AccountsDb {
     // and no longer need to be referenced. This leads to a static reference count
     // of 1. As referencing checking is common in tests, this test wrapper abstracts the behavior
     pub fn assert_ref_count(&self, pubkey: &Pubkey, expected_ref_count: RefCount) {
-        let expected_ref_count = if self.mark_obsolete_accounts {
-            // Account for the case where expected_ref_count is 0 by setting it to the minimum of
-            // current value or 1
-            expected_ref_count.min(1)
-        } else {
-            expected_ref_count
+        let expected_ref_count = match self.mark_obsolete_accounts {
+            // When obsolete accounts are marked, the ref count is always 1 or 0
+            MarkObsoleteAccounts::Enabled => expected_ref_count.min(1),
+            MarkObsoleteAccounts::Disabled => expected_ref_count,
         };
+
         assert_eq!(
             expected_ref_count,
             self.accounts_index.ref_count_from_storage(pubkey)

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1209,8 +1209,8 @@ struct CleaningInfo {
 }
 
 /// Indicates when to mark accounts obsolete
-/// * Disabled - mark accounts obsolete during write cache flush
-/// * Enabled - do not mark accounts obsolete
+/// * Disabled - do not mark accounts obsolete
+/// * Enabled - mark accounts obsolete during write cache flush
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MarkObsoleteAccounts {
     #[default]
@@ -7568,9 +7568,9 @@ impl AccountsDb {
     // of 1. As referencing checking is common in tests, this test wrapper abstracts the behavior
     pub fn assert_ref_count(&self, pubkey: &Pubkey, expected_ref_count: RefCount) {
         let expected_ref_count = match self.mark_obsolete_accounts {
+            MarkObsoleteAccounts::Disabled => expected_ref_count,
             // When obsolete accounts are marked, the ref count is always 1 or 0
             MarkObsoleteAccounts::Enabled => expected_ref_count.min(1),
-            MarkObsoleteAccounts::Disabled => expected_ref_count,
         };
 
         assert_eq!(

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6628,9 +6628,11 @@ fn test_mark_obsolete_accounts_at_startup_multiple_bins() {
 
 // This test verifies that when obsolete accounts are marked, the duplicates lt hash is set to the
 // default value. When they are not marked, it is populated. The second case ensures test validity.
-#[test_case(true; "mark_obsolete_accounts")]
-#[test_case(false; "do_not_mark_obsolete_accounts")]
-fn test_obsolete_accounts_empty_default_duplicate_hash(mark_obsolete_accounts: bool) {
+#[test_case(MarkObsoleteAccounts::Enabled)]
+#[test_case(MarkObsoleteAccounts::Disabled)]
+fn test_obsolete_accounts_empty_default_duplicate_hash(
+    mark_obsolete_accounts: MarkObsoleteAccounts,
+) {
     let slot0 = 0;
     let slot1 = 1;
 
@@ -6663,7 +6665,7 @@ fn test_obsolete_accounts_empty_default_duplicate_hash(mark_obsolete_accounts: b
 
     assert!(!db.accounts_index.contains(&pubkey));
     let result = db.generate_index(None, false);
-    if mark_obsolete_accounts {
+    if mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
         // If obsolete accounts are marked, the duplicates lt hash should be the default value
         // This is because all duplicates are marked as obsolete and skipped during lt hash calculation.
         assert_eq!(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -11,7 +11,7 @@ use {
     log::*,
     rand::{seq::SliceRandom, thread_rng},
     solana_accounts_db::{
-        accounts_db::{AccountShrinkThreshold, AccountsDbConfig},
+        accounts_db::{AccountShrinkThreshold, AccountsDbConfig, MarkObsoleteAccounts},
         accounts_file::StorageAccess,
         accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig, IndexLimitMb, ScanFilter},
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
@@ -414,7 +414,11 @@ pub fn execute(
         })
         .unwrap_or_default();
 
-    let mark_obsolete_accounts = matches.is_present("accounts_db_mark_obsolete_accounts");
+    let mark_obsolete_accounts = if matches.is_present("accounts_db_mark_obsolete_accounts") {
+        MarkObsoleteAccounts::Enabled
+    } else {
+        MarkObsoleteAccounts::Disabled
+    };
 
     let accounts_db_config = AccountsDbConfig {
         index: Some(accounts_index_config),
@@ -553,7 +557,7 @@ pub fn execute(
         UseSnapshotArchivesAtStartup
     );
 
-    if mark_obsolete_accounts
+    if mark_obsolete_accounts == MarkObsoleteAccounts::Enabled
         && use_snapshot_archives_at_startup != UseSnapshotArchivesAtStartup::Always
     {
         Err(format!(


### PR DESCRIPTION
#### Problem
Obsolete Accounts true/false is confusing in test_cases and matrixes

#### Summary of Changes
- Change it into an enum
- I should have done this a while ago

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
