### PR TITLE
Use getters for accounts-index slot list instead of direct access to field

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1998,7 +1998,7 @@ impl AccountsDb {
                                         // ref counts match, nothing to do here
                                     }
                                     std::cmp::Ordering::Greater => {
-                                        let slot_list = index_entry.slot_list();
+                                        let slot_list = index_entry.slot_list_read_lock();
                                         let num_too_new = slot_list
                                             .iter()
                                             .filter(|(slot, _)| slot > &max_slot_inclusive)
@@ -2028,7 +2028,7 @@ impl AccountsDb {
                                             index_entry.ref_count(),
                                             entry.value().len(),
                                             *entry.value(),
-                                            index_entry.slot_list()
+                                            index_entry.slot_list_read_lock()
                                         );
                                     }
                                 }
@@ -6697,7 +6697,7 @@ impl AccountsDb {
                     .scan_accounts_without_data(|offset, account| {
                         let key = account.pubkey();
                         let index_entry = self.accounts_index.get_cloned(key).unwrap();
-                        let slot_list = index_entry.slot_list();
+                        let slot_list = index_entry.slot_list_read_lock();
                         let mut count = 0;
                         for (slot2, account_info2) in slot_list.iter() {
                             if *slot2 == slot {
@@ -7150,7 +7150,7 @@ impl AccountsDb {
             for pubkey in map.keys() {
                 self.accounts_index.get_and_then(&pubkey, |account_entry| {
                     if let Some(account_entry) = account_entry {
-                        let list_r = &account_entry.slot_list();
+                        let list_r = &account_entry.slot_list_read_lock();
                         info!(" key: {} ref_count: {}", pubkey, account_entry.ref_count(),);
                         info!("      slots: {list_r:?}");
                     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1998,7 +1998,7 @@ impl AccountsDb {
                                         // ref counts match, nothing to do here
                                     }
                                     std::cmp::Ordering::Greater => {
-                                        let slot_list = index_entry.slot_list.read().unwrap();
+                                        let slot_list = index_entry.slot_list();
                                         let num_too_new = slot_list
                                             .iter()
                                             .filter(|(slot, _)| slot > &max_slot_inclusive)
@@ -2028,7 +2028,7 @@ impl AccountsDb {
                                             index_entry.ref_count(),
                                             entry.value().len(),
                                             *entry.value(),
-                                            index_entry.slot_list.read().unwrap()
+                                            index_entry.slot_list()
                                         );
                                     }
                                 }
@@ -6697,7 +6697,7 @@ impl AccountsDb {
                     .scan_accounts_without_data(|offset, account| {
                         let key = account.pubkey();
                         let index_entry = self.accounts_index.get_cloned(key).unwrap();
-                        let slot_list = index_entry.slot_list.read().unwrap();
+                        let slot_list = index_entry.slot_list();
                         let mut count = 0;
                         for (slot2, account_info2) in slot_list.iter() {
                             if *slot2 == slot {
@@ -7150,7 +7150,7 @@ impl AccountsDb {
             for pubkey in map.keys() {
                 self.accounts_index.get_and_then(&pubkey, |account_entry| {
                     if let Some(account_entry) = account_entry {
-                        let list_r = &account_entry.slot_list.read().unwrap();
+                        let list_r = &account_entry.slot_list();
                         info!(" key: {} ref_count: {}", pubkey, account_entry.ref_count(),);
                         info!("      slots: {list_r:?}");
                     }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -223,7 +223,7 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
     assert!(!db.accounts_index.contains(&pubkey));
     let result = db.generate_index(None, false);
     let entry = db.accounts_index.get_cloned(&pubkey).unwrap();
-    assert_eq!(entry.slot_list_len(), 1);
+    assert_eq!(entry.slot_list_lock_read_len(), 1);
     assert_eq!(append_vec.alive_bytes(), aligned_stored_size(0));
     assert_eq!(append_vec.accounts_count(), 1);
     assert_eq!(append_vec.count(), 1);
@@ -1231,7 +1231,7 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
             let expected_ref_count = if pass < 2 { 1 } else { 2 };
             assert_eq!(entry.unwrap().ref_count(), expected_ref_count, "{pass}");
             let expected_slot_list = if pass < 1 { 1 } else { 2 };
-            assert_eq!(entry.unwrap().slot_list_len(), expected_slot_list);
+            assert_eq!(entry.unwrap().slot_list_lock_read_len(), expected_slot_list);
             (false, ())
         });
         accounts.accounts_index.get_and_then(&pubkey2, |entry| {
@@ -1255,11 +1255,11 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
                 }
                 1 => {
                     // alive only in slot + 1
-                    assert_eq!(entry.unwrap().slot_list_len(), 1);
+                    assert_eq!(entry.unwrap().slot_list_lock_read_len(), 1);
                     assert_eq!(
                         entry
                             .unwrap()
-                            .slot_list()
+                            .slot_list_read_lock()
                             .first()
                             .map(|(s, _)| s)
                             .cloned()
@@ -1275,11 +1275,11 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
                 }
                 2 => {
                     // alive in both slot, slot + 1
-                    assert_eq!(entry.unwrap().slot_list_len(), 2);
+                    assert_eq!(entry.unwrap().slot_list_lock_read_len(), 2);
 
                     let slots = entry
                         .unwrap()
-                        .slot_list()
+                        .slot_list_read_lock()
                         .iter()
                         .map(|(s, _)| s)
                         .cloned()
@@ -1835,7 +1835,7 @@ fn test_accounts_db_purge_keep_live() {
     // The earlier entry for pubkey in the account index is purged,
     let (slot_list_len, index_slot) = {
         let account_entry = accounts.accounts_index.get_cloned(&pubkey).unwrap();
-        let slot_list = account_entry.slot_list();
+        let slot_list = account_entry.slot_list_read_lock();
         (slot_list.len(), slot_list[0].0)
     };
     assert_eq!(slot_list_len, 1);
@@ -2875,7 +2875,7 @@ fn test_delete_dependencies() {
     for key in [&key0, &key1, &key2] {
         let index_entry = accounts_index.get_cloned(key).unwrap();
         let rooted_entries =
-            accounts_index.get_rooted_entries(index_entry.slot_list().as_slice(), None);
+            accounts_index.get_rooted_entries(index_entry.slot_list_read_lock().as_slice(), None);
         let ref_count = index_entry.ref_count();
         let index = accounts_index.bin_calculator.bin_from_pubkey(key);
         let candidates_bin = &mut candidates[index];
@@ -3691,7 +3691,7 @@ define_accounts_db_test!(test_alive_bytes, |accounts_db| {
                 .accounts_index
                 .get_cloned(account.pubkey())
                 .unwrap()
-                .slot_list()
+                .slot_list_read_lock()
                 // Should only be one entry per key, since every key was only stored to slot 0
                 [0];
             assert_eq!(account_info.0, slot);

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -223,7 +223,7 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
     assert!(!db.accounts_index.contains(&pubkey));
     let result = db.generate_index(None, false);
     let entry = db.accounts_index.get_cloned(&pubkey).unwrap();
-    assert_eq!(entry.slot_list.read().unwrap().len(), 1);
+    assert_eq!(entry.slot_list_len(), 1);
     assert_eq!(append_vec.alive_bytes(), aligned_stored_size(0));
     assert_eq!(append_vec.accounts_count(), 1);
     assert_eq!(append_vec.count(), 1);
@@ -1231,10 +1231,7 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
             let expected_ref_count = if pass < 2 { 1 } else { 2 };
             assert_eq!(entry.unwrap().ref_count(), expected_ref_count, "{pass}");
             let expected_slot_list = if pass < 1 { 1 } else { 2 };
-            assert_eq!(
-                entry.unwrap().slot_list.read().unwrap().len(),
-                expected_slot_list
-            );
+            assert_eq!(entry.unwrap().slot_list_len(), expected_slot_list);
             (false, ())
         });
         accounts.accounts_index.get_and_then(&pubkey2, |entry| {
@@ -1258,13 +1255,11 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
                 }
                 1 => {
                     // alive only in slot + 1
-                    assert_eq!(entry.unwrap().slot_list.read().unwrap().len(), 1);
+                    assert_eq!(entry.unwrap().slot_list_len(), 1);
                     assert_eq!(
                         entry
                             .unwrap()
-                            .slot_list
-                            .read()
-                            .unwrap()
+                            .slot_list()
                             .first()
                             .map(|(s, _)| s)
                             .cloned()
@@ -1280,13 +1275,11 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
                 }
                 2 => {
                     // alive in both slot, slot + 1
-                    assert_eq!(entry.unwrap().slot_list.read().unwrap().len(), 2);
+                    assert_eq!(entry.unwrap().slot_list_len(), 2);
 
                     let slots = entry
                         .unwrap()
-                        .slot_list
-                        .read()
-                        .unwrap()
+                        .slot_list()
                         .iter()
                         .map(|(s, _)| s)
                         .cloned()
@@ -1842,7 +1835,7 @@ fn test_accounts_db_purge_keep_live() {
     // The earlier entry for pubkey in the account index is purged,
     let (slot_list_len, index_slot) = {
         let account_entry = accounts.accounts_index.get_cloned(&pubkey).unwrap();
-        let slot_list = account_entry.slot_list.read().unwrap();
+        let slot_list = account_entry.slot_list();
         (slot_list.len(), slot_list[0].0)
     };
     assert_eq!(slot_list_len, 1);
@@ -2881,8 +2874,8 @@ fn test_delete_dependencies() {
         .collect();
     for key in [&key0, &key1, &key2] {
         let index_entry = accounts_index.get_cloned(key).unwrap();
-        let rooted_entries = accounts_index
-            .get_rooted_entries(index_entry.slot_list.read().unwrap().as_slice(), None);
+        let rooted_entries =
+            accounts_index.get_rooted_entries(index_entry.slot_list().as_slice(), None);
         let ref_count = index_entry.ref_count();
         let index = accounts_index.bin_calculator.bin_from_pubkey(key);
         let candidates_bin = &mut candidates[index];
@@ -3698,9 +3691,7 @@ define_accounts_db_test!(test_alive_bytes, |accounts_db| {
                 .accounts_index
                 .get_cloned(account.pubkey())
                 .unwrap()
-                .slot_list
-                .read()
-                .unwrap()
+                .slot_list()
                 // Should only be one entry per key, since every key was only stored to slot 0
                 [0];
             assert_eq!(account_info.0, slot);

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -717,7 +717,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                 self.get_and_then(&pubkey, |entry| {
                     if let Some(list) = entry {
                         let mut read_lock_timer = Measure::start("read_lock");
-                        let list_r = &list.slot_list();
+                        let list_r = &list.slot_list_read_lock();
                         read_lock_timer.stop();
                         read_lock_elapsed += read_lock_timer.as_us();
                         let mut latest_slot_timer = Measure::start("latest_slot");
@@ -821,7 +821,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         max_root: Option<Slot>,
         callback: impl FnOnce((Slot, T)) -> R,
     ) -> Option<R> {
-        let slot_list = entry.slot_list();
+        let slot_list = entry.slot_list_read_lock();
         self.latest_slot(ancestors, &slot_list, max_root)
             .map(|found_index| callback(slot_list[found_index]))
     }
@@ -1079,7 +1079,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                         let result = if let Some(result) = avoid_callback_result.as_ref() {
                             *result
                         } else {
-                            let slot_list = &locked_entry.slot_list();
+                            let slot_list = &locked_entry.slot_list_read_lock();
                             callback(
                                 pubkey,
                                 Some((slot_list, locked_entry.ref_count())),
@@ -1097,7 +1097,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                                     1,
                                     "ref count expected to be zero, but is {}! {pubkey}, {:?}",
                                     locked_entry.ref_count(),
-                                    locked_entry.slot_list(),
+                                    locked_entry.slot_list_read_lock(),
                                 );
                                 true
                             }
@@ -1107,7 +1107,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                                     info!(
                                         "Unexpected unref {pubkey} with {old_ref} {:?}, expect \
                                          old_ref to be 1",
-                                        locked_entry.slot_list()
+                                        locked_entry.slot_list_read_lock()
                                     );
                                     datapoint_warn!(
                                         "accounts_db-unexpected-unref-zero",
@@ -1148,7 +1148,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                                 {
                                     let local_entry = entry.unwrap();
                                     if local_entry.ref_count() == 1
-                                        && local_entry.slot_list_len() == 1
+                                        && local_entry.slot_list_lock_read_len() == 1
                                     {
                                         // Account was found in memory, but is a single ref single slot account
                                         // For testing purposes, return None as this can be treated like
@@ -1164,7 +1164,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                             assert!(entry.is_some(), "{pubkey}, entry: {entry:?}");
                             let entry = entry.unwrap();
                             assert_eq!(entry.ref_count(), 1, "{pubkey}");
-                            assert_eq!(entry.slot_list_len(), 1, "{pubkey}");
+                            assert_eq!(entry.slot_list_lock_read_len(), 1, "{pubkey}");
                             (false, ())
                         });
                     }
@@ -1577,7 +1577,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         entry: &AccountMapEntry<T>,
         reclaims: &mut ReclaimsSlotList<T>,
     ) -> (u64, T) {
-        let mut slot_list = entry.slot_list_mut();
+        let mut slot_list = entry.slot_list_write_lock();
         let max_slot = slot_list
             .iter()
             .map(|(slot, _account)| *slot)
@@ -1819,7 +1819,7 @@ pub mod tests {
             // clone the AccountMapEntryInner into a new Arc
             match self {
                 PreAllocatedAccountMapEntry::Entry(entry) => {
-                    let (slot, account_info) = entry.slot_list()[0];
+                    let (slot, account_info) = entry.slot_list_read_lock()[0];
                     let meta = AccountMapEntryMeta {
                         dirty: AtomicBool::new(entry.dirty()),
                         age: AtomicAge::new(entry.age()),
@@ -2198,8 +2198,11 @@ pub mod tests {
                 )
                 .into_account_map_entry(&index.storage.storage);
                 assert_eq!(new_entry.ref_count(), 0);
-                assert_eq!(new_entry.slot_list().capacity(), 1);
-                assert_eq!(new_entry.slot_list().to_vec(), vec![(slot, account_info)]);
+                assert_eq!(new_entry.slot_list_read_lock().capacity(), 1);
+                assert_eq!(
+                    new_entry.slot_list_read_lock().to_vec(),
+                    vec![(slot, account_info)]
+                );
 
                 // account_info type that is NOT cached
                 let account_info = true;
@@ -2214,8 +2217,11 @@ pub mod tests {
                 )
                 .into_account_map_entry(&index.storage.storage);
                 assert_eq!(new_entry.ref_count(), 1);
-                assert_eq!(new_entry.slot_list().capacity(), 1);
-                assert_eq!(new_entry.slot_list().to_vec(), vec![(slot, account_info)]);
+                assert_eq!(new_entry.slot_list_read_lock().capacity(), 1);
+                assert_eq!(
+                    new_entry.slot_list_read_lock().to_vec(),
+                    vec![(slot, account_info)]
+                );
             }
         }
     }
@@ -2239,7 +2245,10 @@ pub mod tests {
         for (i, key) in [key0, key1].iter().enumerate() {
             let entry = index.get_cloned(key).unwrap();
             assert_eq!(entry.ref_count(), 1);
-            assert_eq!(entry.slot_list().as_slice(), &[(slot0, account_infos[i])],);
+            assert_eq!(
+                entry.slot_list_read_lock().as_slice(),
+                &[(slot0, account_infos[i])],
+            );
         }
     }
 
@@ -2297,7 +2306,7 @@ pub mod tests {
         // verify the added entry matches expected
         {
             let entry = index.get_cloned(&key).unwrap();
-            let slot_list = entry.slot_list();
+            let slot_list = entry.slot_list_read_lock();
             assert_eq!(entry.ref_count(), RefCount::from(!is_cached));
             assert_eq!(slot_list.as_slice(), &[(slot0, account_infos[0])]);
             let new_entry = PreAllocatedAccountMapEntry::new(
@@ -2307,7 +2316,10 @@ pub mod tests {
                 false,
             )
             .into_account_map_entry(&index.storage.storage);
-            assert_eq!(slot_list.as_slice(), new_entry.slot_list().as_slice(),);
+            assert_eq!(
+                slot_list.as_slice(),
+                new_entry.slot_list_read_lock().as_slice(),
+            );
         }
 
         match upsert_method {
@@ -2355,7 +2367,7 @@ pub mod tests {
         index.populate_and_retrieve_duplicate_keys_from_startup(|_slot_keys| {});
 
         let entry = index.get_cloned(&key).unwrap();
-        let slot_list = entry.slot_list();
+        let slot_list = entry.slot_list_read_lock();
 
         if should_have_reclaims {
             assert_eq!(entry.ref_count(), 1);
@@ -2983,7 +2995,7 @@ pub mod tests {
         // Using brackets to limit scope of read lock
         {
             let entry = index.get_cloned(&key).unwrap();
-            let slot_list = entry.slot_list();
+            let slot_list = entry.slot_list_read_lock();
             assert_eq!(slot_list.len(), 1);
         }
 
@@ -3003,7 +3015,7 @@ pub mod tests {
 
         // Slot list should only have a single entry
         let entry = index.get_cloned(&key).unwrap();
-        let slot_list = entry.slot_list();
+        let slot_list = entry.slot_list_read_lock();
         assert_eq!(slot_list.len(), 1);
     }
 
@@ -3201,7 +3213,7 @@ pub mod tests {
             );
         }
         let entry = index.get_cloned(&key).unwrap();
-        assert_eq!(entry.slot_list_len(), reclaim_slot as usize);
+        assert_eq!(entry.slot_list_lock_read_len(), reclaim_slot as usize);
 
         // Insert an item newer than the one that we will reclaim old slots on
         index.upsert(
@@ -3215,7 +3227,7 @@ pub mod tests {
             UpsertReclaim::IgnoreReclaims,
         );
         let entry = index.get_cloned(&key).unwrap();
-        assert_eq!(entry.slot_list_len(), (reclaim_slot + 1) as usize);
+        assert_eq!(entry.slot_list_lock_read_len(), (reclaim_slot + 1) as usize);
 
         // Reclaim all older slots
         index.upsert(
@@ -3325,9 +3337,9 @@ pub mod tests {
         // Verify that the slot list is length two and consists of the cached account at slot 1
         // and the uncached account at slot 2
         let entry = index.get_cloned(&key).unwrap();
-        assert_eq!(entry.slot_list_len(), 2);
+        assert_eq!(entry.slot_list_lock_read_len(), 2);
         assert_eq!(
-            entry.slot_list()[0],
+            entry.slot_list_read_lock()[0],
             PreAllocatedAccountMapEntry::new(
                 1,
                 CacheableIndexValueTest(true),
@@ -3337,7 +3349,7 @@ pub mod tests {
             .into()
         );
         assert_eq!(
-            entry.slot_list()[1],
+            entry.slot_list_read_lock()[1],
             PreAllocatedAccountMapEntry::new(
                 2,
                 CacheableIndexValueTest(false),
@@ -3953,12 +3965,12 @@ pub mod tests {
 
         {
             let account_map_entry = index.get_cloned(&key).unwrap();
-            let slot_list = account_map_entry.slot_list();
+            let slot_list = account_map_entry.slot_list_read_lock();
             assert_eq!(2, slot_list.len());
             assert_eq!(&[(slot1, value), (slot2, value)], slot_list.as_slice());
         }
         assert!(!index.clean_rooted_entries(&key, &mut gc, Some(slot2)));
-        assert_eq!(2, index.get_cloned(&key).unwrap().slot_list_len());
+        assert_eq!(2, index.get_cloned(&key).unwrap().slot_list_lock_read_len());
         assert!(gc.is_empty());
         {
             {

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -717,7 +717,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                 self.get_and_then(&pubkey, |entry| {
                     if let Some(list) = entry {
                         let mut read_lock_timer = Measure::start("read_lock");
-                        let list_r = &list.slot_list.read().unwrap();
+                        let list_r = &list.slot_list();
                         read_lock_timer.stop();
                         read_lock_elapsed += read_lock_timer.as_us();
                         let mut latest_slot_timer = Measure::start("latest_slot");
@@ -821,7 +821,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         max_root: Option<Slot>,
         callback: impl FnOnce((Slot, T)) -> R,
     ) -> Option<R> {
-        let slot_list = entry.slot_list.read().unwrap();
+        let slot_list = entry.slot_list();
         self.latest_slot(ancestors, &slot_list, max_root)
             .map(|found_index| callback(slot_list[found_index]))
     }
@@ -1079,7 +1079,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                         let result = if let Some(result) = avoid_callback_result.as_ref() {
                             *result
                         } else {
-                            let slot_list = &locked_entry.slot_list.read().unwrap();
+                            let slot_list = &locked_entry.slot_list();
                             callback(
                                 pubkey,
                                 Some((slot_list, locked_entry.ref_count())),
@@ -1097,7 +1097,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                                     1,
                                     "ref count expected to be zero, but is {}! {pubkey}, {:?}",
                                     locked_entry.ref_count(),
-                                    locked_entry.slot_list.read().unwrap(),
+                                    locked_entry.slot_list(),
                                 );
                                 true
                             }
@@ -1107,7 +1107,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                                     info!(
                                         "Unexpected unref {pubkey} with {old_ref} {:?}, expect \
                                          old_ref to be 1",
-                                        locked_entry.slot_list.read().unwrap()
+                                        locked_entry.slot_list()
                                     );
                                     datapoint_warn!(
                                         "accounts_db-unexpected-unref-zero",
@@ -1148,7 +1148,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                                 {
                                     let local_entry = entry.unwrap();
                                     if local_entry.ref_count() == 1
-                                        && local_entry.slot_list.read().unwrap().len() == 1
+                                        && local_entry.slot_list_len() == 1
                                     {
                                         // Account was found in memory, but is a single ref single slot account
                                         // For testing purposes, return None as this can be treated like
@@ -1164,7 +1164,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                             assert!(entry.is_some(), "{pubkey}, entry: {entry:?}");
                             let entry = entry.unwrap();
                             assert_eq!(entry.ref_count(), 1, "{pubkey}");
-                            assert_eq!(entry.slot_list.read().unwrap().len(), 1, "{pubkey}");
+                            assert_eq!(entry.slot_list_len(), 1, "{pubkey}");
                             (false, ())
                         });
                     }
@@ -1577,7 +1577,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         entry: &AccountMapEntry<T>,
         reclaims: &mut ReclaimsSlotList<T>,
     ) -> (u64, T) {
-        let mut slot_list = entry.slot_list.write().unwrap();
+        let mut slot_list = entry.slot_list_mut();
         let max_slot = slot_list
             .iter()
             .map(|(slot, _account)| *slot)
@@ -1819,7 +1819,7 @@ pub mod tests {
             // clone the AccountMapEntryInner into a new Arc
             match self {
                 PreAllocatedAccountMapEntry::Entry(entry) => {
-                    let (slot, account_info) = entry.slot_list.read().unwrap()[0];
+                    let (slot, account_info) = entry.slot_list()[0];
                     let meta = AccountMapEntryMeta {
                         dirty: AtomicBool::new(entry.dirty()),
                         age: AtomicAge::new(entry.age()),
@@ -2198,11 +2198,8 @@ pub mod tests {
                 )
                 .into_account_map_entry(&index.storage.storage);
                 assert_eq!(new_entry.ref_count(), 0);
-                assert_eq!(new_entry.slot_list.read().unwrap().capacity(), 1);
-                assert_eq!(
-                    new_entry.slot_list.read().unwrap().to_vec(),
-                    vec![(slot, account_info)]
-                );
+                assert_eq!(new_entry.slot_list().capacity(), 1);
+                assert_eq!(new_entry.slot_list().to_vec(), vec![(slot, account_info)]);
 
                 // account_info type that is NOT cached
                 let account_info = true;
@@ -2217,11 +2214,8 @@ pub mod tests {
                 )
                 .into_account_map_entry(&index.storage.storage);
                 assert_eq!(new_entry.ref_count(), 1);
-                assert_eq!(new_entry.slot_list.read().unwrap().capacity(), 1);
-                assert_eq!(
-                    new_entry.slot_list.read().unwrap().to_vec(),
-                    vec![(slot, account_info)]
-                );
+                assert_eq!(new_entry.slot_list().capacity(), 1);
+                assert_eq!(new_entry.slot_list().to_vec(), vec![(slot, account_info)]);
             }
         }
     }
@@ -2245,10 +2239,7 @@ pub mod tests {
         for (i, key) in [key0, key1].iter().enumerate() {
             let entry = index.get_cloned(key).unwrap();
             assert_eq!(entry.ref_count(), 1);
-            assert_eq!(
-                entry.slot_list.read().unwrap().as_slice(),
-                &[(slot0, account_infos[i])],
-            );
+            assert_eq!(entry.slot_list().as_slice(), &[(slot0, account_infos[i])],);
         }
     }
 
@@ -2306,7 +2297,7 @@ pub mod tests {
         // verify the added entry matches expected
         {
             let entry = index.get_cloned(&key).unwrap();
-            let slot_list = entry.slot_list.read().unwrap();
+            let slot_list = entry.slot_list();
             assert_eq!(entry.ref_count(), RefCount::from(!is_cached));
             assert_eq!(slot_list.as_slice(), &[(slot0, account_infos[0])]);
             let new_entry = PreAllocatedAccountMapEntry::new(
@@ -2316,10 +2307,7 @@ pub mod tests {
                 false,
             )
             .into_account_map_entry(&index.storage.storage);
-            assert_eq!(
-                slot_list.as_slice(),
-                new_entry.slot_list.read().unwrap().as_slice(),
-            );
+            assert_eq!(slot_list.as_slice(), new_entry.slot_list().as_slice(),);
         }
 
         match upsert_method {
@@ -2367,7 +2355,7 @@ pub mod tests {
         index.populate_and_retrieve_duplicate_keys_from_startup(|_slot_keys| {});
 
         let entry = index.get_cloned(&key).unwrap();
-        let slot_list = entry.slot_list.read().unwrap();
+        let slot_list = entry.slot_list();
 
         if should_have_reclaims {
             assert_eq!(entry.ref_count(), 1);
@@ -2995,7 +2983,7 @@ pub mod tests {
         // Using brackets to limit scope of read lock
         {
             let entry = index.get_cloned(&key).unwrap();
-            let slot_list = entry.slot_list.read().unwrap();
+            let slot_list = entry.slot_list();
             assert_eq!(slot_list.len(), 1);
         }
 
@@ -3015,7 +3003,7 @@ pub mod tests {
 
         // Slot list should only have a single entry
         let entry = index.get_cloned(&key).unwrap();
-        let slot_list = entry.slot_list.read().unwrap();
+        let slot_list = entry.slot_list();
         assert_eq!(slot_list.len(), 1);
     }
 
@@ -3213,7 +3201,7 @@ pub mod tests {
             );
         }
         let entry = index.get_cloned(&key).unwrap();
-        assert_eq!(entry.slot_list.read().unwrap().len(), reclaim_slot as usize);
+        assert_eq!(entry.slot_list_len(), reclaim_slot as usize);
 
         // Insert an item newer than the one that we will reclaim old slots on
         index.upsert(
@@ -3227,10 +3215,7 @@ pub mod tests {
             UpsertReclaim::IgnoreReclaims,
         );
         let entry = index.get_cloned(&key).unwrap();
-        assert_eq!(
-            entry.slot_list.read().unwrap().len(),
-            (reclaim_slot + 1) as usize
-        );
+        assert_eq!(entry.slot_list_len(), (reclaim_slot + 1) as usize);
 
         // Reclaim all older slots
         index.upsert(
@@ -3340,9 +3325,9 @@ pub mod tests {
         // Verify that the slot list is length two and consists of the cached account at slot 1
         // and the uncached account at slot 2
         let entry = index.get_cloned(&key).unwrap();
-        assert_eq!(entry.slot_list.read().unwrap().len(), 2);
+        assert_eq!(entry.slot_list_len(), 2);
         assert_eq!(
-            entry.slot_list.read().unwrap()[0],
+            entry.slot_list()[0],
             PreAllocatedAccountMapEntry::new(
                 1,
                 CacheableIndexValueTest(true),
@@ -3352,7 +3337,7 @@ pub mod tests {
             .into()
         );
         assert_eq!(
-            entry.slot_list.read().unwrap()[1],
+            entry.slot_list()[1],
             PreAllocatedAccountMapEntry::new(
                 2,
                 CacheableIndexValueTest(false),
@@ -3968,21 +3953,12 @@ pub mod tests {
 
         {
             let account_map_entry = index.get_cloned(&key).unwrap();
-            let slot_list = account_map_entry.slot_list.read().unwrap();
+            let slot_list = account_map_entry.slot_list();
             assert_eq!(2, slot_list.len());
             assert_eq!(&[(slot1, value), (slot2, value)], slot_list.as_slice());
         }
         assert!(!index.clean_rooted_entries(&key, &mut gc, Some(slot2)));
-        assert_eq!(
-            2,
-            index
-                .get_cloned(&key)
-                .unwrap()
-                .slot_list
-                .read()
-                .unwrap()
-                .len()
-        );
+        assert_eq!(2, index.get_cloned(&key).unwrap().slot_list_len());
         assert!(gc.is_empty());
         {
             {

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -7,7 +7,7 @@ use {
     solana_clock::Slot,
     std::sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, RwLock,
+        Arc, RwLock, RwLockReadGuard, RwLockWriteGuard,
     },
 };
 
@@ -21,7 +21,7 @@ pub struct AccountMapEntry<T> {
     /// list of slots in which this pubkey was updated
     /// Note that 'clean' removes outdated entries (ie. older roots) from this slot_list
     /// purge_slot() also removes non-rooted slots from this list
-    pub slot_list: RwLock<SlotList<T>>,
+    slot_list: RwLock<SlotList<T>>,
     /// synchronization metadata for in-memory state since last flush to disk accounts index
     pub meta: AccountMapEntryMeta,
 }
@@ -106,6 +106,18 @@ impl<T: IndexValue> AccountMapEntry<T> {
             Ordering::AcqRel,
             Ordering::Relaxed,
         );
+    }
+
+    pub fn slot_list_len(&self) -> usize {
+        self.slot_list.read().unwrap()
+    }
+
+    pub fn slot_list(&self) -> RwLockReadGuard<SlotList<T>> {
+        self.slot_list.read().unwrap()
+    }
+
+    pub fn slot_list_mut(&self) -> RwLockWriteGuard<SlotList<T>> {
+        self.slot_list.write().unwrap()
     }
 }
 

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -109,7 +109,7 @@ impl<T: IndexValue> AccountMapEntry<T> {
     }
 
     pub fn slot_list_len(&self) -> usize {
-        self.slot_list.read().unwrap()
+        self.slot_list.read().unwrap().len()
     }
 
     pub fn slot_list(&self) -> RwLockReadGuard<SlotList<T>> {

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -161,7 +161,7 @@ impl<T: IndexValue> IsZeroLamport for PreAllocatedAccountMapEntry<T> {
     fn is_zero_lamport(&self) -> bool {
         match self {
             PreAllocatedAccountMapEntry::Entry(entry) => {
-                entry.slot_list.read().unwrap()[0].1.is_zero_lamport()
+                entry.slot_list_read_lock()[0].1.is_zero_lamport()
             }
             PreAllocatedAccountMapEntry::Raw(raw) => raw.1.is_zero_lamport(),
         }
@@ -171,7 +171,7 @@ impl<T: IndexValue> IsZeroLamport for PreAllocatedAccountMapEntry<T> {
 impl<T: IndexValue> From<PreAllocatedAccountMapEntry<T>> for (Slot, T) {
     fn from(source: PreAllocatedAccountMapEntry<T>) -> (Slot, T) {
         match source {
-            PreAllocatedAccountMapEntry::Entry(entry) => entry.slot_list.read().unwrap()[0],
+            PreAllocatedAccountMapEntry::Entry(entry) => entry.slot_list_read_lock()[0],
             PreAllocatedAccountMapEntry::Raw(raw) => raw,
         }
     }

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -108,15 +108,15 @@ impl<T: IndexValue> AccountMapEntry<T> {
         );
     }
 
-    pub fn slot_list_len(&self) -> usize {
+    pub fn slot_list_lock_read_len(&self) -> usize {
         self.slot_list.read().unwrap().len()
     }
 
-    pub fn slot_list(&self) -> RwLockReadGuard<SlotList<T>> {
+    pub fn slot_list_read_lock(&self) -> RwLockReadGuard<SlotList<T>> {
         self.slot_list.read().unwrap()
     }
 
-    pub fn slot_list_mut(&self) -> RwLockWriteGuard<SlotList<T>> {
+    pub fn slot_list_write_lock(&self) -> RwLockWriteGuard<SlotList<T>> {
         self.slot_list.write().unwrap()
     }
 }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -436,7 +436,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         match entry {
             Entry::Occupied(occupied) => {
                 let result =
-                    self.remove_if_slot_list_empty_value(occupied.get().slot_list_len() > 0);
+                    self.remove_if_slot_list_empty_value(occupied.get().slot_list_len() == 0);
                 if result {
                     // note there is a potential race here that has existed.
                     // if someone else holds the arc,

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -435,8 +435,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     ) -> bool {
         match entry {
             Entry::Occupied(occupied) => {
-                let result =
-                    self.remove_if_slot_list_empty_value(occupied.get().slot_list_len() == 0);
+                let result = self
+                    .remove_if_slot_list_empty_value(occupied.get().slot_list_lock_read_len() == 0);
                 if result {
                     // note there is a potential race here that has existed.
                     // if someone else holds the arc,
@@ -501,7 +501,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             (
                 true,
                 entry.map(|entry| {
-                    let result = user_fn(&mut entry.slot_list_mut());
+                    let result = user_fn(&mut entry.slot_list_write_lock());
                     // note that to be safe here, we ALWAYS mark the entry as dirty
                     entry.set_dirty(true);
                     result
@@ -513,7 +513,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// Insert a cached entry into the accounts index
     /// If the entry is already present, just mark dirty and set the age to the future
     fn cache_entry_at_slot(current: &AccountMapEntry<T>, new_value: (Slot, T)) {
-        let mut slot_list = current.slot_list_mut();
+        let mut slot_list = current.slot_list_write_lock();
         let (slot, new_entry) = new_value;
         if !slot_list
             .iter()
@@ -600,7 +600,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
                         // Ensure that after callback there is an item in the slot list
                         assert_ne!(
-                            new_value.slot_list_len(),
+                            new_value.slot_list_lock_read_len(),
                             0,
                             "Callback must insert item into slot list"
                         );
@@ -645,7 +645,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         reclaims: &mut ReclaimsSlotList<T>,
         reclaim: UpsertReclaim,
     ) -> usize {
-        let mut slot_list = current.slot_list_mut();
+        let mut slot_list = current.slot_list_write_lock();
         let (slot, new_entry) = new_value;
         let ref_count_change = Self::update_slot_list(
             &mut slot_list,
@@ -821,7 +821,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 // in cache, so merge into cache
                 let (slot, account_info) = new_entry.into();
 
-                let slot_list = occupied.get().slot_list();
+                let slot_list = occupied.get().slot_list_read_lock();
 
                 // If there is only one entry in the slot list, it means that
                 // the previous entry inserted was a duplicate, which should be
@@ -953,7 +953,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 (false, None)
             } else {
                 // only read the slot list if we are planning to throw the item out
-                let slot_list = entry.slot_list();
+                let slot_list = entry.slot_list_read_lock();
                 if slot_list.len() != 1 {
                     if update_stats {
                         Self::update_stat(&self.stats().held_in_mem.slot_list_len, 1);
@@ -1238,7 +1238,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                             loop {
                                 let disk_resize = {
                                     let slot_list =
-                                        slot_list.take().unwrap_or_else(|| v.slot_list());
+                                        slot_list.take().unwrap_or_else(|| v.slot_list_read_lock());
                                     // Check the ref count and slot list one more time before flushing.
                                     // It is possible the foreground has updated this entry since
                                     // we last checked above in `should_evict_from_mem()`.
@@ -1472,7 +1472,7 @@ mod tests {
 
         let mut callback_called = false;
         accounts_index.get_or_create_index_entry_for_pubkey(&pubkey, |entry| {
-            assert_eq!(entry.slot_list_len(), 0);
+            assert_eq!(entry.slot_list_lock_read_len(), 0);
             assert_eq!(entry.ref_count(), 0);
             assert!(entry.dirty());
             InMemAccountsIndex::<u64, u64>::cache_entry_at_slot(entry, (slot, 0));
@@ -1508,7 +1508,7 @@ mod tests {
 
         let mut callback_called = false;
         accounts_index.get_or_create_index_entry_for_pubkey(&pubkey, |entry| {
-            assert_eq!(entry.slot_list_len(), 1);
+            assert_eq!(entry.slot_list_lock_read_len(), 1);
             assert_eq!(entry.ref_count(), 1);
             assert!(entry.dirty());
             callback_called = true;
@@ -1541,7 +1541,7 @@ mod tests {
 
         let mut callback_called = false;
         accounts_index.get_or_create_index_entry_for_pubkey(&pubkey, |entry| {
-            assert_eq!(entry.slot_list_len(), 1);
+            assert_eq!(entry.slot_list_lock_read_len(), 1);
             assert_eq!(entry.ref_count(), 1);
             assert!(!entry.dirty()); // Entry loaded from disk should not be dirty
             InMemAccountsIndex::<u64, u64>::cache_entry_at_slot(entry, (slot, 0));
@@ -2224,7 +2224,7 @@ mod tests {
         {
             // add an entry with a NON empty slot list - it will NOT get removed
             let val = Arc::new(AccountMapEntry::<u64>::empty_for_tests());
-            val.slot_list_mut().push((1, 1));
+            val.slot_list_write_lock().push((1, 1));
             map.insert(key, val);
             // does NOT remove it since it has a non-empty slot list
             let entry = map.entry(key);
@@ -2247,7 +2247,7 @@ mod tests {
             &mut reclaims,
             UpsertReclaim::IgnoreReclaims,
         );
-        assert_eq!(test.slot_list_len(), len);
+        assert_eq!(test.slot_list_lock_read_len(), len);
         assert_eq!(len, 1);
         // update to different slot, should increase
         let len = InMemAccountsIndex::<u64, u64>::lock_and_update_slot_list(
@@ -2257,7 +2257,7 @@ mod tests {
             &mut reclaims,
             UpsertReclaim::IgnoreReclaims,
         );
-        assert_eq!(test.slot_list_len(), len);
+        assert_eq!(test.slot_list_lock_read_len(), len);
         assert_eq!(len, 2);
         // update to same slot, should not increase
         let len = InMemAccountsIndex::<u64, u64>::lock_and_update_slot_list(
@@ -2267,7 +2267,7 @@ mod tests {
             &mut reclaims,
             UpsertReclaim::IgnoreReclaims,
         );
-        assert_eq!(test.slot_list_len(), len);
+        assert_eq!(test.slot_list_lock_read_len(), len);
         assert_eq!(len, 2);
     }
 }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -435,9 +435,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     ) -> bool {
         match entry {
             Entry::Occupied(occupied) => {
-                let result = self.remove_if_slot_list_empty_value(
-                    occupied.get().slot_list.read().unwrap().is_empty(),
-                );
+                let result =
+                    self.remove_if_slot_list_empty_value(occupied.get().slot_list_len() > 0);
                 if result {
                     // note there is a potential race here that has existed.
                     // if someone else holds the arc,
@@ -502,7 +501,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             (
                 true,
                 entry.map(|entry| {
-                    let result = user_fn(&mut entry.slot_list.write().unwrap());
+                    let result = user_fn(&mut entry.slot_list_mut());
                     // note that to be safe here, we ALWAYS mark the entry as dirty
                     entry.set_dirty(true);
                     result
@@ -514,7 +513,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// Insert a cached entry into the accounts index
     /// If the entry is already present, just mark dirty and set the age to the future
     fn cache_entry_at_slot(current: &AccountMapEntry<T>, new_value: (Slot, T)) {
-        let mut slot_list = current.slot_list.write().unwrap();
+        let mut slot_list = current.slot_list_mut();
         let (slot, new_entry) = new_value;
         if !slot_list
             .iter()
@@ -601,7 +600,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
                         // Ensure that after callback there is an item in the slot list
                         assert_ne!(
-                            new_value.slot_list.read().unwrap().len(),
+                            new_value.slot_list_len(),
                             0,
                             "Callback must insert item into slot list"
                         );
@@ -646,7 +645,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         reclaims: &mut ReclaimsSlotList<T>,
         reclaim: UpsertReclaim,
     ) -> usize {
-        let mut slot_list = current.slot_list.write().unwrap();
+        let mut slot_list = current.slot_list_mut();
         let (slot, new_entry) = new_value;
         let ref_count_change = Self::update_slot_list(
             &mut slot_list,
@@ -822,7 +821,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 // in cache, so merge into cache
                 let (slot, account_info) = new_entry.into();
 
-                let slot_list = occupied.get().slot_list.read().unwrap();
+                let slot_list = occupied.get().slot_list();
 
                 // If there is only one entry in the slot list, it means that
                 // the previous entry inserted was a duplicate, which should be
@@ -954,7 +953,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 (false, None)
             } else {
                 // only read the slot list if we are planning to throw the item out
-                let slot_list = entry.slot_list.read().unwrap();
+                let slot_list = entry.slot_list();
                 if slot_list.len() != 1 {
                     if update_stats {
                         Self::update_stat(&self.stats().held_in_mem.slot_list_len, 1);
@@ -1238,9 +1237,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                             // may have to loop if disk has to grow and we have to retry the write
                             loop {
                                 let disk_resize = {
-                                    let slot_list = slot_list
-                                        .take()
-                                        .unwrap_or_else(|| v.slot_list.read().unwrap());
+                                    let slot_list =
+                                        slot_list.take().unwrap_or_else(|| v.slot_list());
                                     // Check the ref count and slot list one more time before flushing.
                                     // It is possible the foreground has updated this entry since
                                     // we last checked above in `should_evict_from_mem()`.
@@ -1474,7 +1472,7 @@ mod tests {
 
         let mut callback_called = false;
         accounts_index.get_or_create_index_entry_for_pubkey(&pubkey, |entry| {
-            assert!(entry.slot_list.read().unwrap().is_empty());
+            assert_eq!(entry.slot_list_len(), 0);
             assert_eq!(entry.ref_count(), 0);
             assert!(entry.dirty());
             InMemAccountsIndex::<u64, u64>::cache_entry_at_slot(entry, (slot, 0));
@@ -1510,7 +1508,7 @@ mod tests {
 
         let mut callback_called = false;
         accounts_index.get_or_create_index_entry_for_pubkey(&pubkey, |entry| {
-            assert_eq!(entry.slot_list.read().unwrap().len(), 1);
+            assert_eq!(entry.slot_list_len(), 1);
             assert_eq!(entry.ref_count(), 1);
             assert!(entry.dirty());
             callback_called = true;
@@ -1543,7 +1541,7 @@ mod tests {
 
         let mut callback_called = false;
         accounts_index.get_or_create_index_entry_for_pubkey(&pubkey, |entry| {
-            assert_eq!(entry.slot_list.read().unwrap().len(), 1);
+            assert_eq!(entry.slot_list_len(), 1);
             assert_eq!(entry.ref_count(), 1);
             assert!(!entry.dirty()); // Entry loaded from disk should not be dirty
             InMemAccountsIndex::<u64, u64>::cache_entry_at_slot(entry, (slot, 0));
@@ -2226,7 +2224,7 @@ mod tests {
         {
             // add an entry with a NON empty slot list - it will NOT get removed
             let val = Arc::new(AccountMapEntry::<u64>::empty_for_tests());
-            val.slot_list.write().unwrap().push((1, 1));
+            val.slot_list_mut().push((1, 1));
             map.insert(key, val);
             // does NOT remove it since it has a non-empty slot list
             let entry = map.entry(key);
@@ -2249,7 +2247,7 @@ mod tests {
             &mut reclaims,
             UpsertReclaim::IgnoreReclaims,
         );
-        assert_eq!(test.slot_list.read().unwrap().len(), len);
+        assert_eq!(test.slot_list_len(), len);
         assert_eq!(len, 1);
         // update to different slot, should increase
         let len = InMemAccountsIndex::<u64, u64>::lock_and_update_slot_list(
@@ -2259,7 +2257,7 @@ mod tests {
             &mut reclaims,
             UpsertReclaim::IgnoreReclaims,
         );
-        assert_eq!(test.slot_list.read().unwrap().len(), len);
+        assert_eq!(test.slot_list_len(), len);
         assert_eq!(len, 2);
         // update to same slot, should not increase
         let len = InMemAccountsIndex::<u64, u64>::lock_and_update_slot_list(
@@ -2269,7 +2267,7 @@ mod tests {
             &mut reclaims,
             UpsertReclaim::IgnoreReclaims,
         );
-        assert_eq!(test.slot_list.read().unwrap().len(), len);
+        assert_eq!(test.slot_list_len(), len);
         assert_eq!(len, 2);
     }
 }

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -232,13 +232,7 @@ impl<'a> SnapshotMinimizer<'a> {
                 .accounts_index
                 .get_and_then(&pubkey, |entry| {
                     if let Some(entry) = entry {
-                        let max_slot = entry
-                            .slot_list
-                            .read()
-                            .unwrap()
-                            .iter()
-                            .map(|(slot, _)| *slot)
-                            .max();
+                        let max_slot = entry.slot_list().iter().map(|(slot, _)| *slot).max();
                         if let Some(max_slot) = max_slot {
                             minimized_slot_set.insert(max_slot);
                         }

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -232,7 +232,11 @@ impl<'a> SnapshotMinimizer<'a> {
                 .accounts_index
                 .get_and_then(&pubkey, |entry| {
                     if let Some(entry) = entry {
-                        let max_slot = entry.slot_list().iter().map(|(slot, _)| *slot).max();
+                        let max_slot = entry
+                            .slot_list_read_lock()
+                            .iter()
+                            .map(|(slot, _)| *slot)
+                            .max();
                         if let Some(max_slot) = max_slot {
                             minimized_slot_set.insert(max_slot);
                         }


### PR DESCRIPTION
#### Problem
`AccountMapEntry`'s slot_list is directly accessed in many places relying on specific implementation of the slot list (as `RwLock<SlotList>`), which makes it difficult to change how slot list is represented (e.g. if we choose to not use a list or lock for regular entries).

#### Summary of Changes
* make `slot_list` field private
* add read-only accessors `slot_list`, `slot_list_len` that lock the list for read and return guard or the length directly
* add write accessor `slot_list_mut` that locks the list for write and returns a guard

This is aimed to be mechanical change without any change in semantics. It is using locks in the same way as they were used before, but it opens up API for further changes (e.g. replacing lock guards with dedicated accessor structs that will recognize different representations of `slot_list`) in such a way, that will minimize diff for the use-sites.