### PR TITLE
SIMD-0185: vote-program: add vote state v4 feature gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11868,6 +11868,7 @@ dependencies = [
  "solana-sha256-hasher",
  "solana-signer",
  "solana-slot-hashes",
+ "solana-svm-feature-set",
  "solana-transaction",
  "solana-transaction-context",
  "solana-vote-interface",

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -159,6 +159,7 @@ impl FeatureSet {
             raise_cpi_nesting_limit_to_8: self.is_active(&raise_cpi_nesting_limit_to_8::id()),
             provide_instruction_data_offset_in_vm_r2: self
                 .is_active(&provide_instruction_data_offset_in_vm_r2::id()),
+            vote_state_v4: self.is_active(&vote_state_v4::id()),
         }
     }
 }
@@ -1145,6 +1146,10 @@ pub mod discard_unexpected_data_complete_shreds {
     solana_pubkey::declare_id!("8MhfKhoZEoiySpVe248bDkisyEcBA7JQLyUS94xoTSqN");
 }
 
+pub mod vote_state_v4 {
+    solana_pubkey::declare_id!("Gx4XFcrVMt4HUvPzTpTSVkdDVgcDSjKhDN1RqRS6KDuZ");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2070,7 +2075,9 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
             discard_unexpected_data_complete_shreds::id(),
             "SIMD-0337: Markers for Alpenglow Fast Leader Handover, DATA_COMPLETE_SHRED placement \
              rules",
-        ), /*************** ADD NEW FEATURES HERE ***************/
+        ),
+        (vote_state_v4::id(), "SIMD-0185: Vote State v4"),
+        /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()
     .cloned()

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1148,6 +1148,10 @@ pub mod discard_unexpected_data_complete_shreds {
 
 pub mod vote_state_v4 {
     solana_pubkey::declare_id!("Gx4XFcrVMt4HUvPzTpTSVkdDVgcDSjKhDN1RqRS6KDuZ");
+
+    pub mod stake_program_buffer {
+        solana_pubkey::declare_id!("BM11F4hqrpinQs28sEZfzQ2fYddivYs4NEAHF6QMjkJF");
+    }
 }
 
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -73,6 +73,7 @@ solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sha256-hasher = { workspace = true }
+solana-svm-feature-set = { workspace = true }
 test-case = { workspace = true }
 
 [[bench]]

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -26,9 +26,6 @@ use {
     },
 };
 
-// TODO: Change me once the program has full v4 feature gate support.
-pub(crate) const TEMP_HARDCODED_TARGET_VERSION: VoteStateTargetVersion = VoteStateTargetVersion::V3;
-
 // Switch that preserves old behavior before vote state v4 feature gate.
 // This should be cleaned up when vote state v4 is activated.
 enum PreserveBehaviorInHandlerHelper {

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -4,14 +4,11 @@
 #[cfg(feature = "dev-context-only-utils")]
 pub mod handler;
 #[cfg(not(feature = "dev-context-only-utils"))]
-mod handler;
+pub(crate) mod handler;
 
-pub use {
-    handler::VoteStateTargetVersion,
-    solana_vote_interface::state::{vote_state_versions::*, *},
-};
+pub use solana_vote_interface::state::{vote_state_versions::*, *};
 use {
-    handler::{VoteStateHandle, VoteStateHandler},
+    handler::{VoteStateHandle, VoteStateHandler, VoteStateTargetVersion},
     log::*,
     solana_account::{AccountSharedData, WritableAccount},
     solana_clock::{Clock, Epoch, Slot},

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5274,6 +5274,16 @@ impl Bank {
         if new_feature_activations.contains(&feature_set::raise_account_cu_limit::id()) {
             self.apply_simd_0306_cost_tracker_changes();
         }
+
+        if new_feature_activations.contains(&feature_set::vote_state_v4::id()) {
+            if let Err(e) = self.upgrade_core_bpf_program(
+                &solana_sdk_ids::stake::id(),
+                &feature_set::vote_state_v4::stake_program_buffer::id(),
+                "upgrade_stake_program_for_vote_state_v4",
+            ) {
+                error!("Failed to upgrade Core BPF Stake program: {e}");
+            }
+        }
     }
 
     fn apply_new_builtin_program_feature_transitions(

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -38,6 +38,7 @@ pub struct SVMFeatureSet {
     pub reenable_zk_elgamal_proof_program: bool,
     pub raise_cpi_nesting_limit_to_8: bool,
     pub provide_instruction_data_offset_in_vm_r2: bool,
+    pub vote_state_v4: bool,
 }
 
 impl SVMFeatureSet {
@@ -81,6 +82,7 @@ impl SVMFeatureSet {
             reenable_zk_elgamal_proof_program: true,
             raise_cpi_nesting_limit_to_8: true,
             provide_instruction_data_offset_in_vm_r2: true,
+            vote_state_v4: true,
         }
     }
 }


### PR DESCRIPTION
#### Problem
After #8191, the Vote program has the necessary plumbing to support a "switch" over to vote state v4 based on a feature gate. That feature gate has not been added yet, but it's time to add it.

With the new feature gate, the program effectively becomes dynamic over the v4 feature gate, continuing to convert vote accounts to v3 as before, but able to switch to v4 as the target version when the feature is activated.

Note there are a number of areas around the codebase that either depend on or test with vote state. As such, many of these areas require refactoring to support/test vote state v4 integration.

#### Summary of Changes
Completes the implementation of `VoteStateV4` in the Vote program by first refactoring the remaining tests in `vote_processor`, then adding the new feature gate that will toggle on support for vote state v4.