### PR TITLE
vote-program: outfit to fully support vote state v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11865,6 +11865,7 @@ dependencies = [
  "solana-sha256-hasher",
  "solana-signer",
  "solana-slot-hashes",
+ "solana-svm-feature-set",
  "solana-transaction",
  "solana-transaction-context",
  "solana-vote-interface",

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -158,6 +158,7 @@ impl FeatureSet {
             raise_cpi_nesting_limit_to_8: self.is_active(&raise_cpi_nesting_limit_to_8::id()),
             provide_instruction_data_offset_in_vm_r2: self
                 .is_active(&provide_instruction_data_offset_in_vm_r2::id()),
+            vote_state_v4: self.is_active(&vote_state_v4::id()),
         }
     }
 }
@@ -1132,6 +1133,10 @@ pub mod provide_instruction_data_offset_in_vm_r2 {
     solana_pubkey::declare_id!("5xXZc66h4UdB6Yq7FzdBxBiRAFMMScMLwHxk2QZDaNZL");
 }
 
+pub mod vote_state_v4 {
+    solana_pubkey::declare_id!("Gx4XFcrVMt4HUvPzTpTSVkdDVgcDSjKhDN1RqRS6KDuZ");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2045,6 +2050,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
             provide_instruction_data_offset_in_vm_r2::id(),
             "SIMD-0321: Provide instruction data offset in VM r2",
         ),
+        (vote_state_v4::id(), "SIMD-0185: Vote State v4"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -73,6 +73,7 @@ solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sha256-hasher = { workspace = true }
+solana-svm-feature-set = { workspace = true }
 test-case = { workspace = true }
 
 [[bench]]

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -1285,9 +1285,16 @@ mod tests {
         );
         assert_eq!(accounts[0].lamports(), 0);
         assert_eq!(accounts[3].lamports(), lamports);
-        let post_state: VoteStateVersions = accounts[0].state().unwrap();
         // State has been deinitialized since balance is zero
-        assert!(post_state.is_uninitialized());
+        if vote_state_v4_enabled {
+            // v4 is always "initialized" per SIMD-0185.
+            let v4 = VoteStateV4::deserialize(accounts[0].data(), &vote_pubkey).unwrap();
+            // After deinitialize, it contains default state.
+            assert_eq!(v4, VoteStateV4::default());
+        } else {
+            let post_state: VoteStateVersions = accounts[0].state().unwrap();
+            assert!(post_state.is_uninitialized());
+        }
 
         // should fail, unsigned
         transaction_accounts[0] = (vote_pubkey, vote_account);

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -638,6 +638,7 @@ pub(crate) fn create_new_vote_state_v4_for_tests(
 }
 
 /// The target version to convert all deserialized vote state into.
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum VoteStateTargetVersion {
     V3,
     V4,

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -864,8 +864,14 @@ impl VoteStateHandler {
                 TargetVoteState::V3(vote_state)
             }
             VoteStateTargetVersion::V4 => {
-                let vote_state =
-                    VoteStateV4::deserialize(vote_account.get_data(), vote_account.get_key())?;
+                // Once `VoteStateV4` is active, `VoteState0_23_5` will be
+                // considered uninitialized. Fail here early if we detect an
+                // enum variant discriminator of 0.
+                let data = vote_account.get_data();
+                if data.first().is_some_and(|b| *b == 0) {
+                    return Err(InstructionError::UninitializedAccount);
+                }
+                let vote_state = VoteStateV4::deserialize(data, vote_account.get_key())?;
                 TargetVoteState::V4(vote_state)
             }
         };

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -231,6 +231,20 @@ pub trait VoteStateHandle {
             self.epoch_credits().last().unwrap().1
         }
     }
