### PR TITLE
Add layered arg proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,7 @@ dependencies = [
  "console 0.16.0",
  "core_affinity",
  "crossbeam-channel",
+ "dirs-next",
  "fd-lock",
  "indicatif 0.18.0",
  "itertools 0.12.1",
@@ -529,6 +530,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tikv-jemallocator",
  "tokio",
+ "toml 0.8.12",
 ]
 
 [[package]]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -20,6 +20,7 @@ clap = { workspace = true }
 console = { workspace = true }
 core_affinity = { workspace = true }
 crossbeam-channel = { workspace = true }
+dirs-next = { workspace = true }
 fd-lock = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
@@ -86,6 +87,7 @@ solana-vote-program = { workspace = true }
 symlink = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+toml = { workspace = true }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 jemallocator = { workspace = true }

--- a/validator/src/args/mod.rs
+++ b/validator/src/args/mod.rs
@@ -1,0 +1,73 @@
+use {
+    crate::config_file::ValidatorConfig,
+    clap::{App, Error},
+};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub trait ClapAppExt<'a, 'b> {
+    fn layered_arg<T: LayeredArg>(self) -> Self;
+}
+
+impl<'a, 'b> ClapAppExt<'a, 'b> for App<'a, 'b> {
+    fn layered_arg<T: LayeredArg>(self) -> Self {
+        T::declare_cli_args(self)
+    }
+}
+
+/// Standardized layered argument scheme.
+///
+/// This trait can be used to configure so called "layered" arguments.
+/// Layered arguments are arguments whose values may be provided via multiple sources
+/// with a particular precedence.
+///
+/// This trait exists to provide a standardized protocol for configuring layered arguments.
+pub trait LayeredArg {
+    /// Declare the CLI arguments, given an [`App`].
+    ///
+    /// Can be used to specify the clap configuration, help text, etc for a given argument.
+    fn declare_cli_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
+        app
+    }
+
+    /// Parse the argument from the validator configuration file.
+    fn from_validator_config(_config: &ValidatorConfig) -> Option<Result<Self>>
+    where
+        Self: Sized,
+    {
+        None
+    }
+
+    /// Parse the argument from the CLI.
+    fn from_clap_arg_matches(_matches: &clap::ArgMatches) -> Option<Result<Self>>
+    where
+        Self: Sized,
+    {
+        None
+    }
+
+    /// Parse the argument from environment variables.
+    fn from_env() -> Option<Result<Self>>
+    where
+        Self: Sized,
+    {
+        None
+    }
+
+    /// Parse the argument from the configured sources.
+    ///
+    /// Precedence is as follows:
+    /// 1. CLI arguments
+    /// 2. Environment variables
+    /// 3. Configuration file
+    fn parse(matches: &clap::ArgMatches, config: &ValidatorConfig) -> Option<Result<Self>>
+    where
+        Self: Sized,
+    {
+        Self::from_clap_arg_matches(matches)
+            .or_else(|| Self::from_env())
+            .or_else(|| Self::from_validator_config(config))
+    }
+}
+
+pub mod xdp;

