### PR TITLE
Implement plumbing steps for passing in obsolete accounts to rebuild_storage

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -6,7 +6,6 @@ use {
         epoch_stakes::VersionedEpochStakes,
         rent_collector::RentCollector,
         runtime_config::RuntimeConfig,
-        serde_snapshot::storage::SerdeObsoleteAccounts,
         snapshot_utils::{SnapshotError, StorageAndNextAccountsFileId},
         stake_account::StakeAccount,
         stakes::{serialize_stake_accounts_to_delegation_format, Stakes},
@@ -63,7 +62,7 @@ mod utils;
 
 pub(crate) use {
     status_cache::{deserialize_status_cache, serialize_status_cache},
-    storage::{SerializableAccountStorageEntry, SerializedAccountsFileId},
+    storage::{SerdeObsoleteAccounts, SerializableAccountStorageEntry, SerializedAccountsFileId},
 };
 
 const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1936,9 +1936,6 @@ pub fn rebuild_storages_from_snapshot_dir(
     let accounts_hardlinks = bank_snapshot_dir.join(SNAPSHOT_ACCOUNTS_HARDLINKS);
     let account_run_paths: HashSet<_> = HashSet::from_iter(account_paths);
 
-    // Initialize the obsolete account structure
-    let obsolete_accounts = HashMap::new();
-
     let read_dir = fs::read_dir(&accounts_hardlinks).map_err(|err| {
         IoError::other(format!(
             "failed to read accounts hardlinks dir '{}': {err}",
@@ -2016,7 +2013,7 @@ pub fn rebuild_storages_from_snapshot_dir(
         next_append_vec_id,
         SnapshotFrom::Dir,
         storage_access,
-        Some(obsolete_accounts),
+        None,
     )?;
 
     Ok((storage, bank_fields, accounts_db_fields))

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1874,6 +1874,7 @@ fn unarchive_snapshot(
                     next_append_vec_id,
                     SnapshotFrom::Archive,
                     accounts_db_config.storage_access,
+                    None,
                 )?,
                 measure_name
             );
@@ -1934,6 +1935,9 @@ pub fn rebuild_storages_from_snapshot_dir(
     let bank_snapshot_dir = &snapshot_info.snapshot_dir;
     let accounts_hardlinks = bank_snapshot_dir.join(SNAPSHOT_ACCOUNTS_HARDLINKS);
     let account_run_paths: HashSet<_> = HashSet::from_iter(account_paths);
+
+    // Initialize the obsolete account structure
+    let obsolete_accounts = HashMap::new();
 
     let read_dir = fs::read_dir(&accounts_hardlinks).map_err(|err| {
         IoError::other(format!(
@@ -2012,6 +2016,7 @@ pub fn rebuild_storages_from_snapshot_dir(
         next_append_vec_id,
         SnapshotFrom::Dir,
         storage_access,
+        Some(obsolete_accounts),
     )?;
 
     Ok((storage, bank_fields, accounts_db_fields))

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -4,8 +4,8 @@ use {
     super::{SnapshotError, SnapshotFrom},
     crate::serde_snapshot::{
         reconstruct_single_storage, remap_and_reconstruct_single_storage,
-        snapshot_storage_lengths_from_fields, AccountsDbFields, SerializableAccountStorageEntry,
-        SerializedAccountsFileId,
+        snapshot_storage_lengths_from_fields, AccountsDbFields, SerdeObsoleteAccounts,
+        SerializableAccountStorageEntry, SerializedAccountsFileId,
     },
     crossbeam_channel::{select, unbounded, Receiver, Sender},
     dashmap::DashMap,
@@ -56,6 +56,8 @@ pub(crate) struct SnapshotStorageRebuilder {
     snapshot_from: SnapshotFrom,
     /// specify how storages are accessed
     storage_access: StorageAccess,
+    /// obsolete accounts for all storages
+    obsolete_accounts: Option<Mutex<HashMap<Slot, SerdeObsoleteAccounts>>>,
 }
 
 impl SnapshotStorageRebuilder {
@@ -68,6 +70,7 @@ impl SnapshotStorageRebuilder {
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
+        obsolete_accounts: Option<HashMap<Slot, SerdeObsoleteAccounts>>,
     ) -> Result<AccountStorageMap, SnapshotError> {
         let snapshot_storage_lengths = snapshot_storage_lengths_from_fields(accounts_db_fields);
 
@@ -79,6 +82,7 @@ impl SnapshotStorageRebuilder {
             append_vec_files,
             snapshot_from,
             storage_access,
+            obsolete_accounts,
         )?;
 
         Ok(account_storage_map)
@@ -93,6 +97,7 @@ impl SnapshotStorageRebuilder {
         snapshot_storage_lengths: HashMap<Slot, HashMap<usize, usize>>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
+        obsolete_accounts: Option<HashMap<Slot, SerdeObsoleteAccounts>>,
     ) -> Self {
         let storage = DashMap::with_capacity_and_hasher(
             snapshot_storage_lengths.len(),
@@ -104,6 +109,7 @@ impl SnapshotStorageRebuilder {
                 (*slot, Mutex::new(Vec::with_capacity(storage_lengths.len())))
             })
             .collect();
+        let obsolete_accounts = obsolete_accounts.map(Mutex::new);
         Self {
             file_receiver,
             num_threads,
@@ -115,6 +121,7 @@ impl SnapshotStorageRebuilder {
             num_collisions: AtomicUsize::new(0),
             snapshot_from,
             storage_access,
+            obsolete_accounts,
         }
     }
 
@@ -127,6 +134,7 @@ impl SnapshotStorageRebuilder {
         append_vec_files: Vec<PathBuf>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
+        obsolete_accounts: Option<HashMap<Slot, SerdeObsoleteAccounts>>,
     ) -> Result<AccountStorageMap, SnapshotError> {
         let rebuilder = Arc::new(SnapshotStorageRebuilder::new(
             file_receiver,
@@ -135,6 +143,7 @@ impl SnapshotStorageRebuilder {
             snapshot_storage_lengths,
             snapshot_from,
             storage_access,
+            obsolete_accounts,
         ));
 
         let thread_pool = rebuilder.build_thread_pool();
@@ -252,7 +261,9 @@ impl SnapshotStorageRebuilder {
                         current_len,
                         old_append_vec_id as AccountsFileId,
                         self.storage_access,
-                        None,
+                        self.obsolete_accounts
+                            .as_ref()
+                            .and_then(|accounts| accounts.lock().unwrap().remove(&slot)),
                     )?,
                 };
 

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -20,7 +20,7 @@ use {
         accounts_file::StorageAccess,
     },
     solana_clock::Slot,
-    solana_nohash_hasher::BuildNoHashHasher,
+    solana_nohash_hasher::{BuildNoHashHasher, IntMap},
     std::{
         collections::HashMap,
         path::PathBuf,
@@ -57,7 +57,7 @@ pub(crate) struct SnapshotStorageRebuilder {
     /// specify how storages are accessed
     storage_access: StorageAccess,
     /// obsolete accounts for all storages
-    obsolete_accounts: Option<Mutex<HashMap<Slot, SerdeObsoleteAccounts>>>,
+    obsolete_accounts: Option<Mutex<IntMap<Slot, SerdeObsoleteAccounts>>>,
 }
 
 impl SnapshotStorageRebuilder {
@@ -70,7 +70,7 @@ impl SnapshotStorageRebuilder {
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
-        obsolete_accounts: Option<HashMap<Slot, SerdeObsoleteAccounts>>,
+        obsolete_accounts: Option<IntMap<Slot, SerdeObsoleteAccounts>>,
     ) -> Result<AccountStorageMap, SnapshotError> {
         let snapshot_storage_lengths = snapshot_storage_lengths_from_fields(accounts_db_fields);
 
@@ -97,7 +97,7 @@ impl SnapshotStorageRebuilder {
         snapshot_storage_lengths: HashMap<Slot, HashMap<usize, usize>>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
-        obsolete_accounts: Option<HashMap<Slot, SerdeObsoleteAccounts>>,
+        obsolete_accounts: Option<IntMap<Slot, SerdeObsoleteAccounts>>,
     ) -> Self {
         let storage = DashMap::with_capacity_and_hasher(
             snapshot_storage_lengths.len(),
@@ -134,7 +134,7 @@ impl SnapshotStorageRebuilder {
         append_vec_files: Vec<PathBuf>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
-        obsolete_accounts: Option<HashMap<Slot, SerdeObsoleteAccounts>>,
+        obsolete_accounts: Option<IntMap<Slot, SerdeObsoleteAccounts>>,
     ) -> Result<AccountStorageMap, SnapshotError> {
         let rebuilder = Arc::new(SnapshotStorageRebuilder::new(
             file_receiver,

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -20,7 +20,7 @@ use {
         accounts_file::StorageAccess,
     },
     solana_clock::Slot,
-    solana_nohash_hasher::{BuildNoHashHasher, IntMap},
+    solana_nohash_hasher::BuildNoHashHasher,
     std::{
         collections::HashMap,
         path::PathBuf,
@@ -57,7 +57,7 @@ pub(crate) struct SnapshotStorageRebuilder {
     /// specify how storages are accessed
     storage_access: StorageAccess,
     /// obsolete accounts for all storages
-    obsolete_accounts: Option<Mutex<IntMap<Slot, SerdeObsoleteAccounts>>>,
+    obsolete_accounts: Option<DashMap<Slot, SerdeObsoleteAccounts>>,
 }
 
 impl SnapshotStorageRebuilder {
@@ -70,7 +70,7 @@ impl SnapshotStorageRebuilder {
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
-        obsolete_accounts: Option<IntMap<Slot, SerdeObsoleteAccounts>>,
+        obsolete_accounts: Option<DashMap<Slot, SerdeObsoleteAccounts>>,
     ) -> Result<AccountStorageMap, SnapshotError> {
         let snapshot_storage_lengths = snapshot_storage_lengths_from_fields(accounts_db_fields);
 
@@ -97,7 +97,7 @@ impl SnapshotStorageRebuilder {
         snapshot_storage_lengths: HashMap<Slot, HashMap<usize, usize>>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
-        obsolete_accounts: Option<IntMap<Slot, SerdeObsoleteAccounts>>,
+        obsolete_accounts: Option<DashMap<Slot, SerdeObsoleteAccounts>>,
     ) -> Self {
         let storage = DashMap::with_capacity_and_hasher(
             snapshot_storage_lengths.len(),
@@ -109,7 +109,6 @@ impl SnapshotStorageRebuilder {
                 (*slot, Mutex::new(Vec::with_capacity(storage_lengths.len())))
             })
             .collect();
-        let obsolete_accounts = obsolete_accounts.map(Mutex::new);
         Self {
             file_receiver,
             num_threads,
@@ -134,7 +133,7 @@ impl SnapshotStorageRebuilder {
         append_vec_files: Vec<PathBuf>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
-        obsolete_accounts: Option<IntMap<Slot, SerdeObsoleteAccounts>>,
+        obsolete_accounts: Option<DashMap<Slot, SerdeObsoleteAccounts>>,
     ) -> Result<AccountStorageMap, SnapshotError> {
         let rebuilder = Arc::new(SnapshotStorageRebuilder::new(
             file_receiver,
@@ -261,9 +260,9 @@ impl SnapshotStorageRebuilder {
                         current_len,
                         old_append_vec_id as AccountsFileId,
                         self.storage_access,
-                        self.obsolete_accounts
-                            .as_ref()
-                            .and_then(|accounts| accounts.lock().unwrap().remove(&slot)),
+                        self.obsolete_accounts.as_ref().and_then(|accounts| {
+                            accounts.remove(&slot).map(|(_slot, accounts)| accounts)
+                        }),
                     )?,
                 };
 


### PR DESCRIPTION
#### Problem
Will need to passed deserialized obsolete accounts into rebuild_storage

#### Summary of Changes
- Pass in optional HashMap<Slot, SerdeObsoleteAccounts> to rebuild_storages
- When calling reconstruct_single_storage, extract Extract the SerdeObsoleteAccounts for the given slot from the hashmap
- Hashmap is optional to avoid having to lock the Mutex when unpacking from archives
- Next PR will populate the hashmap 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
