### PR TITLE
Throw errors when `max_supported_transaction_version` is out of range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11532,6 +11532,7 @@ dependencies = [
  "spl-token-group-interface",
  "spl-token-interface",
  "spl-token-metadata-interface",
+ "test-case",
  "thiserror 2.0.16",
 ]
 

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -494,6 +494,9 @@ pub enum RpcBlockUpdateError {
 
     #[error("unsupported transaction version ({0})")]
     UnsupportedTransactionVersion(u8),
+
+    #[error("{0} is not a valid transaction version in the range 0-127")]
+    InvalidTransactionVersion(u8),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4515,6 +4515,7 @@ pub mod tests {
             self as address_lookup_table,
             state::{AddressLookupTable, LookupTableMeta},
         },
+        solana_client::rpc_custom_error::JSON_RPC_SERVER_ERROR_INVALID_TRANSACTION_VERSION,
         solana_compute_budget_interface::ComputeBudgetInstruction,
         solana_entry::entry::next_versioned_entry,
         solana_fee_calculator::FeeRateGovernor,
@@ -7269,6 +7270,17 @@ pub mod tests {
             confirmed_block.transactions[1].version,
             Some(TransactionVersion::Number(0))
         );
+
+        let request = create_test_request(
+            "getBlock",
+            Some(json!([0u64, { "maxSupportedTransactionVersion": 128 }])),
+        );
+        let response = parse_failure_response(rpc.handle_request_sync(request));
+        let expected = (
+            JSON_RPC_SERVER_ERROR_INVALID_TRANSACTION_VERSION,
+            String::from("128 is not a valid transaction version in the range 0-127"),
+        );
+        assert_eq!(response, expected);
 
         let request = create_test_request("getBlock", Some(json!([0u64,])));
         let response = parse_failure_response(rpc.handle_request_sync(request));

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -355,6 +355,9 @@ fn filter_block_result_txs(
             },
         )
         .map_err(|err| match err {
+            EncodeError::InvalidTransactionVersion(version) => {
+                RpcBlockUpdateError::InvalidTransactionVersion(version)
+            }
             EncodeError::UnsupportedTransactionVersion(version) => {
                 RpcBlockUpdateError::UnsupportedTransactionVersion(version)
             }

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -81,6 +81,8 @@ impl Default for TransactionDetails {
 pub enum EncodeError {
     #[error("Encoding does not support transaction version {0}")]
     UnsupportedTransactionVersion(u8),
+    #[error("{0} is not a valid transaction version in the range 0-127")]
+    InvalidTransactionVersion(u8),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -55,6 +55,7 @@ bencher = { workspace = true }
 bytemuck = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 spl-token-confidential-transfer-proof-extraction = { workspace = true }
+test-case = { workspace = true }
 
 [[bench]]
 name = "extract_memos"


### PR DESCRIPTION
#### Problem

You can tell the RPC that you support transaction version numbers higher than the highest possible version. This should be an error.

#### Summary of Changes

The RPC now throws if you specify `maxSupportedTransactionVersion > 127`.


#### Test Plan

```
curl http://0.0.0.0:8899 -s -X    POST -H "Content-Type: application/json" -d ' 
   {
     "jsonrpc": "2.0",
     "id": 1,
     "method": "getBlock",
     "params": [
       1600,
       {
         "commitment": "confirmed",
         "maxSupportedTransactionVersion": 128,
         "encoding": "json"
       }
     ]
   }
 '
{"jsonrpc":"2.0","error":{"code":-32020,"message":"128 is not a valid transaction version in the range 0-127"},"id":1}
```

Fixes #8159.