### PR TITLE
Replace dashmap with mutex<Vec> for dirty stores

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1241,7 +1241,7 @@ pub struct AccountsDb {
     /// Set of stores which are recently rooted or had accounts removed
     /// such that potentially a 0-lamport account update could be present which
     /// means we can remove the account from the index entirely.
-    dirty_stores: DashMap<Slot, Arc<AccountStorageEntry>, BuildNoHashHasher<Slot>>,
+    dirty_stores: Mutex<HashMap<Slot, Arc<AccountStorageEntry>, BuildNoHashHasher<Slot>>>,
 
     /// Zero-lamport accounts that are *not* purged during clean because they need to stay alive
     /// for incremental snapshot support.
@@ -1443,7 +1443,7 @@ impl AccountsDb {
             load_limit: AtomicU64::default(),
             is_bank_drop_callback_enabled: AtomicBool::default(),
             remove_unrooted_slots_synchronization: RemoveUnrootedSlotsSynchronization::default(),
-            dirty_stores: DashMap::default(),
+            dirty_stores: Mutex::default(),
             zero_lamport_accounts_to_purge_after_full_snapshot: DashSet::default(),
             log_dead_slots: AtomicBool::new(true),
             accounts_file_provider: AccountsFileProvider::default(),
@@ -1835,11 +1835,11 @@ impl AccountsDb {
         let mut dirty_store_processing_time = Measure::start("dirty_store_processing");
         let max_root_inclusive = self.accounts_index.max_root_inclusive();
         let max_slot_inclusive = max_clean_root_inclusive.unwrap_or(max_root_inclusive);
-        let mut dirty_stores = Vec::with_capacity(self.dirty_stores.len());
+        let mut dirty_stores = Vec::with_capacity(self.dirty_stores.lock().unwrap().len());
         // find the oldest dirty slot
         // we'll add logging if that append vec cannot be marked dead
         let mut min_dirty_slot = None::<u64>;
-        self.dirty_stores.retain(|slot, store| {
+        self.dirty_stores.lock().unwrap().retain(|slot, store| {
             if *slot > max_slot_inclusive {
                 true
             } else {
@@ -3161,7 +3161,11 @@ impl AccountsDb {
 
                 if store.num_zero_lamport_single_ref_accounts() == store.count() {
                     // all accounts in this storage can be dead
-                    self.dirty_stores.entry(slot).or_insert(store);
+                    self.dirty_stores
+                        .lock()
+                        .unwrap()
+                        .entry(slot)
+                        .or_insert(store);
                     self.shrink_stats
                         .num_dead_slots_added_to_clean
                         .fetch_add(1, Ordering::Relaxed);
@@ -3219,7 +3223,10 @@ impl AccountsDb {
         {
             if shrink_collect.alive_total_bytes == 0 {
                 // clean needs to take care of this dead slot
-                self.dirty_stores.insert(slot, store.clone());
+                self.dirty_stores
+                    .lock()
+                    .unwrap()
+                    .insert(slot, store.clone());
             }
 
             if !shrink_collect.all_are_zero_lamports {
@@ -3342,7 +3349,10 @@ impl AccountsDb {
 
         let mut not_retaining_store = |store: &Arc<AccountStorageEntry>| {
             if add_dirty_stores {
-                self.dirty_stores.insert(slot, store.clone());
+                self.dirty_stores
+                    .lock()
+                    .unwrap()
+                    .insert(slot, store.clone());
             }
             dead_storages.push(store.clone());
         };
@@ -3702,7 +3712,7 @@ impl AccountsDb {
         // As long as we don't mark anything as dead at slots > latest_full_snapshot_slot, then shrink will have nothing to do for
         // slots > latest_full_snapshot_slot.
         let maybe_clean = || {
-            if self.dirty_stores.len() > DIRTY_STORES_CLEANING_THRESHOLD {
+            if self.dirty_stores.lock().unwrap().len() > DIRTY_STORES_CLEANING_THRESHOLD {
                 let latest_full_snapshot_slot = self.latest_full_snapshot_slot();
                 self.clean_accounts(latest_full_snapshot_slot, is_startup, epoch_schedule);
             }
@@ -5631,7 +5641,7 @@ impl AccountsDb {
                 // This may be different from the check above as this
                 // can be multithreaded
                 if remaining_accounts == 0 {
-                    self.dirty_stores.insert(*slot, store);
+                    self.dirty_stores.lock().unwrap().insert(*slot, store);
                     dead_slots.insert(*slot);
                 } else if Self::is_shrinking_productive(&store)
                     && self.is_candidate_for_shrink(&store)
@@ -6841,7 +6851,7 @@ impl AccountsDb {
             total_accum.all_zeros_slots.len()
         );
         for (slot, storage) in total_accum.all_zeros_slots {
-            self.dirty_stores.insert(slot, storage);
+            self.dirty_stores.lock().unwrap().insert(slot, storage);
         }
 
         // Need to add these last, otherwise older updates will be cleaned
@@ -7001,7 +7011,11 @@ impl AccountsDb {
                 count += store.batch_insert_zero_lamport_single_ref_account_offsets(&offsets);
                 if store.num_zero_lamport_single_ref_accounts() == store.count() {
                     // all accounts in this storage can be dead
-                    self.dirty_stores.entry(slot).or_insert(store);
+                    self.dirty_stores
+                        .lock()
+                        .unwrap()
+                        .entry(slot)
+                        .or_insert(store);
                     dead_stores += 1;
                 } else if Self::is_shrinking_productive(&store)
                     && self.is_candidate_for_shrink(&store)

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4314,7 +4314,7 @@ fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
     // And now, slot 1 should be marked complete dead, which will be added
     // to uncleaned slots, which handle dropping dead storage. And it WON'T
     // be participating shrinking in the next round.
-    assert!(db.dirty_stores.contains_key(&1));
+    assert!(db.dirty_stores.lock().unwrap().contains_key(&1));
     assert!(!db.shrink_candidate_slots.lock().unwrap().contains(&1));
 
     // Now, make slot 0 dead by updating the remaining key
@@ -5488,7 +5488,7 @@ define_accounts_db_test!(test_mark_dirty_dead_stores_empty, |db| {
     for add_dirty_stores in [false, true] {
         let dead_storages = db.mark_dirty_dead_stores(slot, add_dirty_stores, None, false);
         assert!(dead_storages.is_empty());
-        assert!(db.dirty_stores.is_empty());
+        assert!(db.dirty_stores.lock().unwrap().is_empty());
     }
 });
 
@@ -5509,11 +5509,11 @@ fn test_mark_dirty_dead_stores_no_shrink_in_progress() {
         assert_eq!(dead_storages.len(), 1);
         assert_eq!(dead_storages.first().unwrap().id(), old_id);
         if add_dirty_stores {
-            assert_eq!(1, db.dirty_stores.len());
-            let dirty_store = db.dirty_stores.get(&slot).unwrap();
-            assert_eq!(dirty_store.id(), old_id);
+            assert_eq!(1, db.dirty_stores.lock().unwrap().len());
+            let dirty_store_id = db.dirty_stores.lock().unwrap().get(&slot).unwrap().id();
+            assert_eq!(dirty_store_id, old_id);
         } else {
-            assert!(db.dirty_stores.is_empty());
+            assert!(db.dirty_stores.lock().unwrap().is_empty());
         }
         assert!(db.storage.is_empty_entry(slot));
     }
@@ -5536,11 +5536,11 @@ fn test_mark_dirty_dead_stores() {
         assert_eq!(dead_storages.len(), 1);
         assert_eq!(dead_storages.first().unwrap().id(), old_id);
         if add_dirty_stores {
-            assert_eq!(1, db.dirty_stores.len());
-            let dirty_store = db.dirty_stores.get(&slot).unwrap();
-            assert_eq!(dirty_store.id(), old_id);
+            assert_eq!(1, db.dirty_stores.lock().unwrap().len());
+            let dirty_store_id = db.dirty_stores.lock().unwrap().get(&slot).unwrap().id();
+            assert_eq!(dirty_store_id, old_id);
         } else {
-            assert!(db.dirty_stores.is_empty());
+            assert!(db.dirty_stores.lock().unwrap().is_empty());
         }
         assert!(db.storage.get_slot_storage_entry(slot).is_some());
     }
@@ -6360,7 +6360,7 @@ fn test_clean_old_storages_with_reclaims_rooted() {
         accounts_db.uncleaned_pubkeys.remove(&slot);
         // ensure this slot is *not* in the dirty_stores nor uncleaned_pubkeys, because we want to
         // test cleaning *old* storages, i.e. when they aren't explicitly marked for cleaning
-        assert!(!accounts_db.dirty_stores.contains_key(&slot));
+        assert!(!accounts_db.dirty_stores.lock().unwrap().contains_key(&slot));
         assert!(!accounts_db.uncleaned_pubkeys.contains_key(&slot));
     }
 
@@ -6369,7 +6369,11 @@ fn test_clean_old_storages_with_reclaims_rooted() {
         .storage
         .get_slot_storage_entry_shrinking_in_progress_ok(old_slot)
         .unwrap();
-    accounts_db.dirty_stores.insert(old_slot, old_storage);
+    accounts_db
+        .dirty_stores
+        .lock()
+        .unwrap()
+        .insert(old_slot, old_storage);
 
     // ensure the slot list for `pubkey` has both the old and new slots
     let slot_list = accounts_db
@@ -6425,10 +6429,18 @@ fn test_clean_old_storages_with_reclaims_unrooted() {
 
     // ensure `old_slot` is in uncleaned_pubkeys (but not dirty_stores) so it'll be cleaned
     assert!(accounts_db.uncleaned_pubkeys.contains_key(&old_slot));
-    assert!(!accounts_db.dirty_stores.contains_key(&old_slot));
+    assert!(!accounts_db
+        .dirty_stores
+        .lock()
+        .unwrap()
+        .contains_key(&old_slot));
     // and `new_slot` should be in neither
     assert!(!accounts_db.uncleaned_pubkeys.contains_key(&new_slot));
-    assert!(!accounts_db.dirty_stores.contains_key(&new_slot));
+    assert!(!accounts_db
+        .dirty_stores
+        .lock()
+        .unwrap()
+        .contains_key(&new_slot));
 
     // ensure the slot list for `pubkey` has both the old and new slots
     let slot_list = accounts_db


### PR DESCRIPTION
#### Problem
- Dashmap is overkill for dirty store list. Accessors are few, short and unlikely to have many running in parallel. 

- Below shows the length of the list when it is accessed and cleaned during clean. It is usually very short. Every time an ancient shrink is performed it spikes a little but still not to a level that requires a dashmap given how short the lock is held. 

<img width="1673" height="667" alt="image" src="https://github.com/user-attachments/assets/a61769c1-7928-44a7-90dd-e583df0c3d72" />

No performance change when processing dirty stores
<img width="1673" height="460" alt="image" src="https://github.com/user-attachments/assets/783da3bd-a0f0-47f4-82af-b8fe55bba901" />


#### Summary of Changes
- Replace with a mutex around a hashmap
- Mutex seems better than RWLock, as there is only one spot it is read. 
- Potentially more refactoring could be done on the dirty_store list, but only doing one thing. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
