### PR TITLE
Move Arc<BucketMapHolder> to &BucketMapHolder dereference out of loops

### DIFF
--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -109,7 +109,7 @@ pub struct AccountMapEntryMeta {
 
 impl AccountMapEntryMeta {
     pub fn new_dirty<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>(
-        storage: &Arc<BucketMapHolder<T, U>>,
+        storage: &BucketMapHolder<T, U>,
         is_cached: bool,
     ) -> Self {
         AccountMapEntryMeta {
@@ -118,7 +118,7 @@ impl AccountMapEntryMeta {
         }
     }
     pub fn new_clean<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>(
-        storage: &Arc<BucketMapHolder<T, U>>,
+        storage: &BucketMapHolder<T, U>,
     ) -> Self {
         AccountMapEntryMeta {
             dirty: AtomicBool::new(false),
@@ -162,7 +162,7 @@ impl<T: IndexValue> PreAllocatedAccountMapEntry<T> {
     pub fn new<U: DiskIndexValue + From<T> + Into<T>>(
         slot: Slot,
         account_info: T,
-        storage: &Arc<BucketMapHolder<T, U>>,
+        storage: &BucketMapHolder<T, U>,
         store_raw: bool,
     ) -> PreAllocatedAccountMapEntry<T> {
         if store_raw {
@@ -175,7 +175,7 @@ impl<T: IndexValue> PreAllocatedAccountMapEntry<T> {
     fn allocate<U: DiskIndexValue + From<T> + Into<T>>(
         slot: Slot,
         account_info: T,
-        storage: &Arc<BucketMapHolder<T, U>>,
+        storage: &BucketMapHolder<T, U>,
     ) -> Arc<AccountMapEntry<T>> {
         let is_cached = account_info.is_cached();
         let ref_count = RefCount::from(!is_cached);
@@ -189,7 +189,7 @@ impl<T: IndexValue> PreAllocatedAccountMapEntry<T> {
 
     pub fn into_account_map_entry<U: DiskIndexValue + From<T> + Into<T>>(
         self,
-        storage: &Arc<BucketMapHolder<T, U>>,
+        storage: &BucketMapHolder<T, U>,
     ) -> Arc<AccountMapEntry<T>> {
         match self {
             Self::Entry(entry) => entry,

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1068,10 +1068,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let mut num_existed_in_mem = 0;
         let mut num_existed_on_disk = 0;
 
+        let storage = self.storage.as_ref();
         let duplicates = duplicates_put_on_disk
             .into_iter()
             .chain(duplicates.into_iter().map(|(slot, key, info)| {
-                let entry = PreAllocatedAccountMapEntry::new(slot, info, &self.storage, true);
+                let entry = PreAllocatedAccountMapEntry::new(slot, info, storage, true);
                 match self.insert_new_entry_if_missing_with_lock(key, entry) {
                     InsertNewEntryResults::DidNotExist => {
                         num_did_not_exist += 1;


### PR DESCRIPTION
#### Problem
accounts_index is passing around &Arc<BucketMapHolder..> when it could just pass &BucketMapHolder, also across the loop iterations. In some cases we can do just one Arc dereference before the loop.

#### Summary of Changes
* cleanup account_map_entry APIs to use &BucketMapHolder -> signals / enforces that they only use a reference instead of a ref-counted reference, allows passing already dereferenced value from Arc
* optimize two loops to just dereference self.storage once

I don't think this is measurable perf impact, but should be positive and cleans up the code.