### PR TITLE
Revert "votor: ignore event_handler tests (#8243)"

### DIFF
--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -956,7 +956,7 @@ mod tests {
         }
     }
 
-    const TEST_SHORT_TIMEOUT: Duration = Duration::from_millis(30);
+    const TEST_SHORT_TIMEOUT: Duration = Duration::from_millis(50);
 
     fn send_parent_ready_event(
         test_context: &EventHandlerTestContext,

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1201,7 +1201,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_received_block_event_and_parent_ready_event() {
         // Test different orders of received block event and parent ready event
         // some will send Notarize immediately, some will wait for parent ready
@@ -1270,7 +1269,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_received_block_notarized_and_timeout() {
         // Test block notarized event will trigger Finalize vote when all conditions are met
         // But it will not trigger Finalize if any of the conditions are not met
@@ -1354,7 +1352,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_received_timeout_crashed_leader_and_first_shred() {
         let test_context = setup();
 
@@ -1376,7 +1373,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_received_safe_to_notar() {
         let test_context = setup();
 
@@ -1430,7 +1426,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_received_safe_to_skip() {
         let test_context = setup();
 
@@ -1463,7 +1458,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_received_produce_window() {
         let test_context = setup();
 
@@ -1517,7 +1511,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_received_finalized() {
         solana_logger::setup();
         let test_context = setup();
@@ -1554,7 +1547,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_parent_ready_in_middle_of_window() {
         solana_logger::setup();
         let test_context = setup();
@@ -1594,7 +1586,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_received_standstill() {
         solana_logger::setup();
         let test_context = setup();
@@ -1647,7 +1638,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_received_set_identity() {
         solana_logger::setup();
         let test_context = setup();
@@ -1709,7 +1699,6 @@ mod tests {
     #[test_case("bls_receiver")]
     #[test_case("commitment_receiver")]
     #[test_case("own_vote_receiver")]
-    #[ignore]
     fn test_channel_disconnection(channel_name: &str) {
         solana_logger::setup();
         let mut setup_result = setup();


### PR DESCRIPTION
This reverts commit fda07725986faf47beb667dcb2eb09c3af50231b.

#### Problem
We want to revert 8237, but can only revert one PR at a time.
