### PR TITLE
Fix race condition & add additional shutdowns

### DIFF
--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -589,8 +589,12 @@ impl PohService {
                 }
                 PohServiceMessage::SetBank { bank } => {
                     let slot = bank.slot();
+                    let bank_on_last_tick =
+                        bank.tick_height() >= bank.max_tick_height().saturating_sub(1);
                     recorder.set_bank(bank);
-                    record_receiver.restart(slot);
+                    if !bank_on_last_tick {
+                        record_receiver.restart(slot);
+                    }
                 }
             }
         }

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -175,6 +175,9 @@ impl PohService {
         let poh = poh_recorder.read().unwrap().poh.clone();
         let mut last_tick = Instant::now();
         let mut last_tick_of_slot = Self::last_tick_of_slot(&poh_recorder);
+        if last_tick_of_slot {
+            record_receiver.shutdown();
+        }
         while !poh_exit.load(Ordering::Relaxed) {
             let service_message =
                 Self::check_for_service_message(&poh_service_receiver, &mut record_receiver);
@@ -225,6 +228,9 @@ impl PohService {
             if let Some(service_message) = service_message {
                 Self::handle_service_message(&poh_recorder, service_message, &mut record_receiver);
                 last_tick_of_slot = Self::last_tick_of_slot(&poh_recorder);
+                if last_tick_of_slot {
+                    record_receiver.shutdown();
+                }
             }
         }
 
@@ -280,6 +286,9 @@ impl PohService {
         let num_ticks = poh_config.target_tick_count.unwrap();
         let poh = poh_recorder.read().unwrap().poh.clone();
         let mut last_tick_of_slot = Self::last_tick_of_slot(&poh_recorder);
+        if last_tick_of_slot {
+            record_receiver.shutdown();
+        }
 
         while elapsed_ticks < num_ticks {
             let service_message =
@@ -337,6 +346,9 @@ impl PohService {
             if let Some(service_message) = service_message {
                 Self::handle_service_message(&poh_recorder, service_message, &mut record_receiver);
                 last_tick_of_slot = Self::last_tick_of_slot(&poh_recorder);
+                if last_tick_of_slot {
+                    record_receiver.shutdown();
+                }
             }
         }
 

--- a/poh/src/record_channels.rs
+++ b/poh/src/record_channels.rs
@@ -36,13 +36,16 @@ pub fn record_channels(track_transaction_indexes: bool) -> (RecordSender, Record
         None
     };
 
+    let active_senders = Arc::new(AtomicU64::new(0));
     (
         RecordSender {
+            active_senders: active_senders.clone(),
             slot_allowed_insertions: slot_allowed_insertions.clone(),
             sender,
             transaction_indexes: transaction_indexes.clone(),
         },
         RecordReceiver {
+            active_senders,
             slot_allowed_insertions,
             receiver,
             capacity: CAPACITY as u64,
@@ -68,6 +71,9 @@ pub enum RecordSenderError {
 /// immediately if the channel is full, shutdown, or if the slot has changed.
 #[derive(Clone, Debug)]
 pub struct RecordSender {
+    /// Used to track active senders for the current slot. Used so that the receiver
+    /// side can determine that no more sends are in-flight while shutting down.
+    active_senders: Arc<AtomicU64>,
     slot_allowed_insertions: SlotAllowedInsertions,
     sender: Sender<Record>,
     transaction_indexes: Option<Arc<Mutex<usize>>>,
@@ -115,6 +121,9 @@ impl RecordSender {
                 allowed_insertions.wrapping_sub(record.transaction_batches.len() as u64),
             );
 
+            // Increment this before CAS so the receiver can see this send is in-flight.
+            self.active_senders.fetch_add(1, Ordering::AcqRel);
+
             if self
                 .slot_allowed_insertions
                 .0
@@ -129,13 +138,17 @@ impl RecordSender {
                 // Send the record over the channel, space has been reserved successfully.
                 if let Err(err) = self.sender.try_send(record) {
                     assert!(err.is_disconnected());
+                    self.active_senders.fetch_sub(1, Ordering::AcqRel);
                     return Err(RecordSenderError::Disconnected);
                 }
+                self.active_senders.fetch_sub(1, Ordering::AcqRel);
                 return Ok(transaction_indexes.map(|mut transaction_indexes| {
                     let transaction_starting_index = *transaction_indexes;
                     *transaction_indexes += num_transactions;
                     transaction_starting_index
                 }));
+            } else {
+                self.active_senders.fetch_sub(1, Ordering::AcqRel);
             }
         }
     }
@@ -146,6 +159,7 @@ impl RecordSender {
 /// and can restart the channel for a new slot, re-enabling sends.
 pub struct RecordReceiver {
     capacity: u64,
+    active_senders: Arc<AtomicU64>,
     slot_allowed_insertions: SlotAllowedInsertions,
     receiver: Receiver<Record>,
     transaction_indexes: Option<Arc<Mutex<usize>>>,
@@ -203,8 +217,10 @@ impl RecordReceiver {
         core::iter::from_fn(|| self.try_recv().ok())
     }
 
+    /// Channel is empty and there are no active threads attempting to send.
     pub fn is_empty(&self) -> bool {
-        self.receiver.is_empty()
+        // Checking active senders is important - otherwise the race condition is possible.
+        self.active_senders.load(Ordering::Acquire) == 0 && self.receiver.is_empty()
     }
 
     /// Try to receive a record from the channel.


### PR DESCRIPTION
#### Problems

##### Problem 1
- Debug assert on channel not being shutdown is flagging
- We did not shutdown channel everytime `last_tick_of_slot` is set
- If we start with a bank that's partially ticked or we set a partially ticked bank the assert would fail

#### Problem 2
- There's a race condition with the record channels.
- Sender can decrement to reserve slot.
- Sender sleeps
- poh-service calls shutdown stops further decrements for sends
- poh service exits loop because inner channel is empty
- sender wakes up, actually pushes to channel
- poh service sees a record it didn't expect. possibly after it'd reset the bank!
- crash because in previous PRs I added asserts, since we want to detect this sort of recording failure (recording MUST be guaranteed)


#### Summary of Changes
- Add shutdowns to make sure we're shutdown
- Fix race by adding a `active_senders` counter

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
