### PR TITLE
Updates the accounts lt hash inline with transaction processing

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3902,7 +3902,10 @@ impl Bank {
     ) {
         self.update_bank_hash_stats(&accounts);
 
-        // updating the accounts lt hash *must* be done before storing the accounts
+        // Updating the accounts lt hash *must* be done before storing the accounts.
+        // Otherwise, when loading the old account versions, we end up finding the
+        // *new* account versions that we just stored!  This would result in mixing
+        // out the wrong values, leading to an incorrect accounts lt hash.
         self.update_accounts_lt_hash(&accounts);
 
         match caller {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -56,7 +56,6 @@ use {
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
-    accounts_lt_hash::{CacheValue as AccountsLtHashCacheValue, Stats as AccountsLtHashStats},
     agave_feature_set::{self as feature_set, raise_cpi_nesting_limit_to_8, FeatureSet},
     agave_precompiles::{get_precompile, get_precompiles, is_precompile},
     agave_reserved_account_keys::ReservedAccountKeys,
@@ -64,7 +63,6 @@ use {
         create_program_runtime_environment_v1, create_program_runtime_environment_v2,
     },
     ahash::AHashSet,
-    dashmap::DashMap,
     log::*,
     partitioned_epoch_rewards::PartitionedRewardsCalculation,
     rayon::{ThreadPool, ThreadPoolBuilder},
@@ -549,8 +547,6 @@ impl PartialEq for Bank {
             compute_budget: _,
             transaction_account_lock_limit: _,
             fee_structure: _,
-            cache_for_accounts_lt_hash: _,
-            stats_for_accounts_lt_hash: _,
             block_id,
             bank_hash_stats: _,
             epoch_rewards_calculation_cache: _,
@@ -873,21 +869,7 @@ pub struct Bank {
     hash_overrides: Arc<Mutex<HashOverrides>>,
 
     /// The lattice hash of all accounts
-    ///
-    /// The value is only meaningful after freezing.
     accounts_lt_hash: Mutex<AccountsLtHash>,
-
-    /// A cache of *the initial state* of accounts modified in this slot
-    ///
-    /// The accounts lt hash needs both the initial and final state of each
-    /// account that was modified in this slot.  Cache the initial state here.
-    ///
-    /// Note: The initial state must be strictly from an ancestor,
-    /// and not an intermediate state within this slot.
-    cache_for_accounts_lt_hash: DashMap<Pubkey, AccountsLtHashCacheValue, ahash::RandomState>,
-
-    /// Stats related to the accounts lt hash
-    stats_for_accounts_lt_hash: AccountsLtHashStats,
 
     /// The unique identifier for the corresponding block for this bank.
     /// None for banks that have not yet completed replay or for leader banks as we cannot populate block_id
@@ -1092,8 +1074,6 @@ impl Bank {
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
             accounts_lt_hash: Mutex::new(AccountsLtHash(LtHash::identity())),
-            cache_for_accounts_lt_hash: DashMap::default(),
-            stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
             block_id: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
             epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
@@ -1339,8 +1319,6 @@ impl Bank {
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: parent.hash_overrides.clone(),
             accounts_lt_hash: Mutex::new(parent.accounts_lt_hash.lock().unwrap().clone()),
-            cache_for_accounts_lt_hash: DashMap::default(),
-            stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
             block_id: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
             epoch_rewards_calculation_cache: parent.epoch_rewards_calculation_cache.clone(),
@@ -1387,32 +1365,11 @@ impl Bank {
             .transaction_processor
             .fill_missing_sysvar_cache_entries(&new));
 
-        let (num_accounts_modified_this_slot, populate_cache_for_accounts_lt_hash_us) =
-            measure_us!({
-                // The cache for accounts lt hash needs to be made aware of accounts modified
-                // before transaction processing begins.  Otherwise we may calculate the wrong
-                // accounts lt hash due to having the wrong initial state of the account.  The
-                // lt hash cache's initial state must always be from an ancestor, and cannot be
-                // an intermediate state within this Bank's slot.  If the lt hash cache has the
-                // wrong initial account state, we'll mix out the wrong lt hash value, and thus
-                // have the wrong overall accounts lt hash, and diverge.
-                let accounts_modified_this_slot =
-                    new.rc.accounts.accounts_db.get_pubkeys_for_slot(slot);
-                let num_accounts_modified_this_slot = accounts_modified_this_slot.len();
-                for pubkey in accounts_modified_this_slot {
-                    new.cache_for_accounts_lt_hash
-                        .entry(pubkey)
-                        .or_insert(AccountsLtHashCacheValue::BankNew);
-                }
-                num_accounts_modified_this_slot
-            });
-
         time.stop();
         report_new_bank_metrics(
             slot,
             parent.slot(),
             new.block_height,
-            num_accounts_modified_this_slot,
             NewBankTimings {
                 bank_rc_creation_time_us,
                 total_elapsed_time_us: time.as_us(),
@@ -1431,7 +1388,6 @@ impl Bank {
                 cache_preparation_time_us,
                 update_sysvars_time_us,
                 fill_sysvar_cache_time_us,
-                populate_cache_for_accounts_lt_hash_us,
             },
         );
 
@@ -1779,8 +1735,6 @@ impl Bank {
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
             accounts_lt_hash: Mutex::new(fields.accounts_lt_hash),
-            cache_for_accounts_lt_hash: DashMap::default(),
-            stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
             block_id: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::new(&fields.bank_hash_stats),
             epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
@@ -2454,9 +2408,6 @@ impl Bank {
 
             // freeze is a one-way trip, idempotent
             self.freeze_started.store(true, Relaxed);
-            // updating the accounts lt hash must happen *outside* of hash_internal_state() so
-            // that rehash() can be called and *not* modify self.accounts_lt_hash.
-            self.update_accounts_lt_hash();
             *hash = self.hash_internal_state();
             self.rc.accounts.accounts_db.mark_slot_frozen(self.slot());
         }
@@ -3550,12 +3501,10 @@ impl Bank {
             );
 
             let to_store = (self.slot(), accounts_to_store.as_slice());
-            self.update_bank_hash_stats(&to_store);
-            // See https://github.com/solana-labs/solana/pull/31455 for discussion
-            // on *not* updating the index within a threadpool.
-            self.rc
-                .accounts
-                .store_accounts_seq(to_store, transactions.as_deref());
+            self._store_accounts(
+                to_store,
+                StoreAccountsCaller::Inline(transactions.as_deref()),
+            );
         });
 
         // Cached vote and stake accounts are synchronized with accounts-db
@@ -3928,8 +3877,7 @@ impl Bank {
                 )
             })
         });
-        self.update_bank_hash_stats(&accounts);
-        self.rc.accounts.store_accounts_par(accounts, None);
+        self._store_accounts(accounts, StoreAccountsCaller::OutOfBand);
         m.stop();
         self.rc
             .accounts
@@ -3937,6 +3885,36 @@ impl Bank {
             .stats
             .stakes_cache_check_and_store_us
             .fetch_add(m.as_us(), Relaxed);
+    }
+
+    /// Stores `accounts`
+    ///
+    /// This fn handles the common tasks when storing accounts, such as
+    /// updating the bank hash stats, and updating the accounts lt hash.
+    ///
+    /// The two callers are:
+    /// 1. inline with transaction processing, when committing transactions
+    /// 2. out-of-band, e.g. updating sysvars, the incinerator, epoch rewards, etc
+    fn _store_accounts<'a>(
+        &self,
+        accounts: impl StorableAccounts<'a>,
+        caller: StoreAccountsCaller<'a>,
+    ) {
+        self.update_bank_hash_stats(&accounts);
+
+        // updating the accounts lt hash *must* be done before storing the accounts
+        self.update_accounts_lt_hash(&accounts);
+
+        match caller {
+            StoreAccountsCaller::Inline(transactions) => {
+                // See https://github.com/solana-labs/solana/pull/31455 for discussion
+                // on *not* updating the index within a threadpool.
+                self.rc.accounts.store_accounts_seq(accounts, transactions);
+            }
+            StoreAccountsCaller::OutOfBand => {
+                self.rc.accounts.store_accounts_par(accounts, None);
+            }
+        }
     }
 
     pub fn force_flush_accounts_cache(&self) {
@@ -5627,6 +5605,14 @@ impl Bank {
     }
 }
 
+/// Indicates who is calling `_store_accounts()`
+enum StoreAccountsCaller<'a> {
+    /// The caller is inline with transaction processing, e.g. commit_transactions()
+    Inline(Option<&'a [&'a SanitizedTransaction]>),
+    /// The caller is not inline with transaction processing, e.g. updating sysvars
+    OutOfBand,
+}
+
 impl InvokeContextCallback for Bank {
     fn get_epoch_stake(&self) -> u64 {
         self.get_current_epoch_total_stake()
@@ -5669,8 +5655,8 @@ impl TransactionProcessingCallback for Bank {
             .load_with_fixed_root(&self.ancestors, pubkey)
     }
 
-    fn inspect_account(&self, address: &Pubkey, account_state: AccountState, is_writable: bool) {
-        self.inspect_account_for_accounts_lt_hash(address, &account_state, is_writable);
+    fn inspect_account(&self, _address: &Pubkey, _account_state: AccountState, _is_writable: bool) {
+        // nothing to do here
     }
 }
 

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -1,388 +1,64 @@
 use {
     super::Bank,
-    rayon::prelude::*,
-    solana_account::{accounts_equal, AccountSharedData},
-    solana_accounts_db::accounts_db::AccountsDb,
-    solana_hash::Hash,
+    log::{log_enabled, trace, Level},
+    solana_accounts_db::{accounts_db::AccountsDb, storable_accounts::StorableAccounts},
     solana_lattice_hash::lt_hash::LtHash,
-    solana_measure::{meas_dur, measure::Measure},
-    solana_pubkey::Pubkey,
-    solana_svm_callback::AccountState,
-    std::{
-        ops::AddAssign,
-        sync::atomic::{AtomicU64, Ordering},
-        time::Duration,
-    },
 };
 
 impl Bank {
-    /// Updates the accounts lt hash
+    /// Updates the accounts lt hash, inline with transaction processing
     ///
-    /// When freezing a bank, we compute and update the accounts lt hash.
-    /// For each account modified in this bank, we:
-    /// - mix out its previous state, and
-    /// - mix in its current state
+    /// Note that it is critical this fn is called *BEFORE* `accounts` have actually been stored!
     ///
-    /// Since this function is non-idempotent, it should only be called once per bank.
-    pub fn update_accounts_lt_hash(&self) {
-        let delta_lt_hash = self.calculate_delta_lt_hash();
-        let mut accounts_lt_hash = self.accounts_lt_hash.lock().unwrap();
-        accounts_lt_hash.0.mix_in(&delta_lt_hash);
-    }
-
-    /// Calculates the lt hash *of only this slot*
-    ///
-    /// This can be thought of as akin to the accounts delta hash.
-    ///
-    /// For each account modified in this bank, we:
-    /// - mix out its previous state, and
-    /// - mix in its current state
-    ///
-    /// This function is idempotent, and may be called more than once.
-    fn calculate_delta_lt_hash(&self) -> LtHash {
-        let measure_total = Measure::start("");
+    /// Given `accounts` that are about to be stored, mix out each account's previous state and mix
+    /// in each account's new state from this bank's accounts lt hash.
+    pub fn update_accounts_lt_hash<'a>(&self, accounts: &impl StorableAccounts<'a>) {
         let slot = self.slot();
+        let num_accounts = accounts.len();
+        let mut delta_lt_hash = LtHash::identity();
+        for i in 0..num_accounts {
+            let pubkey = accounts.pubkey(i);
 
-        // If we don't find the account in the cache, we need to go load it.
-        // We want the version of the account *before* it was written in this slot.
-        // Bank::ancestors *includes* this slot, so we need to remove it before loading.
-        let strictly_ancestors = {
-            let mut ancestors = self.ancestors.clone();
-            ancestors.remove(&self.slot());
-            ancestors
-        };
-
-        if slot == 0 {
-            // Slot 0 is special when calculating the accounts lt hash.
-            // Primordial accounts (those in genesis) that are modified by transaction processing
-            // in slot 0 will have Alive entries in the accounts lt hash cache.
-            // When calculating the accounts lt hash, if an account was initially alive, we mix
-            // *out* its previous lt hash value.  In slot 0, we haven't stored any previous lt hash
-            // values (since it is in the first slot), yet we'd still mix out these accounts!
-            // This produces the incorrect accounts lt hash.
-            // From the perspective of the accounts lt hash, in slot 0 we cannot have any accounts
-            // as previously alive.  So to work around this issue, we clear the cache.
-            // And since `strictly_ancestors` is empty, loading the previous version of the account
-            // from accounts db will return `None` (aka Dead), which is the correct behavior.
-            assert!(strictly_ancestors.is_empty());
-            self.cache_for_accounts_lt_hash.clear();
-        }
-
-        // Get all the accounts stored in this slot.
-        // Since this bank is in the middle of being frozen, it hasn't been rooted.
-        // That means the accounts should all be in the write cache, and loading will be fast.
-        let (accounts_curr, time_loading_accounts_curr) = meas_dur!({
-            self.rc
+            // MIX OUT
+            let prev_account = self
+                .rc
                 .accounts
-                .accounts_db
-                .get_pubkey_account_for_slot(slot)
-        });
-        let num_accounts_total = accounts_curr.len();
-
-        #[derive(Debug, Default)]
-        struct Stats {
-            num_cache_misses: usize,
-            num_accounts_unmodified: usize,
-            time_loading_accounts_prev: Duration,
-            time_comparing_accounts: Duration,
-            time_computing_hashes: Duration,
-            time_mixing_hashes: Duration,
-        }
-        impl AddAssign for Stats {
-            fn add_assign(&mut self, other: Self) {
-                self.num_cache_misses += other.num_cache_misses;
-                self.num_accounts_unmodified += other.num_accounts_unmodified;
-                self.time_loading_accounts_prev += other.time_loading_accounts_prev;
-                self.time_comparing_accounts += other.time_comparing_accounts;
-                self.time_computing_hashes += other.time_computing_hashes;
-                self.time_mixing_hashes += other.time_mixing_hashes;
+                .load_with_fixed_root_do_not_populate_read_cache(&self.ancestors, pubkey);
+            if let Some((prev_account, _prev_slot)) = prev_account {
+                let prev_lt_hash = AccountsDb::lt_hash_account(&prev_account, pubkey);
+                delta_lt_hash.mix_out(&prev_lt_hash.0);
+                if log_enabled!(Level::Trace) {
+                    trace!(
+                        "lt hash mix out, slot {slot}, {pubkey}, checksum: {}, {prev_account:?}",
+                        prev_lt_hash.0.checksum(),
+                    );
+                }
+            } else {
+                // no previous account, so nothing to mix out; just log
+                if log_enabled!(Level::Trace) {
+                    trace!("lt hash mix out, slot {slot}, {pubkey}, account not found");
+                }
             }
-        }
 
-        let do_calculate_delta_lt_hash = || {
-            // Work on chunks of 128 pubkeys, which is 4 KiB.
-            // And 4 KiB is likely the smallest a real page size will be.
-            // And a single page is likely the smallest size a disk read will actually read.
-            // This can be tuned larger, but likely not smaller.
-            const CHUNK_SIZE: usize = 128;
-            accounts_curr
-                .par_iter()
-                .fold_chunks(
-                    CHUNK_SIZE,
-                    || (LtHash::identity(), Stats::default()),
-                    |mut accum, (pubkey, curr_account)| {
-                        // load the initial state of the account
-                        let (initial_state_of_account, measure_load) = meas_dur!({
-                            let cache_value = self
-                                .cache_for_accounts_lt_hash
-                                .get(pubkey)
-                                .map(|entry| entry.value().clone());
-                            match cache_value {
-                                Some(CacheValue::InspectAccount(initial_state_of_account)) => {
-                                    initial_state_of_account
-                                }
-                                Some(CacheValue::BankNew) | None => {
-                                    accum.1.num_cache_misses += 1;
-                                    // If the initial state of the account is not in the accounts
-                                    // lt hash cache, or is explicitly unknown, then it is likely
-                                    // this account was stored *outside* of transaction processing
-                                    // (e.g. creating a new bank).
-                                    // Do not populate the read cache, as this account likely will
-                                    // not be accessed again soon.
-                                    let account_slot = self
-                                        .rc
-                                        .accounts
-                                        .load_with_fixed_root_do_not_populate_read_cache(
-                                            &strictly_ancestors,
-                                            pubkey,
-                                        );
-                                    match account_slot {
-                                        Some((account, _slot)) => {
-                                            InitialStateOfAccount::Alive(account)
-                                        }
-                                        None => InitialStateOfAccount::Dead,
-                                    }
-                                }
-                            }
-                        });
-                        accum.1.time_loading_accounts_prev += measure_load;
-
-                        // mix out the previous version of the account
-                        match initial_state_of_account {
-                            InitialStateOfAccount::Dead => {
-                                // nothing to do here
-                            }
-                            InitialStateOfAccount::Alive(prev_account) => {
-                                let (are_accounts_equal, measure_is_equal) =
-                                    meas_dur!(accounts_equal(curr_account, &prev_account));
-                                accum.1.time_comparing_accounts += measure_is_equal;
-                                if are_accounts_equal {
-                                    // this account didn't actually change, so skip it for lt hashing
-                                    accum.1.num_accounts_unmodified += 1;
-                                    return accum;
-                                }
-                                let (prev_lt_hash, measure_hashing) =
-                                    meas_dur!(AccountsDb::lt_hash_account(&prev_account, pubkey));
-                                let (_, measure_mixing) =
-                                    meas_dur!(accum.0.mix_out(&prev_lt_hash.0));
-                                accum.1.time_computing_hashes += measure_hashing;
-                                accum.1.time_mixing_hashes += measure_mixing;
-                            }
-                        }
-
-                        // mix in the new version of the account
-                        let (curr_lt_hash, measure_hashing) =
-                            meas_dur!(AccountsDb::lt_hash_account(curr_account, pubkey));
-                        let (_, measure_mixing) = meas_dur!(accum.0.mix_in(&curr_lt_hash.0));
-                        accum.1.time_computing_hashes += measure_hashing;
-                        accum.1.time_mixing_hashes += measure_mixing;
-
-                        accum
-                    },
-                )
-                .reduce(
-                    || (LtHash::identity(), Stats::default()),
-                    |mut accum, elem| {
-                        accum.0.mix_in(&elem.0);
-                        accum.1 += elem.1;
-                        accum
-                    },
-                )
-        };
-        let (delta_lt_hash, stats) = self
-            .rc
-            .accounts
-            .accounts_db
-            .thread_pool_foreground
-            .install(do_calculate_delta_lt_hash);
-
-        let total_time = measure_total.end_as_duration();
-        let num_accounts_modified =
-            num_accounts_total.saturating_sub(stats.num_accounts_unmodified);
-        datapoint_info!(
-            "bank-accounts_lt_hash",
-            ("slot", slot, i64),
-            ("num_accounts_total", num_accounts_total, i64),
-            ("num_accounts_modified", num_accounts_modified, i64),
-            (
-                "num_accounts_unmodified",
-                stats.num_accounts_unmodified,
-                i64
-            ),
-            ("num_cache_misses", stats.num_cache_misses, i64),
-            ("total_us", total_time.as_micros(), i64),
-            (
-                "loading_accounts_curr_us",
-                time_loading_accounts_curr.as_micros(),
-                i64
-            ),
-            (
-                "par_loading_accounts_prev_us",
-                stats.time_loading_accounts_prev.as_micros(),
-                i64
-            ),
-            (
-                "par_comparing_accounts_us",
-                stats.time_comparing_accounts.as_micros(),
-                i64
-            ),
-            (
-                "par_computing_hashes_us",
-                stats.time_computing_hashes.as_micros(),
-                i64
-            ),
-            (
-                "par_mixing_hashes_us",
-                stats.time_mixing_hashes.as_micros(),
-                i64
-            ),
-            (
-                "num_inspect_account_hits",
-                self.stats_for_accounts_lt_hash
-                    .num_inspect_account_hits
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_inspect_account_misses",
-                self.stats_for_accounts_lt_hash
-                    .num_inspect_account_misses
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_inspect_account_after_frozen",
-                self.stats_for_accounts_lt_hash
-                    .num_inspect_account_after_frozen
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "inspect_account_lookup_ns",
-                self.stats_for_accounts_lt_hash
-                    .inspect_account_lookup_time_ns
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "inspect_account_insert_ns",
-                self.stats_for_accounts_lt_hash
-                    .inspect_account_insert_time_ns
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-        );
-
-        delta_lt_hash
-    }
-
-    /// Caches initial state of writeable accounts
-    ///
-    /// If a transaction account is writeable, cache its initial account state.
-    /// The initial state is needed when computing the accounts lt hash for the slot, and caching
-    /// the initial state saves us from having to look it up on disk later.
-    pub fn inspect_account_for_accounts_lt_hash(
-        &self,
-        address: &Pubkey,
-        account_state: &AccountState,
-        is_writable: bool,
-    ) {
-        if !is_writable {
-            // if the account is not writable, then it cannot be modified; nothing to do here
-            return;
-        }
-
-        // Only insert the account the *first* time we see it.
-        // We want to capture the value of the account *before* any modifications during this slot.
-        let (is_in_cache, lookup_time) =
-            meas_dur!(self.cache_for_accounts_lt_hash.contains_key(address));
-        if !is_in_cache {
-            // We need to check if the bank is frozen.  In order to do that safely, we
-            // must hold a read lock on Bank::hash to read the frozen state.
-            let freeze_guard = self.freeze_lock();
-            let is_frozen = *freeze_guard != Hash::default();
-            if is_frozen {
-                // If the bank is frozen, do not add this account to the cache.
-                // It is possible for the leader to be executing transactions after freeze has
-                // started, i.e. while any deferred changes to account state is finishing up.
-                // This means the transaction could load an account *after* it was modified by the
-                // deferred changes, which would be the wrong initial state of the account.
-                // Inserting the wrong initial state of an account into the cache will end up
-                // producing the wrong accounts lt hash.
-                self.stats_for_accounts_lt_hash
-                    .num_inspect_account_after_frozen
-                    .fetch_add(1, Ordering::Relaxed);
-                return;
-            }
-            let (_, insert_time) = meas_dur!({
-                self.cache_for_accounts_lt_hash
-                    .entry(*address)
-                    .or_insert_with(|| {
-                        let initial_state_of_account = match account_state {
-                            AccountState::Dead => InitialStateOfAccount::Dead,
-                            AccountState::Alive(account) => {
-                                InitialStateOfAccount::Alive((*account).clone())
-                            }
-                        };
-                        CacheValue::InspectAccount(initial_state_of_account)
-                    });
+            // MIX IN
+            accounts.account(i, |post_account| {
+                let post_lt_hash = AccountsDb::lt_hash_account(&post_account, pubkey);
+                delta_lt_hash.mix_in(&post_lt_hash.0);
+                if log_enabled!(Level::Trace) {
+                    trace!(
+                        "lt hash mix in,  slot {slot}, {pubkey}, checksum: {}, {post_account:?}",
+                        post_lt_hash.0.checksum(),
+                    );
+                }
             });
-            drop(freeze_guard);
-
-            self.stats_for_accounts_lt_hash
-                .num_inspect_account_misses
-                .fetch_add(1, Ordering::Relaxed);
-            self.stats_for_accounts_lt_hash
-                .inspect_account_insert_time_ns
-                // N.B. this needs to be nanoseconds because it can be so fast
-                .fetch_add(insert_time.as_nanos() as u64, Ordering::Relaxed);
-        } else {
-            // The account is already in the cache, so nothing to do here other than update stats.
-            self.stats_for_accounts_lt_hash
-                .num_inspect_account_hits
-                .fetch_add(1, Ordering::Relaxed);
         }
 
-        self.stats_for_accounts_lt_hash
-            .inspect_account_lookup_time_ns
-            // N.B. this needs to be nanoseconds because it can be so fast
-            .fetch_add(lookup_time.as_nanos() as u64, Ordering::Relaxed);
+        // only lock the accounts_lt_hash mutex if there are actual account updates
+        if delta_lt_hash != LtHash::identity() {
+            let mut accounts_lt_hash = self.accounts_lt_hash.lock().unwrap();
+            accounts_lt_hash.0.mix_in(&delta_lt_hash);
+        }
     }
-}
-
-/// Stats related to accounts lt hash
-#[derive(Debug, Default)]
-pub struct Stats {
-    /// the number of times the cache already contained the account being inspected
-    num_inspect_account_hits: AtomicU64,
-    /// the number of times the cache *did not* already contain the account being inspected
-    num_inspect_account_misses: AtomicU64,
-    /// the number of times an account was inspected after the bank was frozen
-    num_inspect_account_after_frozen: AtomicU64,
-    /// time spent checking if accounts are in the cache
-    inspect_account_lookup_time_ns: AtomicU64,
-    /// time spent inserting accounts into the cache
-    inspect_account_insert_time_ns: AtomicU64,
-}
-
-/// The initial state of an account prior to being modified in this slot/transaction
-#[derive(Debug, Clone, PartialEq)]
-pub enum InitialStateOfAccount {
-    /// The account was initiall dead
-    Dead,
-    /// The account was initially alive
-    Alive(AccountSharedData),
-}
-
-/// The value type for the accounts lt hash cache
-#[derive(Debug, Clone, PartialEq)]
-pub enum CacheValue {
-    /// The value was inserted by `inspect_account()`.
-    /// This means we will have the initial state of the account.
-    InspectAccount(InitialStateOfAccount),
-    /// The value was inserted by `Bank::new()`.
-    /// This means we will *not* have the initial state of the account.
-    BankNew,
 }
 
 #[cfg(test)]
@@ -393,7 +69,7 @@ mod tests {
             bank::tests::new_bank_from_parent_with_bank_forks, runtime_config::RuntimeConfig,
             snapshot_bank_utils, snapshot_config::SnapshotConfig, snapshot_utils,
         },
-        solana_account::{ReadableAccount as _, WritableAccount as _},
+        solana_account::AccountSharedData,
         solana_accounts_db::{
             accounts_db::{AccountsDbConfig, MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING},
             accounts_index::{
@@ -470,7 +146,8 @@ mod tests {
         bank.transfer(amount, &mint_keypair, &keypair5.pubkey())
             .unwrap();
 
-        // manually freeze the bank to trigger update_accounts_lt_hash() to run
+        // freeze the bank to ensure deferred account state changes are completed
+        // e.g. update the slot history sysvar
         bank.freeze();
         let prev_accounts_lt_hash = bank.accounts_lt_hash.lock().unwrap().clone();
 
@@ -489,9 +166,7 @@ mod tests {
         assert!(prev_account4.is_none());
         assert!(prev_account5.is_some());
 
-        // These sysvars are also updated, but outside of transaction processing.  This means they
-        // will not be in the accounts lt hash cache, but *will* be in the list of modified
-        // accounts.  They must be included in the accounts lt hash.
+        // These sysvars are also updated, but outside of transaction processing.
         let sysvars = [
             Pubkey::from_str("SysvarS1otHashes111111111111111111111111111").unwrap(),
             Pubkey::from_str("SysvarC1ock11111111111111111111111111111111").unwrap(),
@@ -513,6 +188,15 @@ mod tests {
         bank.transfer(amount, &keypair2, &keypair1.pubkey())
             .unwrap();
 
+        // send lamports to account 1 in multiple transactions to exercise updating an
+        // account multiple times in the same block
+        bank.register_unique_recent_blockhash_for_test();
+        bank.transfer(amount, &mint_keypair, &keypair1.pubkey())
+            .unwrap();
+        bank.register_unique_recent_blockhash_for_test();
+        bank.transfer(amount, &mint_keypair, &keypair1.pubkey())
+            .unwrap();
+
         // send lamports to account 4, then turn around and send them to account 3
         // account 3 will be alive, and account 4 will end dead
         bank.register_unique_recent_blockhash_for_test();
@@ -525,10 +209,10 @@ mod tests {
         // store account 5 into this new bank, unchanged
         bank.store_account(&keypair5.pubkey(), prev_account5.as_ref().unwrap());
 
-        // freeze the bank to trigger update_accounts_lt_hash() to run
+        // freeze the bank to ensure deferred account state changes are completed
+        // e.g. update the slot history sysvar
         bank.freeze();
 
-        let actual_delta_lt_hash = bank.calculate_delta_lt_hash();
         let post_accounts_lt_hash = bank.accounts_lt_hash.lock().unwrap().clone();
         let post_mint = bank.get_account_with_fixed_root(&mint_keypair.pubkey());
         let post_account1 = bank.get_account_with_fixed_root(&keypair1.pubkey());
@@ -549,21 +233,18 @@ mod tests {
             .map(|address| bank.get_account_with_fixed_root(address))
             .collect();
 
-        let mut expected_delta_lt_hash = LtHash::identity();
         let mut expected_accounts_lt_hash = prev_accounts_lt_hash.clone();
         let mut updater =
             |address: &Pubkey, prev: Option<AccountSharedData>, post: Option<AccountSharedData>| {
                 // if there was an alive account, mix out
                 if let Some(prev) = prev {
                     let prev_lt_hash = AccountsDb::lt_hash_account(&prev, address);
-                    expected_delta_lt_hash.mix_out(&prev_lt_hash.0);
                     expected_accounts_lt_hash.0.mix_out(&prev_lt_hash.0);
                 }
 
                 // mix in the new one
                 let post = post.unwrap_or_default();
                 let post_lt_hash = AccountsDb::lt_hash_account(&post, address);
-                expected_delta_lt_hash.mix_in(&post_lt_hash.0);
                 expected_accounts_lt_hash.0.mix_in(&post_lt_hash.0);
             };
         updater(&mint_keypair.pubkey(), prev_mint, post_mint);
@@ -580,28 +261,19 @@ mod tests {
             );
         }
 
-        // now make sure the delta lt hashes match
-        let expected = expected_delta_lt_hash.checksum();
-        let actual = actual_delta_lt_hash.checksum();
+        // now make sure the accounts lt hashes match
         assert_eq!(
-            expected, actual,
-            "delta_lt_hash, expected: {expected}, actual: {actual}",
-        );
-
-        // ...and the accounts lt hashes match too
-        let expected = expected_accounts_lt_hash.0.checksum();
-        let actual = post_accounts_lt_hash.0.checksum();
-        assert_eq!(
-            expected, actual,
-            "accounts_lt_hash, expected: {expected}, actual: {actual}",
+            expected_accounts_lt_hash,
+            post_accounts_lt_hash,
+            "accounts_lt_hash, expected: {}, actual: {}",
+            expected_accounts_lt_hash.0.checksum(),
+            post_accounts_lt_hash.0.checksum(),
         );
     }
 
     /// Ensure that the accounts lt hash is correct for slot 0
     ///
     /// This test does a simple transfer in slot 0 so that a primordial account is modified.
-    ///
-    /// See the comments in calculate_delta_lt_hash() for more information.
     #[test_case(Features::None; "no features")]
     #[test_case(Features::All; "all features")]
     fn test_slot0_accounts_lt_hash(features: Features) {
@@ -615,7 +287,8 @@ mod tests {
         bank.transfer(LAMPORTS_PER_SOL, &mint_keypair, &Pubkey::new_unique())
             .unwrap();
 
-        // manually freeze the bank to trigger update_accounts_lt_hash() to run
+        // freeze the bank to ensure deferred account state changes are completed
+        // (not strictly needed for this test, but does make it more comprehensive)
         bank.freeze();
         let actual_accounts_lt_hash = bank.accounts_lt_hash.lock().unwrap().clone();
 
@@ -626,114 +299,6 @@ mod tests {
             .accounts_db
             .calculate_accounts_lt_hash_at_startup_from_index(&bank.ancestors, bank.slot());
         assert_eq!(actual_accounts_lt_hash, calculated_accounts_lt_hash);
-    }
-
-    #[test_case(Features::None; "no features")]
-    #[test_case(Features::All; "all features")]
-    fn test_inspect_account_for_accounts_lt_hash(features: Features) {
-        let (genesis_config, _mint_keypair) = genesis_config_with(features);
-        let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-
-        // the cache should start off empty
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 0);
-
-        // ensure non-writable accounts are *not* added to the cache
-        bank.inspect_account_for_accounts_lt_hash(
-            &Pubkey::new_unique(),
-            &AccountState::Dead,
-            false,
-        );
-        bank.inspect_account_for_accounts_lt_hash(
-            &Pubkey::new_unique(),
-            &AccountState::Alive(&AccountSharedData::default()),
-            false,
-        );
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 0);
-
-        // ensure *new* accounts are added to the cache
-        let address = Pubkey::new_unique();
-        bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Dead, true);
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 1);
-        assert!(bank.cache_for_accounts_lt_hash.contains_key(&address));
-
-        // ensure *existing* accounts are added to the cache
-        let address = Pubkey::new_unique();
-        let initial_lamports = 123;
-        let mut account = AccountSharedData::new(initial_lamports, 0, &Pubkey::default());
-        bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Alive(&account), true);
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 2);
-        if let CacheValue::InspectAccount(InitialStateOfAccount::Alive(cached_account)) = bank
-            .cache_for_accounts_lt_hash
-            .get(&address)
-            .unwrap()
-            .value()
-        {
-            assert_eq!(*cached_account, account);
-        } else {
-            panic!("wrong initial state for account");
-        };
-
-        // ensure if an account is modified multiple times that we only cache the *first* one
-        let updated_lamports = account.lamports() + 1;
-        account.set_lamports(updated_lamports);
-        bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Alive(&account), true);
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 2);
-        if let CacheValue::InspectAccount(InitialStateOfAccount::Alive(cached_account)) = bank
-            .cache_for_accounts_lt_hash
-            .get(&address)
-            .unwrap()
-            .value()
-        {
-            assert_eq!(cached_account.lamports(), initial_lamports);
-        } else {
-            panic!("wrong initial state for account");
-        };
-
-        // and ensure multiple updates are handled correctly when the account is initially dead
-        {
-            let address = Pubkey::new_unique();
-            bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Dead, true);
-            assert_eq!(bank.cache_for_accounts_lt_hash.len(), 3);
-            match bank
-                .cache_for_accounts_lt_hash
-                .get(&address)
-                .unwrap()
-                .value()
-            {
-                CacheValue::InspectAccount(InitialStateOfAccount::Dead) => {
-                    // this is expected, nothing to do here
-                }
-                _ => panic!("wrong initial state for account"),
-            };
-
-            bank.inspect_account_for_accounts_lt_hash(
-                &address,
-                &AccountState::Alive(&AccountSharedData::default()),
-                true,
-            );
-            assert_eq!(bank.cache_for_accounts_lt_hash.len(), 3);
-            match bank
-                .cache_for_accounts_lt_hash
-                .get(&address)
-                .unwrap()
-                .value()
-            {
-                CacheValue::InspectAccount(InitialStateOfAccount::Dead) => {
-                    // this is expected, nothing to do here
-                }
-                _ => panic!("wrong initial state for account"),
-            };
-        }
-
-        // ensure accounts are *not* added to the cache if the bank is frozen
-        // N.B. this test should remain *last*, as Bank::freeze() is not meant to be undone
-        bank.freeze();
-        let address = Pubkey::new_unique();
-        let num_cache_entries_prev = bank.cache_for_accounts_lt_hash.len();
-        bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Dead, true);
-        let num_cache_entries_curr = bank.cache_for_accounts_lt_hash.len();
-        assert_eq!(num_cache_entries_curr, num_cache_entries_prev);
-        assert!(!bank.cache_for_accounts_lt_hash.contains_key(&address));
     }
 
     #[test_case(Features::None; "no features")]
@@ -898,44 +463,7 @@ mod tests {
         )
         .unwrap();
 
-        // Correctly calculating the accounts lt hash in Bank::new_from_snapshot() depends on the
-        // bank being frozen.  This is so we don't call `update_accounts_lt_hash()` twice on the
-        // same bank!
-        assert!(roundtrip_bank.is_frozen());
-
         assert_eq!(roundtrip_bank, *bank);
-    }
-
-    /// Ensure that accounts written in Bank::new() are added to the accounts lt hash cache.
-    #[test_case(Features::None; "no features")]
-    #[test_case(Features::All; "all features")]
-    fn test_accounts_lt_hash_cache_values_from_bank_new(features: Features) {
-        let (genesis_config, _mint_keypair) = genesis_config_with(features);
-        let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-
-        let slot = bank.slot() + 1;
-        bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
-
-        // These are the two accounts *currently* added to the bank during Bank::new().
-        // More accounts could be added later, so if the test fails, inspect the actual cache
-        // accounts and update the expected cache accounts as necessary.
-        let expected_cache = &[
-            (
-                Pubkey::from_str_const("SysvarC1ock11111111111111111111111111111111"),
-                CacheValue::BankNew,
-            ),
-            (
-                Pubkey::from_str_const("SysvarS1otHashes111111111111111111111111111"),
-                CacheValue::BankNew,
-            ),
-        ];
-        let mut actual_cache: Vec<_> = bank
-            .cache_for_accounts_lt_hash
-            .iter()
-            .map(|entry| (*entry.key(), entry.value().clone()))
-            .collect();
-        actual_cache.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-        assert_eq!(expected_cache, actual_cache.as_slice());
     }
 
     /// Ensure that the snapshot hash is correct

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -42,7 +42,6 @@ pub(crate) struct NewBankTimings {
     pub(crate) cache_preparation_time_us: u64,
     pub(crate) update_sysvars_time_us: u64,
     pub(crate) fill_sysvar_cache_time_us: u64,
-    pub(crate) populate_cache_for_accounts_lt_hash_us: u64,
 }
 
 pub(crate) fn report_new_epoch_metrics(
@@ -97,7 +96,6 @@ pub(crate) fn report_new_bank_metrics(
     slot: Slot,
     parent_slot: Slot,
     block_height: u64,
-    num_accounts_modified_this_slot: usize,
     timings: NewBankTimings,
 ) {
     datapoint_info!(
@@ -140,16 +138,6 @@ pub(crate) fn report_new_bank_metrics(
         (
             "fill_sysvar_cache_us",
             timings.fill_sysvar_cache_time_us,
-            i64
-        ),
-        (
-            "num_accounts_modified_this_slot",
-            num_accounts_modified_this_slot,
-            i64
-        ),
-        (
-            "populate_cache_for_accounts_lt_hash_us",
-            timings.populate_cache_for_accounts_lt_hash_us,
             i64
         ),
     );

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -23,6 +23,7 @@ use {
     ahash::AHashMap,
     assert_matches::assert_matches,
     crossbeam_channel::{bounded, unbounded},
+    dashmap::DashMap,
     ed25519_dalek::ed25519::signature::Signer as EdSigner,
     itertools::Itertools,
     rand::Rng,


### PR DESCRIPTION
#### Problem

Alessandro was doing some performance profiling running at 100k TPS and found that updating the accounts lt hash during `Bank::freeze()` was a bottle neck.


#### Summary of Changes

Update the accounts lt hash inline with transaction processing.


#### Perf Results

Perf profiling a validator running this PR on mnb showed that, in the `solScHandle` threads, the ones that do `Bank::commit_transactions()`, the `update_accounts_lt_hash()` fn is ~9% of runtime. So overall quite small. Of that 9%, ~80% is calculating the lt hash on each account. Only 2.5% is locking the mutex for the overall `Bank::accounts_lt_hash` field. So not much contention on this mutex either, which is great.

<details><summary>perf profile screenshot</summary>
<p>

<img width="2102" height="1563" alt="Screenshot 2025-09-29 at 3 50 15 PM" src="https://github.com/user-attachments/assets/fc55ac4e-2f0f-4aa7-a659-6956ffd21611" />

</p>
</details> 


#### Other Testing

I have a node running this PR, and as of Mon 2025-09-29 19:54:59 UTC, it has been running for over 170 hours (7+ days). So it's computing correct bank hashes, i.e. it is updating the accounts lt hash correctly. And it is working across epoch boundaries.