### PR TITLE
Implement update_slot_list with retain and push

### DIFF
--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -7,7 +7,6 @@ use {
     solana_clock::Slot,
     std::{
         fmt::Debug,
-        mem,
         ops::Deref,
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -173,16 +172,6 @@ impl<T> SlotListWriteGuard<'_, T> {
         F: FnMut(&mut (Slot, T)) -> bool,
     {
         self.0.retain(f)
-    }
-
-    /// Removes and returns the element at position `index` within the list, shifting all elements after it to the left.
-    pub fn remove_at(&mut self, index: usize) -> (Slot, T) {
-        self.0.remove(index)
-    }
-
-    /// Replaces the element at position `index` within the list returning the previous element stored there.
-    pub fn replace_at(&mut self, index: usize, item: (Slot, T)) -> (Slot, T) {
-        mem::replace(&mut self.0[index], item)
     }
 
     /// Clears the list, removing all elements.

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -657,15 +657,15 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         // If we find an existing account at old_slot, replace it rather than adding a new entry to the list
         let mut found_slot = false;
-        slot_list.retain(|cur| {
-            let (cur_slot, cur_account_info) = cur;
+        slot_list.retain(|cur_item| {
+            let (cur_slot, cur_account_info) = cur_item;
             if *cur_slot == old_slot {
                 // Ensure we only find one!
                 assert!(!found_slot);
                 let is_cur_account_cached = cur_account_info.is_cached();
 
                 // Replace the item
-                let reclaim_item = mem::replace(cur, (slot, account_info));
+                let reclaim_item = mem::replace(cur_item, (slot, account_info));
                 match reclaim {
                     UpsertReclaim::ReclaimOldSlots | UpsertReclaim::PopulateReclaims => {
                         // Reclaims are used to reclaim other versions of accounts when they are
@@ -692,8 +692,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             } else if reclaim == UpsertReclaim::ReclaimOldSlots {
                 let is_cur_account_cached = cur_account_info.is_cached();
                 if !is_cur_account_cached && *cur_slot < slot {
-                    let reclaim_item = *cur;
-                    reclaims.push(reclaim_item);
+                    reclaims.push(*cur_item);
                     ref_count_change -= 1;
                     return false;
                 }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -20,6 +20,7 @@ use {
         cmp,
         collections::{hash_map::Entry, HashMap, HashSet},
         fmt::Debug,
+        mem,
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
             Arc, Mutex, RwLock,
@@ -656,57 +657,57 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         // If we find an existing account at old_slot, replace it rather than adding a new entry to the list
         let mut found_slot = false;
-        (0..slot_list.len())
-            .rev() // rev since we delete from the list in some cases
-            .for_each(|slot_list_index| {
-                let (cur_slot, cur_account_info) = &slot_list[slot_list_index];
-                if *cur_slot == old_slot {
-                    // Ensure we only find one!
-                    assert!(!found_slot);
-                    let is_cur_account_cached = cur_account_info.is_cached();
+        slot_list.retain(|(cur_slot, cur_account_info)| {
+            if *cur_slot == old_slot {
+                // Ensure we only find one!
+                assert!(!found_slot);
+                let is_cur_account_cached = cur_account_info.is_cached();
 
-                    // Replace the item
-                    let reclaim_item = slot_list.replace_at(slot_list_index, (slot, account_info));
-                    match reclaim {
-                        UpsertReclaim::ReclaimOldSlots | UpsertReclaim::PopulateReclaims => {
-                            // Reclaims are used to reclaim other versions of accounts when they are
-                            // rewritten elsewhere. Cached accounts are not in storage, so there is
-                            // no reason to store the reclaim.
-                            if !is_cur_account_cached {
-                                reclaims.push(reclaim_item);
-                            }
-                        }
-                        UpsertReclaim::PreviousSlotEntryWasCached => {
-                            assert!(is_cur_account_cached);
-                        }
-                        UpsertReclaim::IgnoreReclaims => {
-                            // do nothing. nothing to assert. nothing to return in reclaims
+                // Replace the item
+                let reclaim_item = (old_slot, mem::replace(cur_account_info, account_info));
+                match reclaim {
+                    UpsertReclaim::ReclaimOldSlots | UpsertReclaim::PopulateReclaims => {
+                        // Reclaims are used to reclaim other versions of accounts when they are
+                        // rewritten elsewhere. Cached accounts are not in storage, so there is
+                        // no reason to store the reclaim.
+                        if !is_cur_account_cached {
+                            reclaims.push(reclaim_item);
                         }
                     }
-
-                    found_slot = true;
-
-                    if !is_cur_account_cached {
-                        // current info at 'slot' is NOT cached, so we should NOT addref. This slot already has a ref count for this pubkey.
-                        ref_count_change -= 1
+                    UpsertReclaim::PreviousSlotEntryWasCached => {
+                        assert!(is_cur_account_cached);
                     }
-                } else if reclaim == UpsertReclaim::ReclaimOldSlots {
-                    let is_cur_account_cached = cur_account_info.is_cached();
-                    if !is_cur_account_cached && *cur_slot < slot {
-                        let reclaim_item = slot_list.remove_at(slot_list_index);
-                        reclaims.push(reclaim_item);
-                        ref_count_change -= 1;
+                    UpsertReclaim::IgnoreReclaims => {
+                        // do nothing. nothing to assert. nothing to return in reclaims
                     }
-                } else {
-                    // Slot is new item that is being added to the slot list
-                    // If slot is already in the slot list, it must be replaced otherwise it will
-                    // lead to the same slot being duplicated in the list
-                    assert_ne!(
-                        *cur_slot, slot,
-                        "slot_list has slot in slot_list but is not replacing it"
-                    );
                 }
-            });
+
+                found_slot = true;
+
+                if !is_cur_account_cached {
+                    // current info at 'slot' is NOT cached, so we should NOT addref. This slot already has a ref count for this pubkey.
+                    ref_count_change -= 1
+                }
+            } else if reclaim == UpsertReclaim::ReclaimOldSlots {
+                let is_cur_account_cached = cur_account_info.is_cached();
+                if !is_cur_account_cached && *cur_slot < slot {
+                    let reclaim_item = (old_slot, *cur_account_info);
+                    reclaims.push(reclaim_item);
+                    ref_count_change -= 1;
+                    return false;
+                }
+            } else {
+                // Slot is new item that is being added to the slot list
+                // If slot is already in the slot list, it must be replaced otherwise it will
+                // lead to the same slot being duplicated in the list
+                assert_ne!(
+                    *cur_slot, slot,
+                    "slot_list has slot in slot_list but is not replacing it"
+                );
+            }
+            true
+        });
+
         if !found_slot {
             // if we make it here, we did not find the slot in the list
             slot_list.push((slot, account_info));


### PR DESCRIPTION
#### Problem
`InMemAccountsIndex::update_slot_list` performs a replace or remove operation on slot list (and then optionally append new value if slot wasn't found) using index access into the list and calling a couple of slot list accessor functions (e.g. `remove_at`, `replace_at`).
This can be simplified with use of `retain` call and avoid manual index access (more bug prone and potentially less performant) and calling the accessor functions (which might have extra overheads depending on their current or future impl).

#### Summary of Changes
Do a single pass with `retain` where
* when `old_slot` is encountered, uses mut ref given by retain callback to replace the value
* when other slots older than `slot` in `ReclaimOldSlots` mode are encountered, `return false` tells to not retain the element (instead of calling `remove_at`)

##### Performance
checking ledger-tool verify, which calls `update_slot_list` during insertion, shows no changes in total generate index times:
* PR: generate_index overall_us=82789904i total_us=53542135i insertion_time_us=1108045436i 
* master: generate_index overall_us=82789904i total_us=53542135i insertion_time_us=1108045436i

however looking at profiles, the time spend in `update_slot_list` on the loop part decrease:
* PR: 16% samples in `retain`, 81% in `push`
* master: 37% samples on `for_each`, 63% in `push`