### PR TITLE
Bump modular-bitfield to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4672,9 +4672,9 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
+checksum = "be0d5274763b5572c8f29dadb5cd0bc59de64c805de433c1b556075f733b0a1a"
 dependencies = [
  "modular-bitfield-impl",
  "static_assertions",
@@ -4682,13 +4682,13 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield-impl"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
+checksum = "f8eec4327f127d4d18c54c8bfbf7b05d74cc9a1befdcc6283a241238ffbc84c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ memoffset = "0.9"
 merlin = { version = "3", default-features = false }
 min-max-heap = "1.3.0"
 mockall = "0.11.4"
-modular-bitfield = "0.11.2"
+modular-bitfield = "0.12.0"
 nix = "0.30.1"
 num-bigint = "0.4.6"
 num-derive = "0.4"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -3824,9 +3824,9 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
+checksum = "be0d5274763b5572c8f29dadb5cd0bc59de64c805de433c1b556075f733b0a1a"
 dependencies = [
  "modular-bitfield-impl",
  "static_assertions",
@@ -3834,13 +3834,13 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield-impl"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
+checksum = "f8eec4327f127d4d18c54c8bfbf7b05d74cc9a1befdcc6283a241238ffbc84c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.87",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
modular-bitfield got a new release in 2025-05-05, while agave uses the previous stable release from 2020-11-07
Additionally, we know bitfield causes issues with newer Rust lint, so it's desirable to move to newer version (https://github.com/anza-xyz/agave/issues/8117#issuecomment-3343931008), even if this one won't fix the issue, there might be subsequent patch release.

#### Summary of Changes
Switch from 0.11.2 to 0.12.0
The breaking changes don't affect us directly, so it's a clean deps diff. 

Release summary:
##### Breaking changes
* The MSRV is now 1.70. This is not currently a hard requirement of modular-bitfield itself but is instead the path of least resistance due to changes to underlying dev-dependencies, so please open a ticket if you really need support for an even older version of Rust.
* The InvalidBitPattern::invalid_bytes field is now private. Use the InvalidBitPattern::invalid_bytes() method to access the invalid bytes (and InvalidBitPattern::new() to create new errors).

##### Deprecations
* To conform with idiomatic Rust code, the derive macro #[derive(BitfieldSpecifier)] has been renamed to #[derive(Specifier)] because it derives the Specifier trait. The deprecated alias will be removed in the next release of modular-bitfield.

##### Enhancements
* The syn dependency has been updated to version 2.
* Generated constructors and getters are now annotated with #[must_use]. (https://github.com/modular-bitfield/modular-bitfield/issues/79)
* Structs with const generics can now use #[bitfield]. (https://github.com/modular-bitfield/modular-bitfield/issues/87)

##### Bug fixes
* Enumeration variant names will no longer conflict with code generated by #[derive(Specifier)]. (https://github.com/modular-bitfield/modular-bitfield/issues/82)
* Using #[bitfield] on an empty struct now emits an appropriate diagnostic instead of causing a compile-time arithmetic error. (https://github.com/modular-bitfield/modular-bitfield/issues/104)
* Various fixes to lints. (https://github.com/modular-bitfield/modular-bitfield/issues/62, https://github.com/modular-bitfield/modular-bitfield/issues/66, https://github.com/modular-bitfield/modular-bitfield/pull/93, https://github.com/modular-bitfield/modular-bitfield/pull/95. Thanks, @dimpolo, @diseraluca, @nilfit, and @LDVSOFT!)
* Various fixes to documentation formatting. (https://github.com/modular-bitfield/modular-bitfield/pull/91, https://github.com/modular-bitfield/modular-bitfield/pull/101, https://github.com/modular-bitfield/modular-bitfield/pull/103. Thanks, @00xc, @SebastianJL, and @jruderman!)
* When automatically deriving Debug, tuple-like structs are now formatted normally instead of like structs with numeric fields.