### PR TITLE
Optimize zero pubkey scan at startup: sort the pubkey before scanning them.

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7072,7 +7072,7 @@ impl AccountsDb {
         pubkeys: HashSet<Pubkey, PubkeyHasherBuilder>,
     ) -> u64 {
         let mut slot_offsets = HashMap::<_, Vec<_>>::default();
-        let mut pubkeys: Vec<Pubkey> = pubkeys.into_iter().collect();
+        let mut pubkeys: Vec<_> = pubkeys.into_iter().collect();
         pubkeys.sort_unstable();
 
         self.accounts_index.scan(

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7076,7 +7076,7 @@ impl AccountsDb {
 
         // sort the pubkeys first so that in scan, the pubkeys are visited in
         // index bucket in order. This helps to reduce the page faults and speed
-        // up the scan compare to visit the pubkeys in random order.
+        // up the scan compared to visiting the pubkeys in random order.
         pubkeys.sort_unstable();
         self.accounts_index.scan(
             pubkeys.iter(),

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6903,7 +6903,7 @@ impl AccountsDb {
         }
 
         let (num_zero_lamport_single_refs, visit_zero_lamports_us) = measure_us!(
-            self.visit_zero_lamport_pubkeys_during_startup(&total_accum.zero_lamport_pubkeys)
+            self.visit_zero_lamport_pubkeys_during_startup(total_accum.zero_lamport_pubkeys)
         );
         timings.visit_zero_lamports_us = visit_zero_lamports_us;
         timings.num_zero_lamport_single_refs = num_zero_lamport_single_refs;
@@ -7069,9 +7069,12 @@ impl AccountsDb {
     /// Returns the number of zero lamport single ref accounts found.
     fn visit_zero_lamport_pubkeys_during_startup(
         &self,
-        pubkeys: &HashSet<Pubkey, PubkeyHasherBuilder>,
+        pubkeys: HashSet<Pubkey, PubkeyHasherBuilder>,
     ) -> u64 {
         let mut slot_offsets = HashMap::<_, Vec<_>>::default();
+        let mut pubkeys: Vec<Pubkey> = pubkeys.into_iter().collect();
+        pubkeys.sort_unstable();
+
         self.accounts_index.scan(
             pubkeys.iter(),
             |_pubkey, slots_refs, _entry| {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7073,8 +7073,11 @@ impl AccountsDb {
     ) -> u64 {
         let mut slot_offsets = HashMap::<_, Vec<_>>::default();
         let mut pubkeys: Vec<_> = pubkeys.into_iter().collect();
-        pubkeys.sort_unstable();
 
+        // sort the pubkeys first so that in scan, the pubkeys are visited in
+        // index bucket in order. This helps to reduce the page faults and speed
+        // up the scan compare to visit the pubkeys in random order.
+        pubkeys.sort_unstable();
         self.accounts_index.scan(
             pubkeys.iter(),
             |_pubkey, slots_refs, _entry| {


### PR DESCRIPTION
#### Problem

visit zero index scan can be optimized by scanning the pubkey in sorted order. This way, we are scaning pubkey in the same bin together and it reduces mm page fault comparing to non-sorted pubkey scan. 


**Performance Study** 

```
base:  num_zero_lamport_single_refs=11594571i visit_zero_lamports_us=17829074i
sort: num_zero_lamport_single_refs=11594571i visit_zero_lamports_us=13019427i
```

With this PR, we save 4.8s.            


#### Summary of Changes

Sort the pubkey in visit zero index scan.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
