### PR TITLE
Control memlock budget for accounts-db through config field

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -107,7 +107,9 @@ const DEFAULT_NUM_DIRS: u32 = 4;
 // This value reflects recommended memory lock limit documented in the validator's
 // setup instructions at docs/src/operations/guides/validator-start.md allowing use of
 // several io_uring instances with fixed buffers for large disk IO operations.
-pub const DEFAULT_MEMLOCK_BUDGET_BYTES: usize = 2_000_000_000;
+pub const DEFAULT_MEMLOCK_BUDGET_SIZE: usize = 2_000_000_000;
+// Linux distributions often have some small memory lock limit (e.g. 8MB) that we can tap into.
+const TESTS_MEMLOCK_BUDGET_SIZE: usize = 4_000_000;
 
 // When getting accounts for shrinking from the index, this is the # of accounts to lookup per thread.
 // This allows us to split up accounts index accesses across multiple threads.
@@ -305,7 +307,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     num_background_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
-    memlock_budget_bytes: 4 * 1024 * 1024,
+    memlock_budget_size: TESTS_MEMLOCK_BUDGET_SIZE,
 };
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
@@ -328,7 +330,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     num_background_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
-    memlock_budget_bytes: 4 * 1024 * 1024,
+    memlock_budget_size: TESTS_MEMLOCK_BUDGET_SIZE,
 };
 
 struct LoadAccountsIndexForShrink<'a, T: ShrinkCollectRefs<'a>> {
@@ -455,10 +457,10 @@ pub struct AccountsDbConfig {
     pub num_foreground_threads: Option<NonZeroUsize>,
     /// Number of threads for background accounts hashing
     pub num_hash_threads: Option<NonZeroUsize>,
-    /// Amount of memory that is allowed to be locked during operations.
+    /// Amount of memory (in bytes) that is allowed to be locked during db operations.
     /// On linux it's verified on start-up with the kernel limits, such that during runtime
     /// parts of it can be utilized without panicking.
-    pub memlock_budget_bytes: usize,
+    pub memlock_budget_size: usize,
 }
 
 #[cfg(not(test))]

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -104,6 +104,11 @@ const UNREF_ACCOUNTS_BATCH_SIZE: usize = 10_000;
 const DEFAULT_FILE_SIZE: u64 = 4 * 1024 * 1024;
 const DEFAULT_NUM_DIRS: u32 = 4;
 
+// This value reflects recommended memory lock limit documented in the validator's
+// setup instructions at docs/src/operations/guides/validator-start.md allowing use of
+// several io_uring instances with fixed buffers for large disk IO operations.
+pub const DEFAULT_MEMLOCK_BUDGET_BYTES: usize = 2_000_000_000;
+
 // When getting accounts for shrinking from the index, this is the # of accounts to lookup per thread.
 // This allows us to split up accounts index accesses across multiple threads.
 const SHRINK_COLLECT_CHUNK_SIZE: usize = 50;
@@ -300,6 +305,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     num_background_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
+    memlock_budget_bytes: 4 * 1024 * 1024,
 };
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
@@ -322,6 +328,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     num_background_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
+    memlock_budget_bytes: 4 * 1024 * 1024,
 };
 
 struct LoadAccountsIndexForShrink<'a, T: ShrinkCollectRefs<'a>> {
@@ -448,6 +455,10 @@ pub struct AccountsDbConfig {
     pub num_foreground_threads: Option<NonZeroUsize>,
     /// Number of threads for background accounts hashing
     pub num_hash_threads: Option<NonZeroUsize>,
+    /// Amount of memory that is allowed to be locked during operations.
+    /// On linux it's verified on start-up with the kernel limits, such that during runtime
+    /// parts of it can be utilized without panicking.
+    pub memlock_budget_bytes: usize,
 }
 
 #[cfg(not(test))]

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -109,7 +109,7 @@ const DEFAULT_NUM_DIRS: u32 = 4;
 // several io_uring instances with fixed buffers for large disk IO operations.
 pub const DEFAULT_MEMLOCK_BUDGET_SIZE: usize = 2_000_000_000;
 // Linux distributions often have some small memory lock limit (e.g. 8MB) that we can tap into.
-const TESTS_MEMLOCK_BUDGET_SIZE: usize = 4_000_000;
+const MEMLOCK_BUDGET_SIZE_FOR_TESTS: usize = 4_000_000;
 
 // When getting accounts for shrinking from the index, this is the # of accounts to lookup per thread.
 // This allows us to split up accounts index accesses across multiple threads.
@@ -307,7 +307,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     num_background_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
-    memlock_budget_size: TESTS_MEMLOCK_BUDGET_SIZE,
+    memlock_budget_size: MEMLOCK_BUDGET_SIZE_FOR_TESTS,
 };
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
@@ -330,7 +330,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     num_background_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
-    memlock_budget_size: TESTS_MEMLOCK_BUDGET_SIZE,
+    memlock_budget_size: MEMLOCK_BUDGET_SIZE_FOR_TESTS,
 };
 
 struct LoadAccountsIndexForShrink<'a, T: ShrinkCollectRefs<'a>> {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1072,10 +1072,10 @@ fn test_clean_dead_slot_with_obsolete_accounts() {
 
     let accounts = AccountsDb::new_with_config(
         Vec::new(),
-        Some(AccountsDbConfig {
+        AccountsDbConfig {
             mark_obsolete_accounts: MarkObsoleteAccounts::Enabled,
             ..ACCOUNTS_DB_CONFIG_FOR_TESTING
-        }),
+        },
         None,
         Arc::default(),
     );

--- a/accounts-db/src/file_io.rs
+++ b/accounts-db/src/file_io.rs
@@ -210,12 +210,12 @@ impl FileCreator for SyncIoFileCreator<'_> {
     }
 }
 
