### PR TITLE
Resolving linter issue with keypair commenting

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -183,9 +183,8 @@ impl DefaultSigner {
                         })
                         .unwrap_or_else(|| self.path.clone());
                     std::io::Error::other(format!(
-                        "No default signer found, run \"solana-keygen new -o {}\" to create a new \
-                         one",
-                        default_path
+                        "No default signer found, run \"solana-keygen new -o {default_path}\" to create a new \
+                         one"
                     ))
                 })?;
             *self.is_path_checked.borrow_mut() = true;

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -179,9 +179,8 @@ impl DefaultSigner {
                         })
                         .unwrap_or_else(|| self.path.clone());
                     std::io::Error::other(format!(
-                        "No default signer found, run \"solana-keygen new -o {}\" to create a new \
-                         one",
-                        default_path
+                        "No default signer found, run \"solana-keygen new -o {default_path}\" to create a new \
+                         one"
                     ))
                 })?;
             *self.is_path_checked.borrow_mut() = true;


### PR DESCRIPTION
#### Problem
- linter is failing due to interleaved pulls
```
error: variables can be used directly in the `format!` string
   --> clap-utils/src/keypair.rs:185:43
    |
185 |                       std::io::Error::other(format!(
    |  ___________________________________________^
186 | |                         "No default signer found, run \"solana-keygen new -o {}\" to create a new \
187 | |                          one",
188 | |                         default_path
189 | |                     ))
    | |_____________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: requested on the command line with `-D clippy::uninlined-format-args`
```
#### Summary of Changes
- Fix formatting to match expecations

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
