### PR TITLE
Implement set_top_level_instruction_index

### DIFF
--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -141,6 +141,11 @@ impl TransactionContext {
         }
     }
 
+    #[cfg(not(target_os = "solana"))]
+    pub fn set_top_level_instruction_index(&mut self, top_level_instruction_index: usize) {
+        self.top_level_instruction_index = top_level_instruction_index;
+    }
+
     /// Used in mock_process_instruction
     #[cfg(not(target_os = "solana"))]
     pub fn deconstruct_without_keys(self) -> Result<Vec<AccountSharedData>, InstructionError> {

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -141,7 +141,7 @@ impl TransactionContext {
         }
     }
 
-    #[cfg(not(target_os = "solana"))]
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn set_top_level_instruction_index(&mut self, top_level_instruction_index: usize) {
         self.top_level_instruction_index = top_level_instruction_index;
     }


### PR DESCRIPTION
#### Problem
anza made the hacky mollusk thing that doesn't work properly with instructions sysvar, because it is well, hacky.

The main issue is that it runs instruction one by one even if they belong to the same transaction with `process_instructions_chain`

https://github.com/anza-xyz/mollusk/pull/156 The problem blocks this

#### Summary of Changes
Expose setting `top_level_instruction_index` on `TransactionContext`

Can we afford this smell?

