### PR TITLE
Zero lamport obsolete index generation improvement

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -2089,8 +2089,7 @@ pub mod tests {
         let index: AccountsIndex<bool, bool> = AccountsIndex::<bool, bool>::default_for_tests();
         let pubkeys_by_bin: Vec<Pubkey> = vec![];
 
-        let reclaims =
-            index.clean_and_unref_rooted_entries_by_bin(&pubkeys_by_bin);
+        let reclaims = index.clean_and_unref_rooted_entries_by_bin(&pubkeys_by_bin);
 
         assert!(reclaims.is_empty());
     }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1648,11 +1648,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     /// Cleans and unrefs all older rooted entries for each pubkey in the accounts index.
     /// Calls passed in callback on the remaining slot entry
     /// All pubkeys must be from a single bin
-    pub fn clean_and_unref_rooted_entries_by_bin(
-        &self,
-        pubkeys_by_bin: &[Pubkey],
-        callback: impl Fn(Slot, T),
-    ) -> SlotList<T> {
+    pub fn clean_and_unref_rooted_entries_by_bin(&self, pubkeys_by_bin: &[Pubkey]) -> SlotList<T> {
         let mut reclaims = Vec::new();
 
         let map = match pubkeys_by_bin.first() {
@@ -1663,9 +1659,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         for pubkey in pubkeys_by_bin {
             map.get_internal_inner(pubkey, |entry| {
                 let entry = entry.expect("Expected entry to exist in accounts index");
-                let (slot, account_info) =
-                    self.clean_and_unref_slot_list_on_startup(entry, &mut reclaims);
-                callback(slot, account_info);
+                self.clean_and_unref_slot_list_on_startup(entry, &mut reclaims);
                 (false, ())
             });
         }
@@ -2096,7 +2090,7 @@ pub mod tests {
         let pubkeys_by_bin: Vec<Pubkey> = vec![];
 
         let reclaims =
-            index.clean_and_unref_rooted_entries_by_bin(&pubkeys_by_bin, |_slot, _info| {});
+            index.clean_and_unref_rooted_entries_by_bin(&pubkeys_by_bin);
 
         assert!(reclaims.is_empty());
     }
@@ -2122,10 +2116,7 @@ pub mod tests {
 
         assert!(gc.is_empty());
 
-        let reclaims = index.clean_and_unref_rooted_entries_by_bin(&[pubkey], |slot, info| {
-            assert_eq!(slot, 0);
-            assert!(info);
-        });
+        let reclaims = index.clean_and_unref_rooted_entries_by_bin(&[pubkey]);
 
         assert_eq!(reclaims.len(), 0);
     }
@@ -2155,10 +2146,7 @@ pub mod tests {
 
         assert!(gc.is_empty());
 
-        let reclaims = index.clean_and_unref_rooted_entries_by_bin(&[pubkey], |slot, info| {
-            assert_eq!(slot, slot2);
-            assert_eq!(info, account_info2);
-        });
+        let reclaims = index.clean_and_unref_rooted_entries_by_bin(&[pubkey]);
 
         assert_eq!(reclaims, vec![(slot1, account_info1)]);
     }
@@ -2202,7 +2190,7 @@ pub mod tests {
 
         assert!(gc.is_empty());
 
-        let mut reclaims = index.clean_and_unref_rooted_entries_by_bin(&pubkeys, |_slot, _info| {});
+        let mut reclaims = index.clean_and_unref_rooted_entries_by_bin(&pubkeys);
         reclaims.sort_unstable();
         expected_reclaims.sort_unstable();
 


### PR DESCRIPTION
#### Problem
- Visiting all zero lamport accounts is expensive and not needed twice during index generation with obsolete accounts

#### Summary of Changes
- Mark all zero lamport accounts as single refwhen they are found. This is safe as with obsolete accounts enabled, all zero lamport accounts are single ref

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
