### PR TITLE
Allow RxRing struct to return XdpDesc of available frames in crate xdp

### DIFF
--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -329,10 +329,10 @@ impl RingProducer {
 
 #[repr(C)]
 #[derive(Debug, Clone)]
-pub(crate) struct XdpDesc {
-    pub(crate) addr: u64,
-    pub(crate) len: u32,
-    pub(crate) options: u32,
+pub struct XdpDesc {
+    pub addr: u64,
+    pub len: u32,
+    pub options: u32,
 }
 
 pub struct TxCompletionRing {

--- a/xdp/src/socket.rs
+++ b/xdp/src/socket.rs
@@ -369,4 +369,11 @@ impl RxRing {
     pub fn sync(&mut self, commit: bool) {
         self.consumer.sync(commit);
     }
+
+    pub fn read(&mut self) -> Option<XdpDesc> {
+        let index = self.consumer.consume()? & self.size.saturating_sub(1);
+        let base = self.mmap.desc.cast::<XdpDesc>();
+        let desc = unsafe { base.offset(index as isize).read() };
+        Some(desc)
+    }
 }

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -312,7 +312,7 @@ pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>>(
 // With some drivers, or always when we work in SKB mode, we need to explicitly kick the driver once
 // we want the NIC to do something.
 #[inline(always)]
-fn kick(ring: &TxRing<SliceUmemFrame<'_>>) {
+pub fn kick(ring: &TxRing<SliceUmemFrame<'_>>) {
     if !ring.needs_wakeup() {
         return;
     }
@@ -323,7 +323,7 @@ fn kick(ring: &TxRing<SliceUmemFrame<'_>>) {
 }
 
 #[inline(never)]
-fn kick_error(e: std::io::Error) {
+pub fn kick_error(e: std::io::Error) {
     match e.raw_os_error() {
         // these are non-fatal errors
         Some(libc::EBUSY | libc::ENOBUFS | libc::EAGAIN) => {}

--- a/xdp/src/umem.rs
+++ b/xdp/src/umem.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
+    crate::device::XdpDesc,
     libc::{munmap, sysconf, _SC_PAGESIZE},
     std::{
         ffi::c_void,
@@ -41,15 +42,30 @@ pub trait Umem {
     }
 }
 
+#[derive(Debug)]
 pub struct SliceUmemFrame<'a> {
-    offset: usize,
-    len: usize,
+    pub offset: usize,
+    pub len: usize,
     _buf: PhantomData<&'a mut [u8]>,
+}
+
+impl From<XdpDesc> for SliceUmemFrame<'_> {
+    fn from(desc: XdpDesc) -> Self {
+        Self {
+            offset: desc.addr() as usize,
+            len: desc.len(),
+            _buf: PhantomData,
+        }
+    }
 }
 
 impl SliceUmemFrame<'_> {
     pub fn set_len(&mut self, len: usize) {
         self.len = len;
+    }
+
+    pub fn as_xdp(self) -> XdpDesc {
+        XdpDesc::build(self.offset as u64, self.len as u32, 0)
     }
 }
 


### PR DESCRIPTION
#### Problem
Rx ring struct does not implement a method to read xdp descriptors, so the xdp crate is limited to only send packets, not receiving them.

#### Summary of Changes
- Add method read which returns an option with a XdpDesc. If there is an available descriptor to consume, it will return XdpDesc.
- XdpDesc struct is no longer a crate struct, so it can be used from outside the crate to interact with the frames in the UMEM

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
