### PR TITLE
Fix - Restrict address space of sysvar syscalls in SIMD-0219

### DIFF
--- a/programs/sbf/rust/sysvar/src/lib.rs
+++ b/programs/sbf/rust/sysvar/src/lib.rs
@@ -209,6 +209,16 @@ pub fn process_instruction(
 
             Ok(())
         }
+        Some(&4) => {
+            // Attempt to store the result in the input region instead of the stack or heap
+            unsafe {
+                solana_define_syscall::definitions::sol_get_epoch_rewards_sysvar(
+                    accounts[2].data.borrow_mut().as_mut_ptr(),
+                )
+            };
+
+            Ok(())
+        }
         _ => Err(ProgramError::InvalidInstructionData),
     }
 }


### PR DESCRIPTION
#### Problem

ABI v1 aligns the account input region to 8 bytes. Direct mapping however uses the account data allocations which align to at least 16 bytes. Syscalls check the **host** alignment of translated pointers. This means that syscalls which require a 16 byte alignment suddenly pass the alignment check even if their virtual address is only divisible by 8 but not 16. Currently, only the sysvars syscall has a 16 byte alignment requirement. Thus, preventing that from accessing the account input section masks this behavior.

The SDK uses the [stack as destination](https://github.com/anza-xyz/solana-sdk/blob/65527cace3f7799cd47e7123b24a95a7e10c0cfe/sysvar/src/lib.rs#L166) except for the generic `get_sysvar()` syscall, which [could have the account input region as destination](https://github.com/anza-xyz/solana-sdk/blob/65527cace3f7799cd47e7123b24a95a7e10c0cfe/sysvar/src/lib.rs#L187). Also, see section "Syscall parameters" in [SIMD-0219](https://github.com/solana-foundation/solana-improvement-documents/pull/219).

#### Summary of Changes

Restricts the `var_addr` parameter of all sysvar syscalls when `stricter_abi_and_runtime_constraints` is active.
