### PR TITLE
Update offchain message spec to allow line feeds in clear signable messages

### DIFF
--- a/docs/src/proposals/off-chain-message-signing.md
+++ b/docs/src/proposals/off-chain-message-signing.md
@@ -79,7 +79,7 @@ compatibility and composition of messages.
 
 \* Combined length of the [message preamble](#message-preamble) and message body<br/>
 \*\* Those characters for which [`isprint(3)`](https://linux.die.net/man/3/isprint)
-returns true.  That is, `0x20..=0x7e`.
+returns true (`0x20..=0x7e`) and `0x0A`.
 
 Both the message encoding and maximum message length **MUST** be enforced by
 signer and verifier.


### PR DESCRIPTION
There is de-facto support for this in Ledger: https://github.com/LedgerHQ/app-solana/pull/128/files#diff-cd859fb53daaefce1dd59f9ecde29943ac20418436e09297620af789127774aaR52-R66

My understanding is that the intent was to upstream this to the spec/proposal.

cc/ @jordaaash, @tiago18c