### PR TITLE
(Alpenglow) Upstream voting_utils and consensus_metrics.rs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "bs58",
  "crossbeam-channel",
  "dashmap",
+ "histogram",
  "itertools 0.12.1",
  "log",
  "lru",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -294,6 +294,7 @@ dependencies = [
  "bs58",
  "crossbeam-channel",
  "dashmap",
+ "histogram",
  "itertools 0.12.1",
  "log",
  "lru",

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -29,6 +29,7 @@ bitvec = { workspace = true }
 bs58 = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api"] }
+histogram = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }

--- a/votor/src/consensus_metrics.rs
+++ b/votor/src/consensus_metrics.rs
@@ -1,0 +1,228 @@
+#![allow(dead_code)]
+
+use {
+    histogram::Histogram,
+    solana_clock::{Epoch, Slot},
+    solana_metrics::datapoint_info,
+    solana_pubkey::Pubkey,
+    solana_votor_messages::vote::Vote,
+    std::{
+        collections::BTreeMap,
+        time::{Duration, Instant},
+    },
+};
+
+/// Returns a [`Histogram`] configured for the use cases for this module.
+///
+/// Keeps the default precision and reduces the max value to 10s to get finer grained resolution.
+fn build_histogram() -> Histogram {
+    Histogram::configure()
+        .max_value(10_000_000)
+        .build()
+        .unwrap()
+}
+
+/// Tracks all [`Vote`] metrics for a given node.
+#[derive(Debug)]
+struct NodeVoteMetrics {
+    notar: Histogram,
+    notar_fallback: Histogram,
+    skip: Histogram,
+    skip_fallback: Histogram,
+    final_: Histogram,
+}
+
+impl Default for NodeVoteMetrics {
+    fn default() -> Self {
+        let histogram = build_histogram();
+        Self {
+            notar: histogram.clone(),
+            notar_fallback: histogram.clone(),
+            skip: histogram.clone(),
+            skip_fallback: histogram.clone(),
+            final_: histogram,
+        }
+    }
+}
+
+impl NodeVoteMetrics {
+    /// Records metrics for when `vote` was received after `elapsed` time has passed since the start of the slot.
+    fn record_vote(&mut self, vote: &Vote, elapsed: Duration) {
+        let elapsed = elapsed.as_micros();
+        let elapsed = match elapsed.try_into() {
+            Ok(e) => e,
+            Err(err) => {
+                warn!(
+                    "recording duration {elapsed} for vote {vote:?}: conversion to u64 failed \
+                     with {err}"
+                );
+                return;
+            }
+        };
+        let res = match vote {
+            Vote::Notarize(_) => self.notar.increment(elapsed),
+            Vote::NotarizeFallback(_) => self.notar_fallback.increment(elapsed),
+            Vote::Skip(_) => self.skip.increment(elapsed),
+            Vote::SkipFallback(_) => self.skip_fallback.increment(elapsed),
+            Vote::Finalize(_) => self.final_.increment(elapsed),
+        };
+        match res {
+            Ok(()) => (),
+            Err(err) => {
+                warn!(
+                    "recording duration {elapsed} for vote {vote:?}: recording failed with {err}"
+                );
+            }
+        }
+    }
+}
+
+/// Errors returned from [`AgMetrics::record_vote`].
+#[derive(Debug)]
+pub enum RecordVoteError {
+    /// Could not find start of slot entry.
+    SlotNotFound,
+}
+
+/// Errors returned from [`AgMetrics::record_block_hash_seen`].
+#[derive(Debug)]
+pub enum RecordBlockHashError {
+    /// Could not find start of slot entry.
+    SlotNotFound,
+}
+
+/// Tracks various Consensus related metrics.
+pub struct ConsensusMetrics {
+    /// Used to track this node's view of how the other nodes on the network are voting.
+    node_metrics: BTreeMap<Pubkey, NodeVoteMetrics>,
+    /// Used to track when this node received blocks from different leaders in the network.
+    leader_metrics: BTreeMap<Pubkey, Histogram>,
+    /// Tracks when individual slots began.
+    ///
+    /// Relies on [`TimerManager`] to notify of start of slots.
+    /// The manager uses parent ready event and timeouts as per the Alpenglow protocol to determine start of slots.
+    start_of_slot: BTreeMap<Slot, Instant>,
+    /// Tracks the current epoch, used for end of epoch reporting.
+    current_epoch: Epoch,
+}
+
+impl ConsensusMetrics {
+    pub fn new(epoch: Epoch) -> Self {
+        Self {
+            node_metrics: BTreeMap::default(),
+            leader_metrics: BTreeMap::default(),
+            start_of_slot: BTreeMap::default(),
+            current_epoch: epoch,
+        }
+    }
+
+    /// Records a `vote` from the node with `id`.
+    pub fn record_vote(&mut self, id: Pubkey, vote: &Vote) -> Result<(), RecordVoteError> {
+        let Some(start) = self.start_of_slot.get(&vote.slot()) else {
+            return Err(RecordVoteError::SlotNotFound);
+        };
+        let node = self.node_metrics.entry(id).or_default();
+        let elapsed = start.elapsed();
+        node.record_vote(vote, elapsed);
+        Ok(())
+    }
+
+    /// Records when a block for `slot` was seen and the `leader` is responsible for producing it.
+    pub fn record_block_hash_seen(
+        &mut self,
+        leader: Pubkey,
+        slot: Slot,
+    ) -> Result<(), RecordBlockHashError> {
+        let Some(start) = self.start_of_slot.get(&slot) else {
+            return Err(RecordBlockHashError::SlotNotFound);
+        };
+        let elapsed = start.elapsed().as_micros();
+        let elapsed = match elapsed.try_into() {
+            Ok(e) => e,
+            Err(err) => {
+                warn!(
+                    "recording duration {elapsed} for block hash for slot {slot}: conversion to \
+                     u64 failed with {err}"
+                );
+                return Ok(());
+            }
+        };
+        let histogram = self
+            .leader_metrics
+            .entry(leader)
+            .or_insert_with(build_histogram);
+        match histogram.increment(elapsed) {
+            Ok(()) => (),
+            Err(err) => {
+                warn!(
+                    "recording duration {elapsed} for block hash for slot {slot}: recording \
+                     failed with {err}"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Records when a given slot started.
+    pub fn record_start_of_slot(&mut self, slot: Slot) {
+        self.start_of_slot.entry(slot).or_insert(Instant::now());
+    }
+
+    /// Performs end of epoch reporting and reset all the statistics for the subsequent epoch.
+    fn end_of_epoch_reporting(&mut self) {
+        for (addr, metrics) in &self.node_metrics {
+            let addr = addr.to_string();
+            datapoint_info!("votor_consensus_metrics",
+                "address" => addr,
+                ("notar_vote_count", metrics.notar.entries(), i64),
+                ("notar_vote_mean", metrics.notar.mean().ok(), Option<i64>),
+                ("notar_vote_stddev", metrics.notar.stddev(), Option<i64>),
+                ("notar_vote_maximum", metrics.notar.maximum().ok(), Option<i64>),
+
+                ("notar_fallback_vote_count", metrics.notar_fallback.entries(), i64),
+                ("notar_fallback_vote_mean", metrics.notar_fallback.mean().ok(), Option<i64>),
+                ("notar_fallback_vote_stddev", metrics.notar_fallback.stddev(), Option<i64>),
+                ("notar_fallback_vote_maximum", metrics.notar_fallback.maximum().ok(), Option<i64>),
+
+                ("skip_vote_count", metrics.skip.entries(), i64),
+                ("skip_vote_mean", metrics.skip.mean().ok(), Option<i64>),
+                ("skip_vote_stddev", metrics.skip.stddev(), Option<i64>),
+                ("skip_vote_maximum", metrics.skip.maximum().ok(), Option<i64>),
+
+                ("skip_fallback_vote_count", metrics.skip_fallback.entries(), i64),
+                ("skip_fallback_vote_mean", metrics.skip_fallback.mean().ok(), Option<i64>),
+                ("skip_fallback_vote_stddev", metrics.skip_fallback.stddev(), Option<i64>),
+                ("skip_fallback_vote_maximum", metrics.skip_fallback.maximum().ok(), Option<i64>),
+
+                ("finalize_vote_count", metrics.final_.entries(), i64),
+                ("finalize_vote_mean", metrics.final_.mean().ok(), Option<i64>),
+                ("finalize_vote_stddev", metrics.final_.stddev(), Option<i64>),
+                ("finalize_vote_maximum", metrics.final_.maximum().ok(), Option<i64>),
+            );
+        }
+
+        for (addr, histogram) in &self.leader_metrics {
+            let addr = addr.to_string();
+            datapoint_info!("votor_consensus_metrics",
+                "address" => addr,
+                ("blocks_seen_vote_count", histogram.entries(), i64),
+                ("blocks_seen_vote_mean", histogram.mean().ok(), Option<i64>),
+                ("blocks_seen_vote_stddev", histogram.stddev(), Option<i64>),
+                ("blocks_seen_vote_maximum", histogram.maximum().ok(), Option<i64>),
+            );
+        }
+
+        self.node_metrics.clear();
+        self.leader_metrics.clear();
+        self.start_of_slot.clear();
+    }
+
+    /// This function can be called if there is a new [`Epoch`] and it will carry out end of epoch reporting.
+    pub fn maybe_new_epoch(&mut self, epoch: Epoch) {
+        assert!(epoch >= self.current_epoch);
+        if epoch != self.current_epoch {
+            self.current_epoch = epoch;
+            self.end_of_epoch_reporting();
+        }
+    }
+}

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -7,6 +7,9 @@ pub mod commitment;
 pub mod common;
 
 #[cfg(feature = "agave-unstable-api")]
+mod consensus_metrics;
+
+#[cfg(feature = "agave-unstable-api")]
 pub mod consensus_pool;
 
 #[cfg(feature = "agave-unstable-api")]
@@ -35,6 +38,9 @@ pub mod vote_history_storage;
 
 #[cfg(feature = "agave-unstable-api")]
 mod voting_service;
+
+#[cfg(feature = "agave-unstable-api")]
+mod voting_utils;
 
 #[cfg_attr(feature = "frozen-abi", macro_use)]
 #[cfg(feature = "frozen-abi")]

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -1,0 +1,656 @@
+#![allow(dead_code)]
+
+use {
+    crate::{
+        commitment::{CommitmentAggregationData, CommitmentError},
+        consensus_metrics::ConsensusMetrics,
+        vote_history::{VoteHistory, VoteHistoryError},
+        vote_history_storage::{SavedVoteHistory, SavedVoteHistoryVersions},
+        voting_service::BLSOp,
+    },
+    crossbeam_channel::{SendError, Sender},
+    parking_lot::RwLock as PlRwLock,
+    solana_bls_signatures::{
+        keypair::Keypair as BLSKeypair, pubkey::PubkeyCompressed as BLSPubkeyCompressed, BlsError,
+        Pubkey as BLSPubkey,
+    },
+    solana_clock::Slot,
+    solana_keypair::Keypair,
+    solana_pubkey::Pubkey,
+    solana_runtime::{bank::Bank, bank_forks::SharableBanks},
+    solana_signer::Signer,
+    solana_transaction::Transaction,
+    solana_votor_messages::{
+        consensus_message::{ConsensusMessage, VoteMessage, BLS_KEYPAIR_DERIVE_SEED},
+        vote::Vote,
+    },
+    std::{collections::HashMap, sync::Arc},
+    thiserror::Error,
+};
+
+#[derive(Debug)]
+pub enum GenerateVoteTxResult {
+    // The following are transient errors
+    // non voting validator, not eligible for refresh
+    // until authorized keypair is overriden
+    NonVoting,
+    // hot spare validator, not eligble for refresh
+    // until set identity is invoked
+    HotSpare,
+    // The hash verification at startup has not completed
+    WaitForStartupVerification,
+    // Wait to vote slot is not reached
+    WaitToVoteSlot(Slot),
+    // no rank found, this can happen if the validator
+    // is not staked in the current epoch, but it may
+    // still be staked in future or past epochs, so this
+    // is considered a transient error
+    NoRankFound,
+
+    // The following are misconfiguration errors
+    // The authorized voter for the given pubkey and Epoch does not exist
+    NoAuthorizedVoter(Pubkey, u64),
+    // The vote account associated with given pubkey does not exist
+    VoteAccountNotFound(Pubkey),
+
+    // The following are the successful cases
+    // Generated a vote transaction
+    Tx(Transaction),
+    // Generated a ConsensusMessage
+    ConsensusMessage(ConsensusMessage),
+}
+
+impl GenerateVoteTxResult {
+    pub fn is_non_voting(&self) -> bool {
+        matches!(self, Self::NonVoting)
+    }
+
+    pub fn is_hot_spare(&self) -> bool {
+        matches!(self, Self::HotSpare)
+    }
+
+    pub fn is_invalid_config(&self) -> bool {
+        match self {
+            Self::NoAuthorizedVoter(_, _) | Self::VoteAccountNotFound(_) => true,
+            Self::NonVoting
+            | Self::HotSpare
+            | Self::WaitForStartupVerification
+            | Self::WaitToVoteSlot(_)
+            | Self::NoRankFound => false,
+            Self::Tx(_) | Self::ConsensusMessage(_) => false,
+        }
+    }
+
+    pub fn is_transient_error(&self) -> bool {
+        match self {
+            Self::NoAuthorizedVoter(_, _) | Self::VoteAccountNotFound(_) => false,
+            Self::NonVoting
+            | Self::HotSpare
+            | Self::WaitForStartupVerification
+            | Self::WaitToVoteSlot(_)
+            | Self::NoRankFound => true,
+            Self::Tx(_) | Self::ConsensusMessage(_) => false,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum VoteError {
+    #[error("Unable to generate bls vote message, transient error: {0:?}")]
+    TransientError(Box<GenerateVoteTxResult>),
+
+    #[error("Unable to generate bls vote message, configuration error: {0:?}")]
+    InvalidConfig(Box<GenerateVoteTxResult>),
+
+    #[error("Unable to send to certificate pool")]
+    ConsensusPoolError(#[from] SendError<()>),
+
+    #[error("Commitment sender error {0}")]
+    CommitmentSenderError(#[from] CommitmentError),
+
+    #[error("Saved vote history error {0}")]
+    SavedVoteHistoryError(#[from] VoteHistoryError),
+}
+
+/// Context required to construct vote transactions
+pub struct VotingContext {
+    pub vote_history: VoteHistory,
+    pub vote_account_pubkey: Pubkey,
+    pub identity_keypair: Arc<Keypair>,
+    pub authorized_voter_keypairs: Arc<std::sync::RwLock<Vec<Arc<Keypair>>>>,
+    // The BLS keypair should always change with authorized_voter_keypairs.
+    pub derived_bls_keypairs: HashMap<Pubkey, Arc<BLSKeypair>>,
+    pub has_new_vote_been_rooted: bool,
+    pub own_vote_sender: Sender<ConsensusMessage>,
+    pub bls_sender: Sender<BLSOp>,
+    pub commitment_sender: Sender<CommitmentAggregationData>,
+    pub wait_to_vote_slot: Option<u64>,
+    pub sharable_banks: SharableBanks,
+    pub consensus_metrics: Arc<PlRwLock<ConsensusMetrics>>,
+}
+
+fn get_bls_keypair(
+    context: &mut VotingContext,
+    authorized_voter_keypair: &Arc<Keypair>,
+) -> Result<Arc<BLSKeypair>, BlsError> {
+    let pubkey = authorized_voter_keypair.pubkey();
+    if let Some(existing) = context.derived_bls_keypairs.get(&pubkey) {
+        return Ok(existing.clone());
+    }
+
+    let bls_keypair = Arc::new(BLSKeypair::derive_from_signer(
+        authorized_voter_keypair,
+        BLS_KEYPAIR_DERIVE_SEED,
+    )?);
+
+    context
+        .derived_bls_keypairs
+        .insert(pubkey, bls_keypair.clone());
+
+    Ok(bls_keypair)
+}
+
+fn generate_vote_tx(vote: &Vote, bank: &Bank, context: &mut VotingContext) -> GenerateVoteTxResult {
+    let vote_account_pubkey = context.vote_account_pubkey;
+    let authorized_voter_keypair;
+    let bls_pubkey_in_vote_account;
+    {
+        let authorized_voter_keypairs = context.authorized_voter_keypairs.read().unwrap();
+        if authorized_voter_keypairs.is_empty() {
+            return GenerateVoteTxResult::NonVoting;
+        }
+        if let Some(slot) = context.wait_to_vote_slot {
+            if vote.slot() < slot {
+                return GenerateVoteTxResult::WaitToVoteSlot(slot);
+            }
+        }
+        let Some(vote_account) = bank.get_vote_account(&vote_account_pubkey) else {
+            return GenerateVoteTxResult::VoteAccountNotFound(vote_account_pubkey);
+        };
+        let vote_state_view = vote_account.vote_state_view();
+        if vote_state_view.node_pubkey() != &context.identity_keypair.pubkey() {
+            info!(
+                "Vote account node_pubkey mismatch: {} (expected: {}).  Unable to vote",
+                vote_state_view.node_pubkey(),
+                context.identity_keypair.pubkey()
+            );
+            return GenerateVoteTxResult::HotSpare;
+        }
+        let bls_pubkey_serialized = match vote_state_view.bls_pubkey_compressed() {
+            None => {
+                panic!(
+                    "No BLS pubkey in vote account {}",
+                    context.identity_keypair.pubkey()
+                );
+            }
+            Some(key) => key,
+        };
+        bls_pubkey_in_vote_account =
+            (bincode::deserialize::<BLSPubkeyCompressed>(&bls_pubkey_serialized).unwrap())
+                .try_into()
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "Failed to decompress BLS pubkey in vote account {}",
+                        context.identity_keypair.pubkey()
+                    );
+                });
+        let Some(authorized_voter_pubkey) = vote_state_view.get_authorized_voter(bank.epoch())
+        else {
+            return GenerateVoteTxResult::NoAuthorizedVoter(vote_account_pubkey, bank.epoch());
+        };
+
+        let Some(keypair) = authorized_voter_keypairs
+            .iter()
+            .find(|keypair| &keypair.pubkey() == authorized_voter_pubkey)
+        else {
+            warn!(
+                "The authorized keypair {authorized_voter_pubkey} for vote account \
+                 {vote_account_pubkey} is not available.  Unable to vote"
+            );
+            return GenerateVoteTxResult::NonVoting;
+        };
+
+        authorized_voter_keypair = keypair.clone();
+    }
+
+    let bls_keypair = get_bls_keypair(context, &authorized_voter_keypair)
+        .unwrap_or_else(|e| panic!("Failed to derive my own BLS keypair: {e:?}"));
+    let my_bls_pubkey: BLSPubkey = bls_keypair.public;
+    if my_bls_pubkey != bls_pubkey_in_vote_account {
+        panic!(
+            "Vote account bls_pubkey mismatch: {bls_pubkey_in_vote_account:?} (expected: \
+             {my_bls_pubkey:?}).  Unable to vote"
+        );
+    }
+    let vote_serialized = bincode::serialize(&vote).unwrap();
+
+    let epoch = bank.epoch_schedule().get_epoch(vote.slot());
+
+    let Some(epoch_stakes) = bank.epoch_stakes(epoch) else {
+        panic!(
+            "The bank {} doesn't have its own epoch_stakes for {}",
+            bank.slot(),
+            epoch
+        );
+    };
+    let Some(my_rank) = epoch_stakes
+        .bls_pubkey_to_rank_map()
+        .get_rank(&my_bls_pubkey)
+    else {
+        return GenerateVoteTxResult::NoRankFound;
+    };
+    GenerateVoteTxResult::ConsensusMessage(ConsensusMessage::Vote(VoteMessage {
+        vote: *vote,
+        signature: bls_keypair.sign(&vote_serialized).into(),
+        rank: *my_rank,
+    }))
+}
+
+/// Send an alpenglow vote as a BLSMessage
+/// `bank` will be used for:
+/// - startup verification
+/// - vote account checks
+/// - authorized voter checks
+///
+/// We also update the vote history and send the vote to
+/// the certificate pool thread for ingestion.
+///
+/// Returns false if we are currently a non-voting node
+fn insert_vote_and_create_bls_message(
+    vote: Vote,
+    is_refresh: bool,
+    context: &mut VotingContext,
+) -> Result<BLSOp, VoteError> {
+    // Update and save the vote history
+    if !is_refresh {
+        context.vote_history.add_vote(vote);
+    }
+
+    let bank = context.sharable_banks.root();
+    let message = match generate_vote_tx(&vote, &bank, context) {
+        GenerateVoteTxResult::ConsensusMessage(m) => m,
+        e => {
+            if e.is_transient_error() {
+                return Err(VoteError::TransientError(Box::new(e)));
+            } else {
+                return Err(VoteError::InvalidConfig(Box::new(e)));
+            }
+        }
+    };
+    context
+        .own_vote_sender
+        .send(message.clone())
+        .map_err(|_| SendError(()))?;
+
+    // TODO: for refresh votes use a different BLSOp so we don't have to rewrite the same vote history to file
+    let saved_vote_history =
+        SavedVoteHistory::new(&context.vote_history, &context.identity_keypair)?;
+
+    match context
+        .consensus_metrics
+        .write()
+        .record_vote(context.vote_account_pubkey, &vote)
+    {
+        Ok(()) => (),
+        Err(err) => {
+            let slot = vote.slot();
+            error!("recording vote on slot {slot} failed with {err:?}");
+        }
+    }
+
+    // Return vote for sending
+    Ok(BLSOp::PushVote {
+        message: Arc::new(message),
+        slot: vote.slot(),
+        saved_vote_history: SavedVoteHistoryVersions::from(saved_vote_history),
+    })
+}
+
+pub fn generate_vote_message(
+    vote: Vote,
+    is_refresh: bool,
+    vctx: &mut VotingContext,
+) -> Result<Option<BLSOp>, VoteError> {
+    let bls_op = match insert_vote_and_create_bls_message(vote, is_refresh, vctx) {
+        Ok(bls_op) => bls_op,
+        Err(VoteError::InvalidConfig(e)) => {
+            warn!("Failed to generate vote and push to votes: {e:?}");
+            // These are not fatal errors, just skip the vote for now. But they are misconfigurations
+            // that should be warned about.
+            return Ok(None);
+        }
+        Err(VoteError::TransientError(e)) => {
+            info!("Failed to generate vote and push to votes: {e:?}");
+            // These are transient errors, just skip the vote for now.
+            return Ok(None);
+        }
+        Err(e) => return Err(e),
+    };
+    Ok(Some(bls_op))
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crossbeam_channel::unbounded,
+        solana_hash::Hash,
+        solana_runtime::{
+            bank::Bank,
+            bank_forks::BankForks,
+            epoch_stakes::VersionedEpochStakes,
+            genesis_utils::{
+                create_genesis_config_with_alpenglow_vote_accounts, ValidatorVoteKeypairs,
+            },
+        },
+        std::sync::{Arc, RwLock},
+    };
+
+    fn generate_expected_consensus_message(
+        vote: Vote,
+        my_bls_keypair: &BLSKeypair,
+    ) -> ConsensusMessage {
+        let vote_serialized = bincode::serialize(&vote).unwrap();
+        let signature = my_bls_keypair.sign(&vote_serialized);
+        ConsensusMessage::Vote(VoteMessage {
+            vote,
+            signature: signature.into(),
+            rank: 0,
+        })
+    }
+
+    fn setup_voting_context_and_bank_forks(
+        own_vote_sender: Sender<ConsensusMessage>,
+        validator_keypairs: &[ValidatorVoteKeypairs],
+        my_index: usize,
+    ) -> VotingContext {
+        // Can't have stake of 0, so start at 1 and go to 10. In descending order, so 0 has largest stake.
+        let stakes: Vec<u64> = (1u64..=10).rev().map(|x| x.saturating_mul(100)).collect();
+        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
+            1_000_000_000,
+            validator_keypairs,
+            stakes,
+        );
+        let bank0 = Bank::new_for_tests(&genesis.genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank0);
+
+        let my_keys = &validator_keypairs[my_index];
+        let sharable_banks = bank_forks.read().unwrap().sharable_banks();
+        VotingContext {
+            vote_history: VoteHistory::new(my_keys.node_keypair.pubkey(), 0),
+            vote_account_pubkey: my_keys.vote_keypair.pubkey(),
+            identity_keypair: Arc::new(my_keys.node_keypair.insecure_clone()),
+            authorized_voter_keypairs: Arc::new(RwLock::new(vec![Arc::new(
+                my_keys.vote_keypair.insecure_clone(),
+            )])),
+            derived_bls_keypairs: HashMap::new(),
+            has_new_vote_been_rooted: false,
+            own_vote_sender,
+            bls_sender: unbounded().0,
+            commitment_sender: unbounded().0,
+            wait_to_vote_slot: None,
+            sharable_banks,
+            consensus_metrics: Arc::new(PlRwLock::new(ConsensusMetrics::new(0))),
+        }
+    }
+
+    #[test]
+    fn test_generate_own_vote_message() {
+        let (own_vote_sender, own_vote_receiver) = crossbeam_channel::unbounded();
+        // Create 10 node validatorvotekeypairs vec
+        let validator_keypairs = (0..10)
+            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
+            .collect::<Vec<_>>();
+        let my_index = 0;
+        let mut voting_context =
+            setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
+        let my_bls_keypair = BLSKeypair::derive_from_signer(
+            &validator_keypairs[my_index].vote_keypair,
+            BLS_KEYPAIR_DERIVE_SEED,
+        )
+        .unwrap();
+
+        // Generate a normal notarization vote and check it's sent out correctly.
+        let block_id = Hash::new_unique();
+        let vote_slot = 2;
+        let vote = Vote::new_notarization_vote(vote_slot, block_id);
+        let result = generate_vote_message(vote, false, &mut voting_context)
+            .ok()
+            .unwrap()
+            .unwrap();
+        let expected_message = generate_expected_consensus_message(vote, &my_bls_keypair);
+        if let BLSOp::PushVote {
+            message,
+            slot,
+            saved_vote_history,
+        } = &result
+        {
+            assert_eq!(slot, &vote_slot);
+            assert_eq!(**message, expected_message);
+            assert_eq!(
+                saved_vote_history,
+                &SavedVoteHistoryVersions::from(
+                    SavedVoteHistory::new(
+                        &voting_context.vote_history,
+                        &voting_context.identity_keypair
+                    )
+                    .unwrap()
+                )
+            );
+        } else {
+            panic!("Expected BLSOp::PushVote, got {result:?}");
+        }
+
+        // Check that own vote sender receives the vote
+        let received_message = own_vote_receiver.recv().unwrap();
+        assert_eq!(received_message, expected_message);
+    }
+
+    #[test]
+    fn test_wait_to_vote_slot() {
+        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        // Create 10 node validatorvotekeypairs vec
+        let validator_keypairs = (0..10)
+            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
+            .collect::<Vec<_>>();
+        let my_index = 0;
+        let mut voting_context =
+            setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
+
+        // If we haven't reached wait_to_vote_slot yet, return Ok(None)
+        voting_context.wait_to_vote_slot = Some(4);
+        let vote = Vote::new_finalization_vote(2);
+        assert!(generate_vote_message(vote, false, &mut voting_context)
+            .unwrap()
+            .is_none());
+
+        // If we have reached wait_to_vote_slot, we should be able to vote
+        voting_context.wait_to_vote_slot = Some(1);
+        assert!(generate_vote_message(vote, false, &mut voting_context)
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn test_non_voting_node() {
+        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        // Create 10 node validatorvotekeypairs vec
+        let validator_keypairs = (0..10)
+            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
+            .collect::<Vec<_>>();
+        let my_index = 0;
+        let mut voting_context =
+            setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
+
+        // Empty authorized voter keypairs to simulate non voting node
+        voting_context.authorized_voter_keypairs = Arc::new(std::sync::RwLock::new(vec![]));
+        let vote = Vote::new_skip_vote(5);
+        // For non-voting nodes, we just return Ok(None)
+        assert!(generate_vote_message(vote, false, &mut voting_context)
+            .unwrap()
+            .is_none());
+
+        // Recover correct value to vote again
+        voting_context.authorized_voter_keypairs = Arc::new(RwLock::new(vec![Arc::new(
+            validator_keypairs[my_index].vote_keypair.insecure_clone(),
+        )]));
+        assert!(generate_vote_message(vote, false, &mut voting_context)
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn test_wrong_identity_keypair() {
+        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        // Create 10 node validatorvotekeypairs vec
+        let validator_keypairs = (0..10)
+            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
+            .collect::<Vec<_>>();
+        let my_index = 0;
+        let mut voting_context =
+            setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
+
+        // Wrong identity keypair
+        voting_context.identity_keypair = Arc::new(Keypair::new());
+        let vote = Vote::new_notarization_vote(6, Hash::new_unique());
+        assert!(generate_vote_message(vote, true, &mut voting_context)
+            .unwrap()
+            .is_none());
+
+        // Recover correct value to vote again
+        voting_context.identity_keypair =
+            Arc::new(validator_keypairs[my_index].node_keypair.insecure_clone());
+        assert!(generate_vote_message(vote, true, &mut voting_context)
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn test_wrong_vote_account_pubkey() {
+        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        // Create 10 node validatorvotekeypairs vec
+        let validator_keypairs = (0..10)
+            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
+            .collect::<Vec<_>>();
+        let my_index = 0;
+        let mut voting_context =
+            setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
+
+        // Wrong vote account pubkey
+        voting_context.vote_account_pubkey = Pubkey::new_unique();
+        let vote = Vote::new_notarization_vote(7, Hash::new_unique());
+        assert!(generate_vote_message(vote, true, &mut voting_context)
+            .unwrap()
+            .is_none());
+
+        // Recover correct value to vote again
+        voting_context.vote_account_pubkey = validator_keypairs[my_index].vote_keypair.pubkey();
+        assert!(generate_vote_message(vote, true, &mut voting_context)
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    #[should_panic(expected = "Vote account bls_pubkey mismatch")]
+    fn test_wrong_bls_pubkey() {
+        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        // Create 10 node validatorvotekeypairs vec
+        let validator_keypairs = (0..10)
+            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
+            .collect::<Vec<_>>();
+        let my_index = 0;
+        let mut voting_context =
+            setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
+
+        voting_context.derived_bls_keypairs.insert(
+            validator_keypairs[my_index].vote_keypair.pubkey(),
+            Arc::new(BLSKeypair::new()),
+        );
+        let vote = Vote::new_notarization_vote(8, Hash::new_unique());
+        assert!(generate_vote_message(vote, true, &mut voting_context)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "The bank 0 doesn't have its own epoch_stakes for")]
+    fn test_panic_on_future_slot() {
+        solana_logger::setup();
+        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        // Create 10 node validatorvotekeypairs vec
+        let validator_keypairs = (0..10)
+            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
+            .collect::<Vec<_>>();
+        let my_index = 0;
+        let mut voting_context =
+            setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
+
+        // If we try to vote for a slot in the future, we should panic
+        let vote = Vote::new_notarization_vote(1_000_000_000, Hash::new_unique());
+        let _ = generate_vote_message(vote, false, &mut voting_context);
+    }
+
+    #[test]
+    fn test_zero_staked_validator_fails_voting() {
+        solana_logger::setup();
+        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        // Create 10 node validatorvotekeypairs vec
+        let validator_keypairs = (0..10)
+            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
+            .collect::<Vec<_>>();
+        let my_index = 0;
+        let mut voting_context =
+            setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
+
+        // Set the stake of my_index to 0 in epoch 2
+        // For epoch 2, make validator my_index to be zero stake, others have stake in ascending order, 1 < 2 < ... < 9
+        let bank = voting_context.sharable_banks.root();
+        assert_eq!(bank.epoch(), 0);
+        assert!(bank.epoch_stakes(2).is_none());
+        let vote_accounts_hash_map = validator_keypairs
+            .iter()
+            .enumerate()
+            .map(|(i, keypairs)| {
+                let stake = if i == my_index {
+                    0
+                } else {
+                    i.saturating_mul(100)
+                };
+                let authorized_voter = keypairs.vote_keypair.pubkey();
+                // Read vote_account from bank 0
+                let vote_account = bank.get_vote_account(&authorized_voter).unwrap();
+                (authorized_voter, (stake as u64, vote_account))
+            })
+            .collect();
+        let mut new_bank = Bank::new_from_parent(bank, &Pubkey::default(), 1);
+        assert!(new_bank.epoch_stakes(2).is_none());
+        let epoch2_epoch_stakes = VersionedEpochStakes::new_for_tests(vote_accounts_hash_map, 2);
+        new_bank.set_epoch_stakes_for_test(2, epoch2_epoch_stakes);
+        assert!(new_bank.epoch_stakes(2).is_some());
+        new_bank.freeze();
+        let bank_forks = BankForks::new_rw_arc(new_bank);
+        voting_context.sharable_banks = bank_forks.read().unwrap().sharable_banks();
+
+        // If we try to vote for a slot in epoch 1, it should succeed
+        let first_slot_in_epoch_1 = voting_context
+            .sharable_banks
+            .root()
+            .epoch_schedule()
+            .get_first_slot_in_epoch(1);
+        let vote = Vote::new_notarization_vote(first_slot_in_epoch_1, Hash::new_unique());
+        assert!(generate_vote_message(vote, false, &mut voting_context)
+            .unwrap()
+            .is_some());
+
+        // If we try to vote for a slot in epoch 2, we should get NoRankFound error
+        let first_slot_in_epoch_2 = voting_context
+            .sharable_banks
+            .root()
+            .epoch_schedule()
+            .get_first_slot_in_epoch(2);
+        let vote = Vote::new_notarization_vote(first_slot_in_epoch_2, Hash::new_unique());
+        assert!(generate_vote_message(vote, false, &mut voting_context)
+            .unwrap()
+            .is_none());
+    }
+}


### PR DESCRIPTION
- Upstream voting_utils and consensus_metrics.rs
- bankforks::sharable_bank has been changed to bankforks::sharable_banks, changing voting_utils accordingly.
