### PR TITLE
Fix flaky test_should_track_transaction test

### DIFF
--- a/transaction-metrics-tracker/src/lib.rs
+++ b/transaction-metrics-tracker/src/lib.rs
@@ -96,6 +96,7 @@ mod tests {
     fn test_should_track_transaction() {
         let mut sig = [0x0; SIGNATURE_BYTES];
         let track = should_track_transaction(&sig);
+        // TXN_MASK is random and track will evaluate to true if it hits exactly the 0x0 signature
         assert_eq!(track, *TXN_MASK == 0);
 
         // Intentionally matching the randomly generated mask

--- a/transaction-metrics-tracker/src/lib.rs
+++ b/transaction-metrics-tracker/src/lib.rs
@@ -96,7 +96,7 @@ mod tests {
     fn test_should_track_transaction() {
         let mut sig = [0x0; SIGNATURE_BYTES];
         let track = should_track_transaction(&sig);
-        assert!(!track);
+        assert_eq!(track, *TXN_MASK == 0);
 
         // Intentionally matching the randomly generated mask
         // The lower four bits are ignored as only 12 highest bits from


### PR DESCRIPTION
#### Problem
solana-transaction-metrics-tracker  tests::test_should_track_transaction fails every 1/4096 because it assumes random number cannot be 0
(this is especially painful when it happens in coverage CI job https://buildkite.com/anza/agave/builds/29908/steps/canvas?jid=0199189c-1003-45a3-a820-03be4df448c8)

#### Summary of Changes
Let assert handle case of TXN_MASK == 0
