### PR TITLE
re-export solana_rpc_client_api in solana_rpc_client

### DIFF
--- a/rpc-client/src/lib.rs
+++ b/rpc-client/src/lib.rs
@@ -6,6 +6,7 @@ pub mod nonblocking;
 pub mod rpc_client;
 pub mod rpc_sender;
 pub mod spinner;
+pub use solana_rpc_client_api as api;
 
 pub mod mock_sender_for_cli {
     /// Magic `SIGNATURE` value used by `solana-cli` unit tests.


### PR DESCRIPTION
You almost always need to import this when using solana-rpc-client.

I've aliased the re-export as `api`, because we also truncate names like this in the re-exports of solana-rpc-client-api and solana-client