### PR TITLE
Enhance open connection metrics

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -210,6 +210,8 @@ pub struct StreamerStats {
     pub(crate) connection_rate_limiter_length: AtomicUsize,
     // All connections in various states such as Incoming, Connecting, Connection
     pub(crate) open_connections: AtomicUsize,
+    pub(crate) open_staked_connections: AtomicUsize,
+    pub(crate) open_unstaked_connections: AtomicUsize,
     pub(crate) refused_connections_too_many_open_connections: AtomicUsize,
     pub(crate) outstanding_incoming_connection_attempts: AtomicUsize,
     pub(crate) total_incoming_connection_attempts: AtomicUsize,

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -569,6 +569,16 @@ impl StreamerStats {
                 i64
             ),
             (
+                "open_staked_connections",
+                self.open_staked_connections.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "open_unstaked_connections",
+                self.open_unstaked_connections.load(Ordering::Relaxed),
+                i64
+            ),
+            (
                 "refused_connections_too_many_open_connections",
                 self.refused_connections_too_many_open_connections
                     .swap(0, Ordering::Relaxed),


### PR DESCRIPTION
#### Problem

We only have open_connections which include both staked and unstaked. It is hard to tell what is the usage for each.
#### Summary of Changes
introduced open_staked_connections and open_unstaked_connections metrics.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
