### PR TITLE
shred_fetch: enforce fixed fec sets

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -16,7 +16,7 @@ use {
         BytesPacket, BytesPacketBatch, PacketBatch, PacketBatchRecycler, PacketFlags, PacketRef,
     },
     solana_pubkey::Pubkey,
-    solana_runtime::bank_forks::BankForks,
+    solana_runtime::bank_forks::{BankForks, SharableBanks},
     solana_streamer::{
         evicting_sender::EvictingSender,
         streamer::{self, ChannelSend, PacketBatchReceiver, StreamerReceiveStats},
@@ -64,7 +64,7 @@ impl ShredFetchStage {
         recvr: PacketBatchReceiver,
         recvr_stats: Option<Arc<StreamerReceiveStats>>,
         sendr: EvictingSender<PacketBatch>,
-        bank_forks: &RwLock<BankForks>,
+        sharable_banks: &SharableBanks,
         shred_version: u16,
         name: &'static str,
         flags: PacketFlags,
@@ -79,37 +79,18 @@ impl ShredFetchStage {
         const STATS_SUBMIT_CADENCE: Duration = Duration::from_secs(1);
         let mut last_updated = Instant::now();
         let mut keypair = repair_context.as_ref().copied().map(RepairContext::keypair);
-        let (
-            mut last_root,
-            mut slots_per_epoch,
-            mut _feature_set,
-            mut _epoch_schedule,
-            mut last_slot,
-        ) = {
-            let bank_forks_r = bank_forks.read().unwrap();
-            let root_bank = bank_forks_r.root_bank();
-            (
-                root_bank.slot(),
-                root_bank.get_slots_in_epoch(root_bank.epoch()),
-                root_bank.feature_set.clone(),
-                root_bank.epoch_schedule().clone(),
-                bank_forks_r.highest_slot(),
-            )
-        };
         let mut stats = ShredFetchStats::default();
 
         for mut packet_batch in recvr {
+            let root_bank = sharable_banks.root();
+            let feature_set = root_bank.feature_set.clone();
+            let epoch_schedule = root_bank.epoch_schedule().clone();
+            let last_root = root_bank.slot();
+            let slots_per_epoch = root_bank.get_slots_in_epoch(root_bank.epoch());
+            let last_slot = sharable_banks.working().slot();
+
             if last_updated.elapsed().as_millis() as u64 > DEFAULT_MS_PER_SLOT {
                 last_updated = Instant::now();
-                let root_bank = {
-                    let bank_forks_r = bank_forks.read().unwrap();
-                    last_slot = bank_forks_r.highest_slot();
-                    bank_forks_r.root_bank()
-                };
-                _feature_set = root_bank.feature_set.clone();
-                _epoch_schedule = root_bank.epoch_schedule().clone();
-                last_root = root_bank.slot();
-                slots_per_epoch = root_bank.get_slots_in_epoch(root_bank.epoch());
                 keypair = repair_context.as_ref().copied().map(RepairContext::keypair);
             }
             stats.shred_count += packet_batch.len();
@@ -149,6 +130,14 @@ impl ShredFetchStage {
             // Filter out shreds that are way too far in the future to avoid the
             // overhead of having to hold onto them.
             let max_slot = last_slot + MAX_SHRED_DISTANCE_MINIMUM.max(2 * slots_per_epoch);
+            let enforce_fixed_fec_set = |shred_slot| {
+                check_feature_activation(
+                    &agave_feature_set::enforce_fixed_fec_set::id(),
+                    shred_slot,
+                    &feature_set,
+                    &epoch_schedule,
+                )
+            };
             let turbine_disabled = turbine_disabled.load(Ordering::Relaxed);
             for mut packet in packet_batch.iter_mut().filter(|p| !p.meta().discard()) {
                 if turbine_disabled
@@ -157,6 +146,7 @@ impl ShredFetchStage {
                         last_root,
                         max_slot,
                         shred_version,
+                        enforce_fixed_fec_set,
                         &mut stats,
                     )
                 {
@@ -197,6 +187,7 @@ impl ShredFetchStage {
         repair_context: Option<RepairContext>,
         turbine_disabled: Arc<AtomicBool>,
     ) -> (Vec<JoinHandle<()>>, JoinHandle<()>) {
+        let sharable_banks = bank_forks.read().unwrap().sharable_banks();
         let (packet_sender, packet_receiver) =
             EvictingSender::new_bounded(SHRED_FETCH_CHANNEL_SIZE);
         let receiver_stats = Arc::new(StreamerReceiveStats::new(receiver_name));
@@ -225,7 +216,7 @@ impl ShredFetchStage {
                     packet_receiver,
                     Some(receiver_stats),
                     sender,
-                    &bank_forks,
+                    &sharable_banks,
                     shred_version,
                     name,
                     flags,
@@ -315,11 +306,12 @@ impl ShredFetchStage {
                 Builder::new()
                     .name("solTvuFetchRpr".to_string())
                     .spawn(move || {
+                        let sharable_banks = bank_forks.read().unwrap().sharable_banks();
                         Self::modify_packets(
                             packet_receiver,
                             None,
                             sender,
-                            &bank_forks,
+                            &sharable_banks,
                             shred_version,
                             "shred_fetch_repair_quic",
                             PacketFlags::REPAIR,
@@ -348,11 +340,12 @@ impl ShredFetchStage {
             Builder::new()
                 .name("solTvuFetchQuic".to_string())
                 .spawn(move || {
+                    let sharable_banks = bank_forks.read().unwrap().sharable_banks();
                     Self::modify_packets(
                         packet_receiver,
                         None,
                         sender,
-                        &bank_forks,
+                        &sharable_banks,
                         shred_version,
                         "shred_fetch_quic",
                         PacketFlags::empty(),
@@ -436,7 +429,6 @@ pub(crate) fn receive_quic_datagrams(
 
 // Returns true if the feature is effective for the shred slot.
 #[must_use]
-#[allow(dead_code)]
 fn check_feature_activation(
     feature: &Pubkey,
     shred_slot: Slot,

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1122,6 +1122,10 @@ pub mod raise_cpi_nesting_limit_to_8 {
     solana_pubkey::declare_id!("6TkHkRmP7JZy1fdM6fg5uXn76wChQBWGokHBJzrLB3mj");
 }
 
+pub mod enforce_fixed_fec_set {
+    solana_pubkey::declare_id!("fixfecLZYMfkGzwq6NJA11Yw6KYztzXiK9QcL3K78in");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -1363,6 +1367,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (raise_block_limits_to_100m::id(), "SIMD-0286: Raise block limit to 100M"),
         (raise_account_cu_limit::id(), "SIMD-0306: Raise account CU limit to 40% max"),
         (raise_cpi_nesting_limit_to_8::id(), "SIMD-0296: Raise CPI nesting limit from 4 to 8"),
+        (enforce_fixed_fec_set::id(), "SIMD-0317: Enforce 32 data + 32 coding shreds"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -716,27 +716,6 @@ impl ErasureMeta {
         coding_shred.check_coding_shred(shred2)
     }
 
-    /// Returns true if `index` and `fec_set_index` are valid under the assumption that
-    /// all erasure sets contain exactly `DATA_SHREDS_PER_FEC_BLOCK` data and coding shreds:
-    /// - `index` is between `fec_set_index` and `fec_set_index + DATA_SHREDS_PER_FEC_BLOCK`
-    /// - `fec_set_index` is a multiple of `DATA_SHREDS_PER_FEC_BLOCK`
-    pub fn check_fixed_fec_set(index: u32, fec_set_index: u32) -> bool {
-        index >= fec_set_index
-            && index < fec_set_index + DATA_SHREDS_PER_FEC_BLOCK as u32
-            && fec_set_index % DATA_SHREDS_PER_FEC_BLOCK as u32 == 0
-    }
-
-    /// Returns true if `index` of the last data shred is valid under the assumption that
-    /// all erasure sets contain exactly `DATA_SHREDS_PER_FEC_BLOCK` data and coding shreds:
-    /// - `index + 1` must be a multiple of `DATA_SHREDS_PER_FEC_BLOCK`
-    ///
-    /// Note: this check is critical to verify that the last fec set is sufficiently sized.
-    /// This currently is checked post insert in `Blockstore::check_last_fec_set`, but in the
-    /// future it can be solely checked during ingest
-    pub fn check_last_data_shred_index(index: u32) -> bool {
-        (index + 1) % (DATA_SHREDS_PER_FEC_BLOCK as u32) == 0
-    }
-
     pub(crate) fn config(&self) -> ErasureConfig {
         self.config
     }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -813,7 +813,7 @@ where
             };
 
             if !erasure_config.is_fixed() {
-                stats.bad_erasure_config += 1;
+                stats.misaligned_erasure_config += 1;
                 if enforce_fixed_fec_set(slot) {
                     return true;
                 }
@@ -844,7 +844,7 @@ where
             if shred_flags.contains(ShredFlags::LAST_SHRED_IN_SLOT)
                 && !check_last_data_shred_index(index)
             {
-                stats.bad_last_data_index += 1;
+                stats.misaligned_last_data_index += 1;
                 if enforce_fixed_fec_set(slot) {
                     return true;
                 }
@@ -853,7 +853,7 @@ where
     }
 
     if !check_fixed_fec_set(index, fec_set_index) {
-        stats.bad_fec_set_size += 1;
+        stats.misaligned_fec_set += 1;
         if enforce_fixed_fec_set(slot) {
             return true;
         }
@@ -1419,7 +1419,7 @@ mod tests {
                 &mut stats,
             );
             assert_eq!(should_discard, enforce_fixed_fec_set);
-            assert_eq!(stats.bad_fec_set_size, 1);
+            assert_eq!(stats.misaligned_fec_set, 1);
         }
 
         // index not in range [fec_set_index, fec_set_index + 32)
@@ -1449,7 +1449,7 @@ mod tests {
                 &mut stats,
             );
             assert_eq!(should_discard, enforce_fixed_fec_set);
-            assert_eq!(stats.bad_fec_set_size, 1);
+            assert_eq!(stats.misaligned_fec_set, 1);
         }
 
         // bad erasure config 16:32
@@ -1478,7 +1478,7 @@ mod tests {
                 &mut stats,
             );
             assert_eq!(should_discard, enforce_fixed_fec_set);
-            assert_eq!(stats.bad_erasure_config, 1);
+            assert_eq!(stats.misaligned_erasure_config, 1);
         }
 
         // data shred with LAST_SHRED_IN_SLOT flag on shred 30
@@ -1523,7 +1523,7 @@ mod tests {
             &mut stats,
         );
         assert_eq!(should_discard, enforce_fixed_fec_set);
-        assert_eq!(stats.bad_last_data_index, 1);
+        assert_eq!(stats.misaligned_last_data_index, 1);
     }
 
     // Asserts that ShredType is backward compatible with u8.

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -196,9 +196,7 @@ impl ShredData {
         );
         // Shred index in the erasure batch.
         let index = {
-            let fec_set_index = <[u8; 4]>::try_from(shred.get(79..83)?)
-                .map(u32::from_le_bytes)
-                .ok()?;
+            let fec_set_index = shred::layout::get_fec_set_index(shred)?;
             shred::layout::get_index(shred)?
                 .checked_sub(fec_set_index)
                 .map(usize::try_from)?

--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -59,11 +59,11 @@ pub struct ShredFetchStats {
     pub(super) shred_version_mismatch: usize,
     pub(super) bad_parent_offset: usize,
     pub(super) fec_set_index_bad_deserialize: usize,
-    pub(super) bad_fec_set_size: usize,
+    pub(super) misaligned_fec_set: usize,
     pub(super) erasure_config_bad_deserialize: usize,
-    pub(super) bad_erasure_config: usize,
+    pub(super) misaligned_erasure_config: usize,
     pub(super) shred_flags_bad_deserialize: usize,
-    pub(super) bad_last_data_index: usize,
+    pub(super) misaligned_last_data_index: usize,
     since: Option<Instant>,
     pub overflow_shreds: usize,
 }
@@ -193,19 +193,19 @@ impl ShredFetchStats {
                 self.fec_set_index_bad_deserialize,
                 i64
             ),
-            ("bad_fec_set_size", self.bad_fec_set_size, i64),
+            ("misaligned_fec_set_size", self.misaligned_fec_set, i64),
             (
                 "erasure_config_bad_deserialize",
                 self.erasure_config_bad_deserialize,
                 i64
             ),
-            ("bad_erasure_config", self.bad_erasure_config, i64),
+            ("misaligned_erasure_config", self.misaligned_erasure_config, i64),
             (
                 "shred_flags_bad_deserialize",
                 self.shred_flags_bad_deserialize,
                 i64
             ),
-            ("bad_last_data_index", self.bad_last_data_index, i64),
+            ("misaligned_last_data_index", self.misaligned_last_data_index, i64),
             ("overflow_shreds", self.overflow_shreds, i64),
         );
         *self = Self {

--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -58,6 +58,12 @@ pub struct ShredFetchStats {
     pub(super) bad_shred_type: usize,
     pub(super) shred_version_mismatch: usize,
     pub(super) bad_parent_offset: usize,
+    pub(super) fec_set_index_bad_deserialize: usize,
+    pub(super) bad_fec_set_size: usize,
+    pub(super) erasure_config_bad_deserialize: usize,
+    pub(super) bad_erasure_config: usize,
+    pub(super) shred_flags_bad_deserialize: usize,
+    pub(super) bad_last_data_index: usize,
     since: Option<Instant>,
     pub overflow_shreds: usize,
 }
@@ -182,6 +188,24 @@ impl ShredFetchStats {
             ("bad_shred_type", self.bad_shred_type, i64),
             ("shred_version_mismatch", self.shred_version_mismatch, i64),
             ("bad_parent_offset", self.bad_parent_offset, i64),
+            (
+                "fec_set_index_bad_deserialize",
+                self.fec_set_index_bad_deserialize,
+                i64
+            ),
+            ("bad_fec_set_size", self.bad_fec_set_size, i64),
+            (
+                "erasure_config_bad_deserialize",
+                self.erasure_config_bad_deserialize,
+                i64
+            ),
+            ("bad_erasure_config", self.bad_erasure_config, i64),
+            (
+                "shred_flags_bad_deserialize",
+                self.shred_flags_bad_deserialize,
+                i64
+            ),
+            ("bad_last_data_index", self.bad_last_data_index, i64),
             ("overflow_shreds", self.overflow_shreds, i64),
         );
         *self = Self {

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -2,9 +2,12 @@
 // deserializing the entire payload.
 #![deny(clippy::indexing_slicing)]
 use {
-    crate::shred::{
-        self, merkle_tree::SIZE_OF_MERKLE_ROOT, traits::Shred, Error, Nonce, ShredFlags, ShredId,
-        ShredType, ShredVariant, SIZE_OF_COMMON_SHRED_HEADER,
+    crate::{
+        blockstore_meta::ErasureConfig,
+        shred::{
+            self, merkle_tree::SIZE_OF_MERKLE_ROOT, traits::Shred, Error, Nonce, ShredFlags,
+            ShredId, ShredType, ShredVariant, SIZE_OF_COMMON_SHRED_HEADER,
+        },
     },
     solana_clock::Slot,
     solana_hash::Hash,
@@ -102,6 +105,12 @@ pub(super) fn get_version(shred: &[u8]) -> Option<u16> {
     Some(u16::from_le_bytes(bytes))
 }
 
+#[inline]
+pub fn get_fec_set_index(shred: &[u8]) -> Option<u32> {
+    let bytes = <[u8; 4]>::try_from(shred.get(79..79 + 4)?).unwrap();
+    Some(u32::from_le_bytes(bytes))
+}
+
 // The caller should verify first that the shred is data and not code!
 #[inline]
 pub(super) fn get_parent_offset(shred: &[u8]) -> Option<u16> {
@@ -161,6 +170,32 @@ pub(crate) fn get_data(shred: &[u8]) -> Result<&[u8], Error> {
             get_data_size(shred)?,
         ),
     }
+}
+
+/// Returns the ErasureConfig specified by the coding shred
+/// Caller must verify that the shred is a coding shred
+#[inline]
+pub(crate) fn get_erasure_config(shred: &[u8]) -> Result<ErasureConfig, Error> {
+    debug_assert_eq!(get_shred_type(shred).unwrap(), ShredType::Code);
+    let Some(num_data_bytes) = shred.get(83..83 + 2) else {
+        return Err(Error::InvalidPayloadSize(shred.len()));
+    };
+    let Some(num_coding_bytes) = shred.get(85..85 + 2) else {
+        return Err(Error::InvalidPayloadSize(shred.len()));
+    };
+    let num_data = <[u8; 2]>::try_from(num_data_bytes)
+        .map(u16::from_le_bytes)
+        .map(usize::from)
+        .map_err(|_| Error::InvalidErasureConfig)?;
+    let num_coding = <[u8; 2]>::try_from(num_coding_bytes)
+        .map(u16::from_le_bytes)
+        .map(usize::from)
+        .map_err(|_| Error::InvalidErasureConfig)?;
+
+    Ok(ErasureConfig {
+        num_data,
+        num_coding,
+    })
 }
 
 #[inline]

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -172,11 +172,13 @@ pub(crate) fn get_data(shred: &[u8]) -> Result<&[u8], Error> {
     }
 }
 
-/// Returns the ErasureConfig specified by the coding shred
-/// Caller must verify that the shred is a coding shred
+/// Returns the ErasureConfig specified by the coding shred, or an Error if
+/// the shred is a data shred
 #[inline]
 pub(crate) fn get_erasure_config(shred: &[u8]) -> Result<ErasureConfig, Error> {
-    debug_assert_eq!(get_shred_type(shred).unwrap(), ShredType::Code);
+    if !matches!(get_shred_type(shred).unwrap(), ShredType::Code) {
+        return Err(Error::InvalidShredType);
+    }
     let Some(num_data_bytes) = shred.get(83..83 + 2) else {
         return Err(Error::InvalidPayloadSize(shred.len()));
     };


### PR DESCRIPTION
#### Problem
See https://github.com/solana-foundation/solana-improvement-documents/pull/317 for more details.
We wish to enforce that each FEC set has exactly 32 data and 32 coding shreds.

#### Summary of Changes
As outlined in the SIMD, we ignore any shreds that do not meet the index/fec_set_index requirements on ingest.
Specifically ensure that:
- `fec_set_index` is a multiple of 32
- `fec_set_index <= index < fec_set_index + 32`
- The `LAST_SHRED_IN_SLOT` data shred index must be `== 31 (mod 32)`
- The `ErasureConfig` on all coding shreds must specify 32:32

Note: this is a shred feature flag so it takes effect 1 epoch after normal feature activation

An alternate approach considered was performing the verification after ingest and marking the block as dead:
- This approach avoids adding extra repair overhead in case of malicious voters
- However it's add more cost to sigverify and then insert these malicious shreds into blockstore
- and more code complexity to do this at the blockstore level
- FD does not mark block as dead

Some follow up work after FF activation:
- In the next shred version we can consider removing `fec_set_index`, `ErasureConfig`, and `proof_size` from shred headers. 
- Blockstore can be reworked to use 32 offsets instead of the ErasureConfig/searching
- We could recover FEC sets in cases where there are 32 data shreds but 0 coding shreds (need to store some state so that we don't do this repeatedly for the same FEC set)
- ErasureMeta column / data types and related consistency checks can be removed
- Remove check_last_fec_set, we're guaranteed that the last fec set has 32 data shreds