### PR TITLE
vote-program: handler: add v4 variant

### DIFF
--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -946,7 +946,7 @@ impl VoteStateHandler {
     }
 
     #[cfg(test)]
-    pub fn unwrap_v4(&self) -> &VoteStateV4 {
+    pub fn as_ref_v4(&self) -> &VoteStateV4 {
         match &self.target_state {
             TargetVoteState::V4(v4) => v4,
             _ => panic!("not a v4"),
@@ -1927,12 +1927,13 @@ mod tests {
             (50, 5_000),
             (75, 7_500),
             (100, 10_000),
+            (255, 25_500),
         ] {
             handler.set_commission(input);
             assert_eq!(handler.commission(), input);
 
             // Verify the internal V4 state has the correct basis points.
-            let vote_state_v4 = handler.unwrap_v4();
+            let vote_state_v4 = handler.as_ref_v4();
             assert_eq!(vote_state_v4.inflation_rewards_commission_bps, expected);
         }
     }
@@ -1987,7 +1988,7 @@ mod tests {
             )
             .unwrap();
 
-            handler.unwrap_v4().clone()
+            handler.as_ref_v4().clone()
         };
 
         // V0_23_5

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -1626,7 +1626,7 @@ mod tests {
             if let VoteStateVersions::V4(v4) = vote_state_versions {
                 assert_eq!(v4.node_pubkey, vote_init.node_pubkey);
                 assert_eq!(
-                    v4.authorized_voters.get_authorized_voter(0),
+                    v4.authorized_voters.get_authorized_voter(clock.epoch),
                     Some(vote_init.authorized_voter)
                 );
                 assert_eq!(v4.authorized_withdrawer, vote_init.authorized_withdrawer);

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1122,14 +1122,6 @@ mod tests {
         )
     }
 
-    fn get_credits(epoch_credits: &[(Epoch, u64, u64)]) -> u64 {
-        if epoch_credits.is_empty() {
-            0
-        } else {
-            epoch_credits.last().unwrap().1
-        }
-    }
-
     #[test]
     fn test_vote_state_upgrade_from_1_14_11() {
         // Create an initial vote account that is sized for the 1_14_11 version of vote state, and has only the
@@ -1525,14 +1517,14 @@ mod tests {
             process_slot_vote_unchecked(&mut vote_state, i as u64);
         }
 
-        assert_eq!(get_credits(vote_state.epoch_credits()), 0);
+        assert_eq!(vote_state.credits(), 0);
 
         process_slot_vote_unchecked(&mut vote_state, MAX_LOCKOUT_HISTORY as u64 + 1);
-        assert_eq!(get_credits(vote_state.epoch_credits()), 1);
+        assert_eq!(vote_state.credits(), 1);
         process_slot_vote_unchecked(&mut vote_state, MAX_LOCKOUT_HISTORY as u64 + 2);
-        assert_eq!(get_credits(vote_state.epoch_credits()), 2);
+        assert_eq!(vote_state.credits(), 2);
         process_slot_vote_unchecked(&mut vote_state, MAX_LOCKOUT_HISTORY as u64 + 3);
-        assert_eq!(get_credits(vote_state.epoch_credits()), 3);
+        assert_eq!(vote_state.credits(), 3);
     }
 
     #[test]
@@ -2049,14 +2041,8 @@ mod tests {
 
             // Ensure that the credits earned is correct for both vote states
             let vote_group = &test_vote_groups[i];
-            assert_eq!(
-                get_credits(vote_state_1.epoch_credits()),
-                vote_group.2 as u64
-            ); // vote_group.2 is the expected number of credits
-            assert_eq!(
-                get_credits(vote_state_2.epoch_credits()),
-                vote_group.2 as u64
-            ); // vote_group.2 is the expected number of credits
+            assert_eq!(vote_state_1.credits(), vote_group.2 as u64); // vote_group.2 is the expected number of credits
+            assert_eq!(vote_state_2.credits(), vote_group.2 as u64); // vote_group.2 is the expected number of credits
         }
     }
 
@@ -2172,10 +2158,7 @@ mod tests {
                 );
 
                 // Ensure that the credits earned is correct
-                assert_eq!(
-                    get_credits(vote_state.epoch_credits()),
-                    proposed_vote_state.3 as u64
-                );
+                assert_eq!(vote_state.credits(), proposed_vote_state.3 as u64);
             });
     }
 


### PR DESCRIPTION
#### Problem
Building on the back of #8120, we need to outfit the `VoteStateHandler` with support for `VoteStateV4`. As we do this, we want to make sure each implementation is 100% compatible with [SIMD-0185](https://github.com/solana-foundation/solana-improvement-documents/pull/185).

#### Summary of Changes
Adds the v4 variant to the `VoteStateHandler` and adds a bunch of unit tests for compatibility with SIMD-0185. Does not update the Vote program to use v4 yet.