### PR TITLE
validator: Clarify --dynamic-port-range semantics

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -354,6 +354,7 @@ pub fn port_validator(port: String) -> Result<(), String> {
 
 pub fn port_range_validator(port_range: String) -> Result<(), String> {
     if let Some((start, end)) = solana_net_utils::parse_port_range(&port_range) {
+        // The port range is half-open: [start, end)
         if end - start < MINIMUM_VALIDATOR_PORT_RANGE_WIDTH {
             Err(format!(
                 "Port range is too small.  Try --dynamic-port-range {}-{}",
@@ -657,7 +658,10 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .takes_value(true)
                 .default_value(&default_args.dynamic_port_range)
                 .validator(port_range_validator)
-                .help("Range to use for dynamically assigned ports"),
+                .help(
+                    "Range to use for dynamically assigned ports. MIN_PORT-MAX_PORT yields the \
+                     range [MIN_PORT, MAX_PORT)",
+                ),
         )
         .arg(
             Arg::with_name("bind_address")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -368,7 +368,10 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .default_value(&default_args.dynamic_port_range)
             .validator(port_range_validator)
-            .help("Range to use for dynamically assigned ports"),
+            .help(
+                "Range to use for dynamically assigned ports. MIN_PORT-MAX_PORT yields the range \
+                 [MIN_PORT, MAX_PORT)",
+            ),
     )
     .arg(
         Arg::with_name("maximum_local_snapshot_age")


### PR DESCRIPTION
The validator’s --dynamic-port-range check incorrectly required 26 ports instead of the documented 25. For example, specifying 8000-8024 (25 ports) resulted in an error suggesting 8000-8025.

Summary of Changes

Adjusted port range width calculation to use end - start + 1.

Updated validation logic so that exactly 25 ports is accepted.

Fixed error message to correctly suggest the minimum valid range.

Fixes #7759