### PR TITLE
optimize visit_zero_lamports at startup

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6987,9 +6987,6 @@ impl AccountsDb {
             }
         }
 
-        info!("START PROFILE");
-        sleep(Duration::from_secs(3));
-
         let zero_lamport_pubkeys_to_visit =
             std::mem::take(&mut *zero_lamport_pubkeys.lock().unwrap());
         let (num_zero_lamport_single_refs, visit_zero_lamports_us) = measure_us!(
@@ -6997,7 +6994,6 @@ impl AccountsDb {
         );
         timings.visit_zero_lamports_us = visit_zero_lamports_us;
         timings.num_zero_lamport_single_refs = num_zero_lamport_single_refs;
-        info!("STOP PROFILE");
 
         // subtract data.len() from accounts_data_len for all old accounts that are in the index twice
         let mut accounts_data_len_dedup_timer =

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7163,7 +7163,7 @@ impl AccountsDb {
     /// storage.
     /// Returns the number of zero lamport single ref accounts found.
     fn visit_zero_lamport_pubkeys_during_startup(&self, pubkeys: &HashSet<Pubkey>) -> u64 {
-        let mut slot_offsets = HashMap::<Slot, Vec<usize>>::default();
+        let mut slot_offsets = HashMap::<_, Vec<_>>::default();
         self.accounts_index.scan(
             pubkeys.iter(),
             |_pubkey, slots_refs, _entry| {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1112,7 +1112,7 @@ impl AccountStorageEntry {
 
     /// Insert offsets into the zero lamport single ref account offset set.
     /// Return the number of new offsets that were inserted.
-    fn insert_zero_lamport_single_ref_account_offset_batch(&self, offsets: &[usize]) -> u64 {
+    fn batch_insert_zero_lamport_single_ref_account_offsets(&self, offsets: &[Offset]) -> u64 {
         let mut zero_lamport_single_ref_offsets =
             self.zero_lamport_single_ref_offsets.write().unwrap();
         let mut count = 0;
@@ -7163,7 +7163,7 @@ impl AccountsDb {
     /// storage.
     /// Returns the number of zero lamport single ref accounts found.
     fn visit_zero_lamport_pubkeys_during_startup(&self, pubkeys: &HashSet<Pubkey>) -> u64 {
-        let mut slot_offsets = HashMap::<Slot, Vec<usize>>::default();
+        let mut slot_offsets = HashMap::default();
         self.accounts_index.scan(
             pubkeys.iter(),
             |_pubkey, slots_refs, _entry| {
@@ -7189,7 +7189,7 @@ impl AccountsDb {
         let mut count = 0;
         for (slot, offsets) in slot_offsets {
             if let Some(store) = self.storage.get_slot_storage_entry(slot) {
-                count += store.insert_zero_lamport_single_ref_account_offset_batch(&offsets);
+                count += store.batch_insert_zero_lamport_single_ref_account_offsets(&offsets);
                 if store.num_zero_lamport_single_ref_accounts() == store.count() {
                     // all accounts in this storage can be dead
                     self.dirty_stores.entry(slot).or_insert(store);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1110,6 +1110,20 @@ impl AccountStorageEntry {
         zero_lamport_single_ref_offsets.insert(offset)
     }
 
+    /// Insert offsets into the zero lamport single ref account offset set.
+    /// Return the number of new offsets that were inserted.
+    fn insert_zero_lamport_single_ref_account_offset_batch(&self, offsets: &[usize]) -> u64 {
+        let mut zero_lamport_single_ref_offsets =
+            self.zero_lamport_single_ref_offsets.write().unwrap();
+        let mut count = 0;
+        for offset in offsets {
+            if zero_lamport_single_ref_offsets.insert(*offset) {
+                count += 1;
+            }
+        }
+        count
+    }
+
     /// Return the number of zero_lamport_single_ref accounts in the storage.
     fn num_zero_lamport_single_ref_accounts(&self) -> usize {
         self.zero_lamport_single_ref_offsets.read().unwrap().len()
@@ -7145,7 +7159,7 @@ impl AccountsDb {
     /// storage.
     /// Returns the number of zero lamport single ref accounts found.
     fn visit_zero_lamport_pubkeys_during_startup(&self, pubkeys: &HashSet<Pubkey>) -> u64 {
-        let mut count = 0;
+        let mut slot_offsets = HashMap::<Slot, Vec<usize>>::default();
         self.accounts_index.scan(
             pubkeys.iter(),
             |_pubkey, slots_refs, _entry| {
@@ -7155,8 +7169,10 @@ impl AccountsDb {
                     let (slot_alive, account_info) = slot_list.first().unwrap();
                     assert!(!account_info.is_cached());
                     if account_info.is_zero_lamport() {
-                        count += 1;
-                        self.zero_lamport_single_ref_found(*slot_alive, account_info.offset());
+                        slot_offsets
+                            .entry(*slot_alive)
+                            .or_default()
+                            .push(account_info.offset());
                     }
                 }
                 AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
@@ -7165,6 +7181,29 @@ impl AccountsDb {
             false,
             ScanFilter::All,
         );
+
+        let mut count = 0;
+        for (slot, offsets) in slot_offsets {
+            if let Some(store) = self.storage.get_slot_storage_entry(slot) {
+                count += store.insert_zero_lamport_single_ref_account_offset_batch(&offsets);
+                if store.num_zero_lamport_single_ref_accounts() == store.count() {
+                    // all accounts in this storage can be dead
+                    self.dirty_stores.entry(slot).or_insert(store);
+                    self.shrink_stats
+                        .num_dead_slots_added_to_clean
+                        .fetch_add(1, Ordering::Relaxed);
+                } else if Self::is_shrinking_productive(&store)
+                    && self.is_candidate_for_shrink(&store)
+                {
+                    // this store might be eligible for shrinking now
+                    if self.shrink_candidate_slots.lock().unwrap().insert(slot) {
+                        self.shrink_stats
+                            .num_slots_with_zero_lamport_accounts_added_to_shrink
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }
+        }
         count
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7175,8 +7175,7 @@ impl AccountsDb {
                     if account_info.is_zero_lamport() {
                         slot_offsets
                             .entry(*slot_alive)
-                            .or_default()
-                            .push(account_info.offset());
+                            .or_insert_with(|| vec![account_info.offset()]);
                     }
                 }
                 AccountsIndexScanResult::OnlyKeepInMemoryIfDirty

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7175,7 +7175,8 @@ impl AccountsDb {
                     if account_info.is_zero_lamport() {
                         slot_offsets
                             .entry(*slot_alive)
-                            .or_insert_with(|| vec![account_info.offset()]);
+                            .or_default()
+                            .push(account_info.offset());
                     }
                 }
                 AccountsIndexScanResult::OnlyKeepInMemoryIfDirty

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6987,6 +6987,9 @@ impl AccountsDb {
             }
         }
 
+        info!("START PROFILE");
+        sleep(Duration::from_secs(3));
+
         let zero_lamport_pubkeys_to_visit =
             std::mem::take(&mut *zero_lamport_pubkeys.lock().unwrap());
         let (num_zero_lamport_single_refs, visit_zero_lamports_us) = measure_us!(
@@ -6994,6 +6997,7 @@ impl AccountsDb {
         );
         timings.visit_zero_lamports_us = visit_zero_lamports_us;
         timings.num_zero_lamport_single_refs = num_zero_lamport_single_refs;
+        info!("STOP PROFILE");
 
         // subtract data.len() from accounts_data_len for all old accounts that are in the index twice
         let mut accounts_data_len_dedup_timer =

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7163,7 +7163,7 @@ impl AccountsDb {
     /// storage.
     /// Returns the number of zero lamport single ref accounts found.
     fn visit_zero_lamport_pubkeys_during_startup(&self, pubkeys: &HashSet<Pubkey>) -> u64 {
-        let mut slot_offsets = HashMap::default();
+        let mut slot_offsets = HashMap::<Slot, Vec<usize>>::default();
         self.accounts_index.scan(
             pubkeys.iter(),
             |_pubkey, slots_refs, _entry| {


### PR DESCRIPTION
#### Problem

At startup, visit_zero_lamport_account takes about 39s. Profile shows that 44% of the time is spent on looking up the store. 

<img width="714" height="49" alt="image" src="https://github.com/user-attachments/assets/6fe3fff2-92ed-4c87-b4f4-762add40c3af" />


We can optimize it by group all zero accounts update by slot to save the store look up. 


#### Summary of Changes

- Group zero lamport account update by slot

#### Performance 

- Timing (reduced from 38.9s to 17.8s)

```
base: num_zero_lamport_single_refs=11594571i visit_zero_lamports_us=38949986i
opt:  num_zero_lamport_single_refs=11594571i visit_zero_lamports_us=17829074i
```

- Profile

Store look up reduced from 44% to 2.1%

<img width="714" height="28" alt="image" src="https://github.com/user-attachments/assets/96a6b0cc-020d-48e6-8ead-477bd911402e" />


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
