### PR TITLE
vote state handler: port over vote-program-specific methods from vote-interface

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -254,7 +254,7 @@ fn add_validator_accounts(
             identity_pubkey,
             identity_pubkey,
             commission,
-            VoteStateV3::get_rent_exempt_reserve(rent).max(1),
+            rent.minimum_balance(VoteStateV3::size_of()).max(1),
         );
 
         genesis_config.add_account(
@@ -314,7 +314,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     // vote account
     let default_bootstrap_validator_lamports = &(500 * LAMPORTS_PER_SOL)
-        .max(VoteStateV3::get_rent_exempt_reserve(&rent))
+        .max(rent.minimum_balance(VoteStateV3::size_of()))
         .to_string();
     // stake account
     let default_bootstrap_validator_stake_lamports = &(LAMPORTS_PER_SOL / 2)

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -942,7 +942,7 @@ fn main() {
 
     let rent = Rent::default();
     let default_bootstrap_validator_lamports = &(500 * LAMPORTS_PER_SOL)
-        .max(VoteStateV3::get_rent_exempt_reserve(&rent))
+        .max(rent.minimum_balance(VoteStateV3::size_of()))
         .to_string();
     let default_bootstrap_validator_stake_lamports = &(LAMPORTS_PER_SOL / 2)
         .max(rent.minimum_balance(StakeStateV2::size_of()))
@@ -2330,7 +2330,7 @@ fn main() {
                                 identity_pubkey,
                                 identity_pubkey,
                                 100,
-                                VoteStateV3::get_rent_exempt_reserve(&rent).max(1),
+                                rent.minimum_balance(VoteStateV3::size_of()).max(1),
                             );
 
                             bank.store_account(

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -124,7 +124,7 @@ fn create_accounts() -> (Slot, SlotHashes, Vec<TransactionAccount>, Vec<AccountM
 
 fn create_test_account() -> (Pubkey, AccountSharedData) {
     let rent = Rent::default();
-    let balance = VoteStateV3::get_rent_exempt_reserve(&rent);
+    let balance = rent.minimum_balance(VoteStateV3::size_of());
     let vote_pubkey = solana_pubkey::new_rand();
     (
         vote_pubkey,

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -345,7 +345,7 @@ mod tests {
 
     fn create_test_account() -> (Pubkey, AccountSharedData) {
         let rent = Rent::default();
-        let balance = VoteStateV3::get_rent_exempt_reserve(&rent);
+        let balance = rent.minimum_balance(VoteStateV3::size_of());
         let vote_pubkey = solana_pubkey::new_rand();
         (
             vote_pubkey,

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -691,7 +691,18 @@ impl VoteStateHandler {
     #[cfg(test)]
     pub fn nth_recent_lockout(&self, position: usize) -> Option<&Lockout> {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.nth_recent_lockout(position),
+            TargetVoteState::V3(v3) => {
+                if position < v3.votes.len() {
+                    let pos = v3
+                        .votes
+                        .len()
+                        .checked_sub(position)
+                        .and_then(|pos| pos.checked_sub(1))?;
+                    v3.votes.get(pos).map(|vote| &vote.lockout)
+                } else {
+                    None
+                }
+            }
         }
     }
 }

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -61,7 +61,8 @@ pub trait VoteStateHandle {
 
     fn set_votes(&mut self, votes: VecDeque<LandedVote>);
 
-    fn contains_slot(&self, slot: Slot) -> bool;
+    /// Returns if the vote state contains a slot `candidate_slot`
+    fn contains_slot(&self, candidate_slot: Slot) -> bool;
 
     fn last_voted_slot(&self) -> Option<Slot>;
 
@@ -201,8 +202,10 @@ impl VoteStateHandle for VoteStateV3 {
         self.votes = votes;
     }
 
-    fn contains_slot(&self, slot: Slot) -> bool {
-        self.contains_slot(slot)
+    fn contains_slot(&self, candidate_slot: Slot) -> bool {
+        self.votes
+            .binary_search_by(|vote| vote.slot().cmp(&candidate_slot))
+            .is_ok()
     }
 
     fn last_voted_slot(&self) -> Option<Slot> {
@@ -373,9 +376,9 @@ impl VoteStateHandle for VoteStateHandler {
         }
     }
 
-    fn contains_slot(&self, slot: Slot) -> bool {
+    fn contains_slot(&self, candidate_slot: Slot) -> bool {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.contains_slot(slot),
+            TargetVoteState::V3(v3) => v3.contains_slot(candidate_slot),
         }
     }
 

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -762,7 +762,6 @@ mod tests {
             .set_new_authorized_voter(&new_voter, 0, epoch_offset, |_| Ok(()))
             .unwrap();
 
-        // assert_eq!(vote_state.prior_voters.idx, 0); TODO: Field `idx` is private.
         assert_eq!(
             vote_state.prior_voters.last(),
             Some(&(original_voter, 0, epoch_offset))
@@ -784,7 +783,6 @@ mod tests {
         vote_state
             .set_new_authorized_voter(&new_voter2, 3, 3 + epoch_offset, |_| Ok(()))
             .unwrap();
-        // assert_eq!(vote_state.prior_voters.idx, 1); TODO: Field `idx` is private.
         assert_eq!(
             vote_state.prior_voters.last(),
             Some(&(new_voter, epoch_offset, 3 + epoch_offset))
@@ -794,7 +792,6 @@ mod tests {
         vote_state
             .set_new_authorized_voter(&new_voter3, 6, 6 + epoch_offset, |_| Ok(()))
             .unwrap();
-        // assert_eq!(vote_state.prior_voters.idx, 2); TODO: Field `idx` is private.
         assert_eq!(
             vote_state.prior_voters.last(),
             Some(&(new_voter2, 3 + epoch_offset, 6 + epoch_offset))

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -89,7 +89,7 @@ pub trait VoteStateHandle {
 
 impl VoteStateHandle for VoteStateV3 {
     fn is_uninitialized(&self) -> bool {
-        self.is_uninitialized()
+        self.authorized_voters.is_empty()
     }
 
     fn authorized_withdrawer(&self) -> &Pubkey {

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -225,7 +225,11 @@ impl VoteStateHandle for VoteStateV3 {
     }
 
     fn current_epoch(&self) -> Epoch {
-        self.current_epoch()
+        if self.epoch_credits.is_empty() {
+            0
+        } else {
+            self.epoch_credits.last().unwrap().0
+        }
     }
 
     fn epoch_credits_last(&self) -> Option<&(Epoch, u64, u64)> {

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -63,7 +63,7 @@ pub trait VoteStateHandle {
 
     fn set_votes(&mut self, votes: VecDeque<LandedVote>);
 
-    /// Returns if the vote state contains a slot `candidate_slot`
+    /// Returns if the vote state contains a vote for the slot `candidate_slot`
     fn contains_slot(&self, candidate_slot: Slot) -> bool;
 
     fn last_lockout(&self) -> Option<&Lockout>;

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -76,9 +76,6 @@ pub trait VoteStateHandle {
 
     fn current_epoch(&self) -> Epoch;
 
-    /// Number of "credits" owed to this account from the mining pool
-    fn credits(&self) -> u64;
-
     fn epoch_credits_last(&self) -> Option<&(Epoch, u64, u64)>;
 
     /// Returns the credits to award for a vote at the given lockout slot index
@@ -246,14 +243,6 @@ impl VoteStateHandle for VoteStateV3 {
             0
         } else {
             self.epoch_credits.last().unwrap().0
-        }
-    }
-
-    fn credits(&self) -> u64 {
-        if self.epoch_credits.is_empty() {
-            0
-        } else {
-            self.epoch_credits.last().unwrap().1
         }
     }
 
@@ -554,12 +543,6 @@ impl VoteStateHandle for VoteStateHandler {
         }
     }
 
-    fn credits(&self) -> u64 {
-        match &self.target_state {
-            TargetVoteState::V3(v3) => v3.credits(),
-        }
-    }
-
     fn epoch_credits_last(&self) -> Option<&(Epoch, u64, u64)> {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.epoch_credits_last(),
@@ -685,6 +668,19 @@ impl VoteStateHandler {
     pub fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)> {
         match &self.target_state {
             TargetVoteState::V3(v3) => &v3.epoch_credits,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn credits(&self) -> u64 {
+        match &self.target_state {
+            TargetVoteState::V3(v3) => {
+                if v3.epoch_credits.is_empty() {
+                    0
+                } else {
+                    v3.epoch_credits.last().unwrap().1
+                }
+            }
         }
     }
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1080,7 +1080,7 @@ mod tests {
 
     fn create_test_account() -> (Pubkey, RefCell<AccountSharedData>) {
         let rent = Rent::default();
-        let balance = VoteStateV3::get_rent_exempt_reserve(&rent);
+        let balance = rent.minimum_balance(VoteStateV3::size_of());
         let vote_pubkey = solana_pubkey::new_rand();
         (
             vote_pubkey,

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -33,10 +33,6 @@ pub fn to<T: WritableAccount>(versioned: &VoteStateVersions, account: &mut T) ->
     VoteStateV3::serialize(versioned, account.data_as_mut_slice()).ok()
 }
 
-fn compute_vote_latency(voted_for_slot: Slot, current_slot: Slot) -> u8 {
-    std::cmp::min(current_slot.saturating_sub(voted_for_slot), u8::MAX as u64) as u8
-}
-
 /// Checks the proposed vote state with the current and
 /// slot hashes, making adjustments to the root / filtering
 /// votes as needed.
@@ -576,7 +572,7 @@ pub fn process_new_vote_state(
     // have had their latency initialized to 0 by the above loop.  Those will now be updated to their actual latency.
     for new_vote in new_state.iter_mut() {
         if new_vote.latency == 0 {
-            new_vote.latency = compute_vote_latency(new_vote.slot(), current_slot);
+            new_vote.latency = handler::compute_vote_latency(new_vote.slot(), current_slot);
         }
     }
 


### PR DESCRIPTION
#### Problem
In #7822, we added a handler to manage interacting with vote state inside of the Vote program, and to manage the conversion from one state version to another. In doing so, we found that majority of the methods offered by `VoteStateVersions` and `VoteStateV3` are specific only to the Vote program.

Those methods can just be implemented within the `handler` module to clean up the clutter in the SDK and colocate Vote-program-specific operations with the program.

#### Summary of Changes
Reimplements all Vote-program-specific methods inside the Vote program's `handler` module, within the `impl VoteStateHandle for VoteStateV3` block and its test module. Also ports over many tests for these methods as well.

This PR can go hand-in-hand with https://github.com/anza-xyz/solana-sdk/pull/316