### PR TITLE
Remove Default derive from AccountMapEntry

### DIFF
--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -13,7 +13,7 @@ use {
 
 /// one entry in the in-mem accounts index
 /// Represents the value for an account key in the in-memory accounts index
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct AccountMapEntry<T> {
     /// number of alive slots that contain >= 1 instances of account data for this pubkey
     /// where alive represents a slot that has not yet been removed by clean via AccountsDB::clean_stored_dead_slots() for containing no up to date account information
@@ -34,6 +34,16 @@ impl<T: IndexValue> AccountMapEntry<T> {
             meta,
         }
     }
+
+    #[cfg(test)]
+    pub(super) fn empty_for_tests() -> Self {
+        Self {
+            slot_list: RwLock::default(),
+            ref_count: AtomicRefCount::default(),
+            meta: AccountMapEntryMeta::default(),
+        }
+    }
+
     pub fn ref_count(&self) -> RefCount {
         self.ref_count.load(Ordering::Acquire)
     }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -2211,7 +2211,7 @@ mod tests {
 
         {
             // add an entry with an empty slot list
-            let val = Arc::new(AccountMapEntry::<u64>::default());
+            let val = Arc::new(AccountMapEntry::<u64>::empty_for_tests());
             map.insert(key, val);
             let entry = map.entry(key);
             assert_matches!(entry, Entry::Occupied(_));
@@ -2225,7 +2225,7 @@ mod tests {
 
         {
             // add an entry with a NON empty slot list - it will NOT get removed
-            let val = Arc::new(AccountMapEntry::<u64>::default());
+            let val = Arc::new(AccountMapEntry::<u64>::empty_for_tests());
             val.slot_list.write().unwrap().push((1, 1));
             map.insert(key, val);
             // does NOT remove it since it has a non-empty slot list
@@ -2238,7 +2238,7 @@ mod tests {
 
     #[test]
     fn test_lock_and_update_slot_list() {
-        let test = AccountMapEntry::<u64>::default();
+        let test = AccountMapEntry::<u64>::empty_for_tests();
         let info = 65;
         let mut reclaims = ReclaimsSlotList::new();
         // first upsert, should increase


### PR DESCRIPTION
#### Problem
Default account map entry isn't really a valid value that production code creates to put into the map, there are just a few uses in tests that create artificial state.

#### Summary of Changes
* remove `Default` derive from `AccountMapEntry`
* add `empty_for_tests` guarded with `cfg(test)` such that tests can still use a convenience function
