### PR TITLE
Revert "Fix forwarding stage drain timeout (#7957)"

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -268,7 +268,7 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
                 self.buffer_packet_batches(packet_batches, tpu_vote_batch, bank);
 
                 // Drain the channel up to timeout
-                while now.elapsed() < TIMEOUT {
+                while now.elapsed() > TIMEOUT {
                     match self.receiver.try_recv() {
                         Ok((packet_batches, tpu_vote_batch)) => {
                             self.buffer_packet_batches(packet_batches, tpu_vote_batch, bank)


### PR DESCRIPTION
This reverts commit 490089993c6948d44b3315f3d4751b8ae390474f.

# Reversion Plan

Master:

1. [ ] Revert #7957 <-- This PR
2. [ ] Revert #7915
3. [ ] PR with #7915 + #7957

Backports:

#7957 has not been backported yet, so no need to revert.

1. [ ] Backport 2. from master plan
2. [ ] Backport 3. from master plan


<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
