### PR TITLE
Subtract overflow in sort_shrink_indexes_by_bytes_saved

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -15,6 +15,7 @@ use {
         },
         active_stats::ActiveStatItem,
         storable_accounts::{StorableAccounts, StorableAccountsBySlot},
+        u64_align,
     },
     rand::{thread_rng, Rng},
     rayon::prelude::{IntoParallelRefIterator, ParallelIterator},
@@ -162,7 +163,11 @@ impl AncientSlotInfos {
         self.shrink_indexes.sort_unstable_by(|l, r| {
             let amount_shrunk = |index: &usize| {
                 let item = &self.all_infos[*index];
-                item.capacity - item.alive_bytes
+                // alive_bytes assumes the accounts are aligned. `capacity` may
+                // not be aligned for the last account. Therefore, we need to
+                // align it.
+                let aligned_capacity = u64_align!(item.capacity as usize) as u64;
+                aligned_capacity - item.alive_bytes
             };
             amount_shrunk(r).cmp(&amount_shrunk(l))
         });

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -167,15 +167,15 @@ impl AncientSlotInfos {
                 // not be aligned for the last account. Therefore, we need to
                 // align it.
                 let aligned_capacity = u64_align!(item.capacity as usize) as u64;
-                if aligned_capacity <= item.alive_bytes {
+                if aligned_capacity < item.alive_bytes {
                     // should not happen, but if it does, submit warn log it and continue
                     datapoint_warn!(
-                        "aligned_capacity <= alive_bytes",
+                        "aligned_capacity_less_than_alive_bytes",
                         ("aligned_capacity", aligned_capacity, i64),
                         ("alive_bytes", item.alive_bytes, i64)
                     );
                 }
-                aligned_capacity.saturating_sub(item.alive_bytes)
+                item.capacity.saturating_sub(item.alive_bytes)
             };
             amount_shrunk(r).cmp(&amount_shrunk(l))
         });

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -167,7 +167,15 @@ impl AncientSlotInfos {
                 // not be aligned for the last account. Therefore, we need to
                 // align it.
                 let aligned_capacity = u64_align!(item.capacity as usize) as u64;
-                aligned_capacity - item.alive_bytes
+                if aligned_capacity <= item.alive_bytes {
+                    // should not happen, but if it does, submit warn log it and continue
+                    datapoint_warn!(
+                        "aligned_capacity <= alive_bytes",
+                        ("aligned_capacity", aligned_capacity, i64),
+                        ("alive_bytes", item.alive_bytes, i64)
+                    );
+                }
+                aligned_capacity.saturating_sub(item.alive_bytes)
             };
             amount_shrunk(r).cmp(&amount_shrunk(l))
         });


### PR DESCRIPTION
#### Problem

subtract in sort_shrink_indexes_by_bytes_saved overflow at the following line. 

https://github.com/anza-xyz/agave/blob/94eb488d3e7b398cdd44c7b53d69bf0ee3c8172b/accounts-db/src/ancient_append_vecs.rs#L165

See #7699 for more details.

tldr, there is a bug in https://github.com/anza-xyz/agave/blob/94eb488d3e7b398cdd44c7b53d69bf0ee3c8172b/accounts-db/src/ancient_append_vecs.rs#L165

All accounts are logically required to be aligned to u64. When we write accounts to the file, they are aligned properly — except for the last one. For the final account, the padding bytes are not written out. As a result, the actual file size can be up to 7 bytes smaller than the logical size.

Alive accounts use the logical size, so they assume the padding is there. But the capacity is based on the actual file size, which may be missing the padding for the last account. And this can lead to the subtract overflow. 


#### Summary of Changes

u64_align store capacity before subtracting alive_bytes.

Fixes #7699
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
