### PR TITLE
Implement wincode defs for Entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5497,9 +5497,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -8509,9 +8509,11 @@ dependencies = [
  "dlopen2",
  "log",
  "num_cpus",
+ "proptest",
  "rand 0.8.5",
  "rayon",
  "serde",
+ "solana-address",
  "solana-entry",
  "solana-hash",
  "solana-keypair",
@@ -8525,11 +8527,13 @@ dependencies = [
  "solana-pubkey",
  "solana-runtime-transaction",
  "solana-sha256-hasher",
+ "solana-short-vec",
  "solana-signature",
  "solana-signer",
  "solana-system-transaction",
  "solana-transaction",
  "solana-transaction-error",
+ "wincode",
 ]
 
 [[package]]
@@ -9218,6 +9222,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "trees",
+ "wincode",
 ]
 
 [[package]]
@@ -11675,6 +11680,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.17",
  "tokio",
+ "wincode",
 ]
 
 [[package]]
@@ -13693,6 +13699,29 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wincode"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c0b5bd8dce8a24aa92e1b16407ae2a60b35a103150e24e12bb63466e3786397"
+dependencies = [
+ "solana-short-vec",
+ "thiserror 2.0.17",
+ "wincode-derive",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b565e235fa7bbb5f898fc2d55639e41fde3ed66dc02ad7d570d075f41e1cfc1"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -613,6 +613,7 @@ url = "2.5.7"
 vec_extract_if_polyfill = "0.1.0"
 wasm-bindgen = "0.2"
 winapi = "0.3.8"
+wincode = { version = "0.1.0", features = ["derive", "solana-short-vec"] }
 winreg = "0.50"
 x509-parser = "0.14.0"
 zeroize = { version = "1.8", default-features = false }

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -28,20 +28,26 @@ num_cpus = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
+solana-address = { workspace = true }
 solana-hash = { workspace = true }
 solana-measure = { workspace = true }
 solana-merkle-tree = { workspace = true }
+solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-packet = { workspace = true }
 solana-perf = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-sha256-hasher = { workspace = true }
+solana-short-vec = { workspace = true }
+solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 agave-reserved-account-keys = { workspace = true }
 assert_matches = { workspace = true }
+proptest = { workspace = true }
 solana-entry = { path = ".", features = ["dev-context-only-utils"] }
 solana-keypair = { workspace = true }
 solana-logger = { workspace = true }

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -35,6 +35,7 @@ use {
         thread::{self, JoinHandle},
         time::Instant,
     },
+    wincode::{containers::Pod, SchemaRead, SchemaWrite},
 };
 
 pub type EntrySender = Sender<Vec<Entry>>;
@@ -117,17 +118,19 @@ pub struct Api<'a> {
 /// transaction, or read by one or more transactions, but not both.
 /// This enforcement is done via a call to `solana_runtime::accounts::Accounts::lock_accounts()`
 /// with the `txs` argument holding all the `transactions` in the `Entry`.
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq, Clone, SchemaWrite, SchemaRead)]
 pub struct Entry {
     /// The number of hashes since the previous Entry ID.
     pub num_hashes: u64,
 
     /// The SHA-256 hash `num_hashes` after the previous Entry ID.
+    #[wincode(with = "Pod<Hash>")]
     pub hash: Hash,
 
     /// An unordered list of transactions that were observed before the Entry ID was
     /// generated. They may have been observed before a previous Entry ID but were
     /// pushed back into this list to ensure deterministic interpretation of the ledger.
+    #[wincode(with = "Vec<crate::wincode::VersionedTransaction>")]
     pub transactions: Vec<VersionedTransaction>,
 }
 

--- a/entry/src/lib.rs
+++ b/entry/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 pub mod entry;
 pub mod poh;
+mod wincode;
 
 extern crate log;

