### PR TITLE
Skip marking snapshot loadable when unarching snapshot

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1825,8 +1825,6 @@ fn create_snapshot_meta_files_for_unarchived_snapshot(unpack_dir: impl AsRef<Pat
         slot_dir.join(SNAPSHOT_STATUS_CACHE_FILENAME),
     )?;
 
-    mark_bank_snapshot_as_loadable(slot_dir)?;
-
     Ok(())
 }
 


### PR DESCRIPTION
#### Problem
- None of the files written during mark_snapshot_loadable are needed when unarchiving from the snapshot anymore as snapshots now use the version file to detect validity.

#### Summary of Changes
- Remove the call 
- Meant to do this in https://github.com/anza-xyz/agave/pull/8097#discussion_r2363824689, somehow got missed. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
