### PR TITLE
log whether debug assertions are enabled during validator start

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -610,6 +610,12 @@ impl Validator {
         tpu_config: ValidatorTpuConfig,
         admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
     ) -> Result<Self> {
+        #[cfg(debug_assertions)]
+        const DEBUG_ASSERTION_STATUS: &str = "enabled";
+        #[cfg(not(debug_assertions))]
+        const DEBUG_ASSERTION_STATUS: &str = "disabled";
+        info!("debug-assertion status: {DEBUG_ASSERTION_STATUS}");
+
         let ValidatorTpuConfig {
             use_quic,
             vote_use_quic,


### PR DESCRIPTION
#### Problem
took way too long to get a definitive answer as to why devnet nodes crashed

#### Summary of Changes
log whether debug assertions are enable during validator start