### PR TITLE
remote-wallet: remove superflous crate default feature

### DIFF
--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["linux-static-hidraw", "hidapi"]
+default = ["linux-static-hidraw"]
 linux-shared-hidraw = ["hidapi/linux-shared-hidraw"]
 linux-shared-libusb = ["hidapi/linux-shared-libusb"]
 linux-static-hidraw = ["hidapi/linux-static-hidraw"]


### PR DESCRIPTION
#### Problem
we specify the `hidapi` crate feature in remote-wallet default-features, but it is implied by `linux-static-hidraw` already specified in default-features to declare the hidapi backend

#### Summary of Changes
remove `hidapi` crate feature from default-features