### PR TITLE
Avoid copying instruction data when recording CPI instructions (take 2)

### DIFF
--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -477,6 +477,14 @@ impl TransactionContext {
             },
         )
     }
+
+    /// Take ownership of the instruction trace
+    pub fn take_instruction_trace(&mut self) -> Vec<InstructionFrame> {
+        // The last frame is a placeholder for the next instruction to be executed, so it
+        // is empty.
+        self.instruction_trace.pop();
+        std::mem::take(&mut self.instruction_trace)
+    }
 }
 
 /// Return data at the end of a transaction
@@ -493,14 +501,14 @@ pub struct TransactionReturnData {
 /// Instruction shared between runtime and programs.
 #[derive(Debug, Clone, Default)]
 pub struct InstructionFrame {
-    nesting_level: usize,
-    program_account_index_in_tx: IndexOfAccount,
-    instruction_accounts: Vec<InstructionAccount>,
+    pub nesting_level: usize,
+    pub program_account_index_in_tx: IndexOfAccount,
+    pub instruction_accounts: Vec<InstructionAccount>,
     /// This is an account deduplication map that maps index_in_transaction to index_in_instruction
     /// Usage: dedup_map[index_in_transaction] = index_in_instruction
     /// This is a vector of u8s to save memory, since many entries may be unused.
     dedup_map: Vec<u8>,
-    instruction_data: Vec<u8>,
+    pub instruction_data: Vec<u8>,
 }
 
 /// View interface to read instructions.


### PR DESCRIPTION
#### Problem

We could avoid making all copies of instruction data in the repository. For ABIv2, in particular, it is theoretically possible to avoid all copies (given that we can deal with all lifetimes correctly).

In this PR, I wanted to avoid copying instruction data out of InstructionContext when recording inner instructions.

#### Summary of Changes

1. Rename `fn inner_instructions_list_from_instruction_trace` to `fn deconstruct_transaction` and generate and execution record inside there.
2. Make some fields of `InstructionFrame` public to allow the construction of a `CompiledInstruction`.


This PR supersedes https://github.com/anza-xyz/agave/pull/8213.
