### PR TITLE
Fix UDP client binding to localhost breaking vote propagation

### DIFF
--- a/udp-client/Cargo.toml
+++ b/udp-client/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 async-trait = { workspace = true }
 solana-connection-cache = { workspace = true }

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -63,10 +63,17 @@ pub struct UdpConfig {
 
 impl NewConnectionConfig for UdpConfig {
     fn new() -> Result<Self, ClientError> {
+        // Use UNSPECIFIED for production validators to bind to all interfaces
+        // Use LOCALHOST only in tests to avoid port conflicts in CI
+        #[cfg(not(test))]
+        let bind_ip = std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
+        #[cfg(test)]
+        let bind_ip = std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+
         // This will bind to random ports, but VALIDATOR_PORT_RANGE is outside
         // of the range for CI tests when this is running in CI
         let socket = sockets::bind_in_range_with_config(
-            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            bind_ip,
             solana_net_utils::VALIDATOR_PORT_RANGE,
             SocketConfiguration::default(),
         )

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -64,10 +64,10 @@ pub struct UdpConfig {
 impl NewConnectionConfig for UdpConfig {
     fn new() -> Result<Self, ClientError> {
         // Use UNSPECIFIED for production validators to bind to all interfaces
-        // Use LOCALHOST only in tests to avoid port conflicts in CI
-        #[cfg(not(test))]
+        // Use LOCALHOST only in dev/test context to avoid port conflicts in CI
+        #[cfg(not(feature = "dev-context-only-utils"))]
         let bind_ip = std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
-        #[cfg(test)]
+        #[cfg(feature = "dev-context-only-utils")]
         let bind_ip = std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
 
         // This will bind to random ports, but VALIDATOR_PORT_RANGE is outside


### PR DESCRIPTION
Fixes #8339

Commit e1d78e1d04 changed UDP client socket binding from UNSPECIFIED (0.0.0.0) to LOCALHOST (127.0.0.1) to fix test port conflicts in #7490. This broke production validators by preventing vote packets from being sent on actual network interfaces.

**Impact:** Vote latency regressed from ~1 slot to ~2 slots between v2.3.11 and v3.0.4.

**Root cause:** Bisected the entire codebase from v2.3.11 to v3.0.4 and identified commit e1d78e1d04 as the regression point.

**Fix:** Use conditional compilation to bind to LOCALHOST only in tests while restoring UNSPECIFIED binding for production builds.

**Testing:** Tested fix on mainnet validator - vote latency restored to mostly 1s.