--- a/entry/src/wincode.rs
+++ b/entry/src/wincode.rs
@@ -1,0 +1,353 @@
+//! [`wincode`] type definitions for types that comprise [`crate::entry::Entry`].
+//!
+//! These definitions should eventually be upstreamed to the solana sdk repository.
+use {
+    solana_address::Address,
+    solana_hash::Hash,
+    solana_message::{self, legacy, v0, MESSAGE_VERSION_PREFIX},
+    solana_signature::Signature,
+    solana_transaction::versioned,
+    std::mem::MaybeUninit,
+    wincode::{
+        containers::{self, Elem, Pod},
+        error::invalid_tag_encoding,
+        io::{Reader, Writer},
+        len::ShortU16Len,
+        ReadResult, SchemaRead, SchemaWrite, WriteResult,
+    },
+};
+
+#[derive(SchemaWrite, SchemaRead)]
+#[wincode(from = "solana_message::MessageHeader", struct_extensions)]
+struct MessageHeader {
+    num_required_signatures: u8,
+    num_readonly_signed_accounts: u8,
+    num_readonly_unsigned_accounts: u8,
+}
+
+#[derive(SchemaWrite, SchemaRead)]
+#[wincode(from = "solana_transaction::CompiledInstruction")]
+struct CompiledInstruction {
+    program_id_index: u8,
+    accounts: containers::Vec<Pod<u8>, ShortU16Len>,
+    data: containers::Vec<Pod<u8>, ShortU16Len>,
+}
+
+#[derive(SchemaWrite, SchemaRead)]
+#[wincode(from = "legacy::Message", struct_extensions)]
+struct LegacyMessage {
+    header: MessageHeader,
+    account_keys: containers::Vec<Pod<Address>, ShortU16Len>,
+    recent_blockhash: Pod<Hash>,
+    instructions: containers::Vec<Elem<CompiledInstruction>, ShortU16Len>,
+}
+
+#[derive(SchemaWrite, SchemaRead)]
+#[wincode(from = "v0::MessageAddressTableLookup")]
+struct MessageAddressTableLookup {
+    account_key: Pod<Address>,
+    writable_indexes: containers::Vec<Pod<u8>, ShortU16Len>,
+    readonly_indexes: containers::Vec<Pod<u8>, ShortU16Len>,
+}
+
+#[derive(SchemaWrite, SchemaRead)]
+#[wincode(from = "v0::Message")]
+struct V0Message {
+    header: MessageHeader,
+    account_keys: containers::Vec<Pod<Address>, ShortU16Len>,
+    recent_blockhash: Pod<Hash>,
+    instructions: containers::Vec<Elem<CompiledInstruction>, ShortU16Len>,
+    address_table_lookups: containers::Vec<Elem<MessageAddressTableLookup>, ShortU16Len>,
+}
+
+#[derive(SchemaWrite, SchemaRead)]
+#[wincode(from = "versioned::VersionedTransaction")]
+pub(crate) struct VersionedTransaction {
+    signatures: containers::Vec<Pod<Signature>, ShortU16Len>,
+    message: VersionedMsg,
+}
+
+struct VersionedMsg;
+
+impl SchemaWrite for VersionedMsg {
+    type Src = solana_message::VersionedMessage;
+
+    #[inline(always)]
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        match src {
+            solana_message::VersionedMessage::Legacy(message) => LegacyMessage::size_of(message),
+            // +1 for message version prefix
+            solana_message::VersionedMessage::V0(message) => Ok(1 + V0Message::size_of(message)?),
+        }
+    }
+
+    #[inline(always)]
+    fn write(writer: &mut Writer, src: &Self::Src) -> WriteResult<()> {
+        match src {
+            solana_message::VersionedMessage::Legacy(message) => {
+                LegacyMessage::write(writer, message)
+            }
+            solana_message::VersionedMessage::V0(message) => {
+                u8::write(writer, &MESSAGE_VERSION_PREFIX)?;
+                V0Message::write(writer, message)
+            }
+        }
+    }
+}
+
+impl SchemaRead<'_> for VersionedMsg {
+    type Dst = solana_message::VersionedMessage;
+
+    fn read(reader: &mut Reader, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        // From `solana_message`:
+        //
+        // If the first bit is set, the remaining 7 bits will be used to determine
+        // which message version is serialized starting from version `0`. If the first
+        // is bit is not set, all bytes are used to encode the legacy `Message`
+        // format.
+        let variant = u8::get(reader)?;
+
+        if variant & MESSAGE_VERSION_PREFIX != 0 {
+            let version = variant & !MESSAGE_VERSION_PREFIX;
+            return match version {
+                0 => {
+                    let msg = V0Message::get(reader)?;
+                    dst.write(solana_message::VersionedMessage::V0(msg));
+                    Ok(())
+                }
+                _ => Err(invalid_tag_encoding(version as usize)),
+            };
+        }
+
+        let mut msg = MaybeUninit::<legacy::Message>::uninit();
+        // We've already read the variant byte which, in the legacy case, represents
+        // the `num_required_signatures` field.
+        // As such, we need to write the remaining fields into the message manually,
+        // as calling `LegacyMessage::read` will miss the first field.
+        let header_uninit = LegacyMessage::uninit_header_mut(&mut msg);
+
+        MessageHeader::write_uninit_num_required_signatures(variant, header_uninit);
+        MessageHeader::read_num_readonly_signed_accounts(reader, header_uninit)?;
+        MessageHeader::read_num_readonly_unsigned_accounts(reader, header_uninit)?;
+
+        LegacyMessage::read_account_keys(reader, &mut msg)?;
+        LegacyMessage::read_recent_blockhash(reader, &mut msg)?;
+        LegacyMessage::read_instructions(reader, &mut msg)?;
+
+        let msg = unsafe { msg.assume_init() };
+        dst.write(solana_message::VersionedMessage::Legacy(msg));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        crate::entry::Entry,
+        proptest::prelude::*,
+        solana_address::{Address, ADDRESS_BYTES},
+        solana_hash::{Hash, HASH_BYTES},
+        solana_message::{
+            legacy::Message as LegacyMessage,
+            v0::{self, MessageAddressTableLookup},
+            MessageHeader, VersionedMessage,
+        },
+        solana_signature::{Signature, SIGNATURE_BYTES},
+        solana_transaction::{versioned::VersionedTransaction, CompiledInstruction},
+        wincode::Deserialize,
+    };
+
+    fn strat_byte_vec(max_len: usize) -> impl Strategy<Value = Vec<u8>> {
+        proptest::collection::vec(any::<u8>(), 0..=max_len)
+    }
+
+    fn strat_repeated_byte_vec(max_len: usize) -> impl Strategy<Value = Vec<u8>> {
+        (any::<u8>(), 0..=max_len).prop_map(|(b, len)| vec![b; len])
+    }
+
+    fn strat_signature() -> impl Strategy<Value = Signature> {
+        any::<[u8; SIGNATURE_BYTES]>().prop_map(Signature::from)
+    }
+
+    fn strat_address() -> impl Strategy<Value = Address> {
+        any::<[u8; ADDRESS_BYTES]>().prop_map(Address::new_from_array)
+    }
+
+    fn strat_hash() -> impl Strategy<Value = Hash> {
+        any::<[u8; HASH_BYTES]>().prop_map(Hash::new_from_array)
+    }
+
+    fn strat_message_header() -> impl Strategy<Value = MessageHeader> {
+        (0u8..128, any::<u8>(), any::<u8>()).prop_map(|(a, b, c)| MessageHeader {
+            num_required_signatures: a,
+            num_readonly_signed_accounts: b,
+            num_readonly_unsigned_accounts: c,
+        })
+    }
+
+    fn strat_compiled_instruction() -> impl Strategy<Value = CompiledInstruction> {
+        (any::<u8>(), strat_byte_vec(256), strat_byte_vec(256)).prop_map(
+            |(program_id_index, accounts, data)| {
+                CompiledInstruction::new_from_raw_parts(program_id_index, accounts, data)
+            },
+        )
+    }
+
+    fn strat_address_table_lookup() -> impl Strategy<Value = MessageAddressTableLookup> {
+        (strat_address(), strat_byte_vec(256), strat_byte_vec(256)).prop_map(
+            |(account_key, writable_indexes, readonly_indexes)| MessageAddressTableLookup {
+                account_key,
+                writable_indexes,
+                readonly_indexes,
+            },
+        )
+    }
+
+    fn strat_legacy_message() -> impl Strategy<Value = LegacyMessage> {
+        (
+            strat_message_header(),
+            proptest::collection::vec(strat_address(), 0..=16),
+            strat_hash(),
+            proptest::collection::vec(strat_compiled_instruction(), 0..=16),
+        )
+            .prop_map(|(header, account_keys, recent_blockhash, instructions)| {
+                LegacyMessage {
+                    header,
+                    account_keys,
+                    recent_blockhash,
+                    instructions,
+                }
+            })
+    }
+
+    fn strat_v0_message() -> impl Strategy<Value = v0::Message> {
+        (
+            strat_message_header(),
+            proptest::collection::vec(strat_address(), 0..=16),
+            strat_hash(),
+            proptest::collection::vec(strat_compiled_instruction(), 0..=16),
+            proptest::collection::vec(strat_address_table_lookup(), 0..=8),
+        )
+            .prop_map(
+                |(header, account_keys, recent_blockhash, instructions, address_table_lookups)| {
+                    v0::Message {
+                        header,
+                        account_keys,
+                        recent_blockhash,
+                        instructions,
+                        address_table_lookups,
+                    }
+                },
+            )
+    }
+
+    fn strat_versioned_message() -> impl Strategy<Value = VersionedMessage> {
+        prop_oneof![
+            strat_legacy_message().prop_map(VersionedMessage::Legacy),
+            strat_v0_message().prop_map(VersionedMessage::V0),
+        ]
+    }
+
+    fn strat_versioned_transaction() -> impl Strategy<Value = VersionedTransaction> {
+        (
+            proptest::collection::vec(strat_signature(), 0..=16),
+            strat_versioned_message(),
+        )
+            .prop_map(|(signatures, message)| VersionedTransaction {
+                signatures,
+                message,
+            })
+    }
+
+    fn strat_entry() -> impl Strategy<Value = Entry> {
+        (
+            any::<u64>(),
+            strat_hash(),
+            proptest::collection::vec(strat_versioned_transaction(), 0..=8),
+        )
+            .prop_map(|(num_hashes, hash, transactions)| Entry {
+                num_hashes,
+                hash,
+                transactions,
+            })
+    }
+
+    fn strat_entries() -> impl Strategy<Value = Vec<Entry>> {
+        proptest::collection::vec(strat_entry(), 0..=4)
+    }
+
+    proptest! {
+        #[test]
+        fn deser_fails_on_bad_data(data in strat_repeated_byte_vec(1024)) {
+            // represents a zeroed Entry -- valid
+            if data.get(0..48) == Some(&[0; 48]) {
+                prop_assert!(Entry::deserialize(&data).is_ok());
+            } else {
+                prop_assert!(Entry::deserialize(&data).is_err());
+            }
+
+            // represents a bincode length 0 -- valid
+            if data.get(0..8) == Some(&[0; 8]) {
+                prop_assert!(<Vec<Entry>>::deserialize(&data).is_ok());
+            } else {
+                prop_assert!(<Vec<Entry>>::deserialize(&data).is_err());
+            }
+        }
+
+        #[test]
+        fn serialized_size_equivalence(entry in strat_entry()) {
+            let serialized = bincode::serialized_size(&entry).unwrap();
+            let size = wincode::serialized_size(&entry).unwrap();
+            prop_assert_eq!(serialized, size);
+
+        }
+
+        #[test]
+        fn serialized_size_multi_equivalence(entries in strat_entries()) {
+            let serialized = bincode::serialized_size(&entries).unwrap();
+            let size = wincode::serialized_size(&entries).unwrap();
+            prop_assert_eq!(serialized, size);
+        }
+
+        #[test]
+        fn de_equivalence(entry in strat_entry()) {
+            let serialized = bincode::serialize(&entry).unwrap();
+            let deserialized: Entry = wincode::deserialize(&serialized).unwrap();
+            prop_assert_eq!(entry, deserialized);
+        }
+
+        #[test]
+        fn de_multi_equivalence(entries in strat_entries()) {
+            let serialized = bincode::serialize(&entries).unwrap();
+            let deserialized: Vec<Entry> = wincode::deserialize(&serialized).unwrap();
+            prop_assert_eq!(entries, deserialized);
+        }
+
+        #[test]
+        fn ser_equivalence(entry in strat_entry()) {
+            let serialized = wincode::serialize(&entry).unwrap();
+            prop_assert_eq!(serialized, bincode::serialize(&entry).unwrap());
+        }
+
+        #[test]
+        fn ser_multi_equivalence(entries in strat_entries()) {
+            let serialized = wincode::serialize(&entries).unwrap();
+            prop_assert_eq!(serialized, bincode::serialize(&entries).unwrap());
+        }
+
+        #[test]
+        fn roundtrip(entry in strat_entry()) {
+            let serialized = wincode::serialize(&entry).unwrap();
+            let deserialized: Entry = wincode::deserialize(&serialized).unwrap();
+            prop_assert_eq!(&entry, &deserialized);
+        }
+
+        #[test]
+        fn roundtrip_multi(entries in strat_entries()) {
+            let serialized = wincode::serialize(&entries).unwrap();
+            let deserialized: Vec<Entry> = wincode::deserialize(&serialized).unwrap();
+            prop_assert_eq!(entries, deserialized);
+        }
+    }
+}

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -123,6 +123,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
 trees = { workspace = true }
