### PR TITLE
ibrl: remove tpu coalesce

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -140,7 +140,7 @@ fn main() -> Result<()> {
                 packet_sender,
                 recycler.clone(),
                 stats.clone(),
-                Some(Duration::from_millis(1)), // coalesce
+                None, // coalesce
                 true,
                 None,
                 false,

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -46,7 +46,6 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 const SINK_REPORT_INTERVAL: Duration = Duration::from_secs(5);
 const SINK_RECEIVE_TIMEOUT: Duration = Duration::from_secs(1);
 const SOCKET_RECEIVE_TIMEOUT: Duration = Duration::from_secs(1);
-const COALESCE_TIME: Option<Duration> = Some(Duration::from_millis(1));
 
 fn sink(
     exit: Arc<AtomicBool>,
@@ -300,10 +299,10 @@ fn main() -> Result<()> {
                     s_reader,
                     recycler.clone(),
                     stats.clone(),
-                    COALESCE_TIME, // coalesce
-                    true,          // use_pinned_memory
-                    None,          // in_vote_only_mode
-                    false,         // is_staked_service
+                    None,  // coalesce
+                    true,  // use_pinned_memory
+                    None,  // in_vote_only_mode
+                    false, // is_staked_service
                 ));
             }
         }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -1,9 +1,7 @@
 //! The `tpu` module implements the Transaction Processing Unit, a
 //! multi-stage transaction processing pipeline in software.
 
