### PR TITLE
agave-validator: parse ledger path directly in run command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "qualifier_attr",
  "rand 0.8.5",
  "rayon",
+ "scopeguard",
  "serde",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -99,6 +99,7 @@ signal-hook = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 pretty_assertions = { workspace = true }
+scopeguard = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-program-option = { workspace = true }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1871,6 +1871,9 @@ mod tests {
             let default_run_args = RunArgs::default();
             let ledger_path = PathBuf::from("test_ledger_unexisting");
             assert!(!fs::exists(&ledger_path).unwrap());
+            defer! {
+                fs::remove_dir_all(&ledger_path).unwrap()
+            };
 
             let expected_args = RunArgs {
                 ledger_path: absolute(&ledger_path).unwrap(),
@@ -1882,9 +1885,6 @@ mod tests {
                 expected_args,
             );
             assert!(fs::exists(&ledger_path).unwrap());
-            defer! {
-                fs::remove_dir_all(&ledger_path).unwrap()
-            };
         }
 
         // existing relative ledger path
@@ -1893,6 +1893,9 @@ mod tests {
             let ledger_path = PathBuf::from("test_ledger_existing");
             fs::create_dir_all(&ledger_path).unwrap();
             assert!(fs::exists(&ledger_path).unwrap());
+            defer! {
+                fs::remove_dir_all(&ledger_path).unwrap()
+            };
 
             let expected_args = RunArgs {
                 ledger_path: absolute(&ledger_path).unwrap(),
@@ -1904,9 +1907,6 @@ mod tests {
                 expected_args,
             );
             assert!(fs::exists(&ledger_path).unwrap());
-            defer! {
-                fs::remove_dir_all(&ledger_path).unwrap()
-            };
         }
     }
 

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1869,7 +1869,7 @@ mod tests {
         // nonexistent relative ledger path
         {
             let default_run_args = RunArgs::default();
-            let ledger_path = PathBuf::from("test_ledger_unexisting");
+            let ledger_path = PathBuf::from("unexistent_ledger_path");
             assert!(!fs::exists(&ledger_path).unwrap());
             defer! {
                 fs::remove_dir_all(&ledger_path).unwrap()

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1830,7 +1830,7 @@ mod tests {
         {
             let default_run_args = RunArgs::default();
             let tmp_dir = fs::canonicalize(tempfile::tempdir().unwrap()).unwrap();
-            let ledger_path = tmp_dir.join("unexisting_ledger_path");
+            let ledger_path = tmp_dir.join("unexistent_ledger_path");
             assert!(!fs::exists(&ledger_path).unwrap());
 
             let expected_args = RunArgs {

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1890,7 +1890,7 @@ mod tests {
         // existing relative ledger path
         {
             let default_run_args = RunArgs::default();
-            let ledger_path = PathBuf::from("test_ledger_existing");
+            let ledger_path = PathBuf::from("existing_ledger_path");
             fs::create_dir_all(&ledger_path).unwrap();
             assert!(fs::exists(&ledger_path).unwrap());
             defer! {

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1826,7 +1826,7 @@ mod tests {
 
     #[test]
     fn verify_args_struct_by_command_run_with_ledger_path() {
-        // unexisting absolute ledger path
+        // nonexistent absolute ledger path
         {
             let default_run_args = RunArgs::default();
             let tmp_dir = fs::canonicalize(tempfile::tempdir().unwrap()).unwrap();
@@ -1866,7 +1866,7 @@ mod tests {
             assert!(fs::exists(&ledger_path).unwrap());
         }
 
-        // unexisting relative ledger path
+        // nonexistent relative ledger path
         {
             let default_run_args = RunArgs::default();
             let ledger_path = PathBuf::from("test_ledger_unexisting");

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1830,7 +1830,7 @@ mod tests {
         {
             let default_run_args = RunArgs::default();
             let tmp_dir = fs::canonicalize(tempfile::tempdir().unwrap()).unwrap();
-            let ledger_path = tmp_dir.join("unexistent_ledger_path");
+            let ledger_path = tmp_dir.join("nonexistent_ledger_path");
             assert!(!fs::exists(&ledger_path).unwrap());
 
             let expected_args = RunArgs {
@@ -1869,7 +1869,7 @@ mod tests {
         // nonexistent relative ledger path
         {
             let default_run_args = RunArgs::default();
-            let ledger_path = PathBuf::from("unexistent_ledger_path");
+            let ledger_path = PathBuf::from("nonexistent_ledger_path");
             assert!(!fs::exists(&ledger_path).unwrap());
             defer! {
                 fs::remove_dir_all(&ledger_path).unwrap()

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1830,7 +1830,7 @@ mod tests {
         {
             let default_run_args = RunArgs::default();
             let tmp_dir = fs::canonicalize(tempfile::tempdir().unwrap()).unwrap();
-            let ledger_path = tmp_dir.join("my_unexisting_ledger_path");
+            let ledger_path = tmp_dir.join("unexisting_ledger_path");
             assert!(!fs::exists(&ledger_path).unwrap());
 
             let expected_args = RunArgs {
@@ -1849,7 +1849,7 @@ mod tests {
         {
             let default_run_args = RunArgs::default();
             let tmp_dir = tempfile::tempdir().unwrap();
-            let ledger_path = tmp_dir.path().join("my_existing_ledger_path");
+            let ledger_path = tmp_dir.path().join("existing_ledger_path");
             fs::create_dir_all(&ledger_path).unwrap();
             let ledger_path = fs::canonicalize(ledger_path).unwrap();
             assert!(fs::exists(ledger_path.as_path()).unwrap());

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -89,7 +89,6 @@ pub enum Operation {
 pub fn execute(
     matches: &ArgMatches,
     solana_version: &str,
-    ledger_path: &Path,
     operation: Operation,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let run_args = RunArgs::from_clap_arg_match(matches)?;
@@ -165,13 +164,7 @@ pub fn execute(
         .map(Duration::from_millis)
         .unwrap_or(DEFAULT_TPU_COALESCE);
 
-    // Canonicalize ledger path to avoid issues with symlink creation
-    let ledger_path = create_and_canonicalize_directory(ledger_path).map_err(|err| {
-        format!(
-            "unable to access ledger path '{}': {err}",
-            ledger_path.display(),
-        )
-    })?;
+    let ledger_path = run_args.ledger_path;
 
     let max_ledger_shreds = if matches.is_present("limit_ledger_size") {
         let limit_ledger_size = match matches.value_of("limit_ledger_size") {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -27,7 +27,6 @@ pub fn main() {
         ("init", _) => commands::run::execute(
             &matches,
             solana_version,
-            &ledger_path,
             commands::run::execute::Operation::Initialize,
         )
         .inspect_err(|err| error!("Failed to initialize validator: {err}"))
@@ -35,7 +34,6 @@ pub fn main() {
         ("", _) | ("run", _) => commands::run::execute(
             &matches,
             solana_version,
-            &ledger_path,
             commands::run::execute::Operation::Run,
         )
         .inspect_err(|err| error!("Failed to start validator: {err}"))


### PR DESCRIPTION
#### Problem

split from https://github.com/anza-xyz/agave/pull/8072.

#### Summary of Changes

parsing ledger path directly in run command