### PR TITLE
`wincode`: `bincode` compatible de/serializer w/ placement initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5121,9 +5121,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -13665,6 +13665,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wincode"
+version = "0.0.0"
+dependencies = [
+ "bincode",
+ "paste",
+ "proptest",
+ "rand 0.8.5",
+ "serde",
+ "solana-short-vec",
+ "thiserror 2.0.16",
+]
 
 [[package]]
 name = "windows"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13668,7 +13668,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bincode",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -610,6 +610,7 @@ url = "2.5.7"
 vec_extract_if_polyfill = "0.1.0"
 wasm-bindgen = "0.2"
 winapi = "0.3.8"
+wincode = { path = "wincode", features = ["solana-short-vec"] }
 winreg = "0.50"
 x509-parser = "0.14.0"
 zeroize = { version = "1.7", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ members = [
     "validator",
     "verified-packet-receiver",
     "version",
+    "wincode",
     "vortexor",
     "vote",
     "votor",

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -23,6 +23,7 @@ ignores=(
   .cargo
   target
   node_modules
+  wincode
 )
 
 not_paths=()

--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "wincode"
+version = "0.0.0"
+authors.workspace = true
+description = "Fast bincode de/serialization with placement initialization"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+paste = "1.0.15"
+solana-short-vec = { workspace = true, optional = true }
+thiserror = { workspace = true }
+
+[features]
+default = []
+solana-short-vec = ["dep:solana-short-vec"]
+
+[dev-dependencies]
+proptest = { workspace = true }
+solana-short-vec = { workspace = true }
+bincode = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+rand = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wincode"
-version = "0.0.0"
+version = "0.1.0"
 authors.workspace = true
 description = "Fast bincode de/serialization with placement initialization"
 repository.workspace = true

--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -8,25 +8,25 @@ homepage.workspace = true
 license.workspace = true
 edition.workspace = true
 
-[lints]
-workspace = true
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = []
+solana-short-vec = ["dep:solana-short-vec"]
 
 [dependencies]
 paste = "1.0.15"
 solana-short-vec = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
-[features]
-default = []
-solana-short-vec = ["dep:solana-short-vec"]
-
 [dev-dependencies]
-proptest = { workspace = true }
-solana-short-vec = { workspace = true }
 bincode = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+proptest = { workspace = true }
 rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+solana-short-vec = { workspace = true }
 
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+[lints]
+workspace = true

--- a/wincode/Cargo.toml
+++ b/wincode/Cargo.toml
@@ -13,13 +13,15 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["std"]
+alloc = []
+std = ["alloc", "thiserror/std"]
 solana-short-vec = ["dep:solana-short-vec"]
 
 [dependencies]
 paste = "1.0.15"
 solana-short-vec = { workspace = true, optional = true }
-thiserror = { workspace = true }
+thiserror = { workspace = true, default-features = false }
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/wincode/README.md
+++ b/wincode/README.md
@@ -1,0 +1,1 @@
+# wincode

--- a/wincode/README.md
+++ b/wincode/README.md
@@ -1,1 +1,32 @@
 # wincode
+
+Fast, bincode‑compatible serializer/deserializer focused on in‑place initialization and direct memory writes.
+
+[![Crates.io version](https://img.shields.io/crates/v/wincode.svg?style=flat-square)](https://crates.io/crates/wincode)
+[![docs.rs docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://docs.rs/wincode)
+
+## Quickstart
+
+`wincode` traits are implemented for many built-in types (like `Vec`, integers, etc.).
+
+You'll most likely want to start by using `wincode` on your own struct types, which can be
+done with the [`compound!`] macro.
+
+```rust
+struct MyStruct {
+    data: Vec<u64>,
+    win: bool,
+}
+
+compound! {
+    MyStruct {
+        data: Vec<u64>,
+        win: bool,
+    }
+}
+
+let val = MyStruct { data: vec![1,2,3], win: true };
+assert_eq!(wincode::serialize(&val).unwrap(), bincode::serialize(&val).unwrap());
+```
+
+See the [`docs`](https://docs.rs/wincode) for more details.

--- a/wincode/src/error.rs
+++ b/wincode/src/error.rs
@@ -20,9 +20,11 @@ pub enum Error {
     InvalidBoolEncoding(u8),
     #[error("Invalid tag encoding: {0}")]
     InvalidTagEncoding(usize),
+    #[error("Writer has trailing bytes: {0}")]
+    WriterTrailingBytes(usize),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 #[cold]
 pub fn read_size_limit(len: usize) -> Error {
@@ -57,4 +59,9 @@ pub fn invalid_bool_encoding(byte: u8) -> Error {
 #[cold]
 pub fn invalid_tag_encoding(tag: usize) -> Error {
     Error::InvalidTagEncoding(tag)
+}
+
+#[cold]
+pub fn writer_trailing_bytes(bytes: usize) -> Error {
+    Error::WriterTrailingBytes(bytes)
 }

--- a/wincode/src/error.rs
+++ b/wincode/src/error.rs
@@ -1,0 +1,60 @@
+//! Error types and helpers.
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Attempting to read {0} bytes")]
+    ReadSizeLimit(usize),
+    #[error("Attempting to write {0} bytes")]
+    WriteSizeLimit(usize),
+    #[error(
+        "Encoded sequence length exceeded preallocation limit of {limit} bytes (needed {needed} \
+         bytes)"
+    )]
+    PreallocationSizeLimit { needed: usize, limit: usize },
+    #[error("Encoded sequence length would overflow {0}")]
+    SizeHintOverflow(&'static str),
+    #[error("Could not cast integer type to pointer sized type")]
+    PointerSizedDecodeError,
+    #[error("Invalid bool encoding: {0}")]
+    InvalidBoolEncoding(u8),
+    #[error("Invalid tag encoding: {0}")]
+    InvalidTagEncoding(usize),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cold]
+pub fn read_size_limit(len: usize) -> Error {
+    Error::ReadSizeLimit(len)
+}
+
+#[cold]
+pub fn write_size_limit(len: usize) -> Error {
+    Error::WriteSizeLimit(len)
+}
+
+#[cold]
+pub fn preallocation_size_limit(needed: usize, limit: usize) -> Error {
+    Error::PreallocationSizeLimit { needed, limit }
+}
+
+#[cold]
+pub fn size_hint_overflow(max_length: &'static str) -> Error {
+    Error::SizeHintOverflow(max_length)
+}
+
+#[cold]
+pub fn pointer_sized_decode_error() -> Error {
+    Error::PointerSizedDecodeError
+}
+
+#[cold]
+pub fn invalid_bool_encoding(byte: u8) -> Error {
+    Error::InvalidBoolEncoding(byte)
+}
+
+#[cold]
+pub fn invalid_tag_encoding(tag: usize) -> Error {
+    Error::InvalidTagEncoding(tag)
+}

--- a/wincode/src/io.rs
+++ b/wincode/src/io.rs
@@ -1,0 +1,169 @@
+//! [`Reader`] and [`Writer`] implementations.
+use {
+    crate::error::{read_size_limit, write_size_limit, Result},
+    std::{mem::MaybeUninit, ptr},
+};
+
+/// In-memory reader that allows direct reads from the source buffer
+/// into user given destination buffers.
+pub struct Reader<'a> {
+    cursor: &'a [u8],
+}
+
+impl<'a> Reader<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self { cursor: bytes }
+    }
+
+    /// Copy exactly `len` bytes from the [`Reader`] into `buf`.
+    ///
+    /// # Safety
+    ///
+    /// - `buf` must not overlap with the cursor.
+    /// - `buf` must be valid for writes of `len` bytes.
+    #[inline(always)]
+    pub unsafe fn read_exact(&mut self, buf: *mut u8, len: usize) -> Result<()> {
+        let Some((src, rest)) = self.cursor.split_at_checked(len) else {
+            return Err(read_size_limit(len));
+        };
+        unsafe {
+            // SAFETY:
+            // - `src` is a valid pointer to a `[u8]`.
+            // - `src` is valid for reads of `len` bytes (given `split_at_checked`).
+            // - Caller ensures `buf` is valid for writes of `len` bytes.
+            ptr::copy_nonoverlapping(src.as_ptr(), buf, len);
+        }
+        self.cursor = rest;
+        Ok(())
+    }
+
+    /// Copy exactly `size_of::<T>()` bytes from the [`Reader`] into `ptr`.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must not overlap with the cursor.
+    /// - `ptr` must be valid for writes of `size_of::<T>()` bytes.
+    /// - `T` must be plain ol' data.
+    #[inline]
+    pub unsafe fn read_t<T>(&mut self, ptr: *mut T) -> Result<()> {
+        unsafe { self.read_exact(ptr as *mut u8, size_of::<T>()) }
+    }
+
+    /// Read T from the cursor into a new T.
+    ///
+    /// # Safety
+    ///
+    /// - `T` must be plain ol' data.
+    /// - `T` must be initialized by reads of `size_of::<T>()` bytes.
+    #[inline(always)]
+    pub unsafe fn get_t<T>(&mut self) -> Result<T> {
+        let mut val = MaybeUninit::<T>::uninit();
+        unsafe {
+            // SAFETY:
+            // - `val` is a valid pointer to a `T`.
+            // - Caller ensures `T` is plain ol' data and is initialized by reads of `size_of::<T>()` bytes.
+            self.read_exact(val.as_mut_ptr() as *mut u8, size_of::<T>())?;
+        }
+        Ok(val.assume_init())
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        self.cursor
+    }
+
+    /// Advance the cursor by `amt` bytes without checking bounds.
+    #[inline(always)]
+    pub fn consume_unchecked(&mut self, amt: usize) {
+        self.cursor = &self.cursor[amt..];
+    }
+
+    /// Advance `amt` bytes from the reader and discard them.
+    #[inline]
+    pub fn consume(&mut self, amt: usize) -> Result<()> {
+        if self.cursor.len() < amt {
+            return Err(read_size_limit(amt));
+        };
+        self.consume_unchecked(amt);
+        Ok(())
+    }
+}
+
+/// In-memory writer that allows direct writes from user given buffers
+/// into the internal destination buffer.
+pub struct Writer<'a> {
+    buffer: &'a mut Vec<u8>,
+}
+
+impl<'a> Writer<'a> {
+    pub fn new(buffer: &'a mut Vec<u8>) -> Self {
+        Self { buffer }
+    }
+
+    /// Write exactly `len` bytes from the given `buf` into the internal buffer.
+    ///
+    /// # Safety
+    ///
+    /// - `buf` must not overlap with the internal buffer.
+    /// - `buf` must be valid for reads of `len` bytes.
+    #[inline(always)]
+    pub unsafe fn write_exact(&mut self, buf: *const u8, len: usize) -> Result<()> {
+        let self_len = self.ensure_capacity_for(len)?;
+        unsafe {
+            // SAFETY:
+            // - Caller ensures `buf` is valid for reads of `len` bytes.
+            // - Caller ensures `buf` does not overlap with the internal buffer.
+            // - `self.buffer` is valid for writes of `len` bytes (given `capacity` check).
+            ptr::copy_nonoverlapping(buf, self.buffer.as_mut_ptr().add(self_len), len);
+            // SAFETY: capacity was checked above and we just wrote `len` bytes.
+            #[allow(clippy::arithmetic_side_effects)]
+            self.buffer.set_len(self_len + len);
+        }
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn ensure_capacity_for(&self, len: usize) -> Result<usize> {
+        let buf_len = self.buffer.len();
+        if len > self.buffer.capacity().saturating_sub(buf_len) {
+            return Err(write_size_limit(len));
+        }
+        Ok(buf_len)
+    }
+
+    /// Write `len` bytes from the given `write` function into the internal buffer.
+    ///
+    /// Prefer [`Writer::write_exact`] or [`Writer::write_t`] wherever possible.
+    ///
+    /// This method can be used to get `len` [`MaybeUninit<u8>`] bytes from internal
+    /// buffer memory and write into them directly.
+    ///
+    /// # Safety
+    ///
+    /// - `write` must write EXACTLY `len` bytes into the given buffer.
+    /// - `write` must not write from a buffer that overlap with the internal buffer.
+    pub unsafe fn write_with<F>(&mut self, len: usize, write: F) -> Result<()>
+    where
+        F: FnOnce(&mut [MaybeUninit<u8>]) -> Result<()>,
+    {
+        let self_len = self.ensure_capacity_for(len)?;
+        let buf = &mut self.buffer.spare_capacity_mut()[..len];
+        write(buf)?;
+        unsafe {
+            // SAFETY: Caller ensures `write` writes exactly `len` bytes.
+            #[allow(clippy::arithmetic_side_effects)]
+            self.buffer.set_len(self_len + len);
+        }
+        Ok(())
+    }
+
+    /// Write T into the internal buffer.
+    ///
+    /// # Safety
+    ///
+    /// - `T` must be plain ol' data.
+    #[inline(always)]
+    pub unsafe fn write_t<T>(&mut self, value: &T) -> Result<()> {
+        unsafe { self.write_exact(value as *const T as *const u8, size_of::<T>()) }
+    }
+}

--- a/wincode/src/len.rs
+++ b/wincode/src/len.rs
@@ -69,7 +69,7 @@ impl<const MAX_SIZE: usize> SeqLen for BincodeLen<MAX_SIZE> {
 
 #[cfg(feature = "solana-short-vec")]
 pub mod short_vec {
-    use {super::*, solana_short_vec::decode_shortu16_len};
+    use {super::*, core::ptr, solana_short_vec::decode_shortu16_len};
     pub struct ShortU16Len;
 
     /// Branchless computation of the number of bytes needed to encode a short u16.
@@ -107,15 +107,15 @@ pub mod short_vec {
         // byte may only have the 2 least-significant bits set, otherwise the encoded
         // value will overflow the u16.
         match needed {
-            1 => std::ptr::write(dst, len as u8),
+            1 => ptr::write(dst, len as u8),
             2 => {
-                std::ptr::write(dst, ((len & 0x7f) as u8) | 0x80);
-                std::ptr::write(dst.add(1), (len >> 7) as u8);
+                ptr::write(dst, ((len & 0x7f) as u8) | 0x80);
+                ptr::write(dst.add(1), (len >> 7) as u8);
             }
             3 => {
-                std::ptr::write(dst, ((len & 0x7f) as u8) | 0x80);
-                std::ptr::write(dst.add(1), (((len >> 7) & 0x7f) as u8) | 0x80);
-                std::ptr::write(dst.add(2), (len >> 14) as u8);
+                ptr::write(dst, ((len & 0x7f) as u8) | 0x80);
+                ptr::write(dst.add(1), (((len >> 7) & 0x7f) as u8) | 0x80);
+                ptr::write(dst.add(2), (len >> 14) as u8);
             }
             _ => unreachable!(),
         }
@@ -157,7 +157,7 @@ pub mod short_vec {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "alloc"))]
     mod tests {
         use {
             super::*,
@@ -165,6 +165,7 @@ pub mod short_vec {
                 compound,
                 containers::{self, Pod},
             },
+            alloc::vec::Vec,
             proptest::prelude::*,
             solana_short_vec::ShortU16,
         };

--- a/wincode/src/len.rs
+++ b/wincode/src/len.rs
@@ -1,0 +1,227 @@
+//! Support for heterogenous sequence length encoding.
+use crate::{
+    error::{preallocation_size_limit, size_hint_overflow, Result},
+    io::{Reader, Writer},
+    schema::{SchemaRead, SchemaWrite},
+};
+
+/// Behavior to support heterogenous sequence length encoding.
+///
+/// It is possible for sequences to have different length encoding schemes.
+/// This trait abstracts over that possibility, allowing users to specify
+/// the length encoding scheme for a sequence.
+pub trait SeqLen {
+    /// Read the length of a sequence from the reader.
+    fn size_hint(reader: &mut Reader) -> Result<usize>;
+    /// Get the length of a sequence from the reader, potentially
+    /// returning an error if some length condition is not met
+    /// (e.g., size constraints, overflow, etc.).
+    #[inline(always)]
+    fn size_hint_cautious<T>(reader: &mut Reader) -> Result<usize> {
+        Self::size_hint(reader)
+    }
+    /// Write the length of a sequence to the writer.
+    fn encode_len(writer: &mut Writer, len: usize) -> Result<()>;
+    /// Calculate the number of bytes needed to encode the given length.
+    ///
+    /// Useful for variable length encoding schemes.
+    fn bytes_needed(len: usize) -> Result<usize>;
+}
+
+const DEFAULT_BINCODE_LEN_MAX_SIZE: usize = 4 << 20; // 4 MiB
+/// [`SeqLen`] implementation for bincode's default fixint encoding.
+pub struct BincodeLen<const MAX_SIZE: usize = DEFAULT_BINCODE_LEN_MAX_SIZE>;
+
+impl<const MAX_SIZE: usize> SeqLen for BincodeLen<MAX_SIZE> {
+    /// Bincode's default fixint encoding writes lengths as `u64`.
+    #[inline(always)]
+    fn size_hint(reader: &mut Reader) -> Result<usize> {
+        u64::get(reader).map(|len| len as usize)
+    }
+
+    #[inline(always)]
+    fn size_hint_cautious<T>(reader: &mut Reader) -> Result<usize> {
+        let len = Self::size_hint(reader)?;
+        // Disallow lengths greater than `MAX_SIZE`.
+        //
+        // Enforcing this limit lengths prevents malicious input from causing OOM.
+        //
+        // Users can override this limit by implementing their own `SeqLen` implementation.
+        let needed = len
+            .checked_mul(size_of::<T>())
+            .ok_or_else(|| size_hint_overflow("isize::MAX"))?;
+        if needed > MAX_SIZE {
+            return Err(preallocation_size_limit(needed, MAX_SIZE));
+        }
+        Ok(len)
+    }
+
+    #[inline(always)]
+    fn encode_len(writer: &mut Writer, len: usize) -> Result<()> {
+        u64::write(writer, &(len as u64))
+    }
+
+    #[inline(always)]
+    fn bytes_needed(_len: usize) -> Result<usize> {
+        Ok(size_of::<u64>())
+    }
+}
+
+#[cfg(feature = "solana-short-vec")]
+pub mod short_vec {
+    use {super::*, solana_short_vec::decode_shortu16_len};
+    pub struct ShortU16Len;
+
+    /// Branchless computation of the number of bytes needed to encode a short u16.
+    ///
+    /// See [`solana_short_vec::ShortU16`] for more details.
+    #[inline(always)]
+    #[allow(clippy::arithmetic_side_effects)]
+    fn short_u16_bytes_needed(len: u16) -> usize {
+        1 + (len >= 0x80) as usize + (len >= 0x4000) as usize
+    }
+
+    #[inline(always)]
+    fn try_short_u16_bytes_needed<T: TryInto<u16>>(len: T) -> Result<usize> {
+        match len.try_into() {
+            Ok(len) => Ok(short_u16_bytes_needed(len)),
+            Err(_) => Err(size_hint_overflow("u16::MAX")),
+        }
+    }
+
+    /// Encode a short u16 into the given buffer.
+    ///
+    /// See [`solana_short_vec::ShortU16`] for more details.
+    ///
+    /// # Safety
+    ///
+    /// - `dst` must be a valid for writes.
+    /// - `dst` must be valid for `needed` bytes.
+    #[inline(always)]
+    unsafe fn encode_short_u16(dst: *mut u8, needed: usize, len: u16) {
+        // From `solana_short_vec`:
+        //
+        // u16 serialized with 1 to 3 bytes. If the value is above
+        // 0x7f, the top bit is set and the remaining value is stored in the next
+        // bytes. Each byte follows the same pattern until the 3rd byte. The 3rd
+        // byte may only have the 2 least-significant bits set, otherwise the encoded
+        // value will overflow the u16.
+        match needed {
+            1 => std::ptr::write(dst, len as u8),
+            2 => {
+                std::ptr::write(dst, ((len & 0x7f) as u8) | 0x80);
+                std::ptr::write(dst.add(1), (len >> 7) as u8);
+            }
+            3 => {
+                std::ptr::write(dst, ((len & 0x7f) as u8) | 0x80);
+                std::ptr::write(dst.add(1), (((len >> 7) & 0x7f) as u8) | 0x80);
+                std::ptr::write(dst.add(2), (len >> 14) as u8);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    impl SeqLen for ShortU16Len {
+        #[inline(always)]
+        fn size_hint(reader: &mut Reader) -> Result<usize> {
+            let Ok((len, read)) = decode_shortu16_len(reader.as_slice()) else {
+                return Err(size_hint_overflow("u16::MAX"));
+            };
+            // `decode_shortu16_len` successfully read `read` bytes.
+            reader.consume_unchecked(read);
+            Ok(len)
+        }
+
+        #[inline(always)]
+        fn encode_len(writer: &mut Writer, len: usize) -> Result<()> {
+            if len > u16::MAX as usize {
+                return Err(size_hint_overflow("u16::MAX"));
+            }
+
+            let len = len as u16;
+            let needed = short_u16_bytes_needed(len);
+            unsafe {
+                // SAFETY: `writer.write_with` ensures we have at least `needed` bytes of capacity.
+                writer.write_with(needed, |dst| {
+                    encode_short_u16(dst.as_mut_ptr().cast(), needed, len);
+                    Ok(())
+                })?;
+            }
+
+            Ok(())
+        }
+
+        #[inline(always)]
+        fn bytes_needed(len: usize) -> Result<usize> {
+            try_short_u16_bytes_needed(len)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use {
+            super::*,
+            crate::{
+                compound,
+                containers::{self, Pod},
+            },
+            proptest::prelude::*,
+            solana_short_vec::ShortU16,
+        };
+
+        fn our_short_u16_encode(len: u16) -> Vec<u8> {
+            let needed = short_u16_bytes_needed(len);
+            let mut buf = Vec::with_capacity(needed);
+            unsafe {
+                encode_short_u16(buf.as_mut_ptr(), needed, len);
+                buf.set_len(needed);
+            }
+            buf
+        }
+
+        #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+        struct ShortVecStruct {
+            #[serde(with = "solana_short_vec")]
+            bytes: Vec<u8>,
+            #[serde(with = "solana_short_vec")]
+            ar: Vec<[u8; 32]>,
+        }
+
+        compound! {
+            ShortVecStruct {
+                bytes: containers::Vec<Pod<u8>, ShortU16Len>,
+                ar: containers::Vec<Pod<[u8; 32]>, ShortU16Len>,
+            }
+        }
+        fn strat_short_vec_struct() -> impl Strategy<Value = ShortVecStruct> {
+            (
+                proptest::collection::vec(any::<u8>(), 0..=100),
+                proptest::collection::vec(any::<[u8; 32]>(), 0..=16),
+            )
+                .prop_map(|(bytes, ar)| ShortVecStruct { bytes, ar })
+        }
+
+        proptest! {
+            #[test]
+            fn encode_u16_equivalence(len in 0..=u16::MAX) {
+                let our = our_short_u16_encode(len);
+                let bincode = bincode::serialize(&ShortU16(len)).unwrap();
+                prop_assert_eq!(our, bincode);
+            }
+
+            #[test]
+            fn test_short_vec_struct(short_vec_struct in strat_short_vec_struct()) {
+                let bincode_serialized = bincode::serialize(&short_vec_struct).unwrap();
+                let schema_serialized = crate::serialize(&short_vec_struct).unwrap();
+                prop_assert_eq!(&bincode_serialized, &schema_serialized);
+                let bincode_deserialized: ShortVecStruct = bincode::deserialize(&bincode_serialized).unwrap();
+                let schema_deserialized: ShortVecStruct = crate::deserialize(&schema_serialized).unwrap();
+                prop_assert_eq!(&short_vec_struct, &bincode_deserialized);
+                prop_assert_eq!(short_vec_struct, schema_deserialized);
+            }
+        }
+    }
+}
+
+#[cfg(feature = "solana-short-vec")]
+pub use short_vec::*;

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -1,0 +1,15 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+pub mod error;
+pub use error::{Error, Result};
+pub mod io;
+pub mod len;
+mod schema;
+pub use schema::*;
+mod serde;
+pub use serde::*;
+
+#[doc(hidden)]
+pub mod __private {
+    #[doc(hidden)]
+    pub use paste::paste;
+}

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -131,6 +131,10 @@
 //!   layout implied by your `serde` types.
 //! - Length encodings are pluggable via [`SeqLen`](len::SeqLen).
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 pub mod error;
 pub use error::{Error, Result};
 pub mod io;

--- a/wincode/src/lib.rs
+++ b/wincode/src/lib.rs
@@ -1,3 +1,135 @@
+//! wincode is a fast, bincode‑compatible serializer/deserializer focused on in‑place
+//! initialization and direct memory writes.
+//!
+//! In short, `wincode` operates over traits that facilitate direct writes of memory
+//! into final destinations (including heap-allocated buffers) without intermediate
+//! staging buffers.
+//!
+//! # Quickstart
+//!
+//! `wincode` traits are implemented for many built-in types (like `Vec`, integers, etc.).
+//!
+//! You'll most likely want to start by using `wincode` on your own struct types, which can be
+//! done with the [`compound!`] macro.
+//!
+//! ```
+//! # use {wincode::compound, serde::{Serialize, Deserialize}};
+//! # #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+//! struct MyStruct {
+//!     data: Vec<u64>,
+//!     win: bool,
+//! }
+//!
+//! compound! {
+//!     MyStruct {
+//!         data: Vec<u64>,
+//!         win: bool,
+//!     }
+//! }
+//!
+//! let val = MyStruct { data: vec![1,2,3], win: true };
+//! assert_eq!(wincode::serialize(&val).unwrap(), bincode::serialize(&val).unwrap());
+//! ```
+//!
+//! For POD‑like fields (bytes, arrays of bytes, POD newtypes), use [`containers`]
+//! to leverage optimized read/write implementations.
+//!
+//! ```
+//! # use {wincode::{compound, containers::{self, Pod}}, serde::{Serialize, Deserialize}};
+//! # #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug)]
+//! struct MyStruct {
+//!     data: Vec<u8>,
+//!     addresses: Vec<[u8; 32]>,
+//! }
+//!
+//! compound! {
+//!     MyStruct {
+//!         data: containers::Vec<Pod<u8>>,
+//!         addresses: containers::Vec<Pod<[u8; 32]>>,
+//!     }
+//! }
+//!
+//! let val = MyStruct { data: vec![1,2,3], addresses: vec![[0; 32], [1; 32]] };
+//! assert_eq!(wincode::serialize(&val).unwrap(), bincode::serialize(&val).unwrap());
+//! ```
+//!
+//! # Motivation
+//!
+//! Safe Rust offers limited support for placement initialization, especially for heap
+//! memory. The effect of this is a lot of unnecessary copying, which is unacceptable in
+//! performance‑critical code.
+//! `serde` inherits these limitations since it neither attempts to initialize in‑place
+//! nor exposes APIs to do so. `wincode` addresses this by providing schemas that support direct,
+//! in‑place reads and writes for common patterns like byte buffers and POD types.
+//!
+//! # Adapting foreign types
+//!
+//! Another motivating feature of `wincode` is the ability to implement serialization/deserialization
+//! on foreign types, where serialization/deserialization schemes on those types are unoptimized (and
+//! out of your control as a foreign type). For example, suppose the following struct,
+//! defined outside of your crate:
+//! ```
+//! use serde::{Serialize, Deserialize};
+//!
+//! #[derive(Serialize, Deserialize)]
+//! pub struct A {
+//!     pub data: Vec<u8>,
+//!     pub address: [u8; 32],
+//! }
+//! ```
+//!
+//! `serde`'s default, naive, implementation will perform per-element visitation of all bytes
+//! in `Vec<u8>` and `[u8; 32]`. Because these fields are "plain old data", ideally we would
+//! avoid per-element visitation entirely and read / write these fields in a single pass.
+//! The situation worsens if this struct needs to be written into a heap allocated data structure,
+//! like a `Vec<A>` or `Box<[A]>`. Due to lack of placement initialization of heap memory, all
+//! those bytes will be put on the stack before being copied into the heap allocation.
+//!
+//! `wincode` can solve this with the following:
+//! ```
+//! # use wincode::{compound, Serialize, Deserialize, containers::{self, Pod}};
+//! # #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+//! pub struct A {
+//!     pub data: Vec<u8>,
+//!     pub address: [u8; 32],
+//! }
+//!
+//! compound! {
+//!     struct MyA => A {
+//!         data: containers::Vec<Pod<u8>>,
+//!         address: Pod<[u8; 32]>,
+//!     }
+//! }
+//!
+//! let val = A {
+//!     data: vec![1, 2, 3],
+//!     address: [0; 32],
+//! };
+//! let bincode_serialize = bincode::serialize(&val).unwrap();
+//! let wincode_serialize = MyA::serialize(&val).unwrap();
+//! assert_eq!(bincode_serialize, wincode_serialize);
+//!
+//! let bincode_deserialize: A = bincode::deserialize(&bincode_serialize).unwrap();
+//! let wincode_deserialize = MyA::deserialize(&bincode_serialize).unwrap();
+//! assert_eq!(val, bincode_deserialize);
+//! assert_eq!(val, wincode_deserialize);
+//! ```
+//!
+//! Now, when deserializing `A`:
+//! - All initialization is done in-place, including heap-allocated memory
+//!   (true of all supported heap-allocated structures in `wincode`).
+//! - Byte fields are written in a single pass by leveraging the
+//!   [`Pod`](containers::Pod) in the [`containers`] module.
+//! - No intermediate staging buffers: bytes are copied directly into the final
+//!   destination allocation during deserialization and written directly into the
+//!   output buffer during serialization.
+//!
+//! # Compatibility
+//!
+//! - Produces the same bytes as `bincode` for the covered shapes when using bincode's
+//!   default configuration, provided your [`compound!`] schema and [`containers`] match the
+//!   layout implied by your `serde` types.
+//! - Length encodings are pluggable via [`SeqLen`](len::SeqLen).
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 pub mod error;
 pub use error::{Error, Result};

--- a/wincode/src/schema/containers.rs
+++ b/wincode/src/schema/containers.rs
@@ -1,0 +1,508 @@
+//! This module provides specialized "container" types that can be used to opt
+//! into optimized read/write implementations or specialized length encodings.
+//!
+//! # Examples
+//! Raw byte vec with default bincode length encoding:
+//!
+//! ```
+//! use wincode::{containers::{self, Pod}, compound};
+//! use serde::{Serialize, Deserialize};
+//!
+//! #[derive(Serialize, Deserialize, Debug)]
+//! struct MyStruct {
+//!     vec: Vec<u8>,
+//! }
+//!
+//! compound! {
+//!     MyStruct {
+//!         vec: containers::Vec<Pod<u8>>,
+//!     }
+//! }
+//!
+//! let my_struct = MyStruct {
+//!     vec: vec![1, 2, 3],
+//! };
+//! let wincode_bytes = wincode::serialize(&my_struct).unwrap();
+//! let bincode_bytes = bincode::serialize(&my_struct).unwrap();
+//! assert_eq!(wincode_bytes, bincode_bytes);
+//! ```
+//!
+//! Raw byte vec with solana short vec length encoding:
+//!
+//! ```
+//! use wincode::{containers::{self, Pod}, compound, len::ShortU16Len};
+//! use serde::{Serialize, Deserialize};
+//! use solana_short_vec;
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct MyStruct {
+//!     #[serde(with = "solana_short_vec")]
+//!     vec: Vec<u8>,
+//! }
+//!
+//! compound! {
+//!     MyStruct {
+//!         vec: containers::Vec<Pod<u8>, ShortU16Len>,
+//!     }
+//! }
+//!
+//! let my_struct = MyStruct {
+//!     vec: vec![1, 2, 3],
+//! };
+//! let wincode_bytes = wincode::serialize(&my_struct).unwrap();
+//! let bincode_bytes = bincode::serialize(&my_struct).unwrap();
+//! assert_eq!(wincode_bytes, bincode_bytes);
+//! ```
+//!
+//! Vector with non-POD elements and custom length encoding:
+//!
+//! ```
+//! use wincode::{containers::{self, Elem}, compound, len::ShortU16Len};
+//! use serde::{Serialize, Deserialize};
+//! use solana_short_vec;
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct Point {
+//!     x: u64,
+//!     y: u64,
+//! }
+//!
+//! compound! {
+//!     Point {
+//!         x: u64,
+//!         y: u64,
+//!     }
+//! }
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct MyStruct {
+//!     #[serde(with = "solana_short_vec")]
+//!     vec: Vec<Point>,
+//! }
+//!
+//! compound! {
+//!     MyStruct {
+//!         vec: containers::Vec<Elem<Point>, ShortU16Len>,
+//!     }
+//! }
+//!
+//! let my_struct = MyStruct {
+//!     vec: vec![Point { x: 1, y: 2 }, Point { x: 3, y: 4 }],
+//! };
+//! let wincode_bytes = wincode::serialize(&my_struct).unwrap();
+//! let bincode_bytes = bincode::serialize(&my_struct).unwrap();
+//! assert_eq!(wincode_bytes, bincode_bytes);
+//! ```
+use {
+    crate::{
+        error::Result,
+        io::{Reader, Writer},
+        len::{BincodeLen, SeqLen},
+        schema::{size_of_elem_iter, write_elem_iter, SchemaRead, SchemaWrite},
+    },
+    std::{marker::PhantomData, mem::MaybeUninit, ptr},
+};
+
+/// A [`Vec`](std::vec::Vec) with a customizable length encoding and optimized
+/// read/write implementation for [`Pod`].
+pub struct Vec<T, Len = BincodeLen>(PhantomData<Len>, PhantomData<T>);
+
+/// A [`VecDeque`](std::collections::VecDeque) with a customizable length encoding and optimized
+/// read/write implementation for [`Pod`].
+pub struct VecDeque<T, Len = BincodeLen>(PhantomData<Len>, PhantomData<T>);
+
+/// A [`Box<[T]>`](std::boxed::Box) with a customizable length encoding and optimized
+/// read/write implementation for [`Pod`].
+///
+/// # Examples
+///
+/// ```
+/// use wincode::{containers::{self, BoxedSlice, Pod}, compound};
+/// use serde::{Serialize, Deserialize};
+/// # use std::array;
+///
+/// #[derive(Serialize, Deserialize, Clone, Copy)]
+/// #[repr(transparent)]
+/// struct Address([u8; 32]);
+///
+/// #[derive(Serialize, Deserialize)]
+/// struct MyStruct {
+///     address: Box<[Address]>
+/// }
+///
+/// compound! {
+///     MyStruct {
+///         address: BoxedSlice<Pod<Address>>,
+///     }
+/// }
+///
+/// let my_struct = MyStruct {
+///     address: vec![Address(array::from_fn(|i| i as u8)); 10].into_boxed_slice(),
+/// };
+/// let wincode_bytes = wincode::serialize(&my_struct).unwrap();
+/// let bincode_bytes = bincode::serialize(&my_struct).unwrap();
+/// assert_eq!(wincode_bytes, bincode_bytes);
+/// ```
+pub struct BoxedSlice<T, Len = BincodeLen>(PhantomData<T>, PhantomData<Len>);
+
+/// Indicates that the type is an element of a sequence, composable with [`containers`](self).
+///
+/// Prefer [`Pod`] for types representable as raw bytes.
+pub struct Elem<T>(PhantomData<T>);
+
+/// Indicates that the type is represented by raw bytes, composable with sequence [`containers`](self)
+/// or compound types (structs, tuples) for an optimized read/write implementation.
+///
+/// Use [`Elem`] with [`containers`](self) that aren't comprised of POD.
+///
+/// This can be useful outside of sequences as well, for example on newtype structs
+/// containing byte arrays / vectors with `#[repr(transparent)]`.
+///
+/// # Examples
+///
+/// A repr-transparent newtype struct with a byte array:
+/// ```
+/// # use wincode::{containers::{self, Pod}, compound};
+/// # use serde::{Serialize, Deserialize};
+/// # use std::array;
+/// #[derive(Serialize, Deserialize)]
+/// #[repr(transparent)]
+/// struct Address([u8; 32]);
+///
+/// #[derive(Serialize, Deserialize)]
+/// struct MyStruct {
+///     address: Address
+/// }
+///
+/// compound! {
+///     MyStruct {
+///         address: Pod<Address>,
+///     }
+/// }
+///
+/// let my_struct = MyStruct {
+///     address: Address(array::from_fn(|i| i as u8)),
+/// };
+/// let wincode_bytes = wincode::serialize(&my_struct).unwrap();
+/// let bincode_bytes = bincode::serialize(&my_struct).unwrap();
+/// assert_eq!(wincode_bytes, bincode_bytes);
+/// ```
+pub struct Pod<T>(PhantomData<T>);
+
+impl<T> SchemaWrite for Pod<T> {
+    type Src = T;
+
+    #[inline(always)]
+    fn size_of(_src: &Self::Src) -> Result<usize> {
+        Ok(size_of::<T>())
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, src: &Self::Src) -> Result<()> {
+        // SAFETY: caller ensures `T` is plain ol' data.
+        unsafe { writer.write_t(src) }
+    }
+}
+
+impl<T> SchemaRead for Pod<T> {
+    type Dst = T;
+
+    /// Read into `dst` from `reader`.
+    ///
+    /// # Safety
+    ///
+    /// - `dst` must be a valid pointer to a `T`.
+    /// - `T` must be plain ol' data.
+    #[inline(always)]
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        // SAFETY:
+        // - Caller ensures `dst` is a valid pointer to a T.
+        // - Caller ensures `T` is plain ol' data.
+        unsafe { reader.read_t(dst) }
+    }
+}
+
+impl<T, Len> SchemaWrite for Vec<Elem<T>, Len>
+where
+    Len: SeqLen,
+    T: SchemaWrite,
+    T::Src: Sized,
+{
+    type Src = std::vec::Vec<T::Src>;
+
+    #[inline(always)]
+    fn size_of(src: &Self::Src) -> Result<usize> {
+        size_of_elem_iter::<T, Len>(src.iter())
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, src: &Self::Src) -> Result<()> {
+        write_elem_iter::<T, Len>(writer, src.iter())
+    }
+}
+
+impl<T, Len> SchemaRead for Vec<Elem<T>, Len>
+where
+    Len: SeqLen,
+    T: SchemaRead,
+{
+    type Dst = std::vec::Vec<T::Dst>;
+
+    /// Read a sequence of `T::Dst`s from `reader` into `dst`.
+    ///
+    /// This provides a `*mut T::Dst` for each slot in the allocated Vec
+    /// to facilitate in-place writing of Vec memory.
+    ///
+    /// Prefer [`Vec<Pod<T>, Len>`] for sequences representable as raw bytes.
+    ///
+    /// # Safety
+    ///
+    /// - `dst` must not overlap with the cursor.
+    /// - `dst` must be valid pointer to a `Vec<T::Dst>`.
+    /// - `T::read` must properly initialize elements.
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        let len = Len::size_hint_cautious::<T::Dst>(reader)?;
+        let mut vec = std::vec::Vec::with_capacity(len);
+        // Get a raw pointer to the Vec memory to facilitate in-place writing.
+        let vec_ptr = vec.spare_capacity_mut().as_mut_ptr();
+        for i in 0..len {
+            // Yield the current slot to the caller.
+            if let Err(e) = T::read(reader, vec_ptr.add(i) as *mut T::Dst) {
+                unsafe {
+                    // SAFETY: we've read at least `i` elements.
+                    vec.set_len(i);
+                }
+                return Err(e);
+            }
+        }
+        unsafe {
+            // SAFETY: Caller ensures `parse_t` properly initializes elements.
+            vec.set_len(len);
+            // SAFETY: Caller ensures `ptr` is a valid ptr to a Vec<T>.
+            ptr::write(dst, vec);
+        }
+        Ok(())
+    }
+}
+
+impl<T, Len> SchemaWrite for Vec<Pod<T>, Len>
+where
+    Len: SeqLen,
+{
+    type Src = std::vec::Vec<T>;
+
+    #[inline(always)]
+    fn size_of(src: &Self::Src) -> Result<usize> {
+        #[allow(clippy::arithmetic_side_effects)]
+        Ok(Len::bytes_needed(src.len())? + size_of_val(src.as_slice()))
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, src: &Self::Src) -> Result<()> {
+        Len::encode_len(writer, src.len())?;
+        // SAFETY: Caller ensures `src` is plain ol' data.
+        unsafe { writer.write_exact(src.as_ptr() as *const u8, size_of_val(src.as_slice())) }
+    }
+}
+
+impl<T, Len> SchemaRead for Vec<Pod<T>, Len>
+where
+    Len: SeqLen,
+{
+    type Dst = std::vec::Vec<T>;
+
+    /// Read a sequence of bytes or a sequence of fixed length byte arrays from the cursor into `dst`.
+    ///
+    /// This reads the entire sequence at once, rather than yielding each element to the caller.
+    ///
+    /// Should be used with types representable by raw bytes, like `Vec<u8>` or `Vec<[u8; N]>`.
+    ///
+    /// # Safety
+    ///
+    /// - `dst` must not overlap with the cursor.
+    /// - `dst` must be valid pointer to a `Vec<T>`.
+    /// - `T` must be plain ol' data, valid for writes of `size_of::<T>()` bytes.
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        let len = Len::size_hint_cautious::<T>(reader)?;
+        let mut vec = std::vec::Vec::with_capacity(len);
+        let vec_ptr = vec.spare_capacity_mut().as_mut_ptr();
+        unsafe {
+            #[allow(clippy::arithmetic_side_effects)]
+            reader.read_exact(vec_ptr as *mut u8, len * size_of::<T>())?;
+            // SAFETY: Caller ensures `T` is plain ol' data and can be initialized by raw byte reads.
+            vec.set_len(len);
+            // SAFETY: Caller ensures `ptr` is a valid ptr to a Vec<T>.
+            ptr::write(dst, vec);
+        }
+        Ok(())
+    }
+}
+
+impl<T, Len> SchemaWrite for BoxedSlice<Pod<T>, Len>
+where
+    Len: SeqLen,
+{
+    type Src = Box<[T]>;
+
+    #[inline(always)]
+    fn size_of(src: &Self::Src) -> Result<usize> {
+        #[allow(clippy::arithmetic_side_effects)]
+        Ok(Len::bytes_needed(src.len())? + size_of_val(&src[..]))
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, src: &Self::Src) -> Result<()> {
+        Len::encode_len(writer, src.len())?;
+        // SAFETY: Caller ensures `T` is plain ol' data.
+        unsafe { writer.write_exact(src[..].as_ptr() as *const u8, size_of_val(&src[..])) }
+    }
+}
+
+impl<T, Len> SchemaRead for BoxedSlice<Pod<T>, Len>
+where
+    Len: SeqLen,
+{
+    type Dst = Box<[T]>;
+
+    #[inline(always)]
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        let mut vec = MaybeUninit::uninit();
+        unsafe {
+            // Leverage drop safety of the Vec impl.
+            <Vec<Pod<T>, Len>>::read(reader, vec.as_mut_ptr())?;
+            ptr::write(dst, vec.assume_init().into_boxed_slice());
+        }
+        Ok(())
+    }
+}
+
+impl<T, Len> SchemaWrite for BoxedSlice<Elem<T>, Len>
+where
+    Len: SeqLen,
+    T: SchemaWrite,
+    T::Src: Sized,
+{
+    type Src = Box<[T::Src]>;
+
+    #[inline(always)]
+    fn size_of(src: &Self::Src) -> Result<usize> {
+        size_of_elem_iter::<T, Len>(src.iter())
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, src: &Self::Src) -> Result<()> {
+        write_elem_iter::<T, Len>(writer, src.iter())
+    }
+}
+
+impl<T, Len> SchemaRead for BoxedSlice<Elem<T>, Len>
+where
+    Len: SeqLen,
+    T: SchemaRead,
+{
+    type Dst = Box<[T::Dst]>;
+
+    #[inline(always)]
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        let mut v = MaybeUninit::uninit();
+        unsafe {
+            <Vec<Elem<T>, Len>>::read(reader, v.as_mut_ptr())?;
+            ptr::write(dst, v.assume_init().into_boxed_slice());
+        }
+        Ok(())
+    }
+}
+
+impl<T, Len> SchemaWrite for VecDeque<Pod<T>, Len>
+where
+    Len: SeqLen,
+{
+    type Src = std::collections::VecDeque<T>;
+
+    #[inline(always)]
+    fn size_of(src: &Self::Src) -> Result<usize> {
+        #[allow(clippy::arithmetic_side_effects)]
+        Ok(Len::bytes_needed(src.len())? + size_of::<T>() * src.len())
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, src: &Self::Src) -> Result<()> {
+        Len::encode_len(writer, src.len())?;
+        let (front, back) = src.as_slices();
+        unsafe {
+            // SAFETY:
+            // - Caller ensures given `T` is plain ol' data.
+            // - `front` and `back` are valid non-overlapping slices.
+            writer.write_exact(front.as_ptr() as *const u8, size_of_val(front))?;
+            writer.write_exact(back.as_ptr() as *const u8, size_of_val(back))?;
+        }
+        Ok(())
+    }
+}
+
+impl<T, Len> SchemaRead for VecDeque<Pod<T>, Len>
+where
+    Len: SeqLen,
+{
+    type Dst = std::collections::VecDeque<T>;
+
+    #[inline(always)]
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        let mut vec = MaybeUninit::uninit();
+        // Leverage the contiguous read optimization of `Vec`.
+        <Vec<Pod<T>, Len>>::read(reader, vec.as_mut_ptr())?;
+        unsafe {
+            // From<Vec<T>> for VecDeque<T> is basically free.
+            //
+            // SAFETY:
+            // - Caller ensures `dst` is a valid pointer to a VecDeque<T>.
+            // - Caller ensures the given `SchemaRead` properly initializes the dst.
+            ptr::write(dst, vec.assume_init().into());
+        }
+
+        Ok(())
+    }
+}
+
+impl<T, Len> SchemaWrite for VecDeque<Elem<T>, Len>
+where
+    Len: SeqLen,
+    T: SchemaWrite,
+    T::Src: Sized,
+{
+    type Src = std::collections::VecDeque<T::Src>;
+
+    #[inline(always)]
+    fn size_of(value: &Self::Src) -> Result<usize> {
+        size_of_elem_iter::<T, Len>(value.iter())
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, src: &Self::Src) -> Result<()> {
+        write_elem_iter::<T, Len>(writer, src.iter())
+    }
+}
+
+impl<T, Len> SchemaRead for VecDeque<Elem<T>, Len>
+where
+    Len: SeqLen,
+    T: SchemaRead,
+{
+    type Dst = std::collections::VecDeque<T::Dst>;
+
+    #[inline(always)]
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        let mut vec = MaybeUninit::uninit();
+        // Leverage the contiguous read optimization of `Vec`.
+        <Vec<Elem<T>, Len>>::read(reader, vec.as_mut_ptr())?;
+        unsafe {
+            // From<Vec<T>> for VecDeque<T> is basically free.
+            // SAFETY:
+            // - `dst` must be a valid pointer to a VecDeque<T>.
+            // - The given `SchemaRead` must properly initialize the dst.
+            ptr::write(dst, vec.assume_init().into());
+        }
+
+        Ok(())
+    }
+}

--- a/wincode/src/schema/impls.rs
+++ b/wincode/src/schema/impls.rs
@@ -1,0 +1,653 @@
+use {
+    crate::{
+        error::{
+            invalid_bool_encoding, invalid_tag_encoding, pointer_sized_decode_error, Error, Result,
+        },
+        io::{Reader, Writer},
+        len::BincodeLen,
+        schema::{
+            containers::{self, Elem},
+            size_of_elem_iter, write_elem_iter, SchemaRead, SchemaWrite,
+        },
+    },
+    std::{collections::VecDeque, mem::MaybeUninit, ptr},
+};
+
+macro_rules! impl_int {
+    ($type:ty) => {
+        impl SchemaWrite for $type {
+            type Src = $type;
+
+            #[inline(always)]
+            fn size_of(_src: &Self::Src) -> Result<usize> {
+                Ok(size_of::<$type>())
+            }
+
+            #[inline(always)]
+            fn write(writer: &mut Writer, src: &Self::Src) -> Result<()> {
+                // bincode defaults to little endian encoding.
+                // noop on LE machines.
+                unsafe {
+                    // SAFETY: int is plain ol' data.
+                    writer.write_t(&src.to_le_bytes())?;
+                }
+                Ok(())
+            }
+        }
+
+        impl SchemaRead for $type {
+            type Dst = $type;
+
+            #[inline(always)]
+            unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+                // SAFETY: Caller ensures `ptr` is a valid pointer to a u64.
+                unsafe { reader.read_t(dst) }?;
+                // bincode defaults to little endian encoding.
+                #[cfg(target_endian = "big")]
+                {
+                    // SAFETY: `ptr` is initialized by `read_t`.
+                    let val = unsafe { &mut *dst };
+                    *val = val.swap_bytes();
+                }
+
+                Ok(())
+            }
+        }
+    };
+
+    ($type:ty as $cast:ty) => {
+        impl SchemaWrite for $type {
+            type Src = $type;
+
+            #[inline(always)]
+            fn size_of(_src: &Self::Src) -> Result<usize> {
+                Ok(size_of::<$cast>())
+            }
+
+            #[inline(always)]
+            fn write(writer: &mut Writer, src: &Self::Src) -> Result<()> {
+                let src = *src as $cast;
+                // bincode defaults to little endian encoding.
+                // noop on LE machines.
+                unsafe {
+                    // SAFETY: int is plain ol' data.
+                    writer.write_t(&src.to_le_bytes())?;
+                }
+                Ok(())
+            }
+        }
+
+        impl SchemaRead for $type {
+            type Dst = $type;
+
+            #[inline(always)]
+            unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+                let casted = reader.get_t::<$cast>()?;
+                let val = <$type>::from_le(
+                    casted
+                        .try_into()
+                        .map_err(|_| pointer_sized_decode_error())?,
+                );
+
+                unsafe {
+                    ptr::write(dst, val);
+                }
+
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_int!(u16);
+impl_int!(i16);
+impl_int!(u32);
+impl_int!(i32);
+impl_int!(u64);
+impl_int!(i64);
+impl_int!(u128);
+impl_int!(i128);
+impl_int!(usize as u64);
+impl_int!(isize as i64);
+
+macro_rules! impl_pod {
+    ($type:ty) => {
+        impl SchemaWrite for $type {
+            type Src = $type;
+
+            #[inline(always)]
+            fn size_of(_src: &Self::Src) -> Result<usize> {
+                Ok(size_of::<$type>())
+            }
+
+            #[inline(always)]
+            fn write(writer: &mut Writer, src: &Self::Src) -> Result<()> {
+                // SAFETY: `$type` is plain ol' data.
+                unsafe { writer.write_t(src) }
+            }
+        }
+
+        impl SchemaRead for $type {
+            type Dst = $type;
+
+            #[inline(always)]
+            unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+                // SAFETY: `$type` is plain ol' data.
+                unsafe { reader.read_t(dst) }
+            }
+        }
+    };
+}
+
+impl_pod!(u8);
+impl_pod!(i8);
+
+impl SchemaWrite for bool {
+    type Src = bool;
+
+    fn size_of(_src: &Self::Src) -> Result<usize> {
+        Ok(size_of::<u8>())
+    }
+
+    fn write(writer: &mut Writer, src: &Self::Src) -> Result<()> {
+        unsafe { writer.write_t(&(*src as u8)) }
+    }
+}
+
+impl SchemaRead for bool {
+    type Dst = bool;
+
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        let byte = reader.get_t::<u8>()?;
+        match byte {
+            0 => unsafe { ptr::write(dst, false) },
+            1 => unsafe { ptr::write(dst, true) },
+            _ => return Err(invalid_bool_encoding(byte)),
+        }
+        Ok(())
+    }
+}
+
+/// Blanket `Vec<T>` `SchemaWrite` implementation.
+///
+/// If the user wants to serialize a plain `Vec<T>`, we can assume it should
+/// use the default bincode length encoding, as otherwise specifying a length
+/// encoding would require a newtype struct with a custom #[serde(with = "x")],
+/// which is obviously not the case here.
+///
+/// We also cannot make any assumptions about the "Plain Old Data" nature of `T`,
+/// so we play it safe and use `Elem<T>` for the sequence mode.
+impl<T> SchemaWrite for Vec<T>
+where
+    T: SchemaWrite,
+    T::Src: Sized,
+{
+    type Src = Vec<T::Src>;
+
+    #[inline(always)]
+    fn size_of(value: &Self::Src) -> Result<usize> {
+        <containers::Vec<Elem<T>, BincodeLen>>::size_of(value)
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, value: &Self::Src) -> Result<()> {
+        <containers::Vec<Elem<T>, BincodeLen>>::write(writer, value)
+    }
+}
+
+impl<T> SchemaRead for Vec<T>
+where
+    T: SchemaRead,
+{
+    type Dst = Vec<T::Dst>;
+
+    #[inline(always)]
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        <containers::Vec<Elem<T>, BincodeLen>>::read(reader, dst)
+    }
+}
+
+impl<T> SchemaWrite for VecDeque<T>
+where
+    T: SchemaWrite,
+    T::Src: Sized,
+{
+    type Src = VecDeque<T::Src>;
+
+    #[inline(always)]
+    fn size_of(value: &Self::Src) -> Result<usize> {
+        <containers::VecDeque<Elem<T>, BincodeLen>>::size_of(value)
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, value: &Self::Src) -> Result<()> {
+        <containers::VecDeque<Elem<T>, BincodeLen>>::write(writer, value)
+    }
+}
+
+impl<T> SchemaRead for VecDeque<T>
+where
+    T: SchemaRead,
+{
+    type Dst = VecDeque<T::Dst>;
+
+    #[inline(always)]
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        <containers::VecDeque<Elem<T>, BincodeLen>>::read(reader, dst)
+    }
+}
+
+/// Blanket `[T]` `SchemaWrite` implementation.
+///
+/// Similar to `Vec<T>`, we assume the default bincode length encoding and
+/// can't make any assumptions about the "Plain Old Data" nature of `T`.
+impl<T> SchemaWrite for [T]
+where
+    T: SchemaWrite,
+    T::Src: Sized,
+{
+    type Src = [T::Src];
+
+    #[inline(always)]
+    fn size_of(value: &Self::Src) -> Result<usize> {
+        size_of_elem_iter::<T, BincodeLen>(value.iter())
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, value: &Self::Src) -> Result<()> {
+        write_elem_iter::<T, BincodeLen>(writer, value.iter())
+    }
+}
+
+impl<T, const N: usize> SchemaRead for [T; N]
+where
+    T: SchemaRead,
+{
+    type Dst = [T::Dst; N];
+
+    #[inline(always)]
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        let ptr = dst as *mut T::Dst;
+        for i in 0..N {
+            unsafe {
+                // SAFETY:
+                // - `i` is gated by `N`.
+                // - `ptr` must be a valid pointer to a `[T::Dst; N]`.
+                // - `T::read` must properly initialize the `T::Dst`.
+                T::read(reader, ptr.add(i))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T, const N: usize> SchemaWrite for [T; N]
+where
+    T: SchemaWrite,
+    T::Src: Sized,
+{
+    type Src = [T::Src; N];
+
+    #[inline(always)]
+    fn size_of(value: &Self::Src) -> Result<usize> {
+        #[allow(clippy::arithmetic_side_effects)]
+        value
+            .iter()
+            .map(T::size_of)
+            .try_fold(0, |acc, x| Ok::<_, Error>(acc + x?))
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, value: &Self::Src) -> Result<()> {
+        for item in value {
+            T::write(writer, item)?;
+        }
+        Ok(())
+    }
+}
+
+impl<T> SchemaRead for Option<T>
+where
+    T: SchemaRead,
+{
+    type Dst = Option<T::Dst>;
+
+    #[inline(always)]
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        let variant = u8::get(reader)?;
+        match variant {
+            0 => ptr::write(dst, Option::None),
+            1 => {
+                let mut value = MaybeUninit::uninit();
+                unsafe {
+                    // SAFETY:
+                    // - `value` is a valid pointer to a `T::Dst`.
+                    // - `T::read` must properly initialize the `T::Dst`.
+                    T::read(reader, value.as_mut_ptr())?;
+                    ptr::write(dst, Option::Some(value.assume_init()))
+                }
+            }
+            _ => return Err(invalid_tag_encoding(variant as usize)),
+        }
+
+        Ok(())
+    }
+}
+
+impl<T> SchemaWrite for Option<T>
+where
+    T: SchemaWrite,
+    T::Src: Sized,
+{
+    type Src = Option<T::Src>;
+
+    #[inline(always)]
+    fn size_of(src: &Self::Src) -> Result<usize> {
+        #[allow(clippy::arithmetic_side_effects)]
+        match src {
+            Option::Some(value) => Ok(1 + T::size_of(value)?),
+            Option::None => Ok(1),
+        }
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, value: &Self::Src) -> Result<()> {
+        match value {
+            Option::Some(value) => {
+                u8::write(writer, &1)?;
+                T::write(writer, value)
+            }
+            Option::None => u8::write(writer, &0),
+        }
+    }
+}
+
+impl<'a, T> SchemaWrite for &'a T
+where
+    T: SchemaWrite,
+{
+    type Src = &'a T::Src;
+
+    #[inline(always)]
+    fn size_of(src: &Self::Src) -> Result<usize> {
+        T::size_of(src)
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, value: &Self::Src) -> Result<()> {
+        T::write(writer, value)
+    }
+}
+
+impl<T> SchemaWrite for Box<T>
+where
+    T: SchemaWrite,
+{
+    type Src = Box<T::Src>;
+
+    #[inline(always)]
+    fn size_of(src: &Self::Src) -> Result<usize> {
+        T::size_of(src)
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, value: &Self::Src) -> Result<()> {
+        T::write(writer, value)
+    }
+}
+
+impl<T> SchemaWrite for Box<[T]>
+where
+    T: SchemaWrite,
+    T::Src: Sized,
+{
+    type Src = Box<[T::Src]>;
+
+    #[inline(always)]
+    fn size_of(src: &Self::Src) -> Result<usize> {
+        <containers::BoxedSlice<Elem<T>, BincodeLen>>::size_of(src)
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, value: &Self::Src) -> Result<()> {
+        <containers::BoxedSlice<Elem<T>, BincodeLen>>::write(writer, value)
+    }
+}
+
+impl<T> SchemaRead for Box<T>
+where
+    T: SchemaRead,
+{
+    type Dst = Box<T::Dst>;
+
+    #[inline(always)]
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        let mut mem = Box::new_uninit();
+        unsafe {
+            // SAFETY:
+            // - `mem` is a valid pointer to a `T::Dst`.
+            // - `T::read` must properly initialize the `T::Dst`.
+            T::read(reader, mem.as_mut_ptr())?;
+            ptr::write(dst, mem.assume_init());
+        }
+        Ok(())
+    }
+}
+
+impl<T> SchemaRead for Box<[T]>
+where
+    T: SchemaRead,
+{
+    type Dst = Box<[T::Dst]>;
+
+    #[inline(always)]
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()> {
+        <containers::BoxedSlice<Elem<T>, BincodeLen>>::read(reader, dst)
+    }
+}
+
+/// Implement [`SchemaWrite`] and [`SchemaRead`] for a struct by specifying its constituent field schemas.
+///
+/// # Examples
+///
+/// ```
+/// use wincode::compound;
+///
+/// struct Point {
+///     x: u64,
+///     y: u64,
+/// }
+///
+/// compound! {
+///     Point {
+///         x: u64,
+///         y: u64,
+///     }
+/// }
+///
+/// struct MyStruct {
+///     point: Point,
+/// }
+///
+/// compound! {
+///     MyStruct {
+///         point: Point,
+///     }
+/// }
+/// ```
+///
+/// This macro also supports creating intermediate `#[repr(transparent)]` newtype structs that map to a target type.
+/// This is useful when the target type is foreign (defined outside the crate).
+///
+/// ```
+/// # use wincode::{containers::Pod, compound, Serialize, Deserialize};
+/// // Imagine this is a struct defined outside our crate.
+/// # #[derive(Debug, PartialEq, Eq)]
+/// struct ForeignStruct {
+///     pub field: [u8; 32],
+/// }
+///
+/// compound! {
+///     struct OurStruct => ForeignStruct {
+///         field: Pod<[u8; 32]>,
+///     }
+/// }
+///
+/// let foreign_struct = ForeignStruct {
+///     field: [0; 32],
+/// };
+/// let bytes = OurStruct::serialize(&foreign_struct).unwrap();
+/// let deserialized = OurStruct::deserialize(&bytes).unwrap();
+/// assert_eq!(foreign_struct, deserialized);
+/// ```
+///
+/// Omitting the `struct` keyword will allow you to define the newtype yourself.
+/// ```
+///  # use wincode::{containers::Pod, compound, Serialize, Deserialize};
+/// // Imagine this is a struct defined outside our crate.
+/// # #[derive(Debug, PartialEq, Eq)]
+/// struct ForeignStruct {
+///     pub field: [u8; 32],
+/// }
+///
+/// #[repr(transparent)]
+/// struct OurStruct(ForeignStruct);
+///
+/// compound! {
+///     OurStruct => ForeignStruct {
+///         field: Pod<[u8; 32]>,
+///     }
+/// }
+///
+/// let foreign_struct = ForeignStruct {
+///     field: [0; 32],
+/// };
+/// let bytes = OurStruct::serialize(&foreign_struct).unwrap();
+/// let deserialized = OurStruct::deserialize(&bytes).unwrap();
+/// assert_eq!(foreign_struct, deserialized);
+/// ```
+#[macro_export]
+macro_rules! compound {
+    ($vis:vis $src:ident { $($field:ident : $schema:ty),+ $(,)? }) => {
+        $crate::compound! { $src => $src { $($field: $schema),+ } }
+    };
+    ($vis:vis struct $src:ident => $target:ty { $($field:ident : $schema:ty),+ $(,)? }) => {
+        #[repr(transparent)]
+        $vis struct $src($vis $target);
+
+        $crate::compound! {
+            $vis $src => $target {
+                $($field: $schema),+
+            }
+        }
+    };
+    ($vis:vis $src:ident => $target:ty { $($field:ident : $schema:ty),+ $(,)? }) => {
+        $crate::__private::paste! {
+            #[allow(unused)]
+            $vis trait [<$src Ext>] {
+                $(
+                    /// Read the field into the corresponding slot in `dst` from `reader`.
+                    ///
+                    /// # Safety
+                    ///
+                    /// - `dst` must be a valid pointer to a `Self`.
+                    /// - Corresponding element schema must properly initialize the field.
+                    unsafe fn [<read_ $field>](reader: &mut $crate::io::Reader, dst: *mut $target) -> $crate::error::Result<()>;
+                )+
+            }
+
+            impl [<$src Ext>] for $src {
+                #[inline(always)]
+                $(unsafe fn [<read_ $field>](reader: &mut $crate::io::Reader, dst: *mut $target) -> $crate::error::Result<()> {
+                    <$schema as $crate::SchemaRead>::read(reader, unsafe { &raw mut (*dst).$field })
+                })+
+            }
+        }
+
+        impl $crate::SchemaWrite for $src {
+            type Src = $target;
+
+            #[inline(always)]
+            fn size_of(value: &Self::Src) -> $crate::error::Result<usize> {
+                #[allow(clippy::arithmetic_side_effects)]
+                Ok(0 $(+ <$schema as $crate::SchemaWrite>::size_of(&value.$field)?)+)
+            }
+
+
+            #[inline(always)]
+            fn write(writer: &mut $crate::io::Writer, value: &Self::Src) -> $crate::error::Result<()> {
+                $(<$schema as $crate::SchemaWrite>::write(writer, &value.$field)?;)+
+                Ok(())
+            }
+        }
+
+        impl $crate::SchemaRead for $src {
+            type Dst = $target;
+
+            /// Read the fields of `Self` from `reader` into `value`.
+            ///
+            /// # Safety
+            ///
+            /// - `value` must be a valid pointer to a `Self`.
+            /// - Constituent element schemas must properly initialize elements.
+            #[inline(always)]
+            unsafe fn read(reader: &mut $crate::io::Reader, value: *mut Self::Dst) -> $crate::error::Result<()> {
+                $(<$schema as $crate::SchemaRead>::read(reader, unsafe { &raw mut (*value).$field })?;)+
+                Ok(())
+            }
+        }
+    };
+}
+
+macro_rules! impl_tuple {
+    ($($name:ident: $field:tt),+) => {
+        impl<$($name),+> $crate::SchemaWrite for ($($name),+)
+        where
+            $($name: $crate::SchemaWrite),+,
+            $($name::Src: Sized),+
+        {
+            type Src = ($($name::Src),+);
+
+            #[inline(always)]
+            fn size_of(value: &Self::Src) -> $crate::error::Result<usize> {
+                #[allow(clippy::arithmetic_side_effects)]
+                Ok(0 $(+ <$name as $crate::SchemaWrite>::size_of(&value.$field)?)+)
+            }
+
+            #[inline(always)]
+            fn write(writer: &mut $crate::io::Writer, value: &Self::Src) -> $crate::error::Result<()> {
+                $(<$name as $crate::SchemaWrite>::write(writer, &value.$field)?;)+
+                Ok(())
+            }
+        }
+
+        impl<$($name),+> $crate::SchemaRead for ($($name),+)
+        where
+            $($name: $crate::SchemaRead),+,
+        {
+            type Dst = ($($name::Dst),+);
+
+            #[inline(always)]
+            unsafe fn read(reader: &mut $crate::io::Reader, value: *mut Self::Dst) -> $crate::error::Result<()> {
+                $(<$name as $crate::SchemaRead>::read(reader, unsafe { &raw mut (*value).$field })?;)+
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_tuple! { A: 0, B: 1 }
+impl_tuple! { A: 0, B: 1, C: 2 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3, E: 4 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9, K: 10 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9, K: 10, L: 11 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9, K: 10, L: 11, M: 12 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9, K: 10, L: 11, M: 12, N: 13 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9, K: 10, L: 11, M: 12, N: 13, O: 14 }
+impl_tuple! { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9, K: 10, L: 11, M: 12, N: 13, O: 14, P: 15 }

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -1,0 +1,339 @@
+//! Schema definitions that make it simple to implement performant serialization
+//! and deserialization of types, with bincode and [`solana_short_vec`] support.
+//!
+//! # Example
+//!
+//! ```
+//! # use rand::prelude::*;
+//! # use wincode::{compound, Serialize, Deserialize, len::{BincodeLen, ShortU16Len}, containers::{self, Pod}};
+//! # use std::array;
+//!
+//! # #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+//! #[repr(transparent)]
+//! struct Signature([u8; 32]);
+//! # #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+//! #[repr(transparent)]
+//! struct Address([u8; 32]);
+//!
+//! # #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+//! struct MyStruct {
+//!     signature: Vec<Signature>,
+//!     #[serde(with = "solana_short_vec")]
+//!     address: Vec<Address>,
+//! }
+//!
+//! compound! {
+//!     MyStruct {
+//!         signature: containers::Vec<Pod<Signature>, BincodeLen>,
+//!         address: containers::Vec<Pod<Address>, ShortU16Len>,
+//!     }
+//! }
+//!
+//! let my_struct = MyStruct {
+//!     signature: (0..10).map(|_| Signature(array::from_fn(|_| random()))).collect(),
+//!     address: (0..10).map(|_| Address(array::from_fn(|_| random()))).collect(),
+//! };
+//! let bincode_serialized = bincode::serialize(&my_struct).unwrap();
+//! let wincode_serialized = wincode::serialize(&my_struct).unwrap();
+//! assert_eq!(bincode_serialized, wincode_serialized);
+//!
+//! let bincode_deserialized: MyStruct = bincode::deserialize(&bincode_serialized).unwrap();
+//! let wincode_deserialized: MyStruct = wincode::deserialize(&wincode_serialized).unwrap();
+//! assert_eq!(bincode_deserialized, wincode_deserialized);
+//! ```
+use {
+    crate::{
+        error::{Error, Result},
+        io::*,
+        len::SeqLen,
+    },
+    std::mem::MaybeUninit,
+};
+
+pub mod containers;
+mod impls;
+
+/// Types that can be written (serialized) to a byte buffer.
+pub trait SchemaWrite {
+    type Src: ?Sized;
+    /// Get the serialized size of `Self::Src`.
+    fn size_of(src: &Self::Src) -> Result<usize>;
+    /// Write `Self::Src` to `writer`.
+    fn write(writer: &mut Writer, src: &Self::Src) -> Result<()>;
+}
+
+/// Types that can be read (deserialized) from a byte buffer.
+pub trait SchemaRead {
+    type Dst;
+    /// Read into `dst` from `reader`.
+    ///
+    /// # Safety
+    ///
+    /// - `dst` must be a valid pointer to a `Self::Dst`.
+    /// - `Self::Dst` must be plain ol' data.
+    unsafe fn read(reader: &mut Reader, dst: *mut Self::Dst) -> Result<()>;
+    /// Read `Self::Dst` from `reader` into a new `Self::Dst`.
+    #[inline(always)]
+    fn get(reader: &mut Reader) -> Result<Self::Dst> {
+        let mut value = MaybeUninit::uninit();
+        // SAFETY: `value` is a valid pointer to a `Self::Dst`.
+        unsafe {
+            Self::read(reader, value.as_mut_ptr())?;
+            Ok(value.assume_init())
+        }
+    }
+}
+
+#[inline(always)]
+fn size_of_elem_iter<'a, T, Len>(value: impl ExactSizeIterator<Item = &'a T::Src>) -> Result<usize>
+where
+    Len: SeqLen,
+    T: SchemaWrite + 'a,
+{
+    #[allow(clippy::arithmetic_side_effects)]
+    Ok(Len::bytes_needed(value.len())?
+        + value
+            .map(T::size_of)
+            .try_fold(0, |acc, x| Ok::<_, Error>(acc + x?))?)
+}
+
+#[inline(always)]
+fn write_elem_iter<'a, T, Len>(
+    writer: &mut Writer,
+    src: impl ExactSizeIterator<Item = &'a T::Src>,
+) -> Result<()>
+where
+    Len: SeqLen,
+    T: SchemaWrite + 'a,
+{
+    Len::encode_len(writer, src.len())?;
+    for item in src {
+        T::write(writer, item)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        crate::{
+            compound,
+            containers::{self, Elem, Pod},
+            deserialize,
+            len::BincodeLen,
+            serialize, Deserialize, Serialize,
+        },
+        proptest::prelude::*,
+        std::{collections::VecDeque, result::Result},
+    };
+
+    #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+    struct SomeStruct {
+        a: u64,
+        b: u64,
+    }
+
+    compound! {
+        SomeStruct {
+            a: u64,
+            b: u64,
+        }
+    }
+
+    fn strat_some_struct() -> impl Strategy<Value = SomeStruct> {
+        (0..=u64::MAX, 0..=u64::MAX).prop_map(|(a, b)| SomeStruct { a, b })
+    }
+
+    fn strat_byte_array() -> impl Strategy<Value = [u8; 32]> {
+        any::<[u8; 32]>()
+    }
+
+    fn strat_byte_vec() -> impl Strategy<Value = Vec<u8>> {
+        proptest::collection::vec(any::<u8>(), 0..=100)
+    }
+
+    proptest! {
+        #[test]
+        fn test_vec_elem(vec in proptest::collection::vec(strat_some_struct(), 0..=100)) {
+            let bincode_serialized = bincode::serialize(&vec).unwrap();
+            type Target = containers::Vec<Elem<SomeStruct>, BincodeLen>;
+            let schema_serialized = Target::serialize(&vec).unwrap();
+
+            prop_assert_eq!(&bincode_serialized, &schema_serialized);
+
+            let bincode_deserialized: Vec<SomeStruct> = bincode::deserialize(&bincode_serialized).unwrap();
+            let schema_deserialized = Target::deserialize(&schema_serialized).unwrap();
+            prop_assert_eq!(&vec, &bincode_deserialized);
+            prop_assert_eq!(vec, schema_deserialized);
+        }
+
+        #[test]
+        fn test_vec_pod(vec in proptest::collection::vec(strat_byte_array(), 0..=100)) {
+            let bincode_serialized = bincode::serialize(&vec).unwrap();
+            type Target = containers::Vec<Pod<[u8; 32]>, BincodeLen>;
+            let schema_serialized = Target::serialize(&vec).unwrap();
+
+            prop_assert_eq!(&bincode_serialized, &schema_serialized);
+
+            let bincode_deserialized: Vec<[u8; 32]> = bincode::deserialize(&bincode_serialized).unwrap();
+            let schema_deserialized = Target::deserialize(&schema_serialized).unwrap();
+            prop_assert_eq!(&vec, &bincode_deserialized);
+            prop_assert_eq!(vec, schema_deserialized);
+        }
+
+        #[test]
+        fn test_vec_deque_elem(vec in proptest::collection::vec_deque(strat_some_struct(), 0..=100)) {
+            let bincode_serialized = bincode::serialize(&vec).unwrap();
+            type Target = containers::VecDeque<Elem<SomeStruct>, BincodeLen>;
+            let schema_serialized = Target::serialize(&vec).unwrap();
+
+            prop_assert_eq!(&bincode_serialized, &schema_serialized);
+
+            let bincode_deserialized: VecDeque<SomeStruct> = bincode::deserialize(&bincode_serialized).unwrap();
+            let schema_deserialized = Target::deserialize(&schema_serialized).unwrap();
+            prop_assert_eq!(&vec, &bincode_deserialized);
+            prop_assert_eq!(vec, schema_deserialized);
+        }
+
+        #[test]
+        fn test_array(array in strat_byte_array()) {
+            let bincode_serialized = bincode::serialize(&array).unwrap();
+            type Target = [u8; 32];
+            let schema_serialized = Target::serialize(&array).unwrap();
+            prop_assert_eq!(&bincode_serialized, &schema_serialized);
+            let bincode_deserialized: [u8; 32] = bincode::deserialize(&bincode_serialized).unwrap();
+            let schema_deserialized: [u8; 32] = deserialize(&schema_serialized).unwrap();
+            prop_assert_eq!(&array, &bincode_deserialized);
+            prop_assert_eq!(array, schema_deserialized);
+        }
+
+        #[test]
+        fn test_option(option in proptest::option::of(strat_some_struct())) {
+            let bincode_serialized = bincode::serialize(&option).unwrap();
+            let schema_serialized = serialize(&option).unwrap();
+
+            prop_assert_eq!(&bincode_serialized, &schema_serialized);
+            let bincode_deserialized: Option<SomeStruct> = bincode::deserialize(&bincode_serialized).unwrap();
+            let schema_deserialized: Option<SomeStruct> = deserialize(&schema_serialized).unwrap();
+            prop_assert_eq!(&option, &bincode_deserialized);
+            prop_assert_eq!(&option, &schema_deserialized);
+        }
+
+        #[test]
+        fn test_option_container(option in proptest::option::of(strat_byte_array())) {
+            let bincode_serialized = bincode::serialize(&option).unwrap();
+            type Target = Option<Pod<[u8; 32]>>;
+            let schema_serialized = Target::serialize(&option).unwrap();
+            prop_assert_eq!(&bincode_serialized, &schema_serialized);
+            let bincode_deserialized: Option<[u8; 32]> = bincode::deserialize(&bincode_serialized).unwrap();
+            let schema_deserialized: Option<[u8; 32]> = Target::deserialize(&schema_serialized).unwrap();
+            prop_assert_eq!(&option, &bincode_deserialized);
+            prop_assert_eq!(&option, &schema_deserialized);
+        }
+
+        #[test]
+        fn test_bool(val in any::<bool>()) {
+            let bincode_serialized = bincode::serialize(&val).unwrap();
+            let schema_serialized = serialize(&val).unwrap();
+            prop_assert_eq!(&bincode_serialized, &schema_serialized);
+            let bincode_deserialized: bool = bincode::deserialize(&bincode_serialized).unwrap();
+            let schema_deserialized: bool = deserialize(&schema_serialized).unwrap();
+            prop_assert_eq!(val, bincode_deserialized);
+            prop_assert_eq!(val, schema_deserialized);
+        }
+
+        #[test]
+        fn test_bool_invalid_bit_pattern(val in 2u8..=255) {
+            let bincode_deserialized: Result<bool,_> = bincode::deserialize(&[val]);
+            let schema_deserialized: Result<bool,_> = deserialize(&[val]);
+            prop_assert!(bincode_deserialized.is_err());
+            prop_assert!(schema_deserialized.is_err());
+        }
+
+        #[test]
+        fn test_box(ar in strat_byte_array(), s in strat_some_struct()) {
+            let data = (Box::new(ar), Box::new(s));
+            let bincode_serialized = bincode::serialize(&data).unwrap();
+            type Target = (Box<[u8; 32]>, Box<SomeStruct>);
+            type SchemaPodTarget = (Box<Pod<[u8; 32]>>, Box<SomeStruct>);
+            let schema_serialized = Target::serialize(&data).unwrap();
+            let schema_pod_serialized = SchemaPodTarget::serialize(&data).unwrap();
+            prop_assert_eq!(&bincode_serialized, &schema_serialized);
+            prop_assert_eq!(&bincode_serialized, &schema_pod_serialized);
+            let bincode_deserialized: (Box<[u8; 32]>, Box<SomeStruct>) = bincode::deserialize(&bincode_serialized).unwrap();
+            let schema_deserialized: (Box<[u8; 32]>, Box<SomeStruct>) = Target::deserialize(&schema_serialized).unwrap();
+            let schema_pod_deserialized: (Box<[u8; 32]>, Box<SomeStruct>) = SchemaPodTarget::deserialize(&schema_pod_serialized).unwrap();
+            prop_assert_eq!(&data, &bincode_deserialized);
+            prop_assert_eq!(&data, &schema_deserialized);
+            prop_assert_eq!(&data, &schema_pod_deserialized);
+        }
+
+        #[test]
+        fn test_boxed_slice(vec in strat_byte_vec()) {
+            let data = vec.into_boxed_slice();
+            let bincode_serialized = bincode::serialize(&data).unwrap();
+            type Target = Box<[u8]>;
+            type TargetPod = containers::BoxedSlice<Pod<u8>>;
+            let schema_serialized = Target::serialize(&data).unwrap();
+            let schema_pod_serialized = TargetPod::serialize(&data).unwrap();
+            prop_assert_eq!(&bincode_serialized, &schema_serialized);
+            prop_assert_eq!(&bincode_serialized, &schema_pod_serialized);
+            let bincode_deserialized: Box<[u8]> = bincode::deserialize(&bincode_serialized).unwrap();
+            let schema_deserialized: Box<[u8]> = Target::deserialize(&schema_serialized).unwrap();
+            let schema_pod_deserialized: Box<[u8]> = TargetPod::deserialize(&schema_pod_serialized).unwrap();
+            prop_assert_eq!(&data, &bincode_deserialized);
+            prop_assert_eq!(&data, &schema_deserialized);
+            prop_assert_eq!(&data, &schema_pod_deserialized);
+        }
+
+        #[test]
+        fn test_integers(
+            val in (
+                any::<u8>(),
+                any::<i8>(),
+                any::<u16>(),
+                any::<i16>(),
+                any::<u32>(),
+                any::<i32>(),
+                any::<usize>(),
+                any::<isize>(),
+                any::<u64>(),
+                any::<i64>(),
+                any::<u128>(),
+                any::<i128>()
+            )
+        ) {
+            type Target = (u8, i8, u16, i16, u32, i32, usize, isize, u64, i64, u128, i128);
+            let bincode_serialized = bincode::serialize(&val).unwrap();
+            let schema_serialized = serialize(&val).unwrap();
+            prop_assert_eq!(&bincode_serialized, &schema_serialized);
+            let bincode_deserialized: Target = bincode::deserialize(&bincode_serialized).unwrap();
+            let schema_deserialized: Target = deserialize(&schema_serialized).unwrap();
+            prop_assert_eq!(val, bincode_deserialized);
+            prop_assert_eq!(val, schema_deserialized);
+        }
+
+        #[test]
+        fn test_tuple(
+            tuple in (
+                strat_some_struct(),
+                strat_byte_array(),
+                proptest::option::of(strat_some_struct()),
+                proptest::collection::vec(strat_some_struct(), 0..=100),
+                proptest::collection::vec_deque(strat_byte_array(), 0..=100)
+            )
+        ) {
+            let bincode_serialized = bincode::serialize(&tuple).unwrap();
+            type BincodeTarget = (SomeStruct, [u8; 32], Option<SomeStruct>, Vec<SomeStruct>, VecDeque<[u8; 32]>);
+            type Target = (SomeStruct, Pod<[u8; 32]>, Option<SomeStruct>, Vec<SomeStruct>, containers::VecDeque<Pod<[u8; 32]>, BincodeLen>);
+            let schema_serialized = Target::serialize(&tuple).unwrap();
+
+            prop_assert_eq!(&bincode_serialized, &schema_serialized);
+            let bincode_deserialized: BincodeTarget = bincode::deserialize(&bincode_serialized).unwrap();
+            let schema_deserialized = Target::deserialize(&schema_serialized).unwrap();
+            prop_assert_eq!(&tuple, &bincode_deserialized);
+            prop_assert_eq!(&tuple, &schema_deserialized);
+
+        }
+    }
+}

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -46,7 +46,7 @@ use {
         io::*,
         len::SeqLen,
     },
-    std::mem::MaybeUninit,
+    core::mem::MaybeUninit,
 };
 
 pub mod containers;
@@ -116,7 +116,7 @@ where
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "alloc"))]
 mod tests {
     use {
         crate::{
@@ -126,8 +126,9 @@ mod tests {
             len::BincodeLen,
             serialize, Deserialize, Serialize,
         },
+        alloc::{boxed::Box, collections::VecDeque, vec::Vec},
+        core::result::Result,
         proptest::prelude::*,
-        std::{collections::VecDeque, result::Result},
     };
 
     #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]

--- a/wincode/src/schema/mod.rs
+++ b/wincode/src/schema/mod.rs
@@ -1,5 +1,4 @@
-//! Schema definitions that make it simple to implement performant serialization
-//! and deserialization of types, with bincode and [`solana_short_vec`] support.
+//! Schema traits.
 //!
 //! # Example
 //!
@@ -71,6 +70,7 @@ pub trait SchemaRead {
     ///
     /// - Implementation must properly initialize the `Self::Dst`.
     fn read(reader: &mut Reader, dst: &mut MaybeUninit<Self::Dst>) -> Result<()>;
+
     /// Read `Self::Dst` from `reader` into a new `Self::Dst`.
     #[inline(always)]
     fn get(reader: &mut Reader) -> Result<Self::Dst> {
@@ -79,6 +79,7 @@ pub trait SchemaRead {
         // SAFETY: `read` must properly initialize the `Self::Dst`.
         Ok(unsafe { value.assume_init() })
     }
+
     /// Write an instance of `Self::Dst` into `dst`.
     #[doc(hidden)]
     fn write_into_uninit(value: Self::Dst, dst: &mut MaybeUninit<Self::Dst>) {

--- a/wincode/src/serde.rs
+++ b/wincode/src/serde.rs
@@ -1,0 +1,166 @@
+use {
+    crate::{
+        error::Result,
+        io::{Reader, Writer},
+        schema::{SchemaRead, SchemaWrite},
+    },
+    std::mem::MaybeUninit,
+};
+
+/// Helper over [`SchemaRead`] that automatically constructs a reader
+/// and initializes a destination.
+///
+/// # Examples
+///
+/// Using containers (indirect deserialization):
+/// ```
+/// # use wincode::{Deserialize, containers::{self, Pod}};
+/// let vec: Vec<u8> = vec![1, 2, 3];
+/// let bytes = wincode::serialize(&vec).unwrap();
+/// // Use the optimized `Pod` container
+/// type Dst = containers::Vec<Pod<u8>>;
+/// let deserialized = Dst::deserialize(&bytes).unwrap();
+/// assert_eq!(vec, deserialized);
+/// ```
+///
+/// Using direct deserialization (`T::Dst = T`) (non-optimized):
+/// ```
+/// let vec: Vec<u8> = vec![1, 2, 3];
+/// let bytes = wincode::serialize(&vec).unwrap();
+/// let deserialized: Vec<u8> = wincode::deserialize(&bytes).unwrap();
+/// assert_eq!(vec, deserialized);
+/// ```
+pub trait Deserialize: SchemaRead {
+    /// Deserialize `bytes` into a new `Self::Dst`.
+    #[inline(always)]
+    fn deserialize(bytes: &[u8]) -> Result<Self::Dst> {
+        let mut dst = MaybeUninit::uninit();
+        Self::deserialize_into(bytes, &mut dst)?;
+        Ok(unsafe { dst.assume_init() })
+    }
+
+    /// Deserialize `bytes` into `target`.
+    #[inline]
+    fn deserialize_into(bytes: &[u8], target: &mut MaybeUninit<Self::Dst>) -> Result<()> {
+        let mut cursor = Reader::new(bytes);
+        let target_ptr = target.as_mut_ptr();
+        unsafe {
+            // SAFETY:
+            // - `target_ptr` is a valid pointer to a `S::Dst`.
+            // - Implementor ensures `SchemaRead` properly initializes the `S::Dst`.
+            Self::read(&mut cursor, target_ptr)?;
+            Ok(())
+        }
+    }
+}
+
+impl<T> Deserialize for T where T: SchemaRead {}
+
+/// Helper over [`SchemaWrite`] that automatically constructs a writer
+/// and serializes a source.
+///
+/// # Examples
+///
+/// Using containers (indirect serialization):
+/// ```
+/// # use wincode::{Serialize, containers::{self, Pod}};
+/// let vec: Vec<u8> = vec![1, 2, 3];
+/// // Use the optimized `Pod` container
+/// type Src = containers::Vec<Pod<u8>>;
+/// let bytes = Src::serialize(&vec).unwrap();
+/// let deserialized: Vec<u8> = wincode::deserialize(&bytes).unwrap();
+/// assert_eq!(vec, deserialized);
+/// ```
+///
+/// Using direct serialization (`T::Src = T`) (non-optimized):
+/// ```
+/// let vec: Vec<u8> = vec![1, 2, 3];
+/// let bytes = wincode::serialize(&vec).unwrap();
+/// let deserialized: Vec<u8> = wincode::deserialize(&bytes).unwrap();
+/// assert_eq!(vec, deserialized);
+/// ```
+pub trait Serialize: SchemaWrite {
+    /// Serialize a serializable type into a `Vec` of bytes.
+    fn serialize(src: &Self::Src) -> Result<Vec<u8>> {
+        let size = Self::size_of(src)?;
+        let mut buffer = Vec::with_capacity(size);
+        let mut writer = Writer::new(&mut buffer);
+        Self::write(&mut writer, src)?;
+        Ok(buffer)
+    }
+
+    /// Serialize a serializable type into the given byte buffer.
+    fn serialize_into(src: &Self::Src, target: &mut Vec<u8>) -> Result<()> {
+        let mut writer = Writer::new(target);
+        Self::write(&mut writer, src)?;
+        Ok(())
+    }
+
+    /// Get the size in bytes of the type when serialized.
+    fn serialized_size(src: &Self::Src) -> Result<u64> {
+        Self::size_of(src).map(|size| size as u64)
+    }
+}
+
+impl<T> Serialize for T where T: SchemaWrite + ?Sized {}
+
+/// Deserialize a type from the given bytes.
+///
+/// This is a "simplified" version of [`Deserialize::deserialize`] that
+/// requires the `T::Dst` to be `T`. In other words, a schema type
+/// that deserializes to itself.
+///
+/// This helper exists to match the expected signature of `serde`'s
+/// `Deserialize`, where types that implement `Deserialize` deserialize
+/// into themselves. This will be true of a large number of schema types,
+/// but wont, for example, for specialized container structures.
+///
+/// # Examples
+///
+/// ```
+/// let vec: Vec<u8> = vec![1, 2, 3];
+/// let bytes = wincode::serialize(&vec).unwrap();
+/// let deserialized: Vec<u8> = wincode::deserialize(&bytes).unwrap();
+/// assert_eq!(vec, deserialized);
+/// ```
+#[inline(always)]
+pub fn deserialize<T>(bytes: &[u8]) -> Result<T>
+where
+    T: SchemaRead<Dst = T>,
+{
+    T::deserialize(bytes)
+}
+
+/// Serialize a type into a `Vec` of bytes.
+///
+/// This is a "simplified" version of [`Serialize::serialize`] that
+/// requires the `T::Src` to be `T`. In other words, a schema type
+/// that serializes to itself.
+///
+/// This helper exists to match the expected signature of `serde`'s
+/// `Serialize`, where types that implement `Serialize` serialize
+/// themselves. This will be true of a large number of schema types,
+/// but wont, for example, for specialized container structures.
+///
+/// # Examples
+///
+/// ```
+/// let vec: Vec<u8> = vec![1, 2, 3];
+/// let bytes = wincode::serialize(&vec).unwrap();
+/// ```
+#[inline(always)]
+pub fn serialize<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: SchemaWrite<Src = T> + ?Sized,
+{
+    T::serialize(value)
+}
+
+/// Get the size in bytes of the type when serialized.
+#[inline(always)]
+pub fn serialized_size<T>(value: &T) -> Result<u64>
+where
+    T: SchemaWrite<Src = T> + ?Sized,
+{
+    T::serialized_size(value)
+}

--- a/wincode/src/serde.rs
+++ b/wincode/src/serde.rs
@@ -36,7 +36,7 @@ pub trait Deserialize: SchemaRead {
     fn deserialize(bytes: &[u8]) -> Result<Self::Dst> {
         let mut dst = MaybeUninit::uninit();
         Self::deserialize_into(bytes, &mut dst)?;
-        // SAFETY: `Implementor` ensures `SchemaRead` properly initializes the `Self::Dst`.
+        // SAFETY: Implementor ensures `SchemaRead` properly initializes the `Self::Dst`.
         Ok(unsafe { dst.assume_init() })
     }
 


### PR DESCRIPTION
#### Problem

After writing #8141, it's clear that writing manual serialization to overcome performance limitations of `serde` and various solana sdk types is a frequent problem. In particular, Safe Rust offers limited support for placement initialization (direct writes without intermediate staging buffers), especially for heap memory. The effect of this is a lot of unnecessary copying, which is unacceptable in performance‑critical code; made significantly worse by the fact we frequently serialize `Vec`s of fixed sized arrays (`Signature`, `Address`, etc). `serde` inherits these limitations since it neither attempts to initialize in‑place nor exposes APIs to do so (especially in heap memory --again). Worse still, many of these types are serialized with `solana_short_vec`, which does per-element visitation on byte arrays and byte vectors.

The result of this is a proliferation of manual serialization / deserialization implementations across various types to circumvent these limitations. These manual implementations require a lot of time and effort to get right.

#### Summary of Changes

This builds upon those manual implementations, and the patterns observed while writing #8141, and packages that functionality into a its own crate -- `wincode`.

`wincode` is a bincode‑compatible serializer/deserializer focused on in‑place initialization and direct memory writes. The goal is to make it easy to make performant and efficient serializer / deserializers that avoid all the aforementioned pitfalls.
In short, `wincode` operates over traits that facilitate direct writes of memory into final destinations (including heap-allocated buffers) without intermediate staging buffers. It also supports different length encodings, to support `solana-short-vec`, for example.

The simple case looks like the following:
```rs
struct MyStruct {
    data: Vec<u64>,
    win: bool,
}

compound! {
    MyStruct {
        data: Vec<u64>,
        win: bool,
    }
}

let val = MyStruct { data: vec![1,2,3], win: true };
assert_eq!(wincode::serialize(&val).unwrap(), bincode::serialize(&val).unwrap());
```

And here is case more typical of agave:
```rs
struct MyStruct {
    data: Vec<u8>,
    addresses: Vec<[u8; 32]>,
}

compound! {
    MyStruct {
        data: containers::Vec<Pod<u8>>,
        addresses: containers::Vec<Pod<[u8; 32]>>,
    }
}

let val = MyStruct { data: vec![1,2,3], addresses: vec![[0; 32], [1; 32]] };
assert_eq!(wincode::serialize(&val).unwrap(), bincode::serialize(&val).unwrap());
```

In this example,
- All initialization is done in-place, including heap-allocated memory (true of all supported heap-allocated structures in wincode).
- Byte fields are written in a single pass by leveraging the `Pod` `container`.
- No intermediate staging buffers: bytes are copied directly into the final destination allocation during deserialization and written directly into the output buffer during serialization.

APIs like `wincode::serialize` and `wincode::deserialize` should feel nearly identical to what users expect of `bincode::serialize` and `bincode::deserialize`, though there is richer functionality available for more exotic cases -- code is fully documented.

Here is what the `Entry` implementation looks like (replaces #8141)
```rs
compound! {
    struct MessageHeader => solana_message::MessageHeader {
        num_required_signatures: u8,
        num_readonly_signed_accounts: u8,
        num_readonly_unsigned_accounts: u8,
    }
}

compound! {
    struct CompiledInstruction => solana_transaction::CompiledInstruction {
        program_id_index: u8,
        accounts: containers::Vec<Pod<u8>, ShortU16Len>,
        data: containers::Vec<Pod<u8>, ShortU16Len>,
    }
}

compound! {
    struct LegacyMessage => legacy::Message {
        header: MessageHeader,
        account_keys: containers::Vec<Pod<Address>, ShortU16Len>,
        recent_blockhash: Pod<Hash>,
        instructions: containers::Vec<Elem<CompiledInstruction>, ShortU16Len>,
    }
}

compound! {
    struct MessageAddressTableLookup => v0::MessageAddressTableLookup {
        account_key: Pod<Address>,
        writable_indexes: containers::Vec<Pod<u8>, ShortU16Len>,
        readonly_indexes: containers::Vec<Pod<u8>, ShortU16Len>,
    }
}

compound! {
    struct V0Message => v0::Message {
        header: MessageHeader,
        account_keys: containers::Vec<Pod<Address>, ShortU16Len>,
        recent_blockhash: Pod<Hash>,
        instructions: containers::Vec<Elem<CompiledInstruction>, ShortU16Len>,
        address_table_lookups: containers::Vec<Elem<MessageAddressTableLookup>, ShortU16Len>,
    }
}

compound! {
    struct VersionedTx => versioned::VersionedTransaction {
        signatures: containers::Vec<Pod<Signature>, ShortU16Len>,
        message: VersionedMsg,
    }
}

compound! {
    Entry {
        num_hashes: u64,
        hash: Pod<Hash>,
        transactions: Vec<VersionedTx>,
    }
}
```