### PR TITLE
Return final slot list len from accounts map entry accessor retain

### DIFF
--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -169,11 +169,14 @@ impl<T> SlotListWriteGuard<'_, T> {
     }
 
     /// Retains only the elements specified by the predicate.
-    pub fn retain<F>(&mut self, f: F)
+    ///
+    /// Returns number of preserved elements (size of the slot list after processing).
+    pub fn retain<F>(&mut self, f: F) -> usize
     where
         F: FnMut(&mut (Slot, T)) -> bool,
     {
-        self.0.retain(f)
+        self.0.retain(f);
+        self.0.len()
     }
 
     /// Clears the list, removing all elements.

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1893,9 +1893,8 @@ mod tests {
                     other_slot,
                     &mut reclaims,
                     reclaim
-                )
-                .0,
-                1,
+                ),
+                (1, 1),
                 "other_slot: {other_slot:?}"
             );
             assert_eq!(slot_list.clone_list(), SlotList::from([at_new_slot]));
@@ -1923,9 +1922,8 @@ mod tests {
                 other_slot,
                 &mut reclaims,
                 reclaim
-            )
-            .0,
-            0,
+            ),
+            (0, 1),
             "other_slot: {other_slot:?}"
         );
         assert_eq!(slot_list.clone_list(), SlotList::from([at_new_slot]));

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -657,7 +657,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         // If we find an existing account at old_slot, replace it rather than adding a new entry to the list
         let mut found_slot = false;
-        let mut remaining_len = slot_list.retain(|cur_item| {
+        let mut final_len = slot_list.retain(|cur_item| {
             let (cur_slot, cur_account_info) = cur_item;
             if *cur_slot == old_slot {
                 // Ensure we only find one!
@@ -711,9 +711,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         if !found_slot {
             // if we make it here, we did not find the slot in the list
             slot_list.push((slot, account_info));
-            remaining_len += 1;
+            final_len += 1;
         }
-        (ref_count_change, remaining_len)
+        (ref_count_change, final_len)
     }
 
     // convert from raw data on disk to AccountMapEntry, set to age in future

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -604,7 +604,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     ) -> usize {
         let mut slot_list = current.slot_list_write_lock();
         let (slot, new_entry) = new_value;
-        let ref_count_change = Self::update_slot_list(
+        let (ref_count_change, slot_list_len) = Self::update_slot_list(
             &mut slot_list,
             slot,
             new_entry,
@@ -627,7 +627,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             }
         }
         current.set_dirty(true);
-        slot_list.len()
+        slot_list_len
     }
 
     /// Modifies the slot_list by replacing or appending entries.
@@ -637,9 +637,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// - If UpsertReclaim is ReclaimOldSlots, remove all uncached entries older than `slot`
     ///   and add them to reclaims
     ///
-    /// Returns the reference count change as an `i32`. The reference count change
-    /// is the number of entries added (1) - the number of uncached entries removed
-    /// or replaced
+    /// Returns the reference count change as an `i32` and the final length of the slot list.
+    /// The reference count change is the number of entries added (1) - the number of uncached
+    /// entries removed or replaced
     fn update_slot_list(
         slot_list: &mut SlotListWriteGuard<T>,
         slot: Slot,
@@ -647,7 +647,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         other_slot: Option<Slot>,
         reclaims: &mut ReclaimsSlotList<T>,
         reclaim: UpsertReclaim,
-    ) -> i32 {
+    ) -> (i32, usize) {
         let mut ref_count_change = 1;
 
         // Cached accounts are not expected by this function, use cache_entry_at_slot instead
@@ -657,7 +657,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         // If we find an existing account at old_slot, replace it rather than adding a new entry to the list
         let mut found_slot = false;
-        slot_list.retain(|cur_item| {
+        let mut remaining_len = slot_list.retain(|cur_item| {
             let (cur_slot, cur_account_info) = cur_item;
             if *cur_slot == old_slot {
                 // Ensure we only find one!
@@ -711,8 +711,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         if !found_slot {
             // if we make it here, we did not find the slot in the list
             slot_list.push((slot, account_info));
+            remaining_len += 1;
         }
-        ref_count_change
+        (ref_count_change, remaining_len)
     }
 
     // convert from raw data on disk to AccountMapEntry, set to age in future
@@ -1521,7 +1522,7 @@ mod tests {
                     &mut reclaims,
                     reclaim
                 ),
-                1,
+                (1, 1),
                 "other_slot: {other_slot:?}"
             );
             assert_eq!(slot_list.clone_list(), SlotList::from([at_new_slot]));
@@ -1550,7 +1551,7 @@ mod tests {
                 &mut reclaims,
                 reclaim
             ),
-            0,
+            (0, 1),
             "other_slot: {other_slot:?}"
         );
         assert_eq!(slot_list.clone_list(), SlotList::from([at_new_slot]));
@@ -1627,7 +1628,7 @@ mod tests {
                     let original = slot_list.clone_list();
                     let mut reclaims = ReclaimsSlotList::new();
 
-                    let result = InMemAccountsIndex::<u64, u64>::update_slot_list(
+                    let (result, _len) = InMemAccountsIndex::<u64, u64>::update_slot_list(
                         &mut slot_list,
                         new_slot,
                         info,
@@ -1892,7 +1893,8 @@ mod tests {
                     other_slot,
                     &mut reclaims,
                     reclaim
-                ),
+                )
+                .0,
                 1,
                 "other_slot: {other_slot:?}"
             );
@@ -1921,7 +1923,8 @@ mod tests {
                 other_slot,
                 &mut reclaims,
                 reclaim
-            ),
+            )
+            .0,
             0,
             "other_slot: {other_slot:?}"
         );
@@ -2005,7 +2008,7 @@ mod tests {
                     let original = slot_list.clone_list();
                     let mut reclaims = ReclaimsSlotList::new();
 
-                    let result = InMemAccountsIndex::<u64, u64>::update_slot_list(
+                    let (result, _len) = InMemAccountsIndex::<u64, u64>::update_slot_list(
                         &mut slot_list,
                         new_slot,
                         info,


### PR DESCRIPTION
#### Problem
The calls to `SlotListWriteGuard`'s `retain` are usually followed by getting length or checking emptyness of the slot list.

This:
* involves extra call into the accessor, which could be avoided by just returning the len from `retain` function
* keeps the need of holding `SlotListWriteGuard` across several function calls, passing it by `&mut` (instead of passing owned guard into single function - to be addressed in subsequent PR)

#### Summary of Changes
* return `usize` with the final size of the slot list from `retain`
* pass over info whether slot list is empty in `purge_older_root_entries`
* use it instead of checking `slot_list.len()` or `slot_list.is_empty()` after `retain` / `purge_older_root_entries`
