### PR TITLE
The accounts index is kept entirely in memory by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,17 @@ Release channels have their own copy of this changelog:
 ### RPC
 #### Breaking
 #### Changes
+
 ### Validator
+
 #### Breaking
+
 #### Deprecations
 * The `--monitor` flag with `agave-validator exit` is now deprecated. Operators can use the `monitor` command after `exit` instead.
+* The `--disable-accounts-disk-index` flag is now deprecated.
+
+#### Changes
+* The accounts index is now kept entirely in memory by default.
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,8 @@ Release channels have their own copy of this changelog:
 ### RPC
 #### Breaking
 #### Changes
-
 ### Validator
-
 #### Breaking
-
 #### Deprecations
 * The `--monitor` flag with `agave-validator exit` is now deprecated. Operators can use the `monitor` command after `exit` instead.
 * The `--disable-accounts-disk-index` flag is now deprecated.

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -58,7 +58,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndex
     bins: Some(BINS_FOR_TESTING),
     num_flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: IndexLimitMb::Minimal,
+    index_limit_mb: IndexLimitMb::InMemOnly,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
 };
@@ -66,7 +66,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
     bins: Some(BINS_FOR_BENCHMARKS),
     num_flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: IndexLimitMb::Minimal,
+    index_limit_mb: IndexLimitMb::InMemOnly,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
 };
@@ -250,7 +250,7 @@ impl Default for AccountsIndexConfig {
             bins: None,
             num_flush_threads: None,
             drives: None,
-            index_limit_mb: IndexLimitMb::Minimal,
+            index_limit_mb: IndexLimitMb::InMemOnly,
             ages_to_stay_in_cache: None,
             scan_results_limit_bytes: None,
         }

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -56,7 +56,10 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
         Arg::with_name("enable_accounts_disk_index")
             .long("enable-accounts-disk-index")
             .help("Enables the disk-based accounts index")
