### PR TITLE
Pass SlotListWriteGuard instead of &mut to it for slot list updates

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1485,7 +1485,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     /// Returns true if the slot list was completely purged (is empty at the end).
     fn purge_older_root_entries(
         &self,
-        slot_list: &mut SlotListWriteGuard<T>,
+        mut slot_list: SlotListWriteGuard<T>,
         reclaims: &mut ReclaimsSlotList<T>,
         max_clean_root_inclusive: Option<Slot>,
     ) -> bool {
@@ -1533,11 +1533,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         let mut is_slot_list_empty = false;
         let missing_in_accounts_index = self
             .slot_list_mut(pubkey, |mut slot_list| {
-                is_slot_list_empty = self.purge_older_root_entries(
-                    &mut slot_list,
-                    reclaims,
-                    max_clean_root_inclusive,
-                );
+                is_slot_list_empty =
+                    self.purge_older_root_entries(slot_list, reclaims, max_clean_root_inclusive);
             })
             .is_none();
 
@@ -3380,22 +3377,22 @@ pub mod tests {
             1,
             AccountMapEntryMeta::default(),
         );
-        let mut slot_list = entry.slot_list_write_lock();
         let mut reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, None));
+        assert!(!index.purge_older_root_entries(entry.slot_list_write_lock(), &mut reclaims, None));
         assert!(reclaims.is_empty());
         assert_eq!(
-            slot_list.clone_list(),
-            SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
+            entry.slot_list_lock_read_len().as_ref(),
+            &SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
         );
 
         // Add a later root, earlier slots should be reclaimed
+        let mut slot_list = entry.slot_list_write_lock();
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         index.add_root(1);
         // Note 2 is not a root
         index.add_root(5);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, None));
+        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, None));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
         assert_eq!(
             slot_list.clone_list(),
@@ -3405,7 +3402,7 @@ pub mod tests {
         slot_list.assign([(1 as Slot, true), (2, true), (5, true), (9, true)]);
         index.add_root(6);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, None));
+        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, None));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
         assert_eq!(
             slot_list.clone_list(),
@@ -3416,7 +3413,7 @@ pub mod tests {
         // outcome
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(6)));
+        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, Some(6)));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
         assert_eq!(
             slot_list.clone_list(),
@@ -3426,7 +3423,7 @@ pub mod tests {
         // Pass a max root, earlier slots should be reclaimed
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(5)));
+        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, Some(5)));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
         assert_eq!(
             slot_list.clone_list(),
@@ -3437,7 +3434,7 @@ pub mod tests {
         // so nothing will be purged
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(2)));
+        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, Some(2)));
         assert!(reclaims.is_empty());
         assert_eq!(
             slot_list.clone_list(),
@@ -3448,7 +3445,7 @@ pub mod tests {
         // so nothing will be purged
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(1)));
+        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, Some(1)));
         assert!(reclaims.is_empty());
         assert_eq!(
             slot_list.clone_list(),
@@ -3459,7 +3456,7 @@ pub mod tests {
         // some of the roots in the list, shouldn't return those smaller roots
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(7)));
+        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, Some(7)));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
         assert_eq!(
             slot_list.clone_list(),


### PR DESCRIPTION
#### Problem
Several functions have `&mut SlotListWriteGuard` parameter to operate on slot_list, since before https://github.com/anza-xyz/agave/pull/8381 the caller had to check the size of the final list. Now all necessary calculations can be localized to those functions, so they can take owned guard.

#### Summary of Changes
Cleanup code, reduce scope of holding the lock, make it easier to reason about locking - pass `SlotListWriteGuard` to `update_slot_list` and `purge_older_root_entries`
