### PR TITLE
Enable async for io_uring reader and disable sqpoll

### DIFF
--- a/accounts-db/src/io_uring/sequential_file_reader.rs
+++ b/accounts-db/src/io_uring/sequential_file_reader.rs
@@ -21,7 +21,6 @@ use {
 // but peak at 1MiB. Also compare with particular NVME parameters, e.g.
 // 32 pages (Maximum Data Transfer Size) * page size (MPSMIN = Memory Page Size) = 128KiB.
 pub const DEFAULT_READ_SIZE: usize = 1024 * 1024;
-const SQPOLL_IDLE_TIMEOUT: u32 = 50;
 // For large file we don't really use workers as few regularly submitted requests get handled
 // within sqpoll thread. Allow some workers just in case, but limit them.
 const MAX_IOWQ_WORKERS: u32 = 2;
@@ -65,12 +64,20 @@ impl<B: AsMut<[u8]>> SequentialFileReader<B> {
         mut buffer: B,
         read_capacity: usize,
     ) -> io::Result<Self> {
-        // Let submission queue hold half of buffers before we explicitly syscall
-        // to submit them for reading.
-        let ring_qsize = (buffer.as_mut().len() / read_capacity / 2).max(1) as u32;
-        let ring = IoUring::builder()
-            .setup_sqpoll(SQPOLL_IDLE_TIMEOUT)
-            .build(ring_qsize)?;
+        let buf_capacity = buffer.as_mut().len();
+
+        // Let all buffers be submitted for reading at any time
+        let max_inflight_ops = (buf_capacity / read_capacity) as u32;
+
+        // Set the submission queue to fit half of ops to amortize `submit` calls
+        // to just 2 per fully read buffer size.
+        let ring_squeue_size = (max_inflight_ops / 2).max(1);
+
+        // agave io_uring uses cqsize to define state slab size, so cqsize == max inflight ops
+        let ring = io_uring::IoUring::builder()
+            .setup_cqsize(max_inflight_ops)
+            .build(ring_squeue_size)?;
+
         // Maximum number of spawned [bounded IO, unbounded IO] kernel threads, we don't expect
         // any unbounded work, but limit it to 1 just in case (0 leaves it unlimited).
         ring.submitter()

--- a/accounts-db/src/io_uring/sequential_file_reader.rs
+++ b/accounts-db/src/io_uring/sequential_file_reader.rs
@@ -348,6 +348,7 @@ impl RingOp<SequentialFileReaderState> for ReadOp {
         .offset(*file_off as u64)
         .ioprio(IO_PRIO_BE_HIGHEST)
         .build()
+        .flags(squeue::Flags::ASYNC)
     }
 
     fn complete(


### PR DESCRIPTION
#### Problem
* sequential file reader is submitting IOs in so called non-blocking mode (as opposed to async), which makes them executed primarily on the single thread unless they are recognized as blocking
* the above is currently offset by use of sqpoll, which uses dedicated kernel thread spinning full to consume submitted ops and executing them

Primary observation (from a few tests) is that `ASYNC` is always beneficial, IOs are immediately spread across workers, which increases parallelism and any overhead of handing ops to and back from worker seems negligible.
In case of sequential file reader this also makes sqpoll optional - it still does slightly help with avoiding user thread calling `submit` (i.e. syscall), but with the right sizing of submission and completion queues, the impact is very small. The downside of sqpoll is that it utilizes the whole additional core, which make it bad for scaling up use of reader (e.g. reading multiple files)
 
#### Summary of Changes
* enable ASYNC
* adjust io_uring sizing to properly amortize submits - allow as many ops as buffers to be in-flight, make submissions queue sized in such a way, that after filling half of it we will perform `submit`

Note: one side-effect in case of snapshot unpack is that reader and file-creator (running in the same user-thread) now share the kernel worker pool, with a max size specified by both (4) being used - that way read ops end up being placed on more worker threads and all ops are being executed together.

##### Performance impact
There is a very tiny regression (disabled sqpoll) in snapshot unpack times (it's within variance, but avg is a bit higher):

master:
91.8s, 91.2s, 91.8s, 92.9s

PR:
91.4s, 92.0s, 94.1s, 92.5s