### PR TITLE
set non-overlapping port to faucet in JsonRpcConfig default_for_tests

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7832,6 +7832,7 @@ dependencies = [
  "solana-message",
  "solana-metrics",
  "solana-native-token",
+ "solana-net-utils",
  "solana-perf",
  "solana-poh",
  "solana-poh-config",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -64,6 +64,7 @@ solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-native-token = { workspace = true }
+solana-net-utils = { workspace = true }
 solana-perf = { workspace = true }
 solana-poh = { workspace = true }
 solana-poh-config = { workspace = true }
@@ -112,7 +113,6 @@ solana-compute-budget-interface = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-instruction = { workspace = true }
-solana-net-utils = { workspace = true }
 solana-nonce = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-program-option = { workspace = true }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -47,6 +47,7 @@ use {
     },
     solana_message::{AddressLoader, SanitizedMessage},
     solana_metrics::inc_new_counter_info,
+    solana_net_utils::sockets::unique_port_range_for_tests,
     solana_perf::packet::PACKET_DATA_SIZE,
     solana_program_pack::Pack,
     solana_pubkey::{Pubkey, PUBKEY_BYTES},
@@ -109,7 +110,7 @@ use {
         cmp::{max, min, Reverse},
         collections::{BinaryHeap, HashMap, HashSet},
         convert::TryFrom,
-        net::SocketAddr,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
         str::FromStr,
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
@@ -204,6 +205,10 @@ impl Default for JsonRpcConfig {
 impl JsonRpcConfig {
     pub fn default_for_test() -> Self {
         Self {
+            faucet_addr: Some(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                unique_port_range_for_tests(1).start,
+            )),
             full_api: true,
             disable_health_check: true,
             ..Self::default()


### PR DESCRIPTION
#### Problem
Tests that engage ports binding are flaky. This is continuation of #7736

The [JsonRpcConfig default_for_tests](https://github.com/anza-xyz/agave/blob/master/rpc/src/rpc.rs#L205) doesn't take ports from [unique_port_range_for_tests](https://github.com/anza-xyz/agave/blob/master/net-utils/src/sockets.rs#L27) in faucet case.

#### Summary of Changes
- `JsonRpcConfig::default_for_tests` now populate socket with port taken from unique_port_range_for_tests range.