### PR TITLE
Allow obsolete accounts structure to be passed in to reconstruct_single_storage and then recreating the account storage entry

### DIFF
--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -329,7 +329,7 @@ mod tests {
             );
 
             // Create a new AccountStorageEntry from the output file
-            let new_storage = AccountStorageEntry::new_existing(slot, 0, accounts_file, &[]);
+            let new_storage = AccountStorageEntry::new_existing(slot, 0, accounts_file, Vec::new());
 
             // Verify that the new storage has the same length as the reader
             assert_eq!(new_storage.accounts.len(), reader.len());
@@ -431,7 +431,7 @@ mod tests {
                     .unwrap();
 
             // Create a new AccountStorageEntry from the output file
-            let new_storage = AccountStorageEntry::new_existing(slot, 0, accounts_file, &[]);
+            let new_storage = AccountStorageEntry::new_existing(slot, 0, accounts_file, Vec::new());
 
             // Verify that the new storage has the same length as the reader
             assert_eq!(new_storage.accounts.len(), reader.len());

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -137,6 +137,7 @@ mod tests {
         crate::{
             accounts_db::{get_temp_accounts_paths, AccountStorageEntry},
             accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
+            ObsoleteAccounts,
         },
         log::*,
         rand::{rngs::StdRng, seq::SliceRandom, SeedableRng},
@@ -329,7 +330,12 @@ mod tests {
             );
 
             // Create a new AccountStorageEntry from the output file
-            let new_storage = AccountStorageEntry::new_existing(slot, 0, accounts_file, Vec::new());
+            let new_storage = AccountStorageEntry::new_existing(
+                slot,
+                0,
+                accounts_file,
+                ObsoleteAccounts::default(),
+            );
 
             // Verify that the new storage has the same length as the reader
             assert_eq!(new_storage.accounts.len(), reader.len());
@@ -431,7 +437,12 @@ mod tests {
                     .unwrap();
 
             // Create a new AccountStorageEntry from the output file
-            let new_storage = AccountStorageEntry::new_existing(slot, 0, accounts_file, Vec::new());
+            let new_storage = AccountStorageEntry::new_existing(
+                slot,
+                0,
+                accounts_file,
+                ObsoleteAccounts::default(),
+            );
 
             // Verify that the new storage has the same length as the reader
             assert_eq!(new_storage.accounts.len(), reader.len());

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -329,7 +329,7 @@ mod tests {
             );
 
             // Create a new AccountStorageEntry from the output file
-            let new_storage = AccountStorageEntry::new_existing(slot, 0, accounts_file);
+            let new_storage = AccountStorageEntry::new_existing(slot, 0, accounts_file, &[]);
 
             // Verify that the new storage has the same length as the reader
             assert_eq!(new_storage.accounts.len(), reader.len());
@@ -431,7 +431,7 @@ mod tests {
                     .unwrap();
 
             // Create a new AccountStorageEntry from the output file
-            let new_storage = AccountStorageEntry::new_existing(slot, 0, accounts_file);
+            let new_storage = AccountStorageEntry::new_existing(slot, 0, accounts_file, &[]);
 
             // Verify that the new storage has the same length as the reader
             assert_eq!(new_storage.accounts.len(), reader.len());

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -962,7 +962,7 @@ impl AccountStorageEntry {
         slot: Slot,
         id: AccountsFileId,
         accounts: AccountsFile,
-        obsolete_accounts: &[(Offset, usize, Slot)],
+        obsolete_accounts: Vec<(Offset, usize, Slot)>,
     ) -> Self {
         Self {
             id,
@@ -971,7 +971,7 @@ impl AccountStorageEntry {
             count: AtomicUsize::new(0),
             alive_bytes: AtomicUsize::new(0),
             zero_lamport_single_ref_offsets: RwLock::default(),
-            obsolete_accounts: RwLock::new(obsolete_accounts.to_vec()),
+            obsolete_accounts: RwLock::new(obsolete_accounts),
         }
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -958,7 +958,12 @@ impl AccountStorageEntry {
         })
     }
 
-    pub fn new_existing(slot: Slot, id: AccountsFileId, accounts: AccountsFile) -> Self {
+    pub fn new_existing(
+        slot: Slot,
+        id: AccountsFileId,
+        accounts: AccountsFile,
+        obsolete_accounts: &[(Offset, usize, Slot)],
+    ) -> Self {
         Self {
             id,
             slot,
@@ -966,7 +971,7 @@ impl AccountStorageEntry {
             count: AtomicUsize::new(0),
             alive_bytes: AtomicUsize::new(0),
             zero_lamport_single_ref_offsets: RwLock::default(),
-            obsolete_accounts: RwLock::default(),
+            obsolete_accounts: RwLock::new(obsolete_accounts.to_vec()),
         }
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -962,7 +962,7 @@ impl AccountStorageEntry {
         slot: Slot,
         id: AccountsFileId,
         accounts: AccountsFile,
-        obsolete_accounts: Vec<(Offset, usize, Slot)>,
+        obsolete_accounts: ObsoleteAccounts,
     ) -> Self {
         Self {
             id,

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -90,19 +90,7 @@ impl AccountsFile {
         path: impl Into<PathBuf>,
         current_len: usize,
         storage_access: StorageAccess,
-        obsolete_accounts: &[(Offset, usize, Slot)],
     ) -> Result<Self> {
-        // When recreating the account storage entry, some accounts may be marked as obsolete.
-        // During archive generation, the saved size was reduced because obsolete accounts
-        // were excluded when writing to the archive.
-        // However, when rebooting from the directory, these accounts still exist in the
-        // storage file. If any accounts were removed, their sizes need to be added back to
-        // calculate the correct file size.
-        let current_len = current_len
-            + obsolete_accounts
-                .iter()
-                .map(|(_, data_len, _)| AppendVec::calculate_stored_size(*data_len))
-                .sum::<usize>();
         let av = AppendVec::new_for_startup(path, current_len, storage_access)?;
         Ok(Self::AppendVec(av))
     }

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -90,7 +90,19 @@ impl AccountsFile {
         path: impl Into<PathBuf>,
         current_len: usize,
         storage_access: StorageAccess,
+        obsolete_accounts: &[(Offset, usize, Slot)],
     ) -> Result<Self> {
+        // When recreating the account storage entry, some accounts may be marked as obsolete.
+        // During archive generation, the saved size was reduced because obsolete accounts
+        // were excluded when writing to the archive.
+        // However, when rebooting from the directory, these accounts still exist in the
+        // storage file. If any accounts were removed, their sizes need to be added back to
+        // calculate the correct file size.
+        let current_len = current_len
+            + obsolete_accounts
+                .iter()
+                .map(|(_, data_len, _)| AppendVec::calculate_stored_size(*data_len))
+                .sum::<usize>();
         let av = AppendVec::new_for_startup(path, current_len, storage_access)?;
         Ok(Self::AppendVec(av))
     }

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -45,7 +45,10 @@ pub mod tiered_storage;
 pub mod utils;
 pub mod waitable_condvar;
 
-pub use {buffered_reader::large_file_buf_reader, file_io::validate_memlock_limit_for_disk_io};
+pub use {
+    buffered_reader::large_file_buf_reader, file_io::validate_memlock_limit_for_disk_io,
+    obsolete_accounts::ObsoleteAccounts,
+};
 
 #[macro_use]
 extern crate solana_metrics;

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -68,6 +68,7 @@ mod tests {
                 storage_entry.slot(),
                 storage_entry.id(),
                 accounts_file,
+                &[],
             );
             next_append_vec_id = next_append_vec_id.max(new_storage_entry.id());
             storage.insert(new_storage_entry.slot(), Arc::new(new_storage_entry));

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -68,7 +68,7 @@ mod tests {
                 storage_entry.slot(),
                 storage_entry.id(),
                 accounts_file,
-                &[],
+                Vec::new(),
             );
             next_append_vec_id = next_append_vec_id.max(new_storage_entry.id());
             storage.insert(new_storage_entry.slot(), Arc::new(new_storage_entry));

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -22,6 +22,7 @@ mod tests {
                 ACCOUNTS_DB_CONFIG_FOR_TESTING,
             },
             accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
+            ObsoleteAccounts,
         },
         solana_epoch_schedule::EpochSchedule,
         solana_genesis_config::create_genesis_config,
@@ -68,7 +69,7 @@ mod tests {
                 storage_entry.slot(),
                 storage_entry.id(),
                 accounts_file,
-                Vec::new(),
+                ObsoleteAccounts::default(),
             );
             next_append_vec_id = next_append_vec_id.max(new_storage_entry.id());
             storage.insert(new_storage_entry.slot(), Arc::new(new_storage_entry));

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -864,10 +864,10 @@ pub(crate) fn reconstruct_single_storage(
     let (current_len, obsolete_accounts) = if let Some(obsolete_accounts) = obsolete_accounts {
         let updated_len = current_len + obsolete_accounts.bytes as usize;
         let append_vec_id = append_vec_id as SerializedAccountsFileId;
-        if obsolete_accounts.append_vec_id != append_vec_id {
+        if obsolete_accounts.id != append_vec_id {
             return Err(SnapshotError::MismatchedAccountsFileId(
                 append_vec_id,
-                obsolete_accounts.append_vec_id,
+                obsolete_accounts.id,
             ));
         }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -859,7 +859,7 @@ pub(crate) fn reconstruct_single_storage(
     obsolete_accounts: Option<SerdeObsoleteAccounts>,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
     // When restoring from an archive, obsolete accounts will always be `None`
-    // When restoring from directories, obsolete accounts will be 'Some' if the storage contained
+    // When restoring from fastboot, obsolete accounts will be 'Some' if the storage contained
     // accounts marked obsolete at the time the snapshot was taken.
     let (current_len, obsolete_accounts) = if let Some(obsolete_accounts) = obsolete_accounts {
         let updated_len = current_len + obsolete_accounts.bytes as usize;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -14,6 +14,7 @@ use {
     log::*,
     serde::{de::DeserializeOwned, Deserialize, Serialize},
     solana_accounts_db::{
+        account_info::Offset,
         accounts::Accounts,
         accounts_db::{
             AccountStorageEntry, AccountsDb, AccountsDbConfig, AccountsFileId,
@@ -854,14 +855,19 @@ pub(crate) fn reconstruct_single_storage(
     current_len: usize,
     append_vec_id: AccountsFileId,
     storage_access: StorageAccess,
+    obsolete_accounts: Vec<(Offset, usize, Slot)>,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
-    let accounts_file =
-        AccountsFile::new_for_startup(append_vec_path, current_len, storage_access, &[])?;
+    let accounts_file = AccountsFile::new_for_startup(
+        append_vec_path,
+        current_len,
+        storage_access,
+        &obsolete_accounts,
+    )?;
     Ok(Arc::new(AccountStorageEntry::new_existing(
         *slot,
         append_vec_id,
         accounts_file,
-        &[],
+        obsolete_accounts,
     )))
 }
 
@@ -960,6 +966,7 @@ pub(crate) fn remap_and_reconstruct_single_storage(
         current_len,
         remapped_append_vec_id,
         storage_access,
+        Vec::new(),
     )?;
     Ok(storage)
 }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -854,7 +854,7 @@ pub(crate) fn reconstruct_single_storage(
     slot: &Slot,
     append_vec_path: &Path,
     current_len: usize,
-    append_vec_id: AccountsFileId,
+    id: AccountsFileId,
     storage_access: StorageAccess,
     obsolete_accounts: Option<SerdeObsoleteAccounts>,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
@@ -863,10 +863,10 @@ pub(crate) fn reconstruct_single_storage(
     // accounts marked obsolete at the time the snapshot was taken.
     let (current_len, obsolete_accounts) = if let Some(obsolete_accounts) = obsolete_accounts {
         let updated_len = current_len + obsolete_accounts.bytes as usize;
-        let append_vec_id = append_vec_id as SerializedAccountsFileId;
-        if obsolete_accounts.id != append_vec_id {
+        let id = id as SerializedAccountsFileId;
+        if obsolete_accounts.id != id {
             return Err(SnapshotError::MismatchedAccountsFileId(
-                append_vec_id,
+                id,
                 obsolete_accounts.id,
             ));
         }
@@ -880,7 +880,7 @@ pub(crate) fn reconstruct_single_storage(
         AccountsFile::new_for_startup(append_vec_path, current_len, storage_access)?;
     Ok(Arc::new(AccountStorageEntry::new_existing(
         *slot,
-        append_vec_id,
+        id,
         accounts_file,
         obsolete_accounts,
     )))

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -856,11 +856,12 @@ pub(crate) fn reconstruct_single_storage(
     storage_access: StorageAccess,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
     let accounts_file =
-        AccountsFile::new_for_startup(append_vec_path, current_len, storage_access)?;
+        AccountsFile::new_for_startup(append_vec_path, current_len, storage_access, &[])?;
     Ok(Arc::new(AccountStorageEntry::new_existing(
         *slot,
         append_vec_id,
         accounts_file,
+        &[],
     )))
 }
 

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -33,20 +33,6 @@ impl SerializableAccountStorageEntry {
     }
 }
 
-pub(crate) trait SerializableStorage {
-    fn id(&self) -> SerializedAccountsFileId;
-    fn current_len(&self) -> usize;
-}
-
-impl SerializableStorage for SerializableAccountStorageEntry {
-    fn id(&self) -> SerializedAccountsFileId {
-        self.id
-    }
-    fn current_len(&self) -> usize {
-        self.accounts_current_len
-    }
-}
-
 /// This structure handles the load/store of obsolete accounts during snapshot restoration.
 #[derive(Debug, Default)]
 pub(crate) struct SerdeObsoleteAccounts {
@@ -63,3 +49,17 @@ pub(crate) struct SerdeObsoleteAccounts {
 
 #[cfg(feature = "frozen-abi")]
 impl solana_frozen_abi::abi_example::TransparentAsHelper for SerializableAccountStorageEntry {}
+
+pub(crate) trait SerializableStorage {
+    fn id(&self) -> SerializedAccountsFileId;
+    fn current_len(&self) -> usize;
+}
+
+impl SerializableStorage for SerializableAccountStorageEntry {
+    fn id(&self) -> SerializedAccountsFileId {
+        self.id
+    }
+    fn current_len(&self) -> usize {
+        self.accounts_current_len
+    }
+}

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -1,6 +1,6 @@
 use {
     serde::{Deserialize, Serialize},
-    solana_accounts_db::accounts_db::AccountStorageEntry,
+    solana_accounts_db::{accounts_db::AccountStorageEntry, ObsoleteAccounts},
     solana_clock::Slot,
 };
 
@@ -45,6 +45,20 @@ impl SerializableStorage for SerializableAccountStorageEntry {
     fn current_len(&self) -> usize {
         self.accounts_current_len
     }
+}
+
+/// This structure handles the load/store of obsolete accounts during snapshot restoration.
+#[derive(Debug, Default)]
+pub(crate) struct SerdeObsoleteAccounts {
+    /// The ID of the associated append_vec. Used for verification to ensure the restored obsolete
+    /// accounts correspond to the correct append_vec_id.
+    pub append_vec_id: SerializedAccountsFileId,
+    /// The number of obsolete bytes in the storage. These bytes are removed during archive
+    /// serialization/deserialization but are present when restoring from directories. This value
+    /// is used to validate the size when creating the accounts file.
+    pub bytes: u64,
+    /// A list of accounts that are obsolete in the storage being restored.
+    pub accounts: ObsoleteAccounts,
 }
 
 #[cfg(feature = "frozen-abi")]

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -33,23 +33,6 @@ impl SerializableAccountStorageEntry {
     }
 }
 
-/// This structure handles the load/store of obsolete accounts during snapshot restoration.
-#[derive(Debug, Default)]
-pub(crate) struct SerdeObsoleteAccounts {
-    /// The ID of the associated account file. Used for verification to ensure the restored
-    /// obsolete accounts correspond to the correct account file
-    pub id: SerializedAccountsFileId,
-    /// The number of obsolete bytes in the storage. These bytes are removed during archive
-    /// serialization/deserialization but are present when restoring from directories. This value
-    /// is used to validate the size when creating the accounts file.
-    pub bytes: u64,
-    /// A list of accounts that are obsolete in the storage being restored.
-    pub accounts: ObsoleteAccounts,
-}
-
-#[cfg(feature = "frozen-abi")]
-impl solana_frozen_abi::abi_example::TransparentAsHelper for SerializableAccountStorageEntry {}
-
 pub(crate) trait SerializableStorage {
     fn id(&self) -> SerializedAccountsFileId;
     fn current_len(&self) -> usize;
@@ -62,4 +45,21 @@ impl SerializableStorage for SerializableAccountStorageEntry {
     fn current_len(&self) -> usize {
         self.accounts_current_len
     }
+}
+
+#[cfg(feature = "frozen-abi")]
+impl solana_frozen_abi::abi_example::TransparentAsHelper for SerializableAccountStorageEntry {}
+
+/// This structure handles the load/store of obsolete accounts during snapshot restoration.
+#[derive(Debug, Default)]
+pub(crate) struct SerdeObsoleteAccounts {
+    /// The ID of the associated account file. Used for verification to ensure the restored
+    /// obsolete accounts correspond to the correct account file
+    pub id: SerializedAccountsFileId,
+    /// The number of obsolete bytes in the storage. These bytes are removed during archive
+    /// serialization/deserialization but are present when restoring from directories. This value
+    /// is used to validate the size when creating the accounts file.
+    pub bytes: u64,
+    /// A list of accounts that are obsolete in the storage being restored.
+    pub accounts: ObsoleteAccounts,
 }

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -50,9 +50,9 @@ impl SerializableStorage for SerializableAccountStorageEntry {
 /// This structure handles the load/store of obsolete accounts during snapshot restoration.
 #[derive(Debug, Default)]
 pub(crate) struct SerdeObsoleteAccounts {
-    /// The ID of the associated append_vec. Used for verification to ensure the restored obsolete
-    /// accounts correspond to the correct append_vec_id.
-    pub append_vec_id: SerializedAccountsFileId,
+    /// The ID of the associated account file. Used for verification to ensure the restored
+    /// obsolete accounts correspond to the correct account file
+    pub id: SerializedAccountsFileId,
     /// The number of obsolete bytes in the storage. These bytes are removed during archive
     /// serialization/deserialization but are present when restoring from directories. This value
     /// is used to validate the size when creating the accounts file.

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -144,7 +144,7 @@ mod serde_snapshot_tests {
                 storage_entry.slot(),
                 storage_entry.id(),
                 accounts_file,
-                &[],
+                Vec::new(),
             );
             next_append_vec_id = next_append_vec_id.max(new_storage_entry.id());
             storage.insert(new_storage_entry.slot(), Arc::new(new_storage_entry));

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -144,6 +144,7 @@ mod serde_snapshot_tests {
                 storage_entry.slot(),
                 storage_entry.id(),
                 accounts_file,
+                &[],
             );
             next_append_vec_id = next_append_vec_id.max(new_storage_entry.id());
             storage.insert(new_storage_entry.slot(), Arc::new(new_storage_entry));

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -23,6 +23,7 @@ mod serde_snapshot_tests {
             },
             accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
             ancestors::Ancestors,
+            ObsoleteAccounts,
         },
         solana_clock::Slot,
         solana_epoch_schedule::EpochSchedule,
@@ -144,7 +145,7 @@ mod serde_snapshot_tests {
                 storage_entry.slot(),
                 storage_entry.id(),
                 accounts_file,
-                Vec::new(),
+                ObsoleteAccounts::default(),
             );
             next_append_vec_id = next_append_vec_id.max(new_storage_entry.id());
             storage.insert(new_storage_entry.slot(), Arc::new(new_storage_entry));

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1,11 +1,12 @@
 #[cfg(feature = "dev-context-only-utils")]
 use solana_accounts_db::utils::create_accounts_run_and_snapshot_dirs;
+
 use {
     crate::{
         bank::{BankFieldsToDeserialize, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
         serde_snapshot::{
             self, AccountsDbFields, ExtraFieldsToSerialize, SerializableAccountStorageEntry,
-            SnapshotAccountsDbFields, SnapshotBankFields, SnapshotStreams,
+            SnapshotAccountsDbFields, SnapshotBankFields, SnapshotStreams, SerializedAccountsFileId,
         },
         snapshot_archive_info::{
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfo,
@@ -25,9 +26,7 @@ use {
     solana_accounts_db::{
         account_storage::{AccountStorageMap, AccountStoragesOrderer},
         account_storage_reader::AccountStorageReader,
-        accounts_db::{
-            AccountStorageEntry, AccountsDbConfig, AccountsFileId, AtomicAccountsFileId,
-        },
+        accounts_db::{AccountStorageEntry, AccountsDbConfig, AtomicAccountsFileId},
         accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
         hardened_unpack::{self, UnpackError},
         utils::{move_and_async_delete_path, ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR},
@@ -340,10 +339,10 @@ pub enum SnapshotError {
     MismatchedHash(SnapshotHash, SnapshotHash),
 
     #[error(
-        "snapshot accounts file id mismatch: deserialized obsolete accounts file id: {0:?}, \
-         snapshot archive: {1:?}"
+        "snapshot accounts file id mismatch: deserialized obsolete accounts file id: {0}, \
+         snapshot archive: {1}"
     )]
-    MismatchedAccountsFileId(AccountsFileId, AccountsFileId),
+    MismatchedAccountsFileId(SerializedAccountsFileId, SerializedAccountsFileId),
 
     #[error("snapshot slot deltas are invalid: {0}")]
     VerifySlotDeltas(#[from] VerifySlotDeltasError),

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -6,7 +6,8 @@ use {
         bank::{BankFieldsToDeserialize, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
         serde_snapshot::{
             self, AccountsDbFields, ExtraFieldsToSerialize, SerializableAccountStorageEntry,
-            SnapshotAccountsDbFields, SnapshotBankFields, SnapshotStreams, SerializedAccountsFileId,
+            SerializedAccountsFileId, SnapshotAccountsDbFields, SnapshotBankFields,
+            SnapshotStreams,
         },
         snapshot_archive_info::{
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfo,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "dev-context-only-utils")]
 use solana_accounts_db::utils::create_accounts_run_and_snapshot_dirs;
-
 use {
     crate::{
         bank::{BankFieldsToDeserialize, BankFieldsToSerialize, BankHashStats, BankSlotDelta},

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -25,7 +25,9 @@ use {
     solana_accounts_db::{
         account_storage::{AccountStorageMap, AccountStoragesOrderer},
         account_storage_reader::AccountStorageReader,
-        accounts_db::{AccountStorageEntry, AccountsDbConfig, AtomicAccountsFileId},
+        accounts_db::{
+            AccountStorageEntry, AccountsDbConfig, AccountsFileId, AtomicAccountsFileId,
+        },
         accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
         hardened_unpack::{self, UnpackError},
         utils::{move_and_async_delete_path, ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR},
@@ -336,6 +338,12 @@ pub enum SnapshotError {
 
     #[error("snapshot hash mismatch: deserialized bank: {0:?}, snapshot archive: {1:?}")]
     MismatchedHash(SnapshotHash, SnapshotHash),
+
+    #[error(
+        "snapshot accounts file id mismatch: deserialized obsolete accounts file id: {0:?}, \
+         snapshot archive: {1:?}"
+    )]
+    MismatchedAccountsFileId(AccountsFileId, AccountsFileId),
 
     #[error("snapshot slot deltas are invalid: {0}")]
     VerifySlotDeltas(#[from] VerifySlotDeltasError),

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -252,6 +252,7 @@ impl SnapshotStorageRebuilder {
                         current_len,
                         old_append_vec_id as AccountsFileId,
                         self.storage_access,
+                        Vec::new(),
                     )?,
                 };
 

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -252,7 +252,7 @@ impl SnapshotStorageRebuilder {
                         current_len,
                         old_append_vec_id as AccountsFileId,
                         self.storage_access,
-                        Vec::new(),
+                        None,
                     )?,
                 };
 


### PR DESCRIPTION
#### Problem
- When creating a new storage from an existing file, there is no way to pass in obsolete account information 

#### Summary of Changes
- Add new type SerdeObsoleteAccounts to store restored obsolete account information
- Modify AccountStorageEntry::new_existing to accept  obsolete accounts and populate the obsolete account data in the new storage entry
- Pass in expected file size + obsolete_bytes when calling AccountFile::new_for_startup()


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
