### PR TITLE
vote-program: expose `handler` mod under dcou

### DIFF
--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -18,6 +18,7 @@ name = "solana_vote_program"
 
 [features]
 default = ["metrics"]
+dev-context-only-utils = []
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1,6 +1,9 @@
 //! Vote state, vote program
 //! Receive and processes votes from validators
 
+#[cfg(feature = "dev-context-only-utils")]
+pub mod handler;
+#[cfg(not(feature = "dev-context-only-utils"))]
 mod handler;
 
 pub use {


### PR DESCRIPTION
#### Problem
The `handler` module - which contains a unifying API consisting of `VoteStateHandle` and `VoteStateHandler` - is intentionally private. However, it will be extremely useful to be able to use this unifying API both around the monorepo and in the Stake program tests.

#### Summary of Changes
Make the `handler` module public behind DCOU.