### PR TITLE
use BDP for streamer window size calculations

### DIFF
--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -30,8 +30,9 @@ pub(crate) trait QosController<C: ConnectionContext> {
         context: &mut C,
     ) -> impl Future<Output = Option<CancellationToken>> + Send;
 
-    /// Calculate the intended bandwidth allocation for a given peer in kbps
-    fn get_max_bitrate_kbps(&self, context: &C) -> u64;
+    /// The reference TPS desired for a connection
+    /// on the QUIC level (affects RX buffer allocations)
+    fn reference_tps(&self, context: &C) -> u64;
 
     /// Called when a new stream is received on a connection
     fn on_new_stream(&self, context: &C) -> impl Future<Output = ()> + Send;

--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -30,6 +30,9 @@ pub(crate) trait QosController<C: ConnectionContext> {
         context: &mut C,
     ) -> impl Future<Output = Option<CancellationToken>> + Send;
 
+    /// Calculate the intended bandwidth allocation for a given peer in kbps
+    fn get_max_bitrate_kbps(&self, context: &C) -> u64;
+
     /// Called when a new stream is received on a connection
     fn on_new_stream(&self, context: &C) -> impl Future<Output = ()> + Send;
 

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -460,8 +460,8 @@ fn compute_receive_window_and_max_streams(reference_tps: u64, rtt: Duration) -> 
     let reference_transfer_rate = reference_tps * MEAN_TRANSACTION_SIZE as u64;
     // truncate here is safe since u64 millis is an eternity
     let rtt_milliseconds = (rtt.as_millis() as u64).clamp(MIN_ALLOWED_RTT_MS, MAX_ALLOWED_RTT_MS);
-    // Compute the receive window in bytes as reference_transfer_rate * rtt,
-    let receive_window = reference_transfer_rate * rtt_milliseconds;
+    // Compute the receive window in bytes as transfer_rate * rtt,
+    let receive_window = reference_transfer_rate * rtt_milliseconds / 1000;
     // hard constraint the RX window to avoid excess memory use
     let receive_window = receive_window.min(MAX_ALLOWED_RX_WINDOW as u64) as u32;
     // compute max_streams in flight

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -5,7 +5,7 @@ use {
             quic::{
                 get_connection_stake, update_open_connections_stat, ClientConnectionTracker,
                 ConnectionHandlerError, ConnectionPeerType, ConnectionTable, ConnectionTableKey,
-                ConnectionTableType, MEAN_TRANSACTION_SIZE,
+                ConnectionTableType,
             },
             stream_throttle::{
                 throttle_stream, ConnectionStreamCounter, STREAM_THROTTLING_INTERVAL,
@@ -160,9 +160,9 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
         }
     }
 
