### PR TITLE
[zk-elgamal-proof] Update off-by-one account count guard

### DIFF
--- a/programs/zk-elgamal-proof/src/lib.rs
+++ b/programs/zk-elgamal-proof/src/lib.rs
@@ -91,7 +91,11 @@ where
     };
 
     // create context state if additional accounts are provided with the instruction
-    if instruction_context.get_number_of_instruction_accounts() > accessed_accounts {
+    if instruction_context.get_number_of_instruction_accounts()
+        >= accessed_accounts
+            .checked_add(2)
+            .ok_or(InstructionError::ArithmeticOverflow)?
+    {
         let context_state_authority = *instruction_context
             .try_borrow_instruction_account(accessed_accounts.checked_add(1).unwrap())?
             .get_key();


### PR DESCRIPTION
Addressing the following audit findings:

#### Summary

The optional context-creation branch uses an off-by-one guard. It enters when only one extra account is provided, but then reads two extra accounts, leading to NotEnoughAccountKeys instead of skipping context creation when insufficient accounts are present.
Technical Details

Current guard:

        if instruction_context.get_number_of_instruction_accounts() > accessed_accounts { ... }

Inside the block, two accounts are accessed:

        proof_context_account at index accessed_accounts
        context_state_authority at index accessed_accounts + 1

If only one extra account is supplied, the guard passes but borrowing the authority fails with NotEnoughAccountKeys.
Correct guard should require both extra accounts:

        instruction_context.get_number_of_instruction_accounts() >= accessed_accounts + 2

Modes affected:

Embedded proof data (accessed_accounts = 0): requires at least 2 accounts (indices 0 and 1); current guard admits 1.
Proof-from-account mode (accessed_accounts = 1): requires at least 3 accounts total (0: proof data, 1: context, 2: authority); current guard admits 2.

#### Impact

Functional: Calls that accidentally provide only one of the two required extra accounts fail with NotEnoughAccountKeys instead of simply not creating context state.
Security: None identified; failure occurs before any data or lamports are mutated.

#### Recommendation

Update the guard to only enter when both accounts are present: if instruction_context.get_number_of_instruction_accounts() >= accessed_accounts + 2 { ... }