-            .hidden(hidden_unless_forced()),
+            .long_help(
+                "Enables the disk-based accounts index. Reduce the memory footprint of the \
+                 accounts index at the cost of index performance.",
+            ),
         Arg::with_name("accounts_db_skip_shrink")
             .long("accounts-db-skip-shrink")
             .help(

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -42,6 +42,7 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .value_name("PATH")
             .takes_value(true)
             .multiple(true)
+            .requires("enable_accounts_disk_index")
             .help(
                 "Persistent accounts-index location. May be specified multiple times. [default: \
                  <LEDGER>/accounts_index]",
@@ -52,12 +53,10 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .validator(is_pow2)
             .takes_value(true)
             .help("Number of bins to divide the accounts index into"),
-        Arg::with_name("disable_accounts_disk_index")
-            .long("disable-accounts-disk-index")
-            .help(
-                "Disable the disk-based accounts index. It is enabled by default. The entire \
-                 accounts index will be kept in memory.",
-            ),
+        Arg::with_name("enable_accounts_disk_index")
+            .long("enable-accounts-disk-index")
+            .help("Enables the disk-based accounts index")
+            .hidden(hidden_unless_forced()),
         Arg::with_name("accounts_db_skip_shrink")
             .long("accounts-db-skip-shrink")
             .help(
@@ -241,10 +240,10 @@ pub fn get_accounts_db_config(
     let ledger_tool_ledger_path = ledger_path.join(LEDGER_TOOL_DIRECTORY);
 
     let accounts_index_bins = value_t!(arg_matches, "accounts_index_bins", usize).ok();
-    let accounts_index_index_limit_mb = if arg_matches.is_present("disable_accounts_disk_index") {
-        IndexLimitMb::InMemOnly
-    } else {
+    let accounts_index_index_limit_mb = if arg_matches.is_present("enable_accounts_disk_index") {
         IndexLimitMb::Minimal
+    } else {
+        IndexLimitMb::InMemOnly
     };
     let accounts_index_drives = values_t!(arg_matches, "accounts_index_path", String)
         .ok()

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -240,10 +240,10 @@ pub fn get_accounts_db_config(
     let ledger_tool_ledger_path = ledger_path.join(LEDGER_TOOL_DIRECTORY);
 
     let accounts_index_bins = value_t!(arg_matches, "accounts_index_bins", usize).ok();
-    let accounts_index_index_limit_mb = if arg_matches.is_present("enable_accounts_disk_index") {
-        IndexLimitMb::Minimal
-    } else {
+    let accounts_index_index_limit_mb = if !arg_matches.is_present("enable_accounts_disk_index") {
         IndexLimitMb::InMemOnly
+    } else {
+        IndexLimitMb::Minimal
     };
     let accounts_index_drives = values_t!(arg_matches, "accounts_index_path", String)
         .ok()

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -177,9 +177,12 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             usage_warning: "The accounts hash cache is obsolete",
     );
     add_arg!(Arg::with_name("disable_accounts_disk_index")
+        // (actually) deprecated in v3.1.0
         .long("disable-accounts-disk-index")
-        .help("Disable the disk-based accounts index if it is enabled by default."));
-
+        .help("Disable the disk-based accounts index if it is enabled by default.")
+        .conflicts_with("accounts_index_path"),
+        usage_warning: "The disk-based accounts index is disabled by default",
+    );
     add_arg!(
         // deprecated in v3.0.0
         Arg::with_name("gossip_host")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -180,7 +180,7 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         // (actually) deprecated in v3.1.0
         .long("disable-accounts-disk-index")
         .help("Disable the disk-based accounts index if it is enabled by default.")
-        .conflicts_with("accounts_index_path"),
+        .conflicts_with("enable_accounts_disk_index"),
         usage_warning: "The disk-based accounts index is disabled by default",
     );
     add_arg!(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1452,10 +1452,17 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("PATH")
             .takes_value(true)
             .multiple(true)
+            .requires("enable_accounts_disk_index")
             .help(
                 "Persistent accounts-index location. May be specified multiple times. [default: \
                  <LEDGER>/accounts_index]",
             ),
+    )
+    .arg(
+        Arg::with_name("enable_accounts_disk_index")
+            .long("enable-accounts-disk-index")
+            .help("Enables the disk-based accounts index")
+            .hidden(hidden_unless_forced()),
     )
     .arg(
         Arg::with_name("accounts_shrink_optimize_total_space")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1462,7 +1462,10 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
         Arg::with_name("enable_accounts_disk_index")
             .long("enable-accounts-disk-index")
             .help("Enables the disk-based accounts index")
-            .hidden(hidden_unless_forced()),
+            .long_help(
+                "Enables the disk-based accounts index. Reduce the memory footprint of the \
+                 accounts index at the cost of index performance.",
+            ),
     )
     .arg(
         Arg::with_name("accounts_shrink_optimize_total_space")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -302,10 +302,10 @@ pub fn execute(
         accounts_index_config.bins = Some(bins);
     }
 
-    accounts_index_config.index_limit_mb = if matches.is_present("enable_accounts_disk_index") {
-        IndexLimitMb::Minimal
-    } else {
+    accounts_index_config.index_limit_mb = if !matches.is_present("enable_accounts_disk_index") {
         IndexLimitMb::InMemOnly
+    } else {
+        IndexLimitMb::Minimal
     };
 
     {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -302,10 +302,10 @@ pub fn execute(
         accounts_index_config.bins = Some(bins);
     }
 
-    accounts_index_config.index_limit_mb = if matches.is_present("disable_accounts_disk_index") {
-        IndexLimitMb::InMemOnly
-    } else {
+    accounts_index_config.index_limit_mb = if matches.is_present("enable_accounts_disk_index") {
         IndexLimitMb::Minimal
+    } else {
+        IndexLimitMb::InMemOnly
     };
 
     {


### PR DESCRIPTION
#### Problem

The disk-based accounts index is slow [citation needed, but just search for alessandro on slack/discord/twitter talking about it 😸].


#### Summary of Changes

Disable the disk-based accounts index by default, storing the entire index in memory.


#### Justification

There were blockers that prevented us doing this in the past.


##### Startup speed

Startup speed was a concern. The disk-index used to startup faster. This was for two main reasons: (1) the in-mem index was artificially throttled, and (2) the disk-index could reuse its persistent files, instead of having to rebuild them.

The throttling for (1) has been removed, and thanks to other perf improvements, the in-mem index startup times are equivalent-or-faster-than the disk-based index.


##### Total size in memory

RAM usage was the biggest issue. With mnb today, there's around 1 billion accounts. Putting the index entirely in memory took up about 100 GB. There have been many improvements to memory usage to mitigate this. PRs #7975 and #8003 reduced the size of the index from ~100 GB to ~76 GB. The validator itself also uses less RAM overall.

The hardware requirements page recommends a minimum of 256 GB of RAM. A validator with 256 GB of RAM can now safely run with the index entirely in memory. There's not a ton of headroom though! We are continuing work to further reduce the size of the index too. I'm not aware of any serious validator operators that runs nodes with less than 512 GB of RAM on mnb. If needed, there is a hidden cli to turn the disk index back on.

###### More Data!

I ran two nodes, one with the disk index enabled (`Bnk`), and one with the disk index disabled (`brux`). They started up around 14:30 UTC on Sept 12th.

Here's their total mem usage from boot to now:

<img width="920" height="479" alt="mem used" src="https://github.com/user-attachments/assets/9320a8e2-d573-44c1-9dbb-381634704290" />

Other than the epoch boundary bump ~12:30 on Sept 14th, the memory usage for both is quite flat. But note that `brux` is using ~150 GB more than `Bnk`. I thought the in-mem index was only consuming 80 GB though?

Here's the chart of mem usage for the index, which shows the in-mem index using around 80 GB:

<img width="919" height="479" alt="index bytes" src="https://github.com/user-attachments/assets/cba9793d-3265-44f0-8c4e-731b04375aeb" />

And the chart for the number of entries in the in-mem index:

<img width="922" height="482" alt="index count" src="https://github.com/user-attachments/assets/577f36bd-d5c5-423f-804a-ef7f303cea38" />

Then what gives?

The impl of the in-mem index is similar to a dashmap. It uses binned HashMaps, and so there is memory usage for the unused-yet-allocated capacity of each index bin's HashMap. So we need to also look at the *capcity* of the in-mem index bins' HashMaps!

Here's the sum of the each bin's `.capacity()`, which shows 1.88 billion entries. That's just under double the actual number of entries in the whole index.

<img width="923" height="486" alt="capacity count" src="https://github.com/user-attachments/assets/1f05b28a-04b7-4301-a9bf-4c98d7bfd512" />

And here's the memory usage:

<img width="924" height="475" alt="capacity bytes" src="https://github.com/user-attachments/assets/aa4b480b-41bc-4e18-9c93-30613b96b522" />

The *capacity* of the index is 150 GB. So that's where the RAM usage went.

And that also means there's already built in headroom for almost doubling the number of accounts without impacting total RAM usage by the index much! (Not counting the irregular entries (irregular == ref count != 1 OR slot list len != 1), which they are also going away once Rory's 'obsolete accounts' work is enabled.)

We can tackle the capacity number if/when it becomes an issue. And as stated earlier, we are working on reducing the mem footprint per entry as well. These both help me feel comfortable with setting the index to be in-mem by default. Again, in the name of IBRL and improving perf for transaction processing.

(Note also that nodes running with smaller total RAM can opt into using the disk index again as well.)