### PR TITLE
Add target triple env variable to CI

### DIFF
--- a/ci/env.sh
+++ b/ci/env.sh
@@ -25,17 +25,6 @@ if [[ -n $CI ]]; then
       export CI_PULL_REQUEST=
     fi
 
-    case "$(uname -s)" in
-    Linux)
-      export CI_OS_NAME=linux
-      ;;
-    Darwin)
-      export CI_OS_NAME=osx
-      ;;
-    *)
-      ;;
-    esac
-
     if [[ -n $BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG ]]; then
       # The solana-secondary pipeline should use the slug of the pipeline that
       # triggered it
@@ -67,21 +56,29 @@ if [[ -n $CI ]]; then
       export CI_BASE_BRANCH=$GITHUB_BASE_REF
       export CI_PULL_REQUEST=true
     fi
-
-    case $RUNNER_OS in
-    macOS)
-      export CI_OS_NAME=osx
-      ;;
-    Windows)
-      export CI_OS_NAME=windows
-      ;;
-    Linux)
-      export CI_OS_NAME=linux
-      ;;
-    *)
-      ;;
-    esac
   fi
+
+  _arch="$(uname -m)"
+  if [[ $_arch = arm64 ]]; then
+    _arch=aarch64
+  fi
+
+  case $(uname | tr '[:upper:]' '[:lower:]') in
+  linux*)
+    export CI_OS_NAME=linux
+    export CI_BUILD_TARGET_TRIPLE="$_arch-unknown-linux-gnu"
+    ;;
+  darwin*)
+    export CI_OS_NAME=osx
+    export CI_BUILD_TARGET_TRIPLE="$_arch-apple-darwin"
+    ;;
+  msys*)
+    export CI_OS_NAME=windows
+    export CI_BUILD_TARGET_TRIPLE="$_arch-pc-windows-msvc"
+    ;;
+  *)
+    ;;
+  esac
 else
   export CI=
   export CI_BRANCH=
@@ -92,6 +89,7 @@ else
   export CI_PULL_REQUEST=
   export CI_REPO_SLUG=
   export CI_TAG=
+  export CI_BUILD_TARGET_TRIPLE
   # Don't override ci/run-local.sh
   if [[ -z $CI_LOCAL_RUN ]]; then
     export CI_OS_NAME=
@@ -103,6 +101,7 @@ CI=$CI
 CI_BRANCH=$CI_BRANCH
 CI_BASE_BRANCH=$CI_BASE_BRANCH
 CI_BUILD_ID=$CI_BUILD_ID
+CI_BUILD_TARGET_TRIPLE=$CI_BUILD_TARGET_TRIPLE
 CI_COMMIT=$CI_COMMIT
 CI_JOB_ID=$CI_JOB_ID
 CI_PULL_REQUEST=$CI_PULL_REQUEST


### PR DESCRIPTION
#### Problem

Build script uses a target triple when naming release artefacts and it relies on an env variable that's set during env setup.
Since env setup already is using `uname` to get the build platform, it makes sense to consolidate those calls into a single place and make it agnostic of the CI platform.

#### Summary of Changes

- move CI_OS_NAME assignment and make it agnostic of the CI platform by using `uname`
- export a new env variable that contains the platform target triple to be used in tarball names


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