+wincode = { workspace = true }
 
 [dependencies.rocksdb]
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3702,7 +3702,7 @@ impl Blockstore {
                         )))
                     })
                     .and_then(|payload| {
-                        bincode::deserialize::<Vec<Entry>>(&payload).map_err(|e| {
+                        wincode::deserialize::<Vec<Entry>>(&payload).map_err(|e| {
                             BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
                                 format!("could not reconstruct entries: {e:?}"),
                             )))
@@ -5792,7 +5792,7 @@ pub mod tests {
         let num_slots = 5_u64;
         let shreds_per_slot = 5_u64;
         let entry_serialized_size =
-            bincode::serialized_size(&create_ticks(1, 0, Hash::default())).unwrap();
+            wincode::serialized_size(&create_ticks(1, 0, Hash::default())).unwrap();
         let entries_per_slot = (shreds_per_slot * PACKET_DATA_SIZE as u64) / entry_serialized_size;
 
         // Write entries

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -866,8 +866,8 @@ pub fn max_entries_per_n_shred_last_or_not(
     num_shreds: u64,
     is_last_in_slot: bool,
 ) -> u64 {
-    let vec_size = bincode::serialized_size(&vec![entry]).unwrap();
-    let entry_size = bincode::serialized_size(entry).unwrap();
+    let vec_size = wincode::serialized_size(&vec![entry]).unwrap();
+    let entry_size = wincode::serialized_size(entry).unwrap();
     let count_size = vec_size - entry_size;
 
     // Default 32:32 erasure batches yields 64 shreds; log2(64) = 6.
@@ -898,8 +898,8 @@ pub fn max_entries_per_n_shred(
     // Default 32:32 erasure batches yields 64 shreds; log2(64) = 6.
     let data_buffer_size = ShredData::capacity(/*proof_size:*/ 6, /*resigned:*/ true).unwrap();
     let shred_data_size = shred_data_size.unwrap_or(data_buffer_size) as u64;
-    let vec_size = bincode::serialized_size(&vec![entry]).unwrap();
-    let entry_size = bincode::serialized_size(entry).unwrap();
+    let vec_size = wincode::serialized_size(&vec![entry]).unwrap();
+    let entry_size = wincode::serialized_size(entry).unwrap();
     let count_size = vec_size - entry_size;
 
     (shred_data_size * num_shreds - count_size) / entry_size

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -76,7 +76,7 @@ impl Shredder {
         stats: &mut ProcessShredsStats,
     ) -> impl Iterator<Item = Shred> {
         let now = Instant::now();
-        let entries = bincode::serialize(entries).unwrap();
+        let entries = wincode::serialize(entries).unwrap();
         stats.serialize_elapsed += now.elapsed().as_micros() as u64;
         Self::make_shreds_from_data_slice(
             self,
@@ -362,7 +362,7 @@ mod tests {
             let shreds = data_shreds.iter().map(Shred::payload);
             Shredder::deshred(shreds).unwrap()
         };
-        let deshred_entries: Vec<Entry> = bincode::deserialize(&deshred_payload).unwrap();
+        let deshred_entries: Vec<Entry> = wincode::deserialize(&deshred_payload).unwrap();
         assert_eq!(entries, deshred_entries);
     }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -748,7 +748,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -759,7 +759,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -955,7 +955,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1075,7 +1075,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1157,7 +1157,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1264,7 +1264,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1616,7 +1616,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1640,7 +1640,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1651,7 +1651,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1732,7 +1732,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1766,7 +1766,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
  "unicode-xid",
 ]
 
@@ -1847,7 +1847,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1870,7 +1870,7 @@ checksum = "a6cbae11b3de8fce2a456e8ea3dada226b35fe791f0dc1d360c0941f0bb681f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2043,7 +2043,7 @@ checksum = "03cdc46ec28bd728e67540c528013c6a10eb69a02eb31078a1bda695438cbfb8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2056,7 +2056,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2358,7 +2358,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3040,7 +3040,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3848,7 +3848,7 @@ checksum = "f8eec4327f127d4d18c54c8bfbf7b05d74cc9a1befdcc6283a241238ffbc84c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3985,7 +3985,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4058,7 +4058,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4132,7 +4132,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4344,7 +4344,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4385,7 +4385,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4545,9 +4545,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -4632,7 +4632,7 @@ checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5447,7 +5447,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5494,7 +5494,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6706,16 +6706,21 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "serde",
+ "solana-address",
  "solana-hash",
  "solana-measure",
  "solana-merkle-tree",
+ "solana-message",
  "solana-metrics",
  "solana-packet",
  "solana-perf",
  "solana-runtime-transaction",
  "solana-sha256-hasher",
+ "solana-short-vec",
+ "solana-signature",
  "solana-transaction",
  "solana-transaction-error",
+ "wincode",
 ]
 
 [[package]]
@@ -7257,6 +7262,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "trees",
+ "wincode",
 ]
 
 [[package]]
@@ -9064,7 +9070,7 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -9930,6 +9936,7 @@ dependencies = [
  "static_assertions",
  "thiserror 2.0.17",
  "tokio",
+ "wincode",
 ]
 
 [[package]]
@@ -10290,7 +10297,7 @@ checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
 dependencies = [
  "quote",
  "spl-discriminator-syn",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -10302,7 +10309,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.9",
- "syn 2.0.87",
+ "syn 2.0.106",
  "thiserror 1.0.69",
 ]
 
@@ -10561,9 +10568,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10605,7 +10612,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -10741,7 +10748,7 @@ dependencies = [
  "cfg-if 1.0.3",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -10752,7 +10759,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
  "test-case-core",
 ]
 
@@ -10791,7 +10798,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -10802,7 +10809,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -10957,7 +10964,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -11218,7 +11225,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -11565,7 +11572,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -11599,7 +11606,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -11719,6 +11726,29 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wincode"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c0b5bd8dce8a24aa92e1b16407ae2a60b35a103150e24e12bb63466e3786397"
+dependencies = [
+ "solana-short-vec",
+ "thiserror 2.0.17",
+ "wincode-derive",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b565e235fa7bbb5f898fc2d55639e41fde3ed66dc02ad7d570d075f41e1cfc1"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "windows-link"
@@ -12120,7 +12150,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
  "synstructure 0.13.1",
 ]
 
@@ -12150,7 +12180,7 @@ checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -12161,7 +12191,7 @@ checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -12181,7 +12211,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
  "synstructure 0.13.1",
 ]
 
@@ -12202,7 +12232,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -12224,7 +12254,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -58,6 +58,7 @@ solana-transaction-error = { workspace = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+wincode = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = { workspace = true }

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -82,7 +82,7 @@ pub enum Error {
     #[error("Send")]
     Send,
     #[error(transparent)]
-    Serialize(#[from] std::boxed::Box<bincode::ErrorKind>),
+    Serialize(#[from] wincode::WriteError),
     #[error("Shred not found, slot: {slot}, index: {index}")]
     ShredNotFound { slot: Slot, index: u64 },
     #[error(transparent)]

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -1,6 +1,5 @@
 use {
     super::{Error, Result},
-    bincode::serialized_size,
     crossbeam_channel::Receiver,
     solana_clock::Slot,
     solana_entry::entry::Entry,
@@ -15,6 +14,7 @@ use {
         sync::Arc,
         time::{Duration, Instant},
     },
+    wincode::serialized_size,
 };
 
 const ENTRY_COALESCE_DURATION: Duration = Duration::from_millis(50);


### PR DESCRIPTION
#### Problem

From #8141 
> The serialize / deserialize implementations for `Entry` use `solana_short_vec` and `serde_big_array` on byte arrays / vectors, which are inefficient in serialization / deserialization due to the fact that they perform per-element visitation. `Entry` contains many structs with byte arrays / vectors that use this scheme, each of which may contain further structs / vectors of such -- so this problem is compounded. The baseline serde-driven implementation also suffers the typical serde inefficiencies like extra copying due to lack of guaranteed placement initialization for heap memory in Safe Rust -- this problem is _also_ compounded by the fact that we have multiple levels of byte arrays / vectors.
>
> Because `solana_short_vec` uses a custom length encoding for sequences, we cannot simply apply something like `#[serde(with = "serde_bytes")]` to those fields. Additionally, bincode uses its own length encodings, so it's not possible (without forking bincode) to make custom `serialize` / `deserialize` implementations that encode `short_u16` lengths with `serializer::serialize_bytes` -- bincode will always encode a length with its own encoding within `serialize_bytes`.
>
> The `bincode::serialize` format of the current `Entry` implementation also effectively defines the wire format for turbine, so we cannot simply change it for the sake of optimization (without of course some larger effort to formalize and optimize the format).
>
> Here is a profile showing a stack chart implicating the `Deserialize` implementation of `Entry`:
>
> <img width="4048" height="1690" alt="image" src="https://github.com/user-attachments/assets/cb9d8ddf-6bde-4691-ac84-32fb917c7bfd" />
>
> This blocks the replaying of transactions.

#### Summary of Changes

This adds [`wincode`](https://github.com/anza-xyz/wincode), which implements bit-for-bit compatible serialization and deserialization of bincode in a way that avoids all the aforementioned inefficiencies (see https://docs.rs/wincode once the docs.rs job is finished).

The result is a roughly 20-50x (depending on the slot) speedup of `get_slot_entries_in_block`, tested in micro benchmarks and in profiling the validator itself. Deserialization is faster than the latency reading from `rocksdb` and we're effectively only bottlenecked by memory allocation.

<img width="2134" height="1290" alt="image" src="https://github.com/user-attachments/assets/d47b2260-20b8-4344-8e2c-1aa9249ff78d" />

<img width="1745" height="1186" alt="image" src="https://github.com/user-attachments/assets/f2170b79-5326-4c1f-9fe6-19d147e4f941" />
