### PR TITLE
tpu-client-next: Encapsulate WorkersCache implementation details

### DIFF
--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -127,6 +127,9 @@ pub enum WorkersCacheError {
 
     #[error("The WorkersCache is being shutdown.")]
     ShutdownError,
+
+    #[error("No worker exists for the specified peer.")]
+    WorkerNotFound,
 }
 
 impl WorkersCache {
@@ -169,15 +172,50 @@ impl WorkersCache {
         None
     }
 
+    /// Ensures a worker exists for the given peer, creating one if necessary.
+    /// Returns any evicted worker that needs shutdown.
+    pub fn ensure_worker(
+        &mut self,
+        peer: SocketAddr,
+        endpoint: &Endpoint,
+        worker_channel_size: usize,
+        skip_check_transaction_age: bool,
+        max_reconnect_attempts: usize,
+        handshake_timeout: Duration,
+        stats: Arc<SendTransactionStats>,
+    ) -> Option<ShutdownWorker> {
+        if self.contains(&peer) {
+            return None;
+        }
+
+        let worker = spawn_worker(
+            endpoint,
+            &peer,
+            worker_channel_size,
+            skip_check_transaction_age,
+            max_reconnect_attempts,
+            handshake_timeout,
+            stats,
+        );
+
+        self.push(peer, worker)
+    }
+
     /// Attempts to send immediately a batch of transactions to the worker for a
     /// given peer.
     ///
     /// This method returns immediately if the channel of worker corresponding
     /// to this peer is full returning error [`WorkersCacheError::FullChannel`].
-    /// If it happens that the peer's worker is stopped, it returns
-    /// [`WorkersCacheError::ShutdownError`]. In case if the worker is not
-    /// stopped but it's channel is unexpectedly dropped, it returns
-    /// [`WorkersCacheError::ReceiverDropped`].
+    /// If no worker exists for the peer, it returns
+    /// [`WorkersCacheError::WorkerNotFound`]. If it happens that the peer's
+    /// worker is stopped, it returns [`WorkersCacheError::ShutdownError`].
+    /// In case if the worker is not stopped but it's channel is unexpectedly
+    /// dropped, it returns [`WorkersCacheError::ReceiverDropped`].
+    ///
+    /// Note: The worker existence check is necessary because workers can fail
+    /// asynchronously between creation and sending. Worker tasks may exit
+    /// due to connection failures, network issues, or cache evictions,
+    /// making a previously created worker unavailable.
     pub fn try_send_transactions_to_address(
         &mut self,
         peer: &SocketAddr,
@@ -190,10 +228,8 @@ impl WorkersCache {
             return Err(WorkersCacheError::ShutdownError);
         }
 
-        let current_worker = workers.get(peer).expect(
-            "Failed to fetch worker for peer {peer}. Peer existence must be checked before this \
-             call using `contains` method.",
-        );
+        let current_worker = workers.get(peer).ok_or(WorkersCacheError::WorkerNotFound)?;
+
         let send_res = current_worker.try_send_transactions(txs_batch);
 
         if let Err(WorkersCacheError::ReceiverDropped) = send_res {
@@ -215,7 +251,8 @@ impl WorkersCache {
     /// Sends a batch of transactions to the worker for a given peer.
     ///
     /// If the worker for the peer is disconnected or fails, it
-    /// is removed from the cache.
+    /// is removed from the cache. If no worker exists for the peer,
+    /// it returns [`WorkersCacheError::WorkerNotFound`].
     #[allow(
         dead_code,
         reason = "This method will be used in the upcoming changes to implement optional \
@@ -231,10 +268,8 @@ impl WorkersCache {
         } = self;
 
         let body = async move {
-            let current_worker = workers.get(peer).expect(
-                "Failed to fetch worker for peer {peer}. Peer existence must be checked before \
-                 this call using `contains` method.",
-            );
+            let current_worker = workers.get(peer).ok_or(WorkersCacheError::WorkerNotFound)?;
+
             let send_res = current_worker.send_transactions(txs_batch).await;
             if let Err(WorkersCacheError::ReceiverDropped) = send_res {
                 // Remove the worker from the cache, if the peer has disconnected.

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -173,6 +173,7 @@ impl WorkersCache {
     }
 
     /// Ensures a worker exists for the given peer, creating one if necessary.
+    ///
     /// Returns any evicted worker that needs shutdown.
     pub fn ensure_worker(
         &mut self,


### PR DESCRIPTION
#### Problem
The current API of `WorkersCache` leaks implementation details, requiring callers to manually manage worker creation, handle evictions, and check worker existence before sending transactions. This violates encapsulation principles and makes the API error-prone.

As noted in #7134, callers currently need to:
1. Check if a worker exists using `contains()`
2. Manually call `spawn_worker()` to create workers
3. Handle cache evictions when pushing new workers
4. Check existence again before sending transactions

#### Summary of Changes
- Add `ensure_worker()` method that encapsulates worker creation and eviction handling
- Modify `try_send_transactions_to_address()` and `send_transactions_to_address()` to return `WorkerNotFound` error instead of panicking when worker doesn't exist
- Remove redundant `contains()` checks from caller code
- Document why worker existence checks are necessary (workers can fail asynchronously between creation and sending)

This refactoring improves API encapsulation without changing functionality. All existing tests pass unchanged.

Fixes #7134