### PR TITLE
scheduler-bindings: tpu_to_pack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6143,9 +6143,9 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9f34af8112a1f1e6cebc83e44a3e497a7f720f3384161497ef5e35b099b49"
+checksum = "a7ccc6c6ddf12ced79aeae78454bcb4d0f5e31e5bc0aaca490e2f1b012f56b9d"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6142,6 +6142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rts-alloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9f34af8112a1f1e6cebc83e44a3e497a7f720f3384161497ef5e35b099b49"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6714,6 +6723,15 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
+]
+
+[[package]]
+name = "shaq"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c451e9289cd55fd2406917d16abe8af5f83c74b3ba3736398f6aadd2ab1fba2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -8113,6 +8131,7 @@ dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
  "agave-reserved-account-keys",
+ "agave-scheduler-bindings",
  "agave-transaction-view",
  "agave-verified-packet-receiver",
  "agave-votor",
@@ -8148,12 +8167,14 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "rolling-file",
+ "rts-alloc",
  "rustls 0.23.32",
  "serde",
  "serde_bytes",
  "serde_derive",
  "serde_json",
  "serial_test",
+ "shaq",
  "slab",
  "solana-account",
  "solana-accounts-db",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -350,6 +350,7 @@ reqwest = { version = "0.12.23", default-features = false }
 reqwest-middleware = "0.4.2"
 rolling-file = "0.2.0"
 rpassword = "7.4"
+rts-alloc = { version = "0.1.0" }
 rustls = { version = "0.23.32", features = ["std"], default-features = false }
 scopeguard = "1.2.0"
 semver = "1.0.27"
@@ -364,6 +365,7 @@ serde_yaml = "0.9.34"
 serial_test = "2.0.0"
 sha2 = "0.10.9"
 sha3 = "0.10.8"
+shaq = { version = "0.1.0" }
 shuttle = "0.7.1"
 signal-hook = "0.3.18"
 siphasher = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -350,7 +350,7 @@ reqwest = { version = "0.12.23", default-features = false }
 reqwest-middleware = "0.4.2"
 rolling-file = "0.2.0"
 rpassword = "7.4"
