### PR TITLE
ledger-tool: Fixup raw_key_to_slot()

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -138,8 +138,8 @@ fn raw_key_to_slot(key: &[u8], column_name: &str) -> Option<Slot> {
     match column_name {
         cf::SlotMeta::NAME => Some(cf::SlotMeta::slot(cf::SlotMeta::index(key))),
         cf::Orphans::NAME => Some(cf::Orphans::slot(cf::Orphans::index(key))),
-        cf::DeadSlots::NAME => Some(cf::SlotMeta::slot(cf::SlotMeta::index(key))),
-        cf::DuplicateSlots::NAME => Some(cf::SlotMeta::slot(cf::SlotMeta::index(key))),
+        cf::DeadSlots::NAME => Some(cf::DeadSlots::slot(cf::DeadSlots::index(key))),
+        cf::DuplicateSlots::NAME => Some(cf::DuplicateSlots::slot(cf::DuplicateSlots::index(key))),
         cf::ErasureMeta::NAME => Some(cf::ErasureMeta::slot(cf::ErasureMeta::index(key))),
         cf::BankHash::NAME => Some(cf::BankHash::slot(cf::BankHash::index(key))),
         cf::Root::NAME => Some(cf::Root::slot(cf::Root::index(key))),


### PR DESCRIPTION
raw_key_to_slot() extracts the slot from a raw key for any column. The
DeadSlots and DuplicateSlots column cases were using the SlotMeta
function. Correct these cases to use their associated column functions