### PR TITLE
Avoid copying top level instruction data

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -240,11 +240,11 @@ impl VerboseDisplay for Output {}
 // https://github.com/rust-lang/rust/issues/74465
 struct LazyAnalysis<'a, 'b> {
     analysis: Option<Analysis<'a>>,
-    executable: &'a Executable<InvokeContext<'b>>,
+    executable: &'a Executable<InvokeContext<'b, 'b>>,
 }
 
 impl<'a, 'b> LazyAnalysis<'a, 'b> {
-    fn new(executable: &'a Executable<InvokeContext<'b>>) -> Self {
+    fn new(executable: &'a Executable<InvokeContext<'b, 'b>>) -> Self {
         Self {
             analysis: None,
             executable,
@@ -263,8 +263,8 @@ impl<'a, 'b> LazyAnalysis<'a, 'b> {
 fn load_program<'a>(
     filename: &Path,
     program_id: Pubkey,
-    invoke_context: &InvokeContext<'a>,
-) -> Executable<InvokeContext<'a>> {
+    invoke_context: &InvokeContext<'a, 'a>,
+) -> Executable<InvokeContext<'a, 'a>> {
     let mut file = File::open(filename).unwrap();
     let mut magic = [0u8; 4];
     file.read_exact(&mut magic).unwrap();
@@ -324,9 +324,10 @@ fn load_program<'a>(
     #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
     verified_executable.jit_compile().unwrap();
     unsafe {
-        std::mem::transmute::<Executable<InvokeContext<'static>>, Executable<InvokeContext<'a>>>(
-            verified_executable,
-        )
+        std::mem::transmute::<
+            Executable<InvokeContext<'static, 'static>>,
+            Executable<InvokeContext<'a, 'a>>,
+        >(verified_executable)
     }
 }
 

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1143,7 +1143,7 @@ fn consume_compute_meter(invoke_context: &InvokeContext, amount: u64) -> Result<
 fn update_callee_account(
     check_aligned: bool,
     caller_account: &CallerAccount,
-    mut callee_account: BorrowedInstructionAccount<'_>,
+    mut callee_account: BorrowedInstructionAccount<'_, '_>,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
 ) -> Result<bool, Error> {
@@ -1200,7 +1200,7 @@ fn update_caller_account_region(
     memory_mapping: &mut MemoryMapping,
     check_aligned: bool,
     caller_account: &CallerAccount,
-    callee_account: &mut BorrowedInstructionAccount<'_>,
+    callee_account: &mut BorrowedInstructionAccount<'_, '_>,
     account_data_direct_mapping: bool,
 ) -> Result<(), Error> {
     let is_caller_loader_deprecated = !check_aligned;
@@ -1250,7 +1250,7 @@ fn update_caller_account(
     memory_mapping: &MemoryMapping<'_>,
     check_aligned: bool,
     caller_account: &mut CallerAccount<'_>,
-    callee_account: &mut BorrowedInstructionAccount<'_>,
+    callee_account: &mut BorrowedInstructionAccount<'_, '_>,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
 ) -> Result<(), Error> {

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use {
     crate::{
         execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
@@ -428,7 +429,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             program_account_index,
             instruction_accounts,
             transaction_callee_map,
-            instruction.data,
+            Cow::Owned(instruction.data),
         )?;
         Ok(())
     }
@@ -473,7 +474,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             program_account_index,
             instruction_accounts,
             transaction_callee_map,
-            instruction.data.to_vec(),
+            Cow::Owned(instruction.data.to_vec()),
         )?;
         Ok(())
     }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -861,7 +861,6 @@ macro_rules! with_mock_invoke_context {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[allow(unused)]
 pub fn mock_process_instruction_with_feature_set<
     F: FnMut(&mut InvokeContext),
     G: FnMut(&mut InvokeContext),

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -27,7 +27,7 @@ use {
 #[cfg(feature = "metrics")]
 use {solana_svm_measure::measure::Measure, solana_svm_timings::ExecuteDetailsTimings};
 
-pub type ProgramRuntimeEnvironment = Arc<BuiltinProgram<InvokeContext<'static>>>;
+pub type ProgramRuntimeEnvironment = Arc<BuiltinProgram<InvokeContext<'static, 'static>>>;
 pub const MAX_LOADED_ENTRY_COUNT: usize = 512;
 pub const DELAY_VISIBILITY_SLOT_OFFSET: Slot = 1;
 
@@ -144,9 +144,9 @@ pub enum ProgramCacheEntryType {
     /// It continues to track usage statistics even when the compiled executable of the program is evicted from memory.
     Unloaded(ProgramRuntimeEnvironment),
     /// Verified and compiled program
-    Loaded(Executable<InvokeContext<'static>>),
+    Loaded(Executable<InvokeContext<'static, 'static>>),
     /// A built-in program which is not stored on-chain but backed into and distributed with the validator
-    Builtin(BuiltinProgram<InvokeContext<'static>>),
+    Builtin(BuiltinProgram<InvokeContext<'static, 'static>>),
 }
 
 impl Debug for ProgramCacheEntryType {
@@ -341,7 +341,7 @@ impl ProgramCacheEntry {
     /// hasn't changed since it was unloaded.
     pub unsafe fn reload(
         loader_key: &Pubkey,
-        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
+        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static, 'static>>>,
         deployment_slot: Slot,
         effective_slot: Slot,
         elf_bytes: &[u8],
@@ -363,7 +363,7 @@ impl ProgramCacheEntry {
 
     fn new_internal(
         loader_key: &Pubkey,
-        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static>>>,
+        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static, 'static>>>,
         deployment_slot: Slot,
         effective_slot: Slot,
         elf_bytes: &[u8],

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -669,7 +669,6 @@ fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
 #[cfg(test)]
 #[allow(clippy::indexing_slicing)]
 mod tests {
-    use std::borrow::Cow;
     use {
         super::*,
         crate::with_mock_invoke_context,
@@ -684,6 +683,7 @@ mod tests {
             InstructionAccount, TransactionContext, MAX_ACCOUNTS_PER_TRANSACTION,
         },
         std::{
+            borrow::Cow,
             cell::RefCell,
             mem::transmute,
             rc::Rc,

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -669,6 +669,7 @@ fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
 #[cfg(test)]
 #[allow(clippy::indexing_slicing)]
 mod tests {
+    use std::borrow::Cow;
     use {
         super::*,
         crate::with_mock_invoke_context,
@@ -791,7 +792,7 @@ mod tests {
                             0,
                             instruction_accounts,
                             dedup_map,
-                            instruction_data.clone(),
+                            Cow::Owned(instruction_data.clone()),
                         )
                         .unwrap();
                 } else {

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -21,7 +21,7 @@ use {
 
 /// Modifies the memory mapping in serialization and CPI return for stricter_abi_and_runtime_constraints
 pub fn modify_memory_region_of_account(
-    account: &mut BorrowedInstructionAccount<'_>,
+    account: &mut BorrowedInstructionAccount<'_, '_>,
     region: &mut MemoryRegion,
 ) {
     region.len = account.get_data().len() as u64;
@@ -36,7 +36,7 @@ pub fn modify_memory_region_of_account(
 
 /// Creates the memory mapping in serialization and CPI return for account_data_direct_mapping
 pub fn create_memory_region_of_account(
-    account: &mut BorrowedInstructionAccount<'_>,
+    account: &mut BorrowedInstructionAccount<'_, '_>,
     vaddr: u64,
 ) -> Result<MemoryRegion, InstructionError> {
     let can_data_be_changed = account.can_data_be_changed().is_ok();
@@ -52,8 +52,8 @@ pub fn create_memory_region_of_account(
 }
 
 #[allow(dead_code)]
-enum SerializeAccount<'a> {
-    Account(IndexOfAccount, BorrowedInstructionAccount<'a>),
+enum SerializeAccount<'a, 'ix_data> {
+    Account(IndexOfAccount, BorrowedInstructionAccount<'a, 'ix_data>),
     Duplicate(IndexOfAccount),
 }
 
@@ -127,7 +127,7 @@ impl Serializer {
 
     fn write_account(
         &mut self,
-        account: &mut BorrowedInstructionAccount<'_>,
+        account: &mut BorrowedInstructionAccount<'_, '_>,
     ) -> Result<u64, InstructionError> {
         if !self.stricter_abi_and_runtime_constraints {
             let vm_data_addr = self.vaddr.saturating_add(self.buffer.len() as u64);

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -109,7 +109,7 @@ fn set_invoke_context(new: &mut InvokeContext) {
         invoke_context.replace(Some(transmute::<&mut InvokeContext, usize>(new)))
     });
 }
-fn get_invoke_context<'a, 'b>() -> &'a mut InvokeContext<'b> {
+fn get_invoke_context<'a, 'b>() -> &'a mut InvokeContext<'b, 'b> {
     let ptr = INVOKE_CONTEXT.with(|invoke_context| match *invoke_context.borrow() {
         Some(val) => val,
         None => panic!("Invoke context not set!"),

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -8,7 +8,7 @@ use {
     solana_transaction_context::{InstructionAccount, TransactionContext},
 };
 
-fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionContext {
+fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionContext<'static> {
     let program_id = solana_pubkey::new_rand();
     let transaction_accounts = vec![
         (

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -428,7 +428,7 @@ fn process_instruction_finalize(
 declare_builtin_function!(
     Entrypoint,
     fn rust(
-        invoke_context: &mut InvokeContext,
+        invoke_context: &mut InvokeContext<'static, 'static>,
         _arg0: u64,
         _arg1: u64,
         _arg2: u64,
@@ -440,8 +440,8 @@ declare_builtin_function!(
     }
 );
 
-fn process_instruction_inner(
-    invoke_context: &mut InvokeContext,
+fn process_instruction_inner<'a>(
+    invoke_context: &mut InvokeContext<'a, 'a>,
 ) -> Result<u64, Box<dyn std::error::Error>> {
     let log_collector = invoke_context.get_log_collector();
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -1036,7 +1036,7 @@ mod tests {
         vote_pubkey: Pubkey,
         vote_account: AccountSharedData,
         rent: Rent,
-    ) -> TransactionContext {
+    ) -> TransactionContext<'static> {
         let program_account = AccountSharedData::new(0, 0, &native_loader::id());
         let mut transaction_context = TransactionContext::new(
             vec![(id(), program_account), (vote_pubkey, vote_account)],

--- a/svm-test-harness/src/instr.rs
+++ b/svm-test-harness/src/instr.rs
@@ -55,11 +55,11 @@ impl InvokeContextCallback for InstrContextCallback<'_> {
     }
 }
 
-fn compile_accounts(
-    input: &InstrContext,
+fn compile_accounts<'a>(
+    input: &'a InstrContext,
     compute_budget: &ComputeBudget,
     rent: Rent,
-) -> (Vec<InstructionAccount>, TransactionContext) {
+) -> (Vec<InstructionAccount>, TransactionContext<'a>) {
     let mut transaction_accounts: Vec<KeyedAccountSharedData> = input
         .accounts
         .iter()
@@ -129,6 +129,7 @@ pub fn execute_instr(
         ..ProgramRuntimeEnvironments::default()
     };
 
+    let instruction_data = input.instruction.data.iter().copied().collect::<Vec<_>>();
     let result = {
         #[allow(deprecated)]
         let (blockhash, blockhash_lamports_per_signature) = sysvar_cache
@@ -170,7 +171,6 @@ pub fn execute_instr(
             .unwrap();
 
         if invoke_context.is_precompile(&input.instruction.program_id) {
-            let instruction_data = input.instruction.data.iter().copied().collect::<Vec<_>>();
             invoke_context.process_precompile(
                 &input.instruction.program_id,
                 &input.instruction.data,

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -12,10 +12,10 @@ use {
 /// For each instruction it calls the program entrypoint method and verifies that the result of
 /// the call does not violate the bank's accounting rules.
 /// The accounts are committed back to the bank only if every instruction succeeds.
-pub(crate) fn process_message(
-    message: &impl SVMMessage,
+pub(crate) fn process_message<'ix_data>(
+    message: &'ix_data impl SVMMessage,
     program_indices: &[IndexOfAccount],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_, 'ix_data>,
     execute_timings: &mut ExecuteTimings,
     accumulated_consumed_units: &mut u64,
 ) -> Result<(), TransactionError> {

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -26,7 +26,12 @@ pub(crate) fn process_message<'ix_data>(
         .enumerate()
     {
         invoke_context
-            .prepare_next_top_level_instruction(message, &instruction, *program_account_index)
+            .prepare_next_top_level_instruction(
+                message,
+                &instruction,
+                *program_account_index,
+                instruction.data,
+            )
             .map_err(|err| {
                 TransactionError::InstructionError(top_level_instruction_index as u8, err)
             })?;

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1004,7 +1004,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     inner_instructions.push(InnerInstruction {
                         instruction: CompiledInstruction::new_from_raw_parts(
                             ix_in_trace.program_account_index_in_tx as u8,
-                            ix_in_trace.instruction_data,
+                            ix_in_trace.instruction_data.into_owned(),
                             ix_in_trace
                                 .instruction_accounts
                                 .iter()

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -354,7 +354,7 @@ pub fn register_builtins(
     );
 }
 
-pub fn create_custom_loader<'a>() -> BuiltinProgram<InvokeContext<'a>> {
+pub fn create_custom_loader<'a>() -> BuiltinProgram<InvokeContext<'a, 'a>> {
     let compute_budget = SVMTransactionExecutionBudget::default();
     let vm_config = Config {
         max_call_depth: compute_budget.max_call_depth,

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -279,12 +279,12 @@ macro_rules! register_feature_gated_function {
     };
 }
 
-pub fn create_program_runtime_environment_v1<'a>(
+pub fn create_program_runtime_environment_v1<'a, 'ix_data>(
     feature_set: &SVMFeatureSet,
     compute_budget: &SVMTransactionExecutionBudget,
     reject_deployment_of_broken_elfs: bool,
     debugging_features: bool,
-) -> Result<BuiltinProgram<InvokeContext<'a>>, Error> {
+) -> Result<BuiltinProgram<InvokeContext<'a, 'ix_data>>, Error> {
     let enable_alt_bn128_syscall = feature_set.enable_alt_bn128_syscall;
     let enable_alt_bn128_compression_syscall = feature_set.enable_alt_bn128_compression_syscall;
     let enable_big_mod_exp_syscall = feature_set.enable_big_mod_exp_syscall;
@@ -513,10 +513,10 @@ pub fn create_program_runtime_environment_v1<'a>(
     Ok(result)
 }
 
-pub fn create_program_runtime_environment_v2<'a>(
+pub fn create_program_runtime_environment_v2<'a, 'ix_data>(
     compute_budget: &SVMTransactionExecutionBudget,
     debugging_features: bool,
-) -> BuiltinProgram<InvokeContext<'a>> {
+) -> BuiltinProgram<InvokeContext<'a, 'ix_data>> {
     let config = Config {
         max_call_depth: compute_budget.max_call_depth,
         stack_frame_size: compute_budget.stack_frame_size,
@@ -4147,7 +4147,7 @@ mod tests {
     }
 
     type BuiltinFunctionRustInterface<'a> = fn(
-        &mut InvokeContext<'a>,
+        &mut InvokeContext<'a, 'a>,
         u64,
         u64,
         u64,
@@ -4157,7 +4157,7 @@ mod tests {
     ) -> Result<u64, Box<dyn std::error::Error>>;
 
     fn call_program_address_common<'a, 'b: 'a>(
-        invoke_context: &'a mut InvokeContext<'b>,
+        invoke_context: &'a mut InvokeContext<'b, 'b>,
         seeds: &[&[u8]],
         program_id: &Pubkey,
         overlap_outputs: bool,
@@ -4210,8 +4210,8 @@ mod tests {
         result.map(|_| (address, bump_seed))
     }
 
-    fn create_program_address(
-        invoke_context: &mut InvokeContext,
+    fn create_program_address<'a>(
+        invoke_context: &mut InvokeContext<'a, 'a>,
         seeds: &[&[u8]],
         address: &Pubkey,
     ) -> Result<Pubkey, Error> {
@@ -4225,8 +4225,8 @@ mod tests {
         Ok(address)
     }
 
-    fn try_find_program_address(
-        invoke_context: &mut InvokeContext,
+    fn try_find_program_address<'a>(
+        invoke_context: &mut InvokeContext<'a, 'a>,
         seeds: &[&[u8]],
         address: &Pubkey,
     ) -> Result<(Pubkey, u8), Error> {

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -18,7 +18,7 @@ use {
     solana_instructions_sysvar as instructions,
     solana_pubkey::Pubkey,
     solana_sbpf::memory_region::{AccessType, AccessViolationHandler, MemoryRegion},
-    std::{cell::Cell, collections::HashSet, rc::Rc},
+    std::{borrow::Cow, cell::Cell, collections::HashSet, rc::Rc},
 };
 #[cfg(not(target_os = "solana"))]
 use {solana_account::WritableAccount, solana_rent::Rent};

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -127,7 +127,7 @@ pub struct TransactionContext<'ix_data> {
     rent: Rent,
 }
 
-impl TransactionContext<'_> {
+impl<'ix_data> TransactionContext<'ix_data> {
     /// Constructs a new TransactionContext
     #[cfg(not(target_os = "solana"))]
     pub fn new(
@@ -282,7 +282,7 @@ impl TransactionContext<'_> {
         program_index: IndexOfAccount,
         instruction_accounts: Vec<InstructionAccount>,
         deduplication_map: Vec<u8>,
-        instruction_data: Vec<u8>,
+        instruction_data: Cow<'ix_data, [u8]>,
     ) -> Result<(), InstructionError> {
         debug_assert_eq!(deduplication_map.len(), MAX_ACCOUNTS_PER_TRANSACTION);
         let instruction = self
@@ -291,7 +291,7 @@ impl TransactionContext<'_> {
             .ok_or(InstructionError::CallDepth)?;
         instruction.program_account_index_in_tx = program_index;
         instruction.instruction_accounts = instruction_accounts;
-        instruction.instruction_data = Cow::from(instruction_data);
+        instruction.instruction_data = instruction_data;
         instruction.dedup_map = deduplication_map;
         Ok(())
     }
@@ -317,7 +317,7 @@ impl TransactionContext<'_> {
             program_index,
             instruction_accounts,
             dedup_map,
-            instruction_data,
+            Cow::Owned(instruction_data),
         )
     }
 


### PR DESCRIPTION
#### Problem

We copy instruction data for every top level instruction into InstructionFrame. The data is never moved out, so the copy is unnecessary.

#### Summary of Changes

1. Change the instruction data type in InstructionFrame to `Cow<'ix_data, [u8]>`.
2. Get the lifetimes correctly everywhere. Add a new lifetime parameter to InvokeContext and TransactionContext.
3. Change the parameter of `configure_next_instruction` to `Cow<[u8]>`.
4. Add another parameter to `prepare_next_top_level_instruction` to carry the instruction data lifetime to `configure_next_instruction`.
5. Avoid the copy.
