### PR TITLE
Removing add_dirty_store from add_root

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6473,22 +6473,11 @@ impl AccountsDb {
         let mut cache_time = Measure::start("cache_add_root");
         self.accounts_cache.add_root(slot);
         cache_time.stop();
-        let mut store_time = Measure::start("store_add_root");
-        // We would not expect this slot to be shrinking right now, but other slots may be.
-        // But, even if it was, we would just mark a store id as dirty unnecessarily and that is ok.
-        // So, allow shrinking to be in progress.
-        if let Some(store) = self
-            .storage
-            .get_slot_storage_entry_shrinking_in_progress_ok(slot)
-        {
-            self.dirty_stores.insert(slot, store);
-        }
-        store_time.stop();
 
         AccountsAddRootTiming {
             index_us: index_time.as_us(),
             cache_us: cache_time.as_us(),
-            store_us: store_time.as_us(),
+            store_us: 0,
         }
     }
 


### PR DESCRIPTION
#### Problem
- add_dirty_store when adding root is unnecessary. clean cannot clean any of the stores until they have been flushed
- During flush all the accounts are added to the uncleaned pubkey list, which will cause them to get visited during clean

#### Summary of Changes
- Remove add_dirty_store when adding root

<img width="914" height="216" alt="image" src="https://github.com/user-attachments/assets/5f03cab5-ab43-45d1-955a-29506f21b589" />

Seems to reduce clean by about 10%. 
This is baseline code, no obsolete accounts


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
