### PR TITLE
rebuild_bank: move storage map

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -133,7 +133,7 @@ impl AccountStorage {
     pub fn initialize(&mut self, all_storages: AccountStorageMap) {
         assert!(self.map.is_empty());
         assert!(self.no_shrink_in_progress());
-        self.map.extend(all_storages)
+        self.map = all_storages;
     }
 
     /// remove the append vec at 'slot'

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1050,12 +1050,7 @@ where
     );
 
     // Process deserialized data, set necessary fields in self
-    let start = Instant::now();
     accounts_db.storage.initialize(storage);
-    info!(
-        "Reconstructing accounts db from fields: initialized storage in {:?}",
-        start.elapsed()
-    );
     accounts_db
         .next_id
         .store(next_append_vec_id, Ordering::Release);

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1050,7 +1050,12 @@ where
     );
 
     // Process deserialized data, set necessary fields in self
+    let start = Instant::now();
     accounts_db.storage.initialize(storage);
+    info!(
+        "Reconstructing accounts db from fields: initialized storage in {:?}",
+        start.elapsed()
+    );
     accounts_db
         .next_id
         .store(next_append_vec_id, Ordering::Release);


### PR DESCRIPTION
#### Problem

In rebuild_bank, we are copying storage_map, populated in rebuild_storage, into bank's member. Storage map is big and is expensive to copy. Since the storage map is no longer used, we can move the storage map into bank's member.

ledger-tool shows it reduced 0.25s in initialize storage map. 

```
opt.log:[2025-10-08T14:40:07.265768805Z INFO  solana_runtime::serde_snapshot] Reconstructing accounts db from fields: initialized storage in 4.746µs
orig.log:[2025-10-08T14:46:22.956386175Z INFO  solana_runtime::serde_snapshot] Reconstructing accounts db from fields: initialized storage in 255.521381ms
``` 

It is interesting that the rebuild bank time is down by 2s, which is more than the saving from initialize storage map by 1.75s. 
```
opt.log:[2025-10-08T14:40:53.727947470Z INFO  solana_runtime::snapshot_bank_utils] rebuild bank from snapshots took 46.5s
orig.log:[2025-10-08T14:47:11.301613515Z INFO  solana_runtime::snapshot_bank_utils] rebuild bank from snapshots took 48.6s
```

Looking at the build index time. Indeed, that index time is down by 1.7s.

```
opt.log:[2025-10-08T14:40:51.559635707Z INFO  solana_runtime::serde_snapshot] Building accounts index... Done in 44.293846373s
orig.log:[2025-10-08T14:47:09.027096712Z INFO  solana_runtime::serde_snapshot] Building accounts index... Done in 46.070696668s
```

My guess is that the storage map now have better cache locality layout, which helps index building (secondary performance benefits of this change).


#### Summary of Changes

Move the storage map with assignment. Dashmap doesn't implement copy. So assignment is a move. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
