### PR TITLE
XDP: dynamic routing table lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ name = "agave-xdp"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-xdp-ebpf",
+ "arc-swap",
  "aya",
  "caps",
  "crossbeam-channel",
@@ -11704,6 +11705,7 @@ dependencies = [
  "agave-logger",
  "agave-votor",
  "agave-xdp",
+ "arc-swap",
  "assert_matches",
  "bencher",
  "bincode",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1506,26 +1506,27 @@ impl Validator {
             )
         });
 
-        let (xdp_retransmitter, xdp_sender) =
-            if let Some(xdp_config) = config.retransmit_xdp.clone() {
-                let src_port = node.sockets.retransmit_sockets[0]
-                    .local_addr()
-                    .expect("failed to get local address")
-                    .port();
-                let src_ip = match node.bind_ip_addrs.active() {
-                    IpAddr::V4(ip) if !ip.is_unspecified() => Some(ip),
-                    IpAddr::V4(_unspecified) => xdp_config
-                        .interface
-                        .as_ref()
-                        .and_then(|iface| master_ip_if_bonded(iface)),
-                    _ => panic!("IPv6 not supported"),
-                };
-                let (rtx, sender) = XdpRetransmitter::new(xdp_config, src_port, src_ip)
-                    .expect("failed to create xdp retransmitter");
-                (Some(rtx), Some(sender))
-            } else {
-                (None, None)
+        let (xdp_retransmitter, xdp_sender) = if let Some(xdp_config) =
+            config.retransmit_xdp.clone()
+        {
+            let src_port = node.sockets.retransmit_sockets[0]
+                .local_addr()
+                .expect("failed to get local address")
+                .port();
+            let src_ip = match node.bind_ip_addrs.active() {
+                IpAddr::V4(ip) if !ip.is_unspecified() => Some(ip),
+                IpAddr::V4(_unspecified) => xdp_config
+                    .interface
+                    .as_ref()
+                    .and_then(|iface| master_ip_if_bonded(iface)),
+                _ => panic!("IPv6 not supported"),
             };
+            let (rtx, sender) = XdpRetransmitter::new(xdp_config, src_port, src_ip, exit.clone())
+                .expect("failed to create xdp retransmitter");
+            (Some(rtx), Some(sender))
+        } else {
+            (None, None)
+        };
 
         // disable all2all tests if not allowed for a given cluster type
         let alpenglow_socket = if genesis_config.cluster_type == ClusterType::Testnet

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -432,6 +432,7 @@ name = "agave-xdp"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-xdp-ebpf",
+ "arc-swap",
  "aya",
  "caps",
  "crossbeam-channel",
@@ -9657,6 +9658,7 @@ dependencies = [
  "agave-feature-set",
  "agave-votor",
  "agave-xdp",
+ "arc-swap",
  "bincode",
  "bytes",
  "caps",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -415,6 +415,7 @@ name = "agave-xdp"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-xdp-ebpf",
+ "arc-swap",
  "aya",
  "caps",
  "crossbeam-channel",
@@ -10179,6 +10180,7 @@ dependencies = [
  "agave-feature-set",
  "agave-votor",
  "agave-xdp",
+ "arc-swap",
  "bincode",
  "bytes",
  "caps",

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -16,6 +16,7 @@ agave-unstable-api = []
 agave-feature-set = { workspace = true }
 agave-votor = { workspace = true }
 agave-xdp = { workspace = true }
+arc-swap = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -12,6 +12,7 @@ publish = true
 agave-unstable-api = []
 
 [dependencies]
+arc-swap = { workspace = true }
 crossbeam-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -26,6 +26,8 @@ mod program;
 #[cfg(target_os = "linux")]
 pub mod route;
 #[cfg(target_os = "linux")]
+pub mod route_monitor;
+#[cfg(target_os = "linux")]
 pub mod socket;
 #[cfg(target_os = "linux")]
 pub mod tx_loop;

--- a/xdp/src/netlink.rs
+++ b/xdp/src/netlink.rs
@@ -2,23 +2,24 @@
 
 use {
     libc::{
-        getsockname, nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl, socket,
-        AF_INET, AF_INET6, AF_NETLINK, NDA_DST, NDA_LLADDR, NETLINK_EXT_ACK, NETLINK_ROUTE,
-        NLA_ALIGNTO, NLA_TYPE_MASK, NLMSG_DONE, NLMSG_ERROR, NLM_F_DUMP, NLM_F_MULTI,
-        NLM_F_REQUEST, NUD_PERMANENT, NUD_REACHABLE, NUD_STALE, RTA_DST, RTA_GATEWAY, RTA_IIF,
-        RTA_OIF, RTA_PREFSRC, RTA_PRIORITY, RTA_TABLE, RTM_GETNEIGH, RTM_GETROUTE, RTM_NEWNEIGH,
-        RTM_NEWROUTE, RT_TABLE_MAIN, SOCK_RAW, SOL_NETLINK,
+        nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl, socket, AF_INET, AF_INET6,
+        AF_NETLINK, NDA_DST, NDA_LLADDR, NETLINK_EXT_ACK, NETLINK_ROUTE, NLA_ALIGNTO,
+        NLA_TYPE_MASK, NLMSG_DONE, NLMSG_ERROR, NLM_F_DUMP, NLM_F_MULTI, NLM_F_REQUEST, RTA_DST,
+        RTA_GATEWAY, RTA_IIF, RTA_OIF, RTA_PREFSRC, RTA_PRIORITY, RTA_TABLE, RTM_GETNEIGH,
+        RTM_GETROUTE, RTM_NEWNEIGH, RTM_NEWROUTE, RT_TABLE_MAIN, SOCK_RAW, SOL_NETLINK, SOL_SOCKET,
+        SO_RCVBUF,
     },
     std::{
         collections::HashMap,
         io, mem,
         net::{IpAddr, Ipv4Addr, Ipv6Addr},
-        os::fd::{AsRawFd, FromRawFd, OwnedFd},
+        os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd},
         ptr, slice,
     },
     thiserror::Error,
 };
 
+const NETLINK_RCVBUF_SIZE: i32 = 1 << 16;
 const NLA_HDR_LEN: usize = align_to(mem::size_of::<nlattr>(), NLA_ALIGNTO as usize);
 
 pub struct NetlinkSocket {
@@ -50,27 +51,7 @@ impl NetlinkSocket {
         {
             return Err(io::Error::last_os_error());
         }
-
-        // Safety: sockaddr_nl is POD so this is safe
-        let mut addr = unsafe { mem::zeroed::<sockaddr_nl>() };
-        addr.nl_family = AF_NETLINK as u16;
-        let mut addr_len = mem::size_of::<sockaddr_nl>() as u32;
-        // Safety: libc wrapper
-        if unsafe {
-            getsockname(
-                sock.as_raw_fd(),
-                &mut addr as *mut _ as *mut _,
-                &mut addr_len as *mut _,
-            )
-        } < 0
-        {
-            return Err(io::Error::last_os_error());
-        }
-
-        Ok(Self {
-            sock,
-            _nl_pid: addr.nl_pid,
-        })
+        Ok(Self { sock, _nl_pid: 0 })
     }
 
     fn send(&self, msg: &[u8]) -> Result<(), io::Error> {
@@ -88,8 +69,13 @@ impl NetlinkSocket {
         Ok(())
     }
 
-    fn recv(&self) -> Result<Vec<NetlinkMessage>, io::Error> {
-        let mut buf = [0u8; 4096];
+    pub(crate) fn recv(&self) -> Result<Vec<NetlinkMessage>, io::Error> {
+        // The theoretical max size of a single netlink message (including header) is 4GiB.
+        // See: https://elixir.bootlin.com/linux/v6.17.7/source/include/uapi/linux/netlink.h#L46
+        // However, in the kernel, the netlink message size is set to a page size.
+        // If the page size exceeds 8KiB, the netlink message size is capped to 8KiB
+        // See: https://elixir.bootlin.com/linux/v6.17.7/source/include/linux/netlink.h#L267
+        let mut buf = [0u8; 8 * 1024]; // 8 KiB
         let mut messages = Vec::new();
         let mut multipart = true;
         'out: while multipart {
@@ -133,10 +119,49 @@ impl NetlinkSocket {
 
         Ok(messages)
     }
+
+    /// Opens a listener socket for netlink updates
+    /// NETLINK_ROUTE socket subscribed to `groups` bitmask
+    pub fn bind(groups: u32) -> Result<Self, io::Error> {
+        let sock = Self::open()?;
+
+        // Subscribe to multicast groups
+        let mut addr: sockaddr_nl = unsafe { mem::zeroed() };
+        addr.nl_family = AF_NETLINK as u16;
+        addr.nl_groups = groups;
+        if unsafe {
+            libc::bind(
+                sock.as_raw_fd(),
+                &addr as *const _ as *const _,
+                mem::size_of::<sockaddr_nl>() as u32,
+            )
+        } < 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+
+        unsafe {
+            setsockopt(
+                sock.as_raw_fd(),
+                SOL_SOCKET,
+                SO_RCVBUF,
+                &NETLINK_RCVBUF_SIZE as *const _ as *const _,
+                mem::size_of::<i32>() as u32,
+            );
+        }
+
+        Ok(sock)
+    }
+
+    #[inline]
+    pub fn as_raw_fd(&self) -> RawFd {
+        self.sock.as_raw_fd()
+    }
 }
 
+#[derive(Debug, Clone)]
 pub struct NetlinkMessage {
-    header: nlmsghdr,
+    pub(crate) header: nlmsghdr,
     data: Vec<u8>,
     error: Option<nlmsgerr>,
 }
@@ -297,7 +322,7 @@ impl std::fmt::Display for MacAddress {
 }
 
 /// Represents an entry in the neighbor table (ARP/NDP cache)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NeighborEntry {
     // IPv4 or IPv6 address
     pub destination: Option<IpAddr>,
@@ -310,9 +335,12 @@ pub struct NeighborEntry {
 }
 
 impl NeighborEntry {
-    /// Returns true if this neighbor entry is valid and usable
-    pub fn is_valid(&self) -> bool {
-        self.lladdr.is_some() && (self.state & (NUD_REACHABLE | NUD_PERMANENT | NUD_STALE)) != 0
+    #[inline]
+    pub fn key(&self) -> Option<(i32, Ipv4Addr)> {
+        match self.destination {
+            Some(IpAddr::V4(ip)) => Some((self.ifindex, ip)),
+            _ => None,
+        }
     }
 }
 
@@ -320,12 +348,12 @@ impl NeighborEntry {
 #[allow(non_camel_case_types)]
 struct ndmsg {
     ndm_family: u8,
-    ndm_pad1: u8,
-    ndm_pad2: u16,
+    _ndm_pad1: u8,
+    _ndm_pad2: u16,
     ndm_ifindex: i32,
     ndm_state: u16,
-    ndm_flags: u8,
-    ndm_type: u8,
+    _ndm_flags: u8,
+    _ndm_type: u8,
 }
 
 #[repr(C)]
@@ -336,7 +364,7 @@ struct NeighRequest {
 
 /// fetch the kernel's neighbor table (ARP/NDP cache)
 pub fn netlink_get_neighbors(
-    if_index: Option<i32>,
+    if_index: Option<u32>,
     family: u8,
 ) -> Result<Vec<NeighborEntry>, io::Error> {
     let sock = NetlinkSocket::open()?;
@@ -355,7 +383,7 @@ pub fn netlink_get_neighbors(
 
     req.ndm.ndm_family = family;
     if let Some(idx) = if_index {
-        req.ndm.ndm_ifindex = idx;
+        req.ndm.ndm_ifindex = idx as i32;
     }
 
     sock.send(&bytes_of(&req)[..req.header.nlmsg_len as usize])?;
@@ -371,20 +399,21 @@ pub fn netlink_get_neighbors(
             continue;
         }
 
-        let Some(neighbor) = parse_rtm_newneigh(msg, if_index) else {
-            continue;
-        };
-
-        neighbors.push(neighbor);
+        if let Some(neighbor) = parse_rtm_newneigh(&msg, if_index) {
+            neighbors.push(neighbor);
+        }
     }
 
     Ok(neighbors)
 }
 
-pub fn parse_rtm_newneigh(msg: NetlinkMessage, if_index: Option<i32>) -> Option<NeighborEntry> {
+pub fn parse_rtm_newneigh(msg: &NetlinkMessage, if_index: Option<u32>) -> Option<NeighborEntry> {
+    if msg.data.len() < mem::size_of::<ndmsg>() {
+        return None;
+    }
     let nd_msg = unsafe { ptr::read_unaligned(msg.data.as_ptr() as *const ndmsg) };
     if let Some(idx) = if_index {
-        if nd_msg.ndm_ifindex != idx {
+        if nd_msg.ndm_ifindex != idx as i32 {
             return None;
         }
     }
@@ -410,7 +439,7 @@ pub fn parse_rtm_newneigh(msg: NetlinkMessage, if_index: Option<i32>) -> Option<
     Some(neighbor)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RouteEntry {
     pub destination: Option<IpAddr>,
     pub gateway: Option<IpAddr>,
@@ -424,6 +453,18 @@ pub struct RouteEntry {
     pub type_: u8,
     pub family: u8,
     pub dst_len: u8,
+    pub flags: u32,
+}
+
+impl RouteEntry {
+    #[inline]
+    pub fn same_key(&self, other: &Self) -> bool {
+        self.family == other.family
+            && self.dst_len == other.dst_len
+            && self.destination == other.destination
+            && self.table == other.table
+            && self.type_ == other.type_
+    }
 }
 
 #[repr(C)]
@@ -493,17 +534,18 @@ pub fn netlink_get_routes(family: u8) -> Result<Vec<RouteEntry>, io::Error> {
             continue;
         }
 
-        let Some(route) = parse_rtm_newroute(msg) else {
-            continue;
-        };
-
-        routes.push(route);
+        if let Some(route) = parse_rtm_newroute(&msg) {
+            routes.push(route);
+        }
     }
 
     Ok(routes)
 }
 
-pub fn parse_rtm_newroute(msg: NetlinkMessage) -> Option<RouteEntry> {
+pub fn parse_rtm_newroute(msg: &NetlinkMessage) -> Option<RouteEntry> {
+    if msg.data.len() < mem::size_of::<rtmsg>() {
+        return None;
+    }
     let rt_msg = unsafe { ptr::read_unaligned(msg.data.as_ptr() as *const rtmsg) };
     let Ok(attrs) = parse_attrs(&msg.data[mem::size_of::<rtmsg>()..]) else {
         return None;
@@ -521,6 +563,7 @@ pub fn parse_rtm_newroute(msg: NetlinkMessage) -> Option<RouteEntry> {
         type_: rt_msg.rtm_type,
         family: rt_msg.rtm_family,
         dst_len: rt_msg.rtm_dst_len,
+        flags: rt_msg.rtm_flags,
     };
     if let Some(dst_attr) = attrs.get(&RTA_DST) {
         route.destination = parse_ip_address(dst_attr.data, rt_msg.rtm_family);

--- a/xdp/src/route_monitor.rs
+++ b/xdp/src/route_monitor.rs
@@ -1,0 +1,183 @@
+use {
+    crate::{
+        netlink::{parse_rtm_newneigh, parse_rtm_newroute, NetlinkMessage, NetlinkSocket},
+        route::Router,
+    },
+    arc_swap::ArcSwap,
+    libc::{
+        self, pollfd, POLLERR, POLLHUP, POLLIN, POLLNVAL, RTMGRP_IPV4_ROUTE, RTMGRP_NEIGH,
+        RTM_DELNEIGH, RTM_DELROUTE, RTM_NEWNEIGH, RTM_NEWROUTE,
+    },
+    log::*,
+    std::{
+        io::{Error, ErrorKind},
+        net::IpAddr,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread,
+        time::{Duration, Instant},
+    },
+};
+pub struct RouteMonitor;
+
+impl RouteMonitor {
+    /// Subscribes to RTMGRP_IPV4_ROUTE | RTMGRP_NEIGH multicast groups
+    /// Waits for updates to arrive on the netlink socket
+    /// Publishes the updated routing table every `update_interval` if needed
+    pub fn start(
+        atomic_router: Arc<ArcSwap<Router>>,
+        exit: Arc<AtomicBool>,
+        update_interval: Duration,
+    ) -> thread::JoinHandle<()> {
+        thread::Builder::new()
+            .name("solRouteMon".to_string())
+            .spawn(move || {
+                let mut state =
+                    RouteMonitorState::new(Router::new().expect("error creating Router"));
+
+                let timeout = Duration::from_millis(10);
+                while !exit.load(Ordering::Relaxed) {
+                    state.publish_if_needed(&atomic_router, update_interval);
+
+                    let mut pfd = pollfd {
+                        fd: state.sock.as_raw_fd(),
+                        events: POLLIN,
+                        revents: 0,
+                    };
+
+                    let ev = match poll(&mut pfd, timeout) {
+                        // timeout
+                        Ok(0) => continue,
+                        Ok(_) => pfd.revents,
+                        Err(e) => {
+                            error!("netlink poll error: {e}");
+                            state.reset(&atomic_router);
+                            continue;
+                        }
+                    };
+
+                    debug_assert!(ev & POLLNVAL == 0);
+
+                    if (ev & (POLLHUP | POLLERR)) != 0 {
+                        error!(
+                            "netlink poll error (revents={}{})",
+                            if ev & POLLERR != 0 { "POLLERR " } else { "" },
+                            if ev & POLLHUP != 0 { "POLLHUP" } else { "" },
+                        );
+                        state.reset(&atomic_router);
+                        continue;
+                    }
+                    if (ev & POLLIN) == 0 {
+                        continue;
+                    }
+                    // Drain channel
+                    match state.sock.recv() {
+                        Ok(msgs) => {
+                            state.dirty |= Self::process_netlink_updates(&mut state.router, &msgs);
+                        }
+                        Err(e) => {
+                            error!("netlink recv error: {e}");
+                            state.reset(&atomic_router);
+                            continue;
+                        }
+                    }
+                }
+            })
+            .unwrap()
+    }
+
+    #[inline]
+    fn process_netlink_updates(router: &mut Router, msgs: &[NetlinkMessage]) -> bool {
+        let mut dirty = false;
+        for m in msgs {
+            match m.header.nlmsg_type {
+                RTM_NEWROUTE => {
+                    if let Some(r) = parse_rtm_newroute(m) {
+                        dirty |= router.upsert_route(r);
+                    }
+                }
+                RTM_DELROUTE => {
+                    if let Some(r) = parse_rtm_newroute(m) {
+                        dirty |= router.remove_route(r);
+                    }
+                }
+                RTM_NEWNEIGH => {
+                    if let Some(n) = parse_rtm_newneigh(m, None) {
+                        if let Some(IpAddr::V4(_)) = n.destination {
+                            dirty |= router.upsert_neighbor(n);
+                        }
+                    }
+                }
+                RTM_DELNEIGH => {
+                    if let Some(n) = parse_rtm_newneigh(m, None) {
+                        if let Some(IpAddr::V4(ip)) = n.destination {
+                            dirty |= router.remove_neighbor(ip, n.ifindex as u32);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        dirty
+    }
+}
+
+struct RouteMonitorState {
+    sock: NetlinkSocket,
+    router: Router,
+    dirty: bool,
+    last_publish: Instant,
+}
+
+impl RouteMonitorState {
+    /// Creates a new RouteMonitorState with a bounded netlink socket
+    fn new(router: Router) -> Self {
+        Self {
+            sock: NetlinkSocket::bind((RTMGRP_IPV4_ROUTE | RTMGRP_NEIGH) as u32)
+                .expect("error creating netlink socket"),
+            router,
+            dirty: false,
+            last_publish: Instant::now(),
+        }
+    }
+
+    /// Resets the route monitor state by creating a new router and reinitializing
+    /// the netlink socket. Used when errors occur to recover to a clean state
+    fn reset(&mut self, atomic_router: &Arc<ArcSwap<Router>>) {
+        atomic_router.store(Arc::new(Router::new().expect("error creating Router")));
+        *self = Self::new(Arc::unwrap_or_clone(atomic_router.load_full()));
+    }
+
+    /// Publishes the updated router if there are new route/neighbor updates
+    /// and the update interval has elapsed
+    fn publish_if_needed(
+        &mut self,
+        atomic_router: &Arc<ArcSwap<Router>>,
+        update_interval: Duration,
+    ) {
+        if self.dirty && self.last_publish.elapsed() >= update_interval {
+            atomic_router.store(Arc::new(self.router.clone()));
+            self.last_publish = Instant::now();
+            self.dirty = false;
+        }
+    }
+}
+
+/// Wrapper around libc::poll. Polls the netlink socket for incoming events
+#[inline]
+fn poll(pfd: &mut pollfd, timeout: Duration) -> Result<i32, Error> {
+    let rc = loop {
+        // Safety: pfd can't be NULL as references can't be NULL
+        let rc = unsafe { libc::poll(pfd as *mut pollfd, 1, timeout.as_millis() as i32) };
+        if rc < 0 && Error::last_os_error().kind() == ErrorKind::Interrupted {
+            continue;
+        }
+        break rc;
+    };
+    if rc < 0 {
+        return Err(Error::last_os_error());
+    }
+    Ok(rc)
+}


### PR DESCRIPTION
#### Problem
Currently, XDP only reads the routing table on startup. We need to respond to added/removed routes dynamically.

#### Summary of Changes
Subscribe to `RTMGRP_IPV4_ROUTE`, `RTMGRP_NEIGH` netlink updates.
Wait for updates and then coalesce 50ms of updates from channel. 
We have two routing tables
1) The routing table we read from in the tx_loop xdp hot path
2) A working routing table that we update in place and then atomically swap into the hot path if needed

During coalescing, we filter out all updates we don't care about. 
At the end of the coalesce period, we check if we have updated the working routing table. If we have, we atomically swap the table into the xdp hot path.

## Performance:
### original code
#### skb mode: 
```
throughput: 1455780.01 pps | 16.30 Gbps
throughput: 1454491.99 pps | 16.29 Gbps
throughput: 1454499.85 pps | 16.29 Gbps
throughput: 1455591.10 pps | 16.30 Gbps
throughput: 1457574.34 pps | 16.32 Gbps
throughput: 1456163.06 pps | 16.31 Gbps
throughput: 1449123.83 pps | 16.23 Gbps
throughput: 1442855.13 pps | 16.16 Gbps
```

#### zero copy:
```
throughput: 2027129.77 pps | 22.70 Gbps
throughput: 2025403.23 pps | 22.68 Gbps
throughput: 2027450.91 pps | 22.71 Gbps
throughput: 2025724.67 pps | 22.69 Gbps
throughput: 2025724.72 pps | 22.69 Gbps
throughput: 2025275.90 pps | 22.68 Gbps
throughput: 2026300.32 pps | 22.69 Gbps
throughput: 2026236.09 pps | 22.69 Gbps
```

### this PR 
#### skb mode w/ 1s route churn:
```
throughput: 1370919.57 pps | 15.35 Gbps
throughput: 1375657.66 pps | 15.41 Gbps
throughput: 1372904.45 pps | 15.38 Gbps
throughput: 1375653.73 pps | 15.41 Gbps
throughput: 1387173.01 pps | 15.54 Gbps
throughput: 1387302.54 pps | 15.54 Gbps
throughput: 1388456.65 pps | 15.55 Gbps
throughput: 1388519.91 pps | 15.55 Gbps
```

#### zero copy w/ 1s route churn:
```
throughput: 2026898.08 pps | 22.70 Gbps
throughput: 2026380.61 pps | 22.70 Gbps
throughput: 2026156.65 pps | 22.69 Gbps
throughput: 2025150.73 pps | 22.68 Gbps
throughput: 2025406.15 pps | 22.68 Gbps
throughput: 2026814.08 pps | 22.70 Gbps
throughput: 2026814.18 pps | 22.70 Gbps
throughput: 2024127.49 pps | 22.67 Gbps
```

Shoutout @ripatel-fd and @hewang-jump for the inspiration and help on this (they have implemented much of this in C for firedancer)