### PR TITLE
refactor(vote-storage): remove unnecessary Arc vote tx wrapper

### DIFF
--- a/core/src/banking_stage/latest_validator_vote_packet.rs
+++ b/core/src/banking_stage/latest_validator_vote_packet.rs
@@ -8,7 +8,6 @@ use {
     solana_packet::PACKET_DATA_SIZE,
     solana_pubkey::Pubkey,
     solana_vote_program::vote_instruction::VoteInstruction,
-    std::sync::Arc,
 };
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
@@ -18,11 +17,11 @@ pub enum VoteSource {
 }
 
 /// Holds deserialized vote messages as well as their source, and slot
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LatestValidatorVotePacket {
     vote_source: VoteSource,
     vote_pubkey: Pubkey,
-    vote: Option<Arc<ImmutableDeserializedPacket>>,
+    vote: Option<ImmutableDeserializedPacket>,
     slot: Slot,
     hash: Hash,
     timestamp: Option<UnixTimestamp>,
@@ -30,7 +29,7 @@ pub struct LatestValidatorVotePacket {
 
 impl LatestValidatorVotePacket {
     pub fn new_from_immutable(
-        vote: Arc<ImmutableDeserializedPacket>,
+        vote: ImmutableDeserializedPacket,
         vote_source: VoteSource,
         deprecate_legacy_vote_ixs: bool,
     ) -> Result<Self, DeserializedPacketError> {
@@ -93,7 +92,7 @@ impl LatestValidatorVotePacket {
             return Err(DeserializedPacketError::VoteTransactionError);
         }
 
-        let vote = Arc::new(ImmutableDeserializedPacket::new(packet)?);
+        let vote = ImmutableDeserializedPacket::new(packet)?;
         Self::new_from_immutable(vote, vote_source, deprecate_legacy_vote_ixs)
     }
 
@@ -121,7 +120,7 @@ impl LatestValidatorVotePacket {
         self.vote.is_none()
     }
 
-    pub fn take_vote(&mut self) -> Option<Arc<ImmutableDeserializedPacket>> {
+    pub fn take_vote(&mut self) -> Option<ImmutableDeserializedPacket> {
         self.vote.take()
     }
 }

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -337,7 +337,7 @@ impl VoteStorage {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use {
         super::*,
         solana_clock::UnixTimestamp,
@@ -353,7 +353,7 @@ mod tests {
         std::{error::Error, sync::Arc},
     };
 
-    fn packet_from_slots(
+    pub(crate) fn packet_from_slots(
         slots: Vec<(u64, u32)>,
         keypairs: &ValidatorVoteKeypairs,
         timestamp: Option<UnixTimestamp>,

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -12,7 +12,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, epoch_stakes::VersionedEpochStakes},
     solana_sysvar::{self as sysvar, slot_hashes::SlotHashes},
-    std::{cmp, sync::Arc},
+    std::cmp,
 };
 
 /// Maximum number of votes a single receive call will accept
@@ -100,7 +100,7 @@ impl VoteStorage {
         self.insert_batch_with_replenish(
             deserialized_packets.filter_map(|deserialized_packet| {
                 LatestValidatorVotePacket::new_from_immutable(
-                    Arc::new(deserialized_packet),
+                    deserialized_packet,
                     vote_source,
                     should_deprecate_legacy_vote_ixs,
                 )
@@ -113,7 +113,7 @@ impl VoteStorage {
     // Re-insert re-tryable packets.
     pub(crate) fn reinsert_packets(
         &mut self,
-        packets: impl Iterator<Item = Arc<ImmutableDeserializedPacket>>,
+        packets: impl Iterator<Item = ImmutableDeserializedPacket>,
     ) {
         let should_deprecate_legacy_vote_ixs = self.deprecate_legacy_vote_ixs;
         self.insert_batch_with_replenish(
@@ -129,7 +129,7 @@ impl VoteStorage {
         );
     }
 
-    pub fn drain_unprocessed(&mut self, bank: &Bank) -> Vec<Arc<ImmutableDeserializedPacket>> {
+    pub fn drain_unprocessed(&mut self, bank: &Bank) -> Vec<ImmutableDeserializedPacket> {
         let slot_hashes = bank
             .get_account(&sysvar::slot_hashes::id())
             .and_then(|account| from_account::<SlotHashes, _>(&account));
@@ -350,7 +350,7 @@ mod tests {
         solana_signer::Signer,
         solana_vote::vote_transaction::new_tower_sync_transaction,
         solana_vote_program::vote_state::TowerSync,
-        std::error::Error,
+        std::{error::Error, sync::Arc},
     };
 
     fn packet_from_slots(
@@ -573,20 +573,24 @@ mod tests {
         );
 
         // Same votes with smaller timestamps should not override
-        let vote_a = from_slots(
-            vec![(0, 5), (1, 4), (3, 3), (10, 1)],
-            VoteSource::Gossip,
-            &keypair_a,
-            Some(2),
-        );
-        let vote_b = from_slots(
-            vec![(0, 5), (4, 2), (9, 1)],
-            VoteSource::Gossip,
-            &keypair_b,
-            Some(3),
-        );
-        vote_storage.update_latest_vote(vote_a.clone(), false /* should replenish */);
-        vote_storage.update_latest_vote(vote_b.clone(), false /* should replenish */);
+        let vote_a = || {
+            from_slots(
+                vec![(0, 5), (1, 4), (3, 3), (10, 1)],
+                VoteSource::Gossip,
+                &keypair_a,
+                Some(2),
+            )
+        };
+        let vote_b = || {
+            from_slots(
+                vec![(0, 5), (4, 2), (9, 1)],
+                VoteSource::Gossip,
+                &keypair_b,
+                Some(3),
+            )
+        };
+        vote_storage.update_latest_vote(vote_a(), false /* should replenish */);
+        vote_storage.update_latest_vote(vote_b(), false /* should replenish */);
 
         assert_eq!(2, vote_storage.len());
         assert_eq!(
@@ -607,13 +611,13 @@ mod tests {
         assert_eq!(0, vote_storage.len());
 
         // Same votes with same timestamps should not replenish without flag
-        vote_storage.update_latest_vote(vote_a.clone(), false /* should replenish */);
-        vote_storage.update_latest_vote(vote_b.clone(), false /* should replenish */);
+        vote_storage.update_latest_vote(vote_a(), false /* should replenish */);
+        vote_storage.update_latest_vote(vote_b(), false /* should replenish */);
         assert_eq!(0, vote_storage.len());
 
         // Same votes with same timestamps should replenish with the flag
-        vote_storage.update_latest_vote(vote_a, true /* should replenish */);
-        vote_storage.update_latest_vote(vote_b, true /* should replenish */);
+        vote_storage.update_latest_vote(vote_a(), true /* should replenish */);
+        vote_storage.update_latest_vote(vote_b(), true /* should replenish */);
         assert_eq!(0, vote_storage.len());
     }
 

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -259,23 +259,10 @@ impl VoteWorker {
                 vote_packets.len(),
                 slot_metrics_tracker,
             ) {
-                let mut prev = 0;
-                debug_assert!(retryable_vote_indices.iter().all(|&index| {
-                    let ok = index >= prev;
-                    prev = index;
-
-                    ok
-                }));
-
-                let mut vote_packets = vote_packets.into_iter();
-                let mut offset = 0;
-                self.storage
-                    .reinsert_packets(retryable_vote_indices.into_iter().map(|index| {
-                        let additional = index - offset;
-                        offset += additional;
-
-                        vote_packets.nth(additional).unwrap()
-                    }));
+                self.storage.reinsert_packets(Self::extract_retryable(
+                    vote_packets,
+                    retryable_vote_indices,
+                ));
             } else {
                 self.storage.reinsert_packets(vote_packets.drain(..));
             }
@@ -496,6 +483,28 @@ impl VoteWorker {
             .filter_map(|(index, res)| res.as_ref().ok().map(|_| index))
             .collect()
     }
+
+    fn extract_retryable(
+        vote_packets: ArrayVec<ImmutableDeserializedPacket, 16>,
+        retryable_vote_indices: Vec<usize>,
+    ) -> impl Iterator<Item = ImmutableDeserializedPacket> {
+        let mut prev = 0;
+        debug_assert!(retryable_vote_indices.iter().all(|&index| {
+            let ok = index >= prev;
+            prev = index;
+
+            ok
+        }));
+
+        let mut vote_packets = vote_packets.into_iter();
+        let mut offset = 0;
+        retryable_vote_indices.into_iter().map(move |index| {
+            let additional = index - offset;
+            offset += 1 + additional;
+
+            vote_packets.nth(additional).unwrap()
+        })
+    }
 }
 
 fn consume_scan_should_process_packet(
@@ -553,7 +562,11 @@ fn consume_scan_should_process_packet(
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_svm::account_loader::CheckedTransactionDetails};
+    use {
+        super::*, crate::banking_stage::vote_storage::tests::packet_from_slots,
+        solana_runtime::genesis_utils::ValidatorVoteKeypairs,
+        solana_svm::account_loader::CheckedTransactionDetails,
+    };
 
     #[test]
     fn test_bank_prepare_filter_for_pending_transaction() {
@@ -607,5 +620,79 @@ mod tests {
             ]),
             [0, 3, 4, 5]
         );
+    }
+
+    #[test]
+    fn extract_retryable_one_all_retryable() {
+        let keypair_a = ValidatorVoteKeypairs::new_rand();
+        let packets = ArrayVec::from_iter([ImmutableDeserializedPacket::new(
+            packet_from_slots(vec![(1, 1)], &keypair_a, None).as_ref(),
+        )
+        .unwrap()]);
+        let retryable_indices = vec![0];
+
+        // Assert - Able to extract exactly one packet.
+        let expected = *packets[0].message_hash();
+        let mut extracted = VoteWorker::extract_retryable(packets, retryable_indices);
+        assert_eq!(extracted.next().unwrap().message_hash(), &expected);
+        assert!(extracted.next().is_none());
+    }
+
+    #[test]
+    fn extract_retryable_one_none_retryable() {
+        let keypair_a = ValidatorVoteKeypairs::new_rand();
+        let packets = ArrayVec::from_iter([ImmutableDeserializedPacket::new(
+            packet_from_slots(vec![(1, 1)], &keypair_a, None).as_ref(),
+        )
+        .unwrap()]);
+        let retryable_indices = vec![];
+
+        // Assert - Able to extract exactly zero packets.
+        let mut extracted = VoteWorker::extract_retryable(packets, retryable_indices);
+        assert!(extracted.next().is_none());
+    }
+
+    #[test]
+    fn extract_retryable_three_last_retryable() {
+        let keypair_a = ValidatorVoteKeypairs::new_rand();
+        let packets = ArrayVec::from_iter(
+            [
+                packet_from_slots(vec![(5, 3)], &keypair_a, None).as_ref(),
+                packet_from_slots(vec![(6, 2)], &keypair_a, None).as_ref(),
+                packet_from_slots(vec![(7, 1)], &keypair_a, None).as_ref(),
+            ]
+            .into_iter()
+            .map(|packet| ImmutableDeserializedPacket::new(packet).unwrap()),
+        );
+        let retryable_indices = vec![2];
+
+        // Assert - Able to extract exactly one packet.
+        let expected = *packets[2].message_hash();
+        let mut extracted = VoteWorker::extract_retryable(packets, retryable_indices);
+        assert_eq!(extracted.next().unwrap().message_hash(), &expected);
+        assert!(extracted.next().is_none());
+    }
+
+    #[test]
+    fn extract_retryable_three_first_last_retryable() {
+        let keypair_a = ValidatorVoteKeypairs::new_rand();
+        let packets = ArrayVec::from_iter(
+            [
+                packet_from_slots(vec![(5, 3)], &keypair_a, None).as_ref(),
+                packet_from_slots(vec![(6, 2)], &keypair_a, None).as_ref(),
+                packet_from_slots(vec![(7, 1)], &keypair_a, None).as_ref(),
+            ]
+            .into_iter()
+            .map(|packet| ImmutableDeserializedPacket::new(packet).unwrap()),
+        );
+        let retryable_indices = vec![0, 2];
+
+        // Assert - Able to extract exactly one packet.
+        let expected0 = *packets[0].message_hash();
+        let expected1 = *packets[2].message_hash();
+        let mut extracted = VoteWorker::extract_retryable(packets, retryable_indices);
+        assert_eq!(extracted.next().unwrap().message_hash(), &expected0);
+        assert_eq!(extracted.next().unwrap().message_hash(), &expected1);
+        assert!(extracted.next().is_none());
     }
 }


### PR DESCRIPTION
#### Problem

- `LatestValidatorVotePacket` contains an `Option<Arc<ImmutableDeserializedPacket>>` internally. We do not actually need to ever clone this `ImmtuableDeserializedPacket`.
- Having an `Arc<T>` can break `impl &[T]` as `&[Arc<T>]` may not satisfy the more generic trait bound. This currently blocks #8347
 
#### Summary of Changes

- Remove `Arc<>` in latest_validator_vote_packet.rs.
- Fix tests to initialize additional `ImmutableDeserializedPacket` instead of cloning.
- Update VoteWorker to avoid the need to clone `ImmutableDeserializedPacket`.

