### PR TITLE
ledger-tool: Removes --snapshot-archive-path

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -155,43 +155,27 @@ pub fn snapshot_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .takes_value(true)
             .global(true)
             .help("Use DIR for snapshot location [default: --ledger value]"),
-        Arg::with_name("snapshot_archive_path")
-            .long("snapshot-archive-path")
-            .value_name("DIR")
-            .takes_value(true)
-            .global(true)
-            .help("Use DIR as snapshot archives location [default: --snapshots value]")
-            .long_help(
-                "Use DIR as snapshot archives location. This DIR applies to both full and \
-                 incremental snapshots. To specify unique locations for full and incremental \
-                 snapshot archives, use --full-snapshot-archive-path and \
-                 --incremental-snapshot-archive-path instead. [default: --snapshots value]",
-            ),
         Arg::with_name("full_snapshot_archive_path")
             .long("full-snapshot-archive-path")
             .value_name("DIR")
             .takes_value(true)
             .global(true)
-            .conflicts_with("snapshot_archive_path")
             .help("Use DIR as full snapshot archives location [default: --snapshots value]")
             .long_help(
                 "Use DIR as full snapshot archives location. This DIR applies to *only* full \
                  snapshot archives. Refer to --incremental-snapshot-archive-path to specify \
-                 location for incremental snapshot archives. Or refer to --snapshot-archive-path \
-                 to specify location for all snapshot archives. [default: --snapshots value]",
+                 location for incremental snapshot archives. [default: --snapshots value]",
             ),
         Arg::with_name("incremental_snapshot_archive_path")
             .long("incremental-snapshot-archive-path")
             .value_name("DIR")
             .takes_value(true)
             .global(true)
-            .conflicts_with("snapshot_archive_path")
             .help("Use DIR as incremental snapshot archives location [default: --snapshots value]")
             .long_help(
                 "Use DIR as incremental snapshot archives location. This DIR applies to *only* \
                  incremental snapshot archives. Refer to --full-snapshot-archive-path to specify \
-                 location for full snapshot archives. Or refer to --snapshot-archive-path to \
-                 specify location for all snapshot archives. [default: --snapshots value]",
+                 location for full snapshot archives. [default: --snapshots value]",
             ),
         Arg::with_name(use_snapshot_archives_at_startup::cli::NAME)
             .long(use_snapshot_archives_at_startup::cli::LONG_ARG)

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -155,19 +155,44 @@ pub fn snapshot_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .takes_value(true)
             .global(true)
             .help("Use DIR for snapshot location [default: --ledger value]"),
-        Arg::with_name("full_snapshot_archive_path")
-            .long("full-snapshot-archive-path")
-            .alias("snapshot-archive-path")
+        Arg::with_name("snapshot_archive_path")
+            .long("snapshot-archive-path")
             .value_name("DIR")
             .takes_value(true)
             .global(true)
-            .help("Use DIR as full snapshot archives location [default: --snapshots value]"),
+            .help("Use DIR as snapshot archives location [default: --snapshots value]")
+            .long_help(
+                "Use DIR as snapshot archives location. This DIR applies to both full and \
+                 incremental snapshots. To specify unique locations for full and incremental \
+                 snapshot archives, use --full-snapshot-archive-path and \
+                 --incremental-snapshot-archive-path instead. [default: --snapshots value]",
+            ),
+        Arg::with_name("full_snapshot_archive_path")
+            .long("full-snapshot-archive-path")
+            .value_name("DIR")
+            .takes_value(true)
+            .global(true)
+            .conflicts_with("snapshot_archive_path")
+            .help("Use DIR as full snapshot archives location [default: --snapshots value]")
+            .long_help(
+                "Use DIR as full snapshot archives location. This DIR applies to *only* full \
+                 snapshot archives. Refer to --incremental-snapshot-archive-path to specify \
+                 location for incremental snapshot archives. Or refer to --snapshot-archive-path \
+                 to specify location for all snapshot archives. [default: --snapshots value]",
+            ),
         Arg::with_name("incremental_snapshot_archive_path")
             .long("incremental-snapshot-archive-path")
             .value_name("DIR")
             .takes_value(true)
             .global(true)
-            .help("Use DIR as incremental snapshot archives location [default: --snapshots value]"),
+            .conflicts_with("snapshot_archive_path")
+            .help("Use DIR as incremental snapshot archives location [default: --snapshots value]")
+            .long_help(
+                "Use DIR as incremental snapshot archives location. This DIR applies to *only* \
+                 incremental snapshot archives. Refer to --full-snapshot-archive-path to specify \
+                 location for full snapshot archives. Or refer to --snapshot-archive-path to \
+                 specify location for all snapshot archives. [default: --snapshots value]",
+            ),
         Arg::with_name(use_snapshot_archives_at_startup::cli::NAME)
             .long(use_snapshot_archives_at_startup::cli::LONG_ARG)
             .takes_value(true)

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -160,23 +160,13 @@ pub fn snapshot_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .value_name("DIR")
             .takes_value(true)
             .global(true)
