### PR TITLE
fix: enable on-demand leader schedule computation in get_slot_leaders

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -44,7 +44,7 @@ use {
         blockstore::{Blockstore, BlockstoreError, SignatureInfosForAddress},
         blockstore_meta::{PerfSample, PerfSampleV1, PerfSampleV2},
         leader_schedule_cache::LeaderScheduleCache,
-        leader_schedule_utils,
+        leader_schedule_utils::{self, leader_schedule},
     },
     solana_message::{AddressLoader, SanitizedMessage},
     solana_metrics::inc_new_counter_info,
@@ -994,7 +994,7 @@ impl JsonRpcRequestProcessor {
                 Some(leader_schedule)
             } else {
                 // If not in cache, try to compute it if the epoch's stake information is available
-                leader_schedule_utils::leader_schedule(epoch, &bank)
+                leader_schedule(epoch, &bank)
                     .map(Arc::new)
             };
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -44,7 +44,7 @@ use {
         blockstore::{Blockstore, BlockstoreError, SignatureInfosForAddress},
         blockstore_meta::{PerfSample, PerfSampleV1, PerfSampleV2},
         leader_schedule_cache::LeaderScheduleCache,
-        leader_schedule_utils::{self, leader_schedule},
+        leader_schedule_utils::leader_schedule,
     },
     solana_message::{AddressLoader, SanitizedMessage},
     solana_metrics::inc_new_counter_info,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -44,7 +44,7 @@ use {
         blockstore::{Blockstore, BlockstoreError, SignatureInfosForAddress},
         blockstore_meta::{PerfSample, PerfSampleV1, PerfSampleV2},
         leader_schedule_cache::LeaderScheduleCache,
-        leader_schedule_utils::leader_schedule,
+        leader_schedule_utils::{self, leader_schedule},
     },
     solana_message::{AddressLoader, SanitizedMessage},
     solana_metrics::inc_new_counter_info,
