### PR TITLE
(Alpenglow) Upstream lib.rs, event.rs, and slot_stake_counter/stats for consensus pool.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,7 @@ dependencies = [
  "solana-signer",
  "solana-time-utils",
  "solana-transaction",
+ "solana-votor-messages",
  "test-case",
  "thiserror 2.0.16",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "solana-signer",
  "solana-time-utils",
  "solana-transaction",
+ "solana-votor-messages",
  "thiserror 2.0.16",
 ]
 
@@ -6017,6 +6018,7 @@ dependencies = [
  "base64 0.22.1",
  "blst",
  "blstrs",
+ "bytemuck",
  "cfg_eval",
  "ff",
  "group",
@@ -6025,6 +6027,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "solana-signature",
+ "solana-signer",
+ "subtle",
  "thiserror 2.0.16",
 ]
 
@@ -10015,6 +10020,17 @@ dependencies = [
  "solana-transaction-context",
  "solana-vote-interface",
  "thiserror 2.0.16",
+]
+
+[[package]]
+name = "solana-votor-messages"
+version = "3.1.0"
+dependencies = [
+ "serde",
+ "solana-bls-signatures",
+ "solana-clock",
+ "solana-hash",
+ "solana-logger",
 ]
 
 [[package]]

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -62,6 +62,7 @@ solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-time-utils = { workspace = true }
 solana-transaction = { workspace = true }
+solana-votor-messages = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -1,0 +1,117 @@
+use {
+    solana_votor_messages::{consensus_message::Certificate, vote::Vote},
+    std::time::Duration,
+};
+
+// Core consensus types and constants
+pub type Stake = u64;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum VoteType {
+    Finalize,
+    Notarize,
+    NotarizeFallback,
+    Skip,
+    SkipFallback,
+}
+
+impl VoteType {
+    #[allow(dead_code)]
+    pub fn is_notarize_type(&self) -> bool {
+        matches!(self, Self::Notarize | Self::NotarizeFallback)
+    }
+}
+
+pub const fn conflicting_types(vote_type: VoteType) -> &'static [VoteType] {
+    match vote_type {
+        VoteType::Finalize => &[VoteType::NotarizeFallback, VoteType::Skip],
+        VoteType::Notarize => &[VoteType::Skip, VoteType::NotarizeFallback],
+        VoteType::NotarizeFallback => &[VoteType::Finalize, VoteType::Notarize],
+        VoteType::Skip => &[
+            VoteType::Finalize,
+            VoteType::Notarize,
+            VoteType::SkipFallback,
+        ],
+        VoteType::SkipFallback => &[VoteType::Skip],
+    }
+}
+
+/// Lookup from `CertificateId` to the `VoteType`s that contribute,
+/// as well as the stake fraction required for certificate completion.
+///
+/// Must be in sync with `vote_to_certificate_ids`
+pub const fn certificate_limits_and_vote_types(
+    cert_type: Certificate,
+) -> (f64, &'static [VoteType]) {
+    match cert_type {
+        Certificate::Notarize(_, _) => (0.6, &[VoteType::Notarize]),
+        Certificate::NotarizeFallback(_, _) => {
+            (0.6, &[VoteType::Notarize, VoteType::NotarizeFallback])
+        }
+        Certificate::FinalizeFast(_, _) => (0.8, &[VoteType::Notarize]),
+        Certificate::Finalize(_) => (0.6, &[VoteType::Finalize]),
+        Certificate::Skip(_) => (0.6, &[VoteType::Skip, VoteType::SkipFallback]),
+    }
+}
+
+/// Lookup from `Vote` to the `CertificateId`s the vote accounts for
+///
+/// Must be in sync with `certificate_limits_and_vote_types` and `VoteType::get_type`
+pub fn vote_to_certificate_ids(vote: &Vote) -> Vec<Certificate> {
+    match vote {
+        Vote::Notarize(vote) => vec![
+            Certificate::Notarize(vote.slot(), *vote.block_id()),
+            Certificate::NotarizeFallback(vote.slot(), *vote.block_id()),
+            Certificate::FinalizeFast(vote.slot(), *vote.block_id()),
+        ],
+        Vote::NotarizeFallback(vote) => {
+            vec![Certificate::NotarizeFallback(vote.slot(), *vote.block_id())]
+        }
+        Vote::Finalize(vote) => vec![Certificate::Finalize(vote.slot())],
+        Vote::Skip(vote) => vec![Certificate::Skip(vote.slot())],
+        Vote::SkipFallback(vote) => vec![Certificate::Skip(vote.slot())],
+    }
+}
+
+pub const MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES: usize = 1;
+pub const MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE: usize = 3;
+
+pub const SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY: f64 = 0.4;
+pub const SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP: f64 = 0.2;
+pub const SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP: f64 = 0.6;
+
+pub const SAFE_TO_SKIP_THRESHOLD: f64 = 0.4;
+
+/// Time bound assumed on network transmission delays during periods of synchrony.
+const DELTA: Duration = Duration::from_millis(250);
+
+/// Time the leader has for producing and sending the block.
+const DELTA_BLOCK: Duration = Duration::from_millis(400);
+
+/// Base timeout for when leader's first slice should arrive if they sent it immediately.
+const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
+
+#[allow(dead_code)]
+/// TODO(wen): remove allow(dead_code) when timer is fully integrated
+/// Timeout for standstill detection mechanism.
+const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);
+
+/// Returns the Duration for when the `SkipTimer` should be set for for the given slot in the leader window.
+#[inline]
+pub fn skip_timeout(leader_block_index: usize) -> Duration {
+    DELTA_TIMEOUT
+        .saturating_add(
+            DELTA_BLOCK
+                .saturating_mul(leader_block_index as u32)
+                .saturating_add(DELTA_TIMEOUT),
+        )
+        .saturating_add(DELTA)
+}
+
+/// Block timeout, when we should publish the final shred for the leader block index
+/// within the leader window
+#[inline]
+pub fn block_timeout(leader_block_index: usize) -> Duration {
+    // TODO: based on testing, perhaps adjust this
+    DELTA_BLOCK.saturating_mul((leader_block_index as u32).saturating_add(1))
+}

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -1,0 +1,2 @@
+pub mod slot_stake_counters;
+mod stats;

