### PR TITLE
README: Add documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 [![Build status](https://badge.buildkite.com/8cc350de251d61483db98bdfc895b9ea0ac8ffa4a32ee850ed.svg?branch=master)](https://buildkite.com/solana-labs/solana/builds?branch=master)
 [![codecov](https://codecov.io/gh/solana-labs/solana/branch/master/graph/badge.svg)](https://codecov.io/gh/solana-labs/solana)
 
+# Documentation
+
+- [Agave Validator](https://docs.anza.xyz) ([GitHub Repo](https://github.com/anza-xyz/agave))
+- [Solana RPC API](https://solana.com/docs/rpc) ([GitHub Repo](https://github.com/solana-foundation/solana-com/tree/main/apps/web/content/docs))
+
 # Building
 
 ## **1. Install rustc, cargo and rustfmt.**


### PR DESCRIPTION
#### Problem
It is hard to find https://docs.anza.xyz because:
1. https://www.anza.xyz does not link to the docs at https://docs.anza.xyz (but it does link to this repo)
2. This repo does not link to the docs at https://docs.anza.xyz (but it does link to https://www.anza.xyz)

#### Summary of Changes
To improve general discoverability and linking between things, edit the README to have a link to the validator docs and the RPC API docs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
