### PR TITLE
Random state dashmap for account_map

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -2,13 +2,13 @@
 
 use {
     crate::accounts_db::{AccountStorageEntry, AccountsFileId},
-    ahash::RandomState,
     dashmap::DashMap,
     rand::seq::SliceRandom,
     rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
     solana_clock::Slot,
     solana_nohash_hasher::IntMap,
     std::{
+        collections::hash_map::RandomState,
         ops::{Index, Range},
         sync::{
             atomic::{AtomicUsize, Ordering},

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -6,8 +6,9 @@ use {
     rand::seq::SliceRandom,
     rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
     solana_clock::Slot,
-    solana_nohash_hasher::{BuildNoHashHasher, IntMap},
+    solana_nohash_hasher::IntMap,
     std::{
+        collections::hash_map::RandomState,
         ops::{Index, Range},
         sync::{
             atomic::{AtomicUsize, Ordering},
@@ -18,7 +19,7 @@ use {
 
 pub mod stored_account_info;
 
-pub type AccountStorageMap = DashMap<Slot, Arc<AccountStorageEntry>, BuildNoHashHasher<Slot>>;
+pub type AccountStorageMap = DashMap<Slot, Arc<AccountStorageEntry>, RandomState>;
 
 #[derive(Default, Debug)]
 pub struct AccountStorage {
@@ -228,7 +229,7 @@ impl AccountStorage {
 
 /// iterate contents of AccountStorage without exposing internals
 pub struct AccountStorageIter<'a> {
-    iter: dashmap::iter::Iter<'a, Slot, Arc<AccountStorageEntry>, BuildNoHashHasher<Slot>>,
+    iter: dashmap::iter::Iter<'a, Slot, Arc<AccountStorageEntry>, RandomState>,
 }
 
 impl<'a> AccountStorageIter<'a> {

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -8,7 +8,6 @@ use {
     solana_clock::Slot,
     solana_nohash_hasher::IntMap,
     std::{
-        collections::hash_map::RandomState,
         ops::{Index, Range},
         sync::{
             atomic::{AtomicUsize, Ordering},
@@ -19,7 +18,7 @@ use {
 
 pub mod stored_account_info;
 
-pub type AccountStorageMap = DashMap<Slot, Arc<AccountStorageEntry>, RandomState>;
+pub type AccountStorageMap = DashMap<Slot, Arc<AccountStorageEntry>>;
 
 #[derive(Default, Debug)]
 pub struct AccountStorage {
@@ -229,7 +228,7 @@ impl AccountStorage {
 
 /// iterate contents of AccountStorage without exposing internals
 pub struct AccountStorageIter<'a> {
-    iter: dashmap::iter::Iter<'a, Slot, Arc<AccountStorageEntry>, RandomState>,
+    iter: dashmap::iter::Iter<'a, Slot, Arc<AccountStorageEntry>>,
 }
 
 impl<'a> AccountStorageIter<'a> {

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -2,13 +2,13 @@
 
 use {
     crate::accounts_db::{AccountStorageEntry, AccountsFileId},
+    ahash::RandomState,
     dashmap::DashMap,
     rand::seq::SliceRandom,
     rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
     solana_clock::Slot,
     solana_nohash_hasher::IntMap,
     std::{
-        collections::hash_map::RandomState,
         ops::{Index, Range},
         sync::{
             atomic::{AtomicUsize, Ordering},

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -26,7 +26,6 @@ mod tests {
         },
         solana_epoch_schedule::EpochSchedule,
         solana_genesis_config::create_genesis_config,
-        solana_nohash_hasher::BuildNoHashHasher,
         solana_pubkey::Pubkey,
         solana_stake_interface::state::Stake,
         std::{
@@ -47,10 +46,7 @@ mod tests {
         storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_storages(RangeFull).0;
-        let storage: AccountStorageMap = AccountStorageMap::with_capacity_and_hasher(
-            storage_entries.len(),
-            BuildNoHashHasher::default(),
-        );
+        let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -46,7 +46,10 @@ mod tests {
         storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_storages(RangeFull).0;
-        let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
+        let storage: AccountStorageMap = AccountStorageMap::with_capacity_and_hasher(
+            storage_entries.len(),
+            ahash::RandomState::new(),
+        );
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -46,10 +46,7 @@ mod tests {
         storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_storages(RangeFull).0;
-        let storage: AccountStorageMap = AccountStorageMap::with_capacity_and_hasher(
-            storage_entries.len(),
-            ahash::RandomState::new(),
-        );
+        let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -27,7 +27,6 @@ mod serde_snapshot_tests {
         },
         solana_clock::Slot,
         solana_epoch_schedule::EpochSchedule,
-        solana_nohash_hasher::BuildNoHashHasher,
         solana_pubkey::Pubkey,
         std::{
             fs::File,
@@ -125,10 +124,7 @@ mod serde_snapshot_tests {
         storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_storages(RangeFull).0;
-        let storage: AccountStorageMap = AccountStorageMap::with_capacity_and_hasher(
-            storage_entries.len(),
-            BuildNoHashHasher::default(),
-        );
+        let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -124,10 +124,7 @@ mod serde_snapshot_tests {
         storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_storages(RangeFull).0;
-        let storage: AccountStorageMap = AccountStorageMap::with_capacity_and_hasher(
-            storage_entries.len(),
-            ahash::RandomState::new(),
-        );
+        let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -124,7 +124,10 @@ mod serde_snapshot_tests {
         storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_storages(RangeFull).0;
-        let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
+        let storage: AccountStorageMap = AccountStorageMap::with_capacity_and_hasher(
+            storage_entries.len(),
+            ahash::RandomState::new(),
+        );
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -98,7 +98,10 @@ impl SnapshotStorageRebuilder {
         storage_access: StorageAccess,
         obsolete_accounts: Option<DashMap<Slot, SerdeObsoleteAccounts>>,
     ) -> Self {
-        let storage = AccountStorageMap::with_capacity(snapshot_storage_lengths.len());
+        let storage = AccountStorageMap::with_capacity_and_hasher(
+            snapshot_storage_lengths.len(),
+            ahash::RandomState::new(),
+        );
         let storage_paths: DashMap<_, _> = snapshot_storage_lengths
             .iter()
             .map(|(slot, storage_lengths)| {

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -98,10 +98,7 @@ impl SnapshotStorageRebuilder {
         storage_access: StorageAccess,
         obsolete_accounts: Option<DashMap<Slot, SerdeObsoleteAccounts>>,
     ) -> Self {
-        let storage = AccountStorageMap::with_capacity_and_hasher(
-            snapshot_storage_lengths.len(),
-            ahash::RandomState::new(),
-        );
+        let storage = AccountStorageMap::with_capacity(snapshot_storage_lengths.len());
         let storage_paths: DashMap<_, _> = snapshot_storage_lengths
             .iter()
             .map(|(slot, storage_lengths)| {


### PR DESCRIPTION
#### Problem

account_map is used heavily in parallel processing for snapshot_untar and rebuild_banks. Using NoHashHasher causes collisions in the same shard and slow down parallel processing. 

switch to use random state dashmap gives better overall performance.


Performance measurement: 

| Metric              | Original (NoHasher) | Randomized | Improvement      |
|---------------------|--------------------:|------------|------------------|
| **Snapshot untar**  | 99.5s              | 96.4s      | **3.1s (3.1%)** |
| **Rebuild bank**    | 48.6s              | 47.0s      | **1.6s (3.3%)** |
| **Total**           | 148.1s             | 143.4s     | **4.7s (3.2%)** |


The randomized hasher shows ~3% improvements across both phases:
- Untar phase: 3.1s faster (likely due to better hash distribution during deserialization)
- Rebuild phase: 1.6s faster 

<details>
<summary>log</summary>
```
~/src/agave/ledger-tool$ grep "rebuild bank from snapshots" orig.log rnd.log
orig.log:[2025-10-08T14:47:11.301613515Z INFO  solana_runtime::snapshot_bank_utils] rebuild bank from snapshots took 48.6s
rnd.log:[2025-10-08T18:44:50.426599647Z INFO  solana_runtime::snapshot_bank_utils] rebuild bank from snapshots took 47.0s
~/src/agave/ledger-tool$ grep "snapshot untar" orig.log rnd.log
orig.log:[2025-10-08T14:46:22.693805529Z INFO  solana_runtime::snapshot_utils] snapshot untar took 99.5s
rnd.log:[2025-10-08T18:44:03.387147170Z INFO  solana_runtime::snapshot_utils] snapshot untar took 96.4s
```
</details>

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
