### PR TITLE
Cleanup generate_index_for_slot()

### DIFF
--- a/accounts-db/src/account_storage/stored_account_info.rs
+++ b/accounts-db/src/account_storage/stored_account_info.rs
@@ -46,6 +46,12 @@ impl<'storage> StoredAccountInfo<'storage> {
     }
 }
 
+impl IsZeroLamport for StoredAccountInfo<'_> {
+    fn is_zero_lamport(&self) -> bool {
+        self.lamports == 0
+    }
+}
+
 impl ReadableAccount for StoredAccountInfo<'_> {
     fn lamports(&self) -> u64 {
         self.lamports

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6611,7 +6611,7 @@ impl AccountsDb {
             })
             .expect("must scan accounts storage");
 
-        let (insert_time_us, generate_index_results) = self
+        let (insert_time_us, insert_info) = self
             .accounts_index
             .insert_new_if_missing_into_primary_index(slot, keyed_account_infos);
 
@@ -6619,7 +6619,7 @@ impl AccountsDb {
             // second, collect into the shared DashMap once we've figured out all the info per store_id
             let mut info = storage_info.entry(store_id).or_default();
             info.stored_size += stored_size_alive;
-            info.count += generate_index_results.count;
+            info.count += insert_info.count;
 
             // sanity check that stored_size is not larger than the u64 aligned size of the accounts files.
             // Note that the stored_size is aligned, so it can be larger than the size of the accounts file.
@@ -6652,13 +6652,13 @@ impl AccountsDb {
         }
         SlotIndexGenerationInfo {
             insert_time_us,
-            num_accounts: generate_index_results.count as u64,
+            num_accounts: insert_info.count as u64,
             accounts_data_len,
             zero_lamport_pubkeys,
             all_accounts_are_zero_lamports,
-            num_did_not_exist: generate_index_results.num_did_not_exist,
-            num_existed_in_mem: generate_index_results.num_existed_in_mem,
-            num_existed_on_disk: generate_index_results.num_existed_on_disk,
+            num_did_not_exist: insert_info.num_did_not_exist,
+            num_existed_in_mem: insert_info.num_existed_in_mem,
+            num_existed_on_disk: insert_info.num_existed_on_disk,
             slot_lt_hash,
         }
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -50,7 +50,7 @@ use {
         accounts_update_notifier_interface::{AccountForGeyser, AccountsUpdateNotifier},
         active_stats::{ActiveStatItem, ActiveStats},
         ancestors::Ancestors,
-        append_vec::{self, aligned_stored_size, IndexInfo, IndexInfoInner, STORE_META_OVERHEAD},
+        append_vec::{self, aligned_stored_size, STORE_META_OVERHEAD},
         buffered_reader::RequiredLenBufFileRead,
         contains::Contains,
         is_zero_lamport::IsZeroLamport,
@@ -6537,31 +6537,7 @@ impl AccountsDb {
         let mut zero_lamport_offsets = vec![];
         let mut all_accounts_are_zero_lamports = true;
         let mut slot_lt_hash = SlotLtHash::default();
-
         let mut keyed_account_infos = vec![];
-        // this closure is the shared code when scanning the storage
-        let mut itemizer = |info: IndexInfo| {
-            stored_size_alive += info.stored_size_aligned;
-            if info.index_info.lamports > 0 {
-                accounts_data_len += info.index_info.data_len;
-                all_accounts_are_zero_lamports = false;
-            } else {
-                // With obsolete accounts enabled, all zero lamport accounts
-                // are obsolete or single ref by the end of index generation
-                // Store the offsets here
-                if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
-                    zero_lamport_offsets.push(info.index_info.offset);
-                }
-                zero_lamport_pubkeys.push(info.index_info.pubkey);
-            }
-            keyed_account_infos.push((
-                info.index_info.pubkey,
-                AccountInfo::new(
-                    StorageLocation::AppendVec(store_id, info.index_info.offset), // will never be cached
-                    info.index_info.is_zero_lamport(),
-                ),
-            ));
-        };
 
         let geyser_notifier = self
             .accounts_update_notifier
@@ -6582,18 +6558,28 @@ impl AccountsDb {
         storage
             .accounts
             .scan_accounts(reader, |offset, account| {
-                let data_len = account.data.len() as u64;
-                let stored_size_aligned = storage.accounts.calculate_stored_size(data_len as usize);
-                let info = IndexInfo {
-                    stored_size_aligned,
-                    index_info: IndexInfoInner {
-                        offset,
-                        pubkey: *account.pubkey,
-                        lamports: account.lamports,
-                        data_len,
-                    },
-                };
-                itemizer(info);
+                let data_len = account.data.len();
+                stored_size_alive += storage.accounts.calculate_stored_size(data_len);
+                if account.lamports > 0 {
+                    accounts_data_len += data_len as u64;
+                    all_accounts_are_zero_lamports = false;
+                } else {
+                    // With obsolete accounts enabled, all zero lamport accounts
+                    // are obsolete or single ref by the end of index generation
+                    // Store the offsets here
+                    if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
+                        zero_lamport_offsets.push(offset);
+                    }
+                    zero_lamport_pubkeys.push(*account.pubkey);
+                }
+                keyed_account_infos.push((
+                    *account.pubkey,
+                    AccountInfo::new(
+                        StorageLocation::AppendVec(store_id, offset), // will never be cached
+                        account.is_zero_lamport(),
+                    ),
+                ));
+
                 if !self.account_indexes.is_empty() {
                     self.accounts_index.update_secondary_indexes(
                         account.pubkey,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6538,97 +6538,96 @@ impl AccountsDb {
         let mut all_accounts_are_zero_lamports = true;
         let mut slot_lt_hash = SlotLtHash::default();
 
-        let (insert_time_us, generate_index_results) = {
-            let mut keyed_account_infos = vec![];
-            // this closure is the shared code when scanning the storage
-            let mut itemizer = |info: IndexInfo| {
-                stored_size_alive += info.stored_size_aligned;
-                if info.index_info.lamports > 0 {
-                    accounts_data_len += info.index_info.data_len;
-                    all_accounts_are_zero_lamports = false;
-                } else {
-                    // With obsolete accounts enabled, all zero lamport accounts
-                    // are obsolete or single ref by the end of index generation
-                    // Store the offsets here
-                    if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
-                        zero_lamport_offsets.push(info.index_info.offset);
-                    }
-                    zero_lamport_pubkeys.push(info.index_info.pubkey);
+        let mut keyed_account_infos = vec![];
+        // this closure is the shared code when scanning the storage
+        let mut itemizer = |info: IndexInfo| {
+            stored_size_alive += info.stored_size_aligned;
+            if info.index_info.lamports > 0 {
+                accounts_data_len += info.index_info.data_len;
+                all_accounts_are_zero_lamports = false;
+            } else {
+                // With obsolete accounts enabled, all zero lamport accounts
+                // are obsolete or single ref by the end of index generation
+                // Store the offsets here
+                if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
+                    zero_lamport_offsets.push(info.index_info.offset);
                 }
-                keyed_account_infos.push((
-                    info.index_info.pubkey,
-                    AccountInfo::new(
-                        StorageLocation::AppendVec(store_id, info.index_info.offset), // will never be cached
-                        info.index_info.is_zero_lamport(),
-                    ),
-                ));
-            };
-
-            let geyser_notifier = self
-                .accounts_update_notifier
-                .as_ref()
-                .filter(|notifier| notifier.snapshot_notifications_enabled());
-
-            // If geyser notifications at startup from snapshot are enabled, we need to pass in a
-            // write version for each account notification.  This value does not need to be
-            // globally unique, as geyser plugins also receive the slot number.  We only need to
-            // ensure that more recent accounts have a higher write version than older accounts.
-            // Even more relaxed, we really only need to have different write versions if there are
-            // multiple versions of the same account in a single storage, which is not allowed.
-            //
-            // Since we scan the storage from oldest to newest, we can simply increment a local
-            // counter per account and use that for the write version.
-            let mut write_version_for_geyser = 0;
-
-            storage
-                .accounts
-                .scan_accounts(reader, |offset, account| {
-                    let data_len = account.data.len() as u64;
-                    let stored_size_aligned =
-                        storage.accounts.calculate_stored_size(data_len as usize);
-                    let info = IndexInfo {
-                        stored_size_aligned,
-                        index_info: IndexInfoInner {
-                            offset,
-                            pubkey: *account.pubkey,
-                            lamports: account.lamports,
-                            data_len,
-                        },
-                    };
-                    itemizer(info);
-                    if !self.account_indexes.is_empty() {
-                        self.accounts_index.update_secondary_indexes(
-                            account.pubkey,
-                            &account,
-                            &self.account_indexes,
-                        );
-                    }
-
-                    let account_lt_hash = Self::lt_hash_account(&account, account.pubkey());
-                    slot_lt_hash.0.mix_in(&account_lt_hash.0);
-
-                    if let Some(geyser_notifier) = geyser_notifier {
-                        debug_assert!(geyser_notifier.snapshot_notifications_enabled());
-                        let account_for_geyser = AccountForGeyser {
-                            pubkey: account.pubkey(),
-                            lamports: account.lamports(),
-                            owner: account.owner(),
-                            executable: account.executable(),
-                            rent_epoch: account.rent_epoch(),
-                            data: account.data(),
-                        };
-                        geyser_notifier.notify_account_restore_from_snapshot(
-                            slot,
-                            write_version_for_geyser,
-                            &account_for_geyser,
-                        );
-                        write_version_for_geyser += 1;
-                    }
-                })
-                .expect("must scan accounts storage");
-            self.accounts_index
-                .insert_new_if_missing_into_primary_index(slot, keyed_account_infos)
+                zero_lamport_pubkeys.push(info.index_info.pubkey);
+            }
+            keyed_account_infos.push((
+                info.index_info.pubkey,
+                AccountInfo::new(
+                    StorageLocation::AppendVec(store_id, info.index_info.offset), // will never be cached
+                    info.index_info.is_zero_lamport(),
+                ),
+            ));
         };
+
+        let geyser_notifier = self
+            .accounts_update_notifier
+            .as_ref()
+            .filter(|notifier| notifier.snapshot_notifications_enabled());
+
+        // If geyser notifications at startup from snapshot are enabled, we need to pass in a
+        // write version for each account notification.  This value does not need to be
+        // globally unique, as geyser plugins also receive the slot number.  We only need to
+        // ensure that more recent accounts have a higher write version than older accounts.
+        // Even more relaxed, we really only need to have different write versions if there are
+        // multiple versions of the same account in a single storage, which is not allowed.
+        //
+        // Since we scan the storage from oldest to newest, we can simply increment a local
+        // counter per account and use that for the write version.
+        let mut write_version_for_geyser = 0;
+
+        storage
+            .accounts
+            .scan_accounts(reader, |offset, account| {
+                let data_len = account.data.len() as u64;
+                let stored_size_aligned = storage.accounts.calculate_stored_size(data_len as usize);
+                let info = IndexInfo {
+                    stored_size_aligned,
+                    index_info: IndexInfoInner {
+                        offset,
+                        pubkey: *account.pubkey,
+                        lamports: account.lamports,
+                        data_len,
+                    },
+                };
+                itemizer(info);
+                if !self.account_indexes.is_empty() {
+                    self.accounts_index.update_secondary_indexes(
+                        account.pubkey,
+                        &account,
+                        &self.account_indexes,
+                    );
+                }
+
+                let account_lt_hash = Self::lt_hash_account(&account, account.pubkey());
+                slot_lt_hash.0.mix_in(&account_lt_hash.0);
+
+                if let Some(geyser_notifier) = geyser_notifier {
+                    debug_assert!(geyser_notifier.snapshot_notifications_enabled());
+                    let account_for_geyser = AccountForGeyser {
+                        pubkey: account.pubkey(),
+                        lamports: account.lamports(),
+                        owner: account.owner(),
+                        executable: account.executable(),
+                        rent_epoch: account.rent_epoch(),
+                        data: account.data(),
+                    };
+                    geyser_notifier.notify_account_restore_from_snapshot(
+                        slot,
+                        write_version_for_geyser,
+                        &account_for_geyser,
+                    );
+                    write_version_for_geyser += 1;
+                }
+            })
+            .expect("must scan accounts storage");
+
+        let (insert_time_us, generate_index_results) = self
+            .accounts_index
+            .insert_new_if_missing_into_primary_index(slot, keyed_account_infos);
 
         {
             // second, collect into the shared DashMap once we've figured out all the info per store_id

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -124,38 +124,6 @@ impl<'a> ValidSlice<'a> {
     }
 }
 
-/// info from an entry useful for building an index
-pub(crate) struct IndexInfo {
-    /// size of entry, aligned to next u64
-    /// This matches the return of `get_account`
-    pub stored_size_aligned: usize,
-    /// info on the entry
-    pub index_info: IndexInfoInner,
-}
-
-/// info from an entry useful for building an index
-pub(crate) struct IndexInfoInner {
-    /// offset to this entry
-    pub offset: usize,
-    pub pubkey: Pubkey,
-    pub lamports: u64,
-    pub data_len: u64,
-}
-
-impl IsZeroLamport for IndexInfoInner {
-    #[inline(always)]
-    fn is_zero_lamport(&self) -> bool {
-        self.lamports == 0
-    }
-}
-
-impl IsZeroLamport for IndexInfo {
-    #[inline(always)]
-    fn is_zero_lamport(&self) -> bool {
-        self.index_info.is_zero_lamport()
-    }
-}
-
 /// offsets to help navigate the persisted format of `AppendVec`
 #[derive(Debug)]
 struct AccountOffsets {


### PR DESCRIPTION
#### Problem

There's some cruft in generate_index_for_slot() that can now be cleaned up. This was a remnant from when we used to either scan with or without account data based on secondary indexes.


#### Summary of Changes

- remove unnecessary scope
- remove itemizer lambda
- rename to insert_info

Note to reviewers: I recommend going commit-by-commit, and also ignoring whitespace.