### PR TITLE
ci: use curve25519_dalek_backend='serial' for coverage test

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -46,6 +46,7 @@ rm -rf "$here/../target/cov/$COMMIT_HASH"
 
 # https://doc.rust-lang.org/rustc/instrument-coverage.html
 export RUSTFLAGS="-C instrument-coverage $RUSTFLAGS"
+export RUSTFLAGS="--cfg curve25519_dalek_backend=\"serial\" $RUSTFLAGS"
 export LLVM_PROFILE_FILE="$here/../target/cov/${COMMIT_HASH}/profraw/default-%p-%m.profraw"
 
 if [[ -z $1 ]]; then


### PR DESCRIPTION
#### Problem

the coverage test time increasing:

https://discord.com/channels/428295358100013066/560503042458517505/1412484800618696735

and some details:
https://discord.com/channels/428295358100013066/560503042458517505/1413358715742191626
https://discord.com/channels/428295358100013066/560503042458517505/1414612084490240173

according to the [curve25519-dalek docs](https://github.com/dalek-cryptography/curve25519-dalek/blob/c3a82a8a38a58aee500a20bde1664012fcfa83ba/ed25519-dalek/CHANGELOG.md?plain=1#L45-L46), the backends should be automatically selected, however, it seems not to select the fastest backend for coverage test

#### Summary of Changes

use `curve25519_dalek_backend='serial'` specifically