### PR TITLE
Returns original index from AccountStoragesConcurrentConsumer::next()

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -379,9 +379,9 @@ impl<'a> AccountStoragesOrderer<'a> {
 impl Index<usize> for AccountStoragesOrderer<'_> {
     type Output = AccountStorageEntry;
 
-    fn index(&self, index: usize) -> &Self::Output {
-        // SAFETY: Caller must ensure `index` is in range.
-        let original_index = self.original_index(index);
+    fn index(&self, position: usize) -> &Self::Output {
+        // SAFETY: Caller must ensure `position` is in range.
+        let original_index = self.original_index(position);
         // SAFETY: `original_index` must be valid here, so it is a valid index into `storages`.
         self.storages[original_index].as_ref()
     }

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -354,13 +354,13 @@ impl<'a> AccountStoragesOrderer<'a> {
         self.indices.len()
     }
 
-    /// Returns the original index the storages slice for `index`
+    /// Returns the original index, into the storages slice, at `position`
     ///
     /// # Panics
     ///
-    /// Caller must ensure `index` is in range, else will panic.
-    pub fn original_index(&'a self, index: usize) -> usize {
-        self.indices[index]
+    /// Caller must ensure `position` is in range, else will panic.
+    pub fn original_index(&'a self, position: usize) -> usize {
+        self.indices[position]
     }
 
     pub fn iter(&'a self) -> impl ExactSizeIterator<Item = &'a AccountStorageEntry> + 'a {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5555,7 +5555,8 @@ impl AccountsDb {
                             let mut thread_lt_hash = LtHash::identity();
                             let mut reader = append_vec::new_scan_accounts_reader();
 
-                            while let Some(storage) = storages.next() {
+                            while let Some(next_item) = storages.next() {
+                                let storage = next_item.storage;
                                 // Function is calculating the accounts_lt_hash from all accounts in the
                                 // storages as of startup_slot. This means that any accounts marked obsolete at a
                                 // slot newer than startup_slot should be included in the accounts_lt_hash


### PR DESCRIPTION
#### Problem

From the discussion here, https://github.com/anza-xyz/agave/pull/7729#discussion_r2303020907, we'd like to get the original index into the storages slice from the AccountStoragesConcurrentConsumer.


#### Summary of Changes

Update AccountStoragesConcurrentConsumer::next() to return this information.