--- a/validator/src/args/xdp.rs
+++ b/validator/src/args/xdp.rs
@@ -1,0 +1,71 @@
+use {
+    crate::{
+        args::{LayeredArg, Result},
+        config_file::ValidatorConfig,
+    },
+    clap::{App, Arg, ArgMatches, Error},
+    solana_clap_utils::{
+        hidden_unless_forced, input_parsers::parse_cpu_ranges,
+        input_validators::validate_cpu_ranges,
+    },
+    solana_turbine::xdp::XdpConfig,
+};
+
+impl LayeredArg for XdpConfig {
+    fn declare_cli_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
+        app.arg(
+            Arg::with_name("retransmit_xdp_interface")
+                .hidden(hidden_unless_forced())
+                .long("experimental-retransmit-xdp-interface")
+                .takes_value(true)
+                .value_name("INTERFACE")
+                .requires("retransmit_xdp_cpu_cores")
+                .help("EXPERIMENTAL: The network interface to use for XDP retransmit"),
+        )
+        .arg(
+            Arg::with_name("retransmit_xdp_cpu_cores")
+                .hidden(hidden_unless_forced())
+                .long("experimental-retransmit-xdp-cpu-cores")
+                .takes_value(true)
+                .value_name("CPU_LIST")
+                .validator(|value| {
+                    validate_cpu_ranges(value, "--experimental-retransmit-xdp-cpu-cores")
+                })
+                .help("EXPERIMENTAL: Enable XDP retransmit on the specified CPU cores"),
+        )
+        .arg(
+            Arg::with_name("retransmit_xdp_zero_copy")
+                .hidden(hidden_unless_forced())
+                .long("experimental-retransmit-xdp-zero-copy")
+                .takes_value(false)
+                .requires("retransmit_xdp_cpu_cores")
+                .help("EXPERIMENTAL: Enable XDP zero copy. Requires hardware support"),
+        )
+    }
+
+    fn from_clap_arg_matches(matches: &ArgMatches) -> Option<Result<Self>> {
+        let xdp_interface = matches.value_of("retransmit_xdp_interface");
+        let xdp_zero_copy = matches.is_present("retransmit_xdp_zero_copy");
+        let cpus = match parse_cpu_ranges(matches.value_of("retransmit_xdp_cpu_cores")?) {
+            Ok(cores) => cores,
+            Err(error) => return Some(Err(Error::from(error))),
+        };
+
+        Some(Ok(XdpConfig::new(xdp_interface, cpus, xdp_zero_copy)))
+    }
+
+    fn from_validator_config(config: &ValidatorConfig) -> Option<Result<Self>> {
+        let interface = config
+            .net
+            .xdp
+            .interface
+            .as_ref()
+            .and_then(|ifaces| ifaces.first().map(|iface| iface.interface.clone()));
+
+        Some(Ok(XdpConfig::new(
+            interface,
+            config.net.xdp.cpus.as_ref().map(|cpus| cpus.0.clone())?,
+            config.net.xdp.zero_copy.unwrap_or_default(),
+        )))
+    }
+}

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        args::ClapAppExt,
         bootstrap::RpcBootstrapConfig,
         cli::{hash_validator, port_range_validator, port_validator, DefaultArgs},
         commands::{FromClapArgMatches, Result},
@@ -10,7 +11,7 @@ use {
         input_parsers::keypair_of,
         input_validators::{
             is_keypair_or_ask_keyword, is_non_zero, is_parsable, is_pow2, is_pubkey,
-            is_pubkey_or_keypair, is_slot, is_within_range, validate_cpu_ranges,
+            is_pubkey_or_keypair, is_slot, is_within_range,
             validate_maximum_full_snapshot_archives_to_retain,
             validate_maximum_incremental_snapshot_archives_to_retain,
         },
@@ -30,6 +31,7 @@ use {
     },
     solana_signer::Signer,
     solana_streamer::socket::SocketAddrSpace,
+    solana_turbine::xdp::XdpConfig,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     std::{collections::HashSet, net::SocketAddr, str::FromStr},
 };
@@ -1650,34 +1652,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
                  leader used is different from others.",
             ),
     )
