### PR TITLE
Create fastboot obsolete accounts broken test

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -834,7 +834,7 @@ mod tests {
             },
             status_cache::Status,
         },
-        solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING,
+        solana_accounts_db::accounts_db::{MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING},
         solana_genesis_config::create_genesis_config,
         solana_keypair::Keypair,
         solana_native_token::LAMPORTS_PER_SOL,
@@ -1942,6 +1942,142 @@ mod tests {
         .unwrap();
 
         deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
+
+        assert!(
+            deserialized_bank
+                .get_account_modified_slot(&key1.pubkey())
+                .is_none(),
+            "Ensure Account1 has not been brought back from the dead"
+        );
+
+        assert_eq!(*bank3, deserialized_bank);
+    }
+
+    /// Test that restoring from snapshot dir rather than archives correctly handle zero lamport accounts
+    /// slot 0:
+    ///     - send some lamports to Account2 (from mint) to bring it to life
+    ///
+    /// slot 1:
+    ///     - send some lamports to Account1 (from Account2) to bring it to life
+    ///     - Send some lamports to Account3 (from mint) to preserve this slot
+    ///     - Root slot 1 and flush write cache
+    /// slot 2:
+    ///     - make Account1 have zero lamports (send back to Account2)
+    /// slot 3:
+    ///     - remove Account2's reference back to slot 2 by transferring from the mint to Account2
+    ///     - take a full snap shot
+    ///     - verify that recovery from snapshot directories does not bring account1 back to life
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
+    fn test_restore_snapshots_dir_handle_zero_lamport_accounts(storage_access: StorageAccess) {
+        let collector = Pubkey::new_unique();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
+
+        let (mut genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+
+        // Disable fees so fees don't need to be calculated
+        genesis_config.fee_rate_governor = solana_fee_calculator::FeeRateGovernor::new(0, 0);
+
+        let lamports_to_transfer = 123_456 * LAMPORTS_PER_SOL;
+        let bank_test_config = BankTestConfig {
+            accounts_db_config: AccountsDbConfig {
+                storage_access,
+                mark_obsolete_accounts: MarkObsoleteAccounts::Disabled,
+                ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+            },
+        };
+
+        let bank0 = Bank::new_with_config_for_tests(&genesis_config, bank_test_config);
+        let (bank0, bank_forks) = Bank::wrap_with_bank_forks_for_tests(bank0);
+        // Transport some money from mint to key2.
+        bank0
+            .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
+            .unwrap();
+        bank0.fill_bank_with_ticks_for_tests();
+
+        //In slot 1, transfer some money lamports from key2 to key1 and mint to key3
+        let slot = 1;
+        let bank1 =
+            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+        bank1
+            .transfer(lamports_to_transfer, &key2, &key1.pubkey())
+            .unwrap();
+        bank1
+            .transfer(lamports_to_transfer, &mint_keypair, &key3.pubkey())
+            .unwrap();
+        bank1.fill_bank_with_ticks_for_tests();
+        // Force rooting of slot1
+        bank1.squash();
+        bank1.force_flush_accounts_cache();
+
+        // In slot 2 transfer from key1 to key2, such that key2 has zero lamports
+        let slot = slot + 1;
+        let bank2 =
+            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+        bank2
+            .transfer(lamports_to_transfer, &key1, &key2.pubkey())
+            .unwrap();
+        assert_eq!(
+            bank2.get_balance(&key1.pubkey()),
+            0,
+            "Ensure Account1's balance is zero"
+        );
+        bank2.fill_bank_with_ticks_for_tests();
+
+        // In slot 3 transfer into key2 to invalidate the free slot 2
+        let slot = slot + 1;
+        let bank3 =
+            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
+        // Update Account2 so that it no longer holds a reference to slot2
+        bank3
+            .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
+            .unwrap();
+        bank3.fill_bank_with_ticks_for_tests();
+        assert!(
+            bank3.get_account_modified_slot(&key1.pubkey()).is_none(),
+            "Ensure Account1 has been cleaned and purged from AccountsDb"
+        );
+
+        // Take full snapshot
+        bank_to_full_snapshot_archive_with(
+            &bank_snapshots_dir,
+            &bank3,
+            SnapshotVersion::default(),
+            full_snapshot_archives_dir.path(),
+            full_snapshot_archives_dir.path(),
+            SnapshotConfig::default().archive_format,
+            true,
+        ).unwrap();
+
+        let account_paths = &bank3.rc.accounts.accounts_db.paths;
+        let bank_snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
+
+        // Deserialize the bank from the snapshot directory instead of the archives
+        let deserialized_bank = bank_from_snapshot_dir(
+            account_paths,
+            &bank_snapshot,
+            &genesis_config,
+            &RuntimeConfig::default(),
+            None,
+            None,
+            None,
+            false,
+            Some(AccountsDbConfig {
+                ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+            }),
+            None,
+            Arc::default(),
+        )
+        .unwrap();
+
+        deserialized_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
+
+        assert_eq!(deserialized_bank, *bank3);
 
         assert!(
             deserialized_bank

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1978,7 +1978,8 @@ mod tests {
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
 
-        let (mut genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let (mut genesis_config, mint_keypair) =
+            create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
 
         // Disable fees so fees don't need to be calculated
         genesis_config.fee_rate_governor = solana_fee_calculator::FeeRateGovernor::new(0, 0);
@@ -2052,7 +2053,8 @@ mod tests {
             full_snapshot_archives_dir.path(),
             SnapshotConfig::default().archive_format,
             true,
-        ).unwrap();
+        )
+        .unwrap();
 
         let account_paths = &bank3.rc.accounts.accounts_db.paths;
         let bank_snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1953,7 +1953,7 @@ mod tests {
         assert_eq!(*bank3, deserialized_bank);
     }
 
-    /// Test that restoring from snapshot dir rather than archives correctly handle zero lamport accounts
+    /// Test that restoring from snapshot dir rather than archives correctly handles zero lamport accounts
     /// slot 0:
     ///     - send some lamports to Account2 (from mint) to bring it to life
     ///


### PR DESCRIPTION
#### Problem
- Obsolete accounts is not compatible with fast boot yet is passing all existing tests

#### Summary of Changes
- Create a test that recreates the failing behaviour: Specifically zero lamport accounts being brought back to life



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
