### PR TITLE
Remove unused self argument

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -314,7 +314,7 @@ impl AccountsFile {
     /// in data_len
     pub(crate) fn calculate_stored_size(&self, data_len: usize) -> usize {
         match self {
-            Self::AppendVec(av) => av.calculate_stored_size(data_len),
+            Self::AppendVec(_) => AppendVec::calculate_stored_size(data_len),
             Self::TieredStorage(ts) => ts
                 .reader()
                 .expect("Reader must be initialized as stored size is specific to format")

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -919,7 +919,7 @@ impl AppendVec {
         let data_len = self.get_account_data_lens(&[offset]);
         let sizes: usize = data_len
             .iter()
-            .map(|len| self.calculate_stored_size(*len))
+            .map(|len| AppendVec::calculate_stored_size(*len))
             .sum();
         let result = self.get_stored_account_meta_callback(offset, |r_callback| {
             let r2 = self.get_account_shared_data(offset);
@@ -1088,7 +1088,7 @@ impl AppendVec {
 
     /// Calculate the amount of storage required for an account with the passed
     /// in data_len
-    pub(crate) fn calculate_stored_size(&self, data_len: usize) -> usize {
+    pub(crate) fn calculate_stored_size(data_len: usize) -> usize {
         aligned_stored_size(data_len)
     }
 
@@ -1701,7 +1701,7 @@ pub mod tests {
             let stored_size = av
                 .get_account_data_lens(indexes.as_slice())
                 .iter()
-                .map(|len| av.calculate_stored_size(*len))
+                .map(|len| AppendVec::calculate_stored_size(*len))
                 .sum::<usize>();
             assert_eq!(sizes.iter().sum::<usize>(), stored_size);
         }
@@ -2084,7 +2084,7 @@ pub mod tests {
         let account_sizes = append_vec
             .get_account_data_lens(account_offsets.as_slice())
             .iter()
-            .map(|len| append_vec.calculate_stored_size(*len))
+            .map(|len| AppendVec::calculate_stored_size(*len))
             .sum::<usize>();
         assert_eq!(account_sizes, total_stored_size);
     }

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -597,7 +597,7 @@ impl HotStorageReader {
 
     /// Calculate the amount of storage required for an account with the passed
     /// in data_len
-    pub(crate) fn calculate_stored_size(&self, data_len: usize) -> usize {
+    pub(crate) fn calculate_stored_size(data_len: usize) -> usize {
         stored_size(data_len)
     }
 

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -153,7 +153,7 @@ impl TieredStorageReader {
     /// in data_len
     pub(crate) fn calculate_stored_size(&self, data_len: usize) -> usize {
         match self {
-            Self::Hot(hot) => hot.calculate_stored_size(data_len),
+            Self::Hot(_) => HotStorageReader::calculate_stored_size(data_len),
         }
     }
 


### PR DESCRIPTION
#### Problem
- Self is not needed to calculate the stored size for a given data length.

#### Summary of Changes
- Remove self argument
Note: This will be useful for fastboot with obsolete accounts: current_len saved is the length of the storage after removing obsolete accounts, but in the fastboot case, obsolete accounts are not removed from the storage, so the additional size due to obsolete accounts needs to be added back before creating the appendvec. The file size can't be used due to a collision with the snapshot minimize feature. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
