### PR TITLE
Switch SlotList to smallvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,7 +366,7 @@ shuttle = "0.7.1"
 signal-hook = "0.3.18"
 siphasher = "1.0.1"
 slab = "0.4.11"
-smallvec = "1.15.1"
+smallvec = { version = "1.15.1", default-features = false, features = ["union"] }
 smpl_jwt = "0.7.1"
 socket2 = "0.6.0"
 soketto = "0.7"

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5484,7 +5484,7 @@ impl AccountsDb {
                     );
                 });
             });
-            reclaims
+            reclaims.to_vec()
         };
 
         let threshold = 1;
@@ -5509,6 +5509,7 @@ impl AccountsDb {
         } else {
             update(0, len)
         }
+        .into()
     }
 
     fn should_not_shrink(alive_bytes: u64, total_bytes: u64) -> bool {

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -24,6 +24,7 @@ use {
     rayon::iter::{IntoParallelIterator, ParallelIterator},
     roots_tracker::RootsTracker,
     secondary::{RwLockSecondaryIndexEntry, SecondaryIndex, SecondaryIndexEntry},
+    smallvec::SmallVec,
     solana_account::ReadableAccount,
     solana_clock::{BankId, Slot},
     solana_measure::measure::Measure,
@@ -70,7 +71,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
     scan_results_limit_bytes: None,
 };
 pub type ScanResult<T> = Result<T, ScanError>;
-pub type SlotList<T> = Vec<(Slot, T)>;
+pub type SlotList<T> = SmallVec<[(Slot, T); 1]>;
 
 // The ref count cannot be higher than the total number of storages, and we should never have more
 // than 1 million storages. A 32-bit ref count should be *significantly* more than enough.


### PR DESCRIPTION
#### Problem
`SlotList` is typically small, most of the time contains exactly 1 element. Allocating heap memory for 1-element vectors is not very efficient if the same data could be stored inline in the memory reserved for the SlotList itself.

Additionally, in concrete use of `SlotList` for `AccountInfo`, `Vec` memory overhead for 1-element is larger than keeping the single element inline.

#### Summary of Changes
* Switch `SlotList<T>` to `SmallVec<[(Slot, T); 1]>`, i.e. collection that either inlines a single element or falls back to heap allocation whenever >1 element is pushed into the slot list
* enable `union` feature of smallvec - this makes smallvec not utilize extra memory of enum discriminant (marker between inline and heap mode) - it uses `capacity` field as internal marker for operation mode

Typically `AccountsIndex` uses `SlotList` with `AccountInfo`, which is 8-bytes. Then `SlotList<AccounInfo>` uses:
* when holding single element:
  - smallvec (inline mode) - 16 bytes (inlined slot + account info) + 8 bytes (capacity field being usize) = 24 bytes
  - master (Vec) -  16 bytes (buf holding 1 element of slot + account info) + 8 bytes (len field being usize) + 8 bytes (capacity = usize) + 8 bytes (pointer to heap) = 40 bytes
* when holding 2 elements:
  - smallvec (heap mode) - 2x16 bytes (heap buf with 2 slot + account info items) + 8 bytes (capacity field being usize) + 8 bytes (pointer to heap) + 8 bytes (len = usize) = 56 bytes
  - master (Vec) -  2x16 bytes (buf) + 8 bytes (pointer to heap) + 8 bytes (len field being usize) + 8 bytes (capacity = usize) = 56 bytes
 * more elements, similarly as with 2 elements it's the same as `Vec`

Pros:
* less memory used for SlotList with 1 element
* less allocations done for 1-element slot lists
* less indirection and accessed memory pages when operating on 1-element slot lists

Cons:
* extra branch on each operation, since smallvec needs to always check whether collection is inline or heap allocated