### PR TITLE
Make accounts-index get_cloned a test-only function

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -828,6 +828,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     /// Gets the index's entry for `pubkey` and clones it
     ///
     /// Prefer `get_and_then()` whenever possible.
+    #[cfg(test)]
     pub fn get_cloned(&self, pubkey: &Pubkey) -> Option<Arc<AccountMapEntry<T>>> {
         self.get_bin(pubkey)
             .get_internal_cloned(pubkey, |entry| entry)

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -335,6 +335,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
     /// lookup 'pubkey' in the index (in_mem or disk).
     /// call 'callback' whether found or not
+    #[cfg(test)]
     pub(super) fn get_internal_cloned<RT>(
         &self,
         pubkey: &Pubkey,
@@ -355,7 +356,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// then the disk entry *must* also be added to the in-mem cache.
     ///
     /// Prefer `get_internal_inner()` or `get_internal_cloned()` for safe alternatives.
-    pub(super) fn get_internal<RT>(
+    fn get_internal<RT>(
         &self,
         pubkey: &Pubkey,
         // return true if item should be added to in_mem cache


### PR DESCRIPTION
#### Problem
No production code requires getting a cloned `Arc<AccountMapEntry>`, some existing uses of `get_cloned` can be converted to use `get_and_then`

#### Summary of Changes
* mark `AccountsIndex::get_cloned` with `cfg(test)`
* a few minor changes to use `&AccountMapEntry` instead of `Arc<AccountMapEntry>`
