### PR TITLE
Expose the ClientId publicly from the gossip Version message

### DIFF
--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -16,7 +16,7 @@ extern crate solana_frozen_abi_macro;
 mod legacy;
 
 #[derive(Debug, Eq, PartialEq)]
-enum ClientId {
+pub enum ClientId {
     SolanaLabs,
     JitoLabs,
     Firedancer,
@@ -45,7 +45,7 @@ impl Version {
         semver::Version::new(self.major as u64, self.minor as u64, self.patch as u64)
     }
 
-    fn client(&self) -> ClientId {
+    pub fn client(&self) -> ClientId {
         ClientId::from(self.client)
     }
 }


### PR DESCRIPTION
#### Problem
The ClientId from gossip is the only non-public field. It would be helpful to expose this for analytics.

#### Summary of Changes
Expose the ClientId publicly from the gossip Version message
