### PR TITLE
faucet: put unique port range for tests behind debug_assertions gate

### DIFF
--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -15,7 +15,6 @@ use {
     solana_keypair::Keypair,
     solana_message::Message,
     solana_metrics::datapoint_info,
-    solana_net_utils::sockets::unique_port_range_for_tests,
     solana_packet::PACKET_DATA_SIZE,
     solana_pubkey::Pubkey,
     solana_signer::Signer,
@@ -344,7 +343,7 @@ pub fn run_local_faucet(faucet_keypair: Keypair, per_time_cap: Option<u64>) -> S
     let port: u16 = {
         #[cfg(debug_assertions)]
         {
-            unique_port_range_for_tests(1).start
+            solana_net_utils::sockets::unique_port_range_for_tests(1).start
         }
         #[cfg(not(debug_assertions))]
         {


### PR DESCRIPTION
#### Problem
The #7736 had missing gate for import used only in `debug_assertions` case, causing warning in release builds.

#### Summary of Changes
As suggested here https://github.com/anza-xyz/agave/pull/7736#issuecomment-3247019904
Now its properly gated.