### PR TITLE
feat: implement stateful Broadcaster with validator blacklist support

### DIFF
--- a/tpu-client-next/src/lib.rs
+++ b/tpu-client-next/src/lib.rs
@@ -13,7 +13,10 @@ pub mod connection_workers_scheduler;
 pub mod send_transaction_stats;
 pub mod workers_cache;
 pub use crate::{
-    connection_workers_scheduler::{ConnectionWorkersScheduler, ConnectionWorkersSchedulerError},
+    connection_workers_scheduler::{
+        ConnectionWorkersScheduler, ConnectionWorkersSchedulerError, NonblockingBroadcaster,
+        WorkersBroadcaster,
+    },
     send_transaction_stats::SendTransactionStats,
 };
 pub(crate) mod quic_networking;


### PR DESCRIPTION
# Add Stateful Broadcaster with Validator Blacklist Support

ref #7136 

## Problem
The current tpu-client-next Broadcaster is stateless, preventing users from maintaining persistent state like blacklists of validators they want to avoid sending transactions to.

## Solution
- Implemented `StatefulBroadcaster` with validator blacklist functionality
- Updated `WorkersBroadcaster` trait to support stateful implementations while maintaining backward compatibility
- Added comprehensive blacklist management APIs (add, remove, check, clear)
- Transactions to blacklisted validators are automatically skipped during broadcast

can you pls check this @KirillLykov 