### PR TITLE
Create files without O_NONBLOCK flag

### DIFF
--- a/accounts-db/src/io_uring/file_creator.rs
+++ b/accounts-db/src/io_uring/file_creator.rs
@@ -9,7 +9,7 @@ use {
     agave_io_uring::{Completion, FixedSlab, Ring, RingOp},
     core::slice,
     io_uring::{opcode, squeue, types, IoUring},
-    libc::{O_CREAT, O_NOATIME, O_NOFOLLOW, O_NONBLOCK, O_TRUNC, O_WRONLY},
+    libc::{O_CREAT, O_NOATIME, O_NOFOLLOW, O_TRUNC, O_WRONLY},
     smallvec::SmallVec,
     std::{
         collections::VecDeque,
@@ -361,7 +361,7 @@ impl OpenOp {
                 .unwrap_or(libc::AT_FDCWD),
         );
         opcode::OpenAt::new(at_dir_fd, self.path_bytes.as_ptr() as _)
-            .flags(O_CREAT | O_TRUNC | O_NOFOLLOW | O_WRONLY | O_NOATIME | O_NONBLOCK)
+            .flags(O_CREAT | O_TRUNC | O_NOFOLLOW | O_WRONLY | O_NOATIME)
             .mode(self.mode)
             .file_index(Some(
                 types::DestinationSlot::try_from_slot_target(self.file_key as u32).unwrap(),


### PR DESCRIPTION
#### Problem
We do not currently perform writes with `ASYNC` flag, so they are first considered in non-blocking context (directly in the requesting thread, not in a worker) and re-submitted in the worker when they cannot be serviced immediately. 

On older kernels (5.15) such re-submission is however broken in the case of file being open with `O_NONBLOCK` mode, but request needing to be done in blocking fashion (e.g. on a file-system not supporting non-blocking execution natively). 

In other words when IO needs to block, but it is submitted on a file required to not block, kernel just returns error, requiring *the user* to submit IO to the kernel worker, i.e. with `ASYNC` flag (on newer kernel this path is handled automatically). See also discussion in https://github.com/anza-xyz/agave/pull/8053#issuecomment-3324350507

Also, `O_NONBLOCK` flag without `O_DIRECT` is actually an unusual / not supported mode, with io_uring we shouldn't use it at all.

#### Summary of Changes
Don't create files in non-blocking mode, which relieves constraints on how IO is executed by the kernel and prevents `EAGAIN` errors to be surfaced in io_uring completions on older kernels.

Performance is not affected (leaning positive, but that is within noise):
* this PR: snapshot untar took 93.7s, snapshot untar took 97.8s, snapshot untar took 94.9s
* master: snapshot untar took 97.5s, snapshot untar took 97.7s

Fixes #8036
