### PR TITLE
Consolidate bank snapshot completer to single function

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -202,8 +202,8 @@ impl SnapshotPackagerService {
         );
         if let Err(err) = result {
             warn!("Failed to hard link account storages: {err}");
-            // If hard linking the storages failed, we do *NOT* want to write
-            // the "bank snapshot loadable" files, so return early.
+            // If hard linking the storages failed, we do *NOT* want to mark the bank snapshot as
+            // loadable so return early.
             return;
         }
         info!(
@@ -211,10 +211,9 @@ impl SnapshotPackagerService {
             start.elapsed(),
         );
 
-        // Write files that indicate that the bank snapshot is loadable
-        let result = snapshot_utils::write_bank_snapshot_loadable_files(&bank_snapshot_dir);
+        let result = snapshot_utils::mark_bank_snapshot_as_loadable(&bank_snapshot_dir);
         if let Err(err) = result {
-            warn!("Failed to mark snapshot loadable: {err}");
+            warn!("Failed to mark bank snapshot as loadable: {err}");
         }
     }
 }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -203,7 +203,7 @@ impl SnapshotPackagerService {
         if let Err(err) = result {
             warn!("Failed to hard link account storages: {err}");
             // If hard linking the storages failed, we do *NOT* want to write
-            // the "storages flushed" file, so return early.
+            // the "bank snapshot loadable" files, so return early.
             return;
         }
         info!(

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -211,19 +211,10 @@ impl SnapshotPackagerService {
             start.elapsed(),
         );
 
-        // Mark this directory complete. Used in older versions to check if the snapshot is complete
-        // Never read in v3.1, can be removed in v3.2
-        let result = snapshot_utils::write_snapshot_state_complete_file(&bank_snapshot_dir);
+        // Write files that indicate that the bank snapshot is loadable
+        let result = snapshot_utils::write_bank_snapshot_loadable_files(&bank_snapshot_dir);
         if let Err(err) = result {
-            warn!("Failed to mark snapshot 'complete': {err}");
-            // If writing the "state complete" file failed, we do *NOT* want to write
-            // the "storages flushed" file, so return early.
-            return;
-        }
-
-        let result = snapshot_utils::write_storages_flushed_file(&bank_snapshot_dir);
-        if let Err(err) = result {
-            warn!("Failed to mark snapshot storages 'flushed': {err}");
+            warn!("Failed to mark snapshot loadable: {err}");
         }
     }
 }

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2329,11 +2329,12 @@ mod tests {
         // 1. call get_highest_loadable() but bad snapshot dir, so returns None
         assert!(get_highest_loadable_bank_snapshot(&SnapshotConfig::default()).is_none());
 
-        // 2. the 'storages flushed' file hasn't been written yet, so get_highest_loadable() should return NONE
+        // 2. the 'bank snapshot loadable' files haven't been written yet, so get_highest_loadable() should return NONE
         assert!(get_highest_loadable_bank_snapshot(&snapshot_config).is_none());
 
-        // 3. write 'storages flushed' file, get_highest_loadable(), should return highest_bank_snapshot_slot
-        snapshot_utils::write_storages_flushed_file(&highest_bank_snapshot.snapshot_dir).unwrap();
+        // 3. write 'bank snapshot loadable' files, get_highest_loadable(), should return highest_bank_snapshot_slot
+        snapshot_utils::write_bank_snapshot_loadable_files(&highest_bank_snapshot.snapshot_dir)
+            .unwrap();
         let bank_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
         assert_eq!(bank_snapshot, highest_bank_snapshot);
 
@@ -2341,8 +2342,8 @@ mod tests {
         fs::remove_dir_all(&highest_bank_snapshot.snapshot_dir).unwrap();
         assert!(get_highest_loadable_bank_snapshot(&snapshot_config).is_none());
 
-        // 5. write 'storages flushed' file, get_highest_loadable() should return Some() again, with slot-1
-        snapshot_utils::write_storages_flushed_file(get_bank_snapshot_dir(
+        // 5. write 'bank snapshot loadable' files, get_highest_loadable() should return Some() again, with slot-1
+        snapshot_utils::write_bank_snapshot_loadable_files(get_bank_snapshot_dir(
             &snapshot_config.bank_snapshots_dir,
             highest_bank_snapshot.slot - 1,
         ))

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2329,11 +2329,11 @@ mod tests {
         // 1. call get_highest_loadable() but bad snapshot dir, so returns None
         assert!(get_highest_loadable_bank_snapshot(&SnapshotConfig::default()).is_none());
 
-        // 2. the 'bank snapshot loadable' files haven't been written yet, so get_highest_loadable() should return NONE
+        // 2. the bank snapshot has not been marked as loadable, so get_highest_loadable() should return NONE
         assert!(get_highest_loadable_bank_snapshot(&snapshot_config).is_none());
 
-        // 3. write 'bank snapshot loadable' files, get_highest_loadable(), should return highest_bank_snapshot_slot
-        snapshot_utils::write_bank_snapshot_loadable_files(&highest_bank_snapshot.snapshot_dir)
+        // 3. Mark the bank snapshot as loadable, get_highest_loadable() should return highest_bank_snapshot_slot
+        snapshot_utils::mark_bank_snapshot_as_loadable(&highest_bank_snapshot.snapshot_dir)
             .unwrap();
         let bank_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
         assert_eq!(bank_snapshot, highest_bank_snapshot);
@@ -2342,8 +2342,8 @@ mod tests {
         fs::remove_dir_all(&highest_bank_snapshot.snapshot_dir).unwrap();
         assert!(get_highest_loadable_bank_snapshot(&snapshot_config).is_none());
 
-        // 5. write 'bank snapshot loadable' files, get_highest_loadable() should return Some() again, with slot-1
-        snapshot_utils::write_bank_snapshot_loadable_files(get_bank_snapshot_dir(
+        // 5. Mark the bank snapshot as loadable, get_highest_loadable() should return Some() again, with slot-1
+        snapshot_utils::mark_bank_snapshot_as_loadable(get_bank_snapshot_dir(
             &snapshot_config.bank_snapshots_dir,
             highest_bank_snapshot.slot - 1,
         ))

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -448,9 +448,6 @@ pub enum AddBankSnapshotError {
     #[error("failed to flush storage '{1}': {0}")]
     FlushStorage(#[source] AccountsFileError, PathBuf),
 
-    #[error("failed to mark snapshot storages as 'flushed': {0}")]
-    MarkStoragesFlushed(#[source] IoError),
-
     #[error("failed to hard link storages: {0}")]
     HardLinkStorages(#[source] HardLinkStoragesToSnapshotError),
 
@@ -650,20 +647,6 @@ fn is_bank_snapshot_complete(bank_snapshot_dir: impl AsRef<Path>) -> bool {
     version_path.is_file()
 }
 
-/// Marks the bank snapshot as complete
-pub fn write_snapshot_state_complete_file(bank_snapshot_dir: impl AsRef<Path>) -> io::Result<()> {
-    let state_complete_path = bank_snapshot_dir
-        .as_ref()
-        .join(SNAPSHOT_STATE_COMPLETE_FILENAME);
-    fs::File::create(&state_complete_path).map_err(|err| {
-        IoError::other(format!(
-            "failed to create file '{}': {err}",
-            state_complete_path.display(),
-        ))
-    })?;
-    Ok(())
-}
-
 /// Writes the full snapshot slot file into the bank snapshot dir
 pub fn write_full_snapshot_slot_file(
     bank_snapshot_dir: impl AsRef<Path>,
@@ -707,8 +690,23 @@ pub fn read_full_snapshot_slot_file(bank_snapshot_dir: impl AsRef<Path>) -> io::
     Ok(slot)
 }
 
-/// Writes the 'snapshot storages have been flushed' file to the bank snapshot dir
-pub fn write_storages_flushed_file(bank_snapshot_dir: impl AsRef<Path>) -> io::Result<()> {
+/// Writes files that indicate the bank snapshot is loadable
+/// Prior to writing these files, the bank snapshot can be saved to an archive
+/// but can't be loaded from directly
+pub fn write_bank_snapshot_loadable_files(bank_snapshot_dir: impl AsRef<Path>) -> io::Result<()> {
+    // Mark this directory complete. Used in older versions to check if the snapshot is complete
+    // Never read in v3.1, can be removed in v3.2
+    let state_complete_path = bank_snapshot_dir
+        .as_ref()
+        .join(SNAPSHOT_STATE_COMPLETE_FILENAME);
+    fs::File::create(&state_complete_path).map_err(|err| {
+        IoError::other(format!(
+            "failed to create file '{}': {err}",
+            state_complete_path.display(),
+        ))
+    })?;
+
+    // Write the storages flushed file, this is used to determine if the snapshot bank is loadable
     let flushed_storages_path = bank_snapshot_dir
         .as_ref()
         .join(SNAPSHOT_STORAGES_FLUSHED_FILENAME);
@@ -721,8 +719,8 @@ pub fn write_storages_flushed_file(bank_snapshot_dir: impl AsRef<Path>) -> io::R
     Ok(())
 }
 
-/// Were the snapshot storages flushed in this bank snapshot?
-fn are_bank_snapshot_storages_flushed(bank_snapshot_dir: impl AsRef<Path>) -> bool {
+/// Is this bank snapshot loadable?
+fn is_bank_snapshot_loadable(bank_snapshot_dir: impl AsRef<Path>) -> bool {
     let flushed_storages = bank_snapshot_dir
         .as_ref()
         .join(SNAPSHOT_STORAGES_FLUSHED_FILENAME);
@@ -737,9 +735,8 @@ pub fn get_highest_loadable_bank_snapshot(
 ) -> Option<BankSnapshotInfo> {
     let highest_bank_snapshot = get_highest_bank_snapshot(&snapshot_config.bank_snapshots_dir)?;
 
-    let are_storages_flushed =
-        are_bank_snapshot_storages_flushed(&highest_bank_snapshot.snapshot_dir);
-    are_storages_flushed.then_some(highest_bank_snapshot)
+    let is_bank_snapshot_loadable = is_bank_snapshot_loadable(&highest_bank_snapshot.snapshot_dir);
+    is_bank_snapshot_loadable.then_some(highest_bank_snapshot)
 }
 
 /// If the validator halts in the middle of `archive_snapshot_package()`, the temporary staging
@@ -935,14 +932,10 @@ fn serialize_snapshot(
             )
             .map_err(AddBankSnapshotError::HardLinkStorages)?);
 
-            // Mark this directory complete. Used in older versions to check if the snapshot is complete
-            // Never read in v3.1, can be removed in v3.2
-            write_snapshot_state_complete_file(&bank_snapshot_dir)
+            // Now that the storages are flushed and hard linked, mark the snapshot as loadable
+            write_bank_snapshot_loadable_files(&bank_snapshot_dir)
                 .map_err(AddBankSnapshotError::MarkSnapshotComplete)?;
 
-            // Write the storages flushed file
-            write_storages_flushed_file(&bank_snapshot_dir)
-                .map_err(AddBankSnapshotError::MarkStoragesFlushed)?;
             Some((flush_us, hard_link_us))
         } else {
             None
@@ -1757,7 +1750,7 @@ fn create_snapshot_meta_files_for_unarchived_snapshot(unpack_dir: impl AsRef<Pat
         slot_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME),
     )?;
 
-    write_snapshot_state_complete_file(slot_dir)?;
+    write_bank_snapshot_loadable_files(slot_dir)?;
 
     Ok(())
 }
@@ -2849,9 +2842,6 @@ mod tests {
 
             let version_path = snapshot_dir.join(SNAPSHOT_VERSION_FILENAME);
             fs::write(version_path, SnapshotVersion::default().as_str().as_bytes()).unwrap();
-
-            // Mark this directory complete so it can be used.  Check this flag first before selecting for deserialization.
-            write_snapshot_state_complete_file(snapshot_dir).unwrap();
         }
     }
 


### PR DESCRIPTION
#### Problem
- Bank snapshot file writes are done in multiple places which must be kept in sync

#### Summary of Changes
- Consolidate to a single function
- rename function to write_bank_snapshot_loadable_files

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
