### PR TITLE
Return signature verification errors through the RPC as `TransactionError` rather than JSON RPC API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Release channels have their own copy of this changelog:
 ## 3.1.0—Unreleased
 ### RPC
 #### Breaking
+* A signature verification failure in `simulateTransaction()` or the preflight stage of `sendTransaction()` will now be attached to the simulation result's `err` property as `TransactionError::SignatureFailure` instead of being thrown as a JSON RPC API error (-32003). Applications that already guard against JSON RPC exceptions should expect signature verification errors to appear on the simulation result instead. Applications that already handle the materialization of `TransactionErrors` on simulation results can now expect to receive errors of type `TransactionError::SignatureFailure` at those verification sites.
 #### Changes
 ### Validator
 #### Breaking

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3876,20 +3876,7 @@ pub mod rpc_full {
                 }
 
                 let simulation_result = if let Some(err) = verification_error {
-                    TransactionSimulationResult {
-                        fee: None,
-                        inner_instructions: None,
-                        loaded_accounts_data_size: 0,
-                        logs: vec![],
-                        post_balances: None,
-                        post_simulation_accounts: vec![],
-                        post_token_balances: None,
-                        pre_balances: None,
-                        pre_token_balances: None,
-                        result: Err(err),
-                        return_data: None,
-                        units_consumed: 0,
-                    }
+                    TransactionSimulationResult::new_error(err)
                 } else {
                     preflight_bank.simulate_transaction(&transaction, false)
                 };