-rts-alloc = { version = "0.1.0" }
+rts-alloc = { version = "0.1.1" }
 rustls = { version = "0.23.32", features = ["std"], default-features = false }
 scopeguard = "1.2.0"
 semver = "1.0.27"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,6 +43,7 @@ frozen-abi = [
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
 agave-feature-set = { workspace = true }
+agave-scheduler-bindings = { workspace = true }
 agave-transaction-view = { workspace = true }
 agave-verified-packet-receiver = { workspace = true }
 agave-votor = { workspace = true, features = ["agave-unstable-api"] }
@@ -76,10 +77,12 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
 rolling-file = { workspace = true }
+rts-alloc = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_derive = { workspace = true }
+shaq = { workspace = true }
 slab = { workspace = true }
 solana-account = { workspace = true }
 solana-accounts-db = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -77,12 +77,10 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
 rolling-file = { workspace = true }
-rts-alloc = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_derive = { workspace = true }
-shaq = { workspace = true }
 slab = { workspace = true }
 solana-account = { workspace = true }
 solana-accounts-db = { workspace = true }
@@ -183,6 +181,8 @@ trees = { workspace = true }
 jemallocator = { workspace = true }
 
 [target."cfg(unix)".dependencies]
+rts-alloc = { workspace = true }
+shaq = { workspace = true }
 sysctl = { workspace = true }
 
 [dev-dependencies]

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -82,6 +82,7 @@ conditional_vis_mod!(
 );
 conditional_vis_mod!(unified_scheduler, feature = "dev-context-only-utils", pub, pub(crate));
 #[allow(dead_code)]
+#[cfg(unix)]
 mod tpu_to_pack;
 
 /// The maximum number of worker threads that can be spawned by banking stage.

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -81,6 +81,8 @@ conditional_vis_mod!(
     pub
 );
 conditional_vis_mod!(unified_scheduler, feature = "dev-context-only-utils", pub, pub(crate));
+#[allow(dead_code)]
+mod tpu_to_pack;
 
 /// The maximum number of worker threads that can be spawned by banking stage.
 /// 64 because `ThreadAwareAccountLocks` uses a `u64` as a bitmask to

--- a/core/src/banking_stage/tpu_to_pack.rs
+++ b/core/src/banking_stage/tpu_to_pack.rs
@@ -151,12 +151,17 @@ fn handle_packet_batches(
 
 fn flags_from_meta(flags: PacketFlags) -> u8 {
     let mut tpu_message_flags = 0;
-    tpu_message_flags |=
-        tpu_message_flags::IS_SIMPLE_VOTE * u8::from(flags.contains(PacketFlags::SIMPLE_VOTE_TX));
-    tpu_message_flags |=
-        tpu_message_flags::FORWARDED * u8::from(flags.contains(PacketFlags::FORWARDED));
-    tpu_message_flags |= tpu_message_flags::FROM_STAKED_NODE
-        * u8::from(flags.contains(PacketFlags::FROM_STAKED_NODE));
+
+    if flags.contains(PacketFlags::SIMPLE_VOTE_TX) {
+        tpu_message_flags |= tpu_message_flags::IS_SIMPLE_VOTE;
+    }
+    if flags.contains(PacketFlags::FORWARDED) {
+        tpu_message_flags |= tpu_message_flags::FORWARDED;
+    }
+    if flags.contains(PacketFlags::FROM_STAKED_NODE) {
+        tpu_message_flags |= tpu_message_flags::FROM_STAKED_NODE;
+    }
+
     tpu_message_flags
 }
 

--- a/core/src/banking_stage/tpu_to_pack.rs
+++ b/core/src/banking_stage/tpu_to_pack.rs
@@ -86,10 +86,10 @@ fn handle_packet_batches(
     'batch_loop: for batch in packet_batches.iter() {
         for packet in batch.iter() {
             // Check if the packet is valid and get the bytes.
-            let packet_size = packet.meta().size;
-            let Some(packet_bytes) = packet.data(..packet_size) else {
+            let Some(packet_bytes) = packet.data(..) else {
                 continue;
             };
+            let packet_size = packet_bytes.len();
 
             // Allocate enough memory for the packet in the allocator.
             let Some(allocated_ptr) = allocator.allocate(packet_size as u32) else {

--- a/core/src/banking_stage/tpu_to_pack.rs
+++ b/core/src/banking_stage/tpu_to_pack.rs
@@ -1,0 +1,65 @@
+//! Service to send transaction packets to the external scheduler.
+//!
+
+use {
+    agave_banking_stage_ingress_types::BankingPacketReceiver,
+    agave_scheduler_bindings::TpuToPackMessage,
+    rts_alloc::Allocator,
+    std::{
+        path::{Path, PathBuf},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread::JoinHandle,
+    },
+};
+
+pub fn spawn(
+    exit: Arc<AtomicBool>,
+    non_vote_receiver: BankingPacketReceiver,
+    allocator_path: PathBuf,
+    allocator_worker_id: u32,
+    queue_path: PathBuf,
+) -> JoinHandle<()> {
+    std::thread::Builder::new()
+        .name("solTpu2Pack".to_string())
+        .spawn(move || {
+            // Setup allocator and queue
+            if let Some((allocator, producer)) =
+                setup(allocator_path, allocator_worker_id, queue_path)
+            {
+                tpu_to_pack(exit, non_vote_receiver, allocator, producer);
+            }
+        })
+        .unwrap()
+}
+
+fn tpu_to_pack(
+    exit: Arc<AtomicBool>,
+    _non_vote_receiver: BankingPacketReceiver,
+    _allocator: Allocator,
+    _producer: shaq::Producer<TpuToPackMessage>,
+) {
+    while exit.load(Ordering::Relaxed) {}
+}
+
+fn setup(
+    allocator_path: impl AsRef<Path>,
+    allocator_worker_id: u32,
+    queue_path: impl AsRef<Path>,
+) -> Option<(Allocator, shaq::Producer<TpuToPackMessage>)> {
+    let allocator = Allocator::join(allocator_path, allocator_worker_id)
+        .map_err(|err| {
+            error!("Failed to join allocator: {err:?}");
+        })
+        .ok()?;
+
+    let producer = shaq::Producer::join(queue_path)
+        .map_err(|err| {
+            error!("Failed to join queue: {err:?}");
+        })
+        .ok()?;
+
+    Some((allocator, producer))
+}

--- a/core/src/banking_stage/tpu_to_pack.rs
+++ b/core/src/banking_stage/tpu_to_pack.rs
@@ -244,3 +244,38 @@ unsafe fn setup(
 
     Some((allocator, producer))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_flags_from_meta() {
+        assert_eq!(
+            flags_from_meta(PacketFlags::empty()),
+            tpu_message_flags::NONE
+        );
+        assert_eq!(
+            flags_from_meta(PacketFlags::SIMPLE_VOTE_TX),
+            tpu_message_flags::IS_SIMPLE_VOTE
+        );
+        assert_eq!(
+            flags_from_meta(PacketFlags::FORWARDED),
+            tpu_message_flags::FORWARDED
+        );
+        assert_eq!(
+            flags_from_meta(PacketFlags::FROM_STAKED_NODE),
+            tpu_message_flags::FROM_STAKED_NODE
+        );
+        assert_eq!(
+            flags_from_meta(
+                PacketFlags::SIMPLE_VOTE_TX
+                    | PacketFlags::FORWARDED
+                    | PacketFlags::FROM_STAKED_NODE
+            ),
+            tpu_message_flags::IS_SIMPLE_VOTE
+                | tpu_message_flags::FORWARDED
+                | tpu_message_flags::FROM_STAKED_NODE
+        );
+    }
+}

--- a/core/src/banking_stage/tpu_to_pack.rs
+++ b/core/src/banking_stage/tpu_to_pack.rs
@@ -62,12 +62,11 @@ fn tpu_to_pack(
         vec![non_vote_receiver].into_iter().cycle()
     };
 
-    while exit.load(Ordering::Relaxed) {
+    while !exit.load(Ordering::Relaxed) {
         // Receive packets from the next receiver in round-robin order.
-        let Ok(packet_batches) = round_robin_receiver_iter.next().unwrap().try_recv() else {
-            continue;
+        if let Ok(packet_batches) = round_robin_receiver_iter.next().unwrap().try_recv() {
+            handle_packet_batches(&allocator, &mut producer, packet_batches);
         };
-        handle_packet_batches(&allocator, &mut producer, packet_batches);
     }
 }
 

--- a/core/src/banking_stage/tpu_to_pack.rs
+++ b/core/src/banking_stage/tpu_to_pack.rs
@@ -3,10 +3,13 @@
 
 use {
     agave_banking_stage_ingress_types::BankingPacketReceiver,
-    agave_scheduler_bindings::TpuToPackMessage,
+    agave_scheduler_bindings::{tpu_message_flags, SharableTransactionRegion, TpuToPackMessage},
     rts_alloc::Allocator,
+    solana_packet::PacketFlags,
     std::{
+        net::IpAddr,
         path::{Path, PathBuf},
+        ptr::NonNull,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc,
@@ -37,11 +40,107 @@ pub fn spawn(
 
 fn tpu_to_pack(
     exit: Arc<AtomicBool>,
-    _non_vote_receiver: BankingPacketReceiver,
-    _allocator: Allocator,
-    _producer: shaq::Producer<TpuToPackMessage>,
+    non_vote_receiver: BankingPacketReceiver,
+    allocator: Allocator,
+    mut producer: shaq::Producer<TpuToPackMessage>,
 ) {
-    while exit.load(Ordering::Relaxed) {}
+    while exit.load(Ordering::Relaxed) {
+        // Receive packets from the TPU.
+        let Ok(packet_batch) = non_vote_receiver.try_recv() else {
+            continue;
+        };
+
+        // Clean all remote frees in allocator so we have as much
+        // room as possible.
+        allocator.clean_remote_free_lists();
+
+        // Sync producer queue with reader so we have as much room as possible.
+        producer.sync();
+
+        'batch_loop: for batch in packet_batch.iter() {
+            for packet in batch.iter() {
+                // Check if the packet is valid and get the bytes.
+                let packet_size = packet.meta().size;
+                let Some(packet_bytes) = packet.data(..packet_size) else {
+                    continue;
+                };
+
+                // Allocate enough memory for the packet in the allocator.
+                let Some(allocated_ptr) = allocator.allocate(packet_size as u32) else {
+                    // Failed to allocate memory for the packet, drop the rest of the batch.
+                    warn!("Failed to allocate memory for packet. Dropping the rest of the batch.");
+                    break 'batch_loop;
+                };
+
+                // Reserve space in the producer queue for the packet message.
+                let Some(tpu_to_pack_message) = producer.reserve() else {
+                    // Free the allocated packet if we can't reserve space in the queue.
+                    // SAFETY: `allocated_ptr` was allocated from `allocator`.
+                    unsafe {
+                        allocator.free(allocated_ptr);
+                    }
+                    break 'batch_loop;
+                };
+
+                // Copy the packet data into the allocated memory.
+                // SAFETY:
+                // - `allocated_ptr` is valid for `packet_size` bytes.
+                // - src and dst are valid pointers that are properly aligned
+                //   and do not overlap.
+                unsafe {
+                    allocated_ptr.copy_from_nonoverlapping(
+                        NonNull::new(packet_bytes.as_ptr().cast_mut())
+                            .expect("packet bytes must be non-null"),
+                        packet_size,
+                    );
+                }
+
+                // Create a sharable transaction region for the packet.
+                let transaction = SharableTransactionRegion {
+                    // SAFETY: `allocated_ptr` was allocated from `allocator`.
+                    offset: unsafe { allocator.offset(allocated_ptr) },
+                    length: packet_size as u32,
+                };
+
+                // Translate flags from meta.
+                let tpu_message_flags = flags_from_meta(packet.meta().flags);
+
+                // Get the source address of the packet - convert to expected format.
+                let src_addr = map_src_addr(packet.meta().addr);
+
+                // Populate the message and write it to the queue.
+                unsafe {
+                    tpu_to_pack_message.write(TpuToPackMessage {
+                        transaction,
+                        flags: tpu_message_flags,
+                        src_addr,
+                    });
+                }
+            }
+        }
+
+        // Commit the messages to the producer queue.
+        // This makes the messages available to the consumer.
+        producer.commit();
+    }
+}
+
+fn flags_from_meta(flags: PacketFlags) -> u8 {
+    let mut tpu_message_flags = 0;
+    tpu_message_flags |=
+        tpu_message_flags::IS_SIMPLE_VOTE * u8::from(flags.contains(PacketFlags::SIMPLE_VOTE_TX));
+    tpu_message_flags |=
+        tpu_message_flags::FORWARDED * u8::from(flags.contains(PacketFlags::FORWARDED));
+    tpu_message_flags |= tpu_message_flags::FROM_STAKED_NODE
+        * u8::from(flags.contains(PacketFlags::FROM_STAKED_NODE));
+    tpu_message_flags
+}
+
+fn map_src_addr(addr: IpAddr) -> [u8; 16] {
+    match addr {
+        IpAddr::V4(ipv4) => ipv4.to_ipv6_mapped().octets(),
+        IpAddr::V6(ipv6) => ipv6.octets(),
+    }
 }
 
 fn setup(

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -141,6 +141,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-scheduler-bindings"
+version = "3.1.0"
+
+[[package]]
 name = "agave-syscalls"
 version = "3.1.0"
 dependencies = [
@@ -5093,6 +5097,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rts-alloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9f34af8112a1f1e6cebc83e44a3e497a7f720f3384161497ef5e35b099b49"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5536,6 +5549,15 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
+]
+
+[[package]]
+name = "shaq"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c451e9289cd55fd2406917d16abe8af5f83c74b3ba3736398f6aadd2ab1fba2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -6407,6 +6429,7 @@ version = "3.1.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
+ "agave-scheduler-bindings",
  "agave-transaction-view",
  "agave-verified-packet-receiver",
  "agave-votor",
@@ -6440,10 +6463,12 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "rolling-file",
+ "rts-alloc",
  "rustls 0.23.32",
  "serde",
  "serde_bytes",
  "serde_derive",
+ "shaq",
  "slab",
  "solana-account",
  "solana-accounts-db",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5098,9 +5098,9 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9f34af8112a1f1e6cebc83e44a3e497a7f720f3384161497ef5e35b099b49"
+checksum = "a7ccc6c6ddf12ced79aeae78454bcb4d0f5e31e5bc0aaca490e2f1b012f56b9d"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
#### Problem
- When an external scheduler is hooked up, we need to pass it tpu (optionally votes) packets

#### Summary of Changes
- Add tpu_to_pack.rs to spawn a thread that is responsible for passing transaction packets to the external scheduler:
   - allocate region for each packet in shmem allocator
   - copy packet into region
   - send packet message, with flags and src_addr, over shmem queue to external scheduler
- If votes are passed, the thread will simply round-robin between vote & tpu channels for packets to pass

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
