### PR TITLE
Add stat for reclaims

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6004,6 +6004,10 @@ impl AccountsDb {
         // should skip handle_reclaims only when reclaims is empty. No need to
         // check the elements of reclaims are empty.
         if !reclaims.is_empty() {
+            let reclaims_len = reclaims.iter().map(|r| r.len()).sum::<usize>();
+            self.stats
+                .num_reclaims
+                .fetch_add(reclaims_len as u64, Ordering::Relaxed);
             let purge_stats = PurgeStats::default();
             let mut handle_reclaims_time = Measure::start("handle_reclaims");
             self.handle_reclaims(
@@ -6213,6 +6217,11 @@ impl AccountsDb {
                 (
                     "total_data",
                     self.stats.store_total_data.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "num_reclaims",
+                    self.stats.num_reclaims.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -18,6 +18,7 @@ pub struct AccountsStats {
     pub stakes_cache_check_and_store_us: AtomicU64,
     pub store_num_accounts: AtomicU64,
     pub store_total_data: AtomicU64,
+    pub num_reclaims: AtomicU64,
     pub create_store_count: AtomicU64,
     pub dropped_stores: AtomicU64,
     pub handle_dead_keys_us: AtomicU64,


### PR DESCRIPTION
#### Problem

We don't have a stat for num of reclaims when we flush slot cache. 

#### Summary of Changeso

Add a stat for num of reclaims.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
