### PR TITLE
validator: Move PubSub arguments to PubSub module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "num_cpus",
  "predicates",
  "pretty_assertions",
+ "qualifier_attr",
  "rand 0.8.5",
  "rayon",
  "serde",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "libloading",
  "log",
  "num_cpus",
+ "qualifier_attr",
  "rand 0.8.5",
  "rayon",
  "serde",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -31,6 +31,7 @@ libc = { workspace = true }
 libloading = { workspace = true }
 log = { workspace = true }
 num_cpus = { workspace = true }
+qualifier_attr = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -20,8 +20,7 @@ use {
     solana_hash::Hash,
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
     solana_quic_definitions::QUIC_PORT_OFFSET,
-    solana_rayon_threadlimit::get_thread_count,
-    solana_rpc::{rpc::MAX_REQUEST_BODY_SIZE, rpc_pubsub_service::PubSubConfig},
+    solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,
     solana_rpc_client_api::request::{DELINQUENT_VALIDATOR_SLOT_DISTANCE, MAX_MULTIPLE_ACCOUNTS},
     solana_runtime::snapshot_utils::{
         SnapshotVersion, DEFAULT_ARCHIVE_COMPRESSION, DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
@@ -260,9 +259,6 @@ pub struct DefaultArgs {
     pub send_transaction_service_config: send_transaction_service::Config,
 
     pub rpc_max_multiple_accounts: String,
-    pub rpc_pubsub_max_active_subscriptions: String,
-    pub rpc_pubsub_queue_capacity_items: String,
-    pub rpc_pubsub_queue_capacity_bytes: String,
     pub rpc_send_transaction_retry_ms: String,
     pub rpc_send_transaction_batch_ms: String,
     pub rpc_send_transaction_leader_forward_count: String,
@@ -277,8 +273,6 @@ pub struct DefaultArgs {
     pub rpc_bigtable_app_profile_id: String,
     pub rpc_bigtable_max_message_size: String,
     pub rpc_max_request_body_size: String,
-    pub rpc_pubsub_worker_threads: String,
-    pub rpc_pubsub_notification_threads: String,
 
     pub maximum_local_snapshot_age: String,
     pub maximum_full_snapshot_archives_to_retain: String,
@@ -335,15 +329,6 @@ impl DefaultArgs {
             health_check_slot_distance: DELINQUENT_VALIDATOR_SLOT_DISTANCE.to_string(),
             tower_storage: "file".to_string(),
             etcd_domain_name: "localhost".to_string(),
-            rpc_pubsub_max_active_subscriptions: PubSubConfig::default()
-                .max_active_subscriptions
-                .to_string(),
-            rpc_pubsub_queue_capacity_items: PubSubConfig::default()
-                .queue_capacity_items
-                .to_string(),
-            rpc_pubsub_queue_capacity_bytes: PubSubConfig::default()
-                .queue_capacity_bytes
-                .to_string(),
             send_transaction_service_config: send_transaction_service::Config::default(),
             rpc_send_transaction_retry_ms: default_send_transaction_service_config
                 .retry_rate_ms
@@ -372,8 +357,6 @@ impl DefaultArgs {
                 .to_string(),
             rpc_bigtable_max_message_size: solana_storage_bigtable::DEFAULT_MAX_MESSAGE_SIZE
                 .to_string(),
-            rpc_pubsub_worker_threads: "4".to_string(),
-            rpc_pubsub_notification_threads: get_thread_count().to_string(),
             maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN
                 .to_string(),
             maximum_incremental_snapshot_archives_to_retain:

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1070,81 +1070,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Max encoding and decoding message size used in Bigtable Grpc client"),
     )
     .arg(
-        Arg::with_name("rpc_pubsub_worker_threads")
-            .long("rpc-pubsub-worker-threads")
-            .takes_value(true)
-            .value_name("NUMBER")
-            .validator(is_parsable::<usize>)
-            .default_value(&default_args.rpc_pubsub_worker_threads)
-            .help("PubSub worker threads"),
-    )
-    .arg(
-        Arg::with_name("rpc_pubsub_enable_block_subscription")
-            .long("rpc-pubsub-enable-block-subscription")
-            .requires("enable_rpc_transaction_history")
-            .takes_value(false)
-            .help("Enable the unstable RPC PubSub `blockSubscribe` subscription"),
-    )
-    .arg(
-        Arg::with_name("rpc_pubsub_enable_vote_subscription")
-            .long("rpc-pubsub-enable-vote-subscription")
-            .takes_value(false)
-            .help("Enable the unstable RPC PubSub `voteSubscribe` subscription"),
-    )
-    .arg(
-        Arg::with_name("rpc_pubsub_max_active_subscriptions")
-            .long("rpc-pubsub-max-active-subscriptions")
-            .takes_value(true)
-            .value_name("NUMBER")
-            .validator(is_parsable::<usize>)
-            .default_value(&default_args.rpc_pubsub_max_active_subscriptions)
-            .help(
-                "The maximum number of active subscriptions that RPC PubSub will accept across \
-                 all connections.",
-            ),
-    )
-    .arg(
-        Arg::with_name("rpc_pubsub_queue_capacity_items")
-            .long("rpc-pubsub-queue-capacity-items")
-            .takes_value(true)
-            .value_name("NUMBER")
-            .validator(is_parsable::<usize>)
-            .default_value(&default_args.rpc_pubsub_queue_capacity_items)
-            .help(
-                "The maximum number of notifications that RPC PubSub will store across all \
-                 connections.",
-            ),
-    )
-    .arg(
-        Arg::with_name("rpc_pubsub_queue_capacity_bytes")
-            .long("rpc-pubsub-queue-capacity-bytes")
-            .takes_value(true)
-            .value_name("BYTES")
-            .validator(is_parsable::<usize>)
-            .default_value(&default_args.rpc_pubsub_queue_capacity_bytes)
-            .help(
-                "The maximum total size of notifications that RPC PubSub will store across all \
-                 connections.",
-            ),
-    )
-    .arg(
-        Arg::with_name("rpc_pubsub_notification_threads")
-            .long("rpc-pubsub-notification-threads")
-            .requires("full_rpc_api")
-            .takes_value(true)
-            .value_name("NUM_THREADS")
-            .validator(is_parsable::<usize>)
-            .default_value_if(
-                "full_rpc_api",
-                None,
-                &default_args.rpc_pubsub_notification_threads,
-            )
-            .help(
-                "The maximum number of threads that RPC PubSub will use for generating \
-                 notifications. 0 will disable RPC PubSub notifications",
-            ),
-    )
-    .arg(
         Arg::with_name("rpc_send_transaction_retry_ms")
             .long("rpc-send-retry-ms")
             .value_name("MILLISECS")
@@ -1691,6 +1616,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
                  set,tpu-client-next is used by default.",
             ),
     )
+    .args(&pub_sub_config::args())
 }
 
 fn validators_set(

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -52,7 +52,8 @@ mod tests {
     use {
         super::*,
         crate::commands::run::args::{
-            tests::verify_args_struct_by_command_run_with_identity_setup, DefaultArgs, RunArgs,
+            pub_sub_config::DEFAULT_RPC_PUBSUB_NUM_NOTIFICATION_THREADS,
+            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
         },
         solana_rpc::rpc_pubsub_service::PubSubConfig,
         std::{
@@ -249,7 +250,6 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_run_with_full_api() {
         {
-            let default_args = DefaultArgs::new();
             let default_run_args = crate::commands::run::args::RunArgs::default();
             let expected_args = RunArgs {
                 json_rpc_config: JsonRpcConfig {
@@ -259,8 +259,7 @@ mod tests {
                 pub_sub_config: PubSubConfig {
                     notification_threads: Some(
                         NonZeroUsize::new(
-                            default_args
-                                .rpc_pubsub_notification_threads
+                            DEFAULT_RPC_PUBSUB_NUM_NOTIFICATION_THREADS
                                 .parse::<usize>()
                                 .unwrap(),
                         )


### PR DESCRIPTION
#### Summary of Changes
The main function that adds all the arguments to validator app has over 150 arguments. This is cumbersome so move the PubSub related arguments to the PubSub module for organization and code reuse

