### PR TITLE
Updates metrics for approximate size of in-mem accounts index

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -913,7 +913,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
     /// assumes 1 entry in the slot list. Ignores overhead of the HashMap and such
     pub const fn approx_size_of_one_entry() -> usize {
-        size_of::<(Slot, T)>() + size_of::<Pubkey>() + size_of::<AccountMapEntry<T>>()
+        // with only one entry in the slot list, it is stored inline in the SmallVec
+        size_of::<Pubkey>() + size_of::<AccountMapEntry<T>>()
     }
 
     fn should_evict_based_on_age(


### PR DESCRIPTION
#### Problem

Since PR #8003, the size of a 'regular' entry in the in-mem accounts index is not correctly calculated in `InMemAccountsIndex::approx_size_of_one_entry()`.


#### Summary of Changes

Fix it.