### PR TITLE
Use tempfile::TempDir in vote_history tests so they don't interfere with each other.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "solana-votor-messages",
+ "tempfile",
  "test-case",
  "thiserror 2.0.17",
  "tokio-util 0.7.16",

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -82,6 +82,7 @@ solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk-ids = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
+tempfile = { workspace = true }
 test-case = { workspace = true }
 tokio-util = { workspace = true }
 

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -313,7 +313,7 @@ impl VoteHistoryError {
 mod test {
     use {
         super::*, crate::vote_history_storage::FileVoteHistoryStorage, solana_signer::Signer,
-        solana_votor_messages::vote::Vote,
+        solana_votor_messages::vote::Vote, tempfile::TempDir,
     };
 
     // Votes cast since is kept in HashMap, so order is not guaranteed.
@@ -515,7 +515,8 @@ mod test {
     fn test_save_and_restore() {
         let node_keypair = Keypair::new();
         let mut vote_history = VoteHistory::new(node_keypair.pubkey(), 0);
-        let vote_history_storage = FileVoteHistoryStorage::new(std::env::temp_dir());
+        let tmp_dir = TempDir::new().unwrap();
+        let vote_history_storage = FileVoteHistoryStorage::new(tmp_dir.path().to_path_buf());
 
         // Add Notarize on 1 and Skip on 2
         let vote_1 = Vote::new_notarization_vote(1, Hash::new_unique());

--- a/votor/src/vote_history_storage.rs
+++ b/votor/src/vote_history_storage.rs
@@ -173,18 +173,22 @@ impl VoteHistoryStorage for FileVoteHistoryStorage {
 
 #[cfg(test)]
 mod test {
-    use {super::*, solana_keypair::Keypair, solana_votor_messages::vote::Vote};
+    use {super::*, solana_keypair::Keypair, solana_votor_messages::vote::Vote, tempfile::TempDir};
 
     #[test]
     fn test_file_vote_history_storage() {
         solana_logger::setup();
-        let tmp_dir = std::env::temp_dir();
-        let storage = FileVoteHistoryStorage::new(tmp_dir.clone());
+        let tmp_dir = TempDir::new().unwrap();
+        let storage = FileVoteHistoryStorage::new(tmp_dir.path().to_path_buf());
         let keypair = Keypair::new();
         let pubkey = keypair.pubkey();
         assert_eq!(
             storage.filename(&pubkey),
-            PathBuf::from(format!("{}/vote_history-{}.bin", tmp_dir.display(), pubkey))
+            PathBuf::from(format!(
+                "{}/vote_history-{}.bin",
+                tmp_dir.path().display(),
+                pubkey
+            ))
         );
 
         let mut vote_history = VoteHistory::new(pubkey, 0);


### PR DESCRIPTION
#### Problem
Right now I use the system temp dir, this works most of the time, but the tests can interfere with each other.

#### Summary of Changes
Use tempfile::TempDir to give each test its own directory.
