### PR TITLE
rpc-client:  enhance RpcClient documentation with detailed method description and examples

### DIFF
--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -1910,6 +1910,122 @@ impl RpcClient {
             .await
     }
 
+    /// Returns the commitment information for a particular block.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getBlockCommitment`] RPC method.
+    ///
+    /// [`getBlockCommitment`]: https://solana.com/docs/rpc/http/getblockcommitment
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client_api::client_error::Error;
+    /// # use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+    /// # use solana_clock::Slot;
+    /// # futures::executor::block_on(async {
+    /// #     let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let slot: Slot = 5;
+    /// let commitment = rpc_client.get_block_commitment(slot).await?;
+    /// #     Ok::<(), Error>(())
+    /// # })?;
+    /// # Ok::<(), Error>(())
+    /// ```
+    pub async fn get_block_commitment(
+        &self,
+        slot: Slot,
+    ) -> ClientResult<RpcBlockCommitment<[u64; MAX_LOCKOUT_HISTORY + 1]>> {
+        self.send(RpcRequest::GetBlockCommitment, json!([slot]))
+            .await
+    }
+
+    /// Returns the leader of the current slot using the configured [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getSlotLeader`] RPC method.
+    ///
+    /// [`getSlotLeader`]: https://solana.com/docs/rpc/http/getslotleader
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client_api::client_error::Error;
+    /// # use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+    /// # futures::executor::block_on(async {
+    /// #     let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let leader = rpc_client.get_slot_leader().await?;
+    /// #     Ok::<(), Error>(())
+    /// # })?;
+    /// # Ok::<(), Error>(())
+    /// ```
+    pub async fn get_slot_leader(&self) -> ClientResult<Pubkey> {
+        self.get_slot_leader_with_commitment(self.commitment()).await
+    }
+
+    /// Returns the leader of the current slot using the provided [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getSlotLeader`] RPC method.
+    ///
+    /// [`getSlotLeader`]: https://solana.com/docs/rpc/http/getslotleader
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client_api::client_error::Error;
+    /// # use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+    /// # use solana_commitment_config::CommitmentConfig;
+    /// # futures::executor::block_on(async {
+    /// #     let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let commitment_config = CommitmentConfig::processed();
+    /// let leader = rpc_client.get_slot_leader_with_commitment(commitment_config).await?;
+    /// #     Ok::<(), Error>(())
+    /// # })?;
+    /// # Ok::<(), Error>(())
+    /// ```
+    pub async fn get_slot_leader_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> ClientResult<Pubkey> {
+        self.get_slot_leader_with_config(RpcContextConfig {
+            commitment: Some(commitment_config),
+            ..RpcContextConfig::default()
+        })
+        .await
+    }
+
+    /// Returns the leader of the current slot using the provided [`RpcContextConfig`].
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getSlotLeader`] RPC method.
+    ///
+    /// [`getSlotLeader`]: https://solana.com/docs/rpc/http/getslotleader
+    pub async fn get_slot_leader_with_config(
+        &self,
+        config: RpcContextConfig,
+    ) -> ClientResult<Pubkey> {
+        let params = if config == RpcContextConfig::default() {
+            Value::Null
+        } else {
+            json!([config])
+        };
+        let slot_leader: String = self.send(RpcRequest::GetSlotLeader, params).await?;
+        Pubkey::from_str(&slot_leader).map_err(|_| {
+            ClientError::new_with_request(
+                RpcError::ParseError("Pubkey".to_string()).into(),
+                RpcRequest::GetSlotLeader,
+            )
+        })
+    }
+
     /// Returns the slot leaders for a given slot range.
     ///
     /// # RPC Reference
@@ -4263,7 +4379,9 @@ impl RpcClient {
     /// # use solana_commitment_config::CommitmentConfig;
     /// # futures::executor::block_on(async {
     /// #     let rpc_client = RpcClient::new_mock("succeeds".to_string());
-    /// let stake_minimum_delegation = rpc_client.get_stake_minimum_delegation_with_commitment(CommitmentConfig::confirmed()).await?;
+    /// let stake_minimum_delegation = rpc_client
+    ///     .get_stake_minimum_delegation_with_commitment(CommitmentConfig::confirmed())
+    ///     .await?;
     /// #     Ok::<(), Error>(())
     /// # })?;
     /// # Ok::<(), Error>(())
@@ -4281,12 +4399,25 @@ impl RpcClient {
             .value)
     }
 
-    /// Request the transaction count.
+    /// Returns the number of transactions the cluster has processed.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTransactionCount`] RPC method.
+    ///
+    /// [`getTransactionCount`]: https://solana.com/docs/rpc/http/gettransactioncount
     pub async fn get_transaction_count(&self) -> ClientResult<u64> {
         self.get_transaction_count_with_commitment(self.commitment())
             .await
     }
 
+    /// Returns the number of transactions processed by the cluster at the specified commitment level.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTransactionCount`] RPC method.
+    ///
+    /// [`getTransactionCount`]: https://solana.com/docs/rpc/http/gettransactioncount
     pub async fn get_transaction_count_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
@@ -4295,11 +4426,25 @@ impl RpcClient {
             .await
     }
 
+    /// Returns the earliest slot the node retains in its ledger.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getFirstAvailableBlock`] RPC method.
+    ///
+    /// [`getFirstAvailableBlock`]: https://solana.com/docs/rpc/http/getfirstavailableblock
     pub async fn get_first_available_block(&self) -> ClientResult<Slot> {
         self.send(RpcRequest::GetFirstAvailableBlock, Value::Null)
             .await
     }
 
