### PR TITLE
ignore flaky test

### DIFF
--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -2834,6 +2834,7 @@ mod tests {
     const SHORTENED_MAX_POOLING_DURATION: Duration = Duration::from_millis(100);
 
     #[test]
+    #[ignore]
     fn test_scheduler_drop_idle() {
         solana_logger::setup();
 


### PR DESCRIPTION
#### Problem
`test_scheduler_drop_idle` seems to be flaky and hit this assert:
```
thread 'tests::test_scheduler_drop_idle' panicked at unified-scheduler-pool/src/lib.rs:2886:9:
--
  | assertion `left == right` failed
  | left: 0
  | right: 1

```

See https://buildkite.com/anza/agave/builds/31204#01999eda-ad53-4c13-8e73-77882137f119 for an example.

This is causing CI to fail and/or retry and take a long time and slowing down merging into master

#### Summary of Changes
ignore this flaky test