### PR TITLE
Access slot list in AccountMapEntry through accessor helpers holding lock guards

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7099,7 +7099,7 @@ impl AccountsDb {
             for pubkey in map.keys() {
                 self.accounts_index.get_and_then(&pubkey, |account_entry| {
                     if let Some(account_entry) = account_entry {
-                        let list_r = &account_entry.slot_list_read_lock();
+                        let list_r = account_entry.slot_list_read_lock();
                         info!(" key: {} ref_count: {}", pubkey, account_entry.ref_count(),);
                         info!("      slots: {list_r:?}");
                     }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6449,7 +6449,7 @@ fn test_clean_old_storages_with_reclaims_rooted() {
     let slot_list = accounts_db
         .accounts_index
         .get_bin(&pubkey)
-        .slot_list_mut(&pubkey, |slot_list| slot_list.cloned_list())
+        .slot_list_mut(&pubkey, |slot_list| slot_list.clone_list())
         .unwrap();
     assert_eq!(slot_list.len(), slots.len());
     assert!(slot_list.iter().map(|(slot, _)| slot).eq(slots.iter()));
@@ -6462,7 +6462,7 @@ fn test_clean_old_storages_with_reclaims_rooted() {
     let slot_list = accounts_db
         .accounts_index
         .get_bin(&pubkey)
-        .slot_list_mut(&pubkey, |slot_list| slot_list.cloned_list())
+        .slot_list_mut(&pubkey, |slot_list| slot_list.clone_list())
         .unwrap();
     assert_eq!(slot_list.len(), 1);
     assert!(slot_list
@@ -6508,7 +6508,7 @@ fn test_clean_old_storages_with_reclaims_unrooted() {
     let slot_list = accounts_db
         .accounts_index
         .get_bin(&pubkey)
-        .slot_list_mut(&pubkey, |slot_list| slot_list.cloned_list())
+        .slot_list_mut(&pubkey, |slot_list| slot_list.clone_list())
         .unwrap();
     assert_eq!(slot_list.len(), slots.len());
     assert!(slot_list.iter().map(|(slot, _)| slot).eq(slots.iter()));
@@ -6520,7 +6520,7 @@ fn test_clean_old_storages_with_reclaims_unrooted() {
     let slot_list = accounts_db
         .accounts_index
         .get_bin(&pubkey)
-        .slot_list_mut(&pubkey, |slot_list| slot_list.cloned_list())
+        .slot_list_mut(&pubkey, |slot_list| slot_list.clone_list())
         .unwrap();
     assert_eq!(slot_list.len(), slots.len());
     assert!(slot_list.iter().map(|(slot, _)| slot).eq(slots.iter()));

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1835,12 +1835,11 @@ fn test_accounts_db_purge_keep_live() {
     accounts.print_accounts_stats("post_purge");
 
     // The earlier entry for pubkey in the account index is purged,
-    let (slot_list_len, index_slot) = {
-        let slot_list = accounts.accounts_index.get_and_then(&pubkey, |entry| {
-            (false, entry.unwrap().slot_list_read_lock().clone())
-        });
-        (slot_list.len(), slot_list[0].0)
-    };
+    let (slot_list_len, index_slot) = accounts.accounts_index.get_and_then(&pubkey, |entry| {
+        let slot_list = entry.unwrap().slot_list_read_lock();
+        (false, (slot_list.len(), slot_list[0].0))
+    });
+
     assert_eq!(slot_list_len, 1);
     // Zero lamport entry was not the one purged
     assert_eq!(index_slot, zero_lamport_slot);
@@ -6450,7 +6449,7 @@ fn test_clean_old_storages_with_reclaims_rooted() {
     let slot_list = accounts_db
         .accounts_index
         .get_bin(&pubkey)
-        .slot_list_mut(&pubkey, |slot_list| slot_list.clone())
+        .slot_list_mut(&pubkey, |slot_list| slot_list.cloned_list())
         .unwrap();
     assert_eq!(slot_list.len(), slots.len());
     assert!(slot_list.iter().map(|(slot, _)| slot).eq(slots.iter()));
@@ -6463,7 +6462,7 @@ fn test_clean_old_storages_with_reclaims_rooted() {
     let slot_list = accounts_db
         .accounts_index
         .get_bin(&pubkey)
-        .slot_list_mut(&pubkey, |slot_list| slot_list.clone())
+        .slot_list_mut(&pubkey, |slot_list| slot_list.cloned_list())
         .unwrap();
     assert_eq!(slot_list.len(), 1);
     assert!(slot_list
@@ -6509,7 +6508,7 @@ fn test_clean_old_storages_with_reclaims_unrooted() {
     let slot_list = accounts_db
         .accounts_index
         .get_bin(&pubkey)
-        .slot_list_mut(&pubkey, |slot_list| slot_list.clone())
+        .slot_list_mut(&pubkey, |slot_list| slot_list.cloned_list())
         .unwrap();
     assert_eq!(slot_list.len(), slots.len());
     assert!(slot_list.iter().map(|(slot, _)| slot).eq(slots.iter()));
@@ -6521,7 +6520,7 @@ fn test_clean_old_storages_with_reclaims_unrooted() {
     let slot_list = accounts_db
         .accounts_index
         .get_bin(&pubkey)
-        .slot_list_mut(&pubkey, |slot_list| slot_list.clone())
+        .slot_list_mut(&pubkey, |slot_list| slot_list.cloned_list())
         .unwrap();
     assert_eq!(slot_list.len(), slots.len());
     assert!(slot_list.iter().map(|(slot, _)| slot).eq(slots.iter()));

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -5,6 +5,7 @@ mod roots_tracker;
 mod secondary;
 use {
     crate::{
+        accounts_index::account_map_entry::SlotListWriteGuard,
         accounts_index_storage::{AccountsIndexStorage, Startup},
         ancestors::Ancestors,
         bucket_map_holder::Age,
@@ -202,7 +203,7 @@ pub trait IsCached {
     fn is_cached(&self) -> bool;
 }
 
-pub trait IndexValue: 'static + IsCached + IsZeroLamport + DiskIndexValue {}
+pub trait IndexValue: 'static + IsCached + IsZeroLamport + DiskIndexValue + Copy {}
 
 pub trait DiskIndexValue:
     'static + Clone + Debug + PartialEq + Copy + Default + Sync + Send
@@ -845,7 +846,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     fn slot_list_mut<RT>(
         &self,
         pubkey: &Pubkey,
-        user_fn: impl FnOnce(&mut SlotList<T>) -> RT,
+        user_fn: impl FnOnce(SlotListWriteGuard<T>) -> RT,
     ) -> Option<RT> {
         let read_lock = self.get_bin(pubkey);
         read_lock.slot_list_mut(pubkey, user_fn)
@@ -943,7 +944,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         slots_to_purge: impl for<'a> Contains<'a, Slot>,
         reclaims: &mut ReclaimsSlotList<T>,
     ) -> bool {
-        self.slot_list_mut(pubkey, |slot_list| {
+        self.slot_list_mut(pubkey, |mut slot_list| {
             slot_list.retain(|(slot, item)| {
                 let should_purge = slots_to_purge.contains(slot);
                 if should_purge {
@@ -1045,7 +1046,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         avoid_callback_result: Option<AccountsIndexScanResult>,
         filter: ScanFilter,
     ) where
-        F: FnMut(&'a Pubkey, Option<(&SlotList<T>, RefCount)>) -> AccountsIndexScanResult,
+        F: FnMut(&'a Pubkey, Option<(&[(Slot, T)], RefCount)>) -> AccountsIndexScanResult,
         I: Iterator<Item = &'a Pubkey>,
     {
         let mut lock = None;
@@ -1065,8 +1066,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                         let result = if let Some(result) = avoid_callback_result.as_ref() {
                             *result
                         } else {
-                            let slot_list = &locked_entry.slot_list_read_lock();
-                            callback(pubkey, Some((slot_list, locked_entry.ref_count())))
+                            let slot_list = locked_entry.slot_list_read_lock();
+                            callback(pubkey, Some((slot_list.as_ref(), locked_entry.ref_count())))
                         };
                         cache = match result {
                             AccountsIndexScanResult::Unref => {
@@ -1484,7 +1485,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
 
     fn purge_older_root_entries(
         &self,
-        slot_list: &mut SlotList<T>,
+        slot_list: &mut SlotListWriteGuard<T>,
         reclaims: &mut ReclaimsSlotList<T>,
         max_clean_root_inclusive: Option<Slot>,
     ) {
@@ -1531,8 +1532,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     ) -> bool {
         let mut is_slot_list_empty = false;
         let missing_in_accounts_index = self
-            .slot_list_mut(pubkey, |slot_list| {
-                self.purge_older_root_entries(slot_list, reclaims, max_clean_root_inclusive);
+            .slot_list_mut(pubkey, |mut slot_list| {
+                self.purge_older_root_entries(&mut slot_list, reclaims, max_clean_root_inclusive);
                 is_slot_list_empty = slot_list.is_empty();
             })
             .is_none();
@@ -1723,8 +1724,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     // if this account has no more entries. Note this does not update the secondary
     // indexes!
     pub fn purge_roots(&self, pubkey: &Pubkey) -> (SlotList<T>, bool) {
-        self.slot_list_mut(pubkey, |slot_list| {
-            let reclaims = self.get_rooted_entries(slot_list, None);
+        self.slot_list_mut(pubkey, |mut slot_list| {
+            let reclaims = self.get_rooted_entries(&slot_list, None);
             slot_list.retain(|(slot, _)| !self.is_alive_root(*slot));
             (reclaims, slot_list.is_empty())
         })
@@ -2158,7 +2159,7 @@ pub mod tests {
                 )
                 .into_account_map_entry(&index.storage.storage);
                 assert_eq!(new_entry.ref_count(), 0);
-                assert_eq!(new_entry.slot_list_read_lock().capacity(), 1);
+                assert_eq!(new_entry.slot_list_lock_read_len(), 1);
                 assert_eq!(
                     new_entry.slot_list_read_lock().to_vec(),
                     vec![(slot, account_info)]
@@ -2177,7 +2178,7 @@ pub mod tests {
                 )
                 .into_account_map_entry(&index.storage.storage);
                 assert_eq!(new_entry.ref_count(), 1);
-                assert_eq!(new_entry.slot_list_read_lock().capacity(), 1);
+                assert_eq!(new_entry.slot_list_lock_read_len(), 1);
                 assert_eq!(
                     new_entry.slot_list_read_lock().to_vec(),
                     vec![(slot, account_info)]
@@ -2270,7 +2271,7 @@ pub mod tests {
             let entry = entry.unwrap();
             let slot_list = entry.slot_list_read_lock();
             assert_eq!(entry.ref_count(), RefCount::from(!is_cached));
-            assert_eq!(slot_list.as_slice(), &[(slot0, account_infos[0])]);
+            assert_eq!(slot_list.as_ref(), &[(slot0, account_infos[0])]);
             let new_entry = PreAllocatedAccountMapEntry::new(
                 slot0,
                 account_infos[0],
@@ -2278,10 +2279,7 @@ pub mod tests {
                 false,
             )
             .into_account_map_entry(&index.storage.storage);
-            assert_eq!(
-                slot_list.as_slice(),
-                new_entry.slot_list_read_lock().as_slice(),
-            );
+            assert_eq!(slot_list.as_ref(), new_entry.slot_list_read_lock().as_ref(),);
             (false, ())
         });
 
@@ -2335,11 +2333,11 @@ pub mod tests {
 
             if should_have_reclaims {
                 assert_eq!(entry.ref_count(), 1);
-                assert_eq!(slot_list.as_slice(), &[(slot1, account_infos[1])],);
+                assert_eq!(slot_list.as_ref(), &[(slot1, account_infos[1])],);
             } else {
                 assert_eq!(entry.ref_count(), if is_cached { 0 } else { 2 });
                 assert_eq!(
-                    slot_list.as_slice(),
+                    slot_list.as_ref(),
                     &[(slot0, account_infos[0]), (slot1, account_infos[1])],
                 );
             }
@@ -3371,77 +3369,96 @@ pub mod tests {
     fn test_purge_older_root_entries() {
         // No roots, should be no reclaims
         let index = AccountsIndex::<bool, bool>::default_for_tests();
-        let mut slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        let entry = AccountMapEntry::new(
+            SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]),
+            1,
+            AccountMapEntryMeta::default(),
+        );
+        let mut slot_list = entry.slot_list_write_lock();
         let mut reclaims = ReclaimsSlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, None);
         assert!(reclaims.is_empty());
         assert_eq!(
-            slot_list,
+            slot_list.cloned_list(),
             SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
         );
 
         // Add a later root, earlier slots should be reclaimed
-        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         index.add_root(1);
         // Note 2 is not a root
         index.add_root(5);
         reclaims = ReclaimsSlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, None);
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
-        assert_eq!(slot_list, SlotList::from_iter([(5, true), (9, true)]));
-
+        assert_eq!(
+            slot_list.cloned_list(),
+            SlotList::from_iter([(5, true), (9, true)])
+        );
         // Add a later root that is not in the list, should not affect the outcome
-        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        slot_list.assign([(1 as Slot, true), (2, true), (5, true), (9, true)]);
         index.add_root(6);
         reclaims = ReclaimsSlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, None);
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
-        assert_eq!(slot_list, SlotList::from_iter([(5, true), (9, true)]));
+        assert_eq!(
+            slot_list.cloned_list(),
+            SlotList::from_iter([(5, true), (9, true)])
+        );
 
         // Pass a max root >= than any root in the slot list, should not affect
         // outcome
-        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(6));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
-        assert_eq!(slot_list, SlotList::from_iter([(5, true), (9, true)]));
+        assert_eq!(
+            slot_list.cloned_list(),
+            SlotList::from_iter([(5, true), (9, true)])
+        );
 
         // Pass a max root, earlier slots should be reclaimed
-        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(5));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
-        assert_eq!(slot_list, SlotList::from_iter([(5, true), (9, true)]));
+        assert_eq!(
+            slot_list.cloned_list(),
+            SlotList::from_iter([(5, true), (9, true)])
+        );
 
         // Pass a max root 2. This means the latest root < 2 is 1 because 2 is not a root
         // so nothing will be purged
-        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(2));
         assert!(reclaims.is_empty());
         assert_eq!(
-            slot_list,
+            slot_list.cloned_list(),
             SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
         );
 
         // Pass a max root 1. This means the latest root < 3 is 1 because 2 is not a root
         // so nothing will be purged
-        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(1));
         assert!(reclaims.is_empty());
         assert_eq!(
-            slot_list,
+            slot_list.cloned_list(),
             SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
         );
 
         // Pass a max root that doesn't exist in the list but is greater than
         // some of the roots in the list, shouldn't return those smaller roots
-        slot_list = SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)]);
+        slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(7));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
-        assert_eq!(slot_list, SlotList::from_iter([(5, true), (9, true)]));
+        assert_eq!(
+            slot_list.cloned_list(),
+            SlotList::from_iter([(5, true), (9, true)])
+        );
     }
 
     fn check_secondary_index_mapping_correct<SecondaryIndexEntryType>(
@@ -3560,7 +3577,7 @@ pub mod tests {
 
         secondary_indexes.keys = None;
 
-        index.slot_list_mut(&account_key, |slot_list| slot_list.clear());
+        index.slot_list_mut(&account_key, |mut slot_list| slot_list.clear());
 
         // Everything should be deleted
         let _ = index.handle_dead_keys(&[account_key], &secondary_indexes);
@@ -3671,8 +3688,8 @@ pub mod tests {
         // was outdated by the update in the later slot, the primary account key is still alive,
         // so both secondary keys will still be kept alive.
         index.add_root(later_slot);
-        index.slot_list_mut(&account_key, |slot_list| {
-            index.purge_older_root_entries(slot_list, &mut ReclaimsSlotList::new(), None)
+        index.slot_list_mut(&account_key, |mut slot_list| {
+            index.purge_older_root_entries(&mut slot_list, &mut ReclaimsSlotList::new(), None)
         });
 
         check_secondary_index_mapping_correct(
@@ -3950,7 +3967,7 @@ pub mod tests {
             let account_map_entry = entry.unwrap();
             let slot_list = account_map_entry.slot_list_read_lock();
             assert_eq!(2, slot_list.len());
-            assert_eq!(&[(slot1, value), (slot2, value)], slot_list.as_slice());
+            assert_eq!(&[(slot1, value), (slot2, value)], slot_list.as_ref());
             (false, ())
         });
         assert!(!index.clean_rooted_entries(&key, &mut gc, Some(slot2)));

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1737,7 +1737,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
 pub mod tests {
     use {
         super::*,
-        crate::bucket_map_holder::BucketMapHolder,
+        crate::{
+            accounts_index::account_map_entry::AccountMapEntryMeta,
+            bucket_map_holder::BucketMapHolder,
+        },
         secondary::DashMapSecondaryIndexEntry,
         solana_account::{AccountSharedData, WritableAccount},
         solana_pubkey::PUBKEY_BYTES,

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -203,7 +203,7 @@ pub trait IsCached {
     fn is_cached(&self) -> bool;
 }
 
-pub trait IndexValue: 'static + IsCached + IsZeroLamport + DiskIndexValue + Copy {}
+pub trait IndexValue: 'static + IsCached + IsZeroLamport + DiskIndexValue {}
 
 pub trait DiskIndexValue:
     'static + Clone + Debug + PartialEq + Copy + Default + Sync + Send

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -3382,7 +3382,7 @@ pub mod tests {
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, None);
         assert!(reclaims.is_empty());
         assert_eq!(
-            slot_list.cloned_list(),
+            slot_list.clone_list(),
             SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
         );
 
@@ -3395,7 +3395,7 @@ pub mod tests {
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, None);
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
         assert_eq!(
-            slot_list.cloned_list(),
+            slot_list.clone_list(),
             SlotList::from_iter([(5, true), (9, true)])
         );
         // Add a later root that is not in the list, should not affect the outcome
@@ -3405,7 +3405,7 @@ pub mod tests {
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, None);
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
         assert_eq!(
-            slot_list.cloned_list(),
+            slot_list.clone_list(),
             SlotList::from_iter([(5, true), (9, true)])
         );
 
@@ -3416,7 +3416,7 @@ pub mod tests {
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(6));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
         assert_eq!(
-            slot_list.cloned_list(),
+            slot_list.clone_list(),
             SlotList::from_iter([(5, true), (9, true)])
         );
 
@@ -3426,7 +3426,7 @@ pub mod tests {
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(5));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
         assert_eq!(
-            slot_list.cloned_list(),
+            slot_list.clone_list(),
             SlotList::from_iter([(5, true), (9, true)])
         );
 
@@ -3437,7 +3437,7 @@ pub mod tests {
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(2));
         assert!(reclaims.is_empty());
         assert_eq!(
-            slot_list.cloned_list(),
+            slot_list.clone_list(),
             SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
         );
 
@@ -3448,7 +3448,7 @@ pub mod tests {
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(1));
         assert!(reclaims.is_empty());
         assert_eq!(
-            slot_list.cloned_list(),
+            slot_list.clone_list(),
             SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
         );
 
@@ -3459,7 +3459,7 @@ pub mod tests {
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(7));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
         assert_eq!(
-            slot_list.cloned_list(),
+            slot_list.clone_list(),
             SlotList::from_iter([(5, true), (9, true)])
         );
     }

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -176,6 +176,7 @@ impl<T> SlotListWriteGuard<'_, T> {
     }
 
     /// Clears the list, removing all elements.
+    #[cfg(test)]
     pub fn clear(&mut self) {
         self.0.clear();
     }

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -147,6 +147,16 @@ impl<T> Deref for SlotListReadGuard<'_, T> {
     }
 }
 
+impl<T> SlotListReadGuard<'_, T> {
+    #[cfg(test)]
+    pub fn clone_list(&self) -> SlotList<T>
+    where
+        T: Copy,
+    {
+        self.0.iter().copied().collect()
+    }
+}
+
 /// Holds slot list lock for writing and provides mutable API translating changes to the slot list.
 #[derive(Debug)]
 pub struct SlotListWriteGuard<'a, T>(RwLockWriteGuard<'a, SlotList<T>>);

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -167,7 +167,7 @@ impl<T> SlotListWriteGuard<'_, T> {
         self.0.push(item);
     }
 
-    /// Retains only the elements specified by the predicate, passing a mutable reference to it.
+    /// Retains only the elements specified by the predicate.
     pub fn retain<F>(&mut self, f: F)
     where
         F: FnMut(&mut (Slot, T)) -> bool,

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -162,7 +162,7 @@ impl<T> SlotListWriteGuard<'_, T> {
     where
         F: FnMut(&mut (Slot, T)) -> bool,
     {
-        self.0.retain_mut(f)
+        self.0.retain(f)
     }
 
     /// Removes and returns the element at position `index` within the list, shifting all elements after it to the left.
@@ -187,7 +187,7 @@ impl<T> SlotListWriteGuard<'_, T> {
     }
 
     #[cfg(test)]
-    pub fn cloned_list(&self) -> SlotList<T>
+    pub fn clone_list(&self) -> SlotList<T>
     where
         T: Copy,
     {

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -19,7 +19,7 @@ use {
 /// one entry in the in-mem accounts index
 /// Represents the value for an account key in the in-memory accounts index
 #[derive(Debug)]
-pub struct AccountMapEntry<T: Copy> {
+pub struct AccountMapEntry<T> {
     /// number of alive slots that contain >= 1 instances of account data for this pubkey
     /// where alive represents a slot that has not yet been removed by clean via AccountsDB::clean_stored_dead_slots() for containing no up to date account information
     ref_count: AtomicRefCount,

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -5,16 +5,21 @@ use {
         is_zero_lamport::IsZeroLamport,
     },
     solana_clock::Slot,
-    std::sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, RwLock, RwLockReadGuard, RwLockWriteGuard,
+    std::{
+        fmt::Debug,
+        mem,
+        ops::Deref,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, RwLock, RwLockReadGuard, RwLockWriteGuard,
+        },
     },
 };
 
 /// one entry in the in-mem accounts index
 /// Represents the value for an account key in the in-memory accounts index
 #[derive(Debug)]
-pub struct AccountMapEntry<T> {
+pub struct AccountMapEntry<T: Copy> {
     /// number of alive slots that contain >= 1 instances of account data for this pubkey
     /// where alive represents a slot that has not yet been removed by clean via AccountsDB::clean_stored_dead_slots() for containing no up to date account information
     ref_count: AtomicRefCount,
@@ -108,16 +113,92 @@ impl<T: IndexValue> AccountMapEntry<T> {
         );
     }
 
+    /// Return length of the slot list
+    ///
+    /// Do not call it while guard from any locking function (`slot_list_*lock`) is active.
     pub fn slot_list_lock_read_len(&self) -> usize {
         self.slot_list.read().unwrap().len()
     }
 
-    pub fn slot_list_read_lock(&self) -> RwLockReadGuard<SlotList<T>> {
-        self.slot_list.read().unwrap()
+    /// Acquire a read lock on the slot list and return accessor for interpreting its representation
+    ///
+    /// Do not call any locking function (`slot_list_*lock*`) until the returned object is dropped.
+    pub fn slot_list_read_lock(&self) -> SlotListReadGuard<'_, T> {
+        SlotListReadGuard(self.slot_list.read().unwrap())
     }
 
-    pub fn slot_list_write_lock(&self) -> RwLockWriteGuard<SlotList<T>> {
-        self.slot_list.write().unwrap()
+    /// Acquire a write lock on the slot list and return accessor for modifying it
+    ///
+    /// Do not call any locking function (`slot_list_*lock*`) until the returned object is dropped.
+    pub fn slot_list_write_lock(&self) -> SlotListWriteGuard<'_, T> {
+        SlotListWriteGuard(self.slot_list.write().unwrap())
+    }
+}
+
+/// Holds slot list lock for reading and provides read access to its contents.
+#[derive(Debug)]
+pub struct SlotListReadGuard<'a, T>(RwLockReadGuard<'a, SlotList<T>>);
+
+impl<T> Deref for SlotListReadGuard<'_, T> {
+    type Target = [(Slot, T)];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+
+/// Holds slot list lock for writing and provides mutable API translating changes to the slot list.
+#[derive(Debug)]
+pub struct SlotListWriteGuard<'a, T>(RwLockWriteGuard<'a, SlotList<T>>);
+
+impl<T> SlotListWriteGuard<'_, T> {
+    /// Append element to the end of slot list
+    pub fn push(&mut self, item: (Slot, T)) {
+        self.0.push(item);
+    }
+
+    /// Retains only the elements specified by the predicate, passing a mutable reference to it.
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut (Slot, T)) -> bool,
+    {
+        self.0.retain_mut(f)
+    }
+
+    /// Removes and returns the element at position `index` within the list, shifting all elements after it to the left.
+    pub fn remove_at(&mut self, index: usize) -> (Slot, T) {
+        self.0.remove(index)
+    }
+
+    /// Replaces the element at position `index` within the list returning the previous element stored there.
+    pub fn replace_at(&mut self, index: usize, item: (Slot, T)) -> (Slot, T) {
+        mem::replace(&mut self.0[index], item)
+    }
+
+    /// Clears the list, removing all elements.
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    #[cfg(test)]
+    pub fn assign(&mut self, value: impl IntoIterator<Item = (Slot, T)>) {
+        *self.0 = value.into_iter().collect();
+    }
+
+    #[cfg(test)]
+    pub fn cloned_list(&self) -> SlotList<T>
+    where
+        T: Copy,
+    {
+        self.0.iter().copied().collect()
+    }
+}
+
+impl<T> Deref for SlotListWriteGuard<'_, T> {
+    type Target = [(Slot, T)];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
     }
 }
 

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -3,6 +3,7 @@ use {
         accounts_index::{
             account_map_entry::{
                 AccountMapEntry, AccountMapEntryMeta, PreAllocatedAccountMapEntry,
+                SlotListWriteGuard,
             },
             DiskIndexValue, IndexValue, ReclaimsSlotList, RefCount, SlotList, UpsertReclaim,
         },
@@ -162,7 +163,7 @@ struct StartupInfo<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
 
 #[derive(Default, Debug)]
 /// result from scanning in-mem index during flush
-struct FlushScanResult<T> {
+struct FlushScanResult<T: IndexValue> {
     /// pubkeys whose age indicates they may be evicted now, pending further checks.
     evictions_age_possible: Vec<(Pubkey, Arc<AccountMapEntry<T>>)>,
 }
@@ -450,13 +451,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     pub fn slot_list_mut<RT>(
         &self,
         pubkey: &Pubkey,
-        user_fn: impl FnOnce(&mut SlotList<T>) -> RT,
+        user_fn: impl FnOnce(SlotListWriteGuard<T>) -> RT,
     ) -> Option<RT> {
         self.get_internal_inner(pubkey, |entry| {
             (
                 true,
                 entry.map(|entry| {
-                    let result = user_fn(&mut entry.slot_list_write_lock());
+                    let result = user_fn(entry.slot_list_write_lock());
                     // note that to be safe here, we ALWAYS mark the entry as dirty
                     entry.set_dirty(true);
                     result
@@ -639,7 +640,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// is the number of entries added (1) - the number of uncached entries removed
     /// or replaced
     fn update_slot_list(
-        slot_list: &mut SlotList<T>,
+        slot_list: &mut SlotListWriteGuard<T>,
         slot: Slot,
         account_info: T,
         other_slot: Option<Slot>,
@@ -665,8 +666,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     let is_cur_account_cached = cur_account_info.is_cached();
 
                     // Replace the item
-                    let reclaim_item =
-                        std::mem::replace(&mut slot_list[slot_list_index], (slot, account_info));
+                    let reclaim_item = slot_list.replace_at(slot_list_index, (slot, account_info));
                     match reclaim {
                         UpsertReclaim::ReclaimOldSlots | UpsertReclaim::PopulateReclaims => {
                             // Reclaims are used to reclaim other versions of accounts when they are
@@ -693,8 +693,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 } else if reclaim == UpsertReclaim::ReclaimOldSlots {
                     let is_cur_account_cached = cur_account_info.is_cached();
                     if !is_cur_account_cached && *cur_slot < slot {
-                        let reclaim_item = slot_list[slot_list_index];
-                        slot_list.remove(slot_list_index);
+                        let reclaim_item = slot_list.remove_at(slot_list_index);
                         reclaims.push(reclaim_item);
                         ref_count_change -= 1;
                     }
@@ -1509,7 +1508,8 @@ mod tests {
         let unique_other_slot = new_slot + 1;
         for other_slot in [Some(new_slot), Some(unique_other_slot), None] {
             let mut reclaims = ReclaimsSlotList::new();
-            let mut slot_list = SlotList::new();
+            let entry = AccountMapEntry::empty_for_tests();
+            let mut slot_list = entry.slot_list_write_lock();
             // upserting into empty slot_list, so always addref
             assert_eq!(
                 InMemAccountsIndex::<u64, u64>::update_slot_list(
@@ -1523,13 +1523,18 @@ mod tests {
                 1,
                 "other_slot: {other_slot:?}"
             );
-            assert_eq!(slot_list, SlotList::from([at_new_slot]));
+            assert_eq!(slot_list.cloned_list(), SlotList::from([at_new_slot]));
             assert!(reclaims.is_empty());
         }
 
         // replace other
-        let mut slot_list = SlotList::from([(unique_other_slot, other_value)]);
-        let expected_reclaims = ReclaimsSlotList::from(slot_list.as_slice());
+        let entry = AccountMapEntry::new(
+            SlotList::from([(unique_other_slot, other_value)]),
+            1,
+            AccountMapEntryMeta::default(),
+        );
+        let mut slot_list = entry.slot_list_write_lock();
+        let expected_reclaims = ReclaimsSlotList::from(slot_list.as_ref());
         let other_slot = Some(unique_other_slot);
         let mut reclaims = ReclaimsSlotList::new();
         assert_eq!(
@@ -1547,7 +1552,7 @@ mod tests {
             0,
             "other_slot: {other_slot:?}"
         );
-        assert_eq!(slot_list, SlotList::from([at_new_slot]));
+        assert_eq!(slot_list.cloned_list(), SlotList::from([at_new_slot]));
         assert_eq!(reclaims, expected_reclaims);
 
         // nothing will exist at this slot
@@ -1608,12 +1613,17 @@ mod tests {
                     attempts += 1;
                     // initialize slot_list prior to call to 'InMemAccountsIndex::update_slot_list'
                     // by inserting each possible entry at each possible position
-                    let mut slot_list = content_source_indexes
-                        .iter()
-                        .map(|i| possible_initial_slot_list_contents[*i])
-                        .collect::<SlotList<_>>();
-                    let mut expected = slot_list.clone();
-                    let original = slot_list.clone();
+                    let entry = AccountMapEntry::new(
+                        content_source_indexes
+                            .iter()
+                            .map(|i| possible_initial_slot_list_contents[*i])
+                            .collect(),
+                        1,
+                        AccountMapEntryMeta::default(),
+                    );
+                    let mut slot_list = entry.slot_list_write_lock();
+                    let mut expected = slot_list.cloned_list();
+                    let original = slot_list.cloned_list();
                     let mut reclaims = ReclaimsSlotList::new();
 
                     let result = InMemAccountsIndex::<u64, u64>::update_slot_list(
@@ -1624,6 +1634,7 @@ mod tests {
                         &mut reclaims,
                         reclaim,
                     );
+                    let mut slot_list = slot_list.cloned_list();
 
                     // calculate expected reclaims
                     let mut expected_reclaims = ReclaimsSlotList::new();
@@ -1869,7 +1880,8 @@ mod tests {
         let unique_other_slot = new_slot + 1;
         for other_slot in [Some(new_slot), Some(unique_other_slot), None] {
             let mut reclaims = ReclaimsSlotList::new();
-            let mut slot_list = SlotList::new();
+            let entry = AccountMapEntry::empty_for_tests();
+            let mut slot_list = entry.slot_list_write_lock();
             // upserting into empty slot_list, so always addref
             assert_eq!(
                 InMemAccountsIndex::<u64, u64>::update_slot_list(
@@ -1883,13 +1895,18 @@ mod tests {
                 1,
                 "other_slot: {other_slot:?}"
             );
-            assert_eq!(slot_list, SlotList::from([at_new_slot]));
+            assert_eq!(slot_list.cloned_list(), SlotList::from([at_new_slot]));
             assert!(reclaims.is_empty());
         }
 
         // replace other
-        let mut slot_list = SlotList::from([(unique_other_slot, other_value)]);
-        let expected_reclaims = ReclaimsSlotList::from(slot_list.as_slice());
+        let entry = AccountMapEntry::new(
+            SlotList::from([(unique_other_slot, other_value)]),
+            1,
+            AccountMapEntryMeta::default(),
+        );
+        let mut slot_list = entry.slot_list_write_lock();
+        let expected_reclaims = ReclaimsSlotList::from(slot_list.as_ref());
         let other_slot = Some(unique_other_slot);
         let mut reclaims = ReclaimsSlotList::new();
         assert_eq!(
@@ -1907,7 +1924,7 @@ mod tests {
             0,
             "other_slot: {other_slot:?}"
         );
-        assert_eq!(slot_list, SlotList::from([at_new_slot]));
+        assert_eq!(slot_list.cloned_list(), SlotList::from([at_new_slot]));
         assert_eq!(reclaims, expected_reclaims);
 
         // nothing will exist at this slot
@@ -1974,12 +1991,17 @@ mod tests {
                     attempts += 1;
                     // initialize slot_list prior to call to 'InMemAccountsIndex::update_slot_list'
                     // by inserting each possible entry at each possible position
-                    let mut slot_list = content_source_indexes
-                        .iter()
-                        .map(|i| possible_initial_slot_list_contents[*i])
-                        .collect::<SlotList<_>>();
-                    let mut expected = slot_list.clone();
-                    let original = slot_list.clone();
+                    let entry = AccountMapEntry::new(
+                        content_source_indexes
+                            .iter()
+                            .map(|i| possible_initial_slot_list_contents[*i])
+                            .collect(),
+                        1,
+                        AccountMapEntryMeta::default(),
+                    );
+                    let mut slot_list = entry.slot_list_write_lock();
+                    let mut expected = slot_list.cloned_list();
+                    let original = slot_list.cloned_list();
                     let mut reclaims = ReclaimsSlotList::new();
 
                     let result = InMemAccountsIndex::<u64, u64>::update_slot_list(
@@ -1990,6 +2012,7 @@ mod tests {
                         &mut reclaims,
                         reclaim,
                     );
+                    let mut slot_list = slot_list.cloned_list();
 
                     // calculate expected reclaims
                     let mut expected_reclaims = ReclaimsSlotList::new();
@@ -2037,7 +2060,12 @@ mod tests {
     fn test_update_slot_list_new_slot_duplicate_panic(slot_to_replace: u64) {
         let new_slot = 1; // This slot already exists in the list
         let old_slot = 2; // This slot already exists in the list
-        let mut slot_list = SlotList::from_iter([(new_slot, 0u64), (old_slot, 0)]);
+        let entry = AccountMapEntry::new(
+            SlotList::from_iter([(new_slot, 0u64), (old_slot, 0)]),
+            1,
+            AccountMapEntryMeta::default(),
+        );
+        let mut slot_list = entry.slot_list_write_lock();
         let mut reclaims = ReclaimsSlotList::new();
         let new_info = 1;
 

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -163,7 +163,7 @@ struct StartupInfo<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
 
 #[derive(Default, Debug)]
 /// result from scanning in-mem index during flush
-struct FlushScanResult<T: IndexValue> {
+struct FlushScanResult<T> {
     /// pubkeys whose age indicates they may be evicted now, pending further checks.
     evictions_age_possible: Vec<(Pubkey, Arc<AccountMapEntry<T>>)>,
 }
@@ -1523,7 +1523,7 @@ mod tests {
                 1,
                 "other_slot: {other_slot:?}"
             );
-            assert_eq!(slot_list.cloned_list(), SlotList::from([at_new_slot]));
+            assert_eq!(slot_list.clone_list(), SlotList::from([at_new_slot]));
             assert!(reclaims.is_empty());
         }
 
@@ -1552,7 +1552,7 @@ mod tests {
             0,
             "other_slot: {other_slot:?}"
         );
-        assert_eq!(slot_list.cloned_list(), SlotList::from([at_new_slot]));
+        assert_eq!(slot_list.clone_list(), SlotList::from([at_new_slot]));
         assert_eq!(reclaims, expected_reclaims);
 
         // nothing will exist at this slot
@@ -1622,8 +1622,8 @@ mod tests {
                         AccountMapEntryMeta::default(),
                     );
                     let mut slot_list = entry.slot_list_write_lock();
-                    let mut expected = slot_list.cloned_list();
-                    let original = slot_list.cloned_list();
+                    let mut expected = slot_list.clone_list();
+                    let original = slot_list.clone_list();
                     let mut reclaims = ReclaimsSlotList::new();
 
                     let result = InMemAccountsIndex::<u64, u64>::update_slot_list(
@@ -1634,7 +1634,7 @@ mod tests {
                         &mut reclaims,
                         reclaim,
                     );
-                    let mut slot_list = slot_list.cloned_list();
+                    let mut slot_list = slot_list.clone_list();
 
                     // calculate expected reclaims
                     let mut expected_reclaims = ReclaimsSlotList::new();
@@ -1895,7 +1895,7 @@ mod tests {
                 1,
                 "other_slot: {other_slot:?}"
             );
-            assert_eq!(slot_list.cloned_list(), SlotList::from([at_new_slot]));
+            assert_eq!(slot_list.clone_list(), SlotList::from([at_new_slot]));
             assert!(reclaims.is_empty());
         }
 
@@ -1924,7 +1924,7 @@ mod tests {
             0,
             "other_slot: {other_slot:?}"
         );
-        assert_eq!(slot_list.cloned_list(), SlotList::from([at_new_slot]));
+        assert_eq!(slot_list.clone_list(), SlotList::from([at_new_slot]));
         assert_eq!(reclaims, expected_reclaims);
 
         // nothing will exist at this slot
@@ -2000,8 +2000,8 @@ mod tests {
                         AccountMapEntryMeta::default(),
                     );
                     let mut slot_list = entry.slot_list_write_lock();
-                    let mut expected = slot_list.cloned_list();
-                    let original = slot_list.cloned_list();
+                    let mut expected = slot_list.clone_list();
+                    let original = slot_list.clone_list();
                     let mut reclaims = ReclaimsSlotList::new();
 
                     let result = InMemAccountsIndex::<u64, u64>::update_slot_list(
@@ -2012,7 +2012,7 @@ mod tests {
                         &mut reclaims,
                         reclaim,
                     );
-                    let mut slot_list = slot_list.cloned_list();
+                    let mut slot_list = slot_list.clone_list();
 
                     // calculate expected reclaims
                     let mut expected_reclaims = ReclaimsSlotList::new();


### PR DESCRIPTION
This PR builds ground for changing underlying representation of slot list (https://github.com/anza-xyz/agave/pull/8206)

#### Problem
When operating on slot list in `AccountMapEntry` lots of code relies on direct access to its representation, i.e. `SlotList` accessed through a `RwLock` guards.
This limits implementation from adjusting representation / implementation details of storing and updating slot list.

#### Summary of Changes
* create accessor helpers for read and write access to slot list (currently they are newtypes holding lock guards and passing through operations to the underlying slot list)
* write access is now done through specific limited API instead of `DerefMut` to the `SlotList`
* both read and write accessors implement `Deref` to `[(Slot, T)]`, which might be limited further in future (e.g. specific read API would make it more flexible in whether we can provide a slice) 
