### PR TITLE
Avoid copying instruction data when recording CPI instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11431,6 +11431,7 @@ dependencies = [
  "solana-account-info",
  "solana-instruction",
  "solana-instructions-sysvar",
+ "solana-message",
  "solana-program-entrypoint",
  "solana-pubkey",
  "solana-rent",

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -13,7 +13,7 @@ use {
     solana_sdk_ids::bpf_loader_deprecated,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     solana_transaction_context::{
-        BorrowedInstructionAccount, IndexOfAccount, InstructionContext,
+        BorrowedInstructionAccount, IndexOfAccount, InstructionContextView,
         MAX_ACCOUNTS_PER_INSTRUCTION,
     },
     std::mem::{self, size_of},
@@ -220,7 +220,7 @@ impl Serializer {
 }
 
 pub fn serialize_parameters(
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
     mask_out_rent_epoch_in_vm_serialization: bool,
@@ -284,7 +284,7 @@ pub fn serialize_parameters(
 }
 
 pub fn deserialize_parameters(
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
     buffer: &[u8],
@@ -410,7 +410,7 @@ fn serialize_parameters_unaligned(
 }
 
 fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
     buffer: &[u8],
@@ -578,7 +578,7 @@ fn serialize_parameters_aligned(
 }
 
 fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
     buffer: &[u8],

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -16,7 +16,7 @@ use {
     solana_svm_type_overrides::sync::Arc,
     solana_sysvar::SysvarSerialize,
     solana_sysvar_id::SysvarId,
-    solana_transaction_context::{IndexOfAccount, InstructionContext},
+    solana_transaction_context::{IndexOfAccount, InstructionContextView},
 };
 
 #[cfg(feature = "frozen-abi")]
@@ -285,7 +285,7 @@ pub mod get_sysvar_with_account_check {
     use super::*;
 
     fn check_sysvar_account<S: SysvarId>(
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<(), InstructionError> {
         if !S::check_id(
@@ -298,7 +298,7 @@ pub mod get_sysvar_with_account_check {
 
     pub fn clock(
         invoke_context: &InvokeContext,
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<Clock>, InstructionError> {
         check_sysvar_account::<Clock>(instruction_context, instruction_account_index)?;
@@ -307,7 +307,7 @@ pub mod get_sysvar_with_account_check {
 
     pub fn rent(
         invoke_context: &InvokeContext,
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<Rent>, InstructionError> {
         check_sysvar_account::<Rent>(instruction_context, instruction_account_index)?;
@@ -316,7 +316,7 @@ pub mod get_sysvar_with_account_check {
 
     pub fn slot_hashes(
         invoke_context: &InvokeContext,
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<SlotHashes>, InstructionError> {
         check_sysvar_account::<SlotHashes>(instruction_context, instruction_account_index)?;
@@ -326,7 +326,7 @@ pub mod get_sysvar_with_account_check {
     #[allow(deprecated)]
     pub fn recent_blockhashes(
         invoke_context: &InvokeContext,
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<RecentBlockhashes>, InstructionError> {
         check_sysvar_account::<RecentBlockhashes>(instruction_context, instruction_account_index)?;
@@ -335,7 +335,7 @@ pub mod get_sysvar_with_account_check {
 
     pub fn stake_history(
         invoke_context: &InvokeContext,
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<StakeHistory>, InstructionError> {
         check_sysvar_account::<StakeHistory>(instruction_context, instruction_account_index)?;
@@ -344,7 +344,7 @@ pub mod get_sysvar_with_account_check {
 
     pub fn last_restart_slot(
         invoke_context: &InvokeContext,
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<LastRestartSlot>, InstructionError> {
         check_sysvar_account::<LastRestartSlot>(instruction_context, instruction_account_index)?;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -40,7 +40,7 @@ use {
     solana_svm_measure::measure::Measure,
     solana_svm_type_overrides::sync::{atomic::Ordering, Arc},
     solana_system_interface::{instruction as system_instruction, MAX_PERMITTED_DATA_LENGTH},
-    solana_transaction_context::{IndexOfAccount, InstructionContext, TransactionContext},
+    solana_transaction_context::{IndexOfAccount, InstructionContextView, TransactionContext},
     std::{cell::RefCell, mem, rc::Rc},
 };
 
@@ -1413,7 +1413,7 @@ fn common_extend_program(
 
 fn common_close_account(
     authority_address: &Option<Pubkey>,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     log_collector: &Option<Rc<RefCell<LogCollector>>>,
 ) -> Result<(), InstructionError> {
     if authority_address.is_none() {

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -20,7 +20,7 @@ use {
     solana_svm_log_collector::{ic_logger_msg, LogCollector},
     solana_svm_measure::measure::Measure,
     solana_svm_type_overrides::sync::Arc,
-    solana_transaction_context::{BorrowedInstructionAccount, InstructionContext},
+    solana_transaction_context::{BorrowedInstructionAccount, InstructionContextView},
     std::{cell::RefCell, rc::Rc},
 };
 
@@ -57,7 +57,7 @@ fn get_state_mut(data: &mut [u8]) -> Result<&mut LoaderV4State, InstructionError
 
 fn check_program_account(
     log_collector: &Option<Rc<RefCell<LogCollector>>>,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     program: &BorrowedInstructionAccount,
     authority_address: &Pubkey,
 ) -> Result<LoaderV4State, InstructionError> {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9743,6 +9743,7 @@ dependencies = [
  "solana-account",
  "solana-instruction",
  "solana-instructions-sysvar",
+ "solana-message",
  "solana-pubkey",
  "solana-rent",
  "solana-sbpf",

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -10,7 +10,9 @@ use {
     solana_svm_log_collector::ic_msg,
     solana_system_interface::error::SystemError,
     solana_sysvar::rent::Rent,
-    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContextView},
+    solana_transaction_context::{
+        BorrowedInstructionAccount, IndexOfAccount, InstructionContextView,
+    },
     std::collections::HashSet,
 };
 

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -10,7 +10,7 @@ use {
     solana_svm_log_collector::ic_msg,
     solana_system_interface::error::SystemError,
     solana_sysvar::rent::Rent,
-    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContext},
+    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContextView},
     std::collections::HashSet,
 };
 
@@ -81,7 +81,7 @@ pub(crate) fn withdraw_nonce_account(
     rent: &Rent,
     signers: &HashSet<Pubkey>,
     invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
 ) -> Result<(), InstructionError> {
     let mut from = instruction_context.try_borrow_instruction_account(from_account_index)?;
     if !from.is_writable() {

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -17,7 +17,9 @@ use {
     solana_system_interface::{
         error::SystemError, instruction::SystemInstruction, MAX_PERMITTED_DATA_LENGTH,
     },
-    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContextView},
+    solana_transaction_context::{
+        BorrowedInstructionAccount, IndexOfAccount, InstructionContextView,
+    },
     std::collections::HashSet,
 };
 

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -17,7 +17,7 @@ use {
     solana_system_interface::{
         error::SystemError, instruction::SystemInstruction, MAX_PERMITTED_DATA_LENGTH,
     },
-    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContext},
+    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContextView},
     std::collections::HashSet,
 };
 
@@ -153,7 +153,7 @@ fn create_account(
     owner: &Pubkey,
     signers: &HashSet<Pubkey>,
     invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
 ) -> Result<(), InstructionError> {
     // if it looks like the `to` account is already in use, bail
     {
@@ -183,7 +183,7 @@ fn transfer_verified(
     to_account_index: IndexOfAccount,
     lamports: u64,
     invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
 ) -> Result<(), InstructionError> {
     let mut from = instruction_context.try_borrow_instruction_account(from_account_index)?;
     if !from.get_data().is_empty() {
@@ -212,7 +212,7 @@ fn transfer(
     to_account_index: IndexOfAccount,
     lamports: u64,
     invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
 ) -> Result<(), InstructionError> {
     if !instruction_context.is_instruction_account_signer(from_account_index)? {
         ic_msg!(
@@ -240,7 +240,7 @@ fn transfer_with_seed(
     to_account_index: IndexOfAccount,
     lamports: u64,
     invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
 ) -> Result<(), InstructionError> {
     if !instruction_context.is_instruction_account_signer(from_base_account_index)? {
         ic_msg!(

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -10,14 +10,14 @@ use {
         sysvar_cache::get_sysvar_with_account_check,
     },
     solana_pubkey::Pubkey,
-    solana_transaction_context::{BorrowedInstructionAccount, InstructionContext},
+    solana_transaction_context::{BorrowedInstructionAccount, InstructionContextView},
     solana_vote_interface::{instruction::VoteInstruction, program::id, state::VoteAuthorize},
     std::collections::HashSet,
 };
 
 fn process_authorize_with_seed_instruction(
     invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     vote_account: &mut BorrowedInstructionAccount,
     new_authority: &Pubkey,
     authorization_type: VoteAuthorize,

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -15,7 +15,7 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_slot_hashes::SlotHash,
-    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContext},
+    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContextView},
     solana_vote_interface::{error::VoteError, program::id},
     std::{
         cmp::Ordering,
@@ -796,7 +796,7 @@ fn verify_authorized_signer<S: std::hash::BuildHasher>(
 
 /// Withdraw funds from the vote account
 pub fn withdraw<S: std::hash::BuildHasher>(
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     vote_account_index: IndexOfAccount,
     lamports: u64,
     to_account_index: IndexOfAccount,

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -15,7 +15,9 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_slot_hashes::SlotHash,
-    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContextView},
+    solana_transaction_context::{
+        BorrowedInstructionAccount, IndexOfAccount, InstructionContextView,
+    },
     solana_vote_interface::{error::VoteError, program::id},
     std::{
         cmp::Ordering,

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -26,6 +26,7 @@ serde_derive = { workspace = true, optional = true }
 solana-account = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-instructions-sysvar = { workspace = true }
+solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sbpf = { workspace = true }
 

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -115,7 +115,7 @@ pub struct TransactionContext {
     instruction_stack_capacity: usize,
     instruction_trace_capacity: usize,
     instruction_stack: Vec<usize>,
-    instruction_trace: Vec<InstructionFrame>,
+    instruction_trace: Vec<InstructionContext>,
     top_level_instruction_index: usize,
     return_data: TransactionReturnData,
     #[cfg(not(target_os = "solana"))]
@@ -136,7 +136,7 @@ impl TransactionContext {
             instruction_stack_capacity,
             instruction_trace_capacity,
             instruction_stack: Vec::with_capacity(instruction_stack_capacity),
-            instruction_trace: vec![InstructionFrame::default()],
+            instruction_trace: vec![InstructionContext::default()],
             top_level_instruction_index: 0,
             return_data: TransactionReturnData::default(),
             rent,
@@ -337,7 +337,7 @@ impl TransactionContext {
         if index_in_trace >= self.instruction_trace_capacity {
             return Err(InstructionError::MaxInstructionTraceLengthExceeded);
         }
-        self.instruction_trace.push(InstructionFrame::default());
+        self.instruction_trace.push(InstructionContext::default());
         if nesting_level >= self.instruction_stack_capacity {
             return Err(InstructionError::CallDepth);
         }
@@ -492,7 +492,7 @@ pub struct TransactionReturnData {
 
 /// Instruction shared between runtime and programs.
 #[derive(Debug, Clone, Default)]
-pub struct InstructionFrame {
+pub struct InstructionContext {
     nesting_level: usize,
     program_account_index_in_tx: IndexOfAccount,
     instruction_accounts: Vec<InstructionAccount>,

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -211,12 +211,12 @@ impl TransactionContext {
     pub fn get_instruction_context_at_index_in_trace(
         &self,
         index_in_trace: usize,
-    ) -> Result<InstructionContext, InstructionError> {
+    ) -> Result<InstructionContextView, InstructionError> {
         let instruction = self
             .instruction_trace
             .get(index_in_trace)
             .ok_or(InstructionError::CallDepth)?;
-        Ok(InstructionContext {
+        Ok(InstructionContextView {
             transaction_context: self,
             nesting_level: instruction.nesting_level,
             program_account_index_in_tx: instruction.program_account_index_in_tx,
@@ -230,7 +230,7 @@ impl TransactionContext {
     pub fn get_instruction_context_at_nesting_level(
         &self,
         nesting_level: usize,
-    ) -> Result<InstructionContext, InstructionError> {
+    ) -> Result<InstructionContextView, InstructionError> {
         let index_in_trace = *self
             .instruction_stack
             .get(nesting_level)
@@ -252,7 +252,7 @@ impl TransactionContext {
     }
 
     /// Returns a view on the current instruction
-    pub fn get_current_instruction_context(&self) -> Result<InstructionContext, InstructionError> {
+    pub fn get_current_instruction_context(&self) -> Result<InstructionContextView, InstructionError> {
         let level = self
             .get_instruction_stack_height()
             .checked_sub(1)
@@ -263,7 +263,7 @@ impl TransactionContext {
     /// Returns a view on the next instruction. This function assumes it has already been
     /// configured with the correct values in `prepare_next_instruction` or
     /// `prepare_next_top_level_instruction`
-    pub fn get_next_instruction_context(&self) -> Result<InstructionContext, InstructionError> {
+    pub fn get_next_instruction_context(&self) -> Result<InstructionContextView, InstructionError> {
         let index_in_trace = self
             .instruction_trace
             .len()
@@ -505,7 +505,7 @@ pub struct InstructionFrame {
 
 /// View interface to read instructions.
 #[derive(Debug, Clone)]
-pub struct InstructionContext<'a> {
+pub struct InstructionContextView<'a> {
     transaction_context: &'a TransactionContext,
     // The rest of the fields are redundant shortcuts
     nesting_level: usize,
@@ -515,7 +515,7 @@ pub struct InstructionContext<'a> {
     instruction_data: &'a [u8],
 }
 
-impl<'a> InstructionContext<'a> {
+impl<'a> InstructionContextView<'a> {
     /// How many Instructions were on the stack after this one was pushed
     ///
     /// That is the number of nested parent Instructions plus one (itself).


### PR DESCRIPTION
#### Problem

We could avoid making all copies of instruction data in the repository. For ABIv2, in particular, it is theoretically possible to avoid all copies (given that we can deal with all lifetimes correctly).

In this PR, I wanted to avoid copying instruction data out of InstructionContext when recording inner instructions.

#### Summary of Changes

Potentially unnecessary changes for this PR, but I did them because I am pedantic:
1. Rename `InstructionContext` to `InstructionContextView`.
2. Rename `InstructionFrame` to `InstructionContext`.
(I can remove them if someone believe they don't belong in here)


Necessary changes in this PR:
1. Delete `fn inner_instructions_list_from_instruction_trace`.
2. Create `fn deconstruct_into_record` for `TransactionContext`, which integrates the aforementioned function.
3. Move `test_inner_instructions_list_from_instruction_trace` to transaction context.
4. Create `impl Into<CompiledInstruction> for InstructionContext`
