### PR TITLE
Added fastboot version to BankSnapshotInfo

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2505,10 +2505,7 @@ mod tests {
         snapshot_utils::mark_bank_snapshot_as_loadable(&highest_bank_snapshot.snapshot_dir)
             .unwrap();
         let bank_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
-        assert_eq!(
-            bank_snapshot.snapshot_dir,
-            highest_bank_snapshot.snapshot_dir
-        );
+        assert_eq!(bank_snapshot.slot, highest_bank_snapshot.slot);
 
         // 4. delete highest bank snapshot, get_highest_loadable() should return NONE
         fs::remove_dir_all(&highest_bank_snapshot.snapshot_dir).unwrap();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2505,7 +2505,10 @@ mod tests {
         snapshot_utils::mark_bank_snapshot_as_loadable(&highest_bank_snapshot.snapshot_dir)
             .unwrap();
         let bank_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
-        assert_eq!(bank_snapshot, highest_bank_snapshot);
+        assert_eq!(
+            bank_snapshot.snapshot_dir,
+            highest_bank_snapshot.snapshot_dir
+        );
 
         // 4. delete highest bank snapshot, get_highest_loadable() should return NONE
         fs::remove_dir_all(&highest_bank_snapshot.snapshot_dir).unwrap();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -782,6 +782,7 @@ fn is_bank_snapshot_loadable(
     if let Some(version) = version {
         is_snapshot_fastboot_compatible(version)
     } else {
+        // No fastboot version file, so this is not a fastbootable
         Ok(false)
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -216,6 +216,9 @@ impl BankSnapshotInfo {
         let snapshot_fastboot_version_path =
             bank_snapshot_dir.join(SNAPSHOT_FASTBOOT_VERSION_FILENAME);
 
+        // If the version file is absent, fastboot_version will be None. This allows versions 3.1+
+        // to load snapshots created by versions <3.1. In version 3.2, the version file will become
+        // mandatory, and its absence can be treated as an error.
         let fastboot_version = fs::read_to_string(&snapshot_fastboot_version_path)
             .ok()
             .map(|version_string| {


### PR DESCRIPTION
#### Problem
- Fastboot version is not stored, so it cannot be checked later. It will be needed for obsolete accounts

#### Summary of Changes
- Add fastboot version to BankSnapshotInfo as an Option<>
- Populate it when reading the bank snapshot directory
- 
#### Notes
Let me know what you think of this approach. The other method I'm considering is here: 
https://github.com/anza-xyz/agave/pull/8361


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
