### PR TITLE
vendor quinn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5630,8 +5630,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 [[package]]
 name = "quinn"
 version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+source = "git+https://github.com/anza-xyz/quinn?rev=d8944f6085193cc29e750b40d86d0b5cb4a21831#d8944f6085193cc29e750b40d86d0b5cb4a21831"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -5650,8 +5649,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+source = "git+https://github.com/anza-xyz/quinn?rev=d8944f6085193cc29e750b40d86d0b5cb4a21831#d8944f6085193cc29e750b40d86d0b5cb4a21831"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -5672,10 +5670,10 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+version = "0.5.12"
+source = "git+https://github.com/anza-xyz/quinn?rev=d8944f6085193cc29e750b40d86d0b5cb4a21831#d8944f6085193cc29e750b40d86d0b5cb4a21831"
 dependencies = [
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2 0.5.10",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5630,7 +5630,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 [[package]]
 name = "quinn"
 version = "0.11.8"
-source = "git+https://github.com/anza-xyz/quinn?rev=d8944f6085193cc29e750b40d86d0b5cb4a21831#d8944f6085193cc29e750b40d86d0b5cb4a21831"
+source = "git+https://github.com/anza-xyz/quinn?rev=fc4decb0cf79b1b210603294e96849d67e9c22e2#fc4decb0cf79b1b210603294e96849d67e9c22e2"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -5649,7 +5649,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.12"
-source = "git+https://github.com/anza-xyz/quinn?rev=d8944f6085193cc29e750b40d86d0b5cb4a21831#d8944f6085193cc29e750b40d86d0b5cb4a21831"
+source = "git+https://github.com/anza-xyz/quinn?rev=fc4decb0cf79b1b210603294e96849d67e9c22e2#fc4decb0cf79b1b210603294e96849d67e9c22e2"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -5670,10 +5670,10 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
-source = "git+https://github.com/anza-xyz/quinn?rev=d8944f6085193cc29e750b40d86d0b5cb4a21831#d8944f6085193cc29e750b40d86d0b5cb4a21831"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
- "cfg_aliases",
  "libc",
  "once_cell",
  "socket2 0.5.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -644,8 +644,8 @@ opt-level = 3
 # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
 # for details, see https://github.com/anza-xyz/agave/issues/8262
-quinn = { git = "https://github.com/anza-xyz/quinn", rev = "d8944f6085193cc29e750b40d86d0b5cb4a21831" }
-quinn-proto = { git = "https://github.com/anza-xyz/quinn", rev = "d8944f6085193cc29e750b40d86d0b5cb4a21831" }
+quinn = { git = "https://github.com/anza-xyz/quinn", rev = "fc4decb0cf79b1b210603294e96849d67e9c22e2" }
+quinn-proto = { git = "https://github.com/anza-xyz/quinn", rev = "fc4decb0cf79b1b210603294e96849d67e9c22e2" }
 
 # We include the following crates as our dependencies above from crates.io:
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -643,6 +643,9 @@ opt-level = 3
 [patch.crates-io]
 # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
+# for details, see https://github.com/anza-xyz/agave/issues/8262
+quinn = { git = "https://github.com/anza-xyz/quinn", rev = "d8944f6085193cc29e750b40d86d0b5cb4a21831" }
+quinn-proto = { git = "https://github.com/anza-xyz/quinn", rev = "d8944f6085193cc29e750b40d86d0b5cb4a21831" }
 
 # We include the following crates as our dependencies above from crates.io:
 #

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4641,7 +4641,7 @@ dependencies = [
 [[package]]
 name = "quinn"
 version = "0.11.8"
-source = "git+https://github.com/anza-xyz/quinn?rev=fc4decb0cf79b1b210603294e96849d67e9c22e2#d8944f6085193cc29e750b40d86d0b5cb4a21831"
+source = "git+https://github.com/anza-xyz/quinn?rev=fc4decb0cf79b1b210603294e96849d67e9c22e2#fc4decb0cf79b1b210603294e96849d67e9c22e2"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4660,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.12"
-source = "git+https://github.com/anza-xyz/quinn?rev=fc4decb0cf79b1b210603294e96849d67e9c22e2#d8944f6085193cc29e750b40d86d0b5cb4a21831"
+source = "git+https://github.com/anza-xyz/quinn?rev=fc4decb0cf79b1b210603294e96849d67e9c22e2#fc4decb0cf79b1b210603294e96849d67e9c22e2"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -5221,9 +5221,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5467026f437b4cb2a533865eaa73eb840019a0916f4b9ec563c6e617e086c9"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
  "core-foundation 0.10.0",
  "core-foundation-sys",
@@ -5236,7 +5236,7 @@ dependencies = [
  "rustls-webpki 0.103.6",
  "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
 ]
 
@@ -11607,9 +11607,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.6"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c6dfa3ac045bc517de14c7b1384298de1dbd229d38e08e169d9ae8c170937c"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.2",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -11660,9 +11669,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.32"
+version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4641,8 +4641,7 @@ dependencies = [
 [[package]]
 name = "quinn"
 version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+source = "git+https://github.com/anza-xyz/quinn?rev=fc4decb0cf79b1b210603294e96849d67e9c22e2#d8944f6085193cc29e750b40d86d0b5cb4a21831"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4661,8 +4660,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+source = "git+https://github.com/anza-xyz/quinn?rev=fc4decb0cf79b1b210603294e96849d67e9c22e2#d8944f6085193cc29e750b40d86d0b5cb4a21831"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -4683,15 +4681,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5221,9 +5221,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+checksum = "4a5467026f437b4cb2a533865eaa73eb840019a0916f4b9ec563c6e617e086c9"
 dependencies = [
  "core-foundation 0.10.0",
  "core-foundation-sys",
@@ -5236,7 +5236,7 @@ dependencies = [
  "rustls-webpki 0.103.6",
  "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-root-certs 0.26.11",
+ "webpki-root-certs",
  "windows-sys 0.59.0",
 ]
 
@@ -11607,18 +11607,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.11"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.2",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
+checksum = "e8c6dfa3ac045bc517de14c7b1384298de1dbd229d38e08e169d9ae8c170937c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -11669,9 +11660,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.33"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -266,6 +266,10 @@ strip = true
 name = "bpf_loader"
 
 [patch.crates-io]
+# for details, see https://github.com/anza-xyz/agave/issues/8262
+quinn = { git = "https://github.com/anza-xyz/quinn", rev = "fc4decb0cf79b1b210603294e96849d67e9c22e2" }
+quinn-proto = { git = "https://github.com/anza-xyz/quinn", rev = "fc4decb0cf79b1b210603294e96849d67e9c22e2" }
+
 # We include the following crates as our dependencies from crates.io:
 #
 #  * spl-associated-token-account-interface


### PR DESCRIPTION
#### Problem
See #8262

#### Summary of Changes

- Vendor quinn. Point it at https://github.com/anza-xyz/quinn/commit/d8944f6085193cc29e750b40d86d0b5cb4a21831 (v0.11.8 quinn / v0.11.12 quinn-proto versions + some fixes)
- Note that as a side effect, programs/sbf advances `quinn-udp` from v0.5.4 to v0.5.5