-pub fn validate_memlock_limit_for_disk_io(required_size: usize) -> io::Result<()> {
+pub fn validate_memlock_limit_for_disk_io(_required_size: usize) -> io::Result<()> {
     #[cfg(target_os = "linux")]
     {
         // memory locked requirement is only necessary on linux where io_uring is used
         use crate::io_uring::memory::adjust_ulimit_memlock;
-        adjust_ulimit_memlock(required_size)
+        adjust_ulimit_memlock(_required_size)
     }
     #[cfg(not(target_os = "linux"))]
     {

--- a/accounts-db/src/file_io.rs
+++ b/accounts-db/src/file_io.rs
@@ -208,6 +208,19 @@ impl FileCreator for SyncIoFileCreator<'_> {
     }
 }
 
+pub fn validate_memlock_limit_for_disk_io(required_size: usize) -> io::Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        // memory locked requirement is only necessary on linux where io_uring is used
+        use crate::io_uring::memory::adjust_ulimit_memlock;
+        adjust_ulimit_memlock(required_size)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {

--- a/accounts-db/src/file_io.rs
+++ b/accounts-db/src/file_io.rs
@@ -147,9 +147,11 @@ pub fn file_creator<'a>(
     if agave_io_uring::io_uring_supported() {
         use crate::io_uring::file_creator::{IoUringFileCreator, DEFAULT_WRITE_SIZE};
 
-        let buf_size = buf_size.max(DEFAULT_WRITE_SIZE);
-        let io_uring_creator = IoUringFileCreator::with_buffer_capacity(buf_size, file_complete)?;
-        return Ok(Box::new(io_uring_creator));
+        if buf_size >= DEFAULT_WRITE_SIZE {
+            let io_uring_creator =
+                IoUringFileCreator::with_buffer_capacity(buf_size, file_complete)?;
+            return Ok(Box::new(io_uring_creator));
+        }
     }
     Ok(Box::new(SyncIoFileCreator::new(buf_size, file_complete)))
 }

--- a/accounts-db/src/file_io.rs
+++ b/accounts-db/src/file_io.rs
@@ -219,7 +219,7 @@ pub fn validate_memlock_limit_for_disk_io(required_size: usize) -> io::Result<()
     }
     #[cfg(not(target_os = "linux"))]
     {
-        assert!(required_size >= 0);
+        let _ = required_size;
         Ok(())
     }
 }

--- a/accounts-db/src/file_io.rs
+++ b/accounts-db/src/file_io.rs
@@ -210,15 +210,16 @@ impl FileCreator for SyncIoFileCreator<'_> {
     }
 }
 
