### PR TITLE
Align bucket API refcount type with in-memory refcount (u64 -> u32)

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1246,7 +1246,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                                                 .iter()
                                                 .map(|(slot, info)| (*slot, (*info).into()))
                                                 .collect::<Vec<_>>(),
-                                            ref_count.into(), // ref count on disk is u64
+                                            ref_count,
                                         ),
                                     )
                                 };
@@ -1502,7 +1502,7 @@ mod tests {
         let slot = 0;
 
         // Simulate an entry on disk
-        let disk_entry: (&[(u64, u64)], u64) = (&[(0u64, 42u64)], 1u64);
+        let disk_entry: (&[(u64, u64)], u32) = (&[(0u64, 42u64)], 1u32);
         accounts_index
             .bucket
             .as_ref()

--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -284,7 +284,7 @@ impl MultipleSlots {
         data_bucket
             .get_header_mut::<DataBucketRefCountOccupiedHeader>(data_ix)
             .packed_ref_count
-            .set_ref_count(ref_count);
+            .set_ref_count(ref_count.into());
     }
 
     /// ref_count is stored in the header per cell, in `packed_ref_count`
@@ -293,6 +293,8 @@ impl MultipleSlots {
             .get_header::<DataBucketRefCountOccupiedHeader>(data_ix)
             .packed_ref_count
             .ref_count()
+            .try_into()
+            .unwrap() // safe because we only store legal u32 ref counts here
     }
 }
 

--- a/bucket_map/src/lib.rs
+++ b/bucket_map/src/lib.rs
@@ -8,4 +8,4 @@ mod bucket_storage;
 mod index_entry;
 mod restart;
 pub type MaxSearch = u8;
-pub type RefCount = u64;
+pub type RefCount = u32;


### PR DESCRIPTION
#### Problem

The refcount types were inconsistent between different parts of the accounts system:
  - In-memory refcount uses u32
  - Disk bucket API refcount uses u64

  This type inconsistency creates confusion and potential for bugs when working across the accounts
  indexing system.


#### Summary of Changes

Change the disk bucket API's refcount from u64 to u32 to match the in-memory refcount type. Note that internally, bucket map still stores 64bit packed refcount.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
