### PR TITLE
scheduling-utils: Add TransactionPtr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,10 @@ version = "3.1.0"
 name = "agave-scheduling-utils"
 version = "3.1.0"
 dependencies = [
+ "agave-scheduler-bindings",
+ "agave-transaction-view",
  "ahash 0.8.11",
+ "rts-alloc",
  "solana-pubkey",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -148,7 +148,10 @@ version = "3.1.0"
 name = "agave-scheduling-utils"
 version = "3.1.0"
 dependencies = [
+ "agave-scheduler-bindings",
+ "agave-transaction-view",
  "ahash 0.8.11",
+ "rts-alloc",
  "solana-pubkey",
 ]
 

--- a/scheduling-utils/Cargo.toml
+++ b/scheduling-utils/Cargo.toml
@@ -13,8 +13,10 @@ edition = { workspace = true }
 agave-scheduler-bindings = { workspace = true }
 agave-transaction-view = { workspace = true }
 ahash = { workspace = true }
-rts-alloc = { workspace = true }
 solana-pubkey = { workspace = true }
+
+[target."cfg(unix)".dependencies]
+rts-alloc = { workspace = true }
 
 [lints]
 workspace = true

--- a/scheduling-utils/Cargo.toml
+++ b/scheduling-utils/Cargo.toml
@@ -10,7 +10,10 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+agave-scheduler-bindings = { workspace = true }
+agave-transaction-view = { workspace = true }
 ahash = { workspace = true }
+rts-alloc = { workspace = true }
 solana-pubkey = { workspace = true }
 
 [lints]

--- a/scheduling-utils/src/lib.rs
+++ b/scheduling-utils/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod thread_aware_account_locks;
+
+#[cfg(unix)]
 pub mod transaction_ptr;

--- a/scheduling-utils/src/lib.rs
+++ b/scheduling-utils/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod thread_aware_account_locks;
+pub mod transaction_ptr;

--- a/scheduling-utils/src/transaction_ptr.rs
+++ b/scheduling-utils/src/transaction_ptr.rs
@@ -1,0 +1,58 @@
+use {
+    agave_scheduler_bindings::SharableTransactionRegion,
+    agave_transaction_view::transaction_data::TransactionData, core::ptr::NonNull,
+    rts_alloc::Allocator,
+};
+
+pub struct TransactionPtr {
+    ptr: NonNull<u8>,
+    len: usize,
+}
+
+impl TransactionData for TransactionPtr {
+    fn data(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+}
+
+impl TransactionPtr {
+    /// # Safety
+    /// - `sharable_transaction_region` must reference a valid offset and length
+    ///   within the `allocator`.
+    pub unsafe fn from_sharable_transaction_region(
+        sharable_transaction_region: &SharableTransactionRegion,
+        allocator: &Allocator,
+    ) -> Self {
+        let ptr = allocator.ptr_from_offset(sharable_transaction_region.offset);
+        Self {
+            ptr,
+            len: sharable_transaction_region.length as usize,
+        }
+    }
+
+    /// Translate the ptr type into a sharable region.
+    pub fn to_sharable_transaction_region(
+        &self,
+        allocator: &Allocator,
+    ) -> SharableTransactionRegion {
+        // SAFETY: The `TransactionPtr` creation `Self::from_sharable_transaction_region`
+        // is already conditioned on the offset being valid, if that safety constraint
+        // was satisfied translation back to offset is safe.
+        let offset = unsafe { allocator.offset(self.ptr) };
+        SharableTransactionRegion {
+            offset,
+            length: self.len as u32,
+        }
+    }
+
+    /// Frees the memory region pointed to in the `allocator`.
+    /// This should only be called by the owner of the memory
+    /// i.e. the external scheduler.
+    ///
+    /// # Safety
+    /// - Data region pointed to by `TransactionPtr` belongs to the `allocator`.
+    /// - Inner `ptr` must not have been previously freed.
+    pub unsafe fn free(self, allocator: &Allocator) {
+        unsafe { allocator.free(self.ptr) }
+    }
+}

--- a/scheduling-utils/src/transaction_ptr.rs
+++ b/scheduling-utils/src/transaction_ptr.rs
@@ -31,7 +31,11 @@ impl TransactionPtr {
     }
 
     /// Translate the ptr type into a sharable region.
-    pub fn to_sharable_transaction_region(
+    ///
+    /// # Safety
+    /// - `allocator` must be the allocator owning the memory region pointed
+    ///   to by `self`.
+    pub unsafe fn to_sharable_transaction_region(
         &self,
         allocator: &Allocator,
     ) -> SharableTransactionRegion {


### PR DESCRIPTION
#### Problem
- Message types in bindings must be translated into usable ptr/lens.
- This must happen both on the side of the external-schedulers and internal agave threads

#### Summary of Changes
- Add a `TransactionPtr` struct
  - Implements `TransactionData` so it can be used with `TransactionView`
  - Conversion to/from `SharableTransactionRegion`
  - Consuming method to `free` the memory in allocator