### PR TITLE
build: update publish-tarball.sh script

### DIFF
--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -91,10 +91,16 @@ echo --- Creating release tarball
   source ci/rust-version.sh stable
   scripts/cargo-install-all.sh stable "${RELEASE_BASENAME}"
 
-  tar cvf "${TARBALL_BASENAME}"-$TARGET.tar "${RELEASE_BASENAME}"
-  bzip2 "${TARBALL_BASENAME}"-$TARGET.tar
-  cp "${RELEASE_BASENAME}"/bin/agave-install-init agave-install-init-$TARGET
-  cp "${RELEASE_BASENAME}"/version.yml "${TARBALL_BASENAME}"-$TARGET.yml
+  source scripts/agave-build-lists.sh
+  tmp_excludes=$(mktemp)
+  for bin in "${AGAVE_BINS_VAL_OP[@]}"; do
+    find "${RELEASE_BASENAME}" -type f -name "$bin" -print -quit >> "$tmp_excludes"
+  done
+
+  tar -I bzip2 -X "$tmp_excludes" -cvf "${TARBALL_BASENAME}"-"$TARGET".tar.bz2 "${RELEASE_BASENAME}"
+
+  cp "${RELEASE_BASENAME}"/bin/agave-install-init agave-install-init-"$TARGET"
+  cp "${RELEASE_BASENAME}"/version.yml "${TARBALL_BASENAME}"-"$TARGET".yml
 )
 
 # Maybe tarballs are platform agnostic, only publish them from the Linux build

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -89,7 +89,7 @@ echo --- Creating release tarball
   export CHANNEL
 
   source ci/rust-version.sh stable
-  scripts/cargo-install-all.sh --public-release stable "${RELEASE_BASENAME}"
+  scripts/cargo-install-all.sh stable "${RELEASE_BASENAME}"
 
   tar cvf "${TARBALL_BASENAME}"-$TARGET.tar "${RELEASE_BASENAME}"
   bzip2 "${TARBALL_BASENAME}"-$TARGET.tar


### PR DESCRIPTION
#### Problem

Changes to `cargo-install-all.sh` need to be reflected in the publish tarball script.

#### Summary of Changes

- remove deprecated public release flag
- exclude validator operator bins from release tarball

Closes https://github.com/anza-xyz/devops/issues/672
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->

