### PR TITLE
Uses RefCount type alias in more places

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -157,7 +157,7 @@ pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
     fn collect(&mut self, other: Self);
     fn add(
         &mut self,
-        ref_count: u64,
+        ref_count: RefCount,
         account: &'a AccountFromStorage,
         slot_list: &[(Slot, AccountInfo)],
     );
@@ -180,7 +180,7 @@ impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
     }
     fn add(
         &mut self,
-        _ref_count: u64,
+        _ref_count: RefCount,
         account: &'a AccountFromStorage,
         _slot_list: &[(Slot, AccountInfo)],
     ) {
@@ -214,7 +214,7 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
     }
     fn add(
         &mut self,
-        ref_count: u64,
+        ref_count: RefCount,
         account: &'a AccountFromStorage,
         slot_list: &[(Slot, AccountInfo)],
     ) {
@@ -1142,7 +1142,7 @@ pub fn get_temp_accounts_paths(count: u32) -> io::Result<(Vec<TempDir>, Vec<Path
 #[derive(Default, Debug)]
 struct CleaningInfo {
     slot_list: SlotList<AccountInfo>,
-    ref_count: u64,
+    ref_count: RefCount,
     /// Indicates if this account might have a zero lamport index entry.
     /// If false, the account *shall* not have zero lamport index entries.
     /// If true, the account *might* have zero lamport index entries.

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -5296,7 +5296,7 @@ fn test_unref_pubkeys_removed_from_accounts_index() {
             vec![(pk1, vec![slot1].into_iter().collect::<IntSet<_>>())],
             purged_stored_account_slots.into_iter().collect::<Vec<_>>()
         );
-        let expected = u64::from(already_removed);
+        let expected = RefCount::from(already_removed);
         db.assert_ref_count(&pk1, expected);
     }
 }
@@ -5417,7 +5417,10 @@ define_accounts_db_test!(test_many_unrefs, |db| {
         })
         .collect::<HashSet<_>>();
 
-    assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), n);
+    assert_eq!(
+        db.accounts_index.ref_count_from_storage(&pk1),
+        n as RefCount,
+    );
     // unref all 'n' slots
     db.unref_accounts(
         purged_slot_pubkeys,

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -2318,7 +2318,7 @@ pub mod tests {
         {
             let entry = index.get_cloned(&key).unwrap();
             let slot_list = entry.slot_list.read().unwrap();
-            assert_eq!(entry.ref_count(), u64::from(!is_cached));
+            assert_eq!(entry.ref_count(), RefCount::from(!is_cached));
             assert_eq!(slot_list.as_slice(), &[(slot0, account_infos[0])]);
             let new_entry = PreAllocatedAccountMapEntry::new(
                 slot0,

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -52,7 +52,7 @@ impl<T: IndexValue> AccountMapEntry<T> {
 
     /// decrement the ref count by the passed in amount
     /// return the refcount prior to the ref count change
-    pub fn unref_by_count(&self, count: u64) -> RefCount {
+    pub fn unref_by_count(&self, count: RefCount) -> RefCount {
         let previous = self.ref_count.fetch_sub(count, Ordering::Release);
         self.set_dirty(true);
         assert!(

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1122,7 +1122,7 @@ pub mod tests {
                 ShrinkCollectRefs,
             },
             accounts_file::StorageAccess,
-            accounts_index::{AccountsIndexScanResult, ScanFilter, UpsertReclaim},
+            accounts_index::{AccountsIndexScanResult, RefCount, ScanFilter, UpsertReclaim},
             append_vec::{self, aligned_stored_size},
             storable_accounts::StorableAccountsBySlot,
         },
@@ -3739,8 +3739,8 @@ pub mod tests {
                 .map(|_| solana_pubkey::new_rand())
                 .collect::<Vec<_>>();
             // how many of `many_ref_accounts` should be found in the index with ref_count=1
-            let mut expected_ref_counts_before_unref = HashMap::<Pubkey, u64>::default();
-            let mut expected_ref_counts_after_unref = HashMap::<Pubkey, u64>::default();
+            let mut expected_ref_counts_before_unref = HashMap::<Pubkey, RefCount>::default();
+            let mut expected_ref_counts_after_unref = HashMap::<Pubkey, RefCount>::default();
 
             pubkeys_to_unref.iter().for_each(|k| {
                 for slot in 0..2 {


### PR DESCRIPTION
#### Problem

There is a type alias for the accounts index's reference count, `RefCount`. It is not used everywhere though.


#### Summary of Changes

Use it more places.