### PR TITLE
test-validator: update rpc_ports comment in TestValidatorGenesis

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -127,7 +127,9 @@ pub struct TestValidatorGenesis {
     pub rent: Rent,
     rpc_config: JsonRpcConfig,
     pubsub_config: PubSubConfig,
-    rpc_ports: Option<(u16, u16)>, // (JsonRpc, JsonRpcPubSub), None == random ports
+    // (JsonRpc, JsonRpcPubSub), None == solana_net_utils::VALIDATOR_PORT_RANGE in case of !debug_assertions
+    // and random, but non-overlapping ports for tests in case of debug_assertions
+    rpc_ports: Option<(u16, u16)>,
     warp_slot: Option<Slot>,
     accounts: HashMap<Pubkey, AccountSharedData>,
     upgradeable_programs: Vec<UpgradeableProgramInfo>,


### PR DESCRIPTION
#### Problem
The [TestValidatorGenesis](https://github.com/anza-xyz/agave/blob/c9c232c6bf10c0ce6e31f8df10b17eb735530722/test-validator/src/lib.rs#L120) has misleading comment around `rpc_ports` field.

It suggests that in case of `None` variant the ports would be taken randomly, which currently isn't fully true.
When `!debug_assertions` is set, available ports in case of `None` being picked from the [VALIDATOR_PORT_RANGE](https://github.com/anza-xyz/agave/blob/c9c232c6bf10c0ce6e31f8df10b17eb735530722/net-utils/src/lib.rs#L54-L58) range. Otherwise, safely picked thru [localhost_port_range_for_tests()](https://github.com/anza-xyz/agave/blob/c9c232c6bf10c0ce6e31f8df10b17eb735530722/net-utils/src/sockets.rs#L56) from a non-overlapping ports range.

For the sake of making it clear, it might not hurt to update the comment. 

#### Summary of Changes
The comment inform explicitly about two scenarios for `debug_assertions` and `!debug_assertions` separately. Making it clear that these aren't random ports, but selected in controlled way.