### PR TITLE
Implement obsolete account save restore

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -913,6 +913,13 @@ impl AccountStorageEntry {
         self.alive_bytes.load(Ordering::Acquire)
     }
 
+    /// Returns the accounts that were marked obsolete as of the passed in slot
+    /// or earlier. Returned data includes the slots that the accounts were marked
+    /// obsolete at
+    pub fn obsolete_accounts_at_slot(&self, slot: Slot) -> ObsoleteAccounts {
+        self.obsolete_accounts_read_lock()
+            .obsolete_accounts_at_slot(slot)
+    }
     /// Locks obsolete accounts with a read lock and returns the the accounts with the guard
     pub(crate) fn obsolete_accounts_read_lock(&self) -> RwLockReadGuard<ObsoleteAccounts> {
         self.obsolete_accounts.read().unwrap()

--- a/accounts-db/src/obsolete_accounts.rs
+++ b/accounts-db/src/obsolete_accounts.rs
@@ -1,6 +1,6 @@
 use {crate::account_info::Offset, solana_clock::Slot};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 struct ObsoleteAccountItem {
     /// Offset of the account in the account storage entry
     offset: Offset,
@@ -10,7 +10,7 @@ struct ObsoleteAccountItem {
     slot: Slot,
 }
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ObsoleteAccounts {
     accounts: Vec<ObsoleteAccountItem>,
 }
@@ -44,6 +44,22 @@ impl ObsoleteAccounts {
             .iter()
             .filter(move |obsolete_account| slot.is_none_or(|s| obsolete_account.slot <= s))
             .map(|obsolete_account| (obsolete_account.offset, obsolete_account.data_len))
+    }
+
+    /// Returns the accounts that were marked obsolete as of the passed in slot
+    /// or earlier. Returned data includes the slots that the accounts were marked
+    /// obsolete at
+    pub fn obsolete_accounts_at_slot(&self, slot: Slot) -> ObsoleteAccounts {
+        let filtered_accounts = self
+            .accounts
+            .iter()
+            .filter(|account| account.slot <= slot)
+            .cloned()
+            .collect();
+
+        ObsoleteAccounts {
+            accounts: filtered_accounts,
+        }
     }
 }
 #[cfg(test)]
@@ -98,5 +114,40 @@ mod tests {
         let filtered_accounts: Vec<_> = obsolete_accounts.filter_obsolete_accounts(None).collect();
 
         assert_eq!(filtered_accounts, vec![(10, 100), (20, 200), (30, 300)]);
+    }
+
+    #[test]
+    fn test_obsolete_accounts_at_slot() {
+        let mut obsolete_accounts = ObsoleteAccounts::default();
+        let new_accounts = vec![(10, 100, 40), (20, 200, 42), (30, 300, 44)]
+            .into_iter()
+            .map(|(offset, data_len, slot)| ObsoleteAccountItem {
+                offset,
+                data_len,
+                slot,
+            })
+            .collect::<Vec<_>>();
+
+        // Mark accounts obsolete with different slots
+        new_accounts.iter().for_each(|item| {
+            obsolete_accounts
+                .mark_accounts_obsolete([(item.offset, item.data_len)].into_iter(), item.slot)
+        });
+
+        // Filter accounts obsolete as of slot 42
+        let obsolete_accounts_at_slot = obsolete_accounts.obsolete_accounts_at_slot(42);
+
+        let expected_accounts: Vec<_> = new_accounts
+            .iter()
+            .filter(|account| account.slot <= 42)
+            .cloned()
+            .collect();
+
+        assert_eq!(obsolete_accounts_at_slot.accounts, expected_accounts);
+
+        // Filter accounts obsolete passing in no slot (i.e., all obsolete accounts)
+        let obsolete_accounts_at_slot = obsolete_accounts.obsolete_accounts_at_slot(100);
+
+        assert_eq!(obsolete_accounts_at_slot.accounts, new_accounts);
     }
 }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -211,6 +211,21 @@ impl SnapshotPackagerService {
             start.elapsed(),
         );
 
+        info!("Saving obsolete accounts...");
+        let start = Instant::now();
+        let result = snapshot_utils::write_obsolete_accounts_to_snapshot(
+            &bank_snapshot_dir,
+            &state.snapshot_storages,
+            state.snapshot_slot,
+        );
+        if let Err(err) = result {
+            warn!("Failed to serialize obsolete accounts: {err}");
+            // If serializing the obsolete accounts failed, we do *NOT* want to mark the bank snapshot
+            // as loadable so return early.
+            return;
+        }
+        info!("Saving obsolete accounts... Done in {:?}", start.elapsed(),);
+
         let result = snapshot_utils::mark_bank_snapshot_as_loadable(&bank_snapshot_dir);
         if let Err(err) = result {
             warn!("Failed to mark bank snapshot as loadable: {err}");

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -51,7 +51,7 @@ impl SerializableStorage for SerializableAccountStorageEntry {
 impl solana_frozen_abi::abi_example::TransparentAsHelper for SerializableAccountStorageEntry {}
 
 /// This structure handles the load/store of obsolete accounts during snapshot restoration.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub(crate) struct SerdeObsoleteAccounts {
     /// The ID of the associated account file. Used for verification to ensure the restored
     /// obsolete accounts correspond to the correct account file
@@ -62,4 +62,17 @@ pub(crate) struct SerdeObsoleteAccounts {
     pub bytes: u64,
     /// A list of accounts that are obsolete in the storage being restored.
     pub accounts: ObsoleteAccounts,
+}
+
+impl SerdeObsoleteAccounts {
+    pub fn new_from_storage_entry_at_slot(
+        storage: &AccountStorageEntry,
+        snapshot_slot: Slot,
+    ) -> Self {
+        SerdeObsoleteAccounts {
+            id: storage.id() as SerializedAccountsFileId,
+            bytes: storage.get_obsolete_bytes(Some(snapshot_slot)) as u64,
+            accounts: storage.obsolete_accounts_at_slot(snapshot_slot),
+        }
+    }
 }


### PR DESCRIPTION
#### Problem
- Fastboot does not support Obsolete accounts as the obsolete accounts are not persisted. Since the storages used are the same files that were being used prior to restarting, the obsolete account information needs to be saved and restored as well.

#### Summary of Changes
- Added functions to serialize obsolete accounts and deserialize them
- Saved obsolete accounts to a file during teardown or when called during test code

Note: After this change there will be one more PR to remove the validator constraint on use_snapshot_archives_at_startup and remove writing the legacy completer. 

Have verified fastboot 3.0 -> this change and this change -> 3.0 without obsolete accounts. will perform obsolete account test matrix in the next PR.
That will include
3.1 + Obsolete Accounts -> 3.0 (Should revert to archives) 
3.1 + Obsolete Accounts -> 3.1 without obsolete accounts (Should fastboot)
3.1 + Obsolete Accounts -> 3.1 without obsolete accounts -> 3.0 (Should revert to archives) 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
