### PR TITLE
docs: fix typo 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ be backported to release branches.
 Duplicate code should generally be avoided.
 
 Features should be activated on testnet before mainnet in the closest configuration to mainnet as possible
-Relevant metrics need to be monitored and approriate follow-up given after feature activation.
+Relevant metrics need to be monitored and appropriate follow-up given after feature activation.
 
 Avoid “hack” or “one-off” solutions, prefer well-architected designs which are not fragile.
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -512,7 +512,7 @@ pub struct ValidatorTpuConfig {
     pub vote_use_quic: bool,
     /// Controls the connection cache pool size
     pub tpu_connection_pool_size: usize,
-    /// Controls if to enable UDP for TPU tansactions.
+    /// Controls if to enable UDP for TPU transactions.
     pub tpu_enable_udp: bool,
     /// QUIC server config for regular TPU
     pub tpu_quic_server_config: QuicServerParams,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1384,7 +1384,7 @@ impl Blockstore {
         }
     }
 
-    // Bypasses erasure recovery becuase it is called from broadcast stage
+    // Bypasses erasure recovery because it is called from broadcast stage
     // when inserting own shreds during leader slots.
     pub fn insert_cow_shreds<'a>(
         &self,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -5243,7 +5243,7 @@ pub mod tests {
             }),
         );
 
-        // pre_commit_callback() should alwasy be called regardless of tx_result
+        // pre_commit_callback() should always be called regardless of tx_result
         assert!(is_called);
 
         if should_commit {

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -401,7 +401,7 @@ impl QuicClient {
                         .prepare_connection_us
                         .fetch_add(measure_prepare_connection.as_us(), Ordering::Relaxed);
                     trace!(
-                        "Succcessfully sent to {} with id {}, thread: {:?}, data len: {}, \
+                        "Successfully sent to {} with id {}, thread: {:?}, data len: {}, \
                          send_packet_us: {} prepare_connection_us: {}",
                         self.addr,
                         connection.stable_id(),


### PR DESCRIPTION
Corrected `approriate` → `appropriate`
Corrected `tansactions` → `transactions`
Corrected `becuase` → `because`
Corrected `alwasy` → `always`
Corrected `Succcessfully` → `Successfully`
