### PR TITLE
ci: run a separate pipeline for gh-readonly-queue* branches

### DIFF
--- a/.buildkite/pipeline-upload.sh
+++ b/.buildkite/pipeline-upload.sh
@@ -11,8 +11,21 @@ set -e
 cd "$(dirname "$0")"/..
 source ci/_
 
-_ ci/buildkite-pipeline.sh pipeline.yml
-echo +++ pipeline
-cat pipeline.yml
+if [[ $BUILDKITE_BRANCH == gh-readonly-queue* ]]; then
 
-_ buildkite-agent pipeline upload pipeline.yml
+  cat <<EOF | tee /dev/tty | buildkite-agent pipeline upload
+steps:
+  - name: "checks"
+    command: "ci/docker-run-default-image.sh ci/test-checks.sh"
+    timeout_in_minutes: 30
+    agents:
+      queue: "check"
+EOF
+
+else
+  _ ci/buildkite-pipeline.sh pipeline.yml
+  echo +++ pipeline
+  cat pipeline.yml
+
+  _ buildkite-agent pipeline upload pipeline.yml
+fi


### PR DESCRIPTION
#### Problem

time to enable merge queue 😈 

#### Summary of Changes

in this PR, I only added the `check` step to the pre-merge pipeline. it will run on buildkite. it will be grouped by UI, `Merge queue`

<img width="713" height="108" alt="Screenshot 2025-10-08 at 23 59 16" src="https://github.com/user-attachments/assets/27eeacaa-7a2f-47c8-ae02-3fc17c325096" />

if the test failed, it will print this message in the PR

<img width="859" height="63" alt="Screenshot 2025-10-09 at 00 14 10" src="https://github.com/user-attachments/assets/ef3d03e2-81b0-472d-86c1-78713f20c1ca" />