-    .arg(
-        Arg::with_name("retransmit_xdp_interface")
-            .hidden(hidden_unless_forced())
-            .long("experimental-retransmit-xdp-interface")
-            .takes_value(true)
-            .value_name("INTERFACE")
-            .requires("retransmit_xdp_cpu_cores")
-            .help("EXPERIMENTAL: The network interface to use for XDP retransmit"),
-    )
-    .arg(
-        Arg::with_name("retransmit_xdp_cpu_cores")
-            .hidden(hidden_unless_forced())
-            .long("experimental-retransmit-xdp-cpu-cores")
-            .takes_value(true)
-            .value_name("CPU_LIST")
-            .validator(|value| {
-                validate_cpu_ranges(value, "--experimental-retransmit-xdp-cpu-cores")
-            })
-            .help("EXPERIMENTAL: Enable XDP retransmit on the specified CPU cores"),
-    )
-    .arg(
-        Arg::with_name("retransmit_xdp_zero_copy")
-            .hidden(hidden_unless_forced())
-            .long("experimental-retransmit-xdp-zero-copy")
-            .takes_value(false)
-            .requires("retransmit_xdp_cpu_cores")
-            .help("EXPERIMENTAL: Enable XDP zero copy. Requires hardware support"),
-    )
+    .layered_arg::<XdpConfig>()
     .arg(
         Arg::with_name("use_connection_cache")
             .long("use-connection-cache")

--- a/validator/src/config_file.rs
+++ b/validator/src/config_file.rs
@@ -1,0 +1,95 @@
+//! Validator configuration file.
+//!
+//! The validator configuration file is a TOML file that can be used to configure CLI argument defaults.
+//! The default path is `~/.config/agave/validator.toml`.
+use {
+    serde::{de::Deserializer, Deserialize},
+    solana_clap_utils::input_parsers::parse_cpu_ranges,
+    std::{
+        fs::{self},
+        path::{Path, PathBuf},
+    },
+    thiserror::Error,
+};
+
+#[derive(Error, Debug)]
+pub enum ValidatorConfigError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Toml(#[from] toml::de::Error),
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ValidatorConfig {
+    #[serde(default)]
+    pub net: Net,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Net {
+    #[serde(default)]
+    pub xdp: Xdp,
+}
+
+#[derive(Debug)]
+pub struct XdpCpuRanges(pub Vec<usize>);
+
+impl<'de> serde::de::Deserialize<'de> for XdpCpuRanges {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        parse_cpu_ranges(&s)
+            .map(XdpCpuRanges)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Xdp {
+    pub interface: Option<Vec<XdpInterface>>,
+    pub cpus: Option<XdpCpuRanges>,
+    pub zero_copy: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct XdpInterface {
+    pub interface: String,
+    pub queue: u64,
+}
+
+impl ValidatorConfig {
+    pub fn default_path() -> Option<PathBuf> {
+        dirs_next::config_dir().map(|mut path| {
+            path.extend(["agave", "validator.toml"]);
+            path
+        })
+    }
+
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, ValidatorConfigError> {
+        let file = fs::read_to_string(path)?;
+        let config: ValidatorConfig = toml::from_str(&file)?;
+        Ok(config)
+    }
+
+    pub fn load_from_default_path() -> ValidatorConfig {
+        match ValidatorConfig::default_path() {
+            Some(config_path) => ValidatorConfig::from_path(config_path)
+                .inspect_err(|e| match e {
+                    ValidatorConfigError::Io(e) => {
+                        log::warn!("Unable to read validator config file: {e}");
+                    }
+                    ValidatorConfigError::Toml(e) => {
+                        log::warn!("Error parsing validator config file: {e}");
+                    }
+                })
+                .unwrap_or_default(),
+            None => {
+                log::warn!("Unable to determine system config path for validator config");
+                ValidatorConfig::default()
+            }
+        }
+    }
+}

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -15,9 +15,11 @@ use {
 };
 
 pub mod admin_rpc_service;
+pub mod args;
 pub mod bootstrap;
 pub mod cli;
 pub mod commands;
+pub mod config_file;
 pub mod dashboard;
 
 pub fn format_name_value(name: &str, value: &str) -> String {


### PR DESCRIPTION
#### Problem

Follow up and alternative to #7660. See for problem context.

#### Summary of Changes

This outlines a scheme for a layered CLI argument implementation. It is spiritually similar to the existing `FromClapArgMatches` trait, but extends its functionality to provide a comprehensive layered configuration scheme. In particular, it collocates clap arg definitions, clap arg parsing implementations, (toml) config mapping implementation,  and env mapping implementation. All these layers are optional (i.e., the trait provides defaults), which makes it easy to incrementally adopt for existing arguments or argument groups.

Advantages of this approach over #7660:
- Doesn't require mapping config values to clap defaults (i.e., `∀ 'a in App<'a> : T -> &'a str`). 
    - This avoids coupling toml config schema to CLI argument structure and/or necessitating intermediate representations of toml schema for easier mapping to clap defaults
        - e.g., one cannot trivially map `Vec<usize>` to `&'a str` without first mapping to a string and hoisting sufficiently high-up such that `'a : 'App`. This is annoying.
- Makes precedence explicit and easier to reason about
- Similar to the above, provides structured / understandable defaults, rather than requiring in-place `.unwrap_or` in processing logic
- Similar to `RunArgs` / `FromClapArgMatches`, agnostic to underlying clap version. Changes to clap only affect clap specific methods, config / env handling can remain untouched.