-pub use {
-    crate::forwarding_stage::ForwardingClientOption, solana_streamer::quic::DEFAULT_TPU_COALESCE,
-};
+pub use crate::forwarding_stage::ForwardingClientOption;
 use {
     crate::{
         admin_rpc_post_init::{KeyUpdaterType, KeyUpdaters},
@@ -138,7 +136,6 @@ impl Tpu {
         replay_vote_receiver: ReplayVoteReceiver,
         replay_vote_sender: ReplayVoteSender,
         bank_notification_sender: Option<BankNotificationSenderConfig>,
-        tpu_coalesce: Duration,
         duplicate_confirmed_slot_sender: DuplicateConfirmedSlotsSender,
         client: ForwardingClientOption,
         turbine_quic_endpoint_sender: AsyncSender<(SocketAddr, Bytes)>,
@@ -186,7 +183,7 @@ impl Tpu {
             &forwarded_packet_sender,
             forwarded_packet_receiver,
             poh_recorder,
-            Some(tpu_coalesce),
+            None, // coalesce
             Some(bank_forks.read().unwrap().get_vote_only_mode_signal()),
             tpu_enable_udp,
         );
@@ -275,7 +272,6 @@ impl Tpu {
             let adapter = VortexorReceiverAdapter::new(
                 sockets,
                 Duration::from_millis(5),
-                tpu_coalesce,
                 non_vote_sender,
                 enable_block_production_forwarding.then(|| forward_stage_sender.clone()),
                 exit.clone(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -31,7 +31,7 @@ use {
         system_monitor_service::{
             verify_net_stats_access, SystemMonitorService, SystemMonitorStatsReportConfig,
         },
-        tpu::{ForwardingClientOption, Tpu, TpuSockets, DEFAULT_TPU_COALESCE},
+        tpu::{ForwardingClientOption, Tpu, TpuSockets},
         tvu::{Tvu, TvuConfig, TvuSockets},
     },
     agave_snapshots::{
@@ -351,7 +351,6 @@ pub struct ValidatorConfig {
     pub warp_slot: Option<Slot>,
     pub accounts_db_skip_shrink: bool,
     pub accounts_db_force_initial_clean: bool,
-    pub tpu_coalesce: Duration,
     pub staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
     pub validator_exit: Arc<RwLock<Exit>>,
     pub validator_exit_backpressure: HashMap<String, Arc<AtomicBool>>,
@@ -431,7 +430,6 @@ impl ValidatorConfig {
             warp_slot: None,
             accounts_db_skip_shrink: false,
             accounts_db_force_initial_clean: false,
-            tpu_coalesce: DEFAULT_TPU_COALESCE,
             staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
             validator_exit: Arc::new(RwLock::new(Exit::default())),
             validator_exit_backpressure: HashMap::default(),
@@ -577,14 +575,14 @@ impl ValidatorTpuConfig {
     pub fn new_for_tests(tpu_enable_udp: bool) -> Self {
         let tpu_quic_server_config = QuicServerParams {
             max_connections_per_ipaddr_per_min: 32,
-            coalesce_channel_size: 100_000, // smaller channel size for faster test
+            accumulator_channel_size: 100_000, // smaller channel size for faster test
             ..Default::default()
         };
 
         let tpu_fwd_quic_server_config = QuicServerParams {
             max_connections_per_ipaddr_per_min: 32,
             max_unstaked_connections: 0,
-            coalesce_channel_size: 100_000, // smaller channel size for faster test
+            accumulator_channel_size: 100_000, // smaller channel size for faster test
             ..Default::default()
         };
 
@@ -1717,7 +1715,6 @@ impl Validator {
             replay_vote_receiver,
             replay_vote_sender,
             bank_notification_sender,
-            config.tpu_coalesce,
             duplicate_confirmed_slot_sender,
             forwarding_tpu_client,
             turbine_quic_endpoint_sender,

--- a/core/src/vortexor_receiver_adapter.rs
+++ b/core/src/vortexor_receiver_adapter.rs
@@ -38,15 +38,13 @@ impl VortexorReceiverAdapter {
     pub fn new(
         sockets: Vec<Arc<UdpSocket>>,
         recv_timeout: Duration,
-        tpu_coalesce: Duration,
         packets_sender: TracedSender,
         forward_stage_sender: Option<Sender<(BankingPacketBatch, bool)>>,
         exit: Arc<AtomicBool>,
     ) -> Self {
         let (batch_sender, batch_receiver) = unbounded();
 
-        let receiver =
-            VerifiedPacketReceiver::new(sockets, &batch_sender, tpu_coalesce, None, exit.clone());
+        let receiver = VerifiedPacketReceiver::new(sockets, &batch_sender, None, exit.clone());
 
         let thread_hdl = Builder::new()
             .name("vtxRcvAdptr".to_string())

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -48,7 +48,6 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         warp_slot: config.warp_slot,
         accounts_db_skip_shrink: config.accounts_db_skip_shrink,
         accounts_db_force_initial_clean: config.accounts_db_force_initial_clean,
-        tpu_coalesce: config.tpu_coalesce,
         staked_nodes_overrides: config.staked_nodes_overrides.clone(),
         validator_exit: Arc::new(RwLock::new(Exit::default())),
         validator_exit_backpressure: config

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1027,6 +1027,11 @@ fn run_packet_batch_sender(
                 stats
                     .total_chunks_processed_by_batcher
                     .fetch_add(num_chunks, Ordering::Relaxed);
+
+                // prevent getting stuck in loop
+                if packet_batch.len() >= PACKETS_PER_BATCH {
+                    break;
+                }
             }
         }
     }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1602,13 +1602,11 @@ impl Future for EndpointAccept<'_> {
 pub mod test {
     use {
         super::*,
-        crate::{
-            nonblocking::{
-                quic::compute_max_allowed_uni_streams,
-                testing_utilities::{
-                    check_multiple_streams, get_client_config, make_client_endpoint,
-                    setup_quic_server, SpawnTestServerResult,
-                },
+        crate::nonblocking::{
+            quic::compute_max_allowed_uni_streams,
+            testing_utilities::{
+                check_multiple_streams, get_client_config, make_client_endpoint, setup_quic_server,
+                SpawnTestServerResult,
             },
         },
         assert_matches::assert_matches,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -993,8 +993,11 @@ fn run_packet_batch_sender(
                 break;
             }
 
-            // On the first receive, we block on recv.
-            // On subsequent receives, we call try_recv.
+            // On the first receive, we block on recv not to use excessive CPU when the channel is idle. 
+            // This will not block the exit as the channel will be dropped on the sender's side.
+            //
+            // On subsequent receives, we call try_recv, so that we do not get blocked waiting for packets
+            // when we already have something in the batch.
             let mut first = true;
             let mut recv = || {
                 if first {

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -224,18 +224,12 @@ pub fn spawn_server_with_cancel(
         .collect::<Result<Vec<_>, _>>()?;
     let stats = Arc::<StreamerStats>::default();
     let (packet_batch_sender, packet_batch_receiver) =
-        bounded(quic_server_params.coalesce_channel_size);
+        bounded(quic_server_params.accumulator_channel_size);
     task::spawn_blocking({
         let cancel = cancel.clone();
         let stats = stats.clone();
         move || {
-            run_packet_batch_sender(
-                packet_sender,
-                packet_batch_receiver,
-                stats,
-                quic_server_params.coalesce,
-                cancel,
-            );
+            run_packet_batch_sender(packet_sender, packet_batch_receiver, stats, cancel);
         }
     });
 
@@ -947,11 +941,9 @@ fn run_packet_batch_sender(
     packet_sender: Sender<PacketBatch>,
     packet_receiver: Receiver<PacketAccumulator>,
     stats: Arc<StreamerStats>,
-    coalesce: Duration,
     cancel: CancellationToken,
 ) {
     trace!("enter packet_batch_sender");
-    let mut batch_start_time = Instant::now();
     loop {
         let mut packet_perf_measure: Vec<([u8; 64], Instant)> = Vec::default();
         let mut packet_batch = BytesPacketBatch::with_capacity(PACKETS_PER_BATCH);
@@ -968,10 +960,7 @@ fn run_packet_batch_sender(
             if cancel.is_cancelled() {
                 return;
             }
-            let elapsed = batch_start_time.elapsed();
-            if packet_batch.len() >= PACKETS_PER_BATCH
-                || (!packet_batch.is_empty() && elapsed >= coalesce)
-            {
+            if !packet_batch.is_empty() {
                 let len = packet_batch.len();
                 track_streamer_fetch_packet_performance(&packet_perf_measure, &stats);
 
@@ -1004,28 +993,8 @@ fn run_packet_batch_sender(
                 break;
             }
 
-            let timeout_res = if !packet_batch.is_empty() {
-                // If we get here, elapsed < coalesce (see above if condition)
-                packet_receiver.recv_timeout(coalesce - elapsed)
-            } else {
-                // Small bit of non-idealness here: the holder(s) of the other end
-                // of packet_receiver must drop it (without waiting for us to exit)
-                // or we have a chance of sleeping here forever
-                // and never polling exit. Not a huge deal in practice as the
-                // only time this happens is when we tear down the server
-                // and at that time the other end does indeed not wait for us
-                // to exit here
-                packet_receiver
-                    .recv()
-                    .map_err(|_| crossbeam_channel::RecvTimeoutError::Disconnected)
-            };
-
-            if let Ok(mut packet_accumulator) = timeout_res {
-                // Start the timeout from when the packet batch first becomes non-empty
-                if packet_batch.is_empty() {
-                    batch_start_time = Instant::now();
-                }
-
+            /* try_iter() just calls try_recv().ok() under the hood, so we skip the abstraction here */
+            while let Ok(mut packet_accumulator) = packet_receiver.try_recv() {
                 // 86% of transactions/packets come in one chunk. In that case,
                 // we can just move the chunk to the `Packet` and no copy is
                 // made.
@@ -1641,7 +1610,6 @@ pub mod test {
                     setup_quic_server, SpawnTestServerResult,
                 },
             },
-            quic::DEFAULT_TPU_COALESCE,
         },
         assert_matches::assert_matches,
         crossbeam_channel::{unbounded, Receiver},
@@ -1797,13 +1765,7 @@ pub mod test {
         let handle = task::spawn_blocking({
             let cancel = cancel.clone();
             move || {
-                run_packet_batch_sender(
-                    pkt_batch_sender,
-                    pkt_receiver,
-                    stats,
-                    DEFAULT_TPU_COALESCE,
-                    cancel,
-                );
+                run_packet_batch_sender(pkt_batch_sender, pkt_receiver, stats, cancel);
             }
         });
 

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -198,6 +198,16 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             usage_warning:"Use --bind-address instead",
     );
     add_arg!(
+        // deprecated in v3.1.0
+        Arg::with_name("tpu_coalesce_ms")
+            .long("tpu-coalesce-ms")
+            .value_name("MILLISECS")
+            .takes_value(true)
+            .validator(is_parsable::<u64>)
+            .help("Milliseconds to wait in the TPU receiver for packet coalescing."),
+            usage_warning:"tpu_coalesce will be dropped (currently ignored)",
+    );
+    add_arg!(
         // deprecated in v3.0.0
         Arg::with_name("tpu_disable_quic")
             .long("tpu-disable-quic")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -791,14 +791,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("tpu_coalesce_ms")
-            .long("tpu-coalesce-ms")
-            .value_name("MILLISECS")
-            .takes_value(true)
-            .validator(is_parsable::<u64>)
-            .help("Milliseconds to wait in the TPU receiver for packet coalescing."),
-    )
-    .arg(
         Arg::with_name("tpu_connection_pool_size")
             .long("tpu-connection-pool-size")
             .takes_value(true)

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -62,7 +62,7 @@ use {
         snapshot_utils::{self, BANK_SNAPSHOTS_DIR},
     },
     solana_signer::Signer,
-    solana_streamer::quic::{QuicServerParams, DEFAULT_TPU_COALESCE},
+    solana_streamer::quic::QuicServerParams,
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
     solana_turbine::{
         broadcast_stage::BroadcastStageType,
@@ -78,7 +78,6 @@ use {
         process::exit,
         str::FromStr,
         sync::{atomic::AtomicBool, Arc, RwLock},
-        time::Duration,
     },
 };
 
@@ -162,9 +161,6 @@ pub fn execute(
 
     let private_rpc = matches.is_present("private_rpc");
     let do_port_check = !matches.is_present("no_port_check");
-    let tpu_coalesce = value_t!(matches, "tpu_coalesce_ms", u64)
-        .map(Duration::from_millis)
-        .unwrap_or(DEFAULT_TPU_COALESCE);
 
     let ledger_path = run_args.ledger_path;
 
@@ -587,7 +583,6 @@ pub fn execute(
         accounts_db_skip_shrink: true,
         accounts_db_force_initial_clean: matches.is_present("no_skip_initial_accounts_db_clean"),
         snapshot_config,
-        tpu_coalesce,
         no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),
         wait_to_vote_slot: None,
         runtime_config: RuntimeConfig {
@@ -955,7 +950,6 @@ pub fn execute(
         max_unstaked_connections: tpu_max_unstaked_connections.try_into().unwrap(),
         max_streams_per_ms,
         max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
-        coalesce: tpu_coalesce,
         num_threads: tpu_transaction_receive_threads,
         ..Default::default()
     };
@@ -966,7 +960,6 @@ pub fn execute(
         max_unstaked_connections: tpu_max_fwd_unstaked_connections.try_into().unwrap(),
         max_streams_per_ms,
         max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
-        coalesce: tpu_coalesce,
         num_threads: tpu_transaction_forward_receive_threads,
         ..Default::default()
     };

--- a/verified-packet-receiver/src/receiver.rs
+++ b/verified-packet-receiver/src/receiver.rs
@@ -7,7 +7,6 @@ use {
         net::UdpSocket,
         sync::{atomic::AtomicBool, Arc},
         thread::{self, JoinHandle},
-        time::Duration,
     },
 };
 
@@ -19,7 +18,6 @@ impl VerifiedPacketReceiver {
     pub fn new(
         sockets: Vec<Arc<UdpSocket>>,
         sender: &PacketBatchSender,
-        coalesce: Duration,
         in_vote_only_mode: Option<Arc<AtomicBool>>,
         exit: Arc<AtomicBool>,
     ) -> Self {
@@ -38,7 +36,7 @@ impl VerifiedPacketReceiver {
                     sender.clone(),
                     recycler.clone(),
                     tpu_stats.clone(),
-                    Some(coalesce),
+                    None, // coalesce
                     true,
                     in_vote_only_mode.clone(),
                     false, // is_staked_service

--- a/vortexor/src/cli.rs
+++ b/vortexor/src/cli.rs
@@ -4,7 +4,7 @@ use {
     solana_quic_definitions::QUIC_PORT_OFFSET,
     solana_streamer::quic::{
         DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_STAKED_CONNECTIONS,
-        DEFAULT_MAX_STREAMS_PER_MS, DEFAULT_MAX_UNSTAKED_CONNECTIONS, DEFAULT_TPU_COALESCE,
+        DEFAULT_MAX_STREAMS_PER_MS, DEFAULT_MAX_UNSTAKED_CONNECTIONS,
     },
     std::{
         net::{IpAddr, SocketAddr},
@@ -44,12 +44,6 @@ fn get_default_port_range() -> &'static str {
     let range = format!("{}-{}", VALIDATOR_PORT_RANGE.0, VALIDATOR_PORT_RANGE.1);
     let range: &'static str = Box::leak(range.into_boxed_str());
     range
-}
-
-fn get_default_tpu_coalesce_ms() -> &'static str {
-    let coalesce = DEFAULT_TPU_COALESCE.as_millis().to_string();
-    let coalesce: &'static str = Box::leak(coalesce.into_boxed_str());
-    coalesce
 }
 
 /// returns a parser which can validate input URL based on specified schemes.
@@ -137,10 +131,6 @@ pub struct Cli {
     /// Max streams per second for a streamer.
     #[arg(long, default_value_t = DEFAULT_MAX_STREAMS_PER_MS)]
     pub max_streams_per_ms: u64,
-
-    /// Milliseconds to wait in the TPU receiver for packet coalescing.
-    #[arg(long, default_value = get_default_tpu_coalesce_ms())]
-    pub tpu_coalesce_ms: u64,
 
     /// Redirect logging to the specified file, '-' for standard error. Sending the
     /// SIGUSR1 signal to the vortexor process will cause it to re-open the log file.

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -24,7 +24,6 @@ use {
         env,
         net::{IpAddr, SocketAddr},
         sync::{atomic::AtomicBool, Arc, RwLock},
-        time::Duration,
     },
     tokio_util::sync::CancellationToken,
 };
@@ -77,7 +76,6 @@ pub fn main() {
 
     let max_connections_per_ipaddr_per_min = args.max_connections_per_ipaddr_per_minute;
     let num_quic_endpoints = args.num_quic_endpoints;
-    let tpu_coalesce = Duration::from_millis(args.tpu_coalesce_ms);
     let dynamic_port_range = args.dynamic_port_range;
 
     let tpu_address = args.tpu_address;
@@ -202,7 +200,6 @@ pub fn main() {
         max_fwd_unstaked_connections,
         max_streams_per_ms,
         max_connections_per_ipaddr_per_min,
-        tpu_coalesce,
         &identity_keypair,
         cancel.clone(),
     );

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -19,7 +19,6 @@ use {
         net::{SocketAddr, UdpSocket},
         sync::{Arc, Mutex, RwLock},
         thread::{self, JoinHandle},
-        time::Duration,
     },
     tokio_util::sync::CancellationToken,
 };
@@ -114,7 +113,6 @@ impl Vortexor {
         max_fwd_unstaked_connections: usize,
         max_streams_per_ms: u64,
         max_connections_per_ipaddr_per_min: u64,
-        tpu_coalesce: Duration,
         identity_keypair: &Keypair,
         cancel: CancellationToken,
     ) -> Self {
@@ -125,7 +123,6 @@ impl Vortexor {
             max_streams_per_ms,
             max_connections_per_ipaddr_per_min,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-            coalesce: tpu_coalesce,
             ..Default::default()
         };
 

--- a/vortexor/tests/vortexor.rs
+++ b/vortexor/tests/vortexor.rs
@@ -14,7 +14,7 @@ use {
         nonblocking::testing_utilities::check_multiple_streams,
         quic::{
             DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_STAKED_CONNECTIONS,
-            DEFAULT_MAX_STREAMS_PER_MS, DEFAULT_MAX_UNSTAKED_CONNECTIONS, DEFAULT_TPU_COALESCE,
+            DEFAULT_MAX_STREAMS_PER_MS, DEFAULT_MAX_UNSTAKED_CONNECTIONS,
         },
         socket::SocketAddrSpace,
         streamer::StakedNodes,
@@ -76,7 +76,6 @@ async fn test_vortexor() {
         0, // max_fwd_unstaked_connections
         DEFAULT_MAX_STREAMS_PER_MS,
         DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-        DEFAULT_TPU_COALESCE,
         &keypair,
         cancel.clone(),
     );


### PR DESCRIPTION
#### Problem
presently the agave tpu has a 5 ms tpu coalesce period that is hit often by incoming packets. this is RBIL.

additionally, this affects certain diagnostics like recv-time in banking-trace (this is how i know it's hit often).

#### Summary of Changes
remove tpu coalsece from `solana-streamer` and all of its users.

We may want to observe what happens to the typical sigverify batch size with this change before merging. If the batch size is small, then we may need to rewrite how sigverify works to restore sigverify parallelism.
