### PR TITLE
Renames enum to IndexInMemLimit

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -57,7 +57,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndex
     bins: Some(BINS_FOR_TESTING),
     num_flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: IndexLimitMb::Minimal,
+    index_in_mem_limit: IndexInMemLimit::Minimal,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
 };
@@ -65,7 +65,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
     bins: Some(BINS_FOR_BENCHMARKS),
     num_flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: IndexLimitMb::Minimal,
+    index_in_mem_limit: IndexInMemLimit::Minimal,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
 };
@@ -219,7 +219,7 @@ enum ScanTypes<R: RangeBounds<Pubkey>> {
 
 /// specification of how much memory in-mem portion of account index can use
 #[derive(Debug, Copy, Clone)]
-pub enum IndexLimitMb {
+pub enum IndexInMemLimit {
     /// use disk index while keeping a minimal amount in-mem
     Minimal,
     /// in-mem-only was specified, no disk index
@@ -231,7 +231,7 @@ pub struct AccountsIndexConfig {
     pub bins: Option<usize>,
     pub num_flush_threads: Option<NonZeroUsize>,
     pub drives: Option<Vec<PathBuf>>,
-    pub index_limit_mb: IndexLimitMb,
+    pub index_in_mem_limit: IndexInMemLimit,
     pub ages_to_stay_in_cache: Option<Age>,
     pub scan_results_limit_bytes: Option<usize>,
 }
@@ -242,7 +242,7 @@ impl Default for AccountsIndexConfig {
             bins: None,
             num_flush_threads: None,
             drives: None,
-            index_limit_mb: IndexLimitMb::Minimal,
+            index_in_mem_limit: IndexInMemLimit::Minimal,
             ages_to_stay_in_cache: None,
             scan_results_limit_bytes: None,
         }
@@ -2284,10 +2284,10 @@ pub mod tests {
         let key = solana_pubkey::new_rand();
 
         let mut config = ACCOUNTS_INDEX_CONFIG_FOR_TESTING;
-        config.index_limit_mb = if use_disk {
-            IndexLimitMb::Minimal
+        config.index_in_mem_limit = if use_disk {
+            IndexInMemLimit::Minimal
         } else {
-            IndexLimitMb::InMemOnly // in-mem only
+            IndexInMemLimit::InMemOnly // in-mem only
         };
         let index = AccountsIndex::<T, T>::new(&config, Arc::default());
         let mut gc = Vec::new();

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         accounts_index::{
             in_mem_accounts_index::{InMemAccountsIndex, StartupStats},
-            AccountsIndexConfig, DiskIndexValue, IndexLimitMb, IndexValue,
+            AccountsIndexConfig, DiskIndexValue, IndexInMemLimit, IndexValue,
         },
         bucket_map_holder_stats::BucketMapHolderStats,
         waitable_condvar::WaitableCondvar,
@@ -209,9 +209,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             .and_then(|drives| drives.first())
             .map(|drive| drive.join("accounts_index_restart"));
 
-        let disk = match config.index_limit_mb {
-            IndexLimitMb::InMemOnly => None,
-            IndexLimitMb::Minimal => Some(BucketMap::new(bucket_config)),
+        let disk = match config.index_in_mem_limit {
+            IndexInMemLimit::InMemOnly => None,
+            IndexInMemLimit::Minimal => Some(BucketMap::new(bucket_config)),
         };
 
         Self {

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -5,7 +5,7 @@ use {
     solana_accounts_db::{
         accounts_db::{AccountsDbConfig, DEFAULT_MEMLOCK_BUDGET_SIZE},
         accounts_file::StorageAccess,
-        accounts_index::{AccountsIndexConfig, IndexLimitMb, ScanFilter},
+        accounts_index::{AccountsIndexConfig, IndexInMemLimit, ScanFilter},
     },
     solana_clap_utils::{
         hidden_unless_forced,
@@ -241,10 +241,10 @@ pub fn get_accounts_db_config(
     let ledger_tool_ledger_path = ledger_path.join(LEDGER_TOOL_DIRECTORY);
 
     let accounts_index_bins = value_t!(arg_matches, "accounts_index_bins", usize).ok();
-    let accounts_index_index_limit_mb = if arg_matches.is_present("disable_accounts_disk_index") {
-        IndexLimitMb::InMemOnly
+    let accounts_index_in_mem_limit = if arg_matches.is_present("disable_accounts_disk_index") {
+        IndexInMemLimit::InMemOnly
     } else {
-        IndexLimitMb::Minimal
+        IndexInMemLimit::Minimal
     };
     let accounts_index_drives = values_t!(arg_matches, "accounts_index_path", String)
         .ok()
@@ -252,7 +252,7 @@ pub fn get_accounts_db_config(
         .unwrap_or_else(|| vec![ledger_tool_ledger_path.join("accounts_index")]);
     let accounts_index_config = AccountsIndexConfig {
         bins: accounts_index_bins,
-        index_limit_mb: accounts_index_index_limit_mb,
+        index_in_mem_limit: accounts_index_in_mem_limit,
         drives: Some(accounts_index_drives),
         ..AccountsIndexConfig::default()
     };

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -397,7 +397,7 @@ mod tests {
         solana_accounts_db::{
             accounts_db::{AccountsDbConfig, MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING},
             accounts_index::{
-                AccountsIndexConfig, IndexLimitMb, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
+                AccountsIndexConfig, IndexInMemLimit, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
             },
         },
         solana_fee_calculator::FeeRateGovernor,
@@ -780,12 +780,12 @@ mod tests {
 
     #[test_matrix(
         [Features::None, Features::All],
-        [IndexLimitMb::Minimal, IndexLimitMb::InMemOnly],
+        [IndexInMemLimit::Minimal, IndexInMemLimit::InMemOnly],
         [MarkObsoleteAccounts::Disabled, MarkObsoleteAccounts::Enabled]
     )]
     fn test_verify_accounts_lt_hash_at_startup(
         features: Features,
-        accounts_index_limit: IndexLimitMb,
+        accounts_index_in_mem_limit: IndexInMemLimit,
         mark_obsolete_accounts: MarkObsoleteAccounts,
     ) {
         let (mut genesis_config, mint_keypair) = genesis_config_with(features);
@@ -872,7 +872,7 @@ mod tests {
         .unwrap();
         let (_accounts_tempdir, accounts_dir) = snapshot_utils::create_tmp_accounts_dir_for_tests();
         let accounts_index_config = AccountsIndexConfig {
-            index_limit_mb: accounts_index_limit,
+            index_in_mem_limit: accounts_index_in_mem_limit,
             ..ACCOUNTS_INDEX_CONFIG_FOR_TESTING
         };
         let accounts_db_config = AccountsDbConfig {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -13,7 +13,9 @@ use {
     solana_accounts_db::{
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig, MarkObsoleteAccounts},
         accounts_file::StorageAccess,
-        accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig, IndexLimitMb, ScanFilter},
+        accounts_index::{
+            AccountSecondaryIndexes, AccountsIndexConfig, IndexInMemLimit, ScanFilter,
+        },
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         utils::{
             create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories,
@@ -312,10 +314,11 @@ pub fn execute(
         accounts_index_config.bins = Some(bins);
     }
 
-    accounts_index_config.index_limit_mb = if matches.is_present("disable_accounts_disk_index") {
-        IndexLimitMb::InMemOnly
+    accounts_index_config.index_in_mem_limit = if matches.is_present("disable_accounts_disk_index")
+    {
+        IndexInMemLimit::InMemOnly
     } else {
-        IndexLimitMb::Minimal
+        IndexInMemLimit::Minimal
     };
 
     {


### PR DESCRIPTION
#### Problem

The enum, `IndexLimitMb`, isn't a great name. We don't (currently) have any variants that specify a size, so the "Mb" part doesn't pertain to anything. But I do intend to later add a variant for setting a limit, and IMO setting a limit in bytes is clearer than megabytes. (We also use bytes vs megabytes in most places (e.g. the read cache size), so going for consistency too.)


#### Summary of Changes

Rename the enum.