### PR TITLE
fix: replace unwrap() with proper error handling in zstd encoder creation

### DIFF
--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -66,12 +66,19 @@ pub fn encode_ui_account<T: ReadableAccount>(
             encoding,
         ),
         UiAccountEncoding::Base64Zstd => {
-            let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0).unwrap();
-            match encoder
-                .write_all(slice_data(account.data(), data_slice_config))
-                .and_then(|()| encoder.finish())
-            {
-                Ok(zstd_data) => UiAccountData::Binary(BASE64_STANDARD.encode(zstd_data), encoding),
+            match zstd::stream::write::Encoder::new(Vec::new(), 0) {
+                Ok(mut encoder) => {
+                    match encoder
+                        .write_all(slice_data(account.data(), data_slice_config))
+                        .and_then(|()| encoder.finish())
+                    {
+                        Ok(zstd_data) => UiAccountData::Binary(BASE64_STANDARD.encode(zstd_data), encoding),
+                        Err(_) => UiAccountData::Binary(
+                            BASE64_STANDARD.encode(slice_data(account.data(), data_slice_config)),
+                            UiAccountEncoding::Base64,
+                        ),
+                    }
+                }
                 Err(_) => UiAccountData::Binary(
                     BASE64_STANDARD.encode(slice_data(account.data(), data_slice_config)),
                     UiAccountEncoding::Base64,


### PR DESCRIPTION
Replace unwrap() with proper error handling for zstd encoder creation

- Fix potential panic when zstd::stream::write::Encoder::new() fails
- Add graceful fallback to Base64 encoding on encoder creation failure
- Maintain backward compatibility and existing behavior
- Follow project's error handling patterns

This improves code robustness by eliminating a potential panic point
while preserving the same functionality for successful cases.