### PR TITLE
Apply cargo fmt string formatting to rest of repo

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6772,7 +6772,10 @@ impl AccountsDb {
                         }
                         let now = Instant::now();
                         if now - last_update > Duration::from_secs(2) {
-                            info!("generating index: processed {num_processed}/{num_storages} slots...");
+                            info!(
+                                "generating index: processed {num_processed}/{num_storages} \
+                                 slots..."
+                            );
                             last_update = now;
                         }
                         thread::sleep(Duration::from_millis(500))

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -330,8 +330,8 @@ impl AppendVec {
                 let mmap = unsafe { MmapMut::map_mut(&data) };
                 let mmap = mmap.unwrap_or_else(|err| {
                     panic!(
-                        "Failed to map the data file (size: {size}): {err}. Please increase sysctl \
-                         vm.max_map_count or equivalent for your platform.",
+                        "Failed to map the data file (size: {size}): {err}. Please increase \
+                         sysctl vm.max_map_count or equivalent for your platform.",
                     );
                 });
                 APPEND_VEC_STATS

--- a/accounts-db/src/io_uring/memory.rs
+++ b/accounts-db/src/io_uring/memory.rs
@@ -247,8 +247,8 @@ pub fn adjust_ulimit_memlock(min_required: usize) -> io::Result<()> {
 
             if cfg!(target_os = "macos") {
                 log::error!(
-                    "On mac OS you may need to run |sudo launchctl limit memlock \
-                     {min_required} {min_required}| first"
+                    "On mac OS you may need to run |sudo launchctl limit memlock {min_required} \
+                     {min_required}| first"
                 );
             }
             return Err(io::Error::new(

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -87,7 +87,10 @@ fn main() -> Result<()> {
                 .value_name("KEYPAIR")
                 .takes_value(true)
                 .validator(is_keypair_or_ask_keyword)
-                .help("Identity keypair for the QUIC endpoint. If it is not specified a random key is created."),
+                .help(
+                    "Identity keypair for the QUIC endpoint. If it is not specified a random key \
+                     is created.",
+                ),
         )
         .arg(
             Arg::with_name("num-recv-sockets")
@@ -122,7 +125,9 @@ fn main() -> Result<()> {
                 .long("max-connections-per-ipaddr-per-min")
                 .value_name("NUM")
                 .takes_value(true)
-                .help("Maximum client connections per ipaddr per minute allowed on the server side."),
+                .help(
+                    "Maximum client connections per ipaddr per minute allowed on the server side.",
+                ),
         )
         .arg(
             Arg::with_name("connection-pool-size")
@@ -151,7 +156,10 @@ fn main() -> Result<()> {
                 .value_name("HOST:PORT")
                 .takes_value(true)
                 .validator(|arg| solana_net_utils::is_host_port(arg.to_string()))
-                .help("The destination streamer address to which the client will send transactions to"),
+                .help(
+                    "The destination streamer address to which the client will send transactions \
+                     to",
+                ),
         )
         .arg(
             Arg::with_name("use-connection-cache")

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -105,9 +105,8 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .multiple(true)
                         .index(1)
                         .help(
-                            "A list of accounts which if provided the fee response will \
-                             represent the fee to land a transaction with those accounts as \
-                             writable",
+                            "A list of accounts which if provided the fee response will represent \
+                             the fee to land a transaction with those accounts as writable",
                         ),
                 )
                 .arg(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1123,8 +1123,8 @@ impl ReplayStage {
                                     Err(err) => {
                                         error!(
                                             "Unable to load new tower when attempting to change \
-                                             identity from {my_old_pubkey} to {my_pubkey} on
-                                         set-identity, Exiting: {err}"
+                                             identity from {my_old_pubkey} to {my_pubkey} on \
+                                             set-identity, Exiting: {err}"
                                         );
                                         // drop(_exit) will set the exit flag, eventually tearing down the entire process
                                         return;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1123,7 +1123,7 @@ impl ReplayStage {
                                     Err(err) => {
                                         error!(
                                             "Unable to load new tower when attempting to change \
-                                         identity from {my_old_pubkey} to {my_pubkey} on
+                                             identity from {my_old_pubkey} to {my_pubkey} on
                                          set-identity, Exiting: {err}"
                                         );
                                         // drop(_exit) will set the exit flag, eventually tearing down the entire process
@@ -2488,7 +2488,8 @@ impl ReplayStage {
                 {
                     *first_alpenglow_slot = Some(activation_slot);
                     info!(
-                        "alpenglow feature detected in root bank {new_root}, to be enabled on slot {activation_slot}",
+                        "alpenglow feature detected in root bank {new_root}, to be enabled on \
+                         slot {activation_slot}",
                     );
                 }
             }

--- a/dos/src/cli.rs
+++ b/dos/src/cli.rs
@@ -48,7 +48,8 @@ pub struct DosClientParameters {
     #[clap(
         long,
         conflicts_with("skip-gossip"),
-        help = "The shred version to use for gossip discovery. If not provided, will be discovered from the network"
+        help = "The shred version to use for gossip discovery. If not provided, will be \
+                discovered from the network"
     )]
     pub shred_version: Option<u16>,
 
@@ -175,7 +176,10 @@ fn validate_input(params: &DosClientParameters) {
     if params.data_type != DataType::Transaction {
         let tp = &params.transaction_params;
         if tp.valid_blockhash || tp.valid_signatures || tp.unique_transactions {
-            eprintln!("Arguments valid-blockhash, valid-sign, unique-transactions are ignored if data-type != transaction");
+            eprintln!(
+                "Arguments valid-blockhash, valid-sign, unique-transactions are ignored if \
+                 data-type != transaction"
+            );
             exit(1);
         }
     }

--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -63,8 +63,8 @@ async fn main() {
                 .takes_value(true)
                 .multiple(true)
                 .help(
-                    "Allow requests from a particular IP address without request limit; \
-                    recipient address will be used to check request limits instead",
+                    "Allow requests from a particular IP address without request limit; recipient \
+                     address will be used to check request limits instead",
                 ),
         )
         .get_matches();

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -274,11 +274,10 @@ fn add_validator_accounts(
 
 fn rent_exempt_check(stake_lamports: u64, exempt: u64) -> io::Result<()> {
     if stake_lamports < exempt {
-        Err(io::Error::other(
-            format!(
-                "error: insufficient validator stake lamports: {stake_lamports} for rent exemption, requires {exempt}"
-            ),
-        ))
+        Err(io::Error::other(format!(
+            "error: insufficient validator stake lamports: {stake_lamports} for rent exemption, \
+             requires {exempt}"
+        )))
     } else {
         Ok(())
     }
@@ -336,7 +335,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .value_name("RFC3339 DATE TIME")
                 .validator(is_rfc3339_datetime)
                 .takes_value(true)
-                .help("Time when the bootstrap validator will start the cluster [default: current system time]"),
+                .help(
+                    "Time when the bootstrap validator will start the cluster [default: current \
+                     system time]",
+                ),
         )
         .arg(
             Arg::with_name("bootstrap_validator")
@@ -412,8 +414,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .default_value(default_target_lamports_per_signature)
                 .help(
-                    "The cost in lamports that the cluster will charge for signature \
-                     verification when the cluster is operating at target-signatures-per-slot",
+                    "The cost in lamports that the cluster will charge for signature verification \
+                     when the cluster is operating at target-signatures-per-slot",
                 ),
         )
         .arg(
@@ -423,8 +425,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .default_value(default_lamports_per_byte_year)
                 .help(
-                    "The cost in lamports that the cluster will charge per byte per year \
-                     for accounts with data",
+                    "The cost in lamports that the cluster will charge per byte per year for \
+                     accounts with data",
                 ),
         )
         .arg(
@@ -434,8 +436,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .default_value(default_rent_exemption_threshold)
                 .help(
-                    "amount of time (in years) the balance has to include rent for \
-                     to qualify as rent exempted account",
+                    "amount of time (in years) the balance has to include rent for to qualify as \
+                     rent exempted account",
                 ),
         )
         .arg(
@@ -472,10 +474,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .default_value(default_target_signatures_per_slot)
                 .help(
-                    "Used to estimate the desired processing capacity of the cluster. \
-                    When the latest slot processes fewer/greater signatures than this \
-                    value, the lamports-per-signature fee will decrease/increase for \
-                    the next slot. A value of 0 disables signature-based fee adjustments",
+                    "Used to estimate the desired processing capacity of the cluster. When the \
+                     latest slot processes fewer/greater signatures than this value, the \
+                     lamports-per-signature fee will decrease/increase for the next slot. A value \
+                     of 0 disables signature-based fee adjustments",
                 ),
         )
         .arg(
@@ -492,10 +494,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .default_value("auto")
                 .help(
-                    "How many PoH hashes to roll before emitting the next tick. \
-                     If \"auto\", determine based on --target-tick-duration \
-                     and the hash rate of this computer. If \"sleep\", for development \
-                     sleep for --target-tick-duration instead of hashing",
+                    "How many PoH hashes to roll before emitting the next tick. If \"auto\", \
+                     determine based on --target-tick-duration and the hash rate of this \
+                     computer. If \"sleep\", for development sleep for --target-tick-duration \
+                     instead of hashing",
                 ),
         )
         .arg(
@@ -518,8 +520,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             Arg::with_name("enable_warmup_epochs")
                 .long("enable-warmup-epochs")
                 .help(
-                    "When enabled epochs start short and will grow. \
-                     Useful for warming up stake quickly during development"
+                    "When enabled epochs start short and will grow. Useful for warming up stake \
+                     quickly during development",
                 ),
         )
         .arg(
@@ -536,7 +538,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .value_name("FILENAME")
                 .takes_value(true)
                 .multiple(true)
-                .help("The location of a file containing a list of identity, vote, and stake pubkeys and balances for validator accounts to bake into genesis")
+                .help(
+                    "The location of a file containing a list of identity, vote, and stake \
+                     pubkeys and balances for validator accounts to bake into genesis",
+                ),
         )
         .arg(
             Arg::with_name("cluster_type")
@@ -544,9 +549,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .possible_values(&ClusterType::STRINGS)
                 .takes_value(true)
                 .default_value(default_cluster_type)
-                .help(
-                    "Selects the features that will be enabled for the cluster"
-                ),
+                .help("Selects the features that will be enabled for the cluster"),
         )
         .arg(
             Arg::with_name("deactivate_feature")
@@ -555,7 +558,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .value_name("FEATURE_PUBKEY")
                 .validator(is_pubkey)
                 .multiple(true)
-                .help("Deactivate this feature in genesis. Compatible with --cluster-type development"),
+                .help(
+                    "Deactivate this feature in genesis. Compatible with --cluster-type \
+                     development",
+                ),
         )
         .arg(
             Arg::with_name("max_genesis_archive_unpacked_size")
@@ -563,9 +569,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .value_name("NUMBER")
                 .takes_value(true)
                 .default_value(&default_genesis_archive_unpacked_size)
-                .help(
-                    "maximum total uncompressed file size of created genesis archive",
-                ),
+                .help("maximum total uncompressed file size of created genesis archive"),
         )
         .arg(
             Arg::with_name("bpf_program")
@@ -583,7 +587,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .number_of_values(4)
                 .multiple(true)
-                .help("Install an upgradeable SBF program at the given address with the given upgrade authority (or \"none\")"),
+                .help(
+                    "Install an upgradeable SBF program at the given address with the given \
+                     upgrade authority (or \"none\")",
+                ),
         )
         .arg(
             Arg::with_name("inflation")
@@ -602,9 +609,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .global(true)
                 .validator(is_url_or_moniker)
                 .help(
-                    "URL for Solana's JSON RPC or moniker (or their first letter): \
-                    [mainnet-beta, testnet, devnet, localhost]. Used for cloning \
-                    feature sets",
+                    "URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, \
+                     testnet, devnet, localhost]. Used for cloning feature sets",
                 ),
         )
         .get_matches();
@@ -1202,18 +1208,25 @@ mod tests {
 
         assert_eq!(genesis_config.accounts.len(), 4);
 
-        let yaml_string_keypair = "---
-\"[17,12,234,59,35,246,168,6,64,36,169,164,219,96,253,79,238,202,164,160,195,89,9,96,179,117,255,239,32,64,124,66,233,130,19,107,172,54,86,32,119,148,4,39,199,40,122,230,249,47,150,168,163,159,83,233,97,18,25,238,103,25,253,108]\":
+        let yaml_string_keypair =
+            "---
+\"[17,12,234,59,35,246,168,6,64,36,169,164,219,96,253,79,238,202,164,160,195,89,9,96,179,117,255,\
+             239,32,64,124,66,233,130,19,107,172,54,86,32,119,148,4,39,199,40,122,230,249,47,150,\
+             168,163,159,83,233,97,18,25,238,103,25,253,108]\":
   balance: 20
   owner: 9ZfsP6Um1KU8d5gNzTsEbSJxanKYp5EPF36qUu4FJqgp
   data: Y2F0IGRvZw==
   executable: true
-\"[36,246,244,43,37,214,110,50,134,148,148,8,205,82,233,67,223,245,122,5,149,232,213,125,244,182,26,29,56,224,70,45,42,163,71,62,222,33,229,54,73,136,53,174,128,103,247,235,222,27,219,129,180,77,225,174,220,74,201,123,97,155,159,234]\":
+\"[36,246,244,43,37,214,110,50,134,148,148,8,205,82,233,67,223,245,122,5,149,232,213,125,244,182,\
+             26,29,56,224,70,45,42,163,71,62,222,33,229,54,73,136,53,174,128,103,247,235,222,27,\
+             219,129,180,77,225,174,220,74,201,123,97,155,159,234]\":
   balance: 15
   owner: F9dmtjJPi8vfLu1EJN4KkyoGdXGmVfSAhxz35Qo9RDCJ
   data: bW9ua2V5IGVsZXBoYW50
   executable: false
-\"[103,27,132,107,42,149,72,113,24,138,225,109,209,31,158,6,26,11,8,76,24,128,131,215,156,80,251,114,103,220,111,235,56,22,87,5,209,56,53,12,224,170,10,66,82,42,11,138,51,76,120,27,166,200,237,16,200,31,23,5,57,22,131,221]\":
+\"[103,27,132,107,42,149,72,113,24,138,225,109,209,31,158,6,26,11,8,76,24,128,131,215,156,80,251,\
+             114,103,220,111,235,56,22,87,5,209,56,53,12,224,170,10,66,82,42,11,138,51,76,120,27,\
+             166,200,237,16,200,31,23,5,57,22,131,221]\":
   balance: 30
   owner: AwAR5mAbNPbvQ4CvMeBxwWE8caigQoMC2chkWAbh2b9V
   data: Y29tYSBtb2Nh

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -1175,27 +1175,29 @@ mod tests {
 
     #[test]
     fn test_genesis_account_struct_compatibility() {
-        let yaml_string_pubkey = "---
-98frSc8R8toHoS3tQ1xWSvHCvGEADRM9hAm5qmUKjSDX:
-  balance: 4
-  owner: Gw6S9CPzR8jHku1QQMdiqcmUKjC2dhJ3gzagWduA6PGw
-  data:
-  executable: true
-88frSc8R8toHoS3tQ1xWSvHCvGEADRM9hAm5qmUKjSDX:
-  balance: 3
-  owner: Gw7S9CPzR8jHku1QQMdiqcmUKjC2dhJ3gzagWduA6PGw
-  data: ~
-  executable: true
-6s36rsNPDfRSvzwek7Ly3mQu9jUMwgqBhjePZMV6Acp4:
-  balance: 2
-  owner: DBC5d45LUHTCrq42ZmCdzc8A8ufwTaiYsL9pZY7KU6TR
-  data: aGVsbG8=
-  executable: false
-8Y98svZv5sPHhQiPqZvqA5Z5djQ8hieodscvb61RskMJ:
-  balance: 1
-  owner: DSknYr8cPucRbx2VyssZ7Yx3iiRqNGD38VqVahkUvgV1
-  data: aGVsbG8gd29ybGQ=
-  executable: true";
+        #[rustfmt::skip]
+        let yaml_string_pubkey =
+            "---\
+             \n98frSc8R8toHoS3tQ1xWSvHCvGEADRM9hAm5qmUKjSDX:\
+             \n  balance: 4\
+             \n  owner: Gw6S9CPzR8jHku1QQMdiqcmUKjC2dhJ3gzagWduA6PGw\
+             \n  data:\
+             \n  executable: true\
+             \n88frSc8R8toHoS3tQ1xWSvHCvGEADRM9hAm5qmUKjSDX:\
+             \n  balance: 3\
+             \n  owner: Gw7S9CPzR8jHku1QQMdiqcmUKjC2dhJ3gzagWduA6PGw\
+             \n  data: ~\
+             \n  executable: true\
+             \n6s36rsNPDfRSvzwek7Ly3mQu9jUMwgqBhjePZMV6Acp4:\
+             \n  balance: 2\
+             \n  owner: DBC5d45LUHTCrq42ZmCdzc8A8ufwTaiYsL9pZY7KU6TR\
+             \n  data: aGVsbG8=\
+             \n  executable: false\
+             \n8Y98svZv5sPHhQiPqZvqA5Z5djQ8hieodscvb61RskMJ:\
+             \n  balance: 1\
+             \n  owner: DSknYr8cPucRbx2VyssZ7Yx3iiRqNGD38VqVahkUvgV1\
+             \n  data: aGVsbG8gd29ybGQ=\
+             \n  executable: true";
 
         let tmpfile = tempfile::NamedTempFile::new().unwrap();
         let path = tmpfile.path();
@@ -1208,29 +1210,30 @@ mod tests {
 
         assert_eq!(genesis_config.accounts.len(), 4);
 
+        #[rustfmt::skip]
         let yaml_string_keypair =
-            "---
-\"[17,12,234,59,35,246,168,6,64,36,169,164,219,96,253,79,238,202,164,160,195,89,9,96,179,117,255,\
-             239,32,64,124,66,233,130,19,107,172,54,86,32,119,148,4,39,199,40,122,230,249,47,150,\
-             168,163,159,83,233,97,18,25,238,103,25,253,108]\":
-  balance: 20
-  owner: 9ZfsP6Um1KU8d5gNzTsEbSJxanKYp5EPF36qUu4FJqgp
-  data: Y2F0IGRvZw==
-  executable: true
-\"[36,246,244,43,37,214,110,50,134,148,148,8,205,82,233,67,223,245,122,5,149,232,213,125,244,182,\
-             26,29,56,224,70,45,42,163,71,62,222,33,229,54,73,136,53,174,128,103,247,235,222,27,\
-             219,129,180,77,225,174,220,74,201,123,97,155,159,234]\":
-  balance: 15
-  owner: F9dmtjJPi8vfLu1EJN4KkyoGdXGmVfSAhxz35Qo9RDCJ
-  data: bW9ua2V5IGVsZXBoYW50
-  executable: false
-\"[103,27,132,107,42,149,72,113,24,138,225,109,209,31,158,6,26,11,8,76,24,128,131,215,156,80,251,\
-             114,103,220,111,235,56,22,87,5,209,56,53,12,224,170,10,66,82,42,11,138,51,76,120,27,\
-             166,200,237,16,200,31,23,5,57,22,131,221]\":
-  balance: 30
-  owner: AwAR5mAbNPbvQ4CvMeBxwWE8caigQoMC2chkWAbh2b9V
-  data: Y29tYSBtb2Nh
-  executable: true";
+            "---\
+             \n\"[17,12,234,59,35,246,168,6,64,36,169,164,219,96,253,79,238,202,164,160,195,89,9,\
+             96,179,117,255,239,32,64,124,66,233,130,19,107,172,54,86,32,119,148,4,39,199,40,122,\
+             230,249,47,150,168,163,159,83,233,97,18,25,238,103,25,253,108]\":\
+             \n  balance: 20\
+             \n  owner: 9ZfsP6Um1KU8d5gNzTsEbSJxanKYp5EPF36qUu4FJqgp\
+             \n  data: Y2F0IGRvZw==\
+             \n  executable: true\
+             \n\"[36,246,244,43,37,214,110,50,134,148,148,8,205,82,233,67,223,245,122,5,149,232,\
+             213,125,244,182,26,29,56,224,70,45,42,163,71,62,222,33,229,54,73,136,53,174,128,103,\
+             247,235,222,27,219,129,180,77,225,174,220,74,201,123,97,155,159,234]\":\
+             \n  balance: 15\
+             \n  owner: F9dmtjJPi8vfLu1EJN4KkyoGdXGmVfSAhxz35Qo9RDCJ\
+             \n  data: bW9ua2V5IGVsZXBoYW50\
+             \n  executable: false\
+             \n\"[103,27,132,107,42,149,72,113,24,138,225,109,209,31,158,6,26,11,8,76,24,128,131,\
+             215,156,80,251,114,103,220,111,235,56,22,87,5,209,56,53,12,224,170,10,66,82,42,11,138,\
+             51,76,120,27,166,200,237,16,200,31,23,5,57,22,131,221]\":\
+             \n  balance: 30
+             \n  owner: AwAR5mAbNPbvQ4CvMeBxwWE8caigQoMC2chkWAbh2b9V
+             \n  data: Y29tYSBtb2Nh
+             \n  executable: true";
 
         let tmpfile = tempfile::NamedTempFile::new().unwrap();
         let path = tmpfile.path();

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -54,7 +54,8 @@ impl GossipService {
         let (request_sender, request_receiver) =
             EvictingSender::new_bounded(GOSSIP_CHANNEL_CAPACITY);
         trace!(
-            "GossipService: id: {}, listening on primary interface: {:?}, all available interfaces: {:?}",
+            "GossipService: id: {}, listening on primary interface: {:?}, all available \
+             interfaces: {:?}",
             &cluster_info.id(),
             gossip_sockets[0].local_addr().unwrap(),
             gossip_sockets,

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -309,7 +309,8 @@ fn check_env_path_for_bin_dir(config: &Config) {
 
     if !found {
         println!(
-            "\nPlease update your PATH environment variable to include the solana programs:\n    PATH=\"{}:$PATH\"\n",
+            "\nPlease update your PATH environment variable to include the solana programs:\n    \
+             PATH=\"{}:$PATH\"\n",
             config.active_release_bin_dir().to_str().unwrap()
         );
     }
@@ -369,7 +370,10 @@ fn get_windows_path_var() -> Result<Option<String>, String> {
             if let Some(s) = string_from_winreg_value(&val) {
                 Ok(Some(s))
             } else {
-                println!("the registry key HKEY_CURRENT_USER\\Environment\\PATH does not contain valid Unicode. Not modifying the PATH variable");
+                println!(
+                    "the registry key HKEY_CURRENT_USER\\Environment\\PATH does not contain valid \
+                     Unicode. Not modifying the PATH variable"
+                );
                 Ok(None)
             }
         }
@@ -437,9 +441,14 @@ fn add_to_path(new_path: &str) -> bool {
 
     println!(
         "\n{}\n  {}\n\n{}",
-        style("The HKEY_CURRENT_USER/Environment/PATH registry key has been modified to include:").bold(),
+        style("The HKEY_CURRENT_USER/Environment/PATH registry key has been modified to include:")
+            .bold(),
         new_path,
-        style("Future applications will automatically have the correct environment, but you may need to restart your current shell.").bold()
+        style(
+            "Future applications will automatically have the correct environment, but you may \
+             need to restart your current shell."
+        )
+        .bold()
     );
     true
 }
@@ -521,9 +530,14 @@ fn add_to_path(new_path: &str) -> bool {
     if modified_rcfiles {
         println!(
             "\n{}\n  {}\n",
-            style("Close and reopen your terminal to apply the PATH changes or run the following in your existing shell:").bold().blue(),
+            style(
+                "Close and reopen your terminal to apply the PATH changes or run the following in \
+                 your existing shell:"
+            )
+            .bold()
+            .blue(),
             shell_export_string
-       );
+        );
     }
 
     modified_rcfiles
@@ -1003,8 +1017,9 @@ pub fn init_or_update(config_file: &str, is_init: bool, check_only: bool) -> Res
                                         == active_release_version.channel
                                     {
                                         println!(
-                                        "Install is up to date. {release_semver} is the latest compatible release"
-                                    );
+                                            "Install is up to date. {release_semver} is the \
+                                             latest compatible release"
+                                        );
                                         return Ok(false);
                                     }
                                 }
@@ -1297,8 +1312,8 @@ pub fn list(config_file: &str) -> Result<(), String> {
 
     let entries = fs::read_dir(&config.releases_dir).map_err(|err| {
         format!(
-            "Failed to read install directory, \
-            double check that your configuration file is correct: {err}"
+            "Failed to read install directory, double check that your configuration file is \
+             correct: {err}"
         )
     })?;
 

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -230,8 +230,8 @@ impl MetricsAgent {
 
         if num_points > max_points {
             warn!(
-                "Max submission rate of {max_points_per_sec} datapoints per second exceeded. \
-                 Only the first {max_points} of {num_points} points will be submitted."
+                "Max submission rate of {max_points_per_sec} datapoints per second exceeded. Only \
+                 the first {max_points} of {num_points} points will be submitted."
             );
         }
 

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -151,7 +151,11 @@ fn bench_program_alu(bencher: &mut Bencher) {
     assert!(0f64 != summary.median);
     let mips = (instructions * (ns_per_s / summary.median as u64)) / one_million;
     println!("  {:?} MIPS", mips);
-    println!("{{ \"type\": \"bench\", \"name\": \"bench_program_alu_interpreted_mips\", \"median\": {:?}, \"deviation\": 0 }}", mips);
+    println!(
+        "{{ \"type\": \"bench\", \"name\": \"bench_program_alu_interpreted_mips\", \"median\": \
+         {:?}, \"deviation\": 0 }}",
+        mips
+    );
 
     println!("JIT to native:");
     assert_eq!(SUCCESS, vm.execute_program(&executable, false).1.unwrap());
@@ -172,7 +176,11 @@ fn bench_program_alu(bencher: &mut Bencher) {
     assert!(0f64 != summary.median);
     let mips = (instructions * (ns_per_s / summary.median as u64)) / one_million;
     println!("  {:?} MIPS", mips);
-    println!("{{ \"type\": \"bench\", \"name\": \"bench_program_alu_jit_to_native_mips\", \"median\": {:?}, \"deviation\": 0 }}", mips);
+    println!(
+        "{{ \"type\": \"bench\", \"name\": \"bench_program_alu_jit_to_native_mips\", \"median\": \
+         {:?}, \"deviation\": 0 }}",
+        mips
+    );
 }
 
 #[bench]

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -153,8 +153,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
     println!("  {:?} MIPS", mips);
     println!(
         "{{ \"type\": \"bench\", \"name\": \"bench_program_alu_interpreted_mips\", \"median\": \
-         {:?}, \"deviation\": 0 }}",
-        mips
+         {mips:?}, \"deviation\": 0 }}",
     );
 
     println!("JIT to native:");
@@ -178,8 +177,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
     println!("  {:?} MIPS", mips);
     println!(
         "{{ \"type\": \"bench\", \"name\": \"bench_program_alu_jit_to_native_mips\", \"median\": \
-         {:?}, \"deviation\": 0 }}",
-        mips
+         {mips:?}, \"deviation\": 0 }}",
     );
 }
 

--- a/programs/sbf/rust/deprecated_loader/src/lib.rs
+++ b/programs/sbf/rust/deprecated_loader/src/lib.rs
@@ -136,7 +136,10 @@ fn process_instruction(
             }
         }
         Some(&TEST_CPI_ACCOUNT_UPDATE_CALLEE_SHRINKS_SMALLER_THAN_ORIGINAL_LEN) => {
-            msg!("DEPRECATED LOADER TEST_CPI_ACCOUNT_UPDATE_CALLEE_SHRINKS_SMALLER_THAN_ORIGINAL_LEN");
+            msg!(
+                "DEPRECATED LOADER \
+                 TEST_CPI_ACCOUNT_UPDATE_CALLEE_SHRINKS_SMALLER_THAN_ORIGINAL_LEN"
+            );
             const ARGUMENT_INDEX: usize = 1;
             const REALLOC_PROGRAM_INDEX: usize = 2;
             const INVOKE_PROGRAM_INDEX: usize = 3;

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -300,9 +300,8 @@ fn test_program_sbf_loader_deprecated() {
 
 #[test]
 #[cfg(feature = "sbf_rust")]
-#[should_panic(
-    expected = "called `Result::unwrap()` on an `Err` value: TransactionError(InstructionError(0, InvalidAccountData))"
-)]
+#[should_panic(expected = "called `Result::unwrap()` on an `Err` value: \
+                           TransactionError(InstructionError(0, InvalidAccountData))")]
 fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
     solana_logger::setup();
 
@@ -997,7 +996,10 @@ fn test_program_sbf_invoke_sanity() {
                 format!("Program log: invoke {program_lang} program"),
                 "Program log: Test max instruction data len exceeded".into(),
                 "skip".into(), // don't compare compute consumption logs
-                format!("Program {invoke_program_id} failed: Invoked an instruction with data that is too large (10241 > 10240)"),
+                format!(
+                    "Program {invoke_program_id} failed: Invoked an instruction with data that is \
+                     too large (10241 > 10240)"
+                ),
             ]),
             &bank,
         );
@@ -1011,7 +1013,10 @@ fn test_program_sbf_invoke_sanity() {
                 format!("Program log: invoke {program_lang} program"),
                 "Program log: Test max instruction accounts exceeded".into(),
                 "skip".into(), // don't compare compute consumption logs
-                format!("Program {invoke_program_id} failed: Invoked an instruction with too many accounts (256 > 255)"),
+                format!(
+                    "Program {invoke_program_id} failed: Invoked an instruction with too many \
+                     accounts (256 > 255)"
+                ),
             ]),
             &bank,
         );
@@ -1025,7 +1030,10 @@ fn test_program_sbf_invoke_sanity() {
                 format!("Program log: invoke {program_lang} program"),
                 "Program log: Test max account infos exceeded".into(),
                 "skip".into(), // don't compare compute consumption logs
-                format!("Program {invoke_program_id} failed: Invoked an instruction with too many account info's (129 > 128)"),
+                format!(
+                    "Program {invoke_program_id} failed: Invoked an instruction with too many \
+                     account info's (129 > 128)"
+                ),
             ]),
             &bank,
         );
@@ -4987,7 +4995,10 @@ fn test_clone_account_data() {
     let tx = Transaction::new(&[&mint_keypair], message.clone(), bank.last_blockhash());
     let (result, _, logs, _) = process_transaction_and_record_inner(&bank, tx);
     assert!(result.is_err(), "{result:?}");
-    let error = format!("Program {invoke_program_id} failed: instruction modified data of an account it does not own");
+    let error = format!(
+        "Program {invoke_program_id} failed: instruction modified data of an account it does not \
+         own"
+    );
     assert!(logs.iter().any(|log| log.contains(&error)), "{logs:?}");
 
     // II. clone data, modify and then CPI
@@ -5017,7 +5028,10 @@ fn test_clone_account_data() {
     let tx = Transaction::new(&[&mint_keypair], message.clone(), bank.last_blockhash());
     let (result, _, logs, _) = process_transaction_and_record_inner(&bank, tx);
     assert!(result.is_err(), "{result:?}");
-    let error = format!("Program {invoke_program_id} failed: instruction modified data of an account it does not own");
+    let error = format!(
+        "Program {invoke_program_id} failed: instruction modified data of an account it does not \
+         own"
+    );
     assert!(logs.iter().any(|log| log.contains(&error)), "{logs:?}");
 
     // II. Clone data, call, modifiy in callee and then make the same change in the caller - transaction succeeds
@@ -5314,7 +5328,11 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
             bank.store_account(&account_keypair.pubkey(), &account);
 
             for instr in 0..=15 {
-                println!("Testing deprecated:{deprecated} stricter_abi_and_runtime_constraints:{stricter_abi_and_runtime_constraints} instruction:{instr}");
+                println!(
+                    "Testing deprecated:{deprecated} \
+                     stricter_abi_and_runtime_constraints:{stricter_abi_and_runtime_constraints} \
+                     instruction:{instr}"
+                );
                 let instruction =
                     Instruction::new_with_bytes(program_id, &[instr], account_metas.clone());
 
@@ -5334,7 +5352,11 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
             bank.store_account(&account_keypair.pubkey(), &account);
 
             for instr in 0..=15 {
-                println!("Testing deprecated:{deprecated} stricter_abi_and_runtime_constraints:{stricter_abi_and_runtime_constraints} instruction:{instr} zero-length account");
+                println!(
+                    "Testing deprecated:{deprecated} \
+                     stricter_abi_and_runtime_constraints:{stricter_abi_and_runtime_constraints} \
+                     instruction:{instr} zero-length account"
+                );
                 let instruction =
                     Instruction::new_with_bytes(program_id, &[instr, 0], account_metas.clone());
 

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -294,7 +294,8 @@ impl QuicClient {
                             match conn {
                                 Ok(conn) => {
                                     info!(
-                                        "Made 0rtt connection to {} with id {} try_count {}, last_connection_id: {}, last_error: {:?}",
+                                        "Made 0rtt connection to {} with id {} try_count {}, \
+                                         last_connection_id: {}, last_error: {:?}",
                                         self.addr,
                                         conn.stable_id(),
                                         connection_try_count,
@@ -328,7 +329,8 @@ impl QuicClient {
                             Ok(conn) => {
                                 *conn_guard = Some(conn.clone());
                                 info!(
-                                    "Made connection to {} id {} try_count {}, from connection cache warming?: {}",
+                                    "Made connection to {} id {} try_count {}, from connection \
+                                     cache warming?: {}",
                                     self.addr,
                                     conn.connection.stable_id(),
                                     connection_try_count,
@@ -338,8 +340,13 @@ impl QuicClient {
                                 conn.connection.clone()
                             }
                             Err(err) => {
-                                info!("Cannot make connection to {}, error {:}, from connection cache warming?: {}",
-                                    self.addr, err, data.is_empty());
+                                info!(
+                                    "Cannot make connection to {}, error {:}, from connection \
+                                     cache warming?: {}",
+                                    self.addr,
+                                    err,
+                                    data.is_empty()
+                                );
                                 return Err(err);
                             }
                         }
@@ -394,7 +401,8 @@ impl QuicClient {
                         .prepare_connection_us
                         .fetch_add(measure_prepare_connection.as_us(), Ordering::Relaxed);
                     trace!(
-                        "Succcessfully sent to {} with id {}, thread: {:?}, data len: {}, send_packet_us: {} prepare_connection_us: {}",
+                        "Succcessfully sent to {} with id {}, thread: {:?}, data len: {}, \
+                         send_packet_us: {} prepare_connection_us: {}",
                         self.addr,
                         connection.stable_id(),
                         thread::current().id(),

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
 imports_granularity = "One"
+format_strings = true
 group_imports = "One"

--- a/stake-accounts/src/arg_parser.rs
+++ b/stake-accounts/src/arg_parser.rs
@@ -164,8 +164,8 @@ where
                 .possible_values(&["processed", "confirmed", "finalized"])
                 .hide_possible_values(true)
                 .help(
-                    "Return information at the selected commitment level \
-                     [possible values: processed, confirmed, finalized]",
+                    "Return information at the selected commitment level [possible values: \
+                     processed, confirmed, finalized]",
                 ),
         )
         .arg(

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -44,8 +44,8 @@ where
                 .global(true)
                 .validator(is_url_or_moniker)
                 .help(
-                    "URL for Solana's JSON RPC or moniker (or their first letter): \
-                       [mainnet-beta, testnet, devnet, localhost]",
+                    "URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, \
+                     testnet, devnet, localhost]",
                 ),
         )
         .subcommand(
@@ -58,9 +58,9 @@ where
                         .takes_value(true)
                         .value_name("FILE")
                         .help(
-                            "Location for storing distribution database. \
-                            The database is used for tracking transactions as they are finalized \
-                            and preventing double spends.",
+                            "Location for storing distribution database. The database is used for \
+                             tracking transactions as they are finalized and preventing double \
+                             spends.",
                         ),
                 )
                 .arg(
@@ -121,9 +121,9 @@ where
                         .takes_value(true)
                         .value_name("FILE")
                         .help(
-                            "Location for storing distribution database. \
-                            The database is used for tracking transactions as they are finalized \
-                            and preventing double spends.",
+                            "Location for storing distribution database. The database is used for \
+                             tracking transactions as they are finalized and preventing double \
+                             spends.",
                         ),
                 )
                 .arg(
@@ -192,9 +192,9 @@ where
                         .takes_value(true)
                         .value_name("FILE")
                         .help(
-                            "Location for storing distribution database. \
-                            The database is used for tracking transactions as they are finalized \
-                            and preventing double spends.",
+                            "Location for storing distribution database. The database is used for \
+                             tracking transactions as they are finalized and preventing double \
+                             spends.",
                         ),
                 )
                 .arg(
@@ -290,9 +290,9 @@ where
                         .takes_value(true)
                         .value_name("FILE")
                         .help(
-                            "Location for storing distribution database. \
-                            The database is used for tracking transactions as they are finalized \
-                            and preventing double spends.",
+                            "Location for storing distribution database. The database is used for \
+                             tracking transactions as they are finalized and preventing double \
+                             spends.",
                         ),
                 )
                 .arg(

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -145,7 +145,8 @@ pub fn update_finalized_transaction(
     if opt_transaction_status.is_none() {
         if finalized_block_height > last_valid_block_height {
             eprintln!(
-                "Signature not found {signature} and blockhash expired. Transaction either dropped or the validator purged the transaction status."
+                "Signature not found {signature} and blockhash expired. Transaction either \
+                 dropped or the validator purged the transaction status."
             );
             eprintln!();
 

--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -170,7 +170,11 @@ impl ConnectionWorker {
                     }
                     ConnectionState::Retry(num_reconnects) => {
                         if *num_reconnects > self.max_reconnect_attempts {
-                            error!("Failed to establish connection to {}: reached max reconnect attempts", self.peer);
+                            error!(
+                                "Failed to establish connection to {}: reached max reconnect \
+                                 attempts",
+                                self.peer
+                            );
                             self.connection = ConnectionState::Closing;
                             continue;
                         }
@@ -355,7 +359,11 @@ impl ConnectionWorker {
                         self.connection = ConnectionState::Closing;
                     }
                     e => {
-                        error!("Unexpected error has happened while trying to create connection to {}: {e}", self.peer);
+                        error!(
+                            "Unexpected error has happened while trying to create connection to \
+                             {}: {e}",
+                            self.peer
+                        );
                         self.connection = ConnectionState::Closing;
                     }
                 }

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -244,8 +244,7 @@ impl LeaderTpuCache {
                 }
                 Err(err) => {
                     warn!(
-                        "Failed to fetch slot leaders (first_slot: \
-                         {}): {err}",
+                        "Failed to fetch slot leaders (first_slot: {}): {err}",
                         cache_update_info.first_slot
                     );
                     has_error = true;

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -751,15 +751,16 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .validator(solana_net_utils::is_host)
                 .default_value("127.0.0.1")
                 .help(
-                    "IP address to bind the validator ports. Can be repeated. \
-                     The first --bind-address MUST be your public internet address. \
-                     ALL protocols (gossip, repair, IP echo, TVU, TPU, etc.) bind to this address on startup. \
-                     Additional --bind-address values enable multihoming for Gossip/TVU/TPU - \
-                     these protocols bind to ALL interfaces on startup. Gossip reads/sends from \
-                     one interface at a time. TVU/TPU read from ALL interfaces simultaneously \
-                     but send from only one interface at a time. When switching interfaces via \
+                    "IP address to bind the validator ports. Can be repeated. The first \
+                     --bind-address MUST be your public internet address. ALL protocols (gossip, \
+                     repair, IP echo, TVU, TPU, etc.) bind to this address on startup. Additional \
+                     --bind-address values enable multihoming for Gossip/TVU/TPU - these \
+                     protocols bind to ALL interfaces on startup. Gossip reads/sends from one \
+                     interface at a time. TVU/TPU read from ALL interfaces simultaneously but \
+                     send from only one interface at a time. When switching interfaces via \
                      AdminRPC: Gossip switches to send/receive from the new interface, while \
-                     TVU/TPU continue receiving from ALL interfaces but send from the new interface only.",
+                     TVU/TPU continue receiving from ALL interfaces but send from the new \
+                     interface only.",
                 ),
         )
         .arg(

--- a/validator/src/commands/manage_block_production/mod.rs
+++ b/validator/src/commands/manage_block_production/mod.rs
@@ -74,7 +74,8 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     let manage_block_production_args = ManageBlockProductionArgs::from_clap_arg_match(matches)?;
 
     println!(
-        "Respawning block-production threads with method: {}, transaction structure: {} num_workers: {}",
+        "Respawning block-production threads with method: {}, transaction structure: {} \
+         num_workers: {}",
         manage_block_production_args.block_production_method,
         manage_block_production_args.transaction_structure,
         manage_block_production_args.num_workers,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1472,11 +1472,10 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("accounts-db-mark-obsolete-accounts")
             .help("Enables experimental obsolete account tracking")
             .long_help(
-                "Enables experimental obsolete account tracking. \
-                 This feature tracks obsolete accounts in the account storage entry allowing \
-                 for earlier cleaning of obsolete accounts in the storages and index. \
-                 At this time this feature is not compatible with booting from local \
-                 snapshot state and must unpack from archives.",
+                "Enables experimental obsolete account tracking. This feature tracks obsolete \
+                 accounts in the account storage entry allowing for earlier cleaning of obsolete \
+                 accounts in the storages and index. At this time this feature is not compatible \
+                 with booting from local snapshot state and must unpack from archives.",
             )
             .hidden(hidden_unless_forced()),
     )

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -560,9 +560,8 @@ pub fn execute(
         && use_snapshot_archives_at_startup != UseSnapshotArchivesAtStartup::Always
     {
         Err(format!(
-            "The --accounts-db-mark-obsolete-accounts option requires \
-             the --use-snapshot-archives-at-startup option to be set to {}. \
-             Current value: {}",
+            "The --accounts-db-mark-obsolete-accounts option requires the \
+             --use-snapshot-archives-at-startup option to be set to {}. Current value: {}",
             UseSnapshotArchivesAtStartup::Always,
             use_snapshot_archives_at_startup
         ))?;

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -209,7 +209,8 @@ pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>>(
                     // sanity check that the address is routable through our NIC
                     if next_hop.if_index != dev.if_index() {
                         log::warn!(
-                            "dropping packet: turbine peer {addr} must be routed through if_index: {} our if_index: {}",
+                            "dropping packet: turbine peer {addr} must be routed through \
+                             if_index: {} our if_index: {}",
                             next_hop.if_index,
                             dev.if_index()
                         );
@@ -218,7 +219,11 @@ pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>>(
 
                     // we need the MAC address to send the packet
                     if next_hop.mac_addr.is_none() {
-                        log::warn!("dropping packet: turbine peer {addr} must be routed through {} which has no known MAC address", next_hop.ip_addr);
+                        log::warn!(
+                            "dropping packet: turbine peer {addr} must be routed through {} which \
+                             has no known MAC address",
+                            next_hop.ip_addr
+                        );
                         skip = true;
                     };
 


### PR DESCRIPTION
#### Problem
We want automation to keep our code tidy. `cargo fmt` can be tripped up by long lines (which can often be string) which will prevent `fmt` from working properly for other nearby code

#### Summary of Changes
- Finish formatting the existing code
- Add `format_strings = true` to `rustfmt.toml` which will mean this is enforced in CI for all future changes