### PR TITLE
Updates accounts index tests that require disk index to be explicit

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1438,7 +1438,7 @@ impl Drop for FlushGuard<'_> {
 mod tests {
     use {
         super::*,
-        crate::accounts_index::{AccountsIndexConfig, BINS_FOR_TESTING},
+        crate::accounts_index::{AccountsIndexConfig, IndexLimitMb, BINS_FOR_TESTING},
         assert_matches::assert_matches,
         itertools::Itertools,
         test_case::test_case,
@@ -1455,11 +1455,11 @@ mod tests {
     }
 
     fn new_disk_buckets_for_test<T: IndexValue>() -> InMemAccountsIndex<T, T> {
-        let holder = Arc::new(BucketMapHolder::new(
-            BINS_FOR_TESTING,
-            &AccountsIndexConfig::default(),
-            1,
-        ));
+        let config = AccountsIndexConfig {
+            index_limit_mb: IndexLimitMb::Minimal,
+            ..Default::default()
+        };
+        let holder = Arc::new(BucketMapHolder::new(BINS_FOR_TESTING, &config, 1));
         let bin = 0;
         let bucket = InMemAccountsIndex::new(&holder, bin);
         assert!(bucket.storage.is_disk_index_enabled());

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -477,7 +477,10 @@ pub mod tests {
     #[test]
     fn test_disk_index_enabled() {
         let bins = 1;
-        let config = AccountsIndexConfig::default();
+        let config = AccountsIndexConfig {
+            index_limit_mb: IndexLimitMb::Minimal,
+            ..Default::default()
+        };
         let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
         assert!(test.is_disk_index_enabled());
     }


### PR DESCRIPTION
#### Problem

While working on https://github.com/anza-xyz/agave/pull/8015, which disables the disk-index by default, a few tests needed to be updated to explicitly set their config to use the disk-index. Those tests should've been explicit all along.


#### Summary of Changes

Update tests that require the disk index to say so.