### PR TITLE
Add support for configurable accounts_db to define_accounts_db_test

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7218,24 +7218,31 @@ impl AccountsDb {
         AccountsDb::new_for_tests(Vec::new())
     }
 
-    pub fn new_single_for_tests_with_provider(file_provider: AccountsFileProvider) -> Self {
-        AccountsDb::new_for_tests_with_provider(Vec::new(), file_provider)
+    pub fn new_single_for_tests_with_provider_and_config(
+        file_provider: AccountsFileProvider,
+        accounts_db_config: AccountsDbConfig,
+    ) -> Self {
+        AccountsDb::new_for_tests_with_provider_and_config(
+            Vec::new(),
+            file_provider,
+            accounts_db_config,
+        )
     }
 
     pub fn new_for_tests(paths: Vec<PathBuf>) -> Self {
-        Self::new_for_tests_with_provider(paths, AccountsFileProvider::default())
+        Self::new_for_tests_with_provider_and_config(
+            paths,
+            AccountsFileProvider::default(),
+            ACCOUNTS_DB_CONFIG_FOR_TESTING,
+        )
     }
 
-    fn new_for_tests_with_provider(
+    fn new_for_tests_with_provider_and_config(
         paths: Vec<PathBuf>,
         accounts_file_provider: AccountsFileProvider,
+        accounts_db_config: AccountsDbConfig,
     ) -> Self {
-        let mut db = AccountsDb::new_with_config(
-            paths,
-            ACCOUNTS_DB_CONFIG_FOR_TESTING,
-            None,
-            Arc::default(),
-        );
+        let mut db = AccountsDb::new_with_config(paths, accounts_db_config, None, Arc::default());
         db.accounts_file_provider = accounts_file_provider;
         db
     }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -117,13 +117,14 @@ impl AccountStorageEntry {
 ///     define_accounts_db_test!(TEST_NAME, panic = "PANIC_MSG", |accounts_db| { TEST_BODY });
 macro_rules! define_accounts_db_test {
     (@testfn $name:ident, $accounts_file_provider: ident, |$accounts_db:ident| $inner: tt) => {
-            fn run_test($accounts_db: AccountsDb) {
-                $inner
-            }
-            let accounts_db =
-                AccountsDb::new_single_for_tests_with_provider($accounts_file_provider);
-            run_test(accounts_db);
-
+        fn run_test($accounts_db: AccountsDb) {
+            $inner
+        }
+        let accounts_db = AccountsDb::new_single_for_tests_with_provider_and_config(
+            $accounts_file_provider,
+            ACCOUNTS_DB_CONFIG_FOR_TESTING,
+        );
+        run_test(accounts_db);
     };
     ($name:ident, |$accounts_db:ident| $inner: tt) => {
         #[test_case(AccountsFileProvider::AppendVec; "append_vec")]


### PR DESCRIPTION
#### Problem
- Some tests wrapped in the define_accounts_db_test macro behave differently with obsolete accounts marked
- define_accounts_db_test doesn't support configuring the db configuration

#### Summary of Changes
- Add support to specify accountsdb configuration in define_accounts_db_test
- Modify new_single_for_tests_with_provider to new_single_for_tests_with_provider_and_config
- Will be follow up PR to run tests in both obsolete accounts mode and non

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
