### PR TITLE
Refactor: Removed unused CSS properties from styles.module.css

### DIFF
--- a/docs/components/Card.jsx
+++ b/docs/components/Card.jsx
@@ -14,7 +14,7 @@ function Card({ to, header, body, externalIcon = false }) {
   */
 
   return (
-    <div className={clsx("col col--4 ", styles.feature)}>
+    <div className={clsx("col col--4 ")}>
       <Link className="navbar__link card" to={to}>
         <div className="card__header">
           <h3>

--- a/docs/src/pages/styles.module.css
+++ b/docs/src/pages/styles.module.css
@@ -5,41 +5,6 @@
  * and scoped locally.
  */
 
-.heroBanner {
-  padding: 4rem 0;
-  text-align: center;
-  position: relative;
-  overflow: hidden;
-}
-
-@media screen and (max-width: 966px) {
-  .heroBanner {
-    padding: 2rem;
-  }
-}
-
-.cardTitle {
-  color: green;
-}
-
-.buttons {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.features {
-  display: flex;
-  align-items: top;
-  padding: 2rem 0;
-  width: 100%;
-}
-
-.featureImage {
-  height: 200px;
-  width: 200px;
-}
-
 .iconExternalIcon {
   margin-left: 0.5em;
 }


### PR DESCRIPTION
#### Problem

- The styles.feature class was being used in Card.jsx but was not defined in the corresponding styles.module.css file
- `styles.module.css` had a lot of unused properties

#### Summary of Changes

- Removed reference to undefined styles.feature class in `Card.jsx`
- Removed unused properties in `styles.module.css`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
