### PR TITLE
Updating test_accounts_db_serialize1 to support obsolete accounts

### DIFF
--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -309,18 +309,20 @@ mod serde_snapshot_tests {
 
     #[test_matrix(
         [StorageAccess::File, StorageAccess::Mmap],
+        [MarkObsoleteAccounts::Enabled, MarkObsoleteAccounts::Disabled],
         [MarkObsoleteAccounts::Enabled, MarkObsoleteAccounts::Disabled]
     )]
     fn test_accounts_db_serialize1(
         storage_access: StorageAccess,
-        mark_obsolete_accounts: MarkObsoleteAccounts,
+        mark_obsolete_accounts_initial: MarkObsoleteAccounts,
+        mark_obsolete_accounts_restore: MarkObsoleteAccounts,
     ) {
         for pass in 0..2 {
             solana_logger::setup();
             let accounts = AccountsDb::new_with_config(
                 Vec::new(),
                 AccountsDbConfig {
-                    mark_obsolete_accounts,
+                    mark_obsolete_accounts: mark_obsolete_accounts_initial,
                     ..ACCOUNTS_DB_CONFIG_FOR_TESTING
                 },
                 None,
@@ -395,11 +397,15 @@ mod serde_snapshot_tests {
             accounts.check_storage(1, 11, 21);
             accounts.check_storage(2, 31, 31);
 
+            let accounts_db_config = AccountsDbConfig {
+                mark_obsolete_accounts: mark_obsolete_accounts_restore,
+                ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+            };
             let daccounts = reconstruct_accounts_db_via_serialization(
                 &accounts,
                 latest_slot,
                 storage_access,
-                ACCOUNTS_DB_CONFIG_FOR_TESTING,
+                accounts_db_config,
             );
 
             assert_eq!(
@@ -413,10 +419,17 @@ mod serde_snapshot_tests {
             daccounts.check_accounts(&pubkeys[35..], 0, 65, 37);
             daccounts.check_accounts(&pubkeys1, 1, 10, 1);
 
-            // With accounts marked obsolete in the storages, storages are shrunk when saved
-            if mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
+            // If accounts are marked obsolete at initial save time, then the accounts will be
+            // shrunk by snapshot save
+            if mark_obsolete_accounts_initial == MarkObsoleteAccounts::Enabled {
                 daccounts.check_storage(0, 78, 78);
                 daccounts.check_storage(1, 11, 11);
+            // If accoutns are marked obsolete at restore time, then the accounts will be be marked
+            // obsolete and cleaned during snapshot restore but not removed from the storages until
+            // the next shrink
+            } else if mark_obsolete_accounts_restore == MarkObsoleteAccounts::Enabled {
+                daccounts.check_storage(0, 78, 100);
+                daccounts.check_storage(1, 11, 21);
             } else {
                 daccounts.check_storage(0, 100, 100);
                 daccounts.check_storage(1, 21, 21);

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -420,11 +420,11 @@ mod serde_snapshot_tests {
             daccounts.check_accounts(&pubkeys1, 1, 10, 1);
 
             // If accounts are marked obsolete at initial save time, then the accounts will be
-            // shrunk by snapshot save
+            // shrunk during snapshot archive
             if mark_obsolete_accounts_initial == MarkObsoleteAccounts::Enabled {
                 daccounts.check_storage(0, 78, 78);
                 daccounts.check_storage(1, 11, 11);
-            // If accoutns are marked obsolete at restore time, then the accounts will be be marked
+            // If accounts are marked obsolete at restore time, then the accounts will be marked
             // obsolete and cleaned during snapshot restore but not removed from the storages until
             // the next shrink
             } else if mark_obsolete_accounts_restore == MarkObsoleteAccounts::Enabled {


### PR DESCRIPTION
#### Problem
- Test was previously updated to support obsolete accounts by making it run in both obsolete accounts disabled and enabled mode. 
- However Enabling obsolete in test config exposed a new scenario: switching from obsolete accounts disabled to enabled
- This is because the second call to reconstruct the database is hard coded to use the test configuration. 
- Since this is an interesting test case, it makes sense to continue testing it. 

#### Summary of Changes
- Modify reconstruct_accounts_db_via_serialization to accept a passed in configuration
- Run test_accounts_db_serialize1 in all 4 possible configurations
- Add support for the failing case (Disabled->Enabled). This mode cleans the accounts but does not shrink them

3 More after this! the home stretch. 
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
