### PR TITLE
Make ancient append vec shrink test use valid account sizes

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -461,16 +461,3 @@ pub struct StoredAccountsInfo {
     /// total size of all the stored accounts
     pub size: usize,
 }
-
-#[cfg(test)]
-pub mod tests {
-    use crate::accounts_file::AccountsFile;
-    impl AccountsFile {
-        pub(crate) fn set_current_len_for_tests(&self, len: usize) {
-            match self {
-                Self::AppendVec(av) => av.set_current_len_for_tests(len),
-                Self::TieredStorage(_) => {}
-            }
-        }
-    }
-}

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1386,10 +1386,6 @@ pub mod tests {
     };
 
     impl AppendVec {
-        pub(crate) fn set_current_len_for_tests(&self, len: usize) {
-            self.current_len.store(len, Ordering::Release);
-        }
-
         fn append_account_test(&self, data: &(StoredMeta, AccountSharedData)) -> Option<usize> {
             let slot_ignored = Slot::MAX;
             let accounts = [(&data.0.pubkey, &data.1)];


### PR DESCRIPTION
#### Problem
`test_shrink_ancient_overflow_with_min_size` and `test_shrink_overflow_too_much` create accounts above max permitted size, also they seem to be testing some non-existent logic and don't really trigger intended shrink conditions mentioned in their comments.

#### Summary of Changes
* adjust `ancient_storage_ideal_size` in test db when `combine_ancient_slots_packed` is called for easier way to match sizing conditions when only valid account sizes are used
* arrange test input and params in `test_shrink_overflow_too_much` such that it will actually do any shrinking as intended and leave out the one big account out of the shrunk append_vec for other slots

Note: `test_shrink_ancient_overflow_with_min_size` seems to be testing some minimum size requirement, which no longer exists and I can't yet come up with something similar it could be testing instead... maybe this test should just be removed (and/or replaced by other more meaningful tests)?