### PR TITLE
ledger: blockstore prepare for removing unchained

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7061,7 +7061,7 @@ pub mod tests {
                 &keypair,
                 &entries,
                 true,
-                None, //chained_merkle_root
+                Some(Hash::default()), // merkle_root
                 0,
                 0,
                 &rsc,
@@ -7089,9 +7089,9 @@ pub mod tests {
                 &keypair,
                 &[],
                 true,
-                None, //chained_merkle_root
-                6,    // next_shred_index,
-                6,    // next_code_index
+                Some(Hash::default()), // merkle_root
+                6,                     // next_shred_index,
+                6,                     // next_code_index
                 &rsc,
                 &mut ProcessShredsStats::default(),
             )
@@ -7152,9 +7152,9 @@ pub mod tests {
                 &Keypair::new(),
                 &entries,
                 true,
-                None,     //chained_merkle_root
-                last_idx, // next_shred_index,
-                last_idx, // next_code_index
+                Some(Hash::default()), // merkle_root
+                last_idx,              // next_shred_index,
+                last_idx,              // next_code_index
                 &rsc,
                 &mut ProcessShredsStats::default(),
             )

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -6878,7 +6878,7 @@ pub mod tests {
                         &keypair,
                         &[],
                         false,
-                        None,
+                        Some(Hash::default()), // merkle_root
                         (i * gap) as u32,
                         (i * gap) as u32,
                         &reed_solomon_cache,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5336,7 +5336,6 @@ pub mod tests {
             InnerInstruction, InnerInstructions, Reward, Rewards, TransactionTokenBalance,
         },
         std::{cmp::Ordering, time::Duration},
-        test_case::test_case,
     };
 
     // used for tests only
@@ -10244,21 +10243,20 @@ pub mod tests {
         assert_eq!(num_coding_in_index, num_coding);
     }
 
-    #[test_case(false)]
-    #[test_case(true)]
-    fn test_duplicate_slot(chained: bool) {
+    #[test]
+    fn test_duplicate_slot() {
         let slot = 0;
         let entries1 = make_slot_entries_with_transactions(1);
         let entries2 = make_slot_entries_with_transactions(1);
         let leader_keypair = Arc::new(Keypair::new());
         let reed_solomon_cache = ReedSolomonCache::default();
         let shredder = Shredder::new(slot, 0, 0, 0).unwrap();
-        let chained_merkle_root = chained.then(|| Hash::new_from_array(rand::thread_rng().gen()));
+        let merkle_root = Some(Hash::new_from_array(rand::thread_rng().gen()));
         let (shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
             &leader_keypair,
             &entries1,
             true, // is_last_in_slot
-            chained_merkle_root,
+            merkle_root,
             0, // next_shred_index
             0, // next_code_index,
             &reed_solomon_cache,
@@ -10268,7 +10266,7 @@ pub mod tests {
             &leader_keypair,
             &entries2,
             true, // is_last_in_slot
-            chained_merkle_root,
+            merkle_root,
             0, // next_shred_index
             0, // next_code_index
             &reed_solomon_cache,


### PR DESCRIPTION
#### Problem
There is still remaining parts of code that allows for unchained shreds. The unchained shreds are nomore in production.
Cleaning it all at once would result in hard to review PR, that is why taking iterative approach seem to be the way.

This PR is one of many, towards the unchained shreds removal.

#### Summary of Changes
It does turn blockstore tests that had in use unchained shreds into chained variant, as preparations for further actions. 

- `test_find_missing_data_indexes_timeout` has been moved to chained variant
- `test_should_insert_data_shred` has been moved to chained variant
- `test_duplicate_slot` now doesn't use `test_cases` with false/true, but always chained variant
