### PR TITLE
Separate type for reclaims slot list from SlotList

### DIFF
--- a/accounts-db/benches/accounts_index.rs
+++ b/accounts-db/benches/accounts_index.rs
@@ -8,7 +8,7 @@ use {
     solana_accounts_db::{
         account_info::AccountInfo,
         accounts_index::{
-            AccountSecondaryIndexes, AccountsIndex, SlotList, UpsertReclaim,
+            AccountSecondaryIndexes, AccountsIndex, ReclaimsSlotList, UpsertReclaim,
             ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS,
         },
     },
@@ -29,7 +29,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
 
     const NUM_FORKS: u64 = 16;
 
-    let mut reclaims = SlotList::new();
+    let mut reclaims = ReclaimsSlotList::new();
     let index = AccountsIndex::<AccountInfo, AccountInfo>::new(
         &ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS,
         Arc::default(),

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -365,7 +365,7 @@ pub(crate) fn append_single_account_with_default_hash(
             account,
             &AccountSecondaryIndexes::default(),
             account_info,
-            &mut SlotList::new(),
+            &mut ReclaimsSlotList::new(),
             UpsertReclaim::IgnoreReclaims,
         );
     }
@@ -2783,7 +2783,7 @@ fn test_delete_dependencies() {
     let info1 = AccountInfo::new(StorageLocation::AppendVec(1, 0), true);
     let info2 = AccountInfo::new(StorageLocation::AppendVec(2, 0), true);
     let info3 = AccountInfo::new(StorageLocation::AppendVec(3, 0), true);
-    let mut reclaims = SlotList::new();
+    let mut reclaims = ReclaimsSlotList::new();
     accounts_index.upsert(
         0,
         0,
@@ -5302,7 +5302,7 @@ fn test_unref_pubkeys_removed_from_accounts_index() {
         let db = AccountsDb::new_single_for_tests();
         let mut purged_slot_pubkeys = HashSet::default();
         purged_slot_pubkeys.insert((slot1, pk1));
-        let mut reclaims = SlotList::default();
+        let mut reclaims = ReclaimsSlotList::default();
         db.accounts_index.upsert(
             slot1,
             slot1,
@@ -5356,7 +5356,7 @@ fn test_unref_accounts() {
             let db = AccountsDb::new_single_for_tests();
             let mut purged_slot_pubkeys = HashSet::default();
             purged_slot_pubkeys.insert((slot1, pk1));
-            let mut reclaims = SlotList::default();
+            let mut reclaims = ReclaimsSlotList::default();
             db.accounts_index.upsert(
                 slot1,
                 slot1,
@@ -5385,7 +5385,7 @@ fn test_unref_accounts() {
             let db = AccountsDb::new_single_for_tests();
             let mut purged_stored_account_slots = AccountSlots::default();
             let mut purged_slot_pubkeys = HashSet::default();
-            let mut reclaims = SlotList::default();
+            let mut reclaims = ReclaimsSlotList::default();
             // pk1 and pk2 both in slot1 and slot2, so each has refcount of 2
             for slot in [slot1, slot2] {
                 for pk in [pk1, pk2] {
@@ -5425,7 +5425,7 @@ fn test_unref_accounts() {
 
 define_accounts_db_test!(test_many_unrefs, |db| {
     let mut purged_stored_account_slots = AccountSlots::default();
-    let mut reclaims = SlotList::default();
+    let mut reclaims = ReclaimsSlotList::default();
     let pk1 = Pubkey::from([1; 32]);
     // make sure we have > 1 batch. Bigger numbers cost more in test time here.
     let n = (UNREF_ACCOUNTS_BATCH_SIZE + 1) as Slot;
@@ -5801,7 +5801,7 @@ fn test_shrink_collect_simple() {
                                 db.accounts_index.purge_exact(
                                     pubkey,
                                     [slot5].into_iter().collect::<HashSet<_>>(),
-                                    &mut SlotList::new(),
+                                    &mut ReclaimsSlotList::new(),
                                 );
                             });
 
@@ -5977,7 +5977,7 @@ fn test_shrink_collect_with_obsolete_accounts() {
             db.accounts_index.purge_exact(
                 pubkey,
                 [slot].into_iter().collect::<HashSet<_>>(),
-                &mut SlotList::new(),
+                &mut ReclaimsSlotList::new(),
             );
             unref_pubkeys.push(*pubkey);
         }
@@ -6147,7 +6147,7 @@ fn populate_index(db: &AccountsDb, slots: Range<Slot>) {
                         &account,
                         &AccountSecondaryIndexes::default(),
                         info,
-                        &mut SlotList::new(),
+                        &mut ReclaimsSlotList::new(),
                         UpsertReclaim::IgnoreReclaims,
                     );
                 })

--- a/accounts-db/src/accounts_index/iter.rs
+++ b/accounts-db/src/accounts_index/iter.rs
@@ -105,7 +105,7 @@ mod tests {
             super::{secondary::AccountSecondaryIndexes, UpsertReclaim},
             *,
         },
-        crate::accounts_index::SlotList,
+        crate::accounts_index::ReclaimsSlotList,
         solana_account::AccountSharedData,
         std::ops::Range,
     };
@@ -123,7 +123,7 @@ mod tests {
         for key in pubkeys {
             let slot = 0;
             let value = true;
-            let mut gc = SlotList::new();
+            let mut gc = ReclaimsSlotList::new();
             index.upsert(
                 slot,
                 slot,
@@ -162,7 +162,7 @@ mod tests {
         index.add_root(0);
         let mut iter = index.iter(None::<&Range<Pubkey>>, AccountsIndexPubkeyIterOrder::Sorted);
         assert!(iter.next().is_none());
-        let mut gc = SlotList::new();
+        let mut gc = ReclaimsSlotList::new();
         index.upsert(
             0,
             0,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1123,7 +1123,7 @@ pub mod tests {
             },
             accounts_file::StorageAccess,
             accounts_index::{
-                AccountsIndexScanResult, RefCount, ScanFilter, SlotList, UpsertReclaim,
+                AccountsIndexScanResult, ReclaimsSlotList, RefCount, ScanFilter, UpsertReclaim,
             },
             append_vec::{self, aligned_stored_size},
             storable_accounts::StorableAccountsBySlot,
@@ -1793,7 +1793,7 @@ pub mod tests {
                                             [storage.slot()]
                                                 .into_iter()
                                                 .collect::<std::collections::HashSet<Slot>>(),
-                                            &mut SlotList::new()
+                                            &mut ReclaimsSlotList::new()
                                         ));
                                     });
                                 }
@@ -3754,7 +3754,7 @@ pub mod tests {
                         &empty_account,
                         &crate::accounts_index::AccountSecondaryIndexes::default(),
                         AccountInfo::default(),
-                        &mut SlotList::new(),
+                        &mut ReclaimsSlotList::new(),
                         UpsertReclaim::IgnoreReclaims,
                     );
                 }


### PR DESCRIPTION
#### Problem
The slot list used as part of AccountsIndex entry has different usage pattern than reclaims extracted across multiple entries. Even though they both contain a collection of (slot, value) pairs, it makes sense to distinguish them and/or use different collection type for them.

#### Summary of Changes
Define separate type aliast for `ReclaimsSlotList`, replace `SlotList` with `ReclaimsSlotList` in APIs collecting reclaims.
