### PR TITLE
Update metrics for staked/non-staked evictions

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -444,7 +444,9 @@ fn prune_unstaked_connection_table(
 
         let max_connections = max_percentage_full.apply_to(max_unstaked_connections);
         let num_pruned = unstaked_connection_table.prune_oldest(max_connections);
-        stats.num_evictions.fetch_add(num_pruned, Ordering::Relaxed);
+        stats
+            .num_evictions_unstaked
+            .fetch_add(num_pruned, Ordering::Relaxed);
     }
 }
 
@@ -802,7 +804,9 @@ async fn setup_connection(
                         {
                             let num_pruned =
                                 connection_table_l.prune_random(PRUNE_RANDOM_SAMPLE_SIZE, stake);
-                            stats.num_evictions.fetch_add(num_pruned, Ordering::Relaxed);
+                            stats
+                                .num_evictions_staked
+                                .fetch_add(num_pruned, Ordering::Relaxed);
                             update_open_connections_stat(&stats, &connection_table_l);
                         }
 

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -174,7 +174,8 @@ pub struct StreamerStats {
     pub(crate) total_chunks_processed_by_batcher: AtomicUsize,
     pub(crate) total_stream_read_errors: AtomicUsize,
     pub(crate) total_stream_read_timeouts: AtomicUsize,
-    pub(crate) num_evictions: AtomicUsize,
+    pub(crate) num_evictions_staked: AtomicUsize,
+    pub(crate) num_evictions_unstaked: AtomicUsize,
     pub(crate) connection_added_from_staked_peer: AtomicUsize,
     pub(crate) connection_added_from_unstaked_peer: AtomicUsize,
     pub(crate) connection_add_failed: AtomicUsize,
@@ -251,8 +252,13 @@ impl StreamerStats {
                 i64
             ),
             (
-                "evictions",
-                self.num_evictions.swap(0, Ordering::Relaxed),
+                "evictions_staked",
+                self.num_evictions_staked.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "evictions_unstaked",
+                self.num_evictions_unstaked.swap(0, Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem
We only have num_evictions to cover evictions both for staked and unstaked. It cannot tell which table are going through churns easily.

#### Summary of Changes

Split metrics into 

- num_evictions_staked
- num_evictions_unstaked


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
