### PR TITLE
fix various dead links & format errors in docs

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -12,11 +12,13 @@
 //! The only required in memory data structure with a write lock is the index,
 //! which should be fast to update.
 //!
-//! [`AppendVec`]'s only store accounts for single slots.  To bootstrap the
-//! index from a persistent store of [`AppendVec`]'s, the entries include
+//! [`AppendVec`][av]'s only store accounts for single slots.  To bootstrap the
+//! index from a persistent store of [`AppendVec`][av]'s, the entries include
 //! a "write_version".  A single global atomic `AccountsDb::write_version`
 //! tracks the number of commits to the entire data store. So the latest
 //! commit for each slot entry would be indexed.
+//!
+//! [av]: StorageLocation::AppendVec
 
 mod accounts_db_config;
 mod geyser_plugin_utils;

--- a/accounts-db/src/tiered_storage/byte_block.rs
+++ b/accounts-db/src/tiered_storage/byte_block.rs
@@ -131,7 +131,7 @@ pub struct ByteBlockReader;
 
 /// Reads the raw part of the input byte_block, at the specified offset, as type T.
 ///
-/// Returns None if `offset` + size_of::<T>() exceeds the size of the input byte_block.
+/// Returns None if `offset` + `size_of::<T>()` exceeds the size of the input byte_block.
 ///
 /// Type T must be plain ol' data to ensure no undefined behavior.
 pub fn read_pod<T: bytemuck::AnyBitPattern>(byte_block: &[u8], offset: usize) -> Option<&T> {
@@ -142,7 +142,7 @@ pub fn read_pod<T: bytemuck::AnyBitPattern>(byte_block: &[u8], offset: usize) ->
 /// Reads the raw part of the input byte_block at the specified offset
 /// as type T.
 ///
-/// If `offset` + size_of::<T>() exceeds the size of the input byte_block,
+/// If `offset` + `size_of::<T>()` exceeds the size of the input byte_block,
 /// then None will be returned.
 ///
 /// Prefer `read_pod()` when possible, because `read_type()` may cause

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -935,7 +935,7 @@ pub fn keypair_from_source(
 ///
 /// # Examples
 ///
-/// ```no_run`
+/// ```no_run
 /// use clap::{Arg, Command};
 /// use solana_clap_v3_utils::keypair::elgamal_keypair_from_path;
 ///
@@ -1008,7 +1008,7 @@ fn confirm_encodable_keypair_pubkey<K: EncodableKeypair>(keypair: &K, pubkey_lab
 ///
 /// # Examples
 ///
-/// ```no_run`
+/// ```no_run
 /// use clap::{Arg, Command};
 /// use solana_clap_v3_utils::keypair::ae_key_from_path;
 ///

--- a/cli-config/src/lib.rs
+++ b/cli-config/src/lib.rs
@@ -6,12 +6,12 @@
 //! and signer.
 //!
 //! The default path to the configuration file can be retrieved from
-//! [`CONFIG_FILE`], which is a [LazyLock] of `Option<String>`, the value of
-//! which is
+//! [`CONFIG_FILE`], which is a [LazyLock](std::sync::LazyLock) of `Option<String>`,
+//! the value of which is
 //!
 //! > `~/.config/solana/cli/config.yml`
 //!
-//! [`CONFIG_FILE`]: struct@CONFIG_FILE
+//! [`CONFIG_FILE`]: static@CONFIG_FILE
 //!
 //! `CONFIG_FILE` will only be `None` if it is unable to identify the user's
 //! home directory, which should not happen under typical OS environments.

--- a/client/src/client_option.rs
+++ b/client/src/client_option.rs
@@ -8,9 +8,9 @@ use {
 
 /// [`ClientOption`] enum represents the available client types for TPU
 /// communication:
-/// * [`ConnectionCacheClient`]: Uses a shared [`ConnectionCache`] to manage
+/// * `ConnectionCacheClient`: Uses a shared [`ConnectionCache`] to manage
 ///   connections efficiently.
-/// * [`TpuClientNextClient`]: Relies on the `tpu-client-next` crate and
+/// * `TpuClientNextClient`: Relies on the `tpu-client-next` crate and
 ///   requires a reference to a [`Keypair`].
 pub enum ClientOption<'a> {
     ConnectionCache(Arc<ConnectionCache>),

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -91,6 +91,7 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
         }
     }
 
+    #[allow(rustdoc::private_intra_doc_links)]
     /// Pushes transaction ids into the priority queue. If the queue if full,
     /// the lowest priority transactions will be dropped (removed from the
     /// queue and map) **after** all ids have been pushed.

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -52,6 +52,7 @@ use {
 
 mod packet_container;
 
+#[allow(rustdoc::private_intra_doc_links)]
 /// [`ForwardingClientOption`] enum represents the available client types for
 /// TPU communication:
 /// * [`ConnectionCacheClient`]: Uses a shared [`ConnectionCache`] to manage

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -55,7 +55,7 @@ impl Node {
     }
 
     /// create localhost node for tests with provided pubkey
-    /// unlike the [new_with_external_ip], this will also bind RPC sockets.
+    /// unlike the [`Node::new_with_external_ip`], this will also bind RPC sockets.
     pub fn new_localhost_with_pubkey(pubkey: &Pubkey) -> Self {
         let port_range = localhost_port_range_for_tests();
         let bind_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -45,7 +45,7 @@ pub struct Pong {
 /// Maintains records of remote nodes which have returned a valid response to a
 /// ping message, and on-the-fly ping messages pending a pong response from the
 /// remote node.
-/// Const generic parameter N corresponds to token size in Ping<N> type.
+/// Const generic parameter N corresponds to token size in [`Ping<N>`] type.
 pub struct PingCache<const N: usize> {
     // Time-to-live of received pong messages.
     ttl: Duration,

--- a/ledger/src/bit_vec.rs
+++ b/ledger/src/bit_vec.rs
@@ -217,6 +217,7 @@ impl<const NUM_BITS: usize> BitVec<NUM_BITS> {
         (self.words[word_idx] & (1 << bit_idx)) != 0
     }
 
+    #[allow(rustdoc::private_intra_doc_links)]
     /// Get an iterator over the bits in the array within the given range.
     ///
     /// See [`BitVecSlice::from_range_bounds`] for more information.

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2530,9 +2530,10 @@ impl Blockstore {
         missing_indexes
     }
 
+    #[allow(rustdoc::private_intra_doc_links)]
     /// Find missing data shreds for the given `slot`.
     ///
-    /// For more details on the arguments, see [`find_missing_indexes`].
+    /// For more details on the arguments, see [`Blockstore::find_missing_indexes`].
     pub fn find_missing_data_indexes(
         &self,
         slot: Slot,

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -244,7 +244,7 @@ pub type Index = IndexV2;
 pub type ShredIndex = ShredIndexV2;
 /// We currently support falling back to the previous format for migration purposes.
 ///
-/// See https://github.com/anza-xyz/agave/issues/3570.
+/// See <https://github.com/anza-xyz/agave/issues/3570>.
 pub type IndexFallback = IndexV1;
 pub type ShredIndexFallback = ShredIndexV1;
 

--- a/ledger/src/shred/payload.rs
+++ b/ledger/src/shred/payload.rs
@@ -29,6 +29,7 @@ impl Payload {
         self.bytes.into()
     }
 
+    #[allow(rustdoc::private_intra_doc_links)]
     /// Get a mutable reference via [`PayloadMutGuard`] to the payload's _full_ inner bytes.
     /// See [`Payload::get_mut`] for selecting a subset of the payload's inner bytes.
     ///
@@ -40,6 +41,7 @@ impl Payload {
     }
 
     #[inline]
+    #[allow(rustdoc::private_intra_doc_links)]
     /// Get a mutable reference via [`PayloadMutGuard`] to a subset of the payload's inner bytes.
     ///
     /// If the payload is unique (single reference), this will not perform any copying. Otherwise it

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! According to the cargo documentation, integration tests are compiled as individual crates.
 //!
-//!   https://doc.rust-lang.org/book/ch11-03-test-organization.html#the-tests-directory
+//!   <https://doc.rust-lang.org/book/ch11-03-test-organization.html#the-tests-directory>
 //!
 //! Putting shared code into the `tests/` folder, causes it to be recompiled for every test, rather
 //! than being compiled once when it is part of the main crate.  And, at the same time, unused code

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -275,7 +275,7 @@ impl SocketConfig {
     /// **Note:** On Linux the kernel will double the value you specify.
     /// For example, if you specify `16MB`, the kernel will configure the
     /// socket to use `32MB`.
-    /// See: https://man7.org/linux/man-pages/man7/socket.7.html: SO_RCVBUF
+    /// See: <https://man7.org/linux/man-pages/man7/socket.7.html>: SO_RCVBUF
     pub fn recv_buffer_size(mut self, size: usize) -> Self {
         self.recv_buffer_size = Some(size);
         self
@@ -286,7 +286,7 @@ impl SocketConfig {
     /// **Note:** On Linux the kernel will double the value you specify.
     /// For example, if you specify `16MB`, the kernel will configure the
     /// socket to use `32MB`.
-    /// See: https://man7.org/linux/man-pages/man7/socket.7.html: SO_SNDBUF
+    /// See: <https://man7.org/linux/man-pages/man7/socket.7.html>: SO_SNDBUF
     pub fn send_buffer_size(mut self, size: usize) -> Self {
         self.send_buffer_size = Some(size);
         self

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -102,7 +102,7 @@ impl SocketConfiguration {
     /// **Note:** On Linux the kernel will double the value you specify.
     /// For example, if you specify `16MB`, the kernel will configure the
     /// socket to use `32MB`.
-    /// See: https://man7.org/linux/man-pages/man7/socket.7.html: SO_RCVBUF
+    /// See: <https://man7.org/linux/man-pages/man7/socket.7.html>: SO_RCVBUF
     pub fn recv_buffer_size(mut self, size: usize) -> Self {
         self.recv_buffer_size = Some(size);
         self
@@ -113,7 +113,7 @@ impl SocketConfiguration {
     /// **Note:** On Linux the kernel will double the value you specify.
     /// For example, if you specify `16MB`, the kernel will configure the
     /// socket to use `32MB`.
-    /// See: https://man7.org/linux/man-pages/man7/socket.7.html: SO_SNDBUF
+    /// See: <https://man7.org/linux/man-pages/man7/socket.7.html>: SO_SNDBUF
     pub fn send_buffer_size(mut self, size: usize) -> Self {
         self.send_buffer_size = Some(size);
         self

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -174,7 +174,7 @@ pub struct PohRecorder {
     /// if they exist.
     /// This field MUST be kept consistent with the `shared_working_bank` field.
     working_bank: Option<WorkingBank>,
-    /// This is used to store the current working bank - just the Arc<Bank> without
+    /// This is used to store the current working bank - just the [`Arc<Bank>`] without
     /// schduler or any other metadata. It MUST be kept consistent with
     /// the `working_bank` field of this struct.
     shared_working_bank: SharedWorkingBank,

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -224,8 +224,8 @@ impl SVMTransactionExecutionCost {
     ///
     /// 61*n^2 + 542
     ///
-    /// Which aproximates the results of benchmarks of light-posiedon
-    /// library[0]. These results assume 1 CU per 33 ns. Examples:
+    /// Which aproximates the results of benchmarks of [light-posiedon
+    /// library][lpl]. These results assume 1 CU per 33 ns. Examples:
     ///
     /// * 1 input
     ///   * light-poseidon benchmark: `18,303 / 33 ≈ 555`
@@ -237,7 +237,7 @@ impl SVMTransactionExecutionCost {
     ///   * light-poseidon benchmark: `37,549 / 33 ≈ 1,138`
     ///   * function; `61*3^2 + 542 = 1091`
     ///
-    /// [0] https://github.com/Lightprotocol/light-poseidon#performance
+    /// [lpl]: https://github.com/Lightprotocol/light-poseidon#performance
     pub fn poseidon_cost(&self, nr_inputs: u64) -> Option<u64> {
         let squared_inputs = nr_inputs.checked_pow(2)?;
         let mul_result = self

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -621,7 +621,7 @@ impl ProgramTest {
     /// the builtin version of the program, allowing the provided BPF program
     /// to be used at the designated program ID instead.
     ///
-    /// See https://github.com/anza-xyz/agave/blob/c038908600b8a1b0080229dea015d7fc9939c418/runtime/src/bank.rs#L5109-L5126.
+    /// See <https://github.com/anza-xyz/agave/blob/c038908600b8a1b0080229dea015d7fc9939c418/runtime/src/bank.rs#L5109-L5126>.
     pub fn add_upgradeable_program_to_genesis(
         &mut self,
         program_name: &'static str,

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -58,6 +58,12 @@ use {
     tokio::time::sleep,
 };
 
+#[cfg(doc)]
+use {
+    solana_commitment_config::CommitmentLevel, solana_rpc_client_api::client_error,
+    std::collections::HashMap,
+};
+
 /// A client of a remote Solana node.
 ///
 /// `RpcClient` communicates with a Solana node over [JSON-RPC], with the
@@ -104,14 +110,12 @@ use {
 /// # Errors
 ///
 /// Methods on `RpcClient` return
-/// [`client_error::Result`][solana_rpc_client_api::client_error::Result], and many of them
-/// return the [`RpcResult`][solana_rpc_client_api::response::RpcResult] typedef, which
-/// contains [`Response<T>`][solana_rpc_client_api::response::Response] on `Ok`. Both
-/// `client_error::Result` and [`RpcResult`] contain `ClientError` on error. In
-/// the case of `RpcResult`, the actual return value is in the
+/// [`client_error::Result`], and many of them return the [`RpcResult`] typedef, which contains
+/// [`Response<T>`] on `Ok`. Both `client_error::Result` and [`RpcResult`] contain `ClientError` on
+/// error. In the case of `RpcResult`, the actual return value is in the
 /// [`value`][solana_rpc_client_api::response::Response::value] field, with RPC contextual
-/// information in the [`context`][solana_rpc_client_api::response::Response::context]
-/// field, so it is common for the value to be accessed with `?.value`, as in
+/// information in the [`context`][solana_rpc_client_api::response::Response::context] field, so it
+/// is common for the value to be accessed with `?.value`, as in
 ///
 /// ```
 /// # use solana_hash::Hash;
@@ -133,7 +137,7 @@ use {
 ///
 /// Requests may timeout, in which case they return a [`ClientError`] where the
 /// [`ClientErrorKind`] is [`ClientErrorKind::Reqwest`], and where the interior
-/// [`reqwest::Error`](solana_rpc_client_api::client_error::reqwest::Error)s
+/// [`reqwest::Error`]s
 /// [`is_timeout`](solana_rpc_client_api::client_error::reqwest::Error::is_timeout) method
 /// returns `true`. The default timeout is 30 seconds, and may be changed by
 /// calling an appropriate constructor with a `timeout` parameter.
@@ -2344,9 +2348,8 @@ impl RpcClient {
 
     /// Returns identity and transaction information about a confirmed block in the ledger.
     ///
-    /// The encodings are returned in [`UiTransactionEncoding::Json`][uite]
-    /// format. To return transactions in other encodings, use
-    /// [`get_block_with_encoding`].
+    /// The encodings are returned in [`UiTransactionEncoding::Json`] format. To return
+    /// transactions in other encodings, use [`get_block_with_encoding`].
     ///
     /// [`get_block_with_encoding`]: RpcClient::get_block_with_encoding
     /// [uite]: UiTransactionEncoding::Json

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -162,8 +162,8 @@ pub struct GetConfirmedSignaturesForAddress2Config {
 ///
 /// Methods on `RpcClient` return
 /// [`client_error::Result`][solana_rpc_client_api::client_error::Result], and many of them
-/// return the [`RpcResult`][solana_rpc_client_api::response::RpcResult] typedef, which
-/// contains [`Response<T>`][solana_rpc_client_api::response::Response] on `Ok`. Both
+/// return the [`RpcResult`] typedef, which contains
+/// [`Response<T>`][solana_rpc_client_api::response::Response] on `Ok`. Both
 /// `client_error::Result` and [`RpcResult`] contain `ClientError` on error. In
 /// the case of `RpcResult`, the actual return value is in the
 /// [`value`][solana_rpc_client_api::response::Response::value] field, with RPC contextual
@@ -190,7 +190,7 @@ pub struct GetConfirmedSignaturesForAddress2Config {
 ///
 /// Requests may timeout, in which case they return a [`ClientError`] where the
 /// [`ClientErrorKind`] is [`ClientErrorKind::Reqwest`], and where the interior
-/// [`reqwest::Error`](solana_rpc_client_api::client_error::reqwest::Error)s
+/// [`reqwest::Error`]s
 /// [`is_timeout`](solana_rpc_client_api::client_error::reqwest::Error::is_timeout) method
 /// returns `true`. The default timeout is 30 seconds, and may be changed by
 /// calling an appropriate constructor with a `timeout` parameter.
@@ -545,8 +545,8 @@ impl RpcClient {
     ///    for details.
     ///
     /// 2) Custom responses can be configured by providing [`MocksMap`]. This type
-    ///    is a [`HashMap`] from [`RpcRequest`] to a [`Vec`] of JSON [`Value`] responses,
-    ///    Any entries in this map override the default behavior for the given
+    ///    is a [`HashMap`](std::collections::HashMap) from [`RpcRequest`] to a [`Vec`] of JSON
+    ///    [`Value`] responses, Any entries in this map override the default behavior for the given
     ///    request.
     ///
     /// The [`RpcClient::new_mock_with_mocks_map`] function offers further
@@ -2018,12 +2018,11 @@ impl RpcClient {
 
     /// Returns identity and transaction information about a confirmed block in the ledger.
     ///
-    /// The encodings are returned in [`UiTransactionEncoding::Json`][uite]
+    /// The encodings are returned in [`UiTransactionEncoding::Json`]
     /// format. To return transactions in other encodings, use
     /// [`get_block_with_encoding`].
     ///
     /// [`get_block_with_encoding`]: RpcClient::get_block_with_encoding
-    /// [uite]: UiTransactionEncoding::Json
     ///
     /// # RPC Reference
     ///

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -7,7 +7,7 @@
 //!    `solana_transaction::versioned::sanitized::SanitizedVersionedTransaction`, which can be wrapped into
 //!    `RuntimeTransaction` with static transaction metadata extracted.
 //! 2. Dynamically Loaded: after successfully loaded account addresses from onchain
-//!    ALT, RuntimeTransaction<SanitizedMessage> transits into Dynamically Loaded state,
+//!    ALT, [`RuntimeTransaction<SanitizedMessage>`] transits into Dynamically Loaded state,
 //!    with its dynamic metadata loaded.
 use {
     crate::transaction_meta::{DynamicMeta, StaticMeta, TransactionMeta},

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -5,7 +5,7 @@
 //!
 //! The premise is if anything qualifies as metadata, then it must be valid
 //! and available as long as the transaction itself is valid and available.
-//! Hence they are not Option<T> type. Their visibility at different states
+//! Hence they are not [`Option<T>`] type. Their visibility at different states
 //! are defined in traits.
 //!
 //! The StaticMeta and DynamicMeta traits are accessor traits on the

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -342,6 +342,7 @@ impl WaitReason {
 }
 
 #[allow(clippy::large_enum_variant)]
+#[allow(rustdoc::private_intra_doc_links)]
 #[derive(Debug)]
 pub enum SchedulerStatus {
     /// Unified scheduler is disabled or installed scheduler is consumed by
@@ -419,22 +420,22 @@ impl SchedulerStatus {
     }
 }
 
-/// Very thin wrapper around Arc<Bank>
+/// Very thin wrapper around [`Arc<Bank>`]
 ///
 /// It brings type-safety against accidental mixing of bank and scheduler with different slots,
 /// which is a pretty dangerous condition. Also, it guarantees to call wait_for_termination() via
-/// ::drop() by DropBankService, which receives Vec<BankWithScheduler> from BankForks::set_root()'s
-/// pruning, mostly matching to Arc<Bank>'s lifetime by piggybacking on the pruning.
+/// ::drop() by DropBankService, which receives [`Vec<BankWithScheduler>`] from BankForks::set_root()'s
+/// pruning, mostly matching to [`Arc<Bank>`]'s lifetime by piggybacking on the pruning.
 ///
 /// Semantically, a scheduler is tightly coupled with a particular bank. But scheduler wasn't put
 /// into Bank fields to avoid circular-references (a scheduler needs to refer to its accompanied
-/// Arc<Bank>). BankWithScheduler behaves almost like Arc<Bank>. It only adds a few of transaction
+/// [`Arc<Bank>`]). BankWithScheduler behaves almost like [`Arc<Bank>`]. It only adds a few of transaction
 /// scheduling and scheduler management functions. For this reason, `bank` variable names should be
 /// used for `BankWithScheduler` across codebase.
 ///
 /// BankWithScheduler even implements Deref for convenience. And Clone is omitted to implement to
-/// avoid ambiguity as to which to clone: BankWithScheduler or Arc<Bank>. Use
-/// clone_without_scheduler() for Arc<Bank>. Otherwise, use clone_with_scheduler() (this should be
+/// avoid ambiguity as to which to clone: BankWithScheduler or [`Arc<Bank>`]. Use
+/// clone_without_scheduler() for [`Arc<Bank>`]. Otherwise, use clone_with_scheduler() (this should be
 /// unusual outside scheduler code-path)
 #[derive(Debug)]
 pub struct BankWithScheduler {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -585,9 +585,9 @@ pub enum GetSnapshotAccountsHardLinkDirError {
     },
 }
 
-/// The account snapshot directories under <account_path>/snapshot/<slot> contain account files hardlinked
-/// from <account_path>/run taken at snapshot <slot> time.  They are referenced by the symlinks from the
-/// bank snapshot dir snapshot/<slot>/accounts_hardlinks/.  We observed that sometimes the bank snapshot dir
+/// The account snapshot directories under \<account_path\>/snapshot/\<slot\> contain account files hardlinked
+/// from <account_path>/run taken at snapshot \<slot\> time.  They are referenced by the symlinks from the
+/// bank snapshot dir snapshot/\<slot\>/accounts_hardlinks/.  We observed that sometimes the bank snapshot dir
 /// could be deleted but the account snapshot directories were left behind, possibly by some manual operations
 /// or some legacy code not using the symlinks to clean up the account snapshot hardlink directories.
 /// This function cleans up any account snapshot directories that are no longer referenced by the bank

--- a/scheduler-bindings/src/lib.rs
+++ b/scheduler-bindings/src/lib.rs
@@ -224,7 +224,7 @@ pub struct WorkerToPackMessage {
 pub mod worker_message_types {
     use crate::SharablePubkeys;
 
-    /// Tag indicating [`ExecutionResonse`] inner message.
+    /// Tag indicating [`ExecutionResponse`] inner message.
     pub const EXECUTION_RESPONSE: u8 = 0;
 
     /// Response to pack for a transaction that attempted execution.

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -70,7 +70,7 @@
 //! scheduler thread (i.e.  constant; no allocations nor syscalls), while being proportional to the
 //! number of addresses in a given transaction. Note that this statement is held true, regardless
 //! of conflicts. This is because the preloading also pre-allocates some scratch-pad area
-//! ([`blocked_usages_from_tasks`](UsageQueueInner::blocked_usages_from_tasks)) to stash blocked
+//! ([`blocked_usages_from_tasks`](UsageQueueInner::Priority::blocked_usages_from_tasks)) to stash blocked
 //! ones. So, a conflict only incurs some additional fixed number of mem stores, within error
 //! margin of the constant complexity. And additional memory allocation for the scratchpad could
 //! said to be amortized, if such an unusual event should occur.

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -70,7 +70,7 @@ pub enum CertificateType {
 }
 
 impl Certificate {
-    /// Create a new certificate from a CertificateType, Slot, and Option<Hash>
+    /// Create a new certificate from a [`CertificateType`], [`Slot`], and [`Option<Hash>`]
     pub fn new(certificate_type: CertificateType, slot: Slot, hash: Option<Hash>) -> Self {
         match (certificate_type, hash) {
             (CertificateType::Finalize, None) => Certificate::Finalize(slot),


### PR DESCRIPTION


#### Problem

Currently `cargo doc` fails for various crates and produces warnings for even more.

#### Summary of Changes

fixes doc comments across the project to make `cargo doc` work. changes are mostly dead links, formatting errors and linter nits.
