### PR TITLE
Add Obsolete Accounts Module

### DIFF
--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -3,6 +3,7 @@ use {
         account_info::Offset,
         accounts_db::AccountStorageEntry,
         accounts_file::{AccountsFile, InternalsForArchive},
+        obsolete_accounts::ObsoleteAccount,
     },
     solana_clock::Slot,
     std::{
@@ -30,8 +31,9 @@ impl<'a> AccountStorageReader<'a> {
         let num_total_bytes = storage.accounts.len();
         let num_alive_bytes = num_total_bytes - storage.get_obsolete_bytes(snapshot_slot);
 
-        let mut sorted_obsolete_accounts = storage.get_obsolete_accounts(snapshot_slot);
-
+        let mut sorted_obsolete_accounts: Vec<_> = storage
+            .obsolete_accounts()
+            .filter_obsolete_accounts(snapshot_slot);
         // Tiered storage is not compatible with obsolete accounts at this time
         if matches!(storage.accounts, AccountsFile::TieredStorage(_)) {
             assert!(
@@ -181,7 +183,9 @@ mod tests {
         let offset = 0;
         // Mark the obsolete accounts in storage
         let mut size = storage.accounts.get_account_data_lens(&[0]);
-        storage.mark_accounts_obsolete(vec![(offset, size.pop().unwrap())].into_iter(), 0);
+        storage
+            .obsolete_accounts_mut()
+            .mark_accounts_obsolete(vec![(offset, size.pop().unwrap())].into_iter(), 0);
 
         _ = AccountStorageReader::new(&storage, None).unwrap();
     }
@@ -271,7 +275,9 @@ mod tests {
         let data_lens = storage
             .accounts
             .get_account_data_lens(&obsolete_account_offset);
-        storage.mark_accounts_obsolete(obsolete_account_offset.into_iter().zip(data_lens), 0);
+        storage
+            .obsolete_accounts_mut()
+            .mark_accounts_obsolete(obsolete_account_offset.into_iter().zip(data_lens), 0);
 
         let storage = storage
             .reopen_as_readonly(storage_access)
@@ -384,7 +390,7 @@ mod tests {
         let mut slot_marked_dead = 0;
         obsolete_account_offset.into_iter().for_each(|offset| {
             let mut size = storage.accounts.get_account_data_lens(&[offset]);
-            storage.mark_accounts_obsolete(
+            storage.obsolete_accounts().mark_accounts_obsolete(
                 vec![(offset, size.pop().unwrap())].into_iter(),
                 slot_marked_dead,
             );

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -184,7 +184,9 @@ mod tests {
         // Mark the obsolete accounts in storage
         let mut size = storage.accounts.get_account_data_lens(&[0]);
         storage
-            .obsolete_accounts_write_lock()
+            .obsolete_accounts()
+            .write()
+            .unwrap()
             .mark_accounts_obsolete(vec![(offset, size.pop().unwrap())].into_iter(), 0);
 
         _ = AccountStorageReader::new(&storage, None).unwrap();
@@ -276,7 +278,9 @@ mod tests {
             .accounts
             .get_account_data_lens(&obsolete_account_offset);
         storage
-            .obsolete_accounts_write_lock()
+            .obsolete_accounts()
+            .write()
+            .unwrap()
             .mark_accounts_obsolete(obsolete_account_offset.into_iter().zip(data_lens), 0);
 
         let storage = storage
@@ -391,7 +395,9 @@ mod tests {
         obsolete_account_offset.into_iter().for_each(|offset| {
             let mut size = storage.accounts.get_account_data_lens(&[offset]);
             storage
-                .obsolete_accounts_write_lock()
+                .obsolete_accounts()
+                .write()
+                .unwrap()
                 .mark_accounts_obsolete(
                     vec![(offset, size.pop().unwrap())].into_iter(),
                     slot_marked_dead,

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -31,7 +31,7 @@ impl<'a> AccountStorageReader<'a> {
         let num_alive_bytes = num_total_bytes - storage.get_obsolete_bytes(snapshot_slot);
 
         let mut sorted_obsolete_accounts: Vec<_> = storage
-            .obsolete_accounts()
+            .obsolete_accounts_read_lock()
             .filter_obsolete_accounts(snapshot_slot)
             .collect();
         // Tiered storage is not compatible with obsolete accounts at this time
@@ -184,9 +184,7 @@ mod tests {
         // Mark the obsolete accounts in storage
         let mut size = storage.accounts.get_account_data_lens(&[0]);
         storage
-            .obsolete_accounts_for_test()
-            .write()
-            .unwrap()
+            .obsolete_accounts_write_lock()
             .mark_accounts_obsolete(vec![(offset, size.pop().unwrap())].into_iter(), 0);
 
         _ = AccountStorageReader::new(&storage, None).unwrap();
@@ -278,9 +276,7 @@ mod tests {
             .accounts
             .get_account_data_lens(&obsolete_account_offset);
         storage
-            .obsolete_accounts_for_test()
-            .write()
-            .unwrap()
+            .obsolete_accounts_write_lock()
             .mark_accounts_obsolete(obsolete_account_offset.into_iter().zip(data_lens), 0);
 
         let storage = storage
@@ -395,9 +391,7 @@ mod tests {
         obsolete_account_offset.into_iter().for_each(|offset| {
             let mut size = storage.accounts.get_account_data_lens(&[offset]);
             storage
-                .obsolete_accounts_for_test()
-                .write()
-                .unwrap()
+                .obsolete_accounts_write_lock()
                 .mark_accounts_obsolete(
                     vec![(offset, size.pop().unwrap())].into_iter(),
                     slot_marked_dead,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -22,13 +22,10 @@ mod geyser_plugin_utils;
 pub mod stats;
 pub mod tests;
 
-#[cfg(test)]
-use {
-    crate::append_vec::StoredAccountMeta,
-    std::sync::RwLockWriteGuard,
-};
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
+#[cfg(test)]
+use {crate::append_vec::StoredAccountMeta, std::sync::RwLockWriteGuard};
 use {
     crate::{
         account_info::{AccountInfo, Offset, StorageLocation},
@@ -5807,7 +5804,7 @@ impl AccountsDb {
                         let mut pubkeys = Vec::with_capacity(store.count());
                         // Obsolete accounts are already unreffed before this point, so do not add
                         // them to the pubkeys list.
-                        let obsolete_accounts: Vec<_> = store
+                        let obsolete_accounts: HashSet<_> = store
                             .obsolete_accounts_read_lock()
                             .filter_obsolete_accounts(None)
                             .collect();
@@ -7199,7 +7196,7 @@ impl AccountStorageEntry {
 #[cfg(test)]
 impl AccountStorageEntry {
     // Function to modify the list in the account storage entry directly. Only intended for use in testing
-    pub (crate) fn obsolete_accounts_write_lock(&self) -> RwLockWriteGuard<ObsoleteAccounts> {
+    pub(crate) fn obsolete_accounts_write_lock(&self) -> RwLockWriteGuard<ObsoleteAccounts> {
         self.obsolete_accounts.write().unwrap()
     }
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -22,10 +22,10 @@ mod geyser_plugin_utils;
 pub mod stats;
 pub mod tests;
 
+#[cfg(test)]
+use crate::append_vec::StoredAccountMeta;
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
-#[cfg(test)]
-use {crate::append_vec::StoredAccountMeta, std::sync::RwLockWriteGuard};
 use {
     crate::{
         account_info::{AccountInfo, Offset, StorageLocation},
@@ -7196,8 +7196,8 @@ impl AccountStorageEntry {
 #[cfg(test)]
 impl AccountStorageEntry {
     // Function to modify the list in the account storage entry directly. Only intended for use in testing
-    pub(crate) fn obsolete_accounts_write_lock(&self) -> RwLockWriteGuard<ObsoleteAccounts> {
-        self.obsolete_accounts.write().unwrap()
+    pub(crate) fn obsolete_accounts(&self) -> &RwLock<ObsoleteAccounts> {
+        &self.obsolete_accounts
     }
 }
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -745,10 +745,9 @@ fn test_flush_slots_with_reclaim_old_slots() {
         let storage = accounts.storage.get_slot_storage_entry(slot).unwrap();
         assert_eq!(
             storage
-                .obsolete_accounts()
+                .obsolete_accounts_read_lock()
                 .filter_obsolete_accounts(Some(new_slot))
-                .collect::<Vec<_>>()
-                .len() as u64,
+                .count() as u64,
             5 - slot
         );
     }
@@ -1144,10 +1143,9 @@ fn test_clean_dead_slot_with_obsolete_accounts() {
 
     // Ensure that slot1 also still contains the obsolete account
     assert_eq!(
-        slot.obsolete_accounts()
+        slot.obsolete_accounts_read_lock()
             .filter_obsolete_accounts(None)
-            .collect::<Vec<_>>()
-            .len(),
+            .count(),
         1
     );
 
@@ -3722,10 +3720,9 @@ define_accounts_db_test!(test_alive_bytes, |accounts_db| {
                 assert_eq!(before_size, after_size + stored_size_aligned);
                 assert_eq!(
                     storage0
-                        .obsolete_accounts()
+                        .obsolete_accounts_read_lock()
                         .filter_obsolete_accounts(None)
-                        .collect::<Vec<_>>()
-                        .len(),
+                        .count(),
                     num_obsolete_accounts
                 );
             }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -747,6 +747,7 @@ fn test_flush_slots_with_reclaim_old_slots() {
             storage
                 .obsolete_accounts()
                 .filter_obsolete_accounts(Some(new_slot))
+                .collect::<Vec<_>>()
                 .len() as u64,
             5 - slot
         );
@@ -1145,6 +1146,7 @@ fn test_clean_dead_slot_with_obsolete_accounts() {
     assert_eq!(
         slot.obsolete_accounts()
             .filter_obsolete_accounts(None)
+            .collect::<Vec<_>>()
             .len(),
         1
     );
@@ -3722,6 +3724,7 @@ define_accounts_db_test!(test_alive_bytes, |accounts_db| {
                     storage0
                         .obsolete_accounts()
                         .filter_obsolete_accounts(None)
+                        .collect::<Vec<_>>()
                         .len(),
                     num_obsolete_accounts
                 );

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -744,7 +744,10 @@ fn test_flush_slots_with_reclaim_old_slots() {
         // Verify that the obsolete accounts for the remaining slots are correct
         let storage = accounts.storage.get_slot_storage_entry(slot).unwrap();
         assert_eq!(
-            storage.get_obsolete_accounts(Some(new_slot)).len() as u64,
+            storage
+                .obsolete_accounts()
+                .filter_obsolete_accounts(Some(new_slot))
+                .len() as u64,
             5 - slot
         );
     }
@@ -1139,7 +1142,12 @@ fn test_clean_dead_slot_with_obsolete_accounts() {
     let slot = accounts.storage.get_slot_storage_entry(1).unwrap();
 
     // Ensure that slot1 also still contains the obsolete account
-    assert_eq!(slot.get_obsolete_accounts(None).len(), 1);
+    assert_eq!(
+        slot.obsolete_accounts()
+            .filter_obsolete_accounts(None)
+            .len(),
+        1
+    );
 
     // Ref count for pubkey1 should be 1 as obsolete accounts are enabled
     accounts.assert_ref_count(&pubkey, 1);
@@ -3711,7 +3719,10 @@ define_accounts_db_test!(test_alive_bytes, |accounts_db| {
                 let stored_size_aligned = storage0.accounts.calculate_stored_size(account.data_len);
                 assert_eq!(before_size, after_size + stored_size_aligned);
                 assert_eq!(
-                    storage0.get_obsolete_accounts(None).len(),
+                    storage0
+                        .obsolete_accounts()
+                        .filter_obsolete_accounts(None)
+                        .len(),
                     num_obsolete_accounts
                 );
             }

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -30,6 +30,7 @@ pub mod hardened_unpack;
 mod io_uring;
 pub mod is_loadable;
 mod is_zero_lamport;
+mod obsolete_accounts;
 pub mod partitioned_rewards;
 pub mod pubkey_bins;
 #[cfg(feature = "dev-context-only-utils")]

--- a/accounts-db/src/obsolete_accounts.rs
+++ b/accounts-db/src/obsolete_accounts.rs
@@ -99,5 +99,4 @@ mod tests {
 
         assert_eq!(filtered_accounts, vec![(10, 100), (20, 200), (30, 300)]);
     }
-
 }

--- a/accounts-db/src/obsolete_accounts.rs
+++ b/accounts-db/src/obsolete_accounts.rs
@@ -1,39 +1,49 @@
 use {crate::account_info::Offset, solana_clock::Slot};
 
-pub type ObsoleteAccounts = Vec<ObsoleteAccountItem>;
-type ObsoleteAccountItem = (Offset, usize, Slot);
-
-pub trait ObsoleteAccount {
-    fn mark_accounts_obsolete(
-        &mut self,
-        newly_obsolete_accounts: impl ExactSizeIterator<Item = (Offset, usize)>,
-        slot: Slot,
-    );
-    fn filter_obsolete_accounts(&self, slot: Option<Slot>) -> Vec<(Offset, usize)>;
+#[derive(Debug, Clone, PartialEq)]
+struct ObsoleteAccountItem {
+    /// Offset of the account in the storage file
+    offset: Offset,
+    /// Length of the account data
+    data_len: usize,
+    /// Slot when the account was marked obsolete
+    slot: Slot,
 }
 
-impl ObsoleteAccount for ObsoleteAccounts {
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ObsoleteAccounts {
+    accounts: Vec<ObsoleteAccountItem>,
+}
+
+impl ObsoleteAccounts {
     /// Marks the accounts at the given offsets as obsolete
-    fn mark_accounts_obsolete(
+    pub fn mark_accounts_obsolete(
         &mut self,
         newly_obsolete_accounts: impl ExactSizeIterator<Item = (Offset, usize)>,
         slot: Slot,
     ) {
-        self.reserve(newly_obsolete_accounts.len());
+        self.accounts.reserve(newly_obsolete_accounts.len());
 
         for (offset, data_len) in newly_obsolete_accounts {
-            self.push((offset, data_len, slot));
+            self.accounts.push(ObsoleteAccountItem {
+                offset,
+                data_len,
+                slot,
+            });
         }
     }
 
     /// Returns the accounts that were marked obsolete as of the passed in slot
     /// or earlier. If slot is None, then slot will be assumed to be the max root
     /// and all obsolete accounts will be returned.
-    fn filter_obsolete_accounts(&self, slot: Option<Slot>) -> Vec<(Offset, usize)> {
-        self.iter()
-            .filter(move |(_, _, obsolete_slot)| slot.is_none_or(|s| *obsolete_slot <= s))
-            .map(|(offset, data_len, _)| (*offset, *data_len))
-            .collect()
+    pub fn filter_obsolete_accounts(
+        &self,
+        slot: Option<Slot>,
+    ) -> impl Iterator<Item = (Offset, usize)> + '_ {
+        self.accounts
+            .iter()
+            .filter(move |obsolete_account| slot.map_or(true, |s| obsolete_account.slot <= s))
+            .map(|obsolete_account| (obsolete_account.offset, obsolete_account.data_len))
     }
 }
 #[cfg(test)]
@@ -42,44 +52,79 @@ mod tests {
 
     #[test]
     fn test_mark_accounts_obsolete() {
-        let mut obsolete_accounts: ObsoleteAccounts = Vec::new();
+        let mut obsolete_accounts = ObsoleteAccounts::default();
         let new_accounts = vec![(10, 100), (20, 200), (30, 300)];
         let slot: Slot = 42;
 
         obsolete_accounts.mark_accounts_obsolete(new_accounts.into_iter(), slot);
 
         assert_eq!(
-            obsolete_accounts,
-            vec![(10, 100, slot), (20, 200, slot), (30, 300, slot),]
+            obsolete_accounts.accounts,
+            vec![
+                ObsoleteAccountItem {
+                    offset: 10,
+                    data_len: 100,
+                    slot,
+                },
+                ObsoleteAccountItem {
+                    offset: 20,
+                    data_len: 200,
+                    slot,
+                },
+                ObsoleteAccountItem {
+                    offset: 30,
+                    data_len: 300,
+                    slot,
+                },
+            ]
         );
     }
 
     #[test]
     fn test_filter_obsolete_accounts() {
-        let mut obsolete_accounts: ObsoleteAccounts = Vec::new();
-        let new_accounts: ObsoleteAccounts = vec![(10, 100, 40), (20, 200, 42), (30, 300, 44)];
+        let mut obsolete_accounts = ObsoleteAccounts::default();
+        let new_accounts: Vec<ObsoleteAccountItem> = vec![
+            ObsoleteAccountItem {
+                offset: 10,
+                data_len: 100,
+                slot: 40,
+            },
+            ObsoleteAccountItem {
+                offset: 20,
+                data_len: 200,
+                slot: 42,
+            },
+            ObsoleteAccountItem {
+                offset: 30,
+                data_len: 300,
+                slot: 44,
+            },
+        ];
 
         // Mark accounts obsolete with different slots
         new_accounts.into_iter().for_each(|item| {
-            obsolete_accounts.mark_accounts_obsolete([(item.0, item.1)].into_iter(), item.2)
+            obsolete_accounts
+                .mark_accounts_obsolete([(item.offset, item.data_len)].into_iter(), item.slot)
         });
 
         // Filter accounts obsolete as of slot 42
-        let filtered_accounts: Vec<_> = obsolete_accounts.filter_obsolete_accounts(Some(42));
+        let filtered_accounts: Vec<_> = obsolete_accounts
+            .filter_obsolete_accounts(Some(42))
+            .collect();
 
         assert_eq!(filtered_accounts, vec![(10, 100), (20, 200)]);
 
         // Filter accounts obsolete passing in no slot (i.e., all obsolete accounts)
-        let filtered_accounts: Vec<_> = obsolete_accounts.filter_obsolete_accounts(None);
+        let filtered_accounts: Vec<_> = obsolete_accounts.filter_obsolete_accounts(None).collect();
 
         assert_eq!(filtered_accounts, vec![(10, 100), (20, 200), (30, 300)]);
     }
 
     #[test]
     fn test_empty_obsolete_accounts() {
-        let obsolete_accounts: ObsoleteAccounts = Vec::new();
+        let obsolete_accounts: ObsoleteAccounts = ObsoleteAccounts::default();
 
-        let filtered_accounts: Vec<_> = obsolete_accounts.filter_obsolete_accounts(None);
+        let filtered_accounts: Vec<_> = obsolete_accounts.filter_obsolete_accounts(None).collect();
 
         assert!(filtered_accounts.is_empty());
     }

--- a/accounts-db/src/obsolete_accounts.rs
+++ b/accounts-db/src/obsolete_accounts.rs
@@ -1,0 +1,86 @@
+use {crate::account_info::Offset, solana_clock::Slot};
+
+pub type ObsoleteAccounts = Vec<ObsoleteAccountItem>;
+type ObsoleteAccountItem = (Offset, usize, Slot);
+
+pub trait ObsoleteAccount {
+    fn mark_accounts_obsolete(
+        &mut self,
+        newly_obsolete_accounts: impl ExactSizeIterator<Item = (Offset, usize)>,
+        slot: Slot,
+    );
+    fn filter_obsolete_accounts(&self, slot: Option<Slot>) -> Vec<(Offset, usize)>;
+}
+
+impl ObsoleteAccount for ObsoleteAccounts {
+    /// Marks the accounts at the given offsets as obsolete
+    fn mark_accounts_obsolete(
+        &mut self,
+        newly_obsolete_accounts: impl ExactSizeIterator<Item = (Offset, usize)>,
+        slot: Slot,
+    ) {
+        self.reserve(newly_obsolete_accounts.len());
+
+        for (offset, data_len) in newly_obsolete_accounts {
+            self.push((offset, data_len, slot));
+        }
+    }
+
+    /// Returns the accounts that were marked obsolete as of the passed in slot
+    /// or earlier. If slot is None, then slot will be assumed to be the max root
+    /// and all obsolete accounts will be returned.
+    fn filter_obsolete_accounts(&self, slot: Option<Slot>) -> Vec<(Offset, usize)> {
+        self.iter()
+            .filter(move |(_, _, obsolete_slot)| slot.is_none_or(|s| *obsolete_slot <= s))
+            .map(|(offset, data_len, _)| (*offset, *data_len))
+            .collect()
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mark_accounts_obsolete() {
+        let mut obsolete_accounts: ObsoleteAccounts = Vec::new();
+        let new_accounts = vec![(10, 100), (20, 200), (30, 300)];
+        let slot: Slot = 42;
+
+        obsolete_accounts.mark_accounts_obsolete(new_accounts.into_iter(), slot);
+
+        assert_eq!(
+            obsolete_accounts,
+            vec![(10, 100, slot), (20, 200, slot), (30, 300, slot),]
+        );
+    }
+
+    #[test]
+    fn test_filter_obsolete_accounts() {
+        let mut obsolete_accounts: ObsoleteAccounts = Vec::new();
+        let new_accounts: ObsoleteAccounts = vec![(10, 100, 40), (20, 200, 42), (30, 300, 44)];
+
+        // Mark accounts obsolete with different slots
+        new_accounts.into_iter().for_each(|item| {
+            obsolete_accounts.mark_accounts_obsolete([(item.0, item.1)].into_iter(), item.2)
+        });
+
+        // Filter accounts obsolete as of slot 42
+        let filtered_accounts: Vec<_> = obsolete_accounts.filter_obsolete_accounts(Some(42));
+
+        assert_eq!(filtered_accounts, vec![(10, 100), (20, 200)]);
+
+        // Filter accounts obsolete passing in no slot (i.e., all obsolete accounts)
+        let filtered_accounts: Vec<_> = obsolete_accounts.filter_obsolete_accounts(None);
+
+        assert_eq!(filtered_accounts, vec![(10, 100), (20, 200), (30, 300)]);
+    }
+
+    #[test]
+    fn test_empty_obsolete_accounts() {
+        let obsolete_accounts: ObsoleteAccounts = Vec::new();
+
+        let filtered_accounts: Vec<_> = obsolete_accounts.filter_obsolete_accounts(None);
+
+        assert!(filtered_accounts.is_empty());
+    }
+}


### PR DESCRIPTION
#### Problem
- Current separation of obsolete accounts and storage entry made it difficult to test ser/des functionality for fastboot. 
- Updated to allow functions to run independently on the obsolete account structure and at that point, it made sense to implement it in its own module

#### Summary of Changes
- Created ObsoleteAccount type and implemented in own module. 
- Added some unit tests to the module
- Note:: get_filtered_accounts will be updated to return an iterator in a followup PR. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