-    fn get_max_bitrate_kbps(&self, _context: &SimpleQosConnectionContext) -> u64 {
-        // choose max_bitrate with 4x margin
-        self.max_streams_per_second * 4 * MEAN_TRANSACTION_SIZE as u64 * 8 / 1000
+    fn reference_tps(&self, _context: &SimpleQosConnectionContext) -> u64 {
+        // allocate network bandwidth with 4x margin
+        self.max_streams_per_second * 4
     }
 
     #[allow(clippy::manual_async_fn)]

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -37,7 +37,7 @@ use {
 ///
 /// This needs to be constrained to ensure that we can admit a lot of unstaked
 /// connections without consuming too much RAM.
-pub(crate) const UNSTAKED_CONNECTION_REFERENCE_TPS: u64 = 1250;
+pub(crate) const UNSTAKED_CONNECTION_REFERENCE_TPS: u64 = 6000;
 
 /// Reference max TPS for a single staked connection with maximum
 /// stake amount through the cluster. Connections will get
@@ -56,9 +56,8 @@ pub(crate) const UNSTAKED_CONNECTION_REFERENCE_TPS: u64 = 1250;
 /// as it takes time for them to receive feedback from the server and slow
 /// down.
 ///
-/// Current value chosen to allow about 25000 TPS per connection (200K TPS
-/// per staked identity if it uses all 8 connections).
-pub(crate) const MAX_STAKED_CONNECTION_REFERENCE_TPS: u64 = UNSTAKED_CONNECTION_REFERENCE_TPS * 20;
+/// Current value chosen based on legacy values (todo:increase it at least 5x)
+pub(crate) const MAX_STAKED_CONNECTION_REFERENCE_TPS: u64 = UNSTAKED_CONNECTION_REFERENCE_TPS * 4;
 
 #[derive(Clone)]
 pub struct SwQosConfig {


### PR DESCRIPTION
#### Problem

SWQOS ignores RTT in some of its calculations. This means that connections with high latency are heavily rate limited, **much more than the stake amount would suggest**. This happens before the actual stake-based stream throttling even has a change to kick in, and is thus very counterintuitive to the client. 
 A deeper version of https://github.com/anza-xyz/agave/pull/7706. These PRs are mutually exclusive.

Some preliminary concepts:
- Sender can not have more than receive_window bytes in flight between itself and server
- Sender can not have more than max_concurrent_streams worth of open streams at any time
- These together limit how many TXs can be “in flight” between client and server and not yet ACKd. Currently, both these limits are computed based on stake. We need to compute them based on stake and RTT to the client (as longer RTT means you need to have more things on the wire before you see an ACK).
- Beyond all the limits mentioned above, there is an overall stream limit imposed by the code in stream_throttle.rs. This has no impact on staked nodes (as long as we do not have many of them) but caps the unstaked peer TPS at 200. 


**This mechanism is not intended as the actual rate limiter for complaint clients, just as a limit on network buffers and such like. This is designed to allocate more bandwidth than what you'd get today. Note that a client can open up to 8 concurrent connections per identity, allowing each connection to leverage the full bandwidth on the network level (before throttling by stream_throttle.rs logic). So this PR should not reduce the TPU bandwidth in any way, except for customers with extremely low latency to the target validator. If operators want to limit TPS on a per-client basis, they should use throttling logic for it rather than receive_window.**

- Number of concurrent streams  should match the BDP of the link to prevent starvation of the client.
- Throughput in practice is ultimately not limited only by window size or number of streams in flight, but rather the throttling logic behind all this that operates on the per-staked-identity basis, not per connection.

#### Summary of Changes

- Make number of concurrent streams allowed scale with RX window size.
- Set bandwidth allocation for unstaked/min-staked connection to 4 Mbps (800 TPS for 500 byte TXs)
- Set bandwidth allocation for staked connection to 80 Mbps (16 KTPS for 500 byte TXs)
- Bump number of concurrent streams to match the bandwidth allocations (up to 5000)

Formula for bandwidth allocation per connection: 
`min_rate = 4 # Mbit/s`
`max_rate = 80 # Mbit/s`
`min_bit_rate = min_rate + (stake * (max_rate - min_rate) / max_stake)`

Actual bitrate will depend on RTT:

- For RTT < 50ms it will be strictly more than `min_bit_rate` to mimic the behavior before change
- For 50 < RTT < 300 ms it will match min_bit_rate
- For RTT > 300ms it will be roughly min_bit_rate * 300 / RTT

The maximal sustainable TPS per connection will depend on the size of transactions. The concurrent_streams allocation is based on the transaction size of 400 bytes and is calculated as 
`max_streams = receive_window / mean_transaction_size`
 so if transactions are smaller on average, the TPS will be smaller proportionally. For example if your transactions are 200 bytes each, you'd get about half the TPS you would expect given your bandwidth allocation. 

**Without this PR, for the same set of nodes each holding 20% of stake:**
```
{'latency': 10,
'clients': 5,
 'duration': 5.0,
 'tx-size': 1024}
Server captured 610320 transactions (122064 TPS)
```
Allowing 1 Gbit/s worth of transactions from 5 clients is probably excessive... but we will deal with it in a separate PR
```
{'latency': 150,
'clients': 5,
 'duration': 5.0,
 'tx-size': 1024}
Server captured 35930 transactions (7186 TPS)
```
With 150ms latency (Auckland-Barcelona link) we lose nearly all our TPS, down to 58 Mbps with the same stake

**With this PR:**
```
{'latency': 10,
'clients': 5,
'duration': 5.0,
 'tx-size': 1024}
Server captured 547171 transactions (109434 TPS)
```
Roughly same TPS for low-latency nodes
```
{'latency': 150,
'clients': 5,
 'duration': 5.0,
 'tx-size': 1024}
Server captured 132884 transactions (26576 TPS)
```
But now at very high latency, we still provide ~220 Mbps (4x more than before the change)

Clearly, the PR makes the changes in TPS as a result of latency variations less severe, but it does not eliminate them completely. Eliminating them completely is out of scope of this PR.

### Some pretty plots
Each point on the plot is collected via run.sh script in the [repo with test utils](https://github.com/alexpyattaev/streamer_tester). The ideal plot should look like a single flat plane rising along the stake axis and not dependent on latency at all. In reality very high latency connections suffer a bit. Blue = low TPS. Yellow = high TPS.
#### 1024 byte TXs
Before:
<img width="640" height="480" alt="plot_old_1024_bytes" src="https://github.com/user-attachments/assets/2af34601-d056-42c5-9f45-b189a3165de6" />


After:
<img width="640" height="480" alt="plot_new_1024_bytes" src="https://github.com/user-attachments/assets/5ef7c68d-eb57-42fd-90bb-a3c10e935e8d" />


#### 512 byte TXs
Before:


<img width="640" height="480" alt="plot_old_512_bytes" src="https://github.com/user-attachments/assets/daf27ca9-381f-4216-b23d-40aff9b64f2b" />



After:


<img width="640" height="480" alt="plot_new_512_bytes" src="https://github.com/user-attachments/assets/1dea67b8-1ee9-4bb1-b977-4303f3c098c5" />


#### 176 byte TXs
Before:

<img width="640" height="480" alt="plot_old_176_bytes" src="https://github.com/user-attachments/assets/f31bd39c-c867-4624-9331-91d4ed50d54a" />


After:


<img width="640" height="480" alt="plot_new_176_bytes" src="https://github.com/user-attachments/assets/823bf15e-ef35-4c8b-a4f3-7f57319df7ae" />




See also #7745 for relevant discussion.