### PR TITLE
add stateful broadcaster

### DIFF
--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -25,10 +25,7 @@ use {
     solana_signer::Signer,
     solana_system_transaction as system_transaction,
     solana_test_validator::TestValidator,
-    solana_tpu_client_next::{
-        client_builder::ClientBuilder, connection_workers_scheduler::NonblockingBroadcaster,
-        leader_updater::LeaderUpdater,
-    },
+    solana_tpu_client_next::{client_builder::ClientBuilder, leader_updater::LeaderUpdater},
     solana_transaction::Transaction,
     solana_transaction_status::TransactionStatus,
     std::{
@@ -448,7 +445,7 @@ fn test_rpc_subscriptions() {
         ClientBuilder::new(leader_updater)
             .bind_socket(bind_socket)
             .identity(&alice)
-            .build::<NonblockingBroadcaster>()
+            .build()
             .expect("Failed to build TPU client")
     });
 
@@ -547,7 +544,7 @@ fn test_run_tpu_send_transaction() {
         ClientBuilder::new(leader_updater)
             .bind_socket(bind_socket)
             .identity(&mint_keypair)
-            .build::<NonblockingBroadcaster>()
+            .build()
             .expect("Failed to build TPU client")
     });
 

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -18,8 +18,7 @@ use {
     },
     solana_tpu_client_next::{
         connection_workers_scheduler::{
-            BindTarget, ConnectionWorkersSchedulerConfig, Fanout, NonblockingBroadcaster,
-            StakeIdentity,
+            BindTarget, ConnectionWorkersSchedulerConfig, Fanout, StakeIdentity,
         },
         leader_updater::create_pinned_leader_updater,
         send_transaction_stats::SendTransactionStatsNonAtomic,
@@ -902,7 +901,7 @@ async fn test_client_builder() {
         });
 
     let (tx_sender, client) = builder
-        .build::<NonblockingBroadcaster>()
+        .build()
         .expect("Client should be built successfully.");
 
     // Setup sending txs


### PR DESCRIPTION
#### Problem

Currently the `WorkersBroadcaster` is stateless, which limits its functionality, say for example adding filter transaction forwarding based on a blocklist kept by the broadcaster struct.

#### Summary of Changes
Makes the `WorkersBroadcaster` stateful by allowing access to `self` in the trait methods.

Fixes #7136 
