### PR TITLE
SIMD-0160: static instruction limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-system-interface",
  "solana-transaction",
+ "solana-transaction-context",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10443,6 +10443,7 @@ dependencies = [
  "solana-system-interface",
  "solana-system-transaction",
  "solana-transaction",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-vote-interface",
  "thiserror 2.0.16",

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -174,6 +174,8 @@ fn simulate_transaction(
         Some(false), // is_simple_vote_tx
         bank,
         bank.get_reserved_account_keys(),
+        bank.feature_set
+            .is_active(&agave_feature_set::static_instruction_limit::id()),
     ) {
         Err(err) => {
             return BanksTransactionResultWithSimulation {

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1207,6 +1207,8 @@ mod tests {
                 None,
                 loader,
                 &HashSet::default(),
+                bank.feature_set
+                    .is_active(&agave_feature_set::static_instruction_limit::id()),
             )
             .unwrap()
         };

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1789,6 +1789,8 @@ mod tests {
             Some(false),
             bank.as_ref(),
             &ReservedAccountKeys::empty_key_set(),
+            bank.feature_set
+                .is_active(&agave_feature_set::static_instruction_limit::id()),
         )
         .unwrap();
 

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -667,7 +667,7 @@ impl TransactionViewReceiveAndBuffer {
         transaction_account_lock_limit: usize,
     ) -> Result<TransactionViewState, PacketHandlingError> {
         // Parsing and basic sanitization checks
-        let Ok(view) = SanitizedTransactionView::try_new_sanitized(bytes) else {
+        let Ok(view) = SanitizedTransactionView::try_new_sanitized(bytes, working_bank.feature_set.is_active(&agave_feature_set::static_instruction_limit::id())) else {
             return Err(PacketHandlingError::Sanitization);
         };
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -474,7 +474,7 @@ mod tests {
 
         let reserved_addresses = HashSet::default();
         let packet_parser = |data, priority, cost| {
-            let view = SanitizedTransactionView::try_new_sanitized(data).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(data, true).unwrap();
             let view = RuntimeTransaction::<SanitizedTransactionView<_>>::try_from(
                 view,
                 MessageHash::Compute,

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -341,6 +341,7 @@ mod tests {
             Some(true),
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
+            true,
         )
         .unwrap();
 
@@ -360,6 +361,7 @@ mod tests {
             Some(false),
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
+            true,
         )
         .unwrap();
 

--- a/entry/benches/entry_sigverify.rs
+++ b/entry/benches/entry_sigverify.rs
@@ -45,6 +45,7 @@ fn bench_gpusigverify(bencher: &mut Bencher) {
                     None,
                     SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),
+                    true,
                 )
             }?;
 
@@ -89,6 +90,7 @@ fn bench_cpusigverify(bencher: &mut Bencher) {
                     None,
                     SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),
+                    true,
                 )
             }?;
 

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -1076,6 +1076,7 @@ mod tests {
                         None,
                         SimpleAddressLoader::Disabled,
                         &ReservedAccountKeys::empty_key_set(),
+                        true,
                     )
                 }?;
 

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1137,6 +1137,10 @@ pub mod provide_instruction_data_offset_in_vm_r2 {
     solana_pubkey::declare_id!("5xXZc66h4UdB6Yq7FzdBxBiRAFMMScMLwHxk2QZDaNZL");
 }
 
+pub mod static_instruction_limit {
+    solana_pubkey::declare_id!("64ixypL1HPu8WtJhNSMb9mSgfFaJvsANuRkTbHyuLfnx");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2053,6 +2057,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             provide_instruction_data_offset_in_vm_r2::id(),
             "SIMD-0321: Provide instruction data offset in VM r2",
+        ),
+        (
+            static_instruction_limit::id(),
+            "SIMD-0160: static instruction limit",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -470,6 +470,7 @@ fn compute_slot_cost(
                     None,
                     SimpleAddressLoader::Disabled,
                     &reserved_account_keys.active,
+                    feature_set.is_active(&agave_feature_set::static_instruction_limit::id()),
                 )
                 .map_err(|err| {
                     warn!("Failed to compute cost of transaction: {err:?}");

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-svm-transaction",
+ "solana-transaction-context",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8208,6 +8208,7 @@ dependencies = [
  "solana-signature",
  "solana-svm-transaction",
  "solana-transaction",
+ "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.16",
 ]

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -31,6 +31,7 @@ solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true }
 solana-svm-transaction = { workspace = true }
 solana-transaction = { workspace = true }
+solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -220,7 +220,7 @@ mod tests {
 
         let hash = Hash::new_unique();
         let transaction =
-            SanitizedTransactionView::try_new_sanitized(&serialized_transaction[..]).unwrap();
+            SanitizedTransactionView::try_new_sanitized(&serialized_transaction[..], true).unwrap();
         let static_runtime_transaction =
             RuntimeTransaction::<SanitizedTransactionView<_>>::try_from(
                 transaction,
@@ -252,7 +252,8 @@ mod tests {
             reserved_account_keys: &HashSet<Pubkey>,
         ) {
             let bytes = bincode::serialize(&original_transaction).unwrap();
-            let transaction_view = SanitizedTransactionView::try_new_sanitized(&bytes[..]).unwrap();
+            let transaction_view =
+                SanitizedTransactionView::try_new_sanitized(&bytes[..], true).unwrap();
             let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_from(
                 transaction_view,
                 MessageHash::Compute,
@@ -318,7 +319,8 @@ mod tests {
         ) {
             let bytes =
                 bincode::serialize(&original_transaction.to_versioned_transaction()).unwrap();
-            let transaction_view = SanitizedTransactionView::try_new_sanitized(&bytes[..]).unwrap();
+            let transaction_view =
+                SanitizedTransactionView::try_new_sanitized(&bytes[..], true).unwrap();
             let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_from(
                 transaction_view,
                 MessageHash::Compute,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4603,7 +4603,8 @@ impl Bank {
                 if self
                     .feature_set
                     .is_active(&agave_feature_set::static_instruction_limit::id())
-                    && tx.message.instructions().len() > 64
+                    && tx.message.instructions().len()
+                        > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
                 {
                     return Err(solana_transaction_error::TransactionError::SanitizeFailure);
                 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4599,6 +4599,14 @@ impl Bank {
             }
             let message_hash = if verification_mode == TransactionVerificationMode::FullVerification
             {
+                // SIMD-0160, check instruction limit before signature verificaton
+                if self
+                    .feature_set
+                    .is_active(&agave_feature_set::static_instruction_limit::id())
+                    && tx.message.instructions().len() > 64
+                {
+                    return Err(solana_transaction_error::TransactionError::SanitizeFailure);
+                }
                 tx.verify_and_hash_message()?
             } else {
                 tx.message.hash()

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9131,6 +9131,51 @@ fn test_verify_transactions_packet_data_size() {
     }
 }
 
+#[test_case(false; "pre_simd160_static_instruction_limit")]
+#[test_case(true; "simd160_static_instruction_limit")]
+fn test_verify_transactions_instruction_limit(simd_0160_enabled: bool) {
+    let GenesisConfigInfo { genesis_config, .. } =
+        create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
+    let mut bank = Bank::new_for_tests(&genesis_config);
+    if !simd_0160_enabled {
+        bank.deactivate_feature(&feature_set::static_instruction_limit::id());
+    }
+
+    let recent_blockhash = Hash::new_unique();
+    let keypair = Keypair::new();
+    let pubkey = keypair.pubkey();
+    let ix_count = 65;
+    let ixs: Vec<_> = std::iter::repeat_with(|| CompiledInstruction {
+        program_id_index: 1,
+        accounts: vec![0],
+        data: vec![],
+    })
+    .take(ix_count)
+    .collect();
+    let message = Message::new_with_compiled_instructions(
+        1,
+        0,
+        1,
+        vec![pubkey, Pubkey::new_unique()],
+        recent_blockhash,
+        ixs,
+    );
+    let tx = Transaction::new(&[&keypair], message, recent_blockhash);
+
+    assert!(bincode::serialized_size(&tx).unwrap() <= PACKET_DATA_SIZE as u64);
+
+    if simd_0160_enabled {
+        assert_matches!(
+            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
+            Err(TransactionError::SanitizeFailure)
+        );
+    } else {
+        assert!(bank
+            .verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
+            .is_ok());
+    }
+}
+
 #[test]
 fn test_check_reserved_keys() {
     let (genesis_config, _mint_keypair) = create_genesis_config(1);

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -21,6 +21,7 @@ solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true }
 solana-signature = { workspace = true }
 solana-svm-transaction = { workspace = true }
+solana-transaction-context = { workspace = true }
 
 [dev-dependencies]
 # See order-crates-for-publishing.py for using this unusual `path = "."`

--- a/transaction-view/benches/transaction_view.rs
+++ b/transaction-view/benches/transaction_view.rs
@@ -64,7 +64,8 @@ fn bench_transactions_parsing(
     group.bench_function("TransactionView (Sanitized)", |c| {
         c.iter(|| {
             for bytes in serialized_transactions.iter() {
-                let _ = TransactionView::try_new_sanitized(black_box(bytes.as_ref())).unwrap();
+                let _ =
+                    TransactionView::try_new_sanitized(black_box(bytes.as_ref()), true).unwrap();
             }
         });
     });
@@ -132,8 +133,8 @@ fn packed_transfers() -> Vec<VersionedTransaction> {
 
 fn packed_noops() -> Vec<VersionedTransaction> {
     // Creating noop instructions to maximize the number of instructions per
-    // transaction. We can fit up to 355 noops.
-    const MAX_INSTRUCTIONS_PER_TRANSACTION: usize = 355;
+    // transaction. We are allowed to fit up to 64 instructions per transaction.
+    const MAX_INSTRUCTIONS_PER_TRANSACTION: usize = 64;
 
     (0..NUM_TRANSACTIONS)
         .map(|_| {

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -284,7 +284,7 @@ mod tests {
             }),
         };
         let bytes = bincode::serialize(&transaction).unwrap();
-        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref()).unwrap();
+        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
         let result = ResolvedTransactionView::try_new(view, None, &HashSet::default());
         assert!(matches!(
             result,
@@ -315,7 +315,7 @@ mod tests {
             }),
         };
         let bytes = bincode::serialize(&transaction).unwrap();
-        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref()).unwrap();
+        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
         let result =
             ResolvedTransactionView::try_new(view, Some(loaded_addresses), &HashSet::default());
         assert!(matches!(
@@ -352,7 +352,7 @@ mod tests {
             }),
         };
         let bytes = bincode::serialize(&transaction).unwrap();
-        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref()).unwrap();
+        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
         let result =
             ResolvedTransactionView::try_new(view, Some(loaded_addresses), &HashSet::default());
         assert!(matches!(
@@ -402,7 +402,7 @@ mod tests {
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref()).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses),
@@ -425,7 +425,7 @@ mod tests {
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref()).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses),
@@ -448,7 +448,7 @@ mod tests {
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref()).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses),
@@ -509,7 +509,7 @@ mod tests {
             let static_keys = vec![key0, key1, key2];
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref()).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses.clone()),
@@ -528,7 +528,7 @@ mod tests {
             let static_keys = vec![key0, key1, bpf_loader_upgradeable::ID];
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref()).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses.clone()),
@@ -551,7 +551,7 @@ mod tests {
             };
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref()).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
 
             let resolved_view = ResolvedTransactionView::try_new(
                 view,

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -4,10 +4,13 @@ use crate::{
     transaction_view::UnsanitizedTransactionView,
 };
 
-pub(crate) fn sanitize(view: &UnsanitizedTransactionView<impl TransactionData>) -> Result<()> {
+pub(crate) fn sanitize(
+    view: &UnsanitizedTransactionView<impl TransactionData>,
+    enable_static_instruction_limit: bool,
+) -> Result<()> {
     sanitize_signatures(view)?;
     sanitize_account_access(view)?;
-    sanitize_instructions(view)?;
+    sanitize_instructions(view, enable_static_instruction_limit)?;
     sanitize_address_table_lookups(view)
 }
 
@@ -51,7 +54,15 @@ fn sanitize_account_access(view: &UnsanitizedTransactionView<impl TransactionDat
     Ok(())
 }
 
-fn sanitize_instructions(view: &UnsanitizedTransactionView<impl TransactionData>) -> Result<()> {
+fn sanitize_instructions(
+    view: &UnsanitizedTransactionView<impl TransactionData>,
+    enable_static_instruction_limit: bool,
+) -> Result<()> {
+    // SIMD-160: transaction can not have more than 64 top level instructions
+    if enable_static_instruction_limit && view.num_instructions() > 64 {
+        return Err(TransactionViewError::SanitizeError);
+    }
+
     // already verified there is at least one static account.
     let max_program_id_index = view.num_static_account_keys().wrapping_sub(1);
     // verified that there are no more than 256 accounts in `sanitize_account_access`
@@ -172,7 +183,7 @@ mod tests {
         let transaction = multiple_transfers();
         let data = bincode::serialize(&transaction).unwrap();
         let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-        assert!(view.sanitize().is_ok());
+        assert!(view.sanitize(true).is_ok());
     }
 
     #[test]
@@ -379,7 +390,7 @@ mod tests {
             );
             let data = bincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-            assert!(sanitize_instructions(&view).is_ok());
+            assert!(sanitize_instructions(&view, true).is_ok());
 
             let transaction = create_v0_transaction(
                 num_signatures,
@@ -390,7 +401,7 @@ mod tests {
             );
             let data = bincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-            assert!(sanitize_instructions(&view).is_ok());
+            assert!(sanitize_instructions(&view, true).is_ok());
         }
 
         for instruction_index in 0..valid_instructions.len() {
@@ -407,7 +418,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view),
+                    sanitize_instructions(&view, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -426,7 +437,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view),
+                    sanitize_instructions(&view, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -444,7 +455,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view),
+                    sanitize_instructions(&view, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -464,7 +475,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view),
+                    sanitize_instructions(&view, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -488,10 +499,48 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view),
+                    sanitize_instructions(&view, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
+        }
+
+        // SIMD-0160, too many instructions are invalid
+        {
+            let too_many_instructions: Vec<_> = valid_instructions
+                .iter()
+                .cycle()
+                .take(65)
+                .cloned()
+                .collect();
+            let transaction = create_legacy_transaction(
+                num_signatures,
+                header,
+                account_keys.clone(),
+                too_many_instructions.clone(),
+            );
+            let data = bincode::serialize(&transaction).unwrap();
+            let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
+            assert_eq!(
+                sanitize_instructions(&view, true),
+                Err(TransactionViewError::SanitizeError)
+            );
+            assert!(sanitize_instructions(&view, false).is_ok());
+
+            let transaction = create_v0_transaction(
+                num_signatures,
+                header,
+                account_keys.clone(),
+                too_many_instructions.clone(),
+                atls.clone(),
+            );
+            let data = bincode::serialize(&transaction).unwrap();
+            let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
+            assert_eq!(
+                sanitize_instructions(&view, true),
+                Err(TransactionViewError::SanitizeError)
+            );
+            assert!(sanitize_instructions(&view, false).is_ok());
         }
     }
 

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -59,7 +59,10 @@ fn sanitize_instructions(
     enable_static_instruction_limit: bool,
 ) -> Result<()> {
     // SIMD-160: transaction can not have more than 64 top level instructions
-    if enable_static_instruction_limit && view.num_instructions() > 64 {
+    if enable_static_instruction_limit
+        && usize::from(view.num_instructions())
+            > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
+    {
         return Err(TransactionViewError::SanitizeError);
     }
 

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -36,8 +36,11 @@ impl<D: TransactionData> TransactionView<false, D> {
     }
 
     /// Sanitizes the transaction view, returning a sanitized view on success.
-    pub fn sanitize(self) -> Result<SanitizedTransactionView<D>> {
-        sanitize(&self)?;
+    pub fn sanitize(
+        self,
+        enable_static_instruction_limit: bool,
+    ) -> Result<SanitizedTransactionView<D>> {
+        sanitize(&self, enable_static_instruction_limit)?;
         Ok(SanitizedTransactionView {
             data: self.data,
             frame: self.frame,
@@ -47,9 +50,9 @@ impl<D: TransactionData> TransactionView<false, D> {
 
 impl<D: TransactionData> TransactionView<true, D> {
     /// Creates a new `TransactionView`, running sanitization checks.
-    pub fn try_new_sanitized(data: D) -> Result<Self> {
+    pub fn try_new_sanitized(data: D, enable_static_instruction_limit: bool) -> Result<Self> {
         let unsanitized_view = TransactionView::try_new_unsanitized(data)?;
-        unsanitized_view.sanitize()
+        unsanitized_view.sanitize(enable_static_instruction_limit)
     }
 }
 


### PR DESCRIPTION
#### Problem
Issue #8181 for [SIMD-0160](https://github.com/solana-foundation/solana-improvement-documents/pull/160)

#### Summary of Changes
- Add feature gate to start apply limit to transaction's top level instructions during sanitization.

Fixes #8181 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
