### PR TITLE
add Sig to the `ClientId` enum

### DIFF
--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -21,6 +21,7 @@ pub enum ClientId {
     JitoLabs,
     Firedancer,
     Agave,
+    Sig,
     // If new variants are added, update From<u16> and TryFrom<ClientId>.
     Unknown(u16),
 }
@@ -102,6 +103,7 @@ impl From<u16> for ClientId {
             1u16 => Self::JitoLabs,
             2u16 => Self::Firedancer,
             3u16 => Self::Agave,
+            7u16 => Self::Sig,
             _ => Self::Unknown(client),
         }
     }
@@ -116,7 +118,9 @@ impl TryFrom<ClientId> for u16 {
             ClientId::JitoLabs => Ok(1u16),
             ClientId::Firedancer => Ok(2u16),
             ClientId::Agave => Ok(3u16),
+            ClientId::Sig => Ok(7u16),
             ClientId::Unknown(client @ 0u16..=3u16) => Err(format!("Invalid client: {client}")),
+            ClientId::Unknown(client @ 7u16) => Err(format!("Invalid client: {client}")),
             ClientId::Unknown(client) => Ok(client),
         }
     }
@@ -154,20 +158,37 @@ mod test {
         assert_eq!(ClientId::from(1u16), ClientId::JitoLabs);
         assert_eq!(ClientId::from(2u16), ClientId::Firedancer);
         assert_eq!(ClientId::from(3u16), ClientId::Agave);
-        for client in 4u16..=u16::MAX {
+        for client in 4u16..=6u16 {
             assert_eq!(ClientId::from(client), ClientId::Unknown(client));
         }
+        assert_eq!(ClientId::from(7u16), ClientId::Sig);
+        for client in 8u16..u16::MAX {
+            assert_eq!(ClientId::from(client), ClientId::Unknown(client));
+        }
+
+
         assert_eq!(u16::try_from(ClientId::SolanaLabs), Ok(0u16));
         assert_eq!(u16::try_from(ClientId::JitoLabs), Ok(1u16));
         assert_eq!(u16::try_from(ClientId::Firedancer), Ok(2u16));
         assert_eq!(u16::try_from(ClientId::Agave), Ok(3u16));
+        assert_eq!(u16::try_from(ClientId::Sig), Ok(7u16));
         for client in 0..=3u16 {
             assert_eq!(
                 u16::try_from(ClientId::Unknown(client)),
                 Err(format!("Invalid client: {client}"))
             );
         }
-        for client in 4u16..=u16::MAX {
+        for client in 7..=7u16 {
+            assert_eq!(
+                u16::try_from(ClientId::Unknown(client)),
+                Err(format!("Invalid client: {client}"))
+            );
+        }
+        
+        for client in 4u16..=6u16 {
+            assert_eq!(u16::try_from(ClientId::Unknown(client)), Ok(client));
+        }
+        for client in 8u16..=u16::MAX {
             assert_eq!(u16::try_from(ClientId::Unknown(client)), Ok(client));
         }
     }


### PR DESCRIPTION
#### Problem

- We (the [Sig](https://github.com/Syndica/sig) team) would like to have a unique ClientId for the Sig validator.


#### Summary of Changes

- Adds a `Sig` variant to the `ClientId` enum and reserves the id `7` for Sig.

