### PR TITLE
docs: add guide to disable unattended system package updates

### DIFF
--- a/docs/src/operations/best-practices/general.md
+++ b/docs/src/operations/best-practices/general.md
@@ -230,3 +230,36 @@ To get more information on the command, use
 For a more detailed explanation of the different keypairs and other related
 operations refer to
 [vote account management](../guides/vote-accounts.md).
+
+## Disable Automatic Updates on Validator Nodes
+
+Unattended package updates can cause unexpected restarts or crashes on validator nodes. To ensure stability, it is strongly recommended to **disable automatic updates** on your validator host.
+
+
+### Disable auto updates
+
+Edit the auto-upgrade configuration file:
+
+```bash
+sudo nano /etc/apt/apt.conf.d/20auto-upgrades
+```
+
+Set the following values:
+
+```
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Unattended-Upgrade "0";
+```
+
+Save and exit. This disables automatic package updates.
+
+### Disable apt timers
+
+Systemd timers may still trigger updates unless explicitly disabled. Run:
+
+```bash
+sudo systemctl stop apt-daily.timer apt-daily-upgrade.timer
+sudo systemctl disable apt-daily.timer apt-daily-upgrade.timer
+```
+
+This prevents background update jobs from running.


### PR DESCRIPTION
Problem

Validator nodes can become delinquent or crash when unattended system updates (including kernel updates) are not fully disabled. Some operators only turn off auto-upgrades but leave apt timers active, which still allows updates to run.

Summary of Changes
Added documentation under src/operations/best-practices/general
Explained how to disable unattended updates via 20auto-upgrades
Documented how to stop and disable apt-daily and apt-daily-upgrade timers