### PR TITLE
Introduce RuntimeRegistry to validator

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1129,6 +1129,9 @@ impl Validator {
         };
 
         let mut runtimes = RuntimeRegistry::new();
+        if config.use_tpu_client_next {
+            runtimes.insert_runtime(RuntimeId::TpuClientNext, 2);
+        }
 
         let rpc_override_health_check =
             Arc::new(AtomicBool::new(config.rpc_config.disable_health_check));
@@ -1156,8 +1159,6 @@ impl Validator {
             };
 
             let client_option = if config.use_tpu_client_next {
-                runtimes.insert_runtime(RuntimeId::TpuClientNext, 2);
-
                 let runtime_handle = runtimes.get_runtime_handle(RuntimeId::TpuClientNext);
                 ClientOption::TpuClientNext(
                     Arc::as_ref(&identity_keypair),


### PR DESCRIPTION
#### Problem

We introduce a new structure `RuntimeRegistry` to encapsulate the code creating runtimes into it's own structure. This is prerequisite to moving runtime creation inside other components into one place (for example, from streamer https://github.com/anza-xyz/agave/pull/8063).

#### Summary of Changes


