### PR TITLE
run local faucet with non-overlapping ports behind test/debug gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8514,6 +8514,7 @@ dependencies = [
  "solana-logger",
  "solana-message",
  "solana-metrics",
+ "solana-net-utils",
  "solana-packet",
  "solana-pubkey",
  "solana-signer",

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -36,6 +36,7 @@ solana-keypair = "=3.0.1"
 solana-logger = "=3.0.0"
 solana-message = "=3.0.1"
 solana-metrics = { workspace = true }
+solana-net-utils = { workspace = true }
 solana-packet = "=3.0.0"
 solana-pubkey = { version = "=3.0.0", features = ["rand"] }
 solana-signer = "=3.0.0"

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -15,6 +15,7 @@ use {
     solana_keypair::Keypair,
     solana_message::Message,
     solana_metrics::datapoint_info,
+    solana_net_utils::sockets::unique_port_range_for_tests,
     solana_packet::PACKET_DATA_SIZE,
     solana_pubkey::Pubkey,
     solana_signer::Signer,
@@ -343,10 +344,21 @@ pub fn run_local_faucet_with_port(
     });
 }
 
-// For integration tests. Listens on random open port and reports port to Sender.
+/// For integration tests. Listens on a random open port and reports the port to Sender.
+/// In test/debug builds, a non-overlapping port is allocated instead of a random port.
 pub fn run_local_faucet(faucet_keypair: Keypair, per_time_cap: Option<u64>) -> SocketAddr {
+    let port: u16 = {
+        #[cfg(debug_assertions)]
+        {
+            unique_port_range_for_tests(1).start
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            0
+        }
+    };
     let (sender, receiver) = unbounded();
-    run_local_faucet_with_port(faucet_keypair, sender, None, per_time_cap, None, 0);
+    run_local_faucet_with_port(faucet_keypair, sender, None, per_time_cap, None, port);
     receiver
         .recv()
         .expect("run_local_faucet")

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6685,6 +6685,7 @@ dependencies = [
  "solana-logger",
  "solana-message",
  "solana-metrics",
+ "solana-net-utils",
  "solana-packet",
  "solana-pubkey",
  "solana-signer",


### PR DESCRIPTION
#### Problem
Tests which engage ports binding are still randomly flaky. 
While looking for source of the evil, i found that [test_bench_tps_test_validator](https://github.com/anza-xyz/agave/blob/48c9d0c7eccd4bedd8e43209f9d7adb22a9c587a/bench-tps/tests/bench_tps.rs#L113) calls [run_local_faucet](https://github.com/anza-xyz/agave/blob/master/faucet/src/faucet.rs#L347) which takes a port randomly.

This isn't correct behaviour as the randomly picked port might overlap with one of ports allocated thru [unique_port_range_for_tests](https://github.com/anza-xyz/agave/blob/master/net-utils/src/sockets.rs#L27)
 
#### Summary of Changes
- Now, the `run_local_faucet`, Takes non-overlapping port for debug_assertions. Otherwise defaults to random port as before.
