### PR TITLE
Fix recording guarantees for low power poh-service variants

### DIFF
--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -192,6 +192,9 @@ impl PohService {
                 // Only perform the last tick of the slot if there are no records.
                 // This ensures we don't tick, ending the slot, and cause recording
                 // to fail, unless all records have been processed.
+                // If we are on the last tick, the channel is shutdown so no more
+                // records can be received - we will just process the ones that
+                // have already been received.
                 if remaining_tick_time.is_zero()
                     && (!last_tick_of_slot || record_receiver.is_empty())
                 {
@@ -217,6 +220,7 @@ impl PohService {
 
             if let Some(service_message) = service_message {
                 Self::handle_service_message(&poh_recorder, service_message, &mut record_receiver);
+                last_tick_of_slot = Self::last_tick_of_slot(&poh_recorder);
             }
         }
 
@@ -291,6 +295,9 @@ impl PohService {
                 // Only perform the last tick of the slot if there are no records.
                 // This ensures we don't tick, ending the slot, and cause recording
                 // to fail, unless all records have been processed.
+                // If we are on the last tick, the channel is shutdown so no more
+                // records can be received - we will just process the ones that
+                // have already been received.
                 if remaining_tick_time.is_zero()
                     && (!last_tick_of_slot || record_receiver.is_empty())
                 {
@@ -321,6 +328,7 @@ impl PohService {
             }
             if let Some(service_message) = service_message {
                 Self::handle_service_message(&poh_recorder, service_message, &mut record_receiver);
+                last_tick_of_slot = Self::last_tick_of_slot(&poh_recorder);
             }
         }
 

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -195,6 +195,10 @@ impl PohService {
                 // If we are on the last tick, the channel is shutdown so no more
                 // records can be received - we will just process the ones that
                 // have already been received.
+                debug_assert!(
+                    !last_tick_of_slot || record_receiver.is_shutdown(),
+                    "channel should be shutdown if last tick of slot"
+                );
                 if remaining_tick_time.is_zero()
                     && (!last_tick_of_slot || record_receiver.is_empty())
                 {
@@ -298,6 +302,10 @@ impl PohService {
                 // If we are on the last tick, the channel is shutdown so no more
                 // records can be received - we will just process the ones that
                 // have already been received.
+                debug_assert!(
+                    !last_tick_of_slot || record_receiver.is_shutdown(),
+                    "channel should be shutdown if last tick of slot"
+                );
                 if remaining_tick_time.is_zero()
                     && (!last_tick_of_slot || record_receiver.is_empty())
                 {

--- a/poh/src/record_channels.rs
+++ b/poh/src/record_channels.rs
@@ -166,6 +166,12 @@ impl RecordReceiver {
         self.slot_allowed_insertions.shutdown();
     }
 
+    /// Check if the channel is shutdown.
+    pub(crate) fn is_shutdown(&self) -> bool {
+        SlotAllowedInsertions::slot(self.slot_allowed_insertions.0.load(Ordering::Acquire))
+            == SlotAllowedInsertions::DISABLED_SLOT
+    }
+
     /// Re-enable the channel after a shutdown.
     pub fn restart(&mut self, slot: Slot) {
         assert!(slot <= SlotAllowedInsertions::MAX_SLOT);


### PR DESCRIPTION
#### Problem
- https://buildkite.com/anza/agave/builds/30200#019936b2-c157-4da7-95a8-0e60b25bf7e7
- low-power poh service variants are failing in local-cluster tests because the checks I put in #7898 were not strong enough to guarantee we did not do final tick before recording all records for the low-power (non-production) variants of PoH service.

#### Summary of Changes
- Only perform final tick in the slot if we've recorded all records
  - When we detect we are on the final tick we shutdown the channel so no more records can be sent

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
