### PR TITLE
chore: Remove deprecated arg from scripts

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -52,9 +52,6 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --rpc-pubsub-enable-block-subscription ]]; then
       args+=("$1")
       shift
-    elif [[ $1 = --enable-cpi-and-log-storage ]]; then
-      args+=("$1")
-      shift
     elif [[ $1 = --enable-extended-tx-metadata-storage ]]; then
       args+=("$1")
       shift

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -137,9 +137,6 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --enable-rpc-transaction-history ]]; then
       args+=("$1")
       shift
-    elif [[ $1 = --enable-cpi-and-log-storage ]]; then
-      args+=("$1")
-      shift
     elif [[ $1 = --enable-extended-tx-metadata-storage ]]; then
       args+=("$1")
       shift


### PR DESCRIPTION
#### Problem
`--enable-cpi-and-log-storage` was ripped out starting from v3.0.0 via https://github.com/anza-xyz/agave/pull/6551

#### Summary of Changes
Remove parsing from our multinode scripts since passing to `agave-validator` will result in an error anyways