### PR TITLE
status-cache: switch to ahash::HashMap

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -214,7 +214,7 @@ pub const MAX_LEADER_SCHEDULE_STAKES: Epoch = 5;
 pub type BankStatusCache = StatusCache<Result<()>>;
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(digest = "2mR2EKFguLhheKtDzbFxoQonSmUtM9svd8kkgeKpe2vu")
+    frozen_abi(digest = "FUttxQbsCnX5VMRuj8c2sUxZKNARUTaomdgsbg8wM3D6")
 )]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 

--- a/runtime/src/serde_snapshot/status_cache.rs
+++ b/runtime/src/serde_snapshot/status_cache.rs
@@ -16,11 +16,11 @@ use {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(digest = "DNMK4ve8crKwuyUWx4ummQfgA3ydmDuptiJTp8G8m18p")
+    frozen_abi(digest = "AardUUq1At4qq6oNNp9V2JZFsMR5k54RZmBmZkxUfk7m")
 )]
 type SerdeBankSlotDelta = SerdeSlotDelta<Result<(), SerdeTransactionError>>;
 type SerdeSlotDelta<T> = (Slot, bool, SerdeStatus<T>);
-type SerdeStatus<T> = HashMap<Hash, (usize, Vec<(KeySlice, T)>)>;
+type SerdeStatus<T> = ahash::HashMap<Hash, (usize, Vec<(KeySlice, T)>)>;
 
 /// Serializes the status cache's `slot_deltas` to file at `status_cache_path`
 ///
@@ -97,7 +97,7 @@ pub fn deserialize_status_cache(
                             ),
                         )
                     })
-                    .collect::<HashMap<_, _>>();
+                    .collect::<ahash::HashMap<_, _>>();
                 (slot_delta.0, slot_delta.1, Arc::new(Mutex::new(status_map)))
             })
             .collect::<Vec<_>>();

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -1,4 +1,5 @@
 use {
+    ahash::{HashMap, HashMapExt as _},
     log::*,
     rand::{thread_rng, Rng},
     serde::Serialize,
@@ -6,7 +7,7 @@ use {
     solana_clock::{Slot, MAX_RECENT_BLOCKHASHES},
     solana_hash::Hash,
     std::{
-        collections::{hash_map::Entry, HashMap, HashSet},
+        collections::{hash_map::Entry, HashSet},
         sync::{Arc, Mutex},
     },
 };


### PR DESCRIPTION
Removes some overhead in using the status cache.

This is a 10s bench-tps run against master

<img width="2045" height="1211" alt="Screenshot 2025-09-12 at 6 41 29 pm" src="https://github.com/user-attachments/assets/087ac659-5187-4d50-8d33-73227465795c" />

<img width="2056" height="1203" alt="Screenshot 2025-09-12 at 6 41 57 pm" src="https://github.com/user-attachments/assets/7cef110f-34b3-4fb0-ba08-0371185f7342" />

This is the same but with this PR

<img width="2047" height="1206" alt="Screenshot 2025-09-12 at 6 42 30 pm" src="https://github.com/user-attachments/assets/d24b1b76-88de-4f14-8baf-2d7426a719ae" />

<img width="2047" height="1204" alt="Screenshot 2025-09-12 at 6 42 50 pm" src="https://github.com/user-attachments/assets/d782bdd9-10ab-46a3-83f2-ebbf36b0e6f1" />

We get a ~6% improvement in `check_transactions()` and a ~2% improvement in `update_transactions()` 