### PR TITLE
feat: discard shreds that unexpectedly specify data complete

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -153,6 +153,14 @@ impl ShredFetchStage {
                     &epoch_schedule,
                 )
             };
+            let discard_unexpected_data_complete_shreds = |shred_slot| {
+                check_feature_activation(
+                    &agave_feature_set::discard_unexpected_data_complete_shreds::id(),
+                    shred_slot,
+                    &feature_set,
+                    &epoch_schedule,
+                )
+            };
             let turbine_disabled = turbine_disabled.load(Ordering::Relaxed);
             for mut packet in packet_batch.iter_mut().filter(|p| !p.meta().discard()) {
                 if turbine_disabled
@@ -162,6 +170,7 @@ impl ShredFetchStage {
                         max_slot,
                         shred_version,
                         enforce_fixed_fec_set,
+                        discard_unexpected_data_complete_shreds,
                         &mut stats,
                     )
                 {

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1141,6 +1141,10 @@ pub mod static_instruction_limit {
     solana_pubkey::declare_id!("64ixypL1HPu8WtJhNSMb9mSgfFaJvsANuRkTbHyuLfnx");
 }
 
+pub mod discard_unexpected_data_complete_shreds {
+    solana_pubkey::declare_id!("8MhfKhoZEoiySpVe248bDkisyEcBA7JQLyUS94xoTSqN");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -2068,8 +2068,8 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         ),
         (
             discard_unexpected_data_complete_shreds::id(),
-            "SIMD-0337: Markers for Alpenglow Fast Leader Handover, \
-             DATA_COMPLETE_SHRED placement rules",
+            "SIMD-0337: Markers for Alpenglow Fast Leader Handover, DATA_COMPLETE_SHRED placement \
+             rules",
         ), /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -2066,7 +2066,11 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
             static_instruction_limit::id(),
             "SIMD-0160: static instruction limit",
         ),
-        /*************** ADD NEW FEATURES HERE ***************/
+        (
+            discard_unexpected_data_complete_shreds::id(),
+            "SIMD-0337: Markers for Alpenglow Fast Leader Handover, \
+             DATA_COMPLETE_SHRED placement rules",
+        ), /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()
     .cloned()

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -1014,6 +1014,7 @@ mod tests {
     const SIZE_OF_SHRED_VARIANT: usize = 1;
     const SIZE_OF_VERSION: usize = 2;
     const SIZE_OF_FEC_SET_INDEX: usize = 4;
+    const SIZE_OF_PARENT_OFFSET: usize = 2;
 
     const OFFSET_OF_SHRED_VARIANT: usize = SIZE_OF_SIGNATURE;
     const OFFSET_OF_SHRED_SLOT: usize = SIZE_OF_SIGNATURE + SIZE_OF_SHRED_VARIANT;
@@ -1021,6 +1022,9 @@ mod tests {
     const OFFSET_OF_FEC_SET_INDEX: usize =
         OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX + SIZE_OF_VERSION;
     const OFFSET_OF_NUM_DATA: usize = OFFSET_OF_FEC_SET_INDEX + SIZE_OF_FEC_SET_INDEX;
+
+    const OFFSET_OF_PARENT_OFFSET: usize = OFFSET_OF_FEC_SET_INDEX + SIZE_OF_FEC_SET_INDEX;
+    const OFFSET_OF_SHRED_FLAGS: usize = OFFSET_OF_PARENT_OFFSET + SIZE_OF_PARENT_OFFSET;
 
     pub(super) fn make_merkle_shreds_for_tests<R: Rng>(
         rng: &mut R,
@@ -2086,7 +2090,9 @@ mod tests {
             //     85 = SIZE_OF_COMMON_SHRED_HEADER (83) + size of parent offset (i.e., 2)
             //
             // See the top-level comments, which articulate data shred layout, for more details.
-            cursor.seek(SeekFrom::Start(85)).unwrap(); // flags offset
+            cursor
+                .seek(SeekFrom::Start(OFFSET_OF_SHRED_FLAGS as u64))
+                .unwrap(); // flags offset
             cursor
                 .write_all(&[ShredFlags::DATA_COMPLETE_SHRED.bits()])
                 .unwrap();

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -2047,7 +2047,6 @@ mod tests {
             &mut rng,
             slot,
             1200 * 5, // data_size
-            true,     // chained
             false,    // is_last_in_slot
         )
         .unwrap();

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -846,7 +846,7 @@ where
             {
                 stats.unexpected_data_complete_shred += 1;
 
-                if discard_unexpected_data_complete_shreds(slot) {
+                if enforce_fixed_fec_set(slot) && discard_unexpected_data_complete_shreds(slot) {
                     return true;
                 }
             }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -839,6 +839,14 @@ where
                 stats.shred_flags_bad_deserialize += 1;
                 return true;
             };
+
+            if shred_flags.contains(ShredFlags::DATA_COMPLETE_SHRED)
+                && index != fec_set_index + DATA_SHREDS_PER_FEC_BLOCK as u32 - 1
+            {
+                stats.unexpected_data_complete_shred += 1;
+                return true;
+            }
+
             if shred_flags.contains(ShredFlags::LAST_SHRED_IN_SLOT)
                 && !check_last_data_shred_index(index)
             {

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -2068,7 +2068,6 @@ mod tests {
 
         let fec_set_index = 64u32;
         let wrong_index = fec_set_index + 10; // Should be fec_set_index + 31 for DATA_COMPLETE_SHRED
-        let data_complete_flags = ShredFlags::DATA_COMPLETE_SHRED;
 
         // Modify the packet to have DATA_COMPLETE_SHRED flag with wrong index
         {
@@ -2081,8 +2080,16 @@ mod tests {
                 .seek(SeekFrom::Start(OFFSET_OF_FEC_SET_INDEX as u64))
                 .unwrap();
             cursor.write_all(&fec_set_index.to_le_bytes()).unwrap();
+
+            // Flags offset is at 85, where:
+            //
+            //     85 = SIZE_OF_COMMON_SHRED_HEADER (83) + size of parent offset (i.e., 2)
+            //
+            // See the top-level comments, which articulate data shred layout, for more details.
             cursor.seek(SeekFrom::Start(85)).unwrap(); // flags offset
-            cursor.write_all(&[data_complete_flags.bits()]).unwrap();
+            cursor
+                .write_all(&[ShredFlags::DATA_COMPLETE_SHRED.bits()])
+                .unwrap();
         }
 
         let mut stats = ShredFetchStats::default();

--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -64,6 +64,7 @@ pub struct ShredFetchStats {
     pub(super) misaligned_erasure_config: usize,
     pub(super) shred_flags_bad_deserialize: usize,
     pub(super) misaligned_last_data_index: usize,
+    pub(super) unexpected_data_complete_shred: usize,
     since: Option<Instant>,
     pub overflow_shreds: usize,
 }
@@ -199,14 +200,27 @@ impl ShredFetchStats {
                 self.erasure_config_bad_deserialize,
                 i64
             ),
-            ("misaligned_erasure_config", self.misaligned_erasure_config, i64),
+            (
+                "misaligned_erasure_config",
+                self.misaligned_erasure_config,
+                i64
+            ),
             (
                 "shred_flags_bad_deserialize",
                 self.shred_flags_bad_deserialize,
                 i64
             ),
-            ("misaligned_last_data_index", self.misaligned_last_data_index, i64),
+            (
+                "misaligned_last_data_index",
+                self.misaligned_last_data_index,
+                i64
+            ),
             ("overflow_shreds", self.overflow_shreds, i64),
+            (
+                "unexpected_data_complete_shred",
+                self.unexpected_data_complete_shred,
+                i64
+            )
         );
         *self = Self {
             since: Some(Instant::now()),


### PR DESCRIPTION
### Summary
Currently, the `DATA_COMPLETE_SHRED` flag can theoretically be set on any data shred within an FEC set, though in practice it marks FEC set boundaries.

By enforcing `DATA_COMPLETE_SHRED` placement only on the last data shred in each FEC set, validators can detect `BlockComponent` boundaries during online shred ingestion, necessary for Alpenglow Fast Leader Handover.

This PR addresses https://github.com/solana-foundation/solana-improvement-documents/pull/337.