### PR TITLE
Cleanup accounts-index flush and cache evict code

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -60,7 +60,7 @@ impl<T: IndexValue> PossibleEvictions<T> {
     /// clear existing data and prepare to add 'entries' more ages of data
     fn reset(&mut self, entries: Age) {
         self.possible_evictions.iter_mut().for_each(|entry| {
-            entry.evictions_age_possible.clear();
+            entry.evictions_age.clear();
         });
         let entries = entries as usize;
         assert!(
@@ -76,7 +76,7 @@ impl<T: IndexValue> PossibleEvictions<T> {
     fn insert(&mut self, relative_age: Age, key: Pubkey, entry: Arc<AccountMapEntry<T>>) {
         let index = self.index + (relative_age as usize);
         let list = &mut self.possible_evictions[index];
-        list.evictions_age_possible.push((key, entry));
+        list.evictions_age.push((key, entry));
     }
 }
 
@@ -164,7 +164,7 @@ struct StartupInfo<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
 /// result from scanning in-mem index during flush
 struct FlushScanResult<T> {
     /// pubkeys whose age indicates they may be evicted now, pending further checks.
-    evictions_age_possible: Vec<(Pubkey, Arc<AccountMapEntry<T>>)>,
+    evictions_age: Vec<(Pubkey, Arc<AccountMapEntry<T>>)>,
 }
 
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T, U> {
@@ -921,13 +921,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         startup: bool,
         update_stats: bool,
         ages_flushing_now: Age,
-    ) -> (bool, Option<std::sync::RwLockReadGuard<'a, SlotList<T>>>) {
+    ) -> Option<std::sync::RwLockReadGuard<'a, SlotList<T>>> {
         // this could be tunable dynamically based on memory pressure
         // we could look at more ages or we could throw out more items we are choosing to keep in the cache
         if Self::should_evict_based_on_age(current_age, entry, startup, ages_flushing_now) {
             if entry.ref_count() != 1 {
                 Self::update_stat(&self.stats().held_in_mem.ref_count, 1);
-                (false, None)
+                None
             } else {
                 // only read the slot list if we are planning to throw the item out
                 let slot_list = entry.slot_list_read_lock();
@@ -935,18 +935,18 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     if update_stats {
                         Self::update_stat(&self.stats().held_in_mem.slot_list_len, 1);
                     }
-                    (false, None) // keep 0 and > 1 slot lists in mem. They will be cleaned or shrunk soon.
+                    None // keep 0 and > 1 slot lists in mem. They will be cleaned or shrunk soon.
                 } else {
                     // keep items with slot lists that contained cached items
                     let evict = !slot_list.iter().any(|(_, info)| info.is_cached());
                     if !evict && update_stats {
                         Self::update_stat(&self.stats().held_in_mem.slot_list_cached, 1);
                     }
-                    (evict, if evict { Some(slot_list) } else { None })
+                    evict.then_some(slot_list)
                 }
             }
         } else {
-            (false, None)
+            None
         }
     }
 
@@ -1146,102 +1146,91 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         Self::update_stat(&self.stats().buckets_scanned, 1);
 
         // scan in-mem map for items that we may evict
-        let FlushScanResult {
-            mut evictions_age_possible,
-        } = self.flush_scan(current_age, startup, flush_guard, ages_flushing_now);
+        let FlushScanResult { evictions_age } =
+            self.flush_scan(current_age, startup, flush_guard, ages_flushing_now);
 
         // write to disk outside in-mem map read lock
-        {
-            let mut evictions_age = Vec::with_capacity(evictions_age_possible.len());
-            if !evictions_age_possible.is_empty() {
-                let disk = self.bucket.as_ref().unwrap();
-                let mut flush_entries_updated_on_disk = 0;
-                let mut flush_should_evict_us = 0;
-                // we don't care about lock time in this metric - bg threads can wait
-                let m = Measure::start("flush_update");
-
+        let disk = self.bucket.as_ref().unwrap();
+        let mut flush_entries_updated_on_disk = 0;
+        let mut flush_should_evict_us = 0;
+        // we don't care about lock time in this metric - bg threads can wait
+        let m = Measure::start("flush_update");
+        let evictions_age = evictions_age
+            .into_iter()
+            .filter_map(|(k, v)| {
                 // consider whether to write to disk for all the items we may evict
-                for (k, v) in evictions_age_possible.drain(..) {
-                    let mut mse = Measure::start("flush_should_evict");
-                    let (evict_for_age, mut slot_list) = self.should_evict_from_mem(
-                        current_age,
-                        &v,
-                        startup,
-                        true,
-                        ages_flushing_now,
-                    );
-                    mse.stop();
-                    flush_should_evict_us += mse.as_us();
-                    if evict_for_age {
-                        evictions_age.push(k);
-                    } else {
-                        // not evicting, so don't write, even if dirty
-                        continue;
-                    }
+                let mut mse = Measure::start("flush_should_evict");
+                let slot_list_evicted_for_age =
+                    self.should_evict_from_mem(current_age, &v, startup, true, ages_flushing_now);
+                mse.stop();
+                flush_should_evict_us += mse.as_us();
+                let Some(slot_list) = slot_list_evicted_for_age else {
+                    // not evicting, so don't write, even if dirty
+                    return None;
+                };
 
-                    // if we are evicting it, then we need to update disk if we're dirty
-                    if v.clear_dirty() {
-                        // step 1: clear the dirty flag
-                        // step 2: perform the update on disk based on the fields in the entry
-                        // If a parallel operation dirties the item again - even while this flush is occurring,
-                        //  the last thing the writer will do, after updating contents, is set_dirty(true)
-                        //  That prevents dropping an item from cache before disk is updated to latest in mem.
-                        // It is possible that the item in the cache is marked as dirty while these updates are happening. That is ok.
-                        //  The dirty will be picked up and the item will be prevented from being evicted.
+                // if we are evicting it, then we need to update disk if we're dirty
+                if v.clear_dirty() {
+                    // step 1: clear the dirty flag
+                    // step 2: perform the update on disk based on the fields in the entry
+                    // If a parallel operation dirties the item again - even while this flush is occurring,
+                    //  the last thing the writer will do, after updating contents, is set_dirty(true)
+                    //  That prevents dropping an item from cache before disk is updated to latest in mem.
+                    // It is possible that the item in the cache is marked as dirty while these updates are happening. That is ok.
+                    //  The dirty will be picked up and the item will be prevented from being evicted.
 
-                        // may have to loop if disk has to grow and we have to retry the write
-                        loop {
-                            let disk_resize = {
-                                let slot_list =
-                                    slot_list.take().unwrap_or_else(|| v.slot_list_read_lock());
-                                // Check the ref count and slot list one more time before flushing.
-                                // It is possible the foreground has updated this entry since
-                                // we last checked above in `should_evict_from_mem()`.
-                                // If the entry *was* updated, re-mark it as dirty then
-                                // skip to the next pubkey/entry.
-                                let ref_count = v.ref_count();
-                                if ref_count != 1 || slot_list.len() != 1 {
-                                    v.set_dirty(true);
-                                    break;
-                                }
-                                // since we know slot_list.len() == 1, we can create a stack-allocated array for single element.
-                                let (slot, info) = slot_list[0];
-                                let disk_entry = [(slot, info.into())];
-                                disk.try_write(&k, (&disk_entry, ref_count.into()))
-                            };
-                            match disk_resize {
-                                Ok(_) => {
-                                    // successfully written to disk
-                                    flush_entries_updated_on_disk += 1;
-                                    break;
-                                }
-                                Err(err) => {
-                                    // disk needs to resize. This item did not get written. Resize and try again.
-                                    let m = Measure::start("flush_grow");
-                                    disk.grow(err);
-                                    Self::update_time_stat(&self.stats().flush_grow_us, m);
-                                }
+                    // may have to loop if disk has to grow and we have to retry the write
+                    loop {
+                        let disk_resize = {
+                            // Check the ref count and slot list one more time before flushing.
+                            // It is possible the foreground has updated this entry since
+                            // we last checked above in `should_evict_from_mem()`.
+                            // If the entry *was* updated, re-mark it as dirty then
+                            // skip to the next pubkey/entry.
+                            let ref_count = v.ref_count();
+                            if ref_count != 1 || slot_list.len() != 1 {
+                                v.set_dirty(true);
+                                return None;
+                            }
+                            // since we know slot_list.len() == 1, we can create a stack-allocated array for single element.
+                            let (slot, info) = slot_list[0];
+                            let disk_entry = [(slot, info.into())];
+                            disk.try_write(&k, (&disk_entry, ref_count.into()))
+                        };
+                        match disk_resize {
+                            Ok(_) => {
+                                // successfully written to disk
+                                flush_entries_updated_on_disk += 1;
+                                // exit disk-resize loop
+                                break;
+                            }
+                            Err(err) => {
+                                // disk needs to resize. This item did not get written. Resize and try again.
+                                let m = Measure::start("flush_grow");
+                                disk.grow(err);
+                                Self::update_time_stat(&self.stats().flush_grow_us, m);
                             }
                         }
                     }
                 }
-                Self::update_time_stat(&self.stats().flush_update_us, m);
-                Self::update_stat(&self.stats().flush_should_evict_us, flush_should_evict_us);
-                Self::update_stat(
-                    &self.stats().flush_entries_updated_on_disk,
-                    flush_entries_updated_on_disk,
-                );
+                Some(k)
+            })
+            .collect();
+        Self::update_time_stat(&self.stats().flush_update_us, m);
+        Self::update_stat(&self.stats().flush_should_evict_us, flush_should_evict_us);
+        Self::update_stat(
+            &self.stats().flush_entries_updated_on_disk,
+            flush_entries_updated_on_disk,
+        );
 
-                let m = Measure::start("flush_evict");
-                self.evict_from_cache(evictions_age, current_age, startup, ages_flushing_now);
-                Self::update_time_stat(&self.stats().flush_evict_us, m);
-            }
+        let m = Measure::start("flush_evict");
+        self.evict_from_cache(evictions_age, current_age, startup, ages_flushing_now);
+        Self::update_time_stat(&self.stats().flush_evict_us, m);
 
-            if iterate_for_age {
-                // completed iteration of the buckets at the current age
-                assert_eq!(current_age, self.storage.current_age());
-                self.set_has_aged(current_age, can_advance_age);
-            }
+        if iterate_for_age {
+            // completed iteration of the buckets at the current age
+            assert_eq!(current_age, self.storage.current_age());
+            self.set_has_aged(current_age, can_advance_age);
         }
     }
 
@@ -1689,7 +1678,7 @@ mod tests {
                         false,
                         1,
                     )
-                    .0,
+                    .is_some(),
                 ref_count == 1
             );
         }
@@ -1730,10 +1719,10 @@ mod tests {
                 );
                 let evictions = possible_evictions.possible_evictions.pop().unwrap();
                 assert_eq!(
-                    evictions.evictions_age_possible.len(),
+                    evictions.evictions_age.len(),
                     1 + ages_flushing_now as usize
                 );
-                evictions.evictions_age_possible.iter().for_each(|(_k, v)| {
+                evictions.evictions_age.iter().for_each(|(_k, v)| {
                     assert!(
                         InMemAccountsIndex::<u64, u64>::should_evict_based_on_age(
                             current_age,
@@ -1766,110 +1755,72 @@ mod tests {
         ));
 
         // empty slot list
-        assert!(
-            !bucket
-                .should_evict_from_mem(
-                    current_age,
-                    &Arc::new(AccountMapEntry::new(
-                        SlotList::new(),
-                        ref_count,
-                        AccountMapEntryMeta::default()
-                    )),
-                    startup,
-                    false,
-                    0,
-                )
-                .0
-        );
+        assert!(bucket
+            .should_evict_from_mem(
+                current_age,
+                &Arc::new(AccountMapEntry::new(
+                    SlotList::new(),
+                    ref_count,
+                    AccountMapEntryMeta::default()
+                )),
+                startup,
+                false,
+                0,
+            )
+            .is_none());
         // 1 element slot list
-        assert!(
-            bucket
-                .should_evict_from_mem(
-                    current_age,
-                    &one_element_slot_list_entry,
-                    startup,
-                    false,
-                    0,
-                )
-                .0
-        );
+        assert!(bucket
+            .should_evict_from_mem(current_age, &one_element_slot_list_entry, startup, false, 0,)
+            .is_some());
         // 2 element slot list
-        assert!(
-            !bucket
-                .should_evict_from_mem(
-                    current_age,
-                    &Arc::new(AccountMapEntry::new(
-                        SlotList::from_iter([(0, 0u64), (1, 1)]),
-                        ref_count,
-                        AccountMapEntryMeta::default()
-                    )),
-                    startup,
-                    false,
-                    0,
-                )
-                .0
-        );
+        assert!(bucket
+            .should_evict_from_mem(
+                current_age,
+                &Arc::new(AccountMapEntry::new(
+                    SlotList::from_iter([(0, 0u64), (1, 1)]),
+                    ref_count,
+                    AccountMapEntryMeta::default()
+                )),
+                startup,
+                false,
+                0,
+            )
+            .is_none());
 
         {
             let bucket = new_for_test::<f64>();
             // 1 element slot list with a CACHED item - f64 acts like cached
-            assert!(
-                !bucket
-                    .should_evict_from_mem(
-                        current_age,
-                        &Arc::new(AccountMapEntry::new(
-                            SlotList::from([(0, 0.0)]),
-                            ref_count,
-                            AccountMapEntryMeta::default()
-                        )),
-                        startup,
-                        false,
-                        0,
-                    )
-                    .0
-            );
+            assert!(bucket
+                .should_evict_from_mem(
+                    current_age,
+                    &Arc::new(AccountMapEntry::new(
+                        SlotList::from([(0, 0.0)]),
+                        ref_count,
+                        AccountMapEntryMeta::default()
+                    )),
+                    startup,
+                    false,
+                    0,
+                )
+                .is_none());
         }
 
         // 1 element slot list, age is now
-        assert!(
-            bucket
-                .should_evict_from_mem(
-                    current_age,
-                    &one_element_slot_list_entry,
-                    startup,
-                    false,
-                    0,
-                )
-                .0
-        );
+        assert!(bucket
+            .should_evict_from_mem(current_age, &one_element_slot_list_entry, startup, false, 0,)
+            .is_some());
 
         // 1 element slot list, but not current age
         current_age = 1;
-        assert!(
-            !bucket
-                .should_evict_from_mem(
-                    current_age,
-                    &one_element_slot_list_entry,
-                    startup,
-                    false,
-                    0,
-                )
-                .0
-        );
+        assert!(bucket
+            .should_evict_from_mem(current_age, &one_element_slot_list_entry, startup, false, 0,)
+            .is_none());
 
         // 1 element slot list, but at startup and age not current
         startup = true;
-        assert!(
-            bucket
-                .should_evict_from_mem(
-                    current_age,
-                    &one_element_slot_list_entry,
-                    startup,
-                    false,
-                    0,
-                )
-                .0
-        );
+        assert!(bucket
+            .should_evict_from_mem(current_age, &one_element_slot_list_entry, startup, false, 0,)
+            .is_some());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
There is lots of complexity in code used to calculate entries for eviction from in-mem acccounts-index and flushing index to disk.
This includes sub-optimal memory allocations and unnecessarily passing keys for entries re-marked as dirty to eviction (filtered by evicting code later, but it's still non-ideal). 

#### Summary of Changes
* return `Option` instead of `(bool, Option)` from `should_evict_from_mem`
* use `filter_map` instead of `drain` + `push`
* simplify code getting slot_list for entry to be flushed
