### PR TITLE
core: Remove crates.io badge that references solana-labs

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -215,9 +215,6 @@ spl-memo-interface = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 
-[badges]
-codecov = { repository = "solana-labs/solana", branch = "master", service = "github" }
-
 [[bench]]
 name = "banking_stage"
 


### PR DESCRIPTION
#### Problem
Ripping out references to `solana-labs` that still remain

#### Summary of Changes
The code coverage link is to old solana-labs repo, and no other crate displays this badge on crates.io. So for now, rip it out and we can always re-add it across all of our crates if we want it