### PR TITLE
ignore test_proactive_connection_close_detection until we introduce TaskTracket to streamer

### DIFF
--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -753,6 +753,7 @@ async fn test_update_identity() {
 // Test that connection close events are detected immediately via
 // connection.closed() monitoring, not only when send operations fail.
 #[tokio::test]
+#[ignore = "Enable after we introduce TaskTracker to streamer."]
 async fn test_proactive_connection_close_detection() {
     let SpawnTestServerResult {
         join_handle: server_handle,


### PR DESCRIPTION
#### Problem

Without TaskTracker, this test is not really deterministic as explained here https://github.com/anza-xyz/agave/pull/8066

#### Summary of Changes


