### PR TITLE
Unify `InstructionError::NotEnoughAccountKeys` and `InstructionError::MissingAccount`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -348,7 +348,7 @@ impl<'a> InvokeContext<'a> {
                     let cloned_account = {
                         let instruction_account = instruction_accounts
                             .get_mut(*index_in_callee as usize)
-                            .ok_or(InstructionError::NotEnoughAccountKeys)?;
+                            .ok_or(InstructionError::MissingAccount)?;
                         instruction_account.set_is_signer(
                             instruction_account.is_signer() || account_meta.is_signer,
                         );
@@ -378,7 +378,7 @@ impl<'a> InvokeContext<'a> {
                     let (is_signer, is_writable) = {
                         let reference_account = instruction_accounts
                             .get(index_in_callee)
-                            .ok_or(InstructionError::NotEnoughAccountKeys)?;
+                            .ok_or(InstructionError::MissingAccount)?;
                         (
                             reference_account.is_signer(),
                             reference_account.is_writable(),

--- a/programs/bpf-loader-tests/tests/extend_program_ix.rs
+++ b/programs/bpf-loader-tests/tests/extend_program_ix.rs
@@ -522,7 +522,7 @@ async fn test_extend_program_without_payer() {
         &mut context,
         extend_program_checked(&program_address, &upgrade_authority.pubkey(), None, 1024),
         Some(&upgrade_authority),
-        InstructionError::NotEnoughAccountKeys,
+        InstructionError::MissingAccount,
         "should fail because program data has insufficient funds to cover rent",
     )
     .await;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -3070,7 +3070,7 @@ mod tests {
                 ),
             ],
             vec![programdata_meta.clone(), new_upgrade_authority_meta.clone()],
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
 
         // Case: new authority not in instruction
@@ -3087,7 +3087,7 @@ mod tests {
                 ),
             ],
             vec![programdata_meta.clone(), upgrade_authority_meta.clone()],
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
 
         // Case: present authority did not sign
@@ -3470,7 +3470,7 @@ mod tests {
             &instruction,
             transaction_accounts.clone(),
             vec![buffer_meta.clone(), new_authority_meta.clone()],
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
 
         // Case: Missing new authority
@@ -3480,7 +3480,7 @@ mod tests {
             &instruction,
             transaction_accounts.clone(),
             vec![buffer_meta.clone(), authority_meta.clone()],
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
 
         // Case: wrong present authority

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -618,7 +618,7 @@ mod tests {
             &instruction,
             transaction_accounts.clone(),
             &[],
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
 
         // Error: Missing authority account
@@ -627,7 +627,7 @@ mod tests {
             &instruction,
             transaction_accounts.clone(),
             &[(0, false, true)],
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
 
         // Error: Program not owned by loader
@@ -1428,7 +1428,7 @@ mod tests {
             &bincode::serialize(&LoaderV4Instruction::TransferAuthority).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (3, true, false)],
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
 
         // Error: Program is uninitialized

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -1234,7 +1234,7 @@ mod tests {
             &data,
             Vec::new(),
             Vec::new(),
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
 
         // Attempt to transfer with no destination
@@ -1250,7 +1250,7 @@ mod tests {
                 is_signer: true,
                 is_writable: false,
             }],
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
     }
 
@@ -1484,7 +1484,7 @@ mod tests {
             &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
             Vec::new(),
             Vec::new(),
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
     }
 
@@ -1499,7 +1499,7 @@ mod tests {
                 is_signer: true,
                 is_writable: true,
             }],
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
     }
 
@@ -1590,7 +1590,7 @@ mod tests {
             &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
             Vec::new(),
             Vec::new(),
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
     }
 
@@ -1605,7 +1605,7 @@ mod tests {
                 is_signer: true,
                 is_writable: true,
             }],
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
     }
 
@@ -1656,7 +1656,7 @@ mod tests {
             &serialize(&SystemInstruction::InitializeNonceAccount(Pubkey::default())).unwrap(),
             Vec::new(),
             Vec::new(),
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
     }
 
@@ -1672,7 +1672,7 @@ mod tests {
                 is_signer: true,
                 is_writable: true,
             }],
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
     }
 

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -471,7 +471,7 @@ mod tests {
             &[],
             Vec::new(),
             Vec::new(),
-            Err(InstructionError::NotEnoughAccountKeys),
+            Err(InstructionError::MissingAccount),
         );
     }
 
@@ -1926,7 +1926,7 @@ mod tests {
             VoteAuthorize::Voter,
         );
         instruction.accounts = instruction.accounts[0..2].to_vec();
