### PR TITLE
make snapshot archive failure nonfatal

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -102,12 +102,8 @@ impl SnapshotPackagerService {
                             exit_backpressure.is_none(),
                         ));
                     if let Err(err) = archive_result {
-                        error!(
-                            "Stopping {}! Fatal error while archiving snapshot package: {err}",
-                            Self::NAME,
-                        );
-                        exit.store(true, Ordering::Relaxed);
-                        break;
+                        error!("Failed to archive snapshot package: {err}");
+                        continue;
                     }
 
                     if let Some(snapshot_gossip_manager) = snapshot_gossip_manager.as_mut() {


### PR DESCRIPTION
#### Problem
failing to archive snapshot brings down validator. lets not do this

#### Summary of Changes
simply log error and continue onto the next iteration of the loop. in the worst case, everyone will still have ledger and can make a snapshot
