### PR TITLE
Introduce new account layout for program-runtime

### DIFF
--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -1543,7 +1543,7 @@ mod tests {
         // Writing to shared writable account makes it unique (CoW logic)
         assert!(transaction_context
             .accounts()
-            .try_borrow(1)
+            .try_borrow_mut(1)
             .unwrap()
             .is_shared());
         memory_mapping
@@ -1551,7 +1551,7 @@ mod tests {
             .unwrap();
         assert!(!transaction_context
             .accounts()
-            .try_borrow(1)
+            .try_borrow_mut(1)
             .unwrap()
             .is_shared());
         assert_eq!(

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -51,6 +51,7 @@ solana-sha256-hasher = { workspace = true }
 solana-svm-callback = { workspace = true }
 solana-svm-feature-set = { workspace = true }
 solana-system-program = { path = ".", features = ["agave-unstable-api"] }
+solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
 
 [[bench]]
 name = "system"

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -153,15 +153,21 @@ impl Bank {
             return Err(DepositFeeError::InvalidAccountOwner);
         }
 
-        let recipient_pre_rent_state =
-            get_account_rent_state(&self.rent_collector().rent, &account);
+        let recipient_pre_rent_state = get_account_rent_state(
+            &self.rent_collector().rent,
+            account.lamports(),
+            account.data().len(),
+        );
         let distribution = account.checked_add_lamports(fees);
         if distribution.is_err() {
             return Err(DepositFeeError::LamportOverflow);
         }
 
-        let recipient_post_rent_state =
-            get_account_rent_state(&self.rent_collector().rent, &account);
+        let recipient_post_rent_state = get_account_rent_state(
+            &self.rent_collector().rent,
+            account.lamports(),
+            account.data().len(),
+        );
         let rent_state_transition_allowed =
             transition_allowed(&recipient_pre_rent_state, &recipient_post_rent_state);
         if !rent_state_transition_allowed {

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -401,12 +401,14 @@ pub fn validate_fee_payer(
             TransactionError::InsufficientFundsForFee
         })?;
 
-    let payer_pre_rent_state = get_account_rent_state(rent, payer_account);
+    let payer_pre_rent_state =
+        get_account_rent_state(rent, payer_account.lamports(), payer_account.data().len());
     payer_account
         .checked_sub_lamports(fee)
         .map_err(|_| TransactionError::InsufficientFundsForFee)?;
 
-    let payer_post_rent_state = get_account_rent_state(rent, payer_account);
+    let payer_post_rent_state =
+        get_account_rent_state(rent, payer_account.lamports(), payer_account.data().len());
     check_rent_state_with_account(
         &payer_pre_rent_state,
         &payer_post_rent_state,

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -3,7 +3,7 @@
 //! Rent management for SVM.
 
 use {
-    solana_account::{AccountSharedData, ReadableAccount},
+    solana_account::ReadableAccount,
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
@@ -80,7 +80,7 @@ pub fn check_rent_state_with_account(
 /// This method has a default implementation that treats accounts with zero
 /// lamports as uninitialized and uses the implemented `get_rent` to
 /// determine whether an account is rent-exempt.
-pub fn get_account_rent_state(rent: &Rent, account: &AccountSharedData) -> RentState {
+pub fn get_account_rent_state(rent: &Rent, account: &impl ReadableAccount) -> RentState {
     if account.lamports() == 0 {
         RentState::Uninitialized
     } else if rent.is_exempt(account.lamports(), account.data().len()) {

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -3,7 +3,6 @@
 //! Rent management for SVM.
 
 use {
-    solana_account::ReadableAccount,
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
@@ -80,15 +79,19 @@ pub fn check_rent_state_with_account(
 /// This method has a default implementation that treats accounts with zero
 /// lamports as uninitialized and uses the implemented `get_rent` to
 /// determine whether an account is rent-exempt.
-pub fn get_account_rent_state(rent: &Rent, account: &impl ReadableAccount) -> RentState {
-    if account.lamports() == 0 {
+pub fn get_account_rent_state(
+    rent: &Rent,
+    account_lamports: u64,
+    account_size: usize,
+) -> RentState {
+    if account_lamports == 0 {
         RentState::Uninitialized
-    } else if rent.is_exempt(account.lamports(), account.data().len()) {
+    } else if rent.is_exempt(account_lamports, account_size) {
         RentState::RentExempt
     } else {
         RentState::RentPaying {
-            data_size: account.data().len(),
-            lamports: account.lamports(),
+            data_size: account_size,
+            lamports: account_lamports,
         }
     }
 }

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -30,7 +30,11 @@ impl TransactionAccountStateInfo {
                         // balances; however they will never be loaded as writable
                         debug_assert!(!native_loader::check_id(account.owner()));
 
-                        Some(get_account_rent_state(rent, &*account))
+                        Some(get_account_rent_state(
+                            rent,
+                            account.lamports(),
+                            account.data().len(),
+                        ))
                     } else {
                         None
                     };

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -30,7 +30,7 @@ impl TransactionAccountStateInfo {
                         // balances; however they will never be loaded as writable
                         debug_assert!(!native_loader::check_id(account.owner()));
 
-                        Some(get_account_rent_state(rent, &account))
+                        Some(get_account_rent_state(rent, &*account))
                     } else {
                         None
                     };

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -18,11 +18,7 @@ use {
     solana_instructions_sysvar as instructions,
     solana_pubkey::Pubkey,
     solana_sbpf::memory_region::{AccessType, AccessViolationHandler, MemoryRegion},
-    std::{
-        cell::{Cell, UnsafeCell},
-        collections::HashSet,
-        rc::Rc,
-    },
+    std::{cell::Cell, collections::HashSet, rc::Rc},
 };
 #[cfg(not(target_os = "solana"))]
 use {solana_account::WritableAccount, solana_rent::Rent};
@@ -164,15 +160,11 @@ impl TransactionContext {
             return Err(InstructionError::CallDepth);
         }
 
-        let (accounts, _, _) = Rc::try_unwrap(self.accounts)
+        let accounts = Rc::try_unwrap(self.accounts)
             .expect("transaction_context.accounts has unexpected outstanding refs")
-            .take();
+            .deconstruct_into_account_shared_data();
 
-        Ok(UnsafeCell::into_inner(accounts)
-            .into_vec()
-            .into_iter()
-            .map(|(_, account)| account)
-            .collect())
+        Ok(accounts)
     }
 
     #[cfg(not(target_os = "solana"))]
@@ -1070,7 +1062,6 @@ impl From<TransactionContext> for ExecutionRecord {
         let (accounts, touched_flags, resize_delta) = Rc::try_unwrap(context.accounts)
             .expect("transaction_context.accounts has unexpected outstanding refs")
             .take();
-        let accounts = UnsafeCell::into_inner(accounts).into_vec();
         let touched_account_count = touched_flags
             .iter()
             .fold(0usize, |accumulator, was_touched| {

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -76,19 +76,6 @@ impl PartialEq<AccountSharedData> for TransactionAccountView<'_> {
     }
 }
 
-impl TransactionAccountView<'_> {
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn as_account_shared_data_for_tests(&self) -> AccountSharedData {
-        AccountSharedData::create(
-            self.lamports(),
-            self.data().to_vec(),
-            *self.owner(),
-            self.executable(),
-            self.rent_epoch(),
-        )
-    }
-}
-
 #[derive(Debug)]
 pub struct TransactionAccountMutView<'a> {
     svm_account: &'a mut SVMAccount,

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -2,26 +2,249 @@
 use qualifier_attr::qualifiers;
 use {
     crate::{IndexOfAccount, MAX_ACCOUNT_DATA_GROWTH_PER_TRANSACTION, MAX_ACCOUNT_DATA_LEN},
-    solana_account::AccountSharedData,
+    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_instruction::error::InstructionError,
     solana_pubkey::Pubkey,
     std::{
         cell::{Cell, UnsafeCell},
         ops::{Deref, DerefMut},
+        ptr,
+        sync::Arc,
     },
 };
 
+#[repr(C)]
+#[derive(Debug, PartialEq)]
+struct SVMAccount {
+    key: Pubkey,
+    owner: Pubkey,
+    lamports: u64,
+    // The payload is going to be filled with the guest virtual address of the account payload
+    // vector.
+    // payload: VmSlice,
+}
+
+#[derive(Debug, PartialEq)]
+struct SVMAccountDeprecated {
+    rent_epoch: u64,
+    executable: bool,
+}
+
+struct PrivateAccountFields {
+    deprecated_fields: SVMAccountDeprecated,
+    payload: Arc<Vec<u8>>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct TransactionAccountView<'a> {
+    svm_account: &'a SVMAccount,
+    deprecated_fields: &'a SVMAccountDeprecated,
+    payload: &'a [u8],
+}
+
+impl ReadableAccount for TransactionAccountView<'_> {
+    fn lamports(&self) -> u64 {
+        self.svm_account.lamports
+    }
+
+    fn data(&self) -> &[u8] {
+        self.payload
+    }
+
+    fn owner(&self) -> &Pubkey {
+        &self.svm_account.owner
+    }
+
+    fn executable(&self) -> bool {
+        self.deprecated_fields.executable
+    }
+
+    fn rent_epoch(&self) -> u64 {
+        self.deprecated_fields.rent_epoch
+    }
+
+    fn to_account_shared_data(&self) -> AccountSharedData {
+        panic!(
+            "TransactionAccountView can't be transformed into AccountSharedData without losing \
+             reference constraints"
+        );
+    }
+}
+
+impl PartialEq<AccountSharedData> for TransactionAccountView<'_> {
+    fn eq(&self, other: &AccountSharedData) -> bool {
+        other.lamports() == self.lamports()
+            && other.data() == self.data()
+            && other.owner() == self.owner()
+            && other.executable() == self.executable()
+            && other.rent_epoch() == self.rent_epoch()
+    }
+}
+
+impl TransactionAccountView<'_> {
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn as_account_shared_data_for_tests(&self) -> AccountSharedData {
+        AccountSharedData::create(
+            self.lamports(),
+            self.data().to_vec(),
+            *self.owner(),
+            self.executable(),
+            self.rent_epoch(),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct TransactionAccountMutView<'a> {
+    svm_account: &'a mut SVMAccount,
+    deprecated_fields: &'a mut SVMAccountDeprecated,
+    payload: &'a mut Arc<Vec<u8>>,
+}
+
+impl TransactionAccountMutView<'_> {
+    fn data_mut(&mut self) -> &mut Vec<u8> {
+        Arc::make_mut(self.payload)
+    }
+
+    pub(crate) fn resize(&mut self, new_len: usize, value: u8) {
+        self.data_mut().resize(new_len, value)
+    }
+
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    pub(crate) fn set_data_from_slice(&mut self, new_data: &[u8]) {
+        // If the buffer isn't shared, we're going to memcpy in place.
+        let Some(data) = Arc::get_mut(self.payload) else {
+            // If the buffer is shared, the cheapest thing to do is to clone the
+            // incoming slice and replace the buffer.
+            *self.payload = Arc::new(new_data.to_vec());
+            return;
+        };
+
+        let new_len = new_data.len();
+
+        // Reserve additional capacity if needed. Here we make the assumption
+        // that growing the current buffer is cheaper than doing a whole new
+        // allocation to make `new_data` owned.
+        //
+        // This assumption holds true during CPI, especially when the account
+        // size doesn't change but the account is only changed in place. And
+        // it's also true when the account is grown by a small margin (the
+        // realloc limit is quite low), in which case the allocator can just
+        // update the allocation metadata without moving.
+        //
+        // Shrinking and copying in place is always faster than making
+        // `new_data` owned, since shrinking boils down to updating the Vec's
+        // length.
+
+        data.reserve(new_len.saturating_sub(data.len()));
+
+        // Safety:
+        // We just reserved enough capacity. We set data::len to 0 to avoid
+        // possible UB on panic (dropping uninitialized elements), do the copy,
+        // finally set the new length once everything is initialized.
+        #[allow(clippy::uninit_vec)]
+        // this is a false positive, the lint doesn't currently special case set_len(0)
+        unsafe {
+            data.set_len(0);
+            ptr::copy_nonoverlapping(new_data.as_ptr(), data.as_mut_ptr(), new_len);
+            data.set_len(new_len);
+        };
+    }
+
+    pub(crate) fn extend_from_slice(&mut self, data: &[u8]) {
+        self.data_mut().extend_from_slice(data)
+    }
+
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        if let Some(data) = Arc::get_mut(self.payload) {
+            data.reserve(additional)
+        } else {
+            let mut data = Vec::with_capacity(self.payload.len().saturating_add(additional));
+            data.extend_from_slice(self.payload);
+            *self.payload = Arc::new(data);
+        }
+    }
+
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    pub(crate) fn is_shared(&self) -> bool {
+        Arc::strong_count(self.payload) > 1
+    }
+}
+
+impl ReadableAccount for TransactionAccountMutView<'_> {
+    fn lamports(&self) -> u64 {
+        self.svm_account.lamports
+    }
+
+    fn data(&self) -> &[u8] {
+        self.payload.as_slice()
+    }
+
+    fn owner(&self) -> &Pubkey {
+        &self.svm_account.owner
+    }
+
+    fn executable(&self) -> bool {
+        self.deprecated_fields.executable
+    }
+
+    fn rent_epoch(&self) -> u64 {
+        self.deprecated_fields.rent_epoch
+    }
+
+    fn to_account_shared_data(&self) -> AccountSharedData {
+        panic!(
+            "TransactionAccountViewMut can't be transformed into AccountSharedData without losing \
+             reference constraints"
+        );
+    }
+}
+
+impl WritableAccount for TransactionAccountMutView<'_> {
+    fn set_lamports(&mut self, lamports: u64) {
+        self.svm_account.lamports = lamports;
+    }
+
+    fn data_as_mut_slice(&mut self) -> &mut [u8] {
+        Arc::make_mut(self.payload).as_mut_slice()
+    }
+
+    fn set_owner(&mut self, owner: Pubkey) {
+        self.svm_account.owner = owner;
+    }
+
+    fn copy_into_owner_from_slice(&mut self, source: &[u8]) {
+        self.svm_account.owner.as_mut().copy_from_slice(source);
+    }
+
+    fn set_executable(&mut self, executable: bool) {
+        self.deprecated_fields.executable = executable;
+    }
+
+    fn set_rent_epoch(&mut self, epoch: u64) {
+        self.deprecated_fields.rent_epoch = epoch;
+    }
+
+    fn create(
+        _lamports: u64,
+        _data: Vec<u8>,
+        _owner: Pubkey,
+        _executable: bool,
+        _rent_epoch: u64,
+    ) -> Self {
+        panic!("It is not possible to create a TransactionAccountMutView");
+    }
+}
+
 /// An account key and the matching account
 pub type KeyedAccountSharedData = (Pubkey, AccountSharedData);
-pub(crate) type DeconstructedTransactionAccounts = (
-    UnsafeCell<Box<[KeyedAccountSharedData]>>,
-    Box<[Cell<bool>]>,
-    Cell<i64>,
-);
+pub(crate) type DeconstructedTransactionAccounts =
+    (Vec<KeyedAccountSharedData>, Box<[Cell<bool>]>, Cell<i64>);
 
 #[derive(Debug)]
 pub struct TransactionAccounts {
-    accounts: UnsafeCell<Box<[KeyedAccountSharedData]>>,
+    shared_account_fields: UnsafeCell<Box<[SVMAccount]>>,
+    private_account_fields: UnsafeCell<Box<[PrivateAccountFields]>>,
     borrow_counters: Box<[BorrowCounter]>,
     touched_flags: Box<[Cell<bool>]>,
     resize_delta: Cell<i64>,
@@ -33,9 +256,29 @@ impl TransactionAccounts {
     pub(crate) fn new(accounts: Vec<KeyedAccountSharedData>) -> TransactionAccounts {
         let touched_flags = vec![Cell::new(false); accounts.len()].into_boxed_slice();
         let borrow_counters = vec![BorrowCounter::default(); accounts.len()].into_boxed_slice();
-        let accounts = UnsafeCell::new(accounts.into_boxed_slice());
+        let (shared_accounts, private_fields) = accounts
+            .into_iter()
+            .map(|item| {
+                (
+                    SVMAccount {
+                        key: item.0,
+                        owner: *item.1.owner(),
+                        lamports: item.1.lamports(),
+                    },
+                    PrivateAccountFields {
+                        deprecated_fields: SVMAccountDeprecated {
+                            rent_epoch: item.1.rent_epoch(),
+                            executable: item.1.executable(),
+                        },
+                        payload: item.1.data_clone(),
+                    },
+                )
+            })
+            .collect::<(Vec<SVMAccount>, Vec<PrivateAccountFields>)>();
+
         TransactionAccounts {
-            accounts,
+            shared_account_fields: UnsafeCell::new(shared_accounts.into_boxed_slice()),
+            private_account_fields: UnsafeCell::new(private_fields.into_boxed_slice()),
             borrow_counters,
             touched_flags,
             resize_delta: Cell::new(0),
@@ -45,7 +288,7 @@ impl TransactionAccounts {
 
     pub(crate) fn len(&self) -> usize {
         // SAFETY: The borrow is local to this function and is only reading length.
-        unsafe { (*self.accounts.get()).len() }
+        unsafe { (*self.shared_account_fields.get()).len() }
     }
 
     #[cfg(not(target_os = "solana"))]
@@ -102,7 +345,22 @@ impl TransactionAccounts {
         // SAFETY: The borrow counter guarantees this is the only mutable borrow of this account.
         // The unwrap is safe because accounts.len() == borrow_counters.len(), so the missing
         // account error should have been returned above.
-        let account = unsafe { &mut (*self.accounts.get()).get_mut(index as usize).unwrap().1 };
+        let svm_account = unsafe {
+            (*self.shared_account_fields.get())
+                .get_mut(index as usize)
+                .unwrap()
+        };
+        let private_fields = unsafe {
+            (*self.private_account_fields.get())
+                .get_mut(index as usize)
+                .unwrap()
+        };
+
+        let account = TransactionAccountMutView {
+            svm_account,
+            deprecated_fields: &mut private_fields.deprecated_fields,
+            payload: &mut private_fields.payload,
+        };
 
         Ok(AccountRefMut {
             account,
@@ -120,7 +378,22 @@ impl TransactionAccounts {
         // SAFETY: The borrow counter guarantees there are no mutable borrow of this account.
         // The unwrap is safe because accounts.len() == borrow_counters.len(), so the missing
         // account error should have been returned above.
-        let account = unsafe { &(*self.accounts.get()).get(index as usize).unwrap().1 };
+        let svm_account = unsafe {
+            (*self.shared_account_fields.get())
+                .get(index as usize)
+                .unwrap()
+        };
+        let private_fields = unsafe {
+            (*self.private_account_fields.get())
+                .get(index as usize)
+                .unwrap()
+        };
+
+        let account = TransactionAccountView {
+            svm_account,
+            deprecated_fields: &private_fields.deprecated_fields,
+            payload: &private_fields.payload,
+        };
 
         Ok(AccountRef {
             account,
@@ -142,8 +415,46 @@ impl TransactionAccounts {
         self.lamports_delta.get()
     }
 
-    pub(crate) fn take(self) -> DeconstructedTransactionAccounts {
-        (self.accounts, self.touched_flags, self.resize_delta)
+    fn deconstruct_into_keyed_account_shared_data(&mut self) -> Vec<KeyedAccountSharedData> {
+        self.shared_account_fields
+            .get_mut()
+            .into_iter()
+            .zip(&mut *self.private_account_fields.get_mut())
+            .map(|(shared_fields, private_fields)| {
+                (
+                    shared_fields.key,
+                    AccountSharedData::create_from_existing_shared_data(
+                        shared_fields.lamports,
+                        private_fields.payload.clone(),
+                        shared_fields.owner,
+                        private_fields.deprecated_fields.executable,
+                        private_fields.deprecated_fields.rent_epoch,
+                    ),
+                )
+            })
+            .collect()
+    }
+
+    pub(crate) fn deconstruct_into_account_shared_data(&mut self) -> Vec<AccountSharedData> {
+        self.shared_account_fields
+            .get_mut()
+            .into_iter()
+            .zip(&mut *self.private_account_fields.get_mut())
+            .map(|(shared_fields, private_fields)| {
+                AccountSharedData::create_from_existing_shared_data(
+                    shared_fields.lamports,
+                    private_fields.payload.clone(),
+                    shared_fields.owner,
+                    private_fields.deprecated_fields.executable,
+                    private_fields.deprecated_fields.rent_epoch,
+                )
+            })
+            .collect()
+    }
+
+    pub(crate) fn take(mut self) -> DeconstructedTransactionAccounts {
+        let shared_data = self.deconstruct_into_keyed_account_shared_data();
+        (shared_data, self.touched_flags, self.resize_delta)
     }
 
     pub fn resize_delta(&self) -> i64 {
@@ -152,12 +463,20 @@ impl TransactionAccounts {
 
     pub(crate) fn account_key(&self, index: IndexOfAccount) -> Option<&Pubkey> {
         // SAFETY: We never modify an account key, so returning a reference to it is safe.
-        unsafe { (*self.accounts.get()).get(index as usize).map(|acc| &acc.0) }
+        unsafe {
+            (*self.shared_account_fields.get())
+                .get(index as usize)
+                .map(|acc| &acc.key)
+        }
     }
 
     pub(crate) fn account_keys_iter(&self) -> impl Iterator<Item = &Pubkey> {
         // SAFETY: We never modify account keys, so returning an immutable reference to them is safe.
-        unsafe { (*self.accounts.get()).iter().map(|item| &item.0) }
+        unsafe {
+            (*self.shared_account_fields.get())
+                .iter()
+                .map(|item| &item.key)
+        }
     }
 }
 
@@ -214,7 +533,7 @@ impl BorrowCounter {
 }
 
 pub struct AccountRef<'a> {
-    account: &'a AccountSharedData,
+    account: TransactionAccountView<'a>,
     borrow_counter: &'a BorrowCounter,
 }
 
@@ -224,16 +543,16 @@ impl Drop for AccountRef<'_> {
     }
 }
 
-impl Deref for AccountRef<'_> {
-    type Target = AccountSharedData;
+impl<'a> Deref for AccountRef<'a> {
+    type Target = TransactionAccountView<'a>;
     fn deref(&self) -> &Self::Target {
-        self.account
+        &self.account
     }
 }
 
 #[derive(Debug)]
 pub struct AccountRefMut<'a> {
-    account: &'a mut AccountSharedData,
+    account: TransactionAccountMutView<'a>,
     borrow_counter: &'a BorrowCounter,
 }
 
@@ -243,16 +562,16 @@ impl Drop for AccountRefMut<'_> {
     }
 }
 
-impl Deref for AccountRefMut<'_> {
-    type Target = AccountSharedData;
+impl<'a> Deref for AccountRefMut<'a> {
+    type Target = TransactionAccountMutView<'a>;
     fn deref(&self) -> &Self::Target {
-        self.account
+        &self.account
     }
 }
 
 impl DerefMut for AccountRefMut<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.account
+        &mut self.account
     }
 }
 
@@ -311,7 +630,7 @@ mod tests {
             let acc_1_new = tx_accounts.try_borrow(0);
             assert!(acc_1_new.is_ok());
 
-            assert_eq!(&*acc_1.unwrap(), &*acc_1_new.unwrap());
+            assert_eq!(acc_1.unwrap().account, acc_1_new.unwrap().account);
         }
 
         // Two mutable borrows are invalid

--- a/transaction-context/src/vm_slice.rs
+++ b/transaction-context/src/vm_slice.rs
@@ -12,6 +12,7 @@
 use std::marker::PhantomData;
 
 #[repr(C)]
+#[derive(Debug, PartialEq)]
 pub struct VmSlice<T> {
     ptr: u64,
     len: u64,
@@ -37,5 +38,13 @@ impl<T> VmSlice<T> {
 
     pub fn is_empty(&self) -> bool {
         self.len == 0
+    }
+
+    /// # Safety
+    /// Set a new length for the mapped account.
+    /// This function is not safe to use if not coupled with the respective change in
+    /// the underlying vector.
+    pub unsafe fn set_len(&mut self, new_len: u64) {
+        self.len = new_len;
     }
 }


### PR DESCRIPTION
#### Problem

According to [SIMD-0177](https://github.com/solana-foundation/solana-improvement-documents/pull/177), we want a special layout for transaction accounts such that they are contiguous in memory, hold three specific fields (pub key, owner, and lamports) and contain the virtual address of their mapped payload.

The struct `AccountSharedData` does not serve that purpose, so we need a tiny surgery (in this PR, it is contained in `transaction-context`) to come up with an account layout that is suitable for ABIv2 and does not break compatibility with the rest of program-runtime.

#### Summary of Changes

1. Create a `#[repr(C)]` `struct SVMAccount` (I'm open for other names), which is supposed to be shared with programs in ABIv2.
2. Create `struct SVMAccountDeprecated` to hold the fields being deprecated (rent epoch and executable boolean), which are not shared with programs in ABIv2.
3. Create `TransactionAccountView` and `TransactionAccountViewMut` to handle borrows, and implement `ReadableAccount` for both and `WritableAccount` for the former only.
4. `struct TransactionAccount` has now two fields: `shared_account_fields` and `private_account_fields`. The former holding information shared with programs and the latter not shared information.
5. Implement the functions necessary to deal with the account fields.

This PR restricts the new layout and conversions to and from AccountSharedData to transaction context, but we can push them outwards in follow-up PRs. 