+
+    #[cfg(test)]
+    fn nth_recent_lockout(&self, position: usize) -> Option<&Lockout> {
+        if position < self.votes().len() {
+            let pos = self
+                .votes()
+                .len()
+                .checked_sub(position)
+                .and_then(|pos| pos.checked_sub(1))?;
+            self.votes().get(pos).map(|vote| &vote.lockout)
+        } else {
+            None
+        }
+    }
 }
 
 impl VoteStateHandle for VoteStateV3 {
@@ -582,13 +596,11 @@ impl VoteStateHandle for VoteStateV4 {
 }
 
 /// Default block revenue commission rate in basis points (100%) per SIMD-0185.
-#[cfg(test)] // Test-only for now, until later commits.
 const DEFAULT_BLOCK_REVENUE_COMMISSION_BPS: u16 = 10_000;
 
 /// Create a new VoteStateV4 from `VoteInit` with proper SIMD-0185 defaults.
 /// Note this is a temporary substitute for `VoteStateV4::new`.
 #[allow(clippy::arithmetic_side_effects)]
-#[cfg(test)] // Test-only for now, until later commits.
 pub(crate) fn create_new_vote_state_v4(
     vote_pubkey: &Pubkey,
     vote_init: &VoteInit,
@@ -628,12 +640,14 @@ pub(crate) fn create_new_vote_state_v4_for_tests(
 /// The target version to convert all deserialized vote state into.
 pub enum VoteStateTargetVersion {
     V3,
+    V4,
     // New vote state versions will be added here...
 }
 
 #[derive(Clone, Debug, PartialEq)]
 enum TargetVoteState {
     V3(VoteStateV3),
+    V4(VoteStateV4),
     // New vote state versions will be added here...
 }
 
@@ -651,24 +665,28 @@ impl VoteStateHandle for VoteStateHandler {
     fn is_uninitialized(&self) -> bool {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.is_uninitialized(),
+            TargetVoteState::V4(v4) => v4.is_uninitialized(),
         }
     }
 
     fn authorized_withdrawer(&self) -> &Pubkey {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.authorized_withdrawer(),
+            TargetVoteState::V4(v4) => v4.authorized_withdrawer(),
         }
     }
 
     fn set_authorized_withdrawer(&mut self, authorized_withdrawer: Pubkey) {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_authorized_withdrawer(authorized_withdrawer),
+            TargetVoteState::V4(v4) => v4.set_authorized_withdrawer(authorized_withdrawer),
         }
     }
 
     fn authorized_voters(&self) -> &AuthorizedVoters {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.authorized_voters(),
+            TargetVoteState::V4(v4) => v4.authorized_voters(),
         }
     }
 
@@ -686,6 +704,9 @@ impl VoteStateHandle for VoteStateHandler {
             TargetVoteState::V3(v3) => {
                 v3.set_new_authorized_voter(authorized_pubkey, current_epoch, target_epoch, verify)
             }
+            TargetVoteState::V4(v4) => {
+                v4.set_new_authorized_voter(authorized_pubkey, current_epoch, target_epoch, verify)
+            }
         }
     }
 
@@ -695,108 +716,126 @@ impl VoteStateHandle for VoteStateHandler {
     ) -> Result<Pubkey, InstructionError> {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.get_and_update_authorized_voter(current_epoch),
+            TargetVoteState::V4(v4) => v4.get_and_update_authorized_voter(current_epoch),
         }
     }
 
     fn commission(&self) -> u8 {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.commission(),
+            TargetVoteState::V4(v4) => v4.commission(),
         }
     }
 
     fn set_commission(&mut self, commission: u8) {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_commission(commission),
+            TargetVoteState::V4(v4) => v4.set_commission(commission),
         }
     }
 
     fn node_pubkey(&self) -> &Pubkey {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.node_pubkey(),
+            TargetVoteState::V4(v4) => v4.node_pubkey(),
         }
     }
 
     fn set_node_pubkey(&mut self, node_pubkey: Pubkey) {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_node_pubkey(node_pubkey),
+            TargetVoteState::V4(v4) => v4.set_node_pubkey(node_pubkey),
         }
     }
 
     fn votes(&self) -> &VecDeque<LandedVote> {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.votes(),
+            TargetVoteState::V4(v4) => v4.votes(),
         }
     }
 
     fn votes_mut(&mut self) -> &mut VecDeque<LandedVote> {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.votes_mut(),
+            TargetVoteState::V4(v4) => v4.votes_mut(),
         }
     }
 
     fn set_votes(&mut self, votes: VecDeque<LandedVote>) {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_votes(votes),
+            TargetVoteState::V4(v4) => v4.set_votes(votes),
         }
     }
 
     fn contains_slot(&self, candidate_slot: Slot) -> bool {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.contains_slot(candidate_slot),
+            TargetVoteState::V4(v4) => v4.contains_slot(candidate_slot),
         }
     }
 
     fn last_lockout(&self) -> Option<&Lockout> {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.last_lockout(),
+            TargetVoteState::V4(v4) => v4.last_lockout(),
         }
     }
 
     fn last_voted_slot(&self) -> Option<Slot> {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.last_voted_slot(),
+            TargetVoteState::V4(v4) => v4.last_voted_slot(),
         }
     }
 
     fn root_slot(&self) -> Option<Slot> {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.root_slot(),
+            TargetVoteState::V4(v4) => v4.root_slot(),
         }
     }
 
     fn set_root_slot(&mut self, root_slot: Option<Slot>) {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_root_slot(root_slot),
+            TargetVoteState::V4(v4) => v4.set_root_slot(root_slot),
         }
     }
 
     fn current_epoch(&self) -> Epoch {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.current_epoch(),
+            TargetVoteState::V4(v4) => v4.current_epoch(),
         }
     }
 
     fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)> {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.epoch_credits(),
+            TargetVoteState::V4(v4) => v4.epoch_credits(),
         }
     }
 
     fn epoch_credits_mut(&mut self) -> &mut Vec<(Epoch, u64, u64)> {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.epoch_credits_mut(),
+            TargetVoteState::V4(v4) => v4.epoch_credits_mut(),
         }
     }
 
     fn last_timestamp(&self) -> &BlockTimestamp {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.last_timestamp(),
+            TargetVoteState::V4(v4) => v4.last_timestamp(),
         }
     }
 
     fn set_last_timestamp(&mut self, timestamp: BlockTimestamp) {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_last_timestamp(timestamp),
+            TargetVoteState::V4(v4) => v4.set_last_timestamp(timestamp),
         }
     }
 
