### PR TITLE
faucet: switch run_local_faucet_with_config to single thread runtime

### DIFF
--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -345,7 +345,10 @@ pub fn run_local_faucet_with_config(
             config.per_time_cap,
             config.per_request_cap,
         )));
-        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
         runtime.block_on(run_faucet(faucet, faucet_addr, Some(sender)));
     });
 }


### PR DESCRIPTION
#### Problem
Local faucet used in tests and benchmarks spawns a multi-threaded runtime `Runtime::new()`, which creates as many worker threads as available for the cpu. This is clearly overkill.

#### Summary of Changes
- `run_local_faucet_with_config()` calls `Builder::new_current_thread()` instead, avoiding spawning redundant threads.
