### PR TITLE
clean: remove unused `rewards_pool_pubkeys`

### DIFF
--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -1452,7 +1452,7 @@ pub(crate) mod tests {
             .write()
             .unwrap()
             .clear();
-        bank.finish_init(&genesis_config, false);
+        bank.finish_init(false);
 
         // Assert the feature is active and the bank still added the builtin.
         assert!(bank.feature_set.is_active(feature_id));
@@ -1621,7 +1621,7 @@ pub(crate) mod tests {
             .write()
             .unwrap()
             .clear();
-        bank.finish_init(&genesis_config, false);
+        bank.finish_init(false);
 
         check_builtin_is_bpf(&bank);
     }

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -33,7 +33,6 @@ pub(crate) struct NewBankTimings {
     pub(crate) stakes_cache_time_us: u64,
     pub(crate) epoch_stakes_time_us: u64,
     pub(crate) builtin_program_ids_time_us: u64,
-    pub(crate) rewards_pool_pubkeys_time_us: u64,
     pub(crate) executor_cache_time_us: u64,
     pub(crate) transaction_debug_keys_time_us: u64,
     pub(crate) transaction_log_collector_config_time_us: u64,
@@ -116,11 +115,6 @@ pub(crate) fn report_new_bank_metrics(
         (
             "builtin_programs_us",
             timings.builtin_program_ids_time_us,
-            i64
-        ),
-        (
-            "rewards_pool_pubkeys_us",
-            timings.rewards_pool_pubkeys_time_us,
             i64
         ),
         ("executor_cache_us", timings.executor_cache_time_us, i64),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7402,7 +7402,7 @@ fn test_invoke_non_program_account_owned_by_a_builtin(
 fn test_debug_bank() {
     let (genesis_config, _mint_keypair) = create_genesis_config(50000);
     let mut bank = Bank::new_for_tests(&genesis_config);
-    bank.finish_init(&genesis_config, false);
+    bank.finish_init(false);
     let debug = format!("{bank:#?}");
     assert!(!debug.is_empty());
 }
@@ -12375,7 +12375,7 @@ fn test_apply_builtin_program_feature_transitions_for_new_epoch() {
 
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.feature_set = Arc::new(FeatureSet::all_enabled());
-    bank.finish_init(&genesis_config, false);
+    bank.finish_init(false);
 
     // Overwrite precompile accounts to simulate a cluster which already added precompiles.
     for precompile in get_precompiles() {
@@ -12410,7 +12410,7 @@ fn test_startup_from_snapshot_after_precompile_transition() {
 
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.feature_set = Arc::new(FeatureSet::all_enabled());
-    bank.finish_init(&genesis_config, false);
+    bank.finish_init(false);
 
     // Overwrite precompile accounts to simulate a cluster which already added precompiles.
     for precompile in get_precompiles() {
@@ -12421,7 +12421,7 @@ fn test_startup_from_snapshot_after_precompile_transition() {
     bank.freeze();
 
     // Simulate starting up from snapshot finishing the initialization for a frozen bank
-    bank.finish_init(&genesis_config, false);
+    bank.finish_init(false);
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
The `rewards_pool_pubkeys` field is no longer used on bank and can be removed

#### Summary of Changes
Remove it

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
