### PR TITLE
force gossip_ring test to run alone in ci

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -29,6 +29,10 @@ filter = "package(solana-gossip) & test(/^test_star_network_push_ring_200/)"
 threads-required = "num-cpus"
 
 [[profile.ci.overrides]]
+filter = "package(solana-gossip) & test(/^gossip_ring/)"
+threads-required = "num-cpus"
+
+[[profile.ci.overrides]]
 filter = "package(solana-gossip) & test(/^cluster_info::tests::new_with_external_ip_test_random/)"
 threads-required = "num-cpus"
 


### PR DESCRIPTION
#### Problem
constant gossip_ring port allocation issues. we are trying to allocate 40 nodes for this test. 

#### Summary of Changes
just make gossip_ring run on its own in ci. 
This should work for now until we fully remove all of the port allocation issues in tests across the repo
