### PR TITLE
core: Simplified ConsumeWorker loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8153,6 +8153,7 @@ dependencies = [
  "agave-votor",
  "ahash 0.8.11",
  "anyhow",
+ "arc-swap",
  "arrayvec",
  "assert_matches",
  "async-trait",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -48,6 +48,7 @@ agave-verified-packet-receiver = { workspace = true }
 agave-votor = { workspace = true, features = ["agave-unstable-api"] }
 ahash = { workspace = true }
 anyhow = { workspace = true }
+arc-swap = { workspace = true }
 arrayvec = { workspace = true }
 assert_matches = { workspace = true }
 async-trait = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6444,6 +6444,7 @@ dependencies = [
  "agave-votor",
  "ahash 0.8.11",
  "anyhow",
+ "arc-swap",
  "arrayvec",
  "assert_matches",
  "async-trait",


### PR DESCRIPTION
#### Problem
- We're caching the result of previous loaded refs, `Arc` cloning conditionally on if the bank has changed
- We still need to `load_ref` every iteration so it's useless

#### Summary of Changes
- Just use the guard directly from `load_ref` (added arc_swap dependency)
- Remove bank fetching time stats...we'll likely spend more time calling `Instant::now` than we would doing the actual fetch. We can catch this being slow via profiling not with such invasive metrics.
	- timeout using Instant::now is unfortunately still there - made a comment in code.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
