### PR TITLE
chore: Make workspace members inherit Cargo.toml description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ resolver = "2"
 [workspace.package]
 version = "3.1.0"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
+description = "Blockchain, Rebuilt for Scale"
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"
 license = "Apache-2.0"

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "solana-cli-config"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-cli-config"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "solana-cli-output"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-cli-output"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "solana-cli"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-cli"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "solana-core"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-core"
 readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "solana-genesis"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-genesis"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "solana-gossip"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-gossip"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "agave-ledger-tool"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/agave-ledger-tool"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "solana-local-cluster"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-local-cluster"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/measure/Cargo.toml
+++ b/measure/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "solana-measure"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-measure"
 readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -1,12 +1,11 @@
-
 [package]
 name = "solana-sbf-programs"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana"
 readme = "README.md"
 publish = false
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "solana-remote-wallet"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-remote-wallet"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "solana-stake-accounts"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-stake-accounts"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-description = "Blockchain, Rebuilt for Scale"
 name = "proto"
 publish = false
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "solana-test-validator"
-description = "Blockchain, Rebuilt for Scale"
 readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "solana-tokens"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-tokens"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/tps-client/Cargo.toml
+++ b/tps-client/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "solana-tps-client"
-description = "Blockchain, Rebuilt for Scale"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "solana-turbine"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-turbine"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "agave-validator"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/agave-validator"
 default-run = "agave-validator"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "solana-votor-messages"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/solana-votor-messages"
 readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "agave-votor"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/agave-votor"
 readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "agave-watchtower"
-description = "Blockchain, Rebuilt for Scale"
 documentation = "https://docs.rs/agave-watchtower"
 version = { workspace = true }
 authors = { workspace = true }
+description = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION
#### Problem
Some crates have a generic Solana description instead of something specific to that crate. 

#### Summary of Changes
Instead of having this item copy/pasted in each crate, specify the description in the workspace Cargo.toml file and inherit it in crates that don't have a custom description

I'm keeping the PR's focused & small, but will get `readme` in subsequent PR