### PR TITLE
Streamer stop churning unstaked connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10867,7 +10867,6 @@ dependencies = [
  "nix",
  "num_cpus",
  "pem",
- "percentage",
  "quinn",
  "quinn-proto",
  "rand 0.8.5",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9040,7 +9040,6 @@ dependencies = [
  "nix",
  "num_cpus",
  "pem",
- "percentage",
  "quinn",
  "quinn-proto",
  "rand 0.8.5",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9559,7 +9559,6 @@ dependencies = [
  "nix",
  "num_cpus",
  "pem",
- "percentage",
  "quinn",
  "quinn-proto",
  "rand 0.8.5",

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -35,7 +35,6 @@ log = { workspace = true }
 nix = { workspace = true, features = ["net", "poll", "signal"] }
 num_cpus = { workspace = true }
 pem = { workspace = true }
-percentage = { workspace = true }
 quinn = { workspace = true }
 quinn-proto = { workspace = true }
 rand = { workspace = true }

--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -36,9 +36,6 @@ pub(crate) trait QosController<C: ConnectionContext> {
     /// Called when a stream is accepted on a connection
     fn on_stream_accepted(&self, context: &C);
 
-    /// Called when a stream is finished successfully
-    fn on_stream_finished(&self, context: &C);
-
     /// Called when a stream has an error
     fn on_stream_error(&self, context: &C);
 

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -388,7 +388,7 @@ async fn test_connection_pruned_and_reopened() {
     let (scheduler_handle, _update_identity_sender, _scheduler_cancel) =
         setup_connection_worker_scheduler(server_address, tx_receiver, None).await;
 
-    sleep(Duration::from_millis(400)).await;
+    sleep(Duration::from_millis(600)).await;
     let _connection_to_prune_client = make_client_endpoint(&server_address, None).await;
 
     // Check results


### PR DESCRIPTION
#### Problem

Unstaked node pruning logic is fundamentally flawed right now.

We encourage connections to send a bunch of data just to not get evicted in case of high contention for unstaked slots. This generates a lot of spam when the validator is nowhere near its leader slot, and wastes resources.

If we allow 4000 unstaked connection slots, but we have 6000 unstaked client connecting clients trying to connect, we will always have someone trying to reconnect (as they have just been pruned), and each reconnect will have a chance to prune 10% of **all unstaked connections already opened**.  We might end up pruning a connection before it had a chance to send anything beyond initial handshake-associated data.  This is clearly not ideal=) 

### Motivation: 

* when an unstaked node connects, we give it a 500 ms connection lifetime, and server will never terminate an unstaked connections before 500 ms expires. 500 ms time is just a proposal, subject to tuning.
 * pruning still occurs, but will only evict a few connections at a time and will never evict connections that are still "fresh"

With the new setup, the lucky clients that would be able to connect, would have guaranteed QoS to send at reasonable rate for a reasonable amount of time, at which point they could be evicted if there is no room for others to connect.


#### Summary of Changes

- Modify pruning logic for unstaked connections to only prune ones older than 500ms
- Simplify a bunch of code around pruning

Context:

- https://github.com/anza-xyz/agave/pull/8143 removes unstaked NAT 
- https://github.com/anza-xyz/agave/pull/8144 bumps number of unstaked connection slots
 together these should make it more expensive to exhaust the connection pool and activate this code.