### PR TITLE
local-cluster: ignore test_optimistic_confirmation_violation_detection

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1649,6 +1649,7 @@ fn test_no_voting() {
 
 #[test]
 #[serial]
+#[ignore]
 fn test_optimistic_confirmation_violation_detection() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     // First set up the cluster with 2 nodes


### PR DESCRIPTION
#### Problem
local-cluster tests start validators in the order that they are specified.
This causes problems when stakes are not sorted, e.g. the heavier node is started after the smaller node, and both nodes are in the leader schedule:
- Small node (A) starts up and makes some slots and votes on them
- A runs into the threshold check and reaches a lockout of 2^8
- Big node (B) starts up and requests repair for A's blocks
- Due to local-cluster fuckery, repair is delayed
- B ticks over to its leader slot and builds it on top of genesis, or an early block from A that was repaired
- B votes for its block
- Since B is heavier than A, A must now switch over however it's locked out for almost 2 minutes
- Test times out

e.g logs from A:
```
INFO  solana_core::consensus::fork_choice] voting: 19 0%
[...]
INFO solana_core::replay_stage] new fork:8 parent:0 root:0
INFO solana_core::replay_stage] new fork:9 parent:8 root:0
WARN  solana_core::replay_stage] PARTITION DETECTED waiting to join heaviest fork: 8 last vote: 19, reset slot: 8
```

This can also happen in equal stake or sorted staked clusters if repair is so delayed that the later node ends up building and voting on 8 slots.

#### Summary of Changes
#[ignore] for now while I work on a more complete solution, which is WFSM in local-cluster