### PR TITLE
Multihoming: remove egress socket select

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -82,7 +82,6 @@ use {
     },
     solana_measure::measure::Measure,
     solana_metrics::{datapoint_info, metrics::metrics_config_sanity_check},
-    solana_net_utils::multihomed_sockets::EgressSocketSelect,
     solana_poh::{
         poh_recorder::PohRecorder,
         poh_service::{self, PohService},
@@ -869,11 +868,6 @@ impl Validator {
         cluster_info.set_entrypoints(cluster_entrypoints);
         cluster_info.restore_contact_info(ledger_path, config.contact_save_interval);
         cluster_info.set_bind_ip_addrs(node.bind_ip_addrs.clone());
-        let tvu_sockets_per_interface =
-            node.sockets.retransmit_sockets.len() / node.bind_ip_addrs.len();
-        cluster_info.init_egress_socket_select(Arc::new(EgressSocketSelect::new(
-            tvu_sockets_per_interface,
-        )));
         let cluster_info = Arc::new(cluster_info);
         let node_multihoming = Arc::new(NodeMultihoming::from(&node));
 

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -53,7 +53,7 @@ use {
     solana_ledger::shred::Shred,
     solana_net_utils::{
         bind_in_range,
-        multihomed_sockets::{BindIpAddrs, EgressSocketSelect},
+        multihomed_sockets::BindIpAddrs,
         sockets::{bind_gossip_port_in_range, bind_to_localhost_unique},
         PortRange, VALIDATOR_PORT_RANGE,
     },
@@ -170,8 +170,6 @@ pub struct ClusterInfo {
     contact_info_path: PathBuf,
     socket_addr_space: SocketAddrSpace,
     bind_ip_addrs: Arc<BindIpAddrs>,
-    // Egress Multihoming
-    egress_socket_select: Arc<EgressSocketSelect>,
 }
 
 impl ClusterInfo {
@@ -201,7 +199,6 @@ impl ClusterInfo {
             contact_save_interval: 0, // disabled
             socket_addr_space,
             bind_ip_addrs: Arc::new(BindIpAddrs::default()),
-            egress_socket_select: Arc::new(EgressSocketSelect::default()),
         };
         me.refresh_my_gossip_contact_info();
         me
@@ -221,14 +218,6 @@ impl ClusterInfo {
 
     pub fn bind_ip_addrs(&self) -> Arc<BindIpAddrs> {
         self.bind_ip_addrs.clone()
-    }
-
-    pub fn init_egress_socket_select(&mut self, egress_socket_select: Arc<EgressSocketSelect>) {
-        self.egress_socket_select = egress_socket_select;
-    }
-
-    pub fn egress_socket_select(&self) -> &EgressSocketSelect {
-        &self.egress_socket_select
     }
 
     fn refresh_push_active_set(

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -434,16 +434,12 @@ mod multihoming {
                 .set_tvu_socket(tvu_ingress_address)
                 .map_err(|e| e.to_string())?;
 
+            // Update active index for tvu broadcast, tvu retransmit, and tpu forwarding client
             // This will never fail since we have checked index validity above
             let _new_ip_addr = self
                 .bind_ip_addrs
                 .set_active(interface_index)
                 .expect("Interface index out of range");
-
-            // Send from correct tvu retransmit/broadcast sockets
-            cluster_info
-                .egress_socket_select()
-                .select_interface(interface_index);
 
             Ok(())
         }

--- a/net-utils/src/multihomed_sockets.rs
+++ b/net-utils/src/multihomed_sockets.rs
@@ -153,31 +153,3 @@ impl AsRef<[IpAddr]> for BindIpAddrs {
         &self.addrs
     }
 }
-
-#[cfg(feature = "agave-unstable-api")]
-#[derive(Default)]
-pub struct EgressSocketSelect {
-    tvu_retransmit_active_offset: AtomicUsize,
-    num_tvu_retransmit_sockets: usize,
-}
-
-#[cfg(feature = "agave-unstable-api")]
-impl EgressSocketSelect {
-    pub fn new(num_retransmit_sockets: usize) -> Self {
-        Self {
-            tvu_retransmit_active_offset: AtomicUsize::new(0),
-            num_tvu_retransmit_sockets: num_retransmit_sockets,
-        }
-    }
-
-    pub fn select_interface(&self, interface_index: usize) {
-        self.tvu_retransmit_active_offset.store(
-            interface_index.saturating_mul(self.num_tvu_retransmit_sockets),
-            Ordering::Release,
-        );
-    }
-
-    pub fn active_retransmit_offset(&self) -> usize {
-        self.tvu_retransmit_active_offset.load(Ordering::Acquire)
-    }
-}

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -235,11 +235,10 @@ impl<'a> RetransmitSocket<'a> {
         if let Some(xdp_sender) = xdp_sender {
             RetransmitSocket::Xdp(xdp_sender)
         } else if cluster_info.bind_ip_addrs().multihoming_enabled() {
-            let interface_offset = cluster_info
-                .egress_socket_select()
-                .active_retransmit_offset();
             let sockets_per_interface =
                 retransmit_sockets.len() / cluster_info.bind_ip_addrs().len();
+            let active_index = cluster_info.bind_ip_addrs().active_index();
+            let interface_offset = sockets_per_interface.saturating_mul(active_index);
 
             RetransmitSocket::Multihomed {
                 sockets: retransmit_sockets,


### PR DESCRIPTION
#### Problem
We were essentially setting the active interface index in two different places. EgressSocketSelect doesn't serve any useful purpose except for maybe a cache that saves a one multiplication per retransmit. This overhead is minimal

#### Summary of Changes
Unify to one place -> keep BindIpAddrs::active_index(). remove EgressSocketSelect. 

