### PR TITLE
Add Versioning to fastboot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10309,6 +10309,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "regex",
+ "semver 1.0.26",
  "serde",
  "serde_derive",
  "serde_json",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8101,6 +8101,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "regex",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -83,6 +83,7 @@ qualifier_attr = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
+semver = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1676,7 +1676,7 @@ mod tests {
 
         fs::write(&complete_flag_file, new_version.to_string()).unwrap();
 
-        // With an invalid version and no legacy file, the snapshot will be conidered invalid
+        // With an invalid version and no legacy file, the snapshot will be considered invalid
         let snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
         assert_eq!(snapshot.slot, 2);
 


### PR DESCRIPTION
#### Problem
With obsolete accounts, there needs to be a method to determine whether this directory can be used to boot or if boot should use the archives. 

#### Summary of Changes
- Add a versioned completer in addition to the current unversioned completer
- The unversioned file is considered Version 0.0.0
- Currently can fastboot any version older than the current version. 

Notes:
When obsolete accounts fastboot support is enabled, the version will be incremented and the legacy file not be written if any obsolete accounts are present.

Another option would just be renaming the file. This would break fastboot when transitioning between versions though. I'm not sure how important that is. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
