### PR TITLE
Add `blockHeight` to the RPC context object

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -182,6 +182,7 @@ mod tests {
         let account_balance = 1;
         let account_balance_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -205,6 +206,7 @@ mod tests {
 
         let check_fee_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -218,6 +220,7 @@ mod tests {
 
         let check_fee_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -234,6 +237,7 @@ mod tests {
         let account_balance = 2;
         let account_balance_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -241,6 +245,7 @@ mod tests {
         });
         let check_fee_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -261,6 +266,7 @@ mod tests {
         let account_balance = 50;
         let account_balance_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -281,6 +287,7 @@ mod tests {
     fn test_get_fee_for_messages() {
         let check_fee_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -303,6 +310,7 @@ mod tests {
         // No signatures, no fee.
         let check_fee_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2151,6 +2151,7 @@ mod tests {
         let identity_keypair = Keypair::new();
         let vote_account_info_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -2191,6 +2192,7 @@ mod tests {
 
         let vote_account_info_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -2254,6 +2256,7 @@ mod tests {
         let custodian = solana_pubkey::new_rand();
         let vote_account_info_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -1505,6 +1505,7 @@ mod tests {
         };
         let account_info_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -183,7 +183,7 @@ fn test_account_subscription() {
     subscriptions.notify_subscribers(commitment_slots);
 
     let expected = json!({
-    "context": { "slot": 1 },
+        "context": { "blockHeight": 1, "slot": 1 },
         "value": {
             "owner": system_program::id().to_string(),
             "lamports": 100,

--- a/rpc-client-nonce-utils/src/blockhash_query.rs
+++ b/rpc-client-nonce-utils/src/blockhash_query.rs
@@ -285,6 +285,7 @@ mod tests {
         let rpc_blockhash = hash(&[1u8]);
         let get_latest_blockhash_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -295,6 +296,7 @@ mod tests {
         });
         let is_blockhash_valid_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -366,6 +368,7 @@ mod tests {
         );
         let get_account_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },

--- a/rpc-client-nonce-utils/src/nonblocking/blockhash_query.rs
+++ b/rpc-client-nonce-utils/src/nonblocking/blockhash_query.rs
@@ -292,6 +292,7 @@ mod tests {
 
         let get_latest_blockhash_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -303,6 +304,7 @@ mod tests {
 
         let is_blockhash_valid_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },
@@ -386,6 +388,7 @@ mod tests {
         );
         let get_account_response = json!(Response {
             context: RpcResponseContext {
+                block_height: 1,
                 slot: 1,
                 api_version: None
             },

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -72,6 +72,7 @@ pub struct RpcResponseContext {
     pub slot: Slot,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_version: Option<RpcApiVersion>,
+    pub block_height: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -112,8 +113,9 @@ impl<'de> Deserialize<'de> for RpcApiVersion {
 }
 
 impl RpcResponseContext {
-    pub fn new(slot: Slot) -> Self {
+    pub fn new(slot: Slot, block_height: u64) -> Self {
         Self {
+            block_height,
             slot,
             api_version: Some(RpcApiVersion::default()),
         }

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -154,11 +154,19 @@ impl RpcSender for MockSender {
 
         let val = match method.as_str().unwrap() {
             "getAccountInfo" => serde_json::to_value(Response {
-                context: RpcResponseContext { slot: 1, api_version: None },
+                context: RpcResponseContext {
+                    api_version: None,
+                    block_height: 1,
+                    slot: 1,
+                },
                 value: Value::Null,
             })?,
             "getBalance" => serde_json::to_value(Response {
-                context: RpcResponseContext { slot: 1, api_version: None },
+                context: RpcResponseContext {
+                    api_version: None,
+                    block_height: 1,
+                    slot: 1,
+                },
                 value: Value::Number(Number::from(50)),
             })?,
             "getEpochInfo" => serde_json::to_value(EpochInfo {
@@ -199,7 +207,11 @@ impl RpcSender for MockSender {
                     .map(|_| status.clone())
                     .collect();
                 serde_json::to_value(Response {
-                    context: RpcResponseContext { slot: 1, api_version: None },
+                    context: RpcResponseContext {
+                        api_version: None,
+                        block_height: 1,
+                        slot: 1,
+                    },
                     value: statuses,
                 })?
             }
@@ -264,7 +276,11 @@ impl RpcSender for MockSender {
             "getBlockProduction" => {
                 if params.is_null() {
                     json!(Response {
-                        context: RpcResponseContext { slot: 1, api_version: None },
+                        context: RpcResponseContext {
+                            api_version: None,
+                            block_height: 1,
+                            slot: 1,
+                        },
                         value: RpcBlockProduction {
                             by_identity: HashMap::new(),
                             range: RpcBlockProductionRange {
@@ -282,7 +298,11 @@ impl RpcSender for MockSender {
                     let config_range = config.range.unwrap_or_default();
 
                     json!(Response {
-                        context: RpcResponseContext { slot: 1, api_version: None },
+                        context: RpcResponseContext {
+                            api_version: None,
+                            block_height: 1,
+                            slot: 1,
+                        },
                         value: RpcBlockProduction {
                             by_identity,
                             range: RpcBlockProductionRange {
@@ -296,11 +316,19 @@ impl RpcSender for MockSender {
                 }
             }
             "getStakeMinimumDelegation" => json!(Response {
-                context: RpcResponseContext { slot: 1, api_version: None },
+                context: RpcResponseContext {
+                    api_version: None,
+                    block_height: 1,
+                    slot: 1,
+                },
                 value: 123_456_789,
             }),
             "getSupply" => json!(Response {
-                context: RpcResponseContext { slot: 1, api_version: None },
+                context: RpcResponseContext {
+                    api_version: None,
+                    block_height: 1,
+                    slot: 1,
+                },
                 value: RpcSupply {
                     total: 100000000,
                     circulating: 50000,
@@ -315,7 +343,11 @@ impl RpcSender for MockSender {
                 };
 
                 json!(Response {
-                    context: RpcResponseContext { slot: 1, api_version: None },
+                    context: RpcResponseContext {
+                        api_version: None,
+                        block_height: 1,
+                        slot: 1,
+                    },
                     value: vec![rpc_account_balance],
                 })
             }
@@ -346,7 +378,11 @@ impl RpcSender for MockSender {
                 Value::String(signature)
             }
             "simulateTransaction" => serde_json::to_value(Response {
-                context: RpcResponseContext { slot: 1, api_version: None },
+                context: RpcResponseContext {
+                    api_version: None,
+                    block_height: 1,
+                    slot: 1,
+                },
                 value: RpcSimulateTransactionResult {
                     err: None,
                     logs: None,
@@ -373,14 +409,22 @@ impl RpcSender for MockSender {
                 })
             }
             "getLatestBlockhash" => serde_json::to_value(Response {
-                context: RpcResponseContext { slot: 1, api_version: None },
+                context: RpcResponseContext {
+                    api_version: None,
+                    block_height: 1,
+                    slot: 1,
+                },
                 value: RpcBlockhash {
                     blockhash: PUBKEY.to_string(),
                     last_valid_block_height: 1234,
                 },
             })?,
             "getFeeForMessage" => serde_json::to_value(Response {
-                context: RpcResponseContext { slot: 1, api_version: None },
+                context: RpcResponseContext {
+                    api_version: None,
+                    block_height: 1,
+                    slot: 1,
+                },
                 value: json!(Some(0)),
             })?,
             "getClusterNodes" => serde_json::to_value(vec![RpcContactInfo {
@@ -474,7 +518,11 @@ impl RpcSender for MockSender {
             "minimumLedgerSlot" => json![123],
             "getMaxRetransmitSlot" => json![123],
             "getMultipleAccounts" => serde_json::to_value(Response {
-                context: RpcResponseContext { slot: 1, api_version: None },
+                context: RpcResponseContext {
+                    api_version: None,
+                    block_height: 1,
+                    slot: 1,
+                },
                 value: vec![Value::Null, Value::Null]
             })?,
             "getProgramAccounts" => {

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -418,7 +418,7 @@ impl RpcClient {
     /// // Create a mock with a custom response to the `GetBalance` request
     /// let account_balance = 50;
     /// let account_balance_response = json!(Response {
-    ///     context: RpcResponseContext { slot: 1, api_version: None },
+    ///     context: RpcResponseContext { block_height: 1, slot: 1, api_version: None },
     ///     value: json!(account_balance),
     /// });
     ///
@@ -490,6 +490,7 @@ impl RpcClient {
     ///         RpcRequest::GetBalance,
     ///         json!(Response {
     ///             context: RpcResponseContext {
+    ///                 block_height: 1,
     ///                 slot: 1,
     ///                 api_version: None,
     ///             },
@@ -500,6 +501,7 @@ impl RpcClient {
     ///         RpcRequest::GetBalance,
     ///         json!(Response {
     ///             context: RpcResponseContext {
+    ///                 block_height: 1,
     ///                 slot: 1,
     ///                 api_version: None,
     ///             },
@@ -513,6 +515,7 @@ impl RpcClient {
     ///     RpcRequest::GetBalance,
     ///     json!(Response {
     ///         context: RpcResponseContext {
+    ///             block_height: 1,
     ///             slot: 1,
     ///             api_version: None,
     ///         },
@@ -4787,6 +4790,7 @@ pub fn create_rpc_client_mocks() -> crate::mock_sender::Mocks {
     let get_account_request = RpcRequest::GetAccountInfo;
     let get_account_response = serde_json::to_value(Response {
         context: RpcResponseContext {
+            block_height: 1,
             slot: 1,
             api_version: None,
         },

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -497,7 +497,7 @@ impl RpcClient {
     /// // Create a mock with a custom response to the `GetBalance` request
     /// let account_balance = 50;
     /// let account_balance_response = json!(Response {
-    ///     context: RpcResponseContext { slot: 1, api_version: None },
+    ///     context: RpcResponseContext { block_height: 1, slot: 1, api_version: None },
     ///     value: json!(account_balance),
     /// });
     ///
@@ -570,6 +570,7 @@ impl RpcClient {
     ///         RpcRequest::GetBalance,
     ///         json!(Response {
     ///             context: RpcResponseContext {
+    ///                 block_height: 1,
     ///                 slot: 1,
     ///                 api_version: None,
     ///             },
@@ -580,6 +581,7 @@ impl RpcClient {
     ///         RpcRequest::GetBalance,
     ///         json!(Response {
     ///             context: RpcResponseContext {
+    ///                 block_height: 1,
     ///                 slot: 1,
     ///                 api_version: None,
     ///             },
@@ -593,6 +595,7 @@ impl RpcClient {
     ///     RpcRequest::GetBalance,
     ///     json!(Response {
     ///         context: RpcResponseContext {
+    ///             block_height: 1,
     ///             slot: 1,
     ///             api_version: None,
     ///         },
@@ -3788,6 +3791,7 @@ pub fn create_rpc_client_mocks() -> crate::mock_sender::Mocks {
     let get_account_request = RpcRequest::GetAccountInfo;
     let get_account_response = serde_json::to_value(Response {
         context: RpcResponseContext {
+            block_height: 1,
             slot: 1,
             api_version: None,
         },
@@ -4092,6 +4096,7 @@ mod tests {
                 RpcRequest::GetProgramAccounts,
                 serde_json::to_value(OptionalContext::Context(Response {
                     context: RpcResponseContext {
+                        block_height: 1,
                         slot: 1,
                         api_version: None,
                     },
@@ -4136,6 +4141,7 @@ mod tests {
                     RpcRequest::GetProgramAccounts,
                     serde_json::to_value(OptionalContext::Context(Response {
                         context: RpcResponseContext {
+                            block_height: 1,
                             slot: 1,
                             api_version: None,
                         },
@@ -4147,6 +4153,7 @@ mod tests {
                     RpcRequest::GetProgramAccounts,
                     serde_json::to_value(OptionalContext::Context(Response {
                         context: RpcResponseContext {
+                            block_height: 1,
                             slot: 1,
                             api_version: None,
                         },
@@ -4162,6 +4169,7 @@ mod tests {
                 RpcRequest::GetProgramAccounts,
                 serde_json::to_value(OptionalContext::Context(Response {
                     context: RpcResponseContext {
+                        block_height: 1,
                         slot: 1,
                         api_version: None,
                     },
@@ -4178,6 +4186,7 @@ mod tests {
                 RpcRequest::GetProgramAccounts,
                 serde_json::to_value(OptionalContext::Context(Response {
                     context: RpcResponseContext {
+                        block_height: 1,
                         slot: 1,
                         api_version: None,
                     },
@@ -4318,6 +4327,7 @@ mod tests {
                         return future::ok(json!(Response {
                             context: RpcResponseContext {
                                 api_version: None,
+                                block_height: 1,
                                 slot: 1,
                             },
                             value: json!(42),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -144,7 +144,7 @@ pub const PERFORMANCE_SAMPLES_LIMIT: usize = 720;
 
 fn new_response<T>(bank: &Bank, value: T) -> RpcResponse<T> {
     RpcResponse {
-        context: RpcResponseContext::new(bank.slot()),
+        context: RpcResponseContext::new(bank.slot(), bank.block_height()),
         value,
     }
 }
@@ -1053,7 +1053,7 @@ impl JsonRpcRequestProcessor {
 
         if let Some((slot, accounts)) = self.get_cached_largest_accounts(&config.filter) {
             Ok(RpcResponse {
-                context: RpcResponseContext::new(slot),
+                context: RpcResponseContext::new(slot, bank.block_height()),
                 value: accounts,
             })
         } else {
@@ -5106,7 +5106,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
-                "context": {"slot": 0, "apiVersion": RpcApiVersion::default()},
+                "context": {"blockHeight": 0, "slot": 0, "apiVersion": RpcApiVersion::default()},
                 "value":20,
                 },
             "id": 1,
@@ -5560,7 +5560,7 @@ pub mod tests {
         );
         let result: Value = parse_success_result(rpc.handle_request_sync(request));
         let expected = json!({
-            "context": {"slot": 0, "apiVersion": RpcApiVersion::default()},
+            "context": {"blockHeight": 0, "slot": 0, "apiVersion": RpcApiVersion::default()},
             "value":{
                 "owner": "11111111111111111111111111111111",
                 "lamports": TEST_MINT_LAMPORTS,
@@ -5850,7 +5850,7 @@ pub mod tests {
         let result: RpcResponse<Vec<RpcKeyedAccount>> =
             parse_success_result(rpc.handle_request_sync(request));
         let expected = RpcResponse {
-            context: RpcResponseContext::new(0),
+            context: RpcResponseContext::new(0, 0),
             value: expected_value,
         };
         assert_eq!(result, expected);
@@ -6018,7 +6018,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
-                "context": {"slot": 0, "apiVersion": RpcApiVersion::default()},
+                "context": {"blockHeight": 0, "slot": 0, "apiVersion": RpcApiVersion::default()},
                 "value":{
                     "accounts": [
                         null,
@@ -6121,7 +6121,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
-                "context": {"slot": 0, "apiVersion": RpcApiVersion::default()},
+                "context": {"blockHeight": 0, "slot": 0, "apiVersion": RpcApiVersion::default()},
                 "value":{
                     "accounts":null,
                     "err":null,
@@ -6158,7 +6158,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
-                "context": {"slot": 0, "apiVersion": RpcApiVersion::default()},
+                "context": {"blockHeight": 0, "slot": 0, "apiVersion": RpcApiVersion::default()},
                 "value":{
                     "accounts":null,
                     "err":null,
@@ -6219,7 +6219,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc":"2.0",
             "result": {
-                "context": {"slot": 0, "apiVersion": RpcApiVersion::default()},
+                "context": {"blockHeight": 0, "slot": 0, "apiVersion": RpcApiVersion::default()},
                 "value":{
                     "err":"BlockhashNotFound",
                     "accounts":null,
@@ -6259,7 +6259,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
-                "context": {"slot": 0, "apiVersion": RpcApiVersion::default()},
+                "context": {"blockHeight": 0, "slot": 0, "apiVersion": RpcApiVersion::default()},
                 "value":{
                     "accounts":null,
                     "err":null,
@@ -6388,7 +6388,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
-                "context": {"slot": 0, "apiVersion": RpcApiVersion::default()},
+                "context": {"blockHeight": 0, "slot": 0, "apiVersion": RpcApiVersion::default()},
                 "value":{
                     "accounts": [
                         null,
@@ -6501,7 +6501,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
-                "context": {"slot": 0, "apiVersion": RpcApiVersion::default()},
+                "context": {"blockHeight": 0, "slot": 0, "apiVersion": RpcApiVersion::default()},
                 "value":{
                     "accounts": null,
                     "err":null,
@@ -6550,7 +6550,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
-                "context": {"slot": 0, "apiVersion": RpcApiVersion::default()},
+                "context": {"blockHeight": 0, "slot": 0, "apiVersion": RpcApiVersion::default()},
                 "value":{
                     "accounts": null,
                     "err":null,
@@ -6599,7 +6599,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
-                "context": {"slot": 0, "apiVersion": RpcApiVersion::default()},
+                "context": {"blockHeight": 0, "slot": 0, "apiVersion": RpcApiVersion::default()},
                 "value":{
                     "accounts": null,
                     "err":null,

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -732,7 +732,7 @@ mod tests {
            "method": "signatureNotification",
            "params": {
                "result": {
-                   "context": { "slot": 0 },
+                   "context": { "blockHeight": 0, "slot": 0 },
                    "value": expected_res,
                },
                "subscription": 0,
@@ -756,7 +756,11 @@ mod tests {
         )
         .unwrap();
         let received_slot = 1;
-        rpc_subscriptions.notify_signatures_received((received_slot, vec![tx.signatures[0]]));
+        rpc_subscriptions.notify_signatures_received((
+            received_slot,
+            vec![tx.signatures[0]],
+            Some(received_slot),
+        ));
 
         // Test signature confirmation notification
         let response = receiver.recv();
@@ -767,7 +771,7 @@ mod tests {
            "method": "signatureNotification",
            "params": {
                "result": {
-                   "context": { "slot": received_slot },
+                   "context": { "blockHeight": received_slot, "slot": received_slot },
                    "value": expected_res,
                },
                "subscription": 1,
@@ -790,7 +794,11 @@ mod tests {
         )
         .unwrap();
         let received_slot = 2;
-        rpc_subscriptions.notify_signatures_received((received_slot, vec![tx.signatures[0]]));
+        rpc_subscriptions.notify_signatures_received((
+            received_slot,
+            vec![tx.signatures[0]],
+            Some(received_slot),
+        ));
 
         // Test signature confirmation notification
         let response = receiver.recv();
@@ -801,7 +809,7 @@ mod tests {
            "method": "signatureNotification",
            "params": {
                "result": {
-                   "context": { "slot": received_slot },
+                   "context": { "blockHeight": received_slot, "slot": received_slot },
                    "value": expected_res,
                },
                "subscription": 2,
@@ -962,7 +970,7 @@ mod tests {
            "method": "accountNotification",
            "params": {
                "result": {
-                   "context": { "slot": 1 },
+                   "context": { "blockHeight": 1, "slot": 1 },
                    "value": {
                        "owner": vote_program::id().to_string(),
                        "lamports": vote_balance,
@@ -1055,7 +1063,7 @@ mod tests {
            "method": "accountNotification",
            "params": {
                "result": {
-                   "context": { "slot": 1 },
+                   "context": { "blockHeight": 1, "slot": 1 },
                    "value": {
                        "owner": system_program::id().to_string(),
                        "lamports": 100,
@@ -1233,7 +1241,7 @@ mod tests {
            "method": "accountNotification",
            "params": {
                "result": {
-                   "context": { "slot": 1 },
+                   "context": { "blockHeight": 1, "slot": 1 },
                    "value": {
                        "owner": system_program::id().to_string(),
                        "lamports": 100,


### PR DESCRIPTION
#### Problem

Imagine that you had a blockhash, and you wanted to know until which block height it was valid as a transaction lifetime specifier. One idea would be to fetch the `SysvarRecentB1ockHashes11111111111111111111` account, find the candidate blockhash among the list, and count how many blocks from expiry it is.

```shell
curl http://0.0.0.0:8899 -s -X   POST -H "Content-Type: application/json" -d ' 
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "getAccountInfo",
    "params": [
      "SysvarRecentB1ockHashes11111111111111111111",
      {
        "commitment": "confirmed",
        "encoding": "jsonParsed"
      }
    ]
  }
'
{"jsonrpc":"2.0","result":{"context":{"apiVersion":"3.1.0","slot":855},"value":{"data":{"parsed":{"info":[{"blockhash":"EhCjeuR6LmzxTkQii2HWs7Ahdr9HeH61E9tgB8fGdTvq","feeCalculator":{"lamportsPerSignature":"5000"}},{"blockhash":"EEwvW4oACYxquRxdsNeFmH2TtxwQ7KjQopKu2tcsftvF","feeCalculator":{"lamportsPerSignature":"5000"}},{"blockhash":"Yr2bbSRrqeo9Pidj6xVyLdED3iqP8YzCG8HbNKBho1u","feeCalculator":{"lamportsPerSignature":"5000"}},
// ...
```

The problem with that is that though you know how many blocks from expiry it is by looking at its position in the list, you don't know the _current_ block height.

#### Summary of Changes

Add `blockHeight` to the context object.

#### Test Plan

```shell
curl http://0.0.0.0:8899 -s -X   POST -H "Content-Type: application/json" -d ' 
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "getAccountInfo",
    "params": [
      "SysvarRecentB1ockHashes11111111111111111111",
      {
        "commitment": "finalized",
        "encoding": "jsonParsed"
      }
    ]
  }
'
{"jsonrpc":"2.0","result":{"context":{"apiVersion":"3.1.0","blockHeight":855,"slot":855},"value":{"data":{"parsed":{"info":[{"blockhash":"EhCjeuR6LmzxTkQii2HWs7Ahdr9HeH61E9tgB8fGdTvq","feeCalculator":{"lamportsPerSignature":"5000"}},
// ...
```