### PR TITLE
Fix zk proof program

### DIFF
--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -143,7 +143,7 @@ fn process_close_proof_context(invoke_context: &mut InvokeContext) -> Result<(),
             return Err(InstructionError::MissingRequiredSignature);
         }
 
-        *instruction_context.get_program_key()?
+        *instruction_context.get_key_of_instruction_account(2)?
     };
 
     let proof_context_account_pubkey = *instruction_context.get_key_of_instruction_account(0)?;


### PR DESCRIPTION
#### Problem

#7503 introduced a bug in the zk proof program, by retrieving the wrong pub key for the program logic.

PS: Problem found by OtterSec.

#### Summary of Changes

Use the correct pubkey.
