### PR TITLE
Retry IO on short write in io_uring file creator

### DIFF
--- a/accounts-db/src/io_uring/file_creator.rs
+++ b/accounts-db/src/io_uring/file_creator.rs
@@ -484,6 +484,7 @@ impl<'a> WriteOp {
         let total_written = *buf_offset + written;
 
         if written < *write_len {
+            log::warn!("short write ({written}/{}), file={}", *write_len, *file_key);
             ring.push(FileCreatorOp::Write(WriteOp {
                 file_key: *file_key,
                 offset: *offset + written,

--- a/accounts-db/src/io_uring/file_creator.rs
+++ b/accounts-db/src/io_uring/file_creator.rs
@@ -469,7 +469,6 @@ impl<'a> WriteOp {
         let written = match res {
             Ok(0) => return Err(io::ErrorKind::WriteZero.into()), // likely a full disk
             Ok(res) => res as usize,
-            Err(err) if err.kind() == io::ErrorKind::ResourceBusy => 0, // treat as a kind of short write
             Err(err) => return Err(err),
         };
 
@@ -485,8 +484,6 @@ impl<'a> WriteOp {
         let total_written = *buf_offset + written;
 
         if written < *write_len {
-            // On 5.15 kernel the io_uring worker might generate a short write, re-submit
-            // with offsets updated
             ring.push(FileCreatorOp::Write(WriteOp {
                 file_key: *file_key,
                 offset: *offset + written,


### PR DESCRIPTION
#### Problem
As reported in https://github.com/anza-xyz/agave/issues/8036#issuecomment-3289403923 ubuntu 22 with 5.15 kernel and ZFS filesystem experiences error due to short writes.
It's not completely clear which kernel / FS combination give 100% guarantee of not returning `EAGAIN` or short write, this comment https://github.com/axboe/liburing/issues/766#issuecomment-1384274838 suggests 5.15 fixed some issues, but given reports from the wild it's worth fixing.

#### Summary of Changes
Re-submit write when:
* getting resource temporarily unavailable error (`EAGAIN` aka `WouldBlock`)
* getting short write (unless `Ok` with 0-size write happens, which is treated as hard error)

Fixes #8036 (it's not clear where the resource busy errors come from, but write completion is the most likely place)
