### PR TITLE
Optimize visit_zero_lamport_pubkeys_during_startup to use Vec/Sort/Dedup instead of HashMap/Collect/Sort.

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6588,7 +6588,7 @@ impl AccountsDb {
                     insert_us: 0,
                     num_accounts: 0,
                     accounts_data_len: 0,
-                    zero_lamport_pubkeys: Vec::default(),
+                    zero_lamport_pubkeys: Vec::new(),
                     all_accounts_are_zero_lamports_slots: 0,
                     all_zeros_slots: Vec::new(),
                     num_did_not_exist: 0,
@@ -6995,8 +6995,14 @@ impl AccountsDb {
         // sort the pubkeys first so that in scan, the pubkeys are visited in
         // index bucket in order. This helps to reduce the page faults and speed
         // up the scan compared to visiting the pubkeys in random order.
+        let orig_len = pubkeys.len();
         pubkeys.sort_unstable();
         pubkeys.dedup();
+        let uniq_len = pubkeys.len();
+        info!(
+            "visit_zero_lamport_pubkeys_during_startup: {} pubkeys, {} after dedup",
+            orig_len, uniq_len
+        );
 
         self.accounts_index.scan(
             pubkeys.iter(),

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -73,7 +73,7 @@ use {
     solana_lattice_hash::lt_hash::LtHash,
     solana_measure::{meas_dur, measure::Measure, measure_us},
     solana_nohash_hasher::{BuildNoHashHasher, IntMap, IntSet},
-    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
+    solana_pubkey::Pubkey,
     solana_rayon_threadlimit::get_thread_count,
     solana_transaction::sanitized::SanitizedTransaction,
     std::{
@@ -6574,7 +6574,7 @@ impl AccountsDb {
             insert_us: u64,
             num_accounts: u64,
             accounts_data_len: u64,
-            zero_lamport_pubkeys: HashSet<Pubkey, PubkeyHasherBuilder>,
+            zero_lamport_pubkeys: Vec<Pubkey>,
             all_accounts_are_zero_lamports_slots: u64,
             all_zeros_slots: Vec<(Slot, Arc<AccountStorageEntry>)>,
             num_did_not_exist: u64,
@@ -6588,7 +6588,7 @@ impl AccountsDb {
                     insert_us: 0,
                     num_accounts: 0,
                     accounts_data_len: 0,
-                    zero_lamport_pubkeys: HashSet::default(),
+                    zero_lamport_pubkeys: Vec::default(),
                     all_accounts_are_zero_lamports_slots: 0,
                     all_zeros_slots: Vec::new(),
                     num_did_not_exist: 0,
@@ -6990,17 +6990,14 @@ impl AccountsDb {
     /// Visit zero lamport pubkeys and populate zero_lamport_single_ref info on
     /// storage.
     /// Returns the number of zero lamport single ref accounts found.
-    fn visit_zero_lamport_pubkeys_during_startup(
-        &self,
-        pubkeys: HashSet<Pubkey, PubkeyHasherBuilder>,
-    ) -> u64 {
-        let mut slot_offsets = HashMap::<_, Vec<_>>::default();
-        let mut pubkeys: Vec<_> = pubkeys.into_iter().collect();
-
+    fn visit_zero_lamport_pubkeys_during_startup(&self, mut pubkeys: Vec<Pubkey>) -> u64 {
+        let mut slot_offsets = HashMap::<Slot, Vec<usize>>::default();
         // sort the pubkeys first so that in scan, the pubkeys are visited in
         // index bucket in order. This helps to reduce the page faults and speed
         // up the scan compared to visiting the pubkeys in random order.
         pubkeys.sort_unstable();
+        pubkeys.dedup();
+
         self.accounts_index.scan(
             pubkeys.iter(),
             |_pubkey, slots_refs, _entry| {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6991,7 +6991,7 @@ impl AccountsDb {
     /// storage.
     /// Returns the number of zero lamport single ref accounts found.
     fn visit_zero_lamport_pubkeys_during_startup(&self, mut pubkeys: Vec<Pubkey>) -> u64 {
-        let mut slot_offsets = HashMap::<Slot, Vec<usize>>::default();
+        let mut slot_offsets = HashMap::<_, Vec<_>>::default();
         // sort the pubkeys first so that in scan, the pubkeys are visited in
         // index bucket in order. This helps to reduce the page faults and speed
         // up the scan compared to visiting the pubkeys in random order.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6583,7 +6583,7 @@ impl AccountsDb {
             lt_hash: LtHash,
         }
         impl IndexGenerationAccumulator {
-            fn new() -> Self {
+            const fn new() -> Self {
                 Self {
                     insert_us: 0,
                     num_accounts: 0,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7000,8 +7000,7 @@ impl AccountsDb {
         pubkeys.dedup();
         let uniq_len = pubkeys.len();
         info!(
-            "visit_zero_lamport_pubkeys_during_startup: {} pubkeys, {} after dedup",
-            orig_len, uniq_len
+            "visit_zero_lamport_pubkeys_during_startup: {orig_len} pubkeys, {uniq_len} after dedup",
         );
 
         self.accounts_index.scan(


### PR DESCRIPTION
#### Problem

Follow up PR from https://github.com/anza-xyz/agave/pull/7795#issuecomment-3259185097

Replace `HashMap<_>` with more efficient Vec<_> for zero lamport accounts tracking during startup. 

Performance impact on startup:

~6% faster startup time for zero-lamport account processing (800ms improvement)
```
base:  num_zero_lamport_single_refs=11594571 visit_zero_lamports_us=13019427 (~13s)
this:  num_zero_lamport_single_refs=11594571 visit_zero_lamports_us=12220630 (~12.2s)
```

#### Summary of Changes

- Use Vec instead of HashMap to track zero lamport accounts during startup
- Avoid template data allocation due to collect()
- Add `pubkeys.dedup()` after sorting to eliminate adjacent duplicates before processing
