### PR TITLE
Avoid copying instruction data from non-top-level instruction

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -527,7 +527,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         .configure_next_instruction_for_tests(
             program_index.saturating_add(1),
             instruction_accounts,
-            &instruction_data,
+            instruction_data,
         )
         .unwrap();
     invoke_context.push().unwrap();

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1842,7 +1842,7 @@ mod tests {
                     InstructionAccount::new(1, false, true),
                     InstructionAccount::new(1, false, true),
                 ],
-                &[],
+                vec![],
             )
             .unwrap();
         let accounts = translate_accounts_rust(

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -802,7 +802,7 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
         check_aligned,
     )?;
     check_authorized_program(&instruction.program_id, &instruction.data, invoke_context)?;
-    invoke_context.prepare_next_instruction(&instruction, &signers)?;
+    invoke_context.prepare_next_instruction(instruction, &signers)?;
 
     let mut accounts = S::translate_accounts(
         account_infos_addr,
@@ -1324,7 +1324,7 @@ mod tests {
                 .configure_next_instruction_for_tests(
                     $program_account,
                     instruction_accounts,
-                    instruction_data,
+                    instruction_data.to_vec(),
                 )
                 .unwrap();
             $invoke_context.push().unwrap();

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -296,7 +296,7 @@ impl<'a> InvokeContext<'a> {
         instruction: Instruction,
         signers: &[Pubkey],
     ) -> Result<(), InstructionError> {
-        self.prepare_next_instruction(&instruction, signers)?;
+        self.prepare_next_instruction(instruction, signers)?;
         let mut compute_units_consumed = 0;
         self.process_instruction(&mut compute_units_consumed, &mut ExecuteTimings::default())?;
         Ok(())
@@ -306,7 +306,7 @@ impl<'a> InvokeContext<'a> {
     /// and depends on `AccountMeta`s
     pub fn prepare_next_instruction(
         &mut self,
-        instruction: &Instruction,
+        instruction: Instruction,
         signers: &[Pubkey],
     ) -> Result<(), InstructionError> {
         // We reference accounts by an u8 index, so we have a total of 256 accounts.
@@ -895,7 +895,11 @@ pub fn mock_process_instruction_with_feature_set<
     pre_adjustments(&mut invoke_context);
     invoke_context
         .transaction_context
-        .configure_next_instruction_for_tests(program_index, instruction_accounts, instruction_data.to_vec())
+        .configure_next_instruction_for_tests(
+            program_index,
+            instruction_accounts,
+            instruction_data.to_vec(),
+        )
         .unwrap();
     let result = invoke_context.process_instruction(&mut 0, &mut ExecuteTimings::default());
     assert_eq!(result, expected_result);
@@ -1265,7 +1269,7 @@ mod tests {
             metas.clone(),
         );
         invoke_context
-            .prepare_next_instruction(&inner_instruction, &[])
+            .prepare_next_instruction(inner_instruction, &[])
             .unwrap();
 
         let mut compute_units_consumed = 0;
@@ -1452,13 +1456,13 @@ mod tests {
 
         invoke_context.transaction_context.push().unwrap();
         invoke_context
-            .prepare_next_instruction(&instruction_1, &[fee_payer.pubkey()])
+            .prepare_next_instruction(instruction_1, &[fee_payer.pubkey()])
             .unwrap();
         test_case_1(&invoke_context);
 
         invoke_context.transaction_context.push().unwrap();
         invoke_context
-            .prepare_next_instruction(&instruction_2, &[fee_payer.pubkey()])
+            .prepare_next_instruction(instruction_2, &[fee_payer.pubkey()])
             .unwrap();
         test_case_2(&invoke_context);
     }
@@ -1538,7 +1542,7 @@ mod tests {
         );
 
         invoke_context
-            .prepare_next_instruction(&instruction, &[fee_payer.pubkey()])
+            .prepare_next_instruction(instruction, &[fee_payer.pubkey()])
             .unwrap();
         let instruction_context = invoke_context
             .transaction_context

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -443,7 +443,7 @@ impl<'a> InvokeContext<'a> {
             program_account_index,
             instruction_accounts,
             transaction_callee_map,
-            &instruction.data,
+            instruction.data,
         )?;
         Ok(())
     }
@@ -488,7 +488,7 @@ impl<'a> InvokeContext<'a> {
             program_account_index,
             instruction_accounts,
             transaction_callee_map,
-            instruction.data,
+            instruction.data.to_vec(),
         )?;
         Ok(())
     }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -895,7 +895,7 @@ pub fn mock_process_instruction_with_feature_set<
     pre_adjustments(&mut invoke_context);
     invoke_context
         .transaction_context
-        .configure_next_instruction_for_tests(program_index, instruction_accounts, instruction_data)
+        .configure_next_instruction_for_tests(program_index, instruction_accounts, instruction_data.to_vec())
         .unwrap();
     let result = invoke_context.process_instruction(&mut 0, &mut ExecuteTimings::default());
     assert_eq!(result, expected_result);
@@ -1031,7 +1031,7 @@ mod tests {
                         );
                         invoke_context
                             .transaction_context
-                            .configure_next_instruction_for_tests(3, instruction_accounts, &[])
+                            .configure_next_instruction_for_tests(3, instruction_accounts, vec![])
                             .unwrap();
                         let result = invoke_context.push();
                         assert_eq!(result, Err(InstructionError::UnbalancedInstruction));
@@ -1106,7 +1106,7 @@ mod tests {
                 .configure_next_instruction_for_tests(
                     one_more_than_max_depth.saturating_add(depth_reached) as IndexOfAccount,
                     instruction_accounts.clone(),
-                    &[],
+                    vec![],
                 )
                 .unwrap();
             if Err(InstructionError::CallDepth) == invoke_context.push() {
@@ -1136,7 +1136,7 @@ mod tests {
                 .configure_next_instruction_for_tests(
                     0,
                     vec![InstructionAccount::new(0, false, false)],
-                    &[],
+                    vec![],
                 )
                 .unwrap();
             transaction_context.pop().unwrap();
@@ -1197,7 +1197,7 @@ mod tests {
         // Account modification tests
         invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(4, instruction_accounts, &[])
+            .configure_next_instruction_for_tests(4, instruction_accounts, vec![])
             .unwrap();
         invoke_context.push().unwrap();
         let inner_instruction =
@@ -1253,7 +1253,7 @@ mod tests {
         let compute_units_to_consume = 10;
         invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(4, instruction_accounts, &[])
+            .configure_next_instruction_for_tests(4, instruction_accounts, vec![])
             .unwrap();
         invoke_context.push().unwrap();
         let inner_instruction = Instruction::new_with_bincode(
@@ -1298,7 +1298,7 @@ mod tests {
 
         invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(0, vec![], &[])
+            .configure_next_instruction_for_tests(0, vec![], vec![])
             .unwrap();
         invoke_context.push().unwrap();
         assert_eq!(*invoke_context.get_compute_budget(), execution_budget);
@@ -1338,7 +1338,7 @@ mod tests {
 
         invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(2, instruction_accounts, &instruction_data)
+            .configure_next_instruction_for_tests(2, instruction_accounts, instruction_data)
             .unwrap();
         let result = invoke_context.process_instruction(&mut 0, &mut ExecuteTimings::default());
 

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -800,7 +800,7 @@ mod tests {
                         .configure_next_instruction_for_tests(
                             0,
                             instruction_accounts,
-                            &instruction_data,
+                            instruction_data,
                         )
                         .unwrap();
                 }
@@ -961,7 +961,7 @@ mod tests {
                 .configure_next_instruction_for_tests(
                     0,
                     instruction_accounts.clone(),
-                    &instruction_data,
+                    instruction_data,
                 )
                 .unwrap();
             invoke_context.push().unwrap();
@@ -1058,7 +1058,7 @@ mod tests {
             // check serialize_parameters_unaligned
             invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(7, instruction_accounts, &instruction_data)
+                .configure_next_instruction_for_tests(7, instruction_accounts, instruction_data)
                 .unwrap();
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
@@ -1217,14 +1217,13 @@ mod tests {
             ];
             let instruction_accounts =
                 deduplicated_instruction_accounts(&[1, 1, 2, 3, 4, 4, 5, 6], |index| index >= 4);
-            let instruction_data = vec![];
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
             invoke_context
                 .transaction_context
                 .configure_next_instruction_for_tests(
                     0,
                     instruction_accounts.clone(),
-                    &instruction_data,
+                    vec![],
                 )
                 .unwrap();
             invoke_context.push().unwrap();
@@ -1259,7 +1258,7 @@ mod tests {
             // check serialize_parameters_unaligned
             invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(7, instruction_accounts, &instruction_data)
+                .configure_next_instruction_for_tests(7, instruction_accounts, instruction_data)
                 .unwrap();
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
@@ -1483,9 +1482,8 @@ mod tests {
         let transaction_accounts_indexes = [0, 1, 2, 3, 4, 5];
         let instruction_accounts =
             deduplicated_instruction_accounts(&transaction_accounts_indexes, |index| index > 0);
-        let instruction_data = [];
         transaction_context
-            .configure_next_instruction_for_tests(6, instruction_accounts, &instruction_data)
+            .configure_next_instruction_for_tests(6, instruction_accounts, vec![])
             .unwrap();
         transaction_context.push().unwrap();
         let instruction_context = transaction_context

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -791,7 +791,7 @@ mod tests {
                             0,
                             instruction_accounts,
                             dedup_map,
-                            &instruction_data,
+                            instruction_data,
                         )
                         .unwrap();
                 } else {

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -791,7 +791,7 @@ mod tests {
                             0,
                             instruction_accounts,
                             dedup_map,
-                            instruction_data,
+                            instruction_data.clone(),
                         )
                         .unwrap();
                 } else {
@@ -800,7 +800,7 @@ mod tests {
                         .configure_next_instruction_for_tests(
                             0,
                             instruction_accounts,
-                            instruction_data,
+                            instruction_data.clone(),
                         )
                         .unwrap();
                 }
@@ -961,7 +961,7 @@ mod tests {
                 .configure_next_instruction_for_tests(
                     0,
                     instruction_accounts.clone(),
-                    instruction_data,
+                    instruction_data.clone(),
                 )
                 .unwrap();
             invoke_context.push().unwrap();
@@ -1058,7 +1058,11 @@ mod tests {
             // check serialize_parameters_unaligned
             invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(7, instruction_accounts, instruction_data)
+                .configure_next_instruction_for_tests(
+                    7,
+                    instruction_accounts,
+                    instruction_data.clone(),
+                )
                 .unwrap();
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
@@ -1220,11 +1224,7 @@ mod tests {
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
             invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(
-                    0,
-                    instruction_accounts.clone(),
-                    vec![],
-                )
+                .configure_next_instruction_for_tests(0, instruction_accounts.clone(), vec![])
                 .unwrap();
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
@@ -1258,7 +1258,7 @@ mod tests {
             // check serialize_parameters_unaligned
             invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(7, instruction_accounts, instruction_data)
+                .configure_next_instruction_for_tests(7, instruction_accounts, vec![])
                 .unwrap();
             invoke_context.push().unwrap();
             let instruction_context = invoke_context

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -270,7 +270,7 @@ impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
             .collect::<Vec<_>>();
 
         invoke_context
-            .prepare_next_instruction(instruction, &signers)
+            .prepare_next_instruction(instruction.clone(), &signers)
             .unwrap();
 
         // Copy caller's account_info modifications into invoke_context accounts

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -100,7 +100,7 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
         TransactionContext::new(transaction_accounts, Rent::default(), 1, 1);
     let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
     transaction_context
-        .configure_next_instruction_for_tests(0, instruction_accounts, &instruction_data)
+        .configure_next_instruction_for_tests(0, instruction_accounts, instruction_data)
         .unwrap();
     transaction_context.push().unwrap();
     transaction_context

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -69,7 +69,7 @@ macro_rules! with_mock_invoke_context {
         );
         $invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(1, instruction_accounts, &[])
+            .configure_next_instruction_for_tests(1, instruction_accounts, vec![])
             .unwrap();
         $invoke_context.push().unwrap();
     };

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -262,7 +262,7 @@ mod test {
         ($invoke_context:expr, $transaction_context:ident, $instruction_context:ident, $instruction_accounts:ident) => {
             $invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(2, $instruction_accounts, &[])
+                .configure_next_instruction_for_tests(2, $instruction_accounts, vec![])
                 .unwrap();
             $invoke_context.push().unwrap();
             let $transaction_context = &$invoke_context.transaction_context;

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -997,7 +997,7 @@ mod tests {
             .configure_next_instruction_for_tests(
                 0,
                 vec![InstructionAccount::new(1, false, true)],
-                &[],
+                vec![],
             )
             .unwrap();
         transaction_context

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1186,7 +1186,7 @@ mod tests {
             .configure_next_instruction_for_tests(
                 0,
                 vec![InstructionAccount::new(1, false, true)],
-                &[],
+                vec![],
             )
             .unwrap();
         let instruction_context = transaction_context.get_next_instruction_context().unwrap();
@@ -1338,7 +1338,7 @@ mod tests {
             .configure_next_instruction_for_tests(
                 0,
                 vec![InstructionAccount::new(1, false, true)],
-                &[],
+                vec![],
             )
             .unwrap();
         let instruction_context = transaction_context.get_next_instruction_context().unwrap();

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1263,7 +1263,7 @@ mod tests {
             }
             if stack_height > transaction_context.get_instruction_stack_height() {
                 transaction_context
-                    .configure_next_instruction_for_tests(0, vec![], &[index_in_trace as u8])
+                    .configure_next_instruction_for_tests(0, vec![], vec![index_in_trace as u8])
                     .unwrap();
                 transaction_context.push().unwrap();
             }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -4351,7 +4351,7 @@ mod tests {
                     .configure_next_instruction_for_tests(
                         0,
                         instruction_accounts,
-                        &[index_in_trace as u8],
+                        vec![index_in_trace as u8],
                     )
                     .unwrap();
                 invoke_context.transaction_context.push().unwrap();

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2117,7 +2117,7 @@ mod tests {
             with_mock_invoke_context!($invoke_context, transaction_context, transaction_accounts);
             $invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(1, vec![], &[])
+                .configure_next_instruction_for_tests(1, vec![], vec![])
                 .unwrap();
             $invoke_context.push().unwrap();
         };

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -280,7 +280,7 @@ impl TransactionContext {
         program_index: IndexOfAccount,
         instruction_accounts: Vec<InstructionAccount>,
         deduplication_map: Vec<u8>,
-        instruction_data: &[u8],
+        instruction_data: Vec<u8>,
     ) -> Result<(), InstructionError> {
         debug_assert_eq!(deduplication_map.len(), MAX_ACCOUNTS_PER_TRANSACTION);
         let instruction = self
@@ -289,7 +289,7 @@ impl TransactionContext {
             .ok_or(InstructionError::CallDepth)?;
         instruction.program_account_index_in_tx = program_index;
         instruction.instruction_accounts = instruction_accounts;
-        instruction.instruction_data = instruction_data.to_vec();
+        instruction.instruction_data = instruction_data;
         instruction.dedup_map = deduplication_map;
         Ok(())
     }
@@ -315,7 +315,7 @@ impl TransactionContext {
             program_index,
             instruction_accounts,
             dedup_map,
-            instruction_data,
+            instruction_data.to_vec(),
         )
     }
 

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -299,7 +299,7 @@ impl TransactionContext {
         &mut self,
         program_index: IndexOfAccount,
         instruction_accounts: Vec<InstructionAccount>,
-        instruction_data: &[u8],
+        instruction_data: Vec<u8>,
     ) -> Result<(), InstructionError> {
         debug_assert!(instruction_accounts.len() <= u8::MAX as usize);
         let mut dedup_map = vec![u8::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
@@ -315,7 +315,7 @@ impl TransactionContext {
             program_index,
             instruction_accounts,
             dedup_map,
-            instruction_data.to_vec(),
+            instruction_data,
         )
     }
 
@@ -1139,7 +1139,7 @@ mod tests {
             .configure_next_instruction_for_tests(
                 u16::MAX,
                 vec![InstructionAccount::new(0, false, false)],
-                &[],
+                vec![],
             )
             .unwrap();
         let instruction_context = transaction_context.get_next_instruction_context().unwrap();


### PR DESCRIPTION
#### Problem

We can theoretically avoid copies of instruction data in program runtime. In this PR, by changing the argument type of two functions, we can remove the copy from non top level instructions.

#### Summary of Changes

1. `fn prepare_next_instruction` now owns the `Instruction`.
2. `fn configure_next_instruction` and `fn configure_next_instruction_for_tests` now expects an owned vector.
