### PR TITLE
Unify workspace crate readme references

### DIFF
--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -2,7 +2,6 @@
 name = "solana-bucket-map"
 description = "solana-bucket-map"
 documentation = "https://docs.rs/solana-bucket-map"
-readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "solana-core"
 documentation = "https://docs.rs/solana-core"
-readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
 description = { workspace = true }

--- a/measure/Cargo.toml
+++ b/measure/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "solana-measure"
 documentation = "https://docs.rs/solana-measure"
-readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
 description = { workspace = true }

--- a/rayon-threadlimit/Cargo.toml
+++ b/rayon-threadlimit/Cargo.toml
@@ -2,7 +2,6 @@
 name = "solana-rayon-threadlimit"
 description = "solana-rayon-threadlimit"
 documentation = "https://docs.rs/solana-rayon-threadlimit"
-readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/scheduler-bindings/Cargo.toml
+++ b/scheduler-bindings/Cargo.toml
@@ -2,7 +2,6 @@
 name = "agave-scheduler-bindings"
 description = "Agave scheduler-binding message types for external pack process integration"
 documentation = "https://docs.rs/agave-scheduler-bindings"
-readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/svm-measure/Cargo.toml
+++ b/svm-measure/Cargo.toml
@@ -2,7 +2,6 @@
 name = "solana-svm-measure"
 description = "Timing measurement utilities for SVM"
 documentation = "https://docs.rs/solana-svm-measure"
-readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "solana-test-validator"
-readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
 description = { workspace = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "agave-validator"
+readme = "../README.md"
 documentation = "https://docs.rs/agave-validator"
 default-run = "agave-validator"
 version = { workspace = true }

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "solana-votor-messages"
 documentation = "https://docs.rs/solana-votor-messages"
-readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
 description = { workspace = true }

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "agave-votor"
 documentation = "https://docs.rs/agave-votor"
-readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
 description = { workspace = true }


### PR DESCRIPTION
#### Problem
The top level README is mostly scoped for `agave-validator` crate/bin, not necessarily all of the implementation detail crates that also live within this repo

#### Summary of Changes
Leave agave-validator as the only crate referencing the README file at the repo root