### PR TITLE
[zk-elgamal-proof] Add owner/state checks in zk-elgamal-proof close context

### DIFF
--- a/programs/zk-elgamal-proof/src/lib.rs
+++ b/programs/zk-elgamal-proof/src/lib.rs
@@ -142,8 +142,15 @@ fn process_close_proof_context(invoke_context: &mut InvokeContext) -> Result<(),
     }
 
     let mut proof_context_account = instruction_context.try_borrow_instruction_account(0)?;
+    if *proof_context_account.get_owner() != id() {
+        return Err(InstructionError::InvalidAccountOwner);
+    }
     let proof_context_state_meta =
         ProofContextStateMeta::try_from_bytes(proof_context_account.get_data())?;
+    if proof_context_state_meta.proof_type == ProofType::Uninitialized.into() {
+        return Err(InstructionError::UninitializedAccount);
+    }
+
     let expected_owner_pubkey = proof_context_state_meta.context_state_authority;
 
     if owner_pubkey != expected_owner_pubkey {


### PR DESCRIPTION
#### Summary
The CloseContextState instruction path (handled by process_close_proof_context) does not assert program ownership up-front before parsing the account data as a ProofContextStateMeta. While this could appear risky, the Solana runtime enforces that a program may not mutate lamports, data length, or owner of an account it does not own. In this code path, all mutating calls (set_lamports, set_data_length, set_owner) will fail with InvalidAccountOwner if the source account is not owned by the zk-elgamal-proof program.

Therefore, there is no exploitable path to drain or reassign non-owned accounts via CloseContextState. However, adding an explicit owner/state check early would improve clarity and fail-fast behavior.

#### Technical Details

In process_close_proof_context, the program:

    Treats accounts as follows:
        index 0: context state account to be closed
        index 1: destination account to receive lamports
        index 2: authority (must be a signer)
    Reads context_state_authority from ProofContextStateMeta::try_from_bytes(account[0].data).
    Ensures account[2].is_signer and matches context_state_authority.
    Attempts to transfer lamports from account[0] to account[1], then sets account[0] lamports to 0, data_length to 0, and owner to system_program.

Even though there is no explicit if owner != id() check before step 4, the Solana runtime methods invoked (checked_add_lamports, set_lamports, set_data_length, set_owner) will return InvalidAccountOwner if account[0] is not owned by the currently executing program. The code already propagates these errors via ?.

By contrast, the context creation path (process_verify_proof) explicitly checks ownership early. Mirroring that check here would improve error messaging and avoid parsing untrusted data unnecessarily.
Impact

    Exploitation to drain or reassign non–program-owned accounts is not possible through this path, because mutations will fail on ownership checks enforced by the runtime.
    The current implementation may yield later, less-clear errors (e.g., after parsing data) rather than failing fast on non-owned accounts.
    It’s still best practice to explicitly enforce ownership and validate state up-front for clarity and consistency with the creation path.