### PR TITLE
rpc, cli: Add client ID field to cluster nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Release channels have their own copy of this changelog:
 * `--public-tpu-address` and `--public-tpu-forwards-address` CLI arguments and `setPublicTpuForwardsAddress`, `setPublicTpuAddress` RPC methods now specify QUIC ports, not UDP.
 #### Changes
 * Added `--enable-scheduler-bindings` which binds an IPC server at `<ledger-path>/scheduler_bindings.ipc` for external schedulers to connect to.
+* Added `clientId` field to each node in `getClusterNodes` response
 ### Validator
 #### Breaking
 * Removed deprecated arguments

--- a/cli-output/src/cli_clientid.rs
+++ b/cli-output/src/cli_clientid.rs
@@ -1,0 +1,63 @@
+use {
+    serde::{Deserialize, Deserializer, Serialize, Serializer},
+    std::{fmt, str::FromStr},
+};
+
+#[derive(Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
+pub struct CliClientId(Option<u16>);
+
+impl CliClientId {
+    pub fn new(id: Option<u16>) -> Self {
+        Self(id)
+    }
+
+    pub fn unknown() -> Self {
+        Self(None)
+    }
+}
+
+impl fmt::Display for CliClientId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.0 {
+            Some(id) => write!(f, "{id}"),
+            None => write!(f, "unknown"),
+        }
+    }
+}
+
+impl From<Option<u16>> for CliClientId {
+    fn from(id: Option<u16>) -> Self {
+        Self(id)
+    }
+}
+
+impl FromStr for CliClientId {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "unknown" {
+            Ok(CliClientId(None))
+        } else {
+            Ok(CliClientId(Some(s.parse()?)))
+        }
+    }
+}
+
+impl Serialize for CliClientId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for CliClientId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: &str = Deserialize::deserialize(deserializer)?;
+        CliClientId::from_str(s).map_err(serde::de::Error::custom)
+    }
+}

--- a/cli-output/src/lib.rs
+++ b/cli-output/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "agave-unstable-api")]
 #![allow(clippy::arithmetic_side_effects)]
+pub mod cli_clientid;
 mod cli_output;
 pub mod cli_version;
 pub mod display;

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -317,6 +317,8 @@ pub struct RpcContactInfo {
     pub pubsub: Option<SocketAddr>,
     /// Software version
     pub version: Option<String>,
+    /// Client ID
+    pub client_id: Option<u16>,
     /// First 4 bytes of the FeatureSet identifier
     pub feature_set: Option<u32>,
     /// Shred version

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -397,6 +397,7 @@ impl RpcSender for MockSender {
                 rpc: Some(SocketAddr::from(([10, 239, 6, 48], 8899))),
                 pubsub: Some(SocketAddr::from(([10, 239, 6, 48], 8900))),
                 version: Some("1.0.0 c375ce1f".to_string()),
+                client_id: Some(0),
                 feature_set: None,
                 shred_version: None,
             }])?,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3654,12 +3654,16 @@ pub mod rpc_full {
                             .map(|addr| socket_addr_space.check(&addr))
                             .unwrap_or_default()
                     {
-                        let (version, feature_set) = if let Some(version) =
+                        let (version, feature_set, client_id) = if let Some(version) =
                             cluster_info.get_node_version(contact_info.pubkey())
                         {
-                            (Some(version.to_string()), Some(version.feature_set))
+                            (
+                                Some(version.to_string()),
+                                Some(version.feature_set),
+                                Some(version.client),
+                            )
                         } else {
-                            (None, None)
+                            (None, None, None)
                         };
                         Some(RpcContactInfo {
                             pubkey: contact_info.pubkey().to_string(),
@@ -3688,6 +3692,7 @@ pub mod rpc_full {
                                 .rpc_pubsub()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             version,
+                            client_id,
                             feature_set,
                             shred_version: Some(my_shred_version),
                         })
@@ -5187,6 +5192,7 @@ pub mod tests {
             "pubsub": format!("127.0.0.1:8900"),
             "version": format!("{version}"),
             "featureSet": version.feature_set,
+            "clientId": 3u16,
         }, {
             "pubkey": rpc.leader_pubkey().to_string(),
             "gossip": "127.0.0.1:1235",
@@ -5202,6 +5208,7 @@ pub mod tests {
             "pubsub": format!("127.0.0.1:8900"),
             "version": format!("{version}"),
             "featureSet": version.feature_set,
+            "clientId": 3u16,
         }]);
         assert_eq!(result, expected);
     }

--- a/version/src/v3.rs
+++ b/version/src/v3.rs
@@ -18,7 +18,7 @@ pub struct Version {
     pub commit: u32,      // first 4 bytes of the sha1 commit hash
     pub feature_set: u32, // first 4 bytes of the FeatureSet identifier
     #[serde(with = "serde_varint")]
-    client: u16,
+    pub client: u16,
 }
 
 impl Version {


### PR DESCRIPTION
#### Problem

The client ID field in validator version information is not exposed through the RPC interface or CLI, making it impossible to analyze validator client diversity on the network. Users cannot see which client implementation (Agave, Jito, Firedancer, etc.) validators are running.

#### Summary of Changes

- Add `client_id` field to `RpcContactInfo` in getClusterNodes RPC response  
- Make `Version::client` field public to allow access from RPC layer
- Add `CliClientId` type for parsing and displaying client IDs in CLI
- Add client ID column to validator list display
- Support `--sort=client-id` option for sorting validators
- Add stake distribution breakdown by client ID

Fixes #