### PR TITLE
Use explicit ReadWriteState for marking AppendVec as write/read-only

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -498,7 +498,9 @@ impl AppendVec {
         }
     }
 
-    /// Creates an appendvec from file without performing sanitize checks or counting the number of accounts
+    /// Creates an appendvec from existing file in read-only mode and without full data checks
+    ///
+    /// Validation of account data and counting the number of accounts is skipped.
     pub fn new_from_file_unchecked(
         path: impl Into<PathBuf>,
         current_len: usize,
@@ -508,6 +510,7 @@ impl AppendVec {
         let file_size = std::fs::metadata(&path)?.len();
         Self::sanitize_len_and_size(current_len, file_size as usize)?;
 
+        // AppendVec is in read-only mode, but mmap access requires file to be write-able
         let data = OpenOptions::new()
             .read(true)
             .write(storage_access == StorageAccess::Mmap)


### PR DESCRIPTION
#### Problem
There is no explicit marker whether `AppendVec` can be appended or should be read-only, except for used backing storage (mmap vs file), which might not convey the state if selected storage access is mmap or when we switch to file-io for appending in the future.

Also files are opened with write mode even if AppendVec is created for existing file (in file-io mode), which strips us from additional OS-level protection to not mutate existing storages.

#### Summary of Changes
* introduce `ReadWriteState` as field of `AppendVec`
* encapsulate `append_lock: Mutex<()>` to only be stored in `WriteAble` variant of `ReadWriteState`
* `new_from_file_unchecked` is creating `AppendVec` in read-only mode
* when `AppendVec` is created in read-only mode and storage access is File, open `File` with `write(false)`