### PR TITLE
PoH use bank_id instead of slot - stronger guarantee on bank not being switcharoo'd

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1069,7 +1069,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let pubkey = solana_pubkey::new_rand();
         let keypair2 = Keypair::new();
@@ -1080,7 +1080,7 @@ mod tests {
             system_transaction::transfer(&keypair2, &pubkey2, 1, genesis_config.hash()).into(),
         ];
 
-        let summary = recorder.record_transactions(bank.slot(), txs.clone());
+        let summary = recorder.record_transactions(bank.bank_id(), txs.clone());
         assert!(summary.result.is_ok());
         assert_eq!(
             record_receiver.try_recv().unwrap().transaction_batches,
@@ -1088,10 +1088,11 @@ mod tests {
         );
         assert!(record_receiver.try_recv().is_err());
 
-        // Once bank is set to a new bank (setting bank.slot() + 1 in record_transactions),
+        // Once bank is set to a new bank (setting bank id + 1 in record_transactions),
         // record_transactions should throw MaxHeightReached
-        let next_slot = bank.slot() + 1;
-        let RecordTransactionsSummary { result, .. } = recorder.record_transactions(next_slot, txs);
+        let next_bank_id = bank.bank_id() + 1;
+        let RecordTransactionsSummary { result, .. } =
+            recorder.record_transactions(next_bank_id, txs);
         assert_matches!(result, Err(PohRecorderError::MaxHeightReached));
         // Should receive nothing from PohRecorder b/c record failed
         assert!(record_receiver.try_recv().is_err());

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1019,7 +1019,7 @@ mod tests {
             bank.tick_height(),
             None,
         )));
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let pubkey1 = Pubkey::new_unique();
 
@@ -1072,7 +1072,7 @@ mod tests {
             bank.tick_height(),
             None,
         )));
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let pubkey1 = Pubkey::new_unique();
         let pubkey2 = Pubkey::new_unique();
@@ -1136,7 +1136,7 @@ mod tests {
             bank.tick_height(),
             None,
         )));
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let pubkey1 = Pubkey::new_unique();
         let pubkey2 = Pubkey::new_unique();
