### PR TITLE
Rename `TransactionAccount` to `KeyedAccountSharedData`

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -24,7 +24,7 @@ use {
         message_address_table_lookup::SVMMessageAddressTableLookup, svm_message::SVMMessage,
     },
     solana_transaction::sanitized::SanitizedTransaction,
-    solana_transaction_context::transaction_accounts::TransactionAccount,
+    solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
     solana_transaction_error::TransactionResult as Result,
     std::{
         cmp::Reverse,
@@ -242,7 +242,7 @@ impl Accounts {
         &self,
         slot: Slot,
         program_id: Option<&Pubkey>,
-    ) -> Vec<TransactionAccount> {
+    ) -> Vec<KeyedAccountSharedData> {
         self.scan_slot(slot, |stored_account| {
             program_id
                 .map(|program_id| program_id == stored_account.owner())
@@ -307,7 +307,7 @@ impl Accounts {
     }
 
     fn load_while_filtering<F: Fn(&AccountSharedData) -> bool>(
-        collector: &mut Vec<TransactionAccount>,
+        collector: &mut Vec<KeyedAccountSharedData>,
         some_account_tuple: Option<(&Pubkey, AccountSharedData, Slot)>,
         filter: F,
     ) {
@@ -325,7 +325,7 @@ impl Accounts {
         bank_id: BankId,
         program_id: &Pubkey,
         config: &ScanConfig,
-    ) -> ScanResult<Vec<TransactionAccount>> {
+    ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         let mut collector = Vec::new();
         self.accounts_db
             .scan_accounts(
@@ -348,7 +348,7 @@ impl Accounts {
         program_id: &Pubkey,
         filter: F,
         config: &ScanConfig,
-    ) -> ScanResult<Vec<TransactionAccount>> {
+    ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         let mut collector = Vec::new();
         self.accounts_db
             .scan_accounts(
@@ -388,9 +388,9 @@ impl Accounts {
     }
 
     fn maybe_abort_scan(
-        result: ScanResult<Vec<TransactionAccount>>,
+        result: ScanResult<Vec<KeyedAccountSharedData>>,
         config: &ScanConfig,
-    ) -> ScanResult<Vec<TransactionAccount>> {
+    ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         if config.is_aborted() {
             ScanResult::Err(ScanError::Aborted(
                 "The accumulated scan results exceeded the limit".to_string(),
@@ -408,7 +408,7 @@ impl Accounts {
         filter: F,
         config: &ScanConfig,
         byte_limit_for_scan: Option<usize>,
-    ) -> ScanResult<Vec<TransactionAccount>> {
+    ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         let sum = AtomicUsize::default();
         let config = config.recreate_with_abort();
         let mut collector = Vec::new();

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1277,7 +1277,7 @@ mod tests {
         solana_sdk_ids::{bpf_loader, system_program},
         solana_svm_feature_set::SVMFeatureSet,
         solana_transaction_context::{
-            transaction_accounts::TransactionAccount, IndexOfAccount, InstructionAccount,
+            transaction_accounts::KeyedAccountSharedData, IndexOfAccount, InstructionAccount,
         },
         std::{
             cell::{Cell, RefCell},
@@ -1309,7 +1309,7 @@ mod tests {
             let transaction_accounts = $transaction_accounts
                 .into_iter()
                 .map(|a| (a.0, a.1))
-                .collect::<Vec<TransactionAccount>>();
+                .collect::<Vec<KeyedAccountSharedData>>();
             let mut feature_set = SVMFeatureSet::all_enabled();
             feature_set.stricter_abi_and_runtime_constraints = false;
             let feature_set = &feature_set;

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -33,7 +33,7 @@ use {
     solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMMessage},
     solana_svm_type_overrides::sync::Arc,
     solana_transaction_context::{
-        transaction_accounts::TransactionAccount, IndexOfAccount, InstructionAccount,
+        transaction_accounts::KeyedAccountSharedData, IndexOfAccount, InstructionAccount,
         InstructionContext, TransactionContext, MAX_ACCOUNTS_PER_TRANSACTION,
     },
     std::{
@@ -862,7 +862,7 @@ pub fn mock_process_instruction_with_feature_set<
     loader_id: &Pubkey,
     program_index: Option<IndexOfAccount>,
     instruction_data: &[u8],
-    mut transaction_accounts: Vec<TransactionAccount>,
+    mut transaction_accounts: Vec<KeyedAccountSharedData>,
     instruction_account_metas: Vec<AccountMeta>,
     expected_result: Result<(), InstructionError>,
     builtin_function: BuiltinFunctionWithContext,
@@ -940,7 +940,7 @@ pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut Invo
     loader_id: &Pubkey,
     program_index: Option<IndexOfAccount>,
     instruction_data: &[u8],
-    transaction_accounts: Vec<TransactionAccount>,
+    transaction_accounts: Vec<KeyedAccountSharedData>,
     instruction_account_metas: Vec<AccountMeta>,
     expected_result: Result<(), InstructionError>,
     builtin_function: BuiltinFunctionWithContext,
@@ -1379,7 +1379,7 @@ mod tests {
 
     #[test]
     fn test_prepare_instruction_maximum_accounts() {
-        let mut transaction_accounts: Vec<TransactionAccount> =
+        let mut transaction_accounts: Vec<KeyedAccountSharedData> =
             Vec::with_capacity(MAX_ACCOUNTS_PER_TRANSACTION);
         let mut account_metas: Vec<AccountMeta> = Vec::with_capacity(MAX_ACCOUNTS_PER_INSTRUCTION);
 
@@ -1493,7 +1493,7 @@ mod tests {
 
     #[test]
     fn test_duplicated_accounts() {
-        let mut transaction_accounts: Vec<TransactionAccount> =
+        let mut transaction_accounts: Vec<KeyedAccountSharedData> =
             Vec::with_capacity(MAX_ACCOUNTS_PER_TRANSACTION);
         let mut account_metas: Vec<AccountMeta> =
             Vec::with_capacity(MAX_ACCOUNTS_PER_INSTRUCTION.saturating_sub(1));

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -14,7 +14,7 @@ use {
     solana_pubkey::Pubkey,
     solana_sdk_ids::sysvar,
     solana_slot_hashes::{SlotHashes, MAX_ENTRIES},
-    solana_transaction_context::transaction_accounts::TransactionAccount,
+    solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
     solana_vote_program::{
         vote_instruction::VoteInstruction,
         vote_state::{
@@ -25,7 +25,12 @@ use {
     test::Bencher,
 };
 
-fn create_accounts() -> (Slot, SlotHashes, Vec<TransactionAccount>, Vec<AccountMeta>) {
+fn create_accounts() -> (
+    Slot,
+    SlotHashes,
+    Vec<KeyedAccountSharedData>,
+    Vec<AccountMeta>,
+) {
     // vote accounts are usually almost full of votes in normal operation
     let num_initial_votes = MAX_LOCKOUT_HISTORY as Slot;
 
@@ -98,7 +103,7 @@ fn create_accounts() -> (Slot, SlotHashes, Vec<TransactionAccount>, Vec<AccountM
 
 fn bench_process_deprecated_vote_instruction(
     bencher: &mut Bencher,
-    transaction_accounts: Vec<TransactionAccount>,
+    transaction_accounts: Vec<KeyedAccountSharedData>,
     instruction_account_metas: Vec<AccountMeta>,
     instruction_data: Vec<u8>,
 ) {
@@ -122,7 +127,7 @@ fn bench_process_deprecated_vote_instruction(
 
 fn bench_process_vote_instruction(
     bencher: &mut Bencher,
-    transaction_accounts: Vec<TransactionAccount>,
+    transaction_accounts: Vec<KeyedAccountSharedData>,
     instruction_account_metas: Vec<AccountMeta>,
     instruction_data: Vec<u8>,
 ) {

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -14,7 +14,7 @@ use {
     solana_rent::Rent,
     solana_sdk_ids::{sysvar, vote::id},
     solana_slot_hashes::{SlotHashes, MAX_ENTRIES},
-    solana_transaction_context::transaction_accounts::TransactionAccount,
+    solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
     solana_vote_program::{
         vote_instruction::VoteInstruction,
         vote_processor::Entrypoint,
@@ -34,7 +34,12 @@ fn create_default_clock_account() -> AccountSharedData {
     account::create_account_shared_data_for_test(&Clock::default())
 }
 
-fn create_accounts() -> (Slot, SlotHashes, Vec<TransactionAccount>, Vec<AccountMeta>) {
+fn create_accounts() -> (
+    Slot,
+    SlotHashes,
+    Vec<KeyedAccountSharedData>,
+    Vec<AccountMeta>,
+) {
     // vote accounts are usually almost full of votes in normal operation
     let num_initial_votes = MAX_LOCKOUT_HISTORY as Slot;
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -82,7 +82,7 @@ use {
         sanitized::{MessageHash, SanitizedTransaction, MAX_TX_ACCOUNT_LOCKS},
         versioned::VersionedTransaction,
     },
-    solana_transaction_context::transaction_accounts::TransactionAccount,
+    solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
     solana_transaction_error::TransactionError,
     solana_transaction_status::{
         map_inner_instructions, BlockEncodingOptions, ConfirmedBlock,
@@ -310,7 +310,7 @@ impl JsonRpcRequestProcessor {
         program_id: &Pubkey,
         filters: Vec<RpcFilterType>,
         sort_results: bool,
-    ) -> ScanResult<Vec<TransactionAccount>> {
+    ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         let scan_order = if sort_results {
             ScanOrder::Sorted
         } else {

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -11,7 +11,7 @@ use {
     },
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction::sanitized::SanitizedTransaction,
-    solana_transaction_context::transaction_accounts::TransactionAccount,
+    solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
 };
 
 // Used to approximate how many accounts will be calculated for storage so that
@@ -106,7 +106,7 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
     collected_account_transactions: &mut Option<Vec<&'a SanitizedTransaction>>,
     transaction: &'a T,
     transaction_ref: Option<&'a SanitizedTransaction>,
-    transaction_accounts: &'a [TransactionAccount],
+    transaction_accounts: &'a [KeyedAccountSharedData],
 ) {
     for (i, (address, account)) in (0..transaction.account_keys().len()).zip(transaction_accounts) {
         if !transaction.is_writable(i) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -156,7 +156,9 @@ use {
         versioned::VersionedTransaction,
         Transaction, TransactionVerificationMode,
     },
-    solana_transaction_context::{transaction_accounts::TransactionAccount, TransactionReturnData},
+    solana_transaction_context::{
+        transaction_accounts::KeyedAccountSharedData, TransactionReturnData,
+    },
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     solana_vote::vote_account::{VoteAccount, VoteAccountsHashMap},
     std::{
@@ -305,7 +307,7 @@ pub struct LoadAndExecuteTransactionsOutput {
 pub struct TransactionSimulationResult {
     pub result: Result<()>,
     pub logs: TransactionLogMessages,
-    pub post_simulation_accounts: Vec<TransactionAccount>,
+    pub post_simulation_accounts: Vec<KeyedAccountSharedData>,
     pub units_consumed: u64,
     pub loaded_accounts_data_size: u32,
     pub return_data: Option<TransactionReturnData>,
@@ -4174,7 +4176,7 @@ impl Bank {
         &self,
         program_id: &Pubkey,
         config: &ScanConfig,
-    ) -> ScanResult<Vec<TransactionAccount>> {
+    ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         self.rc
             .accounts
             .load_by_program(&self.ancestors, self.bank_id, program_id, config)
@@ -4185,7 +4187,7 @@ impl Bank {
         program_id: &Pubkey,
         filter: F,
         config: &ScanConfig,
-    ) -> ScanResult<Vec<TransactionAccount>> {
+    ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         self.rc.accounts.load_by_program_with_filter(
             &self.ancestors,
             self.bank_id,
@@ -4201,7 +4203,7 @@ impl Bank {
         filter: F,
         config: &ScanConfig,
         byte_limit_for_scan: Option<usize>,
-    ) -> ScanResult<Vec<TransactionAccount>> {
+    ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         self.rc.accounts.load_by_index_key_with_filter(
             &self.ancestors,
             self.bank_id,
@@ -4236,7 +4238,7 @@ impl Bank {
     pub fn get_program_accounts_modified_since_parent(
         &self,
         program_id: &Pubkey,
-    ) -> Vec<TransactionAccount> {
+    ) -> Vec<KeyedAccountSharedData> {
         self.rc
             .accounts
             .load_by_program_slot(self.slot(), Some(program_id))
@@ -4253,7 +4255,7 @@ impl Bank {
     }
 
     /// Returns all the accounts stored in this slot
-    pub fn get_all_accounts_modified_since_parent(&self) -> Vec<TransactionAccount> {
+    pub fn get_all_accounts_modified_since_parent(&self) -> Vec<KeyedAccountSharedData> {
         self.rc.accounts.load_by_program_slot(self.slot(), None)
     }
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -35,7 +35,7 @@ use {
     solana_svm_callback::{AccountState, TransactionProcessingCallback},
     solana_svm_feature_set::SVMFeatureSet,
     solana_svm_transaction::svm_message::SVMMessage,
-    solana_transaction_context::{transaction_accounts::TransactionAccount, IndexOfAccount},
+    solana_transaction_context::{transaction_accounts::KeyedAccountSharedData, IndexOfAccount},
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     std::num::{NonZeroU32, Saturating},
 };
@@ -137,7 +137,7 @@ pub(crate) struct LoadedTransactionAccount {
     field_qualifiers(program_indices(pub), compute_budget(pub))
 )]
 pub struct LoadedTransaction {
-    pub accounts: Vec<TransactionAccount>,
+    pub accounts: Vec<KeyedAccountSharedData>,
     pub(crate) program_indices: Vec<IndexOfAccount>,
     pub fee_details: FeeDetails,
     pub rollback_accounts: RollbackAccounts,
@@ -303,7 +303,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
     fn update_accounts_for_successful_tx(
         &mut self,
         message: &impl SVMMessage,
-        transaction_accounts: &[TransactionAccount],
+        transaction_accounts: &[KeyedAccountSharedData],
     ) {
         for (i, (address, account)) in (0..message.account_keys().len()).zip(transaction_accounts) {
             if !message.is_writable(i) {
@@ -455,7 +455,7 @@ pub(crate) fn load_transaction<CB: TransactionProcessingCallback>(
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 struct LoadedTransactionAccounts {
-    pub(crate) accounts: Vec<TransactionAccount>,
+    pub(crate) accounts: Vec<KeyedAccountSharedData>,
     pub(crate) program_indices: Vec<IndexOfAccount>,
     pub(crate) loaded_accounts_data_size: u32,
 }
@@ -844,7 +844,7 @@ mod tests {
         solana_system_transaction::transfer,
         solana_transaction::{sanitized::SanitizedTransaction, Transaction},
         solana_transaction_context::{
-            transaction_accounts::TransactionAccount, TransactionContext,
+            transaction_accounts::KeyedAccountSharedData, TransactionContext,
         },
         solana_transaction_error::{TransactionError, TransactionResult as Result},
         std::{
@@ -917,7 +917,7 @@ mod tests {
 
     fn load_accounts_with_features_and_rent(
         tx: Transaction,
-        accounts: &[TransactionAccount],
+        accounts: &[KeyedAccountSharedData],
         rent: &Rent,
         error_metrics: &mut TransactionErrorMetrics,
         feature_set: SVMFeatureSet,
@@ -956,7 +956,7 @@ mod tests {
     #[test_case(false; "informal_loaded_size")]
     #[test_case(true; "simd186_loaded_size")]
     fn test_load_accounts_unknown_program_id(formalize_loaded_transaction_data_size: bool) {
-        let mut accounts: Vec<TransactionAccount> = Vec::new();
+        let mut accounts: Vec<KeyedAccountSharedData> = Vec::new();
         let mut error_metrics = TransactionErrorMetrics::default();
 
         let keypair = Keypair::new();
@@ -1002,7 +1002,7 @@ mod tests {
     #[test_case(false; "informal_loaded_size")]
     #[test_case(true; "simd186_loaded_size")]
     fn test_load_accounts_no_loaders(formalize_loaded_transaction_data_size: bool) {
-        let mut accounts: Vec<TransactionAccount> = Vec::new();
+        let mut accounts: Vec<KeyedAccountSharedData> = Vec::new();
         let mut error_metrics = TransactionErrorMetrics::default();
 
         let keypair = Keypair::new();
@@ -1063,7 +1063,7 @@ mod tests {
     #[test_case(false; "informal_loaded_size")]
     #[test_case(true; "simd186_loaded_size")]
     fn test_load_accounts_bad_owner(formalize_loaded_transaction_data_size: bool) {
-        let mut accounts: Vec<TransactionAccount> = Vec::new();
+        let mut accounts: Vec<KeyedAccountSharedData> = Vec::new();
         let mut error_metrics = TransactionErrorMetrics::default();
 
         let keypair = Keypair::new();
@@ -1121,7 +1121,7 @@ mod tests {
     #[test_case(false; "informal_loaded_size")]
     #[test_case(true; "simd186_loaded_size")]
     fn test_load_accounts_not_executable(formalize_loaded_transaction_data_size: bool) {
-        let mut accounts: Vec<TransactionAccount> = Vec::new();
+        let mut accounts: Vec<KeyedAccountSharedData> = Vec::new();
         let mut error_metrics = TransactionErrorMetrics::default();
 
         let keypair = Keypair::new();
@@ -1171,7 +1171,7 @@ mod tests {
     #[test_case(false; "informal_loaded_size")]
     #[test_case(true; "simd186_loaded_size")]
     fn test_load_accounts_multiple_loaders(formalize_loaded_transaction_data_size: bool) {
-        let mut accounts: Vec<TransactionAccount> = Vec::new();
+        let mut accounts: Vec<KeyedAccountSharedData> = Vec::new();
         let mut error_metrics = TransactionErrorMetrics::default();
 
         let keypair = Keypair::new();
@@ -1233,7 +1233,7 @@ mod tests {
     }
 
     fn load_accounts_no_store(
-        accounts: &[TransactionAccount],
+        accounts: &[KeyedAccountSharedData],
         tx: Transaction,
         account_overrides: Option<&AccountOverrides>,
     ) -> TransactionLoadResult {

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -3,7 +3,7 @@ use {
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
-    solana_transaction_context::transaction_accounts::TransactionAccount,
+    solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
 };
 
 /// Captured account state used to rollback account state for nonce and fee
@@ -11,14 +11,14 @@ use {
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum RollbackAccounts {
     FeePayerOnly {
-        fee_payer: TransactionAccount,
+        fee_payer: KeyedAccountSharedData,
     },
     SameNonceAndFeePayer {
-        nonce: TransactionAccount,
+        nonce: KeyedAccountSharedData,
     },
     SeparateNonceAndFeePayer {
-        nonce: TransactionAccount,
-        fee_payer: TransactionAccount,
+        nonce: KeyedAccountSharedData,
+        fee_payer: KeyedAccountSharedData,
     },
 }
 
@@ -26,7 +26,7 @@ pub enum RollbackAccounts {
 impl Default for RollbackAccounts {
     fn default() -> Self {
         Self::FeePayerOnly {
-            fee_payer: TransactionAccount::default(),
+            fee_payer: KeyedAccountSharedData::default(),
         }
     }
 }
@@ -34,12 +34,12 @@ impl Default for RollbackAccounts {
 /// Rollback accounts iterator.
 /// This struct is created by the `RollbackAccounts::iter`.
 pub struct RollbackAccountsIter<'a> {
-    fee_payer: Option<&'a TransactionAccount>,
-    nonce: Option<&'a TransactionAccount>,
+    fee_payer: Option<&'a KeyedAccountSharedData>,
+    nonce: Option<&'a KeyedAccountSharedData>,
 }
 
 impl<'a> Iterator for RollbackAccountsIter<'a> {
-    type Item = &'a TransactionAccount;
+    type Item = &'a KeyedAccountSharedData;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(fee_payer) = self.fee_payer.take() {
@@ -53,7 +53,7 @@ impl<'a> Iterator for RollbackAccountsIter<'a> {
 }
 
 impl<'a> IntoIterator for &'a RollbackAccounts {
-    type Item = &'a TransactionAccount;
+    type Item = &'a KeyedAccountSharedData;
     type IntoIter = RollbackAccountsIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -100,7 +100,7 @@ impl RollbackAccounts {
     }
 
     /// Return a reference to the fee payer account.
-    pub fn fee_payer(&self) -> &TransactionAccount {
+    pub fn fee_payer(&self) -> &KeyedAccountSharedData {
         match self {
             Self::FeePayerOnly { fee_payer } => fee_payer,
             Self::SameNonceAndFeePayer { nonce } => nonce,

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {
-    crate::transaction_accounts::{AccountRefMut, TransactionAccount, TransactionAccounts},
+    crate::transaction_accounts::{AccountRefMut, KeyedAccountSharedData, TransactionAccounts},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_instruction::error::InstructionError,
     solana_instructions_sysvar as instructions,
@@ -126,7 +126,7 @@ impl TransactionContext {
     /// Constructs a new TransactionContext
     #[cfg(not(target_os = "solana"))]
     pub fn new(
-        transaction_accounts: Vec<TransactionAccount>,
+        transaction_accounts: Vec<KeyedAccountSharedData>,
         rent: Rent,
         instruction_stack_capacity: usize,
         instruction_trace_capacity: usize,
@@ -1051,7 +1051,7 @@ impl BorrowedInstructionAccount<'_> {
 /// Everything that needs to be recorded from a TransactionContext after execution
 #[cfg(not(target_os = "solana"))]
 pub struct ExecutionRecord {
-    pub accounts: Vec<TransactionAccount>,
+    pub accounts: Vec<KeyedAccountSharedData>,
     pub return_data: TransactionReturnData,
     pub touched_account_count: u64,
     pub accounts_resize_delta: i64,

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -13,7 +13,7 @@ use {
 
 /// An account key and the matching account
 pub type KeyedAccountSharedData = (Pubkey, AccountSharedData);
-pub(crate) type OwnedTransactionAccounts = (
+pub(crate) type DeconstructedTransactionAccounts = (
     UnsafeCell<Box<[KeyedAccountSharedData]>>,
     Box<[Cell<bool>]>,
     Cell<i64>,
@@ -142,7 +142,7 @@ impl TransactionAccounts {
         self.lamports_delta.get()
     }
 
-    pub(crate) fn take(self) -> OwnedTransactionAccounts {
+    pub(crate) fn take(self) -> DeconstructedTransactionAccounts {
         (self.accounts, self.touched_flags, self.resize_delta)
     }
 

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -12,16 +12,16 @@ use {
 };
 
 /// An account key and the matching account
-pub type TransactionAccount = (Pubkey, AccountSharedData);
+pub type KeyedAccountSharedData = (Pubkey, AccountSharedData);
 pub(crate) type OwnedTransactionAccounts = (
-    UnsafeCell<Box<[TransactionAccount]>>,
+    UnsafeCell<Box<[KeyedAccountSharedData]>>,
     Box<[Cell<bool>]>,
     Cell<i64>,
 );
 
 #[derive(Debug)]
 pub struct TransactionAccounts {
-    accounts: UnsafeCell<Box<[TransactionAccount]>>,
+    accounts: UnsafeCell<Box<[KeyedAccountSharedData]>>,
     borrow_counters: Box<[BorrowCounter]>,
     touched_flags: Box<[Cell<bool>]>,
     resize_delta: Cell<i64>,
@@ -30,7 +30,7 @@ pub struct TransactionAccounts {
 
 impl TransactionAccounts {
     #[cfg(not(target_os = "solana"))]
-    pub(crate) fn new(accounts: Vec<TransactionAccount>) -> TransactionAccounts {
+    pub(crate) fn new(accounts: Vec<KeyedAccountSharedData>) -> TransactionAccounts {
         let touched_flags = vec![Cell::new(false); accounts.len()].into_boxed_slice();
         let borrow_counters = vec![BorrowCounter::default(); accounts.len()].into_boxed_slice();
         let accounts = UnsafeCell::new(accounts.into_boxed_slice());


### PR DESCRIPTION
#### Problem

I'm developing the new account layout for ABIv2, and, although I did not name it `TransactionAccount`, I found that the old definition of `TransactionAccount` for the tuple (pubkey, TransactionAccount) was about to become misleading, since it did not represent a transaction account anymore.

#### Summary of Changes

1. Rename `TransactionAccount` to `KeyedAccountSharedData`.
2. Rename `OwnedTransactionAccounts` to `DeconstructedTransactionAccounts`.
