### PR TITLE
Assert ref count increment does not overflow

### DIFF
--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -39,7 +39,9 @@ impl<T: IndexValue> AccountMapEntry<T> {
     }
 
     pub fn addref(&self) {
-        self.ref_count.fetch_add(1, Ordering::Release);
+        let previous = self.ref_count.fetch_add(1, Ordering::Release);
+        // ensure ref count does not overflow
+        assert_ne!(previous, RefCount::MAX);
         self.set_dirty(true);
     }
 


### PR DESCRIPTION
#### Problem

When incrementing the reference count for accounts index entries, we don't catch potential overflow/wrap around. We *do* have checks when decrementing the ref count though! I believe we should have both.


#### Summary of Changes

Assert the ref count does not overflow when incrementing.