### PR TITLE
Refactors generate_index()'s verify pass

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6745,350 +6745,327 @@ impl AccountsDb {
         let zero_lamport_pubkeys = Mutex::new(HashSet::new());
         let total_lt_hash = Mutex::new(LtHash::identity());
 
-        // pass == 0 always runs and generates the index
-        // pass == 1 only runs if verify == true.
-        // verify checks that all the expected items are in the accounts index and measures how long it takes to look them all up
-        let passes = if verify { 2 } else { 1 };
-        for pass in 0..passes {
-            if pass == 0 {
-                self.accounts_index
-                    .set_startup(Startup::StartupWithExtraThreads);
-            }
-            let storage_info = StorageSizeAndCountMap::default();
-            let total_processed_slots_across_all_threads = AtomicU64::new(0);
-            let outer_slots_len = storages.len();
-            let threads = num_cpus::get();
-            let chunk_size = (outer_slots_len / (std::cmp::max(1, threads.saturating_sub(1)))) + 1; // approximately 400k slots in a snapshot
-            let mut index_time = Measure::start("index");
-            let insertion_time_us = AtomicU64::new(0);
-            let total_including_duplicates = AtomicU64::new(0);
-            let all_accounts_are_zero_lamports_slots = AtomicU64::new(0);
-            let mut all_zeros_slots = Mutex::new(Vec::<(Slot, Arc<AccountStorageEntry>)>::new());
-            let scan_time: u64 = storages
-                .par_chunks(chunk_size)
-                .map(|storages| {
-                    let mut reader = append_vec::new_scan_accounts_reader();
-                    let mut log_status = MultiThreadProgress::new(
-                        &total_processed_slots_across_all_threads,
-                        2,
-                        outer_slots_len as u64,
-                    );
-                    let mut scan_time_sum = 0;
-                    let mut all_accounts_are_zero_lamports_slots_inner = 0;
-                    let mut all_zeros_slots_inner = vec![];
-                    let mut local_zero_lamport_pubkeys = Vec::new();
-                    let mut insert_time_sum = 0;
-                    let mut total_including_duplicates_sum = 0;
-                    let mut accounts_data_len_sum = 0;
-                    let mut local_num_did_not_exist = 0;
-                    let mut local_num_existed_in_mem = 0;
-                    let mut local_num_existed_on_disk = 0;
-                    let mut local_lt_hash = LtHash::identity();
-                    for (index, storage) in storages.iter().enumerate() {
-                        let mut scan_time = Measure::start("scan");
-                        log_status.report(index as u64);
-                        let store_id = storage.id();
-                        let slot = storage.slot();
+        self.accounts_index
+            .set_startup(Startup::StartupWithExtraThreads);
+        let storage_info = StorageSizeAndCountMap::default();
+        let total_processed_slots_across_all_threads = AtomicU64::new(0);
+        let outer_slots_len = storages.len();
+        let threads = num_cpus::get();
+        let chunk_size = (outer_slots_len / (std::cmp::max(1, threads.saturating_sub(1)))) + 1; // approximately 400k slots in a snapshot
+        let mut index_time = Measure::start("index");
+        let insertion_time_us = AtomicU64::new(0);
+        let total_including_duplicates = AtomicU64::new(0);
+        let all_accounts_are_zero_lamports_slots = AtomicU64::new(0);
+        let mut all_zeros_slots = Mutex::new(Vec::<(Slot, Arc<AccountStorageEntry>)>::new());
+        let scan_time: u64 = storages
+            .par_chunks(chunk_size)
+            .map(|storages| {
+                let mut reader = append_vec::new_scan_accounts_reader();
+                let mut log_status = MultiThreadProgress::new(
+                    &total_processed_slots_across_all_threads,
+                    2,
+                    outer_slots_len as u64,
+                );
+                let mut scan_time_sum = 0;
+                let mut all_accounts_are_zero_lamports_slots_inner = 0;
+                let mut all_zeros_slots_inner = vec![];
+                let mut local_zero_lamport_pubkeys = Vec::new();
+                let mut insert_time_sum = 0;
+                let mut total_including_duplicates_sum = 0;
+                let mut accounts_data_len_sum = 0;
+                let mut local_num_did_not_exist = 0;
+                let mut local_num_existed_in_mem = 0;
+                let mut local_num_existed_on_disk = 0;
+                let mut local_lt_hash = LtHash::identity();
+                for (index, storage) in storages.iter().enumerate() {
+                    let mut scan_time = Measure::start("scan");
+                    log_status.report(index as u64);
+                    let store_id = storage.id();
+                    let slot = storage.slot();
 
-                        scan_time.stop();
-                        scan_time_sum += scan_time.as_us();
+                    scan_time.stop();
+                    scan_time_sum += scan_time.as_us();
 
-                        let insert_us = if pass == 0 {
-                            // generate index
-                            self.maybe_throttle_index_generation();
-                            let SlotIndexGenerationInfo {
-                                insert_time_us: insert_us,
-                                num_accounts: total_this_slot,
-                                accounts_data_len: accounts_data_len_this_slot,
-                                zero_lamport_pubkeys: mut zero_lamport_pubkeys_this_slot,
-                                all_accounts_are_zero_lamports,
-                                num_did_not_exist,
-                                num_existed_in_mem,
-                                num_existed_on_disk,
-                                slot_lt_hash,
-                            } = self.generate_index_for_slot(
-                                &mut reader,
-                                storage,
-                                slot,
-                                store_id,
-                                &storage_info,
-                            );
+                    let insert_us = {
+                        // generate index
+                        self.maybe_throttle_index_generation();
+                        let SlotIndexGenerationInfo {
+                            insert_time_us: insert_us,
+                            num_accounts: total_this_slot,
+                            accounts_data_len: accounts_data_len_this_slot,
+                            zero_lamport_pubkeys: mut zero_lamport_pubkeys_this_slot,
+                            all_accounts_are_zero_lamports,
+                            num_did_not_exist,
+                            num_existed_in_mem,
+                            num_existed_on_disk,
+                            slot_lt_hash,
+                        } = self.generate_index_for_slot(
+                            &mut reader,
+                            storage,
+                            slot,
+                            store_id,
+                            &storage_info,
+                        );
 
-                            local_num_did_not_exist += num_did_not_exist;
-                            local_num_existed_in_mem += num_existed_in_mem;
-                            local_num_existed_on_disk += num_existed_on_disk;
-                            total_including_duplicates_sum += total_this_slot;
-                            accounts_data_len_sum += accounts_data_len_this_slot;
-                            if all_accounts_are_zero_lamports {
-                                all_accounts_are_zero_lamports_slots_inner += 1;
-                                all_zeros_slots_inner.push((slot, Arc::clone(storage)));
+                        local_num_did_not_exist += num_did_not_exist;
+                        local_num_existed_in_mem += num_existed_in_mem;
+                        local_num_existed_on_disk += num_existed_on_disk;
+                        total_including_duplicates_sum += total_this_slot;
+                        accounts_data_len_sum += accounts_data_len_this_slot;
+                        if all_accounts_are_zero_lamports {
+                            all_accounts_are_zero_lamports_slots_inner += 1;
+                            all_zeros_slots_inner.push((slot, Arc::clone(storage)));
+                        }
+                        local_zero_lamport_pubkeys.append(&mut zero_lamport_pubkeys_this_slot);
+                        local_lt_hash.mix_in(&slot_lt_hash.0);
+
+                        insert_us
+                    };
+
+                    insert_time_sum += insert_us;
+                }
+
+                let mut zero_lamport_pubkeys_lock = zero_lamport_pubkeys.lock().unwrap();
+                zero_lamport_pubkeys_lock.reserve(local_zero_lamport_pubkeys.len());
+                zero_lamport_pubkeys_lock.extend(local_zero_lamport_pubkeys);
+                drop(zero_lamport_pubkeys_lock);
+
+                total_lt_hash.lock().unwrap().mix_in(&local_lt_hash);
+
+                // This thread has finished processing its chunk of slots.
+                // Update the index stats now.
+                let index_stats = self.accounts_index.bucket_map_holder_stats();
+
+                // stats for inserted entries that previously did *not* exist
+                index_stats.inc_insert_count(local_num_did_not_exist);
+                index_stats.add_mem_count(local_num_did_not_exist as usize);
+
+                // stats for inserted entries that previous did exist *in-mem*
+                index_stats
+                    .entries_from_mem
+                    .fetch_add(local_num_existed_in_mem, Ordering::Relaxed);
+                index_stats
+                    .updates_in_mem
+                    .fetch_add(local_num_existed_in_mem, Ordering::Relaxed);
+
+                // stats for inserted entries that previously did exist *on-disk*
+                index_stats.add_mem_count(local_num_existed_on_disk as usize);
+                index_stats
+                    .entries_missing
+                    .fetch_add(local_num_existed_on_disk, Ordering::Relaxed);
+                index_stats
+                    .updates_in_mem
+                    .fetch_add(local_num_existed_on_disk, Ordering::Relaxed);
+
+                all_accounts_are_zero_lamports_slots.fetch_add(
+                    all_accounts_are_zero_lamports_slots_inner,
+                    Ordering::Relaxed,
+                );
+                all_zeros_slots
+                    .lock()
+                    .unwrap()
+                    .append(&mut all_zeros_slots_inner);
+                insertion_time_us.fetch_add(insert_time_sum, Ordering::Relaxed);
+                total_including_duplicates
+                    .fetch_add(total_including_duplicates_sum, Ordering::Relaxed);
+                accounts_data_len.fetch_add(accounts_data_len_sum, Ordering::Relaxed);
+                scan_time_sum
+            })
+            .sum();
+        index_time.stop();
+
+        if verify {
+            info!("Verifying index...");
+            let start = Instant::now();
+            storages.par_iter().for_each(|storage| {
+                let store_id = storage.id();
+                let slot = storage.slot();
+                storage
+                    .accounts
+                    .scan_accounts_without_data(|offset, account| {
+                        let key = account.pubkey();
+                        let index_entry = self.accounts_index.get_cloned(key).unwrap();
+                        let slot_list = index_entry.slot_list.read().unwrap();
+                        let mut count = 0;
+                        for (slot2, account_info2) in slot_list.iter() {
+                            if *slot2 == slot {
+                                count += 1;
+                                let ai = AccountInfo::new(
+                                    StorageLocation::AppendVec(store_id, offset), // will never be cached
+                                    account.is_zero_lamport(),
+                                );
+                                assert_eq!(&ai, account_info2);
                             }
-                            local_zero_lamport_pubkeys.append(&mut zero_lamport_pubkeys_this_slot);
-                            local_lt_hash.mix_in(&slot_lt_hash.0);
+                        }
+                        assert_eq!(1, count);
+                    })
+                    .expect("must scan accounts storage");
+            });
+            info!("Verifying index... Done in {:?}", start.elapsed());
+        }
 
-                            insert_us
-                        } else {
-                            // verify index matches expected and measure the time to get all items
-                            assert!(verify);
-                            let mut lookup_time = Measure::start("lookup_time");
-                            storage
-                                .accounts
-                                .scan_accounts_without_data(|offset, account| {
-                                    let key = account.pubkey();
-                                    let index_entry = self.accounts_index.get_cloned(key).unwrap();
-                                    let slot_list = index_entry.slot_list.read().unwrap();
-                                    let mut count = 0;
-                                    for (slot2, account_info2) in slot_list.iter() {
-                                        if *slot2 == slot {
-                                            count += 1;
-                                            let ai = AccountInfo::new(
-                                                StorageLocation::AppendVec(store_id, offset), // will never be cached
-                                                account.is_zero_lamport(),
-                                            );
-                                            assert_eq!(&ai, account_info2);
-                                        }
-                                    }
-                                    assert_eq!(1, count);
-                                })
-                                .expect("must scan accounts storage");
-                            lookup_time.stop();
-                            lookup_time.as_us()
-                        };
-                        insert_time_sum += insert_us;
+        let total_duplicate_slot_keys = AtomicU64::default();
+        let total_num_unique_duplicate_keys = AtomicU64::default();
+
+        // outer vec is accounts index bin (determined by pubkey value)
+        // inner vec is the pubkeys within that bin that are present in > 1 slot
+        let unique_pubkeys_by_bin = Mutex::new(Vec::<Vec<Pubkey>>::default());
+        // tell accounts index we are done adding the initial accounts at startup
+        let mut m = Measure::start("accounts_index_idle_us");
+        self.accounts_index.set_startup(Startup::Normal);
+        m.stop();
+        let index_flush_us = m.as_us();
+
+        let populate_duplicate_keys_us = measure_us!({
+            // this has to happen before visit_duplicate_pubkeys_during_startup below
+            // get duplicate keys from acct idx. We have to wait until we've finished flushing.
+            self.accounts_index
+                .populate_and_retrieve_duplicate_keys_from_startup(|slot_keys| {
+                    total_duplicate_slot_keys.fetch_add(slot_keys.len() as u64, Ordering::Relaxed);
+                    let unique_keys =
+                        HashSet::<Pubkey>::from_iter(slot_keys.iter().map(|(_, key)| *key));
+                    for (slot, key) in slot_keys {
+                        self.uncleaned_pubkeys.entry(slot).or_default().push(key);
                     }
-
-                    if pass == 0 {
-                        let mut zero_lamport_pubkeys_lock = zero_lamport_pubkeys.lock().unwrap();
-                        zero_lamport_pubkeys_lock.reserve(local_zero_lamport_pubkeys.len());
-                        zero_lamport_pubkeys_lock.extend(local_zero_lamport_pubkeys.into_iter());
-                        drop(zero_lamport_pubkeys_lock);
-
-                        total_lt_hash.lock().unwrap().mix_in(&local_lt_hash);
-
-                        // This thread has finished processing its chunk of slots.
-                        // Update the index stats now.
-                        let index_stats = self.accounts_index.bucket_map_holder_stats();
-
-                        // stats for inserted entries that previously did *not* exist
-                        index_stats.inc_insert_count(local_num_did_not_exist);
-                        index_stats.add_mem_count(local_num_did_not_exist as usize);
-
-                        // stats for inserted entries that previous did exist *in-mem*
-                        index_stats
-                            .entries_from_mem
-                            .fetch_add(local_num_existed_in_mem, Ordering::Relaxed);
-                        index_stats
-                            .updates_in_mem
-                            .fetch_add(local_num_existed_in_mem, Ordering::Relaxed);
-
-                        // stats for inserted entries that previously did exist *on-disk*
-                        index_stats.add_mem_count(local_num_existed_on_disk as usize);
-                        index_stats
-                            .entries_missing
-                            .fetch_add(local_num_existed_on_disk, Ordering::Relaxed);
-                        index_stats
-                            .updates_in_mem
-                            .fetch_add(local_num_existed_on_disk, Ordering::Relaxed);
-                    }
-
-                    all_accounts_are_zero_lamports_slots.fetch_add(
-                        all_accounts_are_zero_lamports_slots_inner,
-                        Ordering::Relaxed,
-                    );
-                    all_zeros_slots
+                    let unique_pubkeys_by_bin_inner = unique_keys.into_iter().collect::<Vec<_>>();
+                    total_num_unique_duplicate_keys
+                        .fetch_add(unique_pubkeys_by_bin_inner.len() as u64, Ordering::Relaxed);
+                    // does not matter that this is not ordered by slot
+                    unique_pubkeys_by_bin
                         .lock()
                         .unwrap()
-                        .append(&mut all_zeros_slots_inner);
-                    insertion_time_us.fetch_add(insert_time_sum, Ordering::Relaxed);
-                    total_including_duplicates
-                        .fetch_add(total_including_duplicates_sum, Ordering::Relaxed);
-                    accounts_data_len.fetch_add(accounts_data_len_sum, Ordering::Relaxed);
-                    scan_time_sum
-                })
-                .sum();
-            index_time.stop();
+                        .push(unique_pubkeys_by_bin_inner);
+                });
+        })
+        .1;
+        let unique_pubkeys_by_bin = unique_pubkeys_by_bin.into_inner().unwrap();
 
-            let mut index_flush_us = 0;
-            let total_duplicate_slot_keys = AtomicU64::default();
-            let mut populate_duplicate_keys_us = 0;
-            let total_num_unique_duplicate_keys = AtomicU64::default();
+        let mut timings = GenerateIndexTimings {
+            index_flush_us,
+            scan_time,
+            index_time: index_time.as_us(),
+            insertion_time_us: insertion_time_us.load(Ordering::Relaxed),
+            total_duplicate_slot_keys: total_duplicate_slot_keys.load(Ordering::Relaxed),
+            total_num_unique_duplicate_keys: total_num_unique_duplicate_keys
+                .load(Ordering::Relaxed),
+            populate_duplicate_keys_us,
+            total_including_duplicates: total_including_duplicates.load(Ordering::Relaxed),
+            total_slots: storages.len() as u64,
+            all_accounts_are_zero_lamports_slots: all_accounts_are_zero_lamports_slots
+                .load(Ordering::Relaxed),
+            ..GenerateIndexTimings::default()
+        };
 
-            // outer vec is accounts index bin (determined by pubkey value)
-            // inner vec is the pubkeys within that bin that are present in > 1 slot
-            let unique_pubkeys_by_bin = Mutex::new(Vec::<Vec<Pubkey>>::default());
-            if pass == 0 {
-                // tell accounts index we are done adding the initial accounts at startup
-                let mut m = Measure::start("accounts_index_idle_us");
-                self.accounts_index.set_startup(Startup::Normal);
-                m.stop();
-                index_flush_us = m.as_us();
-
-                populate_duplicate_keys_us = measure_us!({
-                    // this has to happen before visit_duplicate_pubkeys_during_startup below
-                    // get duplicate keys from acct idx. We have to wait until we've finished flushing.
-                    self.accounts_index
-                        .populate_and_retrieve_duplicate_keys_from_startup(|slot_keys| {
-                            total_duplicate_slot_keys
-                                .fetch_add(slot_keys.len() as u64, Ordering::Relaxed);
-                            let unique_keys =
-                                HashSet::<Pubkey>::from_iter(slot_keys.iter().map(|(_, key)| *key));
-                            for (slot, key) in slot_keys {
-                                self.uncleaned_pubkeys.entry(slot).or_default().push(key);
-                            }
-                            let unique_pubkeys_by_bin_inner =
-                                unique_keys.into_iter().collect::<Vec<_>>();
-                            total_num_unique_duplicate_keys.fetch_add(
-                                unique_pubkeys_by_bin_inner.len() as u64,
-                                Ordering::Relaxed,
-                            );
-                            // does not matter that this is not ordered by slot
-                            unique_pubkeys_by_bin
-                                .lock()
-                                .unwrap()
-                                .push(unique_pubkeys_by_bin_inner);
-                        });
-                })
-                .1;
-            }
-            let unique_pubkeys_by_bin = unique_pubkeys_by_bin.into_inner().unwrap();
-
-            let mut timings = GenerateIndexTimings {
-                index_flush_us,
-                scan_time,
-                index_time: index_time.as_us(),
-                insertion_time_us: insertion_time_us.load(Ordering::Relaxed),
-                total_duplicate_slot_keys: total_duplicate_slot_keys.load(Ordering::Relaxed),
-                total_num_unique_duplicate_keys: total_num_unique_duplicate_keys
-                    .load(Ordering::Relaxed),
-                populate_duplicate_keys_us,
-                total_including_duplicates: total_including_duplicates.load(Ordering::Relaxed),
-                total_slots: storages.len() as u64,
-                all_accounts_are_zero_lamports_slots: all_accounts_are_zero_lamports_slots
-                    .load(Ordering::Relaxed),
-                ..GenerateIndexTimings::default()
-            };
-
-            if pass == 0 {
-                #[derive(Debug, Default)]
-                struct DuplicatePubkeysVisitedInfo {
-                    accounts_data_len_from_duplicates: u64,
-                    num_duplicate_accounts: u64,
-                    duplicates_lt_hash: Box<DuplicatesLtHash>,
-                }
-                impl DuplicatePubkeysVisitedInfo {
-                    fn reduce(mut self, other: Self) -> Self {
-                        self.accounts_data_len_from_duplicates +=
-                            other.accounts_data_len_from_duplicates;
-                        self.num_duplicate_accounts += other.num_duplicate_accounts;
-                        self.duplicates_lt_hash
-                            .0
-                            .mix_in(&other.duplicates_lt_hash.0);
-                        self
-                    }
-                }
-
-                let zero_lamport_pubkeys_to_visit =
-                    std::mem::take(&mut *zero_lamport_pubkeys.lock().unwrap());
-                let (num_zero_lamport_single_refs, visit_zero_lamports_us) =
-                    measure_us!(self
-                        .visit_zero_lamport_pubkeys_during_startup(&zero_lamport_pubkeys_to_visit));
-                timings.visit_zero_lamports_us = visit_zero_lamports_us;
-                timings.num_zero_lamport_single_refs = num_zero_lamport_single_refs;
-
-                // subtract data.len() from accounts_data_len for all old accounts that are in the index twice
-                let mut accounts_data_len_dedup_timer =
-                    Measure::start("handle accounts data len duplicates");
-                let DuplicatePubkeysVisitedInfo {
-                    accounts_data_len_from_duplicates,
-                    num_duplicate_accounts,
-                    duplicates_lt_hash,
-                } = unique_pubkeys_by_bin
-                    .par_iter()
-                    .fold(
-                        DuplicatePubkeysVisitedInfo::default,
-                        |accum, pubkeys_by_bin| {
-                            let intermediate = pubkeys_by_bin
-                                .par_chunks(4096)
-                                .fold(DuplicatePubkeysVisitedInfo::default, |accum, pubkeys| {
-                                    let (
-                                        accounts_data_len_from_duplicates,
-                                        accounts_duplicates_num,
-                                        duplicates_lt_hash,
-                                    ) = self
-                                        .visit_duplicate_pubkeys_during_startup(pubkeys, &timings);
-                                    let intermediate = DuplicatePubkeysVisitedInfo {
-                                        accounts_data_len_from_duplicates,
-                                        num_duplicate_accounts: accounts_duplicates_num,
-                                        duplicates_lt_hash,
-                                    };
-                                    DuplicatePubkeysVisitedInfo::reduce(accum, intermediate)
-                                })
-                                .reduce(
-                                    DuplicatePubkeysVisitedInfo::default,
-                                    DuplicatePubkeysVisitedInfo::reduce,
-                                );
-                            DuplicatePubkeysVisitedInfo::reduce(accum, intermediate)
-                        },
-                    )
-                    .reduce(
-                        DuplicatePubkeysVisitedInfo::default,
-                        DuplicatePubkeysVisitedInfo::reduce,
-                    );
-                accounts_data_len_dedup_timer.stop();
-                timings.accounts_data_len_dedup_time_us = accounts_data_len_dedup_timer.as_us();
-                timings.num_duplicate_accounts = num_duplicate_accounts;
-
-                total_lt_hash.lock().unwrap().mix_out(&duplicates_lt_hash.0);
-                accounts_data_len.fetch_sub(accounts_data_len_from_duplicates, Ordering::Relaxed);
-                info!(
-                    "accounts data len: {}",
-                    accounts_data_len.load(Ordering::Relaxed)
-                );
-
-                // insert all zero lamport account storage into the dirty stores and add them into the uncleaned roots for clean to pick up
-                let all_zero_slots_to_clean = std::mem::take(all_zeros_slots.get_mut().unwrap());
-                info!(
-                    "insert all zero slots to clean at startup {}",
-                    all_zero_slots_to_clean.len()
-                );
-                for (slot, storage) in all_zero_slots_to_clean {
-                    self.dirty_stores.insert(slot, storage);
-                }
-            }
-
-            if pass == 0 {
-                // Need to add these last, otherwise older updates will be cleaned
-                for storage in &storages {
-                    self.accounts_index.add_root(storage.slot());
-                }
-
-                self.set_storage_count_and_alive_bytes(storage_info, &mut timings);
-
-                if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
-                    let mut mark_obsolete_accounts_time =
-                        Measure::start("mark_obsolete_accounts_time");
-                    // Mark all reclaims at max_slot. This is safe because only the snapshot paths care about
-                    // this information. Since this account was just restored from the previous snapshot and
-                    // it is known that it was already obsolete at that time, it must hold true that it will
-                    // still be obsolete if a newer snapshot is created, since a newer snapshot will always
-                    // be performed on a slot greater than the current slot
-                    let slot_marked_obsolete = storages.last().unwrap().slot();
-                    let obsolete_account_stats = self.mark_obsolete_accounts_at_startup(
-                        slot_marked_obsolete,
-                        unique_pubkeys_by_bin,
-                    );
-
-                    mark_obsolete_accounts_time.stop();
-                    timings.mark_obsolete_accounts_us = mark_obsolete_accounts_time.as_us();
-                    timings.num_obsolete_accounts_marked =
-                        obsolete_account_stats.accounts_marked_obsolete;
-                    timings.num_slots_removed_as_obsolete = obsolete_account_stats.slots_removed;
-                }
-            }
-            total_time.stop();
-            timings.total_time_us = total_time.as_us();
-            timings.report(self.accounts_index.get_startup_stats());
+        #[derive(Debug, Default)]
+        struct DuplicatePubkeysVisitedInfo {
+            accounts_data_len_from_duplicates: u64,
+            num_duplicate_accounts: u64,
+            duplicates_lt_hash: Box<DuplicatesLtHash>,
         }
+        impl DuplicatePubkeysVisitedInfo {
+            fn reduce(mut self, other: Self) -> Self {
+                self.accounts_data_len_from_duplicates += other.accounts_data_len_from_duplicates;
+                self.num_duplicate_accounts += other.num_duplicate_accounts;
+                self.duplicates_lt_hash
+                    .0
+                    .mix_in(&other.duplicates_lt_hash.0);
+                self
+            }
+        }
+
+        let zero_lamport_pubkeys_to_visit =
+            std::mem::take(&mut *zero_lamport_pubkeys.lock().unwrap());
+        let (num_zero_lamport_single_refs, visit_zero_lamports_us) = measure_us!(
+            self.visit_zero_lamport_pubkeys_during_startup(&zero_lamport_pubkeys_to_visit)
+        );
+        timings.visit_zero_lamports_us = visit_zero_lamports_us;
+        timings.num_zero_lamport_single_refs = num_zero_lamport_single_refs;
+
+        // subtract data.len() from accounts_data_len for all old accounts that are in the index twice
+        let mut accounts_data_len_dedup_timer =
+            Measure::start("handle accounts data len duplicates");
+        let DuplicatePubkeysVisitedInfo {
+            accounts_data_len_from_duplicates,
+            num_duplicate_accounts,
+            duplicates_lt_hash,
+        } = unique_pubkeys_by_bin
+            .par_iter()
+            .fold(
+                DuplicatePubkeysVisitedInfo::default,
+                |accum, pubkeys_by_bin| {
+                    let intermediate = pubkeys_by_bin
+                        .par_chunks(4096)
+                        .fold(DuplicatePubkeysVisitedInfo::default, |accum, pubkeys| {
+                            let (
+                                accounts_data_len_from_duplicates,
+                                accounts_duplicates_num,
+                                duplicates_lt_hash,
+                            ) = self.visit_duplicate_pubkeys_during_startup(pubkeys, &timings);
+                            let intermediate = DuplicatePubkeysVisitedInfo {
+                                accounts_data_len_from_duplicates,
+                                num_duplicate_accounts: accounts_duplicates_num,
+                                duplicates_lt_hash,
+                            };
+                            DuplicatePubkeysVisitedInfo::reduce(accum, intermediate)
+                        })
+                        .reduce(
+                            DuplicatePubkeysVisitedInfo::default,
+                            DuplicatePubkeysVisitedInfo::reduce,
+                        );
+                    DuplicatePubkeysVisitedInfo::reduce(accum, intermediate)
+                },
+            )
+            .reduce(
+                DuplicatePubkeysVisitedInfo::default,
+                DuplicatePubkeysVisitedInfo::reduce,
+            );
+        accounts_data_len_dedup_timer.stop();
+        timings.accounts_data_len_dedup_time_us = accounts_data_len_dedup_timer.as_us();
+        timings.num_duplicate_accounts = num_duplicate_accounts;
+
+        total_lt_hash.lock().unwrap().mix_out(&duplicates_lt_hash.0);
+        accounts_data_len.fetch_sub(accounts_data_len_from_duplicates, Ordering::Relaxed);
+        info!(
+            "accounts data len: {}",
+            accounts_data_len.load(Ordering::Relaxed)
+        );
+
+        // insert all zero lamport account storage into the dirty stores and add them into the uncleaned roots for clean to pick up
+        let all_zero_slots_to_clean = std::mem::take(all_zeros_slots.get_mut().unwrap());
+        info!(
+            "insert all zero slots to clean at startup {}",
+            all_zero_slots_to_clean.len()
+        );
+        for (slot, storage) in all_zero_slots_to_clean {
+            self.dirty_stores.insert(slot, storage);
+        }
+
+        // Need to add these last, otherwise older updates will be cleaned
+        for storage in &storages {
+            self.accounts_index.add_root(storage.slot());
+        }
+
+        self.set_storage_count_and_alive_bytes(storage_info, &mut timings);
+
+        if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
+            let mut mark_obsolete_accounts_time = Measure::start("mark_obsolete_accounts_time");
+            // Mark all reclaims at max_slot. This is safe because only the snapshot paths care about
+            // this information. Since this account was just restored from the previous snapshot and
+            // it is known that it was already obsolete at that time, it must hold true that it will
+            // still be obsolete if a newer snapshot is created, since a newer snapshot will always
+            // be performed on a slot greater than the current slot
+            let slot_marked_obsolete = storages.last().unwrap().slot();
+            let obsolete_account_stats =
+                self.mark_obsolete_accounts_at_startup(slot_marked_obsolete, unique_pubkeys_by_bin);
+
+            mark_obsolete_accounts_time.stop();
+            timings.mark_obsolete_accounts_us = mark_obsolete_accounts_time.as_us();
+            timings.num_obsolete_accounts_marked = obsolete_account_stats.accounts_marked_obsolete;
+            timings.num_slots_removed_as_obsolete = obsolete_account_stats.slots_removed;
+        }
+        total_time.stop();
+        timings.total_time_us = total_time.as_us();
+        timings.report(self.accounts_index.get_startup_stats());
 
         self.accounts_index.log_secondary_indexes();
 


### PR DESCRIPTION
#### Problem

The flow of `generate_index()` is convoluted due the way "verify" is implemented. Currently it does multiple passes via a for-loop, which results in lots of special casing for pass 0 or pass 1.


#### Summary of Changes

Refactor it.

The key observation is that the "verify" code is strictly disjoint from the non-verify code. We can remove the for-loop entirely, and instead have a single if-block for the verify code.

Note to reviewers: I recommend ignoring whitespace in the diff, otherwise it'll look like everything has changed.