### PR TITLE
(Alpenglow) Upstream consensus_pool_service.

### DIFF
--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -101,10 +101,13 @@ pub(crate) const DELTA_BLOCK: Duration = Duration::from_millis(400);
 /// Base timeout for when leader's first slice should arrive if they sent it immediately.
 pub(crate) const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
 
-#[allow(dead_code)]
-/// TODO(wen): remove allow(dead_code) when timer is fully integrated
 /// Timeout for standstill detection mechanism.
-const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);
+#[cfg(not(test))]
+pub(crate) const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);
+
+/// Shorter timeout for standstill detection mechanism during tests.
+#[cfg(test)]
+pub(crate) const DELTA_STANDSTILL: Duration = Duration::from_millis(10);
 
 /// Returns the Duration for when the `SkipTimer` should be set for for the given slot in the leader window.
 #[inline]

--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -102,12 +102,7 @@ pub(crate) const DELTA_BLOCK: Duration = Duration::from_millis(400);
 pub(crate) const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
 
 /// Timeout for standstill detection mechanism.
-#[cfg(not(test))]
 pub(crate) const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);
-
-/// Shorter timeout for standstill detection mechanism during tests.
-#[cfg(test)]
-pub(crate) const DELTA_STANDSTILL: Duration = Duration::from_millis(10);
 
 /// Returns the Duration for when the `SkipTimer` should be set for for the given slot in the leader window.
 #[inline]

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -1,0 +1,731 @@
+#![allow(dead_code)]
+
+//! Service in charge of ingesting new messages into the certificate pool
+//! and notifying votor of new events that occur
+
+mod stats;
+
+use {
+    crate::{
+        commitment::{update_commitment_cache, CommitmentAggregationData, CommitmentType},
+        common::DELTA_STANDSTILL,
+        consensus_pool::{
+            parent_ready_tracker::BlockProductionParent, AddVoteError, ConsensusPool,
+        },
+        event::{LeaderWindowInfo, VotorEvent, VotorEventSender},
+        voting_service::BLSOp,
+        votor::Votor,
+    },
+    crossbeam_channel::{select, Receiver, Sender, TrySendError},
+    solana_clock::Slot,
+    solana_gossip::cluster_info::ClusterInfo,
+    solana_ledger::{
+        blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache,
+        leader_schedule_utils::last_of_consecutive_leader_slots,
+    },
+    solana_pubkey::Pubkey,
+    solana_runtime::{bank::Bank, bank_forks::SharableBanks},
+    solana_votor_messages::consensus_message::{CertificateMessage, ConsensusMessage},
+    stats::ConsensusPoolServiceStats,
+    std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, Condvar, Mutex,
+        },
+        thread::{self, Builder, JoinHandle},
+        time::{Duration, Instant},
+    },
+};
+
+/// Inputs for the certificate pool thread
+pub(crate) struct ConsensusPoolContext {
+    pub(crate) exit: Arc<AtomicBool>,
+    pub(crate) start: Arc<(Mutex<bool>, Condvar)>,
+
+    pub(crate) cluster_info: Arc<ClusterInfo>,
+    pub(crate) my_vote_pubkey: Pubkey,
+    pub(crate) blockstore: Arc<Blockstore>,
+    pub(crate) sharable_banks: SharableBanks,
+    pub(crate) leader_schedule_cache: Arc<LeaderScheduleCache>,
+
+    // TODO: for now we ingest our own votes into the certificate pool
+    // just like regular votes. However do we need to convert
+    // Vote -> BLSMessage -> Vote?
+    // consider adding a separate pathway in consensus_pool.add_transaction for ingesting own votes
+    pub(crate) consensus_message_receiver: Receiver<ConsensusMessage>,
+
+    pub(crate) bls_sender: Sender<BLSOp>,
+    pub(crate) event_sender: VotorEventSender,
+    pub(crate) commitment_sender: Sender<CommitmentAggregationData>,
+}
+
+pub(crate) struct ConsensusPoolService {
+    t_ingest: JoinHandle<()>,
+}
+
+impl ConsensusPoolService {
+    pub(crate) fn new(ctx: ConsensusPoolContext) -> Self {
+        let t_ingest = Builder::new()
+            .name("solCertPoolIngest".to_string())
+            .spawn(move || {
+                if let Err(e) = Self::consensus_pool_ingest_loop(ctx) {
+                    info!("Certificate pool service exited: {e:?}. Shutting down");
+                }
+            })
+            .unwrap();
+
+        Self { t_ingest }
+    }
+
+    fn maybe_update_root_and_send_new_certificates(
+        consensus_pool: &mut ConsensusPool,
+        sharable_banks: &SharableBanks,
+        bls_sender: &Sender<BLSOp>,
+        new_finalized_slot: Option<Slot>,
+        new_certificates_to_send: Vec<Arc<CertificateMessage>>,
+        standstill_timer: &mut Instant,
+        stats: &mut ConsensusPoolServiceStats,
+    ) -> Result<(), AddVoteError> {
+        // If we have a new finalized slot, update the root and send new certificates
+        if new_finalized_slot.is_some() {
+            // Reset standstill timer
+            *standstill_timer = Instant::now();
+            ConsensusPoolServiceStats::incr_u16(&mut stats.new_finalized_slot);
+        }
+        let bank = sharable_banks.root();
+        consensus_pool.prune_old_state(bank.slot());
+        ConsensusPoolServiceStats::incr_u64(&mut stats.prune_old_state_called);
+        // Send new certificates to peers
+        Self::send_certificates(bls_sender, new_certificates_to_send, stats)
+    }
+
+    fn send_certificates(
+        bls_sender: &Sender<BLSOp>,
+        certificates_to_send: Vec<Arc<CertificateMessage>>,
+        stats: &mut ConsensusPoolServiceStats,
+    ) -> Result<(), AddVoteError> {
+        for (i, certificate) in certificates_to_send.iter().enumerate() {
+            // The buffer should normally be large enough, so we don't handle
+            // certificate re-send here.
+            match bls_sender.try_send(BLSOp::PushCertificate {
+                certificate: certificate.clone(),
+            }) {
+                Ok(_) => {
+                    ConsensusPoolServiceStats::incr_u16(&mut stats.certificates_sent);
+                }
+                Err(TrySendError::Disconnected(_)) => {
+                    return Err(AddVoteError::ChannelDisconnected(
+                        "VotingService".to_string(),
+                    ));
+                }
+                Err(TrySendError::Full(_)) => {
+                    let dropped = certificates_to_send.len().saturating_sub(i) as u16;
+                    stats.certificates_dropped = stats.certificates_dropped.saturating_add(dropped);
+                    return Err(AddVoteError::VotingServiceQueueFull);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn process_consensus_message(
+        ctx: &mut ConsensusPoolContext,
+        my_pubkey: &Pubkey,
+        message: &ConsensusMessage,
+        consensus_pool: &mut ConsensusPool,
+        events: &mut Vec<VotorEvent>,
+        standstill_timer: &mut Instant,
+        stats: &mut ConsensusPoolServiceStats,
+    ) -> Result<(), AddVoteError> {
+        match message {
+            ConsensusMessage::Certificate(_) => {
+                ConsensusPoolServiceStats::incr_u32(&mut stats.received_certificates);
+            }
+            ConsensusMessage::Vote(_) => {
+                ConsensusPoolServiceStats::incr_u32(&mut stats.received_votes);
+            }
+        }
+        let root_bank = ctx.sharable_banks.root();
+        let (new_finalized_slot, new_certificates_to_send) =
+            Self::add_message_and_maybe_update_commitment(
+                &root_bank,
+                my_pubkey,
+                &ctx.my_vote_pubkey,
+                message,
+                consensus_pool,
+                events,
+                &ctx.commitment_sender,
+            )?;
+        Self::maybe_update_root_and_send_new_certificates(
+            consensus_pool,
+            &ctx.sharable_banks,
+            &ctx.bls_sender,
+            new_finalized_slot,
+            new_certificates_to_send,
+            standstill_timer,
+            stats,
+        )
+    }
+
+    fn handle_channel_disconnected(
+        ctx: &mut ConsensusPoolContext,
+        channel_name: &str,
+    ) -> Result<(), ()> {
+        info!(
+            "{}: {} disconnected. Exiting",
+            ctx.cluster_info.id(),
+            channel_name
+        );
+        ctx.exit.store(true, Ordering::Relaxed);
+        Err(())
+    }
+
+    // Main loop for the certificate pool service, it only exits when any channel is disconnected
+    fn consensus_pool_ingest_loop(mut ctx: ConsensusPoolContext) -> Result<(), ()> {
+        let mut events = vec![];
+        let mut my_pubkey = ctx.cluster_info.id();
+        let root_bank = ctx.sharable_banks.root();
+        let mut consensus_pool = ConsensusPool::new_from_root_bank(my_pubkey, &root_bank);
+
+        // Wait until migration has completed
+        info!("{}: Certificate pool loop initialized", &my_pubkey);
+        Votor::wait_for_migration_or_exit(&ctx.exit, &ctx.start);
+        info!("{}: Certificate pool loop starting", &my_pubkey);
+        let mut stats = ConsensusPoolServiceStats::new();
+
+        // Standstill tracking
+        let mut standstill_timer = Instant::now();
+
+        // Kick off parent ready
+        let root_block = (root_bank.slot(), root_bank.block_id().unwrap_or_default());
+        let mut highest_parent_ready = root_bank.slot();
+        events.push(VotorEvent::ParentReady {
+            slot: root_bank.slot().checked_add(1).unwrap(),
+            parent_block: root_block,
+        });
+
+        // Ingest votes into certificate pool and notify voting loop of new events
+        while !ctx.exit.load(Ordering::Relaxed) {
+            // Update the current pubkey if it has changed
+            let new_pubkey = ctx.cluster_info.id();
+            if my_pubkey != new_pubkey {
+                my_pubkey = new_pubkey;
+                consensus_pool.update_pubkey(my_pubkey);
+                warn!("Certificate pool pubkey updated to {my_pubkey}");
+            }
+
+            Self::add_produce_block_event(
+                &mut highest_parent_ready,
+                &consensus_pool,
+                &my_pubkey,
+                &mut ctx,
+                &mut events,
+                &mut stats,
+            );
+
+            if standstill_timer.elapsed() > DELTA_STANDSTILL {
+                events.push(VotorEvent::Standstill(
+                    consensus_pool.highest_finalized_slot(),
+                ));
+                stats.standstill = true;
+                standstill_timer = Instant::now();
+                match Self::send_certificates(
+                    &ctx.bls_sender,
+                    consensus_pool.get_certs_for_standstill(),
+                    &mut stats,
+                ) {
+                    Ok(()) => (),
+                    Err(AddVoteError::ChannelDisconnected(channel_name)) => {
+                        return Self::handle_channel_disconnected(&mut ctx, channel_name.as_str());
+                    }
+                    Err(e) => {
+                        trace!("{my_pubkey}: unable to push standstill certificates into pool {e}");
+                    }
+                }
+            }
+
+            if events
+                .drain(..)
+                .try_for_each(|event| ctx.event_sender.send(event))
+                .is_err()
+            {
+                return Self::handle_channel_disconnected(&mut ctx, "Votor event receiver");
+            }
+
+            let messages: Vec<ConsensusMessage> = select! {
+                recv(ctx.consensus_message_receiver) -> msg => {
+                    let Ok(first) = msg else {
+                        return Self::handle_channel_disconnected(&mut ctx, "BLS receiver");
+                    };
+                    std::iter::once(first).chain(ctx.consensus_message_receiver.try_iter()).collect()
+                },
+                default(Duration::from_secs(1)) => continue
+            };
+
+            for message in messages {
+                match Self::process_consensus_message(
+                    &mut ctx,
+                    &my_pubkey,
+                    &message,
+                    &mut consensus_pool,
+                    &mut events,
+                    &mut standstill_timer,
+                    &mut stats,
+                ) {
+                    Ok(()) => {}
+                    Err(AddVoteError::ChannelDisconnected(channel_name)) => {
+                        return Self::handle_channel_disconnected(&mut ctx, channel_name.as_str())
+                    }
+                    Err(e) => {
+                        // This is a non critical error, a duplicate vote for example
+                        trace!("{}: unable to push vote into pool {}", &my_pubkey, e);
+                        ConsensusPoolServiceStats::incr_u32(&mut stats.add_message_failed);
+                    }
+                }
+            }
+            stats.maybe_report();
+            consensus_pool.maybe_report();
+        }
+        Ok(())
+    }
+
+    /// Adds a vote to the certificate pool and updates the commitment cache if necessary
+    ///
+    /// If a new finalization slot was recognized, returns the slot
+    fn add_message_and_maybe_update_commitment(
+        root_bank: &Bank,
+        my_pubkey: &Pubkey,
+        my_vote_pubkey: &Pubkey,
+        message: &ConsensusMessage,
+        consensus_pool: &mut ConsensusPool,
+        votor_events: &mut Vec<VotorEvent>,
+        commitment_sender: &Sender<CommitmentAggregationData>,
+    ) -> Result<(Option<Slot>, Vec<Arc<CertificateMessage>>), AddVoteError> {
+        let (new_finalized_slot, new_certificates_to_send) = consensus_pool.add_message(
+            root_bank.epoch_schedule(),
+            root_bank.epoch_stakes_map(),
+            root_bank.slot(),
+            my_vote_pubkey,
+            message,
+            votor_events,
+        )?;
+        let Some(new_finalized_slot) = new_finalized_slot else {
+            return Ok((None, new_certificates_to_send));
+        };
+        trace!("{my_pubkey}: new finalization certificate for {new_finalized_slot}");
+        update_commitment_cache(
+            CommitmentType::Finalized,
+            new_finalized_slot,
+            commitment_sender,
+        )?;
+        Ok((Some(new_finalized_slot), new_certificates_to_send))
+    }
+
+    fn add_produce_block_event(
+        highest_parent_ready: &mut Slot,
+        consensus_pool: &ConsensusPool,
+        my_pubkey: &Pubkey,
+        ctx: &mut ConsensusPoolContext,
+        events: &mut Vec<VotorEvent>,
+        stats: &mut ConsensusPoolServiceStats,
+    ) {
+        let Some(new_highest_parent_ready) = events
+            .iter()
+            .filter_map(|event| match event {
+                VotorEvent::ParentReady { slot, .. } => Some(slot),
+                _ => None,
+            })
+            .max()
+            .copied()
+        else {
+            return;
+        };
+
+        if new_highest_parent_ready <= *highest_parent_ready {
+            return;
+        }
+        *highest_parent_ready = new_highest_parent_ready;
+
+        let root_bank = ctx.sharable_banks.root();
+        let Some(leader_pubkey) = ctx
+            .leader_schedule_cache
+            .slot_leader_at(*highest_parent_ready, Some(&root_bank))
+        else {
+            error!(
+                "Unable to compute the leader at slot {highest_parent_ready}. Something is wrong, \
+                 exiting"
+            );
+            ctx.exit.store(true, Ordering::Relaxed);
+            return;
+        };
+
+        if &leader_pubkey != my_pubkey {
+            return;
+        }
+
+        let start_slot = *highest_parent_ready;
+        let end_slot = last_of_consecutive_leader_slots(start_slot);
+
+        if (start_slot..=end_slot).any(|s| ctx.blockstore.has_existing_shreds_for_slot(s)) {
+            warn!(
+                "{my_pubkey}: We have already produced shreds in the window \
+                 {start_slot}-{end_slot}, skipping production of our leader window"
+            );
+            return;
+        }
+
+        match consensus_pool
+            .parent_ready_tracker
+            .block_production_parent(start_slot)
+        {
+            BlockProductionParent::MissedWindow => {
+                warn!(
+                    "{my_pubkey}: Leader slot {start_slot} has already been certified, skipping \
+                     production of {start_slot}-{end_slot}"
+                );
+                ConsensusPoolServiceStats::incr_u16(&mut stats.parent_ready_missed_window);
+            }
+            BlockProductionParent::ParentNotReady => {
+                // This can't happen, place holder depending on how we hook up optimistic
+                ctx.exit.store(true, Ordering::Relaxed);
+                panic!(
+                    "Must have a block production parent: {:#?}",
+                    consensus_pool.parent_ready_tracker
+                );
+            }
+            BlockProductionParent::Parent(parent_block) => {
+                events.push(VotorEvent::ProduceWindow(LeaderWindowInfo {
+                    start_slot,
+                    end_slot,
+                    parent_block,
+                    // TODO: we can just remove this
+                    skip_timer: Instant::now(),
+                }));
+                ConsensusPoolServiceStats::incr_u16(&mut stats.parent_ready_produce_window);
+            }
+        }
+    }
+
+    pub(crate) fn join(self) -> thread::Result<()> {
+        self.t_ingest.join()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crossbeam_channel::Sender,
+        solana_bls_signatures::{
+            keypair::Keypair as BLSKeypair, signature::Signature as BLSSignature,
+        },
+        solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
+        solana_hash::Hash,
+        solana_ledger::get_tmp_ledger_path_auto_delete,
+        solana_runtime::{
+            bank_forks::{BankForks, SharableBanks},
+            genesis_utils::{
+                create_genesis_config_with_alpenglow_vote_accounts, ValidatorVoteKeypairs,
+            },
+        },
+        solana_signer::Signer,
+        solana_streamer::socket::SocketAddrSpace,
+        solana_votor_messages::{
+            consensus_message::{
+                Certificate, CertificateType, VoteMessage, BLS_KEYPAIR_DERIVE_SEED,
+            },
+            vote::Vote,
+        },
+        std::sync::{Arc, Mutex},
+        test_case::test_case,
+    };
+
+    struct ConsensusPoolServiceTestComponents {
+        consensus_pool_service: ConsensusPoolService,
+        consensus_message_sender: Sender<ConsensusMessage>,
+        bls_receiver: Receiver<BLSOp>,
+        event_receiver: Receiver<VotorEvent>,
+        commitment_receiver: Receiver<CommitmentAggregationData>,
+        validator_keypairs: Vec<ValidatorVoteKeypairs>,
+        exit: Arc<AtomicBool>,
+        leader_schedule_cache: Arc<LeaderScheduleCache>,
+        sharable_banks: SharableBanks,
+    }
+
+    fn setup() -> ConsensusPoolServiceTestComponents {
+        let (consensus_message_sender, consensus_message_receiver) = crossbeam_channel::unbounded();
+        let (bls_sender, bls_receiver) = crossbeam_channel::unbounded();
+        let (event_sender, event_receiver) = crossbeam_channel::unbounded();
+        let (commitment_sender, commitment_receiver) = crossbeam_channel::unbounded();
+        // Create 10 node validatorvotekeypairs vec
+        let validator_keypairs = (0..10)
+            .map(|_| ValidatorVoteKeypairs::new_rand())
+            .collect::<Vec<_>>();
+        // Make stake monotonic decreasing so rank is deterministic
+        let stake = (0..validator_keypairs.len())
+            .rev()
+            .map(|i| ((i.saturating_add(5).saturating_mul(100)) as u64))
+            .collect::<Vec<_>>();
+        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            stake,
+        );
+        let my_keypair = validator_keypairs[0].node_keypair.insecure_clone();
+        let contact_info = ContactInfo::new_localhost(&my_keypair.pubkey(), 0);
+        let cluster_info = ClusterInfo::new(
+            contact_info,
+            Arc::new(my_keypair),
+            SocketAddrSpace::Unspecified,
+        );
+        let bank0 = Bank::new_for_tests(&genesis.genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank0);
+
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let sharable_banks = bank_forks.read().unwrap().sharable_banks();
+        let exit = Arc::new(AtomicBool::new(false));
+        let leader_schedule_cache =
+            Arc::new(LeaderScheduleCache::new_from_bank(&sharable_banks.root()));
+        let ctx = ConsensusPoolContext {
+            exit: exit.clone(),
+            start: Arc::new((Mutex::new(true), Condvar::new())),
+            cluster_info: Arc::new(cluster_info),
+            my_vote_pubkey: Pubkey::new_unique(),
+            blockstore: Arc::new(blockstore),
+            sharable_banks: sharable_banks.clone(),
+            leader_schedule_cache: leader_schedule_cache.clone(),
+            consensus_message_receiver,
+            bls_sender,
+            event_sender,
+            commitment_sender,
+        };
+        ConsensusPoolServiceTestComponents {
+            consensus_pool_service: ConsensusPoolService::new(ctx),
+            consensus_message_sender,
+            bls_receiver,
+            event_receiver,
+            commitment_receiver,
+            validator_keypairs,
+            exit,
+            leader_schedule_cache,
+            sharable_banks,
+        }
+    }
+
+    fn wait_for_event<T>(receiver: &Receiver<T>, condition: impl Fn(&T) -> bool) {
+        let start = Instant::now();
+        let mut event_received = false;
+        while start.elapsed() < Duration::from_secs(5) {
+            if let Ok(event) = receiver.recv_timeout(Duration::from_millis(500)) {
+                if condition(&event) {
+                    event_received = true;
+                    break;
+                }
+            }
+        }
+        assert!(event_received);
+    }
+
+    fn test_send_and_receive<T>(
+        consensus_message_sender: &Sender<ConsensusMessage>,
+        messages_to_send: Vec<ConsensusMessage>,
+        receiver: &Receiver<T>,
+        condition: impl Fn(&T) -> bool,
+    ) {
+        for message in messages_to_send {
+            consensus_message_sender.send(message).unwrap();
+        }
+        wait_for_event(receiver, condition);
+    }
+
+    #[test]
+    fn test_receive_and_send_consensus_message() {
+        solana_logger::setup();
+        let setup_result = setup();
+
+        // validator 0 to 7 send Notarize on slot 2
+        let block_id = Hash::new_unique();
+        let target_slot = 2;
+        let notarize_vote = Vote::new_notarization_vote(target_slot, block_id);
+        let messages_to_send = (0..8)
+            .map(|my_rank| {
+                let vote_keypair = &setup_result.validator_keypairs[my_rank].vote_keypair;
+                let bls_keypair =
+                    BLSKeypair::derive_from_signer(vote_keypair, BLS_KEYPAIR_DERIVE_SEED).unwrap();
+                let vote_serialized = bincode::serialize(&notarize_vote).unwrap();
+                ConsensusMessage::Vote(VoteMessage {
+                    vote: notarize_vote,
+                    signature: bls_keypair.sign(&vote_serialized).into(),
+                    rank: my_rank as u16,
+                })
+            })
+            .collect();
+        test_send_and_receive(
+            &setup_result.consensus_message_sender,
+            messages_to_send,
+            &setup_result.bls_receiver,
+            |event| {
+                if let BLSOp::PushCertificate { certificate } = event {
+                    assert_eq!(certificate.certificate.slot(), target_slot);
+                    let certificate_type = certificate.certificate.certificate_type();
+                    assert!(matches!(
+                        certificate_type,
+                        CertificateType::Notarize
+                            | CertificateType::FinalizeFast
+                            | CertificateType::NotarizeFallback
+                    ));
+                    true
+                } else {
+                    false
+                }
+            },
+        );
+        // Verify that we received a finalized slot event
+        wait_for_event(&setup_result.event_receiver, |event| {
+            if let VotorEvent::Finalized((slot, receivied_block_id), is_fast_finalized) = event {
+                assert_eq!(*slot, target_slot);
+                assert_eq!(*receivied_block_id, block_id);
+                assert!(*is_fast_finalized);
+                true
+            } else {
+                false
+            }
+        });
+        // Verify that we received a commitment update
+        wait_for_event(
+            &setup_result.commitment_receiver,
+            |CommitmentAggregationData {
+                 commitment_type,
+                 slot,
+                 ..
+             }| {
+                assert_eq!(*commitment_type, CommitmentType::Finalized);
+                assert_eq!(*slot, target_slot);
+                true
+            },
+        );
+
+        // Now send a Skip certificate on slot 3, should be forwarded immediately
+        let target_slot = 3;
+        let skip_certificate = CertificateMessage {
+            certificate: Certificate::Skip(target_slot),
+            signature: BLSSignature::default(),
+            bitmap: vec![],
+        };
+        test_send_and_receive(
+            &setup_result.consensus_message_sender,
+            vec![ConsensusMessage::Certificate(skip_certificate)],
+            &setup_result.bls_receiver,
+            |event| {
+                if let BLSOp::PushCertificate { certificate } = event {
+                    matches!(certificate.certificate, Certificate::Skip(slot) if slot == target_slot)
+                } else {
+                    false
+                }
+            },
+        );
+        setup_result.exit.store(true, Ordering::Relaxed);
+        setup_result.consensus_pool_service.join().unwrap();
+    }
+
+    #[test]
+    fn test_send_produce_block_event() {
+        let setup_result = setup();
+        // Find when is the next leader slot for me (validator 0)
+        let my_pubkey = setup_result.validator_keypairs[0].node_keypair.pubkey();
+        let next_leader_slot = setup_result
+            .leader_schedule_cache
+            .next_leader_slot(
+                &my_pubkey,
+                0,
+                &setup_result.sharable_banks.root(),
+                None,
+                1000000,
+            )
+            .expect("Should find a leader slot");
+        // Send skip certificates for all slots up to the next leader slot
+        let messages_to_send = (1..next_leader_slot.0)
+            .map(|slot| {
+                let skip_certificate = CertificateMessage {
+                    certificate: Certificate::Skip(slot),
+                    signature: BLSSignature::default(),
+                    bitmap: vec![],
+                };
+                ConsensusMessage::Certificate(skip_certificate)
+            })
+            .collect();
+        test_send_and_receive(
+            &setup_result.consensus_message_sender,
+            messages_to_send,
+            &setup_result.event_receiver,
+            |event| {
+                if let VotorEvent::ProduceWindow(LeaderWindowInfo { start_slot, .. }) = event {
+                    assert_eq!(*start_slot, next_leader_slot.0);
+                    true
+                } else {
+                    false
+                }
+            },
+        );
+        setup_result.exit.store(true, Ordering::Relaxed);
+        setup_result.consensus_pool_service.join().unwrap();
+    }
+
+    #[test]
+    fn test_send_standstill() {
+        let setup_result = setup();
+        // Do nothing for a little more than DELTA_STANDSTILL
+        thread::sleep(DELTA_STANDSTILL + Duration::from_millis(100));
+        // Verify that we received a standstill event
+        wait_for_event(
+            &setup_result.event_receiver,
+            |event| matches!(event, VotorEvent::Standstill(slot) if *slot == 0),
+        );
+        setup_result.exit.store(true, Ordering::Relaxed);
+        setup_result.consensus_pool_service.join().unwrap();
+    }
+
+    #[test_case("consensus_message_receiver")]
+    #[test_case("bls_receiver")]
+    #[test_case("votor_event_receiver")]
+    #[test_case("commitment_receiver")]
+    fn test_channel_disconnection(channel_name: &str) {
+        let setup_result = setup();
+        // A lot of the receiver needs a finalize certificate to trigger an exit
+        if channel_name != "consensus_message_receiver" {
+            let finalize_certificate = CertificateMessage {
+                certificate: Certificate::FinalizeFast(2, Hash::new_unique()),
+                signature: BLSSignature::default(),
+                bitmap: vec![],
+            };
+            setup_result
+                .consensus_message_sender
+                .send(ConsensusMessage::Certificate(finalize_certificate))
+                .unwrap();
+        }
+        match channel_name {
+            "consensus_message_receiver" => {
+                drop(setup_result.consensus_message_sender);
+            }
+            "bls_receiver" => {
+                drop(setup_result.bls_receiver);
+            }
+            "votor_event_receiver" => {
+                drop(setup_result.event_receiver);
+            }
+            "commitment_receiver" => {
+                drop(setup_result.commitment_receiver);
+            }
+            _ => panic!("Unknown channel name"),
+        }
+        // Verify that the consensus pool service exits within 5 seconds
+        let start = Instant::now();
+        while !setup_result.exit.load(Ordering::Relaxed) && start.elapsed() < Duration::from_secs(5)
+        {
+            thread::sleep(Duration::from_millis(100));
+        }
+        assert!(setup_result.exit.load(Ordering::Relaxed));
+        setup_result.consensus_pool_service.join().unwrap();
+    }
+}

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -672,20 +672,6 @@ mod tests {
         setup_result.consensus_pool_service.join().unwrap();
     }
 
-    #[test]
-    fn test_send_standstill() {
-        let setup_result = setup();
-        // Do nothing for a little more than DELTA_STANDSTILL
-        thread::sleep(DELTA_STANDSTILL + Duration::from_millis(100));
-        // Verify that we received a standstill event
-        wait_for_event(
-            &setup_result.event_receiver,
-            |event| matches!(event, VotorEvent::Standstill(slot) if *slot == 0),
-        );
-        setup_result.exit.store(true, Ordering::Relaxed);
-        setup_result.consensus_pool_service.join().unwrap();
-    }
-
     #[test_case("consensus_message_receiver")]
     #[test_case("bls_receiver")]
     #[test_case("votor_event_receiver")]

--- a/votor/src/consensus_pool_service/stats.rs
+++ b/votor/src/consensus_pool_service/stats.rs
@@ -1,0 +1,96 @@
+use {
+    solana_metrics::datapoint_info,
+    std::time::{Duration, Instant},
+};
+
+const STATS_REPORT_INTERVAL: Duration = Duration::from_secs(10);
+
+#[derive(Debug)]
+pub(crate) struct ConsensusPoolServiceStats {
+    pub(crate) add_message_failed: u32,
+    pub(crate) certificates_sent: u16,
+    pub(crate) certificates_dropped: u16,
+    pub(crate) new_finalized_slot: u16,
+    pub(crate) parent_ready_missed_window: u16,
+    pub(crate) parent_ready_produce_window: u16,
+    pub(crate) received_votes: u32,
+    pub(crate) received_certificates: u32,
+    pub(crate) standstill: bool,
+    pub(crate) prune_old_state_called: u64,
+    last_request_time: Instant,
+}
+
+impl ConsensusPoolServiceStats {
+    pub fn new() -> Self {
+        Self {
+            add_message_failed: 0,
+            certificates_sent: 0,
+            certificates_dropped: 0,
+            new_finalized_slot: 0,
+            parent_ready_missed_window: 0,
+            parent_ready_produce_window: 0,
+            received_votes: 0,
+            received_certificates: 0,
+            standstill: false,
+            prune_old_state_called: 0,
+            last_request_time: Instant::now(),
+        }
+    }
+
+    pub fn incr_u16(value: &mut u16) {
+        *value = value.saturating_add(1);
+    }
+
+    pub fn incr_u32(value: &mut u32) {
+        *value = value.saturating_add(1);
+    }
+
+    pub fn incr_u64(value: &mut u64) {
+        *value = value.saturating_add(1);
+    }
+
+    fn reset(&mut self) {
+        self.add_message_failed = 0;
+        self.certificates_sent = 0;
+        self.certificates_dropped = 0;
+        self.new_finalized_slot = 0;
+        self.parent_ready_missed_window = 0;
+        self.parent_ready_produce_window = 0;
+        self.received_votes = 0;
+        self.received_certificates = 0;
+        self.standstill = false;
+        self.prune_old_state_called = 0;
+        self.last_request_time = Instant::now();
+    }
+
+    fn report(&self) {
+        datapoint_info!(
+            "consensus_pool_service",
+            ("add_message_failed", self.add_message_failed, i64),
+            ("certificates_sent", self.certificates_sent, i64),
+            ("certificates_dropped", self.certificates_dropped, i64),
+            ("new_finalized_slot", self.new_finalized_slot, i64),
+            (
+                "parent_ready_missed_window",
+                self.parent_ready_missed_window,
+                i64
+            ),
+            (
+                "parent_ready_produce_window",
+                self.parent_ready_produce_window,
+                i64
+            ),
+            ("received_votes", self.received_votes, i64),
+            ("received_certificates", self.received_certificates, i64),
+            ("standstill", self.standstill, i64),
+            ("prune_old_state_called", self.prune_old_state_called, i64),
+        );
+    }
+
+    pub fn maybe_report(&mut self) {
+        if self.last_request_time.elapsed() >= STATS_REPORT_INTERVAL {
+            self.report();
+            self.reset();
+        }
+    }
+}

--- a/votor/src/consensus_pool_service/stats.rs
+++ b/votor/src/consensus_pool_service/stats.rs
@@ -1,90 +1,95 @@
 use {
-    solana_metrics::datapoint_info,
-    std::time::{Duration, Instant},
+    solana_metrics::create_datapoint,
+    std::{
+        num::Saturating,
+        time::{Duration, Instant},
+    },
 };
 
 const STATS_REPORT_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Debug)]
 pub(crate) struct ConsensusPoolServiceStats {
-    pub(crate) add_message_failed: u32,
-    pub(crate) certificates_sent: u16,
-    pub(crate) certificates_dropped: u16,
-    pub(crate) new_finalized_slot: u16,
-    pub(crate) parent_ready_missed_window: u16,
-    pub(crate) parent_ready_produce_window: u16,
-    pub(crate) received_votes: u32,
-    pub(crate) received_certificates: u32,
+    pub(crate) add_message_failed: Saturating<usize>,
+    pub(crate) certificates_sent: Saturating<usize>,
+    pub(crate) certificates_dropped: Saturating<usize>,
+    pub(crate) new_finalized_slot: Saturating<usize>,
+    pub(crate) parent_ready_missed_window: Saturating<usize>,
+    pub(crate) parent_ready_produce_window: Saturating<usize>,
+    pub(crate) received_votes: Saturating<usize>,
+    pub(crate) received_certificates: Saturating<usize>,
     pub(crate) standstill: bool,
-    pub(crate) prune_old_state_called: u64,
+    pub(crate) prune_old_state_called: Saturating<usize>,
     last_request_time: Instant,
 }
 
 impl ConsensusPoolServiceStats {
     pub fn new() -> Self {
         Self {
-            add_message_failed: 0,
-            certificates_sent: 0,
-            certificates_dropped: 0,
-            new_finalized_slot: 0,
-            parent_ready_missed_window: 0,
-            parent_ready_produce_window: 0,
-            received_votes: 0,
-            received_certificates: 0,
+            add_message_failed: Saturating(0),
+            certificates_sent: Saturating(0),
+            certificates_dropped: Saturating(0),
+            new_finalized_slot: Saturating(0),
+            parent_ready_missed_window: Saturating(0),
+            parent_ready_produce_window: Saturating(0),
+            received_votes: Saturating(0),
+            received_certificates: Saturating(0),
             standstill: false,
-            prune_old_state_called: 0,
+            prune_old_state_called: Saturating(0),
             last_request_time: Instant::now(),
         }
     }
 
-    pub fn incr_u16(value: &mut u16) {
-        *value = value.saturating_add(1);
-    }
-
-    pub fn incr_u32(value: &mut u32) {
-        *value = value.saturating_add(1);
-    }
-
-    pub fn incr_u64(value: &mut u64) {
-        *value = value.saturating_add(1);
-    }
-
     fn reset(&mut self) {
-        self.add_message_failed = 0;
-        self.certificates_sent = 0;
-        self.certificates_dropped = 0;
-        self.new_finalized_slot = 0;
-        self.parent_ready_missed_window = 0;
-        self.parent_ready_produce_window = 0;
-        self.received_votes = 0;
-        self.received_certificates = 0;
+        self.add_message_failed = Saturating(0);
+        self.certificates_sent = Saturating(0);
+        self.certificates_dropped = Saturating(0);
+        self.new_finalized_slot = Saturating(0);
+        self.parent_ready_missed_window = Saturating(0);
+        self.parent_ready_produce_window = Saturating(0);
+        self.received_votes = Saturating(0);
+        self.received_certificates = Saturating(0);
         self.standstill = false;
-        self.prune_old_state_called = 0;
+        self.prune_old_state_called = Saturating(0);
         self.last_request_time = Instant::now();
     }
 
     fn report(&self) {
-        datapoint_info!(
-            "consensus_pool_service",
-            ("add_message_failed", self.add_message_failed, i64),
-            ("certificates_sent", self.certificates_sent, i64),
-            ("certificates_dropped", self.certificates_dropped, i64),
-            ("new_finalized_slot", self.new_finalized_slot, i64),
+        let &Self {
+            add_message_failed: Saturating(add_message_failed),
+            certificates_sent: Saturating(certificates_sent),
+            certificates_dropped: Saturating(certificates_dropped),
+            new_finalized_slot: Saturating(new_finalized_slot),
+            parent_ready_missed_window: Saturating(parent_ready_missed_window),
+            parent_ready_produce_window: Saturating(parent_ready_produce_window),
+            received_votes: Saturating(received_votes),
+            received_certificates: Saturating(received_certificates),
+            standstill,
+            prune_old_state_called: Saturating(prune_old_state_called),
+            ..
+        } = self;
+        let datapoint = create_datapoint!(
+            @point "consensus_pool_service",
+            ("add_message_failed", add_message_failed, i64),
+            ("certificates_sent", certificates_sent, i64),
+            ("certificates_dropped", certificates_dropped, i64),
+            ("new_finalized_slot", new_finalized_slot, i64),
             (
                 "parent_ready_missed_window",
-                self.parent_ready_missed_window,
+                parent_ready_missed_window,
                 i64
             ),
             (
                 "parent_ready_produce_window",
-                self.parent_ready_produce_window,
+                parent_ready_produce_window,
                 i64
             ),
-            ("received_votes", self.received_votes, i64),
-            ("received_certificates", self.received_certificates, i64),
-            ("standstill", self.standstill, i64),
-            ("prune_old_state_called", self.prune_old_state_called, i64),
+            ("received_votes", received_votes, i64),
+            ("received_certificates", received_certificates, i64),
+            ("standstill", standstill, i64),
+            ("prune_old_state_called", prune_old_state_called, i64),
         );
+        solana_metrics::submit(datapoint, log::Level::Info);
     }
 
     pub fn maybe_report(&mut self) {

--- a/votor/src/consensus_pool_service/stats.rs
+++ b/votor/src/consensus_pool_service/stats.rs
@@ -40,20 +40,6 @@ impl ConsensusPoolServiceStats {
         }
     }
 
-    fn reset(&mut self) {
-        self.add_message_failed = Saturating(0);
-        self.certificates_sent = Saturating(0);
-        self.certificates_dropped = Saturating(0);
-        self.new_finalized_slot = Saturating(0);
-        self.parent_ready_missed_window = Saturating(0);
-        self.parent_ready_produce_window = Saturating(0);
-        self.received_votes = Saturating(0);
-        self.received_certificates = Saturating(0);
-        self.standstill = false;
-        self.prune_old_state_called = Saturating(0);
-        self.last_request_time = Instant::now();
-    }
-
     fn report(&self) {
         let &Self {
             add_message_failed: Saturating(add_message_failed),
@@ -95,7 +81,7 @@ impl ConsensusPoolServiceStats {
     pub fn maybe_report(&mut self) {
         if self.last_request_time.elapsed() >= STATS_REPORT_INTERVAL {
             self.report();
-            self.reset();
+            *self = Self::new();
         }
     }
 }

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -13,6 +13,9 @@ mod consensus_metrics;
 pub mod consensus_pool;
 
 #[cfg(feature = "agave-unstable-api")]
+mod consensus_pool_service;
+
+#[cfg(feature = "agave-unstable-api")]
 pub mod event;
 
 #[cfg(feature = "agave-unstable-api")]
@@ -41,6 +44,9 @@ mod voting_service;
 
 #[cfg(feature = "agave-unstable-api")]
 mod voting_utils;
+
+#[cfg(feature = "agave-unstable-api")]
+mod votor;
 
 #[cfg_attr(feature = "frozen-abi", macro_use)]
 #[cfg(feature = "frozen-abi")]

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -18,7 +18,7 @@ pub mod vote_history;
 pub mod vote_history_storage;
 mod voting_service;
 mod voting_utils;
-mod votor;
+pub mod votor;
 
 #[cfg_attr(feature = "frozen-abi", macro_use)]
 #[cfg(feature = "frozen-abi")]

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -18,8 +18,6 @@ pub mod vote_history;
 pub mod vote_history_storage;
 mod voting_service;
 mod voting_utils;
-
-#[cfg(feature = "agave-unstable-api")]
 mod votor;
 
 #[cfg_attr(feature = "frozen-abi", macro_use)]

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -1,0 +1,16 @@
+#![allow(dead_code)]
+
+// Just a placeholder before the real votor is upstream.
+
+use std::sync::{atomic::AtomicBool, Arc, Condvar, Mutex};
+
+pub struct Votor {}
+
+impl Votor {
+    pub fn wait_for_migration_or_exit(
+        _exit: &Arc<AtomicBool>,
+        _start: &Arc<(Mutex<bool>, Condvar)>,
+    ) {
+        warn!("votor::wait_for_migration_or_exit is a placeholder and does nothing");
+    }
+}


### PR DESCRIPTION
#### Summary of Changes
Upstream consensus_pool_service from Alpenglow repo to Agave:
- Also upstream consensus_pool_service/stats.rs it uses
- Add an empty votor as place holder so we enable tests to run
- Give a different DELTA_STANDSTILL in tests for faster tests