### PR TITLE
remote-wallet: print inner hidapi error message

### DIFF
--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -25,7 +25,7 @@ const HID_USB_DEVICE_CLASS: u8 = 0;
 /// Remote wallet error.
 #[derive(Error, Debug, Clone)]
 pub enum RemoteWalletError {
-    #[error("hidapi error")]
+    #[error("hidapi error: {0}")]
     Hid(String),
 
     #[error("device type mismatch")]


### PR DESCRIPTION
#### Problem
`RemoteWalletError::Hid(String)` message string eats the inner error message

#### Summary of Changes
print it