### PR TITLE
fix: JsonParsed account decoding issue in RPC client

### DIFF
--- a/account-decoder-client-types/src/lib.rs
+++ b/account-decoder-client-types/src/lib.rs
@@ -34,7 +34,7 @@ pub enum UiAccountData {
 
 impl UiAccountData {
     /// Returns decoded account data in binary format if possible
-    /// 
+    ///
     /// For `UiAccountData::Json(_)` (JsonParsed), this will return `None` since
     /// the account data has been parsed into a structured format and cannot be
     /// converted back to raw binary data.
@@ -63,15 +63,21 @@ impl UiAccountData {
     }
 
     /// Returns the account data size from the parsed information if available
-    /// 
+    ///
     /// This can extract the size even from JsonParsed accounts.
     pub fn space(&self) -> Option<u64> {
         match self {
             UiAccountData::Json(parsed) => Some(parsed.space),
-            UiAccountData::LegacyBinary(blob) => bs58::decode(blob).into_vec().ok().map(|v| v.len() as u64),
+            UiAccountData::LegacyBinary(blob) => {
+                bs58::decode(blob).into_vec().ok().map(|v| v.len() as u64)
+            }
             UiAccountData::Binary(blob, encoding) => match encoding {
-                UiAccountEncoding::Base58 => bs58::decode(blob).into_vec().ok().map(|v| v.len() as u64),
-                UiAccountEncoding::Base64 => BASE64_STANDARD.decode(blob).ok().map(|v| v.len() as u64),
+                UiAccountEncoding::Base58 => {
+                    bs58::decode(blob).into_vec().ok().map(|v| v.len() as u64)
+                }
+                UiAccountEncoding::Base64 => {
+                    BASE64_STANDARD.decode(blob).ok().map(|v| v.len() as u64)
+                }
                 #[cfg(feature = "zstd")]
                 UiAccountEncoding::Base64Zstd => {
                     BASE64_STANDARD.decode(blob).ok().and_then(|zstd_data| {
@@ -116,7 +122,7 @@ pub enum UiAccountEncoding {
 
 impl UiAccount {
     /// Decode the UiAccount into a concrete Account type
-    /// 
+    ///
     /// **Note**: This method will return `None` for accounts with `JsonParsed` encoding
     /// since the account data has been parsed into a structured format and cannot be
     /// converted back to raw binary data. For JsonParsed accounts, use `try_decode_with_fallback()`
@@ -133,17 +139,17 @@ impl UiAccount {
     }
 
     /// Attempts to decode the UiAccount, with fallback handling for JsonParsed accounts
-    /// 
+    ///
     /// For JsonParsed accounts where the original binary data is not available,
     /// this method will create an Account with empty data but preserve other metadata.
     /// This is useful for APIs that need to return Account objects but may receive
     /// JsonParsed data.
-    /// 
+    ///
     /// Returns a tuple of (Account, is_json_parsed) where the boolean indicates
     /// whether the account data was JsonParsed (and thus the data field is empty).
     pub fn try_decode_with_fallback<T: WritableAccount>(&self) -> Option<(T, bool)> {
         let owner = Pubkey::from_str(&self.owner).ok()?;
-        
+
         if let Some(data) = self.data.decode() {
             // Normal case - we have binary data
             Some((
@@ -153,7 +159,13 @@ impl UiAccount {
         } else if self.data.is_json_parsed() {
             // JsonParsed case - create account with empty data but preserve metadata
             Some((
-                T::create(self.lamports, vec![], owner, self.executable, self.rent_epoch),
+                T::create(
+                    self.lamports,
+                    vec![],
+                    owner,
+                    self.executable,
+                    self.rent_epoch,
+                ),
                 true,
             ))
         } else {
@@ -190,8 +202,7 @@ pub struct UiDataSliceConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use solana_account::Account;
+    use {super::*, solana_account::Account};
 
     #[test]
     fn test_jsonparsed_account_decoding_fix() {
@@ -212,7 +223,7 @@ mod tests {
             }),
             space: 165,
         };
-        
+
         let ui_account = UiAccount {
             lamports: 2039280,
             data: UiAccountData::Json(parsed_account.clone()),
@@ -221,26 +232,42 @@ mod tests {
             rent_epoch: 361,
             space: Some(165),
         };
-        
+
         // Test 1: Original decode() returns None for JsonParsed (this is the original issue)
         let decoded_account: Option<Account> = ui_account.decode();
-        assert!(decoded_account.is_none(), "decode() should return None for JsonParsed accounts");
-        
+        assert!(
+            decoded_account.is_none(),
+            "decode() should return None for JsonParsed accounts"
+        );
+
         // Test 2: New helper methods work
-        assert!(ui_account.is_json_parsed(), "should detect JsonParsed accounts");
-        assert_eq!(ui_account.data.space(), Some(165), "should extract space from parsed data");
-        
+        assert!(
+            ui_account.is_json_parsed(),
+            "should detect JsonParsed accounts"
+        );
+        assert_eq!(
+            ui_account.data.space(),
+            Some(165),
+            "should extract space from parsed data"
+        );
+
         // Test 3: Can access parsed data
         let parsed = ui_account.parsed_data().unwrap();
         assert_eq!(parsed.program, "spl-token");
         assert_eq!(parsed.space, 165);
-        
+
         // Test 4: New fallback method works
         let (account, is_json_parsed) = ui_account.try_decode_with_fallback::<Account>().unwrap();
         assert!(is_json_parsed, "should indicate this was JsonParsed");
         assert_eq!(account.lamports, 2039280);
-        assert_eq!(account.owner.to_string(), "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
-        assert!(account.data.is_empty(), "data should be empty for JsonParsed accounts");
+        assert_eq!(
+            account.owner.to_string(),
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        );
+        assert!(
+            account.data.is_empty(),
+            "data should be empty for JsonParsed accounts"
+        );
     }
 
     #[test]
@@ -249,24 +276,31 @@ mod tests {
             lamports: 1000000,
             data: UiAccountData::Binary(
                 BASE64_STANDARD.encode(b"test data"),
-                UiAccountEncoding::Base64
+                UiAccountEncoding::Base64,
             ),
             owner: "11111111111111111111111111111111".to_string(),
             executable: false,
             rent_epoch: 361,
             space: Some(9),
         };
-        
+
         // Original decode() still works for binary accounts
         let decoded_account: Option<Account> = ui_account.decode();
-        assert!(decoded_account.is_some(), "decode() should work for binary accounts");
-        
+        assert!(
+            decoded_account.is_some(),
+            "decode() should work for binary accounts"
+        );
+
         let account = decoded_account.unwrap();
         assert_eq!(account.data, b"test data");
-        
+
         // Fallback method also works
-        let (fallback_account, is_json_parsed) = ui_account.try_decode_with_fallback::<Account>().unwrap();
-        assert!(!is_json_parsed, "should not indicate JsonParsed for binary accounts");
+        let (fallback_account, is_json_parsed) =
+            ui_account.try_decode_with_fallback::<Account>().unwrap();
+        assert!(
+            !is_json_parsed,
+            "should not indicate JsonParsed for binary accounts"
+        );
         assert_eq!(fallback_account.data, b"test data");
     }
 }

--- a/account-decoder-client-types/src/lib.rs
+++ b/account-decoder-client-types/src/lib.rs
@@ -34,6 +34,10 @@ pub enum UiAccountData {
 
 impl UiAccountData {
     /// Returns decoded account data in binary format if possible
+    /// 
+    /// For `UiAccountData::Json(_)` (JsonParsed), this will return `None` since
+    /// the account data has been parsed into a structured format and cannot be
+    /// converted back to raw binary data.
     pub fn decode(&self) -> Option<Vec<u8>> {
         match self {
             UiAccountData::Json(_) => None,
@@ -57,6 +61,46 @@ impl UiAccountData {
             },
         }
     }
+
+    /// Returns the account data size from the parsed information if available
+    /// 
+    /// This can extract the size even from JsonParsed accounts.
+    pub fn space(&self) -> Option<u64> {
+        match self {
+            UiAccountData::Json(parsed) => Some(parsed.space),
+            UiAccountData::LegacyBinary(blob) => bs58::decode(blob).into_vec().ok().map(|v| v.len() as u64),
+            UiAccountData::Binary(blob, encoding) => match encoding {
+                UiAccountEncoding::Base58 => bs58::decode(blob).into_vec().ok().map(|v| v.len() as u64),
+                UiAccountEncoding::Base64 => BASE64_STANDARD.decode(blob).ok().map(|v| v.len() as u64),
+                #[cfg(feature = "zstd")]
+                UiAccountEncoding::Base64Zstd => {
+                    BASE64_STANDARD.decode(blob).ok().and_then(|zstd_data| {
+                        let mut data = vec![];
+                        zstd::stream::read::Decoder::new(zstd_data.as_slice())
+                            .and_then(|mut reader| reader.read_to_end(&mut data))
+                            .map(|_| data.len() as u64)
+                            .ok()
+                    })
+                }
+                #[cfg(not(feature = "zstd"))]
+                UiAccountEncoding::Base64Zstd => None,
+                UiAccountEncoding::Binary | UiAccountEncoding::JsonParsed => None,
+            },
+        }
+    }
+
+    /// Returns true if this account data is in JsonParsed format
+    pub fn is_json_parsed(&self) -> bool {
+        matches!(self, UiAccountData::Json(_))
+    }
+
+    /// Returns the parsed account data if this is a JsonParsed account
+    pub fn as_parsed(&self) -> Option<&ParsedAccount> {
+        match self {
+            UiAccountData::Json(parsed) => Some(parsed),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -71,6 +115,12 @@ pub enum UiAccountEncoding {
 }
 
 impl UiAccount {
+    /// Decode the UiAccount into a concrete Account type
+    /// 
+    /// **Note**: This method will return `None` for accounts with `JsonParsed` encoding
+    /// since the account data has been parsed into a structured format and cannot be
+    /// converted back to raw binary data. For JsonParsed accounts, use `try_decode_with_fallback()`
+    /// or access the parsed data directly via `data.as_parsed()`.
     pub fn decode<T: WritableAccount>(&self) -> Option<T> {
         let data = self.data.decode()?;
         Some(T::create(
@@ -80,6 +130,46 @@ impl UiAccount {
             self.executable,
             self.rent_epoch,
         ))
+    }
+
+    /// Attempts to decode the UiAccount, with fallback handling for JsonParsed accounts
+    /// 
+    /// For JsonParsed accounts where the original binary data is not available,
+    /// this method will create an Account with empty data but preserve other metadata.
+    /// This is useful for APIs that need to return Account objects but may receive
+    /// JsonParsed data.
+    /// 
+    /// Returns a tuple of (Account, is_json_parsed) where the boolean indicates
+    /// whether the account data was JsonParsed (and thus the data field is empty).
+    pub fn try_decode_with_fallback<T: WritableAccount>(&self) -> Option<(T, bool)> {
+        let owner = Pubkey::from_str(&self.owner).ok()?;
+        
+        if let Some(data) = self.data.decode() {
+            // Normal case - we have binary data
+            Some((
+                T::create(self.lamports, data, owner, self.executable, self.rent_epoch),
+                false,
+            ))
+        } else if self.data.is_json_parsed() {
+            // JsonParsed case - create account with empty data but preserve metadata
+            Some((
+                T::create(self.lamports, vec![], owner, self.executable, self.rent_epoch),
+                true,
+            ))
+        } else {
+            // Failed to decode for other reasons
+            None
+        }
+    }
+
+    /// Returns true if this account uses JsonParsed encoding
+    pub fn is_json_parsed(&self) -> bool {
+        self.data.is_json_parsed()
+    }
+
+    /// Gets the parsed account data if available
+    pub fn parsed_data(&self) -> Option<&ParsedAccount> {
+        self.data.as_parsed()
     }
 }
 
@@ -96,4 +186,87 @@ pub struct ParsedAccount {
 pub struct UiDataSliceConfig {
     pub offset: usize,
     pub length: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_account::Account;
+
+    #[test]
+    fn test_jsonparsed_account_decoding_fix() {
+        // Create a sample JsonParsed account (like a token account)
+        let parsed_account = ParsedAccount {
+            program: "spl-token".to_string(),
+            parsed: serde_json::json!({
+                "info": {
+                    "mint": "So11111111111111111111111111111111111111112",
+                    "owner": "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+                    "tokenAmount": {
+                        "amount": "1000000000",
+                        "decimals": 9,
+                        "uiAmount": 1.0
+                    }
+                },
+                "type": "account"
+            }),
+            space: 165,
+        };
+        
+        let ui_account = UiAccount {
+            lamports: 2039280,
+            data: UiAccountData::Json(parsed_account.clone()),
+            owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string(),
+            executable: false,
+            rent_epoch: 361,
+            space: Some(165),
+        };
+        
+        // Test 1: Original decode() returns None for JsonParsed (this is the original issue)
+        let decoded_account: Option<Account> = ui_account.decode();
+        assert!(decoded_account.is_none(), "decode() should return None for JsonParsed accounts");
+        
+        // Test 2: New helper methods work
+        assert!(ui_account.is_json_parsed(), "should detect JsonParsed accounts");
+        assert_eq!(ui_account.data.space(), Some(165), "should extract space from parsed data");
+        
+        // Test 3: Can access parsed data
+        let parsed = ui_account.parsed_data().unwrap();
+        assert_eq!(parsed.program, "spl-token");
+        assert_eq!(parsed.space, 165);
+        
+        // Test 4: New fallback method works
+        let (account, is_json_parsed) = ui_account.try_decode_with_fallback::<Account>().unwrap();
+        assert!(is_json_parsed, "should indicate this was JsonParsed");
+        assert_eq!(account.lamports, 2039280);
+        assert_eq!(account.owner.to_string(), "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+        assert!(account.data.is_empty(), "data should be empty for JsonParsed accounts");
+    }
+
+    #[test]
+    fn test_binary_account_still_works() {
+        let ui_account = UiAccount {
+            lamports: 1000000,
+            data: UiAccountData::Binary(
+                BASE64_STANDARD.encode(b"test data"),
+                UiAccountEncoding::Base64
+            ),
+            owner: "11111111111111111111111111111111".to_string(),
+            executable: false,
+            rent_epoch: 361,
+            space: Some(9),
+        };
+        
+        // Original decode() still works for binary accounts
+        let decoded_account: Option<Account> = ui_account.decode();
+        assert!(decoded_account.is_some(), "decode() should work for binary accounts");
+        
+        let account = decoded_account.unwrap();
+        assert_eq!(account.data, b"test data");
+        
+        // Fallback method also works
+        let (fallback_account, is_json_parsed) = ui_account.try_decode_with_fallback::<Account>().unwrap();
+        assert!(!is_json_parsed, "should not indicate JsonParsed for binary accounts");
+        assert_eq!(fallback_account.data, b"test data");
+    }
 }


### PR DESCRIPTION
## Problem

The RPC client methods `get_multiple_accounts_with_config()` and `get_account_with_config()` always return `None` for accounts when using `JsonParsed` encoding. This happens because:
- `UiAccountData::Json(_)` variant cannot be decoded back to binary data (line 39 in `account-decoder-client-types/src/lib.rs`)
- The RPC client methods call `.decode()` which fails for `JsonParsed` accounts, converting them to `None`
- Users lose access to both the account metadata and the parsed data when using `JsonParsed` encoding

## Solution

Backward-compatible enhancements to handle `JsonParsed` accounts:

1. Enhanced `UiAccountData` with new methods:
     - `space()` - extracts size even from `JsonParsed` accounts
     - `is_json_parsed()` - detects `JsonParsed` encoding
     - `as_parsed()` - accesses parsed account data
    
2. New `UiAccount::try_decode_with_fallback()` method:
      - Returns (`Account, is_json_parsed`) tuple
      - Creates Account with empty data for `JsonParsed` accounts while preserving metadata
      - Maintains full functionality for binary accounts
        
3. New RPC client methods with `JsonParsed` support:
     - `get_account_with_config_and_context()`
     - `get_multiple_accounts_with_config_and_context()`
     - Return `AccountWithContext` struct with both decoded Account and original UiAccount data

Closes #6375 

can you pls check this @KirillLykov 