### PR TITLE
Switch tests to use get_and_then for accounts index entry

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -825,15 +825,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             .map(|found_index| callback(slot_list[found_index]))
     }
 
-    /// Gets the index's entry for `pubkey` and clones it
-    ///
-    /// Prefer `get_and_then()` whenever possible.
-    #[cfg(test)]
-    pub fn get_cloned(&self, pubkey: &Pubkey) -> Option<Arc<AccountMapEntry<T>>> {
-        self.get_bin(pubkey)
-            .get_internal_cloned(pubkey, |entry| entry)
-    }
-
     /// Is `pubkey` in the index?
     pub fn contains(&self, pubkey: &Pubkey) -> bool {
         self.get_and_then(pubkey, |entry| (false, entry.is_some()))
@@ -2234,12 +2225,14 @@ pub mod tests {
         index.set_startup(Startup::Normal);
 
         for (i, key) in [key0, key1].iter().enumerate() {
-            let entry = index.get_cloned(key).unwrap();
-            assert_eq!(entry.ref_count(), 1);
-            assert_eq!(
-                entry.slot_list_read_lock().as_slice(),
-                &[(slot0, account_infos[i])],
-            );
+            index.get_and_then(key, |entry| {
+                assert_eq!(entry.unwrap().ref_count(), 1);
+                assert_eq!(
+                    entry.unwrap().slot_list_read_lock().as_ref(),
+                    &[(slot0, account_infos[i])],
+                );
+                (false, ())
+            });
         }
     }
 
@@ -2295,8 +2288,8 @@ pub mod tests {
         assert!(gc.is_empty());
 
         // verify the added entry matches expected
-        {
-            let entry = index.get_cloned(&key).unwrap();
+        index.get_and_then(&key, |entry| {
+            let entry = entry.unwrap();
             let slot_list = entry.slot_list_read_lock();
             assert_eq!(entry.ref_count(), RefCount::from(!is_cached));
             assert_eq!(slot_list.as_slice(), &[(slot0, account_infos[0])]);
@@ -2311,7 +2304,8 @@ pub mod tests {
                 slot_list.as_slice(),
                 new_entry.slot_list_read_lock().as_slice(),
             );
-        }
+            (false, ())
+        });
 
         match upsert_method {
             Some(upsert_method) => {
@@ -2357,19 +2351,22 @@ pub mod tests {
 
         index.populate_and_retrieve_duplicate_keys_from_startup(|_slot_keys| {});
 
-        let entry = index.get_cloned(&key).unwrap();
-        let slot_list = entry.slot_list_read_lock();
+        let last_item = index.get_and_then(&key, |entry| {
+            let entry = entry.unwrap();
+            let slot_list = entry.slot_list_read_lock();
 
-        if should_have_reclaims {
-            assert_eq!(entry.ref_count(), 1);
-            assert_eq!(slot_list.as_slice(), &[(slot1, account_infos[1])],);
-        } else {
-            assert_eq!(entry.ref_count(), if is_cached { 0 } else { 2 });
-            assert_eq!(
-                slot_list.as_slice(),
-                &[(slot0, account_infos[0]), (slot1, account_infos[1])],
-            );
-        }
+            if should_have_reclaims {
+                assert_eq!(entry.ref_count(), 1);
+                assert_eq!(slot_list.as_slice(), &[(slot1, account_infos[1])],);
+            } else {
+                assert_eq!(entry.ref_count(), if is_cached { 0 } else { 2 });
+                assert_eq!(
+                    slot_list.as_slice(),
+                    &[(slot0, account_infos[0]), (slot1, account_infos[1])],
+                );
+            }
+            (false, *slot_list.last().unwrap())
+        });
 
         let new_entry = PreAllocatedAccountMapEntry::new(
             slot1,
@@ -2378,7 +2375,7 @@ pub mod tests {
             false,
         );
 
-        assert_eq!(slot_list.last().unwrap(), &new_entry.into());
+        assert_eq!(last_item, new_entry.into());
     }
 
     #[test_matrix(
@@ -2983,12 +2980,10 @@ pub mod tests {
         assert!(reclaims.is_empty());
 
         // Slot list should only have a single entry
-        // Using brackets to limit scope of read lock
-        {
-            let entry = index.get_cloned(&key).unwrap();
-            let slot_list = entry.slot_list_read_lock();
-            assert_eq!(slot_list.len(), 1);
-        }
+        let slot_list_len = index.get_and_then(&key, |entry| {
+            (false, entry.unwrap().slot_list_lock_read_len())
+        });
+        assert_eq!(slot_list_len, 1);
 
         index.upsert(
             0,
@@ -3005,9 +3000,10 @@ pub mod tests {
         assert!(!reclaims.is_empty());
 
         // Slot list should only have a single entry
-        let entry = index.get_cloned(&key).unwrap();
-        let slot_list = entry.slot_list_read_lock();
-        assert_eq!(slot_list.len(), 1);
+        let slot_list_len = index.get_and_then(&key, |entry| {
+            (false, entry.unwrap().slot_list_lock_read_len())
+        });
+        assert_eq!(slot_list_len, 1);
     }
 
     fn account_maps_stats_len<T: IndexValue>(index: &AccountsIndex<T, T>) -> usize {
@@ -3203,8 +3199,10 @@ pub mod tests {
                 UpsertReclaim::IgnoreReclaims,
             );
         }
-        let entry = index.get_cloned(&key).unwrap();
-        assert_eq!(entry.slot_list_lock_read_len(), reclaim_slot as usize);
+        let slot_list_len = index.get_and_then(&key, |entry| {
+            (false, entry.unwrap().slot_list_lock_read_len())
+        });
+        assert_eq!(slot_list_len, reclaim_slot as usize);
 
         // Insert an item newer than the one that we will reclaim old slots on
         index.upsert(
@@ -3217,8 +3215,10 @@ pub mod tests {
             &mut gc,
             UpsertReclaim::IgnoreReclaims,
         );
-        let entry = index.get_cloned(&key).unwrap();
-        assert_eq!(entry.slot_list_lock_read_len(), (reclaim_slot + 1) as usize);
+        let slot_list_len = index.get_and_then(&key, |entry| {
+            (false, entry.unwrap().slot_list_lock_read_len())
+        });
+        assert_eq!(slot_list_len, (reclaim_slot + 1) as usize);
 
         // Reclaim all older slots
         index.upsert(
@@ -3327,31 +3327,34 @@ pub mod tests {
 
         // Verify that the slot list is length two and consists of the cached account at slot 1
         // and the uncached account at slot 2
-        let entry = index.get_cloned(&key).unwrap();
-        assert_eq!(entry.slot_list_lock_read_len(), 2);
-        assert_eq!(
-            entry.slot_list_read_lock()[0],
-            PreAllocatedAccountMapEntry::new(
-                1,
-                CacheableIndexValueTest(true),
-                &index.storage.storage,
-                false
-            )
-            .into()
-        );
-        assert_eq!(
-            entry.slot_list_read_lock()[1],
-            PreAllocatedAccountMapEntry::new(
-                2,
-                CacheableIndexValueTest(false),
-                &index.storage.storage,
-                false
-            )
-            .into()
-        );
-        // Verify that the uncached account at slot 0 was reclaimed
-        assert_eq!(gc.len(), 1);
-        assert_eq!(gc[0], (0, CacheableIndexValueTest(false)));
+        index.get_and_then(&key, |entry| {
+            let entry = entry.unwrap();
+            assert_eq!(entry.slot_list_lock_read_len(), 2);
+            assert_eq!(
+                entry.slot_list_read_lock()[0],
+                PreAllocatedAccountMapEntry::new(
+                    1,
+                    CacheableIndexValueTest(true),
+                    &index.storage.storage,
+                    false
+                )
+                .into()
+            );
+            assert_eq!(
+                entry.slot_list_read_lock()[1],
+                PreAllocatedAccountMapEntry::new(
+                    2,
+                    CacheableIndexValueTest(false),
+                    &index.storage.storage,
+                    false
+                )
+                .into()
+            );
+            // Verify that the uncached account at slot 0 was reclaimed
+            assert_eq!(gc.len(), 1);
+            assert_eq!(gc[0], (0, CacheableIndexValueTest(false)));
+            (false, ())
+        });
     }
 
     #[test]
@@ -3890,13 +3893,16 @@ pub mod tests {
 
         index.upsert_simple_test(&key, slot1, value);
 
-        let entry = index.get_cloned(&key).unwrap();
-        // check refcount BEFORE the unref
-        assert_eq!(entry.ref_count(), 1);
-        // first time, ref count was at 1, we can unref once. Unref should return 1.
-        assert_eq!(entry.unref(), 1);
-        // check refcount AFTER the unref
-        assert_eq!(entry.ref_count(), 0);
+        index.get_and_then(&key, |entry| {
+            let entry = entry.unwrap();
+            // check refcount BEFORE the unref
+            assert_eq!(entry.ref_count(), 1);
+            // first time, ref count was at 1, we can unref once. Unref should return 1.
+            assert_eq!(entry.unref(), 1);
+            // check refcount AFTER the unref
+            assert_eq!(entry.ref_count(), 0);
+            (false, ())
+        });
     }
 
     #[test]
@@ -3909,13 +3915,16 @@ pub mod tests {
 
         index.upsert_simple_test(&key, slot1, value);
 
-        let entry = index.get_cloned(&key).unwrap();
-        // make ref count be zero
-        assert_eq!(entry.unref(), 1);
-        assert_eq!(entry.ref_count(), 0);
+        index.get_and_then(&key, |entry| {
+            let entry = entry.unwrap();
+            // make ref count be zero
+            assert_eq!(entry.unref(), 1);
+            assert_eq!(entry.ref_count(), 0);
 
-        // unref when already at zero should panic
-        entry.unref();
+            // unref when already at zero should panic
+            entry.unref();
+            (false, ())
+        });
     }
 
     #[test]
@@ -3954,14 +3963,21 @@ pub mod tests {
         assert!(!index.clean_rooted_entries(&key, &mut gc, Some(slot2)));
         index.upsert_simple_test(&key, slot2, value);
 
-        {
-            let account_map_entry = index.get_cloned(&key).unwrap();
+        index.get_and_then(&key, |entry| {
+            let account_map_entry = entry.unwrap();
             let slot_list = account_map_entry.slot_list_read_lock();
             assert_eq!(2, slot_list.len());
             assert_eq!(&[(slot1, value), (slot2, value)], slot_list.as_slice());
-        }
+            (false, ())
+        });
         assert!(!index.clean_rooted_entries(&key, &mut gc, Some(slot2)));
-        assert_eq!(2, index.get_cloned(&key).unwrap().slot_list_lock_read_len());
+        assert_eq!(
+            2,
+            index.get_and_then(&key, |entry| (
+                false,
+                entry.unwrap().slot_list_lock_read_len()
+            ))
+        );
         assert!(gc.is_empty());
         {
             {

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -333,19 +333,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         self.get_internal(pubkey, |entry| callback(entry.map(Arc::as_ref)))
     }
 
-    /// lookup 'pubkey' in the index (in_mem or disk).
-    /// call 'callback' whether found or not
-    #[cfg(test)]
-    pub(super) fn get_internal_cloned<RT>(
-        &self,
-        pubkey: &Pubkey,
-        callback: impl for<'a> FnOnce(Option<Arc<AccountMapEntry<T>>>) -> RT,
-    ) -> RT {
-        // SAFETY: Since we're passing the entry Arc clone to `callback`, we must
-        // also add the entry to the in-mem cache.
-        self.get_internal(pubkey, |entry| (true, callback(entry.cloned())))
-    }
-
     /// lookup 'pubkey' in index (in_mem or disk).
     /// call 'callback' whether found or not
     ///


### PR DESCRIPTION
#### Problem
Tests are using `get_cloned` to obtain a cloned Arc of accounts index entry. This is not a recommended API and forces index to support cloning entries.

#### Summary of Changes
Switch to `get_and_then`
