### PR TITLE
runtime: Avoid redundant collections of stake delegations into a vector

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -595,7 +595,8 @@ impl Bank {
         reward_calc_tracer: Option<impl RewardCalcTracer>,
     ) -> StakeDelegationsMap {
         let stakes = self.stakes_cache.stakes();
-        let stake_delegations = self.filter_stake_delegations(&stakes);
+        // let stake_delegations = self.filter_stake_delegations(&stakes);
+        let stake_delegations: Vec<_> = stakes.stake_delegations().iter().collect();
         // Obtain all unique voter pubkeys from stake delegations.
         fn merge(mut acc: HashSet<Pubkey>, other: HashSet<Pubkey>) -> HashSet<Pubkey> {
             if acc.len() < other.len() {


### PR DESCRIPTION
#### Problem

Stake delegations are stored in an `im::HashMap`, which is convenient to use as a per-bank cache, because of its CoW properties:

* `clone()` is just copying a pointer and increasing a reference counter
* post-clone modification of a single node, makes a copy only of that node, not of the whole map

However, `im::HashMap`:

* has terrible traversal performance - a full iteration over a map with 1,000,000 elements takes 200ms
* doesn't support parallel iteration with Rayon
  * using `par_bridge` performs even worse than a single-threaded iteration - it takes 1.3s

Therefore, it's better to `collect()` the `im::HashMap` before calculating rewards.

The problem is that there were two `collect()` calls made during one epoch boundary.

#### Summary of Changes

Fix that by collecting only once and passing the vector of delegations along.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
