### PR TITLE
agave-validator: move clap args definition into json_rpc_config

### DIFF
--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -311,18 +311,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("health_check_slot_distance")
-            .long("health-check-slot-distance")
-            .value_name("SLOT_DISTANCE")
-            .takes_value(true)
-            .default_value(&default_args.health_check_slot_distance)
-            .help(
-                "Report this validator as healthy if its latest replayed optimistically confirmed \
-                 slot is within the specified number of slots from the cluster's latest \
-                 optimistically confirmed slot",
-            ),
-    )
-    .arg(
         Arg::with_name("skip_preflight_health_check")
             .long("skip-preflight-health-check")
             .takes_value(false)
@@ -1612,7 +1600,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .args(&pub_sub_config::args())
-    .args(&json_rpc_config::args())
+    .args(&json_rpc_config::args(&default_args))
 }
 
 fn validators_set(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -300,17 +300,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Do not perform TCP/UDP reachable port checks at start-up"),
     )
     .arg(
-        Arg::with_name("rpc_max_multiple_accounts")
-            .long("rpc-max-multiple-accounts")
-            .value_name("MAX ACCOUNTS")
-            .takes_value(true)
-            .default_value(&default_args.rpc_max_multiple_accounts)
-            .help(
-                "Override the default maximum accounts accepted by the getMultipleAccounts JSON \
-                 RPC method",
-            ),
-    )
-    .arg(
         Arg::with_name("account_paths")
             .long("accounts")
             .value_name("PATHS")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -309,13 +309,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("enable_bigtable_ledger_upload")
-            .long("enable-bigtable-ledger-upload")
-            .requires("enable_rpc_transaction_history")
-            .takes_value(false)
-            .help("Upload new confirmed blocks into a BigTable instance"),
-    )
-    .arg(
         Arg::with_name("enable_extended_tx_metadata_storage")
             .long("enable-extended-tx-metadata-storage")
             .requires("enable_rpc_transaction_history")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -300,15 +300,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Do not perform TCP/UDP reachable port checks at start-up"),
     )
     .arg(
-        Arg::with_name("enable_rpc_transaction_history")
-            .long("enable-rpc-transaction-history")
-            .takes_value(false)
-            .help(
-                "Enable historical transaction info over JSON RPC, including the \
-                 'getConfirmedBlock' API. This will cause an increase in disk usage and IOPS",
-            ),
-    )
-    .arg(
         Arg::with_name("enable_extended_tx_metadata_storage")
             .long("enable-extended-tx-metadata-storage")
             .requires("enable_rpc_transaction_history")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1656,6 +1656,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .args(&pub_sub_config::args())
+    .args(&json_rpc_config::args())
 }
 
 fn validators_set(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -936,30 +936,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rpc_blocking_threads")
-            .long("rpc-blocking-threads")
-            .value_name("NUMBER")
-            .validator(is_parsable::<usize>)
-            .validator(|value| {
-                value
-                    .parse::<u64>()
-                    .map_err(|err| format!("error parsing '{value}': {err}"))
-                    .and_then(|threads| {
-                        if threads > 0 {
-                            Ok(())
-                        } else {
-                            Err("value must be >= 1".to_string())
-                        }
-                    })
-            })
-            .takes_value(true)
-            .default_value(&default_args.rpc_blocking_threads)
-            .help(
-                "Number of blocking threads to use for servicing CPU bound RPC requests (eg \
-                 getMultipleAccounts)",
-            ),
-    )
-    .arg(
         Arg::with_name("rpc_niceness_adj")
             .long("rpc-niceness-adjustment")
             .value_name("ADJUSTMENT")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -281,12 +281,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Enable JSON RPC on this port, and the next port for the RPC websocket"),
     )
     .arg(
-        Arg::with_name("full_rpc_api")
-            .long("full-rpc-api")
-            .takes_value(false)
-            .help("Expose RPC methods for querying chain state and transaction history"),
-    )
-    .arg(
         Arg::with_name("private_rpc")
             .long("private-rpc")
             .takes_value(false)

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -309,16 +309,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("enable_rpc_bigtable_ledger_storage")
-            .long("enable-rpc-bigtable-ledger-storage")
-            .requires("enable_rpc_transaction_history")
-            .takes_value(false)
-            .help(
-                "Fetch historical transaction info from a BigTable instance as a fallback to \
-                 local ledger data",
-            ),
-    )
-    .arg(
         Arg::with_name("enable_bigtable_ledger_upload")
             .long("enable-bigtable-ledger-upload")
             .requires("enable_rpc_transaction_history")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -936,15 +936,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rpc_threads")
-            .long("rpc-threads")
-            .value_name("NUMBER")
-            .validator(is_parsable::<usize>)
-            .takes_value(true)
-            .default_value(&default_args.rpc_threads)
-            .help("Number of threads to use for servicing RPC requests"),
-    )
-    .arg(
         Arg::with_name("rpc_blocking_threads")
             .long("rpc-blocking-threads")
             .value_name("NUMBER")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -936,18 +936,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rpc_niceness_adj")
-            .long("rpc-niceness-adjustment")
-            .value_name("ADJUSTMENT")
-            .takes_value(true)
-            .validator(solana_perf::thread::is_niceness_adjustment_valid)
-            .default_value(&default_args.rpc_niceness_adjustment)
-            .help(
-                "Add this value to niceness of RPC threads. Negative value increases priority, \
-                 positive value decreases priority.",
-            ),
-    )
-    .arg(
         Arg::with_name("rpc_bigtable_timeout")
             .long("rpc-bigtable-timeout")
             .value_name("SECONDS")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -311,12 +311,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("skip_preflight_health_check")
-            .long("skip-preflight-health-check")
-            .takes_value(false)
-            .help("Skip health check when running a preflight check"),
-    )
-    .arg(
         Arg::with_name("account_paths")
             .long("accounts")
             .value_name("PATHS")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1516,7 +1516,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .args(&pub_sub_config::args())
-    .args(&json_rpc_config::args(&default_args))
+    .args(&json_rpc_config::args(default_args))
 }
 
 fn validators_set(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1055,13 +1055,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rpc_scan_and_fix_roots")
-            .long("rpc-scan-and-fix-roots")
-            .takes_value(false)
-            .requires("enable_rpc_transaction_history")
-            .help("Verifies blockstore roots on boot and fixes any gaps"),
-    )
-    .arg(
         Arg::with_name("rpc_max_request_body_size")
             .long("rpc-max-request-body-size")
             .value_name("BYTES")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -329,14 +329,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Skip health check when running a preflight check"),
     )
     .arg(
-        Arg::with_name("rpc_faucet_addr")
-            .long("rpc-faucet-address")
-            .value_name("HOST:PORT")
-            .takes_value(true)
-            .validator(solana_net_utils::is_host_port)
-            .help("Enable the JSON RPC 'requestAirdrop' API with this faucet address."),
-    )
-    .arg(
         Arg::with_name("account_paths")
             .long("accounts")
             .value_name("PATHS")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -300,16 +300,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Do not perform TCP/UDP reachable port checks at start-up"),
     )
     .arg(
-        Arg::with_name("enable_extended_tx_metadata_storage")
-            .long("enable-extended-tx-metadata-storage")
-            .requires("enable_rpc_transaction_history")
-            .takes_value(false)
-            .help(
-                "Include CPI inner instructions, logs, and return data in the historical \
-                 transaction info stored",
-            ),
-    )
-    .arg(
         Arg::with_name("rpc_max_multiple_accounts")
             .long("rpc-max-multiple-accounts")
             .value_name("MAX ACCOUNTS")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1055,15 +1055,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rpc_max_request_body_size")
-            .long("rpc-max-request-body-size")
-            .value_name("BYTES")
-            .takes_value(true)
-            .validator(is_parsable::<usize>)
-            .default_value(&default_args.rpc_max_request_body_size)
-            .help("The maximum request body size accepted by rpc service"),
-    )
-    .arg(
         Arg::with_name("geyser_plugin_config")
             .long("geyser-plugin-config")
             .alias("accountsdb-plugin-config")

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -137,6 +137,16 @@ pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
                 "Number of blocking threads to use for servicing CPU bound RPC requests (eg \
                          getMultipleAccounts)",
             ),
