### PR TITLE
parent block ID API

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5548,6 +5548,10 @@ impl Bank {
         &self.fee_structure
     }
 
+    pub fn parent_block_id(&self) -> Option<Hash> {
+        self.parent().and_then(|p| p.block_id())
+    }
+
     pub fn block_id(&self) -> Option<Hash> {
         *self.block_id.read().unwrap()
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12423,3 +12423,17 @@ fn test_startup_from_snapshot_after_precompile_transition() {
     // Simulate starting up from snapshot finishing the initialization for a frozen bank
     bank.finish_init(&genesis_config, false);
 }
+
+#[test]
+fn test_parent_block_id() {
+    // Setup parent bank and populate block ID.
+    let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
+    let parent_bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let parent_block_id = Some(Hash::new_unique());
+    parent_bank.set_block_id(parent_block_id);
+
+    // Create child from parent and ensure parent block ID links back to the
+    // expected value.
+    let child_bank = Bank::new_from_parent(parent_bank, &Pubkey::new_unique(), 1);
+    assert_eq!(parent_block_id, child_bank.parent_block_id());
+}


### PR DESCRIPTION
#### Problem
This API is needed for Alpenglow when `votor` crate gets integrated (see #7802)

#### Summary of Changes

- Add API to get the block ID of the parent from the child bank.
- Add test for this API.