### PR TITLE
reduce complexity in ConnectionStreamCounter

### DIFF
--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -185,34 +185,27 @@ impl StakedStreamLoadEMA {
 
 #[derive(Debug)]
 pub(crate) struct ConnectionStreamCounter {
-    pub(crate) stream_count: AtomicU64,
-    last_throttling_instant: RwLock<tokio::time::Instant>,
+    pub(crate) stream_count: u64,
+    last_throttling_instant: tokio::time::Instant,
 }
 
 impl ConnectionStreamCounter {
     pub(crate) fn new() -> Self {
         Self {
-            stream_count: AtomicU64::default(),
-            last_throttling_instant: RwLock::new(tokio::time::Instant::now()),
+            stream_count: 0,
+            last_throttling_instant: tokio::time::Instant::now(),
         }
     }
 
     /// Reset the counter and last throttling instant and
-    /// return last_throttling_instant regardless it is reset or not.
-    pub(crate) fn reset_throttling_params_if_needed(&self) -> tokio::time::Instant {
-        let last_throttling_instant = *self.last_throttling_instant.read().unwrap();
+    /// return last throttling instant.
+    pub(crate) fn reset_throttling_params_if_needed(&mut self) -> tokio::time::Instant {
+        let last_throttling_instant = self.last_throttling_instant;
         if tokio::time::Instant::now().duration_since(last_throttling_instant)
             > STREAM_THROTTLING_INTERVAL
         {
-            let mut last_throttling_instant = self.last_throttling_instant.write().unwrap();
-            // Recheck as some other thread might have done throttling since this thread tried to acquire the write lock.
-            if tokio::time::Instant::now().duration_since(*last_throttling_instant)
-                > STREAM_THROTTLING_INTERVAL
-            {
-                *last_throttling_instant = tokio::time::Instant::now();
-                self.stream_count.store(0, Ordering::Relaxed);
-            }
-            *last_throttling_instant
+            self.stream_count = 0;
+            tokio::time::Instant::now()
         } else {
             last_throttling_instant
         }


### PR DESCRIPTION
This is actually not a great idea since we want to allow >1 connection per staked identity
#### Problem

* ConnectionStreamCounter does not need mutexes

#### Summary of Changes

- Simplify it a whole lot. Functionally the same thing.