### PR TITLE
Use TaskTracket in streamer for graceful exit and avoiding flaky tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12934,6 +12934,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -11006,6 +11006,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -58,7 +58,7 @@ solana-transaction-error = { workspace = true }
 solana-transaction-metrics-tracker = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tokio-util = { workspace = true, features = ["rt"]}
+tokio-util = { workspace = true, features = ["rt"] }
 x509-parser = { workspace = true }
 
 [dev-dependencies]

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -58,7 +58,7 @@ solana-transaction-error = { workspace = true }
 solana-transaction-metrics-tracker = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["rt"]}
 x509-parser = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
#### Problem

When streamer service is launched, it spawns task and returns handle for this task. 
In tests we typically do the following:
```rust
exit.store(true, Relaxed);
task_handle.await;

//check some stats
```

Yet inside of this root task of streamer, it creates many other tasks to handle connections and streams, which this root task has no idea about. 
Which means that when the root task has stopped we have no idea if it's child tasks have completed or not.

This leads to flaky tests. For example, in `nonblocking::quic::test::test_quic_server_multiple_streams` we stop the streamer and after that check `stats.total_connections.load(Ordering::Relaxed)`. This counter counts how many task are handling at giving moment connections. It might happen that these tasks haven't finished before we do this check, so all the checks below `task_handle.await` are potentially flaky.

#### Summary of Changes

Use `TaskTracker` [as tokio documentation suggests](https://docs.rs/tokio-util/0.7.16/tokio_util/task/task_tracker/struct.TaskTracker.html)
