### PR TITLE
Reduces the index's ref count type to 32-bits

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -35,7 +35,7 @@ use {
         ops::{Bound, Range, RangeBounds},
         path::PathBuf,
         sync::{
-            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering},
             Arc, Mutex, RwLock,
         },
     },
@@ -71,8 +71,14 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
 };
 pub type ScanResult<T> = Result<T, ScanError>;
 pub type SlotList<T> = Vec<(Slot, T)>;
-pub type RefCount = u64;
-pub type AtomicRefCount = AtomicU64;
+
+// The ref count cannot be higher than the total number of storages, and we should never have more
+// than 1 million storages. A 32-bit ref count should be *significantly* more than enough.
+// (We already effectively limit the number of storages to 2^32 since the storage ID type is a u32.)
+// The majority of accounts should only exist in one storage, so the most common ref count is '1'.
+// Heavily updated accounts should still have a ref count that is < 100.
+pub type RefCount = u32;
+pub type AtomicRefCount = AtomicU32;
 
 /// values returned from `insert_new_if_missing_into_primary_index()`
 #[derive(Default, Debug, PartialEq, Eq)]


### PR DESCRIPTION
#### Problem

The account index's reference count type is 64-bits. Since every account lives in the index, and every index entry has a reference count, this type ends up adding up to a not-insignificant size. At 1 billion accounts, the ref counts alone take up 8 GB. 

We know that the majority of accounts have a ref count of 1.

We also know that we cannot have a ref count value larger than the number of storages. And we already limit the number of storages because we use a u32 for the storage ID. Practically through, index entries should never exceed 100, and really single digits is the common case.

If we want to keep the whole accounts index in RAM, every bit counts. We can reduce the reference count bits to save RAM.


#### Summary of Changes

Reduce the index's ref count type to 32-bits.

What's extra cool, is that we end up saving 8 bytes per index entry, not just 4 bytes. That's because of the padding in `AccountMapEntry`.

Here's the struct:

https://github.com/anza-xyz/agave/blob/490089993c6948d44b3315f3d4751b8ae390474f/accounts-db/src/accounts_index/account_map_entry.rs#L17-L27

The current size is 56 bytes. `ref_count` is currently 8 bytes, `slot_list` is currently 40 bytes, and `meta` is 2 bytes. However due to alignment/padding, the size must be 56, not 50.

With `ref_count` as 4 bytes, then `meta` can use those spare 4 padding bytes. That means the size of `AccountMapEntry` drops to 48 bytes, not just 52. 

**Tl;dr, we save 8 bytes per account index entry. And that's 8 GB if the whole index is in RAM.**

Here's my dev node running this PR. It was previously running stock master with the index all in RAM. The inflection point shows the change in size. Previously the index was 103.5 GB, and with this PR the index is now 95.5 GB. And that's the 8 GB savings.

<img width="919" height="465" alt="Screenshot 2025-09-09 at 1 38 06 PM" src="https://github.com/user-attachments/assets/c824d13a-f1a2-4c60-a31f-54b45e3d3e1c" />