### PR TITLE
Fix rustfmt in `rpc/src/rpc_pubsub_service.rs`

### DIFF
--- a/rpc/src/rpc_pubsub_service.rs
+++ b/rpc/src/rpc_pubsub_service.rs
@@ -454,7 +454,8 @@ async fn listen(
         }
         Err(e) => {
             error!(
-                "failed to bind rpc_pubsub listener on {listen_address:?}: {e}. Hint: is the port already in use?"
+                "failed to bind rpc_pubsub listener on {listen_address:?}: {e}. Hint: is the port \
+                 already in use?"
             );
             return Err(e);
         }


### PR DESCRIPTION
#### Problem

Have people found that green PRs (https://github.com/anza-xyz/agave/pull/7883) are failing in master's CI? https://buildkite.com/anza/agave/builds/30513/steps/canvas?jid=019958df-e162-4966-8ebc-b814492cba00

_EDIT: Hmm… maybe CI never ran on that PR at all._

#### Summary of Changes

Fixed formatting according to message in CI.