+        Arg::with_name("rpc_niceness_adj")
+            .long("rpc-niceness-adjustment")
+            .value_name("ADJUSTMENT")
+            .takes_value(true)
+            .validator(solana_perf::thread::is_niceness_adjustment_valid)
+            .default_value(&default_args.rpc_niceness_adjustment)
+            .help(
+                "Add this value to niceness of RPC threads. Negative value increases priority, \
+                         positive value decreases priority.",
+            ),
     ]
 }
 

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -151,6 +151,11 @@ pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
             .long("full-rpc-api")
             .takes_value(false)
             .help("Expose RPC methods for querying chain state and transaction history"),
+        Arg::with_name("rpc_scan_and_fix_roots")
+            .long("rpc-scan-and-fix-roots")
+            .takes_value(false)
+            .requires("enable_rpc_transaction_history")
+            .help("Verifies blockstore roots on boot and fixes any gaps"),
     ]
 }
 

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -67,6 +67,14 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .requires("enable_rpc_transaction_history")
             .takes_value(false)
             .help("Upload new confirmed blocks into a BigTable instance"),
+        Arg::with_name("enable_extended_tx_metadata_storage")
+            .long("enable-extended-tx-metadata-storage")
+            .requires("enable_rpc_transaction_history")
+            .takes_value(false)
+            .help(
+                "Include CPI inner instructions, logs, and return data in the historical \
+                 transaction info stored",
+            ),
     ]
 }
 

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -1,6 +1,6 @@
 use {
     crate::commands::{FromClapArgMatches, Result},
-    clap::{value_t, ArgMatches},
+    clap::{value_t, Arg, ArgMatches},
     solana_accounts_db::accounts_index::AccountSecondaryIndexes,
     solana_rpc::rpc::{JsonRpcConfig, RpcBigtableConfig},
 };
