### PR TITLE
Use impl instead of Box<dyn> for accounts-db large_file_buf_reader

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1717,7 +1717,7 @@ fn decompressed_tar_reader(
     archive_format: ArchiveFormat,
     archive_path: impl AsRef<Path>,
     buf_size: u64,
-) -> Result<ArchiveFormatDecompressor<Box<dyn BufRead + 'static>>> {
+) -> Result<ArchiveFormatDecompressor<impl BufRead>> {
     let buf_reader =
         solana_accounts_db::large_file_buf_reader(archive_path.as_ref(), buf_size as usize)
             .map_err(|err| {


### PR DESCRIPTION
#### Problem
On linux we require use io-uring, but `large_file_buf_reader` has a fallback, which forces it to return Box<dyn> of the `BufRead` trait. Since we can statically compile different impl for linux and non-linux, this is unnecessary overhead.

#### Summary of Changes
* assert io_uring is supported when on linux
* return `io::Result<impl BufRead>` instead of `io::Result<Box<dyn BufRead>>`
