### PR TITLE
Fix flaky test_task_handler_poh_recording

### DIFF
--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -2746,6 +2746,7 @@ mod tests {
         super::*,
         crate::sleepless_testing,
         assert_matches::assert_matches,
+        crossbeam_channel::TryRecvError,
         solana_clock::{Slot, MAX_PROCESSING_AGE},
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -2755,7 +2756,7 @@ mod tests {
             create_new_tmp_ledger_auto_delete,
             leader_schedule_cache::LeaderScheduleCache,
         },
-        solana_poh::poh_recorder::create_test_recorder_with_index_tracking,
+        solana_poh::poh_recorder::{create_test_recorder_with_index_tracking, WorkingBankEntry},
         solana_pubkey::Pubkey,
         solana_runtime::{
             bank::Bank,
@@ -4607,6 +4608,28 @@ mod tests {
         assert_eq!(bank.transaction_error_count(), 0);
         DefaultTaskHandler::handle(result, timings, scheduling_context, &task, handler_context);
 
+        // Join PoH service now to make sure there are no more messages coming in
+        // after we process the task.
+        exit.store(true, Ordering::Relaxed);
+        poh_service.join().unwrap();
+
+        // Helper function to just ignore tick entries received from PoH service.
+        // This can happen sporadically because we suck at writing tests.
+        fn try_recv_ignoring_ticks(
+            signal_receiver: &Receiver<WorkingBankEntry>,
+        ) -> std::result::Result<WorkingBankEntry, TryRecvError> {
+            loop {
+                match signal_receiver.try_recv() {
+                    Ok(working_bank_entry) => {
+                        if !working_bank_entry.1 .0.is_tick() {
+                            return Ok(working_bank_entry);
+                        }
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+        }
+
         if should_succeed_to_record_to_poh {
             if expected_tx_result.is_ok() {
                 assert_matches!(result, Ok(()));
@@ -4624,7 +4647,7 @@ mod tests {
                     )))
                 );
                 assert_matches!(
-                    signal_receiver.try_recv(),
+                    try_recv_ignoring_ticks(&signal_receiver),
                     Ok((_, (solana_entry::entry::Entry {transactions, ..} , _)))
                         if transactions == vec![tx.to_versioned_transaction()]
                 );
@@ -4633,7 +4656,7 @@ mod tests {
                 assert_eq!(bank.transaction_count(), 0);
                 assert_eq!(bank.transaction_error_count(), 0);
                 assert_matches!(receiver.try_recv(), Err(_));
-                assert_matches!(signal_receiver.try_recv(), Err(_));
+                assert_matches!(try_recv_ignoring_ticks(&signal_receiver), Err(_));
             }
         } else {
             if expected_tx_result.is_ok() {
@@ -4646,9 +4669,6 @@ mod tests {
             assert_matches!(receiver.try_recv(), Err(_));
             assert_matches!(signal_receiver.try_recv(), Err(_));
         }
-
-        exit.store(true, Ordering::Relaxed);
-        poh_service.join().unwrap();
     }
 
     #[derive(Debug)]


### PR DESCRIPTION
#### Problem
- Test was failing sporadically because poh produced a tick before the task completed, thus when we went to receive from `signal_receiver` there was a tick there, when we actually expected it to be empty,
- AFAICT, this is caused by #7444 which changed scheduler logic. Potentially made it slightly slower in this case and causes ticks to be produced when they previously were not 

#### Summary of Changes
- Add a helper fn to try_recv but ignores ticks to avoid failure when we happen to be slow due to running a bunch of threads during testing

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
