### PR TITLE
Redo visit_zero_lamports optimization at startup with tests

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1037,6 +1037,20 @@ impl AccountStorageEntry {
         zero_lamport_single_ref_offsets.insert(offset)
     }
 
+    /// Insert offsets into the zero lamport single ref account offset set.
+    /// Return the number of new offsets that were inserted.
+    fn batch_insert_zero_lamport_single_ref_account_offsets(&self, offsets: &[Offset]) -> u64 {
+        let mut zero_lamport_single_ref_offsets =
+            self.zero_lamport_single_ref_offsets.write().unwrap();
+        let mut count = 0;
+        for offset in offsets {
+            if zero_lamport_single_ref_offsets.insert(*offset) {
+                count += 1;
+            }
+        }
+        count
+    }
+
     /// Return the number of zero_lamport_single_ref accounts in the storage.
     fn num_zero_lamport_single_ref_accounts(&self) -> usize {
         self.zero_lamport_single_ref_offsets.read().unwrap().len()
@@ -6472,9 +6486,7 @@ impl AccountsDb {
         // This is safe with obsolete accounts as all zero lamport accounts will be single ref
         // or obsolete by the end of index generation
         if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
-            for offset in zero_lamport_offsets {
-                storage.insert_zero_lamport_single_ref_account_offset(offset);
-            }
+            storage.batch_insert_zero_lamport_single_ref_account_offsets(&zero_lamport_offsets);
             zero_lamport_pubkeys = Vec::new();
         }
         SlotIndexGenerationInfo {
@@ -6930,8 +6942,19 @@ impl AccountsDb {
     /// Visit zero lamport pubkeys and populate zero_lamport_single_ref info on
     /// storage.
     /// Returns the number of zero lamport single ref accounts found.
-    fn visit_zero_lamport_pubkeys_during_startup(&self, pubkeys: Vec<Pubkey>) -> u64 {
-        let mut count = 0;
+    fn visit_zero_lamport_pubkeys_during_startup(&self, mut pubkeys: Vec<Pubkey>) -> u64 {
+        let mut slot_offsets = HashMap::<_, Vec<_>>::default();
+        // sort the pubkeys first so that in scan, the pubkeys are visited in
+        // index bucket in order. This helps to reduce the page faults and speed
+        // up the scan compared to visiting the pubkeys in random order.
+        let orig_len = pubkeys.len();
+        pubkeys.sort_unstable();
+        pubkeys.dedup();
+        let uniq_len = pubkeys.len();
+        info!(
+            "visit_zero_lamport_pubkeys_during_startup: {orig_len} pubkeys, {uniq_len} after dedup",
+        );
+
         self.accounts_index.scan(
             pubkeys.iter(),
             |_pubkey, slots_refs, _entry| {
@@ -6941,8 +6964,10 @@ impl AccountsDb {
                     let (slot_alive, account_info) = slot_list.first().unwrap();
                     assert!(!account_info.is_cached());
                     if account_info.is_zero_lamport() {
-                        count += 1;
-                        self.zero_lamport_single_ref_found(*slot_alive, account_info.offset());
+                        slot_offsets
+                            .entry(*slot_alive)
+                            .or_default()
+                            .push(account_info.offset());
                     }
                 }
                 AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
@@ -6951,6 +6976,46 @@ impl AccountsDb {
             false,
             ScanFilter::All,
         );
+
+        let mut count = 0;
+        let mut dead_stores = 0;
+        let mut shrink_stores = 0;
+        let mut non_shrink_stores = 0;
+        for (slot, offsets) in slot_offsets {
+            if let Some(store) = self.storage.get_slot_storage_entry(slot) {
+                count += store.batch_insert_zero_lamport_single_ref_account_offsets(&offsets);
+                if store.num_zero_lamport_single_ref_accounts() == store.count() {
+                    // all accounts in this storage can be dead
+                    self.dirty_stores.entry(slot).or_insert(store);
+                    dead_stores += 1;
+                } else if Self::is_shrinking_productive(&store)
+                    && self.is_candidate_for_shrink(&store)
+                {
+                    // this store might be eligible for shrinking now
+                    if self.shrink_candidate_slots.lock().unwrap().insert(slot) {
+                        shrink_stores += 1;
+                    }
+                } else {
+                    non_shrink_stores += 1;
+                }
+            }
+        }
+        self.shrink_stats
+            .num_zero_lamport_single_ref_accounts_found
+            .fetch_add(count, Ordering::Relaxed);
+
+        self.shrink_stats
+            .num_dead_slots_added_to_clean
+            .fetch_add(dead_stores, Ordering::Relaxed);
+
+        self.shrink_stats
+            .num_slots_with_zero_lamport_accounts_added_to_shrink
+            .fetch_add(shrink_stores, Ordering::Relaxed);
+
+        self.shrink_stats
+            .marking_zero_dead_accounts_in_non_shrinkable_store
+            .fetch_add(non_shrink_stores, Ordering::Relaxed);
+
         count
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6486,7 +6486,9 @@ impl AccountsDb {
         // This is safe with obsolete accounts as all zero lamport accounts will be single ref
         // or obsolete by the end of index generation
         if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
-            storage.batch_insert_zero_lamport_single_ref_account_offsets(&zero_lamport_offsets);
+            for offset in zero_lamport_offsets {
+                storage.insert_zero_lamport_single_ref_account_offset(offset);
+            }
             zero_lamport_pubkeys = Vec::new();
         }
         SlotIndexGenerationInfo {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6544,3 +6544,39 @@ fn test_mark_obsolete_accounts_at_startup_multiple_bins() {
     assert_eq!(obsolete_stats.accounts_marked_obsolete, 2);
     assert_eq!(obsolete_stats.slots_removed, 1);
 }
+
+#[test]
+fn test_batch_insert_zero_lamport_single_ref_account_offsets() {
+    let accounts = AccountsDb::new_single_for_tests();
+    let storage = accounts.create_and_insert_store(1, 100, "test");
+
+    // Test inserting new offsets
+    let offsets1 = vec![10, 20, 30];
+    let count1 = storage.batch_insert_zero_lamport_single_ref_account_offsets(&offsets1);
+    assert_eq!(count1, 3, "Should insert all 3 new offsets");
+    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 3);
+
+    // Test inserting some duplicate and some new offsets
+    let offsets2 = vec![20, 30, 40, 50]; // 20,30 are duplicates, 40,50 are new
+    let count2 = storage.batch_insert_zero_lamport_single_ref_account_offsets(&offsets2);
+    assert_eq!(count2, 2, "Should insert only 2 new offsets (40, 50)");
+    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 5);
+
+    // Test inserting all duplicates
+    let offsets3 = vec![10, 20];
+    let count3 = storage.batch_insert_zero_lamport_single_ref_account_offsets(&offsets3);
+    assert_eq!(count3, 0, "Should not insert any duplicates");
+    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 5);
+
+    // Test inserting empty slice
+    let empty_offsets: Vec<usize> = vec![];
+    let count4 = storage.batch_insert_zero_lamport_single_ref_account_offsets(&empty_offsets);
+    assert_eq!(count4, 0, "Should handle empty slice");
+    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 5);
+
+    // Test inserting large batch with mixed duplicates
+    let offsets5 = vec![10, 60, 20, 70, 30, 80, 40]; // 10,20,30,40 duplicates, 60,70,80 new
+    let count5 = storage.batch_insert_zero_lamport_single_ref_account_offsets(&offsets5);
+    assert_eq!(count5, 3, "Should insert only 3 new offsets (60, 70, 80)");
+    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 8);
+}


### PR DESCRIPTION
#### Problem

Following https://github.com/anza-xyz/agave/pull/7892#issuecomment-3259447486

The original PR #7758 lacks a test for the new function batch_insert_zero_lamport_single_ref_account_offsets, making it not backportable.

This PR combines the zero-lamport account optimization from #7758 and the test coverage from #7892, along with additional changes from #7794 and #7795, into a single PR. By consolidating all three PRs, this PR is now ready to be backported to v3.0.

#### Summary of Changes

Redo visit_zero_lamports optimization with test 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
