### PR TITLE
apply new features at genesis

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -749,7 +749,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     }
 
     solana_stake_program::add_genesis_accounts(&mut genesis_config);
-    solana_runtime::genesis_utils::activate_all_features(&mut genesis_config);
+    solana_runtime::genesis_utils::add_all_feature_accounts(&mut genesis_config);
     if !features_to_deactivate.is_empty() {
         solana_runtime::genesis_utils::deactivate_features(
             &mut genesis_config,

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -638,7 +638,7 @@ mod tests {
             bank_forks::BankForks,
             commitment::{BlockCommitmentCache, CommitmentSlots},
             genesis_utils::{
-                activate_all_features, create_genesis_config,
+                add_all_feature_accounts, create_genesis_config,
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
             },
         },
@@ -871,7 +871,7 @@ mod tests {
             ..
         } = create_genesis_config(10_000_000_000);
         genesis_config.rent = Rent::default();
-        activate_all_features(&mut genesis_config);
+        add_all_feature_accounts(&mut genesis_config);
 
         let validator = Keypair::new();
         let voter = Keypair::new();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1154,6 +1154,7 @@ impl Bank {
 
         bank.finish_init(
             genesis_config,
+            ApplyFeatureActivationsCaller::NewWithPaths,
             additional_builtins,
             debug_do_not_add_builtins,
         );
@@ -1840,6 +1841,7 @@ impl Bank {
 
         bank.finish_init(
             genesis_config,
+            ApplyFeatureActivationsCaller::NewFromFields,
             additional_builtins,
             debug_do_not_add_builtins,
         );
@@ -4082,6 +4084,7 @@ impl Bank {
     fn finish_init(
         &mut self,
         genesis_config: &GenesisConfig,
+        caller: ApplyFeatureActivationsCaller,
         additional_builtins: Option<&[BuiltinPrototype]>,
         debug_do_not_add_builtins: bool,
     ) {
@@ -4093,10 +4096,7 @@ impl Bank {
         self.rewards_pool_pubkeys =
             Arc::new(genesis_config.rewards_pools.keys().cloned().collect());
 
-        self.apply_feature_activations(
-            ApplyFeatureActivationsCaller::FinishInit,
-            debug_do_not_add_builtins,
-        );
+        self.apply_feature_activations(caller, debug_do_not_add_builtins);
 
         // Cost-Tracker is not serialized in snapshot or any configs.
         // We must apply previously activated features related to limits here
@@ -5350,7 +5350,8 @@ impl Bank {
     ) {
         use ApplyFeatureActivationsCaller as Caller;
         let allow_new_activations = match caller {
-            Caller::FinishInit => false,
+            Caller::NewWithPaths => true,
+            Caller::NewFromFields => false,
             Caller::NewFromParent => true,
             Caller::WarpFromParent => false,
         };
@@ -6066,7 +6067,8 @@ fn calculate_data_size_delta(old_data_size: usize, new_data_size: usize) -> i64 
 /// those callers explicitly.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 enum ApplyFeatureActivationsCaller {
-    FinishInit,
+    NewWithPaths,
+    NewFromFields,
     NewFromParent,
     WarpFromParent,
 }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -404,7 +404,7 @@ pub(crate) mod tests {
                 create_genesis_config, create_simple_test_bank,
                 new_bank_from_parent_with_bank_forks,
             },
-            Bank,
+            ApplyFeatureActivationsCaller, Bank,
         },
         agave_feature_set::FeatureSet,
         assert_matches::assert_matches,
@@ -1452,7 +1452,12 @@ pub(crate) mod tests {
             .write()
             .unwrap()
             .clear();
-        bank.finish_init(&genesis_config, None, false);
+        bank.finish_init(
+            &genesis_config,
+            ApplyFeatureActivationsCaller::NewFromFields,
+            None,
+            false,
+        );
 
         // Assert the feature is active and the bank still added the builtin.
         assert!(bank.feature_set.is_active(feature_id));
@@ -1621,7 +1626,12 @@ pub(crate) mod tests {
             .write()
             .unwrap()
             .clear();
-        bank.finish_init(&genesis_config, None, false);
+        bank.finish_init(
+            &genesis_config,
+            crate::bank::ApplyFeatureActivationsCaller::NewFromFields,
+            None,
+            false,
+        );
 
         check_builtin_is_bpf(&bank);
     }

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -4,7 +4,7 @@ mod tests {
         crate::{
             bank::{test_utils as bank_test_utils, Bank},
             epoch_stakes::{EpochAuthorizedVoters, NodeIdToVoteAccounts, VersionedEpochStakes},
-            genesis_utils::activate_all_features,
+            genesis_utils::add_all_feature_accounts,
             runtime_config::RuntimeConfig,
             serde_snapshot::{self, ExtraFieldsToSerialize, SnapshotStreams},
             snapshot_bank_utils,
@@ -266,7 +266,7 @@ mod tests {
         solana_logger::setup();
 
         let (mut genesis_config, _) = create_genesis_config(500);
-        activate_all_features(&mut genesis_config);
+        add_all_feature_accounts(&mut genesis_config);
 
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);


### PR DESCRIPTION
#### Problem
Some feature gate activations require special one-time logic to run during activation but that logic doesn't get run for new development cluster genesis configs

#### Summary of Changes
Differentiate validator startup from genesis vs snapshot so that new feature activation logic can be run when starting from genesis.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
