### PR TITLE
Make agave-unstable-api default for votor/ so we don't need to specify it many times.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
 name = "agave-votor"
 version = "3.1.0"
 dependencies = [
+ "agave-votor",
  "anyhow",
  "bincode",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,6 @@ dependencies = [
 name = "agave-votor"
 version = "3.1.0"
 dependencies = [
- "agave-votor",
  "anyhow",
  "bincode",
  "bitvec",

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -76,6 +76,7 @@ solana-votor-messages = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+agave-votor = { path = ".", features = ["agave-unstable-api"] }
 rand = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-perf = { workspace = true, features = ["dev-context-only-utils"] }

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 
 [features]
 agave-unstable-api = []
-default = [ "agave-unstable-api" ]
+default = ["agave-unstable-api"]
 dev-context-only-utils = ["solana-runtime/dev-context-only-utils"]
 frozen-abi = [
     "dep:solana-frozen-abi",

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [features]
 agave-unstable-api = []
+default = [ "agave-unstable-api" ]
 dev-context-only-utils = ["solana-runtime/dev-context-only-utils"]
 frozen-abi = [
     "dep:solana-frozen-abi",
@@ -76,7 +77,6 @@ solana-votor-messages = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-agave-votor = { path = ".", features = ["agave-unstable-api"] }
 rand = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-perf = { workspace = true, features = ["dev-context-only-utils"] }

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -1,45 +1,21 @@
+#![cfg(feature = "agave-unstable-api")]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
-#[cfg(feature = "agave-unstable-api")]
-pub mod commitment;
-
-#[cfg(feature = "agave-unstable-api")]
-pub mod common;
-
-#[cfg(feature = "agave-unstable-api")]
-mod consensus_metrics;
-
-#[cfg(feature = "agave-unstable-api")]
-pub mod consensus_pool;
-
-#[cfg(feature = "agave-unstable-api")]
-pub mod event;
-
-#[cfg(feature = "agave-unstable-api")]
-pub mod root_utils;
-
-#[cfg(feature = "agave-unstable-api")]
 #[macro_use]
 extern crate log;
-
-#[cfg(feature = "agave-unstable-api")]
 extern crate serde_derive;
 
-#[cfg(feature = "agave-unstable-api")]
+pub mod commitment;
+pub mod common;
+mod consensus_metrics;
+pub mod consensus_pool;
+pub mod event;
+pub mod root_utils;
 mod staked_validators_cache;
-
-#[cfg(feature = "agave-unstable-api")]
 mod timer_manager;
-
-#[cfg(feature = "agave-unstable-api")]
 pub mod vote_history;
-#[cfg(feature = "agave-unstable-api")]
 pub mod vote_history_storage;
-
-#[cfg(feature = "agave-unstable-api")]
 mod voting_service;
-
-#[cfg(feature = "agave-unstable-api")]
 mod voting_utils;
 
 #[cfg_attr(feature = "frozen-abi", macro_use)]

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "agave-unstable-api")]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 #[macro_use]

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "agave-unstable-api")]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 #[macro_use]


### PR DESCRIPTION
#### Problem
We now have tons of agave-unstable-api in votor/src/lib.rs.

#### Summary of Changes
Just make it default feature in Cargo.toml, this is recommended practice.