### PR TITLE
docs: use correct argument in the genesis setup example

### DIFF
--- a/genesis/README.md
+++ b/genesis/README.md
@@ -7,7 +7,7 @@
 --bootstrap-validator-lamports <LAMPORTS>
 --bootstrap-validator-stake-lamports <LAMPORTS>
 ```
-Note: you can pass in `--bootstrap-validator ...` multiple times but the lamports associated with `--bootstrap-validator-lamports` and `--bootstrap-validator-stake-lamports` will apply to all `--bootstrap-validator` arguments.
+Note: you can pass in `--bootstrap-validator ...` multiple times, but the lamports associated with `--bootstrap-validator-lamports` and `--bootstrap-validator-stake-lamports` will apply to all `--bootstrap-validator` arguments.
 For example:
 ```
 cargo run --bin solana-genesis --
@@ -16,7 +16,7 @@ cargo run --bin solana-genesis --
     ...
     --bootstrap-validator <IDENTITY_PUBKEY_N> <VOTE_PUBKEY_N> <STAKE_PUBKEY_N>
     --bootstrap-validator-stake-lamports 10000000000
-    --bootstrap-validator 100000000000
+    --bootstrap-validator-lamports 100000000000
 ```
 All validator accounts will receive the same number of stake and account lamports
 


### PR DESCRIPTION
#### Problem

The example doesn't use the correct argument - it seems like a copy/paste error.
