### PR TITLE
nextest override for bench-tps & accounts-cluster-bench

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -127,3 +127,11 @@ slow-timeout = { period = "60s", terminate-after = 3 }
 [[profile.ci.overrides]]
 filter = 'package(solana-svm) & test(/^execute_fixtures/)'
 slow-timeout = { period = "60s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
+filter = "package(solana-bench-tps)"
+threads-required = "num-cpus"
+
+[[profile.ci.overrides]]
+filter = "package(solana-accounts-cluster-bench)"
+threads-required = "num-cpus"


### PR DESCRIPTION
#### Problem
The `bench-tps` and `account-cluster-bench` benchmarks allocate ports randomly, which can cause conflicts with ports already in use by other tests running in parallel.

#### Summary of Changes

- `bench-tps` and `account-cluster-bench` now have dedicated override which demands full thread count making it impossible to run in the same time as other stuff