### PR TITLE
Use Github REST API to download platform tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7653,6 +7653,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.23",
  "semver 1.0.27",
+ "serde",
  "serial_test",
  "solana-file-download",
  "solana-keypair",
@@ -8690,9 +8691,9 @@ dependencies = [
 
 [[package]]
 name = "solana-file-download"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842227f0ae5ebffdfe686597a909cb406d2bd9b92432c516503b8cbd490a3ea6"
+checksum = "f6884e13cc98f58e609a9b73e3d53f728f0f743b8c15c6768cad6f6382c336c1"
 dependencies = [
  "console 0.15.11",
  "indicatif 0.17.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -432,7 +432,7 @@ solana-feature-gate-interface = "3.0.0"
 solana-fee = { path = "fee", version = "=3.1.0" }
 solana-fee-calculator = "3.0.0"
 solana-fee-structure = "3.0.0"
-solana-file-download = "3.0.0"
+solana-file-download = "3.1.0"
 solana-frozen-abi = "3.0.0"
 solana-frozen-abi-macro = "3.0.0"
 solana-genesis = { path = "genesis", version = "=3.1.0" }

--- a/platform-tools-sdk/cargo-build-sbf/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/Cargo.toml
@@ -23,9 +23,10 @@ clap = { version = "3.1.5", features = ["cargo", "env"] }
 itertools = { workspace = true }
 log = { workspace = true, features = ["std"] }
 regex = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "rustls-tls", "rustls-tls-native-roots" ] }
+reqwest = { workspace = true, features = ["blocking", "rustls-tls", "rustls-tls-native-roots", "json" ] }
 semver = { workspace = true }
-solana-file-download = "=3.0.0"
+serde = { workspace = true }
+solana-file-download = "=3.1.0"
 solana-keypair = "=3.0.1"
 solana-logger = "=3.0.0"
 tar = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6870,9 +6870,9 @@ dependencies = [
 
 [[package]]
 name = "solana-file-download"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842227f0ae5ebffdfe686597a909cb406d2bd9b92432c516503b8cbd490a3ea6"
+checksum = "f6884e13cc98f58e609a9b73e3d53f728f0f743b8c15c6768cad6f6382c336c1"
 dependencies = [
  "console 0.15.11",
  "indicatif 0.17.12",


### PR DESCRIPTION
#### Problem

Downloads directly from the browser URL may fail in slow connections because Github now restricts them to a five minute window. One of the alternatives discussed in https://github.com/orgs/community/discussions/169381#discussioncomment-14105326 is using the Github REST API for the download.

This PR should fix https://github.com/anza-xyz/platform-tools/issues/108 and https://github.com/anza-xyz/platform-tools/issues/107.

#### Summary of Changes

1. Bump create `solana-file-download`.
2. Query Github for the object ID and download url.
3. Download from gihtub REST API.

