### PR TITLE
Fix - Built-in entry in core program migration tests

### DIFF
--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -658,7 +658,11 @@ pub(crate) mod tests {
             bank.add_builtin(
                 builtin_id,
                 builtin_name.as_str(),
-                ProgramCacheEntry::default(),
+                ProgramCacheEntry::new_builtin(
+                    0,
+                    builtin_name.len(),
+                    |_invoke_context, _param0, _param1, _param2, _param3, _param4| {},
+                ),
             );
             account
         };
@@ -794,7 +798,11 @@ pub(crate) mod tests {
             bank.add_builtin(
                 builtin_id,
                 builtin_name.as_str(),
-                ProgramCacheEntry::default(),
+                ProgramCacheEntry::new_builtin(
+                    0,
+                    builtin_name.len(),
+                    |_invoke_context, _param0, _param1, _param2, _param3, _param4| {},
+                ),
             );
             account
         };
@@ -844,7 +852,11 @@ pub(crate) mod tests {
             bank.add_builtin(
                 builtin_id,
                 builtin_name.as_str(),
-                ProgramCacheEntry::default(),
+                ProgramCacheEntry::new_builtin(
+                    0,
+                    builtin_name.len(),
+                    |_invoke_context, _param0, _param1, _param2, _param3, _param4| {},
+                ),
             );
             account
         };
@@ -894,7 +906,11 @@ pub(crate) mod tests {
             bank.add_builtin(
                 builtin_id,
                 builtin_name.as_str(),
-                ProgramCacheEntry::default(),
+                ProgramCacheEntry::new_builtin(
+                    0,
+                    builtin_name.len(),
+                    |_invoke_context, _param0, _param1, _param2, _param3, _param4| {},
+                ),
             );
             account
         };


### PR DESCRIPTION
#### Problem

These tests currently mock built-ins with `ProgramCacheEntry::default()` which is a `Closed` tombstone.

#### Summary of Changes

Change it to the proper `ProgramCacheEntry::new_builtin()`.
