### PR TITLE
Increase number of iterations in shuttle

### DIFF
--- a/ci/test-shuttle.sh
+++ b/ci/test-shuttle.sh
@@ -4,4 +4,4 @@ set -eo pipefail
 
 source ci/_
 
-cargo nextest run --profile ci  --manifest-path="svm/Cargo.toml" --features="shuttle-test" --test concurrent_tests --jobs 1
+cargo nextest run --profile ci  --manifest-path="svm/Cargo.toml" --features="shuttle-test" --test concurrent_tests --release --jobs 1

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -33,6 +33,8 @@ use {
 
 mod mock_bank;
 
+const MAX_ITERATIONS: usize = 10_000;
+
 fn program_cache_execution(threads: usize) {
     let mut mock_bank = MockBankCallback::default();
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
@@ -111,7 +113,7 @@ fn test_program_cache_with_probabilistic_scheduler() {
         move || {
             program_cache_execution(4);
         },
-        10_000,
+        MAX_ITERATIONS,
         5,
     );
 }
@@ -119,7 +121,7 @@ fn test_program_cache_with_probabilistic_scheduler() {
 // In this case, the scheduler is random and may preempt threads at any point and any time.
 #[test]
 fn test_program_cache_with_random_scheduler() {
-    shuttle::check_random(move || program_cache_execution(4), 10_000);
+    shuttle::check_random(move || program_cache_execution(4), MAX_ITERATIONS);
 }
 
 // This test explores all the possible thread scheduling patterns that might affect the program
@@ -130,7 +132,7 @@ fn test_program_cache_with_exhaustive_scheduler() {
     // values in a thread.
     // Since this is not the case for the execution of jitted program, we can still run the test
     // but with decreased accuracy.
-    let scheduler = shuttle::scheduler::DfsScheduler::new(Some(10_000), true);
+    let scheduler = shuttle::scheduler::DfsScheduler::new(Some(MAX_ITERATIONS), true);
     let runner = Runner::new(scheduler, Default::default());
     runner.run(move || program_cache_execution(4));
 }
@@ -300,7 +302,7 @@ fn test_svm_with_probabilistic_scheduler() {
         move || {
             svm_concurrent();
         },
-        10_000,
+        MAX_ITERATIONS,
         5,
     );
 }

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -111,7 +111,7 @@ fn test_program_cache_with_probabilistic_scheduler() {
         move || {
             program_cache_execution(4);
         },
-        300,
+        10_000,
         5,
     );
 }
@@ -119,7 +119,7 @@ fn test_program_cache_with_probabilistic_scheduler() {
 // In this case, the scheduler is random and may preempt threads at any point and any time.
 #[test]
 fn test_program_cache_with_random_scheduler() {
-    shuttle::check_random(move || program_cache_execution(4), 300);
+    shuttle::check_random(move || program_cache_execution(4), 10_000);
 }
 
 // This test explores all the possible thread scheduling patterns that might affect the program
@@ -130,7 +130,7 @@ fn test_program_cache_with_exhaustive_scheduler() {
     // values in a thread.
     // Since this is not the case for the execution of jitted program, we can still run the test
     // but with decreased accuracy.
-    let scheduler = shuttle::scheduler::DfsScheduler::new(Some(500), true);
+    let scheduler = shuttle::scheduler::DfsScheduler::new(Some(10_000), true);
     let runner = Runner::new(scheduler, Default::default());
     runner.run(move || program_cache_execution(4));
 }
@@ -300,7 +300,7 @@ fn test_svm_with_probabilistic_scheduler() {
         move || {
             svm_concurrent();
         },
-        300,
+        10_000,
         5,
     );
 }


### PR DESCRIPTION
#### Problem

300 iterations might be too few to detect race conditions in the program cache.

#### Summary of Changes

Increase to 10k iterations and use a release build for test.