### PR TITLE
Deprecate the RPC client methods that accept a `UiAccountEncoding` config and return `Account`

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3111,7 +3111,7 @@ fn setup_transfer_scan_threads(
                 }
                 if let Some(total_scan_balance) = client
                     .rpc_client()
-                    .get_program_accounts_with_config(
+                    .get_program_ui_accounts_with_config(
                         &system_program::id(),
                         scan_commitment_config.clone(),
                     )

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7987,6 +7987,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account",
+ "solana-account-decoder",
  "solana-account-decoder-client-types",
  "solana-clock",
  "solana-commitment-config",

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -33,6 +33,7 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 solana-account = { workspace = true }
+solana-account-decoder = { workspace = true }
 solana-account-decoder-client-types = { workspace = true, features = ["zstd"] }
 solana-clock = { workspace = true }
 solana-commitment-config = { workspace = true }

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -4124,7 +4124,6 @@ impl RpcClient {
         pubkey: &Pubkey,
         mut config: RpcProgramAccountsConfig,
     ) -> ClientResult<Vec<(Pubkey, Account)>> {
-        // TODO
         let commitment = config
             .account_config
             .commitment

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -3786,7 +3786,7 @@ impl RpcClient {
         pubkeys: &[Pubkey],
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Vec<Option<Account>>> {
-        self.get_multiple_accounts_with_config(
+        self.get_multiple_ui_accounts_with_config(
             pubkeys,
             RpcAccountInfoConfig {
                 encoding: Some(UiAccountEncoding::Base64Zstd),
@@ -3796,6 +3796,22 @@ impl RpcClient {
             },
         )
         .await
+        .map(|response| Response {
+            context: response.context,
+            value: response
+                .value
+                .into_iter()
+                .map(|ui_account| {
+                    ui_account.map(|ui_account| {
+                        ui_account.decode().expect(
+                            "It should be impossible at this point for the account data not to be \
+                             decodable. Ensure that the account was fetched using a binary \
+                             encoding.",
+                        )
+                    })
+                })
+                .collect(),
+        })
     }
 
     #[deprecated(

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -4071,7 +4071,7 @@ impl RpcClient {
         &self,
         pubkey: &Pubkey,
     ) -> ClientResult<Vec<(Pubkey, Account)>> {
-        self.get_program_accounts_with_config(
+        self.get_program_ui_accounts_with_config(
             pubkey,
             RpcProgramAccountsConfig {
                 account_config: RpcAccountInfoConfig {
@@ -4082,6 +4082,21 @@ impl RpcClient {
             },
         )
         .await
+        .map(|response| {
+            response
+                .into_iter()
+                .map(|(pubkey, ui_account)| {
+                    (
+                        pubkey,
+                        ui_account.decode().expect(
+                            "It should be impossible at this point for the account data not to be \
+                             decodable. Ensure that the account was fetched using a binary \
+                             encoding.",
+                        ),
+                    )
+                })
+                .collect()
+        })
     }
 
     #[deprecated(

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -3524,7 +3524,17 @@ impl RpcClient {
             min_context_slot: None,
         };
 
-        self.get_account_with_config(pubkey, config).await
+        self.get_ui_account_with_config(pubkey, config)
+            .await
+            .map(|response| Response {
+                context: response.context,
+                value: response.value.map(|ui_account| {
+                    ui_account.decode().expect(
+                        "It should be impossible at this point for the account data not to be \
+                         decodable. Ensure that the account was fetched using a binary encoding.",
+                    )
+                }),
+            })
     }
 
     #[deprecated(

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -3527,13 +3527,55 @@ impl RpcClient {
         self.get_account_with_config(pubkey, config).await
     }
 
+    #[deprecated(
+        note = "Use `get_ui_account_with_config()` instead. This function will be removed in a \
+                future version of `solana_rpc_client`."
+    )]
+    pub async fn get_account_with_config(
+        &self,
+        pubkey: &Pubkey,
+        config: RpcAccountInfoConfig,
+    ) -> RpcResult<Option<Account>> {
+        let response = self
+            .send(
+                RpcRequest::GetAccountInfo,
+                json!([pubkey.to_string(), config]),
+            )
+            .await;
+
+        response
+            .map(|result_json: Value| {
+                if result_json.is_null() {
+                    return Err(
+                        RpcError::ForUser(format!("AccountNotFound: pubkey={pubkey}")).into(),
+                    );
+                }
+                let Response {
+                    context,
+                    value: rpc_account,
+                } = serde_json::from_value::<Response<Option<UiAccount>>>(result_json)?;
+                trace!("Response account {pubkey:?} {rpc_account:?}");
+                let account = rpc_account.and_then(|rpc_account| rpc_account.decode());
+
+                Ok(Response {
+                    context,
+                    value: account,
+                })
+            })
+            .map_err(|err| {
+                Into::<ClientError>::into(RpcError::ForUser(format!(
+                    "AccountNotFound: pubkey={pubkey}: {err}"
+                )))
+            })?
+    }
+
     /// Returns all information associated with the account of the provided pubkey.
     ///
     /// If the account does not exist, this method returns `Ok(None)`.
     ///
-    /// To get multiple accounts at once, use the [`get_multiple_accounts_with_config`] method.
+    /// To get multiple accounts at once, use the [`get_multiple_ui_accounts_with_config`] method.
     ///
-    /// [`get_multiple_accounts_with_config`]: RpcClient::get_multiple_accounts_with_config
+    /// [`get_multiple_ui_accounts_with_config`]: RpcClient::get_multiple_ui_accounts_with_config
     ///
     /// # RPC Reference
     ///
@@ -3565,20 +3607,20 @@ impl RpcClient {
     ///     commitment: Some(commitment_config),
     ///     .. RpcAccountInfoConfig::default()
     /// };
-    /// let account = rpc_client.get_account_with_config(
+    /// let ui_account = rpc_client.get_ui_account_with_config(
     ///     &alice_pubkey,
     ///     config,
     /// ).await?;
-    /// assert!(account.value.is_some());
+    /// assert!(ui_account.value.is_some());
     /// #     Ok::<(), Error>(())
     /// # })?;
     /// # Ok::<(), Error>(())
     /// ```
-    pub async fn get_account_with_config(
+    pub async fn get_ui_account_with_config(
         &self,
         pubkey: &Pubkey,
         config: RpcAccountInfoConfig,
-    ) -> RpcResult<Option<Account>> {
+    ) -> RpcResult<Option<UiAccount>> {
         let response = self
             .send(
                 RpcRequest::GetAccountInfo,
@@ -3595,14 +3637,12 @@ impl RpcClient {
                 }
                 let Response {
                     context,
-                    value: rpc_account,
+                    value: ui_account,
                 } = serde_json::from_value::<Response<Option<UiAccount>>>(result_json)?;
-                trace!("Response account {pubkey:?} {rpc_account:?}");
-                let account = rpc_account.and_then(|rpc_account| rpc_account.decode());
-
+                trace!("Response account {pubkey:?} {ui_account:?}");
                 Ok(Response {
                     context,
-                    value: account,
+                    value: ui_account,
                 })
             })
             .map_err(|err| {
@@ -3748,6 +3788,37 @@ impl RpcClient {
         .await
     }
 
+    #[deprecated(
+        note = "Use `get_multiple_ui_accounts_with_config()` instead. This function will be \
+                removed in a future version of `solana_rpc_client`."
+    )]
+    pub async fn get_multiple_accounts_with_config(
+        &self,
+        pubkeys: &[Pubkey],
+        config: RpcAccountInfoConfig,
+    ) -> RpcResult<Vec<Option<Account>>> {
+        let config = RpcAccountInfoConfig {
+            commitment: config.commitment.or_else(|| Some(self.commitment())),
+            ..config
+        };
+        let pubkeys: Vec<_> = pubkeys.iter().map(|pubkey| pubkey.to_string()).collect();
+        let response = self
+            .send(RpcRequest::GetMultipleAccounts, json!([pubkeys, config]))
+            .await?;
+        let Response {
+            context,
+            value: accounts,
+        } = serde_json::from_value::<Response<Vec<Option<UiAccount>>>>(response)?;
+        let accounts: Vec<Option<Account>> = accounts
+            .into_iter()
+            .map(|rpc_account| rpc_account.and_then(|a| a.decode()))
+            .collect();
+        Ok(Response {
+            context,
+            value: accounts,
+        })
+    }
+
     /// Returns the account information for a list of pubkeys.
     ///
     /// # RPC Reference
@@ -3779,7 +3850,7 @@ impl RpcClient {
     ///     commitment: Some(commitment_config),
     ///     .. RpcAccountInfoConfig::default()
     /// };
-    /// let accounts = rpc_client.get_multiple_accounts_with_config(
+    /// let ui_accounts = rpc_client.get_multiple_ui_accounts_with_config(
     ///     &pubkeys,
     ///     config,
     /// ).await?;
@@ -3787,11 +3858,11 @@ impl RpcClient {
     /// # })?;
     /// # Ok::<(), Error>(())
     /// ```
-    pub async fn get_multiple_accounts_with_config(
+    pub async fn get_multiple_ui_accounts_with_config(
         &self,
         pubkeys: &[Pubkey],
         config: RpcAccountInfoConfig,
-    ) -> RpcResult<Vec<Option<Account>>> {
+    ) -> RpcResult<Vec<Option<UiAccount>>> {
         let config = RpcAccountInfoConfig {
             commitment: config.commitment.or_else(|| Some(self.commitment())),
             ..config
@@ -3802,15 +3873,11 @@ impl RpcClient {
             .await?;
         let Response {
             context,
-            value: accounts,
+            value: ui_accounts,
         } = serde_json::from_value::<Response<Vec<Option<UiAccount>>>>(response)?;
-        let accounts: Vec<Option<Account>> = accounts
-            .into_iter()
-            .map(|rpc_account| rpc_account.and_then(|a| a.decode()))
-            .collect();
         Ok(Response {
             context,
-            value: accounts,
+            value: ui_accounts,
         })
     }
 
@@ -4007,6 +4074,33 @@ impl RpcClient {
         .await
     }
 
+    #[deprecated(
+        note = "Use `get_program_ui_accounts_with_config()` instead. This function will be \
+                removed in a future version of `solana_rpc_client`."
+    )]
+    pub async fn get_program_accounts_with_config(
+        &self,
+        pubkey: &Pubkey,
+        mut config: RpcProgramAccountsConfig,
+    ) -> ClientResult<Vec<(Pubkey, Account)>> {
+        // TODO
+        let commitment = config
+            .account_config
+            .commitment
+            .unwrap_or_else(|| self.commitment());
+        config.account_config.commitment = Some(commitment);
+
+        let accounts = self
+            .send::<OptionalContext<Vec<RpcKeyedAccount>>>(
+                RpcRequest::GetProgramAccounts,
+                json!([pubkey.to_string(), config]),
+            )
+            .await?
+            .parse_value();
+        #[allow(deprecated)]
+        parse_keyed_accounts(accounts, RpcRequest::GetProgramAccounts)
+    }
+
     /// Returns all accounts owned by the provided program pubkey.
     ///
     /// # RPC Reference
@@ -4056,7 +4150,7 @@ impl RpcClient {
     ///     with_context: Some(false),
     ///     sort_results: Some(true),
     /// };
-    /// let accounts = rpc_client.get_program_accounts_with_config(
+    /// let ui_accounts = rpc_client.get_program_ui_accounts_with_config(
     ///     &alice.pubkey(),
     ///     config,
     /// ).await?;
@@ -4064,11 +4158,11 @@ impl RpcClient {
     /// # })?;
     /// # Ok::<(), Error>(())
     /// ```
-    pub async fn get_program_accounts_with_config(
+    pub async fn get_program_ui_accounts_with_config(
         &self,
         pubkey: &Pubkey,
         mut config: RpcProgramAccountsConfig,
-    ) -> ClientResult<Vec<(Pubkey, Account)>> {
+    ) -> ClientResult<Vec<(Pubkey, UiAccount)>> {
         let commitment = config
             .account_config
             .commitment
@@ -4082,7 +4176,10 @@ impl RpcClient {
             )
             .await?
             .parse_value();
-        parse_keyed_accounts(accounts, RpcRequest::GetProgramAccounts)
+        pubkey_ui_account_client_result_from_keyed_accounts(
+            accounts,
+            RpcRequest::GetProgramAccounts,
+        )
     }
 
     /// Returns the stake minimum delegation, in lamports.
@@ -4755,6 +4852,10 @@ pub(crate) fn get_rpc_request_str(rpc_addr: SocketAddr, tls: bool) -> String {
     }
 }
 
+#[deprecated(
+    note = "Parsing accounts whose data is of type `UiAccountData::Json` will yield `None` when \
+            it should not. Do not use this function."
+)]
 pub(crate) fn parse_keyed_accounts(
     accounts: Vec<RpcKeyedAccount>,
     request: RpcRequest,
@@ -4778,6 +4879,23 @@ pub(crate) fn parse_keyed_accounts(
         ));
     }
     Ok(pubkey_accounts)
+}
+
+fn pubkey_ui_account_client_result_from_keyed_accounts(
+    accounts: Vec<RpcKeyedAccount>,
+    request: RpcRequest,
+) -> ClientResult<Vec<(Pubkey, UiAccount)>> {
+    let mut pubkey_ui_accounts: Vec<(Pubkey, UiAccount)> = Vec::with_capacity(accounts.len());
+    for RpcKeyedAccount { account, pubkey } in accounts.iter() {
+        let pubkey = pubkey.parse().map_err(|_| {
+            ClientError::new_with_request(
+                RpcError::ParseError("Pubkey".to_string()).into(),
+                request,
+            )
+        })?;
+        pubkey_ui_accounts.push((pubkey, account.clone()));
+    }
+    Ok(pubkey_ui_accounts)
 }
 
 #[doc(hidden)]

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -4109,6 +4109,7 @@ mod tests {
             .into_iter()
             .collect();
             let rpc_client = RpcClient::new_mock_with_mocks("mock_client".to_string(), mocks);
+            #[allow(deprecated)]
             let result = rpc_client
                 .get_program_accounts_with_config(
                     &program_id,
@@ -4144,6 +4145,7 @@ mod tests {
             .into_iter()
             .collect();
             let rpc_client = RpcClient::new_mock_with_mocks("mock_client".to_string(), mocks);
+            #[allow(deprecated)]
             let result = rpc_client
                 .get_program_accounts_with_config(
                     &program_id,
@@ -4229,6 +4231,7 @@ mod tests {
             );
 
             let rpc_client = RpcClient::new_mock_with_mocks_map("mock_client".to_string(), mocks);
+            #[allow(deprecated)]
             let mut result1 = rpc_client
                 .get_program_accounts_with_config(
                     &program_id,
@@ -4248,6 +4251,7 @@ mod tests {
 
             assert_eq!(result1.len(), 1);
 
+            #[allow(deprecated)]
             let result2 = rpc_client
                 .get_program_accounts_with_config(
                     &program_id,
@@ -4267,6 +4271,7 @@ mod tests {
 
             assert_eq!(result2.len(), 1);
 
+            #[allow(deprecated)]
             let result_3 = rpc_client
                 .get_program_accounts_with_config(
                     &program_id,
@@ -4286,6 +4291,7 @@ mod tests {
 
             assert_eq!(result_3.len(), 3);
 
+            #[allow(deprecated)]
             let result_4 = rpc_client
                 .get_program_accounts_with_config(
                     &program_id,

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -3854,7 +3854,7 @@ mod tests {
         jsonrpc_core::{futures::prelude::*, Error, IoHandler, Params},
         jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBuilder},
         serde_json::{json, Number},
-        solana_account_decoder::encode_ui_account,
+        solana_account_decoder::UiAccountData,
         solana_account_decoder_client_types::UiAccountEncoding,
         solana_hash::Hash,
         solana_instruction::error::InstructionError,
@@ -4084,19 +4084,20 @@ mod tests {
     }
 
     #[test]
-    fn test_get_program_accounts_with_config() {
+    fn test_get_program_ui_accounts_with_config() {
         let program_id = Pubkey::new_unique();
         let pubkey = Pubkey::new_unique();
-        let account = Account {
+        let account = UiAccount {
             lamports: 1_000_000,
-            data: vec![],
-            owner: program_id,
+            data: UiAccountData::Binary("".to_string(), UiAccountEncoding::Base64),
+            owner: program_id.to_string(),
             executable: false,
             rent_epoch: 0,
+            space: Some(0),
         };
         let keyed_account = RpcKeyedAccount {
+            account: account.clone(),
             pubkey: pubkey.to_string(),
-            account: encode_ui_account(&pubkey, &account, UiAccountEncoding::Base64, None, None),
         };
         let expected_result = vec![(pubkey, account.clone())];
         // Test: without context
@@ -4110,7 +4111,7 @@ mod tests {
             .collect();
             let rpc_client = RpcClient::new_mock_with_mocks("mock_client".to_string(), mocks);
             let result = rpc_client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     &program_id,
                     RpcProgramAccountsConfig {
                         filters: None,
@@ -4145,7 +4146,7 @@ mod tests {
             .collect();
             let rpc_client = RpcClient::new_mock_with_mocks("mock_client".to_string(), mocks);
             let result = rpc_client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     &program_id,
                     RpcProgramAccountsConfig {
                         filters: None,
@@ -4230,7 +4231,7 @@ mod tests {
 
             let rpc_client = RpcClient::new_mock_with_mocks_map("mock_client".to_string(), mocks);
             let mut result1 = rpc_client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     &program_id,
                     RpcProgramAccountsConfig {
                         filters: None,
@@ -4249,7 +4250,7 @@ mod tests {
             assert_eq!(result1.len(), 1);
 
             let result2 = rpc_client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     &program_id,
                     RpcProgramAccountsConfig {
                         filters: None,
@@ -4268,7 +4269,7 @@ mod tests {
             assert_eq!(result2.len(), 1);
 
             let result_3 = rpc_client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     &program_id,
                     RpcProgramAccountsConfig {
                         filters: None,
@@ -4287,7 +4288,7 @@ mod tests {
             assert_eq!(result_3.len(), 3);
 
             let result_4 = rpc_client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     &program_id,
                     RpcProgramAccountsConfig {
                         filters: None,

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -20,6 +20,7 @@ use {
     serde::Serialize,
     serde_json::Value,
     solana_account::{Account, ReadableAccount},
+    solana_account_decoder::UiAccount,
     solana_account_decoder_client_types::token::{UiTokenAccount, UiTokenAmount},
     solana_clock::{Epoch, Slot, UnixTimestamp},
     solana_commitment_config::CommitmentConfig,
@@ -3020,13 +3021,26 @@ impl RpcClient {
         )
     }
 
+    #[deprecated(
+        note = "Use `get_ui_account_with_config()` instead. This function will be removed in a \
+                future version of `solana_rpc_client`."
+    )]
+    pub fn get_account_with_config(
+        &self,
+        pubkey: &Pubkey,
+        config: RpcAccountInfoConfig,
+    ) -> RpcResult<Option<Account>> {
+        #[allow(deprecated)]
+        self.invoke((self.rpc_client.as_ref()).get_account_with_config(pubkey, config))
+    }
+
     /// Returns all information associated with the account of the provided pubkey.
     ///
     /// If the account does not exist, this method returns `Ok(None)`.
     ///
-    /// To get multiple accounts at once, use the [`get_multiple_accounts_with_config`] method.
+    /// To get multiple accounts at once, use the [`get_multiple_ui_accounts_with_config`] method.
     ///
-    /// [`get_multiple_accounts_with_config`]: RpcClient::get_multiple_accounts_with_config
+    /// [`get_multiple_ui_accounts_with_config`]: RpcClient::get_multiple_ui_accounts_with_config
     ///
     /// # RPC Reference
     ///
@@ -3057,19 +3071,19 @@ impl RpcClient {
     ///     commitment: Some(commitment_config),
     ///     .. RpcAccountInfoConfig::default()
     /// };
-    /// let account = rpc_client.get_account_with_config(
+    /// let ui_account = rpc_client.get_ui_account_with_config(
     ///     &alice_pubkey,
     ///     config,
     /// )?;
-    /// assert!(account.value.is_some());
+    /// assert!(ui_account.value.is_some());
     /// # Ok::<(), Error>(())
     /// ```
-    pub fn get_account_with_config(
+    pub fn get_ui_account_with_config(
         &self,
         pubkey: &Pubkey,
         config: RpcAccountInfoConfig,
-    ) -> RpcResult<Option<Account>> {
-        self.invoke((self.rpc_client.as_ref()).get_account_with_config(pubkey, config))
+    ) -> RpcResult<Option<UiAccount>> {
+        self.invoke((self.rpc_client.as_ref()).get_ui_account_with_config(pubkey, config))
     }
 
     /// Get the max slot seen from retransmit stage.
@@ -3182,6 +3196,19 @@ impl RpcClient {
         )
     }
 
+    #[deprecated(
+        note = "Use `get_multiple_ui_accounts_with_config()` instead. This function will be \
+                removed in a future version of `solana_rpc_client`."
+    )]
+    pub fn get_multiple_accounts_with_config(
+        &self,
+        pubkeys: &[Pubkey],
+        config: RpcAccountInfoConfig,
+    ) -> RpcResult<Vec<Option<Account>>> {
+        #[allow(deprecated)]
+        self.invoke((self.rpc_client.as_ref()).get_multiple_accounts_with_config(pubkeys, config))
+    }
+
     /// Returns the account information for a list of pubkeys.
     ///
     /// # RPC Reference
@@ -3212,18 +3239,20 @@ impl RpcClient {
     ///     commitment: Some(commitment_config),
     ///     .. RpcAccountInfoConfig::default()
     /// };
-    /// let accounts = rpc_client.get_multiple_accounts_with_config(
+    /// let ui_accounts = rpc_client.get_multiple_ui_accounts_with_config(
     ///     &pubkeys,
     ///     config,
     /// )?;
     /// # Ok::<(), Error>(())
     /// ```
-    pub fn get_multiple_accounts_with_config(
+    pub fn get_multiple_ui_accounts_with_config(
         &self,
         pubkeys: &[Pubkey],
         config: RpcAccountInfoConfig,
-    ) -> RpcResult<Vec<Option<Account>>> {
-        self.invoke((self.rpc_client.as_ref()).get_multiple_accounts_with_config(pubkeys, config))
+    ) -> RpcResult<Vec<Option<UiAccount>>> {
+        self.invoke(
+            (self.rpc_client.as_ref()).get_multiple_ui_accounts_with_config(pubkeys, config),
+        )
     }
 
     /// Gets the raw data associated with an account.
@@ -3374,6 +3403,19 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).get_program_accounts(pubkey))
     }
 
+    #[deprecated(
+        note = "Use `get_program_ui_accounts_with_config()` instead. This function will be \
+                removed in a future version of `solana_rpc_client`."
+    )]
+    pub fn get_program_accounts_with_config(
+        &self,
+        pubkey: &Pubkey,
+        config: RpcProgramAccountsConfig,
+    ) -> ClientResult<Vec<(Pubkey, Account)>> {
+        #[allow(deprecated)]
+        self.invoke((self.rpc_client.as_ref()).get_program_accounts_with_config(pubkey, config))
+    }
+
     /// Returns all accounts owned by the provided program pubkey.
     ///
     /// # RPC Reference
@@ -3422,18 +3464,18 @@ impl RpcClient {
     ///     with_context: Some(false),
     ///     sort_results: Some(true),
     /// };
-    /// let accounts = rpc_client.get_program_accounts_with_config(
+    /// let ui_accounts = rpc_client.get_program_ui_accounts_with_config(
     ///     &alice.pubkey(),
     ///     config,
     /// )?;
     /// # Ok::<(), Error>(())
     /// ```
-    pub fn get_program_accounts_with_config(
+    pub fn get_program_ui_accounts_with_config(
         &self,
         pubkey: &Pubkey,
         config: RpcProgramAccountsConfig,
-    ) -> ClientResult<Vec<(Pubkey, Account)>> {
-        self.invoke((self.rpc_client.as_ref()).get_program_accounts_with_config(pubkey, config))
+    ) -> ClientResult<Vec<(Pubkey, UiAccount)>> {
+        self.invoke((self.rpc_client.as_ref()).get_program_ui_accounts_with_config(pubkey, config))
     }
 
     /// Returns the stake minimum delegation, in lamports.


### PR DESCRIPTION
#### Problem

All fetches for accounts with `UiAccountEncoding::JsonParsed` will return `None`, even if the account exists. Nothing can be done about these methods to fix them without changing the return type (which is a breaking change) or prohibiting the use of `JsonParsed` encoding at the input (which is also a breaking change).

We will deprecate the methods instead.

#### Summary of Changes

1. Deprecate `get_account_with_config`, `get_multiple_accounts_with_config`, and `get_program_accounts_with_config` because those methods, in all cases, lie when you supply `UiAccountEncoding::JsonParsed`
2. Replace them with methods that return `UiAccount` instead.
3. Deprecate `parse_keyed_accounts`
4. Codemod all first-party uses of deprecated methods to the new ones

Fixes #4202.