### PR TITLE
poh recording performance improvement

### DIFF
--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -503,6 +503,9 @@ impl SimulatorLoop {
                     new_bank,
                 );
                 // Wait for the controller message to be processed.
+                // This loop assumes that
+                // `update_bank_forks_and_poh_recorder_for_new_tpu_bank`
+                // takes immediate effect in PohRecorder's working bank.
                 while self.poh_controller.has_pending_message() {}
 
                 (bank, bank_created) = (

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -743,7 +743,7 @@ impl BankingSimulator {
         );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
         let (record_sender, record_receiver) = record_channels(false);
-        let transaction_recorder = TransactionRecorder::new(record_sender, exit.clone());
+        let transaction_recorder = TransactionRecorder::new(record_sender);
         let (poh_controller, poh_service_message_receiver) = PohController::new();
         let poh_service = PohService::new(
             poh_recorder.clone(),

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -502,6 +502,9 @@ impl SimulatorLoop {
                     &mut self.poh_controller,
                     new_bank,
                 );
+                // Wait for the controller message to be processed.
+                while self.poh_controller.has_pending_message() {}
+
                 (bank, bank_created) = (
                     self.bank_forks
                         .read()

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -29,6 +29,7 @@ use {
         poh_controller::PohController,
         poh_recorder::{PohRecorder, GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS},
         poh_service::{PohService, DEFAULT_HASHES_PER_BATCH, DEFAULT_PINNED_CPU_CORE},
+        record_channels::record_channels,
         transaction_recorder::TransactionRecorder,
     },
     solana_pubkey::Pubkey,
@@ -741,7 +742,7 @@ impl BankingSimulator {
             exit.clone(),
         );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(false);
         let transaction_recorder = TransactionRecorder::new(record_sender, exit.clone());
         let (poh_controller, poh_service_message_receiver) = PohController::new();
         let poh_service = PohService::new(

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1185,7 +1185,7 @@ mod tests {
     }
 
     pub(crate) fn simulate_poh(
-        record_receiver: RecordReceiver,
+        mut record_receiver: RecordReceiver,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
     ) -> JoinHandle<()> {
         let poh_recorder = poh_recorder.clone();
@@ -1195,8 +1195,9 @@ mod tests {
             .spawn(move || loop {
                 PohService::read_record_receiver_and_process(
                     &poh_recorder,
-                    &record_receiver,
+                    &mut record_receiver,
                     Duration::from_millis(10),
+                    64,
                 );
                 if is_exited.load(Ordering::Relaxed) {
                     break;

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -694,13 +694,11 @@ mod tests {
                 create_genesis_config, create_genesis_config_with_leader, GenesisConfigInfo,
             },
             get_tmp_ledger_path_auto_delete,
-            leader_schedule_cache::LeaderScheduleCache,
         },
         solana_perf::packet::to_packet_batches,
         solana_poh::{
             poh_recorder::{create_test_recorder, PohRecorderError},
-            poh_service::PohService,
-            record_channels::{record_channels, RecordReceiver},
+            record_channels::record_channels,
             transaction_recorder::RecordTransactionsSummary,
         },
         solana_poh_config::PohConfig,
@@ -712,11 +710,7 @@ mod tests {
         solana_transaction::{sanitized::SanitizedTransaction, Transaction},
         solana_vote::vote_transaction::new_tower_sync_transaction,
         solana_vote_program::vote_state::TowerSync,
-        std::{
-            sync::atomic::{AtomicBool, Ordering},
-            thread::sleep,
-            time::Instant,
-        },
+        std::{sync::atomic::Ordering, thread::sleep, time::Instant},
         test_case::test_case,
     };
 
@@ -1110,31 +1104,11 @@ mod tests {
             ..
         } = create_genesis_config(10_000);
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path())
-            .expect("Expected to be able to open database ledger");
-        let (poh_recorder, entry_receiver) = PohRecorder::new(
-            // TODO use record_receiver
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            None,
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let (record_sender, record_receiver) = record_channels(false);
-        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
-        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
+        let (record_sender, mut record_receiver) = record_channels(false);
+        let recorder = TransactionRecorder::new(record_sender);
+        record_receiver.restart(bank.slot());
 
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
         let pubkey = solana_pubkey::new_rand();
         let keypair2 = Keypair::new();
         let pubkey2 = solana_pubkey::new_rand();
@@ -1144,9 +1118,13 @@ mod tests {
             system_transaction::transfer(&keypair2, &pubkey2, 1, genesis_config.hash()).into(),
         ];
 
-        let _ = recorder.record_transactions(bank.slot(), txs.clone());
-        let (_bank, (entry, _tick_height)) = entry_receiver.recv().unwrap();
-        assert_eq!(entry.transactions, txs);
+        let summary = recorder.record_transactions(bank.slot(), txs.clone());
+        assert!(summary.result.is_ok());
+        assert_eq!(
+            record_receiver.try_recv().unwrap().transaction_batches,
+            vec![txs.clone()]
+        );
+        assert!(record_receiver.try_recv().is_err());
 
         // Once bank is set to a new bank (setting bank.slot() + 1 in record_transactions),
         // record_transactions should throw MaxHeightReached
@@ -1154,14 +1132,7 @@ mod tests {
         let RecordTransactionsSummary { result, .. } = recorder.record_transactions(next_slot, txs);
         assert_matches!(result, Err(PohRecorderError::MaxHeightReached));
         // Should receive nothing from PohRecorder b/c record failed
-        assert!(entry_receiver.try_recv().is_err());
-
-        poh_recorder
-            .read()
-            .unwrap()
-            .is_exited
-            .store(true, Ordering::Relaxed);
-        let _ = poh_simulator.join();
+        assert!(record_receiver.try_recv().is_err());
     }
 
     pub(crate) fn create_slow_genesis_config(lamports: u64) -> GenesisConfigInfo {
@@ -1182,28 +1153,6 @@ mod tests {
         // For these tests there's only 1 slot, don't want to run out of ticks
         config_info.genesis_config.ticks_per_slot *= 1024;
         config_info
-    }
-
-    pub(crate) fn simulate_poh(
-        mut record_receiver: RecordReceiver,
-        poh_recorder: &Arc<RwLock<PohRecorder>>,
-    ) -> JoinHandle<()> {
-        let poh_recorder = poh_recorder.clone();
-        let is_exited = poh_recorder.read().unwrap().is_exited.clone();
-        let tick_producer = Builder::new()
-            .name("solana-simulate_poh".to_string())
-            .spawn(move || loop {
-                PohService::read_record_receiver_and_process(
-                    &poh_recorder,
-                    &mut record_receiver,
-                    Duration::from_millis(10),
-                    64,
-                );
-                if is_exited.load(Ordering::Relaxed) {
-                    break;
-                }
-            });
-        tick_producer.unwrap()
     }
 
     #[test_case(TransactionStructure::Sdk)]

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -683,7 +683,7 @@ mod tests {
         super::*,
         crate::banking_trace::{BankingTracer, Channels},
         agave_banking_stage_ingress_types::BankingPacketBatch,
-        crossbeam_channel::{unbounded, Receiver},
+        crossbeam_channel::unbounded,
         itertools::Itertools,
         solana_entry::entry::{self, EntrySlice},
         solana_hash::Hash,
@@ -698,8 +698,9 @@ mod tests {
         },
         solana_perf::packet::to_packet_batches,
         solana_poh::{
-            poh_recorder::{create_test_recorder, PohRecorderError, Record},
+            poh_recorder::{create_test_recorder, PohRecorderError},
             poh_service::PohService,
+            record_channels::{record_channels, RecordReceiver},
             transaction_recorder::RecordTransactionsSummary,
         },
         solana_poh_config::PohConfig,
@@ -1124,7 +1125,7 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
@@ -1184,7 +1185,7 @@ mod tests {
     }
 
     pub(crate) fn simulate_poh(
-        record_receiver: Receiver<Record>,
+        record_receiver: RecordReceiver,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
     ) -> JoinHandle<()> {
         let poh_recorder = poh_recorder.clone();

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -765,26 +765,21 @@ mod tests {
             committer::Committer,
             qos_service::QosService,
             scheduler_messages::{MaxAge, TransactionBatchId},
-            tests::{create_slow_genesis_config, sanitize_transactions, simulate_poh},
+            tests::{create_slow_genesis_config, sanitize_transactions},
         },
         crossbeam_channel::unbounded,
         solana_clock::{Slot, MAX_PROCESSING_AGE},
         solana_genesis_config::GenesisConfig,
         solana_keypair::Keypair,
-        solana_ledger::{
-            blockstore::Blockstore, genesis_utils::GenesisConfigInfo,
-            get_tmp_ledger_path_auto_delete, leader_schedule_cache::LeaderScheduleCache,
-        },
+        solana_ledger::genesis_utils::GenesisConfigInfo,
         solana_message::{
             v0::{self, LoadedAddresses},
             AddressLookupTableAccount, SimpleAddressLoader, VersionedMessage,
         },
         solana_poh::{
-            poh_recorder::{PohRecorder, WorkingBankEntry},
-            record_channels::record_channels,
+            record_channels::{record_channels, RecordReceiver},
             transaction_recorder::TransactionRecorder,
         },
-        solana_poh_config::PohConfig,
         solana_pubkey::Pubkey,
         solana_runtime::{
             bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
@@ -803,9 +798,7 @@ mod tests {
         std::{
             collections::HashSet,
             sync::{atomic::AtomicBool, RwLock},
-            thread::JoinHandle,
         },
-        tempfile::TempDir,
         test_case::test_case,
     };
 
@@ -816,11 +809,9 @@ mod tests {
         genesis_config: GenesisConfig,
         bank: Arc<Bank>,
         _bank_forks: Arc<RwLock<BankForks>>,
-        _ledger_path: TempDir,
-        _entry_receiver: Receiver<WorkingBankEntry>,
-        poh_recorder: Arc<RwLock<PohRecorder>>,
-        _poh_simulator: JoinHandle<()>,
         _replay_vote_receiver: ReplayVoteReceiver,
+        record_receiver: RecordReceiver,
+        shared_working_bank: SharedWorkingBank,
 
         consume_sender: Sender<ConsumeWork<RuntimeTransaction<SanitizedTransaction>>>,
         consumed_receiver: Receiver<FinishedConsumeWork<RuntimeTransaction<SanitizedTransaction>>>,
@@ -849,24 +840,8 @@ mod tests {
         }
         let bank = Arc::new(bank);
 
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path())
-            .expect("Expected to be able to open database ledger");
-        let (poh_recorder, entry_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
         let (record_sender, record_receiver) = record_channels(false);
-        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
-        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
+        let recorder = TransactionRecorder::new(record_sender);
 
         let (replay_vote_sender, replay_vote_receiver) = unbounded();
         let committer = Committer::new(
@@ -875,6 +850,7 @@ mod tests {
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
         let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let shared_working_bank = SharedWorkingBank::empty();
 
         let (consume_sender, consume_receiver) = unbounded();
         let (consumed_sender, consumed_receiver) = unbounded();
@@ -884,7 +860,7 @@ mod tests {
             consume_receiver,
             consumer,
             consumed_sender,
-            poh_recorder.read().unwrap().shared_working_bank(),
+            shared_working_bank.clone(),
         );
 
         (
@@ -893,11 +869,9 @@ mod tests {
                 genesis_config,
                 bank,
                 _bank_forks: bank_forks,
-                _ledger_path: ledger_path,
-                _entry_receiver: entry_receiver,
-                poh_recorder,
-                _poh_simulator: poh_simulator,
                 _replay_vote_receiver: replay_vote_receiver,
+                record_receiver,
+                shared_working_bank,
                 consume_sender,
                 consumed_receiver,
             },
@@ -951,21 +925,20 @@ mod tests {
 
     #[test]
     fn test_worker_consume_simple() {
-        let (test_frame, worker) = setup_test_frame(true);
+        let (mut test_frame, worker) = setup_test_frame(true);
         let TestFrame {
             mint_keypair,
             genesis_config,
             bank,
-            poh_recorder,
+            ref mut record_receiver,
+            ref mut shared_working_bank,
             consume_sender,
             consumed_receiver,
             ..
-        } = &test_frame;
+        } = &mut test_frame;
         let worker_thread = std::thread::spawn(move || worker.run());
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
+        shared_working_bank.store(bank.clone());
+        record_receiver.restart(bank.slot());
 
         let pubkey1 = Pubkey::new_unique();
 
@@ -1001,21 +974,20 @@ mod tests {
     #[test_case(false; "old")]
     #[test_case(true; "simd83")]
     fn test_worker_consume_self_conflicting(relax_intrabatch_account_locks: bool) {
-        let (test_frame, worker) = setup_test_frame(relax_intrabatch_account_locks);
+        let (mut test_frame, worker) = setup_test_frame(relax_intrabatch_account_locks);
         let TestFrame {
             mint_keypair,
             genesis_config,
             bank,
-            poh_recorder,
+            ref mut record_receiver,
+            ref mut shared_working_bank,
             consume_sender,
             consumed_receiver,
             ..
-        } = &test_frame;
+        } = &mut test_frame;
         let worker_thread = std::thread::spawn(move || worker.run());
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
+        shared_working_bank.store(bank.clone());
+        record_receiver.restart(bank.slot());
 
         let pubkey1 = Pubkey::new_unique();
         let pubkey2 = Pubkey::new_unique();
@@ -1062,21 +1034,20 @@ mod tests {
 
     #[test]
     fn test_worker_consume_multiple_messages() {
-        let (test_frame, worker) = setup_test_frame(true);
+        let (mut test_frame, worker) = setup_test_frame(true);
         let TestFrame {
             mint_keypair,
             genesis_config,
             bank,
-            poh_recorder,
+            ref mut record_receiver,
+            ref mut shared_working_bank,
             consume_sender,
             consumed_receiver,
             ..
-        } = &test_frame;
+        } = &mut test_frame;
         let worker_thread = std::thread::spawn(move || worker.run());
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
+        shared_working_bank.store(bank.clone());
+        record_receiver.restart(bank.slot());
 
         let pubkey1 = Pubkey::new_unique();
         let pubkey2 = Pubkey::new_unique();
@@ -1137,21 +1108,20 @@ mod tests {
 
     #[test]
     fn test_worker_ttl() {
-        let (test_frame, worker) = setup_test_frame(true);
+        let (mut test_frame, worker) = setup_test_frame(true);
         let TestFrame {
             mint_keypair,
             genesis_config,
             bank,
-            poh_recorder,
+            ref mut record_receiver,
+            ref mut shared_working_bank,
             consume_sender,
             consumed_receiver,
             ..
-        } = &test_frame;
+        } = &mut test_frame;
         let worker_thread = std::thread::spawn(move || worker.run());
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
+        shared_working_bank.store(bank.clone());
+        record_receiver.restart(bank.slot());
         assert!(bank.slot() > 0);
         assert!(bank.epoch() > 0);
 

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -781,6 +781,7 @@ mod tests {
         },
         solana_poh::{
             poh_recorder::{PohRecorder, WorkingBankEntry},
+            record_channels::record_channels,
             transaction_recorder::TransactionRecorder,
         },
         solana_poh_config::PohConfig,
@@ -862,7 +863,7 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -537,8 +537,7 @@ mod tests {
                 atomic::{AtomicBool, AtomicU64, Ordering},
                 Arc, RwLock,
             },
-            thread::{Builder, JoinHandle},
-            time::Duration,
+            thread::JoinHandle,
         },
         test_case::test_case,
     };
@@ -830,35 +829,10 @@ mod tests {
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         fn poh_tick_before_returning_record_response(
-            record_receiver: RecordReceiver,
-            poh_recorder: Arc<RwLock<PohRecorder>>,
+            _record_receiver: RecordReceiver,
+            _poh_recorder: Arc<RwLock<PohRecorder>>,
         ) -> JoinHandle<()> {
-            let is_exited = poh_recorder.read().unwrap().is_exited.clone();
-            let tick_producer = Builder::new()
-                .name("solana-simulate_poh".to_string())
-                .spawn(move || loop {
-                    let timeout = Duration::from_millis(10);
-                    let record = record_receiver.recv_timeout(timeout);
-                    if let Ok(record) = record {
-                        let record_response = poh_recorder.write().unwrap().record(
-                            record.slot,
-                            record.mixins,
-                            record.transaction_batches,
-                        );
-                        poh_recorder.write().unwrap().tick();
-                        if record
-                            .sender
-                            .send(record_response.map(|r| r.starting_transaction_index))
-                            .is_err()
-                        {
-                            panic!("Error returning mixin hash");
-                        }
-                    }
-                    if is_exited.load(Ordering::Relaxed) {
-                        break;
-                    }
-                });
-            tick_producer.unwrap()
+            todo!()
         }
 
         // Simulate a race condition by setting up poh to do the last tick

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -487,7 +487,7 @@ mod tests {
             create_slow_genesis_config, sanitize_transactions, simulate_poh,
         },
         agave_reserved_account_keys::ReservedAccountKeys,
-        crossbeam_channel::{unbounded, Receiver},
+        crossbeam_channel::unbounded,
         solana_account::{state_traits::StateMut, AccountSharedData},
         solana_address_lookup_table_interface::{
             self as address_lookup_table,
@@ -515,7 +515,10 @@ mod tests {
         },
         solana_nonce::{self as nonce, state::DurableNonce},
         solana_nonce_account::verify_nonce_account,
-        solana_poh::poh_recorder::{PohRecorder, Record},
+        solana_poh::{
+            poh_recorder::PohRecorder,
+            record_channels::{record_channels, RecordReceiver},
+        },
         solana_poh_config::PohConfig,
         solana_pubkey::Pubkey,
         solana_rpc::transaction_status_service::TransactionStatusService,
@@ -559,7 +562,7 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
@@ -670,7 +673,7 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
@@ -822,12 +825,12 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::new(false)),
         );
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         fn poh_tick_before_returning_record_response(
-            record_receiver: Receiver<Record>,
+            record_receiver: RecordReceiver,
             poh_recorder: Arc<RwLock<PohRecorder>>,
         ) -> JoinHandle<()> {
             let is_exited = poh_recorder.read().unwrap().is_exited.clone();
@@ -968,7 +971,7 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
@@ -1056,7 +1059,7 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
@@ -1249,7 +1252,7 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
@@ -1501,7 +1504,7 @@ mod tests {
 
         // Poh Recorder has no working bank, so should throw MaxHeightReached error on
         // record
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
 
         let poh_simulator = simulate_poh(record_receiver, &Arc::new(RwLock::new(poh_recorder)));
@@ -1612,7 +1615,7 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
@@ -1758,7 +1761,7 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -483,9 +483,7 @@ impl Consumer {
 mod tests {
     use {
         super::*,
-        crate::banking_stage::tests::{
-            create_slow_genesis_config, sanitize_transactions, simulate_poh,
-        },
+        crate::banking_stage::tests::{create_slow_genesis_config, sanitize_transactions},
         agave_reserved_account_keys::ReservedAccountKeys,
         crossbeam_channel::unbounded,
         solana_account::{state_traits::StateMut, AccountSharedData},
@@ -507,7 +505,6 @@ mod tests {
                 GenesisConfigInfo,
             },
             get_tmp_ledger_path_auto_delete,
-            leader_schedule_cache::LeaderScheduleCache,
         },
         solana_message::{
             v0::{self, MessageAddressTableLookup},
@@ -515,11 +512,7 @@ mod tests {
         },
         solana_nonce::{self as nonce, state::DurableNonce},
         solana_nonce_account::verify_nonce_account,
-        solana_poh::{
-            poh_recorder::PohRecorder,
-            record_channels::{record_channels, RecordReceiver},
-        },
-        solana_poh_config::PohConfig,
+        solana_poh::record_channels::record_channels,
         solana_pubkey::Pubkey,
         solana_rpc::transaction_status_service::TransactionStatusService,
         solana_runtime::prioritization_fee_cache::PrioritizationFeeCache,
@@ -534,43 +527,22 @@ mod tests {
         std::{
             borrow::Cow,
             sync::{
-                atomic::{AtomicBool, AtomicU64, Ordering},
-                Arc, RwLock,
+                atomic::{AtomicBool, AtomicU64},
+                Arc,
             },
-            thread::JoinHandle,
         },
         test_case::test_case,
     };
 
-    fn execute_transactions_with_dummy_poh_service(
+    fn execute_transactions_for_test(
         bank: Arc<Bank>,
         transactions: Vec<Transaction>,
     ) -> ProcessTransactionBatchOutput {
         let transactions = sanitize_transactions(transactions);
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path())
-            .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let (record_sender, record_receiver) = record_channels(false);
-        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
-
-        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
+        let (record_sender, mut record_receiver) = record_channels(false);
+        let recorder = TransactionRecorder::new(record_sender);
+        record_receiver.restart(bank.slot());
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(
@@ -579,17 +551,7 @@ mod tests {
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
         let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
-        let process_transactions_summary =
-            consumer.process_and_record_transactions(&bank, &transactions);
-
-        poh_recorder
-            .read()
-            .unwrap()
-            .is_exited
-            .store(true, Ordering::Relaxed);
-        let _ = poh_simulator.join();
-
-        process_transactions_summary
+        consumer.process_and_record_transactions(&bank, &transactions)
     }
 
     fn generate_new_address_lookup_table(
@@ -658,30 +620,10 @@ mod tests {
             genesis_config.hash(),
         )]);
 
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path())
-            .expect("Expected to be able to open database ledger");
-        let (poh_recorder, entry_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let (record_sender, record_receiver) = record_channels(false);
-        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let (record_sender, mut record_receiver) = record_channels(false);
+        let recorder = TransactionRecorder::new(record_sender);
+        record_receiver.restart(bank.slot());
 
-        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
-
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(
             None,
@@ -709,27 +651,14 @@ mod tests {
         );
         assert!(commit_transactions_result.is_ok());
 
-        // Tick up to max tick height
-        while poh_recorder.read().unwrap().tick_height() != bank.max_tick_height() {
-            poh_recorder.write().unwrap().tick();
-        }
+        // When poh is near end of slot, it will be shutdown.
+        record_receiver.shutdown();
 
-        let mut done = false;
-        // read entries until I find mine, might be ticks...
-        while let Ok((_bank, (entry, _tick_height))) = entry_receiver.recv() {
-            if !entry.is_tick() {
-                trace!("got entry");
-                assert_eq!(entry.transactions.len(), transactions.len());
-                assert_eq!(bank.get_balance(&pubkey), 1);
-                done = true;
-            }
-            if done {
-                break;
-            }
-        }
-        trace!("done ticking");
-
-        assert!(done);
+        let record = record_receiver.drain().next().unwrap();
+        assert_eq!(record.slot, bank.slot());
+        assert_eq!(record.transaction_batches.len(), 1);
+        let transaction_batch = record.transaction_batches[0].clone();
+        assert_eq!(transaction_batch.len(), 1);
 
         let transactions = sanitize_transactions(vec![system_transaction::transfer(
             &mint_keypair,
@@ -761,13 +690,6 @@ mod tests {
             commit_transactions_result,
             Err(PohRecorderError::MaxHeightReached)
         );
-
-        poh_recorder
-            .read()
-            .unwrap()
-            .is_exited
-            .store(true, Ordering::Relaxed);
-        let _ = poh_simulator.join();
 
         assert_eq!(bank.get_balance(&pubkey), 1);
     }
@@ -810,47 +732,13 @@ mod tests {
             nonce_hash,
         )]);
 
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path())
-            .expect("Expected to be able to open database ledger");
-        let (poh_recorder, entry_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::new(false)),
-        );
-        let (record_sender, record_receiver) = record_channels(false);
-        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let (record_sender, mut record_receiver) = record_channels(false);
+        let recorder = TransactionRecorder::new(record_sender);
 
-        fn poh_tick_before_returning_record_response(
-            _record_receiver: RecordReceiver,
-            _poh_recorder: Arc<RwLock<PohRecorder>>,
-        ) -> JoinHandle<()> {
-            todo!()
-        }
+        record_receiver.restart(bank.slot());
 
-        // Simulate a race condition by setting up poh to do the last tick
-        // right before returning the transaction record response so that
-        // bank blockhash queue is updated before transactions are
-        // committed.
-        let poh_simulator =
-            poh_tick_before_returning_record_response(record_receiver, poh_recorder.clone());
-
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
-
-        // Tick up to max tick height - 1 so that only one tick remains
-        // before recording transactions to poh
-        while poh_recorder.read().unwrap().tick_height() != bank.max_tick_height() - 1 {
-            poh_recorder.write().unwrap().tick();
+        while bank.tick_height() != bank.max_tick_height() - 1 {
+            bank.register_default_tick_for_test();
         }
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
@@ -878,30 +766,7 @@ mod tests {
             }
         );
         assert!(commit_transactions_result.is_ok());
-
-        // Ensure that poh did the last tick after recording transactions
-        assert_eq!(
-            poh_recorder.read().unwrap().tick_height(),
-            bank.max_tick_height()
-        );
-
-        let mut done = false;
-        // read entries until I find mine, might be ticks...
-        while let Ok((_bank, (entry, _tick_height))) = entry_receiver.recv() {
-            if !entry.is_tick() {
-                assert_eq!(entry.transactions.len(), transactions.len());
-                done = true;
-                break;
-            }
-        }
-        assert!(done);
-
-        poh_recorder
-            .read()
-            .unwrap()
-            .is_exited
-            .store(true, Ordering::Relaxed);
-        let _ = poh_simulator.join();
+        bank.register_default_tick_for_test();
 
         // check that the nonce was advanced to the current bank's last blockhash
         // rather than the current bank's blockhash as would occur had the update
@@ -931,30 +796,10 @@ mod tests {
             sanitize_transactions(vec![tx])
         };
 
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path())
-            .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let (record_sender, record_receiver) = record_channels(false);
-        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let (record_sender, mut record_receiver) = record_channels(false);
+        let recorder = TransactionRecorder::new(record_sender);
+        record_receiver.restart(bank.slot());
 
-        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
-
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(
             None,
@@ -991,13 +836,6 @@ mod tests {
                 1
             ])
         );
-
-        poh_recorder
-            .read()
-            .unwrap()
-            .is_exited
-            .store(true, Ordering::Relaxed);
-        let _ = poh_simulator.join();
     }
 
     #[test_case(false; "old")]
@@ -1019,30 +857,10 @@ mod tests {
         let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let pubkey = solana_pubkey::new_rand();
 
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path())
-            .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let (record_sender, record_receiver) = record_channels(false);
-        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let (record_sender, mut record_receiver) = record_channels(false);
+        let recorder = TransactionRecorder::new(record_sender);
+        record_receiver.restart(bank.slot());
 
-        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
-
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(
             None,
@@ -1162,13 +980,6 @@ mod tests {
 
         assert_eq!(get_block_cost(), expected_block_cost);
         assert_eq!(get_tx_count(), 2);
-
-        poh_recorder
-            .read()
-            .unwrap()
-            .is_exited
-            .store(true, Ordering::Relaxed);
-        let _ = poh_simulator.join();
     }
 
     #[test_case(false, false; "old::locked")]
@@ -1212,30 +1023,9 @@ mod tests {
             use_duplicate_transaction
         );
 
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path())
-            .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let (record_sender, record_receiver) = record_channels(false);
-        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
-
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
-
-        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
+        let (record_sender, mut record_receiver) = record_channels(false);
+        let recorder = TransactionRecorder::new(record_sender);
+        record_receiver.restart(bank.slot());
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(
@@ -1261,13 +1051,6 @@ mod tests {
 
         let process_transactions_batch_output =
             consumer.process_and_record_transactions(&bank, &transactions);
-
-        poh_recorder
-            .read()
-            .unwrap()
-            .is_exited
-            .store(true, Ordering::Relaxed);
-        let _ = poh_simulator.join();
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -1322,7 +1105,7 @@ mod tests {
         let ProcessTransactionBatchOutput {
             execute_and_commit_transactions_output,
             ..
-        } = execute_transactions_with_dummy_poh_service(bank, transactions);
+        } = execute_transactions_for_test(bank, transactions);
 
         // All the transactions should have been replayed
         assert_eq!(
@@ -1397,7 +1180,7 @@ mod tests {
         let ProcessTransactionBatchOutput {
             execute_and_commit_transactions_output,
             ..
-        } = execute_transactions_with_dummy_poh_service(bank, transactions);
+        } = execute_transactions_for_test(bank, transactions);
 
         // If SIMD-83 is enabled *and* the transactions are distinct, all are executed.
         // In the three other cases, only one is executed. In all four cases, all are attempted.
@@ -1461,27 +1244,10 @@ mod tests {
             genesis_config.hash(),
         )]);
 
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path())
-            .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-
         // Poh Recorder has no working bank, so should throw MaxHeightReached error on
         // record
-        let (record_sender, record_receiver) = record_channels(false);
-        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
-
-        let poh_simulator = simulate_poh(record_receiver, &Arc::new(RwLock::new(poh_recorder)));
+        let (record_sender, _record_receiver) = record_channels(false);
+        let recorder = TransactionRecorder::new(record_sender);
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(
@@ -1530,9 +1296,6 @@ mod tests {
             execute_and_commit_transactions_output.retryable_transaction_indexes,
             expected
         );
-
-        recorder.is_exited.store(true, Ordering::Relaxed);
-        let _ = poh_simulator.join();
     }
 
     #[test]
@@ -1578,27 +1341,9 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
         let blockstore = Arc::new(blockstore);
-        let (poh_recorder, _entry_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            blockstore.clone(),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let (record_sender, record_receiver) = record_channels(false);
-        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
-
-        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
-
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
+        let (record_sender, mut record_receiver) = record_channels(false);
+        let recorder = TransactionRecorder::new(record_sender);
+        record_receiver.restart(bank.slot());
 
         let shreds = entries_to_test_shreds(
             &entries,
@@ -1659,13 +1404,6 @@ mod tests {
             ),
         ];
         assert_eq!(actual_tx_results, expected_tx_results);
-
-        poh_recorder
-            .read()
-            .unwrap()
-            .is_exited
-            .store(true, Ordering::Relaxed);
-        let _ = poh_simulator.join();
     }
 
     #[test]
@@ -1724,27 +1462,10 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
         let blockstore = Arc::new(blockstore);
-        let (poh_recorder, _entry_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            blockstore.clone(),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let (record_sender, record_receiver) = record_channels(false);
-        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
-        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
-        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
-
-        poh_recorder
-            .write()
-            .unwrap()
-            .set_bank_for_test(bank.clone());
+        let (record_sender, mut record_receiver) = record_channels(false);
+        let recorder = TransactionRecorder::new(record_sender);
+        record_receiver.restart(bank.slot());
 
         let shreds = entries_to_test_shreds(
             &entries,
@@ -1826,11 +1547,5 @@ mod tests {
                 ..TransactionStatusMeta::default()
             }
         );
-        poh_recorder
-            .read()
-            .unwrap()
-            .is_exited
-            .store(true, Ordering::Relaxed);
-        let _ = poh_simulator.join();
     }
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -941,7 +941,7 @@ impl Validator {
         let prioritization_fee_cache = Arc::new(PrioritizationFeeCache::default());
 
         let leader_schedule_cache = Arc::new(leader_schedule_cache);
-        let (mut poh_recorder, entry_receiver) = {
+        let (poh_recorder, entry_receiver) = {
             let bank = &bank_forks.read().unwrap().working_bank();
             PohRecorder::new_with_clear_signal(
                 bank.tick_height(),
@@ -957,9 +957,6 @@ impl Validator {
                 exit.clone(),
             )
         };
-        if transaction_status_sender.is_some() {
-            poh_recorder.track_transaction_indexes();
-        }
         let (record_sender, record_receiver) = record_channels(transaction_status_sender.is_some());
         let transaction_recorder = TransactionRecorder::new(record_sender);
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -86,6 +86,7 @@ use {
         poh_controller::PohController,
         poh_recorder::PohRecorder,
         poh_service::{self, PohService},
+        record_channels::record_channels,
         transaction_recorder::TransactionRecorder,
     },
     solana_pubkey::Pubkey,
@@ -959,7 +960,7 @@ impl Validator {
         if transaction_status_sender.is_some() {
             poh_recorder.track_transaction_indexes();
         }
-        let (record_sender, record_receiver) = unbounded();
+        let (record_sender, record_receiver) = record_channels(transaction_status_sender.is_some());
         let transaction_recorder =
             TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -961,8 +961,7 @@ impl Validator {
             poh_recorder.track_transaction_indexes();
         }
         let (record_sender, record_receiver) = record_channels(transaction_status_sender.is_some());
-        let transaction_recorder =
-            TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
+        let transaction_recorder = TransactionRecorder::new(record_sender);
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
         let (poh_controller, poh_service_message_receiver) = PohController::new();
 

--- a/poh/benches/poh.rs
+++ b/poh/benches/poh.rs
@@ -82,7 +82,7 @@ fn bench_poh_lock_time_per_batch(bencher: &mut Bencher) {
 }
 
 #[bench]
-fn bench_poh_recorder_record_transaction_index(bencher: &mut Bencher) {
+fn bench_poh_recorder_record(bencher: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore =
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");
@@ -124,8 +124,6 @@ fn bench_poh_recorder_record_transaction_index(bencher: &mut Bencher) {
                 vec![test::black_box(h1)],
                 vec![test::black_box(txs.clone())],
             )
-            .unwrap()
-            .starting_transaction_index
             .unwrap();
     });
     poh_recorder.tick();

--- a/poh/benches/poh.rs
+++ b/poh/benches/poh.rs
@@ -101,7 +101,6 @@ fn bench_poh_recorder_record(bencher: &mut Bencher) {
         &PohConfig::default(),
         Arc::new(AtomicBool::default()),
     );
-    poh_recorder.track_transaction_indexes();
     let h1 = hash(b"hello Agave, hello Anza!");
 
     poh_recorder.set_bank_for_test(bank.clone());
@@ -149,7 +148,6 @@ fn bench_poh_recorder_set_bank(bencher: &mut Bencher) {
         &PohConfig::default(),
         Arc::new(AtomicBool::default()),
     );
-    poh_recorder.track_transaction_indexes();
     bencher.iter(|| {
         poh_recorder.set_bank_for_test(bank.clone());
         poh_recorder.tick();

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -10,6 +10,7 @@ use {
         poh_controller::PohController,
         poh_recorder::PohRecorder,
         poh_service::{PohService, DEFAULT_HASHES_PER_BATCH, DEFAULT_PINNED_CPU_CORE},
+        record_channels::record_channels,
         transaction_recorder::TransactionRecorder,
     },
     solana_poh_config::PohConfig,
@@ -60,7 +61,7 @@ fn bench_record_transactions(c: &mut Criterion) {
     );
     poh_recorder.set_bank_for_test(bank.clone());
 
-    let (record_sender, record_receiver) = crossbeam_channel::unbounded();
+    let (record_sender, record_receiver) = record_channels(false);
     let transaction_recorder = TransactionRecorder::new(record_sender, exit.clone());
 
     let txs: Vec<_> = (0..NUM_TRANSACTIONS)

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -15,7 +15,7 @@ use {
     },
     solana_poh_config::PohConfig,
     solana_pubkey::Pubkey,
-    solana_runtime::bank::Bank,
+    solana_runtime::{bank::Bank, installed_scheduler_pool::BankWithScheduler},
     solana_transaction::versioned::VersionedTransaction,
     std::{
         sync::{atomic::AtomicBool, Arc, RwLock},
@@ -48,7 +48,7 @@ fn bench_record_transactions(c: &mut Criterion) {
     let blockstore = Arc::new(
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger"),
     );
-    let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
+    let (poh_recorder, _entry_receiver) = PohRecorder::new(
         bank.tick_height(),
         bank.last_blockhash(),
         bank.clone(),
@@ -59,7 +59,6 @@ fn bench_record_transactions(c: &mut Criterion) {
         &genesis_config_info.genesis_config.poh_config,
         exit.clone(),
     );
-    poh_recorder.set_bank_for_test(bank.clone());
 
     let (record_sender, record_receiver) = record_channels(false);
     let transaction_recorder = TransactionRecorder::new(record_sender);
@@ -75,8 +74,8 @@ fn bench_record_transactions(c: &mut Criterion) {
         })
         .collect();
 
+    let (mut poh_controller, poh_service_receiver) = PohController::new();
     let poh_recorder = Arc::new(RwLock::new(poh_recorder));
-    let (_poh_controller, poh_service_message_receiver) = PohController::new();
     let poh_service = PohService::new(
         poh_recorder.clone(),
         &genesis_config_info.genesis_config.poh_config,
@@ -85,8 +84,11 @@ fn bench_record_transactions(c: &mut Criterion) {
         DEFAULT_PINNED_CPU_CORE,
         DEFAULT_HASHES_PER_BATCH,
         record_receiver,
-        poh_service_message_receiver,
+        poh_service_receiver,
     );
+    poh_controller
+        .set_bank_sync(BankWithScheduler::new_without_scheduler(bank.clone()))
+        .unwrap();
 
     let mut group = c.benchmark_group("record_transactions");
     group.throughput(criterion::Throughput::Elements(
@@ -98,16 +100,18 @@ fn bench_record_transactions(c: &mut Criterion) {
 
             for _ in 0..iters {
                 let tx_batches: Vec<_> = (0..NUM_BATCHES).map(|_| txs.clone()).collect();
-                poh_recorder.write().unwrap().clear_bank_for_test();
+                let next_slot = bank.slot().wrapping_add(1);
+                poh_controller
+                    .reset_sync(bank.clone(), Some((next_slot, next_slot)))
+                    .unwrap();
                 bank = Arc::new(Bank::new_from_parent(
                     bank.clone(),
                     &Pubkey::default(),
-                    bank.slot().wrapping_add(1),
+                    next_slot,
                 ));
-                poh_recorder
-                    .write()
-                    .unwrap()
-                    .set_bank_for_test(bank.clone());
+                poh_controller
+                    .set_bank_sync(BankWithScheduler::new_without_scheduler(bank.clone()))
+                    .unwrap();
 
                 let start = Instant::now();
                 for txs in tx_batches {

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -62,7 +62,7 @@ fn bench_record_transactions(c: &mut Criterion) {
     poh_recorder.set_bank_for_test(bank.clone());
 
     let (record_sender, record_receiver) = record_channels(false);
-    let transaction_recorder = TransactionRecorder::new(record_sender, exit.clone());
+    let transaction_recorder = TransactionRecorder::new(record_sender);
 
     let txs: Vec<_> = (0..NUM_TRANSACTIONS)
         .map(|_| {

--- a/poh/src/lib.rs
+++ b/poh/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod poh_controller;
 pub mod poh_recorder;
 pub mod poh_service;
+pub mod record_channels;
 pub mod transaction_recorder;
 
 #[macro_use]

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -193,7 +193,6 @@ pub struct PohRecorder {
 
     // Allocation to hold PohEntrys recorded into PoHStream.
     entries: Vec<PohEntry>,
-    track_transaction_indexes: bool,
 
     // Alpenglow related migration things
     pub is_alpenglow_enabled: bool,
@@ -284,15 +283,10 @@ impl PohRecorder {
                 last_reported_slot_for_pending_fork: Arc::default(),
                 is_exited,
                 entries: Vec::with_capacity(64),
-                track_transaction_indexes: false,
                 is_alpenglow_enabled: false,
             },
             working_bank_receiver,
         )
-    }
-
-    pub fn track_transaction_indexes(&mut self) {
-        self.track_transaction_indexes = true;
     }
 
     // synchronize PoH with a bank
@@ -916,7 +910,7 @@ fn do_create_test_recorder(
     };
     let exit = Arc::new(AtomicBool::new(false));
     let poh_config = poh_config.unwrap_or_default();
-    let (mut poh_recorder, entry_receiver) = PohRecorder::new(
+    let (poh_recorder, entry_receiver) = PohRecorder::new(
         bank.tick_height(),
         bank.last_blockhash(),
         bank.clone(),
@@ -927,9 +921,6 @@ fn do_create_test_recorder(
         &poh_config,
         exit.clone(),
     );
-    if track_transaction_indexes {
-        poh_recorder.track_transaction_indexes();
-    }
     let ticks_per_slot = bank.ticks_per_slot();
 
     let (record_sender, record_receiver) = record_channels(track_transaction_indexes);

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -14,7 +14,7 @@
 use qualifier_attr::qualifiers;
 use {
     crate::{
-        poh_controller::PohController, poh_service::PohService,
+        poh_controller::PohController, poh_service::PohService, record_channels::record_channels,
         transaction_recorder::TransactionRecorder,
     },
     arc_swap::ArcSwapOption,
@@ -948,7 +948,7 @@ fn do_create_test_recorder(
 
     poh_recorder.set_bank(BankWithScheduler::new_without_scheduler(bank));
 
-    let (record_sender, record_receiver) = unbounded();
+    let (record_sender, record_receiver) = record_channels(track_transaction_indexes);
     let transaction_recorder = TransactionRecorder::new(record_sender, exit.clone());
     let poh_recorder = Arc::new(RwLock::new(poh_recorder));
     let (poh_controller, poh_service_message_receiver) = PohController::new();

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -932,12 +932,10 @@ fn do_create_test_recorder(
     }
     let ticks_per_slot = bank.ticks_per_slot();
 
-    poh_recorder.set_bank(BankWithScheduler::new_without_scheduler(bank));
-
     let (record_sender, record_receiver) = record_channels(track_transaction_indexes);
     let transaction_recorder = TransactionRecorder::new(record_sender);
     let poh_recorder = Arc::new(RwLock::new(poh_recorder));
-    let (poh_controller, poh_service_message_receiver) = PohController::new();
+    let (mut poh_controller, poh_service_message_receiver) = PohController::new();
     let poh_service = PohService::new(
         poh_recorder.clone(),
         &poh_config,
@@ -948,6 +946,10 @@ fn do_create_test_recorder(
         record_receiver,
         poh_service_message_receiver,
     );
+
+    poh_controller
+        .set_bank_sync(BankWithScheduler::new_without_scheduler(bank))
+        .unwrap();
 
     (
         exit,

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -935,7 +935,7 @@ fn do_create_test_recorder(
     poh_recorder.set_bank(BankWithScheduler::new_without_scheduler(bank));
 
     let (record_sender, record_receiver) = record_channels(track_transaction_indexes);
-    let transaction_recorder = TransactionRecorder::new(record_sender, exit.clone());
+    let transaction_recorder = TransactionRecorder::new(record_sender);
     let poh_recorder = Arc::new(RwLock::new(poh_recorder));
     let (poh_controller, poh_service_message_receiver) = PohController::new();
     let poh_service = PohService::new(

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -225,6 +225,16 @@ impl PohService {
                 Self::handle_service_message(&poh_recorder, service_message, &mut record_receiver);
             }
         }
+
+        record_receiver.shutdown();
+        while !record_receiver.is_empty() {
+            Self::read_record_receiver_and_process(
+                &poh_recorder,
+                &mut record_receiver,
+                Duration::ZERO,
+                ticks_per_slot,
+            );
+        }
     }
 
     pub fn read_record_receiver_and_process(
@@ -324,6 +334,16 @@ impl PohService {
             if let Some(service_message) = service_message {
                 Self::handle_service_message(&poh_recorder, service_message, &mut record_receiver);
             }
+        }
+
+        record_receiver.shutdown();
+        while !record_receiver.is_empty() {
+            Self::read_record_receiver_and_process(
+                &poh_recorder,
+                &mut record_receiver,
+                Duration::ZERO,
+                ticks_per_slot,
+            );
         }
     }
 

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -9,7 +9,7 @@ use {
     log::*,
     solana_clock::DEFAULT_HASHES_PER_SECOND,
     solana_entry::poh::Poh,
-    solana_measure::{measure::Measure, measure_us},
+    solana_measure::measure::Measure,
     solana_poh_config::PohConfig,
     std::{
         sync::{
@@ -49,7 +49,6 @@ struct PohTiming {
     total_tick_time_ns: u64,
     last_metric: Instant,
     total_record_time_us: u64,
-    total_send_record_result_us: u64,
 }
 
 impl PohTiming {
@@ -63,7 +62,6 @@ impl PohTiming {
             total_tick_time_ns: 0,
             last_metric: Instant::now(),
             total_record_time_us: 0,
-            total_send_record_result_us: 0,
         }
     }
     fn report(&mut self, ticks_per_slot: u64) {
@@ -80,11 +78,6 @@ impl PohTiming {
                 ("total_lock_time_us", self.total_lock_time_ns / 1000, i64),
                 ("total_hash_time_us", self.total_hash_time_ns / 1000, i64),
                 ("total_record_time_us", self.total_record_time_us, i64),
-                (
-                    "total_send_record_result_us",
-                    self.total_send_record_result_us,
-                    i64
-                ),
             );
             self.total_sleep_us = 0;
             self.num_ticks = 0;
@@ -94,7 +87,6 @@ impl PohTiming {
             self.total_hash_time_ns = 0;
             self.last_metric = Instant::now();
             self.total_record_time_us = 0;
-            self.total_send_record_result_us = 0;
         }
     }
 }
@@ -122,6 +114,7 @@ impl PohService {
                             &poh_exit,
                             record_receiver,
                             poh_service_receiver,
+                            ticks_per_slot,
                         );
                     } else {
                         Self::short_lived_low_power_tick_producer(
@@ -130,6 +123,7 @@ impl PohService {
                             &poh_exit,
                             record_receiver,
                             poh_service_receiver,
+                            ticks_per_slot,
                         );
                     }
                 } else {
@@ -174,51 +168,88 @@ impl PohService {
         poh_recorder: Arc<RwLock<PohRecorder>>,
         poh_config: &PohConfig,
         poh_exit: &AtomicBool,
-        record_receiver: RecordReceiver,
+        mut record_receiver: RecordReceiver,
         poh_service_receiver: PohServiceMessageReceiver,
+        ticks_per_slot: u64,
     ) {
+        let poh = poh_recorder.read().unwrap().poh.clone();
         let mut last_tick = Instant::now();
         while !poh_exit.load(Ordering::Relaxed) {
-            let service_message = poh_service_receiver.try_recv();
+            let service_message =
+                Self::check_for_service_message(&poh_service_receiver, &mut record_receiver);
+            loop {
+                let remaining_tick_time = poh_config
+                    .target_tick_duration
+                    .saturating_sub(last_tick.elapsed());
+                Self::read_record_receiver_and_process(
+                    &poh_recorder,
+                    &mut record_receiver,
+                    remaining_tick_time,
+                    ticks_per_slot,
+                );
+                if remaining_tick_time.is_zero() {
+                    last_tick = Instant::now();
+                    poh_recorder.write().unwrap().tick();
 
-            let remaining_tick_time = poh_config
-                .target_tick_duration
-                .saturating_sub(last_tick.elapsed());
-            Self::read_record_receiver_and_process(
-                &poh_recorder,
-                &record_receiver,
-                remaining_tick_time,
-            );
-            if remaining_tick_time.is_zero() {
-                last_tick = Instant::now();
-                poh_recorder.write().unwrap().tick();
+                    let last_tick = {
+                        let poh_recorder = poh_recorder.read().unwrap();
+                        poh_recorder
+                            .bank()
+                            .map(|bank| {
+                                bank.max_tick_height().wrapping_sub(1) == poh_recorder.tick_height()
+                            })
+                            .unwrap_or(false)
+                    };
+
+                    if last_tick
+                        || record_receiver.should_shutdown(
+                            poh.lock().unwrap().remaining_hashes_in_slot(ticks_per_slot),
+                            ticks_per_slot,
+                        )
+                    {
+                        record_receiver.shutdown();
+                    }
+
+                    // If there is a service message (channel is shut down), and there
+                    // still records to process, we must loop to call `read_record_receiver_and_process`
+                    // again.
+                    if service_message.is_some() && !record_receiver.is_empty() {
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
             }
 
-            if let Ok(service_message) = service_message {
-                Self::handle_service_message(&poh_recorder, service_message);
+            if let Some(service_message) = service_message {
+                Self::handle_service_message(&poh_recorder, service_message, &mut record_receiver);
             }
         }
     }
 
     pub fn read_record_receiver_and_process(
         poh_recorder: &Arc<RwLock<PohRecorder>>,
-        record_receiver: &RecordReceiver,
+        record_receiver: &mut RecordReceiver,
         timeout: Duration,
+        ticks_per_slot: u64,
     ) {
         let record = record_receiver.recv_timeout(timeout);
         if let Ok(record) = record {
-            if record
-                .sender
-                .send(
-                    poh_recorder
-                        .write()
-                        .unwrap()
-                        .record(record.slot, record.mixins, record.transaction_batches)
-                        .map(|summary| summary.starting_transaction_index),
-                )
-                .is_err()
-            {
-                panic!("Error returning mixin hash");
+            match poh_recorder.write().unwrap().record(
+                record.slot,
+                record.mixins,
+                record.transaction_batches,
+            ) {
+                Ok(record_summary) => {
+                    if record_receiver
+                        .should_shutdown(record_summary.remaining_hashes_in_slot, ticks_per_slot)
+                    {
+                        record_receiver.shutdown();
+                    }
+                }
+                Err(err) => {
+                    panic!("PohRecorder::record failed: {err:?}");
+                }
             }
         }
     }
@@ -227,36 +258,71 @@ impl PohService {
         poh_recorder: Arc<RwLock<PohRecorder>>,
         poh_config: &PohConfig,
         poh_exit: &AtomicBool,
-        record_receiver: RecordReceiver,
+        mut record_receiver: RecordReceiver,
         poh_service_receiver: PohServiceMessageReceiver,
+        ticks_per_slot: u64,
     ) {
         let mut warned = false;
         let mut elapsed_ticks = 0;
         let mut last_tick = Instant::now();
         let num_ticks = poh_config.target_tick_count.unwrap();
-        while elapsed_ticks < num_ticks {
-            let service_message = poh_service_receiver.try_recv();
+        let poh = poh_recorder.read().unwrap().poh.clone();
 
-            let remaining_tick_time = poh_config
-                .target_tick_duration
-                .saturating_sub(last_tick.elapsed());
-            Self::read_record_receiver_and_process(
-                &poh_recorder,
-                &record_receiver,
-                Duration::from_millis(0),
-            );
-            if remaining_tick_time.is_zero() {
-                last_tick = Instant::now();
-                poh_recorder.write().unwrap().tick();
-                elapsed_ticks += 1;
+        while elapsed_ticks < num_ticks {
+            let service_message =
+                Self::check_for_service_message(&poh_service_receiver, &mut record_receiver);
+
+            loop {
+                let remaining_tick_time = poh_config
+                    .target_tick_duration
+                    .saturating_sub(last_tick.elapsed());
+                Self::read_record_receiver_and_process(
+                    &poh_recorder,
+                    &mut record_receiver,
+                    Duration::from_millis(0),
+                    ticks_per_slot,
+                );
+                if remaining_tick_time.is_zero() {
+                    last_tick = Instant::now();
+                    poh_recorder.write().unwrap().tick();
+                    elapsed_ticks += 1;
+
+                    let last_tick = {
+                        let poh_recorder = poh_recorder.read().unwrap();
+                        poh_recorder
+                            .bank()
+                            .map(|bank| {
+                                bank.max_tick_height().wrapping_sub(1) == poh_recorder.tick_height()
+                            })
+                            .unwrap_or(false)
+                    };
+
+                    if last_tick
+                        || record_receiver.should_shutdown(
+                            poh.lock().unwrap().remaining_hashes_in_slot(ticks_per_slot),
+                            ticks_per_slot,
+                        )
+                    {
+                        record_receiver.shutdown();
+                    }
+                }
+
+                // If there is a service message (channel is shut down), and there
+                // still records to process, we must loop to call `record_or_hash`
+                // again.
+                if service_message.is_some() && !record_receiver.is_empty() {
+                    continue;
+                } else {
+                    break;
+                }
             }
+
             if poh_exit.load(Ordering::Relaxed) && !warned {
                 warned = true;
                 warn!("exit signal is ignored because PohService is scheduled to exit soon");
             }
-
-            if let Ok(service_message) = service_message {
-                Self::handle_service_message(&poh_recorder, service_message);
+            if let Some(service_message) = service_message {
+                Self::handle_service_message(&poh_recorder, service_message, &mut record_receiver);
             }
         }
     }
@@ -266,10 +332,11 @@ impl PohService {
         next_record: &mut Option<Record>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         timing: &mut PohTiming,
-        record_receiver: &RecordReceiver,
+        record_receiver: &mut RecordReceiver,
         hashes_per_batch: u64,
         poh: &Arc<Mutex<Poh>>,
         target_ns_per_tick: u64,
+        ticks_per_slot: u64,
     ) -> bool {
         match next_record.take() {
             Some(mut record) => {
@@ -281,17 +348,24 @@ impl PohService {
                 timing.total_lock_time_ns += lock_time.as_ns();
                 let mut record_time = Measure::start("record");
                 loop {
-                    let res = poh_recorder_l.record(
+                    match poh_recorder_l.record(
                         record.slot,
                         record.mixins,
                         std::mem::take(&mut record.transaction_batches),
-                    );
-                    let (send_res, send_record_result_us) = measure_us!(record
-                        .sender
-                        .send(res.map(|summary| summary.starting_transaction_index)));
-                    debug_assert!(send_res.is_ok(), "Record wasn't sent.");
+                    ) {
+                        Ok(record_summary) => {
+                            if record_receiver.should_shutdown(
+                                record_summary.remaining_hashes_in_slot,
+                                ticks_per_slot,
+                            ) {
+                                record_receiver.shutdown();
+                            }
+                        }
+                        Err(err) => {
+                            panic!("PohRecorder::record failed: {err:?}");
+                        }
+                    }
 
-                    timing.total_send_record_result_us += send_record_result_us;
                     timing.num_hashes += 1; // note: may have also ticked inside record
                     if let Ok(new_record) = record_receiver.try_recv() {
                         // we already have second request to record, so record again while we still have the mutex
@@ -316,6 +390,17 @@ impl PohService {
                     let should_tick = poh_l.hash(hashes_per_batch);
                     let ideal_time = poh_l.target_poh_time(target_ns_per_tick);
                     hash_time.stop();
+
+                    // shutdown if another batch would push us over the shutdown threshold.
+                    let remaining_hashes_in_slot = poh_l.remaining_hashes_in_slot(ticks_per_slot);
+                    let remaining_hashes_after_next_batch =
+                        remaining_hashes_in_slot.saturating_sub(hashes_per_batch);
+                    if record_receiver
+                        .should_shutdown(remaining_hashes_after_next_batch, ticks_per_slot)
+                    {
+                        record_receiver.shutdown();
+                    }
+
                     timing.total_hash_time_ns += hash_time.as_ns();
                     if should_tick {
                         // nothing else can be done. tick required.
@@ -357,54 +442,100 @@ impl PohService {
         poh_exit: &AtomicBool,
         ticks_per_slot: u64,
         hashes_per_batch: u64,
-        record_receiver: RecordReceiver,
+        mut record_receiver: RecordReceiver,
         poh_service_receiver: PohServiceMessageReceiver,
         target_ns_per_tick: u64,
     ) {
         let poh = poh_recorder.read().unwrap().poh.clone();
         let mut timing = PohTiming::new();
         let mut next_record = None;
+        let mut should_exit = poh_exit.load(Ordering::Relaxed);
 
         loop {
-            let service_message = poh_service_receiver.try_recv();
-            let should_tick = Self::record_or_hash(
-                &mut next_record,
-                &poh_recorder,
-                &mut timing,
-                &record_receiver,
-                hashes_per_batch,
-                &poh,
-                target_ns_per_tick,
-            );
-            if should_tick {
-                // Lock PohRecorder only for the final hash. record_or_hash will lock PohRecorder for record calls but not for hashing.
-                {
-                    let mut lock_time = Measure::start("lock");
-                    let mut poh_recorder_l = poh_recorder.write().unwrap();
-                    lock_time.stop();
-                    timing.total_lock_time_ns += lock_time.as_ns();
-                    let mut tick_time = Measure::start("tick");
-                    poh_recorder_l.tick();
-                    tick_time.stop();
-                    timing.total_tick_time_ns += tick_time.as_ns();
-                }
-                timing.num_ticks += 1;
+            // If we should exit, close the channel so no more records are accepted,
+            // but we still want to process any pending records.
+            // We should **not** however process any service messages once we have detected
+            // the exit signal.
+            should_exit |= poh_exit.load(Ordering::Relaxed); // once set, stay set.
+            if should_exit {
+                record_receiver.shutdown();
+            }
 
-                timing.report(ticks_per_slot);
-                if poh_exit.load(Ordering::Relaxed) {
+            let service_message =
+                Self::check_for_service_message(&poh_service_receiver, &mut record_receiver);
+            loop {
+                let should_tick = Self::record_or_hash(
+                    &mut next_record,
+                    &poh_recorder,
+                    &mut timing,
+                    &mut record_receiver,
+                    hashes_per_batch,
+                    &poh,
+                    target_ns_per_tick,
+                    ticks_per_slot,
+                );
+                if should_tick {
+                    // Lock PohRecorder only for the final hash. record_or_hash will lock PohRecorder for record calls but not for hashing.
+                    {
+                        let mut lock_time = Measure::start("lock");
+                        let mut poh_recorder_l = poh_recorder.write().unwrap();
+                        lock_time.stop();
+                        timing.total_lock_time_ns += lock_time.as_ns();
+                        let mut tick_time = Measure::start("tick");
+                        poh_recorder_l.tick();
+                        tick_time.stop();
+                        timing.total_tick_time_ns += tick_time.as_ns();
+                    }
+                    timing.num_ticks += 1;
+
+                    timing.report(ticks_per_slot);
+                }
+
+                // If there is a service message (channel is shut down), and there
+                // still records to process, we must loop to call `record_or_hash`
+                // again.
+                if service_message.is_some() && !record_receiver.is_empty() {
+                    continue;
+                } else {
                     break;
                 }
             }
 
-            if let Ok(service_message) = service_message {
-                Self::handle_service_message(&poh_recorder, service_message);
+            if let Some(service_message) = service_message {
+                if !should_exit {
+                    Self::handle_service_message(
+                        &poh_recorder,
+                        service_message,
+                        &mut record_receiver,
+                    );
+                }
             }
+
+            // If exit signal is set and there are no more records to process, exit.
+            if should_exit && record_receiver.is_empty() {
+                break;
+            }
+        }
+    }
+
+    /// Check for a service message and shutdown the channel if there is one.
+    fn check_for_service_message<'a>(
+        service_message_receiver: &'a PohServiceMessageReceiver,
+        record_receiver: &mut RecordReceiver,
+    ) -> Option<PohServiceMessageGuard<'a>> {
+        match service_message_receiver.try_recv() {
+            Ok(bank_message) => {
+                record_receiver.shutdown();
+                Some(bank_message)
+            }
+            Err(_) => None,
         }
     }
 
     fn handle_service_message(
         poh_recorder: &RwLock<PohRecorder>,
         mut service_message: PohServiceMessageGuard,
+        record_receiver: &mut RecordReceiver,
     ) {
         {
             let mut recorder = poh_recorder.write().unwrap();
@@ -416,7 +547,9 @@ impl PohService {
                     recorder.reset(reset_bank, next_leader_slot);
                 }
                 PohServiceMessage::SetBank { bank } => {
+                    let slot = bank.slot();
                     recorder.set_bank(bank);
+                    record_receiver.restart(slot);
                 }
             }
         }

--- a/poh/src/record_channels.rs
+++ b/poh/src/record_channels.rs
@@ -247,13 +247,11 @@ mod tests {
         let (sender, mut receiver) = record_channels(false);
 
         // Initially shutdown.
-        let (dummy_sender, _receiver) = bounded(0);
         assert!(matches!(
             sender.try_send(Record {
                 slot: 0,
                 transaction_batches: vec![],
                 mixins: vec![],
-                sender: dummy_sender.clone(),
             }),
             Err(RecordSenderError::Shutdown)
         ));
@@ -267,7 +265,6 @@ mod tests {
                 slot: 0,
                 transaction_batches: vec![],
                 mixins: vec![],
-                sender: dummy_sender.clone(),
             }),
             Err(RecordSenderError::InactiveSlot)
         ));
@@ -278,7 +275,6 @@ mod tests {
                 slot: 1,
                 transaction_batches: vec![vec![]],
                 mixins: vec![],
-                sender: dummy_sender.clone(),
             }),
             Ok(None)
         ));
@@ -289,7 +285,6 @@ mod tests {
                 slot: 1,
                 transaction_batches: vec![vec![]; 1_023],
                 mixins: vec![],
-                sender: dummy_sender.clone(),
             }),
             Err(RecordSenderError::Full(_))
         ));
@@ -300,7 +295,6 @@ mod tests {
                 slot: 1,
                 transaction_batches: vec![vec![]; 1_022],
                 mixins: vec![],
-                sender: dummy_sender.clone(),
             }),
             Ok(None)
         ));
@@ -311,7 +305,6 @@ mod tests {
                 slot: 1,
                 transaction_batches: vec![vec![]],
                 mixins: vec![],
-                sender: dummy_sender.clone(),
             }),
             Err(RecordSenderError::Full(_))
         ));
@@ -328,13 +321,11 @@ mod tests {
         let (sender, mut receiver) = record_channels(true);
 
         // Initially shutdown.
-        let (dummy_sender, _receiver) = bounded(0);
         assert!(matches!(
             sender.try_send(Record {
                 slot: 0,
                 transaction_batches: vec![],
                 mixins: vec![],
-                sender: dummy_sender.clone(),
             }),
             Err(RecordSenderError::Shutdown)
         ));
@@ -348,7 +339,6 @@ mod tests {
                 slot: 0,
                 transaction_batches: vec![],
                 mixins: vec![],
-                sender: dummy_sender.clone(),
             }),
             Err(RecordSenderError::InactiveSlot)
         ));
@@ -359,7 +349,6 @@ mod tests {
                 slot: 1,
                 transaction_batches: vec![vec![VersionedTransaction::default()]],
                 mixins: vec![],
-                sender: dummy_sender.clone(),
             }),
             Ok(Some(0))
         ));
@@ -376,7 +365,6 @@ mod tests {
                     ],
                 ],
                 mixins: vec![],
-                sender: dummy_sender.clone(),
             }),
             Ok(Some(1))
         ));

--- a/poh/src/record_channels.rs
+++ b/poh/src/record_channels.rs
@@ -317,9 +317,9 @@ mod tests {
         ));
 
         // Receive 1 record.
-        assert!(matches!(receiver.try_recv(), Ok(_)));
+        assert!(receiver.try_recv().is_ok());
         assert!(!receiver.is_empty());
-        assert!(matches!(receiver.try_recv(), Ok(_)));
+        assert!(receiver.try_recv().is_ok());
         assert!(receiver.is_empty());
     }
 

--- a/poh/src/record_channels.rs
+++ b/poh/src/record_channels.rs
@@ -1,0 +1,386 @@
+use {
+    crate::poh_recorder::Record,
+    crossbeam_channel::{bounded, Receiver, RecvTimeoutError, Sender, TryRecvError},
+    solana_clock::Slot,
+    std::{
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            Arc, Mutex,
+        },
+        time::Duration,
+    },
+};
+
+/// Create a channel pair for communicating [`Record`]s.
+pub fn record_channels(track_transaction_indexes: bool) -> (RecordSender, RecordReceiver) {
+    const CAPACITY: usize = SlotAllowedInsertions::MAX_ALLOWED_INSERTIONS as usize;
+    let (sender, receiver) = bounded(CAPACITY);
+
+    // Begin in a shutdown state.
+    let slot_allowed_insertions = SlotAllowedInsertions::new_shutdown();
+    let transaction_indexes = if track_transaction_indexes {
+        Some(Arc::new(Mutex::new(0)))
+    } else {
+        None
+    };
+
+    (
+        RecordSender {
+            slot_allowed_insertions: slot_allowed_insertions.clone(),
+            sender,
+            transaction_indexes: transaction_indexes.clone(),
+        },
+        RecordReceiver {
+            slot_allowed_insertions,
+            receiver,
+            capacity: CAPACITY as u64,
+            transaction_indexes,
+        },
+    )
+}
+
+pub enum RecordSenderError {
+    Full(Record),
+    Shutdown,
+    InactiveSlot,
+    Disconnected,
+}
+
+/// A sender for sending [`Record`]s to PohService.
+/// The sender does not wait for service to pick up the records, and will return
+/// immediately if the channel is full, shutdown, or if the slot has changed.
+#[derive(Clone, Debug)]
+pub struct RecordSender {
+    slot_allowed_insertions: SlotAllowedInsertions,
+    sender: Sender<Record>,
+    transaction_indexes: Option<Arc<Mutex<usize>>>,
+}
+
+impl RecordSender {
+    pub fn try_send(&self, record: Record) -> Result<Option<usize>, RecordSenderError> {
+        let num_transactions: usize = record
+            .transaction_batches
+            .iter()
+            .map(|batch| batch.len())
+            .sum();
+        loop {
+            // Grab lock on `transaction_indexes` here to ensure we are sending
+            // sequentially, ONLY if this exists.
+            let transaction_indexes = self
+                .transaction_indexes
+                .as_ref()
+                .map(|transaction_indexes| transaction_indexes.lock().unwrap());
+
+            // Get the current slot and allowed insertions.
+            // If the number of allowed insertions is less than the number of
+            // batches, the channel is full - just return immediately.
+            // If the `record`'s slot is different from the current slot,
+            // return immediately.
+            let current_slot_allowed_insertions =
+                self.slot_allowed_insertions.0.load(Ordering::Acquire);
+            let (slot, allowed_insertions) = (
+                SlotAllowedInsertions::slot(current_slot_allowed_insertions),
+                SlotAllowedInsertions::allowed_insertions(current_slot_allowed_insertions),
+            );
+
+            if slot == SlotAllowedInsertions::DISABLED_SLOT {
+                return Err(RecordSenderError::Shutdown);
+            }
+            if slot != record.slot {
+                return Err(RecordSenderError::InactiveSlot);
+            }
+            if allowed_insertions < record.transaction_batches.len() as u64 {
+                return Err(RecordSenderError::Full(record));
+            }
+
+            let new_slot_allowed_insertions = SlotAllowedInsertions::encoded_value(
+                slot,
+                allowed_insertions.wrapping_sub(record.transaction_batches.len() as u64),
+            );
+
+            if self
+                .slot_allowed_insertions
+                .0
+                .compare_exchange(
+                    current_slot_allowed_insertions,
+                    new_slot_allowed_insertions,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                // Send the record over the channel, space has been reserved successfully.
+                if let Err(err) = self.sender.try_send(record) {
+                    assert!(err.is_disconnected());
+                    return Err(RecordSenderError::Disconnected);
+                }
+                return Ok(transaction_indexes.map(|mut transaction_indexes| {
+                    let transaction_starting_index = *transaction_indexes;
+                    *transaction_indexes += num_transactions;
+                    transaction_starting_index
+                }));
+            }
+        }
+    }
+}
+
+/// A receiver for receiving [`Record`]s in PohService.
+/// The receiver can shutdown the channel, preventing any further sends,
+/// and can restart the channel for a new slot, re-enabling sends.
+pub struct RecordReceiver {
+    capacity: u64,
+    slot_allowed_insertions: SlotAllowedInsertions,
+    receiver: Receiver<Record>,
+    transaction_indexes: Option<Arc<Mutex<usize>>>,
+}
+
+impl RecordReceiver {
+    /// Returns true if the channel should be shutdown.
+    pub fn should_shutdown(&self, remaining_hashes_in_slot: u64, ticks_per_slot: u64) -> bool {
+        // This channel must guarantee that all sent records are recorded.
+        // Each batch in a record consumes one hash in the PoH stream,
+        // each tick also consumes at least one hash in the PoH stream.
+        // As a conservative estimate, we assume no ticks have been recorded.
+        remaining_hashes_in_slot.saturating_sub(ticks_per_slot) <= self.capacity
+    }
+
+    /// Shutdown the channel immediately.
+    pub fn shutdown(&mut self) {
+        self.slot_allowed_insertions.0.store(
+            SlotAllowedInsertions::encoded_value(SlotAllowedInsertions::DISABLED_SLOT, 0),
+            Ordering::Release,
+        );
+    }
+
+    /// Re-enable the channel after a shutdown.
+    pub fn restart(&mut self, slot: Slot) {
+        assert!(slot <= SlotAllowedInsertions::MAX_SLOT);
+        assert!(self.receiver.is_empty()); // Should be empty before restarting.
+
+        // Reset transaction indexes if tracking them - BEFORE allowing new insertions.
+        if let Some(transaction_indexes) = self.transaction_indexes.as_ref() {
+            *transaction_indexes.lock().unwrap() = 0;
+        }
+
+        self.slot_allowed_insertions.0.store(
+            SlotAllowedInsertions::encoded_value(slot, self.capacity),
+            Ordering::Release,
+        );
+    }
+
+    pub fn drain(&self) -> impl Iterator<Item = Record> + '_ {
+        core::iter::from_fn(|| self.try_recv().ok())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.receiver.is_empty()
+    }
+
+    /// Try to receive a record from the channel.
+    pub fn try_recv(&self) -> Result<Record, TryRecvError> {
+        let record = self.receiver.try_recv()?;
+        self.on_received_record(record.transaction_batches.len() as u64);
+        Ok(record)
+    }
+
+    pub fn recv_timeout(&self, duration: Duration) -> Result<Record, RecvTimeoutError> {
+        let record = self.receiver.recv_timeout(duration)?;
+        self.on_received_record(record.transaction_batches.len() as u64);
+        Ok(record)
+    }
+
+    fn on_received_record(&self, num_batches: u64) {
+        self.slot_allowed_insertions
+            .0
+            .fetch_add(num_batches, Ordering::AcqRel);
+    }
+}
+
+/// Encoded u64 where the upper 54 bits are the slot and the lower 10 bits are
+/// the number of allowed insertions at the current time.
+/// The number of allowed insertions is based on the number of **batches** sent,
+/// not the number of [`Record`]. This is because each batch is a separate hash
+/// in the PoH stream, and we must guarantee enough space for each hash, if we
+/// allow a [`Record`] to be sent.
+#[derive(Clone, Debug)]
+struct SlotAllowedInsertions(Arc<AtomicU64>);
+
+impl SlotAllowedInsertions {
+    const NUM_BITS: u64 = 64;
+    const ALLOWED_INSERTIONS_BITS: u64 = 10;
+    const SLOT_BITS: u64 = Self::NUM_BITS - Self::ALLOWED_INSERTIONS_BITS;
+
+    const DISABLED_SLOT: Slot = (1 << Self::SLOT_BITS) - 1;
+    const MAX_SLOT: Slot = Self::DISABLED_SLOT - 1;
+    const MAX_ALLOWED_INSERTIONS: u64 = (1 << Self::ALLOWED_INSERTIONS_BITS) - 1;
+
+    /// Create a new `SlotAllowedInsertions` with state consistent with a
+    /// shutdown state.
+    fn new_shutdown() -> Self {
+        Self(Arc::new(AtomicU64::new(Self::encoded_value(
+            Self::DISABLED_SLOT,
+            0,
+        ))))
+    }
+
+    fn encoded_value(slot: Slot, allowed_insertions: u64) -> u64 {
+        assert!(slot <= Self::DISABLED_SLOT);
+        assert!(allowed_insertions <= Self::MAX_ALLOWED_INSERTIONS);
+        (slot << 10) | allowed_insertions
+    }
+
+    fn slot(value: u64) -> Slot {
+        (value >> 10) & Self::DISABLED_SLOT
+    }
+
+    fn allowed_insertions(value: u64) -> u64 {
+        value & Self::MAX_ALLOWED_INSERTIONS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_transaction::versioned::VersionedTransaction};
+
+    #[test]
+    fn test_record_channels() {
+        let (sender, mut receiver) = record_channels(false);
+
+        // Initially shutdown.
+        let (dummy_sender, _receiver) = bounded(0);
+        assert!(matches!(
+            sender.try_send(Record {
+                slot: 0,
+                transaction_batches: vec![],
+                mixins: vec![],
+                sender: dummy_sender.clone(),
+            }),
+            Err(RecordSenderError::Shutdown)
+        ));
+
+        // Restart for slot 1.
+        receiver.restart(1);
+
+        // Record for slot 0 fails.
+        assert!(matches!(
+            sender.try_send(Record {
+                slot: 0,
+                transaction_batches: vec![],
+                mixins: vec![],
+                sender: dummy_sender.clone(),
+            }),
+            Err(RecordSenderError::InactiveSlot)
+        ));
+
+        // Record for slot 1 with 1 batch succeeds.
+        assert!(matches!(
+            sender.try_send(Record {
+                slot: 1,
+                transaction_batches: vec![vec![]],
+                mixins: vec![],
+                sender: dummy_sender.clone(),
+            }),
+            Ok(None)
+        ));
+
+        // Record for slot 1 with 1023 batches fails (channel full).
+        assert!(matches!(
+            sender.try_send(Record {
+                slot: 1,
+                transaction_batches: vec![vec![]; 1_023],
+                mixins: vec![],
+                sender: dummy_sender.clone(),
+            }),
+            Err(RecordSenderError::Full(_))
+        ));
+
+        // Record for slot 1 with 1023 batches succeeds (channel full).
+        assert!(matches!(
+            sender.try_send(Record {
+                slot: 1,
+                transaction_batches: vec![vec![]; 1_022],
+                mixins: vec![],
+                sender: dummy_sender.clone(),
+            }),
+            Ok(None)
+        ));
+
+        // Record for slot 1 with 1 batch fails (channel full).
+        assert!(matches!(
+            sender.try_send(Record {
+                slot: 1,
+                transaction_batches: vec![vec![]],
+                mixins: vec![],
+                sender: dummy_sender.clone(),
+            }),
+            Err(RecordSenderError::Full(_))
+        ));
+
+        // Receive 1 record.
+        assert!(matches!(receiver.try_recv(), Ok(_)));
+        assert!(!receiver.is_empty());
+        assert!(matches!(receiver.try_recv(), Ok(_)));
+        assert!(receiver.is_empty());
+    }
+
+    #[test]
+    fn test_record_channels_track_indexes() {
+        let (sender, mut receiver) = record_channels(true);
+
+        // Initially shutdown.
+        let (dummy_sender, _receiver) = bounded(0);
+        assert!(matches!(
+            sender.try_send(Record {
+                slot: 0,
+                transaction_batches: vec![],
+                mixins: vec![],
+                sender: dummy_sender.clone(),
+            }),
+            Err(RecordSenderError::Shutdown)
+        ));
+
+        // Restart for slot 1.
+        receiver.restart(1);
+
+        // Record for slot 0 fails.
+        assert!(matches!(
+            sender.try_send(Record {
+                slot: 0,
+                transaction_batches: vec![],
+                mixins: vec![],
+                sender: dummy_sender.clone(),
+            }),
+            Err(RecordSenderError::InactiveSlot)
+        ));
+
+        // Record for slot 1 with 1 batch succeeds.
+        assert!(matches!(
+            sender.try_send(Record {
+                slot: 1,
+                transaction_batches: vec![vec![VersionedTransaction::default()]],
+                mixins: vec![],
+                sender: dummy_sender.clone(),
+            }),
+            Ok(Some(0))
+        ));
+
+        // Record for slot 1 with 2 batches (3 transactions) succeeds.
+        assert!(matches!(
+            sender.try_send(Record {
+                slot: 1,
+                transaction_batches: vec![
+                    vec![VersionedTransaction::default()],
+                    vec![
+                        VersionedTransaction::default(),
+                        VersionedTransaction::default()
+                    ],
+                ],
+                mixins: vec![],
+                sender: dummy_sender.clone(),
+            }),
+            Ok(Some(1))
+        ));
+
+        assert!(*sender.transaction_indexes.as_ref().unwrap().lock().unwrap() == 4);
+    }
+}

--- a/poh/src/record_channels.rs
+++ b/poh/src/record_channels.rs
@@ -256,12 +256,12 @@ impl SlotAllowedInsertions {
     fn encoded_value(slot: Slot, allowed_insertions: u64) -> u64 {
         assert!(slot <= Self::DISABLED_SLOT);
         assert!(allowed_insertions <= Self::MAX_ALLOWED_INSERTIONS);
-        (slot << 10) | allowed_insertions
+        (slot << Self::ALLOWED_INSERTIONS_BITS) | allowed_insertions
     }
 
     /// The current slot, or `DISABLED_SLOT` if shutdown.
     fn slot(value: u64) -> Slot {
-        (value >> 10) & Self::DISABLED_SLOT
+        (value >> Self::ALLOWED_INSERTIONS_BITS) & Self::DISABLED_SLOT
     }
 
     /// How many insertions/sends are allowed at this time.

--- a/poh/src/record_channels.rs
+++ b/poh/src/record_channels.rs
@@ -42,9 +42,14 @@ pub fn record_channels(track_transaction_indexes: bool) -> (RecordSender, Record
 }
 
 pub enum RecordSenderError {
+    /// The channel is full, the record was not sent.
     Full(Record),
+    /// The channel is in a shutdown state, it is not valid to
+    /// send records for this slot anymore.
     Shutdown,
+    /// The record's slot does not match the current slot of the channel.
     InactiveSlot,
+    /// The receiver has been dropped, the channel is disconnected.
     Disconnected,
 }
 

--- a/poh/src/transaction_recorder.rs
+++ b/poh/src/transaction_recorder.rs
@@ -1,9 +1,8 @@
 use {
     crate::{
-        poh_recorder::{PohRecorderError, Record, Result},
-        record_channels::RecordSender,
+        poh_recorder::{PohRecorderError, Record},
+        record_channels::{RecordSender, RecordSenderError},
     },
-    crossbeam_channel::{bounded, RecvTimeoutError},
     solana_clock::Slot,
     solana_entry::entry::hash_transactions,
     solana_hash::Hash,
@@ -11,11 +10,7 @@ use {
     solana_transaction::versioned::VersionedTransaction,
     std::{
         num::Saturating,
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Arc,
-        },
-        time::Duration,
+        sync::{atomic::AtomicBool, Arc},
     },
 };
 
@@ -38,7 +33,7 @@ pub struct RecordTransactionsSummary {
     // Metrics describing how time was spent recording transactions
     pub record_transactions_timings: RecordTransactionsTimings,
     // Result of trying to record the transactions into the PoH stream
-    pub result: Result<()>,
+    pub result: Result<(), PohRecorderError>,
     // Index in the slot of the first transaction recorded
     pub starting_transaction_index: Option<usize>,
 }
@@ -81,21 +76,27 @@ impl TransactionRecorder {
                 Ok(starting_index) => {
                     starting_transaction_index = starting_index;
                 }
-                Err(PohRecorderError::MaxHeightReached) => {
+                Err(RecordSenderError::InactiveSlot | RecordSenderError::Shutdown) => {
                     return RecordTransactionsSummary {
                         record_transactions_timings,
                         result: Err(PohRecorderError::MaxHeightReached),
                         starting_transaction_index: None,
-                    };
+                    }
                 }
-                Err(PohRecorderError::SendError(e)) => {
+                Err(RecordSenderError::Full(_)) => {
                     return RecordTransactionsSummary {
                         record_transactions_timings,
-                        result: Err(PohRecorderError::SendError(e)),
+                        result: Err(PohRecorderError::ChannelFull),
                         starting_transaction_index: None,
                     };
                 }
-                Err(e) => panic!("Poh recorder returned unexpected error: {e:?}"),
+                Err(RecordSenderError::Disconnected) => {
+                    return RecordTransactionsSummary {
+                        record_transactions_timings,
+                        result: Err(PohRecorderError::ChannelDisconnected),
+                        starting_transaction_index: None,
+                    };
+                }
             }
         }
 
@@ -112,41 +113,8 @@ impl TransactionRecorder {
         bank_slot: Slot,
         mixins: Vec<Hash>,
         transaction_batches: Vec<Vec<VersionedTransaction>>,
-    ) -> Result<Option<usize>> {
-        // create a new channel so that there is only 1 sender and when it goes out of scope, the receiver fails
-        let (result_sender, result_receiver) = bounded(1);
-        let res = self.record_sender.try_send(Record::new(
-            mixins,
-            transaction_batches,
-            bank_slot,
-            result_sender,
-        ));
-        if res.is_err() {
-            // If the channel is dropped, then the validator is shutting down so return that we are hitting
-            //  the max tick height to stop transaction processing and flush any transactions in the pipeline.
-            return Err(PohRecorderError::MaxHeightReached);
-        }
-        // Besides validator exit, this timeout should primarily be seen to affect test execution environments where the various pieces can be shutdown abruptly
-        let mut is_exited = false;
-        loop {
-            let res = result_receiver.recv_timeout(Duration::from_millis(1000));
-            match res {
-                Err(RecvTimeoutError::Timeout) => {
-                    if is_exited {
-                        return Err(PohRecorderError::MaxHeightReached);
-                    } else {
-                        // A result may have come in between when we timed out checking this
-                        // bool, so check the channel again, even if is_exited == true
-                        is_exited = self.is_exited.load(Ordering::SeqCst);
-                    }
-                }
-                Err(RecvTimeoutError::Disconnected) => {
-                    return Err(PohRecorderError::MaxHeightReached);
-                }
-                Ok(result) => {
-                    return result;
-                }
-            }
-        }
+    ) -> Result<Option<usize>, RecordSenderError> {
+        self.record_sender
+            .try_send(Record::new(mixins, transaction_batches, bank_slot))
     }
 }

--- a/poh/src/transaction_recorder.rs
+++ b/poh/src/transaction_recorder.rs
@@ -8,10 +8,7 @@ use {
     solana_hash::Hash,
     solana_measure::measure_us,
     solana_transaction::versioned::VersionedTransaction,
-    std::{
-        num::Saturating,
-        sync::{atomic::AtomicBool, Arc},
-    },
+    std::num::Saturating,
 };
 
 #[derive(Default, Debug)]
@@ -43,15 +40,11 @@ pub struct RecordTransactionsSummary {
 pub struct TransactionRecorder {
     // shared by all users of PohRecorder
     pub record_sender: RecordSender,
-    pub is_exited: Arc<AtomicBool>,
 }
 
 impl TransactionRecorder {
-    pub fn new(record_sender: RecordSender, is_exited: Arc<AtomicBool>) -> Self {
-        Self {
-            record_sender,
-            is_exited,
-        }
+    pub fn new(record_sender: RecordSender) -> Self {
+        Self { record_sender }
     }
 
     /// Hashes `transactions` and sends to PoH service for recording. Waits for response up to 1s.


### PR DESCRIPTION
#### Problem
- Recording to PoH is monstrously slow due to 2-way communication
- 2-way communication is not necessary!

#### Summary of Changes
- PoH service will process all in-flight before applying requested changes from `PohController`
- TransactionRecorder uses shared atomics to determine if it can send, if sent recording is guaranteed.
- Kill simulated PoH in tests
  - While this was not **strictly** necessary for the changes, the simulated service would have needed updates similar to those in poh service. Since recording success is now determinable from the recording side, we do not need a faux poh service 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
