### PR TITLE
Use cheaper PubkeyHasherBuilder for Hash containers used in accounts-db clean and reclaims algorithm

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -710,7 +710,7 @@ pub type AccountsFileId = u32;
 type AccountSlots = HashMap<Pubkey, IntSet<Slot>, PubkeyHasherBuilder>;
 type SlotOffsets = IntMap<Slot, IntSet<Offset>>;
 type ReclaimResult = (AccountSlots, SlotOffsets);
-type PubkeysRemovedFromAccountsIndex = HashSet<Pubkey, PubkeyHasherBuilder>;
+pub(crate) type PubkeysRemovedFromAccountsIndex = HashSet<Pubkey, PubkeyHasherBuilder>;
 type ShrinkCandidates = IntSet<Slot>;
 
 // Some hints for applicability of additional sanity checks for the do_load fast-path;
@@ -1668,7 +1668,7 @@ impl AccountsDb {
     fn clean_accounts_older_than_root(
         &self,
         reclaims: &SlotList<AccountInfo>,
-        pubkeys_removed_from_accounts_index: &HashSet<Pubkey>,
+        pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
     ) -> ReclaimResult {
         let mut measure = Measure::start("clean_old_root_reclaims");
 
@@ -2229,7 +2229,7 @@ impl AccountsDb {
         let useful_accum = AtomicU64::new(0);
         let reclaims: SlotList<AccountInfo> = Vec::with_capacity(num_candidates as usize);
         let reclaims = Mutex::new(reclaims);
-        let pubkeys_removed_from_accounts_index: PubkeysRemovedFromAccountsIndex = HashSet::new();
+        let pubkeys_removed_from_accounts_index = PubkeysRemovedFromAccountsIndex::default();
         let pubkeys_removed_from_accounts_index = Mutex::new(pubkeys_removed_from_accounts_index);
         // parallel scan the index.
         let do_clean_scan = || {
@@ -7154,7 +7154,7 @@ impl AccountsDb {
                 self.handle_reclaims(
                     (!reclaims.is_empty()).then(|| reclaims.iter()),
                     None,
-                    &HashSet::new(),
+                    &PubkeysRemovedFromAccountsIndex::default(),
                     HandleReclaims::ProcessDeadSlots(&stats),
                     MarkAccountsObsolete::Yes(slot_marked_obsolete),
                 );

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -710,7 +710,7 @@ pub type AccountsFileId = u32;
 type AccountSlots = HashMap<Pubkey, IntSet<Slot>, PubkeyHasherBuilder>;
 type SlotOffsets = IntMap<Slot, IntSet<Offset>>;
 type ReclaimResult = (AccountSlots, SlotOffsets);
-type PubkeysRemovedFromAccountsIndex = HashSet<Pubkey>;
+type PubkeysRemovedFromAccountsIndex = HashSet<Pubkey, PubkeyHasherBuilder>;
 type ShrinkCandidates = IntSet<Slot>;
 
 // Some hints for applicability of additional sanity checks for the do_load fast-path;

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -74,7 +74,7 @@ use {
     solana_lattice_hash::lt_hash::LtHash,
     solana_measure::{meas_dur, measure::Measure, measure_us},
     solana_nohash_hasher::{BuildNoHashHasher, IntMap, IntSet},
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_rayon_threadlimit::get_thread_count,
     solana_transaction::sanitized::SanitizedTransaction,
     std::{
@@ -707,7 +707,7 @@ impl<'a> MultiThreadProgress<'a> {
 pub type AtomicAccountsFileId = AtomicU32;
 pub type AccountsFileId = u32;
 
-type AccountSlots = HashMap<Pubkey, IntSet<Slot>>;
+type AccountSlots = HashMap<Pubkey, IntSet<Slot>, PubkeyHasherBuilder>;
 type SlotOffsets = IntMap<Slot, IntSet<Offset>>;
 type ReclaimResult = (AccountSlots, SlotOffsets);
 type PubkeysRemovedFromAccountsIndex = HashSet<Pubkey>;

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1095,7 +1095,11 @@ fn test_clean_dead_slot_with_obsolete_accounts() {
     old_storage.mark_accounts_obsolete(vec![(0, 1)].into_iter(), 2);
 
     // Unreference pubkey, which would occur during the normal mark_accounts_obsolete flow
-    accounts.unref_pubkeys([pubkey].iter(), 1, &HashSet::new());
+    accounts.unref_pubkeys(
+        [pubkey].iter(),
+        1,
+        &PubkeysRemovedFromAccountsIndex::default(),
+    );
 
     // Pubkey1 should now have two references: Slot0 and Slot2.
     accounts.assert_ref_count(&pubkey, 2);

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -5,6 +5,7 @@ mod roots_tracker;
 mod secondary;
 use {
     crate::{
+        accounts_db::PubkeysRemovedFromAccountsIndex,
         accounts_index_storage::{AccountsIndexStorage, Startup},
         ancestors::Ancestors,
         bucket_map_holder::Age,
@@ -874,8 +875,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         &self,
         dead_keys: &[&Pubkey],
         account_indexes: &AccountSecondaryIndexes,
-    ) -> HashSet<Pubkey> {
-        let mut pubkeys_removed_from_accounts_index = HashSet::default();
+    ) -> PubkeysRemovedFromAccountsIndex {
+        let mut pubkeys_removed_from_accounts_index = PubkeysRemovedFromAccountsIndex::default();
         if !dead_keys.is_empty() {
             for key in dead_keys.iter() {
                 let w_index = self.get_bin(key);
@@ -4046,7 +4047,9 @@ pub mod tests {
 
         assert_eq!(
             index.handle_dead_keys(&[&key], &AccountSecondaryIndexes::default()),
-            vec![key].into_iter().collect::<HashSet<_>>()
+            [key]
+                .into_iter()
+                .collect::<PubkeysRemovedFromAccountsIndex>()
         );
     }
 


### PR DESCRIPTION
#### Problem

Accounts-db uses default hash containers for pubkey hashing in reclaim and clean algorithms. The default hasher (RandomState) is more expensive but provides better defense against collision attacks through randomization. However, in the accounts-db clean and reclaim algorithms, collision attacks are not a relevant threat since these are internal operations on trusted data.

#### Summary of Changes

Optimize hasher usage for hash containers in accounts-db reclaim and clean algorithms.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
