### PR TITLE
Use get functions passing ref to AccountMapEntry instead of full arc

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -772,17 +772,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             if config.is_aborted() {
                 break;
             }
-            self.get_and_then(&pubkey, |entry| {
-                if let Some(entry) = entry {
-                    self.get_account_info_with_and_then(
-                        entry,
-                        Some(ancestors),
-                        max_root,
-                        |(slot, account_info)| func(&pubkey, (&account_info, slot)),
-                    );
-                }
-                (false, ())
-            });
+            self.get_with_and_then(
+                &pubkey,
+                Some(ancestors),
+                max_root,
+                false,
+                |(slot, account_info)| func(&pubkey, (&account_info, slot)),
+            );
         }
     }
 

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -776,7 +776,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                 &pubkey,
                 Some(ancestors),
                 max_root,
-                false,
+                true,
                 |(slot, account_info)| func(&pubkey, (&account_info, slot)),
             );
         }


### PR DESCRIPTION
#### Problem
* no production code requires getting a cloned Arc<AccountMapEntry>, some existing uses of get_cloned can be converted to use get_and_then.
* use of in-mem index `get_internal` outside of that module only uses reference to the entry, not the arc
 
#### Summary of Changes
* switch from `get_cloned` to `get_and_then` for production code
* switch from `get_internal` to `get_internal_inner` outside of in-mem module