@@ -4016,20 +4003,7 @@ pub mod rpc_full {
             };
 
             let simulation_result = if let Some(err) = verification_error {
-                TransactionSimulationResult {
-                    fee: None,
-                    inner_instructions: None,
-                    loaded_accounts_data_size: 0,
-                    logs: vec![],
-                    post_balances: None,
-                    post_simulation_accounts: vec![],
-                    post_token_balances: None,
-                    pre_balances: None,
-                    pre_token_balances: None,
-                    result: Err(err),
-                    return_data: None,
-                    units_consumed: 0,
-                }
+                TransactionSimulationResult::new_error(err)
             } else {
                 bank.simulate_transaction(&transaction, enable_cpi_recording)
             };

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3855,7 +3855,7 @@ pub mod rpc_full {
             if !skip_preflight {
                 let verification_error = transaction.verify().err();
 
-                if !meta.config.skip_preflight_health_check {
+                if verification_error.is_none() && !meta.config.skip_preflight_health_check {
                     match meta.health.check() {
                         RpcHealthStatus::Ok => (),
                         RpcHealthStatus::Unknown => {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2411,15 +2411,6 @@ pub(crate) fn optimize_filters(filters: &mut [RpcFilterType]) {
     })
 }
 
-fn verify_transaction(transaction: &SanitizedTransaction) -> Result<()> {
-    #[allow(clippy::question_mark)]
-    if transaction.verify().is_err() {
-        return Err(RpcCustomError::TransactionSignatureVerificationFailure.into());
-    }
-
-    Ok(())
-}
-
 pub(crate) fn verify_filters(filters: &[RpcFilterType]) -> Result<()> {
     if filters.len() > MAX_GET_PROGRAM_ACCOUNT_FILTERS {
         return Err(Error::invalid_params(format!(
@@ -3862,7 +3853,7 @@ pub mod rpc_full {
             }
 
             if !skip_preflight {
-                verify_transaction(&transaction)?;
+                let verification_error = transaction.verify().err();
 
                 if !meta.config.skip_preflight_health_check {
                     match meta.health.check() {
@@ -3884,6 +3875,25 @@ pub mod rpc_full {
                     }
                 }
 
+                let simulation_result = if let Some(err) = verification_error {
+                    TransactionSimulationResult {
+                        fee: None,
+                        inner_instructions: None,
+                        loaded_accounts_data_size: 0,
+                        logs: vec![],
+                        post_balances: None,
+                        post_simulation_accounts: vec![],
+                        post_token_balances: None,
+                        pre_balances: None,
+                        pre_token_balances: None,
+                        result: Err(err),
+                        return_data: None,
+                        units_consumed: 0,
+                    }
+                } else {
+                    preflight_bank.simulate_transaction(&transaction, false)
+                };
+
                 if let TransactionSimulationResult {
                     result: Err(err),
                     logs,
@@ -3897,7 +3907,7 @@ pub mod rpc_full {
                     post_balances: _,
                     pre_token_balances: _,
                     post_token_balances: _,
-                } = preflight_bank.simulate_transaction(&transaction, false)
+                } = simulation_result
                 {
                     match err {
                         TransactionError::BlockhashNotFound => {
@@ -3998,9 +4008,31 @@ pub mod rpc_full {
                 bank.feature_set
                     .is_active(&agave_feature_set::static_instruction_limit::id()),
             )?;
-            if sig_verify {
-                verify_transaction(&transaction)?;
-            }
+
+            let verification_error = if sig_verify {
+                transaction.verify().err()
+            } else {
+                None
+            };
+
+            let simulation_result = if let Some(err) = verification_error {
+                TransactionSimulationResult {
+                    fee: None,
+                    inner_instructions: None,
+                    loaded_accounts_data_size: 0,
+                    logs: vec![],
+                    post_balances: None,
+                    post_simulation_accounts: vec![],
+                    post_token_balances: None,
+                    pre_balances: None,
+                    pre_token_balances: None,
+                    result: Err(err),
+                    return_data: None,
+                    units_consumed: 0,
+                }
+            } else {
+                bank.simulate_transaction(&transaction, enable_cpi_recording)
+            };
 
             let TransactionSimulationResult {
                 result,
@@ -4015,7 +4047,7 @@ pub mod rpc_full {
                 post_balances,
                 pre_token_balances,
                 post_token_balances,
-            } = bank.simulate_transaction(&transaction, enable_cpi_recording);
+            } = simulation_result;
 
             let account_keys = transaction.message().account_keys();
             let number_of_accounts = account_keys.len();
@@ -6109,12 +6141,27 @@ pub mod tests {
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let expected = json!({
-            "jsonrpc":"2.0",
-            "error": {
-                "code": -32003,
-                "message": "Transaction signature verification failure"
+            "jsonrpc": "2.0",
+            "result": {
+                "context": { "slot": 0, "apiVersion": RpcApiVersion::default() },
+                "value": {
+                    "accounts": null,
+                    "err": "SignatureFailure",
+                    "innerInstructions": null,
+                    "loadedAccountsDataSize": 0,
+                    "fee": null,
+                    "loadedAddresses": { "readonly": [], "writable": [] },
+                    "preBalances": null,
+                    "postBalances": null,
+                    "preTokenBalances": null,
+                    "postTokenBalances": null,
+                    "logs": [],
+                    "replacementBlockhash": null,
+                    "returnData": null,
+                    "unitsConsumed": 0,
+                }
             },
-            "id":1
+            "id": 1,
         });
 
         let expected: Response =
@@ -6941,7 +6988,7 @@ pub mod tests {
                 r#"{"jsonrpc":"2.0","error":{"code":-32005,"message":"Node is behind by 42 slots","data":{"numSlotsBehind":42}},"id":1}"#.to_string(),
             )
         );
-        health.stub_set_health_status(None);
+        health.stub_set_health_status(Some(RpcHealthStatus::Ok));
 
         // sendTransaction will fail due to invalid signature
         bad_transaction.signatures[0] = Signature::default();
@@ -6951,12 +6998,36 @@ pub mod tests {
             bs58::encode(serialize(&bad_transaction).unwrap()).into_string()
         );
         let res = io.handle_request_sync(&req, meta.clone());
-        assert_eq!(
-            res,
-            Some(
-                r#"{"jsonrpc":"2.0","error":{"code":-32003,"message":"Transaction signature verification failure"},"id":1}"#.to_string(),
-            )
-        );
+        let expected = json!({
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32002,
+                "data": {
+                    "accounts": null,
+                    "err": "SignatureFailure",
+                    "innerInstructions": null,
+                    "loadedAccountsDataSize": 0,
+                    "fee": null,
+                    "loadedAddresses": null,
+                    "preBalances": null,
+                    "postBalances": null,
+                    "preTokenBalances": null,
+                    "postTokenBalances": null,
+                    "logs": [],
+                    "replacementBlockhash": null,
+                    "returnData": null,
+                    "unitsConsumed": 0,
+                },
+                "message": "Transaction simulation failed: Transaction did not pass signature verification",
+            },
+            "id": 1,
+        });
+
+        let expected: Response =
+            serde_json::from_value(expected).expect("expected response deserialization");
+        let result: Response = serde_json::from_str(&res.expect("actual response"))
+            .expect("actual response deserialization");
+        assert_eq!(result, expected);
 
         // sendTransaction will now succeed because skipPreflight=true even though it's a bad
         // transaction

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -317,6 +317,25 @@ pub struct TransactionSimulationResult {
     pub post_token_balances: Option<Vec<SvmTokenInfo>>,
 }
 
+impl TransactionSimulationResult {
+    pub fn new_error(err: TransactionError) -> Self {
+        Self {
+            fee: None,
+            inner_instructions: None,
+            loaded_accounts_data_size: 0,
+            logs: vec![],
+            post_balances: None,
+            post_simulation_accounts: vec![],
+            post_token_balances: None,
+            pre_balances: None,
+            pre_token_balances: None,
+            result: Err(err),
+            return_data: None,
+            units_consumed: 0,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct TransactionBalancesSet {
     pub pre_balances: TransactionBalances,


### PR DESCRIPTION
#### Problem

There exists `TransactionError::SignatureFailure`. Until [5 years ago](https://github.com/solana-labs/solana/pull/13080/files) this would be returned as `err` in the simulation result when calling `send_transaction()` or `simulate_transaction()`. After that point, the whole request would fail with a JSON RPC API error.

#### Summary of Changes

This PR puts it back the way it was. Now:

* a signature verification failure in `simulate_transaction()` with `sigVerify` set to `true` will return a `RpcSimulateTransactionResult` with `err` set to `TransactionError::SignatureFailure`
* a signature verification failure in `send_transaction()` with `skipPreflight` set to `false` will return a `RpcSimulateTransactionResult` with `err` set to `TransactionError::SignatureFailure` as the `data` of the JSON RPC API error representing the preflight error.

If none of that made any sense, just look at the tests.

Fixes #4122.