### PR TITLE
Add a versioned completer to the snapshot directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10297,6 +10297,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "regex",
+ "semver 1.0.27",
  "serde",
  "serde_derive",
  "serde_json",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8089,6 +8089,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "regex",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -84,6 +84,7 @@ qualifier_attr = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
+semver = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -822,6 +822,7 @@ mod tests {
             },
             status_cache::Status,
         },
+        semver::Version,
         solana_accounts_db::{
             accounts_db::{MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING},
             accounts_file::StorageAccess,
@@ -1626,6 +1627,73 @@ mod tests {
 
         // When the bank snapshot is removed, all the snapshot hardlink directories should be removed.
         assert!(hardlink_dirs.iter().all(|dir| fs::metadata(dir).is_err()));
+    }
+
+    /// Test versioning when booting from directories
+    /// If the storages flushed file is present, booting from directories should always pass
+    /// If the loadable version file is present, the version should be checked for compatibility
+    #[test]
+    fn test_snapshot_versioning() {
+        let genesis_config = GenesisConfig::default();
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 3, true);
+
+        let snapshot_config = SnapshotConfig {
+            bank_snapshots_dir: bank_snapshots_dir.as_ref().to_path_buf(),
+            full_snapshot_archives_dir: bank_snapshots_dir.as_ref().to_path_buf(),
+            incremental_snapshot_archives_dir: bank_snapshots_dir.as_ref().to_path_buf(),
+            ..Default::default()
+        };
+
+        // Verify the snapshot is found with all the version files present
+        let snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
+        assert_eq!(snapshot.slot, 3);
+
+        // Test 1: Remove the storages flushed file
+        let storages_flushed_file = snapshot
+            .snapshot_dir
+            .join(snapshot_utils::SNAPSHOT_STORAGES_FLUSHED_FILENAME);
+        fs::remove_file(storages_flushed_file).unwrap();
+
+        // If the storages flushed file is removed, the version in the version file should be
+        // checked, and the snapshot should be found
+        let snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
+        assert_eq!(snapshot.slot, 3);
+
+        // Test 2: Modify the version in the loadable bank snapshot version file to something newer
+        // than current
+        let complete_flag_file = snapshot
+            .snapshot_dir
+            .join(snapshot_utils::SNAPSHOT_LOADABLE_BANK_SNAPSHOT_VERSION_FILENAME);
+        let version = fs::read_to_string(&complete_flag_file).unwrap();
+        let version = Version::parse(&version).unwrap();
+        let new_version = Version::new(version.major + 1, version.minor, version.patch);
+
+        fs::write(&complete_flag_file, new_version.to_string()).unwrap();
+
+        // With an invalid version and no legacy file, the snapshot will be considered invalid
+        let new_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config);
+        assert!(new_snapshot.is_none());
+
+        // Test 3: Remove the bank snapshot version file
+        let complete_flag_file = snapshot
+            .snapshot_dir
+            .join(snapshot_utils::SNAPSHOT_VERSION_FILENAME);
+        fs::remove_file(complete_flag_file).unwrap();
+
+        // This will now find the previous entry in the directory, which is slot 2
+        let snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
+        assert_eq!(snapshot.slot, 2);
+
+        // Test 4: Remove the loadable bank snapshot file
+        let complete_flag_file = snapshot
+            .snapshot_dir
+            .join(snapshot_utils::SNAPSHOT_LOADABLE_BANK_SNAPSHOT_VERSION_FILENAME);
+        fs::remove_file(complete_flag_file).unwrap();
+
+        // The flush file will still be found, making this a valid snapshot
+        let snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
+        assert_eq!(snapshot.slot, 2);
     }
 
     #[test_case(false)]

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -659,17 +659,6 @@ fn is_bank_snapshot_complete(bank_snapshot_dir: impl AsRef<Path>) -> bool {
     version_path.is_file()
 }
 
-/// Is the fastboot snapshot version compatible?
-fn is_snapshot_fastboot_compatible(
-    version: &Version,
-) -> std::result::Result<bool, SnapshotFastbootError> {
-    if version.major <= SNAPSHOT_FASTBOOT_VERSION.major {
-        Ok(true)
-    } else {
-        Err(SnapshotFastbootError::IncompatibleVersion(version.clone()))
-    }
-}
-
 /// Writes the full snapshot slot file into the bank snapshot dir
 pub fn write_full_snapshot_slot_file(
     bank_snapshot_dir: impl AsRef<Path>,
@@ -784,6 +773,17 @@ fn is_bank_snapshot_loadable(
     }
 }
 
+/// Is the fastboot snapshot version compatible?
+fn is_snapshot_fastboot_compatible(
+    version: &Version,
+) -> std::result::Result<bool, SnapshotFastbootError> {
+    if version.major <= SNAPSHOT_FASTBOOT_VERSION.major {
+        Ok(true)
+    } else {
+        Err(SnapshotFastbootError::IncompatibleVersion(version.clone()))
+    }
+}
+
 /// Gets the highest, loadable, bank snapshot
 ///
 /// The highest bank snapshot is the one with the highest slot.
@@ -798,7 +798,10 @@ pub fn get_highest_loadable_bank_snapshot(
         Ok(true) => Some(highest_bank_snapshot),
         Ok(false) => None,
         Err(err) => {
-            warn!("Error checking if bank snapshot is loadable: {err}");
+            warn!(
+                "Bank snapshot is not loadable '{}': {err}",
+                highest_bank_snapshot.snapshot_dir.display()
+            );
             None
         }
     }


### PR DESCRIPTION
#### Problem
- There is no way to check compatibility of loadable bank snapshot directories

#### Summary of Changes
- Add a version file
- Continue accepting flushed file as a backup for compatibility with older versions

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
