### PR TITLE
program-test: format error for core bpf

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -625,8 +625,9 @@ impl ProgramTest {
         program_name: &'static str,
         program_id: &Pubkey,
     ) {
-        let program_file = find_file(&format!("{program_name}.so"))
-            .expect("Program file data not available for {program_name} ({program_id})");
+        let program_file = find_file(&format!("{program_name}.so")).unwrap_or_else(|| {
+            panic!("Program file data not available for {program_name} ({program_id})")
+        });
         let elf = read_file(program_file);
         let program_accounts =
             programs::bpf_loader_upgradeable_program_accounts(program_id, &elf, &Rent::default());


### PR DESCRIPTION
#### Problem
`add_upgradeable_program_to_genesis()` means to use a format string but doesnt

#### Summary of Changes
use one