--- a/votor/src/consensus_pool/slot_stake_counters.rs
+++ b/votor/src/consensus_pool/slot_stake_counters.rs
@@ -3,9 +3,13 @@
 
 use {
     crate::{
-        consensus_pool::stats::ConsensusPoolStats, event::VotorEvent, Stake,
-        SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP, SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP,
-        SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY, SAFE_TO_SKIP_THRESHOLD,
+        common::{
+            Stake, SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP,
+            SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP, SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY,
+            SAFE_TO_SKIP_THRESHOLD,
+        },
+        consensus_pool::stats::ConsensusPoolStats,
+        event::VotorEvent,
     },
     solana_hash::Hash,
     solana_votor_messages::vote::Vote,

--- a/votor/src/consensus_pool/slot_stake_counters.rs
+++ b/votor/src/consensus_pool/slot_stake_counters.rs
@@ -1,0 +1,307 @@
+#![allow(dead_code)]
+// TODO(wen): remove allow(dead_code) when consensus_pool is fully integrated
+
+use {
+    crate::{
+        consensus_pool::stats::ConsensusPoolStats, event::VotorEvent, Stake,
+        SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP, SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP,
+        SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY, SAFE_TO_SKIP_THRESHOLD,
+    },
+    solana_hash::Hash,
+    solana_votor_messages::vote::Vote,
+    std::collections::BTreeMap,
+};
+
+#[derive(Debug, Default)]
+pub(crate) struct SlotStakeCounters {
+    my_first_vote: Option<Vote>,
+    total_stake: Stake,
+    skip_total: Stake,
+    notarize_total: Stake,
+    notarize_entry_total: BTreeMap<Hash, Stake>,
+    top_notarized_stake: Stake,
+    safe_to_notar_sent: Vec<Hash>,
+    safe_to_skip_sent: bool,
+}
+
+impl SlotStakeCounters {
+    pub fn new(total_stake: Stake) -> Self {
+        Self {
+            total_stake,
+            ..Default::default()
+        }
+    }
+
+    pub fn add_vote(
+        &mut self,
+        vote: &Vote,
+        entry_stake: Stake,
+        is_my_own_vote: bool,
+        events: &mut Vec<VotorEvent>,
+        stats: &mut ConsensusPoolStats,
+    ) {
+        match vote {
+            Vote::Skip(_) => self.skip_total = entry_stake,
+            Vote::Notarize(vote) => {
+                let old_entry_stake = self
+                    .notarize_entry_total
+                    .insert(*vote.block_id(), entry_stake)
+                    .unwrap_or(0);
+                self.notarize_total = self
+                    .notarize_total
+                    .saturating_sub(old_entry_stake)
+                    .saturating_add(entry_stake);
+                self.top_notarized_stake = self.top_notarized_stake.max(entry_stake);
+            }
+            _ => return, // Not interested in other vote types
+        }
+        if self.my_first_vote.is_none() && is_my_own_vote {
+            self.my_first_vote = Some(*vote);
+        }
+        if self.my_first_vote.is_none() {
+            // We have not voted yet, no need to check safe to notarize or skip
+            return;
+        }
+        let slot = vote.slot();
+        // Check safe to notar
+        for (block_id, stake) in &self.notarize_entry_total {
+            if !self.safe_to_notar_sent.contains(block_id) && self.is_safe_to_notar(block_id, stake)
+            {
+                events.push(VotorEvent::SafeToNotar((slot, *block_id)));
+                stats.event_safe_to_notarize = stats.event_safe_to_notarize.saturating_add(1);
+                self.safe_to_notar_sent.push(*block_id);
+            }
+        }
+        // Check safe to skip
+        if !self.safe_to_skip_sent && self.is_safe_to_skip() {
+            events.push(VotorEvent::SafeToSkip(slot));
+            self.safe_to_skip_sent = true;
+            stats.event_safe_to_skip = stats.event_safe_to_skip.saturating_add(1);
+        }
+    }
+
+    fn is_safe_to_notar(&self, block_id: &Hash, stake: &Stake) -> bool {
+        // White paper v1.1 page 22: The event is only issued if the node voted in slot s already,
+        // but not to notarize b. Moreover:
+        // notar(b) >= 40% or (skip(s) + notar(b) >= 60% and notar(b) >= 20%)
+        if let Some(Vote::Notarize(my_vote)) = self.my_first_vote.as_ref() {
+            if my_vote.block_id() == block_id {
+                return false; // I voted for the same block, no need to send NotarizeFallback
+            }
+        }
+        let skip_ratio = self.skip_total as f64 / self.total_stake as f64;
+        let notarized_ratio = *stake as f64 / self.total_stake as f64;
+        trace!("safe_to_notar {block_id:?} {skip_ratio} {notarized_ratio}");
+        // Check if the block fits condition (i) 40% of stake holders voted notarize
+        notarized_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY
+            // Check if the block fits condition (ii) 20% notarized, and 60% notarized or skip
+            || (notarized_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP
+                && notarized_ratio + skip_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP)
+    }
+
+    fn is_safe_to_skip(&self) -> bool {
+        // White paper v1.1 page 22: The event is only issued if the node voted in slot s already,
+        // but not to skip s. Moreover:
+        // skip(s) + Sum of all notarize - (max in notarize(b)) >= 40%
+        if let Some(Vote::Notarize(_)) = self.my_first_vote.as_ref() {
+            trace!(
+                "safe_to_skip {} {:?} {} {} {}",
+                self.my_first_vote.unwrap().slot(),
+                self.my_first_vote.unwrap().block_id(),
+                self.skip_total,
+                self.notarize_total,
+                self.top_notarized_stake
+            );
+            self.skip_total
+                .saturating_add(self.notarize_total.saturating_sub(self.top_notarized_stake))
+                as f64
+                / self.total_stake as f64
+                >= SAFE_TO_SKIP_THRESHOLD
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_votor_messages::vote::Vote};
+
+    #[test]
+    fn test_safe_to_notar() {
+        let mut counters = SlotStakeCounters::new(100);
+
+        let mut events = vec![];
+        let mut stats = ConsensusPoolStats::default();
+        let slot = 2;
+        // I voted for skip
+        counters.add_vote(
+            &Vote::new_skip_vote(slot),
+            10,
+            true,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_notarize, 0);
+
+        // 40% of stake holders voted notarize
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, Hash::default()),
+            40,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(events[0], VotorEvent::SafeToNotar((s, block_id)) if s == slot && block_id == Hash::default())
+        );
+        assert_eq!(stats.event_safe_to_notarize, 1);
+        events.clear();
+
+        // Adding more notarizations does not trigger more events
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, Hash::default()),
+            20,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_notarize, 1);
+
+        // Reset counters
+        counters = SlotStakeCounters::new(100);
+        events.clear();
+        stats = ConsensusPoolStats::default();
+
+        // I voted for notarize b
+        let hash_1 = Hash::new_unique();
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, hash_1),
+            1,
+            true,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_notarize, 0);
+
+        // 25% of stake holders voted notarize b'
+        let hash_2 = Hash::new_unique();
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, hash_2),
+            25,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_notarize, 0);
+
+        // 35% more of stake holders voted skip
+        counters.add_vote(
+            &Vote::new_skip_vote(slot),
+            35,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(events[0], VotorEvent::SafeToNotar((s, block_id)) if s == slot && block_id == hash_2)
+        );
+        assert_eq!(stats.event_safe_to_notarize, 1);
+    }
+
+    #[test]
+    fn test_safe_to_skip() {
+        let mut counters = SlotStakeCounters::new(100);
+
+        let mut events = vec![];
+        let mut stats = ConsensusPoolStats::default();
+        let slot = 2;
+        // I voted for notarize b
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, Hash::default()),
+            10,
+            true,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_skip, 0);
+
+        // 40% of stake holders voted skip
+        counters.add_vote(
+            &Vote::new_skip_vote(slot),
+            40,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], VotorEvent::SafeToSkip(s) if s == slot));
+        assert_eq!(stats.event_safe_to_skip, 1);
+        events.clear();
+
+        // Adding more skips does not trigger more events
+        counters.add_vote(
+            &Vote::new_skip_vote(slot),
+            20,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_skip, 1);
+
+        // Reset counters
+        counters = SlotStakeCounters::new(100);
+        events.clear();
+        stats = ConsensusPoolStats::default();
+
+        // I voted for notarize b, 10% of stake holders voted with me
+        let hash_1 = Hash::new_unique();
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, hash_1),
+            10,
+            true,
+            &mut events,
+            &mut stats,
+        );
+        // 20% of stake holders voted a different notarization b'
+        let hash_2 = Hash::new_unique();
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, hash_2),
+            20,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        // 30% of stake holders voted skip
+        counters.add_vote(
+            &Vote::new_skip_vote(slot),
+            30,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], VotorEvent::SafeToSkip(s) if s == slot));
+        assert_eq!(stats.event_safe_to_skip, 1);
+        events.clear();
+
+        // Adding more notarization on b does not trigger more events
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, hash_1),
+            10,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_skip, 1);
+    }
+}

