### PR TITLE
Modify buildscripts to work with offline builds (e.g. nix builds)

### DIFF
--- a/cargo
+++ b/cargo
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ -n "${NO_RUSTUP_OVERRIDE}" ]]; then
+  set -x
+  exec cargo "${@}"
+fi
+
 # shellcheck source=ci/rust-version.sh
 here=$(dirname "$0")
 

--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+function installPerfLibSymlinks() {
+  for dir in target/{debug,release}/{,deps/}; do
+    mkdir -p "$dir"
+    ln -sfT "$1" "${dir}perf-libs"
+  done
+}
+
+if [[ -n "$SOLANA_PERF_LIBS_PATH" ]]; then
+  mkdir -p target
+
+  ln -sfT "$SOLANA_PERF_LIBS_PATH" target/perf-libs
+  installPerfLibSymlinks "$SOLANA_PERF_LIBS_PATH"
+
+  exit 0
+fi
+
 PERF_LIBS_VERSION=v0.19.3
 VERSION=$PERF_LIBS_VERSION-1
 
@@ -41,11 +57,7 @@ if [[ $VERSION != "$(cat target/perf-libs/.version 2> /dev/null)" ]]; then
 
   # Setup symlinks so the perf-libs/ can be found from all binaries run out of
   # target/
-  for dir in target/{debug,release}/{,deps/}; do
-    mkdir -p $dir
-    ln -sfT ../perf-libs ${dir}perf-libs
-  done
-
+  installPerfLibSymlinks ../perf-libs
 fi
 
 exit 0

--- a/net/net.sh
+++ b/net/net.sh
@@ -211,7 +211,7 @@ build() {
 
     $MAYBE_DOCKER bash -c "
       set -ex
-      $profilerFlags scripts/cargo-install-all.sh farf $buildVariant --validator-only
+      $profilerFlags scripts/cargo-install-all.sh farf $buildVariant --validator-only --no-spl-token
     "
   )
 

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -29,7 +29,7 @@ usage() {
     echo "Error: $*"
   fi
   cat <<EOF
-usage: $0 [+<cargo version>] [--debug] [--validator-only] [--release-with-debug] <install directory>
+usage: $0 [+<cargo version>] [--debug] [--validator-only] [--release-with-debug] [--no-spl-token] <install directory>
 EOF
   exit $exitcode
 }
@@ -42,6 +42,7 @@ installDir=
 buildProfileArg='--profile release'
 buildProfile='release'
 validatorOnly=
+noSPLToken=
 
 while [[ -n $1 ]]; do
   if [[ ${1:0:1} = - ]]; then
@@ -59,6 +60,9 @@ while [[ -n $1 ]]; do
       shift
     elif [[ $1 = --validator-only ]]; then
       validatorOnly=true
+      shift
+    elif [[ $1 = --no-spl-token ]]; then
+      noSPLToken=true
       shift
     else
       usage "Unknown option: $1"
@@ -163,8 +167,8 @@ check_dcou() {
     cargo_build "${dcouBinArgs[@]}"
   fi
 
-  # Exclude `spl-token` binary for net.sh builds
-  if [[ -z "$validatorOnly" ]]; then
+  # Exclude `spl-token` if requested
+  if [[ -z "$noSPLToken" ]]; then
     # shellcheck source=scripts/spl-token-cli-version.sh
     source "$SOLANA_ROOT"/scripts/spl-token-cli-version.sh
 


### PR DESCRIPTION
#### Problem

Currently it is not possible to download the git and all rust dependencies and build agave offline using the provided build scripts.

#### Summary of Changes

In our setup we're using `nix` to build agave and switched to using the provided scripts, due to issues such as DCOU flags being addressed in there and using the official build-scripts. This PR includes our minimal patches to those build scripts.

Changes:
1. Introduce new env var: `SKIP_RUSTUP_VERSION_CHECK`, if non-zero `cargo` will be invoked directly and the user is responsible to ensure the correct version of Rust/Cargo is used.
2. Introduce new env var: `SOLANA_PERF_LIBS_PATH`, which if set will be used to find the unpacked version of the `solana-perf-libs`, skipping the network dependency during build-time.
3. Introducing new flag `--no-spl-token` to build script. When this flag is used, `spl-token` will not be downloaded during the build phase, skipping the network dependency. Previously this was possible by using the `--validator-only` flag, however it is desirable to have a build with no network dependencies that includes more than just the validator.