### PR TITLE
Extend tpu_client_next types

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -601,7 +601,7 @@ impl TpuClientNextClient {
 
         let config = Self::create_config(bind_socket, stake_identity);
         let (update_certificate_sender, update_certificate_receiver) = watch::channel(None);
-        let scheduler: ConnectionWorkersScheduler = ConnectionWorkersScheduler::new(
+        let scheduler = ConnectionWorkersScheduler::new(
             Box::new(leader_updater),
             receiver,
             update_certificate_receiver,

--- a/tpu-client-next/src/transaction_batch.rs
+++ b/tpu-client-next/src/transaction_batch.rs
@@ -2,6 +2,17 @@
 
 use {solana_time_utils::timestamp, tokio_util::bytes::Bytes};
 
+type WiredTransaction = Bytes;
+
+pub trait WorkerPayload:
+    IntoIterator<Item = WiredTransaction, IntoIter = std::vec::IntoIter<WiredTransaction>>
+    + Clone
+    + Send
+    + 'static
+{
+    fn timestamp(&self) -> u64;
+}
+
 /// Batch of generated transactions timestamp is used to discard batches which
 /// are too old to have valid blockhash.
 #[derive(Clone, PartialEq)]
@@ -10,8 +21,6 @@ pub struct TransactionBatch {
     // Time of creation of this batch, used for batch timeouts
     timestamp: u64,
 }
-
-type WiredTransaction = Bytes;
 
 impl IntoIterator for TransactionBatch {
     type Item = Bytes;
@@ -37,6 +46,12 @@ impl TransactionBatch {
         }
     }
     pub fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+}
+
+impl WorkerPayload for TransactionBatch {
+    fn timestamp(&self) -> u64 {
         self.timestamp
     }
 }


### PR DESCRIPTION
#### Problem
Currently tpu client next is accepts only `TransactionBatch` making it work with other custom types impossible, The Broadcaster is also stateless which makes it functionality for exensions in the future limited, 

this PR addreses both by making the TpuClientNext accept generic payloads that implements the `WorkerPayload` trait, also gives the option for a stateful broadcaster by accepting self in the generic
