### PR TITLE
ledger-tool: Specify bank hash in latest-optimistic-slots

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -716,7 +716,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
 
             println!(
                 "{:>20} {:>44} {:>32} {:>13}",
-                "Slot", "Hash", "Timestamp", "Vote Only?"
+                "Slot", "Bank Hash", "Timestamp", "Vote Only?"
             );
             for (slot, hash_and_timestamp_opt, contains_nonvote) in slots.iter() {
                 let (time_str, hash_str) = if let Some((hash, timestamp)) = hash_and_timestamp_opt {


### PR DESCRIPTION
#### Problem
The stored hash is a bank hash, but the command just states "hash". We have lots of hashes so adjust the output header to specify that this is a bank hash.

**New output:**
```
                Slot                                    Bank Hash                        Timestamp    Vote Only?
           372061086 C1PHzk4mWxechFWwydQ5hENFG6kW8bYEqBU8EHA74iz2    2025-10-08T18:22:14.728+00:00         false
```
**Old output:**
```
                Slot                                         Hash                        Timestamp    Vote Only?
           372061340 7ZaWjLa2xxmwqqvUGKBNHHcxvceFSHEPb5odeZAzq3Hs    2025-10-08T18:23:54.414+00:00         false
```           