### PR TITLE
RFC: proposal to make networking tests less flaky

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2409,8 +2409,8 @@ pub struct Sockets {
 pub struct NodeConfig {
     /// The IP address advertised to the cluster in gossip
     pub advertised_ip: IpAddr,
-    /// The gossip port advertised to the cluster
-    pub gossip_port: u16,
+    pub gossip_sockets: Vec<UdpSocket>,
+    pub ip_echo_sockets: Vec<TcpListener>,
     pub port_range: PortRange,
     /// Multihoming: The IP addresses the node can bind to
     pub bind_ip_addrs: BindIpAddrs,
@@ -2882,9 +2882,13 @@ mod tests {
     fn new_with_external_ip_test_random() {
         let ip = Ipv4Addr::LOCALHOST;
         let port_range = localhost_port_range_for_tests();
+        let sockaddr = SocketAddr::new(IpAddr::V4(ip), port_range.0);
+        let gossip_sockets = vec![UdpSocket::bind(sockaddr).unwrap()];
+        let ip_echo_sockets = vec![TcpListener::bind(sockaddr).unwrap()];
         let config = NodeConfig {
             advertised_ip: IpAddr::V4(ip),
-            gossip_port: 0,
+            gossip_sockets,
+            ip_echo_sockets,
             port_range,
             bind_ip_addrs: BindIpAddrs::new(vec![IpAddr::V4(ip)]).unwrap(),
             public_tpu_addr: None,
@@ -2906,10 +2910,13 @@ mod tests {
         // port returned by `bind_in_range()` might be snatched up before `Node::new_with_external_ip()` runs
         let port_range = localhost_port_range_for_tests();
         let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let port = port_range.0;
+        let sockaddr = SocketAddr::new(ip, port_range.0);
+        let gossip_sockets = vec![UdpSocket::bind(sockaddr).unwrap()];
+        let ip_echo_sockets = vec![TcpListener::bind(sockaddr).unwrap()];
         let config = NodeConfig {
             advertised_ip: ip,
-            gossip_port: port,
+            gossip_sockets,
+            ip_echo_sockets,
             port_range,
             bind_ip_addrs: BindIpAddrs::new(vec![ip]).unwrap(),
             public_tpu_addr: None,

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -64,7 +64,7 @@ use {
         fmt::Display,
         fs::{self, remove_dir_all, File},
         io::Read,
-        net::{IpAddr, Ipv4Addr, SocketAddr},
+        net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, UdpSocket},
         num::{NonZero, NonZeroU64},
         path::{Path, PathBuf},
         str::FromStr,
@@ -1026,9 +1026,13 @@ impl TestValidator {
         )?;
         let node = {
             let bind_ip_addr = config.node_config.bind_ip_addr;
+            let sockaddr = SocketAddr::new(bind_ip_addr, config.node_config.gossip_addr.port());
+            let gossip_sockets = vec![UdpSocket::bind(sockaddr).unwrap()];
+            let ip_echo_sockets = vec![TcpListener::bind(sockaddr).unwrap()];
             let validator_node_config = NodeConfig {
                 bind_ip_addrs: BindIpAddrs::new(vec![bind_ip_addr])?,
-                gossip_port: config.node_config.gossip_addr.port(),
+                gossip_sockets,
+                ip_echo_sockets,
                 port_range: config.node_config.port_range,
                 advertised_ip: bind_ip_addr,
                 public_tpu_addr: None,


### PR DESCRIPTION
#### Problem

`NodeConfig` is used to "reserve" ports, which we bind sockets to later.  These result in test flakiness when the port numbers get used by some other test or process in between reservation and bind.

See https://buildkite.com/anza/alpenglow/builds/2068#0199aa45-5e61-4b23-9ce8-0da651e73d5f for an example.

Also see https://anza-xyz.slack.com/archives/C06GZ20BPQB/p1759500146705429 for a discussion on the problem.


#### Summary of Changes

This PR proposes to change `NodeConfig` so that instead of reserving ports, it creates the sockets right away.  CI is failing on it due to clippy issues however `cargo test` running locally on my dev machine passed.  I would like to get some feedback on the approach and if this makes sense or if there are any hidden gotchas that I am missing.  