### PR TITLE
Move VmSlice to transaction context

### DIFF
--- a/program-runtime/src/memory.rs
+++ b/program-runtime/src/memory.rs
@@ -2,6 +2,7 @@
 
 use {
     solana_sbpf::memory_region::{AccessType, MemoryMapping},
+    solana_transaction_context::vm_slice::VmSlice,
     std::{mem::align_of, slice::from_raw_parts_mut},
 };
 
@@ -126,4 +127,25 @@ pub fn translate_slice_mut_for_cpi<'a, T>(
         T,
         check_aligned,
     )
+}
+
+pub trait TranslateSlice {
+    type Data;
+    /// Returns a slice using a mapped physical address
+    fn translate<'a>(
+        &self,
+        memory_mapping: &'a MemoryMapping,
+        check_aligned: bool,
+    ) -> Result<&'a [Self::Data], Box<dyn std::error::Error>>;
+}
+
+impl<T> TranslateSlice for VmSlice<T> {
+    type Data = T;
+    fn translate<'a>(
+        &self,
+        memory_mapping: &'a MemoryMapping,
+        check_aligned: bool,
+    ) -> Result<&'a [T], Box<dyn std::error::Error>> {
+        translate_slice::<T>(memory_mapping, self.ptr(), self.len(), check_aligned)
+    }
 }

--- a/program-runtime/src/memory.rs
+++ b/program-runtime/src/memory.rs
@@ -129,23 +129,10 @@ pub fn translate_slice_mut_for_cpi<'a, T>(
     )
 }
 
-pub trait TranslateSlice {
-    type Data;
-    /// Returns a slice using a mapped physical address
-    fn translate<'a>(
-        &self,
-        memory_mapping: &'a MemoryMapping,
-        check_aligned: bool,
-    ) -> Result<&'a [Self::Data], Box<dyn std::error::Error>>;
-}
-
-impl<T> TranslateSlice for VmSlice<T> {
-    type Data = T;
-    fn translate<'a>(
-        &self,
-        memory_mapping: &'a MemoryMapping,
-        check_aligned: bool,
-    ) -> Result<&'a [T], Box<dyn std::error::Error>> {
-        translate_slice::<T>(memory_mapping, self.ptr(), self.len(), check_aligned)
-    }
+pub fn translate_vm_slice<'a, T>(
+    slice: &VmSlice<T>,
+    memory_mapping: &'a MemoryMapping,
+    check_aligned: bool,
+) -> Result<&'a [T], Box<dyn std::error::Error>> {
+    translate_slice::<T>(memory_mapping, slice.ptr(), slice.len(), check_aligned)
 }

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -8,7 +8,7 @@ use {
             SolInstruction, SolSignerSeedC, SolSignerSeedsC, SyscallInvokeSigned,
             TranslatedAccount,
         },
-        memory::{translate_slice, translate_type},
+        memory::{translate_slice, translate_type, translate_vm_slice},
     },
     solana_stable_layout::stable_instruction::StableInstruction,
 };
@@ -148,7 +148,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
                 let seeds = untranslated_seeds
                     .iter()
                     .map(|untranslated_seed| {
-                        untranslated_seed.translate(memory_mapping, check_aligned)
+                        translate_vm_slice(untranslated_seed, memory_mapping, check_aligned)
                     })
                     .collect::<Result<Vec<_>, Error>>()?;
                 let signer = Pubkey::create_program_address(&seeds, program_id)

--- a/syscalls/src/logging.rs
+++ b/syscalls/src/logging.rs
@@ -1,4 +1,6 @@
-use {super::*, solana_sbpf::vm::ContextObject};
+use {
+    super::*, solana_program_runtime::memory::translate_vm_slice, solana_sbpf::vm::ContextObject,
+};
 
 declare_builtin_function!(
     /// Log a user's info message
@@ -143,7 +145,7 @@ declare_builtin_function!(
         let mut fields = Vec::with_capacity(untranslated_fields.len());
 
         for untranslated_field in untranslated_fields {
-            fields.push(untranslated_field.translate(memory_mapping, invoke_context.get_check_aligned())?);
+            fields.push(translate_vm_slice(untranslated_field, memory_mapping, invoke_context.get_check_aligned())?);
         }
 
         let log_collector = invoke_context.get_log_collector();

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -19,6 +19,7 @@ use {
 use {solana_account::WritableAccount, solana_rent::Rent};
 
 pub mod transaction_accounts;
+pub mod vm_slice;
 
 pub const MAX_ACCOUNTS_PER_TRANSACTION: usize = 256;
 // This is one less than MAX_ACCOUNTS_PER_TRANSACTION because

--- a/transaction-context/src/vm_slice.rs
+++ b/transaction-context/src/vm_slice.rs
@@ -1,0 +1,41 @@
+// The VmSlice class is used for cases when you need a slice that is stored in the BPF
+// interpreter's virtual address space. Because this source code can be compiled with
+// addresses of different bit depths, we cannot assume that the 64-bit BPF interpreter's
+// pointer sizes can be mapped to physical pointer sizes. In particular, if you need a
+// slice-of-slices in the virtual space, the inner slices will be different sizes in a
+// 32-bit app build than in the 64-bit virtual space. Therefore instead of a slice-of-slices,
+// you should implement a slice-of-VmSlices, which can then use VmSlice::translate() to
+// map to the physical address.
+// This class must consist only of 16 bytes: a u64 ptr and a u64 len, to match the 64-bit
+// implementation of a slice in Rust. The PhantomData entry takes up 0 bytes.
+
+use std::marker::PhantomData;
+
+#[repr(C)]
+pub struct VmSlice<T> {
+    ptr: u64,
+    len: u64,
+    resource_type: PhantomData<T>,
+}
+
+impl<T> VmSlice<T> {
+    pub fn new(ptr: u64, len: u64) -> Self {
+        VmSlice {
+            ptr,
+            len,
+            resource_type: PhantomData,
+        }
+    }
+
+    pub fn ptr(&self) -> u64 {
+        self.ptr
+    }
+
+    pub fn len(&self) -> u64 {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}


### PR DESCRIPTION
#### Problem

In ABIv2, the type `struct VmSlice` is going to be used both in programs and on runtime, so we should move it to `transaction-context`. It also allows us to share the same data structures with runtime and programs.

#### Summary of Changes

1. Move `VmSlice` from `syscalls/src/lib.rs` to `transaction-context/src/vm_slice.rs`.
2. Delete `fn resize`, which was unused. Also, we shouldn't be resizing slices, right? Not even Rust allows that.
3. Implement `fn translate` as a standalone function.