### PR TITLE
Eliminate entry cloning when flushing index

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1139,7 +1139,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
             // Process each eviction candidate
             // For dirty entries: lock map briefly, get entry, calculate disk value, release lock, then write to disk
-            // For non-dirty entries: skip checks and pass to evict_from_cache
+            // For clean entries: skip checks and pass to evict_from_cache
             let evictions_age: Vec<_> = evictions_age_possible
                 .iter()
                 .filter_map(|(key, is_dirty)| {

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1185,7 +1185,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                                 return None;
                             }
 
-                            // Acquire the slot list lock just before extracting disk data
                             let slot_list = entry.slot_list_read_lock();
                             ref_count = entry.ref_count(); // re-check ref count after grabbing slot list lock
                             if ref_count != 1 || slot_list.len() != 1 {
@@ -1194,13 +1193,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                                 return None;
                             }
 
-                            // Extract data for disk write
                             // since we know slot_list.len() == 1, we can create a stack-allocated array for single element
                             let (slot, info) = slot_list[0];
                             let disk_entry = [(slot, info.into())];
 
                             (disk_entry, ref_count)
-                        }; // Locks released here
+                        };
 
                         flush_stats.flush_read_lock_us += lock_measure.end_as_us();
 

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1144,7 +1144,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 .filter_map(|(key, is_dirty)| {
                     if *is_dirty {
                         // Entry was dirty at scan time, need to write to disk
-                        // Extract disk data while holding map read lock, then write outside the lock
                         let lock_measure = Measure::start("flush_read_lock");
                         let (disk_entry, disk_ref_count) = {
                             let map_read_guard = self.map_internal.read().unwrap();

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1198,7 +1198,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                             let (slot, info) = slot_list[0];
                             let disk_entry = [(slot, info.into())];
 
-                            // map_read_guard and slot_list are dropped here, releasing locks
                             (disk_entry, ref_count)
                         }; // Locks released here
 

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -944,10 +944,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 continue;
             }
 
-            // Capture dirty flag early during scan
-            let is_dirty = v.dirty();
-
-            possible_evictions.insert(0, *k, is_dirty);
+            possible_evictions.insert(0, *k, v.dirty());
         }
     }
 

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1151,7 +1151,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                             let map_read_guard = self.map_internal.read().unwrap();
                             let entry = map_read_guard.get(key)?;
 
-                            // Calculate should_evict_from_mem under read lock
                             let mut mse = Measure::start("flush_should_evict");
                             let should_evict = self.should_evict_from_mem(
                                 current_age,

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -164,9 +164,8 @@ struct StartupInfo<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
 /// result from scanning in-mem index during flush
 struct FlushScanResult {
     /// pubkeys whose age indicates they may be evicted now, pending further checks.
-    /// Each entry contains: (pubkey, is_dirty)
     /// Entries with ref_count != 1 are filtered out during scan
-    evictions_age_possible: Vec<(Pubkey, bool)>,
+    evictions_age_possible: Vec<(Pubkey, /*is_dirty*/ bool)>,
 }
 
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T, U> {

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1169,7 +1169,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                                 return None;
                             }
 
-                            // Clear dirty and prepare disk write
                             if !entry.clear_dirty() {
                                 // Entry was not dirty anymore, skip disk write
                                 flush_stats.flush_read_lock_us += lock_measure.end_as_us();

--- a/accounts-db/src/bucket_map_holder_stats.rs
+++ b/accounts-db/src/bucket_map_holder_stats.rs
@@ -63,6 +63,7 @@ pub struct BucketMapHolderStats {
     last_time: AtomicInterval,
     bins: u64,
     pub flush_should_evict_us: AtomicU64,
+    pub flush_read_lock_us: AtomicU64,
 }
 
 impl BucketMapHolderStats {
@@ -420,6 +421,11 @@ impl BucketMapHolderStats {
                 (
                     "flush_evict_us",
                     self.flush_evict_us.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_read_lock_us",
+                    self.flush_read_lock_us.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (


### PR DESCRIPTION
#### Problem

We want to avoid using `Arc` in the in-memory index to save 16 bytes per entry. However, the current disk flush implementation clones entries (requiring Arc), preventing this optimization. This PR changes disk flush to avoid entry cloning and refactors the eviction logic to minimize lock contention.

#### Summary of Changes

Refactor disk flush to avoid cloning entries and minimize read lock contention, enabling future memory optimization by removing Arc from in-memory index entries.


#### Performance Measurement
The mainnet results indicate that the read lock is held for only ~3 K µs, compared to 300 K–3.5 M µs total update time.
This shows that lock contention is minimal, and the time spent under the read lock is only a very small fraction of the overall update duration.


<img width="2485" height="594" alt="image" src="https://github.com/user-attachments/assets/6d5cbe39-8e3f-42df-a52c-3c1a99098102" />



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