+    /// Returns the cluster's genesis hash.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getGenesisHash`] RPC method.
+    ///
+    /// [`getGenesisHash`]: https://solana.com/docs/rpc/http/getgenesishash
     pub async fn get_genesis_hash(&self) -> ClientResult<Hash> {
         let hash_str: String = self.send(RpcRequest::GetGenesisHash, Value::Null).await?;
         let hash = hash_str.parse().map_err(|_| {
@@ -4311,12 +4456,26 @@ impl RpcClient {
         Ok(hash)
     }
 
+    /// Checks the node's health status.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getHealth`] RPC method.
+    ///
+    /// [`getHealth`]: https://solana.com/docs/rpc/http/gethealth
     pub async fn get_health(&self) -> ClientResult<()> {
         self.send::<String>(RpcRequest::GetHealth, Value::Null)
             .await
             .map(|_| ())
     }
 
+    /// Returns the parsed token account for the provided address, if present.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getAccountInfo`] RPC method.
+    ///
+    /// [`getAccountInfo`]: https://solana.com/docs/rpc/http/getaccountinfo
     pub async fn get_token_account(&self, pubkey: &Pubkey) -> ClientResult<Option<UiTokenAccount>> {
         Ok(self
             .get_token_account_with_commitment(pubkey, self.commitment())
@@ -4324,6 +4483,15 @@ impl RpcClient {
             .value)
     }
 
+    /// Returns the parsed token account for the provided address at the chosen [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getAccountInfo`] RPC method.
+    ///
+    /// [`getAccountInfo`]: https://solana.com/docs/rpc/http/getaccountinfo
     pub async fn get_token_account_with_commitment(
         &self,
         pubkey: &Pubkey,
@@ -4380,6 +4548,13 @@ impl RpcClient {
             })?
     }
 
+    /// Returns the SPL token balance for the provided account.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenAccountBalance`] RPC method.
+    ///
+    /// [`getTokenAccountBalance`]: https://solana.com/docs/rpc/http/gettokenaccountbalance
     pub async fn get_token_account_balance(&self, pubkey: &Pubkey) -> ClientResult<UiTokenAmount> {
         Ok(self
             .get_token_account_balance_with_commitment(pubkey, self.commitment())
@@ -4387,6 +4562,15 @@ impl RpcClient {
             .value)
     }
 
+    /// Returns the SPL token balance for the provided account at the specified [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenAccountBalance`] RPC method.
+    ///
+    /// [`getTokenAccountBalance`]: https://solana.com/docs/rpc/http/gettokenaccountbalance
     pub async fn get_token_account_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
@@ -4399,6 +4583,13 @@ impl RpcClient {
         .await
     }
 
+    /// Returns SPL token accounts delegated to the provided authority.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenAccountsByDelegate`] RPC method.
+    ///
+    /// [`getTokenAccountsByDelegate`]: https://solana.com/docs/rpc/http/gettokenaccountsbydelegate
     pub async fn get_token_accounts_by_delegate(
         &self,
         delegate: &Pubkey,
@@ -4414,6 +4605,15 @@ impl RpcClient {
             .value)
     }
 
+    /// Returns SPL token accounts delegated to the provided authority using the specified [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenAccountsByDelegate`] RPC method.
+    ///
+    /// [`getTokenAccountsByDelegate`]: https://solana.com/docs/rpc/http/gettokenaccountsbydelegate
     pub async fn get_token_accounts_by_delegate_with_commitment(
         &self,
         delegate: &Pubkey,
@@ -4441,6 +4641,13 @@ impl RpcClient {
         .await
     }
 
+    /// Returns SPL token accounts owned by the provided address.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenAccountsByOwner`] RPC method.
+    ///
+    /// [`getTokenAccountsByOwner`]: https://solana.com/docs/rpc/http/gettokenaccountsbyowner
     pub async fn get_token_accounts_by_owner(
         &self,
         owner: &Pubkey,
@@ -4456,6 +4663,15 @@ impl RpcClient {
             .value)
     }
 
+    /// Returns SPL token accounts owned by the provided address using the specified [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenAccountsByOwner`] RPC method.
+    ///
+    /// [`getTokenAccountsByOwner`]: https://solana.com/docs/rpc/http/gettokenaccountsbyowner
     pub async fn get_token_accounts_by_owner_with_commitment(
         &self,
         owner: &Pubkey,
@@ -4483,6 +4699,13 @@ impl RpcClient {
         .await
     }
 
+    /// Returns the largest token accounts for a mint, ordered by balance.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenLargestAccounts`] RPC method.
+    ///
+    /// [`getTokenLargestAccounts`]: https://solana.com/docs/rpc/http/gettokenlargestaccounts
     pub async fn get_token_largest_accounts(
         &self,
         mint: &Pubkey,
@@ -4493,6 +4716,15 @@ impl RpcClient {
             .value)
     }
 
+    /// Returns the largest token accounts for a mint using the specified [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenLargestAccounts`] RPC method.
+    ///
+    /// [`getTokenLargestAccounts`]: https://solana.com/docs/rpc/http/gettokenlargestaccounts
     pub async fn get_token_largest_accounts_with_commitment(
         &self,
         mint: &Pubkey,
@@ -4505,6 +4737,13 @@ impl RpcClient {
         .await
     }
 
+    /// Returns supply information for an SPL token mint.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenSupply`] RPC method.
+    ///
+    /// [`getTokenSupply`]: https://solana.com/docs/rpc/http/gettokensupply
     pub async fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<UiTokenAmount> {
         Ok(self
             .get_token_supply_with_commitment(mint, self.commitment())
@@ -4512,6 +4751,15 @@ impl RpcClient {
             .value)
     }
 
+    /// Returns supply information for an SPL token mint using the provided [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenSupply`] RPC method.
+    ///
+    /// [`getTokenSupply`]: https://solana.com/docs/rpc/http/gettokensupply
     pub async fn get_token_supply_with_commitment(
         &self,
         mint: &Pubkey,
@@ -4524,6 +4772,13 @@ impl RpcClient {
         .await
     }
 
+    /// Requests an air-drop of lamports to the provided address.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`requestAirdrop`] RPC method.
+    ///
+    /// [`requestAirdrop`]: https://solana.com/docs/rpc/http/requestairdrop
     pub async fn request_airdrop(&self, pubkey: &Pubkey, lamports: u64) -> ClientResult<Signature> {
         self.request_airdrop_with_config(
             pubkey,
@@ -4536,6 +4791,14 @@ impl RpcClient {
         .await
     }
 
+    /// Requests an air-drop while specifying a recent blockhash used for the transfer.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`requestAirdrop`] RPC method when the blockhash
+    /// parameter is supplied explicitly.
+    ///
+    /// [`requestAirdrop`]: https://solana.com/docs/rpc/http/requestairdrop
     pub async fn request_airdrop_with_blockhash(
         &self,
         pubkey: &Pubkey,
@@ -4553,6 +4816,16 @@ impl RpcClient {
         .await
     }
 
+    /// Requests an air-drop with fine-grained configuration options.
+    ///
+    /// The `config` argument allows the caller to specify parameters such as the desired
+    /// commitment level or a preselected blockhash.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`requestAirdrop`] RPC method.
+    ///
+    /// [`requestAirdrop`]: https://solana.com/docs/rpc/http/requestairdrop
     pub async fn request_airdrop_with_config(
         &self,
         pubkey: &Pubkey,
@@ -4609,6 +4882,12 @@ impl RpcClient {
         }
     }
 
+    /// Polls the network for the account's balance until a response is received.
+    ///
+    /// The method retries for up to one second, querying with the supplied [commitment level][cl].
+    /// It returns the balance the first time the request succeeds.
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
     pub async fn poll_get_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
@@ -4623,6 +4902,11 @@ impl RpcClient {
         .await
     }
 
+    /// Waits for an account balance to reach an expected value.
+    ///
+    /// The method polls [`poll_get_balance_with_commitment`] repeatedly. If `expected_balance` is
+    /// `Some`, the function returns once the balance matches that value; otherwise it returns the
+    /// first retrieved balance.
     pub async fn wait_for_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
@@ -4739,6 +5023,14 @@ impl RpcClient {
         Ok(confirmed_blocks)
     }
 
+    /// Returns the number of confirmed blocks elapsed since the provided signature was observed.
+    ///
+    /// # RPC Reference
+    ///
+    /// This helper uses the [`getSignatureStatuses`] RPC method and inspects the
+    /// `confirmations` field of the response.
+    ///
+    /// [`getSignatureStatuses`]: https://solana.com/docs/rpc/http/getsignaturestatuses
     pub async fn get_num_blocks_since_signature_confirmation(
         &self,
         signature: &Signature,
@@ -4763,6 +5055,13 @@ impl RpcClient {
         Ok(confirmations)
     }
 
+    /// Returns the most recent blockhash observed by the cluster.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getLatestBlockhash`] RPC method.
+    ///
+    /// [`getLatestBlockhash`]: https://solana.com/docs/rpc/http/getlatestblockhash
     pub async fn get_latest_blockhash(&self) -> ClientResult<Hash> {
         let (blockhash, _) = self
             .get_latest_blockhash_with_commitment(self.commitment())
@@ -4770,6 +5069,15 @@ impl RpcClient {
         Ok(blockhash)
     }
 
+    /// Returns the most recent blockhash along with the last valid block height for commitment-aware clients.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getLatestBlockhash`] RPC method and uses the
+    /// provided [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    /// [`getLatestBlockhash`]: https://solana.com/docs/rpc/http/getlatestblockhash
     pub async fn get_latest_blockhash_with_commitment(
         &self,
         commitment: CommitmentConfig,
@@ -4790,6 +5098,13 @@ impl RpcClient {
         Ok((blockhash, last_valid_block_height))
     }
 
+    /// Checks whether a blockhash is still valid for submitting transactions.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`isBlockhashValid`] RPC method.
+    ///
+    /// [`isBlockhashValid`]: https://solana.com/docs/rpc/http/isblockhashvalid
     pub async fn is_blockhash_valid(
         &self,
         blockhash: &Hash,
@@ -4804,6 +5119,13 @@ impl RpcClient {
             .value)
     }
 
+    /// Returns the fee that the cluster would charge to process the provided message.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getFeeForMessage`] RPC method.
+    ///
+    /// [`getFeeForMessage`]: https://solana.com/docs/rpc/http/getfeeformessage
     pub async fn get_fee_for_message(
         &self,
         message: &impl SerializableMessage,
@@ -4821,6 +5143,13 @@ impl RpcClient {
             .ok_or_else(|| ClientErrorKind::Custom("Invalid blockhash".to_string()).into())
     }
 
+    /// Fetches a fresh latest blockhash, retrying until it differs from the provided value.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method repeatedly calls [`getLatestBlockhash`] until the returned value changes.
+    ///
+    /// [`getLatestBlockhash`]: https://solana.com/docs/rpc/http/getlatestblockhash
     pub async fn get_new_latest_blockhash(&self, blockhash: &Hash) -> ClientResult<Hash> {
         let mut num_retries = 0;
         let start = Instant::now();
@@ -4845,6 +5174,9 @@ impl RpcClient {
         .into())
     }
 
+    /// Sends an RPC request using the configured transport.
+    ///
+    /// Most high-level helpers delegate to this method to construct and submit typed requests.
     pub async fn send<T>(&self, request: RpcRequest, params: Value) -> ClientResult<T>
     where
         T: serde::de::DeserializeOwned,
@@ -4860,6 +5192,7 @@ impl RpcClient {
             .map_err(|err| ClientError::new_with_request(err.into(), request))
     }
 
+    /// Returns accumulated transport metrics for this client instance.
     pub fn get_transport_stats(&self) -> RpcTransportStats {
         self.sender.get_transport_stats()
     }

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -43,6 +43,7 @@ use {
         EncodedConfirmedBlock, EncodedConfirmedTransactionWithStatusMeta, TransactionStatus,
         UiConfirmedBlock, UiTransactionEncoding,
     },
+    solana_vote_interface::state::MAX_LOCKOUT_HISTORY,
     std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration},
 };
 
@@ -53,6 +54,20 @@ pub struct RpcClientConfig {
 }
 
 impl RpcClientConfig {
+    /// Create a new [`RpcClientConfig`] that uses the provided [`CommitmentConfig`].
+    ///
+    /// All other configuration fields retain their default values. This helper is
+    /// convenient when a caller needs to tweak only the commitment level while
+    /// relying on the standard timeouts used by [`RpcClient`]'s constructors.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_commitment_config::CommitmentConfig;
+    /// # use solana_rpc_client::rpc_client::RpcClientConfig;
+    /// let config = RpcClientConfig::with_commitment(CommitmentConfig::processed());
+    /// assert_eq!(config.commitment_config, CommitmentConfig::processed());
+    /// ```
     pub fn with_commitment(commitment_config: CommitmentConfig) -> Self {
         RpcClientConfig {
             commitment_config,
@@ -965,6 +980,30 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).send_transaction_with_config(transaction, config))
     }
 
+    /// Issue an arbitrary JSON-RPC request and deserialize the response.
+    ///
+    /// This low-level helper exposes the raw RPC transport so that callers can
+    /// invoke Solana RPC methods that do not yet have dedicated wrappers on
+    /// [`RpcClient`]. The caller supplies both the [`RpcRequest`] variant and
+    /// the JSON-serializable parameter payload; the response body is converted
+    /// into the requested type.
+    ///
+    /// When possible prefer the higher-level convenience methods, which add
+    /// client-side validation and ergonomic defaults. Reach for `send` only
+    /// when you need access to new or less common RPC endpoints.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use serde_json::json;
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # use solana_rpc_client_api::request::RpcRequest;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let slot: u64 = rpc_client
+    ///     .send(RpcRequest::GetSlot, json!([]))?;
+    /// assert!(slot >= 0);
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn send<T>(&self, request: RpcRequest, params: Value) -> ClientResult<T>
     where
         T: serde::de::DeserializeOwned,
@@ -1691,6 +1730,86 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).get_block_height_with_commitment(commitment_config))
     }
 
+    /// Returns the commitment information for a particular block.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getBlockCommitment`] RPC method.
+    ///
+    /// [`getBlockCommitment`]: https://solana.com/docs/rpc/http/getblockcommitment
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client_api::client_error::Error;
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let commitment = rpc_client.get_block_commitment(5)?;
+    /// # Ok::<(), Error>(())
+    /// ```
+    pub fn get_block_commitment(
+        &self,
+        slot: Slot,
+    ) -> ClientResult<RpcBlockCommitment<[u64; MAX_LOCKOUT_HISTORY + 1]>> {
+        self.invoke((self.rpc_client.as_ref()).get_block_commitment(slot))
+    }
+
+    /// Returns the leader of the current slot using the configured [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getSlotLeader`] RPC method.
+    ///
+    /// [`getSlotLeader`]: https://solana.com/docs/rpc/http/getslotleader
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client_api::client_error::Error;
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let leader = rpc_client.get_slot_leader()?;
+    /// # Ok::<(), Error>(())
+    /// ```
+    pub fn get_slot_leader(&self) -> ClientResult<Pubkey> {
+        self.invoke((self.rpc_client.as_ref()).get_slot_leader())
+    }
+
+    /// Returns the leader of the current slot using the provided [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getSlotLeader`] RPC method.
+    ///
+    /// [`getSlotLeader`]: https://solana.com/docs/rpc/http/getslotleader
+    pub fn get_slot_leader_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> ClientResult<Pubkey> {
+        self.invoke(
+            (self.rpc_client.as_ref())
+                .get_slot_leader_with_commitment(commitment_config),
+        )
+    }
+
+    /// Returns the leader of the current slot using the provided [`RpcContextConfig`].
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getSlotLeader`] RPC method.
+    ///
+    /// [`getSlotLeader`]: https://solana.com/docs/rpc/http/getslotleader
+    pub fn get_slot_leader_with_config(
+        &self,
+        config: RpcContextConfig,
+    ) -> ClientResult<Pubkey> {
+        self.invoke((self.rpc_client.as_ref()).get_slot_leader_with_config(config))
+    }
+
     /// Returns the slot leaders for a given slot range.
     ///
     /// # RPC Reference
@@ -1808,6 +1927,14 @@ impl RpcClient {
 
     /// Returns information about the current supply.
     ///
+    /// This method corresponds directly to the [`getSupply`] RPC method and
+    /// is an alias for [`Self::supply`].
+    pub fn get_supply(&self) -> RpcResult<RpcSupply> {
+        self.supply()
+    }
+
+    /// Returns information about the current supply.
+    ///
     /// # RPC Reference
     ///
     /// This method corresponds directly to the [`getSupply`] RPC method.
@@ -1832,6 +1959,20 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<RpcSupply> {
         self.invoke((self.rpc_client.as_ref()).supply_with_commitment(commitment_config))
+    }
+
+    /// Returns information about the current supply using the provided
+    /// [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// This method corresponds directly to the [`getSupply`] RPC method and
+    /// is an alias for [`Self::supply_with_commitment`].
+    pub fn get_supply_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> RpcResult<RpcSupply> {
+        self.supply_with_commitment(commitment_config)
     }
 
     /// Returns the 20 largest accounts, by lamport balance.
@@ -1971,6 +2112,30 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).get_vote_accounts_with_config(config))
     }
 
+    /// Wait until the largest activated stake percentage drops below `max_stake_percent`.
+    ///
+    /// The client repeatedly polls [`get_vote_accounts_with_commitment`] using the supplied
+    /// [`CommitmentConfig`], sleeping briefly between iterations. Once the most heavily staked
+    /// validator controls less than the requested proportion of active stake, the method returns
+    /// successfully. This helper is useful when orchestrating cluster restarts or migrations that
+    /// require stake concentration to fall under a specific threshold before continuing.
+    ///
+    /// [`get_vote_accounts_with_commitment`]: RpcClient::get_vote_accounts_with_commitment
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`ClientError`] produced by [`get_vote_accounts_with_commitment`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_commitment_config::CommitmentConfig;
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let commitment = CommitmentConfig::processed();
+    /// rpc_client.wait_for_max_stake(commitment, 25.0)?;
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn wait_for_max_stake(
         &self,
         commitment: CommitmentConfig,
@@ -1979,6 +2144,36 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).wait_for_max_stake(commitment, max_stake_percent))
     }
 
+    /// Wait until the largest activated stake percentage drops below `max_stake_percent`,
+    /// aborting if `timeout` is reached.
+    ///
+    /// This behaves like [`wait_for_max_stake`], but bounds the wait time. If the threshold is not
+    /// satisfied before the timeout elapses, the method returns a [`ClientErrorKind::Custom`]
+    /// error. Use this variant when coordinating operations that must fail fast if stake does not
+    /// redistribute in time.
+    ///
+    /// [`ClientErrorKind::Custom`]: solana_rpc_client_api::client_error::ErrorKind::Custom
+    ///
+    /// # Errors
+    ///
+    /// In addition to the errors described for [`wait_for_max_stake`], this method returns an
+    /// error if the timeout expires.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// # use solana_commitment_config::CommitmentConfig;
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let commitment = CommitmentConfig::processed();
+    /// rpc_client.wait_for_max_stake_below_threshold_with_timeout(
+    ///     commitment,
+    ///     33.3,
+    ///     Duration::from_secs(30),
+    /// )?;
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn wait_for_max_stake_below_threshold_with_timeout(
         &self,
         commitment: CommitmentConfig,
@@ -3528,11 +3723,55 @@ impl RpcClient {
         )
     }
 
-    /// Request the transaction count.
+    /// Returns the total number of transactions processed by the cluster.
+    ///
+    /// This method uses the client's configured [commitment level][cl] when querying the
+    /// validator.
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTransactionCount`] RPC method.
+    ///
+    /// [`getTransactionCount`]: https://solana.com/docs/rpc/http/gettransactioncount
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let count = rpc_client.get_transaction_count()?;
+    /// assert!(count > 0);
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_transaction_count(&self) -> ClientResult<u64> {
         self.invoke((self.rpc_client.as_ref()).get_transaction_count())
     }
 
+    /// Returns the total number of transactions processed by the cluster using the supplied
+    /// [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTransactionCount`] RPC method.
+    ///
+    /// [`getTransactionCount`]: https://solana.com/docs/rpc/http/gettransactioncount
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_commitment_config::CommitmentConfig;
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let processed = rpc_client.get_transaction_count_with_commitment(
+    ///     CommitmentConfig::processed(),
+    /// )?;
+    /// assert!(processed > 0);
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_transaction_count_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
@@ -3542,22 +3781,126 @@ impl RpcClient {
         )
     }
 
+    /// Returns the earliest slot that still has ledger data available on the node.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getFirstAvailableBlock`] RPC method.
+    ///
+    /// [`getFirstAvailableBlock`]: https://solana.com/docs/rpc/http/getfirstavailableblock
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let first_slot = rpc_client.get_first_available_block()?;
+    /// assert!(first_slot > 0);
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_first_available_block(&self) -> ClientResult<Slot> {
         self.invoke((self.rpc_client.as_ref()).get_first_available_block())
     }
 
+    /// Returns the genesis hash advertised by the node.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getGenesisHash`] RPC method.
+    ///
+    /// [`getGenesisHash`]: https://solana.com/docs/rpc/http/getgenesishash
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let genesis_hash = rpc_client.get_genesis_hash()?;
+    /// assert!(!genesis_hash.to_string().is_empty());
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_genesis_hash(&self) -> ClientResult<Hash> {
         self.invoke((self.rpc_client.as_ref()).get_genesis_hash())
     }
 
+    /// Returns `Ok(())` when the RPC node reports a healthy status.
+    ///
+    /// Nodes typically respond with a non-error string such as `"ok"` when healthy; any other
+    /// response is converted into a [`ClientError`].
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getHealth`] RPC method.
+    ///
+    /// [`getHealth`]: https://solana.com/docs/rpc/http/gethealth
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// rpc_client.get_health()?;
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_health(&self) -> ClientResult<()> {
         self.invoke((self.rpc_client.as_ref()).get_health())
     }
 
+    /// Returns parsed SPL token account information for the given account address.
+    ///
+    /// The request is issued with the client's default [commitment level][cl] and deserializes the
+    /// result into [`UiTokenAccount`]. If the account does not exist or is not a token account,
+    /// `Ok(None)` is returned.
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method is built on the [`getAccountInfo`] RPC method.
+    ///
+    /// [`getAccountInfo`]: https://solana.com/docs/rpc/http/getaccountinfo
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # use solana_keypair::Keypair;
+    /// # use solana_signer::Signer;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let token_account = rpc_client.get_token_account(&Keypair::new().pubkey())?;
+    /// assert!(token_account.is_none());
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_token_account(&self, pubkey: &Pubkey) -> ClientResult<Option<UiTokenAccount>> {
         self.invoke((self.rpc_client.as_ref()).get_token_account(pubkey))
     }
 
+    /// Returns parsed SPL token account information for the given account address using the
+    /// provided [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method is built on the [`getAccountInfo`] RPC method.
+    ///
+    /// [`getAccountInfo`]: https://solana.com/docs/rpc/http/getaccountinfo
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_commitment_config::CommitmentConfig;
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # use solana_keypair::Keypair;
+    /// # use solana_signer::Signer;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let info = rpc_client.get_token_account_with_commitment(
+    ///     &Keypair::new().pubkey(),
+    ///     CommitmentConfig::processed(),
+    /// )?;
+    /// assert!(info.value.is_none());
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_token_account_with_commitment(
         &self,
         pubkey: &Pubkey,
@@ -3568,10 +3911,55 @@ impl RpcClient {
         )
     }
 
+    /// Returns the SPL token balance for the provided token account.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenAccountBalance`] RPC method.
+    ///
+    /// [`getTokenAccountBalance`]: https://solana.com/docs/rpc/http/gettokenaccountbalance
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # use solana_keypair::Keypair;
+    /// # use solana_signer::Signer;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let balance = rpc_client.get_token_account_balance(&Keypair::new().pubkey())?;
+    /// assert_eq!(balance.amount, "0");
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_token_account_balance(&self, pubkey: &Pubkey) -> ClientResult<UiTokenAmount> {
         self.invoke((self.rpc_client.as_ref()).get_token_account_balance(pubkey))
     }
 
+    /// Returns the SPL token balance for the provided token account using the given
+    /// [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenAccountBalance`] RPC method.
+    ///
+    /// [`getTokenAccountBalance`]: https://solana.com/docs/rpc/http/gettokenaccountbalance
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_commitment_config::CommitmentConfig;
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # use solana_keypair::Keypair;
+    /// # use solana_signer::Signer;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let balance = rpc_client.get_token_account_balance_with_commitment(
+    ///     &Keypair::new().pubkey(),
+    ///     CommitmentConfig::processed(),
+    /// )?;
+    /// assert_eq!(balance.amount, "0");
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_token_account_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
@@ -3583,6 +3971,33 @@ impl RpcClient {
         )
     }
 
+    /// Returns SPL token accounts delegated to the provided authority.
+    ///
+    /// The `token_account_filter` argument matches the filters supported by the
+    /// [`getTokenAccountsByDelegate`] RPC method.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenAccountsByDelegate`] RPC method.
+    ///
+    /// [`getTokenAccountsByDelegate`]: https://solana.com/docs/rpc/http/gettokenaccountsbydelegate
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # use solana_rpc_client_api::request::TokenAccountsFilter;
+    /// # use solana_keypair::Keypair;
+    /// # use solana_signer::Signer;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let delegate = Keypair::new().pubkey();
+    /// let accounts = rpc_client.get_token_accounts_by_delegate(
+    ///     &delegate,
+    ///     TokenAccountsFilter::ProgramId(Keypair::new().pubkey()),
+    /// )?;
+    /// assert!(accounts.is_empty());
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_token_accounts_by_delegate(
         &self,
         delegate: &Pubkey,
@@ -3594,6 +4009,16 @@ impl RpcClient {
         )
     }
 
+    /// Returns SPL token accounts delegated to the provided authority using the specified
+    /// [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenAccountsByDelegate`] RPC method.
+    ///
+    /// [`getTokenAccountsByDelegate`]: https://solana.com/docs/rpc/http/gettokenaccountsbydelegate
     pub fn get_token_accounts_by_delegate_with_commitment(
         &self,
         delegate: &Pubkey,
@@ -3609,6 +4034,30 @@ impl RpcClient {
         )
     }
 
+    /// Returns SPL token accounts owned by the provided wallet or program address.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenAccountsByOwner`] RPC method.
+    ///
+    /// [`getTokenAccountsByOwner`]: https://solana.com/docs/rpc/http/gettokenaccountsbyowner
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # use solana_rpc_client_api::request::TokenAccountsFilter;
+    /// # use solana_keypair::Keypair;
+    /// # use solana_signer::Signer;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let owner = Keypair::new().pubkey();
+    /// let accounts = rpc_client.get_token_accounts_by_owner(
+    ///     &owner,
+    ///     TokenAccountsFilter::ProgramId(Keypair::new().pubkey()),
+    /// )?;
+    /// assert!(accounts.is_empty());
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_token_accounts_by_owner(
         &self,
         owner: &Pubkey,
@@ -3619,6 +4068,16 @@ impl RpcClient {
         )
     }
 
+    /// Returns SPL token accounts owned by the provided address using the specified
+    /// [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenAccountsByOwner`] RPC method.
+    ///
+    /// [`getTokenAccountsByOwner`]: https://solana.com/docs/rpc/http/gettokenaccountsbyowner
     pub fn get_token_accounts_by_owner_with_commitment(
         &self,
         owner: &Pubkey,
@@ -3634,6 +4093,26 @@ impl RpcClient {
         )
     }
 
+    /// Returns the largest token accounts for a mint, ordered by balance.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenLargestAccounts`] RPC method.
+    ///
+    /// [`getTokenLargestAccounts`]: https://solana.com/docs/rpc/http/gettokenlargestaccounts
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # use solana_keypair::Keypair;
+    /// # use solana_signer::Signer;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let mint = Keypair::new().pubkey();
+    /// let accounts = rpc_client.get_token_largest_accounts(&mint)?;
+    /// assert!(accounts.is_empty());
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_token_largest_accounts(
         &self,
         mint: &Pubkey,
@@ -3641,6 +4120,15 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).get_token_largest_accounts(mint))
     }
 
+    /// Returns the largest token accounts for a mint using the specified [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenLargestAccounts`] RPC method.
+    ///
+    /// [`getTokenLargestAccounts`]: https://solana.com/docs/rpc/http/gettokenlargestaccounts
     pub fn get_token_largest_accounts_with_commitment(
         &self,
         mint: &Pubkey,
@@ -3652,10 +4140,39 @@ impl RpcClient {
         )
     }
 
+    /// Returns supply information for an SPL token mint.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenSupply`] RPC method.
+    ///
+    /// [`getTokenSupply`]: https://solana.com/docs/rpc/http/gettokensupply
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # use solana_keypair::Keypair;
+    /// # use solana_signer::Signer;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let mint = Keypair::new().pubkey();
+    /// let supply = rpc_client.get_token_supply(&mint)?;
+    /// assert_eq!(supply.amount, "0");
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<UiTokenAmount> {
         self.invoke((self.rpc_client.as_ref()).get_token_supply(mint))
     }
 
+    /// Returns supply information for an SPL token mint using the provided [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getTokenSupply`] RPC method.
+    ///
+    /// [`getTokenSupply`]: https://solana.com/docs/rpc/http/gettokensupply
     pub fn get_token_supply_with_commitment(
         &self,
         mint: &Pubkey,
@@ -3666,10 +4183,37 @@ impl RpcClient {
         )
     }
 
+    /// Requests an air-drop of lamports to the provided address.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`requestAirdrop`] RPC method.
+    ///
+    /// [`requestAirdrop`]: https://solana.com/docs/rpc/http/requestairdrop
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_rpc_client::rpc_client::RpcClient;
+    /// # use solana_keypair::Keypair;
+    /// # use solana_signer::Signer;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let signature = rpc_client.request_airdrop(&Keypair::new().pubkey(), 1_000_000)?;
+    /// assert!(!signature.to_string().is_empty());
+    /// # Ok::<(), solana_rpc_client_api::client_error::Error>(())
+    /// ```
     pub fn request_airdrop(&self, pubkey: &Pubkey, lamports: u64) -> ClientResult<Signature> {
         self.invoke((self.rpc_client.as_ref()).request_airdrop(pubkey, lamports))
     }
 
+    /// Requests an air-drop while specifying a recent blockhash used for the transfer.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`requestAirdrop`] RPC method with an explicit
+    /// blockhash parameter.
+    ///
+    /// [`requestAirdrop`]: https://solana.com/docs/rpc/http/requestairdrop
     pub fn request_airdrop_with_blockhash(
         &self,
         pubkey: &Pubkey,
@@ -3683,6 +4227,16 @@ impl RpcClient {
         ))
     }
 
+    /// Requests an air-drop with fine-grained configuration.
+    ///
+    /// The `config` argument allows the caller to supply options such as the desired commitment or
+    /// a preselected blockhash.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`requestAirdrop`] RPC method.
+    ///
+    /// [`requestAirdrop`]: https://solana.com/docs/rpc/http/requestairdrop
     pub fn request_airdrop_with_config(
         &self,
         pubkey: &Pubkey,
@@ -3694,6 +4248,12 @@ impl RpcClient {
         )
     }
 
+    /// Polls the network for the account's balance until a response is received.
+    ///
+    /// The method retries for up to one second, querying with the supplied [commitment level][cl].
+    /// It returns the balance the first time the request succeeds.
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
     pub fn poll_get_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
@@ -3704,6 +4264,12 @@ impl RpcClient {
         )
     }
 
+    /// Waits for an account balance to reach an expected value.
+    ///
+    /// The method polls [`poll_get_balance_with_commitment`] repeatedly. If `expected_balance` is
+    /// `Some`, the function returns the balance once it matches that value; otherwise it returns the
+    /// first retrieved balance. Any polling error is swallowed and reported as `None` to mirror the
+    /// historical behavior of this synchronous helper.
     pub fn wait_for_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
@@ -3747,6 +4313,14 @@ impl RpcClient {
         )
     }
 
+    /// Returns the number of confirmed blocks elapsed since the provided signature was observed.
+    ///
+    /// # RPC Reference
+    ///
+    /// This helper uses the [`getSignatureStatuses`] RPC method and inspects the
+    /// `confirmations` field of the response.
+    ///
+    /// [`getSignatureStatuses`]: https://solana.com/docs/rpc/http/getsignaturestatuses
     pub fn get_num_blocks_since_signature_confirmation(
         &self,
         signature: &Signature,
@@ -3756,10 +4330,26 @@ impl RpcClient {
         )
     }
 
+    /// Returns the most recent blockhash observed by the cluster.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getLatestBlockhash`] RPC method.
+    ///
+    /// [`getLatestBlockhash`]: https://solana.com/docs/rpc/http/getlatestblockhash
     pub fn get_latest_blockhash(&self) -> ClientResult<Hash> {
         self.invoke((self.rpc_client.as_ref()).get_latest_blockhash())
     }
 
+    /// Returns the most recent blockhash along with the last valid block height for commitment-aware clients.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getLatestBlockhash`] RPC method and uses the
+    /// provided [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    /// [`getLatestBlockhash`]: https://solana.com/docs/rpc/http/getlatestblockhash
     pub fn get_latest_blockhash_with_commitment(
         &self,
         commitment: CommitmentConfig,
@@ -3767,6 +4357,13 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).get_latest_blockhash_with_commitment(commitment))
     }
 
+    /// Checks whether a blockhash is still valid for submitting transactions.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`isBlockhashValid`] RPC method.
+    ///
+    /// [`isBlockhashValid`]: https://solana.com/docs/rpc/http/isblockhashvalid
     pub fn is_blockhash_valid(
         &self,
         blockhash: &Hash,
@@ -3775,18 +4372,36 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).is_blockhash_valid(blockhash, commitment))
     }
 