--- a/votor/src/consensus_pool/stats.rs
+++ b/votor/src/consensus_pool/stats.rs
@@ -1,0 +1,232 @@
+#![allow(dead_code)]
+// TODO(wen): remove allow(dead_code) when consensus_pool is fully integrated
+
+use {
+    crate::VoteType,
+    solana_metrics::datapoint_info,
+    solana_votor_messages::consensus_message::CertificateType,
+    std::time::{Duration, Instant},
+};
+
+const STATS_REPORT_INTERVAL: Duration = Duration::from_secs(10);
+
+#[derive(Debug)]
+pub(crate) struct ConsensusPoolStats {
+    pub(crate) conflicting_votes: u32,
+    pub(crate) event_safe_to_notarize: u32,
+    pub(crate) event_safe_to_skip: u32,
+    pub(crate) exist_certs: u32,
+    pub(crate) exist_votes: u32,
+    pub(crate) incoming_certs: u32,
+    pub(crate) incoming_votes: u32,
+    pub(crate) out_of_range_certs: u32,
+    pub(crate) out_of_range_votes: u32,
+
+    pub(crate) new_certs_generated: Vec<u32>,
+    pub(crate) new_certs_ingested: Vec<u32>,
+    pub(crate) ingested_votes: Vec<u32>,
+
+    pub(crate) last_request_time: Instant,
+}
+
+impl Default for ConsensusPoolStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConsensusPoolStats {
+    pub fn new() -> Self {
+        let num_vote_types = (VoteType::SkipFallback as usize).saturating_add(1);
+        let num_cert_types = (CertificateType::Skip as usize).saturating_add(1);
+        Self {
+            conflicting_votes: 0,
+            event_safe_to_notarize: 0,
+            event_safe_to_skip: 0,
+            exist_certs: 0,
+            exist_votes: 0,
+            incoming_certs: 0,
+            incoming_votes: 0,
+            out_of_range_certs: 0,
+            out_of_range_votes: 0,
+
+            new_certs_ingested: vec![0; num_cert_types],
+            new_certs_generated: vec![0; num_cert_types],
+            ingested_votes: vec![0; num_vote_types],
+
+            last_request_time: Instant::now(),
+        }
+    }
+
+    pub fn incr_ingested_vote_type(&mut self, vote_type: VoteType) {
+        let index = vote_type as usize;
+
+        self.ingested_votes[index] = self.ingested_votes[index].saturating_add(1);
+    }
+
+    pub fn incr_cert_type(&mut self, cert_type: CertificateType, is_generated: bool) {
+        let index = cert_type as usize;
+        let array = if is_generated {
+            &mut self.new_certs_generated
+        } else {
+            &mut self.new_certs_ingested
+        };
+
+        array[index] = array[index].saturating_add(1);
+    }
+
+    fn report(&self) {
+        datapoint_info!(
+            "consensus_pool_stats",
+            ("conflicting_votes", self.conflicting_votes as i64, i64),
+            ("event_safe_to_skip", self.event_safe_to_skip as i64, i64),
+            (
+                "event_safe_to_notarize",
+                self.event_safe_to_notarize as i64,
+                i64
+            ),
+            ("exist_votes", self.exist_votes as i64, i64),
+            ("exist_certs", self.exist_certs as i64, i64),
+            ("incoming_votes", self.incoming_votes as i64, i64),
+            ("incoming_certs", self.incoming_certs as i64, i64),
+            ("out_of_range_votes", self.out_of_range_votes as i64, i64),
+            ("out_of_range_certs", self.out_of_range_certs as i64, i64),
+        );
+
+        datapoint_info!(
+            "consensus_ingested_votes",
+            (
+                "finalize",
+                *self
+                    .ingested_votes
+                    .get(VoteType::Finalize as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+            (
+                "notarize",
+                *self
+                    .ingested_votes
+                    .get(VoteType::Notarize as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+            (
+                "notarize_fallback",
+                *self
+                    .ingested_votes
+                    .get(VoteType::NotarizeFallback as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+            (
+                "skip",
+                *self.ingested_votes.get(VoteType::Skip as usize).unwrap() as i64,
+                i64
+            ),
+            (
+                "skip_fallback",
+                *self
+                    .ingested_votes
+                    .get(VoteType::SkipFallback as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+        );
+
+        datapoint_info!(
+            "certfificate_pool_ingested_certs",
+            (
+                "finalize",
+                *self
+                    .new_certs_ingested
+                    .get(CertificateType::Finalize as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+            (
+                "finalize_fast",
+                *self
+                    .new_certs_ingested
+                    .get(CertificateType::FinalizeFast as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+            (
+                "notarize",
+                *self
+                    .new_certs_ingested
+                    .get(CertificateType::Notarize as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+            (
+                "notarize_fallback",
+                *self
+                    .new_certs_ingested
+                    .get(CertificateType::NotarizeFallback as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+            (
+                "skip",
+                *self
+                    .new_certs_ingested
+                    .get(CertificateType::Skip as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+        );
+
+        datapoint_info!(
+            "consensus_pool_generated_certs",
+            (
+                "finalize",
+                *self
+                    .new_certs_generated
+                    .get(CertificateType::Finalize as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+            (
+                "finalize_fast",
+                *self
+                    .new_certs_generated
+                    .get(CertificateType::FinalizeFast as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+            (
+                "notarize",
+                *self
+                    .new_certs_generated
+                    .get(CertificateType::Notarize as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+            (
+                "notarize_fallback",
+                *self
+                    .new_certs_generated
+                    .get(CertificateType::NotarizeFallback as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+            (
+                "skip",
+                *self
+                    .new_certs_generated
+                    .get(CertificateType::Skip as usize)
+                    .unwrap() as i64,
+                i64
+            ),
+        );
+    }
+
+    pub fn maybe_report(&mut self) {
+        if self.last_request_time.elapsed() >= STATS_REPORT_INTERVAL {
+            self.report();
+            *self = Self::new();
+        }
+    }
+}

--- a/votor/src/consensus_pool/stats.rs
+++ b/votor/src/consensus_pool/stats.rs
@@ -2,7 +2,7 @@
 // TODO(wen): remove allow(dead_code) when consensus_pool is fully integrated
 
 use {
-    crate::VoteType,
+    crate::common::VoteType,
     solana_metrics::datapoint_info,
     solana_votor_messages::consensus_message::CertificateType,
     std::time::{Duration, Instant},

--- a/votor/src/event.rs
+++ b/votor/src/event.rs
@@ -1,0 +1,96 @@
+use {
+    crossbeam_channel::{Receiver, Sender},
+    solana_clock::Slot,
+    solana_runtime::bank::Bank,
+    solana_votor_messages::consensus_message::Block,
+    std::{sync::Arc, time::Instant},
+};
+
+#[derive(Debug, Clone)]
+pub struct CompletedBlock {
+    pub slot: Slot,
+    // TODO: once we have the async execution changes this can be (block_id, parent_block_id) instead
+    pub bank: Arc<Bank>,
+}
+
+/// Context for the block creation loop to start a leader window
+#[derive(Copy, Clone, Debug)]
+pub struct LeaderWindowInfo {
+    pub start_slot: Slot,
+    pub end_slot: Slot,
+    pub parent_block: Block,
+    pub skip_timer: Instant,
+}
+
+pub type VotorEventSender = Sender<VotorEvent>;
+pub type VotorEventReceiver = Receiver<VotorEvent>;
+
+/// Events that trigger actions in Votor
+/// TODO: remove bank hash once we update votes
+#[derive(Debug, Clone)]
+pub enum VotorEvent {
+    /// A block has completed replay and is ready for voting
+    Block(CompletedBlock),
+
+    /// The block has received a notarization certificate
+    BlockNotarized(Block),
+
+    /// Received the first shred for the slot.
+    FirstShred(Slot),
+
+    /// The pool has marked the given block as a ready parent for `slot`
+    ParentReady { slot: Slot, parent_block: Block },
+
+    //// Timeout to early detect that a honest that has crashed and
+    /// if the leader window should be skipped.
+    TimeoutCrashedLeader(Slot),
+
+    /// Timeout to inspect whether the remaining leader window should be skipped.
+    Timeout(Slot),
+
+    /// The given block has reached the safe to notar status
+    SafeToNotar(Block),
+
+    /// The given slot has reached the safe to skip status
+    SafeToSkip(Slot),
+
+    /// We are the leader for this window and have reached the parent ready status
+    /// Produce the window
+    ProduceWindow(LeaderWindowInfo),
+
+    /// The block has received a slow or fast finalization certificate and is eligble for rooting
+    /// The second bool indicates whether the block is a fast finalization
+    Finalized(Block, bool),
+
+    /// We have not observed a finalization and reached the standstill timeout
+    /// The slot is the highest finalized slot
+    Standstill(Slot),
+
+    /// The identity keypair has changed due to an operator calling set-identity
+    SetIdentity,
+}
+
+impl VotorEvent {
+    /// Ignore old events
+    #[allow(dead_code)]
+    // TODO(wen): remove allow(dead_code) when event_handler is fully integrated
+    pub(crate) fn should_ignore(&self, root: Slot) -> bool {
+        match self {
+            VotorEvent::Block(completed_block) => completed_block.slot <= root,
+            VotorEvent::Timeout(s)
+            | VotorEvent::SafeToSkip(s)
+            | VotorEvent::TimeoutCrashedLeader(s)
+            | VotorEvent::FirstShred(s)
+            | VotorEvent::SafeToNotar((s, _))
+            | VotorEvent::Finalized((s, _), _)
+            | VotorEvent::BlockNotarized((s, _))
+            | VotorEvent::ParentReady {
+                slot: s,
+                parent_block: _,
+            } => s <= &root,
+            VotorEvent::ProduceWindow(_) => false,
+            VotorEvent::Standstill(_) => false,
+            VotorEvent::SetIdentity => false,
+        }
+    }
+}

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -1,3 +1,132 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "agave-unstable-api")]
+use {
+    solana_votor_messages::{consensus_message::Certificate, vote::Vote},
+    std::time::Duration,
+};
+
+pub mod consensus_pool;
+pub mod event;
 pub mod root_utils;
+
+#[macro_use]
+extern crate log;
+
+extern crate serde_derive;
+
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
+extern crate solana_frozen_abi_macro;
+
+// Core consensus types and constants
+pub type Stake = u64;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum VoteType {
+    Finalize,
+    Notarize,
+    NotarizeFallback,
+    Skip,
+    SkipFallback,
+}
+
+impl VoteType {
+    #[allow(dead_code)]
+    pub fn is_notarize_type(&self) -> bool {
+        matches!(self, Self::Notarize | Self::NotarizeFallback)
+    }
+}
+
+pub const fn conflicting_types(vote_type: VoteType) -> &'static [VoteType] {
+    match vote_type {
+        VoteType::Finalize => &[VoteType::NotarizeFallback, VoteType::Skip],
+        VoteType::Notarize => &[VoteType::Skip, VoteType::NotarizeFallback],
+        VoteType::NotarizeFallback => &[VoteType::Finalize, VoteType::Notarize],
+        VoteType::Skip => &[
+            VoteType::Finalize,
+            VoteType::Notarize,
+            VoteType::SkipFallback,
+        ],
+        VoteType::SkipFallback => &[VoteType::Skip],
+    }
+}
+
+/// Lookup from `CertificateId` to the `VoteType`s that contribute,
+/// as well as the stake fraction required for certificate completion.
+///
+/// Must be in sync with `vote_to_certificate_ids`
+pub const fn certificate_limits_and_vote_types(
+    cert_type: Certificate,
+) -> (f64, &'static [VoteType]) {
+    match cert_type {
+        Certificate::Notarize(_, _) => (0.6, &[VoteType::Notarize]),
+        Certificate::NotarizeFallback(_, _) => {
+            (0.6, &[VoteType::Notarize, VoteType::NotarizeFallback])
+        }
+        Certificate::FinalizeFast(_, _) => (0.8, &[VoteType::Notarize]),
+        Certificate::Finalize(_) => (0.6, &[VoteType::Finalize]),
+        Certificate::Skip(_) => (0.6, &[VoteType::Skip, VoteType::SkipFallback]),
+    }
+}
+
+/// Lookup from `Vote` to the `CertificateId`s the vote accounts for
+///
+/// Must be in sync with `certificate_limits_and_vote_types` and `VoteType::get_type`
+pub fn vote_to_certificate_ids(vote: &Vote) -> Vec<Certificate> {
+    match vote {
+        Vote::Notarize(vote) => vec![
+            Certificate::Notarize(vote.slot(), *vote.block_id()),
+            Certificate::NotarizeFallback(vote.slot(), *vote.block_id()),
+            Certificate::FinalizeFast(vote.slot(), *vote.block_id()),
+        ],
+        Vote::NotarizeFallback(vote) => {
+            vec![Certificate::NotarizeFallback(vote.slot(), *vote.block_id())]
+        }
+        Vote::Finalize(vote) => vec![Certificate::Finalize(vote.slot())],
+        Vote::Skip(vote) => vec![Certificate::Skip(vote.slot())],
+        Vote::SkipFallback(vote) => vec![Certificate::Skip(vote.slot())],
+    }
+}
+
+pub const MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES: usize = 1;
+pub const MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE: usize = 3;
+
+pub const SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY: f64 = 0.4;
+pub const SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP: f64 = 0.2;
+pub const SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP: f64 = 0.6;
+
+pub const SAFE_TO_SKIP_THRESHOLD: f64 = 0.4;
+
+/// Time bound assumed on network transmission delays during periods of synchrony.
+const DELTA: Duration = Duration::from_millis(250);
+
+/// Time the leader has for producing and sending the block.
+const DELTA_BLOCK: Duration = Duration::from_millis(400);
+
+/// Base timeout for when leader's first slice should arrive if they sent it immediately.
+const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
+
+#[allow(dead_code)]
+/// TODO(wen): remove allow(dead_code) when timer is fully integrated
+/// Timeout for standstill detection mechanism.
+const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);
+
+/// Returns the Duration for when the `SkipTimer` should be set for for the given slot in the leader window.
+#[inline]
+pub fn skip_timeout(leader_block_index: usize) -> Duration {
+    DELTA_TIMEOUT
+        .saturating_add(
+            DELTA_BLOCK
+                .saturating_mul(leader_block_index as u32)
+                .saturating_add(DELTA_TIMEOUT),
+        )
+        .saturating_add(DELTA)
+}
+
+/// Block timeout, when we should publish the final shred for the leader block index
+/// within the leader window
+#[inline]
+pub fn block_timeout(leader_block_index: usize) -> Duration {
+    // TODO: based on testing, perhaps adjust this
+    DELTA_BLOCK.saturating_mul((leader_block_index as u32).saturating_add(1))
+}

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -14,10 +14,6 @@ extern crate log;
 
 extern crate serde_derive;
 
-#[cfg_attr(feature = "frozen-abi", macro_use)]
-#[cfg(feature = "frozen-abi")]
-extern crate solana_frozen_abi_macro;
-
 // Core consensus types and constants
 pub type Stake = u64;
 

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -1,128 +1,20 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#[cfg(feature = "agave-unstable-api")]
-use {
-    solana_votor_messages::{consensus_message::Certificate, vote::Vote},
-    std::time::Duration,
-};
 
+#[cfg(feature = "agave-unstable-api")]
+pub mod common;
+
+#[cfg(feature = "agave-unstable-api")]
 pub mod consensus_pool;
+
+#[cfg(feature = "agave-unstable-api")]
 pub mod event;
+
+#[cfg(feature = "agave-unstable-api")]
 pub mod root_utils;
 
+#[cfg(feature = "agave-unstable-api")]
 #[macro_use]
 extern crate log;
 
+#[cfg(feature = "agave-unstable-api")]
 extern crate serde_derive;
-
-// Core consensus types and constants
-pub type Stake = u64;
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum VoteType {
-    Finalize,
-    Notarize,
-    NotarizeFallback,
-    Skip,
-    SkipFallback,
-}
-
-impl VoteType {
-    #[allow(dead_code)]
-    pub fn is_notarize_type(&self) -> bool {
-        matches!(self, Self::Notarize | Self::NotarizeFallback)
-    }
-}
-
-pub const fn conflicting_types(vote_type: VoteType) -> &'static [VoteType] {
-    match vote_type {
-        VoteType::Finalize => &[VoteType::NotarizeFallback, VoteType::Skip],
-        VoteType::Notarize => &[VoteType::Skip, VoteType::NotarizeFallback],
-        VoteType::NotarizeFallback => &[VoteType::Finalize, VoteType::Notarize],
-        VoteType::Skip => &[
-            VoteType::Finalize,
-            VoteType::Notarize,
-            VoteType::SkipFallback,
-        ],
-        VoteType::SkipFallback => &[VoteType::Skip],
-    }
-}
-
-/// Lookup from `CertificateId` to the `VoteType`s that contribute,
-/// as well as the stake fraction required for certificate completion.
-///
-/// Must be in sync with `vote_to_certificate_ids`
-pub const fn certificate_limits_and_vote_types(
-    cert_type: Certificate,
-) -> (f64, &'static [VoteType]) {
-    match cert_type {
-        Certificate::Notarize(_, _) => (0.6, &[VoteType::Notarize]),
-        Certificate::NotarizeFallback(_, _) => {
-            (0.6, &[VoteType::Notarize, VoteType::NotarizeFallback])
-        }
-        Certificate::FinalizeFast(_, _) => (0.8, &[VoteType::Notarize]),
-        Certificate::Finalize(_) => (0.6, &[VoteType::Finalize]),
-        Certificate::Skip(_) => (0.6, &[VoteType::Skip, VoteType::SkipFallback]),
-    }
-}
-
-/// Lookup from `Vote` to the `CertificateId`s the vote accounts for
-///
-/// Must be in sync with `certificate_limits_and_vote_types` and `VoteType::get_type`
-pub fn vote_to_certificate_ids(vote: &Vote) -> Vec<Certificate> {
-    match vote {
-        Vote::Notarize(vote) => vec![
-            Certificate::Notarize(vote.slot(), *vote.block_id()),
-            Certificate::NotarizeFallback(vote.slot(), *vote.block_id()),
-            Certificate::FinalizeFast(vote.slot(), *vote.block_id()),
-        ],
-        Vote::NotarizeFallback(vote) => {
-            vec![Certificate::NotarizeFallback(vote.slot(), *vote.block_id())]
-        }
-        Vote::Finalize(vote) => vec![Certificate::Finalize(vote.slot())],
-        Vote::Skip(vote) => vec![Certificate::Skip(vote.slot())],
-        Vote::SkipFallback(vote) => vec![Certificate::Skip(vote.slot())],
-    }
-}
-
-pub const MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES: usize = 1;
-pub const MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE: usize = 3;
-
-pub const SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY: f64 = 0.4;
-pub const SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP: f64 = 0.2;
-pub const SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP: f64 = 0.6;
-
-pub const SAFE_TO_SKIP_THRESHOLD: f64 = 0.4;
-
-/// Time bound assumed on network transmission delays during periods of synchrony.
-const DELTA: Duration = Duration::from_millis(250);
-
-/// Time the leader has for producing and sending the block.
-const DELTA_BLOCK: Duration = Duration::from_millis(400);
-
-/// Base timeout for when leader's first slice should arrive if they sent it immediately.
-const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
-
-#[allow(dead_code)]
-/// TODO(wen): remove allow(dead_code) when timer is fully integrated
-/// Timeout for standstill detection mechanism.
-const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);
-
-/// Returns the Duration for when the `SkipTimer` should be set for for the given slot in the leader window.
-#[inline]
-pub fn skip_timeout(leader_block_index: usize) -> Duration {
-    DELTA_TIMEOUT
-        .saturating_add(
-            DELTA_BLOCK
-                .saturating_mul(leader_block_index as u32)
-                .saturating_add(DELTA_TIMEOUT),
-        )
-        .saturating_add(DELTA)
-}
-
-/// Block timeout, when we should publish the final shred for the leader block index
-/// within the leader window
-#[inline]
-pub fn block_timeout(leader_block_index: usize) -> Duration {
-    // TODO: based on testing, perhaps adjust this
-    DELTA_BLOCK.saturating_mul((leader_block_index as u32).saturating_add(1))
-}


### PR DESCRIPTION
Move the following components from Alpenglow repo to Agave:
- votor/src/lib.rs (removed unmoved mods for now)
- votor/src/event.rs
- votor/src/consensus_pool/stats.rs
- votor/src/consensus_pool/slot_stake_counters.rs
- also move constants and logic originally in votor/src/lib.rs to votor/src/common.rs so we can easily protect everything in lib.rs with agave-unstable-api.