### PR TITLE
Allow 4 unstaked TPU peers per IP instead of 8

### DIFF
--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -267,7 +267,7 @@ fn main() -> Result<()> {
                 max_connections_per_ipaddr_per_min: max_connections_per_ipaddr_per_min
                     .try_into()
                     .unwrap(),
-                max_connections_per_peer,
+                max_connections_per_staked_peer: max_connections_per_peer,
                 max_staked_connections: max_connections,
                 max_unstaked_connections: 0,
                 ..Default::default()

--- a/streamer/examples/swqos.rs
+++ b/streamer/examples/swqos.rs
@@ -118,7 +118,7 @@ async fn main() -> anyhow::Result<()> {
         sender,
         staked_nodes,
         QuicServerParams {
-            max_connections_per_peer: cli.max_connections_per_peer,
+            max_connections_per_staked_peer: cli.max_connections_per_peer,
             ..QuicServerParams::default()
         },
         cancel.clone(),

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -354,7 +354,7 @@ async fn test_connection_pruned_and_reopened() {
     } = setup_quic_server(
         None,
         QuicServerParams {
-            max_connections_per_peer: 100,
+            max_connections_per_staked_peer: 100,
             max_unstaked_connections: 1,
             ..QuicServerParams::default_for_tests()
         },
@@ -556,7 +556,7 @@ async fn test_rate_limiting() {
     } = setup_quic_server(
         None,
         QuicServerParams {
-            max_connections_per_peer: 100,
+            max_connections_per_staked_peer: 100,
             max_connections_per_ipaddr_per_min: 1,
             ..QuicServerParams::default_for_tests()
         },
@@ -617,7 +617,7 @@ async fn test_rate_limiting_establish_connection() {
     } = setup_quic_server(
         None,
         QuicServerParams {
-            max_connections_per_peer: 100,
+            max_connections_per_staked_peer: 100,
             max_connections_per_ipaddr_per_min: 1,
             ..QuicServerParams::default_for_tests()
         },
@@ -761,7 +761,7 @@ async fn test_proactive_connection_close_detection() {
     } = setup_quic_server(
         None,
         QuicServerParams {
-            max_connections_per_peer: 1,
+            max_connections_per_staked_peer: 1,
             max_unstaked_connections: 1,
             ..QuicServerParams::default_for_tests()
         },

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -946,7 +946,7 @@ pub fn execute(
     node.info.hot_swap_pubkey(identity_keypair.pubkey());
 
     let tpu_quic_server_config = QuicServerParams {
-        max_connections_per_peer: tpu_max_connections_per_peer.try_into().unwrap(),
+        max_connections_per_staked_peer: tpu_max_connections_per_peer.try_into().unwrap(),
         max_staked_connections: tpu_max_staked_connections.try_into().unwrap(),
         max_unstaked_connections: tpu_max_unstaked_connections.try_into().unwrap(),
         max_streams_per_ms,
@@ -957,7 +957,7 @@ pub fn execute(
     };
 
     let tpu_fwd_quic_server_config = QuicServerParams {
-        max_connections_per_peer: tpu_max_connections_per_peer.try_into().unwrap(),
+        max_connections_per_staked_peer: tpu_max_connections_per_peer.try_into().unwrap(),
         max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
         max_unstaked_connections: tpu_max_fwd_unstaked_connections.try_into().unwrap(),
         max_streams_per_ms,
@@ -970,7 +970,7 @@ pub fn execute(
     // Vote shares TPU forward's characteristics, except that we accept 1 connection
     // per peer and no unstaked connections are accepted.
     let mut vote_quic_server_config = tpu_fwd_quic_server_config.clone();
-    vote_quic_server_config.max_connections_per_peer = 1;
+    vote_quic_server_config.max_connections_per_staked_peer = 1;
     vote_quic_server_config.max_unstaked_connections = 0;
     vote_quic_server_config.num_threads = tpu_vote_transaction_receive_threads;
 

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -119,7 +119,7 @@ impl Vortexor {
         cancel: CancellationToken,
     ) -> Self {
         let mut quic_server_params = QuicServerParams {
-            max_connections_per_peer,
+            max_connections_per_staked_peer: max_connections_per_peer,
             max_staked_connections: max_tpu_staked_connections,
             max_unstaked_connections: max_tpu_unstaked_connections,
             max_streams_per_ms,


### PR DESCRIPTION
#### Problem

- TPU does not need to support 8 peers per IP (NAT has limited use for trader bots)
- Currently people use this for spam

#### Summary of Changes

- Change max unstaked connections per IP to 1