### PR TITLE
Skip reading full_snapshot_slot file

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2333,9 +2333,6 @@ mod tests {
             )
             .unwrap();
         }
-
-        let highest_full_snapshot_archive =
-            get_highest_full_snapshot_archive_info(&snapshot_archives_dir).unwrap();
         let highest_bank_snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
 
         // 1. call get_highest_loadable() but bad snapshot dir, so returns None
@@ -2350,7 +2347,6 @@ mod tests {
         assert_eq!(bank_snapshot, highest_bank_snapshot);
 
         // 4. delete highest full snapshot archive and highest bank snapshot, get_highest_loadable() should return NONE
-        fs::remove_file(highest_full_snapshot_archive.path()).unwrap();
         fs::remove_dir_all(&highest_bank_snapshot.snapshot_dir).unwrap();
         assert!(get_highest_loadable_bank_snapshot(&snapshot_config).is_none());
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2290,23 +2290,17 @@ mod tests {
         }
     }
 
-    #[test_case(true; "Load Only")]
-    #[test_case(false; "Default")]
-    fn test_get_highest_loadable_bank_snapshot(load_only: bool) {
+    #[test_case(SnapshotConfig::new_load_only())]
+    #[test_case(SnapshotConfig::default())]
+    fn test_get_highest_loadable_bank_snapshot(snapshot_config: SnapshotConfig) {
         let bank_snapshots_dir = TempDir::new().unwrap();
         let snapshot_archives_dir = TempDir::new().unwrap();
-
-        let init_function = if load_only {
-            SnapshotConfig::new_load_only()
-        } else {
-            SnapshotConfig::default()
-        };
 
         let snapshot_config = SnapshotConfig {
             bank_snapshots_dir: bank_snapshots_dir.as_ref().to_path_buf(),
             full_snapshot_archives_dir: snapshot_archives_dir.as_ref().to_path_buf(),
             incremental_snapshot_archives_dir: snapshot_archives_dir.as_ref().to_path_buf(),
-            ..init_function
+            ..snapshot_config
         };
 
         let genesis_config = GenesisConfig::default();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2346,7 +2346,7 @@ mod tests {
         let bank_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
         assert_eq!(bank_snapshot, highest_bank_snapshot);
 
-        // 4. delete highest full snapshot archive and highest bank snapshot, get_highest_loadable() should return NONE
+        // 4. delete highest bank snapshot, get_highest_loadable() should return NONE
         fs::remove_dir_all(&highest_bank_snapshot.snapshot_dir).unwrap();
         assert!(get_highest_loadable_bank_snapshot(&snapshot_config).is_none());
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -818,7 +818,6 @@ mod tests {
                 purge_bank_snapshots_older_than_slot, purge_incomplete_bank_snapshots,
                 purge_old_bank_snapshots, purge_old_bank_snapshots_at_startup,
                 snapshot_storage_rebuilder::get_slot_and_append_vec_id,
-                SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME,
             },
             status_cache::Status,
         },
@@ -2350,19 +2349,12 @@ mod tests {
         let bank_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
         assert_eq!(bank_snapshot, highest_bank_snapshot);
 
-        // 4. delete highest full snapshot archive, get_highest_loadable() should return NONE
+        // 4. delete highest full snapshot archive and highest bank snapshot, get_highest_loadable() should return NONE
         fs::remove_file(highest_full_snapshot_archive.path()).unwrap();
-        assert!(get_highest_loadable_bank_snapshot(&snapshot_config).is_none());
-
-        // 5. get_highest_loadable(), but with a load-only snapshot config, should return Some()
-        let bank_snapshot = get_highest_loadable_bank_snapshot(&load_only_snapshot_config).unwrap();
-        assert_eq!(bank_snapshot, highest_bank_snapshot);
-
-        // 6. delete highest bank snapshot, get_highest_loadable() should return NONE
         fs::remove_dir_all(&highest_bank_snapshot.snapshot_dir).unwrap();
         assert!(get_highest_loadable_bank_snapshot(&snapshot_config).is_none());
 
-        // 7. write 'storages flushed' file, get_highest_loadable() should return Some() again, with slot-1
+        // 5. write 'storages flushed' file, get_highest_loadable() should return Some() again, with slot-1
         snapshot_utils::write_storages_flushed_file(get_bank_snapshot_dir(
             &snapshot_config.bank_snapshots_dir,
             highest_bank_snapshot.slot - 1,
@@ -2371,16 +2363,7 @@ mod tests {
         let bank_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
         assert_eq!(bank_snapshot.slot, highest_bank_snapshot.slot - 1);
 
-        // 8. delete the full snapshot slot file, get_highest_loadable() should return NONE
-        fs::remove_file(
-            bank_snapshot
-                .snapshot_dir
-                .join(SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME),
-        )
-        .unwrap();
-        assert!(get_highest_loadable_bank_snapshot(&snapshot_config).is_none());
-
-        // 9. however, a load-only snapshot config should return Some() again
+        // 6. delete the full snapshot slot file, get_highest_loadable() should return return Some() again, with slot-1
         let bank_snapshot2 =
             get_highest_loadable_bank_snapshot(&load_only_snapshot_config).unwrap();
         assert_eq!(bank_snapshot2, bank_snapshot);


### PR DESCRIPTION
#### Problem
- full snapshot slot file is no longer needed, it adds complexity to the snapshot flow

#### Summary of Changes
- Remove reading it, so it can be removed fully in the next version. Stil needs to be written for backwards compatibility. 
- Update tests 

Note: 
Behavioural update with this change: Previously if the snapshot archive that bank a snapshot was associated with was missing, get_highest_loadable_bank_snapshot would return None. Now it will return Some. 

This check was originally added in https://github.com/solana-labs/solana/issues/35367 when incremental snapshots and full snapshots were written in different threads. Now they are written in the same thread, so creating this behaviour would involve user intervention/bugginess elsewhere to recreate this flow. 

Given that there are many different wants to recreate similar scenarios (eg giving a snapshot file the wrong name), this scenario is no longer valuable to protect against. 

Testing was done with both fastboot enabled and disabled. Testing flow was
V3.0, save snapshot -> This change, save snapshot -> V3.0, save snapshot


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
