### PR TITLE
streamer: disable migration

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -91,6 +91,10 @@ pub(crate) fn configure_server(
     let quic_server_config = QuicServerConfig::try_from(server_tls_config)?;
 
     let mut server_config = ServerConfig::with_crypto(Arc::new(quic_server_config));
+
+    // disable path migration as we do not expect TPU clients to be on a mobile device
+    server_config.migration(false);
+
     let config = Arc::get_mut(&mut server_config.transport).unwrap();
 
     // QUIC_MAX_CONCURRENT_STREAMS doubled, which was found to improve reliability


### PR DESCRIPTION
#### Problem

- Some of the streamer features are not used - we do not have cases where the clients are mobile.

#### Summary of Changes

- Disable them to save memory