### PR TITLE
Version Two of the fix

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -153,7 +153,7 @@ pub struct LoadableBankSnapshotInfo {
     pub snapshot_dir: PathBuf,
     /// Snapshot version
     pub snapshot_version: SnapshotVersion,
-    /// Fastboot version
+    /// Fastboot version. Can be made non-optional in Version 3.2
     pub fastboot_version: Option<Version>,
 }
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -157,6 +157,12 @@ pub struct LoadableBankSnapshotInfo {
     pub fastboot_version: Option<Version>,
 }
 
+impl LoadableBankSnapshotInfo {
+    pub fn snapshot_path(&self) -> PathBuf {
+        self.snapshot_dir.join(get_snapshot_file_name(self.slot))
+    }
+}
+
 /// Information about a bank snapshot. Namely the slot of the bank, the path to the snapshot, and
 /// the kind of the snapshot.
 #[derive(PartialEq, Eq, Debug)]
@@ -1950,7 +1956,7 @@ fn streaming_snapshot_dir_files(
 /// Handles reading the snapshot file and version file,
 /// then returning those fields plus the rebuilt storages.
 pub fn rebuild_storages_from_snapshot_dir(
-    snapshot_info: &BankSnapshotInfo,
+    snapshot_info: &LoadableBankSnapshotInfo,
     account_paths: &[PathBuf],
     next_append_vec_id: Arc<AtomicAccountsFileId>,
     storage_access: StorageAccess,


### PR DESCRIPTION
#### Problem
- Fastboot version is not stored, so it cannot be checked later. It will be needed for obsolete accounts


#### Summary of Changes
- Add new type LoadableBankSnapshotInfo which has fastboot version
- Populate it when reading getting the highest loadable snapshot

#### Notes
- Let me know what you think of this approach. The other method I'm considering is here:
https://github.com/anza-xyz/agave/pull/8360

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
