### PR TITLE
local-cluster: fix oc_bad_signatures flaky test

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2823,7 +2823,6 @@ fn test_oc_bad_signatures() {
     let client = cluster
         .build_validator_tpu_quic_client(cluster.entry_point_info.pubkey())
         .unwrap();
-    let cluster_funding_keypair = cluster.funding_keypair.insecure_clone();
     let voter_thread_sleep_ms: usize = 100;
     let num_votes_simulated = Arc::new(AtomicUsize::new(0));
     let gossip_voter = cluster_tests::start_gossip_voter(
@@ -2866,7 +2865,7 @@ fn test_oc_bad_signatures() {
                 );
                 LocalCluster::send_transaction_with_retries(
                     &client,
-                    &[&cluster_funding_keypair, &bad_authorized_signer_keypair],
+                    &[&node_keypair, &bad_authorized_signer_keypair],
                     &mut vote_tx,
                     5,
                 )


### PR DESCRIPTION
#### Problem
Test fails with `KeypairPubkeyMismatch`

```Thread '<unnamed>' panicked at /home/sol/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/solana-transaction-3.0.1/src/lib.rs:719:13:
Transaction::sign failed with error KeypairPubkeyMismatch
stack backtrace:
   0: rust_begin_unwind
             at /rustc/9cd60bd2ccc41bc898d2ad86728f14035d2df72d/library/std/src/panicking.rs:695:5
   1: core::panicking::panic_fmt
             at /rustc/9cd60bd2ccc41bc898d2ad86728f14035d2df72d/library/core/src/panicking.rs:75:14
   2: solana_transaction::Transaction::sign
             at /home/sol/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/solana-transaction-3.0.1/src/lib.rs:719:13
   3: solana_local_cluster::local_cluster::LocalCluster::send_transaction_with_retries
             at ./src/local_cluster.rs:765:13
   4: local_cluster::test_oc_bad_signatures::{{closure}}::{{closure}}
             at ./tests/local_cluster.rs:2867:17
   5: solana_local_cluster::cluster_tests::start_gossip_voter::{{closure}}
             at ./src/cluster_tests.rs:604:25
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

#### Summary of Changes
Use the proper `node_pubkey`, no clue how this works sometimes...
