### PR TITLE
chore: Move displaced comment back to proper place

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -190,10 +190,10 @@ fs_extra = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
 solana-account = { workspace = true, features = ["dev-context-only-utils"] }
-# See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-bpf-loader-program = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-compute-budget-program = { workspace = true }
+# See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-core = { path = ".", features = ["dev-context-only-utils"] }
 solana-cost-model = { workspace = true, features = ["dev-context-only-utils"] }
 solana-keypair = { workspace = true }


### PR DESCRIPTION
#### Problem
Noticed this comment got shifted around and was no longer above the line it is supposed to refer to (the crate "self reference")