### PR TITLE
remote-wallet: fix build with hidapi libusb backend

### DIFF
--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -116,7 +116,12 @@ impl RemoteWalletManager {
         let mut detected_devices = vec![];
         let mut errors = vec![];
         for device_info in devices.filter(|&device_info| {
-            is_valid_hid_device(device_info.usage_page(), device_info.interface_number())
+            #[cfg(not(any(feature = "linux-static-libusb", feature = "linux-shared-libusb")))]
+            let is_valid_hid_device =
+                is_valid_hid_device(device_info.usage_page(), device_info.interface_number());
+            #[cfg(any(feature = "linux-static-libusb", feature = "linux-shared-libusb"))]
+            let is_valid_hid_device = true; // libusb backend does not provide DeviceInfo::usage_page()
+            is_valid_hid_device
                 && is_valid_ledger(device_info.vendor_id(), device_info.product_id())
         }) {
             match usb.open_path(device_info.path()) {


### PR DESCRIPTION
#### Problem
the libusb hidapi backend doesn't provide the `DeviceInfo::usage_page()` method, which we use as some kind of hid support test when enumerating available devices. i can't find any reasoning that this test improves the situation over the vid:pid test immediately after it.

#### Summary of Changes
skip hid support device check when built with libusb hidapi backend