### PR TITLE
refactor: uses `filter_map` instead of first `filter`ing and then `map`ping

### DIFF
--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -202,7 +202,7 @@ impl BankForks {
     pub fn frozen_banks(&self) -> impl Iterator<Item = (Slot, Arc<Bank>)> + '_ {
         self.banks.iter().filter_map(|(&slot, bank)| {
             bank.is_frozen()
-                .then_some((slot, bank.clone_without_scheduler()))
+                .then(|| (slot, bank.clone_without_scheduler()))
         })
     }
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -200,17 +200,16 @@ impl BankForks {
     }
 
     pub fn frozen_banks(&self) -> impl Iterator<Item = (Slot, Arc<Bank>)> + '_ {
-        self.banks
-            .iter()
-            .filter(|(_, b)| b.is_frozen())
-            .map(|(&k, b)| (k, b.clone_without_scheduler()))
+        self.banks.iter().filter_map(|(&slot, bank)| {
+            bank.is_frozen()
+                .then_some((slot, bank.clone_without_scheduler()))
+        })
     }
 
     pub fn active_bank_slots(&self) -> Vec<Slot> {
         self.banks
             .iter()
-            .filter(|(_, v)| !v.is_frozen())
-            .map(|(k, _v)| *k)
+            .filter_map(|(&slot, bank)| (!bank.is_frozen()).then_some(slot))
             .collect()
     }
 


### PR DESCRIPTION
#### Problem

A couple of functions in `bank_forks.rs` are first calling `filter` and then `map`.  In effect, they are iterating over the items twice.

#### Summary of Changes

- Use `filter_map` instead to only iterate once.
- also uses more descriptive names