@@ -43,6 +43,10 @@ impl FromClapArgMatches for JsonRpcConfig {
             disable_health_check: false,
         })
     }
+}
+
+pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
+    vec![]
 }
 
 #[cfg(test)]

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -5,6 +5,7 @@ use {
     },
     clap::{value_t, Arg, ArgMatches},
     solana_accounts_db::accounts_index::AccountSecondaryIndexes,
+    solana_clap_utils::input_validators::is_parsable,
     solana_rpc::rpc::{JsonRpcConfig, RpcBigtableConfig},
 };
 
@@ -107,6 +108,13 @@ pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
                 "Override the default maximum accounts accepted by the getMultipleAccounts JSON \
                  RPC method",
             ),
+        Arg::with_name("rpc_threads")
+            .long("rpc-threads")
+            .value_name("NUMBER")
+            .validator(is_parsable::<usize>)
+            .takes_value(true)
+            .default_value(&default_args.rpc_threads)
+            .help("Number of threads to use for servicing RPC requests"),
     ]
 }
 

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -98,6 +98,15 @@ pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
             .long("skip-preflight-health-check")
             .takes_value(false)
             .help("Skip health check when running a preflight check"),
+        Arg::with_name("rpc_max_multiple_accounts")
+            .long("rpc-max-multiple-accounts")
+            .value_name("MAX ACCOUNTS")
+            .takes_value(true)
+            .default_value(&default_args.rpc_max_multiple_accounts)
+            .help(
+                "Override the default maximum accounts accepted by the getMultipleAccounts JSON \
+                 RPC method",
+            ),
     ]
 }
 

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -94,6 +94,10 @@ pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
                          slot is within the specified number of slots from the cluster's latest \
                          optimistically confirmed slot",
             ),
+        Arg::with_name("skip_preflight_health_check")
+            .long("skip-preflight-health-check")
+            .takes_value(false)
+            .help("Skip health check when running a preflight check"),
     ]
 }
 

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -46,14 +46,21 @@ impl FromClapArgMatches for JsonRpcConfig {
 }
 
 pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
