### PR TITLE
Revert "move forwarding stage backed up warning to send-side (#7915)"

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -268,12 +268,25 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
                 self.buffer_packet_batches(packet_batches, tpu_vote_batch, bank);
 
                 // Drain the channel up to timeout
-                while now.elapsed() > TIMEOUT {
+                let timed_out = loop {
+                    if now.elapsed() >= TIMEOUT {
+                        break true;
+                    }
                     match self.receiver.try_recv() {
                         Ok((packet_batches, tpu_vote_batch)) => {
                             self.buffer_packet_batches(packet_batches, tpu_vote_batch, bank)
                         }
-                        Err(_) => break,
+                        Err(_) => break false,
+                    }
+                };
+
+                // If timeout was reached, prevent backup by draining all
+                // packets in the channel.
+                if timed_out {
+                    warn!("ForwardingStage is backed up, dropping packets");
+                    while let Ok((packet_batch, _)) = self.receiver.try_recv() {
+                        self.metrics.dropped_on_timeout +=
+                            packet_batch.iter().map(|b| b.len()).sum::<usize>();
                     }
                 }
 
@@ -750,6 +763,8 @@ struct ForwardingStageMetrics {
     non_votes_dropped_on_data_budget: usize,
     non_votes_forwarded: usize,
     non_votes_dropped_on_send: usize,
+
+    dropped_on_timeout: usize,
 }
 
 impl ForwardingStageMetrics {
@@ -829,6 +844,7 @@ impl Default for ForwardingStageMetrics {
             non_votes_dropped_on_data_budget: 0,
             non_votes_forwarded: 0,
             non_votes_dropped_on_send: 0,
+            dropped_on_timeout: 0,
         }
     }
 }

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -13,7 +13,7 @@ use {
         sigverify_stage::{SigVerifier, SigVerifyServiceError},
     },
     agave_banking_stage_ingress_types::BankingPacketBatch,
-    crossbeam_channel::{Sender, TrySendError},
+    crossbeam_channel::Sender,
     solana_perf::{cuda_runtime::PinnedVec, packet::PacketBatch, recycler::Recycler, sigverify},
 };
 
@@ -61,11 +61,7 @@ impl SigVerifier for TransactionSigVerifier {
         if let Some(forward_stage_sender) = &self.forward_stage_sender {
             self.banking_stage_sender
                 .send(banking_packet_batch.clone())?;
-            if let Err(TrySendError::Full(_)) =
-                forward_stage_sender.try_send((banking_packet_batch, self.reject_non_vote))
-            {
-                warn!("forwarding stage channel is full, dropping packets.");
-            }
+            let _ = forward_stage_sender.try_send((banking_packet_batch, self.reject_non_vote));
         } else {
             self.banking_stage_sender.send(banking_packet_batch)?;
         }


### PR DESCRIPTION
This reverts commit cbe84f281d5efaafba27df5dc2af9577179c9c57.

# Reversion Plan

Master:

1. [x] Revert #7957
2. [ ] Revert #7915 <-- This PR
3. [ ] PR with #7915 + #7957

Backports:

#7957 has not been backported yet, so no need to revert.

1. [ ] Backport 2. from master plan
2. [ ] Backport 3. from master plan


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
