### PR TITLE
Implement serialize/deserialize for obsolete accounts

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -913,6 +913,14 @@ impl AccountStorageEntry {
         self.alive_bytes.load(Ordering::Acquire)
     }
 
+    /// Returns the accounts that were marked obsolete as of the passed in slot
+    /// or earlier. Returned data includes the slots that the accounts were marked
+    /// obsolete at
+    pub fn obsolete_accounts_for_snapshots(&self, slot: Slot) -> ObsoleteAccounts {
+        self.obsolete_accounts_read_lock()
+            .obsolete_accounts_for_snapshots(slot)
+    }
+
     /// Locks obsolete accounts with a read lock and returns the the accounts with the guard
     pub(crate) fn obsolete_accounts_read_lock(&self) -> RwLockReadGuard<ObsoleteAccounts> {
         self.obsolete_accounts.read().unwrap()

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -46,8 +46,9 @@ pub mod utils;
 pub mod waitable_condvar;
 
 pub use {
-    buffered_reader::large_file_buf_reader, file_io::validate_memlock_limit_for_disk_io,
-    obsolete_accounts::ObsoleteAccounts,
+    buffered_reader::large_file_buf_reader,
+    file_io::validate_memlock_limit_for_disk_io,
+    obsolete_accounts::{ObsoleteAccountItem, ObsoleteAccounts},
 };
 
 #[macro_use]

--- a/accounts-db/src/obsolete_accounts.rs
+++ b/accounts-db/src/obsolete_accounts.rs
@@ -1,18 +1,18 @@
 use {crate::account_info::Offset, solana_clock::Slot};
 
 #[derive(Debug, Clone, PartialEq)]
-struct ObsoleteAccountItem {
+pub struct ObsoleteAccountItem {
     /// Offset of the account in the account storage entry
-    offset: Offset,
+    pub offset: Offset,
     /// Length of the account data
-    data_len: usize,
+    pub data_len: usize,
     /// Slot when the account was marked obsolete
-    slot: Slot,
+    pub slot: Slot,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct ObsoleteAccounts {
-    accounts: Vec<ObsoleteAccountItem>,
+    pub accounts: Vec<ObsoleteAccountItem>,
 }
 
 impl ObsoleteAccounts {
@@ -44,6 +44,22 @@ impl ObsoleteAccounts {
             .iter()
             .filter(move |obsolete_account| slot.is_none_or(|s| obsolete_account.slot <= s))
             .map(|obsolete_account| (obsolete_account.offset, obsolete_account.data_len))
+    }
+
+    /// Returns the accounts that were marked obsolete as of the passed in slot
+    /// or earlier. Returned data includes the slots that the accounts were marked
+    /// obsolete at
+    pub fn obsolete_accounts_for_snapshots(&self, slot: Slot) -> ObsoleteAccounts {
+        let filtered_accounts = self
+            .accounts
+            .iter()
+            .filter(|account| account.slot <= slot)
+            .cloned()
+            .collect();
+
+        ObsoleteAccounts {
+            accounts: filtered_accounts,
+        }
     }
 }
 #[cfg(test)]
@@ -98,5 +114,41 @@ mod tests {
         let filtered_accounts: Vec<_> = obsolete_accounts.filter_obsolete_accounts(None).collect();
 
         assert_eq!(filtered_accounts, vec![(10, 100), (20, 200), (30, 300)]);
+    }
+
+    #[test]
+    fn test_obsolete_accounts_for_snapshots() {
+        let mut obsolete_accounts = ObsoleteAccounts::default();
+        let new_accounts = vec![(10, 100, 40), (20, 200, 42), (30, 300, 44)]
+            .into_iter()
+            .map(|(offset, data_len, slot)| ObsoleteAccountItem {
+                offset,
+                data_len,
+                slot,
+            })
+            .collect::<Vec<_>>();
+
+        // Mark accounts obsolete with different slots
+        new_accounts.iter().for_each(|item| {
+            obsolete_accounts
+                .mark_accounts_obsolete([(item.offset, item.data_len)].into_iter(), item.slot)
+        });
+
+        // Filter accounts obsolete as of slot 42
+        let obsolete_accounts_for_snapshots = obsolete_accounts.obsolete_accounts_for_snapshots(42);
+
+        let expected_accounts: Vec<_> = new_accounts
+            .iter()
+            .filter(|account| account.slot <= 42)
+            .cloned()
+            .collect();
+
+        assert_eq!(obsolete_accounts_for_snapshots.accounts, expected_accounts);
+
+        // Filter accounts obsolete passing in no slot (i.e., all obsolete accounts)
+        let obsolete_accounts_for_snapshots =
+            obsolete_accounts.obsolete_accounts_for_snapshots(100);
+
+        assert_eq!(obsolete_accounts_for_snapshots.accounts, new_accounts);
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1658,6 +1658,7 @@ dependencies = [
  "once_cell",
  "parking_lot_core 0.9.8",
  "rayon",
+ "serde",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -65,7 +65,7 @@ blake3 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true }
 crossbeam-channel = { workspace = true }
-dashmap = { workspace = true, features = ["rayon", "raw-api"] }
+dashmap = { workspace = true, features = ["rayon", "raw-api", "serde"] }
 dir-diff = { workspace = true }
 fnv = { workspace = true }
 im = { workspace = true, features = ["rayon", "serde"] }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -54,6 +54,7 @@ use {
     types::SerdeAccountsLtHash,
 };
 
+mod obsolete_accounts;
 mod status_cache;
 mod storage;
 mod tests;
@@ -61,8 +62,9 @@ mod types;
 mod utils;
 
 pub(crate) use {
+    obsolete_accounts::SerdeObsoleteAccountsMap,
     status_cache::{deserialize_status_cache, serialize_status_cache},
-    storage::{SerdeObsoleteAccounts, SerializableAccountStorageEntry, SerializedAccountsFileId},
+    storage::{SerializableAccountStorageEntry, SerializedAccountsFileId},
 };
 
 const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;
@@ -369,7 +371,18 @@ impl<T> SnapshotAccountsDbFields<T> {
     }
 }
 
-fn deserialize_from<R, T>(reader: R) -> bincode::Result<T>
+pub(crate) fn serialize_into<W, T>(writer: W, value: &T) -> bincode::Result<()>
+where
+    W: Write,
+    T: Serialize,
+{
+    bincode::options()
+        .with_fixint_encoding()
+        .with_limit(MAX_STREAM_SIZE)
+        .serialize_into(writer, value)
+}
+
+pub(crate) fn deserialize_from<R, T>(reader: R) -> bincode::Result<T>
 where
     R: Read,
     T: DeserializeOwned,
@@ -855,22 +868,21 @@ pub(crate) fn reconstruct_single_storage(
     current_len: usize,
     id: AccountsFileId,
     storage_access: StorageAccess,
-    obsolete_accounts: Option<SerdeObsoleteAccounts>,
+    obsolete_accounts: Option<(ObsoleteAccounts, AccountsFileId, usize)>,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
     // When restoring from an archive, obsolete accounts will always be `None`
     // When restoring from fastboot, obsolete accounts will be 'Some' if the storage contained
     // accounts marked obsolete at the time the snapshot was taken.
     let (current_len, obsolete_accounts) = if let Some(obsolete_accounts) = obsolete_accounts {
-        let updated_len = current_len + obsolete_accounts.bytes as usize;
-        let id = id as SerializedAccountsFileId;
-        if obsolete_accounts.id != id {
+        let updated_len = current_len + obsolete_accounts.2;
+        if obsolete_accounts.1 != id {
             return Err(SnapshotError::MismatchedAccountsFileId(
                 id,
-                obsolete_accounts.id,
+                obsolete_accounts.1,
             ));
         }
 
-        (updated_len, obsolete_accounts.accounts)
+        (updated_len, obsolete_accounts.0)
     } else {
         (current_len, ObsoleteAccounts::default())
     };

--- a/runtime/src/serde_snapshot/obsolete_accounts.rs
+++ b/runtime/src/serde_snapshot/obsolete_accounts.rs
@@ -1,0 +1,175 @@
+use {
+    crate::serde_snapshot::SerializedAccountsFileId,
+    dashmap::DashMap,
+    rayon::iter::{IntoParallelRefIterator, ParallelIterator},
+    serde::{Deserialize, Serialize},
+    solana_accounts_db::{
+        account_info::Offset,
+        accounts_db::{AccountStorageEntry, AccountsFileId},
+        ObsoleteAccountItem, ObsoleteAccounts,
+    },
+    solana_clock::Slot,
+    std::sync::Arc,
+};
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct SerdeObsoleteAccounts {
+    /// The ID of the associated account file. Used for verification to ensure the restored
+    /// obsolete accounts correspond to the correct account file
+    pub id: SerializedAccountsFileId,
+    /// The number of obsolete bytes in the storage. These bytes are removed during archive
+    /// serialization/deserialization but are present when restoring from directories. This value
+    /// is used to validate the size when creating the accounts file.
+    pub bytes: u64,
+    /// A list of accounts that are obsolete in the storage being restored.
+    pub accounts: Vec<(Offset, usize, Slot)>,
+}
+
+impl SerdeObsoleteAccounts {
+    /// Creates a new `SerdeObsoleteAccounts` instance from a given storage entry and snapshot slot.
+    fn new_from_storage_entry_at_slot(storage: &AccountStorageEntry, snapshot_slot: Slot) -> Self {
+        let accounts = storage
+            .obsolete_accounts_for_snapshots(snapshot_slot)
+            .accounts
+            .into_iter()
+            .map(|item| (item.offset, item.data_len, item.slot))
+            .collect();
+
+        SerdeObsoleteAccounts {
+            id: storage.id() as SerializedAccountsFileId,
+            bytes: storage.get_obsolete_bytes(Some(snapshot_slot)) as u64,
+            accounts,
+        }
+    }
+}
+
+/// Represents a map of obsolete accounts data for multiple slots.
+/// This struct is serialized/deserialized as part of the snapshot process
+/// to capture and restore obsolete accounts information for account storages.
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "12qimMBghYs9dL4nhws7Xe1B5MXWBV75VTMTGLHxevYE")
+)]
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct SerdeObsoleteAccountsMap {
+    map: DashMap<Slot, SerdeObsoleteAccounts>,
+}
+
+impl SerdeObsoleteAccountsMap {
+    /// Creates a new `SerdeObsoleteAccountsMap` from a list of storage entries and a snapshot slot.
+    pub(crate) fn new_from_storages(
+        snapshot_storages: &[Arc<AccountStorageEntry>],
+        snapshot_slot: Slot,
+    ) -> Self {
+        let map = DashMap::with_capacity(snapshot_storages.len());
+        snapshot_storages.par_iter().for_each(|storage| {
+            map.insert(
+                storage.slot(),
+                SerdeObsoleteAccounts::new_from_storage_entry_at_slot(storage, snapshot_slot),
+            );
+        });
+        SerdeObsoleteAccountsMap { map }
+    }
+
+    /// Removes and returns the obsolete accounts data for a given slot.
+    pub(crate) fn remove(&self, slot: &Slot) -> Option<(ObsoleteAccounts, AccountsFileId, usize)> {
+        self.map.remove(slot).map(|(_, entry)| {
+            let accounts = entry
+                .accounts
+                .into_iter()
+                .map(|(offset, data_len, slot)| ObsoleteAccountItem {
+                    offset,
+                    data_len,
+                    slot,
+                })
+                .collect();
+
+            (
+                ObsoleteAccounts { accounts },
+                entry.id as AccountsFileId,
+                entry.bytes as usize,
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::serde_snapshot::{deserialize_from, serialize_into},
+        std::io::{BufReader, BufWriter, Cursor},
+        test_case::test_case,
+    };
+
+    /// Tests the serialization and deserialization of obsolete accounts
+    #[test_case(0, 0)]
+    #[test_case(1, 0)]
+    #[test_case(10, 15)]
+    fn test_serialize_and_deserialize_obsolete_accounts(
+        num_storages: u64,
+        num_obsolete_accounts_per_storage: usize,
+    ) {
+        // Create a set of obsolete accounts
+        let obsolete_accounts = DashMap::<Slot, ObsoleteAccounts>::new();
+        for slot in 1..=num_storages {
+            let obsolete_accounts_list = ObsoleteAccounts {
+                accounts: (0..num_obsolete_accounts_per_storage)
+                    .map(|j| ObsoleteAccountItem {
+                        offset: j as Offset,
+                        data_len: j * 10,
+                        slot: slot + 1,
+                    })
+                    .collect(),
+            };
+
+            obsolete_accounts.insert(slot, obsolete_accounts_list);
+        }
+
+        // Convert the obsolete accounts into a SerdeObsoleteAccountsMap
+        let map = obsolete_accounts
+            .iter()
+            .map(|entry| {
+                let accounts = entry
+                    .value()
+                    .accounts
+                    .iter()
+                    .map(|item| (item.offset, item.data_len, item.slot))
+                    .collect();
+                let serde_obsolete_accounts = SerdeObsoleteAccounts {
+                    id: *entry.key() as SerializedAccountsFileId,
+                    bytes: num_obsolete_accounts_per_storage as u64 * 1000,
+                    accounts,
+                };
+                (*entry.key(), serde_obsolete_accounts)
+            })
+            .collect();
+        let obsolete_accounts_map = SerdeObsoleteAccountsMap { map };
+
+        // Serialize the obsolete accounts map
+        let mut buf = Vec::new();
+        let cursor = Cursor::new(&mut buf);
+        let mut writer = BufWriter::new(cursor);
+        serialize_into(&mut writer, &obsolete_accounts_map).unwrap();
+        drop(writer);
+
+        // Deserialize the obsolete accounts map
+        let cursor = Cursor::new(buf.as_slice());
+        let mut reader = BufReader::new(cursor);
+        let deserialized_obsolete_accounts: SerdeObsoleteAccountsMap =
+            deserialize_from(&mut reader).unwrap();
+
+        // Verify the deserialized data matches the original obsolete accounts
+        assert_eq!(
+            deserialized_obsolete_accounts.map.len(),
+            obsolete_accounts.len()
+        );
+        for (slot, obsolete_accounts) in obsolete_accounts {
+            let deserialized_obsolete_accounts =
+                deserialized_obsolete_accounts.remove(&slot).unwrap();
+            assert_eq!(obsolete_accounts, deserialized_obsolete_accounts.0);
+        }
+    }
+}

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -1,6 +1,6 @@
 use {
     serde::{Deserialize, Serialize},
-    solana_accounts_db::{accounts_db::AccountStorageEntry, ObsoleteAccounts},
+    solana_accounts_db::accounts_db::AccountStorageEntry,
     solana_clock::Slot,
 };
 
@@ -49,17 +49,3 @@ impl SerializableStorage for SerializableAccountStorageEntry {
 
 #[cfg(feature = "frozen-abi")]
 impl solana_frozen_abi::abi_example::TransparentAsHelper for SerializableAccountStorageEntry {}
-
-/// This structure handles the load/store of obsolete accounts during snapshot restoration.
-#[derive(Debug, Default)]
-pub(crate) struct SerdeObsoleteAccounts {
-    /// The ID of the associated account file. Used for verification to ensure the restored
-    /// obsolete accounts correspond to the correct account file
-    pub id: SerializedAccountsFileId,
-    /// The number of obsolete bytes in the storage. These bytes are removed during archive
-    /// serialization/deserialization but are present when restoring from directories. This value
-    /// is used to validate the size when creating the accounts file.
-    pub bytes: u64,
-    /// A list of accounts that are obsolete in the storage being restored.
-    pub accounts: ObsoleteAccounts,
-}

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -4,8 +4,8 @@ use {
     crate::{
         bank::{BankFieldsToDeserialize, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
         serde_snapshot::{
-            self, AccountsDbFields, ExtraFieldsToSerialize, SerializableAccountStorageEntry,
-            SerializedAccountsFileId, SnapshotAccountsDbFields, SnapshotBankFields,
+            self, AccountsDbFields, ExtraFieldsToSerialize, SerdeObsoleteAccountsMap,
+            SerializableAccountStorageEntry, SnapshotAccountsDbFields, SnapshotBankFields,
             SnapshotStreams,
         },
         snapshot_archive_info::{
@@ -26,7 +26,9 @@ use {
     solana_accounts_db::{
         account_storage::{AccountStorageMap, AccountStoragesOrderer},
         account_storage_reader::AccountStorageReader,
-        accounts_db::{AccountStorageEntry, AccountsDbConfig, AtomicAccountsFileId},
+        accounts_db::{
+            AccountStorageEntry, AccountsDbConfig, AccountsFileId, AtomicAccountsFileId,
+        },
         accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
         hardened_unpack::{self, UnpackError},
         utils::{move_and_async_delete_path, ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR},
@@ -66,6 +68,12 @@ pub const SNAPSHOT_STATE_COMPLETE_FILENAME: &str = "state_complete";
 pub const SNAPSHOT_STORAGES_FLUSHED_FILENAME: &str = "storages_flushed";
 pub const SNAPSHOT_ACCOUNTS_HARDLINKS: &str = "accounts_hardlinks";
 pub const SNAPSHOT_ARCHIVE_DOWNLOAD_DIR: &str = "remote";
+pub const SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME: &str = "obsolete_accounts";
+/// Limit the size of the obsolete accounts file
+/// If it exceeds this limit, remove the file which will force restore from archives
+/// Limit is set assuming 24 bytes per entry, 5% of 10 billion accounts
+/// = 500 million entries * 24 bytes = 12 GB
+pub const MAX_OBSOLETE_ACCOUNTS_FILE_SIZE: u64 = 1024 * 1024 * 1024 * 12; // 12 GB
 /// No longer checked in version v3.1. Can be removed in v3.2
 pub const SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME: &str = "full_snapshot_slot";
 /// When a snapshot is taken of a bank, the state is serialized under this directory.
@@ -359,7 +367,7 @@ pub enum SnapshotError {
         "snapshot accounts file id mismatch: deserialized obsolete accounts file id: {0}, \
          snapshot archive: {1}"
     )]
-    MismatchedAccountsFileId(SerializedAccountsFileId, SerializedAccountsFileId),
+    MismatchedAccountsFileId(AccountsFileId, AccountsFileId),
 
     #[error("snapshot slot deltas are invalid: {0}")]
     VerifySlotDeltas(#[from] VerifySlotDeltasError),
@@ -1289,6 +1297,75 @@ fn do_get_highest_bank_snapshot(
 ) -> Option<BankSnapshotInfo> {
     bank_snapshots.sort_unstable();
     bank_snapshots.into_iter().next_back()
+}
+
+pub fn write_obsolete_accounts_to_snapshot(
+    bank_snapshot_dir: impl AsRef<Path>,
+    snapshot_storages: &[Arc<AccountStorageEntry>],
+    snapshot_slot: Slot,
+) -> Result<u64> {
+    let obsolete_accounts =
+        SerdeObsoleteAccountsMap::new_from_storages(snapshot_storages, snapshot_slot);
+    serialize_obsolete_accounts(
+        bank_snapshot_dir,
+        &obsolete_accounts,
+        MAX_OBSOLETE_ACCOUNTS_FILE_SIZE,
+    )
+}
+
+fn serialize_obsolete_accounts(
+    bank_snapshot_dir: impl AsRef<Path>,
+    obsolete_accounts_map: &SerdeObsoleteAccountsMap,
+    maximum_obsolete_accounts_file_size: u64,
+) -> Result<u64> {
+    let obsolete_accounts_path = bank_snapshot_dir
+        .as_ref()
+        .join(SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME);
+    let obsolete_accounts_file = fs::File::create(&obsolete_accounts_path)?;
+    let mut file_stream = BufWriter::new(obsolete_accounts_file);
+
+    serde_snapshot::serialize_into(&mut file_stream, obsolete_accounts_map)?;
+
+    file_stream.flush()?;
+
+    let consumed_size = file_stream.stream_position()?;
+    if consumed_size > maximum_obsolete_accounts_file_size {
+        let error_message = format!(
+            "too large obsolete accounts file to serialize: '{}' has {consumed_size} bytes, max \
+             size is {maximum_obsolete_accounts_file_size}",
+            obsolete_accounts_path.display(),
+        );
+        return Err(IoError::other(error_message).into());
+    }
+    Ok(consumed_size)
+}
+
+#[allow(dead_code)]
+fn deserialize_obsolete_accounts(
+    bank_snapshot_dir: impl AsRef<Path>,
+    maximum_obsolete_accounts_file_size: u64,
+) -> Result<SerdeObsoleteAccountsMap> {
+    let obsolete_accounts_path = bank_snapshot_dir
+        .as_ref()
+        .join(SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME);
+    let obsolete_accounts_file = fs::File::open(&obsolete_accounts_path)?;
+    // If the file is too large return error
+    let obsolete_accounts_file_metadata = fs::metadata(&obsolete_accounts_path)?;
+    if obsolete_accounts_file_metadata.len() > maximum_obsolete_accounts_file_size {
+        let error_message = format!(
+            "too large obsolete accounts file to deserialize: '{}' has {} bytes (max size is \
+             {maximum_obsolete_accounts_file_size} bytes)",
+            obsolete_accounts_path.display(),
+            obsolete_accounts_file_metadata.len(),
+        );
+        return Err(IoError::other(error_message).into());
+    }
+
+    let mut data_file_stream = BufReader::new(obsolete_accounts_file);
+
+    let obsolete_accounts = serde_snapshot::deserialize_from(&mut data_file_stream)?;
+
+    Ok(obsolete_accounts)
 }
 
 pub fn serialize_snapshot_data_file<F>(data_file_path: &Path, serializer: F) -> Result<u64>
@@ -2574,8 +2651,10 @@ mod tests {
         super::*,
         assert_matches::assert_matches,
         bincode::{deserialize_from, serialize_into},
+        solana_accounts_db::accounts_file::AccountsFileProvider,
         std::{convert::TryFrom, mem::size_of},
         tempfile::NamedTempFile,
+        test_case::test_case,
     };
 
     #[test]
@@ -3548,5 +3627,103 @@ mod tests {
                 .to_string()
                 .starts_with("invalid full snapshot slot file size"));
         }
+    }
+
+    #[test_case(0)]
+    #[test_case(1)]
+    #[test_case(10)]
+    fn test_serialize_deserialize_account_storage_entries(num_storages: u64) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bank_snapshot_dir = temp_dir.path();
+        let snapshot_slot = num_storages + 1 as Slot;
+
+        // Create AccountStorageEntries
+        let mut snapshot_storages = Vec::new();
+        for i in 0..num_storages {
+            let storage = Arc::new(AccountStorageEntry::new(
+                &PathBuf::new(),
+                i,        // Incrementing slot
+                i as u32, // Incrementing id
+                1024,
+                AccountsFileProvider::AppendVec,
+                StorageAccess::File,
+            ));
+            snapshot_storages.push(storage);
+        }
+
+        // write obsolete accounts to snapshot
+        write_obsolete_accounts_to_snapshot(bank_snapshot_dir, &snapshot_storages, snapshot_slot)
+            .unwrap();
+
+        // Deserialize
+        let deserialized_accounts =
+            deserialize_obsolete_accounts(bank_snapshot_dir, MAX_OBSOLETE_ACCOUNTS_FILE_SIZE)
+                .unwrap();
+
+        // Verify
+        for storage in &snapshot_storages {
+            assert!(deserialized_accounts.remove(&storage.slot()).unwrap().2 == 0);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "too large obsolete accounts file to serialize")]
+    fn test_serialize_obsolete_accounts_too_large_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bank_snapshot_dir = temp_dir.path();
+        let num_storages = 10;
+        let snapshot_slot = num_storages + 1 as Slot;
+
+        // Create AccountStorageEntries
+        let mut snapshot_storages = Vec::new();
+        for i in 0..num_storages {
+            let storage = Arc::new(AccountStorageEntry::new(
+                &PathBuf::new(),
+                i,        // Incrementing slot
+                i as u32, // Incrementing id
+                1024,
+                AccountsFileProvider::AppendVec,
+                StorageAccess::File,
+            ));
+            snapshot_storages.push(storage);
+        }
+
+        // write obsolete accounts to snapshot
+        let obsolete_accounts =
+            SerdeObsoleteAccountsMap::new_from_storages(&snapshot_storages, snapshot_slot);
+
+        // Limit the file size to something low for the test
+        serialize_obsolete_accounts(bank_snapshot_dir, &obsolete_accounts, 100).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "too large obsolete accounts file to deserialize")]
+    fn test_deserialize_obsolete_accounts_too_large_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bank_snapshot_dir = temp_dir.path();
+        let num_storages = 10;
+        let snapshot_slot = num_storages + 1 as Slot;
+
+        // Create AccountStorageEntries
+        let mut snapshot_storages = Vec::new();
+        for i in 0..num_storages {
+            let storage = Arc::new(AccountStorageEntry::new(
+                &PathBuf::new(),
+                i,        // Incrementing slot
+                i as u32, // Incrementing id
+                1024,
+                AccountsFileProvider::AppendVec,
+                StorageAccess::File,
+            ));
+            snapshot_storages.push(storage);
+        }
+
+        // Write obsolete accounts to snapshot
+        write_obsolete_accounts_to_snapshot(bank_snapshot_dir, &snapshot_storages, snapshot_slot)
+            .unwrap();
+
+        // Set a very low maximum file size for deserialization
+        // This should panic
+        deserialize_obsolete_accounts(bank_snapshot_dir, 100).unwrap();
     }
 }

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -4,7 +4,7 @@ use {
     super::{SnapshotError, SnapshotFrom},
     crate::serde_snapshot::{
         reconstruct_single_storage, remap_and_reconstruct_single_storage,
-        snapshot_storage_lengths_from_fields, AccountsDbFields, SerdeObsoleteAccounts,
+        snapshot_storage_lengths_from_fields, AccountsDbFields, SerdeObsoleteAccountsMap,
         SerializableAccountStorageEntry, SerializedAccountsFileId,
     },
     crossbeam_channel::{select, unbounded, Receiver, Sender},
@@ -57,7 +57,7 @@ pub(crate) struct SnapshotStorageRebuilder {
     /// specify how storages are accessed
     storage_access: StorageAccess,
     /// obsolete accounts for all storages
-    obsolete_accounts: Option<DashMap<Slot, SerdeObsoleteAccounts>>,
+    obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
 }
 
 impl SnapshotStorageRebuilder {
@@ -70,7 +70,7 @@ impl SnapshotStorageRebuilder {
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
-        obsolete_accounts: Option<DashMap<Slot, SerdeObsoleteAccounts>>,
+        obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
     ) -> Result<AccountStorageMap, SnapshotError> {
         let snapshot_storage_lengths = snapshot_storage_lengths_from_fields(accounts_db_fields);
 
@@ -97,7 +97,7 @@ impl SnapshotStorageRebuilder {
         snapshot_storage_lengths: HashMap<Slot, HashMap<usize, usize>>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
-        obsolete_accounts: Option<DashMap<Slot, SerdeObsoleteAccounts>>,
+        obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
     ) -> Self {
         let storage = DashMap::with_capacity_and_hasher(
             snapshot_storage_lengths.len(),
@@ -133,7 +133,7 @@ impl SnapshotStorageRebuilder {
         append_vec_files: Vec<PathBuf>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
-        obsolete_accounts: Option<DashMap<Slot, SerdeObsoleteAccounts>>,
+        obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
     ) -> Result<AccountStorageMap, SnapshotError> {
         let rebuilder = Arc::new(SnapshotStorageRebuilder::new(
             file_receiver,
@@ -260,9 +260,9 @@ impl SnapshotStorageRebuilder {
                         current_len,
                         old_append_vec_id as AccountsFileId,
                         self.storage_access,
-                        self.obsolete_accounts.as_ref().and_then(|accounts| {
-                            accounts.remove(&slot).map(|(_slot, accounts)| accounts)
-                        }),
+                        self.obsolete_accounts
+                            .as_ref()
+                            .and_then(|accounts| accounts.remove(&slot)),
                     )?,
                 };
 


### PR DESCRIPTION
#### Problem
- Fastboot does not support Obsolete accounts as the obsolete accounts are not persisted. Since the storages used are the same files that were being used prior to restarting, the obsolete account information needs to be saved and restored as well.

#### Summary of Changes
- Added functions to serialize obsolete accounts and deserialize them

Note: After this change there will be one more PR to hook up save/restore of obsolete accounts, remove the legacy completers, rev the fastboot version and remove validator constraints.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
