### PR TITLE
Set latest full snapshot slot in various tests to make behaviour consistent with mark obsolete accounts enabled

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1375,7 +1375,7 @@ fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
     let pubkey2 = solana_pubkey::new_rand();
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
-    // If there is no latest full snapshot, zero lamport accounts can be cleaned and removed 
+    // If there is no latest full snapshot, zero lamport accounts can be cleaned and removed
     // immediately. Set latest full snapshot slot to zero to avoid cleaning zero lamport accounts
     accounts.set_latest_full_snapshot_slot(0);
 
@@ -1764,7 +1764,7 @@ fn test_accounts_db_purge_keep_live() {
     let accounts = AccountsDb::new_single_for_tests();
     accounts.add_root_and_flush_write_cache(0);
 
-    // If there is no latest full snapshot, zero lamport accounts can be cleaned and removed 
+    // If there is no latest full snapshot, zero lamport accounts can be cleaned and removed
     // immediately. Set latest full snapshot slot to zero to avoid cleaning zero lamport accounts
     accounts.set_latest_full_snapshot_slot(0);
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1375,8 +1375,8 @@ fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
     let pubkey2 = solana_pubkey::new_rand();
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
-    // If there's not a latest full snapshot, zero lamport accounts can be cleaned and removed immediately
-    // Set latest full snapshot slot to zero to avoid cleaning zero lamport accounts
+    // If there is no latest full snapshot, zero lamport accounts can be cleaned and removed 
+    // immediately. Set latest full snapshot slot to zero to avoid cleaning zero lamport accounts
     accounts.set_latest_full_snapshot_slot(0);
 
     // Store 2 accounts in slot 0, then update account 1 in two more slots
@@ -1764,8 +1764,8 @@ fn test_accounts_db_purge_keep_live() {
     let accounts = AccountsDb::new_single_for_tests();
     accounts.add_root_and_flush_write_cache(0);
 
-    // When snapshots are not enabled, zero lamport accounts can be purged immediately
-    // Set snapshot slot to zero to avoid purging zero lamport accounts
+    // If there is no latest full snapshot, zero lamport accounts can be cleaned and removed 
+    // immediately. Set latest full snapshot slot to zero to avoid cleaning zero lamport accounts
     accounts.set_latest_full_snapshot_slot(0);
 
     // Step A

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1375,7 +1375,7 @@ fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
     let pubkey2 = solana_pubkey::new_rand();
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
-    // When snapshots are not enabled, zero lamport accounts can be cleaned and removed immediately
+    // If there's not a latest full snapshot, zero lamport accounts can be cleaned and removed immediately
     // Set latest full snapshot slot to zero to avoid cleaning zero lamport accounts
     accounts.set_latest_full_snapshot_slot(0);
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1376,7 +1376,7 @@ fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
     // When snapshots are not enabled, zero lamport accounts can be cleaned and removed immediately
-    // Set snapshot slot to zero to avoid cleaning zero lamport accounts
+    // Set latest full snapshot slot to zero to avoid cleaning zero lamport accounts
     accounts.set_latest_full_snapshot_slot(0);
 
     // Store 2 accounts in slot 0, then update account 1 in two more slots

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3378,10 +3378,6 @@ fn test_flush_cache_dont_clean_zero_lamport_account() {
         AccountSharedData::new(original_lamports, 1, AccountSharedData::default().owner());
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
-    // Without snapshots, mark_obsolete_accounts can always discard dead_accounts
-    // Setting a full snapshot to 0 to ensure preservation
-    db.set_latest_full_snapshot_slot(0);
-
     // Store into slot 0, and then flush the slot to storage
     db.store_for_tests((0, &[(&zero_lamport_account_key, &slot0_account)][..]));
     // Second key keeps other lamport account entry for slot 0 alive,

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -523,6 +523,9 @@ mod serde_snapshot_tests {
     fn test_accounts_purge_chained_purge_before_snapshot_restore(storage_access: StorageAccess) {
         solana_logger::setup();
         with_chained_zero_lamport_accounts(|accounts, current_slot| {
+            // When snapshots are not enabled, zero lamport accounts can be cleaned immediately
+            // Set snapshot slot to zero to avoid purging before saving the snapshot
+            accounts.set_latest_full_snapshot_slot(0);
             accounts.clean_accounts_for_tests();
             reconstruct_accounts_db_via_serialization(&accounts, current_slot, storage_access)
         });

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -523,8 +523,8 @@ mod serde_snapshot_tests {
     fn test_accounts_purge_chained_purge_before_snapshot_restore(storage_access: StorageAccess) {
         solana_logger::setup();
         with_chained_zero_lamport_accounts(|accounts, current_slot| {
-            // If there is no latest full snapshot, zero lamport accounts can be cleaned and 
-            // removed immediately. Set latest full snapshot slot to zero to avoid cleaning 
+            // If there is no latest full snapshot, zero lamport accounts can be cleaned and
+            // removed immediately. Set latest full snapshot slot to zero to avoid cleaning
             // zero lamport accounts
             accounts.set_latest_full_snapshot_slot(0);
             accounts.clean_accounts_for_tests();

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -523,8 +523,9 @@ mod serde_snapshot_tests {
     fn test_accounts_purge_chained_purge_before_snapshot_restore(storage_access: StorageAccess) {
         solana_logger::setup();
         with_chained_zero_lamport_accounts(|accounts, current_slot| {
-            // When snapshots are not enabled, zero lamport accounts can be cleaned immediately
-            // Set snapshot slot to zero to avoid purging before saving the snapshot
+            // If there is no latest full snapshot, zero lamport accounts can be cleaned and 
+            // removed immediately. Set latest full snapshot slot to zero to avoid cleaning 
+            // zero lamport accounts
             accounts.set_latest_full_snapshot_slot(0);
             accounts.clean_accounts_for_tests();
             reconstruct_accounts_db_via_serialization(&accounts, current_slot, storage_access)


### PR DESCRIPTION
#### Problem
- Some tests attempt to test clean behaviour with zero lamport accounts. 
- with obsolete accounts, the zero lamport accounts can be cleaned if the latest full snapshot slot is not set.  

#### Summary of Changes
- Given that the purpose of these tests is to test clean behaviour, and not the behaviour to setup the accounts: Set the latest snapshot slot so that the tests can run with mark_obsolete_accounts disabled or enabled. 

General Update: After this change there are 9 tests failing with obsolete accounts enabled. Almost there! 
```
    accounts_db::tests::test_accountsdb_count_stores::append_vec
    accounts_db::tests::test_accountsdb_count_stores::hot_storage
    accounts_db::tests::test_flush_cache_dont_clean_zero_lamport_account
    accounts_db::tests::test_remove_zero_lamport_multi_ref_accounts_panic
    accounts_db::tests::test_remove_zero_lamport_single_ref_accounts_after_shrink
    accounts_db::tests::test_shrink_unref
    accounts_db::tests::test_shrink_unref_handle_zero_lamport_single_ref_accounts
    test serde_snapshot::tests::serde_snapshot_tests::test_accounts_db_serialize1::storageaccess_file_markobsoleteaccounts_disabled_expects
    test serde_snapshot::tests::serde_snapshot_tests::test_accounts_db_serialize1::storageaccess_mmap_markobsoleteaccounts_disabled_expects
```
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
