### PR TITLE
Removes --accounts-db-hash-threads

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -10,7 +10,7 @@ use {
     solana_clap_utils::{
         hidden_unless_forced,
         input_parsers::pubkeys_of,
-        input_validators::{is_parsable, is_pow2, is_within_range},
+        input_validators::{is_parsable, is_pow2},
     },
     solana_cli_output::CliAccountNewConfig,
     solana_clock::Slot,
@@ -21,7 +21,6 @@ use {
     solana_runtime::runtime_config::RuntimeConfig,
     std::{
         collections::HashSet,
-        num::NonZeroUsize,
         path::{Path, PathBuf},
         sync::Arc,
     },
@@ -107,13 +106,6 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .takes_value(true)
             .possible_values(&["mmap", "file"])
             .help("Access account storages using this method"),
-        Arg::with_name("accounts_db_hash_threads")
-            .long("accounts-db-hash-threads")
-            .value_name("NUM_THREADS")
-            .takes_value(true)
-            .validator(|s| is_within_range(s, 1..=num_cpus::get()))
-            .help("Number of threads to use for background accounts hashing")
-            .hidden(hidden_unless_forced()),
         Arg::with_name("accounts_db_ancient_storage_ideal_size")
             .long("accounts-db-ancient-storage-ideal-size")
             .value_name("BYTES")
@@ -290,10 +282,6 @@ pub fn get_accounts_db_config(
         })
         .unwrap_or_default();
 
-    let num_hash_threads = arg_matches
-        .is_present("accounts_db_hash_threads")
-        .then(|| value_t_or_exit!(arg_matches, "accounts_db_hash_threads", NonZeroUsize));
-
     AccountsDbConfig {
         index: Some(accounts_index_config),
         base_working_path: Some(ledger_tool_ledger_path),
@@ -310,7 +298,6 @@ pub fn get_accounts_db_config(
         skip_initial_hash_calc: arg_matches.is_present("accounts_db_skip_initial_hash_calculation"),
         storage_access,
         scan_filter_for_shrinking,
-        num_hash_threads,
         memlock_budget_size: DEFAULT_MEMLOCK_BUDGET_SIZE,
         ..AccountsDbConfig::default()
     }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -136,6 +136,14 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         replaced_by: "accounts-db-background-threads",
     );
     add_arg!(
+        // deprecated in v3.1.0
+        Arg::with_name("accounts_db_hash_threads")
+            .long("accounts-db-hash-threads")
+            .takes_value(true)
+            .value_name("NUMBER"),
+        usage_warning: "There is no more startup background accounts hash calculation",
+    );
+    add_arg!(
         // deprecated in v3.0.0
         Arg::with_name("accounts_db_read_cache_limit_mb")
             .long("accounts-db-read-cache-limit-mb")

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -13,7 +13,6 @@ use {
 pub struct DefaultThreadArgs {
     pub accounts_db_background_threads: String,
     pub accounts_db_foreground_threads: String,
-    pub accounts_db_hash_threads: String,
     pub accounts_index_flush_threads: String,
     pub block_production_num_workers: String,
     pub ip_echo_server_threads: String,
@@ -37,7 +36,6 @@ impl Default for DefaultThreadArgs {
                 .to_string(),
             accounts_db_foreground_threads: AccountsDbForegroundThreadsArg::bounded_default()
                 .to_string(),
-            accounts_db_hash_threads: AccountsDbHashThreadsArg::bounded_default().to_string(),
             accounts_index_flush_threads: AccountsIndexFlushThreadsArg::bounded_default()
                 .to_string(),
             block_production_num_workers: BankingStage::default_num_workers().to_string(),
@@ -65,7 +63,6 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
     vec![
         new_thread_arg::<AccountsDbBackgroundThreadsArg>(&defaults.accounts_db_background_threads),
         new_thread_arg::<AccountsDbForegroundThreadsArg>(&defaults.accounts_db_foreground_threads),
-        new_thread_arg::<AccountsDbHashThreadsArg>(&defaults.accounts_db_hash_threads),
         new_thread_arg::<AccountsIndexFlushThreadsArg>(&defaults.accounts_index_flush_threads),
         new_thread_arg::<BlockProductionNumWorkersArg>(&defaults.block_production_num_workers),
         new_thread_arg::<IpEchoServerThreadsArg>(&defaults.ip_echo_server_threads),
@@ -101,7 +98,6 @@ fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
 pub struct NumThreadConfig {
     pub accounts_db_background_threads: NonZeroUsize,
     pub accounts_db_foreground_threads: NonZeroUsize,
-    pub accounts_db_hash_threads: NonZeroUsize,
     pub accounts_index_flush_threads: NonZeroUsize,
     pub block_production_num_workers: NonZeroUsize,
     pub ip_echo_server_threads: NonZeroUsize,
@@ -129,11 +125,6 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
         accounts_db_foreground_threads: value_t_or_exit!(
             matches,
             AccountsDbForegroundThreadsArg::NAME,
-            NonZeroUsize
-        ),
-        accounts_db_hash_threads: value_t_or_exit!(
-            matches,
-            AccountsDbHashThreadsArg::NAME,
             NonZeroUsize
         ),
         accounts_index_flush_threads: value_t_or_exit!(
@@ -239,17 +230,6 @@ impl ThreadArg for AccountsDbForegroundThreadsArg {
 
     fn default() -> usize {
         accounts_db::default_num_foreground_threads()
-    }
-}
-
-struct AccountsDbHashThreadsArg;
-impl ThreadArg for AccountsDbHashThreadsArg {
-    const NAME: &'static str = "accounts_db_hash_threads";
-    const LONG_NAME: &'static str = "accounts-db-hash-threads";
-    const HELP: &'static str = "Number of threads to use for accounts hash verification at startup";
-
-    fn default() -> usize {
-        accounts_db::default_num_hash_threads().get()
     }
 }
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -100,7 +100,6 @@ pub fn execute(
     let cli::thread_args::NumThreadConfig {
         accounts_db_background_threads,
         accounts_db_foreground_threads,
-        accounts_db_hash_threads,
         accounts_index_flush_threads,
         block_production_num_workers,
         ip_echo_server_threads,
@@ -443,7 +442,6 @@ pub fn execute(
         scan_filter_for_shrinking,
         num_background_threads: Some(accounts_db_background_threads),
         num_foreground_threads: Some(accounts_db_foreground_threads),
-        num_hash_threads: Some(accounts_db_hash_threads),
         mark_obsolete_accounts,
         memlock_budget_size: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_SIZE,
         ..AccountsDbConfig::default()


### PR DESCRIPTION
#### Problem

At startup, accounts verification is now done inline and not pushed to the the background. As such, the `--accounts-db-hash-threads` cli (et al) is now obsolete.


#### Summary of Changes

Remove it!