-    vec![Arg::with_name("enable_rpc_bigtable_ledger_storage")
-        .long("enable-rpc-bigtable-ledger-storage")
-        .requires("enable_rpc_transaction_history")
-        .takes_value(false)
-        .help(
-            "Fetch historical transaction info from a BigTable instance as a fallback to \
+    vec![
+        Arg::with_name("enable_rpc_bigtable_ledger_storage")
+            .long("enable-rpc-bigtable-ledger-storage")
+            .requires("enable_rpc_transaction_history")
+            .takes_value(false)
+            .help(
+                "Fetch historical transaction info from a BigTable instance as a fallback to \
                      local ledger data",
-        )]
+            ),
+        Arg::with_name("enable_bigtable_ledger_upload")
+            .long("enable-bigtable-ledger-upload")
+            .requires("enable_rpc_transaction_history")
+            .takes_value(false)
+            .help("Upload new confirmed blocks into a BigTable instance"),
+    ]
 }
 
 #[cfg(test)]

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -75,6 +75,12 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
                 "Include CPI inner instructions, logs, and return data in the historical \
                  transaction info stored",
             ),
+        Arg::with_name("rpc_faucet_addr")
+            .long("rpc-faucet-address")
+            .value_name("HOST:PORT")
+            .takes_value(true)
+            .validator(solana_net_utils::is_host_port)
+            .help("Enable the JSON RPC 'requestAirdrop' API with this faucet address."),
     ]
 }
 

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -115,6 +115,28 @@ pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
             .takes_value(true)
             .default_value(&default_args.rpc_threads)
             .help("Number of threads to use for servicing RPC requests"),
+        Arg::with_name("rpc_blocking_threads")
+            .long("rpc-blocking-threads")
+            .value_name("NUMBER")
+            .validator(is_parsable::<usize>)
+            .validator(|value| {
+                value
+                    .parse::<u64>()
+                    .map_err(|err| format!("error parsing '{value}': {err}"))
+                    .and_then(|threads| {
+                        if threads > 0 {
+                            Ok(())
+                        } else {
+                            Err("value must be >= 1".to_string())
+                        }
+                    })
+            })
+            .takes_value(true)
+            .default_value(&default_args.rpc_blocking_threads)
+            .help(
+                "Number of blocking threads to use for servicing CPU bound RPC requests (eg \
+                         getMultipleAccounts)",
+            ),
     ]
 }
 

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -156,6 +156,13 @@ pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
             .takes_value(false)
             .requires("enable_rpc_transaction_history")
             .help("Verifies blockstore roots on boot and fixes any gaps"),
+        Arg::with_name("rpc_max_request_body_size")
+            .long("rpc-max-request-body-size")
+            .value_name("BYTES")
+            .takes_value(true)
+            .validator(is_parsable::<usize>)
+            .default_value(&default_args.rpc_max_request_body_size)
+            .help("The maximum request body size accepted by rpc service"),
     ]
 }
 

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -47,6 +47,13 @@ impl FromClapArgMatches for JsonRpcConfig {
 
 pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
     vec![
+        Arg::with_name("enable_rpc_transaction_history")
+            .long("enable-rpc-transaction-history")
+            .takes_value(false)
+            .help(
+                "Enable historical transaction info over JSON RPC, including the \
+                'getConfirmedBlock' API. This will cause an increase in disk usage and IOPS",
+            ),
         Arg::with_name("enable_rpc_bigtable_ledger_storage")
             .long("enable-rpc-bigtable-ledger-storage")
             .requires("enable_rpc_transaction_history")

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -46,7 +46,14 @@ impl FromClapArgMatches for JsonRpcConfig {
 }
 
 pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
-    vec![]
+    vec![Arg::with_name("enable_rpc_bigtable_ledger_storage")
+        .long("enable-rpc-bigtable-ledger-storage")
+        .requires("enable_rpc_transaction_history")
+        .takes_value(false)
+        .help(
+            "Fetch historical transaction info from a BigTable instance as a fallback to \
+                     local ledger data",
+        )]
 }
 
 #[cfg(test)]

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -147,6 +147,10 @@ pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
                 "Add this value to niceness of RPC threads. Negative value increases priority, \
                          positive value decreases priority.",
             ),
