### PR TITLE
Add is_xdp flag to broadcast and retransmit metrics

### DIFF
--- a/turbine/src/broadcast_stage/broadcast_metrics.rs
+++ b/turbine/src/broadcast_stage/broadcast_metrics.rs
@@ -30,6 +30,7 @@ pub struct TransmitShredsStats {
     pub(crate) dropped_packets_udp: usize,
     pub(crate) dropped_packets_quic: usize,
     pub(crate) dropped_packets_xdp: usize,
+    pub(crate) is_xdp: bool,
 }
 
 impl BroadcastStats for TransmitShredsStats {
@@ -49,6 +50,7 @@ impl BroadcastStats for TransmitShredsStats {
         if was_interrupted {
             datapoint_info!(
                 "broadcast-transmit-shreds-interrupted-stats",
+                "is_xdp" => self.is_xdp.to_string(),
                 ("slot", slot as i64, i64),
                 ("transmit_elapsed", self.transmit_elapsed as i64, i64),
                 ("send_mmsg_elapsed", self.send_mmsg_elapsed as i64, i64),
@@ -68,6 +70,7 @@ impl BroadcastStats for TransmitShredsStats {
         } else {
             datapoint_info!(
                 "broadcast-transmit-shreds-stats",
+                "is_xdp" => self.is_xdp.to_string(),
                 ("slot", slot as i64, i64),
                 (
                     "end_to_end_elapsed",
@@ -239,6 +242,7 @@ mod test {
                 dropped_packets_udp: 8,
                 dropped_packets_quic: 9,
                 dropped_packets_xdp: 10,
+                is_xdp: false,
             },
             &Some(BroadcastShredBatchInfo {
                 slot: 0,
@@ -275,6 +279,7 @@ mod test {
                 dropped_packets_udp: 18,
                 dropped_packets_quic: 19,
                 dropped_packets_xdp: 20,
+                is_xdp: false,
             },
             &None,
         );
@@ -308,6 +313,7 @@ mod test {
                 dropped_packets_udp: 1,
                 dropped_packets_quic: 1,
                 dropped_packets_xdp: 1,
+                is_xdp: false,
             },
             &Some(BroadcastShredBatchInfo {
                 slot: 0,

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -384,7 +384,10 @@ impl StandardBroadcastRun {
         quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
     ) -> Result<()> {
         trace!("Broadcasting {:?} shreds", shreds.len());
-        let mut transmit_stats = TransmitShredsStats::default();
+        let mut transmit_stats = TransmitShredsStats {
+            is_xdp: matches!(sock, BroadcastSocket::Xdp(_)),
+            ..Default::default()
+        };
         // Broadcast the shreds
         let mut transmit_time = Measure::start("broadcast_shreds");
 

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -120,6 +120,7 @@ impl RetransmitStats {
         working_bank: &Bank,
         cluster_info: &ClusterInfo,
         cluster_nodes_cache: &ClusterNodesCache<RetransmitStage>,
+        is_xdp: bool,
     ) {
         const SUBMIT_CADENCE: Duration = Duration::from_secs(2);
         if self.since.elapsed() < SUBMIT_CADENCE {
@@ -130,6 +131,7 @@ impl RetransmitStats {
             .submit_metrics("cluster_nodes_retransmit", timestamp());
         datapoint_info!(
             "retransmit-stage",
+            "is_xdp" => is_xdp.to_string(),
             ("total_time", self.total_time, i64),
             ("epoch_fetch", self.epoch_fetch, i64),
             ("epoch_cache_update", self.epoch_cache_update, i64),
@@ -431,7 +433,13 @@ fn retransmit(
     );
     timer_start.stop();
     stats.total_time += timer_start.as_us();
-    stats.maybe_submit(&root_bank, &working_bank, cluster_info, cluster_nodes_cache);
+    stats.maybe_submit(
+        &root_bank,
+        &working_bank,
+        cluster_info,
+        cluster_nodes_cache,
+        xdp_sender.is_some(),
+    );
     Ok(())
 }
 


### PR DESCRIPTION
This adds an is_xdp=true|false tag to broadcast-transmit-shreds* and retransmit-stage.

I don't know if there's a better way to do this, I refuse to learn influxdb.