### PR TITLE
vote-program: plumb `target_version` through the program

### DIFF
--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -946,6 +946,14 @@ impl VoteStateHandler {
     }
 
     #[cfg(test)]
+    pub fn as_ref_v3(&self) -> &VoteStateV3 {
+        match &self.target_state {
+            TargetVoteState::V3(v3) => v3,
+            _ => panic!("not a v3"),
+        }
+    }
+
+    #[cfg(test)]
     pub fn as_ref_v4(&self) -> &VoteStateV4 {
         match &self.target_state {
             TargetVoteState::V4(v4) => v4,

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -952,6 +952,24 @@ impl VoteStateHandler {
             _ => panic!("not a v4"),
         }
     }
+
+    #[cfg(test)]
+    pub fn serialize(self) -> Vec<u8> {
+        match self.target_state {
+            TargetVoteState::V3(v3) => {
+                let mut data = vec![0; VoteStateV3::size_of()];
+                let versioned = VoteStateVersions::V3(Box::new(v3));
+                bincode::serialize_into(&mut data[..], &versioned).unwrap();
+                data
+            }
+            TargetVoteState::V4(v4) => {
+                let mut data = vec![0; VoteStateV4::size_of()];
+                let versioned = VoteStateVersions::V4(Box::new(v4));
+                bincode::serialize_into(&mut data[..], &versioned).unwrap();
+                data
+            }
+        }
+    }
 }
 
 // Computes the vote latency for vote on voted_for_slot where the vote itself landed in current_slot

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1151,11 +1151,11 @@ mod tests {
         // required lamports for rent exempt minimum at that size
         let vote_state_v1_14_11 = match target_version {
             VoteStateTargetVersion::V3 => {
-                // V1_14_11 can be converted directly to v3.
+                // v3 can be converted directly to V1_14_11.
                 VoteState1_14_11::from(vote_state.as_ref_v3().clone())
             }
             VoteStateTargetVersion::V4 => {
-                // V1_14_11 cannot be converted directly to v4 (lossy).
+                // v4 cannot be converted directly to V1_14_11.
                 VoteState1_14_11 {
                     node_pubkey: *vote_state.node_pubkey(),
                     authorized_withdrawer: *vote_state.authorized_withdrawer(),


### PR DESCRIPTION
#### Problem
Building on the back of #8178, the next step is to outfit the program to be dynamic over some target vote state version, so we can feed the handler with the desired state version to deserialize to and target for state changes.

#### Summary of Changes
The main change of this PR is in the first commit, where I plumb the `target_version: VoteStateTargetVersion` argument through all of the processor functions that operate on vote state.

After that, I update all of the tests (mostly using `test_case` wherever possible) to test all of the `vote_state/mod` functions individually with each target version V3 and V4.

In the top-level of the program processor, the target version is fixed to V3, so the Vote program is still functionally unchanged after this PR.