@@ -1214,7 +1214,7 @@ mod tests {
             bank.tick_height(),
             None,
         )));
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
         assert!(bank.slot() > 0);
         assert!(bank.epoch() > 0);
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -383,7 +383,7 @@ impl Consumer {
 
         let (record_transactions_summary, record_us) = measure_us!(self
             .transaction_recorder
-            .record_transactions(bank.slot(), processed_transactions));
+            .record_transactions(bank.bank_id(), processed_transactions));
         execute_and_commit_timings.record_us = record_us;
 
         let RecordTransactionsSummary {
@@ -578,7 +578,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(
@@ -658,7 +658,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(
@@ -777,7 +777,7 @@ mod tests {
         let (record_sender, mut record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender);
 
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         while bank.tick_height() != bank.max_tick_height() - 1 {
             bank.register_default_tick_for_test();
@@ -840,7 +840,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(
@@ -901,7 +901,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(
@@ -1070,7 +1070,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(
@@ -1397,7 +1397,7 @@ mod tests {
         let blockstore = Arc::new(blockstore);
         let (record_sender, mut record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let shreds = entries_to_test_shreds(
             &entries,
@@ -1521,7 +1521,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let shreds = entries_to_test_shreds(
             &entries,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -691,7 +691,7 @@ mod tests {
         record_receiver.shutdown();
 
         let record = record_receiver.drain().next().unwrap();
-        assert_eq!(record.slot, bank.slot());
+        assert_eq!(record.bank_id, bank.bank_id());
         assert_eq!(record.transaction_batches.len(), 1);
         let transaction_batch = record.transaction_batches[0].clone();
         assert_eq!(transaction_batch.len(), 1);

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -115,7 +115,7 @@ fn bench_record_transactions(c: &mut Criterion) {
 
                 let start = Instant::now();
                 for txs in tx_batches {
-                    let summary = transaction_recorder.record_transactions(bank.slot(), txs);
+                    let summary = transaction_recorder.record_transactions(bank.bank_id(), txs);
                     assert!(summary.result.is_ok());
                 }
                 let elapsed = start.elapsed();

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -257,7 +257,7 @@ impl PohService {
         let record = record_receiver.recv_timeout(timeout);
         if let Ok(record) = record {
             match poh_recorder.write().unwrap().record(
-                record.slot,
+                record.bank_id,
                 record.mixins,
                 record.transaction_batches,
             ) {
@@ -400,7 +400,7 @@ impl PohService {
                 let mut record_time = Measure::start("record");
                 loop {
                     match poh_recorder_l.record(
-                        record.slot,
+                        record.bank_id,
                         record.mixins,
                         std::mem::take(&mut record.transaction_batches),
                     ) {

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -594,13 +594,13 @@ impl PohService {
                     recorder.reset(reset_bank, next_leader_slot);
                 }
                 PohServiceMessage::SetBank { bank } => {
-                    let slot = bank.slot();
+                    let bank_id = bank.bank_id();
                     let bank_max_tick_height = bank.max_tick_height();
                     recorder.set_bank(bank);
                     let should_restart =
                         recorder.tick_height() < bank_max_tick_height.saturating_sub(1);
                     if should_restart {
-                        record_receiver.restart(slot);
+                        record_receiver.restart(bank_id);
                     }
                 }
             }

--- a/poh/src/transaction_recorder.rs
+++ b/poh/src/transaction_recorder.rs
@@ -3,7 +3,7 @@ use {
         poh_recorder::{PohRecorderError, Record},
         record_channels::{RecordSender, RecordSenderError},
     },
-    solana_clock::Slot,
+    solana_clock::BankId,
     solana_entry::entry::hash_transactions,
     solana_hash::Hash,
     solana_measure::measure_us,
@@ -51,7 +51,7 @@ impl TransactionRecorder {
     /// Panics on unexpected (non-`MaxHeightReached`) errors.
     pub fn record_transactions(
         &self,
-        bank_slot: Slot,
+        bank_id: BankId,
         transactions: Vec<VersionedTransaction>,
     ) -> RecordTransactionsSummary {
         let mut record_transactions_timings = RecordTransactionsTimings::default();
@@ -62,7 +62,7 @@ impl TransactionRecorder {
             record_transactions_timings.hash_us = Saturating(hash_us);
 
             let (res, poh_record_us) =
-                measure_us!(self.record(bank_slot, vec![hash], vec![transactions]));
+                measure_us!(self.record(bank_id, vec![hash], vec![transactions]));
             record_transactions_timings.poh_record_us = Saturating(poh_record_us);
 
             match res {
@@ -103,11 +103,11 @@ impl TransactionRecorder {
     // Returns the index of `transactions.first()` in the slot, if being tracked by WorkingBank
     pub fn record(
         &self,
-        bank_slot: Slot,
+        bank_id: BankId,
         mixins: Vec<Hash>,
         transaction_batches: Vec<Vec<VersionedTransaction>>,
     ) -> Result<Option<usize>, RecordSenderError> {
         self.record_sender
-            .try_send(Record::new(mixins, transaction_batches, bank_slot))
+            .try_send(Record::new(mixins, transaction_batches, bank_id))
     }
 }

--- a/poh/src/transaction_recorder.rs
+++ b/poh/src/transaction_recorder.rs
@@ -69,7 +69,7 @@ impl TransactionRecorder {
                 Ok(starting_index) => {
                     starting_transaction_index = starting_index;
                 }
-                Err(RecordSenderError::InactiveSlot | RecordSenderError::Shutdown) => {
+                Err(RecordSenderError::InactiveBankId | RecordSenderError::Shutdown) => {
                     return RecordTransactionsSummary {
                         record_transactions_timings,
                         result: Err(PohRecorderError::MaxHeightReached),

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -1134,7 +1134,10 @@ impl TaskHandler for DefaultTaskHandler {
                     .transaction_recorder
                     .as_ref()
                     .unwrap()
-                    .record_transactions(bank.slot(), vec![transaction.to_versioned_transaction()]);
+                    .record_transactions(
+                        bank.bank_id(),
+                        vec![transaction.to_versioned_transaction()],
+                    );
                 match result {
                     Ok(()) => Ok(starting_transaction_index),
                     Err(_) => {
@@ -3901,7 +3904,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(true);
         let transaction_recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         if matches!(scheduling_mode, BlockProduction) {
             pool.register_banking_stage(
@@ -3957,7 +3960,7 @@ mod tests {
         // Update the slot so recording can succeed on new bank's slot.
         record_receiver.shutdown();
         for _ in record_receiver.drain() {}
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let context = SchedulingContext::new_with_mode(scheduling_mode, bank.clone());
         let scheduler = pool.take_scheduler(context);
@@ -4042,7 +4045,7 @@ mod tests {
         let scheduler = pool.take_scheduler(context);
         let old_scheduler_id = scheduler.id();
         let bank = BankWithScheduler::new(bank, Some(scheduler));
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
         bank.schedule_transaction_executions([(tx, ORIGINAL_TRANSACTION_INDEX)].into_iter())
             .unwrap();
         bank.unpause_new_block_production_scheduler();
@@ -4072,7 +4075,7 @@ mod tests {
         // Make sure the same scheduler is used to test its internal cross-session behavior
         assert_eq!(scheduler.id(), old_scheduler_id);
         let bank = BankWithScheduler::new(bank, Some(scheduler));
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
         bank.unpause_new_block_production_scheduler();
 
         // Calling wait_for_completed_scheduler() for block production scheduler causes it to be
@@ -4534,7 +4537,7 @@ mod tests {
         // Recording will succeed based upon if the channel is shutdown or not.
         if should_succeed_to_record_to_poh {
             // If we should succeed, we reset the channel to accept records.
-            record_receiver.restart(bank.slot());
+            record_receiver.restart(bank.bank_id());
         }
 
         assert_eq!(bank.transaction_count(), 0);
@@ -4609,7 +4612,7 @@ mod tests {
         let (_banking_packet_sender, banking_packet_receiver) = crossbeam_channel::unbounded();
         let (record_sender, mut record_receiver) = record_channels(true);
         let transaction_recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         pool.register_banking_stage(
             None,
@@ -4669,7 +4672,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(true);
         let transaction_recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         // send fake packet batch to trigger banking_packet_handler
         let (banking_packet_sender, banking_packet_receiver) = crossbeam_channel::unbounded();
@@ -4733,7 +4736,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(true);
         let transaction_recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         // Create a dummy handler which unconditionally sends tx0 back to the scheduler thread
         let tx0 = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
@@ -4812,7 +4815,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(true);
         let transaction_recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let (_banking_packet_sender, banking_packet_receiver) = crossbeam_channel::unbounded();
         pool.register_banking_stage(
@@ -4863,7 +4866,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(true);
         let transaction_recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let (_banking_packet_sender, banking_packet_receiver) = crossbeam_channel::unbounded();
         pool.register_banking_stage(
@@ -4939,7 +4942,7 @@ mod tests {
 
         let (record_sender, mut record_receiver) = record_channels(true);
         let transaction_recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         let (_banking_packet_sender, banking_packet_receiver) = crossbeam_channel::unbounded();
         pool.register_banking_stage(
@@ -4986,7 +4989,7 @@ mod tests {
         let (_banking_packet_sender, banking_packet_receiver) = crossbeam_channel::unbounded();
         let (record_sender, mut record_receiver) = record_channels(true);
         let transaction_recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         pool.register_banking_stage(
             None,
@@ -5071,7 +5074,7 @@ mod tests {
             .unwrap();
         let (record_sender, mut record_receiver) = record_channels(true);
         let transaction_recorder = TransactionRecorder::new(record_sender);
-        record_receiver.restart(bank.slot());
+        record_receiver.restart(bank.bank_id());
 
         pool.register_banking_stage(
             None,


### PR DESCRIPTION
#### Problem
- Alpenglow plans to allow us to switch parent mid slot
- That would lead to a race condition:

```
1. worker begins executing txs on bank with slot N
2. parent switch initiates
3. "poh" shutdown channel, flushes, switches bank.
4. worker finishes execution, goes to record - succeeds because the slot is the same
```
- The issue here is that PoH only checks equivalence on `Slot`.

#### Summary of Changes
- Use `BankId` instead of `Slot` for checks on poh channels && recorder

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
