### PR TITLE
accounts-db: Scale parallelism based on installed threadpool

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2042,9 +2042,9 @@ impl AccountsDb {
         );
         let total = pubkey_refcount.len();
         let failed = AtomicBool::default();
-        let threads = quarter_thread_count();
-        let per_batch = total / threads;
-        (0..=threads).into_par_iter().for_each(|attempt| {
+        let num_threads = rayon::current_num_threads();
+        let per_batch = total / num_threads;
+        (0..=num_threads).into_par_iter().for_each(|attempt| {
             pubkey_refcount
                 .iter()
                 .skip(attempt * per_batch)
@@ -5587,7 +5587,7 @@ impl AccountsDb {
             UpdateIndexThreadSelection::PoolWithThreshold,
         ) && len > threshold
         {
-            let chunk_size = std::cmp::max(1, len / quarter_thread_count()); // # pubkeys/thread
+            let chunk_size = std::cmp::max(1, len / rayon::current_num_threads()); // # pubkeys/thread
             let batches = 1 + len / chunk_size;
             thread_pool.install(|| {
                 (0..batches)


### PR DESCRIPTION
#### Problem
There are several instances where work is divided up for a threadpool by doing `work_length / num_threads`. However, num_threads is being set based on `quarter_thread_count()`. This is the size of the background pool, but two functions may get called with global or foreground pool. Each of these pools could be a different size.

#### Summary of Changes
So, figure out num_threads by using rayon::current_num_threads()