### PR TITLE
fix all2all catchup

### DIFF
--- a/core/src/mock_alpenglow_consensus.rs
+++ b/core/src/mock_alpenglow_consensus.rs
@@ -543,7 +543,6 @@ impl MockAlpenglowConsensus {
                 if self.prepare_to_receive(s, slot_start).is_err() {
                     error!("Can not initiate mock voting, slot {s} was not released");
                     datapoint_info!("mock_alpenglow", ("runner_stuck", 2, i64), ("slot", s, i64));
-                    return;
                 }
                 slot_start += ONE_SLOT;
             }
@@ -551,7 +550,7 @@ impl MockAlpenglowConsensus {
 
         if let Some(slot_sender) = self.slot_sender.as_ref() {
             if slot_sender.try_send(slot).is_err() {
-                error!("Can not initiate mock voting, workers is busy");
+                error!("Can not initiate mock voting, worker is busy");
                 datapoint_info!(
                     "mock_alpenglow",
                     ("runner_stuck", 1, i64),
@@ -586,7 +585,7 @@ impl MockAlpenglowConsensus {
                         let mut lockguard = get_state_for_slot(&state, slot).lock().unwrap();
                         // check if tasks have been aborted and do not report garbage
                         if lockguard.current_slot == 0 {
-                            return;
+                            continue;
                         }
                         let total_staked = lockguard.total_staked;
                         let peers = lockguard.reset();

--- a/core/src/mock_alpenglow_consensus.rs
+++ b/core/src/mock_alpenglow_consensus.rs
@@ -107,6 +107,12 @@ impl SharedState {
             alpenglow_state: AgStateMachine::default(),
         }
     }
+    fn available(&self) -> bool {
+        self.current_slot == 0
+    }
+    fn is_ready_for_slot(&self, slot: Slot) -> bool {
+        self.current_slot == slot
+    }
 }
 const ONE_SLOT: Duration = Duration::from_millis(DEFAULT_MS_PER_SLOT);
 
@@ -240,7 +246,7 @@ impl MockAlpenglowConsensus {
         let staked_nodes = self.epoch_specs.current_epoch_staked_nodes();
 
         let mut state = get_state_for_slot(&self.state, slot).lock().unwrap();
-        if state.current_slot != 0 {
+        if !state.available() {
             return Err(state.current_slot);
         }
         state.current_slot = slot;
@@ -331,7 +337,7 @@ impl MockAlpenglowConsensus {
                     .lock()
                     .unwrap();
 
-                if vote_pkt.slot_number != state.current_slot {
+                if !state.is_ready_for_slot(vote_pkt.slot_number) {
                     trace!(
                         "Packet does not have matching slot number {} != {}",
                         vote_pkt.slot_number,
@@ -479,7 +485,7 @@ impl MockAlpenglowConsensus {
             {
                 let state = get_state_for_slot(&state, slot).lock().unwrap();
                 // check if our task was aborted, avoid sending if it was.
-                if state.current_slot != slot {
+                if !state.is_ready_for_slot(slot) {
                     return;
                 }
 
@@ -583,12 +589,13 @@ impl MockAlpenglowConsensus {
                     // collect stats from the previous slot's voting
                     let (peers, total_staked) = {
                         let mut lockguard = get_state_for_slot(&state, slot).lock().unwrap();
-                        // check if tasks have been aborted and do not report garbage
-                        if lockguard.current_slot == 0 {
-                            continue;
-                        }
+                        let state_slot = lockguard.current_slot;
                         let total_staked = lockguard.total_staked;
                         let peers = lockguard.reset();
+                        // check if state is for correct slot to not report garbage
+                        if state_slot != slot {
+                            continue;
+                        }
                         (peers, total_staked)
                     };
                     report_collected_votes(peers, total_staked, slot);

--- a/core/src/mock_alpenglow_consensus.rs
+++ b/core/src/mock_alpenglow_consensus.rs
@@ -50,6 +50,7 @@ pub(crate) struct MockAlpenglowConsensus {
     runner_thread: JoinHandle<()>,   // thread that signals others to perform voting tasks
     state: Arc<StateArray>,          // internal state of the test for each round
     highest_slot: Slot,              // highest slot we have observed so far
+    last_slot_instant: Instant,      // time when we have observed the last slot
     should_exit: Arc<AtomicBool>,
     // external state
     epoch_specs: EpochSpecs,
@@ -224,6 +225,7 @@ impl MockAlpenglowConsensus {
             should_exit,
             epoch_specs,
             cluster_info,
+            last_slot_instant: Instant::now(),
             highest_slot: 0,
             slot_sender: Some(slot_sender),
         }
@@ -497,6 +499,13 @@ impl MockAlpenglowConsensus {
     }
 
     fn check_conditions_to_vote(&mut self, slot: Slot, root_bank: &Bank) -> bool {
+        let dt = self.last_slot_instant.elapsed();
+        self.last_slot_instant = Instant::now();
+        if dt < ONE_SLOT / 2 {
+            trace!("Skipping AG logic for slot {slot} since we are catching up, slot length was {dt:?}");
+            return false;
+        }
+
         // ensure we do not start process for a slot which is "in the past"
         if slot <= self.highest_slot {
             trace!(


### PR DESCRIPTION
#### Problem

- It is possible to deadlock the all2all test if sufficiently short interval is selected because of voting during catch-up
- This happens because we are casting 6-10 votes per slot, and we only have 4 slots available for the test data. This may result in voting thread massively overrunning the all2all runner thread, which simply does not have enough time to send all the packets. On top of that, we also end up not signaling the runner thread to start its work and release the slots, resulting in a permanent loss of all2all voting capability.

#### Summary of Changes

- Make the logic more resilient to state pollution during catchup phase
- Prevent mock all2all from triggering during catchup phase to avoid cluttering the network