### PR TITLE
Renames AccountsBackgroundService's thread

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -433,7 +433,7 @@ impl AccountsBackgroundService {
         let mut removed_slots_count = 0;
         let mut total_remove_slots_time = 0;
         let t_background = Builder::new()
-            .name("solBgAccounts".to_string())
+            .name("solAcctsBgSvc".to_string())
             .spawn({
                 let is_running = is_running.clone();
                 let stop = stop.clone();


### PR DESCRIPTION
#### Problem

The AccountsBackgroundService thread has a non-ideal name, "solBgAccounts".

1. Since we also have the accounts-db foreground and background thread pools, there's some ambiguity between the ABS thread and the bg thread pool, named "solAcctsDbBg". It's unlikely that someone without preexisting knowledge will understand the difference.

2. There is precedent for naming the thread of services as "Svc", but ABS does not follow this convention. Here's some examples:

```
core/src/warm_quic_cache_service.rs
69:            .name("solWarmQuicSvc".to_string())

core/src/repair/ancestor_hashes_service.rs
254:            .name("solAncHashesSvc".to_string())

core/src/repair/repair_service.rs
453:                .name("solRepairSvc".to_string())

core/src/commitment_service.rs
80:                    .name("solAggCommitSvc".to_string())

core/src/cost_update_service.rs
34:            .name("solCostUpdtSvc".to_string())

runtime/src/prioritization_fee_cache.rs
190:                .name("solPrFeeCachSvc".to_string())

rpc/src/rpc_service.rs
810:            .name("solJsonRpcSvc".to_string())
```



#### Summary of Changes

Rename the ABS thread to "solAcctsBgSvc".