### PR TITLE
Moves trait impls for AccountInfo

### DIFF
--- a/accounts-db/src/account_info.rs
+++ b/accounts-db/src/account_info.rs
@@ -4,8 +4,10 @@
 //! Note that AccountInfo is saved to disk buckets during runtime, but disk buckets are recreated at startup.
 use {
     crate::{
-        accounts_db::AccountsFileId, accounts_file::ALIGN_BOUNDARY_OFFSET,
-        accounts_index::IsCached, is_zero_lamport::IsZeroLamport,
+        accounts_db::AccountsFileId,
+        accounts_file::ALIGN_BOUNDARY_OFFSET,
+        accounts_index::{DiskIndexValue, IndexValue, IsCached},
+        is_zero_lamport::IsZeroLamport,
     },
     modular_bitfield::prelude::*,
 };
@@ -99,6 +101,10 @@ impl IsCached for AccountInfo {
     }
 }
 
+impl IndexValue for AccountInfo {}
+
+impl DiskIndexValue for AccountInfo {}
+
 impl IsCached for StorageLocation {
     fn is_cached(&self) -> bool {
         matches!(self, StorageLocation::Cached)
@@ -164,6 +170,7 @@ impl AccountInfo {
         }
     }
 }
+
 #[cfg(test)]
 mod test {
     use {super::*, crate::append_vec::MAXIMUM_APPEND_VEC_FILE_SIZE};

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -42,9 +42,9 @@ use {
         accounts_hash::{AccountLtHash, AccountsLtHash, ZERO_LAMPORT_ACCOUNT_LT_HASH},
         accounts_index::{
             in_mem_accounts_index::StartupStats, AccountSecondaryIndexes, AccountsIndex,
-            AccountsIndexConfig, AccountsIndexRootsStats, AccountsIndexScanResult, DiskIndexValue,
-            IndexKey, IndexValue, IsCached, RefCount, ScanConfig, ScanFilter, ScanResult, SlotList,
-            UpsertReclaim, ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
+            AccountsIndexConfig, AccountsIndexRootsStats, AccountsIndexScanResult, IndexKey,
+            IsCached, RefCount, ScanConfig, ScanFilter, ScanResult, SlotList, UpsertReclaim,
+            ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
         },
         accounts_index_storage::Startup,
         accounts_update_notifier_interface::{AccountForGeyser, AccountsUpdateNotifier},
@@ -657,9 +657,6 @@ impl GenerateIndexTimings {
         );
     }
 }
-
-impl IndexValue for AccountInfo {}
-impl DiskIndexValue for AccountInfo {}
 
 impl IsZeroLamport for AccountSharedData {
     fn is_zero_lamport(&self) -> bool {


### PR DESCRIPTION
A little clean up.

The code that implements `IndexValue` and `DiskIndexValue` for `AccountInfo` should either live next to AccountInfo or IndexValue. Currently it's neither 🙃.

Move 'em to `account_info.rs`.