### PR TITLE
Fixes build error due to removing Option wrapper around AccountsDbConfig

### DIFF
--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -30,7 +30,7 @@ const ACCOUNTS_COUNTS: [usize; 4] = [
 ];
 
 fn bench_write_accounts_file(c: &mut Criterion, storage_access: StorageAccess) {
-    let mut group = c.benchmark_group(format!("write_accounts_file_{:?}", storage_access));
+    let mut group = c.benchmark_group(format!("write_accounts_file_{storage_access:?}"));
 
     // most accounts on mnb are 165-200 bytes, so use that here too
     let space = 200;

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1081,10 +1081,10 @@ fn test_clean_dead_slot_with_obsolete_accounts() {
 
     let accounts = AccountsDb::new_with_config(
         Vec::new(),
-        Some(AccountsDbConfig {
+        AccountsDbConfig {
             mark_obsolete_accounts: MarkObsoleteAccounts::Enabled,
             ..ACCOUNTS_DB_CONFIG_FOR_TESTING
-        }),
+        },
         None,
         Arc::default(),
     );


### PR DESCRIPTION
#### Problem

The build is broken because #7851 removed the Option wrapper around AccountsDbConfig, but #7682 didn't include this change and merged second.


#### Summary of Changes

Fix it.