### PR TITLE
allow relevant bins to select remote-wallet backend

### DIFF
--- a/cargo-registry/Cargo.toml
+++ b/cargo-registry/Cargo.toml
@@ -13,7 +13,10 @@ edition = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
+default = ["remote-wallet-hidraw"]
 dev-context-only-utils = []
+remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
+remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
 clap = { workspace = true }
@@ -33,7 +36,7 @@ solana-commitment-config = { workspace = true }
 solana-keypair = { workspace = true }
 solana-logger = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-remote-wallet = { workspace = true, features = ["default"] }
+solana-remote-wallet = { workspace = true }
 solana-rpc-client = { workspace = true, features = ["default"] }
 solana-rpc-client-api = { workspace = true }
 solana-signer = { workspace = true }

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -29,7 +29,7 @@ solana-message = { workspace = true }
 solana-native-token = { workspace = true }
 solana-presigner = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-remote-wallet = { workspace = true, features = ["default"] }
+solana-remote-wallet = { workspace = true }
 solana-seed-phrase = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -16,7 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 name = "solana_clap_v3_utils"
 
 [features]
-default = []
 elgamal = ["dep:solana-zk-sdk"]
 
 [dependencies]
@@ -34,7 +33,7 @@ solana-message = { workspace = true }
 solana-native-token = { workspace = true }
 solana-presigner = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-remote-wallet = { workspace = true, features = ["default"] }
+solana-remote-wallet = { workspace = true }
 solana-seed-derivable = { workspace = true }
 solana-seed-phrase = { workspace = true }
 solana-signature = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,10 @@ name = "solana"
 path = "src/main.rs"
 
 [features]
+default = ["remote-wallet-hidraw"]
 dev-context-only-utils = ["solana-faucet/dev-context-only-utils"]
+remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
+remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -74,7 +77,7 @@ solana-program-runtime = { workspace = true }
 solana-pubkey = { version = "=3.0.0", default-features = false }
 solana-pubsub-client = { workspace = true }
 solana-quic-client = { workspace = true }
-solana-remote-wallet = { workspace = true, features = ["default"] }
+solana-remote-wallet = { workspace = true }
 solana-rent = "=3.0.0"
 solana-rpc-client = { workspace = true, features = ["default"] }
 solana-rpc-client-api = { workspace = true }

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -16,6 +16,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 name = "solana-keygen"
 path = "src/keygen.rs"
 
+[features]
+default = ["remote-wallet-hidraw"]
+remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
+remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
+
 [dependencies]
 bs58 = { workspace = true, features = ["std"] }
 clap = { version = "3.1.5", features = ["cargo"] }
@@ -29,7 +34,7 @@ solana-instruction = { version = "=3.0.0", features = ["bincode"] }
 solana-keypair = "=3.0.1"
 solana-message = { version = "=3.0.1", features = ["bincode"] }
 solana-pubkey = { version = "=3.0.0", default-features = false }
-solana-remote-wallet = { workspace = true, features = ["default"] }
+solana-remote-wallet = { workspace = true }
 solana-seed-derivable = "=3.0.0"
 solana-signer = "=3.0.0"
 solana-version = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2647,19 +2647,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
-name = "hidapi"
-version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b876ecf37e86b359573c16c8366bc3eba52b689884a0fc42ba3f67203d2a8b"
-dependencies = [
- "cc",
- "cfg-if 1.0.3",
- "libc",
- "pkg-config",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7876,7 +7863,6 @@ version = "3.1.0"
 dependencies = [
  "console 0.16.1",
  "dialoguer",
- "hidapi",
  "log",
  "num-derive",
  "num-traits",

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -12,6 +12,11 @@ edition = { workspace = true }
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[features]
+default = ["remote-wallet-hidraw"]
+remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
+remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
+
 [dependencies]
 clap = { workspace = true }
 solana-account = { workspace = true }
@@ -27,7 +32,7 @@ solana-keypair = { workspace = true }
 solana-message = { workspace = true }
 solana-native-token = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-remote-wallet = { workspace = true, features = ["default"] }
+solana-remote-wallet = { workspace = true }
 solana-rpc-client = { workspace = true, features = ["default"] }
 solana-rpc-client-api = { workspace = true }
 solana-signature = { workspace = true }

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -9,6 +9,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+default = ["remote-wallet-hidraw"]
+remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
+remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
+
 [dependencies]
 chrono = { workspace = true, features = ["default", "serde"] }
 clap = "2.33.0"
@@ -34,7 +39,7 @@ solana-native-token = { workspace = true }
 solana-program-error = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-remote-wallet = { workspace = true, features = ["default"] }
+solana-remote-wallet = { workspace = true }
 solana-rpc-client = { workspace = true, features = ["default"] }
 solana-rpc-client-api = { workspace = true }
 solana-signature = { workspace = true }


### PR DESCRIPTION
#### Problem
some platforms (chromeos) do not support the linux hidraw interface, making them incompatible with the `solana-remote-wallet` crate

#### Summary of Changes
plumb hidapi backend selection crate features through to the relevant bin crates