-pub fn validate_memlock_limit_for_disk_io(_required_size: usize) -> io::Result<()> {
+pub fn validate_memlock_limit_for_disk_io(required_size: usize) -> io::Result<()> {
     #[cfg(target_os = "linux")]
     {
         // memory locked requirement is only necessary on linux where io_uring is used
         use crate::io_uring::memory::adjust_ulimit_memlock;
-        adjust_ulimit_memlock(_required_size)
+        adjust_ulimit_memlock(required_size)
     }
     #[cfg(not(target_os = "linux"))]
     {
+        assert!(required_size >= 0);
         Ok(())
     }
 }

--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -542,7 +542,7 @@ fn unpack_genesis<A: Read>(
 ) -> Result<()> {
     unpack_archive(
         archive,
-        0,
+        0, /* don't provide memlock budget (forces sync IO), since genesis archives are small */
         max_genesis_archive_unpacked_size,
         max_genesis_archive_unpacked_size,
         MAX_GENESIS_ARCHIVE_UNPACKED_COUNT,

--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -93,7 +93,7 @@ pub enum UnpackPath<'a> {
 
 fn unpack_archive<'a, A, C, D>(
     mut archive: Archive<A>,
-    input_archive_size: u64,
+    memlock_budget_size: usize,
     apparent_limit_size: u64,
     actual_limit_size: u64,
     limit_count: u64,
@@ -115,7 +115,7 @@ where
     // Bound the buffer based on provided limit of unpacked data and input archive size
     // (decompression multiplies content size, but buffering more than origin isn't necessary).
     let buf_size =
-        (input_archive_size.min(actual_limit_size) as usize).min(MAX_UNPACK_WRITE_BUF_SIZE);
+        (memlock_budget_size.min(actual_limit_size as usize)).min(MAX_UNPACK_WRITE_BUF_SIZE);
     let mut files_creator = file_creator(buf_size, file_path_processor)?;
 
     for entry in archive.entries()? {
@@ -342,14 +342,14 @@ pub type UnpackedAppendVecMap = HashMap<String, PathBuf>;
 /// Unpacks snapshot and collects AppendVec file names & paths
 pub fn unpack_snapshot<A: Read>(
     archive: Archive<A>,
-    input_archive_size: u64,
+    memlock_budget_size: usize,
     ledger_dir: &Path,
     account_paths: &[PathBuf],
 ) -> Result<UnpackedAppendVecMap> {
     let mut unpacked_append_vec_map = UnpackedAppendVecMap::new();
     unpack_snapshot_with_processors(
         archive,
-        input_archive_size,
+        memlock_budget_size,
         ledger_dir,
         account_paths,
         |file, path| {
@@ -364,14 +364,14 @@ pub fn unpack_snapshot<A: Read>(
 /// sends entry file paths through the `sender` channel
 pub fn streaming_unpack_snapshot<A: Read>(
     archive: Archive<A>,
-    input_archive_size: u64,
+    memlock_budget_size: usize,
     ledger_dir: &Path,
     account_paths: &[PathBuf],
     sender: &Sender<PathBuf>,
 ) -> Result<()> {
     unpack_snapshot_with_processors(
         archive,
-        input_archive_size,
+        memlock_budget_size,
         ledger_dir,
         account_paths,
         |_, _| {},
@@ -389,7 +389,7 @@ pub fn streaming_unpack_snapshot<A: Read>(
 
 fn unpack_snapshot_with_processors<A, F, G>(
     archive: Archive<A>,
-    input_archive_size: u64,
+    memlock_budget_size: usize,
     ledger_dir: &Path,
     account_paths: &[PathBuf],
     mut accounts_path_processor: F,
@@ -404,7 +404,7 @@ where
 
     unpack_archive(
         archive,
-        input_archive_size,
+        memlock_budget_size,
         MAX_SNAPSHOT_ARCHIVE_UNPACKED_APPARENT_SIZE,
         MAX_SNAPSHOT_ARCHIVE_UNPACKED_ACTUAL_SIZE,
         MAX_SNAPSHOT_ARCHIVE_UNPACKED_COUNT,
@@ -529,7 +529,7 @@ pub fn unpack_genesis_archive(
     let archive = Archive::new(tar);
     unpack_genesis(
         archive,
-        archive_size,
+        archive_size as usize, // TODO: adjust with budget
         destination_dir,
         max_genesis_archive_unpacked_size,
     )?;
@@ -543,13 +543,13 @@ pub fn unpack_genesis_archive(
 
 fn unpack_genesis<A: Read>(
     archive: Archive<A>,
-    input_archive_size: u64,
+    memlock_budget_size: usize,
     unpack_dir: &Path,
     max_genesis_archive_unpacked_size: u64,
 ) -> Result<()> {
     unpack_archive(
         archive,
-        input_archive_size,
+        memlock_budget_size,
         max_genesis_archive_unpacked_size,
         max_genesis_archive_unpacked_size,
         MAX_GENESIS_ARCHIVE_UNPACKED_COUNT,

--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -524,15 +524,9 @@ pub fn unpack_genesis_archive(
 
     fs::create_dir_all(destination_dir)?;
     let tar_bz2 = File::open(archive_filename)?;
-    let archive_size = tar_bz2.metadata()?.len();
     let tar = BzDecoder::new(BufReader::new(tar_bz2));
     let archive = Archive::new(tar);
-    unpack_genesis(
-        archive,
-        archive_size as usize, // TODO: adjust with budget
-        destination_dir,
-        max_genesis_archive_unpacked_size,
-    )?;
+    unpack_genesis(archive, destination_dir, max_genesis_archive_unpacked_size)?;
     info!(
         "Extracted {:?} in {:?}",
         archive_filename,
@@ -543,13 +537,12 @@ pub fn unpack_genesis_archive(
 
 fn unpack_genesis<A: Read>(
     archive: Archive<A>,
-    memlock_budget_size: usize,
     unpack_dir: &Path,
     max_genesis_archive_unpacked_size: u64,
 ) -> Result<()> {
     unpack_archive(
         archive,
-        memlock_budget_size,
+        0,
         max_genesis_archive_unpacked_size,
         max_genesis_archive_unpacked_size,
         MAX_GENESIS_ARCHIVE_UNPACKED_COUNT,
@@ -835,7 +828,7 @@ mod tests {
 
     fn finalize_and_unpack_genesis(archive: tar::Builder<Vec<u8>>) -> Result<()> {
         with_finalize_and_unpack(archive, |a, b| {
-            unpack_genesis(a, 256, b, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE)
+            unpack_genesis(a, b, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE)
         })
     }
 

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -44,8 +44,7 @@ pub mod tiered_storage;
 pub mod utils;
 pub mod waitable_condvar;
 
-pub use buffered_reader::large_file_buf_reader;
-pub use file_io::validate_memlock_limit_for_disk_io;
+pub use {buffered_reader::large_file_buf_reader, file_io::validate_memlock_limit_for_disk_io};
 
 #[macro_use]
 extern crate solana_metrics;

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -45,6 +45,7 @@ pub mod utils;
 pub mod waitable_condvar;
 
 pub use buffered_reader::large_file_buf_reader;
+pub use file_io::validate_memlock_limit_for_disk_io;
 
 #[macro_use]
 extern crate solana_metrics;

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1,5 +1,6 @@
 //! The `validator` module hosts all the validator microservices.
 
+use solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_BYTES;
 pub use solana_perf::report_target_features;
 use {
     crate::{
@@ -700,6 +701,13 @@ impl Validator {
         }
         sigverify::init();
         info!("Initializing sigverify done.");
+
+        let accounts_db_config = config.accounts_db_config.as_ref();
+        solana_accounts_db::validate_memlock_limit_for_disk_io(
+            accounts_db_config
+                .map(|config| config.memlock_budget_bytes)
+                .unwrap_or(DEFAULT_MEMLOCK_BUDGET_BYTES),
+        )?;
 
         if !ledger_path.is_dir() {
             return Err(anyhow!(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -33,9 +33,7 @@ use {
     crossbeam_channel::{bounded, unbounded, Receiver},
     quinn::Endpoint,
     solana_accounts_db::{
-        accounts_db::{
-            AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_TESTING, DEFAULT_MEMLOCK_BUDGET_SIZE,
-        },
+        accounts_db::{AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_TESTING},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         hardened_unpack::{
             open_genesis_config, OpenGenesisConfigError, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
@@ -703,11 +701,8 @@ impl Validator {
         sigverify::init();
         info!("Initializing sigverify done.");
 
-        let accounts_db_config = config.accounts_db_config.as_ref();
         solana_accounts_db::validate_memlock_limit_for_disk_io(
-            accounts_db_config
-                .map(|config| config.memlock_budget_size)
-                .unwrap_or(DEFAULT_MEMLOCK_BUDGET_SIZE),
+            config.accounts_db_config.memlock_budget_size,
         )?;
 
         if !ledger_path.is_dir() {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -34,7 +34,7 @@ use {
     quinn::Endpoint,
     solana_accounts_db::{
         accounts_db::{
-            AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_TESTING, DEFAULT_MEMLOCK_BUDGET_BYTES,
+            AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_TESTING, DEFAULT_MEMLOCK_BUDGET_SIZE,
         },
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         hardened_unpack::{
@@ -706,8 +706,8 @@ impl Validator {
         let accounts_db_config = config.accounts_db_config.as_ref();
         solana_accounts_db::validate_memlock_limit_for_disk_io(
             accounts_db_config
-                .map(|config| config.memlock_budget_bytes)
-                .unwrap_or(DEFAULT_MEMLOCK_BUDGET_BYTES),
+                .map(|config| config.memlock_budget_size)
+                .unwrap_or(DEFAULT_MEMLOCK_BUDGET_SIZE),
         )?;
 
         if !ledger_path.is_dir() {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1,6 +1,5 @@
 //! The `validator` module hosts all the validator microservices.
 
-use solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_BYTES;
 pub use solana_perf::report_target_features;
 use {
     crate::{
@@ -34,7 +33,9 @@ use {
     crossbeam_channel::{bounded, unbounded, Receiver},
     quinn::Endpoint,
     solana_accounts_db::{
-        accounts_db::{AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_TESTING},
+        accounts_db::{
+            AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_TESTING, DEFAULT_MEMLOCK_BUDGET_BYTES,
+        },
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         hardened_unpack::{
             open_genesis_config, OpenGenesisConfigError, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -825,8 +825,8 @@ mod tests {
             status_cache::Status,
         },
         solana_accounts_db::{
-            accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING, accounts_file::StorageAccess,
-            MarkObsoleteAccounts,
+            accounts_db::{MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING},
+            accounts_file::StorageAccess,
         },
         solana_genesis_config::create_genesis_config,
         solana_keypair::Keypair,

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -58,7 +58,7 @@ use {
 pub fn bank_fields_from_snapshot_archives(
     full_snapshot_archives_dir: impl AsRef<Path>,
     incremental_snapshot_archives_dir: impl AsRef<Path>,
-    accounts_db_config: Option<&AccountsDbConfig>,
+    accounts_db_config: &AccountsDbConfig,
 ) -> snapshot_utils::Result<BankFieldsToDeserialize> {
     let full_snapshot_archive_info =
         get_highest_full_snapshot_archive_info(&full_snapshot_archives_dir).ok_or_else(|| {
@@ -1592,10 +1592,10 @@ mod tests {
         let bank_fields = bank_fields_from_snapshot_archives(
             &all_snapshots_dir,
             &all_snapshots_dir,
-            Some(&AccountsDbConfig {
+            &AccountsDbConfig {
                 storage_access,
                 ..ACCOUNTS_DB_CONFIG_FOR_TESTING
-            }),
+            },
         )
         .unwrap();
         assert_eq!(bank_fields.slot, bank2.slot());

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1592,7 +1592,10 @@ mod tests {
         let bank_fields = bank_fields_from_snapshot_archives(
             &all_snapshots_dir,
             &all_snapshots_dir,
-            Some(&ACCOUNTS_DB_CONFIG_FOR_TESTING),
+            Some(&AccountsDbConfig {
+                storage_access,
+                ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+            }),
         )
         .unwrap();
         assert_eq!(bank_fields.slot, bank2.slot());

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -8,7 +8,6 @@ use {
             SnapshotRootPaths, UnpackedSnapshotsDirAndVersion,
         },
     },
-    solana_accounts_db::accounts_file::StorageAccess,
     tempfile::TempDir,
 };
 use {
@@ -59,7 +58,7 @@ use {
 pub fn bank_fields_from_snapshot_archives(
     full_snapshot_archives_dir: impl AsRef<Path>,
     incremental_snapshot_archives_dir: impl AsRef<Path>,
-    storage_access: StorageAccess,
+    accounts_db_config: Option<&AccountsDbConfig>,
 ) -> snapshot_utils::Result<BankFieldsToDeserialize> {
     let full_snapshot_archive_info =
         get_highest_full_snapshot_archive_info(&full_snapshot_archives_dir).ok_or_else(|| {
@@ -88,7 +87,7 @@ pub fn bank_fields_from_snapshot_archives(
         &full_snapshot_archive_info,
         incremental_snapshot_archive_info.as_ref(),
         &account_paths,
-        storage_access,
+        accounts_db_config,
     )?;
 
     bank_fields_from_snapshots(
@@ -173,7 +172,7 @@ pub fn bank_from_snapshot_archives(
         full_snapshot_archive_info,
         incremental_snapshot_archive_info,
         account_paths,
-        accounts_db_config.storage_access,
+        &accounts_db_config,
     )?;
 
     if let Some(incremental_storage) = incremental_storage {
@@ -825,7 +824,10 @@ mod tests {
             },
             status_cache::Status,
         },
-        solana_accounts_db::accounts_db::{MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING},
+        solana_accounts_db::{
+            accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING, accounts_file::StorageAccess,
+            MarkObsoleteAccounts,
+        },
         solana_genesis_config::create_genesis_config,
         solana_keypair::Keypair,
         solana_native_token::LAMPORTS_PER_SOL,
@@ -1590,7 +1592,7 @@ mod tests {
         let bank_fields = bank_fields_from_snapshot_archives(
             &all_snapshots_dir,
             &all_snapshots_dir,
-            storage_access,
+            Some(&ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
         .unwrap();
         assert_eq!(bank_fields.slot, bank2.slot());

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -26,7 +26,7 @@ use {
         account_storage_reader::AccountStorageReader,
         accounts_db::{
             AccountStorageEntry, AccountsDbConfig, AtomicAccountsFileId,
-            DEFAULT_MEMLOCK_BUDGET_BYTES,
+            DEFAULT_MEMLOCK_BUDGET_SIZE,
         },
         accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
         hardened_unpack::{self, UnpackError},
@@ -1890,8 +1890,8 @@ fn unarchive_snapshot(
 
     let (memlock_budget_size, storage_access) = accounts_db_config
         .as_ref()
-        .map(|config| (config.memlock_budget_bytes, config.storage_access))
-        .unwrap_or((DEFAULT_MEMLOCK_BUDGET_BYTES, StorageAccess::default()));
+        .map(|config| (config.memlock_budget_size, config.storage_access))
+        .unwrap_or((DEFAULT_MEMLOCK_BUDGET_SIZE, StorageAccess::default()));
 
     let (file_sender, file_receiver) = crossbeam_channel::unbounded();
     let unarchive_handle = streaming_unarchive_snapshot(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -24,7 +24,10 @@ use {
     solana_accounts_db::{
         account_storage::{AccountStorageMap, AccountStoragesOrderer},
         account_storage_reader::AccountStorageReader,
-        accounts_db::{AccountStorageEntry, AtomicAccountsFileId},
+        accounts_db::{
+            AccountStorageEntry, AccountsDbConfig, AtomicAccountsFileId,
+            DEFAULT_MEMLOCK_BUDGET_BYTES,
+        },
         accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
         hardened_unpack::{self, UnpackError},
         utils::{move_and_async_delete_path, ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR},
@@ -1596,7 +1599,7 @@ pub fn verify_and_unarchive_snapshots(
     full_snapshot_archive_info: &FullSnapshotArchiveInfo,
     incremental_snapshot_archive_info: Option<&IncrementalSnapshotArchiveInfo>,
     account_paths: &[PathBuf],
-    storage_access: StorageAccess,
+    accounts_db_config: Option<&AccountsDbConfig>,
 ) -> Result<(UnarchivedSnapshots, UnarchivedSnapshotsGuard)> {
     check_are_snapshots_compatible(
         full_snapshot_archive_info,
@@ -1619,7 +1622,7 @@ pub fn verify_and_unarchive_snapshots(
         account_paths,
         full_snapshot_archive_info.archive_format(),
         next_append_vec_id.clone(),
-        storage_access,
+        accounts_db_config,
     )?;
 
     let (
@@ -1645,7 +1648,7 @@ pub fn verify_and_unarchive_snapshots(
             account_paths,
             incremental_snapshot_archive_info.archive_format(),
             next_append_vec_id.clone(),
-            storage_access,
+            accounts_db_config,
         )?;
         (
             Some(unpack_dir),
@@ -1690,17 +1693,19 @@ fn streaming_unarchive_snapshot(
     ledger_dir: PathBuf,
     snapshot_archive_path: PathBuf,
     archive_format: ArchiveFormat,
+    memlock_budget_size: usize,
 ) -> JoinHandle<Result<()>> {
     Builder::new()
         .name("solTarUnpack".to_string())
         .spawn(move || {
-            let archive_size = fs::metadata(&snapshot_archive_path)?.len();
-            let buf_size = archive_size.min(MAX_SNAPSHOT_READER_BUF_SIZE);
+            let archive_size = fs::metadata(&snapshot_archive_path)?.len() as usize;
+            let read_write_budget_size = (memlock_budget_size / 2).min(archive_size);
+            let read_buf_size = MAX_SNAPSHOT_READER_BUF_SIZE.min(read_write_budget_size as u64);
             let decompressor =
-                decompressed_tar_reader(archive_format, snapshot_archive_path, buf_size)?;
+                decompressed_tar_reader(archive_format, snapshot_archive_path, read_buf_size)?;
             hardened_unpack::streaming_unpack_snapshot(
                 Archive::new(decompressor),
-                archive_size,
+                read_write_budget_size,
                 ledger_dir.as_path(),
                 &account_paths,
                 &file_sender,
@@ -1876,12 +1881,17 @@ fn unarchive_snapshot(
     account_paths: &[PathBuf],
     archive_format: ArchiveFormat,
     next_append_vec_id: Arc<AtomicAccountsFileId>,
-    storage_access: StorageAccess,
+    accounts_db_config: Option<&AccountsDbConfig>,
 ) -> Result<UnarchivedSnapshot> {
     let unpack_dir = tempfile::Builder::new()
         .prefix(unpacked_snapshots_dir_prefix)
         .tempdir_in(bank_snapshots_dir)?;
     let unpacked_snapshots_dir = unpack_dir.path().join(BANK_SNAPSHOTS_DIR);
+
+    let (memlock_budget_size, storage_access) = accounts_db_config
+        .as_ref()
+        .map(|config| (config.memlock_budget_bytes, config.storage_access))
+        .unwrap_or((DEFAULT_MEMLOCK_BUDGET_BYTES, StorageAccess::default()));
 
     let (file_sender, file_receiver) = crossbeam_channel::unbounded();
     let unarchive_handle = streaming_unarchive_snapshot(
@@ -1890,6 +1900,7 @@ fn unarchive_snapshot(
         unpack_dir.path().to_path_buf(),
         snapshot_archive_path.as_ref().to_path_buf(),
         archive_format,
+        memlock_budget_size,
     );
 
     let num_rebuilder_threads = num_cpus::get_physical().saturating_sub(1).max(1);

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -445,7 +445,7 @@ pub fn execute(
         num_foreground_threads: Some(accounts_db_foreground_threads),
         num_hash_threads: Some(accounts_db_hash_threads),
         mark_obsolete_accounts,
-        memlock_budget_bytes: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_BYTES,
+        memlock_budget_size: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_SIZE,
         ..AccountsDbConfig::default()
     };
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -445,6 +445,7 @@ pub fn execute(
         num_foreground_threads: Some(accounts_db_foreground_threads),
         num_hash_threads: Some(accounts_db_hash_threads),
         mark_obsolete_accounts,
+        memlock_budget_bytes: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_BYTES,
         ..AccountsDbConfig::default()
     };
 


### PR DESCRIPTION
#### Problem
io_uring operation requires locking memory (for fixed buffers, but also for ring queues themselves), which is often subject to limits configured at OS level.
The amount of used locked memory can be controlled down to a point by changing sizes of buffers, thus most of the code can still run with lower limits - this is often desired or required for tests or for solana-test-validator.

Additionally we want to fail-fast at validator start-up if the memlock limit is too low, instead of panicking later during runtime when attempts to register buffers in kernel fails.

#### Summary of Changes
* introduce `AccountsDbConfig` field for memlock budget that accounts db shouldn't exceed as it runs
* use different constants for prod (in line with current config guideline docs) and for test / dev environments (trying to fit into usual linux distros limit)
* use provided budget during snapshot unpacking, splitting it to reader and file creator (more uses as coming as io_uring will be used in account scans)
* switch genesis unpacking to use sync file creator, as it operates on small data anyway and it's cumbersome to provide memlock budget value to various places where genesis unpacking is used (it uses sync io for archive reading already)