### PR TITLE
Fix memlock budget in ledger-tool

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -3,7 +3,7 @@ use {
     clap::{value_t, value_t_or_exit, values_t, values_t_or_exit, Arg, ArgMatches},
     solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
     solana_accounts_db::{
-        accounts_db::AccountsDbConfig,
+        accounts_db::{AccountsDbConfig, DEFAULT_MEMLOCK_BUDGET_SIZE},
         accounts_file::StorageAccess,
         accounts_index::{AccountsIndexConfig, IndexLimitMb, ScanFilter},
     },
@@ -311,6 +311,7 @@ pub fn get_accounts_db_config(
         storage_access,
         scan_filter_for_shrinking,
         num_hash_threads,
+        memlock_budget_size: DEFAULT_MEMLOCK_BUDGET_SIZE,
         ..AccountsDbConfig::default()
     }
 }


### PR DESCRIPTION
#### Problem
After https://github.com/anza-xyz/agave/commit/09d520c04404a5eba55ed26f8bf209202462e1d6 accounts-db config needs to be populated with reasonable memlock budget in order to use performance io_uring implementations for snapshot unpacking.
However ledger-tool uses `AccountsDbConfig::default()` except for explicitly listed field, so it gets budget=0. 

#### Summary of Changes
Use prod default value for `memlock_budget_size` in ledger-tool
