### PR TITLE
Revert "run local faucet with non-overlapping ports ... (#7736)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8593,7 +8593,6 @@ dependencies = [
  "solana-logger",
  "solana-message",
  "solana-metrics",
- "solana-net-utils",
  "solana-packet",
  "solana-pubkey",
  "solana-signer",

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -36,7 +36,6 @@ solana-keypair = "=3.0.1"
 solana-logger = "=3.0.0"
 solana-message = "=3.0.1"
 solana-metrics = { workspace = true }
-solana-net-utils = { workspace = true }
 solana-packet = "=3.0.0"
 solana-pubkey = { version = "=3.0.0", features = ["rand"] }
 solana-signer = "=3.0.0"

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -15,7 +15,6 @@ use {
     solana_keypair::Keypair,
     solana_message::Message,
     solana_metrics::datapoint_info,
-    solana_net_utils::sockets::unique_port_range_for_tests,
     solana_packet::PACKET_DATA_SIZE,
     solana_pubkey::Pubkey,
     solana_signer::Signer,
@@ -338,21 +337,10 @@ pub fn run_local_faucet_with_port(
     });
 }
 
-/// For integration tests. Listens on a random open port and reports the port to Sender.
-/// In test/debug builds, a non-overlapping port is allocated instead of a random port.
+// For integration tests. Listens on random open port and reports port to Sender.
 pub fn run_local_faucet(faucet_keypair: Keypair, per_time_cap: Option<u64>) -> SocketAddr {
-    let port: u16 = {
-        #[cfg(debug_assertions)]
-        {
-            unique_port_range_for_tests(1).start
-        }
-        #[cfg(not(debug_assertions))]
-        {
-            0
-        }
-    };
     let (sender, receiver) = unbounded();
-    run_local_faucet_with_port(faucet_keypair, sender, None, per_time_cap, None, port);
+    run_local_faucet_with_port(faucet_keypair, sender, None, per_time_cap, None, 0);
     receiver
         .recv()
         .expect("run_local_faucet")

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6785,7 +6785,6 @@ dependencies = [
  "solana-logger",
  "solana-message",
  "solana-metrics",
- "solana-net-utils",
  "solana-packet",
  "solana-pubkey",
  "solana-signer",


### PR DESCRIPTION
#### Problem
 Switching behavior based on whether debug assertions are enabled or not seems fragile, so we should take another approach to solving the problem this PR aimed to solve

#### Summary of Changes
This reverts commit 0417f3dc18e71a3b257e153b80a23e14f13a4778.