### PR TITLE
Add clippy rule to deny uninlined-format-args

### DIFF
--- a/accounts-db/src/io_uring/sequential_file_reader.rs
+++ b/accounts-db/src/io_uring/sequential_file_reader.rs
@@ -421,7 +421,7 @@ mod tests {
 
         // Verify the contents
         for (i, byte) in all_read_data.iter().enumerate() {
-            assert_eq!(*byte, pattern[i % pattern.len()], "Mismatch - pos {}", i);
+            assert_eq!(*byte, pattern[i % pattern.len()], "Mismatch - pos {i}");
         }
     }
 

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -177,7 +177,7 @@ fn bench_banking(
         .unwrap()
         .set_limits(u64::MAX, u64::MAX, u64::MAX);
 
-    debug!("threads: {} txs: {}", num_threads, txes);
+    debug!("threads: {num_threads} txs: {txes}");
 
     let transactions = match tx_type {
         TransactionType::Accounts | TransactionType::AccountsAndVotes => {

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -53,7 +53,7 @@ fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {
             p.meta_mut().addr = ips[ip_index];
         }
     }
-    info!("total packets: {}", total);
+    info!("total packets: {total}");
 
     bencher.iter(move || {
         SigVerifyStage::discard_excess_packets(&mut batches, 10_000);
@@ -175,7 +175,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
         }
         let mut received = 0;
         let expected = if use_same_tx { 1 } else { sent_len };
-        trace!("sent: {}, expected: {}", sent_len, expected);
+        trace!("sent: {sent_len}, expected: {expected}");
         loop {
             if let Ok(verifieds) = verified_r.recv_timeout(Duration::from_millis(10)) {
                 received += verifieds.iter().map(|batch| batch.len()).sum::<usize>();
@@ -185,7 +185,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
                 }
             }
         }
-        trace!("received: {}", received);
+        trace!("received: {received}");
     });
     // This will wait for all packets to make it through sigverify.
     stage.join().unwrap();

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -429,7 +429,7 @@ impl SystemMonitorService {
         }
 
         fn normalize_err<E: std::fmt::Display>(key: &str, error: E) -> String {
-            format!("Failed to query value for {}: {}", key, error)
+            format!("Failed to query value for {key}: {error}")
         }
         INTERESTING_LIMITS
             .iter()
@@ -438,7 +438,7 @@ impl SystemMonitorService {
                     .map_err(|e| normalize_err(key, e))
                     .and_then(|val| val.parse::<i64>().map_err(|e| normalize_err(key, e)))
                     .unwrap_or_else(|e| {
-                        error!("{}", e);
+                        error!("{e}");
                         -1
                     });
                 (*key, interesting_limit, current_value)
@@ -498,7 +498,7 @@ impl SystemMonitorService {
                 }
                 *net_stats = Some(new_stats);
             }
-            Err(e) => warn!("read_net_stats: {}", e),
+            Err(e) => warn!("read_net_stats: {e}"),
         }
     }
 
@@ -833,7 +833,7 @@ impl SystemMonitorService {
                 }
                 *disk_stats = Some(new_stats);
             }
-            Err(e) => warn!("read_disk_stats: {}", e),
+            Err(e) => warn!("read_disk_stats: {e}"),
         }
     }
 

