### PR TITLE
Remove redundant import in connection_cache tests

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -198,7 +198,6 @@ impl solana_connection_cache::nonblocking::client_connection::ClientConnection
 mod tests {
     use {
         super::*,
-        crate::connection_cache::ConnectionCache,
         solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
         std::net::{IpAddr, Ipv4Addr, SocketAddr},
     };


### PR DESCRIPTION
Delete duplicate use crate::connection_cache::ConnectionCache; in tests
super::* already brings ConnectionCache into scope