### PR TITLE
make failure to send votes an error

### DIFF
--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -71,7 +71,7 @@ fn send_vote_transaction(
     let client = connection_cache.get_connection(&tpu);
 
     client.send_data_async(buf).map_err(|err| {
-        trace!("Ran into an error when sending vote: {err:?} to {tpu:?}");
+        error!("Ran into an error when sending vote: {err:?} to {tpu:?}");
         SendVoteError::from(err)
     })
 }


### PR DESCRIPTION
#### Problem

- Today sending votes to unrouteable address is silently ignored, this is not ideal

#### Summary of Changes

- At least we can make it a more visible error