-            .help("Use DIR as full snapshot archives location [default: --snapshots value]")
-            .long_help(
-                "Use DIR as full snapshot archives location. This DIR applies to *only* full \
-                 snapshot archives. Refer to --incremental-snapshot-archive-path to specify \
-                 location for incremental snapshot archives. [default: --snapshots value]",
-            ),
+            .help("Use DIR as full snapshot archives location [default: --snapshots value]"),
         Arg::with_name("incremental_snapshot_archive_path")
             .long("incremental-snapshot-archive-path")
             .value_name("DIR")
             .takes_value(true)
             .global(true)
-            .help("Use DIR as incremental snapshot archives location [default: --snapshots value]")
-            .long_help(
-                "Use DIR as incremental snapshot archives location. This DIR applies to *only* \
-                 incremental snapshot archives. Refer to --full-snapshot-archive-path to specify \
-                 location for full snapshot archives. [default: --snapshots value]",
-            ),
+            .help("Use DIR as incremental snapshot archives location [default: --snapshots value]"),
         Arg::with_name(use_snapshot_archives_at_startup::cli::NAME)
             .long(use_snapshot_archives_at_startup::cli::LONG_ARG)
             .takes_value(true)

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -143,16 +143,20 @@ pub fn load_and_process_ledger(
                 .join(LEDGER_TOOL_DIRECTORY)
                 .join(BANK_SNAPSHOTS_DIR)
         };
+        let snapshot_archives_dir = value_t!(arg_matches, "snapshot_archive_path", String)
+            .ok()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| snapshots_dir.clone());
         let full_snapshot_archives_dir =
             value_t!(arg_matches, "full_snapshot_archive_path", String)
                 .ok()
                 .map(PathBuf::from)
-                .unwrap_or_else(|| snapshots_dir.clone());
+                .unwrap_or_else(|| snapshot_archives_dir.clone());
         let incremental_snapshot_archives_dir =
             value_t!(arg_matches, "incremental_snapshot_archive_path", String)
                 .ok()
                 .map(PathBuf::from)
-                .unwrap_or_else(|| snapshots_dir.clone());
+                .unwrap_or_else(|| snapshot_archives_dir.clone());
         if let Some(full_snapshot_slot) =
             snapshot_utils::get_highest_full_snapshot_archive_slot(&full_snapshot_archives_dir)
         {

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -143,20 +143,16 @@ pub fn load_and_process_ledger(
                 .join(LEDGER_TOOL_DIRECTORY)
                 .join(BANK_SNAPSHOTS_DIR)
         };
-        let snapshot_archives_dir = value_t!(arg_matches, "snapshot_archive_path", String)
-            .ok()
-            .map(PathBuf::from)
-            .unwrap_or_else(|| snapshots_dir.clone());
         let full_snapshot_archives_dir =
             value_t!(arg_matches, "full_snapshot_archive_path", String)
                 .ok()
                 .map(PathBuf::from)
-                .unwrap_or_else(|| snapshot_archives_dir.clone());
+                .unwrap_or_else(|| snapshots_dir.clone());
         let incremental_snapshot_archives_dir =
             value_t!(arg_matches, "incremental_snapshot_archive_path", String)
                 .ok()
                 .map(PathBuf::from)
-                .unwrap_or_else(|| snapshot_archives_dir.clone());
+                .unwrap_or_else(|| snapshots_dir.clone());
         if let Some(full_snapshot_slot) =
             snapshot_utils::get_highest_full_snapshot_archive_slot(&full_snapshot_archives_dir)
         {


### PR DESCRIPTION
#### Problem

Setting correct paths for using snapshots with ledger-tool is a mess. IMO is stems from having aliases on the cli args, which results in implicit fallbacks when certain args are present and others are missing.

Recently, a change between v2.3 and v3.0 resulted in `ledger-tool create-snapshot --snapshot-archive-path` only starting up from full snapshot archives, and not finding the incremental snapshot archives.

The help text in v3.0 at least indicated why this happened, but I'd argue this behavior is unexpected and should change.


#### Summary of Changes

Remove `--snapshot-archive-path`.

Now a user will specify `--full-snapshot-archive-path` and `--incremental-snapshot-archive-path`. This makes ledger-tool consistent with agave-validator as well, which also does not have `--snapshot-archive-path`.

This should make it straight forward to reason about and code, plus makes these behaviors *explicit* and visible to the user in `--help`.

Note that I intend to backport this to v3.0.