### PR TITLE
vote-program: handler: init v4 support

### DIFF
--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -81,9 +81,6 @@ pub trait VoteStateHandle {
 
     fn epoch_credits_last(&self) -> Option<&(Epoch, u64, u64)>;
 
-    /// Returns the credits to award for a vote at the given lockout slot index
-    fn credits_for_vote_at_index(&self, index: usize) -> u64;
-
     /// increment credits, record credits for last epoch if new epoch
     fn increment_credits(&mut self, epoch: Epoch, credits: u64);
 
@@ -257,37 +254,6 @@ impl VoteStateHandle for VoteStateV3 {
         self.epoch_credits.last()
     }
 
-    fn credits_for_vote_at_index(&self, index: usize) -> u64 {
-        let latency = self
-            .votes
-            .get(index)
-            .map_or(0, |landed_vote| landed_vote.latency);
-
-        // If latency is 0, this means that the Lockout was created and stored from a software version that did not
-        // store vote latencies; in this case, 1 credit is awarded
-        if latency == 0 {
-            1
-        } else {
-            match latency.checked_sub(VOTE_CREDITS_GRACE_SLOTS) {
-                None | Some(0) => {
-                    // latency was <= VOTE_CREDITS_GRACE_SLOTS, so maximum credits are awarded
-                    VOTE_CREDITS_MAXIMUM_PER_SLOT as u64
-                }
-
-                Some(diff) => {
-                    // diff = latency - VOTE_CREDITS_GRACE_SLOTS, and diff > 0
-                    // Subtract diff from VOTE_CREDITS_MAXIMUM_PER_SLOT which is the number of credits to award
-                    match VOTE_CREDITS_MAXIMUM_PER_SLOT.checked_sub(diff) {
-                        // If diff >= VOTE_CREDITS_MAXIMUM_PER_SLOT, 1 credit is awarded
-                        None | Some(0) => 1,
-
-                        Some(credits) => credits as u64,
-                    }
-                }
-            }
-        }
-    }
-
     fn increment_credits(&mut self, epoch: Epoch, credits: u64) {
         // increment credits, record by epoch
 
@@ -372,7 +338,7 @@ impl VoteStateHandle for VoteStateV3 {
 
         // Once the stack is full, pop the oldest lockout and distribute rewards
         if self.votes.len() == MAX_LOCKOUT_HISTORY {
-            let credits = self.credits_for_vote_at_index(0);
+            let credits = credits_for_vote_at_index(self, 0);
             let landed_vote = self.votes.pop_front().unwrap();
             self.root_slot = Some(landed_vote.slot());
 
@@ -527,10 +493,6 @@ impl VoteStateHandle for VoteStateV4 {
 
     fn epoch_credits_last(&self) -> Option<&(Epoch, u64, u64)> {
         self.epoch_credits.last()
-    }
-
-    fn credits_for_vote_at_index(&self, _index: usize) -> u64 {
-        todo!()
     }
 
     fn increment_credits(&mut self, _epoch: Epoch, _credits: u64) {
@@ -727,12 +689,6 @@ impl VoteStateHandle for VoteStateHandler {
         }
     }
 
-    fn credits_for_vote_at_index(&self, index: usize) -> u64 {
-        match &self.target_state {
-            TargetVoteState::V3(v3) => v3.credits_for_vote_at_index(index),
-        }
-    }
-
     fn increment_credits(&mut self, epoch: Epoch, credits: u64) {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.increment_credits(epoch, credits),
@@ -884,6 +840,37 @@ impl VoteStateHandler {
 // Computes the vote latency for vote on voted_for_slot where the vote itself landed in current_slot
 pub(crate) fn compute_vote_latency(voted_for_slot: Slot, current_slot: Slot) -> u8 {
     std::cmp::min(current_slot.saturating_sub(voted_for_slot), u8::MAX as u64) as u8
+}
+
+pub(crate) fn credits_for_vote_at_index<T: VoteStateHandle>(vote_state: &T, index: usize) -> u64 {
+    let latency = vote_state
+        .votes()
+        .get(index)
+        .map_or(0, |landed_vote| landed_vote.latency);
+
+    // If latency is 0, this means that the Lockout was created and stored from a software version that did not
+    // store vote latencies; in this case, 1 credit is awarded
+    if latency == 0 {
+        1
+    } else {
+        match latency.checked_sub(VOTE_CREDITS_GRACE_SLOTS) {
+            None | Some(0) => {
+                // latency was <= VOTE_CREDITS_GRACE_SLOTS, so maximum credits are awarded
+                VOTE_CREDITS_MAXIMUM_PER_SLOT as u64
+            }
+
+            Some(diff) => {
+                // diff = latency - VOTE_CREDITS_GRACE_SLOTS, and diff > 0
+                // Subtract diff from VOTE_CREDITS_MAXIMUM_PER_SLOT which is the number of credits to award
+                match VOTE_CREDITS_MAXIMUM_PER_SLOT.checked_sub(diff) {
+                    // If diff >= VOTE_CREDITS_MAXIMUM_PER_SLOT, 1 credit is awarded
+                    None | Some(0) => 1,
+
+                    Some(credits) => credits as u64,
+                }
+            }
+        }
+    }
 }
 
 #[allow(clippy::arithmetic_side_effects)]

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -486,7 +486,10 @@ pub fn process_new_vote_state(
             // than the new proposed root
             if current_vote.slot() <= new_root {
                 earned_credits = earned_credits
-                    .checked_add(vote_state.credits_for_vote_at_index(current_vote_state_index))
+                    .checked_add(handler::credits_for_vote_at_index(
+                        vote_state,
+                        current_vote_state_index,
+                    ))
                     .expect("`earned_credits` does not overflow");
                 current_vote_state_index = current_vote_state_index.checked_add(1).expect(
                     "`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when \

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -587,7 +587,7 @@ pub fn process_new_vote_state(
     }
     if let Some(timestamp) = timestamp {
         let last_slot = new_state.back().unwrap().slot();
-        vote_state.process_timestamp(last_slot, timestamp)?;
+        handler::process_timestamp(vote_state, last_slot, timestamp)?;
     }
     vote_state.set_root_slot(new_root);
     vote_state.set_votes(new_state);
@@ -915,7 +915,7 @@ pub fn process_vote_with_account<S: std::hash::BuildHasher>(
             .iter()
             .max()
             .ok_or(VoteError::EmptySlots)
-            .and_then(|slot| vote_state.process_timestamp(*slot, timestamp))?;
+            .and_then(|slot| handler::process_timestamp(&mut vote_state, *slot, timestamp))?;
     }
     vote_state.set_vote_account_state(vote_account)
 }

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -606,7 +606,7 @@ pub fn process_vote_unfiltered<T: VoteStateHandle>(
     check_slots_are_valid(vote_state, vote_slots, &vote.hash, slot_hashes)?;
     vote_slots
         .iter()
-        .for_each(|s| vote_state.process_next_vote_slot(*s, epoch, current_slot));
+        .for_each(|s| handler::process_next_vote_slot(vote_state, *s, epoch, current_slot));
     Ok(())
 }
 
@@ -1188,7 +1188,7 @@ mod tests {
             134, 135,
         ]
         .into_iter()
-        .for_each(|v| vote_state.process_next_vote_slot(v, 4, 0));
+        .for_each(|v| handler::process_next_vote_slot(&mut vote_state, v, 4, 0));
 
         let version1_14_11_serialized = bincode::serialize(&VoteStateVersions::V1_14_11(Box::new(
             VoteState1_14_11::from(vote_state.clone()),

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -16,7 +16,7 @@ use {
     solana_rent::Rent,
     solana_slot_hashes::SlotHash,
     solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContext},
-    solana_vote_interface::{authorized_voters::AuthorizedVoters, error::VoteError, program::id},
+    solana_vote_interface::{error::VoteError, program::id},
     std::{
         cmp::Ordering,
         collections::{HashSet, VecDeque},
@@ -1044,24 +1044,6 @@ pub fn create_account_with_authorized(
     vote_account
 }
 
-// TODO(wen): when we have VoteStateV4::new(), switch all users there.
-pub fn new_v4_vote_state(
-    node_pubkey: &Pubkey,
-    authorized_voter: &Pubkey,
-    authorized_withdrawer: &Pubkey,
-    bls_pubkey_compressed: Option<[u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]>,
-    inflation_rewards_commission_bps: u16,
-) -> VoteStateV4 {
-    VoteStateV4 {
-        node_pubkey: *node_pubkey,
-        authorized_voters: AuthorizedVoters::new(0, *authorized_voter),
-        authorized_withdrawer: *authorized_withdrawer,
-        bls_pubkey_compressed,
-        inflation_rewards_commission_bps,
-        ..VoteStateV4::default()
-    }
-}
-
 pub fn create_v4_account_with_authorized(
     node_pubkey: &Pubkey,
     authorized_voter: &Pubkey,
@@ -1072,7 +1054,7 @@ pub fn create_v4_account_with_authorized(
 ) -> AccountSharedData {
     let mut vote_account = AccountSharedData::new(lamports, VoteStateV4::size_of(), &id());
 
-    let vote_state = new_v4_vote_state(
+    let vote_state = handler::create_new_vote_state_v4_for_tests(
         node_pubkey,
         authorized_voter,
         authorized_withdrawer,
@@ -1109,6 +1091,7 @@ mod tests {
         solana_clock::DEFAULT_SLOTS_PER_EPOCH,
         solana_sha256_hasher::hash,
         solana_transaction_context::{InstructionAccount, TransactionContext},
+        solana_vote_interface::authorized_voters::AuthorizedVoters,
         std::cell::RefCell,
         test_case::test_case,
     };


### PR DESCRIPTION
#### Problem
Now that we have a "vote state handler" that can help us gate new vote state targets behind feature gates, it's time to implement `VoteStateV4` within the handler.

#### Summary of Changes
Implements the `VoteStateHandle` trait for `VoteStateV4` in the program's `handler` module and does some moderate refactoring to simplify the trait where possible and share functionality across free functions.

This change does not add a `V4` variant to the handler yet.