@@ -806,6 +845,7 @@ impl VoteStateHandle for VoteStateHandler {
     ) -> Result<(), InstructionError> {
         match self.target_state {
             TargetVoteState::V3(v3) => v3.set_vote_account_state(vote_account),
+            TargetVoteState::V4(v4) => v4.set_vote_account_state(vote_account),
         }
     }
 }
@@ -822,6 +862,11 @@ impl VoteStateHandler {
                 let vote_state = VoteStateV3::deserialize(vote_account.get_data())?;
                 TargetVoteState::V3(vote_state)
             }
+            VoteStateTargetVersion::V4 => {
+                let vote_state =
+                    VoteStateV4::deserialize(vote_account.get_data(), vote_account.get_key())?;
+                TargetVoteState::V4(vote_state)
+            }
         };
         Ok(Self { target_state })
     }
@@ -836,6 +881,10 @@ impl VoteStateHandler {
             VoteStateTargetVersion::V3 => {
                 VoteStateV3::new(vote_init, clock).set_vote_account_state(vote_account)
             }
+            VoteStateTargetVersion::V4 => {
+                let vote_state = create_new_vote_state_v4(vote_account.get_key(), vote_init, clock);
+                vote_state.set_vote_account_state(vote_account)
+            }
         }
     }
 
@@ -847,6 +896,9 @@ impl VoteStateHandler {
             VoteStateTargetVersion::V3 => {
                 VoteStateV3::default().set_vote_account_state(vote_account)
             }
+            VoteStateTargetVersion::V4 => {
+                VoteStateV4::default().set_vote_account_state(vote_account)
+            }
         }
     }
 
@@ -857,6 +909,7 @@ impl VoteStateHandler {
         let length = vote_account.get_data().len();
         let expected = match target_version {
             VoteStateTargetVersion::V3 => VoteStateV3::size_of(),
+            VoteStateTargetVersion::V4 => VoteStateV4::size_of(),
         };
         if length != expected {
             Err(InstructionError::InvalidAccountData)
@@ -873,33 +926,20 @@ impl VoteStateHandler {
     }
 
     #[cfg(test)]
+    pub fn new_v4(vote_state: VoteStateV4) -> Self {
+        Self {
+            target_state: TargetVoteState::V4(vote_state),
+        }
+    }
+
+    #[cfg(test)]
     pub fn default_v3() -> Self {
         Self::new_v3(VoteStateV3::default())
     }
 
     #[cfg(test)]
-    pub fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)> {
-        match &self.target_state {
-            TargetVoteState::V3(v3) => &v3.epoch_credits,
-        }
-    }
-
-    #[cfg(test)]
-    pub fn nth_recent_lockout(&self, position: usize) -> Option<&Lockout> {
-        match &self.target_state {
-            TargetVoteState::V3(v3) => {
-                if position < v3.votes.len() {
-                    let pos = v3
-                        .votes
-                        .len()
-                        .checked_sub(position)
-                        .and_then(|pos| pos.checked_sub(1))?;
-                    v3.votes.get(pos).map(|vote| &vote.lockout)
-                } else {
-                    None
-                }
-            }
-        }
+    pub fn default_v4() -> Self {
+        Self::new_v4(VoteStateV4::default())
     }
 }
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1122,14 +1122,6 @@ mod tests {
         )
     }
 
