### PR TITLE
Remove reference to pre snapshots

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2314,11 +2314,9 @@ mod tests {
         let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         // take some snapshots, and archive them
-        // note the `+1` at the end; we'll turn it into a PRE afterwards
         for _ in 0..snapshot_config
             .maximum_full_snapshot_archives_to_retain
             .get()
-            + 1
         {
             let slot = bank.slot() + 1;
             bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));


### PR DESCRIPTION
#### Problem
- https://github.com/anza-xyz/agave/pull/7938 removed BankSnapshotType but a reference to pre was left behind

#### Summary of Changes
- Remove the Pre comment
- Remove the +1 in the loop as it was referenced by the PRE comment and is no longer required. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
