### PR TITLE
Require io_uring support on linux when removing dir

### DIFF
--- a/accounts-db/src/utils.rs
+++ b/accounts-db/src/utils.rs
@@ -138,7 +138,8 @@ pub fn move_and_async_delete_path(path: impl AsRef<Path>) {
 /// Removes a directory and all its contents.
 pub fn remove_dir_all(path: impl Into<PathBuf> + AsRef<Path>) -> io::Result<()> {
     #[cfg(target_os = "linux")]
-    if io_uring_supported() {
+    {
+        assert!(io_uring_supported());
         if let Ok(mut remover) = RingDirRemover::new() {
             return remover.remove_dir_all(path);
         }
@@ -152,7 +153,8 @@ pub fn remove_dir_contents(path: impl AsRef<Path>) {
     let path = path.as_ref();
 
     #[cfg(target_os = "linux")]
-    if io_uring_supported() {
+    {
+        assert!(io_uring_supported());
         if let Ok(mut remover) = RingDirRemover::new() {
             if let Err(e) = remover.remove_dir_contents(path) {
                 warn!("Failed to delete contents of '{}': {e}", path.display());


### PR DESCRIPTION
#### Problem
io_uring is supported with all required capabilities on all kernels allowed by agave, but we gate some logic based on `io_uring_supported` function.

#### Summary of Changes
Change if to assert for io_uring support in accounts-db dir removal