### PR TITLE
fix: correct rust version reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ When building the master branch, please make sure you are using the latest stabl
 $ rustup update
 ```
 
-When building a specific release branch, you should check the rust version in `ci/rust-version.sh` and if necessary, install that version by running:
+When building a specific release branch, you should check the rust version in `rust-toolchain.toml` and if necessary, install that version by running:
 ```bash
 $ rustup install VERSION
 ```


### PR DESCRIPTION
#### Problem
Update README.md to reference `rust-toolchain.toml` instead of `ci/rust-version.sh`  for checking the rust version when building release branches. The ci/rust-version.sh  script actually reads the rust version from rust-toolchain.toml, so developers should look at the source file directly for accurate version information