### PR TITLE
rpc-client-types: add missing re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10214,6 +10214,8 @@ dependencies = [
  "solana-fee-calculator",
  "solana-inflation",
  "solana-pubkey",
+ "solana-reward-info",
+ "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-version",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10689,7 +10689,7 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.3",
  "proc-macro2",
  "quote",
  "syn 2.0.87",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8047,6 +8047,8 @@ dependencies = [
  "solana-commitment-config",
  "solana-fee-calculator",
  "solana-inflation",
+ "solana-reward-info",
+ "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-version",

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -1,9 +1,9 @@
 use crate::client_error;
 pub use solana_rpc_client_types::response::{
-    solana_transaction, EncodedTransaction, EncodedTransactionWithStatusMeta, FeeCalculator,
-    FeeRateGovernor, OptionSerializer, OptionalContext, ParsedAccount, ParsedInstruction,
-    ProcessedSignatureResult, ReceivedSignatureResult, Response, Reward, RewardType, Rewards,
-    RpcAccountBalance, RpcApiVersion, RpcBlockCommitment, RpcBlockProduction,
+    solana_transaction as transaction, EncodedTransaction, EncodedTransactionWithStatusMeta,
+    FeeCalculator, FeeRateGovernor, OptionSerializer, OptionalContext, ParsedAccount,
+    ParsedInstruction, ProcessedSignatureResult, ReceivedSignatureResult, Response, Reward,
+    RewardType, Rewards, RpcAccountBalance, RpcApiVersion, RpcBlockCommitment, RpcBlockProduction,
     RpcBlockProductionRange, RpcBlockUpdate, RpcBlockUpdateError, RpcBlockhash,
     RpcBlockhashFeeCalculator, RpcConfirmedTransactionStatusWithSignature, RpcContactInfo,
     RpcFeeCalculator, RpcFeeRateGovernor, RpcIdentity, RpcInflationGovernor, RpcInflationRate,

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -1,6 +1,6 @@
 use crate::client_error;
 pub use solana_rpc_client_types::response::{
-    solana_transaction as transaction, EncodedTransaction, EncodedTransactionWithStatusMeta,
+    transaction, EncodedTransaction, EncodedTransactionWithStatusMeta,
     FeeCalculator, FeeRateGovernor, OptionSerializer, OptionalContext, ParsedAccount,
     ParsedInstruction, ProcessedSignatureResult, ReceivedSignatureResult, Response, Reward,
     RewardType, Rewards, RpcAccountBalance, RpcApiVersion, RpcBlockCommitment, RpcBlockProduction,

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -1,9 +1,9 @@
 use crate::client_error;
 pub use solana_rpc_client_types::response::{
-    transaction, EncodedTransaction, EncodedTransactionWithStatusMeta,
-    FeeCalculator, FeeRateGovernor, OptionSerializer, OptionalContext, ParsedAccount,
-    ParsedInstruction, ProcessedSignatureResult, ReceivedSignatureResult, Response, Reward,
-    RewardType, Rewards, RpcAccountBalance, RpcApiVersion, RpcBlockCommitment, RpcBlockProduction,
+    transaction, EncodedTransaction, EncodedTransactionWithStatusMeta, FeeCalculator,
+    FeeRateGovernor, OptionSerializer, OptionalContext, ParsedAccount, ParsedInstruction,
+    ProcessedSignatureResult, ReceivedSignatureResult, Response, Reward, RewardType, Rewards,
+    RpcAccountBalance, RpcApiVersion, RpcBlockCommitment, RpcBlockProduction,
     RpcBlockProductionRange, RpcBlockUpdate, RpcBlockUpdateError, RpcBlockhash,
     RpcBlockhashFeeCalculator, RpcConfirmedTransactionStatusWithSignature, RpcContactInfo,
     RpcFeeCalculator, RpcFeeRateGovernor, RpcIdentity, RpcInflationGovernor, RpcInflationRate,

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -1,6 +1,8 @@
 use crate::client_error;
 pub use solana_rpc_client_types::response::{
-    OptionalContext, ProcessedSignatureResult, ReceivedSignatureResult, Response,
+    solana_transaction, EncodedTransaction, EncodedTransactionWithStatusMeta, FeeCalculator,
+    FeeRateGovernor, OptionSerializer, OptionalContext, ParsedAccount, ParsedInstruction,
+    ProcessedSignatureResult, ReceivedSignatureResult, Response, Reward, RewardType, Rewards,
     RpcAccountBalance, RpcApiVersion, RpcBlockCommitment, RpcBlockProduction,
     RpcBlockProductionRange, RpcBlockUpdate, RpcBlockUpdateError, RpcBlockhash,
     RpcBlockhashFeeCalculator, RpcConfirmedTransactionStatusWithSignature, RpcContactInfo,
@@ -9,7 +11,12 @@ pub use solana_rpc_client_types::response::{
     RpcPrioritizationFee, RpcResponseContext, RpcSignatureConfirmation, RpcSignatureResult,
     RpcSimulateTransactionResult, RpcSnapshotSlotInfo, RpcStorageTurn, RpcSupply,
     RpcTokenAccountBalance, RpcVersionInfo, RpcVote, RpcVoteAccountInfo, RpcVoteAccountStatus,
-    SlotInfo, SlotTransactionStats, SlotUpdate, StakeActivationState,
+    SlotInfo, SlotTransactionStats, SlotUpdate, StakeActivationState, TransactionBinaryEncoding,
+    TransactionConfirmationStatus, TransactionError, TransactionParsedAccount, TransactionResult,
+    UiAccount, UiAccountData, UiAccountEncoding, UiAccountsList, UiCompiledInstruction,
+    UiConfirmedBlock, UiInnerInstructions, UiInstruction, UiLoadedAddresses, UiParsedInstruction,
+    UiPartiallyDecodedInstruction, UiReturnDataEncoding, UiTokenAmount, UiTransactionError,
+    UiTransactionReturnData, UiTransactionStatusMeta, UiTransactionTokenBalance, Value,
 };
 
 pub type RpcResult<T> = client_error::Result<Response<T>>;

--- a/rpc-client-types/Cargo.toml
+++ b/rpc-client-types/Cargo.toml
@@ -26,6 +26,8 @@ solana-clock = { workspace = true }
 solana-commitment-config = { workspace = true, features = ["serde"] }
 solana-fee-calculator = { workspace = true, features = ["serde"] }
 solana-inflation = { workspace = true }
+solana-reward-info = { workspace = true }
+solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
 solana-version = { workspace = true }

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -19,7 +19,7 @@ pub use {
     },
     solana_fee_calculator::{FeeCalculator, FeeRateGovernor},
     solana_reward_info::RewardType, // used in Reward
-    solana_transaction, // used in EncodedTransaction (may as well re-export the whole crate)
+    solana_transaction as transaction, // used in EncodedTransaction (may as well re-export the whole crate)
     solana_transaction_error::{TransactionError, TransactionResult},
     solana_transaction_status_client_types::{
         option_serializer::OptionSerializer, // used in UiTransactionStatusMeta

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -6,22 +6,43 @@ use {
     std::{collections::HashMap, fmt, net::SocketAddr, str::FromStr},
     thiserror::Error,
 };
+// we re-export types that are part of the public API,
+// and recursively re-export types that are part of those types' public APIs
 pub use {
-    serde_json::Value,
+    serde_json::Value, // used in ParsedInstruction
     solana_account_decoder_client_types::{
-        token::UiTokenAmount, ParsedAccount, UiAccount, UiAccountData, UiAccountEncoding,
+        token::UiTokenAmount,
+        ParsedAccount, // used in UiAccountData
+        UiAccount,
+        UiAccountData,     // used in UiAccount
+        UiAccountEncoding, // used in UiAccountData
     },
     solana_fee_calculator::{FeeCalculator, FeeRateGovernor},
-    solana_reward_info::RewardType,
-    solana_transaction,
+    solana_reward_info::RewardType, // used in Reward
+    solana_transaction, // used in EncodedTransaction (may as well re-export the whole crate)
     solana_transaction_error::{TransactionError, TransactionResult},
     solana_transaction_status_client_types::{
-        option_serializer::OptionSerializer, EncodedTransaction, EncodedTransactionWithStatusMeta,
-        ParsedAccount as TransactionParsedAccount, ParsedInstruction, Reward, Rewards,
-        TransactionBinaryEncoding, TransactionConfirmationStatus, UiAccountsList,
-        UiCompiledInstruction, UiConfirmedBlock, UiInnerInstructions, UiInstruction,
-        UiLoadedAddresses, UiParsedInstruction, UiPartiallyDecodedInstruction,
-        UiReturnDataEncoding, UiTransactionError, UiTransactionReturnData, UiTransactionStatusMeta,
+        option_serializer::OptionSerializer, // used in UiTransactionStatusMeta
+        EncodedTransaction,                  // used in EncodedTransactionWithStatusMeta
+        EncodedTransactionWithStatusMeta,    // used in UiConfirmedBlock
+        ParsedAccount as TransactionParsedAccount, // used in UiAccountsList
+        ParsedInstruction,                   // used in UiParsedInstruction
+        Reward,                              // used in Rewards
+        Rewards,                             // used in UiConfirmedBlock
+        TransactionBinaryEncoding,           // used in EncodedTransaction
+        TransactionConfirmationStatus,
+        UiAccountsList,        // used in EncodedTransaction
+        UiCompiledInstruction, // used in UiInstruction
+        UiConfirmedBlock,
+        UiInnerInstructions,
+        UiInstruction, // used in UiInnerInstructions
+        UiLoadedAddresses,
+        UiParsedInstruction,           // used in UiInstruction
+        UiPartiallyDecodedInstruction, // used in UiParsedInstruction
+        UiReturnDataEncoding,          // used in UiTransactionReturnData
+        UiTransactionError,
+        UiTransactionReturnData,
+        UiTransactionStatusMeta, // used in EncodedTransactionWithStatusMeta
         UiTransactionTokenBalance,
     },
 };

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -18,7 +18,7 @@ pub use {
         UiAccountEncoding, // used in UiAccountData
     },
     solana_fee_calculator::{FeeCalculator, FeeRateGovernor},
-    solana_reward_info::RewardType, // used in Reward
+    solana_reward_info::RewardType,    // used in Reward
     solana_transaction as transaction, // used in EncodedTransaction (may as well re-export the whole crate)
     solana_transaction_error::{TransactionError, TransactionResult},
     solana_transaction_status_client_types::{

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -13,7 +13,7 @@ pub use {
     },
     solana_fee_calculator::{FeeCalculator, FeeRateGovernor},
     solana_reward_info::RewardType,
-    solana_transaction as transaction,
+    solana_transaction,
     solana_transaction_error::{TransactionError, TransactionResult},
     solana_transaction_status_client_types::{
         option_serializer::OptionSerializer, EncodedTransaction, EncodedTransactionWithStatusMeta,

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -7,7 +7,7 @@ use {
     thiserror::Error,
 };
 pub use {
-    serde_json::Value as JsonValue,
+    serde_json::Value,
     solana_account_decoder_client_types::{
         token::UiTokenAmount, ParsedAccount, UiAccount, UiAccountData, UiAccountEncoding,
     },

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -13,7 +13,7 @@ pub use {
     },
     solana_fee_calculator::{FeeCalculator, FeeRateGovernor},
     solana_reward_info::RewardType,
-    solana_transaction::versioned::{TransactionVersion, VersionedTransaction},
+    solana_transaction as transaction,
     solana_transaction_error::{TransactionError, TransactionResult},
     solana_transaction_status_client_types::{
         option_serializer::OptionSerializer, EncodedTransaction, EncodedTransactionWithStatusMeta,

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -13,7 +13,7 @@ pub use {
     },
     solana_fee_calculator::{FeeCalculator, FeeRateGovernor},
     solana_reward_info::RewardType,
-    solana_transaction::versioned::TransactionVersion,
+    solana_transaction::versioned::{TransactionVersion, VersionedTransaction},
     solana_transaction_error::{TransactionError, TransactionResult},
     solana_transaction_status_client_types::{
         option_serializer::OptionSerializer, EncodedTransaction, EncodedTransactionWithStatusMeta,

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -7,12 +7,22 @@ use {
     thiserror::Error,
 };
 pub use {
-    solana_account_decoder_client_types::{token::UiTokenAmount, UiAccount},
+    serde_json::Value as JsonValue,
+    solana_account_decoder_client_types::{
+        token::UiTokenAmount, ParsedAccount, UiAccount, UiAccountData, UiAccountEncoding,
+    },
     solana_fee_calculator::{FeeCalculator, FeeRateGovernor},
-    solana_transaction_error::TransactionResult,
+    solana_reward_info::RewardType,
+    solana_transaction::versioned::TransactionVersion,
+    solana_transaction_error::{TransactionError, TransactionResult},
     solana_transaction_status_client_types::{
-        TransactionConfirmationStatus, UiConfirmedBlock, UiInnerInstructions, UiLoadedAddresses,
-        UiTransactionError, UiTransactionReturnData, UiTransactionTokenBalance,
+        option_serializer::OptionSerializer, EncodedTransaction, EncodedTransactionWithStatusMeta,
+        ParsedAccount as TransactionParsedAccount, ParsedInstruction, Reward, Rewards,
+        TransactionBinaryEncoding, TransactionConfirmationStatus, UiAccountsList,
+        UiCompiledInstruction, UiConfirmedBlock, UiInnerInstructions, UiInstruction,
+        UiLoadedAddresses, UiParsedInstruction, UiPartiallyDecodedInstruction,
+        UiReturnDataEncoding, UiTransactionError, UiTransactionReturnData, UiTransactionStatusMeta,
+        UiTransactionTokenBalance,
     },
 };
 


### PR DESCRIPTION
These are types that are used by currently exported items, mostly in struct fields or enum variants