### PR TITLE
Revert "runtime: Avoid locking during stake vote rewards calculation (#6900)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10681,9 +10681,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f912ae679b683365348dea482dbd9468d22ff258b554fd36e3d3683c2122e3"
+checksum = "9fd582fe900e43db96651a5b43956b8ebfab1944d091b391d89140635900ef46"
 dependencies = [
  "borsh",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -515,7 +515,7 @@ solana-signer = "3.0.0"
 solana-slot-hashes = "3.0.0"
 solana-slot-history = "3.0.0"
 solana-stable-layout = "3.0.0"
-solana-stake-interface = { version = "2.0.1" }
+solana-stake-interface = { version = "2.0.0" }
 solana-stake-program = { path = "programs/stake", version = "=3.1.0" }
 solana-storage-bigtable = { path = "storage-bigtable", version = "=3.1.0" }
 solana-storage-proto = { path = "storage-proto", version = "=3.1.0" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -81,7 +81,7 @@ solana-sdk-ids = "=3.0.0"
 solana-signature = { version = "=3.1.0", default-features = false }
 solana-signer = "=3.0.0"
 solana-slot-history = "=3.0.0"
-solana-stake-interface = "=2.0.1"
+solana-stake-interface = "=2.0.0"
 solana-streamer = { workspace = true }
 solana-system-interface = { version = "=2.0", features = ["bincode"] }
 solana-sysvar = "=3.0.0"

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -54,7 +54,7 @@ solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk-ids = "=3.0.0"
 solana-signer = "=3.0.0"
-solana-stake-interface = { version = "=2.0.1", features = ["borsh"] }
+solana-stake-interface = { version = "=2.0.0", features = ["borsh"] }
 solana-stake-program = { workspace = true }
 solana-time-utils = "3.0.0"
 solana-version = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9126,9 +9126,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f912ae679b683365348dea482dbd9468d22ff258b554fd36e3d3683c2122e3"
+checksum = "9fd582fe900e43db96651a5b43956b8ebfab1944d091b391d89140635900ef46"
 dependencies = [
  "num-traits",
  "serde",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -157,7 +157,7 @@ solana-sbpf = "=0.12.2"
 solana-sdk-ids = "=3.0.0"
 solana-secp256k1-recover = "=3.0.0"
 solana-sha256-hasher = { version = "=3.0.0", features = ["sha2"] }
-solana-stake-interface = { version = "=2.0.1", features = ["bincode"] }
+solana-stake-interface = { version = "=2.0.0", features = ["bincode"] }
 solana-svm = { path = "../../svm", version = "=3.1.0" }
 solana-svm-callback = { path = "../../svm-callback", version = "=3.1.0" }
 solana-svm-feature-set = { path = "../../svm-feature-set", version = "=3.1.0" }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -63,7 +63,7 @@ use {
     agave_syscalls::{
         create_program_runtime_environment_v1, create_program_runtime_environment_v2,
     },
-    ahash::AHashSet,
+    ahash::{AHashSet, RandomState},
     dashmap::DashMap,
     log::*,
     partitioned_epoch_rewards::PartitionedRewardsCalculation,
@@ -113,7 +113,7 @@ use {
     solana_program_runtime::{
         invoke_context::BuiltinFunctionWithContext, loaded_programs::ProgramCacheEntry,
     },
-    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
+    solana_pubkey::Pubkey,
     solana_reward_info::RewardInfo,
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
@@ -916,7 +916,7 @@ struct VoteReward {
     vote_rewards: u64,
 }
 
-type VoteRewards = HashMap<Pubkey, VoteReward, PubkeyHasherBuilder>;
+type VoteRewards = DashMap<Pubkey, VoteReward, RandomState>;
 
 #[derive(Debug, Default)]
 pub struct NewBankOptions {

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -271,10 +271,6 @@ impl Bank {
                         "partition reward out of bound: {index} >= {}",
                         partition_rewards.all_stake_rewards.len()
                     )
-                })
-                .as_ref()
-                .unwrap_or_else(|| {
-                    panic!("partition reward {index} is empty");
                 });
             let stake_pubkey = partitioned_stake_reward.stake_pubkey;
             let reward_amount = partitioned_stake_reward.stake_reward;
@@ -343,7 +339,7 @@ mod tests {
         let expected_num = 100;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .map(|_| PartitionedStakeReward::new_random())
             .collect::<Vec<_>>();
 
         let partition_indices =
@@ -367,7 +363,7 @@ mod tests {
         let expected_num = 1;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .map(|_| PartitionedStakeReward::new_random())
             .collect::<Vec<_>>();
 
         let partition_indices = hash_rewards_into_partitions(
@@ -753,11 +749,7 @@ mod tests {
 
         let expected_total = converted_rewards
             .iter()
-            .filter_map(|stake_reward| {
-                stake_reward
-                    .as_ref()
-                    .map(|stake_reward| stake_reward.stake_reward)
-            })
+            .map(|stake_reward| stake_reward.stake_reward)
             .sum::<u64>();
 
         let partitioned_rewards = StartBlockHeightAndPartitionedRewards {

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -39,14 +39,14 @@ pub(crate) struct PartitionedStakeReward {
     pub commission: u8,
 }
 
-type PartitionedStakeRewards = Vec<Option<PartitionedStakeReward>>;
+type PartitionedStakeRewards = Vec<PartitionedStakeReward>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct StartBlockHeightAndRewards {
     /// the block height of the slot at which rewards distribution began
     pub(crate) distribution_starting_block_height: u64,
     /// calculated epoch rewards before partitioning
-    pub(crate) all_stake_rewards: Arc<PartitionedStakeRewards>,
+    pub(crate) all_stake_rewards: Arc<Vec<PartitionedStakeReward>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -55,7 +55,7 @@ pub(crate) struct StartBlockHeightAndPartitionedRewards {
     pub(crate) distribution_starting_block_height: u64,
 
     /// calculated epoch rewards pending distribution
-    pub(crate) all_stake_rewards: Arc<PartitionedStakeRewards>,
+    pub(crate) all_stake_rewards: Arc<Vec<PartitionedStakeReward>>,
 
     /// indices of calculated epoch rewards per partition, outer Vec is by
     /// partition (one partition per block), inner Vec is the indices for one
@@ -196,7 +196,7 @@ pub(super) struct CalculateRewardsAndDistributeVoteRewardsResult {
     /// vote accounts
     pub(super) point_value: PointValue,
     /// stake rewards that still need to be distributed
-    pub(super) stake_rewards: Arc<PartitionedStakeRewards>,
+    pub(super) stake_rewards: Arc<Vec<PartitionedStakeReward>>,
 }
 
 pub(crate) type StakeRewards = Vec<StakeReward>;
@@ -234,7 +234,7 @@ impl Bank {
     pub(crate) fn set_epoch_reward_status_calculation(
         &mut self,
         distribution_starting_block_height: u64,
-        stake_rewards: Arc<PartitionedStakeRewards>,
+        stake_rewards: Arc<Vec<PartitionedStakeReward>>,
     ) {
         self.epoch_reward_status =
             EpochRewardStatus::Active(EpochRewardPhase::Calculation(StartBlockHeightAndRewards {
@@ -246,7 +246,7 @@ impl Bank {
     pub(crate) fn set_epoch_reward_status_distribution(
         &mut self,
         distribution_starting_block_height: u64,
-        all_stake_rewards: Arc<PartitionedStakeRewards>,
+        all_stake_rewards: Arc<Vec<PartitionedStakeReward>>,
         partition_indices: Vec<Vec<usize>>,
     ) {
         self.epoch_reward_status = EpochRewardStatus::Active(EpochRewardPhase::Distribution(
@@ -351,9 +351,9 @@ mod tests {
     }
 
     pub fn build_partitioned_stake_rewards(
-        stake_rewards: &[Option<PartitionedStakeReward>],
+        stake_rewards: &[PartitionedStakeReward],
         partition_indices: &[Vec<usize>],
-    ) -> Vec<Vec<Option<PartitionedStakeReward>>> {
+    ) -> Vec<Vec<PartitionedStakeReward>> {
         partition_indices
             .iter()
             .map(|partition_index| {
@@ -372,7 +372,7 @@ mod tests {
     ) -> PartitionedStakeRewards {
         stake_rewards
             .into_iter()
-            .map(|stake_reward| Some(PartitionedStakeReward::maybe_from(&stake_reward).unwrap()))
+            .map(|stake_reward| PartitionedStakeReward::maybe_from(&stake_reward).unwrap())
             .collect()
     }
 
@@ -546,7 +546,7 @@ mod tests {
         let expected_num = 100;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .map(|_| PartitionedStakeReward::new_random())
             .collect::<Vec<_>>();
 
         let partition_indices = vec![(0..expected_num).collect()];
@@ -598,7 +598,7 @@ mod tests {
             |num_stakes: u64, expected_num_reward_distribution_blocks: u64| {
                 // Given the short epoch, i.e. 32 slots, we should cap the number of reward distribution blocks to 32/10 = 3.
                 let stake_rewards = (0..num_stakes)
-                    .map(|_| Some(PartitionedStakeReward::new_random()))
+                    .map(|_| PartitionedStakeReward::new_random())
                     .collect::<Vec<_>>();
 
                 assert_eq!(
@@ -636,7 +636,7 @@ mod tests {
         // Given 8k rewards, it will take 2 blocks to credit all the rewards
         let expected_num = 8192;
         let stake_rewards = (0..expected_num)
-            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .map(|_| PartitionedStakeReward::new_random())
             .collect::<Vec<_>>();
 
         assert_eq!(bank.get_reward_distribution_num_blocks(&stake_rewards), 2);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11362,7 +11362,7 @@ fn test_system_instruction_unsigned_transaction() {
 
 #[test]
 fn test_calc_vote_accounts_to_store_empty() {
-    let vote_account_rewards = HashMap::default();
+    let vote_account_rewards = DashMap::default();
     let result = Bank::calc_vote_accounts_to_store(vote_account_rewards);
     assert_eq!(
         result.accounts_with_rewards.len(),
@@ -11373,7 +11373,7 @@ fn test_calc_vote_accounts_to_store_empty() {
 
 #[test]
 fn test_calc_vote_accounts_to_store_overflow() {
-    let mut vote_account_rewards = HashMap::default();
+    let vote_account_rewards = DashMap::default();
     let pubkey = solana_pubkey::new_rand();
     let mut vote_account = AccountSharedData::default();
     vote_account.set_lamports(u64::MAX);
@@ -11398,7 +11398,7 @@ fn test_calc_vote_accounts_to_store_normal() {
     let pubkey = solana_pubkey::new_rand();
     for commission in 0..2 {
         for vote_rewards in 0..2 {
-            let mut vote_account_rewards = HashMap::default();
+            let vote_account_rewards = DashMap::default();
             let mut vote_account = AccountSharedData::default();
             vote_account.set_lamports(1);
             vote_account_rewards.insert(


### PR DESCRIPTION
This reverts commit e752ae6d8f8cf07acd6a644502a08a7ffb34373a.