### PR TITLE
Avoid port conflicts for quic_client in tests

### DIFF
--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -17,7 +17,7 @@ use {
     },
     solana_keypair::Keypair,
     solana_measure::measure::Measure,
-    solana_net_utils::sockets::{self, unique_port_range_for_tests},
+    solana_net_utils::sockets,
     solana_quic_definitions::{
         QUIC_CONNECTION_HANDSHAKE_TIMEOUT, QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT, QUIC_SEND_FAIRNESS,
     },
@@ -80,7 +80,7 @@ impl QuicLazyInitializedEndpoint {
         } else {
             let port_range = if cfg!(debug_assertions) {
                 // Avoid port collision during tests
-                let range = unique_port_range_for_tests(1);
+                let range = sockets::unique_port_range_for_tests(1);
                 (range.start, range.end)
             } else {
                 solana_net_utils::VALIDATOR_PORT_RANGE


### PR DESCRIPTION
#### Problem
quic_client create endpoint using lazy initialization for connection in range VALIDATOR_PORT_RANGE which may cause later collisions with test using unique_port_range_for_tests or hard coded port.

#### Summary of Changes
for test configuration, use unique_port_range_for_tests for quic_client endpoint lazy initialization 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