+    /// Returns the fee that the cluster would charge to process the provided message.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getFeeForMessage`] RPC method.
+    ///
+    /// [`getFeeForMessage`]: https://solana.com/docs/rpc/http/getfeeformessage
     pub fn get_fee_for_message(&self, message: &impl SerializableMessage) -> ClientResult<u64> {
         self.invoke((self.rpc_client.as_ref()).get_fee_for_message(message))
     }
 
+    /// Fetches a fresh latest blockhash, retrying until it differs from the provided value.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method repeatedly calls [`getLatestBlockhash`] until the returned value changes.
+    ///
+    /// [`getLatestBlockhash`]: https://solana.com/docs/rpc/http/getlatestblockhash
     pub fn get_new_latest_blockhash(&self, blockhash: &Hash) -> ClientResult<Hash> {
         self.invoke((self.rpc_client.as_ref()).get_new_latest_blockhash(blockhash))
     }
 
+    /// Returns accumulated transport metrics for this client instance.
     pub fn get_transport_stats(&self) -> RpcTransportStats {
         (self.rpc_client.as_ref()).get_transport_stats()
     }
 
+    /// Returns the slot at which a feature was activated, if it has been activated.
+    ///
+    /// The method downloads the feature account and deserializes it into a `Feature` struct.
     pub fn get_feature_activation_slot(&self, feature_id: &Pubkey) -> ClientResult<Option<Slot>> {
         self.get_account_with_commitment(feature_id, self.commitment())
             .and_then(|maybe_feature_account| {
@@ -3806,6 +4421,7 @@ impl RpcClient {
             })
     }
 
+    /// Blocks on the provided future using the client's Tokio runtime.
     fn invoke<T, F: std::future::Future<Output = ClientResult<T>>>(&self, f: F) -> ClientResult<T> {
         // `block_on()` panics if called within an asynchronous execution context. Whereas
         // `block_in_place()` only panics if called from a current_thread runtime, which is the
@@ -3813,10 +4429,12 @@ impl RpcClient {
         tokio::task::block_in_place(move || self.runtime.as_ref().expect("runtime").block_on(f))
     }
 
+    /// Returns a reference to the underlying asynchronous RPC client.
     pub fn get_inner_client(&self) -> &Arc<nonblocking::rpc_client::RpcClient> {
         &self.rpc_client
     }
 
+    /// Returns the Tokio runtime used to execute blocking RPC calls.
     pub fn runtime(&self) -> &tokio::runtime::Runtime {
         self.runtime.as_ref().expect("runtime")
     }
@@ -4081,6 +4699,56 @@ mod tests {
                 .unwrap();
             assert_eq!(expected_minimum_delegation, actual_minimum_delegation);
         }
+    }
+
+    #[test]
+    fn test_get_slot_leader_variants() {
+        let expected_leader: Pubkey = PUBKEY.parse().unwrap();
+        let rpc_client = RpcClient::new_mock("succeeds".to_string());
+
+        let leader = rpc_client.get_slot_leader().unwrap();
+        assert_eq!(leader, expected_leader);
+
+        let leader_with_commitment = rpc_client
+            .get_slot_leader_with_commitment(CommitmentConfig::processed())
+            .unwrap();
+        assert_eq!(leader_with_commitment, expected_leader);
+
+        let leader_with_config = rpc_client
+            .get_slot_leader_with_config(RpcContextConfig {
+                commitment: Some(CommitmentConfig::confirmed()),
+                min_context_slot: Some(1),
+            })
+            .unwrap();
+        assert_eq!(leader_with_config, expected_leader);
+    }
+
+    #[test]
+    fn test_get_block_commitment() {
+        let rpc_client = RpcClient::new_mock("succeeds".to_string());
+        let commitment = rpc_client.get_block_commitment(5).unwrap();
+
+        assert_eq!(commitment.total_stake, 42);
+        let slots = commitment.commitment.expect("commitment available");
+        assert_eq!(slots.len(), MAX_LOCKOUT_HISTORY + 1);
+    }
+
+    #[test]
+    fn test_get_supply_aliases() {
+        let rpc_client = RpcClient::new_mock("succeeds".to_string());
+
+        let supply = rpc_client.supply().unwrap();
+        let supply_alias = rpc_client.get_supply().unwrap();
+        assert_eq!(supply, supply_alias);
+
+        let commitment = CommitmentConfig::processed();
+        let supply_with_commitment = rpc_client
+            .supply_with_commitment(commitment)
+            .unwrap();
+        let supply_with_commitment_alias = rpc_client
+            .get_supply_with_commitment(commitment)
+            .unwrap();
+        assert_eq!(supply_with_commitment, supply_with_commitment_alias);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Several public helpers in rpc_client.rs and nonblocking/rpc_client.rs lacked clear documentation and runnable examples, making it harder for developers to understand how to use the RPC methods.

#### Summary of Changes
- Added detailed documentation and examples for various helpers (token queries, blockhash utilities, stake waiters, supply aliases, transport methods)...
