### PR TITLE
clean: remove unused genesis native processors config

### DIFF
--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -41,7 +41,6 @@ fn program_account(program_data: &[u8]) -> AccountSharedData {
 }
 
 fn test_bench_tps_local_cluster(config: Config) {
-    let native_instruction_processors = vec![];
     let additional_accounts = vec![(
         spl_instruction_padding_interface::ID,
         program_account(include_bytes!("fixtures/spl_instruction_padding.so")),
@@ -68,7 +67,6 @@ fn test_bench_tps_local_cluster(config: Config) {
                 },
                 NUM_NODES,
             ),
-            native_instruction_processors,
             additional_accounts,
             ..ClusterConfig::default()
         },

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -1095,7 +1095,6 @@ pub mod test {
 
         // 2. Create a local cluster which is aware of faucet
         let num_nodes = 1;
-        let native_instruction_processors = vec![];
         let cluster = LocalCluster::new(
             &mut ClusterConfig {
                 node_stakes: vec![999_990; num_nodes],
@@ -1110,7 +1109,6 @@ pub mod test {
                     },
                     num_nodes,
                 ),
-                native_instruction_processors,
                 ..ClusterConfig::default()
             },
             SocketAddrSpace::Unspecified,

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -710,7 +710,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     );
 
     let mut genesis_config = GenesisConfig {
-        native_instruction_processors: vec![],
         ticks_per_slot,
         poh_config,
         fee_rate_governor,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -95,7 +95,6 @@ pub struct ClusterConfig {
     pub slots_per_epoch: u64,
     pub stakers_slot_offset: u64,
     pub skip_warmup_slots: bool,
-    pub native_instruction_processors: Vec<(String, Pubkey)>,
     pub cluster_type: ClusterType,
     pub poh_config: PohConfig,
     pub additional_accounts: Vec<(Pubkey, AccountSharedData)>,
@@ -134,7 +133,6 @@ impl Default for ClusterConfig {
             ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
             slots_per_epoch: DEFAULT_DEV_SLOTS_PER_EPOCH,
             stakers_slot_offset: DEFAULT_DEV_SLOTS_PER_EPOCH,
-            native_instruction_processors: vec![],
             cluster_type: ClusterType::Development,
             poh_config: PohConfig::default(),
             skip_warmup_slots: false,
@@ -328,9 +326,6 @@ impl LocalCluster {
             !config.skip_warmup_slots,
         );
         genesis_config.poh_config = config.poh_config.clone();
-        genesis_config
-            .native_instruction_processors
-            .extend_from_slice(&config.native_instruction_processors);
 
         let mut leader_config = safe_clone_config(&config.validator_configs[0]);
         let (leader_ledger_path, _blockhash) = create_new_tmp_ledger_with_size!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2628,11 +2628,6 @@ impl Bank {
             self.slots_per_year,
             genesis_config.rent.clone(),
         );
-
-        // Add additional builtin programs specified in the genesis config
-        for (name, program_id) in &genesis_config.native_instruction_processors {
-            self.add_builtin_account(name, program_id);
-        }
     }
 
     fn burn_and_purge_account(&self, program_id: &Pubkey, mut account: AccountSharedData) {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -124,7 +124,7 @@ use {
     },
     spl_generic_token::token,
     std::{
-        collections::{HashMap, HashSet},
+        collections::{BTreeMap, HashMap, HashSet},
         convert::TryInto,
         fs::File,
         io::Read,
@@ -5296,11 +5296,16 @@ fn test_fuzz_instructions() {
 // added feature.
 #[test]
 fn test_bank_hash_consistency() {
-    let account = AccountSharedData::new(1_000_000_000_000, 0, &system_program::id());
-    let mut genesis_config = GenesisConfig::new(&[(Pubkey::from([42; 32]), account)], &[]);
-    // Override the creation time to ensure bank hash consistency
-    genesis_config.creation_time = 0;
-    genesis_config.cluster_type = ClusterType::MainnetBeta;
+    let genesis_config = GenesisConfig {
+        // Override the creation time to ensure bank hash consistency
+        creation_time: 0,
+        accounts: BTreeMap::from([(
+            Pubkey::from([42; 32]),
+            Account::new(1_000_000_000_000, 0, &system_program::id()),
+        )]),
+        cluster_type: ClusterType::MainnetBeta,
+        ..GenesisConfig::default()
+    };
 
     // Set the feature set to all enabled so that we detect any inconsistencies
     // in the hash computation that may arise from feature set changes


### PR DESCRIPTION
#### Problem
Genesis and local cluster configs allow specifying a list of custom builtin programs but this feature is unused and also broken because those builtins are not added properly to the program cache.

#### Summary of Changes
Remove uses of genesis native instruction processors

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
