### PR TITLE
agave-validator: extract accounts-db-config

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -382,7 +382,7 @@ pub const DEFAULT_MAX_ANCIENT_STORAGES: usize = 100_000;
 #[cfg(not(test))]
 const ABSURD_CONSECUTIVE_FAILED_ITERATIONS: usize = 100;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AccountShrinkThreshold {
     /// Measure the total space sparseness across all candidates
     /// And select the candidates by using the top sparse account storage entries to shrink.

--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -16,7 +16,7 @@ use {
     std::{num::NonZeroUsize, path::PathBuf},
 };
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct AccountsDbConfig {
     pub index: Option<AccountsIndexConfig>,
     pub account_indexes: Option<AccountSecondaryIndexes>,

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -227,7 +227,7 @@ enum ScanTypes<R: RangeBounds<Pubkey>> {
 }
 
 /// specification of how much memory in-mem portion of account index can use
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum IndexLimitMb {
     /// use disk index while keeping a minimal amount in-mem
     Minimal,
@@ -235,7 +235,7 @@ pub enum IndexLimitMb {
     InMemOnly,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AccountsIndexConfig {
     pub bins: Option<usize>,
     pub num_flush_threads: Option<NonZeroUsize>,

--- a/accounts-db/src/partitioned_rewards.rs
+++ b/accounts-db/src/partitioned_rewards.rs
@@ -6,7 +6,7 @@
 /// This constant affects consensus.
 const MAX_PARTITIONED_REWARDS_PER_BLOCK: u64 = 4096;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 /// Configuration options for partitioned epoch rewards.
 pub struct PartitionedEpochRewardsConfig {
     /// number of stake accounts to store in one block during partitioned reward interval

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -230,7 +230,7 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
 
 // Helper to add arguments that are no longer used but are being kept around to avoid breaking
 // validator startup commands.
-fn get_deprecated_arguments() -> Vec<Arg<'static, 'static>> {
+pub(crate) fn get_deprecated_arguments() -> Vec<Arg<'static, 'static>> {
     deprecated_arguments()
         .into_iter()
         .map(|info| {

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -96,7 +96,6 @@ fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
 }
 
 pub struct NumThreadConfig {
-    pub accounts_db_foreground_threads: NonZeroUsize,
     pub block_production_num_workers: NonZeroUsize,
     pub ip_echo_server_threads: NonZeroUsize,
     pub rayon_global_threads: NonZeroUsize,
@@ -112,11 +111,6 @@ pub struct NumThreadConfig {
 
 pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
     NumThreadConfig {
-        accounts_db_foreground_threads: value_t_or_exit!(
-            matches,
-            AccountsDbForegroundThreadsArg::NAME,
-            NonZeroUsize
-        ),
         block_production_num_workers: value_t_or_exit!(
             matches,
             BlockProductionNumWorkersArg::NAME,
@@ -206,7 +200,7 @@ impl ThreadArg for AccountsDbBackgroundThreadsArg {
     }
 }
 
-struct AccountsDbForegroundThreadsArg;
+pub struct AccountsDbForegroundThreadsArg;
 impl ThreadArg for AccountsDbForegroundThreadsArg {
     const NAME: &'static str = "accounts_db_foreground_threads";
     const LONG_NAME: &'static str = "accounts-db-foreground-threads";

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -96,7 +96,6 @@ fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
 }
 
 pub struct NumThreadConfig {
-    pub accounts_db_background_threads: NonZeroUsize,
     pub accounts_db_foreground_threads: NonZeroUsize,
     pub block_production_num_workers: NonZeroUsize,
     pub ip_echo_server_threads: NonZeroUsize,
@@ -112,15 +111,7 @@ pub struct NumThreadConfig {
 }
 
 pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
-    let accounts_db_background_threads = {
-        if matches.is_present("accounts_db_clean_threads") {
-            value_t_or_exit!(matches, "accounts_db_clean_threads", NonZeroUsize)
-        } else {
-            value_t_or_exit!(matches, AccountsDbBackgroundThreadsArg::NAME, NonZeroUsize)
-        }
-    };
     NumThreadConfig {
-        accounts_db_background_threads,
         accounts_db_foreground_threads: value_t_or_exit!(
             matches,
             AccountsDbForegroundThreadsArg::NAME,
@@ -204,7 +195,7 @@ pub trait ThreadArg {
     }
 }
 
-struct AccountsDbBackgroundThreadsArg;
+pub struct AccountsDbBackgroundThreadsArg;
 impl ThreadArg for AccountsDbBackgroundThreadsArg {
     const NAME: &'static str = "accounts_db_background_threads";
     const LONG_NAME: &'static str = "accounts-db-background-threads";

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -98,7 +98,6 @@ fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
 pub struct NumThreadConfig {
     pub accounts_db_background_threads: NonZeroUsize,
     pub accounts_db_foreground_threads: NonZeroUsize,
-    pub accounts_index_flush_threads: NonZeroUsize,
     pub block_production_num_workers: NonZeroUsize,
     pub ip_echo_server_threads: NonZeroUsize,
     pub rayon_global_threads: NonZeroUsize,
@@ -125,11 +124,6 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
         accounts_db_foreground_threads: value_t_or_exit!(
             matches,
             AccountsDbForegroundThreadsArg::NAME,
-            NonZeroUsize
-        ),
-        accounts_index_flush_threads: value_t_or_exit!(
-            matches,
-            AccountsIndexFlushThreadsArg::NAME,
             NonZeroUsize
         ),
         block_production_num_workers: value_t_or_exit!(
@@ -233,7 +227,7 @@ impl ThreadArg for AccountsDbForegroundThreadsArg {
     }
 }
 
-struct AccountsIndexFlushThreadsArg;
+pub struct AccountsIndexFlushThreadsArg;
 impl ThreadArg for AccountsIndexFlushThreadsArg {
     const NAME: &'static str = "accounts_index_flush_threads";
     const LONG_NAME: &'static str = "accounts-index-flush-threads";

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -189,7 +189,7 @@ pub trait ThreadArg {
     }
 }
 
-pub struct AccountsDbBackgroundThreadsArg;
+pub(crate) struct AccountsDbBackgroundThreadsArg;
 impl ThreadArg for AccountsDbBackgroundThreadsArg {
     const NAME: &'static str = "accounts_db_background_threads";
     const LONG_NAME: &'static str = "accounts-db-background-threads";

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -200,7 +200,7 @@ impl ThreadArg for AccountsDbBackgroundThreadsArg {
     }
 }
 
-pub struct AccountsDbForegroundThreadsArg;
+pub(crate) struct AccountsDbForegroundThreadsArg;
 impl ThreadArg for AccountsDbForegroundThreadsArg {
     const NAME: &'static str = "accounts_db_foreground_threads";
     const LONG_NAME: &'static str = "accounts-db-foreground-threads";
@@ -212,7 +212,7 @@ impl ThreadArg for AccountsDbForegroundThreadsArg {
     }
 }
 
-pub struct AccountsIndexFlushThreadsArg;
+pub(crate) struct AccountsIndexFlushThreadsArg;
 impl ThreadArg for AccountsIndexFlushThreadsArg {
     const NAME: &'static str = "accounts_index_flush_threads";
     const LONG_NAME: &'static str = "accounts-index-flush-threads";

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1594,6 +1594,7 @@ mod tests {
                         num_flush_threads: Some(
                             solana_accounts_db::accounts_index::default_num_flush_threads(),
                         ),
+                        drives: Some(vec![]),
                         ..AccountsIndexConfig::default()
                     }),
                     ..AccountsDbConfig::default()

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1597,7 +1597,7 @@ mod tests {
                         num_flush_threads: Some(
                             solana_accounts_db::accounts_index::default_num_flush_threads(),
                         ),
-                        drives: Some(vec![]),
+                        drives: Some(vec![ledger_path.join("accounts_index")]),
                         ..AccountsIndexConfig::default()
                     }),
                     account_indexes: Some(AccountSecondaryIndexes::default()),

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -6,6 +6,7 @@ use {
     },
     agave_snapshots::SUPPORTED_ARCHIVE_COMPRESSION,
     clap::{values_t, App, Arg, ArgMatches},
+    solana_accounts_db::accounts_db::AccountsDbConfig,
     solana_accounts_db::utils::create_and_canonicalize_directory,
     solana_clap_utils::{
         hidden_unless_forced,
@@ -59,6 +60,7 @@ const WEN_RESTART_HELP: &str =
      watch the discord channel for instructions.";
 
 pub mod account_secondary_indexes;
+pub mod accounts_db_config;
 pub mod blockstore_options;
 pub mod json_rpc_config;
 pub mod pub_sub_config;
@@ -79,6 +81,7 @@ pub struct RunArgs {
     pub json_rpc_config: JsonRpcConfig,
     pub pub_sub_config: PubSubConfig,
     pub send_transaction_service_config: SendTransactionServiceConfig,
+    pub accounts_db_config: AccountsDbConfig,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -147,6 +150,7 @@ impl FromClapArgMatches for RunArgs {
             send_transaction_service_config: SendTransactionServiceConfig::from_clap_arg_match(
                 matches,
             )?,
+            accounts_db_config: AccountsDbConfig::from_clap_arg_match(matches)?,
         })
     }
 }
@@ -1583,6 +1587,7 @@ mod tests {
                     ..PubSubConfig::default_for_tests()
                 },
                 send_transaction_service_config: SendTransactionServiceConfig::default(),
+                accounts_db_config: AccountsDbConfig::default(),
             }
         }
     }
@@ -1601,6 +1606,7 @@ mod tests {
                 json_rpc_config: self.json_rpc_config.clone(),
                 pub_sub_config: self.pub_sub_config.clone(),
                 send_transaction_service_config: self.send_transaction_service_config.clone(),
+                accounts_db_config: self.accounts_db_config.clone(),
             }
         }
     }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1609,6 +1609,7 @@ mod tests {
                         )
                         .unwrap(),
                     ),
+                    memlock_budget_size: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_SIZE,
                     ..AccountsDbConfig::default()
                 },
             }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -6,8 +6,7 @@ use {
     },
     agave_snapshots::SUPPORTED_ARCHIVE_COMPRESSION,
     clap::{values_t, App, Arg, ArgMatches},
-    solana_accounts_db::accounts_db::AccountsDbConfig,
-    solana_accounts_db::utils::create_and_canonicalize_directory,
+    solana_accounts_db::{accounts_db::AccountsDbConfig, utils::create_and_canonicalize_directory},
     solana_clap_utils::{
         hidden_unless_forced,
         input_parsers::keypair_of,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1545,7 +1545,7 @@ fn validators_set(
 mod tests {
     use {
         super::*,
-        crate::cli::thread_args::thread_args,
+        crate::cli::{get_deprecated_arguments, thread_args::thread_args},
         scopeguard::defer,
         solana_accounts_db::accounts_index::AccountsIndexConfig,
         solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,
@@ -1627,7 +1627,8 @@ mod tests {
         expected_args: RunArgs,
     ) {
         let app = add_args(App::new("run_command"), default_args)
-            .args(&thread_args(&default_args.thread_args));
+            .args(&thread_args(&default_args.thread_args))
+            .args(&get_deprecated_arguments());
 
         crate::commands::tests::verify_args_struct_by_command::<RunArgs>(
             app,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -137,6 +137,8 @@ impl FromClapArgMatches for RunArgs {
 
         let socket_addr_space = SocketAddrSpace::new(matches.is_present("allow_private_addr"));
 
+        let accounts_db_config = accounts_db_config::new_accounts_db_config(matches, &ledger_path)?;
+
         Ok(RunArgs {
             identity_keypair,
             ledger_path,
@@ -151,7 +153,7 @@ impl FromClapArgMatches for RunArgs {
             send_transaction_service_config: SendTransactionServiceConfig::from_clap_arg_match(
                 matches,
             )?,
-            accounts_db_config: AccountsDbConfig::from_clap_arg_match(matches)?,
+            accounts_db_config,
         })
     }
 }
@@ -1567,7 +1569,7 @@ mod tests {
 
             RunArgs {
                 identity_keypair,
-                ledger_path,
+                ledger_path: ledger_path.clone(),
                 logfile,
                 entrypoints,
                 known_validators,
@@ -1599,6 +1601,7 @@ mod tests {
                         ..AccountsIndexConfig::default()
                     }),
                     account_indexes: Some(AccountSecondaryIndexes::default()),
+                    base_working_path: Some(ledger_path.clone()),
                     num_background_threads: Some(
                         NonZeroUsize::new(solana_accounts_db::accounts_db::quarter_thread_count())
                             .unwrap(),

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1612,7 +1612,8 @@ mod tests {
                         )
                         .unwrap(),
                     ),
-                    memlock_budget_size: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_SIZE,
+                    memlock_budget_size:
+                        solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_SIZE,
                     ..AccountsDbConfig::default()
                 },
             }
@@ -1743,6 +1744,14 @@ mod tests {
 
             let expected_args = RunArgs {
                 ledger_path: ledger_path.clone(),
+                accounts_db_config: AccountsDbConfig {
+                    index: Some(AccountsIndexConfig {
+                        drives: Some(vec![ledger_path.join("accounts_index")]),
+                        ..default_run_args.accounts_db_config.clone().index.unwrap()
+                    }),
+                    base_working_path: Some(ledger_path.clone()),
+                    ..default_run_args.accounts_db_config.clone()
+                },
                 ..default_run_args.clone()
             };
             verify_args_struct_by_command_run_with_identity_setup(
@@ -1764,6 +1773,14 @@ mod tests {
 
             let expected_args = RunArgs {
                 ledger_path: ledger_path.clone(),
+                accounts_db_config: AccountsDbConfig {
+                    index: Some(AccountsIndexConfig {
+                        drives: Some(vec![ledger_path.join("accounts_index")]),
+                        ..default_run_args.accounts_db_config.clone().index.unwrap()
+                    }),
+                    base_working_path: Some(ledger_path.clone()),
+                    ..default_run_args.accounts_db_config.clone()
+                },
                 ..default_run_args.clone()
             };
             verify_args_struct_by_command_run_with_identity_setup(
@@ -1783,8 +1800,17 @@ mod tests {
                 fs::remove_dir_all(&ledger_path).unwrap()
             };
 
+            let expected_ledger_path = absolute(&ledger_path).unwrap();
             let expected_args = RunArgs {
-                ledger_path: absolute(&ledger_path).unwrap(),
+                ledger_path: expected_ledger_path.clone(),
+                accounts_db_config: AccountsDbConfig {
+                    index: Some(AccountsIndexConfig {
+                        drives: Some(vec![expected_ledger_path.join("accounts_index")]),
+                        ..default_run_args.accounts_db_config.clone().index.unwrap()
+                    }),
+                    base_working_path: Some(expected_ledger_path.clone()),
+                    ..default_run_args.accounts_db_config.clone()
+                },
                 ..default_run_args.clone()
             };
             verify_args_struct_by_command_run_with_identity_setup(
@@ -1805,8 +1831,17 @@ mod tests {
                 fs::remove_dir_all(&ledger_path).unwrap()
             };
 
+            let expected_ledger_path = absolute(&ledger_path).unwrap();
             let expected_args = RunArgs {
-                ledger_path: absolute(&ledger_path).unwrap(),
+                ledger_path: expected_ledger_path.clone(),
+                accounts_db_config: AccountsDbConfig {
+                    index: Some(AccountsIndexConfig {
+                        drives: Some(vec![expected_ledger_path.join("accounts_index")]),
+                        ..default_run_args.accounts_db_config.clone().index.unwrap()
+                    }),
+                    base_working_path: Some(expected_ledger_path.clone()),
+                    ..default_run_args.accounts_db_config.clone()
+                },
                 ..default_run_args.clone()
             };
             verify_args_struct_by_command_run_with_identity_setup(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1552,6 +1552,7 @@ mod tests {
         std::{
             fs,
             net::{IpAddr, Ipv4Addr},
+            num::NonZeroUsize,
             path::{absolute, PathBuf},
         },
     };
@@ -1598,6 +1599,10 @@ mod tests {
                         ..AccountsIndexConfig::default()
                     }),
                     account_indexes: Some(AccountSecondaryIndexes::default()),
+                    num_background_threads: Some(
+                        NonZeroUsize::new(solana_accounts_db::accounts_db::quarter_thread_count())
+                            .unwrap(),
+                    ),
                     ..AccountsDbConfig::default()
                 },
             }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1603,6 +1603,12 @@ mod tests {
                         NonZeroUsize::new(solana_accounts_db::accounts_db::quarter_thread_count())
                             .unwrap(),
                     ),
+                    num_foreground_threads: Some(
+                        NonZeroUsize::new(
+                            solana_accounts_db::accounts_db::default_num_foreground_threads(),
+                        )
+                        .unwrap(),
+                    ),
                     ..AccountsDbConfig::default()
                 },
             }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1547,7 +1547,7 @@ mod tests {
         super::*,
         crate::cli::{get_deprecated_arguments, thread_args::thread_args},
         scopeguard::defer,
-        solana_accounts_db::accounts_index::AccountsIndexConfig,
+        solana_accounts_db::accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig},
         solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,
         std::{
             fs,
@@ -1597,6 +1597,7 @@ mod tests {
                         drives: Some(vec![]),
                         ..AccountsIndexConfig::default()
                     }),
+                    account_indexes: Some(AccountSecondaryIndexes::default()),
                     ..AccountsDbConfig::default()
                 },
             }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -61,6 +61,7 @@ const WEN_RESTART_HELP: &str =
 
 pub mod account_secondary_indexes;
 pub mod accounts_db_config;
+pub mod accounts_index_config;
 pub mod blockstore_options;
 pub mod json_rpc_config;
 pub mod pub_sub_config;
@@ -1546,6 +1547,7 @@ mod tests {
         super::*,
         crate::cli::thread_args::thread_args,
         scopeguard::defer,
+        solana_accounts_db::accounts_index::AccountsIndexConfig,
         solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,
         std::{
             fs,
@@ -1587,7 +1589,15 @@ mod tests {
                     ..PubSubConfig::default_for_tests()
                 },
                 send_transaction_service_config: SendTransactionServiceConfig::default(),
-                accounts_db_config: AccountsDbConfig::default(),
+                accounts_db_config: AccountsDbConfig {
+                    index: Some(AccountsIndexConfig {
+                        num_flush_threads: Some(
+                            solana_accounts_db::accounts_index::default_num_flush_threads(),
+                        ),
+                        ..AccountsIndexConfig::default()
+                    }),
+                    ..AccountsDbConfig::default()
+                },
             }
         }
     }

--- a/validator/src/commands/run/args/account_secondary_indexes.rs
+++ b/validator/src/commands/run/args/account_secondary_indexes.rs
@@ -66,6 +66,7 @@ mod tests {
         crate::commands::run::args::{
             tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
         },
+        solana_accounts_db::accounts_db::AccountsDbConfig,
         solana_rpc::rpc::JsonRpcConfig,
         test_case::test_case,
     };
@@ -78,13 +79,18 @@ mod tests {
         expected_index: AccountIndex,
     ) {
         let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_account_indexes = AccountSecondaryIndexes {
+            keys: None,
+            indexes: HashSet::from([expected_index]),
+        };
         let expected_args = RunArgs {
             json_rpc_config: JsonRpcConfig {
-                account_indexes: AccountSecondaryIndexes {
-                    keys: None,
-                    indexes: HashSet::from([expected_index]),
-                },
+                account_indexes: expected_account_indexes.clone(),
                 ..default_run_args.json_rpc_config.clone()
+            },
+            accounts_db_config: AccountsDbConfig {
+                account_indexes: Some(expected_account_indexes.clone()),
+                ..default_run_args.accounts_db_config.clone()
             },
             ..default_run_args.clone()
         };
@@ -98,17 +104,22 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_run_with_account_indexes_multiple() {
         let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_account_indexes = AccountSecondaryIndexes {
+            keys: None,
+            indexes: HashSet::from([
+                AccountIndex::ProgramId,
+                AccountIndex::SplTokenMint,
+                AccountIndex::SplTokenOwner,
+            ]),
+        };
         let expected_args = RunArgs {
             json_rpc_config: JsonRpcConfig {
-                account_indexes: AccountSecondaryIndexes {
-                    keys: None,
-                    indexes: HashSet::from([
-                        AccountIndex::ProgramId,
-                        AccountIndex::SplTokenMint,
-                        AccountIndex::SplTokenOwner,
-                    ]),
-                },
+                account_indexes: expected_account_indexes.clone(),
                 ..default_run_args.json_rpc_config.clone()
+            },
+            accounts_db_config: AccountsDbConfig {
+                account_indexes: Some(expected_account_indexes.clone()),
+                ..default_run_args.accounts_db_config.clone()
             },
             ..default_run_args.clone()
         };
@@ -132,16 +143,21 @@ mod tests {
         {
             let default_run_args = crate::commands::run::args::RunArgs::default();
             let account_pubkey_1 = Pubkey::new_unique();
+            let expected_account_indexes = AccountSecondaryIndexes {
+                keys: Some(AccountSecondaryIndexesIncludeExclude {
+                    exclude: false,
+                    keys: HashSet::from([account_pubkey_1]),
+                }),
+                indexes: HashSet::from([AccountIndex::ProgramId]),
+            };
             let expected_args = RunArgs {
                 json_rpc_config: JsonRpcConfig {
-                    account_indexes: AccountSecondaryIndexes {
-                        keys: Some(AccountSecondaryIndexesIncludeExclude {
-                            exclude: false,
-                            keys: HashSet::from([account_pubkey_1]),
-                        }),
-                        indexes: HashSet::from([AccountIndex::ProgramId]),
-                    },
+                    account_indexes: expected_account_indexes.clone(),
                     ..default_run_args.json_rpc_config.clone()
+                },
+                accounts_db_config: AccountsDbConfig {
+                    account_indexes: Some(expected_account_indexes.clone()),
+                    ..default_run_args.accounts_db_config.clone()
                 },
                 ..default_run_args.clone()
             };
@@ -163,20 +179,21 @@ mod tests {
             let account_pubkey_1 = Pubkey::new_unique();
             let account_pubkey_2 = Pubkey::new_unique();
             let account_pubkey_3 = Pubkey::new_unique();
+            let expected_account_indexes = AccountSecondaryIndexes {
+                keys: Some(AccountSecondaryIndexesIncludeExclude {
+                    exclude: false,
+                    keys: HashSet::from([account_pubkey_1, account_pubkey_2, account_pubkey_3]),
+                }),
+                indexes: HashSet::from([AccountIndex::ProgramId]),
+            };
             let expected_args = RunArgs {
                 json_rpc_config: JsonRpcConfig {
-                    account_indexes: AccountSecondaryIndexes {
-                        keys: Some(AccountSecondaryIndexesIncludeExclude {
-                            exclude: false,
-                            keys: HashSet::from([
-                                account_pubkey_1,
-                                account_pubkey_2,
-                                account_pubkey_3,
-                            ]),
-                        }),
-                        indexes: HashSet::from([AccountIndex::ProgramId]),
-                    },
+                    account_indexes: expected_account_indexes.clone(),
                     ..default_run_args.json_rpc_config.clone()
+                },
+                accounts_db_config: AccountsDbConfig {
+                    account_indexes: Some(expected_account_indexes.clone()),
+                    ..default_run_args.accounts_db_config.clone()
                 },
                 ..default_run_args.clone()
             };
@@ -203,16 +220,21 @@ mod tests {
         {
             let default_run_args = crate::commands::run::args::RunArgs::default();
             let account_pubkey_1 = Pubkey::new_unique();
+            let expected_account_indexes = AccountSecondaryIndexes {
+                keys: Some(AccountSecondaryIndexesIncludeExclude {
+                    exclude: true,
+                    keys: HashSet::from([account_pubkey_1]),
+                }),
+                indexes: HashSet::from([AccountIndex::ProgramId]),
+            };
             let expected_args = RunArgs {
                 json_rpc_config: JsonRpcConfig {
-                    account_indexes: AccountSecondaryIndexes {
-                        keys: Some(AccountSecondaryIndexesIncludeExclude {
-                            exclude: true,
-                            keys: HashSet::from([account_pubkey_1]),
-                        }),
-                        indexes: HashSet::from([AccountIndex::ProgramId]),
-                    },
+                    account_indexes: expected_account_indexes.clone(),
                     ..default_run_args.json_rpc_config.clone()
+                },
+                accounts_db_config: AccountsDbConfig {
+                    account_indexes: Some(expected_account_indexes.clone()),
+                    ..default_run_args.accounts_db_config.clone()
                 },
                 ..default_run_args.clone()
             };
@@ -234,20 +256,21 @@ mod tests {
             let account_pubkey_1 = Pubkey::new_unique();
             let account_pubkey_2 = Pubkey::new_unique();
             let account_pubkey_3 = Pubkey::new_unique();
+            let expected_account_indexes = AccountSecondaryIndexes {
+                keys: Some(AccountSecondaryIndexesIncludeExclude {
+                    exclude: true,
+                    keys: HashSet::from([account_pubkey_1, account_pubkey_2, account_pubkey_3]),
+                }),
+                indexes: HashSet::from([AccountIndex::ProgramId]),
+            };
             let expected_args = RunArgs {
                 json_rpc_config: JsonRpcConfig {
-                    account_indexes: AccountSecondaryIndexes {
-                        keys: Some(AccountSecondaryIndexesIncludeExclude {
-                            exclude: true,
-                            keys: HashSet::from([
-                                account_pubkey_1,
-                                account_pubkey_2,
-                                account_pubkey_3,
-                            ]),
-                        }),
-                        indexes: HashSet::from([AccountIndex::ProgramId]),
-                    },
+                    account_indexes: expected_account_indexes.clone(),
                     ..default_run_args.json_rpc_config.clone()
+                },
+                accounts_db_config: AccountsDbConfig {
+                    account_indexes: Some(expected_account_indexes.clone()),
+                    ..default_run_args.accounts_db_config.clone()
                 },
                 ..default_run_args.clone()
             };

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -73,6 +73,9 @@ impl FromClapArgMatches for AccountsDbConfig {
             .ok()
             .map(|mb| mb * MIB as u64);
 
+        let ancient_append_vec_offset =
+            value_t!(matches, "accounts_db_ancient_append_vecs", i64).ok();
+
         Ok(AccountsDbConfig {
             index: Some(accounts_index_config),
             account_indexes: Some(account_indexes),
@@ -80,6 +83,7 @@ impl FromClapArgMatches for AccountsDbConfig {
             shrink_ratio,
             read_cache_limit_bytes,
             write_cache_limit_bytes,
+            ancient_append_vec_offset,
             ..Default::default()
         })
     }
@@ -232,6 +236,23 @@ mod tests {
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
             vec!["--accounts-db-cache-limit-mb", "10"],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_accounts_db_ancient_append_vecs() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            accounts_db_config: AccountsDbConfig {
+                ancient_append_vec_offset: Some(999_999),
+                ..default_run_args.accounts_db_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--accounts-db-ancient-append-vecs", "999999"],
             expected_args,
         );
     }

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -76,6 +76,9 @@ impl FromClapArgMatches for AccountsDbConfig {
         let ancient_append_vec_offset =
             value_t!(matches, "accounts_db_ancient_append_vecs", i64).ok();
 
+        let ancient_storage_ideal_size =
+            value_t!(matches, "accounts_db_ancient_storage_ideal_size", u64).ok();
+
         Ok(AccountsDbConfig {
             index: Some(accounts_index_config),
             account_indexes: Some(account_indexes),
@@ -84,6 +87,7 @@ impl FromClapArgMatches for AccountsDbConfig {
             read_cache_limit_bytes,
             write_cache_limit_bytes,
             ancient_append_vec_offset,
+            ancient_storage_ideal_size,
             ..Default::default()
         })
     }
@@ -253,6 +257,23 @@ mod tests {
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
             vec!["--accounts-db-ancient-append-vecs", "999999"],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_accounts_db_ancient_storage_ideal_size() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            accounts_db_config: AccountsDbConfig {
+                ancient_storage_ideal_size: Some(999_999),
+                ..default_run_args.accounts_db_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--accounts-db-ancient-storage-ideal-size", "999999"],
             expected_args,
         );
     }

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -148,7 +148,7 @@ pub fn new_accounts_db_config(
         num_foreground_threads: Some(accounts_db_foreground_threads),
         mark_obsolete_accounts,
         memlock_budget_size: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_SIZE,
-        ..Default::default()
+        ..AccountsDbConfig::default()
     })
 }
 

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -13,12 +13,15 @@ use {
         utils::{create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories},
     },
     solana_clap_utils::input_parsers::values_of,
-    std::{num::NonZeroUsize, path::PathBuf},
+    std::{
+        num::NonZeroUsize,
+        path::{Path, PathBuf},
+    },
 };
 
 pub fn new_accounts_db_config(
     matches: &ArgMatches,
-    ledger_path: &PathBuf,
+    ledger_path: &Path,
 ) -> Result<AccountsDbConfig> {
     let accounts_index_config = AccountsIndexConfig::from_clap_arg_match(matches)?;
 
@@ -33,7 +36,7 @@ pub fn new_accounts_db_config(
         return Err(crate::commands::Error::Dynamic(
             Box::<dyn std::error::Error>::from(format!(
                 "the specified account-shrink-ratio is invalid, it must be between 0. and 1.0 \
-             inclusive: {shrink_ratio}"
+                 inclusive: {shrink_ratio}"
             )),
         ));
     }
@@ -133,7 +136,7 @@ pub fn new_accounts_db_config(
     Ok(AccountsDbConfig {
         index: Some(accounts_index_config),
         account_indexes: Some(account_indexes),
-        base_working_path: Some(ledger_path.clone()),
+        base_working_path: Some(ledger_path.to_path_buf()),
         shrink_paths: account_shrink_run_paths,
         shrink_ratio,
         read_cache_limit_bytes,
@@ -152,6 +155,7 @@ pub fn new_accounts_db_config(
     })
 }
 
+#[allow(clippy::type_complexity)]
 pub fn parse_account_shrink_paths(
     matches: &ArgMatches,
 ) -> Result<(Option<Vec<PathBuf>>, Option<Vec<PathBuf>>)> {
@@ -262,8 +266,8 @@ mod tests {
         );
     }
 
-    #[test_case("1,10", (1 * 1024 * 1024, 10 * 1024 * 1024))]
-    #[test_case("1", (1 * 1024 * 1024, 1 * 1024 * 1024))]
+    #[test_case("1,10", (1024 * 1024, 10 * 1024 * 1024))]
+    #[test_case("1", (1024 * 1024, 1024 * 1024))]
     fn verify_args_struct_by_command_run_with_accounts_db_read_cache_limit_mb(
         accounts_db_read_cache_limit_mb: &str,
         expected_read_cache_limit_bytes: (usize, usize),

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -82,6 +82,8 @@ impl FromClapArgMatches for AccountsDbConfig {
         let max_ancient_storages =
             value_t!(matches, "accounts_db_max_ancient_storages", usize).ok();
 
+        let exhaustively_verify_refcounts = matches.is_present("accounts_db_verify_refcounts");
+
         Ok(AccountsDbConfig {
             index: Some(accounts_index_config),
             account_indexes: Some(account_indexes),
@@ -92,6 +94,7 @@ impl FromClapArgMatches for AccountsDbConfig {
             ancient_append_vec_offset,
             ancient_storage_ideal_size,
             max_ancient_storages,
+            exhaustively_verify_refcounts,
             ..Default::default()
         })
     }
@@ -295,6 +298,23 @@ mod tests {
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
             vec!["--accounts-db-max-ancient-storages", "999999"],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_accounts_db_verify_refcounts() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            accounts_db_config: AccountsDbConfig {
+                exhaustively_verify_refcounts: true,
+                ..default_run_args.accounts_db_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--accounts-db-verify-refcounts"],
             expected_args,
         );
     }

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -79,6 +79,9 @@ impl FromClapArgMatches for AccountsDbConfig {
         let ancient_storage_ideal_size =
             value_t!(matches, "accounts_db_ancient_storage_ideal_size", u64).ok();
 
+        let max_ancient_storages =
+            value_t!(matches, "accounts_db_max_ancient_storages", usize).ok();
+
         Ok(AccountsDbConfig {
             index: Some(accounts_index_config),
             account_indexes: Some(account_indexes),
@@ -88,6 +91,7 @@ impl FromClapArgMatches for AccountsDbConfig {
             write_cache_limit_bytes,
             ancient_append_vec_offset,
             ancient_storage_ideal_size,
+            max_ancient_storages,
             ..Default::default()
         })
     }
@@ -274,6 +278,23 @@ mod tests {
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
             vec!["--accounts-db-ancient-storage-ideal-size", "999999"],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_accounts_db_max_ancient_storages() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            accounts_db_config: AccountsDbConfig {
+                max_ancient_storages: Some(999_999),
+                ..default_run_args.accounts_db_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--accounts-db-max-ancient-storages", "999999"],
             expected_args,
         );
     }

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -1,6 +1,8 @@
 use {
     crate::{
-        cli::thread_args::{AccountsDbBackgroundThreadsArg, ThreadArg},
+        cli::thread_args::{
+            AccountsDbBackgroundThreadsArg, AccountsDbForegroundThreadsArg, ThreadArg,
+        },
         commands::{FromClapArgMatches, Result},
     },
     clap::{value_t, values_t, ArgMatches},
@@ -121,6 +123,9 @@ impl FromClapArgMatches for AccountsDbConfig {
             }
         };
 
+        let accounts_db_foreground_threads =
+            value_t!(matches, AccountsDbForegroundThreadsArg::NAME, NonZeroUsize)?;
+
         Ok(AccountsDbConfig {
             index: Some(accounts_index_config),
             account_indexes: Some(account_indexes),
@@ -135,6 +140,7 @@ impl FromClapArgMatches for AccountsDbConfig {
             storage_access,
             scan_filter_for_shrinking,
             num_background_threads: Some(accounts_db_background_threads),
+            num_foreground_threads: Some(accounts_db_foreground_threads),
             ..Default::default()
         })
     }
@@ -429,6 +435,23 @@ mod tests {
                 accounts_db_background_threads,
                 accounts_db_background_threads_value,
             ],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_accounts_db_foreground_threads() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            accounts_db_config: AccountsDbConfig {
+                num_foreground_threads: Some(NonZeroUsize::new(2).unwrap()),
+                ..default_run_args.accounts_db_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--accounts-db-foreground-threads", "2"],
             expected_args,
         );
     }

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -1,0 +1,13 @@
+use {
+    crate::commands::{FromClapArgMatches, Result},
+    clap::ArgMatches,
+    solana_accounts_db::accounts_db::AccountsDbConfig,
+};
+
+impl FromClapArgMatches for AccountsDbConfig {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        Ok(AccountsDbConfig {
+            ..Default::default()
+        })
+    }
+}

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -148,6 +148,7 @@ impl FromClapArgMatches for AccountsDbConfig {
             num_background_threads: Some(accounts_db_background_threads),
             num_foreground_threads: Some(accounts_db_foreground_threads),
             mark_obsolete_accounts,
+            memlock_budget_size: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_SIZE,
             ..Default::default()
         })
     }

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -1,12 +1,15 @@
 use {
     crate::commands::{FromClapArgMatches, Result},
     clap::ArgMatches,
-    solana_accounts_db::accounts_db::AccountsDbConfig,
+    solana_accounts_db::{accounts_db::AccountsDbConfig, accounts_index::AccountsIndexConfig},
 };
 
 impl FromClapArgMatches for AccountsDbConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        let accounts_index_config = AccountsIndexConfig::from_clap_arg_match(matches)?;
+
         Ok(AccountsDbConfig {
+            index: Some(accounts_index_config),
             ..Default::default()
         })
     }

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -1,15 +1,18 @@
 use {
     crate::commands::{FromClapArgMatches, Result},
     clap::ArgMatches,
-    solana_accounts_db::{accounts_db::AccountsDbConfig, accounts_index::AccountsIndexConfig},
+    solana_accounts_db::{accounts_db::AccountsDbConfig, accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig}},
 };
 
 impl FromClapArgMatches for AccountsDbConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         let accounts_index_config = AccountsIndexConfig::from_clap_arg_match(matches)?;
 
+        let account_indexes = AccountSecondaryIndexes::from_clap_arg_match(matches)?;
+
         Ok(AccountsDbConfig {
             index: Some(accounts_index_config),
+            account_indexes: Some(account_indexes),
             ..Default::default()
         })
     }

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -23,7 +23,10 @@ pub fn new_accounts_db_config(
     matches: &ArgMatches,
     ledger_path: &Path,
 ) -> Result<AccountsDbConfig> {
-    let accounts_index_config = AccountsIndexConfig::from_clap_arg_match(matches)?;
+    let mut accounts_index_config = AccountsIndexConfig::from_clap_arg_match(matches)?;
+    if accounts_index_config.drives.as_ref().unwrap().is_empty() {
+        accounts_index_config.drives = Some(vec![ledger_path.join("accounts_index")]);
+    }
 
     let account_indexes = AccountSecondaryIndexes::from_clap_arg_match(matches)?;
 

--- a/validator/src/commands/run/args/accounts_db_config.rs
+++ b/validator/src/commands/run/args/accounts_db_config.rs
@@ -1,7 +1,12 @@
 use {
     crate::commands::{FromClapArgMatches, Result},
-    clap::ArgMatches,
-    solana_accounts_db::{accounts_db::AccountsDbConfig, accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig}},
+    clap::{values_t, ArgMatches},
+    solana_accounts_db::{
+        accounts_db::AccountsDbConfig,
+        accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig},
+        utils::{create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories},
+    },
+    std::path::PathBuf,
 };
 
 impl FromClapArgMatches for AccountsDbConfig {
@@ -10,10 +15,77 @@ impl FromClapArgMatches for AccountsDbConfig {
 
         let account_indexes = AccountSecondaryIndexes::from_clap_arg_match(matches)?;
 
+        let (account_shrink_run_paths, _) = parse_account_shrink_paths(matches)?;
+
         Ok(AccountsDbConfig {
             index: Some(accounts_index_config),
             account_indexes: Some(account_indexes),
+            shrink_paths: account_shrink_run_paths,
             ..Default::default()
         })
+    }
+}
+
+pub fn parse_account_shrink_paths(
+    matches: &ArgMatches,
+) -> Result<(Option<Vec<PathBuf>>, Option<Vec<PathBuf>>)> {
+    let account_shrink_paths: Option<Vec<PathBuf>> =
+        values_t!(matches, "account_shrink_path", String)
+            .map(|shrink_paths| shrink_paths.into_iter().map(PathBuf::from).collect())
+            .ok();
+    let account_shrink_paths = account_shrink_paths
+        .as_ref()
+        .map(|paths| {
+            create_and_canonicalize_directories(paths).map_err(|err| {
+                crate::commands::Error::Dynamic(Box::<dyn std::error::Error>::from(format!(
+                    "unable to access account shrink path: {err}"
+                )))
+            })
+        })
+        .transpose()?;
+
+    let (account_shrink_run_paths, account_shrink_snapshot_paths) = account_shrink_paths
+        .map(|paths| {
+            create_all_accounts_run_and_snapshot_dirs(&paths).map_err(|err| {
+                crate::commands::Error::Dynamic(Box::<dyn std::error::Error>::from(format!(
+                    "unable to create account subdirectories: {err}"
+                )))
+            })
+        })
+        .transpose()?
+        .unzip();
+
+    Ok((account_shrink_run_paths, account_shrink_snapshot_paths))
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        crate::commands::run::args::{
+            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+        },
+        solana_accounts_db::{accounts_db::AccountsDbConfig, utils::ACCOUNTS_RUN_DIR},
+    };
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_account_shrink_path() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let expected_args = RunArgs {
+            accounts_db_config: AccountsDbConfig {
+                shrink_paths: Some(vec![tmp_dir
+                    .path()
+                    .canonicalize()
+                    .unwrap()
+                    .join(ACCOUNTS_RUN_DIR)]),
+                ..default_run_args.accounts_db_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--account-shrink-path", tmp_dir.path().to_str().unwrap()],
+            expected_args,
+        );
     }
 }

--- a/validator/src/commands/run/args/accounts_index_config.rs
+++ b/validator/src/commands/run/args/accounts_index_config.rs
@@ -40,7 +40,7 @@ impl FromClapArgMatches for AccountsIndexConfig {
             index_limit_mb,
             drives: Some(accounts_index_paths),
             scan_results_limit_bytes,
-            ..AccountsIndexConfig::default()
+            ages_to_stay_in_cache: None,
         })
     }
 }

--- a/validator/src/commands/run/args/accounts_index_config.rs
+++ b/validator/src/commands/run/args/accounts_index_config.rs
@@ -1,0 +1,52 @@
+use {
+    crate::{
+        cli::thread_args::{AccountsIndexFlushThreadsArg, ThreadArg},
+        commands::{FromClapArgMatches, Result},
+    },
+    clap::{value_t, ArgMatches},
+    solana_accounts_db::accounts_index::AccountsIndexConfig,
+    std::num::NonZeroUsize,
+};
+
+impl FromClapArgMatches for AccountsIndexConfig {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        let num_flush_threads = value_t!(matches, AccountsIndexFlushThreadsArg::NAME, NonZeroUsize)
+            .unwrap_or_else(|_| solana_accounts_db::accounts_index::default_num_flush_threads());
+
+        Ok(AccountsIndexConfig {
+            num_flush_threads: Some(num_flush_threads),
+            ..AccountsIndexConfig::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::commands::run::args::{
+            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+        },
+        solana_accounts_db::accounts_db::AccountsDbConfig,
+    };
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_accounts_index_flush_threads() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            accounts_db_config: AccountsDbConfig {
+                index: Some(AccountsIndexConfig {
+                    num_flush_threads: Some(NonZeroUsize::new(2).unwrap()),
+                    ..default_run_args.accounts_db_config.clone().index.unwrap()
+                }),
+                ..default_run_args.accounts_db_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--accounts-index-flush-threads", "2"],
+            expected_args,
+        );
+    }
+}

--- a/validator/src/commands/run/args/accounts_index_config.rs
+++ b/validator/src/commands/run/args/accounts_index_config.rs
@@ -15,6 +15,7 @@ impl FromClapArgMatches for AccountsIndexConfig {
 
         Ok(AccountsIndexConfig {
             num_flush_threads: Some(num_flush_threads),
+            bins: value_t!(matches, "accounts_index_bins", usize).ok(),
             ..AccountsIndexConfig::default()
         })
     }
@@ -46,6 +47,26 @@ mod tests {
         verify_args_struct_by_command_run_with_identity_setup(
             default_run_args,
             vec!["--accounts-index-flush-threads", "2"],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_accounts_index_bins() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            accounts_db_config: AccountsDbConfig {
+                index: Some(AccountsIndexConfig {
+                    bins: Some(512),
+                    ..default_run_args.accounts_db_config.clone().index.unwrap()
+                }),
+                ..default_run_args.accounts_db_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--accounts-index-bins", "512"],
             expected_args,
         );
     }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -13,7 +13,6 @@ use {
     rand::{seq::SliceRandom, thread_rng},
     solana_accounts_db::{
         accounts_db::{AccountsDbConfig, MarkObsoleteAccounts},
-        accounts_file::StorageAccess,
         accounts_index::{AccountsIndexConfig, ScanFilter},
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         utils::{
@@ -288,18 +287,6 @@ pub fn execute(
         accounts_index_config.drives = Some(vec![ledger_path.join("accounts_index")]);
     }
 
-    let storage_access = matches
-        .value_of("accounts_db_access_storages_method")
-        .map(|method| match method {
-            "mmap" => StorageAccess::Mmap,
-            "file" => StorageAccess::File,
-            _ => {
-                // clap will enforce one of the above values is given
-                unreachable!("invalid value given to accounts-db-access-storages-method")
-            }
-        })
-        .unwrap_or_default();
-
     let scan_filter_for_shrinking = matches
         .value_of("accounts_db_scan_filter_for_shrinking")
         .map(|filter| match filter {
@@ -331,7 +318,7 @@ pub fn execute(
         ancient_storage_ideal_size: run_args.accounts_db_config.ancient_storage_ideal_size.clone(),
         max_ancient_storages: run_args.accounts_db_config.max_ancient_storages.clone(),
         exhaustively_verify_refcounts: run_args.accounts_db_config.exhaustively_verify_refcounts.clone(),
-        storage_access,
+        storage_access: run_args.accounts_db_config.storage_access.clone(),
         scan_filter_for_shrinking,
         num_background_threads: Some(accounts_db_background_threads),
         num_foreground_threads: Some(accounts_db_foreground_threads),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -285,12 +285,6 @@ pub fn execute(
         accounts_index_config.drives = Some(vec![ledger_path.join("accounts_index")]);
     }
 
-    let mark_obsolete_accounts = if matches.is_present("accounts_db_mark_obsolete_accounts") {
-        MarkObsoleteAccounts::Enabled
-    } else {
-        MarkObsoleteAccounts::Disabled
-    };
-
     let accounts_db_config = AccountsDbConfig {
         index: run_args.accounts_db_config.index.clone(),
         account_indexes: run_args.accounts_db_config.account_indexes.clone(),
@@ -319,7 +313,7 @@ pub fn execute(
             .clone(),
         num_background_threads: run_args.accounts_db_config.num_background_threads.clone(),
         num_foreground_threads: run_args.accounts_db_config.num_foreground_threads.clone(),
-        mark_obsolete_accounts,
+        mark_obsolete_accounts: run_args.accounts_db_config.mark_obsolete_accounts.clone(),
         memlock_budget_size: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_SIZE,
         ..AccountsDbConfig::default()
     };
@@ -392,7 +386,7 @@ pub fn execute(
         UseSnapshotArchivesAtStartup
     );
 
-    if mark_obsolete_accounts == MarkObsoleteAccounts::Enabled
+    if run_args.accounts_db_config.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled
         && use_snapshot_archives_at_startup != UseSnapshotArchivesAtStartup::Always
     {
         Err(format!(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -14,7 +14,7 @@ use {
     solana_accounts_db::{
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig, MarkObsoleteAccounts},
         accounts_file::StorageAccess,
-        accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig, IndexLimitMb, ScanFilter},
+        accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig, ScanFilter},
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         utils::{
             create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories,
@@ -301,12 +301,6 @@ pub fn execute(
         Arc::new(tower_storage::FileTowerStorage::new(tower_path));
 
     let mut accounts_index_config = AccountsIndexConfig::from_clap_arg_match(matches)?;
-
-    accounts_index_config.index_limit_mb = if !matches.is_present("enable_accounts_disk_index") {
-        IndexLimitMb::InMemOnly
-    } else {
-        IndexLimitMb::Minimal
-    };
 
     {
         let mut accounts_index_paths: Vec<PathBuf> = if matches.is_present("accounts_index_path") {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -306,10 +306,6 @@ pub fn execute(
     }
 
     const MB: usize = 1_024 * 1_024;
-    accounts_index_config.scan_results_limit_bytes =
-        value_t!(matches, "accounts_index_scan_results_limit_mb", usize)
-            .ok()
-            .map(|mb| mb * MB);
 
     let account_shrink_paths: Option<Vec<PathBuf>> =
         values_t!(matches, "account_shrink_path", String)

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -329,7 +329,7 @@ pub fn execute(
         write_cache_limit_bytes: run_args.accounts_db_config.write_cache_limit_bytes.clone(),
         ancient_append_vec_offset: run_args.accounts_db_config.ancient_append_vec_offset.clone(),
         ancient_storage_ideal_size: run_args.accounts_db_config.ancient_storage_ideal_size.clone(),
-        max_ancient_storages: value_t!(matches, "accounts_db_max_ancient_storages", usize).ok(),
+        max_ancient_storages: run_args.accounts_db_config.max_ancient_storages.clone(),
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
         storage_access,
         scan_filter_for_shrinking,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -96,7 +96,6 @@ pub fn execute(
     let cli::thread_args::NumThreadConfig {
         accounts_db_background_threads,
         accounts_db_foreground_threads,
-        accounts_index_flush_threads,
         block_production_num_workers,
         ip_echo_server_threads,
         rayon_global_threads,
@@ -301,10 +300,7 @@ pub fn execute(
     let tower_storage: Arc<dyn tower_storage::TowerStorage> =
         Arc::new(tower_storage::FileTowerStorage::new(tower_path));
 
-    let mut accounts_index_config = AccountsIndexConfig {
-        num_flush_threads: Some(accounts_index_flush_threads),
-        ..AccountsIndexConfig::default()
-    };
+    let mut accounts_index_config = AccountsIndexConfig::from_clap_arg_match(matches)?;
     if let Ok(bins) = value_t!(matches, "accounts_index_bins", usize) {
         accounts_index_config.bins = Some(bins);
     }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -288,8 +288,6 @@ pub fn execute(
         accounts_index_config.drives = Some(vec![ledger_path.join("accounts_index")]);
     }
 
-    const MB: usize = 1_024 * 1_024;
-
     let storage_access = matches
         .value_of("accounts_db_access_storages_method")
         .map(|method| match method {
@@ -328,9 +326,7 @@ pub fn execute(
         shrink_paths: run_args.accounts_db_config.shrink_paths.clone(),
         shrink_ratio: run_args.accounts_db_config.shrink_ratio.clone(),
         read_cache_limit_bytes: run_args.accounts_db_config.read_cache_limit_bytes.clone(),
-        write_cache_limit_bytes: value_t!(matches, "accounts_db_cache_limit_mb", u64)
-            .ok()
-            .map(|mb| mb * MB as u64),
+        write_cache_limit_bytes: run_args.accounts_db_config.write_cache_limit_bytes.clone(),
         ancient_append_vec_offset: value_t!(matches, "accounts_db_ancient_append_vecs", i64).ok(),
         ancient_storage_ideal_size: value_t!(
             matches,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -22,7 +22,7 @@ use {
         },
     },
     solana_clap_utils::input_parsers::{
-        keypair_of, keypairs_of, parse_cpu_ranges, pubkey_of, value_of, values_of,
+        keypair_of, keypairs_of, parse_cpu_ranges, pubkey_of, value_of,
     },
     solana_clock::{Slot, DEFAULT_SLOTS_PER_EPOCH},
     solana_core::{
@@ -290,35 +290,6 @@ pub fn execute(
 
     const MB: usize = 1_024 * 1_024;
 
-    let read_cache_limit_bytes =
-        values_of::<usize>(matches, "accounts_db_read_cache_limit").map(|limits| {
-            match limits.len() {
-                2 => (limits[0], limits[1]),
-                _ => {
-                    // clap will enforce two values are given
-                    unreachable!("invalid number of values given to accounts-db-read-cache-limit")
-                }
-            }
-        });
-    // accounts-db-read-cache-limit-mb was deprecated in v3.0.0
-    let read_cache_limit_mb =
-        values_of::<usize>(matches, "accounts_db_read_cache_limit_mb").map(|limits| {
-            match limits.len() {
-                // we were given explicit low and high watermark values, so use them
-                2 => (limits[0] * MB, limits[1] * MB),
-                // we were given a single value, so use it for both low and high watermarks
-                1 => (limits[0] * MB, limits[0] * MB),
-                _ => {
-                    // clap will enforce either one or two values is given
-                    unreachable!(
-                        "invalid number of values given to accounts-db-read-cache-limit-mb"
-                    )
-                }
-            }
-        });
-    // clap will enforce only one cli arg is provided, so pick whichever is Some
-    let read_cache_limit_bytes = read_cache_limit_bytes.or(read_cache_limit_mb);
-
     let storage_access = matches
         .value_of("accounts_db_access_storages_method")
         .map(|method| match method {
@@ -356,7 +327,7 @@ pub fn execute(
         base_working_path: Some(ledger_path.clone()),
         shrink_paths: run_args.accounts_db_config.shrink_paths.clone(),
         shrink_ratio: run_args.accounts_db_config.shrink_ratio.clone(),
-        read_cache_limit_bytes,
+        read_cache_limit_bytes: run_args.accounts_db_config.read_cache_limit_bytes.clone(),
         write_cache_limit_bytes: value_t!(matches, "accounts_db_cache_limit_mb", u64)
             .ok()
             .map(|mb| mb * MB as u64),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -327,7 +327,7 @@ pub fn execute(
         shrink_ratio: run_args.accounts_db_config.shrink_ratio.clone(),
         read_cache_limit_bytes: run_args.accounts_db_config.read_cache_limit_bytes.clone(),
         write_cache_limit_bytes: run_args.accounts_db_config.write_cache_limit_bytes.clone(),
-        ancient_append_vec_offset: value_t!(matches, "accounts_db_ancient_append_vecs", i64).ok(),
+        ancient_append_vec_offset: run_args.accounts_db_config.ancient_append_vec_offset.clone(),
         ancient_storage_ideal_size: value_t!(
             matches,
             "accounts_db_ancient_storage_ideal_size",

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -314,7 +314,7 @@ pub fn execute(
         num_background_threads: run_args.accounts_db_config.num_background_threads.clone(),
         num_foreground_threads: run_args.accounts_db_config.num_foreground_threads.clone(),
         mark_obsolete_accounts: run_args.accounts_db_config.mark_obsolete_accounts.clone(),
-        memlock_budget_size: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_SIZE,
+        memlock_budget_size: run_args.accounts_db_config.memlock_budget_size.clone(),
         ..AccountsDbConfig::default()
     };
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -13,7 +13,6 @@ use {
     rand::{seq::SliceRandom, thread_rng},
     solana_accounts_db::{
         accounts_db::MarkObsoleteAccounts,
-        accounts_index::AccountsIndexConfig,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         utils::{
             create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories,
@@ -279,11 +278,6 @@ pub fn execute(
         .unwrap_or_else(|| ledger_path.clone());
     let tower_storage: Arc<dyn tower_storage::TowerStorage> =
         Arc::new(tower_storage::FileTowerStorage::new(tower_path));
-
-    let mut accounts_index_config = AccountsIndexConfig::from_clap_arg_match(matches)?;
-    if accounts_index_config.drives.as_ref().unwrap().is_empty() {
-        accounts_index_config.drives = Some(vec![ledger_path.join("accounts_index")]);
-    }
 
     let on_start_geyser_plugin_config_files = if matches.is_present("geyser_plugin_config") {
         Some(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -13,7 +13,7 @@ use {
     rand::{seq::SliceRandom, thread_rng},
     solana_accounts_db::{
         accounts_db::{AccountsDbConfig, MarkObsoleteAccounts},
-        accounts_index::{AccountsIndexConfig, ScanFilter},
+        accounts_index::AccountsIndexConfig,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         utils::{
             create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories,
@@ -287,19 +287,6 @@ pub fn execute(
         accounts_index_config.drives = Some(vec![ledger_path.join("accounts_index")]);
     }
 
-    let scan_filter_for_shrinking = matches
-        .value_of("accounts_db_scan_filter_for_shrinking")
-        .map(|filter| match filter {
-            "all" => ScanFilter::All,
-            "only-abnormal" => ScanFilter::OnlyAbnormal,
-            "only-abnormal-with-verify" => ScanFilter::OnlyAbnormalWithVerify,
-            _ => {
-                // clap will enforce one of the above values is given
-                unreachable!("invalid value given to accounts_db_scan_filter_for_shrinking")
-            }
-        })
-        .unwrap_or_default();
-
     let mark_obsolete_accounts = if matches.is_present("accounts_db_mark_obsolete_accounts") {
         MarkObsoleteAccounts::Enabled
     } else {
@@ -314,12 +301,24 @@ pub fn execute(
         shrink_ratio: run_args.accounts_db_config.shrink_ratio.clone(),
         read_cache_limit_bytes: run_args.accounts_db_config.read_cache_limit_bytes.clone(),
         write_cache_limit_bytes: run_args.accounts_db_config.write_cache_limit_bytes.clone(),
-        ancient_append_vec_offset: run_args.accounts_db_config.ancient_append_vec_offset.clone(),
-        ancient_storage_ideal_size: run_args.accounts_db_config.ancient_storage_ideal_size.clone(),
+        ancient_append_vec_offset: run_args
+            .accounts_db_config
+            .ancient_append_vec_offset
+            .clone(),
+        ancient_storage_ideal_size: run_args
+            .accounts_db_config
+            .ancient_storage_ideal_size
+            .clone(),
         max_ancient_storages: run_args.accounts_db_config.max_ancient_storages.clone(),
-        exhaustively_verify_refcounts: run_args.accounts_db_config.exhaustively_verify_refcounts.clone(),
+        exhaustively_verify_refcounts: run_args
+            .accounts_db_config
+            .exhaustively_verify_refcounts
+            .clone(),
         storage_access: run_args.accounts_db_config.storage_access.clone(),
-        scan_filter_for_shrinking,
+        scan_filter_for_shrinking: run_args
+            .accounts_db_config
+            .scan_filter_for_shrinking
+            .clone(),
         num_background_threads: Some(accounts_db_background_threads),
         num_foreground_threads: Some(accounts_db_foreground_threads),
         mark_obsolete_accounts,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -301,9 +301,6 @@ pub fn execute(
         Arc::new(tower_storage::FileTowerStorage::new(tower_path));
 
     let mut accounts_index_config = AccountsIndexConfig::from_clap_arg_match(matches)?;
-    if let Ok(bins) = value_t!(matches, "accounts_index_bins", usize) {
-        accounts_index_config.bins = Some(bins);
-    }
 
     accounts_index_config.index_limit_mb = if !matches.is_present("enable_accounts_disk_index") {
         IndexLimitMb::InMemOnly

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -388,7 +388,7 @@ pub fn execute(
     };
 
     let accounts_db_config = AccountsDbConfig {
-        index: Some(accounts_index_config),
+        index: run_args.accounts_db_config.index.clone(),
         account_indexes: Some(account_indexes.clone()),
         base_working_path: Some(ledger_path.clone()),
         shrink_paths: account_shrink_run_paths,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -93,7 +93,6 @@ pub fn execute(
     let run_args = RunArgs::from_clap_arg_match(matches)?;
 
     let cli::thread_args::NumThreadConfig {
-        accounts_db_background_threads,
         accounts_db_foreground_threads,
         block_production_num_workers,
         ip_echo_server_threads,
@@ -319,7 +318,7 @@ pub fn execute(
             .accounts_db_config
             .scan_filter_for_shrinking
             .clone(),
-        num_background_threads: Some(accounts_db_background_threads),
+        num_background_threads: run_args.accounts_db_config.num_background_threads.clone(),
         num_foreground_threads: Some(accounts_db_foreground_threads),
         mark_obsolete_accounts,
         memlock_budget_size: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_SIZE,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -12,7 +12,7 @@ use {
     log::*,
     rand::{seq::SliceRandom, thread_rng},
     solana_accounts_db::{
-        accounts_db::{AccountsDbConfig, MarkObsoleteAccounts},
+        accounts_db::MarkObsoleteAccounts,
         accounts_index::AccountsIndexConfig,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         utils::{
@@ -285,27 +285,6 @@ pub fn execute(
         accounts_index_config.drives = Some(vec![ledger_path.join("accounts_index")]);
     }
 
-    let accounts_db_config = AccountsDbConfig {
-        index: run_args.accounts_db_config.index.clone(),
-        account_indexes: run_args.accounts_db_config.account_indexes.clone(),
-        base_working_path: Some(ledger_path.clone()),
-        shrink_paths: run_args.accounts_db_config.shrink_paths.clone(),
-        shrink_ratio: run_args.accounts_db_config.shrink_ratio,
-        read_cache_limit_bytes: run_args.accounts_db_config.read_cache_limit_bytes,
-        write_cache_limit_bytes: run_args.accounts_db_config.write_cache_limit_bytes,
-        ancient_append_vec_offset: run_args.accounts_db_config.ancient_append_vec_offset,
-        ancient_storage_ideal_size: run_args.accounts_db_config.ancient_storage_ideal_size,
-        max_ancient_storages: run_args.accounts_db_config.max_ancient_storages,
-        exhaustively_verify_refcounts: run_args.accounts_db_config.exhaustively_verify_refcounts,
-        storage_access: run_args.accounts_db_config.storage_access,
-        scan_filter_for_shrinking: run_args.accounts_db_config.scan_filter_for_shrinking,
-        num_background_threads: run_args.accounts_db_config.num_background_threads,
-        num_foreground_threads: run_args.accounts_db_config.num_foreground_threads,
-        mark_obsolete_accounts: run_args.accounts_db_config.mark_obsolete_accounts,
-        memlock_budget_size: run_args.accounts_db_config.memlock_budget_size,
-        ..AccountsDbConfig::default()
-    };
-
     let on_start_geyser_plugin_config_files = if matches.is_present("geyser_plugin_config") {
         Some(
             values_t_or_exit!(matches, "geyser_plugin_config", String)
@@ -443,7 +422,7 @@ pub fn execute(
         process_ledger_before_services: matches.is_present("process_ledger_before_services"),
         account_paths: account_run_paths,
         account_snapshot_paths,
-        accounts_db_config,
+        accounts_db_config: run_args.accounts_db_config,
         accounts_db_skip_shrink: true,
         accounts_db_force_initial_clean: matches.is_present("no_skip_initial_accounts_db_clean"),
         snapshot_config,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -301,20 +301,8 @@ pub fn execute(
         Arc::new(tower_storage::FileTowerStorage::new(tower_path));
 
     let mut accounts_index_config = AccountsIndexConfig::from_clap_arg_match(matches)?;
-
-    {
-        let mut accounts_index_paths: Vec<PathBuf> = if matches.is_present("accounts_index_path") {
-            values_t_or_exit!(matches, "accounts_index_path", String)
-                .into_iter()
-                .map(PathBuf::from)
-                .collect()
-        } else {
-            vec![]
-        };
-        if accounts_index_paths.is_empty() {
-            accounts_index_paths = vec![ledger_path.join("accounts_index")];
-        }
-        accounts_index_config.drives = Some(accounts_index_paths);
+    if accounts_index_config.drives.as_ref().unwrap().is_empty() {
+        accounts_index_config.drives = Some(vec![ledger_path.join("accounts_index")]);
     }
 
     const MB: usize = 1_024 * 1_024;

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -14,7 +14,7 @@ use {
     solana_accounts_db::{
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig, MarkObsoleteAccounts},
         accounts_file::StorageAccess,
-        accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig, ScanFilter},
+        accounts_index::{AccountsIndexConfig, ScanFilter},
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         utils::{
             create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories,
@@ -244,8 +244,6 @@ pub fn execute(
 
     let contact_debug_interval = value_t_or_exit!(matches, "contact_debug_interval", u64);
 
-    let account_indexes = AccountSecondaryIndexes::from_clap_arg_match(matches)?;
-
     let restricted_repair_only_mode = matches.is_present("restricted_repair_only_mode");
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
@@ -389,7 +387,7 @@ pub fn execute(
 
     let accounts_db_config = AccountsDbConfig {
         index: run_args.accounts_db_config.index.clone(),
-        account_indexes: Some(account_indexes.clone()),
+        account_indexes: run_args.accounts_db_config.account_indexes.clone(),
         base_working_path: Some(ledger_path.clone()),
         shrink_paths: account_shrink_run_paths,
         shrink_ratio,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -93,7 +93,6 @@ pub fn execute(
     let run_args = RunArgs::from_clap_arg_match(matches)?;
 
     let cli::thread_args::NumThreadConfig {
-        accounts_db_foreground_threads,
         block_production_num_workers,
         ip_echo_server_threads,
         rayon_global_threads,
@@ -319,7 +318,7 @@ pub fn execute(
             .scan_filter_for_shrinking
             .clone(),
         num_background_threads: run_args.accounts_db_config.num_background_threads.clone(),
-        num_foreground_threads: Some(accounts_db_foreground_threads),
+        num_foreground_threads: run_args.accounts_db_config.num_foreground_threads.clone(),
         mark_obsolete_accounts,
         memlock_budget_size: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_SIZE,
         ..AccountsDbConfig::default()

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -290,31 +290,19 @@ pub fn execute(
         account_indexes: run_args.accounts_db_config.account_indexes.clone(),
         base_working_path: Some(ledger_path.clone()),
         shrink_paths: run_args.accounts_db_config.shrink_paths.clone(),
-        shrink_ratio: run_args.accounts_db_config.shrink_ratio.clone(),
-        read_cache_limit_bytes: run_args.accounts_db_config.read_cache_limit_bytes.clone(),
-        write_cache_limit_bytes: run_args.accounts_db_config.write_cache_limit_bytes.clone(),
-        ancient_append_vec_offset: run_args
-            .accounts_db_config
-            .ancient_append_vec_offset
-            .clone(),
-        ancient_storage_ideal_size: run_args
-            .accounts_db_config
-            .ancient_storage_ideal_size
-            .clone(),
-        max_ancient_storages: run_args.accounts_db_config.max_ancient_storages.clone(),
-        exhaustively_verify_refcounts: run_args
-            .accounts_db_config
-            .exhaustively_verify_refcounts
-            .clone(),
-        storage_access: run_args.accounts_db_config.storage_access.clone(),
-        scan_filter_for_shrinking: run_args
-            .accounts_db_config
-            .scan_filter_for_shrinking
-            .clone(),
-        num_background_threads: run_args.accounts_db_config.num_background_threads.clone(),
-        num_foreground_threads: run_args.accounts_db_config.num_foreground_threads.clone(),
-        mark_obsolete_accounts: run_args.accounts_db_config.mark_obsolete_accounts.clone(),
-        memlock_budget_size: run_args.accounts_db_config.memlock_budget_size.clone(),
+        shrink_ratio: run_args.accounts_db_config.shrink_ratio,
+        read_cache_limit_bytes: run_args.accounts_db_config.read_cache_limit_bytes,
+        write_cache_limit_bytes: run_args.accounts_db_config.write_cache_limit_bytes,
+        ancient_append_vec_offset: run_args.accounts_db_config.ancient_append_vec_offset,
+        ancient_storage_ideal_size: run_args.accounts_db_config.ancient_storage_ideal_size,
+        max_ancient_storages: run_args.accounts_db_config.max_ancient_storages,
+        exhaustively_verify_refcounts: run_args.accounts_db_config.exhaustively_verify_refcounts,
+        storage_access: run_args.accounts_db_config.storage_access,
+        scan_filter_for_shrinking: run_args.accounts_db_config.scan_filter_for_shrinking,
+        num_background_threads: run_args.accounts_db_config.num_background_threads,
+        num_foreground_threads: run_args.accounts_db_config.num_foreground_threads,
+        mark_obsolete_accounts: run_args.accounts_db_config.mark_obsolete_accounts,
+        memlock_budget_size: run_args.accounts_db_config.memlock_budget_size,
         ..AccountsDbConfig::default()
     };
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -330,7 +330,7 @@ pub fn execute(
         ancient_append_vec_offset: run_args.accounts_db_config.ancient_append_vec_offset.clone(),
         ancient_storage_ideal_size: run_args.accounts_db_config.ancient_storage_ideal_size.clone(),
         max_ancient_storages: run_args.accounts_db_config.max_ancient_storages.clone(),
-        exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
+        exhaustively_verify_refcounts: run_args.accounts_db_config.exhaustively_verify_refcounts.clone(),
         storage_access,
         scan_filter_for_shrinking,
         num_background_threads: Some(accounts_db_background_threads),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -328,12 +328,7 @@ pub fn execute(
         read_cache_limit_bytes: run_args.accounts_db_config.read_cache_limit_bytes.clone(),
         write_cache_limit_bytes: run_args.accounts_db_config.write_cache_limit_bytes.clone(),
         ancient_append_vec_offset: run_args.accounts_db_config.ancient_append_vec_offset.clone(),
-        ancient_storage_ideal_size: value_t!(
-            matches,
-            "accounts_db_ancient_storage_ideal_size",
-            u64
-        )
-        .ok(),
+        ancient_storage_ideal_size: run_args.accounts_db_config.ancient_storage_ideal_size.clone(),
         max_ancient_storages: value_t!(matches, "accounts_db_max_ancient_storages", usize).ok(),
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
         storage_access,


### PR DESCRIPTION
#### Problem

part of #4082

btw, I think the trait `FromClapArgMatches` is a too early design. in `fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self>`, 1) we couldn't pass shared args/structs like ledger_path/AccountSecondaryIndexes. 2) it also couldn't custom the return to maybe Option<Self> or Result<Option<Self>>.

for these 2 reasons, I'm thinking to relax the restrictions.

#### Summary of Changes

- impl FromClapArgMatches for `AccountSecondaryIndexes`
- adding `pub fn new_accounts_db_config(matches: &ArgMatches, ledger_path: &Path,) -> Result<AccountsDbConfig>`
