### PR TITLE
ci: update publish tarball logic

### DIFF
--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -3,19 +3,6 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-if [[ -n $APPVEYOR ]]; then
-  # Bootstrap rust build environment
-  source ci/env.sh
-  source ci/rust-version.sh
-
-  appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  export USERPROFILE="D:\\"
-  ./rustup-init -yv --default-toolchain "$rust_stable" --default-host x86_64-pc-windows-msvc
-  export PATH="$PATH:/d/.cargo/bin"
-  rustc -vV
-  cargo -vV
-fi
-
 DRYRUN=
 if [[ -z $CI_BRANCH ]]; then
   DRYRUN="echo"
@@ -141,9 +128,6 @@ for file in "${TARBALL_BASENAME}"-$TARGET.tar.bz2 "${TARBALL_BASENAME}"-$TARGET.
       mkdir -p github-action-release-upload/
       cp -v "$file" github-action-release-upload/
     fi
-  elif [[ -n $APPVEYOR ]]; then
-    # Add artifacts for .appveyor.yml to upload
-    appveyor PushArtifact "$file" -FileName "$CHANNEL_OR_TAG"/"$file"
   fi
 done
 

--- a/ci/upload-ci-artifact.sh
+++ b/ci/upload-ci-artifact.sh
@@ -16,31 +16,6 @@ upload-ci-artifact() {
   fi
 }
 
-upload-s3-artifact() {
-  echo "--- artifact: $1 to $2"
-  (
-    args=(
-      --rm
-      --env AWS_ACCESS_KEY_ID
-      --env AWS_SECRET_ACCESS_KEY
-      --volume "$PWD:/solana"
-
-    )
-    if [[ $(uname -m) = arm64 ]]; then
-      # Ref: https://blog.jaimyn.dev/how-to-build-multi-architecture-docker-images-on-an-m1-mac/#tldr
-      args+=(
-        --platform linux/amd64
-      )
-    fi
-    args+=(
-      amazon/aws-cli:2.13.11
-      s3 cp "$1" "$2" --acl public-read
-    )
-    set -x
-    docker run "${args[@]}"
-  )
-}
-
 upload-gcs-artifact() {
   echo "--- artifact: $1 to $2"
   docker run --rm \


### PR DESCRIPTION
#### Problem

`publish-tarball.sh` and `upload-ci-artifact.sh` both contain logic to upload artefacts that is not being used anymore.

#### Summary of Changes

- remove unused s3 and appveyor upload logic

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
closes https://github.com/anza-xyz/devops/issues/689
