### PR TITLE
Rename `InstructionContext` -> `InstructionContextView` and `InstructionFrame` -> `InstructionContext`

### DIFF
--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -13,7 +13,7 @@ use {
     solana_sdk_ids::bpf_loader_deprecated,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     solana_transaction_context::{
-        BorrowedInstructionAccount, IndexOfAccount, InstructionContext,
+        BorrowedInstructionAccount, IndexOfAccount, InstructionContextView,
         MAX_ACCOUNTS_PER_INSTRUCTION,
     },
     std::mem::{self, size_of},
@@ -220,7 +220,7 @@ impl Serializer {
 }
 
 pub fn serialize_parameters(
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
     mask_out_rent_epoch_in_vm_serialization: bool,
@@ -284,7 +284,7 @@ pub fn serialize_parameters(
 }
 
 pub fn deserialize_parameters(
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
     buffer: &[u8],
@@ -410,7 +410,7 @@ fn serialize_parameters_unaligned(
 }
 
 fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
     buffer: &[u8],
@@ -578,7 +578,7 @@ fn serialize_parameters_aligned(
 }
 
 fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
     buffer: &[u8],

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -16,7 +16,7 @@ use {
     solana_svm_type_overrides::sync::Arc,
     solana_sysvar::SysvarSerialize,
     solana_sysvar_id::SysvarId,
-    solana_transaction_context::{IndexOfAccount, InstructionContext},
+    solana_transaction_context::{IndexOfAccount, InstructionContextView},
 };
 
 #[cfg(feature = "frozen-abi")]
@@ -285,7 +285,7 @@ pub mod get_sysvar_with_account_check {
     use super::*;
 
     fn check_sysvar_account<S: SysvarId>(
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<(), InstructionError> {
         if !S::check_id(
@@ -298,7 +298,7 @@ pub mod get_sysvar_with_account_check {
 
     pub fn clock(
         invoke_context: &InvokeContext,
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<Clock>, InstructionError> {
         check_sysvar_account::<Clock>(instruction_context, instruction_account_index)?;
@@ -307,7 +307,7 @@ pub mod get_sysvar_with_account_check {
 
     pub fn rent(
         invoke_context: &InvokeContext,
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<Rent>, InstructionError> {
         check_sysvar_account::<Rent>(instruction_context, instruction_account_index)?;
@@ -316,7 +316,7 @@ pub mod get_sysvar_with_account_check {
 
     pub fn slot_hashes(
         invoke_context: &InvokeContext,
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<SlotHashes>, InstructionError> {
         check_sysvar_account::<SlotHashes>(instruction_context, instruction_account_index)?;
@@ -326,7 +326,7 @@ pub mod get_sysvar_with_account_check {
     #[allow(deprecated)]
     pub fn recent_blockhashes(
         invoke_context: &InvokeContext,
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<RecentBlockhashes>, InstructionError> {
         check_sysvar_account::<RecentBlockhashes>(instruction_context, instruction_account_index)?;
@@ -335,7 +335,7 @@ pub mod get_sysvar_with_account_check {
 
     pub fn stake_history(
         invoke_context: &InvokeContext,
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<StakeHistory>, InstructionError> {
         check_sysvar_account::<StakeHistory>(instruction_context, instruction_account_index)?;
@@ -344,7 +344,7 @@ pub mod get_sysvar_with_account_check {
 
     pub fn last_restart_slot(
         invoke_context: &InvokeContext,
-        instruction_context: &InstructionContext,
+        instruction_context: &InstructionContextView,
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<LastRestartSlot>, InstructionError> {
         check_sysvar_account::<LastRestartSlot>(instruction_context, instruction_account_index)?;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -40,7 +40,7 @@ use {
     solana_svm_measure::measure::Measure,
     solana_svm_type_overrides::sync::{atomic::Ordering, Arc},
     solana_system_interface::{instruction as system_instruction, MAX_PERMITTED_DATA_LENGTH},
-    solana_transaction_context::{IndexOfAccount, InstructionContext, TransactionContext},
+    solana_transaction_context::{IndexOfAccount, InstructionContextView, TransactionContext},
     std::{cell::RefCell, mem, rc::Rc},
 };
 
@@ -1413,7 +1413,7 @@ fn common_extend_program(
 
 fn common_close_account(
     authority_address: &Option<Pubkey>,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     log_collector: &Option<Rc<RefCell<LogCollector>>>,
 ) -> Result<(), InstructionError> {
     if authority_address.is_none() {

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -20,7 +20,7 @@ use {
     solana_svm_log_collector::{ic_logger_msg, LogCollector},
     solana_svm_measure::measure::Measure,
     solana_svm_type_overrides::sync::Arc,
-    solana_transaction_context::{BorrowedInstructionAccount, InstructionContext},
+    solana_transaction_context::{BorrowedInstructionAccount, InstructionContextView},
     std::{cell::RefCell, rc::Rc},
 };
 
@@ -57,7 +57,7 @@ fn get_state_mut(data: &mut [u8]) -> Result<&mut LoaderV4State, InstructionError
 
 fn check_program_account(
     log_collector: &Option<Rc<RefCell<LogCollector>>>,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     program: &BorrowedInstructionAccount,
     authority_address: &Pubkey,
 ) -> Result<LoaderV4State, InstructionError> {

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -10,7 +10,9 @@ use {
     solana_svm_log_collector::ic_msg,
     solana_system_interface::error::SystemError,
     solana_sysvar::rent::Rent,
-    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContext},
+    solana_transaction_context::{
+        BorrowedInstructionAccount, IndexOfAccount, InstructionContextView,
+    },
     std::collections::HashSet,
 };
 
@@ -81,7 +83,7 @@ pub(crate) fn withdraw_nonce_account(
     rent: &Rent,
     signers: &HashSet<Pubkey>,
     invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
 ) -> Result<(), InstructionError> {
     let mut from = instruction_context.try_borrow_instruction_account(from_account_index)?;
     if !from.is_writable() {

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -17,7 +17,9 @@ use {
     solana_system_interface::{
         error::SystemError, instruction::SystemInstruction, MAX_PERMITTED_DATA_LENGTH,
     },
-    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContext},
+    solana_transaction_context::{
+        BorrowedInstructionAccount, IndexOfAccount, InstructionContextView,
+    },
     std::collections::HashSet,
 };
 
@@ -153,7 +155,7 @@ fn create_account(
     owner: &Pubkey,
     signers: &HashSet<Pubkey>,
     invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
 ) -> Result<(), InstructionError> {
     // if it looks like the `to` account is already in use, bail
     {
@@ -183,7 +185,7 @@ fn transfer_verified(
     to_account_index: IndexOfAccount,
     lamports: u64,
     invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
 ) -> Result<(), InstructionError> {
     let mut from = instruction_context.try_borrow_instruction_account(from_account_index)?;
     if !from.get_data().is_empty() {
@@ -212,7 +214,7 @@ fn transfer(
     to_account_index: IndexOfAccount,
     lamports: u64,
     invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
 ) -> Result<(), InstructionError> {
     if !instruction_context.is_instruction_account_signer(from_account_index)? {
         ic_msg!(
@@ -240,7 +242,7 @@ fn transfer_with_seed(
     to_account_index: IndexOfAccount,
     lamports: u64,
     invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
 ) -> Result<(), InstructionError> {
     if !instruction_context.is_instruction_account_signer(from_base_account_index)? {
         ic_msg!(

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -10,14 +10,14 @@ use {
         sysvar_cache::get_sysvar_with_account_check,
     },
     solana_pubkey::Pubkey,
-    solana_transaction_context::{BorrowedInstructionAccount, InstructionContext},
+    solana_transaction_context::{BorrowedInstructionAccount, InstructionContextView},
     solana_vote_interface::{instruction::VoteInstruction, program::id, state::VoteAuthorize},
     std::collections::HashSet,
 };
 
 fn process_authorize_with_seed_instruction(
     invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     vote_account: &mut BorrowedInstructionAccount,
     target_version: vote_state::VoteStateTargetVersion,
     new_authority: &Pubkey,

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -18,7 +18,9 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_slot_hashes::SlotHash,
-    solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContext},
+    solana_transaction_context::{
+        BorrowedInstructionAccount, IndexOfAccount, InstructionContextView,
+    },
     solana_vote_interface::{error::VoteError, program::id},
     std::{
         cmp::Ordering,
@@ -797,7 +799,7 @@ fn verify_authorized_signer<S: std::hash::BuildHasher>(
 
 /// Withdraw funds from the vote account
 pub fn withdraw<S: std::hash::BuildHasher>(
-    instruction_context: &InstructionContext,
+    instruction_context: &InstructionContextView,
     vote_account_index: IndexOfAccount,
     target_version: VoteStateTargetVersion,
     lamports: u64,


### PR DESCRIPTION
#### Problem

`InstructionContext` has been recently renamed to `InstructionFrame`, when a new `InstructionContext` struct was introduced. `InstructionContext` is simply a view over `InstructionFrame`, but the new naming was confusing.

#### Summary of Changes

For better clarity, rename `InstructionContext` to `InstructionContextView` and `InstructionFrame` to `InstructionFrame`.