+        Arg::with_name("full_rpc_api")
+            .long("full-rpc-api")
+            .takes_value(false)
+            .help("Expose RPC methods for querying chain state and transaction history"),
     ]
 }
 

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -49,14 +49,14 @@ impl FromClapArgMatches for JsonRpcConfig {
     }
 }
 
-pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
+pub(crate) fn args<'a>(default_args: &DefaultArgs) -> Vec<Arg<'_, 'a>> {
     vec![
         Arg::with_name("enable_rpc_transaction_history")
             .long("enable-rpc-transaction-history")
             .takes_value(false)
             .help(
                 "Enable historical transaction info over JSON RPC, including the \
-                'getConfirmedBlock' API. This will cause an increase in disk usage and IOPS",
+                 'getConfirmedBlock' API. This will cause an increase in disk usage and IOPS",
             ),
         Arg::with_name("enable_rpc_bigtable_ledger_storage")
             .long("enable-rpc-bigtable-ledger-storage")
@@ -64,7 +64,7 @@ pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
             .takes_value(false)
             .help(
                 "Fetch historical transaction info from a BigTable instance as a fallback to \
-                     local ledger data",
+                 local ledger data",
             ),
         Arg::with_name("enable_bigtable_ledger_upload")
             .long("enable-bigtable-ledger-upload")
@@ -92,8 +92,8 @@ pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
             .default_value(&default_args.health_check_slot_distance)
             .help(
                 "Report this validator as healthy if its latest replayed optimistically confirmed \
-                         slot is within the specified number of slots from the cluster's latest \
-                         optimistically confirmed slot",
+                 slot is within the specified number of slots from the cluster's latest \
+                 optimistically confirmed slot",
             ),
         Arg::with_name("skip_preflight_health_check")
             .long("skip-preflight-health-check")
@@ -135,7 +135,7 @@ pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
             .default_value(&default_args.rpc_blocking_threads)
             .help(
                 "Number of blocking threads to use for servicing CPU bound RPC requests (eg \
-                         getMultipleAccounts)",
+                 getMultipleAccounts)",
             ),
         Arg::with_name("rpc_niceness_adj")
             .long("rpc-niceness-adjustment")
@@ -145,7 +145,7 @@ pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
             .default_value(&default_args.rpc_niceness_adjustment)
             .help(
                 "Add this value to niceness of RPC threads. Negative value increases priority, \
-                         positive value decreases priority.",
+                 positive value decreases priority.",
             ),
         Arg::with_name("full_rpc_api")
             .long("full-rpc-api")

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -1,5 +1,8 @@
 use {
-    crate::commands::{FromClapArgMatches, Result},
+    crate::{
+        cli::DefaultArgs,
+        commands::{FromClapArgMatches, Result},
+    },
     clap::{value_t, Arg, ArgMatches},
     solana_accounts_db::accounts_index::AccountSecondaryIndexes,
     solana_rpc::rpc::{JsonRpcConfig, RpcBigtableConfig},
@@ -45,7 +48,7 @@ impl FromClapArgMatches for JsonRpcConfig {
     }
 }
 
-pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
+pub(crate) fn args<'a, 'b>(default_args: &'a DefaultArgs) -> Vec<Arg<'a, 'b>> {
     vec![
         Arg::with_name("enable_rpc_transaction_history")
             .long("enable-rpc-transaction-history")
@@ -81,6 +84,16 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .takes_value(true)
             .validator(solana_net_utils::is_host_port)
             .help("Enable the JSON RPC 'requestAirdrop' API with this faucet address."),
+        Arg::with_name("health_check_slot_distance")
+            .long("health-check-slot-distance")
+            .value_name("SLOT_DISTANCE")
+            .takes_value(true)
+            .default_value(&default_args.health_check_slot_distance)
+            .help(
+                "Report this validator as healthy if its latest replayed optimistically confirmed \
+                         slot is within the specified number of slots from the cluster's latest \
+                         optimistically confirmed slot",
+            ),
     ]
 }
 


### PR DESCRIPTION
#### Problem

the validator command's arg list is just too long now

#### Summary of Changes

follow the same approach as #8042 for json_rpc_config