### PR TITLE
net-utils: remove duplicated tests / migrate remaining to non-deprecated functions / swap UNSPECIFED with LOCALHOST

### DIFF
--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -748,10 +748,8 @@ mod tests {
 
     #[test]
     fn test_bind_with_any_port() {
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let config = SocketConfig::default();
-        let x = bind_with_any_port_with_config(ip_addr, config).unwrap();
-        let y = bind_with_any_port_with_config(ip_addr, config).unwrap();
+        let x = sockets::bind_to_localhost_unique().unwrap();
+        let y = sockets::bind_to_localhost_unique().unwrap();
         assert_ne!(
             x.local_addr().unwrap().port(),
             y.local_addr().unwrap().port()


### PR DESCRIPTION
#### Problem
There are duplicated tests between whats in lib and sockets. Some tests bind to port 0 or even at 0.0.0.0, if that wasn't enough multiple been calling deprecated functions.

#### Summary of Changes
- Removed duplicated tests between lib and sockets
- Swapped bindings to port 0 and 0.0.0.0 to unique, localhost for tests
- Tests that been calling deprecated functions been moved to non-deprecated equivalent.