--- a/gossip/benches/crds_shards.rs
+++ b/gossip/benches/crds_shards.rs
@@ -31,7 +31,7 @@ fn bench_crds_shards_find(c: &mut Criterion, num_values: usize, mask_bits: u32) 
         assert!(shards.insert(index, value));
     }
     c.bench_function(
-        &format!("bench_crds_shards_find: mask_bits: {:?}", mask_bits),
+        &format!("bench_crds_shards_find: mask_bits: {mask_bits:?}"),
         |b| {
             b.iter(|| {
                 let mask = rng.gen();

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -319,7 +319,7 @@ fn check_env_path_for_bin_dir(config: &Config) {
 #[cfg(windows)]
 pub fn string_to_winreg_bytes(s: &str) -> Vec<u8> {
     use std::{ffi::OsString, os::windows::ffi::OsStrExt};
-    let v: Vec<_> = OsString::from(format!("{}\x00", s)).encode_wide().collect();
+    let v: Vec<_> = OsString::from(format!("{s}\x00")).encode_wide().collect();
     unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 2).to_vec() }
 }
 
@@ -361,7 +361,7 @@ fn get_windows_path_var() -> Result<Option<String>, String> {
     let root = RegKey::predef(HKEY_CURRENT_USER);
     let environment = root
         .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
-        .map_err(|err| format!("Unable to open HKEY_CURRENT_USER\\Environment: {}", err))?;
+        .map_err(|err| format!("Unable to open HKEY_CURRENT_USER\\Environment: {err}"))?;
 
     let reg_value = environment.get_raw_value("PATH");
     match reg_value {
@@ -395,7 +395,7 @@ fn add_to_path(new_path: &str) -> bool {
     };
 
     let Some(old_path) =
-        get_windows_path_var().unwrap_or_else(|err| panic!("Unable to get PATH: {}", err))
+        get_windows_path_var().unwrap_or_else(|err| panic!("Unable to get PATH: {err}"))
     else {
         return false;
     };
@@ -410,7 +410,7 @@ fn add_to_path(new_path: &str) -> bool {
         let root = RegKey::predef(HKEY_CURRENT_USER);
         let environment = root
             .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
-            .unwrap_or_else(|err| panic!("Unable to open HKEY_CURRENT_USER\\Environment: {}", err));
+            .unwrap_or_else(|err| panic!("Unable to open HKEY_CURRENT_USER\\Environment: {err}"));
 
         let reg_value = RegValue {
             bytes: string_to_winreg_bytes(&new_path),
@@ -419,9 +419,7 @@ fn add_to_path(new_path: &str) -> bool {
 
         environment
             .set_raw_value("PATH", &reg_value)
-            .unwrap_or_else(|err| {
-                panic!("Unable set HKEY_CURRENT_USER\\Environment\\PATH: {}", err)
-            });
+            .unwrap_or_else(|err| panic!("Unable set HKEY_CURRENT_USER\\Environment\\PATH: {err}"));
 
         // Tell other processes to update their environment
         unsafe {

--- a/io-uring/src/lib.rs
+++ b/io-uring/src/lib.rs
@@ -28,7 +28,7 @@ pub fn io_uring_supported() -> bool {
                     true
                 }
                 Err(e) => {
-                    log::info!("io_uring NOT supported: {}", e);
+                    log::info!("io_uring NOT supported: {e}");
                     false
                 }
             };

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -149,7 +149,7 @@ fn bench_sigverify_uneven(b: &mut Bencher) {
         }
         batches.push(PacketBatch::from(batch));
     }
-    info!("num_packets: {} valid: {}", num_packets, num_valid);
+    info!("num_packets: {num_packets} valid: {num_valid}");
 
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();

--- a/perf/src/thread.rs
+++ b/perf/src/thread.rs
@@ -58,7 +58,7 @@ pub fn is_renice_allowed(adjustment: i8) -> bool {
     } else {
         nix::unistd::geteuid().is_root()
             || caps::has_cap(None, CapSet::Effective, Capability::CAP_SYS_NICE)
-                .map_err(|err| warn!("Failed to get thread's capabilities: {}", err))
+                .map_err(|err| warn!("Failed to get thread's capabilities: {err}"))
                 .unwrap_or(false)
     }
 }

--- a/programs/sbf/tests/simulation.rs
+++ b/programs/sbf/tests/simulation.rs
@@ -88,8 +88,8 @@ fn test_no_panic_rpc_client() {
         match rpc_client.send_and_confirm_transaction(&transaction) {
             Ok(_) => break,
             Err(e) => {
-                if !format!("{:?}", e).contains("Program is not deployed") {
-                    panic!("Unexpected error: {:?}", e);
+                if !format!("{e:?}").contains("Program is not deployed") {
+                    panic!("Unexpected error: {e:?}");
                 }
                 attempt += 1;
                 if attempt > MAX_ATTEMPTS {

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -149,7 +149,7 @@ fn do_bench_transactions(
     info!("  {:?} ns/iter median", summary.median as u64);
     assert!(0f64 != summary.median);
     let tps = transactions.len() as u64 * (ns_per_s / summary.median as u64);
-    info!("  {:?} TPS", tps);
+    info!("  {tps:?} TPS");
 }
 
 #[bench]

--- a/scripts/cargo-clippy-nightly.sh
+++ b/scripts/cargo-clippy-nightly.sh
@@ -29,4 +29,5 @@ source "$here/../ci/rust-version.sh" nightly
   --deny=clippy::default_trait_access \
   --deny=clippy::arithmetic_side_effects \
   --deny=clippy::manual_let_else \
+  --deny=clippy::uninlined-format-args \
   --deny=clippy::used_underscore_binding

--- a/streamer/examples/swqos.rs
+++ b/streamer/examples/swqos.rs
@@ -40,7 +40,7 @@ fn parse_duration(arg: &str) -> Result<std::time::Duration, std::num::ParseFloat
 const LAMPORTS_PER_SOL: u64 = 1000000000;
 
 pub fn load_staked_nodes_overrides(path: &String) -> anyhow::Result<HashMap<Pubkey, u64>> {
-    debug!("Loading staked nodes overrides configuration from {}", path);
+    debug!("Loading staked nodes overrides configuration from {path}");
     if Path::new(&path).exists() {
         let file = std::fs::File::open(path)?;
         let reader = BufReader::new(file);

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -61,14 +61,14 @@ pub(crate) fn recv_from(
                 }
             }
             Err(e) => {
-                trace!("recv_from err {:?}", e);
+                trace!("recv_from err {e:?}");
                 return Err(e);
             }
             Ok(npkts) => {
                 if i == 0 {
                     socket.set_nonblocking(true)?;
                 }
-                trace!("got {} packets", npkts);
+                trace!("got {npkts} packets");
                 i += npkts;
                 // Try to batch into big enough buffers
                 // will cause less re-shuffling later on.

--- a/thread-manager/examples/core_contention_basics.rs
+++ b/thread-manager/examples/core_contention_basics.rs
@@ -58,7 +58,7 @@ fn main() -> anyhow::Result<()> {
             join_handle.join().expect("Load generator crashed!")
         });
         //print out the results of the bench run
-        info!("Results are: {:?}", results);
+        info!("Results are: {results:?}");
     }
     Ok(())
 }

--- a/thread-manager/examples/core_contention_sweep.rs
+++ b/thread-manager/examples/core_contention_sweep.rs
@@ -122,7 +122,7 @@ fn main() -> anyhow::Result<()> {
                 };
                 jh.join().expect("Some of the threads crashed!")
             })?;
-            info!("Results are: {:?}", measurement);
+            info!("Results are: {measurement:?}");
             results.latencies_s.push(measurement.latency_s);
             results
                 .requests_per_second

--- a/thread-manager/src/lib.rs
+++ b/thread-manager/src/lib.rs
@@ -227,7 +227,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn validate_affinity(expect_cores: &[usize], error_msg: &str) {
         let affinity = affinity::get_thread_affinity().unwrap();
-        assert_eq!(affinity, expect_cores, "{}", error_msg);
+        assert_eq!(affinity, expect_cores, "{error_msg}");
     }
     #[test]
     #[cfg(target_os = "linux")]

--- a/thread-manager/src/policy.rs
+++ b/thread-manager/src/policy.rs
@@ -61,7 +61,7 @@ cfg_if::cfg_if! {
                 policy,
                 thread_priority::ThreadPriority::Crossplatform((priority).try_into().expect("Priority value outside of OS-supported range")),
             ) {
-                panic!("Can not set thread priority, OS error {:?}", e);
+                panic!("Can not set thread priority, OS error {e:?}");
             }
         }
         pub fn parse_policy(policy: &str) -> ThreadSchedulePolicy {

--- a/transaction-view/benches/bytes.rs
+++ b/transaction-view/benches/bytes.rs
@@ -55,12 +55,8 @@ fn bench_u16_parsing(c: &mut Criterion) {
 fn decode_shortu16_len_iter(values_serialized_lengths_and_buffers: &[(u16, usize, Vec<u8>)]) {
     for (value, serialized_len, buffer) in values_serialized_lengths_and_buffers.iter() {
         let (read_value, bytes_read) = decode_shortu16_len(black_box(buffer)).unwrap();
-        assert_eq!(read_value, *value as usize, "Value mismatch for: {}", value);
-        assert_eq!(
-            bytes_read, *serialized_len,
-            "Offset mismatch for: {}",
-            value
-        );
+        assert_eq!(read_value, *value as usize, "Value mismatch for: {value}");
+        assert_eq!(bytes_read, *serialized_len, "Offset mismatch for: {value}");
     }
 }
 
@@ -68,8 +64,8 @@ fn read_compressed_u16_iter(values_serialized_lengths_and_buffers: &[(u16, usize
     for (value, serialized_len, buffer) in values_serialized_lengths_and_buffers.iter() {
         let mut offset = 0;
         let read_value = read_compressed_u16(black_box(buffer), &mut offset).unwrap();
-        assert_eq!(read_value, *value, "Value mismatch for: {}", value);
-        assert_eq!(offset, *serialized_len, "Offset mismatch for: {}", value);
+        assert_eq!(read_value, *value, "Value mismatch for: {value}");
+        assert_eq!(offset, *serialized_len, "Offset mismatch for: {value}");
     }
 }
 
@@ -79,8 +75,8 @@ fn optimized_read_compressed_u16_iter(
     for (value, serialized_len, buffer) in values_serialized_lengths_and_buffers.iter() {
         let mut offset = 0;
         let read_value = optimized_read_compressed_u16(black_box(buffer), &mut offset).unwrap();
-        assert_eq!(read_value, *value, "Value mismatch for: {}", value);
-        assert_eq!(offset, *serialized_len, "Offset mismatch for: {}", value);
+        assert_eq!(read_value, *value, "Value mismatch for: {value}");
+        assert_eq!(offset, *serialized_len, "Offset mismatch for: {value}");
     }
 }
 

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -247,6 +247,6 @@ mod tests {
     fn test_router() {
         let router = Router::new().unwrap();
         let next_hop = router.route("1.1.1.1".parse().unwrap()).unwrap();
-        eprintln!("{:?}", next_hop);
+        eprintln!("{next_hop:?}");
     }
 }


### PR DESCRIPTION
#### Problem
This lint is on by default in >= Rust 1.88.0. We are currently unable to upgrade Rust version due to an unrelated issue

#### Summary of Changes
Add the lint to keep our code compliant and ready to upgrade once we can do so

~~This PR was originally opened with items that are non-compliant to observe CI failures. Once https://github.com/anza-xyz/agave/pull/7825 merges and this PR is rebased, CI should complete without issue~~

Referenced PR merged + this PR rebased