### PR TITLE
feature-set: Apply cargo fmt string formatting

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1129,245 +1129,912 @@ pub mod enforce_fixed_fec_set {
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
-        (deprecate_rewards_sysvar::id(), "deprecate unused rewards sysvar"),
+        (
+            deprecate_rewards_sysvar::id(),
+            "deprecate unused rewards sysvar",
+        ),
         (pico_inflation::id(), "pico inflation"),
-        (full_inflation::devnet_and_testnet::id(), "full inflation on devnet and testnet"),
+        (
+            full_inflation::devnet_and_testnet::id(),
+            "full inflation on devnet and testnet",
+        ),
         (spl_token_v2_multisig_fix::id(), "spl-token multisig fix"),
-        (no_overflow_rent_distribution::id(), "no overflow rent distribution"),
-        (filter_stake_delegation_accounts::id(), "filter stake_delegation_accounts #14062"),
-        (require_custodian_for_locked_stake_authorize::id(), "require custodian to authorize withdrawer change for locked stake"),
-        (spl_token_v2_self_transfer_fix::id(), "spl-token self-transfer fix"),
-        (full_inflation::mainnet::certusone::enable::id(), "full inflation enabled by Certus One"),
-        (full_inflation::mainnet::certusone::vote::id(), "community vote allowing Certus One to enable full inflation"),
-        (warp_timestamp_again::id(), "warp timestamp again, adjust bounding to 25% fast 80% slow #15204"),
+        (
+            no_overflow_rent_distribution::id(),
+            "no overflow rent distribution",
+        ),
+        (
+            filter_stake_delegation_accounts::id(),
+            "filter stake_delegation_accounts #14062",
+        ),
+        (
+            require_custodian_for_locked_stake_authorize::id(),
+            "require custodian to authorize withdrawer change for locked stake",
+        ),
+        (
+            spl_token_v2_self_transfer_fix::id(),
+            "spl-token self-transfer fix",
+        ),
+        (
+            full_inflation::mainnet::certusone::enable::id(),
+            "full inflation enabled by Certus One",
+        ),
+        (
+            full_inflation::mainnet::certusone::vote::id(),
+            "community vote allowing Certus One to enable full inflation",
+        ),
+        (
+            warp_timestamp_again::id(),
+            "warp timestamp again, adjust bounding to 25% fast 80% slow #15204",
+        ),
         (check_init_vote_data::id(), "check initialized Vote data"),
-        (secp256k1_recover_syscall_enabled::id(), "secp256k1_recover syscall"),
-        (system_transfer_zero_check::id(), "perform all checks for transfers of 0 lamports"),
+        (
+            secp256k1_recover_syscall_enabled::id(),
+            "secp256k1_recover syscall",
+        ),
+        (
+            system_transfer_zero_check::id(),
+            "perform all checks for transfers of 0 lamports",
+        ),
         (blake3_syscall_enabled::id(), "blake3 syscall"),
-        (dedupe_config_program_signers::id(), "dedupe config program signers"),
-        (verify_tx_signatures_len::id(), "prohibit extra transaction signatures"),
-        (vote_stake_checked_instructions::id(), "vote/state program checked instructions #18345"),
-        (rent_for_sysvars::id(), "collect rent from accounts owned by sysvars"),
-        (libsecp256k1_0_5_upgrade_enabled::id(), "upgrade libsecp256k1 to v0.5.0"),
+        (
+            dedupe_config_program_signers::id(),
+            "dedupe config program signers",
+        ),
+        (
+            verify_tx_signatures_len::id(),
+            "prohibit extra transaction signatures",
+        ),
+        (
+            vote_stake_checked_instructions::id(),
+            "vote/state program checked instructions #18345",
+        ),
+        (
+            rent_for_sysvars::id(),
+            "collect rent from accounts owned by sysvars",
+        ),
+        (
+            libsecp256k1_0_5_upgrade_enabled::id(),
+            "upgrade libsecp256k1 to v0.5.0",
+        ),
         (tx_wide_compute_cap::id(), "transaction wide compute cap"),
-        (spl_token_v2_set_authority_fix::id(), "spl-token set_authority fix"),
-        (merge_nonce_error_into_system_error::id(), "merge NonceError into SystemError"),
+        (
+            spl_token_v2_set_authority_fix::id(),
+            "spl-token set_authority fix",
+        ),
+        (
+            merge_nonce_error_into_system_error::id(),
+            "merge NonceError into SystemError",
+        ),
         (disable_fees_sysvar::id(), "disable fees sysvar"),
-        (stake_merge_with_unmatched_credits_observed::id(), "allow merging active stakes with unmatched credits_observed #18985"),
-        (zk_token_sdk_enabled::id(), "enable Zk Token proof program and syscalls"),
-        (curve25519_syscall_enabled::id(), "enable curve25519 syscalls"),
-        (versioned_tx_message_enabled::id(), "enable versioned transaction message processing"),
-        (libsecp256k1_fail_on_bad_count::id(), "fail libsecp256k1_verify if count appears wrong"),
-        (libsecp256k1_fail_on_bad_count2::id(), "fail libsecp256k1_verify if count appears wrong"),
-        (instructions_sysvar_owned_by_sysvar::id(), "fix owner for instructions sysvar"),
-        (stake_program_advance_activating_credits_observed::id(), "Enable advancing credits observed for activation epoch #19309"),
-        (credits_auto_rewind::id(), "Auto rewind stake's credits_observed if (accidental) vote recreation is detected #22546"),
-        (demote_program_write_locks::id(), "demote program write locks to readonly, except when upgradeable loader present #19593 #20265"),
-        (ed25519_program_enabled::id(), "enable builtin ed25519 signature verify program"),
-        (return_data_syscall_enabled::id(), "enable sol_{set,get}_return_data syscall"),
-        (reduce_required_deploy_balance::id(), "reduce required payer balance for program deploys"),
-        (sol_log_data_syscall_enabled::id(), "enable sol_log_data syscall"),
-        (stakes_remove_delegation_if_inactive::id(), "remove delegations from stakes cache when inactive"),
-        (do_support_realloc::id(), "support account data reallocation"),
-        (prevent_calling_precompiles_as_programs::id(), "prevent calling precompiles as programs"),
-        (optimize_epoch_boundary_updates::id(), "optimize epoch boundary updates"),
-        (remove_native_loader::id(), "remove support for the native loader"),
-        (send_to_tpu_vote_port::id(), "send votes to the tpu vote port"),
+        (
+            stake_merge_with_unmatched_credits_observed::id(),
+            "allow merging active stakes with unmatched credits_observed #18985",
+        ),
+        (
+            zk_token_sdk_enabled::id(),
+            "enable Zk Token proof program and syscalls",
+        ),
+        (
+            curve25519_syscall_enabled::id(),
+            "enable curve25519 syscalls",
+        ),
+        (
+            versioned_tx_message_enabled::id(),
+            "enable versioned transaction message processing",
+        ),
+        (
+            libsecp256k1_fail_on_bad_count::id(),
+            "fail libsecp256k1_verify if count appears wrong",
+        ),
+        (
+            libsecp256k1_fail_on_bad_count2::id(),
+            "fail libsecp256k1_verify if count appears wrong",
+        ),
+        (
+            instructions_sysvar_owned_by_sysvar::id(),
+            "fix owner for instructions sysvar",
+        ),
+        (
+            stake_program_advance_activating_credits_observed::id(),
+            "Enable advancing credits observed for activation epoch #19309",
+        ),
+        (
+            credits_auto_rewind::id(),
+            "Auto rewind stake's credits_observed if (accidental) vote recreation is detected \
+             #22546",
+        ),
+        (
+            demote_program_write_locks::id(),
+            "demote program write locks to readonly, except when upgradeable loader present \
+             #19593 #20265",
+        ),
+        (
+            ed25519_program_enabled::id(),
+            "enable builtin ed25519 signature verify program",
+        ),
+        (
+            return_data_syscall_enabled::id(),
+            "enable sol_{set,get}_return_data syscall",
+        ),
+        (
+            reduce_required_deploy_balance::id(),
+            "reduce required payer balance for program deploys",
+        ),
+        (
+            sol_log_data_syscall_enabled::id(),
+            "enable sol_log_data syscall",
+        ),
+        (
+            stakes_remove_delegation_if_inactive::id(),
+            "remove delegations from stakes cache when inactive",
+        ),
+        (
+            do_support_realloc::id(),
+            "support account data reallocation",
+        ),
+        (
+            prevent_calling_precompiles_as_programs::id(),
+            "prevent calling precompiles as programs",
+        ),
+        (
+            optimize_epoch_boundary_updates::id(),
+            "optimize epoch boundary updates",
+        ),
+        (
+            remove_native_loader::id(),
+            "remove support for the native loader",
+        ),
+        (
+            send_to_tpu_vote_port::id(),
+            "send votes to the tpu vote port",
+        ),
         (requestable_heap_size::id(), "Requestable heap frame size"),
         (disable_fee_calculator::id(), "deprecate fee calculator"),
-        (add_compute_budget_program::id(), "Add compute_budget_program"),
+        (
+            add_compute_budget_program::id(),
+            "Add compute_budget_program",
+        ),
         (nonce_must_be_writable::id(), "nonce must be writable"),
         (spl_token_v3_3_0_release::id(), "spl-token v3.3.0 release"),
         (leave_nonce_on_success::id(), "leave nonce as is on success"),
-        (reject_empty_instruction_without_program::id(), "fail instructions which have native_loader as program_id directly"),
-        (fixed_memcpy_nonoverlapping_check::id(), "use correct check for nonoverlapping regions in memcpy syscall"),
-        (reject_non_rent_exempt_vote_withdraws::id(), "fail vote withdraw instructions which leave the account non-rent-exempt"),
-        (evict_invalid_stakes_cache_entries::id(), "evict invalid stakes cache entries on epoch boundaries"),
-        (allow_votes_to_directly_update_vote_state::id(), "enable direct vote state update"),
-        (max_tx_account_locks::id(), "enforce max number of locked accounts per transaction"),
-        (require_rent_exempt_accounts::id(), "require all new transaction accounts with data to be rent-exempt"),
-        (filter_votes_outside_slot_hashes::id(), "filter vote slots older than the slot hashes history"),
+        (
+            reject_empty_instruction_without_program::id(),
+            "fail instructions which have native_loader as program_id directly",
+        ),
+        (
+            fixed_memcpy_nonoverlapping_check::id(),
+            "use correct check for nonoverlapping regions in memcpy syscall",
+        ),
+        (
+            reject_non_rent_exempt_vote_withdraws::id(),
+            "fail vote withdraw instructions which leave the account non-rent-exempt",
+        ),
+        (
+            evict_invalid_stakes_cache_entries::id(),
+            "evict invalid stakes cache entries on epoch boundaries",
+        ),
+        (
+            allow_votes_to_directly_update_vote_state::id(),
+            "enable direct vote state update",
+        ),
+        (
+            max_tx_account_locks::id(),
+            "enforce max number of locked accounts per transaction",
+        ),
+        (
+            require_rent_exempt_accounts::id(),
+            "require all new transaction accounts with data to be rent-exempt",
+        ),
+        (
+            filter_votes_outside_slot_hashes::id(),
+            "filter vote slots older than the slot hashes history",
+        ),
         (update_syscall_base_costs::id(), "update syscall base costs"),
-        (stake_deactivate_delinquent_instruction::id(), "enable the deactivate delinquent stake instruction #23932"),
-        (vote_withdraw_authority_may_change_authorized_voter::id(), "vote account withdraw authority may change the authorized voter #22521"),
-        (spl_associated_token_account_v1_0_4::id(), "SPL Associated Token Account Program release version 1.0.4, tied to token 3.3.0 #22648"),
-        (reject_vote_account_close_unless_zero_credit_epoch::id(), "fail vote account withdraw to 0 unless account earned 0 credits in last completed epoch"),
-        (add_get_processed_sibling_instruction_syscall::id(), "add add_get_processed_sibling_instruction_syscall"),
-        (bank_transaction_count_fix::id(), "fixes Bank::transaction_count to include all committed transactions, not just successful ones"),
-        (disable_bpf_deprecated_load_instructions::id(), "disable ldabs* and ldind* SBF instructions"),
-        (disable_bpf_unresolved_symbols_at_runtime::id(), "disable reporting of unresolved SBF symbols at runtime"),
-        (record_instruction_in_transaction_context_push::id(), "move the CPI stack overflow check to the end of push"),
+        (
+            stake_deactivate_delinquent_instruction::id(),
+            "enable the deactivate delinquent stake instruction #23932",
+        ),
+        (
+            vote_withdraw_authority_may_change_authorized_voter::id(),
+            "vote account withdraw authority may change the authorized voter #22521",
+        ),
+        (
+            spl_associated_token_account_v1_0_4::id(),
+            "SPL Associated Token Account Program release version 1.0.4, tied to token 3.3.0 \
+             #22648",
+        ),
+        (
+            reject_vote_account_close_unless_zero_credit_epoch::id(),
+            "fail vote account withdraw to 0 unless account earned 0 credits in last completed \
+             epoch",
+        ),
+        (
+            add_get_processed_sibling_instruction_syscall::id(),
+            "add add_get_processed_sibling_instruction_syscall",
+        ),
+        (
+            bank_transaction_count_fix::id(),
+            "fixes Bank::transaction_count to include all committed transactions, not just \
+             successful ones",
+        ),
+        (
+            disable_bpf_deprecated_load_instructions::id(),
+            "disable ldabs* and ldind* SBF instructions",
+        ),
+        (
+            disable_bpf_unresolved_symbols_at_runtime::id(),
+            "disable reporting of unresolved SBF symbols at runtime",
+        ),
+        (
+            record_instruction_in_transaction_context_push::id(),
+            "move the CPI stack overflow check to the end of push",
+        ),
         (syscall_saturated_math::id(), "syscalls use saturated math"),
-        (check_physical_overlapping::id(), "check physical overlapping regions"),
-        (limit_secp256k1_recovery_id::id(), "limit secp256k1 recovery id"),
-        (disable_deprecated_loader::id(), "disable the deprecated BPF loader"),
-        (check_slice_translation_size::id(), "check size when translating slices"),
-        (stake_split_uses_rent_sysvar::id(), "stake split instruction uses rent sysvar"),
-        (add_get_minimum_delegation_instruction_to_stake_program::id(), "add GetMinimumDelegation instruction to stake program"),
-        (error_on_syscall_bpf_function_hash_collisions::id(), "error on bpf function hash collisions"),
+        (
+            check_physical_overlapping::id(),
+            "check physical overlapping regions",
+        ),
+        (
+            limit_secp256k1_recovery_id::id(),
+            "limit secp256k1 recovery id",
+        ),
+        (
+            disable_deprecated_loader::id(),
+            "disable the deprecated BPF loader",
+        ),
+        (
+            check_slice_translation_size::id(),
+            "check size when translating slices",
+        ),
+        (
+            stake_split_uses_rent_sysvar::id(),
+            "stake split instruction uses rent sysvar",
+        ),
+        (
+            add_get_minimum_delegation_instruction_to_stake_program::id(),
+            "add GetMinimumDelegation instruction to stake program",
+        ),
+        (
+            error_on_syscall_bpf_function_hash_collisions::id(),
+            "error on bpf function hash collisions",
+        ),
         (reject_callx_r10::id(), "Reject bpf callx r10 instructions"),
-        (drop_redundant_turbine_path::id(), "drop redundant turbine path"),
-        (executables_incur_cpi_data_cost::id(), "Executables incur CPI data costs"),
-        (fix_recent_blockhashes::id(), "stop adding hashes for skipped slots to recent blockhashes"),
-        (update_rewards_from_cached_accounts::id(), "update rewards from cached accounts"),
-        (spl_token_v3_4_0::id(), "SPL Token Program version 3.4.0 release #24740"),
-        (spl_associated_token_account_v1_1_0::id(), "SPL Associated Token Account Program version 1.1.0 release #24741"),
-        (default_units_per_instruction::id(), "Default max tx-wide compute units calculated per instruction"),
-        (stake_allow_zero_undelegated_amount::id(), "Allow zero-lamport undelegated amount for initialized stakes #24670"),
-        (require_static_program_ids_in_transaction::id(), "require static program ids in versioned transactions"),
-        (stake_raise_minimum_delegation_to_1_sol::id(), "Raise minimum stake delegation to 1.0 SOL #24357"),
-        (stake_minimum_delegation_for_rewards::id(), "stakes must be at least the minimum delegation to earn rewards"),
-        (add_set_compute_unit_price_ix::id(), "add compute budget ix for setting a compute unit price"),
-        (disable_deploy_of_alloc_free_syscall::id(), "disable new deployments of deprecated sol_alloc_free_ syscall"),
-        (include_account_index_in_rent_error::id(), "include account index in rent tx error #25190"),
-        (add_shred_type_to_shred_seed::id(), "add shred-type to shred seed #25556"),
-        (warp_timestamp_with_a_vengeance::id(), "warp timestamp again, adjust bounding to 150% slow #25666"),
-        (separate_nonce_from_blockhash::id(), "separate durable nonce and blockhash domains #25744"),
+        (
+            drop_redundant_turbine_path::id(),
+            "drop redundant turbine path",
+        ),
+        (
+            executables_incur_cpi_data_cost::id(),
+            "Executables incur CPI data costs",
+        ),
+        (
+            fix_recent_blockhashes::id(),
+            "stop adding hashes for skipped slots to recent blockhashes",
+        ),
+        (
+            update_rewards_from_cached_accounts::id(),
+            "update rewards from cached accounts",
+        ),
+        (
+            spl_token_v3_4_0::id(),
+            "SPL Token Program version 3.4.0 release #24740",
+        ),
+        (
+            spl_associated_token_account_v1_1_0::id(),
+            "SPL Associated Token Account Program version 1.1.0 release #24741",
+        ),
+        (
+            default_units_per_instruction::id(),
+            "Default max tx-wide compute units calculated per instruction",
+        ),
+        (
+            stake_allow_zero_undelegated_amount::id(),
+            "Allow zero-lamport undelegated amount for initialized stakes #24670",
+        ),
+        (
+            require_static_program_ids_in_transaction::id(),
+            "require static program ids in versioned transactions",
+        ),
+        (
+            stake_raise_minimum_delegation_to_1_sol::id(),
+            "Raise minimum stake delegation to 1.0 SOL #24357",
+        ),
+        (
+            stake_minimum_delegation_for_rewards::id(),
+            "stakes must be at least the minimum delegation to earn rewards",
+        ),
+        (
+            add_set_compute_unit_price_ix::id(),
+            "add compute budget ix for setting a compute unit price",
+        ),
+        (
+            disable_deploy_of_alloc_free_syscall::id(),
+            "disable new deployments of deprecated sol_alloc_free_ syscall",
+        ),
+        (
+            include_account_index_in_rent_error::id(),
+            "include account index in rent tx error #25190",
+        ),
+        (
+            add_shred_type_to_shred_seed::id(),
+            "add shred-type to shred seed #25556",
+        ),
+        (
+            warp_timestamp_with_a_vengeance::id(),
+            "warp timestamp again, adjust bounding to 150% slow #25666",
+        ),
+        (
+            separate_nonce_from_blockhash::id(),
+            "separate durable nonce and blockhash domains #25744",
+        ),
         (enable_durable_nonce::id(), "enable durable nonce #25744"),
-        (vote_state_update_credit_per_dequeue::id(), "Calculate vote credits for VoteStateUpdate per vote dequeue to match credit awards for Vote instruction"),
+        (
+            vote_state_update_credit_per_dequeue::id(),
+            "Calculate vote credits for VoteStateUpdate per vote dequeue to match credit awards \
+             for Vote instruction",
+        ),
         (quick_bail_on_panic::id(), "quick bail on panic"),
         (nonce_must_be_authorized::id(), "nonce must be authorized"),
-        (nonce_must_be_advanceable::id(), "durable nonces must be advanceable"),
-        (vote_authorize_with_seed::id(), "An instruction you can use to change a vote accounts authority when the current authority is a derived key #25860"),
-        (preserve_rent_epoch_for_rent_exempt_accounts::id(), "preserve rent epoch for rent exempt accounts #26479"),
-        (enable_bpf_loader_extend_program_ix::id(), "enable bpf upgradeable loader ExtendProgram instruction #25234"),
-        (skip_rent_rewrites::id(), "skip rewriting rent exempt accounts during rent collection #26491"),
-        (enable_early_verification_of_account_modifications::id(), "enable early verification of account modifications #25899"),
-        (disable_rehash_for_rent_epoch::id(), "on accounts hash calculation, do not try to rehash accounts #28934"),
-        (account_hash_ignore_slot::id(), "ignore slot when calculating an account hash #28420"),
-        (set_exempt_rent_epoch_max::id(), "set rent epoch to Epoch::MAX for rent-exempt accounts #28683"),
-        (on_load_preserve_rent_epoch_for_rent_exempt_accounts::id(), "on bank load account, do not try to fix up rent_epoch #28541"),
-        (prevent_crediting_accounts_that_end_rent_paying::id(), "prevent crediting rent paying accounts #26606"),
-        (cap_bpf_program_instruction_accounts::id(), "enforce max number of accounts per bpf program instruction #26628"),
-        (loosen_cpi_size_restriction::id(), "loosen cpi size restrictions #26641"),
-        (use_default_units_in_fee_calculation::id(), "use default units per instruction in fee calculation #26785"),
-        (compact_vote_state_updates::id(), "Compact vote state updates to lower block size"),
-        (incremental_snapshot_only_incremental_hash_calculation::id(), "only hash accounts in incremental snapshot during incremental snapshot creation #26799"),
-        (disable_cpi_setting_executable_and_rent_epoch::id(), "disable setting is_executable and_rent_epoch in CPI #26987"),
-        (relax_authority_signer_check_for_lookup_table_creation::id(), "relax authority signer check for lookup table creation #27205"),
-        (stop_sibling_instruction_search_at_parent::id(), "stop the search in get_processed_sibling_instruction when the parent instruction is reached #27289"),
-        (vote_state_update_root_fix::id(), "fix root in vote state updates #27361"),
-        (cap_accounts_data_allocations_per_transaction::id(), "cap accounts data allocations per transaction #27375"),
-        (epoch_accounts_hash::id(), "enable epoch accounts hash calculation #27539"),
-        (remove_deprecated_request_unit_ix::id(), "remove support for RequestUnitsDeprecated instruction #27500"),
-        (increase_tx_account_lock_limit::id(), "increase tx account lock limit to 128 #27241"),
-        (limit_max_instruction_trace_length::id(), "limit max instruction trace length #27939"),
-        (check_syscall_outputs_do_not_overlap::id(), "check syscall outputs do_not overlap #28600"),
-        (enable_bpf_loader_set_authority_checked_ix::id(), "enable bpf upgradeable loader SetAuthorityChecked instruction #28424"),
-        (enable_alt_bn128_syscall::id(), "add alt_bn128 syscalls #27961"),
-        (simplify_alt_bn128_syscall_error_codes::id(), "SIMD-0129: simplify alt_bn128 syscall error codes"),
-        (enable_program_redeployment_cooldown::id(), "enable program redeployment cooldown #29135"),
-        (commission_updates_only_allowed_in_first_half_of_epoch::id(), "validator commission updates are only allowed in the first half of an epoch #29362"),
-        (enable_turbine_fanout_experiments::id(), "enable turbine fanout experiments #29393"),
-        (disable_turbine_fanout_experiments::id(), "disable turbine fanout experiments #29393"),
-        (move_serialized_len_ptr_in_cpi::id(), "cpi ignore serialized_len_ptr #29592"),
-        (update_hashes_per_tick::id(), "Update desired hashes per tick on epoch boundary"),
-        (enable_big_mod_exp_syscall::id(), "add big_mod_exp syscall #28503"),
-        (disable_builtin_loader_ownership_chains::id(), "disable builtin loader ownership chains #29956"),
-        (cap_transaction_accounts_data_size::id(), "cap transaction accounts data size up to a limit #27839"),
-        (remove_congestion_multiplier_from_fee_calculation::id(), "Remove congestion multiplier from transaction fee calculation #29881"),
-        (enable_request_heap_frame_ix::id(), "Enable transaction to request heap frame using compute budget instruction #30076"),
-        (prevent_rent_paying_rent_recipients::id(), "prevent recipients of rent rewards from ending in rent-paying state #30151"),
-        (delay_visibility_of_program_deployment::id(), "delay visibility of program upgrades #30085"),
-        (apply_cost_tracker_during_replay::id(), "apply cost tracker to blocks during replay #29595"),
-        (add_set_tx_loaded_accounts_data_size_instruction::id(), "add compute budget instruction for setting account data size per transaction #30366"),
-        (switch_to_new_elf_parser::id(), "switch to new ELF parser #30497"),
-        (round_up_heap_size::id(), "round up heap size when calculating heap cost #30679"),
-        (remove_bpf_loader_incorrect_program_id::id(), "stop incorrectly throwing IncorrectProgramId in bpf_loader #30747"),
-        (include_loaded_accounts_data_size_in_fee_calculation::id(), "include transaction loaded accounts data size in base fee calculation #30657"),
-        (native_programs_consume_cu::id(), "Native program should consume compute units #30620"),
-        (simplify_writable_program_account_check::id(), "Simplify checks performed for writable upgradeable program accounts #30559"),
-        (stop_truncating_strings_in_syscalls::id(), "Stop truncating strings in syscalls #31029"),
-        (clean_up_delegation_errors::id(), "Return InsufficientDelegation instead of InsufficientFunds or InsufficientStake where applicable #31206"),
-        (vote_state_add_vote_latency::id(), "replace Lockout with LandedVote (including vote latency) in vote state #31264"),
-        (checked_arithmetic_in_fee_validation::id(), "checked arithmetic in fee validation #31273"),
-        (stricter_abi_and_runtime_constraints::id(), "use memory regions to map account data into the rbpf vm instead of copying the data"),
-        (last_restart_slot_sysvar::id(), "enable new sysvar last_restart_slot"),
-        (reduce_stake_warmup_cooldown::id(), "reduce stake warmup cooldown from 25% to 9%"),
-        (revise_turbine_epoch_stakes::id(), "revise turbine epoch stakes"),
+        (
+            nonce_must_be_advanceable::id(),
+            "durable nonces must be advanceable",
+        ),
+        (
+            vote_authorize_with_seed::id(),
+            "An instruction you can use to change a vote accounts authority when the current \
+             authority is a derived key #25860",
+        ),
+        (
+            preserve_rent_epoch_for_rent_exempt_accounts::id(),
+            "preserve rent epoch for rent exempt accounts #26479",
+        ),
+        (
+            enable_bpf_loader_extend_program_ix::id(),
+            "enable bpf upgradeable loader ExtendProgram instruction #25234",
+        ),
+        (
+            skip_rent_rewrites::id(),
+            "skip rewriting rent exempt accounts during rent collection #26491",
+        ),
+        (
+            enable_early_verification_of_account_modifications::id(),
+            "enable early verification of account modifications #25899",
+        ),
+        (
+            disable_rehash_for_rent_epoch::id(),
+            "on accounts hash calculation, do not try to rehash accounts #28934",
+        ),
+        (
+            account_hash_ignore_slot::id(),
+            "ignore slot when calculating an account hash #28420",
+        ),
+        (
+            set_exempt_rent_epoch_max::id(),
+            "set rent epoch to Epoch::MAX for rent-exempt accounts #28683",
+        ),
+        (
+            on_load_preserve_rent_epoch_for_rent_exempt_accounts::id(),
+            "on bank load account, do not try to fix up rent_epoch #28541",
+        ),
+        (
+            prevent_crediting_accounts_that_end_rent_paying::id(),
+            "prevent crediting rent paying accounts #26606",
+        ),
+        (
+            cap_bpf_program_instruction_accounts::id(),
+            "enforce max number of accounts per bpf program instruction #26628",
+        ),
+        (
+            loosen_cpi_size_restriction::id(),
+            "loosen cpi size restrictions #26641",
+        ),
+        (
+            use_default_units_in_fee_calculation::id(),
+            "use default units per instruction in fee calculation #26785",
+        ),
+        (
+            compact_vote_state_updates::id(),
+            "Compact vote state updates to lower block size",
+        ),
+        (
+            incremental_snapshot_only_incremental_hash_calculation::id(),
+            "only hash accounts in incremental snapshot during incremental snapshot creation \
+             #26799",
+        ),
+        (
+            disable_cpi_setting_executable_and_rent_epoch::id(),
+            "disable setting is_executable and_rent_epoch in CPI #26987",
+        ),
+        (
+            relax_authority_signer_check_for_lookup_table_creation::id(),
+            "relax authority signer check for lookup table creation #27205",
+        ),
+        (
+            stop_sibling_instruction_search_at_parent::id(),
+            "stop the search in get_processed_sibling_instruction when the parent instruction is \
+             reached #27289",
+        ),
+        (
+            vote_state_update_root_fix::id(),
+            "fix root in vote state updates #27361",
+        ),
+        (
+            cap_accounts_data_allocations_per_transaction::id(),
+            "cap accounts data allocations per transaction #27375",
+        ),
+        (
+            epoch_accounts_hash::id(),
+            "enable epoch accounts hash calculation #27539",
+        ),
+        (
+            remove_deprecated_request_unit_ix::id(),
+            "remove support for RequestUnitsDeprecated instruction #27500",
+        ),
+        (
+            increase_tx_account_lock_limit::id(),
+            "increase tx account lock limit to 128 #27241",
+        ),
+        (
+            limit_max_instruction_trace_length::id(),
+            "limit max instruction trace length #27939",
+        ),
+        (
+            check_syscall_outputs_do_not_overlap::id(),
+            "check syscall outputs do_not overlap #28600",
+        ),
+        (
+            enable_bpf_loader_set_authority_checked_ix::id(),
+            "enable bpf upgradeable loader SetAuthorityChecked instruction #28424",
+        ),
+        (
+            enable_alt_bn128_syscall::id(),
+            "add alt_bn128 syscalls #27961",
+        ),
+        (
+            simplify_alt_bn128_syscall_error_codes::id(),
+            "SIMD-0129: simplify alt_bn128 syscall error codes",
+        ),
+        (
+            enable_program_redeployment_cooldown::id(),
+            "enable program redeployment cooldown #29135",
+        ),
+        (
+            commission_updates_only_allowed_in_first_half_of_epoch::id(),
+            "validator commission updates are only allowed in the first half of an epoch #29362",
+        ),
+        (
+            enable_turbine_fanout_experiments::id(),
+            "enable turbine fanout experiments #29393",
+        ),
+        (
+            disable_turbine_fanout_experiments::id(),
+            "disable turbine fanout experiments #29393",
+        ),
+        (
+            move_serialized_len_ptr_in_cpi::id(),
+            "cpi ignore serialized_len_ptr #29592",
+        ),
+        (
+            update_hashes_per_tick::id(),
+            "Update desired hashes per tick on epoch boundary",
+        ),
+        (
+            enable_big_mod_exp_syscall::id(),
+            "add big_mod_exp syscall #28503",
+        ),
+        (
+            disable_builtin_loader_ownership_chains::id(),
+            "disable builtin loader ownership chains #29956",
+        ),
+        (
+            cap_transaction_accounts_data_size::id(),
+            "cap transaction accounts data size up to a limit #27839",
+        ),
+        (
+            remove_congestion_multiplier_from_fee_calculation::id(),
+            "Remove congestion multiplier from transaction fee calculation #29881",
+        ),
+        (
+            enable_request_heap_frame_ix::id(),
+            "Enable transaction to request heap frame using compute budget instruction #30076",
+        ),
+        (
+            prevent_rent_paying_rent_recipients::id(),
+            "prevent recipients of rent rewards from ending in rent-paying state #30151",
+        ),
+        (
+            delay_visibility_of_program_deployment::id(),
+            "delay visibility of program upgrades #30085",
+        ),
+        (
+            apply_cost_tracker_during_replay::id(),
+            "apply cost tracker to blocks during replay #29595",
+        ),
+        (
+            add_set_tx_loaded_accounts_data_size_instruction::id(),
+            "add compute budget instruction for setting account data size per transaction #30366",
+        ),
+        (
+            switch_to_new_elf_parser::id(),
+            "switch to new ELF parser #30497",
+        ),
+        (
+            round_up_heap_size::id(),
+            "round up heap size when calculating heap cost #30679",
+        ),
+        (
+            remove_bpf_loader_incorrect_program_id::id(),
+            "stop incorrectly throwing IncorrectProgramId in bpf_loader #30747",
+        ),
+        (
+            include_loaded_accounts_data_size_in_fee_calculation::id(),
+            "include transaction loaded accounts data size in base fee calculation #30657",
+        ),
+        (
+            native_programs_consume_cu::id(),
+            "Native program should consume compute units #30620",
+        ),
+        (
+            simplify_writable_program_account_check::id(),
+            "Simplify checks performed for writable upgradeable program accounts #30559",
+        ),
+        (
+            stop_truncating_strings_in_syscalls::id(),
+            "Stop truncating strings in syscalls #31029",
+        ),
+        (
+            clean_up_delegation_errors::id(),
+            "Return InsufficientDelegation instead of InsufficientFunds or InsufficientStake \
+             where applicable #31206",
+        ),
+        (
+            vote_state_add_vote_latency::id(),
+            "replace Lockout with LandedVote (including vote latency) in vote state #31264",
+        ),
+        (
+            checked_arithmetic_in_fee_validation::id(),
+            "checked arithmetic in fee validation #31273",
+        ),
+        (
+            stricter_abi_and_runtime_constraints::id(),
+            "use memory regions to map account data into the rbpf vm instead of copying the data",
+        ),
+        (
+            last_restart_slot_sysvar::id(),
+            "enable new sysvar last_restart_slot",
+        ),
+        (
+            reduce_stake_warmup_cooldown::id(),
+            "reduce stake warmup cooldown from 25% to 9%",
+        ),
+        (
+            revise_turbine_epoch_stakes::id(),
+            "revise turbine epoch stakes",
+        ),
         (enable_poseidon_syscall::id(), "Enable Poseidon syscall"),
-        (timely_vote_credits::id(), "use timeliness of votes in determining credits to award"),
-        (remaining_compute_units_syscall_enabled::id(), "enable the remaining_compute_units syscall"),
+        (
+            timely_vote_credits::id(),
+            "use timeliness of votes in determining credits to award",
+        ),
+        (
+            remaining_compute_units_syscall_enabled::id(),
+            "enable the remaining_compute_units syscall",
+        ),
         (enable_loader_v4::id(), "SIMD-0167: Enable Loader-v4"),
-        (require_rent_exempt_split_destination::id(), "Require stake split destination account to be rent exempt"),
-        (better_error_codes_for_tx_lamport_check::id(), "better error codes for tx lamport check #33353"),
-        (enable_alt_bn128_compression_syscall::id(), "add alt_bn128 compression syscalls"),
-        (update_hashes_per_tick2::id(), "Update desired hashes per tick to 2.8M"),
-        (update_hashes_per_tick3::id(), "Update desired hashes per tick to 4.4M"),
-        (update_hashes_per_tick4::id(), "Update desired hashes per tick to 7.6M"),
-        (update_hashes_per_tick5::id(), "Update desired hashes per tick to 9.2M"),
-        (update_hashes_per_tick6::id(), "Update desired hashes per tick to 10M"),
-        (validate_fee_collector_account::id(), "validate fee collector account #33888"),
-        (disable_rent_fees_collection::id(), "Disable rent fees collection #33945"),
-        (enable_zk_transfer_with_fee::id(), "enable Zk Token proof program transfer with fee"),
+        (
+            require_rent_exempt_split_destination::id(),
+            "Require stake split destination account to be rent exempt",
+        ),
+        (
+            better_error_codes_for_tx_lamport_check::id(),
+            "better error codes for tx lamport check #33353",
+        ),
+        (
+            enable_alt_bn128_compression_syscall::id(),
+            "add alt_bn128 compression syscalls",
+        ),
+        (
+            update_hashes_per_tick2::id(),
+            "Update desired hashes per tick to 2.8M",
+        ),
+        (
+            update_hashes_per_tick3::id(),
+            "Update desired hashes per tick to 4.4M",
+        ),
+        (
+            update_hashes_per_tick4::id(),
+            "Update desired hashes per tick to 7.6M",
+        ),
+        (
+            update_hashes_per_tick5::id(),
+            "Update desired hashes per tick to 9.2M",
+        ),
+        (
+            update_hashes_per_tick6::id(),
+            "Update desired hashes per tick to 10M",
+        ),
+        (
+            validate_fee_collector_account::id(),
+            "validate fee collector account #33888",
+        ),
+        (
+            disable_rent_fees_collection::id(),
+            "Disable rent fees collection #33945",
+        ),
+        (
+            enable_zk_transfer_with_fee::id(),
+            "enable Zk Token proof program transfer with fee",
+        ),
         (drop_legacy_shreds::id(), "drops legacy shreds #34328"),
-        (allow_commission_decrease_at_any_time::id(), "Allow commission decrease at any time in epoch #33843"),
-        (consume_blockstore_duplicate_proofs::id(), "consume duplicate proofs from blockstore in consensus #34372"),
-        (add_new_reserved_account_keys::id(), "add new unwritable reserved accounts #34899"),
-        (index_erasure_conflict_duplicate_proofs::id(), "generate duplicate proofs for index and erasure conflicts #34360"),
-        (merkle_conflict_duplicate_proofs::id(), "generate duplicate proofs for merkle root conflicts #34270"),
-        (disable_bpf_loader_instructions::id(), "disable bpf loader management instructions #34194"),
-        (enable_zk_proof_from_account::id(), "Enable zk token proof program to read proof from accounts instead of instruction data #34750"),
-        (curve25519_restrict_msm_length::id(), "restrict curve25519 multiscalar multiplication vector lengths #34763"),
-        (cost_model_requested_write_lock_cost::id(), "cost model uses number of requested write locks #34819"),
-        (enable_gossip_duplicate_proof_ingestion::id(), "enable gossip duplicate proof ingestion #32963"),
-        (enable_chained_merkle_shreds::id(), "Enable chained Merkle shreds #34916"),
-        (remove_rounding_in_fee_calculation::id(), "Removing unwanted rounding in fee calculation #34982"),
-        (deprecate_unused_legacy_vote_plumbing::id(), "Deprecate unused legacy vote tx plumbing"),
-        (enable_tower_sync_ix::id(), "Enable tower sync vote instruction"),
-        (chained_merkle_conflict_duplicate_proofs::id(), "generate duplicate proofs for chained merkle root conflicts"),
-        (reward_full_priority_fee::id(), "Reward full priority fee to validators #34731"),
-        (abort_on_invalid_curve::id(), "SIMD-0137: Abort when elliptic curve syscalls invoked on invalid curve id"),
-        (get_sysvar_syscall_enabled::id(), "Enable syscall for fetching Sysvar bytes #615"),
-        (migrate_feature_gate_program_to_core_bpf::id(), "Migrate Feature Gate program to Core BPF (programify) #1003"),
+        (
+            allow_commission_decrease_at_any_time::id(),
+            "Allow commission decrease at any time in epoch #33843",
+        ),
+        (
+            consume_blockstore_duplicate_proofs::id(),
+            "consume duplicate proofs from blockstore in consensus #34372",
+        ),
+        (
+            add_new_reserved_account_keys::id(),
+            "add new unwritable reserved accounts #34899",
+        ),
+        (
+            index_erasure_conflict_duplicate_proofs::id(),
+            "generate duplicate proofs for index and erasure conflicts #34360",
+        ),
+        (
+            merkle_conflict_duplicate_proofs::id(),
+            "generate duplicate proofs for merkle root conflicts #34270",
+        ),
+        (
+            disable_bpf_loader_instructions::id(),
+            "disable bpf loader management instructions #34194",
+        ),
+        (
+            enable_zk_proof_from_account::id(),
+            "Enable zk token proof program to read proof from accounts instead of instruction \
+             data #34750",
+        ),
+        (
+            curve25519_restrict_msm_length::id(),
+            "restrict curve25519 multiscalar multiplication vector lengths #34763",
+        ),
+        (
+            cost_model_requested_write_lock_cost::id(),
+            "cost model uses number of requested write locks #34819",
+        ),
+        (
+            enable_gossip_duplicate_proof_ingestion::id(),
+            "enable gossip duplicate proof ingestion #32963",
+        ),
+        (
+            enable_chained_merkle_shreds::id(),
+            "Enable chained Merkle shreds #34916",
+        ),
+        (
+            remove_rounding_in_fee_calculation::id(),
+            "Removing unwanted rounding in fee calculation #34982",
+        ),
+        (
+            deprecate_unused_legacy_vote_plumbing::id(),
+            "Deprecate unused legacy vote tx plumbing",
+        ),
+        (
+            enable_tower_sync_ix::id(),
+            "Enable tower sync vote instruction",
+        ),
+        (
+            chained_merkle_conflict_duplicate_proofs::id(),
+            "generate duplicate proofs for chained merkle root conflicts",
+        ),
+        (
+            reward_full_priority_fee::id(),
+            "Reward full priority fee to validators #34731",
+        ),
+        (
+            abort_on_invalid_curve::id(),
+            "SIMD-0137: Abort when elliptic curve syscalls invoked on invalid curve id",
+        ),
+        (
+            get_sysvar_syscall_enabled::id(),
+            "Enable syscall for fetching Sysvar bytes #615",
+        ),
+        (
+            migrate_feature_gate_program_to_core_bpf::id(),
+            "Migrate Feature Gate program to Core BPF (programify) #1003",
+        ),
         (vote_only_full_fec_sets::id(), "vote only full fec sets"),
-        (migrate_config_program_to_core_bpf::id(), "Migrate Config program to Core BPF #1378"),
-        (enable_get_epoch_stake_syscall::id(), "Enable syscall: sol_get_epoch_stake #884"),
-        (migrate_address_lookup_table_program_to_core_bpf::id(), "Migrate Address Lookup Table program to Core BPF #1651"),
-        (zk_elgamal_proof_program_enabled::id(), "SIMD-0153: Enable ZkElGamalProof program"),
-        (verify_retransmitter_signature::id(), "Verify retransmitter signature #1840"),
-        (move_stake_and_move_lamports_ixs::id(), "Enable MoveStake and MoveLamports stake program instructions #1610"),
-        (ed25519_precompile_verify_strict::id(), "SIMD-0152: Use strict verification in ed25519 precompile"),
-        (vote_only_retransmitter_signed_fec_sets::id(), "vote only on retransmitter signed fec sets"),
-        (move_precompile_verification_to_svm::id(), "SIMD-0159: Move precompile verification into SVM"),
-        (enable_transaction_loading_failure_fees::id(), "SIMD-0082: Enable fees for some additional transaction failures"),
-        (enable_turbine_extended_fanout_experiments::id(), "enable turbine extended fanout experiments #"),
-        (deprecate_legacy_vote_ixs::id(), "Deprecate legacy vote instructions"),
-        (partitioned_epoch_rewards_superfeature::id(), "SIMD-0118: replaces enable_partitioned_epoch_reward to enable partitioned rewards at epoch boundary"),
-        (disable_sbpf_v0_execution::id(), "SIMD-0161: Disables execution of SBPFv0 programs"),
-        (reenable_sbpf_v0_execution::id(), "Re-enables execution of SBPFv0 programs"),
-        (enable_sbpf_v1_deployment_and_execution::id(), "SIMD-0166: Enable deployment and execution of SBPFv1 programs"),
-        (enable_sbpf_v2_deployment_and_execution::id(), "SIMD-0173 and SIMD-0174: Enable deployment and execution of SBPFv2 programs"),
-        (enable_sbpf_v3_deployment_and_execution::id(), "SIMD-0178, SIMD-0179 and SIMD-0189: Enable deployment and execution of SBPFv3 programs"),
-        (remove_accounts_executable_flag_checks::id(), "SIMD-0162: Remove checks of accounts is_executable flag"),
-        (disable_account_loader_special_case::id(), "Disable account loader special case #3513"),
-        (accounts_lt_hash::id(), "SIMD-0215: enables lattice-based accounts hash"),
-        (snapshots_lt_hash::id(), "SIMD-0220: snapshots use lattice-based accounts hash"),
-        (remove_accounts_delta_hash::id(), "SIMD-0223: removes accounts delta hash"),
-        (enable_secp256r1_precompile::id(), "SIMD-0075: Enable secp256r1 precompile"),
-        (migrate_stake_program_to_core_bpf::id(), "SIMD-0196: Migrate Stake program to Core BPF #3655"),
-        (deplete_cu_meter_on_vm_failure::id(), "SIMD-0182: Deplete compute meter for vm errors #3993"),
-        (reserve_minimal_cus_for_builtin_instructions::id(), "SIMD-0170: Reserve minimal CUs for builtin instructions #2562"),
-        (raise_block_limits_to_50m::id(), "SIMD-0207: Raise block limit to 50M"),
-        (fix_alt_bn128_multiplication_input_length::id(), "SIMD-0222: fix alt_bn128 multiplication input length #3686"),
-        (drop_unchained_merkle_shreds::id(), "drops unchained Merkle shreds #2149"),
-        (relax_intrabatch_account_locks::id(), "SIMD-0083: Allow batched transactions to read/write and write/write the same accounts"),
-        (create_slashing_program::id(), "SIMD-0204: creates an enshrined slashing program"),
-        (disable_partitioned_rent_collection::id(), "SIMD-0175: Disable partitioned rent collection #4562"),
-        (enable_vote_address_leader_schedule::id(), "SIMD-0180: Enable vote address leader schedule #4573"),
-        (require_static_nonce_account::id(), "SIMD-0242: Static Nonce Account Only"),
-        (raise_block_limits_to_60m::id(), "SIMD-0256: Raise block limit to 60M"),
-        (mask_out_rent_epoch_in_vm_serialization::id(), "SIMD-0267: Sets rent_epoch to a constant in the VM"),
-        (enshrine_slashing_program::id(), "SIMD-0204: Slashable event verification"),
-        (enable_extend_program_checked::id(), "Enable ExtendProgramChecked instruction"),
-        (formalize_loaded_transaction_data_size::id(), "SIMD-0186: Loaded transaction data size specification"),
-        (alpenglow::id(), "SIMD-0326: Alpenglow: new consensus algorithm"),
-        (disable_zk_elgamal_proof_program::id(), "Disables zk-elgamal-proof program"),
-        (reenable_zk_elgamal_proof_program::id(), "Re-enables zk-elgamal-proof program"),
-        (raise_block_limits_to_100m::id(), "SIMD-0286: Raise block limit to 100M"),
-        (raise_account_cu_limit::id(), "SIMD-0306: Raise account CU limit to 40% max"),
-        (raise_cpi_nesting_limit_to_8::id(), "SIMD-0268: Raise CPI nesting limit from 4 to 8"),
-        (enforce_fixed_fec_set::id(), "SIMD-0317: Enforce 32 data + 32 coding shreds"),
+        (
+            migrate_config_program_to_core_bpf::id(),
+            "Migrate Config program to Core BPF #1378",
+        ),
+        (
+            enable_get_epoch_stake_syscall::id(),
+            "Enable syscall: sol_get_epoch_stake #884",
+        ),
+        (
+            migrate_address_lookup_table_program_to_core_bpf::id(),
+            "Migrate Address Lookup Table program to Core BPF #1651",
+        ),
+        (
+            zk_elgamal_proof_program_enabled::id(),
+            "SIMD-0153: Enable ZkElGamalProof program",
+        ),
+        (
+            verify_retransmitter_signature::id(),
+            "Verify retransmitter signature #1840",
+        ),
+        (
+            move_stake_and_move_lamports_ixs::id(),
+            "Enable MoveStake and MoveLamports stake program instructions #1610",
+        ),
+        (
+            ed25519_precompile_verify_strict::id(),
+            "SIMD-0152: Use strict verification in ed25519 precompile",
+        ),
+        (
+            vote_only_retransmitter_signed_fec_sets::id(),
+            "vote only on retransmitter signed fec sets",
+        ),
+        (
+            move_precompile_verification_to_svm::id(),
+            "SIMD-0159: Move precompile verification into SVM",
+        ),
+        (
+            enable_transaction_loading_failure_fees::id(),
+            "SIMD-0082: Enable fees for some additional transaction failures",
+        ),
+        (
+            enable_turbine_extended_fanout_experiments::id(),
+            "enable turbine extended fanout experiments #",
+        ),
+        (
+            deprecate_legacy_vote_ixs::id(),
+            "Deprecate legacy vote instructions",
+        ),
+        (
+            partitioned_epoch_rewards_superfeature::id(),
+            "SIMD-0118: replaces enable_partitioned_epoch_reward to enable partitioned rewards at \
+             epoch boundary",
+        ),
+        (
+            disable_sbpf_v0_execution::id(),
+            "SIMD-0161: Disables execution of SBPFv0 programs",
+        ),
+        (
+            reenable_sbpf_v0_execution::id(),
+            "Re-enables execution of SBPFv0 programs",
+        ),
+        (
+            enable_sbpf_v1_deployment_and_execution::id(),
+            "SIMD-0166: Enable deployment and execution of SBPFv1 programs",
+        ),
+        (
+            enable_sbpf_v2_deployment_and_execution::id(),
+            "SIMD-0173 and SIMD-0174: Enable deployment and execution of SBPFv2 programs",
+        ),
+        (
+            enable_sbpf_v3_deployment_and_execution::id(),
+            "SIMD-0178, SIMD-0179 and SIMD-0189: Enable deployment and execution of SBPFv3 \
+             programs",
+        ),
+        (
+            remove_accounts_executable_flag_checks::id(),
+            "SIMD-0162: Remove checks of accounts is_executable flag",
+        ),
+        (
+            disable_account_loader_special_case::id(),
+            "Disable account loader special case #3513",
+        ),
+        (
+            accounts_lt_hash::id(),
+            "SIMD-0215: enables lattice-based accounts hash",
+        ),
+        (
+            snapshots_lt_hash::id(),
+            "SIMD-0220: snapshots use lattice-based accounts hash",
+        ),
+        (
+            remove_accounts_delta_hash::id(),
+            "SIMD-0223: removes accounts delta hash",
+        ),
+        (
+            enable_secp256r1_precompile::id(),
+            "SIMD-0075: Enable secp256r1 precompile",
+        ),
+        (
+            migrate_stake_program_to_core_bpf::id(),
+            "SIMD-0196: Migrate Stake program to Core BPF #3655",
+        ),
+        (
+            deplete_cu_meter_on_vm_failure::id(),
+            "SIMD-0182: Deplete compute meter for vm errors #3993",
+        ),
+        (
+            reserve_minimal_cus_for_builtin_instructions::id(),
+            "SIMD-0170: Reserve minimal CUs for builtin instructions #2562",
+        ),
+        (
+            raise_block_limits_to_50m::id(),
+            "SIMD-0207: Raise block limit to 50M",
+        ),
+        (
+            fix_alt_bn128_multiplication_input_length::id(),
+            "SIMD-0222: fix alt_bn128 multiplication input length #3686",
+        ),
+        (
+            drop_unchained_merkle_shreds::id(),
+            "drops unchained Merkle shreds #2149",
+        ),
+        (
+            relax_intrabatch_account_locks::id(),
+            "SIMD-0083: Allow batched transactions to read/write and write/write the same accounts",
+        ),
+        (
+            create_slashing_program::id(),
+            "SIMD-0204: creates an enshrined slashing program",
+        ),
+        (
+            disable_partitioned_rent_collection::id(),
+            "SIMD-0175: Disable partitioned rent collection #4562",
+        ),
+        (
+            enable_vote_address_leader_schedule::id(),
+            "SIMD-0180: Enable vote address leader schedule #4573",
+        ),
+        (
+            require_static_nonce_account::id(),
+            "SIMD-0242: Static Nonce Account Only",
+        ),
+        (
+            raise_block_limits_to_60m::id(),
+            "SIMD-0256: Raise block limit to 60M",
+        ),
+        (
+            mask_out_rent_epoch_in_vm_serialization::id(),
+            "SIMD-0267: Sets rent_epoch to a constant in the VM",
+        ),
+        (
+            enshrine_slashing_program::id(),
+            "SIMD-0204: Slashable event verification",
+        ),
+        (
+            enable_extend_program_checked::id(),
+            "Enable ExtendProgramChecked instruction",
+        ),
+        (
+            formalize_loaded_transaction_data_size::id(),
+            "SIMD-0186: Loaded transaction data size specification",
+        ),
+        (
+            alpenglow::id(),
+            "SIMD-0326: Alpenglow: new consensus algorithm",
+        ),
+        (
+            disable_zk_elgamal_proof_program::id(),
+            "Disables zk-elgamal-proof program",
+        ),
+        (
+            reenable_zk_elgamal_proof_program::id(),
+            "Re-enables zk-elgamal-proof program",
+        ),
+        (
+            raise_block_limits_to_100m::id(),
+            "SIMD-0286: Raise block limit to 100M",
+        ),
+        (
+            raise_account_cu_limit::id(),
+            "SIMD-0306: Raise account CU limit to 40% max",
+        ),
+        (
+            raise_cpi_nesting_limit_to_8::id(),
+            "SIMD-0268: Raise CPI nesting limit from 4 to 8",
+        ),
+        (
+            enforce_fixed_fec_set::id(),
+            "SIMD-0317: Enforce 32 data + 32 coding shreds",
+        ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Moving us towards having `format_strings = true` set in `rustfmt.toml`

#### Summary of Changes
Run cargo fmt with format_strings = true in rustfmt.toml
