### PR TITLE
disk index flush : use stack array to avoid heap vec allocation in collect()

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1251,16 +1251,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                                         v.set_dirty(true);
                                         break;
                                     }
-                                    disk.try_write(
-                                        &k,
-                                        (
-                                            &slot_list
-                                                .iter()
-                                                .map(|(slot, info)| (*slot, (*info).into()))
-                                                .collect::<Vec<_>>(),
-                                            ref_count.into(), // ref count on disk is u64
-                                        ),
-                                    )
+                                    // since we know slot_list.len() == 1, we can create a stack-allocated array for single element.
+                                    let (slot, info) = slot_list[0];
+                                    let disk_entry = [(slot, info.into())];
+                                    disk.try_write(&k, (&disk_entry, ref_count.into()))
                                 };
                                 match disk_resize {
                                     Ok(_) => {


### PR DESCRIPTION
#### Problem

`flush_internal` creates intermediate vec for disk write.

```
&slot_list.iter()
      .map(|(slot, info)| (*slot, (*info).into()))
      .collect::<Vec<_>>(),
```

Since we know that there is only a single element to write, we can create a stack-allocated array to write.



#### Summary of Changes

use stack-allocated array for disk write in flush_internal.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