-    fn get_credits(epoch_credits: &[(Epoch, u64, u64)]) -> u64 {
-        if epoch_credits.is_empty() {
-            0
-        } else {
-            epoch_credits.last().unwrap().1
-        }
-    }
-
     #[test]
     fn test_vote_state_upgrade_from_1_14_11() {
         // Create an initial vote account that is sized for the 1_14_11 version of vote state, and has only the
@@ -1525,14 +1517,14 @@ mod tests {
             process_slot_vote_unchecked(&mut vote_state, i as u64);
         }
 
-        assert_eq!(get_credits(vote_state.epoch_credits()), 0);
+        assert_eq!(vote_state.credits(), 0);
 
         process_slot_vote_unchecked(&mut vote_state, MAX_LOCKOUT_HISTORY as u64 + 1);
-        assert_eq!(get_credits(vote_state.epoch_credits()), 1);
+        assert_eq!(vote_state.credits(), 1);
         process_slot_vote_unchecked(&mut vote_state, MAX_LOCKOUT_HISTORY as u64 + 2);
-        assert_eq!(get_credits(vote_state.epoch_credits()), 2);
+        assert_eq!(vote_state.credits(), 2);
         process_slot_vote_unchecked(&mut vote_state, MAX_LOCKOUT_HISTORY as u64 + 3);
-        assert_eq!(get_credits(vote_state.epoch_credits()), 3);
+        assert_eq!(vote_state.credits(), 3);
     }
 
     #[test]
@@ -2049,14 +2041,8 @@ mod tests {
 
             // Ensure that the credits earned is correct for both vote states
             let vote_group = &test_vote_groups[i];
-            assert_eq!(
-                get_credits(vote_state_1.epoch_credits()),
-                vote_group.2 as u64
-            ); // vote_group.2 is the expected number of credits
-            assert_eq!(
-                get_credits(vote_state_2.epoch_credits()),
-                vote_group.2 as u64
-            ); // vote_group.2 is the expected number of credits
+            assert_eq!(vote_state_1.credits(), vote_group.2 as u64); // vote_group.2 is the expected number of credits
+            assert_eq!(vote_state_2.credits(), vote_group.2 as u64); // vote_group.2 is the expected number of credits
         }
     }
 
@@ -2172,10 +2158,7 @@ mod tests {
                 );
 
                 // Ensure that the credits earned is correct
-                assert_eq!(
-                    get_credits(vote_state.epoch_credits()),
-                    proposed_vote_state.3 as u64
-                );
+                assert_eq!(vote_state.credits(), proposed_vote_state.3 as u64);
             });
     }
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -3,12 +3,8 @@
 
 mod handler;
 
-pub use {
-    handler::VoteStateTargetVersion,
-    solana_vote_interface::state::{vote_state_versions::*, *},
-};
 use {
-    handler::{VoteStateHandle, VoteStateHandler},
+    handler::VoteStateHandler,
     log::*,
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_clock::{Clock, Epoch, Slot},
@@ -25,9 +21,10 @@ use {
         collections::{HashSet, VecDeque},
     },
 };
-
-// TODO: Change me once the program has full v4 feature gate support.
-pub(crate) const TEMP_HARDCODED_TARGET_VERSION: VoteStateTargetVersion = VoteStateTargetVersion::V3;
+pub use {
+    handler::{VoteStateHandle, VoteStateTargetVersion},
+    solana_vote_interface::state::{vote_state_versions::*, *},
+};
 
 // utility function, used by Stakes, tests
 pub fn from<T: ReadableAccount>(account: &T) -> Option<VoteStateV3> {

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -37,6 +37,7 @@ pub struct SVMFeatureSet {
     pub reenable_zk_elgamal_proof_program: bool,
     pub raise_cpi_nesting_limit_to_8: bool,
     pub provide_instruction_data_offset_in_vm_r2: bool,
+    pub vote_state_v4: bool,
 }
 
 impl SVMFeatureSet {
@@ -79,6 +80,7 @@ impl SVMFeatureSet {
             reenable_zk_elgamal_proof_program: true,
             raise_cpi_nesting_limit_to_8: true,
             provide_instruction_data_offset_in_vm_r2: true,
+            vote_state_v4: true,
         }
     }
 }


### PR DESCRIPTION
#### Problem
Now that #8120 has landed, `VoteStateV4` is now compatible with the `VoteStateHandle` API used by the Vote program. However, both the handler and the program themselves don't directly support v4 vote state.

In order to enable this support and thus complete the implementation of [SIMD-0185](https://github.com/solana-foundation/solana-improvement-documents/pull/185), the Vote program must be outfitted to support `VoteStateV4`.

#### Summary of Changes
First add a new `TargetVoteStateVersion::V4` variant to the `VoteStateHandler` struct and flesh out the unit tests for the handler. Then, plumb a `target_version: TargetVoteStateVersion` parameter throughout the Vote program.

With the addition of the new parameter I overhauled a bunch of tests but tried to keep everything pinned to v3-only, until finally adding the feature gate in the second-last commit and converting the rest of the tests.

In the final commit, I took a stab at addressing some offline discussion @jstarry and I were having about v1 vote account states being accidentally deserialized as initialized v4 states, since v4 are always initialized.