### PR TITLE
Update security instructions for SPL programs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,9 +14,8 @@ Provide a helpful title, detailed description of the vulnerability and an exploi
 proof-of-concept. Speculative submissions without proof-of-concept will be closed
 with no further consideration.
 
-Please refer to the
-[Solana Program Library (SPL) security policy](https://github.com/solana-labs/solana-program-library/security/policy)
-for vulnerabilities regarding SPL programs such as SPL Token.
+For vulnerabilities regarding SPL programs, please refer to the repositories
+and their associated security policy within the [solana-program organization](https://github.com/solana-program).
 
 If you haven't done so already, please **enable two-factor auth** in your GitHub account.
 


### PR DESCRIPTION
#### Problem
Auditing instances of `solana-labs` in Agave and this one came up

#### Summary of Changes
Refer to the new organization instead of the now archived and solana-labs owned solana-program-library repository

I'm a little on the fence here; I think it is preferable to NOT point to an archived repo but at the same time, the `SECURITY.md` file [in the old repo](https://github.com/solana-labs/solana-program-library/blob/master/SECURITY.md) is pretty good and includes the individual links. Figured I'd create the PR for sake of discussion, can shut it down if people like old diff more:
