### PR TITLE
Change flush to flush without clean in remove_zero_lamport_single_ref_accounts_after_shrink test

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1213,7 +1213,7 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
                 // This test pass is still relevant with obsolete accounts enabled, but can be
                 // removed if all scenarios where flush_write_cache doesn't clean are eliminated.
 
-                // add root and flush without clean  (causing ref count to increase)
+                // add root and flush without clean (causing ref count to increase)
                 accounts.add_root(slot + 1);
                 accounts.flush_rooted_accounts_cache(None, false);
             }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1210,8 +1210,12 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
             accounts
                 .store_for_tests((slot + 1, [(&pubkey_zero, &zero_lamport_account)].as_slice()));
             if pass == 2 {
-                // move to a storage (causing ref count to increase)
-                accounts.add_root_and_flush_write_cache(slot + 1);
+                // This test pass is still relevant with obsolete accounts enabled, but can be
+                // removed if all scenarios where flush_write_cache doesn't clean are eliminated.
+
+                // add root and flush without clean  (causing ref count to increase)
+                accounts.add_root(slot + 1);
+                accounts.flush_rooted_accounts_cache(None, false);
             }
         }
 


### PR DESCRIPTION
#### Problem
- Test conditions fail with obsolete accounts enabled, specifically refcount checks and slot list checks.

#### Summary of Changes
- Change flush from flush with clean to flush without clean
- Add comments about situation for test deprecation.


#### Notes
- Similar strategy to: https://github.com/anza-xyz/agave/pull/8039
- Test is still valid to run with obsolete accounts enabled unless flush without clean can be entirely removed
- No reason to run with obsolete accounts both enabled and disabled. Obsolete accounts just change the setup process.
- I considered removing the test as its largely similar to the previous test and doesn't provide any additional test coverage, but is intended to be a unit a test on the function remove_zero_lamport_single_ref_accounts_after_shrink

#### Double Note
- This is the last test! After this all tests are passing!

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
