### PR TITLE
define 64 max instruction trace length per transaction in const

### DIFF
--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -1,5 +1,6 @@
 use {
-    solana_fee_structure::FeeDetails, solana_program_entrypoint::HEAP_LENGTH, std::num::NonZeroU32,
+    solana_fee_structure::FeeDetails, solana_program_entrypoint::HEAP_LENGTH,
+    solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH, std::num::NonZeroU32,
 };
 
 /// Max instruction stack depth. This is the maximum nesting of instructions that can happen during
@@ -74,7 +75,7 @@ impl SVMTransactionExecutionBudget {
         SVMTransactionExecutionBudget {
             compute_unit_limit: u64::from(MAX_COMPUTE_UNIT_LIMIT),
             max_instruction_stack_depth: get_max_instruction_stack_depth(simd_0268_active),
-            max_instruction_trace_length: 64,
+            max_instruction_trace_length: MAX_INSTRUCTION_TRACE_LENGTH,
             sha256_max_slices: 20_000,
             max_call_depth: MAX_CALL_DEPTH,
             stack_frame_size: STACK_FRAME_SIZE,

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -32,6 +32,8 @@ pub const MAX_ACCOUNT_DATA_LEN: u64 = 10 * 1024 * 1024;
 // an account up to MAX_ACCOUNT_DATA_GROWTH_PER_INSTRUCTION at once.
 pub const MAX_ACCOUNT_DATA_GROWTH_PER_TRANSACTION: i64 = MAX_ACCOUNT_DATA_LEN as i64 * 2;
 pub const MAX_ACCOUNT_DATA_GROWTH_PER_INSTRUCTION: usize = 10 * 1_024;
+// Maximum cross-program invocation and instructions per transaction
+pub const MAX_INSTRUCTION_TRACE_LENGTH: usize = 64;
 
 #[cfg(test)]
 static_assertions::const_assert_eq!(


### PR DESCRIPTION
#### Problem

`max_instruction_trace_length` is hardcoded to `64`. SIMD-0160 proposed to limit transaction's top level instructions to the same number, because otherwise tx will fail in SVM. It'd better to define `64` is a shared const for readability; also help to keep logic consistent in case SVM increases the value in future.

#### Summary of Changes
- add `const MAX_INSTRUCTION_TRACE_LENGTH`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
