### PR TITLE
fetch-core-bpf: Add "v" to release name

### DIFF
--- a/fetch-core-bpf.sh
+++ b/fetch-core-bpf.sh
@@ -21,7 +21,7 @@ add_core_bpf_program_to_fetch() {
   declare loader=$4
 
   so_name="solana_${name//-/_}_program.so"
-  declare download_url="https://github.com/solana-program/$name/releases/download/program%40$version/$so_name"
+  declare download_url="https://github.com/solana-program/$name/releases/download/program%40v$version/$so_name"
 
   programs+=("$name $version $address $loader $download_url")
 }


### PR DESCRIPTION
#### Problem

The core bpf download script doesn't work for all programs, because some include a "v" in the release name, and others don't. For example, we have `program@v1.0.0` for the stake program, and `program@3.0.0` for the address lookup table program. This makes new clusters not work properly.

#### Summary of changes

Since using the "v" is more common across the program repos, change the fetch script to use that one, meaning: fetch `program@v1.0.0` instead of `program@1.0.0`.

I created dual releases / tags for each of the four core bpf programs, with a "v" and without a "v", so we don't need to backport the change. Going forward, program releases must contain the "v".