### PR TITLE
update comments/cli to clarify multihoming functionality

### DIFF
--- a/net-utils/src/multihomed_sockets.rs
+++ b/net-utils/src/multihomed_sockets.rs
@@ -74,8 +74,8 @@ impl SocketProvider for MultihomedSocketProvider {
 #[derive(Debug, Clone)]
 pub struct BindIpAddrs {
     /// The IP addresses this node may bind to
-    /// Index 0 is the primary address
-    /// Index 1+ are secondary addresses
+    /// Index 0 is the public internet address
+    /// Index 1+ are secondary addresses (i.e. multihoming)
     addrs: Vec<IpAddr>,
     active_index: Arc<AtomicUsize>,
 }
@@ -115,7 +115,7 @@ impl BindIpAddrs {
         self.addrs[self.active_index.load(Ordering::Acquire)]
     }
 
-    /// Change active to index (0 = primary)
+    /// Change active to index (0 = public internet IP, 1+ = secondary IPs)
     pub fn set_active(&self, index: usize) -> Result<IpAddr, String> {
         if index >= self.addrs.len() {
             return Err(format!(

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -751,8 +751,15 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .validator(solana_net_utils::is_host)
                 .default_value("127.0.0.1")
                 .help(
-                    "IP address to bind the validator ports [default: 127.0.0.1]. Can be repeated \
-                     to specify multihoming options.",
+                    "IP address to bind the validator ports. Can be repeated. \
+                     The first --bind-address MUST be your public internet address. \
+                     ALL protocols (gossip, repair, IP echo, TVU, TPU, etc.) bind to this address on startup. \
+                     Additional --bind-address values enable multihoming for Gossip/TVU/TPU - \
+                     these protocols bind to ALL interfaces on startup. Gossip reads/sends from \
+                     one interface at a time. TVU/TPU read from ALL interfaces simultaneously \
+                     but send from only one interface at a time. When switching interfaces via \
+                     AdminRPC: Gossip switches to send/receive from the new interface, while \
+                     TVU/TPU continue receiving from ALL interfaces but send from the new interface only.",
                 ),
         )
         .arg(


### PR DESCRIPTION
#### Problem
Since not all protocols will be multihomed, we need to clarify how `--bind-address` affects which interface(s) the validator will bind to

#### Summary of Changes
No code changes. This will be updated in the future if/when we remove gossip multihoming

Dictate that the first `--bind-address` must be connected to the public internet. The following `--bind-address`es indicate other additional interfaces.

BindIpAddrs is updated to indicate index = 0 is the public internet IP
