### PR TITLE
CostTracker: Add a getter to expose cost by writable accounts

### DIFF
--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -31,7 +31,6 @@ frozen-abi = [
     "solana-pubkey/frozen-abi",
     "solana-vote-program/frozen-abi",
 ]
-post-analysis = []
 
 [dependencies]
 agave-feature-set = { workspace = true }

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -31,6 +31,7 @@ frozen-abi = [
     "solana-pubkey/frozen-abi",
     "solana-vote-program/frozen-abi",
 ]
+post-analysis = []
 
 [dependencies]
 agave-feature-set = { workspace = true }

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -431,6 +431,11 @@ impl CostTracker {
             .filter(|units| **units > 0)
             .count()
     }
+
+    /// Get a reference to the cost by writable accounts map
+    pub fn get_cost_by_writable_accounts(&self) -> &HashMap<Pubkey, u64, ahash::RandomState> {
+        &self.cost_by_writable_accounts
+    }
 }
 
 #[cfg(test)]

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -3,11 +3,10 @@
 //! - would_fit(&tx_cost), immutable function to test if tx with tx_cost would fit into current block
 //! - add_transaction_cost(&tx_cost), mutable function to accumulate tx_cost to tracker.
 //!
+#[cfg(feature = "post-analysis")]
+use crate::cost_tracker_post_analysis::CostTrackerPostAnalysis;
 use {
-    crate::{
-        block_cost_limits::*, cost_tracker_post_analysis::CostTrackerPostAnalysis,
-        transaction_cost::TransactionCost,
-    },
+    crate::{block_cost_limits::*, transaction_cost::TransactionCost},
     solana_metrics::datapoint_info,
     solana_pubkey::Pubkey,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -439,6 +438,7 @@ impl CostTracker {
 /// Implement the trait for the cost tracker
 /// This is only used for post-analysis to avoid lock contention
 /// Do not use in the hot path
+#[cfg(feature = "post-analysis")]
 impl CostTrackerPostAnalysis for CostTracker {
     fn get_cost_by_writable_accounts(&self) -> &HashMap<Pubkey, u64, ahash::RandomState> {
         &self.cost_by_writable_accounts
@@ -1012,6 +1012,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "post-analysis")]
     fn test_get_cost_by_writable_accounts_post_analysis() {
         let mut cost_tracker = CostTracker::default();
         let cost = 100u64;

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -3,10 +3,11 @@
 //! - would_fit(&tx_cost), immutable function to test if tx with tx_cost would fit into current block
 //! - add_transaction_cost(&tx_cost), mutable function to accumulate tx_cost to tracker.
 //!
-#[cfg(feature = "post-analysis")]
-use crate::cost_tracker_post_analysis::CostTrackerPostAnalysis;
 use {
-    crate::{block_cost_limits::*, transaction_cost::TransactionCost},
+    crate::{
+        block_cost_limits::*, cost_tracker_post_analysis::CostTrackerPostAnalysis,
+        transaction_cost::TransactionCost,
+    },
     solana_metrics::datapoint_info,
     solana_pubkey::Pubkey,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -438,7 +439,6 @@ impl CostTracker {
 /// Implement the trait for the cost tracker
 /// This is only used for post-analysis to avoid lock contention
 /// Do not use in the hot path
-#[cfg(feature = "post-analysis")]
 impl CostTrackerPostAnalysis for CostTracker {
     fn get_cost_by_writable_accounts(&self) -> &HashMap<Pubkey, u64, ahash::RandomState> {
         &self.cost_by_writable_accounts
@@ -1012,7 +1012,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "post-analysis")]
     fn test_get_cost_by_writable_accounts_post_analysis() {
         let mut cost_tracker = CostTracker::default();
         let cost = 100u64;

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -4,7 +4,10 @@
 //! - add_transaction_cost(&tx_cost), mutable function to accumulate tx_cost to tracker.
 //!
 use {
-    crate::{block_cost_limits::*, transaction_cost::TransactionCost},
+    crate::{
+        block_cost_limits::*, cost_tracker_post_analysis::CostTrackerPostAnalysis,
+        transaction_cost::TransactionCost,
+    },
     solana_metrics::datapoint_info,
     solana_pubkey::Pubkey,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -431,9 +434,13 @@ impl CostTracker {
             .filter(|units| **units > 0)
             .count()
     }
+}
 
-    /// Get a reference to the cost by writable accounts map
-    pub fn get_cost_by_writable_accounts(&self) -> &HashMap<Pubkey, u64, ahash::RandomState> {
+/// Implement the trait for the cost tracker
+/// This is only used for post-analysis to avoid lock contention
+/// Do not use in the hot path
+impl CostTrackerPostAnalysis for CostTracker {
+    fn get_cost_by_writable_accounts(&self) -> &HashMap<Pubkey, u64, ahash::RandomState> {
         &self.cost_by_writable_accounts
     }
 }
@@ -1002,5 +1009,21 @@ mod tests {
         assert_eq!(0, cost_tracker.block_cost);
         assert_eq!(0, cost_tracker.vote_cost);
         assert_eq!(0, cost_tracker.allocated_accounts_data_size.0);
+    }
+
+    #[test]
+    fn test_get_cost_by_writable_accounts_post_analysis() {
+        let mut cost_tracker = CostTracker::default();
+        let cost = 100u64;
+        let transaction = WritableKeysTransaction(vec![Pubkey::new_unique()]);
+        let tx_cost = simple_transaction_cost(&transaction, cost);
+        cost_tracker.add_transaction_cost(&tx_cost);
+        let cost_by_writable_accounts = cost_tracker.get_cost_by_writable_accounts();
+        assert_eq!(1, cost_by_writable_accounts.len());
+        assert_eq!(cost, *cost_by_writable_accounts.values().next().unwrap());
+        assert_eq!(
+            *cost_by_writable_accounts,
+            cost_tracker.cost_by_writable_accounts
+        );
     }
 }

--- a/cost-model/src/cost_tracker_post_analysis.rs
+++ b/cost-model/src/cost_tracker_post_analysis.rs
@@ -1,0 +1,8 @@
+use {solana_pubkey::Pubkey, std::collections::HashMap};
+
+/// Trait to help with post-analysis of a given block
+pub trait CostTrackerPostAnalysis {
+    /// Only use in post-analyze to avoid lock contention
+    /// Do not use in the hot path
+    fn get_cost_by_writable_accounts(&self) -> &HashMap<Pubkey, u64, ahash::RandomState>;
+}

--- a/cost-model/src/lib.rs
+++ b/cost-model/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod block_cost_limits;
 pub mod cost_model;
 pub mod cost_tracker;
+pub mod cost_tracker_post_analysis;
 pub mod transaction_cost;
 
 #[cfg_attr(feature = "frozen-abi", macro_use)]

--- a/cost-model/src/lib.rs
+++ b/cost-model/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod block_cost_limits;
 pub mod cost_model;
 pub mod cost_tracker;
+#[cfg(feature = "post-analysis")]
 pub mod cost_tracker_post_analysis;
 pub mod transaction_cost;
 

--- a/cost-model/src/lib.rs
+++ b/cost-model/src/lib.rs
@@ -4,7 +4,6 @@
 pub mod block_cost_limits;
 pub mod cost_model;
 pub mod cost_tracker;
-#[cfg(feature = "post-analysis")]
 pub mod cost_tracker_post_analysis;
 pub mod transaction_cost;
 


### PR DESCRIPTION
Summary    
This change adds a new method to the CostTracker that provides a breakdown of compute unit costs for each writable account during block processing.

Problem
Currently, CostTracker aggregates compute unit costs but doesn't expose a detailed breakdown of costs per account. This makes it difficult to analyze resource consumption patterns and identify which accounts are the biggest resource consumers within a block during post-analysis.

Proposed Changes
A new method, get_cost_by_writable_accounts(), has been added to the CostTracker which exposes a reference to the map that holds the detailed breakdown of costs per account.
