### PR TITLE
Fix create tarball script to work in CI

### DIFF
--- a/scripts/create-release-tarball.sh
+++ b/scripts/create-release-tarball.sh
@@ -118,6 +118,9 @@ if [[ "$include_val_bins" -eq 0 ]]; then
   done
 fi
 
+cp "${build_dir}/bin/agave-install-init" "agave-install-init-${target}"
+cp "${build_dir}/version.yml" "${tarball_basename}-${target}.yml"
+
 output_tar="${tarball_basename}-${target}.tar.bz2"
 echo "--- Creating tarball"
 


### PR DESCRIPTION
#### Problem

Script does not produce all the files required by `publish-tarball.sh`

#### Summary of Changes

Add commands to copy agave-install-init and version.yml to the working directory.
