### PR TITLE
bpf_loader: expose SBPF interpreter mode and debugger features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7577,6 +7577,7 @@ dependencies = [
  "agave-syscalls",
  "assert_matches",
  "bincode",
+ "cfg-if 1.0.3",
  "criterion",
  "qualifier_attr",
  "rand 0.9.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,6 +3314,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdbstub"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e02bf1b1a624d96925c608f1b268d82a76cbc587ce9e59f7c755e9ea11c75c"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.4",
+ "log",
+ "managed",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
 name = "gen-headers"
 version = "4.0.0-alpha.0"
 dependencies = [
@@ -4676,6 +4690,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "maplit"
@@ -7577,7 +7597,7 @@ dependencies = [
  "agave-syscalls",
  "assert_matches",
  "bincode",
- "cfg-if 1.0.3",
+ "cfg-if 1.0.4",
  "criterion",
  "qualifier_attr",
  "rand 0.9.2",
@@ -10557,6 +10577,7 @@ checksum = "b15b079e08471a9dbfe1e48b2c7439c85aa2a055cbd54eddd8bd257b0a7dbb29"
 dependencies = [
  "byteorder",
  "combine 3.8.1",
+ "gdbstub",
  "hash32",
  "libc",
  "log",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6521,6 +6521,7 @@ version = "4.0.0-alpha.0"
 dependencies = [
  "agave-syscalls",
  "bincode",
+ "cfg-if 1.0.4",
  "qualifier_attr",
  "solana-account",
  "solana-bincode",

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -20,11 +20,7 @@ name = "solana_bpf_loader_program"
 default = ["metrics"]
 agave-unstable-api = []
 metrics = ["solana-program-runtime/metrics"]
-sbpf-debugger = [
-    "sbpf-interpreter-mode",
-    "solana-sbpf/debugger",
-]
-sbpf-interpreter-mode = []
+sbpf-debugger = ["solana-sbpf/debugger"]
 shuttle-test = [
     "solana-program-runtime/shuttle-test",
     "solana-sbpf/shuttle-test",

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -20,6 +20,11 @@ name = "solana_bpf_loader_program"
 default = ["metrics"]
 agave-unstable-api = []
 metrics = ["solana-program-runtime/metrics"]
+sbpf-debugger = [
+    "sbpf-interpreter-mode",
+    "solana-sbpf/debugger",
+]
+sbpf-interpreter-mode = []
 shuttle-test = [
     "solana-program-runtime/shuttle-test",
     "solana-sbpf/shuttle-test",

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -35,6 +35,7 @@ svm-internal = []
 [dependencies]
 agave-syscalls = { workspace = true }
 bincode = { workspace = true }
+cfg-if = { workspace = true }
 qualifier_attr = { workspace = true }
 solana-account = { workspace = true }
 solana-bincode = { workspace = true }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1466,9 +1466,17 @@ fn execute<'a, 'b: 'a>(
     let program_id = *instruction_context.get_program_key()?;
     let is_loader_deprecated =
         instruction_context.get_program_owner()? == bpf_loader_deprecated::id();
-    #[cfg(any(target_os = "windows", not(target_arch = "x86_64")))]
+    #[cfg(any(
+        target_os = "windows",
+        not(target_arch = "x86_64"),
+        feature = "sbpf-interpreter-mode"
+    ))]
     let use_jit = false;
-    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
+    #[cfg(all(
+        not(target_os = "windows"),
+        target_arch = "x86_64",
+        not(feature = "sbpf-interpreter-mode")
+    ))]
     let use_jit = executable.get_compiled_program().is_some();
     let stricter_abi_and_runtime_constraints = invoke_context
         .get_feature_set()

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1471,7 +1471,6 @@ fn execute<'a, 'b: 'a>(
         if #[cfg(any(
             target_os = "windows",
             not(target_arch = "x86_64"),
-            feature = "sbpf-interpreter-mode"
         ))] {
             let use_jit = false;
         } else {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -13,6 +13,7 @@
 #[cfg(feature = "svm-internal")]
 use qualifier_attr::qualifiers;
 use {
+    cfg_if::cfg_if,
     solana_bincode::limited_deserialize,
     solana_clock::Slot,
     solana_instruction::{error::InstructionError, AccountMeta},
@@ -1466,18 +1467,17 @@ fn execute<'a, 'b: 'a>(
     let program_id = *instruction_context.get_program_key()?;
     let is_loader_deprecated =
         instruction_context.get_program_owner()? == bpf_loader_deprecated::id();
-    #[cfg(any(
-        target_os = "windows",
-        not(target_arch = "x86_64"),
-        feature = "sbpf-interpreter-mode"
-    ))]
-    let use_jit = false;
-    #[cfg(all(
-        not(target_os = "windows"),
-        target_arch = "x86_64",
-        not(feature = "sbpf-interpreter-mode")
-    ))]
-    let use_jit = executable.get_compiled_program().is_some();
+    cfg_if! {
+        if #[cfg(any(
+            target_os = "windows",
+            not(target_arch = "x86_64"),
+            feature = "sbpf-interpreter-mode"
+        ))] {
+            let use_jit = false;
+        } else {
+            let use_jit = executable.get_compiled_program().is_some();
+        }
+    }
     let stricter_abi_and_runtime_constraints = invoke_context
         .get_feature_set()
         .stricter_abi_and_runtime_constraints;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1471,6 +1471,7 @@ fn execute<'a, 'b: 'a>(
         if #[cfg(any(
             target_os = "windows",
             not(target_arch = "x86_64"),
+            feature = "sbpf-debugger"
         ))] {
             let use_jit = false;
         } else {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6358,7 +6358,7 @@ version = "4.0.0-alpha.0"
 dependencies = [
  "agave-syscalls",
  "bincode",
- "cfg-if 1.0.3",
+ "cfg-if 1.0.4",
  "qualifier_attr",
  "solana-account",
  "solana-bincode",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6358,6 +6358,7 @@ version = "4.0.0-alpha.0"
 dependencies = [
  "agave-syscalls",
  "bincode",
+ "cfg-if 1.0.3",
  "qualifier_attr",
  "solana-account",
  "solana-bincode",


### PR DESCRIPTION
Introduces two features:
- `sbpf-interpreter-mode` that forces the Solana SBPF VM to work in `interpreter mode`. ~~It is only this mode from which **register tracing** could be obtained.~~ On MacOS it is this mode that is always used, but on Linux it always defaults to using jit compiled programs. This feature allows Linux users to also be able to work in `interpreter mode` that is particularly useful for development and debugging purposes.
- `sbpf-debugger` is to provide a way to enable the `debugger` feature in the `solana-sbpf` crate. The debugger is tied to `interpreter mode` and hence upon enabling this feature switch to interpreter mode.

EDIT: register tracing is also possible for JIT mode. 