-        process_instruction_as_one_arg(&instruction, Err(InstructionError::NotEnoughAccountKeys));
+        process_instruction_as_one_arg(&instruction, Err(InstructionError::MissingAccount));
 
         let mut instruction = authorize_checked(
             &vote_pubkey,
@@ -1935,7 +1935,7 @@ mod tests {
             VoteAuthorize::Withdrawer,
         );
         instruction.accounts = instruction.accounts[0..2].to_vec();
-        process_instruction_as_one_arg(&instruction, Err(InstructionError::NotEnoughAccountKeys));
+        process_instruction_as_one_arg(&instruction, Err(InstructionError::MissingAccount));
 
         // Test with non-signing new_authorized_pubkey
         let mut instruction = authorize_checked(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6364,7 +6364,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len(formalize_loaded_transaction_
         Some(&mint_keypair.pubkey()),
     );
     assert_eq!(
-        TransactionError::InstructionError(0, InstructionError::NotEnoughAccountKeys),
+        TransactionError::InstructionError(0, InstructionError::MissingAccount),
         bank_client
             .send_and_confirm_message(&[&mint_keypair], message)
             .unwrap_err()
@@ -11957,10 +11957,7 @@ fn test_loader_v3_to_v4_migration(formalize_loaded_transaction_data_size: bool) 
         AccountMeta::new_readonly(upgrade_authority_keypair.pubkey(), true),
     ];
     for (instruction_accounts, expected_error) in [
-        (
-            case_too_few_accounts,
-            InstructionError::NotEnoughAccountKeys,
-        ),
+        (case_too_few_accounts, InstructionError::MissingAccount),
         (case_readonly_programdata, InstructionError::InvalidArgument),
         (
             case_incorrect_authority,

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -175,7 +175,7 @@ impl TransactionContext {
     ) -> Result<&Pubkey, InstructionError> {
         self.accounts
             .account_key(index_in_transaction)
-            .ok_or(InstructionError::NotEnoughAccountKeys)
+            .ok_or(InstructionError::MissingAccount)
     }
 
     /// Searches for an account by its key
@@ -526,7 +526,7 @@ impl<'a> InstructionContext<'a> {
         expected_at_least: IndexOfAccount,
     ) -> Result<(), InstructionError> {
         if self.get_number_of_instruction_accounts() < expected_at_least {
-            Err(InstructionError::NotEnoughAccountKeys)
+            Err(InstructionError::MissingAccount)
         } else {
             Ok(())
         }
@@ -542,7 +542,7 @@ impl<'a> InstructionContext<'a> {
         &self,
     ) -> Result<IndexOfAccount, InstructionError> {
         if self.program_account_index_in_tx == u16::MAX {
-            Err(InstructionError::NotEnoughAccountKeys)
+            Err(InstructionError::MissingAccount)
         } else {
             Ok(self.program_account_index_in_tx)
         }
@@ -556,7 +556,7 @@ impl<'a> InstructionContext<'a> {
         Ok(self
             .instruction_accounts
             .get(instruction_account_index as usize)
-            .ok_or(InstructionError::NotEnoughAccountKeys)?
+            .ok_or(InstructionError::MissingAccount)?
             .index_in_transaction as IndexOfAccount)
     }
 
@@ -625,7 +625,7 @@ impl<'a> InstructionContext<'a> {
         let instruction_account = *self
             .instruction_accounts
             .get(index_in_instruction as usize)
-            .ok_or(InstructionError::NotEnoughAccountKeys)?;
+            .ok_or(InstructionError::MissingAccount)?;
 
         let account = self
             .transaction_context
@@ -1137,12 +1137,12 @@ mod tests {
         let instruction_context = transaction_context.get_next_instruction_context().unwrap();
 
         let result = instruction_context.get_index_of_program_account_in_transaction();
-        assert_eq!(result, Err(InstructionError::NotEnoughAccountKeys));
+        assert_eq!(result, Err(InstructionError::MissingAccount));
 
         let result = instruction_context.get_program_key();
-        assert_eq!(result, Err(InstructionError::NotEnoughAccountKeys));
+        assert_eq!(result, Err(InstructionError::MissingAccount));
 
         let result = instruction_context.get_program_owner();
-        assert_eq!(result.err(), Some(InstructionError::NotEnoughAccountKeys));
+        assert_eq!(result.err(), Some(InstructionError::MissingAccount));
     }
 }

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -52,7 +52,7 @@ impl TransactionAccounts {
     pub fn touch(&self, index: IndexOfAccount) -> Result<(), InstructionError> {
         self.touched_flags
             .get(index as usize)
-            .ok_or(InstructionError::NotEnoughAccountKeys)?
+            .ok_or(InstructionError::MissingAccount)?
             .set(true);
         Ok(())
     }


### PR DESCRIPTION
#### Problem

`InstructionError::NotEnoughAccountKeys` represent the same error as `InstructionError::MissingAccount`. They are used interchangeably in Agave, and it is becoming difficult to maintain Firedancer compatibility since tracking down where these errors come from is cumbersome.

#### Summary of Changes

Remove usages of `Instruction::NotEnoughAccountKeys` in favor of `InstructionError::MissingAccount`.

PS: I believe this PR could go well with https://github.com/anza-xyz/solana-sdk/pull/312.
