### PR TITLE
ci: remove cargo.lock filtering logic from version bump script

### DIFF
--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -146,48 +146,6 @@ done
 # Update cargo lock files
 scripts/cargo-for-all-lock-files.sh tree >/dev/null
 
-# Filter out unrelated changes
-# some other dependencies might change after the tree command (like hashbrown)
-# the workaround is to filter out unrelated changes then apply the patch
-(
-  shopt -s globstar
-  git diff --unified=0 ./**/Cargo.lock >cargo-lock-patch
-  grep -E '^(diff|index|---|\+\+\+|@@.*@@ name = .*|-version|\+version|@@.*@@ dependencies.*|- "agave-|\+ "agave-|- "solana-|\+ "solana-)' cargo-lock-patch >filtered-cargo-lock-patch
-
-  # there might some orphaned dependency lines in the filtered file
-  # this is a workaround to filter them out
-  # 1. read the filtered file into an array
-  # 2. iterate over the array
-  # 3. if the line is a dependency line, check the next line to see if it's an orphaned dependency line
-  #     a. if it is, add the current line to the file
-  #     b. if it's not, don't add the current line to the file
-  tmp_file=$(mktemp)
-  mapfile -t lines <filtered-cargo-lock-patch
-  i=0
-  total=${#lines[@]}
-  while [ "$i" -lt "$total" ]; do
-    line="${lines[$i]}"
-    i=$((i + 1))
-
-    # filter out orphaned dependency lines
-    if [[ "$line" =~ ^@@.*dependencies ]]; then
-      if [ "$i" -lt "$total" ]; then
-        next_line="${lines[$i]}"
-        if [[ "$next_line" =~ ^[+-] ]]; then
-          echo "$line" >>"$tmp_file"
-        fi
-      fi
-    else
-      echo "$line" >>"$tmp_file"
-    fi
-  done
-  mv "$tmp_file" filtered-cargo-lock-patch
-
-  git ls-files -- **/Cargo.lock | xargs -I {} git checkout {}
-  git apply --unidiff-zero filtered-cargo-lock-patch
-  rm cargo-lock-patch filtered-cargo-lock-patch
-)
-
 echo "$currentVersion -> $newVersion"
 
 exit 0


### PR DESCRIPTION
#### Problem

we added a hack for cargo.lock during version bumps because some dependency versions were being updated unexpectedly. however, the hack doesn't really fit all cases. in our latest 3.0.x release, we updated `solana-curve25519`, but its checksum was filtered out since it wasn't included in the filter logic 🫠 

honestly, the hack is just a workaround. I just checked v3.0 and v3.1 (master) and it looks like the unexpected behavior has disappeared. I think we can try removing the hack and see how it goes.

#### Summary of Changes

remove the hacking logic from version bump script