### PR TITLE
runtime: Avoid locking during stake vote rewards calculation

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -63,7 +63,7 @@ use {
     agave_syscalls::{
         create_program_runtime_environment_v1, create_program_runtime_environment_v2,
     },
-    ahash::{AHashSet, RandomState},
+    ahash::AHashSet,
     dashmap::DashMap,
     log::*,
     partitioned_epoch_rewards::PartitionedRewardsCalculation,
@@ -113,7 +113,7 @@ use {
     solana_program_runtime::{
         invoke_context::BuiltinFunctionWithContext, loaded_programs::ProgramCacheEntry,
     },
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_reward_info::RewardInfo,
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
@@ -909,7 +909,7 @@ struct VoteReward {
     vote_rewards: u64,
 }
 
-type VoteRewards = DashMap<Pubkey, VoteReward, RandomState>;
+type VoteRewards = HashMap<Pubkey, VoteReward, PubkeyHasherBuilder>;
 
 #[derive(Debug, Default)]
 pub struct NewBankOptions {

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -163,7 +163,7 @@ impl Bank {
         let metrics = RewardsStoreMetrics {
             pre_capitalization,
             post_capitalization: self.capitalization(),
-            total_stake_accounts_count: partition_rewards.all_stake_rewards.len(),
+            total_stake_accounts_count: partition_rewards.all_stake_rewards.num_rewards(),
             total_num_partitions: partition_rewards.partition_indices.len(),
             partition_index,
             store_stake_accounts_us,
@@ -269,8 +269,12 @@ impl Bank {
                 .unwrap_or_else(|| {
                     panic!(
                         "partition reward out of bound: {index} >= {}",
-                        partition_rewards.all_stake_rewards.len()
+                        partition_rewards.all_stake_rewards.total_len()
                     )
+                })
+                .as_ref()
+                .unwrap_or_else(|| {
+                    panic!("partition reward {index} is empty");
                 });
             let stake_pubkey = partitioned_stake_reward.stake_pubkey;
             let reward_amount = partitioned_stake_reward.stake_reward;
@@ -307,7 +311,7 @@ mod tests {
             bank::{
                 partitioned_epoch_rewards::{
                     epoch_rewards_hasher::hash_rewards_into_partitions, tests::convert_rewards,
-                    REWARD_CALCULATION_NUM_BLOCKS,
+                    PartitionedStakeRewards, REWARD_CALCULATION_NUM_BLOCKS,
                 },
                 tests::create_genesis_config,
             },
@@ -339,8 +343,8 @@ mod tests {
         let expected_num = 100;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| PartitionedStakeReward::new_random())
-            .collect::<Vec<_>>();
+            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .collect::<PartitionedStakeRewards>();
 
         let partition_indices =
             hash_rewards_into_partitions(&stake_rewards, &Hash::new_from_array([1; 32]), 2);
@@ -363,8 +367,8 @@ mod tests {
         let expected_num = 1;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| PartitionedStakeReward::new_random())
-            .collect::<Vec<_>>();
+            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .collect::<PartitionedStakeRewards>();
 
         let partition_indices = hash_rewards_into_partitions(
             &stake_rewards,
@@ -388,7 +392,7 @@ mod tests {
 
         bank.set_epoch_reward_status_distribution(
             bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
-            Arc::new(vec![]),
+            Arc::new(PartitionedStakeRewards::default()),
             vec![],
         );
 
@@ -745,11 +749,11 @@ mod tests {
             .map(|_| StakeReward::new_random())
             .collect::<Vec<_>>();
         populate_starting_stake_accounts_from_stake_rewards(&bank, &stake_rewards);
-        let converted_rewards: Vec<_> = convert_rewards(stake_rewards);
+        let converted_rewards = convert_rewards(stake_rewards);
 
         let expected_total = converted_rewards
-            .iter()
-            .map(|stake_reward| stake_reward.stake_reward)
+            .enumerated_rewards_iter()
+            .map(|(_, stake_reward)| stake_reward.stake_reward)
             .sum::<u64>();
 
         let partitioned_rewards = StartBlockHeightAndPartitionedRewards {
@@ -772,7 +776,7 @@ mod tests {
 
         let partitioned_rewards = StartBlockHeightAndPartitionedRewards {
             distribution_starting_block_height: bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
-            all_stake_rewards: Arc::new(vec![]),
+            all_stake_rewards: Arc::new(PartitionedStakeRewards::default()),
             partition_indices: vec![vec![]],
         };
 

--- a/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
@@ -1,17 +1,17 @@
 use {
-    crate::bank::partitioned_epoch_rewards::PartitionedStakeReward, itertools::enumerate,
+    crate::bank::partitioned_epoch_rewards::PartitionedStakeRewards,
     solana_epoch_rewards_hasher::EpochRewardsHasher, solana_hash::Hash,
 };
 
 pub(in crate::bank::partitioned_epoch_rewards) fn hash_rewards_into_partitions(
-    stake_rewards: &[PartitionedStakeReward],
+    stake_rewards: &PartitionedStakeRewards,
     parent_blockhash: &Hash,
     num_partitions: usize,
 ) -> Vec<Vec<usize>> {
     let hasher = EpochRewardsHasher::new(num_partitions, parent_blockhash);
     let mut indices = vec![vec![]; num_partitions];
 
-    for (i, reward) in enumerate(stake_rewards) {
+    for (i, reward) in stake_rewards.enumerated_rewards_iter() {
         // clone here so the hasher's state is re-used on each call to `hash_address_to_partition`.
         // This prevents us from re-hashing the seed each time.
         // The clone is explicit (as opposed to an implicit copy) so it is clear this is intended.
@@ -43,8 +43,8 @@ mod tests {
         let expected_num = 12345;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| PartitionedStakeReward::new_random())
-            .collect::<Vec<_>>();
+            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .collect::<PartitionedStakeRewards>();
 
         let partition_indices = hash_rewards_into_partitions(&stake_rewards, &Hash::default(), 5);
         let total_num_after_hash_partition: usize = partition_indices.iter().map(|x| x.len()).sum();
@@ -55,7 +55,7 @@ mod tests {
 
     #[test]
     fn test_hash_rewards_into_partitions_empty() {
-        let stake_rewards = vec![];
+        let stake_rewards = PartitionedStakeRewards::default();
 
         let num_partitions = 5;
         let partition_indices =
@@ -79,8 +79,8 @@ mod tests {
         // simulate 40K - 1 rewards, the expected num of credit blocks should be 10.
         let expected_num = 40959;
         let stake_rewards = (0..expected_num)
-            .map(|_| PartitionedStakeReward::new_random())
-            .collect::<Vec<_>>();
+            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .collect::<PartitionedStakeRewards>();
 
         let partition_indices =
             hash_rewards_into_partitions(&stake_rewards, &Hash::new_from_array([1; 32]), 10);

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -20,7 +20,7 @@ use {
     solana_reward_info::RewardInfo,
     solana_stake_interface::state::{Delegation, Stake},
     solana_vote::vote_account::VoteAccounts,
-    std::sync::Arc,
+    std::{mem::MaybeUninit, sync::Arc},
 };
 
 /// Number of blocks for reward calculation and storing vote accounts.
@@ -39,14 +39,79 @@ pub(crate) struct PartitionedStakeReward {
     pub commission: u8,
 }
 
-type PartitionedStakeRewards = Vec<PartitionedStakeReward>;
+/// A vector of stake rewards.
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct PartitionedStakeRewards {
+    /// Inner vector.
+    rewards: Vec<Option<PartitionedStakeReward>>,
+    /// Number of stake rewards.
+    num_rewards: usize,
+}
+
+impl PartitionedStakeRewards {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        let rewards = Vec::with_capacity(capacity);
+        Self {
+            rewards,
+            num_rewards: 0,
+        }
+    }
+
+    /// Number of stake rewards.
+    pub(crate) fn num_rewards(&self) -> usize {
+        self.num_rewards
+    }
+
+    /// Total length, including both `Some` and `None` elements.
+    pub(crate) fn total_len(&self) -> usize {
+        self.rewards.len()
+    }
+
+    pub(crate) fn get(&self, index: usize) -> Option<&Option<PartitionedStakeReward>> {
+        self.rewards.get(index)
+    }
+
+    pub(crate) fn enumerated_rewards_iter(
+        &self,
+    ) -> impl Iterator<Item = (usize, &PartitionedStakeReward)> {
+        self.rewards
+            .iter()
+            .enumerate()
+            .filter_map(|(index, reward)| Some((index, reward.as_ref()?)))
+    }
+
+    fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<Option<PartitionedStakeReward>>] {
+        self.rewards.spare_capacity_mut()
+    }
+
+    unsafe fn assume_init(&mut self, num_stake_rewards: usize) {
+        self.rewards.set_len(self.rewards.capacity());
+        self.num_rewards = num_stake_rewards;
+    }
+}
+
+#[cfg(test)]
+impl FromIterator<Option<PartitionedStakeReward>> for PartitionedStakeRewards {
+    fn from_iter<T: IntoIterator<Item = Option<PartitionedStakeReward>>>(iter: T) -> Self {
+        let mut len_some: usize = 0;
+        let rewards = Vec::from_iter(iter.into_iter().inspect(|reward| {
+            if reward.is_some() {
+                len_some = len_some.saturating_add(1);
+            }
+        }));
+        Self {
+            rewards,
+            num_rewards: len_some,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct StartBlockHeightAndRewards {
     /// the block height of the slot at which rewards distribution began
     pub(crate) distribution_starting_block_height: u64,
     /// calculated epoch rewards before partitioning
-    pub(crate) all_stake_rewards: Arc<Vec<PartitionedStakeReward>>,
+    pub(crate) all_stake_rewards: Arc<PartitionedStakeRewards>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -55,7 +120,7 @@ pub(crate) struct StartBlockHeightAndPartitionedRewards {
     pub(crate) distribution_starting_block_height: u64,
 
     /// calculated epoch rewards pending distribution
-    pub(crate) all_stake_rewards: Arc<Vec<PartitionedStakeReward>>,
+    pub(crate) all_stake_rewards: Arc<PartitionedStakeRewards>,
 
     /// indices of calculated epoch rewards per partition, outer Vec is by
     /// partition (one partition per block), inner Vec is the indices for one
@@ -196,7 +261,7 @@ pub(super) struct CalculateRewardsAndDistributeVoteRewardsResult {
     /// vote accounts
     pub(super) point_value: PointValue,
     /// stake rewards that still need to be distributed
-    pub(super) stake_rewards: Arc<Vec<PartitionedStakeReward>>,
+    pub(super) stake_rewards: Arc<PartitionedStakeRewards>,
 }
 
 pub(crate) type StakeRewards = Vec<StakeReward>;
@@ -234,7 +299,7 @@ impl Bank {
     pub(crate) fn set_epoch_reward_status_calculation(
         &mut self,
         distribution_starting_block_height: u64,
-        stake_rewards: Arc<Vec<PartitionedStakeReward>>,
+        stake_rewards: Arc<PartitionedStakeRewards>,
     ) {
         self.epoch_reward_status =
             EpochRewardStatus::Active(EpochRewardPhase::Calculation(StartBlockHeightAndRewards {
@@ -246,7 +311,7 @@ impl Bank {
     pub(crate) fn set_epoch_reward_status_distribution(
         &mut self,
         distribution_starting_block_height: u64,
-        all_stake_rewards: Arc<Vec<PartitionedStakeReward>>,
+        all_stake_rewards: Arc<PartitionedStakeRewards>,
         partition_indices: Vec<Vec<usize>>,
     ) {
         self.epoch_reward_status = EpochRewardStatus::Active(EpochRewardPhase::Distribution(
@@ -277,7 +342,7 @@ impl Bank {
         &self,
         rewards: &PartitionedStakeRewards,
     ) -> u64 {
-        let total_stake_accounts = rewards.len();
+        let total_stake_accounts = rewards.num_rewards();
         if self.epoch_schedule.warmup && self.epoch < self.first_normal_epoch() {
             1
         } else {
@@ -351,9 +416,9 @@ mod tests {
     }
 
     pub fn build_partitioned_stake_rewards(
-        stake_rewards: &[PartitionedStakeReward],
+        stake_rewards: &PartitionedStakeRewards,
         partition_indices: &[Vec<usize>],
-    ) -> Vec<Vec<PartitionedStakeReward>> {
+    ) -> Vec<PartitionedStakeRewards> {
         partition_indices
             .iter()
             .map(|partition_index| {
@@ -361,8 +426,8 @@ mod tests {
                 // that belong to this partition
                 partition_index
                     .iter()
-                    .map(|&index| stake_rewards[index].clone())
-                    .collect::<Vec<_>>()
+                    .map(|&index| stake_rewards.get(index).unwrap().clone())
+                    .collect::<PartitionedStakeRewards>()
             })
             .collect::<Vec<_>>()
     }
@@ -372,7 +437,7 @@ mod tests {
     ) -> PartitionedStakeRewards {
         stake_rewards
             .into_iter()
-            .map(|stake_reward| PartitionedStakeReward::maybe_from(&stake_reward).unwrap())
+            .map(|stake_reward| Some(PartitionedStakeReward::maybe_from(&stake_reward).unwrap()))
             .collect()
     }
 
@@ -544,8 +609,8 @@ mod tests {
         let expected_num = 100;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| PartitionedStakeReward::new_random())
-            .collect::<Vec<_>>();
+            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .collect::<PartitionedStakeRewards>();
 
         let partition_indices = vec![(0..expected_num).collect()];
 
@@ -594,8 +659,8 @@ mod tests {
             |num_stakes: u64, expected_num_reward_distribution_blocks: u64| {
                 // Given the short epoch, i.e. 32 slots, we should cap the number of reward distribution blocks to 32/10 = 3.
                 let stake_rewards = (0..num_stakes)
-                    .map(|_| PartitionedStakeReward::new_random())
-                    .collect::<Vec<_>>();
+                    .map(|_| Some(PartitionedStakeReward::new_random()))
+                    .collect::<PartitionedStakeRewards>();
 
                 assert_eq!(
                     bank.get_reward_distribution_num_blocks(&stake_rewards),
@@ -632,8 +697,8 @@ mod tests {
         // Given 8k rewards, it will take 2 blocks to credit all the rewards
         let expected_num = 8192;
         let stake_rewards = (0..expected_num)
-            .map(|_| PartitionedStakeReward::new_random())
-            .collect::<Vec<_>>();
+            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .collect::<PartitionedStakeRewards>();
 
         assert_eq!(bank.get_reward_distribution_num_blocks(&stake_rewards), 2);
     }
@@ -645,7 +710,33 @@ mod tests {
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
 
         let bank = Bank::new_for_tests(&genesis_config);
-        let rewards = vec![];
+        let rewards = PartitionedStakeRewards::default();
+        assert_eq!(bank.get_reward_distribution_num_blocks(&rewards), 1);
+    }
+
+    /// Test get_reward_distribution_num_blocks with `None` elements in the
+    /// partitioned stake rewards. `None` elements can occur if for any stake
+    /// delegation:
+    /// * there is no payout or if any deserved payout is < 1 lamport
+    /// * corresponding vote account was not found in cache and accounts-db
+    #[test]
+    fn test_get_reward_distribution_num_blocks_none() {
+        let rewards_all = 8192;
+        let expected_rewards_some = 6144;
+        let rewards = (0..rewards_all)
+            .map(|i| {
+                if i % 4 == 0 {
+                    None
+                } else {
+                    Some(PartitionedStakeReward::new_random())
+                }
+            })
+            .collect::<PartitionedStakeRewards>();
+        assert_eq!(rewards.rewards.len(), rewards_all);
+        assert_eq!(rewards.num_rewards(), expected_rewards_some);
+
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let bank = Bank::new_for_tests(&genesis_config);
         assert_eq!(bank.get_reward_distribution_num_blocks(&rewards), 1);
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11350,7 +11350,7 @@ fn test_system_instruction_unsigned_transaction() {
 
 #[test]
 fn test_calc_vote_accounts_to_store_empty() {
-    let vote_account_rewards = DashMap::default();
+    let vote_account_rewards = HashMap::default();
     let result = Bank::calc_vote_accounts_to_store(vote_account_rewards);
     assert_eq!(
         result.accounts_with_rewards.len(),
@@ -11361,7 +11361,7 @@ fn test_calc_vote_accounts_to_store_empty() {
 
 #[test]
 fn test_calc_vote_accounts_to_store_overflow() {
-    let vote_account_rewards = DashMap::default();
+    let mut vote_account_rewards = HashMap::default();
     let pubkey = solana_pubkey::new_rand();
     let mut vote_account = AccountSharedData::default();
     vote_account.set_lamports(u64::MAX);
@@ -11386,7 +11386,7 @@ fn test_calc_vote_accounts_to_store_normal() {
     let pubkey = solana_pubkey::new_rand();
     for commission in 0..2 {
         for vote_rewards in 0..2 {
-            let vote_account_rewards = DashMap::default();
+            let mut vote_account_rewards = HashMap::default();
             let mut vote_account = AccountSharedData::default();
             vote_account.set_lamports(1);
             vote_account_rewards.insert(


### PR DESCRIPTION
#### Problem

`calculate_stake_vote_rewards` was storing accumulated rewards per vote account in a `DashMap`, which then was used in a parallel iterator over all stake delegations.

There are over 1,000,000 stake delegations and around 1,000 validators. Each thread processes one of the stake delegations and tries to acquire the lock on a `DashMap` shard corresponding to a validator. Given that the number of validators is disproportionally small and they have thousands of delegations, such solution results in high contention, with some threads spending the most of their time on waiting for lock.

The time spent on these calculations was ~208.47ms:

```
redeem_rewards_us=208475i
```

Threads spent 65% of their time on waiting for locks:

<img width="1905" height="481" alt="reward-calculation-before-1" src="https://github.com/user-attachments/assets/01373b52-80de-477a-be47-ac21e85de553" />

#### Summary of Changes

Fix that by:

* Removing the `DashMap` and instead using `fold` and `reduce` operations to build a regular `HashMap`.
* Pre-allocating the `stake_rewards` vector and passing `&mut [MaybeUninit<PartitionedStakeReward>]` to the thread pool.
* Pulling the optimization of `StakeHistory::get` in `solana-stake-interface`. solana-program/stake#81

The time spent on the calculation decreased to ~49ms:

```
redeem_rewards_us=48781i
```

Threads spend the most of time doing actual calculations:

<img width="3824" height="1929" alt="epoch-rewards-final" src="https://github.com/user-attachments/assets/0041375f-08a3-481f-a89a-aceab09ca07e" />

Fixes #6899
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
