### PR TITLE
Move snapshot completer to flush and stop reading

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -211,9 +211,14 @@ impl SnapshotPackagerService {
             start.elapsed(),
         );
 
+        // Mark this directory complete. Used in older versions to check if the snapshot is complete
+        // Never read in v3.1, can be removed in v3.2
         let result = snapshot_utils::write_snapshot_state_complete_file(&bank_snapshot_dir);
         if let Err(err) = result {
             warn!("Failed to mark snapshot 'complete': {err}");
+            // If writing the "state complete" file failed, we do *NOT* want to write
+            // the "storages flushed" file, so return early.
+            return;
         }
 
         let result = snapshot_utils::write_storages_flushed_file(&bank_snapshot_dir);

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -211,6 +211,11 @@ impl SnapshotPackagerService {
             start.elapsed(),
         );
 
+        let result = snapshot_utils::write_snapshot_state_complete_file(&bank_snapshot_dir);
+        if let Err(err) = result {
+            warn!("Failed to mark snapshot 'complete': {err}");
+        }
+
         let result = snapshot_utils::write_storages_flushed_file(&bank_snapshot_dir);
         if let Err(err) = result {
             warn!("Failed to mark snapshot storages 'flushed': {err}");

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1643,10 +1643,10 @@ mod tests {
         let snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
         assert_eq!(snapshot.slot, 4);
 
-        let complete_flag_file = snapshot
+        let version_file = snapshot
             .snapshot_dir
-            .join(snapshot_utils::SNAPSHOT_STATE_COMPLETE_FILENAME);
-        fs::remove_file(complete_flag_file).unwrap();
+            .join(snapshot_utils::SNAPSHOT_VERSION_FILENAME);
+        fs::remove_file(version_file).unwrap();
         // The incomplete snapshot dir should still exist
         let snapshot_dir_4 = snapshot.snapshot_dir;
         assert!(snapshot_dir_4.exists());
@@ -1743,12 +1743,11 @@ mod tests {
             should_flush_and_hard_link_storages,
         );
 
-        // remove the "state complete" files so the snapshots will be purged
+        // remove the "version" files so the snapshots will be purged
         for slot in [1, 2] {
             let bank_snapshot_dir = get_bank_snapshot_dir(&bank_snapshots_dir, slot);
-            let state_complete_file =
-                bank_snapshot_dir.join(snapshot_utils::SNAPSHOT_STATE_COMPLETE_FILENAME);
-            fs::remove_file(state_complete_file).unwrap();
+            let version_file = bank_snapshot_dir.join(snapshot_utils::SNAPSHOT_VERSION_FILENAME);
+            fs::remove_file(version_file).unwrap();
         }
 
         purge_incomplete_bank_snapshots(&bank_snapshots_dir);

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -934,13 +934,13 @@ fn serialize_snapshot(
                 snapshot_storages
             )
             .map_err(AddBankSnapshotError::HardLinkStorages)?);
-            
+
             // Mark this directory complete. Used in older versions to check if the snapshot is complete
             // Never read in v3.1, can be removed in v3.2
             write_snapshot_state_complete_file(&bank_snapshot_dir)
                 .map_err(AddBankSnapshotError::MarkSnapshotComplete)?;
-            
-            // Write the storages flushed file     
+
+            // Write the storages flushed file
             write_storages_flushed_file(&bank_snapshot_dir)
                 .map_err(AddBankSnapshotError::MarkStoragesFlushed)?;
             Some((flush_us, hard_link_us))

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1953,7 +1953,7 @@ pub fn rebuild_storages_from_snapshot_dir(
 /// Reads the `snapshot_version` from a file. Before opening the file, its size
 /// is compared to `MAX_SNAPSHOT_VERSION_FILE_SIZE`. If the size exceeds this
 /// threshold, it is not opened and an error is returned.
-fn snapshot_version_from_file(path: impl AsRef<Path>) -> std::result::Result<String, IoError> {
+fn snapshot_version_from_file(path: impl AsRef<Path>) -> io::Result<String> {
     // Check file size.
     let file_metadata = fs::metadata(&path).map_err(|err| {
         IoError::other(format!(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -927,12 +927,6 @@ fn serialize_snapshot(
                     AddBankSnapshotError::FlushStorage(err, storage.path().to_path_buf())
                 })?;
             }
-
-            // Mark this directory complete. Used in older versions to check if the snapshot is complete
-            // Never read in v3.1, can be removed in v3.2
-            write_snapshot_state_complete_file(&bank_snapshot_dir)
-                .map_err(AddBankSnapshotError::MarkSnapshotComplete)?;
-
             let flush_us = flush_measure.end_as_us();
             let (_, hard_link_us) = measure_us!(hard_link_storages_to_snapshot(
                 &bank_snapshot_dir,
@@ -940,6 +934,13 @@ fn serialize_snapshot(
                 snapshot_storages
             )
             .map_err(AddBankSnapshotError::HardLinkStorages)?);
+            
+            // Mark this directory complete. Used in older versions to check if the snapshot is complete
+            // Never read in v3.1, can be removed in v3.2
+            write_snapshot_state_complete_file(&bank_snapshot_dir)
+                .map_err(AddBankSnapshotError::MarkSnapshotComplete)?;
+            
+            // Write the storages flushed file     
             write_storages_flushed_file(&bank_snapshot_dir)
                 .map_err(AddBankSnapshotError::MarkStoragesFlushed)?;
             Some((flush_us, hard_link_us))


### PR DESCRIPTION
#### Problem
- Snapshots currently have multiple completers, when it can be consolidated
- The completer has no purpose other than backwards compatibility, as a snapshot is not loadable until the storages have been flushed

#### Summary of Changes
- Change is directory complete check to be based on version file rather than completer
- Move the completer to teardown
- Write completer during archive_snapshot when should_flush_and_hard_link_storages is true

Testing
Tested Fastboot 3.0 -> This code -> 3.0
Tested load from archives 3.0 -> This code -> 3.0
Tested loading a 3.0 snapshot with this PR ledger-tool
Tested loading a snapshot from this PR with 3.0 ledger-tool
Tested commenting out create_snapshot_meta_files_for_unarchived_snapshot to ensure it had proper test coverage. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