@@ -5570,7 +5570,7 @@ pub mod tests {
         let current_epoch = bank.epoch();
 
         // Verify we can compute leader schedules using the utility function
-        let computed_schedule = leader_schedule_utils::leader_schedule(current_epoch, &bank);
+        let computed_schedule = leader_schedule(current_epoch, &bank);
         assert!(computed_schedule.is_some(), "Should be able to compute current epoch schedule");
 
         // Test the actual fix logic: cache miss falls back to computation
@@ -5580,8 +5580,8 @@ pub mod tests {
             Some(leader_schedule)
         } else {
             // This is the new fallback logic added to get_slot_leaders
-            leader_schedule_utils::leader_schedule(current_epoch, &bank)
-                .map(std::sync::Arc::new)
+            leader_schedule(current_epoch, &bank)
+                .map(Arc::new)
         };
 
         assert!(leader_schedule.is_some(), "Fix should provide leader schedule");

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5568,14 +5568,14 @@ pub mod tests {
         let rpc = RpcHandler::start();
         let bank = rpc.working_bank();
         let current_epoch = bank.epoch();
-        
+
         // Verify we can compute leader schedules using the utility function
         let computed_schedule = leader_schedule_utils::leader_schedule(current_epoch, &bank);
         assert!(computed_schedule.is_some(), "Should be able to compute current epoch schedule");
-        
+
         // Test the actual fix logic: cache miss falls back to computation
         let leader_schedule = if let Some(leader_schedule) =
-            rpc.leader_schedule_cache.get_epoch_leader_schedule(current_epoch)
+            rpc.meta.leader_schedule_cache.get_epoch_leader_schedule(current_epoch)
         {
             Some(leader_schedule)
         } else {
@@ -5583,7 +5583,7 @@ pub mod tests {
             leader_schedule_utils::leader_schedule(current_epoch, &bank)
                 .map(std::sync::Arc::new)
         };
-        
+
         assert!(leader_schedule.is_some(), "Fix should provide leader schedule");
         if let Some(schedule) = leader_schedule {
             assert!(!schedule.get_slot_leaders().is_empty(), "Should have leaders");

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -44,6 +44,7 @@ use {
         blockstore::{Blockstore, BlockstoreError, SignatureInfosForAddress},
         blockstore_meta::{PerfSample, PerfSampleV1, PerfSampleV2},
         leader_schedule_cache::LeaderScheduleCache,
+        leader_schedule_utils,
     },
     solana_message::{AddressLoader, SanitizedMessage},
     solana_metrics::inc_new_counter_info,
@@ -986,9 +987,18 @@ impl JsonRpcRequestProcessor {
 
         let mut slot_leaders = Vec::with_capacity(limit);
         while slot_leaders.len() < limit {
-            if let Some(leader_schedule) =
+            // First try to get from cache
+            let leader_schedule = if let Some(leader_schedule) =
                 self.leader_schedule_cache.get_epoch_leader_schedule(epoch)
             {
+                Some(leader_schedule)
+            } else {
+                // If not in cache, try to compute it if the epoch's stake information is available
+                leader_schedule_utils::leader_schedule(epoch, &bank)
+                    .map(std::sync::Arc::new)
+            };
+
+            if let Some(leader_schedule) = leader_schedule {
                 slot_leaders.extend(
                     leader_schedule
                         .get_slot_leaders()
@@ -5537,7 +5547,8 @@ pub mod tests {
         );
         assert_eq!(response, expected);
 
-        // Test that invalid epoch returns an error
+        // Test that epochs beyond max_epoch return appropriate error
+        // The fix enables computation when possible, but still fails when appropriate
         let query_start = 2 * bank.epoch_schedule().slots_per_epoch;
         let query_limit = 10;
 
@@ -5549,6 +5560,34 @@ pub mod tests {
             String::from("Invalid slot range: leader schedule for epoch 2 is unavailable"),
         );
         assert_eq!(response, expected);
+    }
+
+    #[test]
+    fn test_get_slot_leaders_computation_fallback() {
+        // Test that the fix enables leader schedule computation on cache miss
+        let rpc = RpcHandler::start();
+        let bank = rpc.working_bank();
+        let current_epoch = bank.epoch();
+        
+        // Verify we can compute leader schedules using the utility function
+        let computed_schedule = leader_schedule_utils::leader_schedule(current_epoch, &bank);
+        assert!(computed_schedule.is_some(), "Should be able to compute current epoch schedule");
+        
+        // Test the actual fix logic: cache miss falls back to computation
+        let leader_schedule = if let Some(leader_schedule) =
+            rpc.leader_schedule_cache.get_epoch_leader_schedule(current_epoch)
+        {
+            Some(leader_schedule)
+        } else {
+            // This is the new fallback logic added to get_slot_leaders
+            leader_schedule_utils::leader_schedule(current_epoch, &bank)
+                .map(std::sync::Arc::new)
+        };
+        
+        assert!(leader_schedule.is_some(), "Fix should provide leader schedule");
+        if let Some(schedule) = leader_schedule {
+            assert!(!schedule.get_slot_leaders().is_empty(), "Should have leaders");
+        }
     }
 
     #[test]

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -995,7 +995,7 @@ impl JsonRpcRequestProcessor {
             } else {
                 // If not in cache, try to compute it if the epoch's stake information is available
                 leader_schedule_utils::leader_schedule(epoch, &bank)
-                    .map(std::sync::Arc::new)
+                    .map(Arc::new)
             };
 
             if let Some(leader_schedule) = leader_schedule {


### PR DESCRIPTION
# Fix get_slot_leaders epoch transition failures

## Problem
`get_slot_leaders` RPC was failing with "Invalid slot range: leader schedule for epoch X is unavailable" for approximately 31 slots during every epoch transition. This occurred because:

- `get_slot_leaders` only checked `leader_schedule_cache.get_epoch_leader_schedule(epoch)`
- During epoch transitions, the new epoch's leader schedule isn't cached until the first slot of that epoch is rooted
- This created a ~31 slot window where valid requests would fail
- Caused network spam as clients sent transactions to wrong leaders during transitions

## Solution
- Add fallback to leader_schedule_utils::leader_schedule() on cache miss
- Enables on-demand computation when bank has stake information available
- Preserves all existing behavior and error handling
- No performance impact for cached schedules


Closes #6845 , can you pls check. @KirillLykov 
