### PR TITLE
Update comment for write zero condition

### DIFF
--- a/accounts-db/src/io_uring/file_creator.rs
+++ b/accounts-db/src/io_uring/file_creator.rs
@@ -467,7 +467,9 @@ impl<'a> WriteOp {
         Self: Sized,
     {
         let written = match res {
-            Ok(0) => return Err(io::ErrorKind::WriteZero.into()), // likely a full disk
+            // Fail fast if no progress. FS should report an error (e.g. `StorageFull`) if the
+            // condition isn't transient, but it's hard to verify without extra tracking.
+            Ok(0) => return Err(io::ErrorKind::WriteZero.into()),
             Ok(res) => res as usize,
             Err(err) => return Err(err),
         };


### PR DESCRIPTION
#### Problem
The comment for case where 0-sized write is detected suggests it happens when storage is full. Normally file-system actually generates a dedicated error, so the situation of 0-write is more of a sanity check or unexpected condition (bug?) that we report upstream.

#### Summary of Changes
Make the comment state that we fail-fast due to no-progress.
