### PR TITLE
BankingStage: shutdown and respawn vote thread

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -425,7 +425,7 @@ impl BankingStage {
         num_workers: NonZeroUsize,
     ) -> thread::Result<()> {
         if let Some(context) = self.context.as_ref() {
-            info!("Shutting down banking stage non-vote threads");
+            info!("Shutting down banking stage threads");
             context.exit_signal.store(true, Ordering::Relaxed);
             for bank_thread_hdl in self.thread_hdls.drain(..) {
                 bank_thread_hdl.join()?;

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -776,7 +776,7 @@ impl AdminRpc for AdminRpcImpl {
             };
 
             banking_stage
-                .spawn_non_vote_threads(transaction_struct, block_production_method, num_workers)
+                .spawn_threads(transaction_struct, block_production_method, num_workers)
                 .map_err(|err| {
                     error!("Failed to spawn new non-vote threads: {err:?}");
                     jsonrpc_core::error::Error::internal_error()


### PR DESCRIPTION
#### Problem
- scheduler-bindings will support passing votes to the external scheduler or not
- we do not currently support de/respawning the vote thread

#### Summary of Changes
- Respawn vote threads with non-vote threads
- Name changes since context is no longer just non-vote

^ Above changes will allow us to add an additional option for external to optionally NOT spawn the vote thread.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
