### PR TITLE
Remove unused entry parameter in accounts index scan callback

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3749,7 +3749,7 @@ define_accounts_db_test!(
         // scan the accounts to track zlsr accounts
         accounts_db.accounts_index.scan(
             pubkeys.iter(),
-            |_pubkey, slots_refs, _entry| {
+            |_pubkey, slots_refs| {
                 let (slot_list, ref_count) = slots_refs.unwrap();
                 assert_eq!(slot_list.len(), 1);
                 assert_eq!(ref_count, 1);
@@ -3760,7 +3760,6 @@ define_accounts_db_test!(
                 AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
             },
             None,
-            false,
             ScanFilter::All,
         );
 

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1052,14 +1052,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         pubkeys: I,
         mut callback: F,
         avoid_callback_result: Option<AccountsIndexScanResult>,
-        provide_entry_in_callback: bool,
         filter: ScanFilter,
     ) where
-        F: FnMut(
-            &'a Pubkey,
-            Option<(&SlotList<T>, RefCount)>,
-            Option<&Arc<AccountMapEntry<T>>>,
-        ) -> AccountsIndexScanResult,
+        F: FnMut(&'a Pubkey, Option<(&SlotList<T>, RefCount)>) -> AccountsIndexScanResult,
         I: Iterator<Item = &'a Pubkey>,
     {
         let mut lock = None;
@@ -1080,11 +1075,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                             *result
                         } else {
                             let slot_list = &locked_entry.slot_list_read_lock();
-                            callback(
-                                pubkey,
-                                Some((slot_list, locked_entry.ref_count())),
-                                provide_entry_in_callback.then_some(locked_entry),
-                            )
+                            callback(pubkey, Some((slot_list, locked_entry.ref_count())))
                         };
                         cache = match result {
                             AccountsIndexScanResult::Unref => {
@@ -1122,7 +1113,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                         };
                     }
                     None => {
-                        avoid_callback_result.unwrap_or_else(|| callback(pubkey, None, None));
+                        avoid_callback_result.unwrap_or_else(|| callback(pubkey, None));
                     }
                 }
                 (cache, ())

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -3783,7 +3783,7 @@ pub mod tests {
             // Assert ref_counts before unref.
             db.accounts_index.scan(
                 shrink_collect.pubkeys_to_unref.iter().cloned(),
-                |k, slot_refs, _entry| {
+                |k, slot_refs| {
                     assert_eq!(
                         expected_ref_counts_before_unref.remove(k).unwrap(),
                         slot_refs.unwrap().1
@@ -3791,7 +3791,6 @@ pub mod tests {
                     AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
                 },
                 None,
-                false,
                 ScanFilter::All,
             );
             assert!(expected_ref_counts_before_unref.is_empty());
@@ -3802,7 +3801,7 @@ pub mod tests {
             // Assert ref_counts after unref
             db.accounts_index.scan(
                 shrink_collect.pubkeys_to_unref.iter().cloned(),
-                |k, slot_refs, _entry| {
+                |k, slot_refs| {
                     assert_eq!(
                         expected_ref_counts_after_unref.remove(k).unwrap(),
                         slot_refs.unwrap().1
@@ -3810,7 +3809,6 @@ pub mod tests {
                     AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
                 },
                 None,
-                false,
                 ScanFilter::All,
             );
             // should have removed all of them


### PR DESCRIPTION
#### Problem
* `provide_entry_in_callback` is always specified as `false`
* entry parameter is never used

#### Summary of Changes
Remove callback parameter and scan function parameter