### PR TITLE
Rekey `reenable_zk_elgamal_proof_program` feature gate

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1107,7 +1107,7 @@ pub mod disable_zk_elgamal_proof_program {
 }
 
 pub mod reenable_zk_elgamal_proof_program {
-    solana_pubkey::declare_id!("zkeygbBwEGgThKda6nVFVUjJHSYXbwydbmaPUeNQbmK");
+    solana_pubkey::declare_id!("zkesAyFB19sTkX8i9ReoKaMNDA4YNTPYJpZKPDt7FMW");
 }
 
 pub mod raise_block_limits_to_100m {


### PR DESCRIPTION
#### Problem
Sorry, due to the zk-sdk migration from the agave repo to the zk-elgamal-proof repo, I had to make security fixes separately on master and v2.3.

On master, security fixes were resolved in a single PR https://github.com/anza-xyz/agave/pull/7126 that replaces the master zk-sdk with the migrated zk-sdk.

For v2.3, the fixes were individually added in two separate PRs: https://github.com/anza-xyz/agave/pull/7128 and https://github.com/anza-xyz/agave/pull/7129.

For each of the v2.3 PRs, I rekeyed the feature gate `reenable_zk_elgamal_proof_program`.

For changes in master, I missed rekeying the feature gate appropriately.

#### Summary of Changes
To make the feature gate address consistent in v2.3, v3.0 and master, I need to rekey.

I know that I should include the rekeying in the same commit as the changes. I will make sure that this situation never happens in the future 🙏 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
