### PR TITLE
bump solana-stake-interface from 2.0.0 to 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10742,9 +10742,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd582fe900e43db96651a5b43956b8ebfab1944d091b391d89140635900ef46"
+checksum = "f6f912ae679b683365348dea482dbd9468d22ff258b554fd36e3d3683c2122e3"
 dependencies = [
  "borsh",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -515,7 +515,7 @@ solana-signer = "3.0.0"
 solana-slot-hashes = "3.0.0"
 solana-slot-history = "3.0.0"
 solana-stable-layout = "3.0.0"
-solana-stake-interface = { version = "2.0.0" }
+solana-stake-interface = { version = "2.0.1" }
 solana-stake-program = { path = "programs/stake", version = "=3.1.0" }
 solana-storage-bigtable = { path = "storage-bigtable", version = "=3.1.0" }
 solana-storage-proto = { path = "storage-proto", version = "=3.1.0" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -81,7 +81,7 @@ solana-sdk-ids = "=3.0.0"
 solana-signature = { version = "=3.1.0", default-features = false }
 solana-signer = "=3.0.0"
 solana-slot-history = "=3.0.0"
-solana-stake-interface = "=2.0.0"
+solana-stake-interface = "=2.0.1"
 solana-streamer = { workspace = true }
 solana-system-interface = { version = "=2.0", features = ["bincode"] }
 solana-sysvar = "=3.0.0"

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -54,7 +54,7 @@ solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk-ids = "=3.0.0"
 solana-signer = "=3.0.0"
-solana-stake-interface = { version = "=2.0.0", features = ["borsh"] }
+solana-stake-interface = { version = "=2.0.1", features = ["borsh"] }
 solana-stake-program = { workspace = true }
 solana-time-utils = "3.0.0"
 solana-version = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9218,9 +9218,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd582fe900e43db96651a5b43956b8ebfab1944d091b391d89140635900ef46"
+checksum = "f6f912ae679b683365348dea482dbd9468d22ff258b554fd36e3d3683c2122e3"
 dependencies = [
  "num-traits",
  "serde",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -157,7 +157,7 @@ solana-sbpf = "=0.12.2"
 solana-sdk-ids = "=3.0.0"
 solana-secp256k1-recover = "=3.0.0"
 solana-sha256-hasher = { version = "=3.0.0", features = ["sha2"] }
-solana-stake-interface = { version = "=2.0.0", features = ["bincode"] }
+solana-stake-interface = { version = "=2.0.1", features = ["bincode"] }
 solana-svm = { path = "../../svm", version = "=3.1.0" }
 solana-svm-callback = { path = "../../svm-callback", version = "=3.1.0" }
 solana-svm-feature-set = { path = "../../svm-feature-set", version = "=3.1.0" }
@@ -236,7 +236,7 @@ solana-sbf-rust-realloc-invoke-dep = { workspace = true }
 solana-sbpf = { workspace = true, features = ["jit"] }
 solana-sdk-ids = "3.0.0"
 solana-signer = "3.0.0"
-solana-stake-interface = "2.0.0"
+solana-stake-interface = "2.0.1"
 solana-svm = { workspace = true }
 solana-svm-callback = { workspace = true }
 solana-svm-feature-set = { workspace = true }


### PR DESCRIPTION
#### Problem

`StakeHistory::get` in solana-stake-interface was performing a binary search for every requested epoch, which was a visible performance bottleneck.

<img width="1908" height="493" alt="stake-history-before" src="https://github.com/user-attachments/assets/78f36ad1-1c1b-4919-ad8f-78b4723b28a1" />

#### Summary of Changes

solana-program/stake#81 fixed that by subtracting the indices. The fix was released in 2.0.1.

<img width="3376" height="832" alt="slot--cache-after" src="https://github.com/user-attachments/assets/014b3680-ccf1-4b0e-8fab-6a10d65c3997" />

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
