### PR TITLE
docs: Fix typo in metrics dashboard description

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -32,7 +32,7 @@ The cluster telemetry dashboard shows the current state of the cluster:
 
 1. Cluster Stability
 2. Validator Streamer
-3. Tomer Consensus
+3. Tower Consensus
 4. IP Network
 5. Snapshots
 6. RPC Send Transaction Service


### PR DESCRIPTION
#### Problem



Change "Tomer Consensus" to "Tower Consensus" in metrics README.Tower BFT is the official consensus algorithm used by Solana, this was a simple documentation typo.
