### PR TITLE
Consistently use SlotList in AccountsIndex APIs

### DIFF
--- a/accounts-db/benches/accounts_index.rs
+++ b/accounts-db/benches/accounts_index.rs
@@ -8,7 +8,7 @@ use {
     solana_accounts_db::{
         account_info::AccountInfo,
         accounts_index::{
-            AccountSecondaryIndexes, AccountsIndex, UpsertReclaim,
+            AccountSecondaryIndexes, AccountsIndex, SlotList, UpsertReclaim,
             ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS,
         },
     },
@@ -29,7 +29,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
 
     const NUM_FORKS: u64 = 16;
 
-    let mut reclaims = vec![];
+    let mut reclaims = SlotList::new();
     let index = AccountsIndex::<AccountInfo, AccountInfo>::new(
         &ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS,
         Arc::default(),

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1531,7 +1531,7 @@ impl AccountsDb {
     ) -> SlotList<AccountInfo> {
         let one_epoch_old = self.get_oldest_non_ancient_slot(epoch_schedule);
         let mut clean_rooted = Measure::start("clean_old_root-ms");
-        let mut reclaims = Vec::new();
+        let mut reclaims = SlotList::new();
         let removed_from_index = self.accounts_index.clean_rooted_entries(
             pubkey,
             &mut reclaims,
@@ -1691,11 +1691,11 @@ impl AccountsDb {
     pub fn purge_keys_exact<C>(
         &self,
         pubkey_to_slot_set: impl IntoIterator<Item = (Pubkey, C)>,
-    ) -> (Vec<(Slot, AccountInfo)>, PubkeysRemovedFromAccountsIndex)
+    ) -> (SlotList<AccountInfo>, PubkeysRemovedFromAccountsIndex)
     where
         C: for<'a> Contains<'a, Slot>,
     {
-        let mut reclaims = Vec::new();
+        let mut reclaims = SlotList::new();
         let mut dead_keys = Vec::new();
 
         let mut purge_exact_count = 0;
@@ -2119,7 +2119,7 @@ impl AccountsDb {
         let not_found_on_fork_accum = AtomicU64::new(0);
         let missing_accum = AtomicU64::new(0);
         let useful_accum = AtomicU64::new(0);
-        let reclaims: SlotList<AccountInfo> = Vec::with_capacity(num_candidates as usize);
+        let reclaims: SlotList<AccountInfo> = SlotList::with_capacity(num_candidates as usize);
         let reclaims = Mutex::new(reclaims);
         let pubkeys_removed_from_accounts_index: PubkeysRemovedFromAccountsIndex = HashSet::new();
         let pubkeys_removed_from_accounts_index = Mutex::new(pubkeys_removed_from_accounts_index);
@@ -5481,7 +5481,7 @@ impl AccountsDb {
         }
 
         let update = |start, end| {
-            let mut reclaims = Vec::with_capacity((end - start) / 2);
+            let mut reclaims = SlotList::with_capacity((end - start) / 2);
 
             (start..end).for_each(|i| {
                 let info = infos[i];

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -365,7 +365,7 @@ pub(crate) fn append_single_account_with_default_hash(
             account,
             &AccountSecondaryIndexes::default(),
             account_info,
-            &mut Vec::default(),
+            &mut SlotList::new(),
             UpsertReclaim::IgnoreReclaims,
         );
     }
@@ -2783,7 +2783,7 @@ fn test_delete_dependencies() {
     let info1 = AccountInfo::new(StorageLocation::AppendVec(1, 0), true);
     let info2 = AccountInfo::new(StorageLocation::AppendVec(2, 0), true);
     let info3 = AccountInfo::new(StorageLocation::AppendVec(3, 0), true);
-    let mut reclaims = vec![];
+    let mut reclaims = SlotList::new();
     accounts_index.upsert(
         0,
         0,
@@ -5132,7 +5132,7 @@ fn test_filter_zero_lamport_clean_for_incremental_snapshots() {
         candidates[0].insert(
             pubkey,
             CleaningInfo {
-                slot_list: vec![(slot, account_info)],
+                slot_list: SlotList::from([(slot, account_info)]),
                 ref_count: 1,
                 ..Default::default()
             },
@@ -5781,7 +5781,7 @@ fn test_shrink_collect_simple() {
                                 db.accounts_index.purge_exact(
                                     pubkey,
                                     [slot5].into_iter().collect::<HashSet<_>>(),
-                                    &mut Vec::default(),
+                                    &mut SlotList::new(),
                                 );
                             });
 
@@ -5957,7 +5957,7 @@ fn test_shrink_collect_with_obsolete_accounts() {
             db.accounts_index.purge_exact(
                 pubkey,
                 [slot].into_iter().collect::<HashSet<_>>(),
-                &mut Vec::default(),
+                &mut SlotList::new(),
             );
             unref_pubkeys.push(*pubkey);
         }
@@ -6127,7 +6127,7 @@ fn populate_index(db: &AccountsDb, slots: Range<Slot>) {
                         &account,
                         &AccountSecondaryIndexes::default(),
                         info,
-                        &mut Vec::default(),
+                        &mut SlotList::new(),
                         UpsertReclaim::IgnoreReclaims,
                     );
                 })

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1616,7 +1616,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     /// Calls passed in callback on the remaining slot entry
     /// All pubkeys must be from a single bin
     pub fn clean_and_unref_rooted_entries_by_bin(&self, pubkeys_by_bin: &[Pubkey]) -> SlotList<T> {
-        let mut reclaims = Vec::new();
+        let mut reclaims = SlotList::new();
 
         let map = match pubkeys_by_bin.first() {
             Some(pubkey) => self.get_bin(pubkey),
@@ -1820,7 +1820,7 @@ pub mod tests {
                         age: AtomicAge::new(entry.age()),
                     };
                     PreAllocatedAccountMapEntry::Entry(Arc::new(AccountMapEntry::new(
-                        vec![(slot, account_info)],
+                        SlotList::from([(slot, account_info)]),
                         entry.ref_count(),
                         meta,
                     )))
@@ -1902,7 +1902,7 @@ pub mod tests {
     fn test_insert_no_ancestors() {
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         index.upsert(
             0,
             0,
@@ -2080,7 +2080,7 @@ pub mod tests {
         let slot = 0;
         let account_info = true;
 
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         index.upsert(
             slot,
             slot,
@@ -2108,7 +2108,7 @@ pub mod tests {
         let account_info1 = 0;
         let account_info2 = 1;
 
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         for (slot, account_info) in [(slot1, account_info1), (slot2, account_info2)] {
             index.upsert(
                 slot,
@@ -2125,8 +2125,7 @@ pub mod tests {
         assert!(gc.is_empty());
 
         let reclaims = index.clean_and_unref_rooted_entries_by_bin(&[pubkey]);
-
-        assert_eq!(reclaims, vec![(slot1, account_info1)]);
+        assert_eq!(reclaims, SlotList::from([(slot1, account_info1)]));
     }
 
     #[test]
@@ -2134,8 +2133,8 @@ pub mod tests {
         let index: AccountsIndex<bool, bool> = AccountsIndex::<bool, bool>::default_for_tests();
         let bin_index = 0;
         let mut pubkeys = Vec::new();
-        let mut expected_reclaims = Vec::new();
-        let mut gc: Vec<(u64, bool)> = Vec::new();
+        let mut expected_reclaims = SlotList::new();
+        let mut gc = SlotList::new();
 
         while pubkeys.len() < 10 {
             let new_pubkey = solana_pubkey::new_rand();
@@ -2272,7 +2271,7 @@ pub mod tests {
             IndexLimitMb::InMemOnly // in-mem only
         };
         let index = AccountsIndex::<T, T>::new(&config, Arc::default());
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
 
         match upsert_method {
             Some(upsert_method) => {
@@ -2459,7 +2458,7 @@ pub mod tests {
     fn test_insert_wrong_ancestors() {
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         index.upsert(
             0,
             0,
@@ -2492,7 +2491,7 @@ pub mod tests {
             // non-cached
             let key = solana_pubkey::new_rand();
             let index = AccountsIndex::<u64, u64>::default_for_tests();
-            let mut reclaims = Vec::new();
+            let mut reclaims = SlotList::new();
             let slot = 0;
             let value = 1;
             assert!(!value.is_cached());
@@ -2538,7 +2537,7 @@ pub mod tests {
             // cached
             let key = solana_pubkey::new_rand();
             let index = AccountsIndex::<AccountInfoTest, AccountInfoTest>::default_for_tests();
-            let mut reclaims = Vec::new();
+            let mut reclaims = SlotList::new();
             let slot = 0;
             let value = 1.0;
             assert!(value.is_cached());
@@ -2585,7 +2584,7 @@ pub mod tests {
     fn test_insert_with_ancestors() {
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         index.upsert(
             0,
             0,
@@ -2645,7 +2644,7 @@ pub mod tests {
                 &AccountSharedData::default(),
                 &AccountSecondaryIndexes::default(),
                 true,
-                &mut vec![],
+                &mut SlotList::new(),
                 UPSERT_RECLAIM_TEST_DEFAULT,
             );
             new_pubkey
@@ -2662,7 +2661,7 @@ pub mod tests {
                 &AccountSharedData::default(),
                 &AccountSecondaryIndexes::default(),
                 true,
-                &mut vec![],
+                &mut SlotList::new(),
                 UPSERT_RECLAIM_TEST_DEFAULT,
             );
         }
@@ -2710,7 +2709,7 @@ pub mod tests {
     fn test_insert_with_root() {
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         index.upsert(
             0,
             0,
@@ -2758,7 +2757,7 @@ pub mod tests {
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<u64, u64>::default_for_tests();
         let ancestors = vec![(0, 0)].into_iter().collect();
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         index.upsert(
             0,
             0,
@@ -2783,7 +2782,7 @@ pub mod tests {
             )
             .unwrap();
 
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         index.upsert(
             0,
             0,
@@ -2794,7 +2793,7 @@ pub mod tests {
             &mut gc,
             UPSERT_RECLAIM_TEST_DEFAULT,
         );
-        assert_eq!(gc, vec![(0, 1)]);
+        assert_eq!(gc, SlotList::from([(0, 1)]));
         index
             .get_with_and_then(
                 &key,
@@ -2815,7 +2814,7 @@ pub mod tests {
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let ancestors = vec![(0, 0)].into_iter().collect();
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         index.upsert(
             0,
             0,
@@ -2869,7 +2868,7 @@ pub mod tests {
     fn test_update_gc_purged_slot() {
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         index.upsert(
             0,
             0,
@@ -2927,7 +2926,7 @@ pub mod tests {
 
         // Updating index should not purge older roots, only purges
         // previous updates within the same slot
-        assert_eq!(gc, vec![]);
+        assert_eq!(gc, SlotList::new());
         index
             .get_with_and_then(&key, None, None, false, |(slot, account_info)| {
                 assert_eq!(slot, 3);
@@ -2960,7 +2959,7 @@ pub mod tests {
         let key = solana_pubkey::new_rand();
         let index =
             AccountsIndex::<CacheableIndexValueTest, CacheableIndexValueTest>::default_for_tests();
-        let mut reclaims = Vec::new();
+        let mut reclaims = SlotList::new();
         index.upsert(
             0,
             0,
@@ -3023,7 +3022,7 @@ pub mod tests {
     fn test_purge() {
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<u64, u64>::default_for_tests();
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         assert_eq!(0, account_maps_stats_len(&index));
         index.upsert(
             1,
@@ -3050,11 +3049,11 @@ pub mod tests {
         assert_eq!(1, account_maps_stats_len(&index));
 
         let purges = index.purge_roots(&key);
-        assert_eq!(purges, (vec![], false));
+        assert_eq!(purges, (SlotList::new(), false));
         index.add_root(1);
 
         let purges = index.purge_roots(&key);
-        assert_eq!(purges, (vec![(1, 10)], true));
+        assert_eq!(purges, (SlotList::from([(1, 10)]), true));
 
         assert_eq!(1, account_maps_stats_len(&index));
         index.upsert(
@@ -3153,7 +3152,7 @@ pub mod tests {
                 ),
                 secondary_indexes,
                 true,
-                &mut vec![],
+                &mut SlotList::new(),
                 UPSERT_RECLAIM_TEST_DEFAULT,
             );
         }
@@ -3178,7 +3177,7 @@ pub mod tests {
         index.purge_exact(
             &account_key,
             slots.into_iter().collect::<HashSet<Slot>>(),
-            &mut vec![],
+            &mut SlotList::new(),
         );
 
         let _ = index.handle_dead_keys(&[account_key], secondary_indexes);
@@ -3191,7 +3190,7 @@ pub mod tests {
         solana_logger::setup();
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<u64, u64>::default_for_tests();
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         let reclaim_slot = 5;
         let account_value = 50;
 
@@ -3284,7 +3283,7 @@ pub mod tests {
         let key = solana_pubkey::new_rand();
         let index =
             AccountsIndex::<CacheableIndexValueTest, CacheableIndexValueTest>::default_for_tests();
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
 
         // Insert an uncached account at slot 0 and an cached account at slot 1
         index.upsert(
@@ -3393,68 +3392,77 @@ pub mod tests {
     fn test_purge_older_root_entries() {
         // No roots, should be no reclaims
         let index = AccountsIndex::<bool, bool>::default_for_tests();
-        let mut slot_list = vec![(1, true), (2, true), (5, true), (9, true)];
-        let mut reclaims = vec![];
+        let mut slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        let mut reclaims = SlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, None);
         assert!(reclaims.is_empty());
-        assert_eq!(slot_list, vec![(1, true), (2, true), (5, true), (9, true)]);
+        assert_eq!(
+            slot_list,
+            SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
+        );
 
         // Add a later root, earlier slots should be reclaimed
-        slot_list = vec![(1, true), (2, true), (5, true), (9, true)];
+        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
         index.add_root(1);
         // Note 2 is not a root
         index.add_root(5);
-        reclaims = vec![];
+        reclaims = SlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, None);
-        assert_eq!(reclaims, vec![(1, true), (2, true)]);
-        assert_eq!(slot_list, vec![(5, true), (9, true)]);
+        assert_eq!(reclaims, SlotList::from_iter([(1, true), (2, true)]));
+        assert_eq!(slot_list, SlotList::from_iter([(5, true), (9, true)]));
 
         // Add a later root that is not in the list, should not affect the outcome
-        slot_list = vec![(1, true), (2, true), (5, true), (9, true)];
+        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
         index.add_root(6);
-        reclaims = vec![];
+        reclaims = SlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, None);
-        assert_eq!(reclaims, vec![(1, true), (2, true)]);
-        assert_eq!(slot_list, vec![(5, true), (9, true)]);
+        assert_eq!(reclaims, SlotList::from_iter([(1, true), (2, true)]));
+        assert_eq!(slot_list, SlotList::from_iter([(5, true), (9, true)]));
 
         // Pass a max root >= than any root in the slot list, should not affect
         // outcome
-        slot_list = vec![(1, true), (2, true), (5, true), (9, true)];
-        reclaims = vec![];
+        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        reclaims = SlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(6));
-        assert_eq!(reclaims, vec![(1, true), (2, true)]);
-        assert_eq!(slot_list, vec![(5, true), (9, true)]);
+        assert_eq!(reclaims, SlotList::from_iter([(1, true), (2, true)]));
+        assert_eq!(slot_list, SlotList::from_iter([(5, true), (9, true)]));
 
         // Pass a max root, earlier slots should be reclaimed
-        slot_list = vec![(1, true), (2, true), (5, true), (9, true)];
-        reclaims = vec![];
+        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        reclaims = SlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(5));
-        assert_eq!(reclaims, vec![(1, true), (2, true)]);
-        assert_eq!(slot_list, vec![(5, true), (9, true)]);
+        assert_eq!(reclaims, SlotList::from_iter([(1, true), (2, true)]));
+        assert_eq!(slot_list, SlotList::from_iter([(5, true), (9, true)]));
 
         // Pass a max root 2. This means the latest root < 2 is 1 because 2 is not a root
         // so nothing will be purged
-        slot_list = vec![(1, true), (2, true), (5, true), (9, true)];
-        reclaims = vec![];
+        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        reclaims = SlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(2));
         assert!(reclaims.is_empty());
-        assert_eq!(slot_list, vec![(1, true), (2, true), (5, true), (9, true)]);
+        assert_eq!(
+            slot_list,
+            SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
+        );
 
         // Pass a max root 1. This means the latest root < 3 is 1 because 2 is not a root
         // so nothing will be purged
-        slot_list = vec![(1, true), (2, true), (5, true), (9, true)];
-        reclaims = vec![];
+        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        reclaims = SlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(1));
         assert!(reclaims.is_empty());
-        assert_eq!(slot_list, vec![(1, true), (2, true), (5, true), (9, true)]);
+        assert_eq!(
+            slot_list,
+            SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
+        );
 
         // Pass a max root that doesn't exist in the list but is greater than
         // some of the roots in the list, shouldn't return those smaller roots
-        slot_list = vec![(1, true), (2, true), (5, true), (9, true)];
-        reclaims = vec![];
+        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        reclaims = SlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(7));
-        assert_eq!(reclaims, vec![(1, true), (2, true)]);
-        assert_eq!(slot_list, vec![(5, true), (9, true)]);
+        assert_eq!(reclaims, SlotList::from_iter([(1, true), (2, true)]));
+        assert_eq!(slot_list, SlotList::from_iter([(5, true), (9, true)]));
     }
 
     fn check_secondary_index_mapping_correct<SecondaryIndexEntryType>(
@@ -3504,7 +3512,7 @@ pub mod tests {
             &AccountSharedData::create(0, account_data.to_vec(), Pubkey::default(), false, 0),
             &secondary_indexes,
             true,
-            &mut vec![],
+            &mut SlotList::new(),
             UPSERT_RECLAIM_TEST_DEFAULT,
         );
         assert!(secondary_index.index.is_empty());
@@ -3518,7 +3526,7 @@ pub mod tests {
             &AccountSharedData::create(0, account_data[1..].to_vec(), *token_id, false, 0),
             &secondary_indexes,
             true,
-            &mut vec![],
+            &mut SlotList::new(),
             UPSERT_RECLAIM_TEST_DEFAULT,
         );
         assert!(secondary_index.index.is_empty());
@@ -3643,7 +3651,7 @@ pub mod tests {
             &AccountSharedData::create(0, account_data1.to_vec(), *token_id, false, 0),
             secondary_indexes,
             true,
-            &mut vec![],
+            &mut SlotList::new(),
             UPSERT_RECLAIM_TEST_DEFAULT,
         );
 
@@ -3655,7 +3663,7 @@ pub mod tests {
             &AccountSharedData::create(0, account_data2.to_vec(), *token_id, false, 0),
             secondary_indexes,
             true,
-            &mut vec![],
+            &mut SlotList::new(),
             UPSERT_RECLAIM_TEST_DEFAULT,
         );
 
@@ -3675,7 +3683,7 @@ pub mod tests {
             &AccountSharedData::create(0, account_data1.to_vec(), *token_id, false, 0),
             secondary_indexes,
             true,
-            &mut vec![],
+            &mut SlotList::new(),
             UPSERT_RECLAIM_TEST_DEFAULT,
         );
         assert_eq!(secondary_index.get(&secondary_key1), vec![account_key]);
@@ -3685,7 +3693,7 @@ pub mod tests {
         // so both secondary keys will still be kept alive.
         index.add_root(later_slot);
         index.slot_list_mut(&account_key, |slot_list| {
-            index.purge_older_root_entries(slot_list, &mut vec![], None)
+            index.purge_older_root_entries(slot_list, &mut SlotList::new(), None)
         });
 
         check_secondary_index_mapping_correct(
@@ -3696,7 +3704,7 @@ pub mod tests {
 
         // Removing the remaining entry for this pubkey in the index should mark the
         // pubkey as dead and finally remove all the secondary indexes
-        let mut reclaims = vec![];
+        let mut reclaims = SlotList::new();
         index.purge_exact(&account_key, later_slot, &mut reclaims);
         let _ = index.handle_dead_keys(&[account_key], secondary_indexes);
         assert!(secondary_index.index.is_empty());
@@ -3852,7 +3860,7 @@ pub mod tests {
 
     impl<T: IndexValue> AccountsIndex<T, T> {
         fn upsert_simple_test(&self, key: &Pubkey, slot: Slot, value: T) {
-            let mut gc = Vec::new();
+            let mut gc = SlotList::new();
 
             // It is invalid to reclaim older slots if the slot being upserted
             // is unrooted
@@ -3926,7 +3934,7 @@ pub mod tests {
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let slot1 = 1;
 
-        let mut gc = Vec::new();
+        let mut gc = SlotList::new();
         // return true if we don't know anything about 'key_unknown'
         // the item did not exist in the accounts index at all, so index is up to date
         assert!(index.clean_rooted_entries(&key_unknown, &mut gc, None));
@@ -3941,9 +3949,9 @@ pub mod tests {
         // this will delete the entry because it is <= max_root_inclusive and NOT a root
         // note this has to be slot2 because of inclusive vs exclusive in the call to can_purge_older_entries
         {
-            let mut gc = Vec::new();
+            let mut gc = SlotList::new();
             assert!(index.clean_rooted_entries(&key, &mut gc, Some(slot2)));
-            assert_eq!(gc, vec![(slot1, value)]);
+            assert_eq!(gc, SlotList::from([(slot1, value)]));
         }
 
         // re-add it
@@ -3974,7 +3982,7 @@ pub mod tests {
         {
             {
                 let roots_tracker = &index.roots_tracker.read().unwrap();
-                let slot_list = vec![(slot2, value)];
+                let slot_list = SlotList::from([(slot2, value)]);
                 assert_eq!(
                     0,
                     AccountsIndex::<bool, bool>::get_newest_root_in_slot_list(
@@ -3987,7 +3995,7 @@ pub mod tests {
             index.add_root(slot2);
             {
                 let roots_tracker = &index.roots_tracker.read().unwrap();
-                let slot_list = vec![(slot2, value)];
+                let slot_list = SlotList::from([(slot2, value)]);
                 assert_eq!(
                     slot2,
                     AccountsIndex::<bool, bool>::get_newest_root_in_slot_list(
@@ -4009,12 +4017,12 @@ pub mod tests {
 
         assert!(gc.is_empty());
         assert!(!index.clean_rooted_entries(&key, &mut gc, Some(slot2)));
-        assert_eq!(gc, vec![(slot1, value)]);
+        assert_eq!(gc, SlotList::from([(slot1, value)]));
         gc.clear();
         index.clean_dead_slot(slot2);
         let slot3 = 3;
         assert!(index.clean_rooted_entries(&key, &mut gc, Some(slot3)));
-        assert_eq!(gc, vec![(slot2, value)]);
+        assert_eq!(gc, SlotList::from([(slot2, value)]));
     }
 
     #[test]

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -183,7 +183,7 @@ impl<T: IndexValue> PreAllocatedAccountMapEntry<T> {
         let ref_count = RefCount::from(!is_cached);
         let meta = AccountMapEntryMeta::new_dirty(storage, is_cached);
         Arc::new(AccountMapEntry::new(
-            vec![(slot, account_info)],
+            SlotList::from([(slot, account_info)]),
             ref_count,
             meta,
         ))

--- a/accounts-db/src/accounts_index/iter.rs
+++ b/accounts-db/src/accounts_index/iter.rs
@@ -105,6 +105,7 @@ mod tests {
             super::{secondary::AccountSecondaryIndexes, UpsertReclaim},
             *,
         },
+        crate::accounts_index::SlotList,
         solana_account::AccountSharedData,
         std::ops::Range,
     };
@@ -122,7 +123,7 @@ mod tests {
         for key in pubkeys {
             let slot = 0;
             let value = true;
-            let mut gc = Vec::new();
+            let mut gc = SlotList::new();
             index.upsert(
                 slot,
                 slot,
@@ -161,7 +162,7 @@ mod tests {
         index.add_root(0);
         let mut iter = index.iter(None::<&Range<Pubkey>>, AccountsIndexPubkeyIterOrder::Sorted);
         assert!(iter.next().is_none());
-        let mut gc = vec![];
+        let mut gc = SlotList::new();
         index.upsert(
             0,
             0,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1122,7 +1122,9 @@ pub mod tests {
                 ShrinkCollectRefs,
             },
             accounts_file::StorageAccess,
-            accounts_index::{AccountsIndexScanResult, RefCount, ScanFilter, UpsertReclaim},
+            accounts_index::{
+                AccountsIndexScanResult, RefCount, ScanFilter, SlotList, UpsertReclaim,
+            },
             append_vec::{self, aligned_stored_size},
             storable_accounts::StorableAccountsBySlot,
         },
@@ -1791,7 +1793,7 @@ pub mod tests {
                                             [storage.slot()]
                                                 .into_iter()
                                                 .collect::<std::collections::HashSet<Slot>>(),
-                                            &mut Vec::default()
+                                            &mut SlotList::new()
                                         ));
                                     });
                                 }
@@ -3752,7 +3754,7 @@ pub mod tests {
                         &empty_account,
                         &crate::accounts_index::AccountSecondaryIndexes::default(),
                         AccountInfo::default(),
-                        &mut Vec::default(),
+                        &mut SlotList::new(),
                         UpsertReclaim::IgnoreReclaims,
                     );
                 }

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -68,11 +68,11 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
     }
 
     /// Get the values for Pubkey `key`
-    pub fn read_value(&self, key: &Pubkey) -> Option<(Vec<T>, RefCount)> {
+    pub fn read_value<C: for<'a> From<&'a [T]>>(&self, key: &Pubkey) -> Option<(C, RefCount)> {
         self.bucket.read().unwrap().as_ref().and_then(|bucket| {
             bucket
                 .read_value(key)
-                .map(|(value, ref_count)| (value.to_vec(), ref_count))
+                .map(|(value, ref_count)| (C::from(value), ref_count))
         })
     }
 


### PR DESCRIPTION
#### Problem
`SlotList` is a type alias for a specific container, but many places in code assume it's a `Vec`

#### Summary of Changes
* switch all APIs to operate on `SlotList`
* switch tests to construct lists with `SlotList::new()`, `SlotList::from([(slot, x)])` or `SlotList::from_iter([(s1, x1), (s2, x2)])` - this choice is designed to increase compatibility with other containers (i.e. testing with smallvec allows switching without further code changes)
