### PR TITLE
Support simple QOS -- with QOS trait refactoring

### DIFF
--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -16,9 +16,10 @@ use {
     solana_pubkey::Pubkey,
     solana_signer::Signer,
     solana_streamer::{
+        nonblocking::swqos::SwQosConfig,
         packet::PacketBatchRecycler,
         quic::{
-            spawn_server_with_cancel, QuicServerParams, DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER,
+            spawn_server_with_cancel, QuicStreamerConfig, DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER,
             DEFAULT_MAX_STAKED_CONNECTIONS,
         },
         streamer::{receiver, PacketBatchReceiver, StakedNodes, StreamerReceiveStats},
@@ -262,7 +263,7 @@ fn main() -> Result<()> {
         let stats = Arc::new(StreamerReceiveStats::new("bench-vote-test"));
 
         if let Some(quic_params) = &quic_params {
-            let quic_server_params = QuicServerParams {
+            let quic_server_params = QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: max_connections_per_ipaddr_per_min
                     .try_into()
                     .unwrap(),
@@ -271,6 +272,7 @@ fn main() -> Result<()> {
                 max_unstaked_connections: 0,
                 ..Default::default()
             };
+            let qos_config = SwQosConfig::default();
             let (s_reader, r_reader) = unbounded();
             read_channels.push(r_reader);
 
@@ -282,6 +284,7 @@ fn main() -> Result<()> {
                 s_reader,
                 quic_params.staked_nodes.clone(),
                 quic_server_params,
+                qos_config,
                 cancel.clone(),
             )
             .unwrap();

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -49,7 +49,10 @@ use {
         vote_sender_types::{ReplayVoteReceiver, ReplayVoteSender},
     },
     solana_streamer::{
-        quic::{spawn_server_with_cancel, QuicServerParams, SpawnServerResult},
+        quic::{
+            spawn_server_with_cancel, spawn_simple_qos_server_with_cancel, QuicServerParams,
+            SimpleQosQuicServerParams, SpawnServerResult,
+        },
         streamer::StakedNodes,
     },
     solana_turbine::{
@@ -148,7 +151,7 @@ impl Tpu {
         tpu_enable_udp: bool,
         tpu_quic_server_config: QuicServerParams,
         tpu_fwd_quic_server_config: QuicServerParams,
-        vote_quic_server_config: QuicServerParams,
+        vote_quic_server_config: SimpleQosQuicServerParams,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         block_production_method: BlockProductionMethod,
         block_production_num_workers: NonZeroUsize,
@@ -209,7 +212,7 @@ impl Tpu {
             endpoints: _,
             thread: tpu_vote_quic_t,
             key_updater: vote_streamer_key_updater,
-        } = spawn_server_with_cancel(
+        } = spawn_simple_qos_server_with_cancel(
             "solQuicTVo",
             "quic_streamer_tpu_vote",
             tpu_vote_quic_sockets,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -99,6 +99,9 @@ impl SigVerifier {
     }
 }
 
+// Conservatively allow 20 TPS per validator.
+pub const MAX_VOTES_PER_SECOND: u64 = 20;
+
 pub struct Tpu {
     fetch_stage: FetchStage,
     sig_verifier: SigVerifier,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -50,8 +50,8 @@ use {
     },
     solana_streamer::{
         quic::{
-            spawn_server_with_cancel, spawn_simple_qos_server_with_cancel, QuicServerParams,
-            SpawnServerResult,
+            spawn_server_with_cancel, spawn_simple_qos_server_with_cancel,
+            SimpleQosQuicStreamerConfig, SpawnServerResult, SwQosQuicStreamerConfig,
         },
         streamer::StakedNodes,
     },
@@ -152,9 +152,9 @@ impl Tpu {
         banking_tracer_channels: Channels,
         tracer_thread_hdl: TracerThread,
         tpu_enable_udp: bool,
-        tpu_quic_server_config: QuicServerParams,
-        tpu_fwd_quic_server_config: QuicServerParams,
-        vote_quic_server_config: QuicServerParams,
+        tpu_quic_server_config: SwQosQuicStreamerConfig,
+        tpu_fwd_quic_server_config: SwQosQuicStreamerConfig,
+        vote_quic_server_config: SimpleQosQuicStreamerConfig,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         block_production_method: BlockProductionMethod,
         block_production_num_workers: NonZeroUsize,
@@ -222,7 +222,8 @@ impl Tpu {
             keypair,
             vote_packet_sender.clone(),
             staked_nodes.clone(),
-            vote_quic_server_config,
+            vote_quic_server_config.quic_streamer_config,
+            vote_quic_server_config.qos_config,
             cancel.clone(),
         )
         .unwrap();
@@ -240,7 +241,8 @@ impl Tpu {
                 keypair,
                 packet_sender,
                 staked_nodes.clone(),
-                tpu_quic_server_config,
+                tpu_quic_server_config.quic_streamer_config,
+                tpu_quic_server_config.qos_config,
                 cancel.clone(),
             )
             .unwrap();
@@ -262,7 +264,8 @@ impl Tpu {
                 keypair,
                 forwarded_packet_sender,
                 staked_nodes.clone(),
-                tpu_fwd_quic_server_config,
+                tpu_fwd_quic_server_config.quic_streamer_config,
+                tpu_fwd_quic_server_config.qos_config,
                 cancel,
             )
             .unwrap();

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -51,7 +51,7 @@ use {
     solana_streamer::{
         quic::{
             spawn_server_with_cancel, spawn_simple_qos_server_with_cancel, QuicServerParams,
-            SimpleQosQuicServerParams, SpawnServerResult,
+            SpawnServerResult,
         },
         streamer::StakedNodes,
     },
@@ -154,7 +154,7 @@ impl Tpu {
         tpu_enable_udp: bool,
         tpu_quic_server_config: QuicServerParams,
         tpu_fwd_quic_server_config: QuicServerParams,
-        vote_quic_server_config: SimpleQosQuicServerParams,
+        vote_quic_server_config: QuicServerParams,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         block_production_method: BlockProductionMethod,
         block_production_num_workers: NonZeroUsize,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -134,7 +134,11 @@ use {
     solana_send_transaction_service::send_transaction_service::Config as SendTransactionServiceConfig,
     solana_shred_version::compute_shred_version,
     solana_signer::Signer,
-    solana_streamer::{quic::QuicServerParams, socket::SocketAddrSpace, streamer::StakedNodes},
+    solana_streamer::{
+        quic::{QuicServerParams, SimpleQosQuicServerParams},
+        socket::SocketAddrSpace,
+        streamer::StakedNodes,
+    },
     solana_time_utils::timestamp,
     solana_tpu_client::tpu_client::{
         DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC, DEFAULT_VOTE_USE_QUIC,
@@ -566,7 +570,7 @@ pub struct ValidatorTpuConfig {
     /// QUIC server config for TPU forward
     pub tpu_fwd_quic_server_config: QuicServerParams,
     /// QUIC server config for Vote
-    pub vote_quic_server_config: QuicServerParams,
+    pub vote_quic_server_config: SimpleQosQuicServerParams,
 }
 
 impl ValidatorTpuConfig {
@@ -587,7 +591,15 @@ impl ValidatorTpuConfig {
         };
 
         // vote and tpu_fwd share the same characteristics -- disallow non-staked connections:
-        let vote_quic_server_config = tpu_fwd_quic_server_config.clone();
+        let vote_quic_server_config = SimpleQosQuicServerParams {
+            quic_server_params: QuicServerParams {
+                max_connections_per_ipaddr_per_min: 32,
+                max_unstaked_connections: 0,
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
+                ..Default::default()
+            },
+            ..Default::default()
+        };
 
         ValidatorTpuConfig {
             use_quic: DEFAULT_TPU_USE_QUIC,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -134,7 +134,12 @@ use {
     solana_send_transaction_service::send_transaction_service::Config as SendTransactionServiceConfig,
     solana_shred_version::compute_shred_version,
     solana_signer::Signer,
-    solana_streamer::{quic::QuicServerParams, socket::SocketAddrSpace, streamer::StakedNodes},
+    solana_streamer::{
+        nonblocking::{simple_qos::SimpleQosConfig, swqos::SwQosConfig},
+        quic::{QuicStreamerConfig, SimpleQosQuicStreamerConfig, SwQosQuicStreamerConfig},
+        socket::SocketAddrSpace,
+        streamer::StakedNodes,
+    },
     solana_time_utils::timestamp,
     solana_tpu_client::tpu_client::{
         DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC, DEFAULT_VOTE_USE_QUIC,
@@ -562,36 +567,45 @@ pub struct ValidatorTpuConfig {
     /// Controls if to enable UDP for TPU tansactions.
     pub tpu_enable_udp: bool,
     /// QUIC server config for regular TPU
-    pub tpu_quic_server_config: QuicServerParams,
+    pub tpu_quic_server_config: SwQosQuicStreamerConfig,
     /// QUIC server config for TPU forward
-    pub tpu_fwd_quic_server_config: QuicServerParams,
+    pub tpu_fwd_quic_server_config: SwQosQuicStreamerConfig,
     /// QUIC server config for Vote
-    pub vote_quic_server_config: QuicServerParams,
+    pub vote_quic_server_config: SimpleQosQuicStreamerConfig,
 }
 
 impl ValidatorTpuConfig {
     /// A convenient function to build a ValidatorTpuConfig for testing with good
     /// default.
     pub fn new_for_tests(tpu_enable_udp: bool) -> Self {
-        let tpu_quic_server_config = QuicServerParams {
-            max_connections_per_ipaddr_per_min: 32,
-            accumulator_channel_size: 100_000, // smaller channel size for faster test
-            ..Default::default()
+        let tpu_quic_server_config = SwQosQuicStreamerConfig {
+            quic_streamer_config: QuicStreamerConfig {
+                max_connections_per_ipaddr_per_min: 32,
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
+                ..Default::default()
+            },
+            qos_config: SwQosConfig::default(),
         };
 
-        let tpu_fwd_quic_server_config = QuicServerParams {
-            max_connections_per_ipaddr_per_min: 32,
-            max_unstaked_connections: 0,
-            accumulator_channel_size: 100_000, // smaller channel size for faster test
-            ..Default::default()
+        let tpu_fwd_quic_server_config = SwQosQuicStreamerConfig {
+            quic_streamer_config: QuicStreamerConfig {
+                max_connections_per_ipaddr_per_min: 32,
+                max_unstaked_connections: 0,
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
+                ..Default::default()
+            },
+            qos_config: SwQosConfig::default(),
         };
 
         // vote and tpu_fwd share the same characteristics -- disallow non-staked connections:
-        let vote_quic_server_config = QuicServerParams {
-            max_connections_per_ipaddr_per_min: 32,
-            max_unstaked_connections: 0,
-            coalesce_channel_size: 100_000, // smaller channel size for faster test
-            ..Default::default()
+        let vote_quic_server_config = SimpleQosQuicStreamerConfig {
+            quic_streamer_config: QuicStreamerConfig {
+                max_connections_per_ipaddr_per_min: 32,
+                max_unstaked_connections: 0,
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
+                ..Default::default()
+            },
+            qos_config: SimpleQosConfig::default(),
         };
 
         ValidatorTpuConfig {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -581,7 +581,7 @@ impl ValidatorTpuConfig {
         let tpu_quic_server_config = SwQosQuicStreamerConfig {
             quic_streamer_config: QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: 32,
-                coalesce_channel_size: 100_000, // smaller channel size for faster test
+                accumulator_channel_size: 100_000, // smaller channel size for faster test
                 ..Default::default()
             },
             qos_config: SwQosConfig::default(),
@@ -591,7 +591,7 @@ impl ValidatorTpuConfig {
             quic_streamer_config: QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: 32,
                 max_unstaked_connections: 0,
-                coalesce_channel_size: 100_000, // smaller channel size for faster test
+                accumulator_channel_size: 100_000, // smaller channel size for faster test
                 ..Default::default()
             },
             qos_config: SwQosConfig::default(),
@@ -602,7 +602,7 @@ impl ValidatorTpuConfig {
             quic_streamer_config: QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: 32,
                 max_unstaked_connections: 0,
-                coalesce_channel_size: 100_000, // smaller channel size for faster test
+                accumulator_channel_size: 100_000, // smaller channel size for faster test
                 ..Default::default()
             },
             qos_config: SimpleQosConfig::default(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -134,11 +134,7 @@ use {
     solana_send_transaction_service::send_transaction_service::Config as SendTransactionServiceConfig,
     solana_shred_version::compute_shred_version,
     solana_signer::Signer,
-    solana_streamer::{
-        quic::{QuicServerParams, SimpleQosQuicServerParams},
-        socket::SocketAddrSpace,
-        streamer::StakedNodes,
-    },
+    solana_streamer::{quic::QuicServerParams, socket::SocketAddrSpace, streamer::StakedNodes},
     solana_time_utils::timestamp,
     solana_tpu_client::tpu_client::{
         DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC, DEFAULT_VOTE_USE_QUIC,
@@ -570,7 +566,7 @@ pub struct ValidatorTpuConfig {
     /// QUIC server config for TPU forward
     pub tpu_fwd_quic_server_config: QuicServerParams,
     /// QUIC server config for Vote
-    pub vote_quic_server_config: SimpleQosQuicServerParams,
+    pub vote_quic_server_config: QuicServerParams,
 }
 
 impl ValidatorTpuConfig {
@@ -591,13 +587,10 @@ impl ValidatorTpuConfig {
         };
 
         // vote and tpu_fwd share the same characteristics -- disallow non-staked connections:
-        let vote_quic_server_config = SimpleQosQuicServerParams {
-            quic_server_params: QuicServerParams {
-                max_connections_per_ipaddr_per_min: 32,
-                max_unstaked_connections: 0,
-                coalesce_channel_size: 100_000, // smaller channel size for faster test
-                ..Default::default()
-            },
+        let vote_quic_server_config = QuicServerParams {
+            max_connections_per_ipaddr_per_min: 32,
+            max_unstaked_connections: 0,
+            coalesce_channel_size: 100_000, // smaller channel size for faster test
             ..Default::default()
         };
 

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -23,8 +23,6 @@ use {
     thiserror::Error,
 };
 
-// Convservatively allow 50 TPS per validator.
-pub const MAX_VOTES_PER_SECOND: u64 = 50;
 pub enum VoteOp {
     PushVote {
         tx: Transaction,

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -23,6 +23,8 @@ use {
     thiserror::Error,
 };
 
+// Convservatively allow 50 TPS per validator.
+pub const MAX_VOTES_PER_SECOND: u64 = 50;
 pub enum VoteOp {
     PushVote {
         tx: Transaction,

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -12,7 +12,8 @@ mod tests {
         solana_perf::packet::PacketBatch,
         solana_quic_client::nonblocking::quic_client::{QuicClient, QuicLazyInitializedEndpoint},
         solana_streamer::{
-            quic::{QuicServerParams, SpawnServerResult},
+            nonblocking::swqos::SwQosConfig,
+            quic::{QuicStreamerConfig, SpawnServerResult},
             streamer::StakedNodes,
         },
         solana_tls_utils::{new_dummy_x509_certificate, QuicClientCertificate},
@@ -80,7 +81,8 @@ mod tests {
             &keypair,
             sender,
             staked_nodes,
-            QuicServerParams::default_for_tests(),
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
             cancel.clone(),
         )
         .unwrap();
@@ -160,7 +162,8 @@ mod tests {
             &keypair,
             sender,
             staked_nodes,
-            QuicServerParams::default_for_tests(),
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
             cancel.clone(),
         )
         .unwrap();
@@ -218,7 +221,8 @@ mod tests {
             &keypair,
             sender,
             staked_nodes.clone(),
-            QuicServerParams::default_for_tests(),
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
             request_recv_cancel.clone(),
         )
         .unwrap();
@@ -242,7 +246,8 @@ mod tests {
             &keypair2,
             sender2,
             staked_nodes,
-            QuicServerParams::default_for_tests(),
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
             response_recv_cancel.clone(),
         )
         .unwrap();
@@ -328,7 +333,8 @@ mod tests {
             &keypair,
             sender,
             staked_nodes,
-            QuicServerParams::default_for_tests(),
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
             cancel.clone(),
         )
         .unwrap();

--- a/streamer/examples/swqos.rs
+++ b/streamer/examples/swqos.rs
@@ -15,7 +15,8 @@ use {
     solana_net_utils::sockets::{bind_to_with_config, SocketConfiguration},
     solana_pubkey::Pubkey,
     solana_streamer::{
-        nonblocking::quic::SpawnNonBlockingServerResult, quic::QuicServerParams,
+        nonblocking::{quic::SpawnNonBlockingServerResult, swqos::SwQosConfig},
+        quic::QuicStreamerConfig,
         streamer::StakedNodes,
     },
     std::{
@@ -117,10 +118,11 @@ async fn main() -> anyhow::Result<()> {
         &keypair,
         sender,
         staked_nodes,
-        QuicServerParams {
+        QuicStreamerConfig {
             max_connections_per_peer: cli.max_connections_per_peer,
-            ..QuicServerParams::default()
+            ..QuicStreamerConfig::default()
         },
+        SwQosConfig::default(),
         cancel.clone(),
     )?;
     info!("Server listening on {}", socket.local_addr()?);

--- a/streamer/src/nonblocking/mod.rs
+++ b/streamer/src/nonblocking/mod.rs
@@ -3,6 +3,8 @@ pub mod quic;
 #[cfg(feature = "dev-context-only-utils")]
 pub mod recvmmsg;
 pub mod sendmmsg;
+pub mod simple_qos;
 mod stream_throttle;
+pub mod swqos;
 #[cfg(feature = "dev-context-only-utils")]
 pub mod testing_utilities;

--- a/streamer/src/nonblocking/mod.rs
+++ b/streamer/src/nonblocking/mod.rs
@@ -1,4 +1,5 @@
 pub mod connection_rate_limiter;
+pub mod qos;
 pub mod quic;
 #[cfg(feature = "dev-context-only-utils")]
 pub mod recvmmsg;

--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -1,0 +1,74 @@
+use {
+    crate::{
+        nonblocking::{
+            quic::{ClientConnectionTracker, ConnectionPeerType},
+            stream_throttle::ConnectionStreamCounter,
+        },
+        streamer::StakedNodes,
+    },
+    quinn::Connection,
+    std::{
+        sync::{atomic::AtomicU64, Arc, RwLock},
+        time::Duration,
+    },
+};
+
+/// A trait to provide context about a connection, such as peer type,
+/// remote pubkey. This is opaque to the framework and is provided by
+/// the concrete implementation of QosController.
+pub(crate) trait ConnectionContext: Clone + Send + Sync {
+    fn peer_type(&self) -> ConnectionPeerType;
+    fn max_connections_per_peer(&self) -> usize;
+    fn remote_pubkey(&self) -> Option<solana_pubkey::Pubkey>;
+    fn total_stake(&self) -> u64;
+}
+
+/// A trait to manage QoS for connections. This includes
+/// 1) deriving the ConnectionContext for a connection
+/// 2) managing connect caching and connection limits
+pub(crate) trait QosController<C: ConnectionContext> {
+    /// Derive the ConnectionContext for a connection
+    fn derive_connection_context(
+        &self,
+        connection: &Connection,
+        staked_nodes: &RwLock<StakedNodes>,
+    ) -> C;
+
+    /// Try to add a new connection. If successful, return a CancellationToken and
+    /// a ConnectionStreamCounter to track the streams created on this connection.
+    fn try_add_connection(
+        &self,
+        client_connection_tracker: ClientConnectionTracker,
+        connection: &quinn::Connection,
+        context: &mut C,
+    ) -> impl std::future::Future<
+        Output = Option<(
+            Arc<AtomicU64>,
+            tokio_util::sync::CancellationToken,
+            Arc<ConnectionStreamCounter>,
+        )>,
+    > + Send;
+
+    /// The maximum number of streams that can be opened per throttling interval
+    /// on this connection.
+    fn max_streams_per_throttling_interval(&self, context: &C) -> u64;
+
+    /// Called when a stream is accepted on a connection
+    fn on_stream_accepted(&self, context: &C);
+
+    /// Called when a stream has an error
+    fn on_stream_error(&self, context: &C);
+
+    /// Called when a stream is closed
+    fn on_stream_closed(&self, context: &C);
+
+    /// Remove a connection. Return the number of open connections after removal.
+    fn remove_connection(
+        &self,
+        context: &C,
+        connection: Connection,
+    ) -> impl std::future::Future<Output = usize> + Send;
+
+    /// The timeout duration to wait for a chunk to arrive on a stream
+    fn wait_for_chunk_timeout(&self) -> Duration;
+}

--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -1,10 +1,7 @@
 use {
-    crate::nonblocking::{
-        quic::{ClientConnectionTracker, ConnectionPeerType},
-        stream_throttle::ConnectionStreamCounter,
-    },
+    crate::nonblocking::quic::{ClientConnectionTracker, ConnectionPeerType},
     quinn::Connection,
-    std::{future::Future, sync::Arc},
+    std::future::Future,
     tokio_util::sync::CancellationToken,
 };
 
@@ -32,11 +29,10 @@ pub(crate) trait QosController<C: ConnectionContext> {
         client_connection_tracker: ClientConnectionTracker,
         connection: &quinn::Connection,
         context: &mut C,
-    ) -> impl Future<Output = Option<(CancellationToken, Arc<ConnectionStreamCounter>)>> + Send;
+    ) -> impl Future<Output = Option<CancellationToken>> + Send;
 
-    /// The maximum number of streams that can be opened per throttling interval
-    /// on this connection.
-    fn max_streams_per_throttling_interval(&self, context: &C) -> u64;
+    /// Called when a new stream is received on a connection
+    fn on_new_stream(&self, context: &C) -> impl Future<Output = ()> + Send;
 
     /// Called when a stream is accepted on a connection
     fn on_stream_accepted(&self, context: &C);

--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -4,10 +4,7 @@ use {
         stream_throttle::ConnectionStreamCounter,
     },
     quinn::Connection,
-    std::{
-        sync::{atomic::AtomicU64, Arc},
-        time::Duration,
-    },
+    std::{sync::Arc, time::Duration},
     tokio_util::sync::CancellationToken,
 };
 
@@ -34,13 +31,8 @@ pub(crate) trait QosController<C: ConnectionContext> {
         client_connection_tracker: ClientConnectionTracker,
         connection: &quinn::Connection,
         context: &mut C,
-    ) -> impl std::future::Future<
-        Output = Option<(
-            Arc<AtomicU64>,
-            CancellationToken,
-            Arc<ConnectionStreamCounter>,
-        )>,
-    > + Send;
+    ) -> impl std::future::Future<Output = Option<(CancellationToken, Arc<ConnectionStreamCounter>)>>
+           + Send;
 
     /// The maximum number of streams that can be opened per throttling interval
     /// on this connection.
@@ -50,6 +42,9 @@ pub(crate) trait QosController<C: ConnectionContext> {
 
     /// Called when a stream is accepted on a connection
     fn on_stream_accepted(&self, context: &C);
+
+    /// Called when a stream is finished successfully
+    fn on_stream_finished(&self, context: &C);
 
     /// Called when a stream has an error
     fn on_stream_error(&self, context: &C);

--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -26,10 +26,10 @@ pub(crate) trait QosController<C: ConnectionContext> {
     /// Derive the ConnectionContext for a connection
     fn derive_connection_context(&self, connection: &Connection) -> C;
 
-    /// Try to add a new connection. If successful, return a CancellationToken and
+    /// Try to add a new connection to cache. If successful, return a CancellationToken and
     /// a ConnectionStreamCounter to track the streams created on this connection.
     /// Otherwise return None.
-    fn try_add_connection(
+    fn try_cache_connection(
         &self,
         client_connection_tracker: ClientConnectionTracker,
         connection: &quinn::Connection,

--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -8,6 +8,7 @@ use {
         sync::{atomic::AtomicU64, Arc},
         time::Duration,
     },
+    tokio_util::sync::CancellationToken,
 };
 
 /// A trait to provide context about a connection, such as peer type,
@@ -27,6 +28,7 @@ pub(crate) trait QosController<C: ConnectionContext> {
 
     /// Try to add a new connection. If successful, return a CancellationToken and
     /// a ConnectionStreamCounter to track the streams created on this connection.
+    /// Otherwise return None.
     fn try_add_connection(
         &self,
         client_connection_tracker: ClientConnectionTracker,
@@ -35,7 +37,7 @@ pub(crate) trait QosController<C: ConnectionContext> {
     ) -> impl std::future::Future<
         Output = Option<(
             Arc<AtomicU64>,
-            tokio_util::sync::CancellationToken,
+            CancellationToken,
             Arc<ConnectionStreamCounter>,
         )>,
     > + Send;

--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -18,7 +18,7 @@ pub(crate) trait ConnectionContext: Clone + Send + Sync {
 
 /// A trait to manage QoS for connections. This includes
 /// 1) deriving the ConnectionContext for a connection
-/// 2) managing connect caching and connection limits
+/// 2) managing connection caching and connection limits, stream limits
 pub(crate) trait QosController<C: ConnectionContext> {
     /// Derive the ConnectionContext for a connection
     fn derive_connection_context(&self, connection: &Connection) -> C;

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -3,14 +3,10 @@ use {
         nonblocking::{
             connection_rate_limiter::{ConnectionRateLimiter, TotalConnectionRateLimiter},
             qos::{ConnectionContext, QosController},
-            simple_qos::SimpleQos,
             stream_throttle::{ConnectionStreamCounter, STREAM_THROTTLING_INTERVAL},
             swqos::SwQos,
         },
-        quic::{
-            configure_server, QuicServerError, QuicServerParams, SimpleQosQuicServerParams,
-            StreamerStats,
-        },
+        quic::{configure_server, QuicServerError, QuicServerParams, StreamerStats},
         streamer::StakedNodes,
     },
     bytes::{BufMut, Bytes, BytesMut},
@@ -217,6 +213,7 @@ where
 
     spawn_server_with_cancel_and_qos(
         name,
+        stats,
         sockets,
         keypair,
         packet_sender,
@@ -227,48 +224,9 @@ where
 }
 
 /// Spawn a streamer instance in the current tokio runtime.
-pub fn spawn_simple_qos_server_with_cancel(
-    name: &'static str,
-    sockets: impl IntoIterator<Item = UdpSocket>,
-    keypair: &Keypair,
-    packet_sender: Sender<PacketBatch>,
-    staked_nodes: Arc<RwLock<StakedNodes>>,
-    quic_server_params: SimpleQosQuicServerParams,
-    cancel: CancellationToken,
-) -> Result<SpawnNonBlockingServerResult, QuicServerError>
-where
-{
-    let stats = Arc::<StreamerStats>::default();
-
-    let SimpleQosQuicServerParams {
-        quic_server_params,
-        max_streams_per_second,
-    } = quic_server_params;
-
-    let simple_qos = Arc::new(SimpleQos::new(
-        max_streams_per_second,
-        quic_server_params.max_connections_per_peer,
-        quic_server_params.max_staked_connections,
-        quic_server_params.wait_for_chunk_timeout,
-        stats.clone(),
-        staked_nodes,
-        cancel.clone(),
-    ));
-
-    spawn_server_with_cancel_and_qos(
-        name,
-        sockets,
-        keypair,
-        packet_sender,
-        quic_server_params,
-        cancel,
-        simple_qos,
-    )
-}
-
-/// Spawn a streamer instance in the current tokio runtime.
 pub(crate) fn spawn_server_with_cancel_and_qos<Q, C>(
     name: &'static str,
+    stats: Arc<StreamerStats>,
     sockets: impl IntoIterator<Item = UdpSocket>,
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
@@ -280,8 +238,6 @@ where
     Q: QosController<C> + Send + Sync + 'static,
     C: ConnectionContext + Send + Sync + 'static,
 {
-    let stats = Arc::<StreamerStats>::default();
-
     let sockets: Vec<_> = sockets.into_iter().collect();
     info!("Start {name} quic server on {sockets:?}");
     let (config, _) = configure_server(keypair)?;

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -499,6 +499,7 @@ pub fn get_connection_stake(
     ))
 }
 
+#[derive(Debug)]
 pub(crate) enum ConnectionHandlerError {
     ConnectionAddError,
     MaxStreamError,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1,12 +1,15 @@
+#[allow(deprecated)]
 use {
     crate::{
         nonblocking::{
             connection_rate_limiter::{ConnectionRateLimiter, TotalConnectionRateLimiter},
             qos::{ConnectionContext, QosController},
             stream_throttle::ConnectionStreamCounter,
-            swqos::SwQos,
+            swqos::{SwQos, SwQosConfig},
         },
-        quic::{configure_server, QuicServerError, QuicServerParams, StreamerStats},
+        quic::{
+            configure_server, QuicServerError, QuicServerParams, QuicStreamerConfig, StreamerStats,
+        },
         streamer::StakedNodes,
     },
     bytes::{BufMut, Bytes, BytesMut},
@@ -130,6 +133,7 @@ pub struct SpawnNonBlockingServerResult {
 }
 
 #[deprecated(since = "3.0.0", note = "Use spawn_server instead")]
+#[allow(deprecated)]
 pub fn spawn_server_multi(
     name: &'static str,
     sockets: impl IntoIterator<Item = UdpSocket>,
@@ -152,6 +156,7 @@ pub fn spawn_server_multi(
 }
 
 #[deprecated(since = "3.1.0", note = "Use spawn_server_with_cancel instead")]
+#[allow(deprecated)]
 pub fn spawn_server(
     name: &'static str,
     sockets: impl IntoIterator<Item = UdpSocket>,
@@ -174,14 +179,18 @@ pub fn spawn_server(
             }
         }
     });
-
+    let quic_server_config = QuicStreamerConfig::from(&quic_server_params);
+    let qos_config = SwQosConfig {
+        max_streams_per_ms: quic_server_params.max_streams_per_ms,
+    };
     spawn_server_with_cancel(
         name,
         sockets,
         keypair,
         packet_sender,
         staked_nodes,
-        quic_server_params,
+        quic_server_config,
+        qos_config,
         cancel,
     )
 }
@@ -193,7 +202,8 @@ pub fn spawn_server_with_cancel(
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
     staked_nodes: Arc<RwLock<StakedNodes>>,
-    quic_server_params: QuicServerParams,
+    quic_server_params: QuicStreamerConfig,
+    qos_config: SwQosConfig,
     cancel: CancellationToken,
 ) -> Result<SpawnNonBlockingServerResult, QuicServerError>
 where
@@ -201,7 +211,7 @@ where
     let stats = Arc::<StreamerStats>::default();
 
     let swqos = Arc::new(SwQos::new(
-        quic_server_params.max_streams_per_ms,
+        qos_config,
         quic_server_params.max_staked_connections,
         quic_server_params.max_unstaked_connections,
         quic_server_params.max_connections_per_peer,
@@ -229,7 +239,7 @@ pub(crate) fn spawn_server_with_cancel_and_qos<Q, C>(
     sockets: impl IntoIterator<Item = UdpSocket>,
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
-    quic_server_params: QuicServerParams,
+    quic_server_params: QuicStreamerConfig,
     cancel: CancellationToken,
     qos: Arc<Q>,
 ) -> Result<SpawnNonBlockingServerResult, QuicServerError>
@@ -342,7 +352,7 @@ async fn run_server<Q, C>(
     endpoints: Vec<Endpoint>,
     packet_batch_sender: Sender<PacketAccumulator>,
     stats: Arc<StreamerStats>,
-    quic_server_params: QuicServerParams,
+    quic_server_params: QuicStreamerConfig,
     cancel: CancellationToken,
     qos: Arc<Q>,
 ) -> TaskTracker
@@ -517,7 +527,7 @@ async fn setup_connection<Q, C>(
     client_connection_tracker: ClientConnectionTracker,
     packet_sender: Sender<PacketAccumulator>,
     stats: Arc<StreamerStats>,
-    server_params: Arc<QuicServerParams>,
+    server_params: Arc<QuicStreamerConfig>,
     qos: Arc<Q>,
     tasks: TaskTracker,
 ) where
@@ -1433,7 +1443,11 @@ pub mod test {
             server_address: _,
             stats: _,
             cancel,
-        } = setup_quic_server(None, QuicServerParams::default_for_tests());
+        } = setup_quic_server(
+            None,
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
+        );
         cancel.cancel();
         join_handle.await.unwrap();
         // test that it is stopped by cancel, not due to receiver
@@ -1450,7 +1464,11 @@ pub mod test {
             server_address,
             stats: _,
             cancel,
-        } = setup_quic_server(None, QuicServerParams::default_for_tests());
+        } = setup_quic_server(
+            None,
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
+        );
 
         check_timeout(receiver, server_address).await;
         cancel.cancel();
@@ -1511,7 +1529,11 @@ pub mod test {
             server_address,
             stats,
             cancel,
-        } = setup_quic_server(None, QuicServerParams::default_for_tests());
+        } = setup_quic_server(
+            None,
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
+        );
 
         let conn1 = make_client_endpoint(&server_address, None).await;
         assert_eq!(stats.active_streams.load(Ordering::Relaxed), 0);
@@ -1547,7 +1569,11 @@ pub mod test {
             server_address,
             stats: _,
             cancel,
-        } = setup_quic_server(None, QuicServerParams::default_for_tests());
+        } = setup_quic_server(
+            None,
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
+        );
         check_block_multiple_connections(server_address).await;
         cancel.cancel();
         drop(receiver);
@@ -1566,10 +1592,11 @@ pub mod test {
             cancel,
         } = setup_quic_server(
             None,
-            QuicServerParams {
+            QuicStreamerConfig {
                 max_connections_per_peer: 2,
-                ..QuicServerParams::default_for_tests()
+                ..QuicStreamerConfig::default_for_tests()
             },
+            SwQosConfig::default(),
         );
 
         let client_socket = bind_to_localhost_unique().expect("should bind - client");
@@ -1646,7 +1673,11 @@ pub mod test {
             server_address,
             stats: _,
             cancel,
-        } = setup_quic_server(None, QuicServerParams::default_for_tests());
+        } = setup_quic_server(
+            None,
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
+        );
         check_multiple_writes(receiver, server_address, None).await;
         cancel.cancel();
         join_handle.await.unwrap();
@@ -1668,7 +1699,11 @@ pub mod test {
             server_address,
             stats,
             cancel,
-        } = setup_quic_server(Some(staked_nodes), QuicServerParams::default_for_tests());
+        } = setup_quic_server(
+            Some(staked_nodes),
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
+        );
         check_multiple_writes(receiver, server_address, Some(&client_keypair)).await;
         cancel.cancel();
         join_handle.await.unwrap();
@@ -1700,7 +1735,11 @@ pub mod test {
             server_address,
             stats,
             cancel,
-        } = setup_quic_server(Some(staked_nodes), QuicServerParams::default_for_tests());
+        } = setup_quic_server(
+            Some(staked_nodes),
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
+        );
         check_multiple_writes(receiver, server_address, Some(&client_keypair)).await;
         cancel.cancel();
         join_handle.await.unwrap();
@@ -1724,7 +1763,11 @@ pub mod test {
             server_address,
             stats,
             cancel,
-        } = setup_quic_server(None, QuicServerParams::default_for_tests());
+        } = setup_quic_server(
+            None,
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
+        );
         check_multiple_writes(receiver, server_address, None).await;
         cancel.cancel();
         join_handle.await.unwrap();
@@ -1759,10 +1802,11 @@ pub mod test {
             &keypair,
             sender,
             staked_nodes,
-            QuicServerParams {
+            QuicStreamerConfig {
                 max_unstaked_connections: 0, // Do not allow any connection from unstaked clients/nodes
-                ..QuicServerParams::default_for_tests()
+                ..QuicStreamerConfig::default_for_tests()
             },
+            SwQosConfig::default(),
             cancel.clone(),
         )
         .unwrap();
@@ -1792,10 +1836,11 @@ pub mod test {
             &keypair,
             sender,
             staked_nodes,
-            QuicServerParams {
+            QuicStreamerConfig {
                 max_connections_per_peer: 2,
-                ..QuicServerParams::default_for_tests()
+                ..QuicStreamerConfig::default_for_tests()
             },
+            SwQosConfig::default(),
             cancel.clone(),
         )
         .unwrap();
@@ -2093,7 +2138,11 @@ pub mod test {
             server_address,
             stats,
             cancel,
-        } = setup_quic_server(None, QuicServerParams::default_for_tests());
+        } = setup_quic_server(
+            None,
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
+        );
 
         let client_connection = make_client_endpoint(&server_address, None).await;
 
@@ -2151,7 +2200,11 @@ pub mod test {
             stats,
             cancel,
             ..
-        } = setup_quic_server(None, QuicServerParams::default_for_tests());
+        } = setup_quic_server(
+            None,
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
+        );
 
         let client_connection = make_client_endpoint(&server_address, None).await;
 

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -22,7 +22,6 @@ use {
     solana_perf::packet::{BytesPacket, BytesPacketBatch, PacketBatch, PACKETS_PER_BATCH},
     solana_pubkey::Pubkey,
     solana_signature::Signature,
-    solana_time_utils as timing,
     solana_tls_utils::get_pubkey_from_tls_certificate,
     solana_transaction_metrics_tracker::signature_if_should_track_packet,
     std::{
@@ -534,7 +533,7 @@ async fn setup_connection<Q, C>(
                 }
 
                 let mut conn_context = qos.derive_connection_context(&new_connection);
-                if let Some((last_update, cancel_connection, stream_counter)) = qos
+                if let Some((cancel_connection, stream_counter)) = qos
                     .try_cache_connection(
                         client_connection_tracker,
                         &new_connection,
@@ -546,7 +545,6 @@ async fn setup_connection<Q, C>(
                         packet_sender.clone(),
                         new_connection,
                         stats,
-                        last_update,
                         conn_context.clone(),
                         qos,
                         stream_counter,
@@ -759,7 +757,6 @@ async fn handle_connection<Q, C>(
     packet_sender: Sender<PacketAccumulator>,
     connection: Connection,
     stats: Arc<StreamerStats>,
-    last_update: Arc<AtomicU64>,
     context: C,
     qos: Arc<Q>,
     stream_counter: Arc<ConnectionStreamCounter>,
@@ -888,7 +885,7 @@ async fn handle_connection<Q, C>(
             ) {
                 // The stream is finished, break out of the loop and close the stream.
                 Ok(StreamState::Finished) => {
-                    last_update.store(timing::timestamp(), Ordering::Relaxed);
+                    qos.on_stream_finished(&context);
                     break;
                 }
                 // The stream is still active, continue reading.
@@ -1184,7 +1181,7 @@ impl ConnectionTable {
         client_connection_tracker: ClientConnectionTracker,
         connection: Option<Connection>,
         peer_type: ConnectionPeerType,
-        last_update: u64,
+        last_update: Arc<AtomicU64>,
         max_connections_per_peer: usize,
     ) -> Option<(
         Arc<AtomicU64>,
@@ -1199,7 +1196,6 @@ impl ConnectionTable {
             .unwrap_or(false);
         if has_connection_capacity {
             let cancel = self.cancel.child_token();
-            let last_update = Arc::new(AtomicU64::new(last_update));
             let stream_counter = connection_entry
                 .first()
                 .map(|entry| entry.stream_counter.clone())
@@ -1811,7 +1807,7 @@ pub mod test {
                     ClientConnectionTracker::new(stats.clone(), 1000).unwrap(),
                     None,
                     ConnectionPeerType::Unstaked,
-                    i as u64,
+                    Arc::new(AtomicU64::new(i as u64)),
                     max_connections_per_peer,
                 )
                 .unwrap();
@@ -1824,7 +1820,7 @@ pub mod test {
                 ClientConnectionTracker::new(stats.clone(), 1000).unwrap(),
                 None,
                 ConnectionPeerType::Unstaked,
-                5,
+                Arc::new(AtomicU64::new(5)),
                 max_connections_per_peer,
             )
             .unwrap();
@@ -1867,7 +1863,7 @@ pub mod test {
                     ClientConnectionTracker::new(stats.clone(), 1000).unwrap(),
                     None,
                     ConnectionPeerType::Unstaked,
-                    i as u64,
+                    Arc::new(AtomicU64::new(i as u64)),
                     max_connections_per_peer,
                 )
                 .unwrap();
@@ -1903,7 +1899,7 @@ pub mod test {
                     ClientConnectionTracker::new(stats.clone(), 1000).unwrap(),
                     None,
                     ConnectionPeerType::Unstaked,
-                    i as u64,
+                    Arc::new(AtomicU64::new(i as u64)),
                     max_connections_per_peer,
                 )
                 .unwrap();
@@ -1918,7 +1914,7 @@ pub mod test {
                 ClientConnectionTracker::new(stats.clone(), 1000).unwrap(),
                 None,
                 ConnectionPeerType::Unstaked,
-                10,
+                Arc::new(AtomicU64::new(10)),
                 max_connections_per_peer,
             )
             .is_none());
@@ -1933,7 +1929,7 @@ pub mod test {
                 ClientConnectionTracker::new(stats.clone(), 1000).unwrap(),
                 None,
                 ConnectionPeerType::Unstaked,
-                10,
+                Arc::new(AtomicU64::new(10)),
                 max_connections_per_peer,
             )
             .is_some());
@@ -1973,7 +1969,7 @@ pub mod test {
                     ClientConnectionTracker::new(stats.clone(), 1000).unwrap(),
                     None,
                     ConnectionPeerType::Staked((i + 1) as u64),
-                    i as u64,
+                    Arc::new(AtomicU64::new(i as u64)),
                     max_connections_per_peer,
                 )
                 .unwrap();
@@ -2017,7 +2013,7 @@ pub mod test {
                     ClientConnectionTracker::new(stats.clone(), 1000).unwrap(),
                     None,
                     ConnectionPeerType::Unstaked,
-                    (i * 2) as u64,
+                    Arc::new(AtomicU64::new((i * 2) as u64)),
                     max_connections_per_peer,
                 )
                 .unwrap();
@@ -2029,7 +2025,7 @@ pub mod test {
                     ClientConnectionTracker::new(stats.clone(), 1000).unwrap(),
                     None,
                     ConnectionPeerType::Unstaked,
-                    (i * 2 + 1) as u64,
+                    Arc::new(AtomicU64::new((i * 2 + 1) as u64)),
                     max_connections_per_peer,
                 )
                 .unwrap();
@@ -2044,7 +2040,7 @@ pub mod test {
                 ClientConnectionTracker::new(stats.clone(), 1000).unwrap(),
                 None,
                 ConnectionPeerType::Unstaked,
-                (num_ips * 2) as u64,
+                Arc::new(AtomicU64::new((num_ips * 2) as u64)),
                 max_connections_per_peer,
             )
             .unwrap();

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -555,7 +555,6 @@ async fn setup_connection<Q, C>(
                     );
                     return;
                 }
-                stats.total_new_connections.fetch_add(1, Ordering::Relaxed);
 
                 if !overall_connection_rate_limiter.is_allowed() {
                     debug!(

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -535,7 +535,7 @@ async fn setup_connection<Q, C>(
 
                 let mut conn_context = qos.derive_connection_context(&new_connection);
                 if let Some((last_update, cancel_connection, stream_counter)) = qos
-                    .try_add_connection(
+                    .try_cache_connection(
                         client_connection_tracker,
                         &new_connection,
                         &mut conn_context,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -559,6 +559,8 @@ async fn setup_connection<Q, C>(
                     return;
                 }
 
+                stats.total_new_connections.fetch_add(1, Ordering::Relaxed);
+
                 let mut conn_context = qos.derive_connection_context(&new_connection);
                 if let Some((cancel_connection, stream_counter)) = qos
                     .try_cache_connection(

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -208,6 +208,7 @@ where
         quic_server_params.max_connections_per_peer,
         quic_server_params.wait_for_chunk_timeout,
         stats.clone(),
+        staked_nodes,
         cancel.clone(),
     ));
 
@@ -246,7 +247,6 @@ where
                 name,
                 endpoints.clone(),
                 packet_batch_sender,
-                staked_nodes,
                 stats.clone(),
                 quic_server_params,
                 cancel,
@@ -316,7 +316,6 @@ async fn run_server<Q, C>(
     name: &'static str,
     endpoints: Vec<Endpoint>,
     packet_batch_sender: Sender<PacketAccumulator>,
-    staked_nodes: Arc<RwLock<StakedNodes>>,
     stats: Arc<StreamerStats>,
     quic_server_params: QuicServerParams,
     cancel: CancellationToken,
@@ -417,7 +416,6 @@ where
                         overall_connection_rate_limiter,
                         client_connection_tracker,
                         packet_batch_sender.clone(),
-                        staked_nodes.clone(),
                         stats.clone(),
                         qos.clone(),
                         tasks.clone(),
@@ -491,7 +489,6 @@ async fn setup_connection<Q, C>(
     overall_connection_rate_limiter: Arc<TotalConnectionRateLimiter>,
     client_connection_tracker: ClientConnectionTracker,
     packet_sender: Sender<PacketAccumulator>,
-    staked_nodes: Arc<RwLock<StakedNodes>>,
     stats: Arc<StreamerStats>,
     qos: Arc<Q>,
     tasks: TaskTracker,
@@ -536,8 +533,7 @@ async fn setup_connection<Q, C>(
                     return;
                 }
 
-                let mut conn_context =
-                    qos.derive_connection_context(&new_connection, &staked_nodes);
+                let mut conn_context = qos.derive_connection_context(&new_connection);
                 if let Some((last_update, cancel_connection, stream_counter)) = qos
                     .try_add_connection(
                         client_connection_tracker,
@@ -773,7 +769,7 @@ async fn handle_connection<Q, C>(
     C: ConnectionContext + Send + Sync + 'static,
 {
     let peer_type = context.peer_type();
-    let total_stake = context.total_stake();
+    let total_stake = qos.total_stake();
     let remote_addr = connection.remote_address();
     debug!(
         "quic new connection {} streams: {} connections: {}",

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1389,6 +1389,34 @@ pub mod test {
         }
         s1.finish().unwrap();
 
+        check_received_packets(receiver, num_expected_packets, num_bytes).await;
+    }
+
+    pub async fn check_multiple_packets(
+        receiver: Receiver<PacketBatch>,
+        server_address: SocketAddr,
+        client_keypair: Option<&Keypair>,
+        num_expected_packets: usize,
+    ) {
+        let conn1 = Arc::new(make_client_endpoint(&server_address, client_keypair).await);
+
+        // Send a full size packet with single byte writes.
+        let num_bytes = PACKET_DATA_SIZE;
+        let packet = vec![1u8; num_bytes];
+        for _ in 0..num_expected_packets {
+            let mut s1 = conn1.open_uni().await.unwrap();
+            s1.write_all(&packet).await.unwrap();
+            s1.finish().unwrap();
+        }
+
+        check_received_packets(receiver, num_expected_packets, num_bytes).await;
+    }
+
+    async fn check_received_packets(
+        receiver: Receiver<PacketBatch>,
+        num_expected_packets: usize,
+        num_bytes: usize,
+    ) {
         let mut all_packets = vec![];
         let now = Instant::now();
         let mut total_packets = 0;

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -3,10 +3,14 @@ use {
         nonblocking::{
             connection_rate_limiter::{ConnectionRateLimiter, TotalConnectionRateLimiter},
             qos::{ConnectionContext, QosController},
+            simple_qos::SimpleQos,
             stream_throttle::{ConnectionStreamCounter, STREAM_THROTTLING_INTERVAL},
             swqos::SwQos,
         },
-        quic::{configure_server, QuicServerError, QuicServerParams, StreamerStats},
+        quic::{
+            configure_server, QuicServerError, QuicServerParams, SimpleQosQuicServerParams,
+            StreamerStats,
+        },
         streamer::StakedNodes,
     },
     bytes::{BufMut, Bytes, BytesMut},
@@ -211,6 +215,73 @@ where
         cancel.clone(),
     ));
 
+    spawn_server_with_cancel_and_qos(
+        name,
+        sockets,
+        keypair,
+        packet_sender,
+        quic_server_params,
+        cancel,
+        swqos,
+    )
+}
+
+/// Spawn a streamer instance in the current tokio runtime.
+pub fn spawn_simple_qos_server_with_cancel(
+    name: &'static str,
+    sockets: impl IntoIterator<Item = UdpSocket>,
+    keypair: &Keypair,
+    packet_sender: Sender<PacketBatch>,
+    staked_nodes: Arc<RwLock<StakedNodes>>,
+    quic_server_params: SimpleQosQuicServerParams,
+    cancel: CancellationToken,
+) -> Result<SpawnNonBlockingServerResult, QuicServerError>
+where
+{
+    let stats = Arc::<StreamerStats>::default();
+
+    let SimpleQosQuicServerParams {
+        quic_server_params,
+        max_streams_per_second,
+    } = quic_server_params;
+
+    let simple_qos = Arc::new(SimpleQos::new(
+        max_streams_per_second,
+        quic_server_params.max_connections_per_peer,
+        quic_server_params.max_staked_connections,
+        quic_server_params.wait_for_chunk_timeout,
+        stats.clone(),
+        staked_nodes,
+        cancel.clone(),
+    ));
+
+    spawn_server_with_cancel_and_qos(
+        name,
+        sockets,
+        keypair,
+        packet_sender,
+        quic_server_params,
+        cancel,
+        simple_qos,
+    )
+}
+
+/// Spawn a streamer instance in the current tokio runtime.
+pub(crate) fn spawn_server_with_cancel_and_qos<Q, C>(
+    name: &'static str,
+    sockets: impl IntoIterator<Item = UdpSocket>,
+    keypair: &Keypair,
+    packet_sender: Sender<PacketBatch>,
+    quic_server_params: QuicServerParams,
+    cancel: CancellationToken,
+    qos: Arc<Q>,
+) -> Result<SpawnNonBlockingServerResult, QuicServerError>
+where
+    Q: QosController<C> + Send + Sync + 'static,
+    C: ConnectionContext + Send + Sync + 'static,
+{
+    let stats = Arc::<StreamerStats>::default();
+
     let sockets: Vec<_> = sockets.into_iter().collect();
     info!("Start {name} quic server on {sockets:?}");
     let (config, _) = configure_server(keypair)?;
@@ -249,7 +320,7 @@ where
                 stats.clone(),
                 quic_server_params,
                 cancel,
-                swqos,
+                qos,
             )
             .await;
             tasks.close();

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -205,7 +205,9 @@ where
         quic_server_params.max_staked_connections,
         quic_server_params.max_unstaked_connections,
         quic_server_params.max_connections_per_peer,
+        quic_server_params.wait_for_chunk_timeout,
         stats.clone(),
+        cancel.clone(),
     ));
 
     let sockets: Vec<_> = sockets.into_iter().collect();
@@ -248,6 +250,7 @@ where
                 stats.clone(),
                 quic_server_params,
                 cancel,
+                swqos,
             )
             .await;
             tasks.close();
@@ -317,7 +320,12 @@ async fn run_server<Q, P>(
     stats: Arc<StreamerStats>,
     quic_server_params: QuicServerParams,
     cancel: CancellationToken,
-) -> TaskTracker {
+    qos: Arc<Q>,
+) -> TaskTracker
+where
+    Q: Qos<P> + Send + Sync + 'static,
+    P: ConnectionQosParams + Send + Sync + 'static,
+{
     let rate_limiter = Arc::new(ConnectionRateLimiter::new(
         quic_server_params.max_connections_per_ipaddr_per_min,
     ));
@@ -331,15 +339,6 @@ async fn run_server<Q, P>(
     stats
         .quic_endpoints_count
         .store(endpoints.len(), Ordering::Relaxed);
-    let (sender, receiver) = bounded(coalesce_channel_size);
-
-    thread::spawn({
-        let exit = exit.clone();
-        let stats = stats.clone();
-        move || {
-            packet_batch_sender(packet_sender, receiver, exit, stats, coalesce);
-        }
-    });
 
     let mut accepts = endpoints
         .iter()
@@ -508,6 +507,22 @@ pub(crate) trait Qos<P: ConnectionQosParams> {
         params: &P,
         connection: Connection,
     ) -> impl std::future::Future<Output = usize> + Send;
+    fn wait_for_chunk_timeout(&self) -> Duration;
+}
+
+pub(crate) fn update_open_connections_stat(
+    stats: &StreamerStats,
+    connection_table: &ConnectionTable,
+) {
+    if connection_table.is_staked() {
+        stats
+            .open_staked_connections
+            .store(connection_table.table_size(), Ordering::Relaxed);
+    } else {
+        stats
+            .open_unstaked_connections
+            .store(connection_table.table_size(), Ordering::Relaxed);
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -567,16 +582,15 @@ async fn setup_connection<Q, P>(
                     .try_add_connection(client_connection_tracker, &new_connection, &mut params)
                     .await
                 {
-                    tokio::spawn(handle_connection(
+                    tasks.spawn(handle_connection(
                         packet_sender.clone(),
                         new_connection,
                         stats,
                         last_update,
-                        cancel_connection,
                         params.clone(),
-                        wait_for_chunk_timeout,
                         qos,
                         stream_counter,
+                        cancel_connection,
                     ));
                 }
             }
@@ -786,9 +800,7 @@ async fn handle_connection<Q, P>(
     connection: Connection,
     stats: Arc<StreamerStats>,
     last_update: Arc<AtomicU64>,
-    cancel: CancellationToken,
     params: P,
-    wait_for_chunk_timeout: Duration,
     qos: Arc<Q>,
     stream_counter: Arc<ConnectionStreamCounter>,
     cancel: CancellationToken,
@@ -880,7 +892,7 @@ async fn handle_connection<Q, P>(
             // packet loss or the peer stops sending for whatever reason.
             let n_chunks = match tokio::select! {
                 chunk = tokio::time::timeout(
-                    params.wait_for_chunk_timeout,
+                    qos.wait_for_chunk_timeout(),
                     stream.read_chunks(&mut chunks)) => chunk,
 
                 // If the peer gets disconnected stop the task right away.
@@ -1127,7 +1139,7 @@ impl ConnectionTableKey {
     }
 }
 
-enum ConnectionTableType {
+pub(crate) enum ConnectionTableType {
     Staked,
     Unstaked,
 }
@@ -1144,14 +1156,24 @@ pub(crate) struct ConnectionTable {
 ///
 /// Return number pruned
 impl ConnectionTable {
-    fn new(table_type: ConnectionTableType, cancel: CancellationToken) -> Self {
+    pub(crate) fn new(table_type: ConnectionTableType, cancel: CancellationToken) -> Self {
         Self {
             table: IndexMap::default(),
             total_size: 0,
+            table_type,
+            cancel,
         }
     }
 
-    fn prune_oldest(&mut self, max_size: usize) -> usize {
+    fn table_size(&self) -> usize {
+        self.total_size
+    }
+
+    fn is_staked(&self) -> bool {
+        matches!(self.table_type, ConnectionTableType::Staked)
+    }
+
+    pub(crate) fn prune_oldest(&mut self, max_size: usize) -> usize {
         let mut num_pruned = 0;
         let key = |(_, connections): &(_, &Vec<_>)| {
             connections.iter().map(ConnectionEntry::last_update).min()

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1289,12 +1289,9 @@ impl Future for EndpointAccept<'_> {
 pub mod test {
     use {
         super::*,
-        crate::{
-            nonblocking::testing_utilities::{
-                check_multiple_streams, get_client_config, make_client_endpoint, setup_quic_server,
-                SpawnTestServerResult,
-            },
-            quic::DEFAULT_TPU_COALESCE,
+        crate::nonblocking::testing_utilities::{
+            check_multiple_streams, get_client_config, make_client_endpoint, setup_quic_server,
+            SpawnTestServerResult,
         },
         assert_matches::assert_matches,
         crossbeam_channel::{unbounded, Receiver},

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         nonblocking::{
             connection_rate_limiter::{ConnectionRateLimiter, TotalConnectionRateLimiter},
+            qos::{ConnectionContext, QosController},
             stream_throttle::{ConnectionStreamCounter, STREAM_THROTTLING_INTERVAL},
             swqos::SwQos,
         },
@@ -466,66 +467,6 @@ pub fn get_connection_stake(
 pub(crate) enum ConnectionHandlerError {
     ConnectionAddError,
     MaxStreamError,
-}
-
-/// A trait to provide context about a connection, such as peer type,
-/// remote pubkey. This is opaque to the framework and is provided by
-/// the concrete implementation of QosController.
-pub(crate) trait ConnectionContext: Clone + Send + Sync {
-    fn peer_type(&self) -> ConnectionPeerType;
-    fn max_connections_per_peer(&self) -> usize;
-    fn remote_pubkey(&self) -> Option<solana_pubkey::Pubkey>;
-    fn total_stake(&self) -> u64;
-}
-
-/// A trait to manage QoS for connections. This includes
-/// 1) deriving the ConnectionContext for a connection
-/// 2) managing connect caching and connection limits
-pub(crate) trait QosController<C: ConnectionContext> {
-    /// Derive the ConnectionContext for a connection
-    fn derive_connection_context(
-        &self,
-        connection: &Connection,
-        staked_nodes: &RwLock<StakedNodes>,
-    ) -> C;
-
-    /// Try to add a new connection. If successful, return a CancellationToken and
-    /// a ConnectionStreamCounter to track the streams created on this connection.
-    fn try_add_connection(
-        &self,
-        client_connection_tracker: ClientConnectionTracker,
-        connection: &quinn::Connection,
-        context: &mut C,
-    ) -> impl std::future::Future<
-        Output = Option<(
-            Arc<AtomicU64>,
-            tokio_util::sync::CancellationToken,
-            Arc<ConnectionStreamCounter>,
-        )>,
-    > + Send;
-
-    /// The maximum number of streams that can be opened per throttling interval
-    /// on this connection.
-    fn max_streams_per_throttling_interval(&self, context: &C) -> u64;
-
-    /// Called when a stream is accepted on a connection
-    fn on_stream_accepted(&self, context: &C);
-
-    /// Called when a stream has an error
-    fn on_stream_error(&self, context: &C);
-
-    /// Called when a stream is closed
-    fn on_stream_closed(&self, context: &C);
-
-    /// Remove a connection. Return the number of open connections after removal.
-    fn remove_connection(
-        &self,
-        context: &C,
-        connection: Connection,
-    ) -> impl std::future::Future<Output = usize> + Send;
-
-    /// The timeout duration to wait for a chunk to arrive on a stream
-    fn wait_for_chunk_timeout(&self) -> Duration;
 }
 
 pub(crate) fn update_open_connections_stat(

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -226,7 +226,6 @@ where
             .map_err(QuicServerError::EndpointFailed)
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let stats = Arc::<StreamerStats>::default();
     let (packet_batch_sender, packet_batch_receiver) =
         bounded(quic_server_params.accumulator_channel_size);
     task::spawn_blocking({

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -312,7 +312,7 @@ impl ClientConnectionTracker {
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn run_server<Q, P>(
+async fn run_server<Q, C>(
     name: &'static str,
     endpoints: Vec<Endpoint>,
     packet_batch_sender: Sender<PacketAccumulator>,
@@ -323,8 +323,8 @@ async fn run_server<Q, P>(
     qos: Arc<Q>,
 ) -> TaskTracker
 where
-    Q: Qos<P> + Send + Sync + 'static,
-    P: ConnectionQosParams + Send + Sync + 'static,
+    Q: QosController<C> + Send + Sync + 'static,
+    C: ConnectionContext + Send + Sync + 'static,
 {
     let rate_limiter = Arc::new(ConnectionRateLimiter::new(
         quic_server_params.max_connections_per_ipaddr_per_min,
@@ -469,16 +469,26 @@ pub(crate) enum ConnectionHandlerError {
     MaxStreamError,
 }
 
-pub(crate) trait ConnectionQosParams: Clone + Send + Sync {
+/// A trait to provide context about a connection, such as peer type,
+/// remote pubkey. This is opaque to the framework and is provided by
+/// the concrete implementation of QosController.
+pub(crate) trait ConnectionContext: Clone + Send + Sync {
     fn peer_type(&self) -> ConnectionPeerType;
     fn max_connections_per_peer(&self) -> usize;
     fn remote_pubkey(&self) -> Option<solana_pubkey::Pubkey>;
     fn total_stake(&self) -> u64;
 }
 
-pub(crate) trait Qos<P: ConnectionQosParams> {
-    /// Derive the QosParams for a connection
-    fn derive_qos_params(&self, connection: &Connection, staked_nodes: &RwLock<StakedNodes>) -> P;
+/// A trait to manage QoS for connections. This includes
+/// 1) deriving the ConnectionContext for a connection
+/// 2) managing connect caching and connection limits
+pub(crate) trait QosController<C: ConnectionContext> {
+    /// Derive the ConnectionContext for a connection
+    fn derive_connection_context(
+        &self,
+        connection: &Connection,
+        staked_nodes: &RwLock<StakedNodes>,
+    ) -> C;
 
     /// Try to add a new connection. If successful, return a CancellationToken and
     /// a ConnectionStreamCounter to track the streams created on this connection.
@@ -486,7 +496,7 @@ pub(crate) trait Qos<P: ConnectionQosParams> {
         &self,
         client_connection_tracker: ClientConnectionTracker,
         connection: &quinn::Connection,
-        params: &mut P,
+        context: &mut C,
     ) -> impl std::future::Future<
         Output = Option<(
             Arc<AtomicU64>,
@@ -497,16 +507,25 @@ pub(crate) trait Qos<P: ConnectionQosParams> {
 
     /// The maximum number of streams that can be opened per throttling interval
     /// on this connection.
-    fn max_streams_per_throttling_interval(&self, params: &P) -> u64;
+    fn max_streams_per_throttling_interval(&self, context: &C) -> u64;
 
-    fn on_stream_accepted(&self, params: &P);
-    fn on_stream_error(&self, params: &P);
-    fn on_stream_closed(&self, params: &P);
+    /// Called when a stream is accepted on a connection
+    fn on_stream_accepted(&self, context: &C);
+
+    /// Called when a stream has an error
+    fn on_stream_error(&self, context: &C);
+
+    /// Called when a stream is closed
+    fn on_stream_closed(&self, context: &C);
+
+    /// Remove a connection. Return the number of open connections after removal.
     fn remove_connection(
         &self,
-        params: &P,
+        context: &C,
         connection: Connection,
     ) -> impl std::future::Future<Output = usize> + Send;
+
+    /// The timeout duration to wait for a chunk to arrive on a stream
     fn wait_for_chunk_timeout(&self) -> Duration;
 }
 
@@ -526,7 +545,7 @@ pub(crate) fn update_open_connections_stat(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn setup_connection<Q, P>(
+async fn setup_connection<Q, C>(
     connecting: Connecting,
     rate_limiter: Arc<ConnectionRateLimiter>,
     overall_connection_rate_limiter: Arc<TotalConnectionRateLimiter>,
@@ -537,8 +556,8 @@ async fn setup_connection<Q, P>(
     qos: Arc<Q>,
     tasks: TaskTracker,
 ) where
-    Q: Qos<P> + Send + Sync + 'static,
-    P: ConnectionQosParams + Send + Sync + 'static,
+    Q: QosController<C> + Send + Sync + 'static,
+    C: ConnectionContext + Send + Sync + 'static,
 {
     let from = connecting.remote_address();
     let res = timeout(QUIC_CONNECTION_HANDSHAKE_TIMEOUT, connecting).await;
@@ -577,9 +596,14 @@ async fn setup_connection<Q, P>(
                     return;
                 }
 
-                let mut params = qos.derive_qos_params(&new_connection, &staked_nodes);
+                let mut conn_context =
+                    qos.derive_connection_context(&new_connection, &staked_nodes);
                 if let Some((last_update, cancel_connection, stream_counter)) = qos
-                    .try_add_connection(client_connection_tracker, &new_connection, &mut params)
+                    .try_add_connection(
+                        client_connection_tracker,
+                        &new_connection,
+                        &mut conn_context,
+                    )
                     .await
                 {
                     tasks.spawn(handle_connection(
@@ -587,7 +611,7 @@ async fn setup_connection<Q, P>(
                         new_connection,
                         stats,
                         last_update,
-                        params.clone(),
+                        conn_context.clone(),
                         qos,
                         stream_counter,
                         cancel_connection,
@@ -795,21 +819,21 @@ fn track_streamer_fetch_packet_performance(
         .fetch_add(measure.as_us(), Ordering::Relaxed);
 }
 
-async fn handle_connection<Q, P>(
+async fn handle_connection<Q, C>(
     packet_sender: Sender<PacketAccumulator>,
     connection: Connection,
     stats: Arc<StreamerStats>,
     last_update: Arc<AtomicU64>,
-    params: P,
+    context: C,
     qos: Arc<Q>,
     stream_counter: Arc<ConnectionStreamCounter>,
     cancel: CancellationToken,
 ) where
-    Q: Qos<P> + Send + Sync + 'static,
-    P: ConnectionQosParams + Send + Sync + 'static,
+    Q: QosController<C> + Send + Sync + 'static,
+    C: ConnectionContext + Send + Sync + 'static,
 {
-    let peer_type = params.peer_type();
-    let total_stake = params.total_stake();
+    let peer_type = context.peer_type();
+    let total_stake = context.total_stake();
     let remote_addr = connection.remote_address();
     debug!(
         "quic new connection {} streams: {} connections: {}",
@@ -833,7 +857,7 @@ async fn handle_connection<Q, P>(
             _ = cancel.cancelled() => break,
         };
 
-        let max_streams_per_throttling_interval = qos.max_streams_per_throttling_interval(&params);
+        let max_streams_per_throttling_interval = qos.max_streams_per_throttling_interval(&context);
 
         let throttle_interval_start = stream_counter.reset_throttling_params_if_needed();
         let streams_read_in_throttle_interval = stream_counter.stream_count.load(Ordering::Relaxed);
@@ -866,7 +890,7 @@ async fn handle_connection<Q, P>(
                 sleep(throttle_duration).await;
             }
         }
-        qos.on_stream_accepted(&params);
+        qos.on_stream_accepted(&context);
         stream_counter.stream_count.fetch_add(1, Ordering::Relaxed);
         stats.active_streams.fetch_add(1, Ordering::Relaxed);
         stats.total_new_streams.fetch_add(1, Ordering::Relaxed);
@@ -940,17 +964,17 @@ async fn handle_connection<Q, P>(
                         CONNECTION_CLOSE_REASON_INVALID_STREAM,
                     );
                     stats.active_streams.fetch_sub(1, Ordering::Relaxed);
-                    qos.on_stream_error(&params);
+                    qos.on_stream_error(&context);
                     break 'conn;
                 }
             }
         }
 
         stats.active_streams.fetch_sub(1, Ordering::Relaxed);
-        qos.on_stream_closed(&params);
+        qos.on_stream_closed(&context);
     }
 
-    let removed_connection_count = qos.remove_connection(&params, connection).await;
+    let removed_connection_count = qos.remove_connection(&context, connection).await;
     if removed_connection_count > 0 {
         stats
             .connection_removed

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1,4 +1,6 @@
 #[allow(deprecated)]
+use crate::quic::QuicServerParams;
+
 use {
     crate::{
         nonblocking::{
@@ -8,7 +10,7 @@ use {
             swqos::{SwQos, SwQosConfig},
         },
         quic::{
-            configure_server, QuicServerError, QuicServerParams, QuicStreamerConfig, StreamerStats,
+            configure_server, QuicServerError, QuicStreamerConfig, StreamerStats,
         },
         streamer::StakedNodes,
     },

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1,6 +1,5 @@
 #[allow(deprecated)]
 use crate::quic::QuicServerParams;
-
 use {
     crate::{
         nonblocking::{
@@ -9,9 +8,7 @@ use {
             stream_throttle::ConnectionStreamCounter,
             swqos::{SwQos, SwQosConfig},
         },
-        quic::{
-            configure_server, QuicServerError, QuicStreamerConfig, StreamerStats,
-        },
+        quic::{configure_server, QuicServerError, QuicStreamerConfig, StreamerStats},
         streamer::StakedNodes,
     },
     bytes::{BufMut, Bytes, BytesMut},

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -3,7 +3,7 @@ use {
         nonblocking::{
             connection_rate_limiter::{ConnectionRateLimiter, TotalConnectionRateLimiter},
             qos::{ConnectionContext, QosController},
-            stream_throttle::{ConnectionStreamCounter, STREAM_THROTTLING_INTERVAL},
+            stream_throttle::ConnectionStreamCounter,
             swqos::SwQos,
         },
         quic::{configure_server, QuicServerError, QuicServerParams, StreamerStats},
@@ -564,7 +564,7 @@ async fn setup_connection<Q, C>(
                 stats.total_new_connections.fetch_add(1, Ordering::Relaxed);
 
                 let mut conn_context = qos.build_connection_context(&new_connection);
-                if let Some((cancel_connection, stream_counter)) = qos
+                if let Some(cancel_connection) = qos
                     .try_add_connection(
                         client_connection_tracker,
                         &new_connection,
@@ -579,7 +579,6 @@ async fn setup_connection<Q, C>(
                         server_params.wait_for_chunk_timeout,
                         conn_context.clone(),
                         qos,
-                        stream_counter,
                         cancel_connection,
                     ));
                 }
@@ -792,7 +791,6 @@ async fn handle_connection<Q, C>(
     wait_for_chunk_timeout: Duration,
     context: C,
     qos: Arc<Q>,
-    stream_counter: Arc<ConnectionStreamCounter>,
     cancel: CancellationToken,
 ) where
     Q: QosController<C> + Send + Sync + 'static,
@@ -822,41 +820,8 @@ async fn handle_connection<Q, C>(
             _ = cancel.cancelled() => break,
         };
 
-        let max_streams_per_throttling_interval = qos.max_streams_per_throttling_interval(&context);
-
-        let throttle_interval_start = stream_counter.reset_throttling_params_if_needed();
-        let streams_read_in_throttle_interval = stream_counter.stream_count.load(Ordering::Relaxed);
-        if streams_read_in_throttle_interval >= max_streams_per_throttling_interval {
-            // The peer is sending faster than we're willing to read. Sleep for what's
-            // left of this read interval so the peer backs off.
-            let throttle_duration =
-                STREAM_THROTTLING_INTERVAL.saturating_sub(throttle_interval_start.elapsed());
-
-            if !throttle_duration.is_zero() {
-                debug!(
-                    "Throttling stream from {remote_addr:?}, peer type: {peer_type:?}, \
-                     max_streams_per_interval: {max_streams_per_throttling_interval}, \
-                     read_interval_streams: {streams_read_in_throttle_interval} \
-                     throttle_duration: {throttle_duration:?}"
-                );
-                stats.throttled_streams.fetch_add(1, Ordering::Relaxed);
-                match peer_type {
-                    ConnectionPeerType::Unstaked => {
-                        stats
-                            .throttled_unstaked_streams
-                            .fetch_add(1, Ordering::Relaxed);
-                    }
-                    ConnectionPeerType::Staked(_) => {
-                        stats
-                            .throttled_staked_streams
-                            .fetch_add(1, Ordering::Relaxed);
-                    }
-                }
-                sleep(throttle_duration).await;
-            }
-        }
+        qos.on_new_stream(&context).await;
         qos.on_stream_accepted(&context);
-        stream_counter.stream_count.fetch_add(1, Ordering::Relaxed);
         stats.active_streams.fetch_add(1, Ordering::Relaxed);
         stats.total_new_streams.fetch_add(1, Ordering::Relaxed);
 

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -205,7 +205,6 @@ where
         quic_server_params.max_staked_connections,
         quic_server_params.max_unstaked_connections,
         quic_server_params.max_connections_per_peer,
-        quic_server_params.wait_for_chunk_timeout,
         stats.clone(),
         staked_nodes,
         cancel.clone(),
@@ -351,6 +350,7 @@ where
     Q: QosController<C> + Send + Sync + 'static,
     C: ConnectionContext + Send + Sync + 'static,
 {
+    let quic_server_params = Arc::new(quic_server_params);
     let rate_limiter = Arc::new(ConnectionRateLimiter::new(
         quic_server_params.max_connections_per_ipaddr_per_min,
     ));
@@ -443,6 +443,7 @@ where
                         client_connection_tracker,
                         packet_batch_sender.clone(),
                         stats.clone(),
+                        quic_server_params.clone(),
                         qos.clone(),
                         tasks.clone(),
                     ));
@@ -516,6 +517,7 @@ async fn setup_connection<Q, C>(
     client_connection_tracker: ClientConnectionTracker,
     packet_sender: Sender<PacketAccumulator>,
     stats: Arc<StreamerStats>,
+    server_params: Arc<QuicServerParams>,
     qos: Arc<Q>,
     tasks: TaskTracker,
 ) where
@@ -561,9 +563,9 @@ async fn setup_connection<Q, C>(
 
                 stats.total_new_connections.fetch_add(1, Ordering::Relaxed);
 
-                let mut conn_context = qos.derive_connection_context(&new_connection);
+                let mut conn_context = qos.build_connection_context(&new_connection);
                 if let Some((cancel_connection, stream_counter)) = qos
-                    .try_cache_connection(
+                    .try_add_connection(
                         client_connection_tracker,
                         &new_connection,
                         &mut conn_context,
@@ -574,6 +576,7 @@ async fn setup_connection<Q, C>(
                         packet_sender.clone(),
                         new_connection,
                         stats,
+                        server_params.wait_for_chunk_timeout,
                         conn_context.clone(),
                         qos,
                         stream_counter,
@@ -786,6 +789,7 @@ async fn handle_connection<Q, C>(
     packet_sender: Sender<PacketAccumulator>,
     connection: Connection,
     stats: Arc<StreamerStats>,
+    wait_for_chunk_timeout: Duration,
     context: C,
     qos: Arc<Q>,
     stream_counter: Arc<ConnectionStreamCounter>,
@@ -795,7 +799,6 @@ async fn handle_connection<Q, C>(
     C: ConnectionContext + Send + Sync + 'static,
 {
     let peer_type = context.peer_type();
-    let total_stake = qos.total_stake();
     let remote_addr = connection.remote_address();
     debug!(
         "quic new connection {} streams: {} connections: {}",
@@ -831,10 +834,10 @@ async fn handle_connection<Q, C>(
 
             if !throttle_duration.is_zero() {
                 debug!(
-                    "Throttling stream from {remote_addr:?}, peer type: {peer_type:?}, total \
-                     stake: {total_stake}, max_streams_per_interval: \
-                     {max_streams_per_throttling_interval}, read_interval_streams: \
-                     {streams_read_in_throttle_interval} throttle_duration: {throttle_duration:?}"
+                    "Throttling stream from {remote_addr:?}, peer type: {peer_type:?}, \
+                     max_streams_per_interval: {max_streams_per_throttling_interval}, \
+                     read_interval_streams: {streams_read_in_throttle_interval} \
+                     throttle_duration: {throttle_duration:?}"
                 );
                 stats.throttled_streams.fetch_add(1, Ordering::Relaxed);
                 match peer_type {
@@ -878,7 +881,7 @@ async fn handle_connection<Q, C>(
             // packet loss or the peer stops sending for whatever reason.
             let n_chunks = match tokio::select! {
                 chunk = tokio::time::timeout(
-                    qos.wait_for_chunk_timeout(),
+                    wait_for_chunk_timeout,
                     stream.read_chunks(&mut chunks)) => chunk,
 
                 // If the peer gets disconnected stop the task right away.

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -2,10 +2,8 @@ use {
     crate::{
         nonblocking::{
             connection_rate_limiter::{ConnectionRateLimiter, TotalConnectionRateLimiter},
-            stream_throttle::{
-                ConnectionStreamCounter, StakedStreamLoadEMA, STREAM_THROTTLING_INTERVAL,
-                STREAM_THROTTLING_INTERVAL_MS,
-            },
+            stream_throttle::{ConnectionStreamCounter, STREAM_THROTTLING_INTERVAL},
+            swqos::SwQos,
         },
         quic::{configure_server, QuicServerError, QuicServerParams, StreamerStats},
         streamer::StakedNodes,
@@ -14,9 +12,7 @@ use {
     crossbeam_channel::{bounded, Receiver, Sender, TryRecvError, TrySendError},
     futures::{stream::FuturesUnordered, Future, StreamExt as _},
     indexmap::map::{Entry, IndexMap},
-    percentage::Percentage,
-    quinn::{Accept, Connecting, Connection, Endpoint, EndpointConfig, TokioRuntime, VarInt},
-    quinn_proto::VarIntBoundsExceeded,
+    quinn::{Accept, Connecting, Connection, Endpoint, EndpointConfig, TokioRuntime},
     rand::{thread_rng, Rng},
     smallvec::SmallVec,
     solana_keypair::Keypair,
@@ -24,12 +20,6 @@ use {
     solana_packet::{Meta, PACKET_DATA_SIZE},
     solana_perf::packet::{BytesPacket, BytesPacketBatch, PacketBatch, PACKETS_PER_BATCH},
     solana_pubkey::Pubkey,
-    solana_quic_definitions::{
-        QUIC_MAX_STAKED_CONCURRENT_STREAMS, QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO,
-        QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS, QUIC_MIN_STAKED_CONCURRENT_STREAMS,
-        QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO, QUIC_TOTAL_STAKED_CONCURRENT_STREAMS,
-        QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO,
-    },
     solana_signature::Signature,
     solana_time_utils as timing,
     solana_tls_utils::get_pubkey_from_tls_certificate,
@@ -58,7 +48,6 @@ use {
         // (i.e. lock order is always async Mutex -> RwLock). Also, be careful not to
         // introduce any other awaits while holding the RwLock.
         select,
-        sync::{Mutex, MutexGuard},
         task::{self, JoinHandle},
         time::{sleep, timeout},
     },
@@ -72,11 +61,12 @@ pub const ALPN_TPU_PROTOCOL_ID: &[u8] = b"solana-tpu";
 const CONNECTION_CLOSE_CODE_DROPPED_ENTRY: u32 = 1;
 const CONNECTION_CLOSE_REASON_DROPPED_ENTRY: &[u8] = b"dropped";
 
-const CONNECTION_CLOSE_CODE_DISALLOWED: u32 = 2;
-const CONNECTION_CLOSE_REASON_DISALLOWED: &[u8] = b"disallowed";
+pub(crate) const CONNECTION_CLOSE_CODE_DISALLOWED: u32 = 2;
+pub(crate) const CONNECTION_CLOSE_REASON_DISALLOWED: &[u8] = b"disallowed";
 
-const CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT: u32 = 3;
-const CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT: &[u8] = b"exceed_max_stream_count";
+pub(crate) const CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT: u32 = 3;
+pub(crate) const CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT: &[u8] =
+    b"exceed_max_stream_count";
 
 const CONNECTION_CLOSE_CODE_TOO_MANY: u32 = 4;
 const CONNECTION_CLOSE_REASON_TOO_MANY: &[u8] = b"too_many";
@@ -205,7 +195,19 @@ pub fn spawn_server_with_cancel(
     staked_nodes: Arc<RwLock<StakedNodes>>,
     quic_server_params: QuicServerParams,
     cancel: CancellationToken,
-) -> Result<SpawnNonBlockingServerResult, QuicServerError> {
+) -> Result<SpawnNonBlockingServerResult, QuicServerError>
+where
+{
+    let stats = Arc::<StreamerStats>::default();
+
+    let swqos = Arc::new(SwQos::new(
+        quic_server_params.max_streams_per_ms,
+        quic_server_params.max_staked_connections,
+        quic_server_params.max_unstaked_connections,
+        quic_server_params.max_connections_per_peer,
+        stats.clone(),
+    ));
+
     let sockets: Vec<_> = sockets.into_iter().collect();
     info!("Start {name} quic server on {sockets:?}");
     let (config, _) = configure_server(keypair)?;
@@ -265,8 +267,8 @@ pub fn spawn_server_with_cancel(
 /// litter the code with open connection tracking. This is added into the
 /// connection table as part of the ConnectionEntry. The reference is auto
 /// reduced when it is dropped.
-struct ClientConnectionTracker {
-    stats: Arc<StreamerStats>,
+pub struct ClientConnectionTracker {
+    pub(crate) stats: Arc<StreamerStats>,
 }
 
 /// This is required by ConnectionEntry for supporting debug format.
@@ -307,7 +309,7 @@ impl ClientConnectionTracker {
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn run_server(
+async fn run_server<Q, P>(
     name: &'static str,
     endpoints: Vec<Endpoint>,
     packet_batch_sender: Sender<PacketAccumulator>,
@@ -326,20 +328,18 @@ async fn run_server(
     const WAIT_FOR_CONNECTION_TIMEOUT: Duration = Duration::from_secs(1);
     debug!("spawn quic server");
     let mut last_datapoint = Instant::now();
-    let unstaked_connection_table: Arc<Mutex<ConnectionTable>> = Arc::new(Mutex::new(
-        ConnectionTable::new(ConnectionTableType::Unstaked, cancel.clone()),
-    ));
-    let stream_load_ema = Arc::new(StakedStreamLoadEMA::new(
-        stats.clone(),
-        quic_server_params.max_unstaked_connections,
-        quic_server_params.max_streams_per_ms,
-    ));
     stats
         .quic_endpoints_count
         .store(endpoints.len(), Ordering::Relaxed);
-    let staked_connection_table: Arc<Mutex<ConnectionTable>> = Arc::new(Mutex::new(
-        ConnectionTable::new(ConnectionTableType::Staked, cancel.clone()),
-    ));
+    let (sender, receiver) = bounded(coalesce_channel_size);
+
+    thread::spawn({
+        let exit = exit.clone();
+        let stats = stats.clone();
+        move || {
+            packet_batch_sender(packet_sender, receiver, exit, stats, coalesce);
+        }
+    });
 
     let mut accepts = endpoints
         .iter()
@@ -417,13 +417,10 @@ async fn run_server(
                         rate_limiter,
                         overall_connection_rate_limiter,
                         client_connection_tracker,
-                        unstaked_connection_table.clone(),
-                        staked_connection_table.clone(),
                         packet_batch_sender.clone(),
                         staked_nodes.clone(),
                         stats.clone(),
-                        stream_load_ema.clone(),
-                        quic_server_params.clone(),
+                        qos.clone(),
                         tasks.clone(),
                     ));
                 }
@@ -441,23 +438,6 @@ async fn run_server(
     tasks
 }
 
-fn prune_unstaked_connection_table(
-    unstaked_connection_table: &mut ConnectionTable,
-    max_unstaked_connections: usize,
-    stats: Arc<StreamerStats>,
-) {
-    if unstaked_connection_table.total_size >= max_unstaked_connections {
-        const PRUNE_TABLE_TO_PERCENTAGE: u8 = 90;
-        let max_percentage_full = Percentage::from(PRUNE_TABLE_TO_PERCENTAGE);
-
-        let max_connections = max_percentage_full.apply_to(max_unstaked_connections);
-        let num_pruned = unstaked_connection_table.prune_oldest(max_connections);
-        stats
-            .num_evictions_unstaked
-            .fetch_add(num_pruned, Ordering::Relaxed);
-    }
-}
-
 pub fn get_remote_pubkey(connection: &Connection) -> Option<Pubkey> {
     // Use the client cert only if it is self signed and the chain length is 1.
     connection
@@ -469,7 +449,7 @@ pub fn get_remote_pubkey(connection: &Connection) -> Option<Pubkey> {
         .and_then(get_pubkey_from_tls_certificate)
 }
 
-fn get_connection_stake(
+pub fn get_connection_stake(
     connection: &Connection,
     staked_nodes: &RwLock<StakedNodes>,
 ) -> Option<(Pubkey, u64, u64, u64, u64)> {
@@ -485,254 +465,66 @@ fn get_connection_stake(
     ))
 }
 
-fn compute_max_allowed_uni_streams(peer_type: ConnectionPeerType, total_stake: u64) -> usize {
-    match peer_type {
-        ConnectionPeerType::Staked(peer_stake) => {
-            // No checked math for f64 type. So let's explicitly check for 0 here
-            if total_stake == 0 || peer_stake > total_stake {
-                warn!(
-                    "Invalid stake values: peer_stake: {peer_stake:?}, total_stake: \
-                     {total_stake:?}"
-                );
-
-                QUIC_MIN_STAKED_CONCURRENT_STREAMS
-            } else {
-                let delta = (QUIC_TOTAL_STAKED_CONCURRENT_STREAMS
-                    - QUIC_MIN_STAKED_CONCURRENT_STREAMS) as f64;
-
-                (((peer_stake as f64 / total_stake as f64) * delta) as usize
-                    + QUIC_MIN_STAKED_CONCURRENT_STREAMS)
-                    .clamp(
-                        QUIC_MIN_STAKED_CONCURRENT_STREAMS,
-                        QUIC_MAX_STAKED_CONCURRENT_STREAMS,
-                    )
-            }
-        }
-        ConnectionPeerType::Unstaked => QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,
-    }
-}
-
-enum ConnectionHandlerError {
+pub(crate) enum ConnectionHandlerError {
     ConnectionAddError,
     MaxStreamError,
 }
 
-#[derive(Clone)]
-struct NewConnectionHandlerParams {
-    packet_sender: Sender<PacketAccumulator>,
-    remote_pubkey: Option<Pubkey>,
-    peer_type: ConnectionPeerType,
-    total_stake: u64,
-    max_connections_per_peer: usize,
-    stats: Arc<StreamerStats>,
-    max_stake: u64,
-    min_stake: u64,
-    max_connections: usize,
-    wait_for_chunk_timeout: Duration,
+pub(crate) trait ConnectionQosParams: Clone + Send + Sync {
+    fn peer_type(&self) -> ConnectionPeerType;
+    fn max_connections_per_peer(&self) -> usize;
+    fn remote_pubkey(&self) -> Option<solana_pubkey::Pubkey>;
+    fn total_stake(&self) -> u64;
 }
 
-impl NewConnectionHandlerParams {
-    fn new_unstaked(
-        packet_sender: Sender<PacketAccumulator>,
-        max_connections_per_peer: usize,
-        stats: Arc<StreamerStats>,
-        wait_for_chunk_timeout: Duration,
-        max_connections: usize,
-    ) -> NewConnectionHandlerParams {
-        NewConnectionHandlerParams {
-            packet_sender,
-            remote_pubkey: None,
-            peer_type: ConnectionPeerType::Unstaked,
-            total_stake: 0,
-            max_connections_per_peer,
-            stats,
-            max_stake: 0,
-            min_stake: 0,
-            max_connections,
-            wait_for_chunk_timeout,
-        }
-    }
-}
+pub(crate) trait Qos<P: ConnectionQosParams> {
+    /// Derive the QosParams for a connection
+    fn derive_qos_params(&self, connection: &Connection, staked_nodes: &RwLock<StakedNodes>) -> P;
 
-fn update_open_connections_stat(stats: &StreamerStats, connection_table: &ConnectionTable) {
-    if connection_table.is_staked() {
-        stats
-            .open_staked_connections
-            .store(connection_table.table_size(), Ordering::Relaxed);
-    } else {
-        stats
-            .open_unstaked_connections
-            .store(connection_table.table_size(), Ordering::Relaxed);
-    }
-}
+    /// Try to add a new connection. If successful, return a CancellationToken and
+    /// a ConnectionStreamCounter to track the streams created on this connection.
+    fn try_add_connection(
+        &self,
+        client_connection_tracker: ClientConnectionTracker,
+        connection: &quinn::Connection,
+        params: &mut P,
+    ) -> impl std::future::Future<
+        Output = Option<(
+            Arc<AtomicU64>,
+            tokio_util::sync::CancellationToken,
+            Arc<ConnectionStreamCounter>,
+        )>,
+    > + Send;
 
-fn handle_and_cache_new_connection(
-    client_connection_tracker: ClientConnectionTracker,
-    connection: Connection,
-    mut connection_table_l: MutexGuard<ConnectionTable>,
-    connection_table: Arc<Mutex<ConnectionTable>>,
-    params: &NewConnectionHandlerParams,
-    stream_load_ema: Arc<StakedStreamLoadEMA>,
-    tasks: TaskTracker,
-) -> Result<(), ConnectionHandlerError> {
-    if let Ok(max_uni_streams) = VarInt::from_u64(compute_max_allowed_uni_streams(
-        params.peer_type,
-        params.total_stake,
-    ) as u64)
-    {
-        let remote_addr = connection.remote_address();
-        let receive_window =
-            compute_recieve_window(params.max_stake, params.min_stake, params.peer_type);
+    /// The maximum number of streams that can be opened per throttling interval
+    /// on this connection.
+    fn max_streams_per_throttling_interval(&self, params: &P) -> u64;
 
-        debug!(
-            "Peer type {:?}, total stake {}, max streams {} receive_window {:?} from peer {}",
-            params.peer_type,
-            params.total_stake,
-            max_uni_streams.into_inner(),
-            receive_window,
-            remote_addr,
-        );
-
-        if let Some((last_update, cancel_connection, stream_counter)) = connection_table_l
-            .try_add_connection(
-                ConnectionTableKey::new(remote_addr.ip(), params.remote_pubkey),
-                remote_addr.port(),
-                client_connection_tracker,
-                Some(connection.clone()),
-                params.peer_type,
-                timing::timestamp(),
-                params.max_connections_per_peer,
-            )
-        {
-            update_open_connections_stat(&params.stats, &connection_table_l);
-            drop(connection_table_l);
-
-            if let Ok(receive_window) = receive_window {
-                connection.set_receive_window(receive_window);
-            }
-            connection.set_max_concurrent_uni_streams(max_uni_streams);
-
-            tasks.spawn(handle_connection(
-                connection,
-                remote_addr,
-                last_update,
-                connection_table,
-                params.clone(),
-                stream_load_ema,
-                stream_counter,
-                cancel_connection,
-            ));
-            Ok(())
-        } else {
-            params
-                .stats
-                .connection_add_failed
-                .fetch_add(1, Ordering::Relaxed);
-            Err(ConnectionHandlerError::ConnectionAddError)
-        }
-    } else {
-        connection.close(
-            CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT.into(),
-            CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT,
-        );
-        params
-            .stats
-            .connection_add_failed_invalid_stream_count
-            .fetch_add(1, Ordering::Relaxed);
-        Err(ConnectionHandlerError::MaxStreamError)
-    }
-}
-
-async fn prune_unstaked_connections_and_add_new_connection(
-    client_connection_tracker: ClientConnectionTracker,
-    connection: Connection,
-    connection_table: Arc<Mutex<ConnectionTable>>,
-    params: &NewConnectionHandlerParams,
-    stream_load_ema: Arc<StakedStreamLoadEMA>,
-    tasks: TaskTracker,
-) -> Result<(), ConnectionHandlerError> {
-    let stats = params.stats.clone();
-    if params.max_connections > 0 {
-        let connection_table_clone = connection_table.clone();
-        let mut connection_table = connection_table.lock().await;
-        prune_unstaked_connection_table(&mut connection_table, params.max_connections, stats);
-        handle_and_cache_new_connection(
-            client_connection_tracker,
-            connection,
-            connection_table,
-            connection_table_clone,
-            params,
-            stream_load_ema,
-            tasks,
-        )
-    } else {
-        connection.close(
-            CONNECTION_CLOSE_CODE_DISALLOWED.into(),
-            CONNECTION_CLOSE_REASON_DISALLOWED,
-        );
-        Err(ConnectionHandlerError::ConnectionAddError)
-    }
-}
-
-/// Calculate the ratio for per connection receive window from a staked peer
-fn compute_receive_window_ratio_for_staked_node(max_stake: u64, min_stake: u64, stake: u64) -> u64 {
-    // Testing shows the maximum throughput from a connection is achieved at receive_window =
-    // PACKET_DATA_SIZE * 10. Beyond that, there is not much gain. We linearly map the
-    // stake to the ratio range from QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO to
-    // QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO. Where the linear algebra of finding the ratio 'r'
-    // for stake 's' is,
-    // r(s) = a * s + b. Given the max_stake, min_stake, max_ratio, min_ratio, we can find
-    // a and b.
-
-    if stake > max_stake {
-        return QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO;
-    }
-
-    let max_ratio = QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO;
-    let min_ratio = QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO;
-    if max_stake > min_stake {
-        let a = (max_ratio - min_ratio) as f64 / (max_stake - min_stake) as f64;
-        let b = max_ratio as f64 - ((max_stake as f64) * a);
-        let ratio = (a * stake as f64) + b;
-        ratio.round() as u64
-    } else {
-        QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO
-    }
-}
-
-fn compute_recieve_window(
-    max_stake: u64,
-    min_stake: u64,
-    peer_type: ConnectionPeerType,
-) -> Result<VarInt, VarIntBoundsExceeded> {
-    match peer_type {
-        ConnectionPeerType::Unstaked => {
-            VarInt::from_u64(PACKET_DATA_SIZE as u64 * QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO)
-        }
-        ConnectionPeerType::Staked(peer_stake) => {
-            let ratio =
-                compute_receive_window_ratio_for_staked_node(max_stake, min_stake, peer_stake);
-            VarInt::from_u64(PACKET_DATA_SIZE as u64 * ratio)
-        }
-    }
+    fn on_stream_accepted(&self, params: &P);
+    fn on_stream_error(&self, params: &P);
+    fn on_stream_closed(&self, params: &P);
+    fn remove_connection(
+        &self,
+        params: &P,
+        connection: Connection,
+    ) -> impl std::future::Future<Output = usize> + Send;
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn setup_connection(
+async fn setup_connection<Q, P>(
     connecting: Connecting,
     rate_limiter: Arc<ConnectionRateLimiter>,
     overall_connection_rate_limiter: Arc<TotalConnectionRateLimiter>,
     client_connection_tracker: ClientConnectionTracker,
-    unstaked_connection_table: Arc<Mutex<ConnectionTable>>,
-    staked_connection_table: Arc<Mutex<ConnectionTable>>,
     packet_sender: Sender<PacketAccumulator>,
     staked_nodes: Arc<RwLock<StakedNodes>>,
     stats: Arc<StreamerStats>,
-    stream_load_ema: Arc<StakedStreamLoadEMA>,
-    quic_server_params: QuicServerParams,
+    qos: Arc<Q>,
     tasks: TaskTracker,
-) {
-    const PRUNE_RANDOM_SAMPLE_SIZE: usize = 2;
+) where
+    Q: Qos<P> + Send + Sync + 'static,
+    P: ConnectionQosParams + Send + Sync + 'static,
+{
     let from = connecting.remote_address();
     let res = timeout(QUIC_CONNECTION_HANDSHAKE_TIMEOUT, connecting).await;
     stats
@@ -770,120 +562,22 @@ async fn setup_connection(
                     return;
                 }
 
-                let params = get_connection_stake(&new_connection, &staked_nodes).map_or(
-                    NewConnectionHandlerParams::new_unstaked(
+                let mut params = qos.derive_qos_params(&new_connection, &staked_nodes);
+                if let Some((last_update, cancel_connection, stream_counter)) = qos
+                    .try_add_connection(client_connection_tracker, &new_connection, &mut params)
+                    .await
+                {
+                    tokio::spawn(handle_connection(
                         packet_sender.clone(),
-                        quic_server_params.max_connections_per_peer,
-                        stats.clone(),
-                        quic_server_params.wait_for_chunk_timeout,
-                        quic_server_params.max_unstaked_connections,
-                    ),
-                    |(pubkey, stake, total_stake, max_stake, min_stake)| {
-                        // The heuristic is that the stake should be large enough to have 1 stream pass through within one throttle
-                        // interval during which we allow max (MAX_STREAMS_PER_MS * STREAM_THROTTLING_INTERVAL_MS) streams.
-                        let min_stake_ratio = 1_f64
-                            / (quic_server_params.max_streams_per_ms
-                                * STREAM_THROTTLING_INTERVAL_MS)
-                                as f64;
-                        let stake_ratio = stake as f64 / total_stake as f64;
-                        let peer_type = if stake_ratio < min_stake_ratio {
-                            // If it is a staked connection with ultra low stake ratio, treat it as unstaked.
-                            ConnectionPeerType::Unstaked
-                        } else {
-                            ConnectionPeerType::Staked(stake)
-                        };
-                        NewConnectionHandlerParams {
-                            packet_sender,
-                            remote_pubkey: Some(pubkey),
-                            peer_type,
-                            total_stake,
-                            max_connections_per_peer: quic_server_params.max_connections_per_peer,
-                            stats: stats.clone(),
-                            max_stake,
-                            min_stake,
-                            wait_for_chunk_timeout: quic_server_params.wait_for_chunk_timeout,
-                            max_connections: quic_server_params.max_staked_connections,
-                        }
-                    },
-                );
-
-                match params.peer_type {
-                    ConnectionPeerType::Staked(stake) => {
-                        let mut connection_table_l = staked_connection_table.lock().await;
-
-                        if connection_table_l.total_size
-                            >= quic_server_params.max_staked_connections
-                        {
-                            let num_pruned =
-                                connection_table_l.prune_random(PRUNE_RANDOM_SAMPLE_SIZE, stake);
-                            stats
-                                .num_evictions_staked
-                                .fetch_add(num_pruned, Ordering::Relaxed);
-                            update_open_connections_stat(&stats, &connection_table_l);
-                        }
-
-                        if connection_table_l.total_size < quic_server_params.max_staked_connections
-                        {
-                            if let Ok(()) = handle_and_cache_new_connection(
-                                client_connection_tracker,
-                                new_connection,
-                                connection_table_l,
-                                staked_connection_table.clone(),
-                                &params,
-                                stream_load_ema.clone(),
-                                tasks,
-                            ) {
-                                stats
-                                    .connection_added_from_staked_peer
-                                    .fetch_add(1, Ordering::Relaxed);
-                            }
-                        } else {
-                            // If we couldn't prune a connection in the staked connection table, let's
-                            // put this connection in the unstaked connection table. If needed, prune a
-                            // connection from the unstaked connection table.
-                            if let Ok(()) = prune_unstaked_connections_and_add_new_connection(
-                                client_connection_tracker,
-                                new_connection,
-                                unstaked_connection_table.clone(),
-                                &params,
-                                stream_load_ema.clone(),
-                                tasks,
-                            )
-                            .await
-                            {
-                                stats
-                                    .connection_added_from_staked_peer
-                                    .fetch_add(1, Ordering::Relaxed);
-                            } else {
-                                stats
-                                    .connection_add_failed_on_pruning
-                                    .fetch_add(1, Ordering::Relaxed);
-                                stats
-                                    .connection_add_failed_staked_node
-                                    .fetch_add(1, Ordering::Relaxed);
-                            }
-                        }
-                    }
-                    ConnectionPeerType::Unstaked => {
-                        if let Ok(()) = prune_unstaked_connections_and_add_new_connection(
-                            client_connection_tracker,
-                            new_connection,
-                            unstaked_connection_table.clone(),
-                            &params,
-                            stream_load_ema.clone(),
-                            tasks,
-                        )
-                        .await
-                        {
-                            stats
-                                .connection_added_from_unstaked_peer
-                                .fetch_add(1, Ordering::Relaxed);
-                        } else {
-                            stats
-                                .connection_add_failed_unstaked_node
-                                .fetch_add(1, Ordering::Relaxed);
-                        }
-                    }
+                        new_connection,
+                        stats,
+                        last_update,
+                        cancel_connection,
+                        params.clone(),
+                        wait_for_chunk_timeout,
+                        qos,
+                        stream_counter,
+                    ));
                 }
             }
             Err(e) => {
@@ -1087,25 +781,24 @@ fn track_streamer_fetch_packet_performance(
         .fetch_add(measure.as_us(), Ordering::Relaxed);
 }
 
-async fn handle_connection(
+async fn handle_connection<Q, P>(
+    packet_sender: Sender<PacketAccumulator>,
     connection: Connection,
-    remote_addr: SocketAddr,
+    stats: Arc<StreamerStats>,
     last_update: Arc<AtomicU64>,
-    connection_table: Arc<Mutex<ConnectionTable>>,
-    params: NewConnectionHandlerParams,
-    stream_load_ema: Arc<StakedStreamLoadEMA>,
+    cancel: CancellationToken,
+    params: P,
+    wait_for_chunk_timeout: Duration,
+    qos: Arc<Q>,
     stream_counter: Arc<ConnectionStreamCounter>,
     cancel: CancellationToken,
-) {
-    let NewConnectionHandlerParams {
-        packet_sender,
-        peer_type,
-        remote_pubkey,
-        stats,
-        total_stake,
-        ..
-    } = params;
-
+) where
+    Q: Qos<P> + Send + Sync + 'static,
+    P: ConnectionQosParams + Send + Sync + 'static,
+{
+    let peer_type = params.peer_type();
+    let total_stake = params.total_stake();
+    let remote_addr = connection.remote_address();
     debug!(
         "quic new connection {} streams: {} connections: {}",
         remote_addr,
@@ -1128,8 +821,7 @@ async fn handle_connection(
             _ = cancel.cancelled() => break,
         };
 
-        let max_streams_per_throttling_interval =
-            stream_load_ema.available_load_capacity_in_throttling_duration(peer_type, total_stake);
+        let max_streams_per_throttling_interval = qos.max_streams_per_throttling_interval(&params);
 
         let throttle_interval_start = stream_counter.reset_throttling_params_if_needed();
         let streams_read_in_throttle_interval = stream_counter.stream_count.load(Ordering::Relaxed);
@@ -1162,7 +854,7 @@ async fn handle_connection(
                 sleep(throttle_duration).await;
             }
         }
-        stream_load_ema.increment_load(peer_type);
+        qos.on_stream_accepted(&params);
         stream_counter.stream_count.fetch_add(1, Ordering::Relaxed);
         stats.active_streams.fetch_add(1, Ordering::Relaxed);
         stats.total_new_streams.fetch_add(1, Ordering::Relaxed);
@@ -1236,28 +928,17 @@ async fn handle_connection(
                         CONNECTION_CLOSE_REASON_INVALID_STREAM,
                     );
                     stats.active_streams.fetch_sub(1, Ordering::Relaxed);
-                    stream_load_ema.update_ema_if_needed();
+                    qos.on_stream_error(&params);
                     break 'conn;
                 }
             }
         }
 
         stats.active_streams.fetch_sub(1, Ordering::Relaxed);
-        stream_load_ema.update_ema_if_needed();
+        qos.on_stream_closed(&params);
     }
 
-    let stable_id = connection.stable_id();
-    let removed_connection_count = {
-        let mut connection_table = connection_table.lock().await;
-        let removed_connection_count = connection_table.remove_connection(
-            ConnectionTableKey::new(remote_addr.ip(), remote_pubkey),
-            remote_addr.port(),
-            stable_id,
-        );
-        update_open_connections_stat(&stats, &connection_table);
-        removed_connection_count
-    };
-
+    let removed_connection_count = qos.remove_connection(&params, connection).await;
     if removed_connection_count > 0 {
         stats
             .connection_removed
@@ -1433,13 +1114,13 @@ impl Drop for ConnectionEntry {
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-enum ConnectionTableKey {
+pub(crate) enum ConnectionTableKey {
     IP(IpAddr),
     Pubkey(Pubkey),
 }
 
 impl ConnectionTableKey {
-    fn new(ip: IpAddr, maybe_pubkey: Option<Pubkey>) -> Self {
+    pub(crate) fn new(ip: IpAddr, maybe_pubkey: Option<Pubkey>) -> Self {
         maybe_pubkey.map_or(ConnectionTableKey::IP(ip), |pubkey| {
             ConnectionTableKey::Pubkey(pubkey)
         })
@@ -1452,9 +1133,9 @@ enum ConnectionTableType {
 }
 
 // Map of IP to list of connection entries
-struct ConnectionTable {
+pub(crate) struct ConnectionTable {
     table: IndexMap<ConnectionTableKey, Vec<ConnectionEntry>>,
-    total_size: usize,
+    pub(crate) total_size: usize,
     table_type: ConnectionTableType,
     cancel: CancellationToken,
 }
@@ -1467,17 +1148,7 @@ impl ConnectionTable {
         Self {
             table: IndexMap::default(),
             total_size: 0,
-            table_type,
-            cancel,
         }
-    }
-
-    fn table_size(&self) -> usize {
-        self.total_size
-    }
-
-    fn is_staked(&self) -> bool {
-        matches!(self.table_type, ConnectionTableType::Staked)
     }
 
     fn prune_oldest(&mut self, max_size: usize) -> usize {
@@ -1502,7 +1173,7 @@ impl ConnectionTable {
     // lowest stake, and returns the number of pruned connections.
     // If the stakes of all the sampled connections are higher than the
     // threshold_stake, rejects the pruning attempt, and returns 0.
-    fn prune_random(&mut self, sample_size: usize, threshold_stake: u64) -> usize {
+    pub(crate) fn prune_random(&mut self, sample_size: usize, threshold_stake: u64) -> usize {
         let num_pruned = std::iter::once(self.table.len())
             .filter(|&size| size > 0)
             .flat_map(|size| {
@@ -1524,7 +1195,7 @@ impl ConnectionTable {
         num_pruned
     }
 
-    fn try_add_connection(
+    pub(crate) fn try_add_connection(
         &mut self,
         key: ConnectionTableKey,
         port: u16,
@@ -1574,7 +1245,12 @@ impl ConnectionTable {
     }
 
     // Returns number of connections that were removed
-    fn remove_connection(&mut self, key: ConnectionTableKey, port: u16, stable_id: usize) -> usize {
+    pub(crate) fn remove_connection(
+        &mut self,
+        key: ConnectionTableKey,
+        port: u16,
+        stable_id: usize,
+    ) -> usize {
         if let Entry::Occupied(mut e) = self.table.entry(key) {
             let e_ref = e.get_mut();
             let old_size = e_ref.len();
@@ -1628,12 +1304,12 @@ impl Future for EndpointAccept<'_> {
 pub mod test {
     use {
         super::*,
-        crate::nonblocking::{
-            quic::compute_max_allowed_uni_streams,
-            testing_utilities::{
+        crate::{
+            nonblocking::testing_utilities::{
                 check_multiple_streams, get_client_config, make_client_endpoint, setup_quic_server,
                 SpawnTestServerResult,
             },
+            quic::DEFAULT_TPU_COALESCE,
         },
         assert_matches::assert_matches,
         crossbeam_channel::{unbounded, Receiver},
@@ -1996,9 +1672,9 @@ pub mod test {
 
         assert_eq!(
             stats
-                .connection_added_from_unstaked_peer
+                .connection_added_from_staked_peer
                 .load(Ordering::Relaxed),
-            0
+            1
         );
         assert_eq!(stats.connection_removed.load(Ordering::Relaxed), 1);
         assert_eq!(stats.connection_remove_failed.load(Ordering::Relaxed), 0);
@@ -2402,68 +2078,6 @@ pub mod test {
         }
         assert_eq!(table.total_size, 0);
         assert_eq!(stats.open_connections.load(Ordering::Relaxed), 0);
-    }
-
-    #[test]
-
-    fn test_max_allowed_uni_streams() {
-        assert_eq!(
-            compute_max_allowed_uni_streams(ConnectionPeerType::Unstaked, 0),
-            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS
-        );
-        assert_eq!(
-            compute_max_allowed_uni_streams(ConnectionPeerType::Staked(10), 0),
-            QUIC_MIN_STAKED_CONCURRENT_STREAMS
-        );
-        let delta =
-            (QUIC_TOTAL_STAKED_CONCURRENT_STREAMS - QUIC_MIN_STAKED_CONCURRENT_STREAMS) as f64;
-        assert_eq!(
-            compute_max_allowed_uni_streams(ConnectionPeerType::Staked(1000), 10000),
-            QUIC_MAX_STAKED_CONCURRENT_STREAMS,
-        );
-        assert_eq!(
-            compute_max_allowed_uni_streams(ConnectionPeerType::Staked(100), 10000),
-            ((delta / (100_f64)) as usize + QUIC_MIN_STAKED_CONCURRENT_STREAMS)
-                .min(QUIC_MAX_STAKED_CONCURRENT_STREAMS)
-        );
-        assert_eq!(
-            compute_max_allowed_uni_streams(ConnectionPeerType::Unstaked, 10000),
-            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS
-        );
-    }
-
-    #[test]
-    fn test_cacluate_receive_window_ratio_for_staked_node() {
-        let mut max_stake = 10000;
-        let mut min_stake = 0;
-        let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, min_stake);
-        assert_eq!(ratio, QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO);
-
-        let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake);
-        let max_ratio = QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO;
-        assert_eq!(ratio, max_ratio);
-
-        let ratio =
-            compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake / 2);
-        let average_ratio =
-            (QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO + QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO) / 2;
-        assert_eq!(ratio, average_ratio);
-
-        max_stake = 10000;
-        min_stake = 10000;
-        let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake);
-        assert_eq!(ratio, max_ratio);
-
-        max_stake = 0;
-        min_stake = 0;
-        let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake);
-        assert_eq!(ratio, max_ratio);
-
-        max_stake = 1000;
-        min_stake = 10;
-        let ratio =
-            compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake + 10);
-        assert_eq!(ratio, max_ratio);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -137,7 +137,7 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
     }
 
     #[allow(clippy::manual_async_fn)]
-    fn try_add_connection(
+    fn try_cache_connection(
         &self,
         client_connection_tracker: ClientConnectionTracker,
         connection: &quinn::Connection,

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -340,10 +340,10 @@ mod tests {
         let client_connect_future = client_endpoint.connect(server_addr, "localhost").unwrap();
 
         // Wait for both to complete - we want the server-side connection
-        let (server_connection, _client_connection) =
+        let (server_connection, client_connection) =
             tokio::join!(server_connection_future, client_connect_future);
 
-        let _client_connection = _client_connection.unwrap();
+        let _client_connection = client_connection.unwrap();
 
         (server_connection, client_endpoint, server_endpoint)
     }

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -1,10 +1,11 @@
 use {
     crate::{
         nonblocking::{
+            qos::{ConnectionContext, QosController},
             quic::{
                 get_connection_stake, update_open_connections_stat, ClientConnectionTracker,
-                ConnectionContext, ConnectionHandlerError, ConnectionPeerType, ConnectionTable,
-                ConnectionTableKey, ConnectionTableType, QosController,
+                ConnectionHandlerError, ConnectionPeerType, ConnectionTable, ConnectionTableKey,
+                ConnectionTableType,
             },
             stream_throttle::{ConnectionStreamCounter, STREAM_THROTTLING_INTERVAL},
         },

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -145,7 +145,7 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
     ) -> impl std::future::Future<
         Output = Option<(
             Arc<AtomicU64>,
-            tokio_util::sync::CancellationToken,
+            CancellationToken,
             Arc<ConnectionStreamCounter>,
         )>,
     > + Send {

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -103,7 +103,7 @@ impl SimpleQos {
 }
 
 #[derive(Clone)]
-struct SimpleQosConnectionContext {
+pub struct SimpleQosConnectionContext {
     peer_type: ConnectionPeerType,
     remote_pubkey: Option<solana_pubkey::Pubkey>,
     last_update: Arc<AtomicU64>,

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -1,0 +1,217 @@
+use {
+    crate::{
+        nonblocking::{
+            quic::{
+                get_connection_stake, ClientConnectionTracker, ConnectionHandlerError,
+                ConnectionPeerType, ConnectionQosParams, ConnectionTable, ConnectionTableKey, Qos,
+            },
+            stream_throttle::{ConnectionStreamCounter, STREAM_THROTTLING_INTERVAL},
+        },
+        quic::StreamerStats,
+        streamer::StakedNodes,
+    },
+    quinn::Connection,
+    solana_time_utils as timing,
+    std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, RwLock,
+    },
+    tokio::sync::{Mutex, MutexGuard},
+};
+
+pub struct SimpleQos {
+    max_streams_per_second: u64,
+    max_staked_connections: usize,
+    max_connections_per_peer: usize,
+    stats: Arc<StreamerStats>,
+    staked_connection_table: Arc<Mutex<ConnectionTable>>,
+}
+
+impl SimpleQos {
+    pub fn new(
+        max_streams_per_second: u64,
+        max_connections_per_peer: usize,
+        max_staked_connections: usize,
+        stats: Arc<StreamerStats>,
+    ) -> Self {
+        Self {
+            max_streams_per_second,
+            max_connections_per_peer,
+            max_staked_connections,
+            stats,
+            staked_connection_table: Arc::new(Mutex::new(ConnectionTable::new())),
+        }
+    }
+
+    fn handle_and_cache_new_connection(
+        &self,
+        client_connection_tracker: ClientConnectionTracker,
+        connection: &Connection,
+        mut connection_table_l: MutexGuard<ConnectionTable>,
+        params: &SimpleQosParams,
+    ) -> Result<
+        (
+            Arc<AtomicU64>,
+            tokio_util::sync::CancellationToken,
+            Arc<ConnectionStreamCounter>,
+        ),
+        ConnectionHandlerError,
+    > {
+        let remote_addr = connection.remote_address();
+
+        debug!(
+            "Peer type {:?}, from peer {}",
+            params.peer_type(),
+            remote_addr,
+        );
+
+        if let Some((last_update, cancel_connection, stream_counter)) = connection_table_l
+            .try_add_connection(
+                ConnectionTableKey::new(remote_addr.ip(), params.remote_pubkey),
+                remote_addr.port(),
+                client_connection_tracker,
+                Some(connection.clone()),
+                params.peer_type(),
+                timing::timestamp(),
+                params.max_connections_per_peer(),
+            )
+        {
+            drop(connection_table_l);
+
+            Ok((last_update, cancel_connection, stream_counter))
+        } else {
+            self.stats
+                .connection_add_failed
+                .fetch_add(1, Ordering::Relaxed);
+            Err(ConnectionHandlerError::ConnectionAddError)
+        }
+    }
+}
+
+#[derive(Clone)]
+struct SimpleQosParams {
+    peer_type: ConnectionPeerType,
+    max_connections_per_peer: usize,
+    remote_pubkey: Option<solana_pubkey::Pubkey>,
+    total_stake: u64,
+}
+
+impl ConnectionQosParams for SimpleQosParams {
+    fn peer_type(&self) -> ConnectionPeerType {
+        self.peer_type
+    }
+
+    fn max_connections_per_peer(&self) -> usize {
+        self.max_connections_per_peer
+    }
+
+    fn remote_pubkey(&self) -> Option<solana_pubkey::Pubkey> {
+        self.remote_pubkey
+    }
+    fn total_stake(&self) -> u64 {
+        self.total_stake
+    }
+}
+
+impl Qos<SimpleQosParams> for SimpleQos {
+    fn derive_qos_params(
+        &self,
+        connection: &Connection,
+        staked_nodes: &RwLock<StakedNodes>,
+    ) -> SimpleQosParams {
+        let (peer_type, remote_pubkey, total_stake) =
+            get_connection_stake(connection, staked_nodes).map_or(
+                (ConnectionPeerType::Unstaked, None, 0),
+                |(pubkey, stake, total_stake, _max_stake, _min_stake)| {
+                    // The heuristic is that the stake should be large engouh to have 1 stream pass throuh within one throttle
+                    // interval during which we allow max (MAX_STREAMS_PER_MS * STREAM_THROTTLING_INTERVAL_MS) streams.
+                    (ConnectionPeerType::Staked(stake), Some(pubkey), total_stake)
+                },
+            );
+
+        SimpleQosParams {
+            peer_type,
+            max_connections_per_peer: self.max_connections_per_peer,
+            remote_pubkey,
+            total_stake,
+        }
+    }
+
+    #[allow(clippy::manual_async_fn)]
+    fn try_add_connection(
+        &self,
+        client_connection_tracker: ClientConnectionTracker,
+        connection: &quinn::Connection,
+        params: &mut SimpleQosParams,
+    ) -> impl std::future::Future<
+        Output = Option<(
+            Arc<AtomicU64>,
+            tokio_util::sync::CancellationToken,
+            Arc<ConnectionStreamCounter>,
+        )>,
+    > + Send {
+        async move {
+            const PRUNE_RANDOM_SAMPLE_SIZE: usize = 2;
+            match params.peer_type() {
+                ConnectionPeerType::Staked(stake) => {
+                    let mut connection_table_l = self.staked_connection_table.lock().await;
+
+                    if connection_table_l.total_size >= self.max_staked_connections {
+                        let num_pruned =
+                            connection_table_l.prune_random(PRUNE_RANDOM_SAMPLE_SIZE, stake);
+                        self.stats
+                            .num_evictions
+                            .fetch_add(num_pruned, Ordering::Relaxed);
+                    }
+
+                    if connection_table_l.total_size < self.max_staked_connections {
+                        if let Ok((last_update, cancel_connection, stream_counter)) = self
+                            .handle_and_cache_new_connection(
+                                client_connection_tracker,
+                                connection,
+                                connection_table_l,
+                                params,
+                            )
+                        {
+                            self.stats
+                                .connection_added_from_staked_peer
+                                .fetch_add(1, Ordering::Relaxed);
+                            return Some((last_update, cancel_connection, stream_counter));
+                        }
+                    }
+                    None
+                }
+                ConnectionPeerType::Unstaked => None,
+            }
+        }
+    }
+
+    fn on_stream_accepted(&self, _params: &SimpleQosParams) {}
+
+    fn on_stream_error(&self, _params: &SimpleQosParams) {}
+
+    fn on_stream_closed(&self, _params: &SimpleQosParams) {}
+
+    fn max_streams_per_throttling_interval(&self, _params: &SimpleQosParams) -> u64 {
+        let interval_ms = STREAM_THROTTLING_INTERVAL.as_millis() as u64;
+        (self.max_streams_per_second * interval_ms / 1000).max(1)
+    }
+
+    #[allow(clippy::manual_async_fn)]
+    fn remove_connection(
+        &self,
+        params: &SimpleQosParams,
+        connection: Connection,
+    ) -> impl std::future::Future<Output = usize> + Send {
+        async move {
+            let stable_id = connection.stable_id();
+            let remote_addr = connection.remote_address();
+
+            self.staked_connection_table.lock().await.remove_connection(
+                ConnectionTableKey::new(remote_addr.ip(), params.remote_pubkey()),
+                remote_addr.port(),
+                stable_id,
+            )
+        }
+    }
+}

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -11,7 +11,7 @@ use {
                 throttle_stream, ConnectionStreamCounter, STREAM_THROTTLING_INTERVAL,
             },
         },
-        quic::StreamerStats,
+        quic::{StreamerStats, DEFAULT_MAX_STREAMS_PER_MS},
         streamer::StakedNodes,
     },
     quinn::Connection,
@@ -27,6 +27,19 @@ use {
     tokio_util::sync::CancellationToken,
 };
 
+#[derive(Clone)]
+pub struct SimpleQosConfig {
+    pub max_streams_per_second: u64,
+}
+
+impl Default for SimpleQosConfig {
+    fn default() -> Self {
+        SimpleQosConfig {
+            max_streams_per_second: DEFAULT_MAX_STREAMS_PER_MS * 1000,
+        }
+    }
+}
+
 pub struct SimpleQos {
     max_streams_per_second: u64,
     max_staked_connections: usize,
@@ -38,7 +51,7 @@ pub struct SimpleQos {
 
 impl SimpleQos {
     pub fn new(
-        max_streams_per_second: u64,
+        qos_config: SimpleQosConfig,
         max_connections_per_peer: usize,
         max_staked_connections: usize,
         stats: Arc<StreamerStats>,
@@ -46,7 +59,7 @@ impl SimpleQos {
         cancel: CancellationToken,
     ) -> Self {
         Self {
-            max_streams_per_second,
+            max_streams_per_second: qos_config.max_streams_per_second,
             max_connections_per_peer,
             max_staked_connections,
             stats,

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -125,8 +125,6 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
             get_connection_stake(connection, &self.staked_nodes).map_or(
                 (ConnectionPeerType::Unstaked, None, 0),
                 |(pubkey, stake, total_stake, _max_stake, _min_stake)| {
-                    // The heuristic is that the stake should be large engouh to have 1 stream pass throuh within one throttle
-                    // interval during which we allow max (MAX_STREAMS_PER_MS * STREAM_THROTTLING_INTERVAL_MS) streams.
                     (ConnectionPeerType::Staked(stake), Some(pubkey), total_stake)
                 },
             );

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -294,9 +294,12 @@ mod tests {
         quinn::Endpoint,
         solana_keypair::{Keypair, Signer},
         solana_net_utils::sockets::bind_to_localhost_unique,
-        std::sync::{
-            atomic::{AtomicU64, Ordering},
-            Arc, RwLock,
+        std::{
+            collections::HashMap,
+            sync::{
+                atomic::{AtomicU64, Ordering},
+                Arc, RwLock,
+            },
         },
         tokio_util::sync::CancellationToken,
     };
@@ -359,12 +362,11 @@ mod tests {
         client_keypair: &Keypair,
         stake_amount: u64,
     ) -> Arc<RwLock<StakedNodes>> {
-        let mut stakes = std::collections::HashMap::new();
+        let mut stakes = HashMap::new();
         stakes.insert(server_keypair.pubkey(), stake_amount);
         stakes.insert(client_keypair.pubkey(), stake_amount);
 
-        let overrides: std::collections::HashMap<solana_pubkey::Pubkey, u64> =
-            std::collections::HashMap::new();
+        let overrides: HashMap<solana_pubkey::Pubkey, u64> = HashMap::new();
 
         Arc::new(RwLock::new(StakedNodes::new(Arc::new(stakes), overrides)))
     }
@@ -754,15 +756,14 @@ mod tests {
         let client_keypair2 = Keypair::new();
         let stake_amount = 50_000_000; // 50M lamports
 
-        let mut stakes = std::collections::HashMap::new();
+        let mut stakes = HashMap::new();
         stakes.insert(server_keypair1.pubkey(), stake_amount);
         stakes.insert(client_keypair1.pubkey(), stake_amount);
         stakes.insert(server_keypair2.pubkey(), stake_amount);
         // client 2 has higher stake so that it can prune client 1
         stakes.insert(client_keypair2.pubkey(), stake_amount * 2);
 
-        let overrides: std::collections::HashMap<solana_pubkey::Pubkey, u64> =
-            std::collections::HashMap::new();
+        let overrides: HashMap<solana_pubkey::Pubkey, u64> = HashMap::new();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(Arc::new(stakes), overrides)));
 
         let simple_qos = SimpleQos::new(
@@ -825,14 +826,13 @@ mod tests {
         let high_stake = 100_000_000; // 100M lamports
         let low_stake = 10_000_000; // 10M lamports
 
-        let mut stakes = std::collections::HashMap::new();
+        let mut stakes = HashMap::new();
         stakes.insert(server_keypair1.pubkey(), high_stake);
         stakes.insert(client_keypair1.pubkey(), high_stake);
         stakes.insert(server_keypair2.pubkey(), low_stake);
         stakes.insert(client_keypair2.pubkey(), low_stake);
 
-        let overrides: std::collections::HashMap<solana_pubkey::Pubkey, u64> =
-            std::collections::HashMap::new();
+        let overrides: HashMap<solana_pubkey::Pubkey, u64> = HashMap::new();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(Arc::new(stakes), overrides)));
 
         let simple_qos = SimpleQos::new(

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -177,7 +177,7 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
                         let num_pruned =
                             connection_table_l.prune_random(PRUNE_RANDOM_SAMPLE_SIZE, stake);
 
-                        println!(
+                        debug!(
                             "Pruned {} staked connections to make room for new staked connection \
                              from {}",
                             num_pruned,

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -31,6 +31,7 @@ pub(crate) struct StakedStreamLoadEMA {
     max_staked_load_in_ema_window: u64,
     // Maximum number of streams for an unstaked connection in stream throttling window
     max_unstaked_load_in_throttling_window: u64,
+    max_streams_per_ms: u64,
 }
 
 impl StakedStreamLoadEMA {
@@ -63,6 +64,7 @@ impl StakedStreamLoadEMA {
             stats,
             max_staked_load_in_ema_window,
             max_unstaked_load_in_throttling_window,
+            max_streams_per_ms,
         }
     }
 
@@ -181,16 +183,20 @@ impl StakedStreamLoadEMA {
             }
         }
     }
+
+    pub(crate) fn max_streams_per_ms(&self) -> u64 {
+        self.max_streams_per_ms
+    }
 }
 
 #[derive(Debug)]
-pub(crate) struct ConnectionStreamCounter {
+pub struct ConnectionStreamCounter {
     pub(crate) stream_count: AtomicU64,
     last_throttling_instant: RwLock<tokio::time::Instant>,
 }
 
 impl ConnectionStreamCounter {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             stream_count: AtomicU64::default(),
             last_throttling_instant: RwLock::new(tokio::time::Instant::now()),

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -337,7 +337,7 @@ impl QosController<SwQosConnectionContext> for SwQos {
     }
 
     #[allow(clippy::manual_async_fn)]
-    fn try_add_connection(
+    fn try_cache_connection(
         &self,
         client_connection_tracker: ClientConnectionTracker,
         connection: &quinn::Connection,

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -14,7 +14,7 @@ use {
                 STREAM_THROTTLING_INTERVAL_MS,
             },
         },
-        quic::StreamerStats,
+        quic::{StreamerStats, DEFAULT_MAX_STREAMS_PER_MS},
         streamer::StakedNodes,
     },
     percentage::Percentage,
@@ -37,6 +37,19 @@ use {
     tokio::sync::{Mutex, MutexGuard},
     tokio_util::sync::CancellationToken,
 };
+
+#[derive(Clone)]
+pub struct SwQosConfig {
+    pub max_streams_per_ms: u64,
+}
+
+impl Default for SwQosConfig {
+    fn default() -> Self {
+        SwQosConfig {
+            max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
+        }
+    }
+}
 
 pub struct SwQos {
     max_staked_connections: usize,
@@ -75,7 +88,7 @@ impl ConnectionContext for SwQosConnectionContext {
 
 impl SwQos {
     pub fn new(
-        max_streams_per_ms: u64,
+        qos_config: SwQosConfig,
         max_staked_connections: usize,
         max_unstaked_connections: usize,
         max_connections_per_peer: usize,
@@ -90,7 +103,7 @@ impl SwQos {
             staked_stream_load_ema: Arc::new(StakedStreamLoadEMA::new(
                 stats.clone(),
                 max_unstaked_connections,
-                max_streams_per_ms,
+                qos_config.max_streams_per_ms,
             )),
             stats,
             staked_nodes,

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -1,12 +1,12 @@
 use {
     crate::{
         nonblocking::{
+            qos::{ConnectionContext, QosController},
             quic::{
                 get_connection_stake, update_open_connections_stat, ClientConnectionTracker,
-                ConnectionContext, ConnectionHandlerError, ConnectionPeerType, ConnectionTable,
-                ConnectionTableKey, ConnectionTableType, QosController,
-                CONNECTION_CLOSE_CODE_DISALLOWED, CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT,
-                CONNECTION_CLOSE_REASON_DISALLOWED,
+                ConnectionHandlerError, ConnectionPeerType, ConnectionTable, ConnectionTableKey,
+                ConnectionTableType, CONNECTION_CLOSE_CODE_DISALLOWED,
+                CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT, CONNECTION_CLOSE_REASON_DISALLOWED,
                 CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT,
             },
             stream_throttle::{
@@ -450,7 +450,8 @@ impl QosController<SwQosConnectionContext> for SwQos {
     }
 
     fn on_stream_accepted(&self, conn_context: &SwQosConnectionContext) {
-        self.staked_stream_load_ema.increment_load(conn_context.peer_type);
+        self.staked_stream_load_ema
+            .increment_load(conn_context.peer_type);
     }
 
     fn on_stream_error(&self, _conn_context: &SwQosConnectionContext) {

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -105,7 +105,7 @@ impl SwQos {
 
 /// Calculate the ratio for per connection receive window from a staked peer
 fn compute_receive_window_ratio_for_staked_node(max_stake: u64, min_stake: u64, stake: u64) -> u64 {
-    // Testing shows the maximum througput from a connection is achieved at receive_window =
+    // Testing shows the maximum throughput from a connection is achieved at receive_window =
     // PACKET_DATA_SIZE * 10. Beyond that, there is not much gain. We linearly map the
     // stake to the ratio range from QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO to
     // QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO. Where the linear algebra of finding the ratio 'r'
@@ -313,7 +313,7 @@ impl QosController<SwQosConnectionContext> for SwQos {
                 last_update: Arc::new(AtomicU64::new(timing::timestamp())),
             },
             |(pubkey, stake, total_stake, max_stake, min_stake)| {
-                // The heuristic is that the stake should be large engouh to have 1 stream pass throuh within one throttle
+                // The heuristic is that the stake should be large enough to have 1 stream pass through within one throttle
                 // interval during which we allow max (MAX_STREAMS_PER_MS * STREAM_THROTTLING_INTERVAL_MS) streams.
 
                 let peer_type = {

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -482,11 +482,13 @@ impl QosController<SwQosConnectionContext> for SwQos {
             let stable_id = connection.stable_id();
             let remote_addr = connection.remote_address();
 
-            lock.remove_connection(
+            let removed_count = lock.remove_connection(
                 ConnectionTableKey::new(remote_addr.ip(), params.remote_pubkey()),
                 remote_addr.port(),
                 stable_id,
-            )
+            );
+            update_open_connections_stat(&self.stats, &lock);
+            removed_count
         }
     }
 

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -3,9 +3,10 @@ use {
         nonblocking::{
             quic::{
                 get_connection_stake, update_open_connections_stat, ClientConnectionTracker,
-                ConnectionHandlerError, ConnectionPeerType, ConnectionQosParams, ConnectionTable,
-                ConnectionTableKey, ConnectionTableType, Qos, CONNECTION_CLOSE_CODE_DISALLOWED,
-                CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT, CONNECTION_CLOSE_REASON_DISALLOWED,
+                ConnectionContext, ConnectionHandlerError, ConnectionPeerType, ConnectionTable,
+                ConnectionTableKey, ConnectionTableType, QosController,
+                CONNECTION_CLOSE_CODE_DISALLOWED, CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT,
+                CONNECTION_CLOSE_REASON_DISALLOWED,
                 CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT,
             },
             stream_throttle::{
@@ -56,7 +57,7 @@ pub struct SwQosParams {
     in_staked_table: bool,
 }
 
-impl ConnectionQosParams for SwQosParams {
+impl ConnectionContext for SwQosParams {
     fn peer_type(&self) -> ConnectionPeerType {
         self.peer_type
     }
@@ -301,8 +302,8 @@ impl SwQos {
     }
 }
 
-impl Qos<SwQosParams> for SwQos {
-    fn derive_qos_params(
+impl QosController<SwQosParams> for SwQos {
+    fn derive_connection_context(
         &self,
         connection: &Connection,
         staked_nodes: &RwLock<StakedNodes>,

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -1,0 +1,544 @@
+use {
+    crate::{
+        nonblocking::{
+            quic::{
+                get_connection_stake, ClientConnectionTracker, ConnectionHandlerError,
+                ConnectionPeerType, ConnectionQosParams, ConnectionTable, ConnectionTableKey, Qos,
+                CONNECTION_CLOSE_CODE_DISALLOWED, CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT,
+                CONNECTION_CLOSE_REASON_DISALLOWED,
+                CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT,
+            },
+            stream_throttle::{
+                ConnectionStreamCounter, StakedStreamLoadEMA, STREAM_THROTTLING_INTERVAL_MS,
+            },
+        },
+        quic::StreamerStats,
+        streamer::StakedNodes,
+    },
+    percentage::Percentage,
+    quinn::{Connection, VarInt, VarIntBoundsExceeded},
+    solana_packet::PACKET_DATA_SIZE,
+    solana_quic_definitions::{
+        QUIC_MAX_STAKED_CONCURRENT_STREAMS, QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO,
+        QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS, QUIC_MIN_STAKED_CONCURRENT_STREAMS,
+        QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO, QUIC_TOTAL_STAKED_CONCURRENT_STREAMS,
+        QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO,
+    },
+    solana_time_utils as timing,
+    std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, RwLock,
+    },
+    tokio::sync::{Mutex, MutexGuard},
+    tokio_util::sync::CancellationToken,
+};
+
+pub struct SwQos {
+    max_staked_connections: usize,
+    max_unstaked_connections: usize,
+    max_connections_per_peer: usize,
+    staked_stream_load_ema: Arc<StakedStreamLoadEMA>,
+    stats: Arc<StreamerStats>,
+    unstaked_connection_table: Arc<Mutex<ConnectionTable>>,
+    staked_connection_table: Arc<Mutex<ConnectionTable>>,
+}
+
+// QoS Params for Stake weighted QoS
+#[derive(Clone)]
+pub struct SwQosParams {
+    peer_type: ConnectionPeerType,
+    max_connections_per_peer: usize,
+    max_stake: u64,
+    min_stake: u64,
+    remote_pubkey: Option<solana_pubkey::Pubkey>,
+    total_stake: u64,
+    in_staked_table: bool,
+}
+
+impl ConnectionQosParams for SwQosParams {
+    fn peer_type(&self) -> ConnectionPeerType {
+        self.peer_type
+    }
+
+    fn max_connections_per_peer(&self) -> usize {
+        self.max_connections_per_peer
+    }
+
+    fn remote_pubkey(&self) -> Option<solana_pubkey::Pubkey> {
+        self.remote_pubkey
+    }
+
+    fn total_stake(&self) -> u64 {
+        self.total_stake
+    }
+}
+
+impl SwQos {
+    pub fn new(
+        max_streams_per_ms: u64,
+        max_staked_connections: usize,
+        max_unstaked_connections: usize,
+        max_connections_per_peer: usize,
+        stats: Arc<StreamerStats>,
+    ) -> Self {
+        Self {
+            max_staked_connections,
+            max_unstaked_connections,
+            max_connections_per_peer,
+            staked_stream_load_ema: Arc::new(StakedStreamLoadEMA::new(
+                stats.clone(),
+                max_unstaked_connections,
+                max_streams_per_ms,
+            )),
+            stats,
+            unstaked_connection_table: Arc::new(Mutex::new(ConnectionTable::new())),
+            staked_connection_table: Arc::new(Mutex::new(ConnectionTable::new())),
+        }
+    }
+}
+
+/// Calculate the ratio for per connection receive window from a staked peer
+fn compute_receive_window_ratio_for_staked_node(max_stake: u64, min_stake: u64, stake: u64) -> u64 {
+    // Testing shows the maximum througput from a connection is achieved at receive_window =
+    // PACKET_DATA_SIZE * 10. Beyond that, there is not much gain. We linearly map the
+    // stake to the ratio range from QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO to
+    // QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO. Where the linear algebra of finding the ratio 'r'
+    // for stake 's' is,
+    // r(s) = a * s + b. Given the max_stake, min_stake, max_ratio, min_ratio, we can find
+    // a and b.
+
+    if stake > max_stake {
+        return QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO;
+    }
+
+    let max_ratio = QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO;
+    let min_ratio = QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO;
+    if max_stake > min_stake {
+        let a = (max_ratio - min_ratio) as f64 / (max_stake - min_stake) as f64;
+        let b = max_ratio as f64 - ((max_stake as f64) * a);
+        let ratio = (a * stake as f64) + b;
+        ratio.round() as u64
+    } else {
+        QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO
+    }
+}
+
+fn compute_recieve_window(
+    max_stake: u64,
+    min_stake: u64,
+    peer_type: ConnectionPeerType,
+) -> Result<VarInt, VarIntBoundsExceeded> {
+    match peer_type {
+        ConnectionPeerType::Unstaked => {
+            VarInt::from_u64(PACKET_DATA_SIZE as u64 * QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO)
+        }
+        ConnectionPeerType::Staked(peer_stake) => {
+            let ratio =
+                compute_receive_window_ratio_for_staked_node(max_stake, min_stake, peer_stake);
+            VarInt::from_u64(PACKET_DATA_SIZE as u64 * ratio)
+        }
+    }
+}
+
+fn compute_max_allowed_uni_streams(peer_type: ConnectionPeerType, total_stake: u64) -> usize {
+    match peer_type {
+        ConnectionPeerType::Staked(peer_stake) => {
+            // No checked math for f64 type. So let's explicitly check for 0 here
+            if total_stake == 0 || peer_stake > total_stake {
+                warn!(
+                    "Invalid stake values: peer_stake: {peer_stake:?}, total_stake: \
+                     {total_stake:?}"
+                );
+
+                QUIC_MIN_STAKED_CONCURRENT_STREAMS
+            } else {
+                let delta = (QUIC_TOTAL_STAKED_CONCURRENT_STREAMS
+                    - QUIC_MIN_STAKED_CONCURRENT_STREAMS) as f64;
+
+                (((peer_stake as f64 / total_stake as f64) * delta) as usize
+                    + QUIC_MIN_STAKED_CONCURRENT_STREAMS)
+                    .clamp(
+                        QUIC_MIN_STAKED_CONCURRENT_STREAMS,
+                        QUIC_MAX_STAKED_CONCURRENT_STREAMS,
+                    )
+            }
+        }
+        ConnectionPeerType::Unstaked => QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,
+    }
+}
+
+impl SwQos {
+    fn handle_and_cache_new_connection(
+        &self,
+        client_connection_tracker: ClientConnectionTracker,
+        connection: &Connection,
+        mut connection_table_l: MutexGuard<ConnectionTable>,
+        params: &SwQosParams,
+    ) -> Result<
+        (
+            Arc<AtomicU64>,
+            CancellationToken,
+            Arc<ConnectionStreamCounter>,
+        ),
+        ConnectionHandlerError,
+    > {
+        if let Ok(max_uni_streams) = VarInt::from_u64(compute_max_allowed_uni_streams(
+            params.peer_type(),
+            params.total_stake,
+        ) as u64)
+        {
+            let remote_addr = connection.remote_address();
+            let receive_window =
+                compute_recieve_window(params.max_stake, params.min_stake, params.peer_type());
+
+            debug!(
+                "Peer type {:?}, total stake {}, max streams {} receive_window {:?} from peer {}",
+                params.peer_type(),
+                params.total_stake,
+                max_uni_streams.into_inner(),
+                receive_window,
+                remote_addr,
+            );
+
+            if let Some((last_update, cancel_connection, stream_counter)) = connection_table_l
+                .try_add_connection(
+                    ConnectionTableKey::new(remote_addr.ip(), params.remote_pubkey),
+                    remote_addr.port(),
+                    client_connection_tracker,
+                    Some(connection.clone()),
+                    params.peer_type(),
+                    timing::timestamp(),
+                    params.max_connections_per_peer(),
+                )
+            {
+                drop(connection_table_l);
+
+                if let Ok(receive_window) = receive_window {
+                    connection.set_receive_window(receive_window);
+                }
+                connection.set_max_concurrent_uni_streams(max_uni_streams);
+
+                Ok((last_update, cancel_connection, stream_counter))
+            } else {
+                self.stats
+                    .connection_add_failed
+                    .fetch_add(1, Ordering::Relaxed);
+                Err(ConnectionHandlerError::ConnectionAddError)
+            }
+        } else {
+            connection.close(
+                CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT.into(),
+                CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT,
+            );
+            self.stats
+                .connection_add_failed_invalid_stream_count
+                .fetch_add(1, Ordering::Relaxed);
+            Err(ConnectionHandlerError::MaxStreamError)
+        }
+    }
+
+    fn prune_unstaked_connection_table(
+        &self,
+        unstaked_connection_table: &mut ConnectionTable,
+        max_unstaked_connections: usize,
+        stats: Arc<StreamerStats>,
+    ) {
+        if unstaked_connection_table.total_size >= max_unstaked_connections {
+            const PRUNE_TABLE_TO_PERCENTAGE: u8 = 90;
+            let max_percentage_full = Percentage::from(PRUNE_TABLE_TO_PERCENTAGE);
+
+            let max_connections = max_percentage_full.apply_to(max_unstaked_connections);
+            let num_pruned = unstaked_connection_table.prune_oldest(max_connections);
+            stats.num_evictions.fetch_add(num_pruned, Ordering::Relaxed);
+        }
+    }
+
+    async fn prune_unstaked_connections_and_add_new_connection(
+        &self,
+        client_connection_tracker: ClientConnectionTracker,
+        connection: &Connection,
+        connection_table: Arc<Mutex<ConnectionTable>>,
+        max_connections: usize,
+        params: &SwQosParams,
+    ) -> Result<
+        (
+            Arc<AtomicU64>,
+            CancellationToken,
+            Arc<ConnectionStreamCounter>,
+        ),
+        ConnectionHandlerError,
+    > {
+        let stats = self.stats.clone();
+        if max_connections > 0 {
+            let mut connection_table = connection_table.lock().await;
+            self.prune_unstaked_connection_table(&mut connection_table, max_connections, stats);
+            self.handle_and_cache_new_connection(
+                client_connection_tracker,
+                connection,
+                connection_table,
+                params,
+            )
+        } else {
+            connection.close(
+                CONNECTION_CLOSE_CODE_DISALLOWED.into(),
+                CONNECTION_CLOSE_REASON_DISALLOWED,
+            );
+            Err(ConnectionHandlerError::ConnectionAddError)
+        }
+    }
+}
+
+impl Qos<SwQosParams> for SwQos {
+    fn derive_qos_params(
+        &self,
+        connection: &Connection,
+        staked_nodes: &RwLock<StakedNodes>,
+    ) -> SwQosParams {
+        get_connection_stake(connection, staked_nodes).map_or(
+            SwQosParams {
+                peer_type: ConnectionPeerType::Unstaked,
+                max_connections_per_peer: self.max_connections_per_peer,
+                max_stake: 0,
+                min_stake: 0,
+                total_stake: 0,
+                remote_pubkey: None,
+                in_staked_table: false,
+            },
+            |(pubkey, stake, total_stake, max_stake, min_stake)| {
+                // The heuristic is that the stake should be large engouh to have 1 stream pass throuh within one throttle
+                // interval during which we allow max (MAX_STREAMS_PER_MS * STREAM_THROTTLING_INTERVAL_MS) streams.
+
+                let peer_type = {
+                    let max_streams_per_ms = self.staked_stream_load_ema.max_streams_per_ms();
+                    let min_stake_ratio =
+                        1_f64 / (max_streams_per_ms * STREAM_THROTTLING_INTERVAL_MS) as f64;
+                    let stake_ratio = stake as f64 / total_stake as f64;
+                    if stake_ratio < min_stake_ratio {
+                        // If it is a staked connection with ultra low stake ratio, treat it as unstaked.
+                        ConnectionPeerType::Unstaked
+                    } else {
+                        ConnectionPeerType::Staked(stake)
+                    }
+                };
+
+                SwQosParams {
+                    peer_type,
+                    max_connections_per_peer: self.max_connections_per_peer,
+                    max_stake,
+                    min_stake,
+                    total_stake,
+                    remote_pubkey: Some(pubkey),
+                    in_staked_table: false,
+                }
+            },
+        )
+    }
+
+    #[allow(clippy::manual_async_fn)]
+    fn try_add_connection(
+        &self,
+        client_connection_tracker: ClientConnectionTracker,
+        connection: &quinn::Connection,
+        params: &mut SwQosParams,
+    ) -> impl std::future::Future<
+        Output = Option<(
+            Arc<AtomicU64>,
+            tokio_util::sync::CancellationToken,
+            Arc<ConnectionStreamCounter>,
+        )>,
+    > + Send {
+        async move {
+            const PRUNE_RANDOM_SAMPLE_SIZE: usize = 2;
+
+            match params.peer_type() {
+                ConnectionPeerType::Staked(stake) => {
+                    let mut connection_table_l = self.staked_connection_table.lock().await;
+
+                    if connection_table_l.total_size >= self.max_staked_connections {
+                        let num_pruned =
+                            connection_table_l.prune_random(PRUNE_RANDOM_SAMPLE_SIZE, stake);
+                        self.stats
+                            .num_evictions
+                            .fetch_add(num_pruned, Ordering::Relaxed);
+                    }
+
+                    if connection_table_l.total_size < self.max_staked_connections {
+                        if let Ok((last_update, cancel_connection, stream_counter)) = self
+                            .handle_and_cache_new_connection(
+                                client_connection_tracker,
+                                connection,
+                                connection_table_l,
+                                params,
+                            )
+                        {
+                            self.stats
+                                .connection_added_from_staked_peer
+                                .fetch_add(1, Ordering::Relaxed);
+                            params.in_staked_table = true;
+                            return Some((last_update, cancel_connection, stream_counter));
+                        }
+                    } else {
+                        // If we couldn't prune a connection in the staked connection table, let's
+                        // put this connection in the unstaked connection table. If needed, prune a
+                        // connection from the unstaked connection table.
+                        if let Ok((last_update, cancel_connection, stream_counter)) = self
+                            .prune_unstaked_connections_and_add_new_connection(
+                                client_connection_tracker,
+                                connection,
+                                self.unstaked_connection_table.clone(),
+                                self.max_unstaked_connections,
+                                params,
+                            )
+                            .await
+                        {
+                            self.stats
+                                .connection_added_from_staked_peer
+                                .fetch_add(1, Ordering::Relaxed);
+                            params.in_staked_table = false;
+                            return Some((last_update, cancel_connection, stream_counter));
+                        } else {
+                            self.stats
+                                .connection_add_failed_on_pruning
+                                .fetch_add(1, Ordering::Relaxed);
+                            self.stats
+                                .connection_add_failed_staked_node
+                                .fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                }
+                ConnectionPeerType::Unstaked => {
+                    if let Ok((last_update, cancel_connection, stream_counter)) = self
+                        .prune_unstaked_connections_and_add_new_connection(
+                            client_connection_tracker,
+                            connection,
+                            self.unstaked_connection_table.clone(),
+                            self.max_unstaked_connections,
+                            params,
+                        )
+                        .await
+                    {
+                        self.stats
+                            .connection_added_from_unstaked_peer
+                            .fetch_add(1, Ordering::Relaxed);
+                        params.in_staked_table = false;
+                        return Some((last_update, cancel_connection, stream_counter));
+                    } else {
+                        self.stats
+                            .connection_add_failed_unstaked_node
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }
+
+            None
+        }
+    }
+
+    fn on_stream_accepted(&self, params: &SwQosParams) {
+        self.staked_stream_load_ema.increment_load(params.peer_type);
+    }
+
+    fn on_stream_error(&self, _params: &SwQosParams) {
+        self.staked_stream_load_ema.update_ema_if_needed();
+    }
+
+    fn on_stream_closed(&self, _params: &SwQosParams) {
+        self.staked_stream_load_ema.update_ema_if_needed();
+    }
+
+    fn max_streams_per_throttling_interval(&self, params: &SwQosParams) -> u64 {
+        self.staked_stream_load_ema
+            .available_load_capacity_in_throttling_duration(params.peer_type, params.total_stake)
+    }
+
+    #[allow(clippy::manual_async_fn)]
+    fn remove_connection(
+        &self,
+        params: &SwQosParams,
+        connection: Connection,
+    ) -> impl std::future::Future<Output = usize> + Send {
+        async move {
+            let mut lock = if params.in_staked_table {
+                self.staked_connection_table.lock().await
+            } else {
+                self.unstaked_connection_table.lock().await
+            };
+
+            let stable_id = connection.stable_id();
+            let remote_addr = connection.remote_address();
+
+            lock.remove_connection(
+                ConnectionTableKey::new(remote_addr.ip(), params.remote_pubkey()),
+                remote_addr.port(),
+                stable_id,
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
+    #[test]
+    fn test_cacluate_receive_window_ratio_for_staked_node() {
+        let mut max_stake = 10000;
+        let mut min_stake = 0;
+        let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, min_stake);
+        assert_eq!(ratio, QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO);
+
+        let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake);
+        let max_ratio = QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO;
+        assert_eq!(ratio, max_ratio);
+
+        let ratio =
+            compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake / 2);
+        let average_ratio =
+            (QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO + QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO) / 2;
+        assert_eq!(ratio, average_ratio);
+
+        max_stake = 10000;
+        min_stake = 10000;
+        let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake);
+        assert_eq!(ratio, max_ratio);
+
+        max_stake = 0;
+        min_stake = 0;
+        let ratio = compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake);
+        assert_eq!(ratio, max_ratio);
+
+        max_stake = 1000;
+        min_stake = 10;
+        let ratio =
+            compute_receive_window_ratio_for_staked_node(max_stake, min_stake, max_stake + 10);
+        assert_eq!(ratio, max_ratio);
+    }
+
+    #[test]
+
+    fn test_max_allowed_uni_streams() {
+        assert_eq!(
+            compute_max_allowed_uni_streams(ConnectionPeerType::Unstaked, 0),
+            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS
+        );
+        assert_eq!(
+            compute_max_allowed_uni_streams(ConnectionPeerType::Staked(10), 0),
+            QUIC_MIN_STAKED_CONCURRENT_STREAMS
+        );
+        let delta =
+            (QUIC_TOTAL_STAKED_CONCURRENT_STREAMS - QUIC_MIN_STAKED_CONCURRENT_STREAMS) as f64;
+        assert_eq!(
+            compute_max_allowed_uni_streams(ConnectionPeerType::Staked(1000), 10000),
+            QUIC_MAX_STAKED_CONCURRENT_STREAMS,
+        );
+        assert_eq!(
+            compute_max_allowed_uni_streams(ConnectionPeerType::Staked(100), 10000),
+            ((delta / (100_f64)) as usize + QUIC_MIN_STAKED_CONCURRENT_STREAMS)
+                .min(QUIC_MAX_STAKED_CONCURRENT_STREAMS)
+        );
+        assert_eq!(
+            compute_max_allowed_uni_streams(ConnectionPeerType::Unstaked, 10000),
+            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS
+        );
+    }
+}

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -345,7 +345,7 @@ impl QosController<SwQosConnectionContext> for SwQos {
     ) -> impl std::future::Future<
         Output = Option<(
             Arc<AtomicU64>,
-            tokio_util::sync::CancellationToken,
+            CancellationToken,
             Arc<ConnectionStreamCounter>,
         )>,
     > + Send {

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -2,8 +2,8 @@
 use {
     super::quic::{SpawnNonBlockingServerResult, ALPN_TPU_PROTOCOL_ID},
     crate::{
-        nonblocking::quic::spawn_server_with_cancel,
-        quic::{QuicServerParams, StreamerStats},
+        nonblocking::{quic::spawn_server_with_cancel, swqos::SwQosConfig},
+        quic::{QuicStreamerConfig, StreamerStats},
         streamer::StakedNodes,
     },
     crossbeam_channel::{unbounded, Receiver},
@@ -77,16 +77,18 @@ pub fn create_quic_server_sockets() -> Vec<UdpSocket> {
 
 pub fn setup_quic_server(
     option_staked_nodes: Option<StakedNodes>,
-    quic_server_params: QuicServerParams,
+    quic_server_params: QuicStreamerConfig,
+    qos_config: SwQosConfig,
 ) -> SpawnTestServerResult {
     let sockets = create_quic_server_sockets();
-    setup_quic_server_with_sockets(sockets, option_staked_nodes, quic_server_params)
+    setup_quic_server_with_sockets(sockets, option_staked_nodes, quic_server_params, qos_config)
 }
 
 pub fn setup_quic_server_with_sockets(
     sockets: Vec<UdpSocket>,
     option_staked_nodes: Option<StakedNodes>,
-    quic_server_params: QuicServerParams,
+    quic_server_params: QuicStreamerConfig,
+    qos_config: SwQosConfig,
 ) -> SpawnTestServerResult {
     let (sender, receiver) = unbounded();
     let keypair = Keypair::new();
@@ -106,6 +108,7 @@ pub fn setup_quic_server_with_sockets(
         sender,
         staked_nodes,
         quic_server_params,
+        qos_config,
         cancel.clone(),
     )
     .unwrap();

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -896,6 +896,38 @@ mod test {
         (t, receiver, server_address, cancel)
     }
 
+    fn setup_simple_qos_quic_server_with_params(
+        server_params: SimpleQosQuicServerParams,
+        staked_nodes: Arc<RwLock<StakedNodes>>,
+    ) -> (
+        std::thread::JoinHandle<()>,
+        crossbeam_channel::Receiver<PacketBatch>,
+        SocketAddr,
+        CancellationToken,
+    ) {
+        let s = bind_to_localhost_unique().expect("should bind");
+        let (sender, receiver) = unbounded();
+        let keypair = Keypair::new();
+        let server_address = s.local_addr().unwrap();
+        let cancel = CancellationToken::new();
+        let SpawnServerResult {
+            endpoints: _,
+            thread: t,
+            key_updater: _,
+        } = spawn_simple_qos_server_with_cancel(
+            "solQuicTest",
+            "quic_streamer_test",
+            [s],
+            &keypair,
+            sender,
+            staked_nodes,
+            server_params,
+            cancel.clone(),
+        )
+        .unwrap();
+        (t, receiver, server_address, cancel)
+    }
+
     fn setup_quic_server() -> (
         std::thread::JoinHandle<()>,
         crossbeam_channel::Receiver<PacketBatch>,
@@ -997,15 +1029,17 @@ mod test {
             HashMap::<Pubkey, u64>::default(), // overrides
         );
 
-        let server_params = QuicServerParams {
-            max_unstaked_connections: 0,
-            qos_mode: QosMode::SimpleStreamsPerSecond {
-                max_streams_per_second: 50,
+        let server_params = SimpleQosQuicServerParams {
+            quic_server_params: QuicServerParams {
+                max_unstaked_connections: 0,
+                ..QuicServerParams::default_for_tests()
             },
-            ..QuicServerParams::default_for_tests()
+            max_streams_per_second: 50,
         };
-        let (t, receiver, server_address, cancel) =
-            setup_quic_server_with_params(server_params, Arc::new(RwLock::new(staked_nodes)));
+        let (t, receiver, server_address, cancel) = setup_simple_qos_quic_server_with_params(
+            server_params,
+            Arc::new(RwLock::new(staked_nodes)),
+        );
 
         let runtime = rt_for_test();
         let num_expected_packets = 50;

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -3,8 +3,8 @@ use {
         nonblocking::{
             qos::{ConnectionContext, QosController},
             quic::{ALPN_TPU_PROTOCOL_ID, DEFAULT_WAIT_FOR_CHUNK_TIMEOUT},
-            simple_qos::SimpleQos,
-            swqos::SwQos,
+            simple_qos::{SimpleQos, SimpleQosConfig},
+            swqos::{SwQos, SwQosConfig},
         },
         streamer::StakedNodes,
     },
@@ -603,6 +603,7 @@ impl StreamerStats {
 }
 
 #[deprecated(since = "3.0.0", note = "Use spawn_server_with_cancel instead")]
+#[allow(deprecated)]
 pub fn spawn_server_multi(
     thread_name: &'static str,
     metrics_name: &'static str,
@@ -627,6 +628,7 @@ pub fn spawn_server_multi(
 }
 
 #[derive(Clone)]
+#[deprecated(since = "3.1.0", note = "Use QuicStreamerConfig instead")]
 pub struct QuicServerParams {
     pub max_connections_per_peer: usize,
     pub max_staked_connections: usize,
@@ -636,9 +638,33 @@ pub struct QuicServerParams {
     pub accumulator_channel_size: usize,
     pub num_threads: NonZeroUsize,
     pub max_streams_per_ms: u64,
-    pub max_streams_per_second: u64,
 }
 
+#[derive(Clone)]
+pub struct QuicStreamerConfig {
+    pub max_connections_per_peer: usize,
+    pub max_staked_connections: usize,
+    pub max_unstaked_connections: usize,
+    pub max_connections_per_ipaddr_per_min: u64,
+    pub wait_for_chunk_timeout: Duration,
+    pub coalesce: Duration,
+    pub coalesce_channel_size: usize,
+    pub num_threads: NonZeroUsize,
+}
+
+#[derive(Clone)]
+pub struct SwQosQuicStreamerConfig {
+    pub quic_streamer_config: QuicStreamerConfig,
+    pub qos_config: SwQosConfig,
+}
+
+#[derive(Clone)]
+pub struct SimpleQosQuicStreamerConfig {
+    pub quic_streamer_config: QuicStreamerConfig,
+    pub qos_config: SimpleQosConfig,
+}
+
+#[allow(deprecated)]
 impl Default for QuicServerParams {
     fn default() -> Self {
         QuicServerParams {
@@ -650,11 +676,11 @@ impl Default for QuicServerParams {
             accumulator_channel_size: DEFAULT_ACCUMULATOR_CHANNEL_SIZE,
             num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
             max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
-            max_streams_per_second: DEFAULT_MAX_STREAMS_PER_MS * 1000,
         }
     }
 }
 
+#[allow(deprecated)]
 impl QuicServerParams {
     #[cfg(feature = "dev-context-only-utils")]
     pub const DEFAULT_NUM_SERVER_THREADS_FOR_TEST: NonZeroUsize = NonZeroUsize::new(8).unwrap();
@@ -667,6 +693,36 @@ impl QuicServerParams {
             ..Self::default()
         }
     }
+}
+
+impl Default for QuicStreamerConfig {
+    fn default() -> Self {
+        Self {
+            max_connections_per_peer: 1,
+            max_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS,
+            max_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS,
+            max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
+            wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
+            coalesce: DEFAULT_TPU_COALESCE,
+            coalesce_channel_size: DEFAULT_MAX_COALESCE_CHANNEL_SIZE,
+            num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
+        }
+    }
+}
+
+impl QuicStreamerConfig {
+    #[cfg(feature = "dev-context-only-utils")]
+    pub const DEFAULT_NUM_SERVER_THREADS_FOR_TEST: NonZeroUsize = NonZeroUsize::new(8).unwrap();
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn default_for_tests() -> Self {
+        // Shrink the channel size to avoid a massive allocation for tests
+        Self {
+            coalesce_channel_size: 100_000,
+            num_threads: Self::DEFAULT_NUM_SERVER_THREADS_FOR_TEST,
+            ..Self::default()
+        }
+    }
 
     pub(crate) fn max_concurrent_connections(&self) -> usize {
         let conns = self.max_staked_connections + self.max_unstaked_connections;
@@ -674,7 +730,24 @@ impl QuicServerParams {
     }
 }
 
+#[allow(deprecated)]
+impl From<&QuicServerParams> for QuicStreamerConfig {
+    fn from(params: &QuicServerParams) -> Self {
+        Self {
+            max_connections_per_peer: params.max_connections_per_peer,
+            max_staked_connections: params.max_staked_connections,
+            max_unstaked_connections: params.max_unstaked_connections,
+            max_connections_per_ipaddr_per_min: params.max_connections_per_ipaddr_per_min,
+            wait_for_chunk_timeout: params.wait_for_chunk_timeout,
+            coalesce: params.coalesce,
+            coalesce_channel_size: params.coalesce_channel_size,
+            num_threads: params.num_threads,
+        }
+    }
+}
+
 #[deprecated(since = "3.1.0", note = "Use spawn_server_with_cancel instead")]
+#[allow(deprecated)]
 pub fn spawn_server(
     thread_name: &'static str,
     metrics_name: &'static str,
@@ -696,6 +769,10 @@ pub fn spawn_server(
             thread::sleep(Duration::from_millis(100));
         }
     });
+    let quic_server_config: QuicStreamerConfig = (&quic_server_params).into();
+    let qos_config = SwQosConfig {
+        max_streams_per_ms: quic_server_params.max_streams_per_ms,
+    };
     spawn_server_with_cancel(
         thread_name,
         metrics_name,
@@ -703,7 +780,8 @@ pub fn spawn_server(
         keypair,
         packet_sender,
         staked_nodes,
-        quic_server_params,
+        quic_server_config,
+        qos_config,
         cancel,
     )
 }
@@ -716,7 +794,7 @@ fn spawn_server_with_cancel_generic<Q, C>(
     sockets: impl IntoIterator<Item = UdpSocket>,
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
-    quic_server_params: QuicServerParams,
+    quic_server_params: QuicStreamerConfig,
     cancel: CancellationToken,
     qos: Arc<Q>,
 ) -> Result<SpawnServerResult, QuicServerError>
@@ -764,12 +842,13 @@ pub fn spawn_server_with_cancel(
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
     staked_nodes: Arc<RwLock<StakedNodes>>,
-    quic_server_params: QuicServerParams,
+    quic_server_params: QuicStreamerConfig,
+    qos_config: SwQosConfig,
     cancel: CancellationToken,
 ) -> Result<SpawnServerResult, QuicServerError> {
     let stats = Arc::<StreamerStats>::default();
     let swqos = Arc::new(SwQos::new(
-        quic_server_params.max_streams_per_ms,
+        qos_config,
         quic_server_params.max_staked_connections,
         quic_server_params.max_unstaked_connections,
         quic_server_params.max_connections_per_peer,
@@ -798,13 +877,14 @@ pub fn spawn_simple_qos_server_with_cancel(
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
     staked_nodes: Arc<RwLock<StakedNodes>>,
-    quic_server_params: QuicServerParams,
+    quic_server_params: QuicStreamerConfig,
+    qos_config: SimpleQosConfig,
     cancel: CancellationToken,
 ) -> Result<SpawnServerResult, QuicServerError> {
     let stats = Arc::<StreamerStats>::default();
 
     let simple_qos = Arc::new(SimpleQos::new(
-        quic_server_params.max_streams_per_second,
+        qos_config,
         quic_server_params.max_connections_per_peer,
         quic_server_params.max_staked_connections,
         stats.clone(),
@@ -840,12 +920,12 @@ mod test {
     fn rt_for_test() -> Runtime {
         rt(
             "solQuicTestRt".to_string(),
-            QuicServerParams::DEFAULT_NUM_SERVER_THREADS_FOR_TEST,
+            QuicStreamerConfig::DEFAULT_NUM_SERVER_THREADS_FOR_TEST,
         )
     }
 
     fn setup_quic_server_with_params(
-        server_params: QuicServerParams,
+        server_params: QuicStreamerConfig,
         staked_nodes: Arc<RwLock<StakedNodes>>,
     ) -> (
         std::thread::JoinHandle<()>,
@@ -870,6 +950,7 @@ mod test {
             sender,
             staked_nodes,
             server_params,
+            SwQosConfig::default(),
             cancel.clone(),
         )
         .unwrap();
@@ -877,7 +958,7 @@ mod test {
     }
 
     fn setup_simple_qos_quic_server_with_params(
-        server_params: QuicServerParams,
+        server_params: SimpleQosQuicStreamerConfig,
         staked_nodes: Arc<RwLock<StakedNodes>>,
     ) -> (
         std::thread::JoinHandle<()>,
@@ -901,7 +982,8 @@ mod test {
             &keypair,
             sender,
             staked_nodes,
-            server_params,
+            server_params.quic_streamer_config,
+            server_params.qos_config,
             cancel.clone(),
         )
         .unwrap();
@@ -915,7 +997,7 @@ mod test {
         CancellationToken,
     ) {
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
-        setup_quic_server_with_params(QuicServerParams::default_for_tests(), staked_nodes)
+        setup_quic_server_with_params(QuicStreamerConfig::default_for_tests(), staked_nodes)
     }
 
     #[test]
@@ -966,10 +1048,11 @@ mod test {
             &keypair,
             sender,
             staked_nodes,
-            QuicServerParams {
+            QuicStreamerConfig {
                 max_connections_per_peer: 2,
-                ..QuicServerParams::default_for_tests()
+                ..QuicStreamerConfig::default_for_tests()
             },
+            SwQosConfig::default(),
             cancel.clone(),
         )
         .unwrap();
@@ -1009,10 +1092,16 @@ mod test {
             HashMap::<Pubkey, u64>::default(), // overrides
         );
 
-        let server_params = QuicServerParams {
+        let server_params = QuicStreamerConfig {
             max_unstaked_connections: 0,
-            max_streams_per_second: 20,
-            ..QuicServerParams::default_for_tests()
+            ..QuicStreamerConfig::default_for_tests()
+        };
+        let qos_config = SimpleQosConfig {
+            max_streams_per_second: 20, // low limit to ensure staked node can send all packets
+        };
+        let server_params = SimpleQosQuicStreamerConfig {
+            quic_streamer_config: server_params,
+            qos_config,
         };
         let (t, receiver, server_address, cancel) = setup_simple_qos_quic_server_with_params(
             server_params,
@@ -1052,10 +1141,11 @@ mod test {
             &keypair,
             sender,
             staked_nodes,
-            QuicServerParams {
+            QuicStreamerConfig {
                 max_unstaked_connections: 0,
-                ..QuicServerParams::default_for_tests()
+                ..QuicStreamerConfig::default_for_tests()
             },
+            SwQosConfig::default(),
             cancel.clone(),
         )
         .unwrap();

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -1034,7 +1034,7 @@ mod test {
                 max_unstaked_connections: 0,
                 ..QuicServerParams::default_for_tests()
             },
-            max_streams_per_second: 50,
+            max_streams_per_second: 20,
         };
         let (t, receiver, server_address, cancel) = setup_simple_qos_quic_server_with_params(
             server_params,
@@ -1042,7 +1042,7 @@ mod test {
         );
 
         let runtime = rt_for_test();
-        let num_expected_packets = 50;
+        let num_expected_packets = 20;
 
         runtime.block_on(check_multiple_packets(
             receiver,

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -1,6 +1,11 @@
 use {
     crate::{
-        nonblocking::quic::{ALPN_TPU_PROTOCOL_ID, DEFAULT_WAIT_FOR_CHUNK_TIMEOUT},
+        nonblocking::{
+            qos::{ConnectionContext, QosController},
+            quic::{ALPN_TPU_PROTOCOL_ID, DEFAULT_WAIT_FOR_CHUNK_TIMEOUT},
+            simple_qos::SimpleQos,
+            swqos::SwQos,
+        },
         streamer::StakedNodes,
     },
     crossbeam_channel::Sender,
@@ -716,28 +721,34 @@ pub fn spawn_server(
     )
 }
 
-/// Spawns a tokio runtime and a streamer instance inside it.
-pub fn spawn_server_with_cancel(
+/// Generic function to spawn a QUIC server with any QoS implementation
+fn spawn_server_with_cancel_generic<Q, C>(
     thread_name: &'static str,
     metrics_name: &'static str,
+    stats: Arc<StreamerStats>,
     sockets: impl IntoIterator<Item = UdpSocket>,
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
-    staked_nodes: Arc<RwLock<StakedNodes>>,
     quic_server_params: QuicServerParams,
     cancel: CancellationToken,
-) -> Result<SpawnServerResult, QuicServerError> {
+    qos: Arc<Q>,
+) -> Result<SpawnServerResult, QuicServerError>
+where
+    Q: QosController<C> + Send + Sync + 'static,
+    C: ConnectionContext + Send + Sync + 'static,
+{
     let runtime = rt(format!("{thread_name}Rt"), quic_server_params.num_threads);
     let result = {
         let _guard = runtime.enter();
-        crate::nonblocking::quic::spawn_server_with_cancel(
+        crate::nonblocking::quic::spawn_server_with_cancel_and_qos(
             metrics_name,
+            stats,
             sockets,
             keypair,
             packet_sender,
-            staked_nodes,
             quic_server_params,
             cancel,
+            qos,
         )
     }?;
     let handle = thread::Builder::new()
@@ -759,6 +770,41 @@ pub fn spawn_server_with_cancel(
 }
 
 /// Spawns a tokio runtime and a streamer instance inside it.
+pub fn spawn_server_with_cancel(
+    thread_name: &'static str,
+    metrics_name: &'static str,
+    sockets: impl IntoIterator<Item = UdpSocket>,
+    keypair: &Keypair,
+    packet_sender: Sender<PacketBatch>,
+    staked_nodes: Arc<RwLock<StakedNodes>>,
+    quic_server_params: QuicServerParams,
+    cancel: CancellationToken,
+) -> Result<SpawnServerResult, QuicServerError> {
+    let stats = Arc::<StreamerStats>::default();
+    let swqos = Arc::new(SwQos::new(
+        quic_server_params.max_streams_per_ms,
+        quic_server_params.max_staked_connections,
+        quic_server_params.max_unstaked_connections,
+        quic_server_params.max_connections_per_peer,
+        quic_server_params.wait_for_chunk_timeout,
+        stats.clone(),
+        staked_nodes,
+        cancel.clone(),
+    ));
+    spawn_server_with_cancel_generic(
+        thread_name,
+        metrics_name,
+        stats,
+        sockets,
+        keypair,
+        packet_sender,
+        quic_server_params,
+        cancel,
+        swqos,
+    )
+}
+
+/// Spawns a tokio runtime and a streamer instance inside it.
 pub fn spawn_simple_qos_server_with_cancel(
     thread_name: &'static str,
     metrics_name: &'static str,
@@ -769,38 +815,34 @@ pub fn spawn_simple_qos_server_with_cancel(
     quic_server_params: SimpleQosQuicServerParams,
     cancel: CancellationToken,
 ) -> Result<SpawnServerResult, QuicServerError> {
-    let runtime = rt(
-        format!("{thread_name}Rt"),
-        quic_server_params.quic_server_params.num_threads,
-    );
-    let result = {
-        let _guard = runtime.enter();
-        crate::nonblocking::quic::spawn_simple_qos_server_with_cancel(
-            metrics_name,
-            sockets,
-            keypair,
-            packet_sender,
-            staked_nodes,
-            quic_server_params,
-            cancel,
-        )
-    }?;
-    let handle = thread::Builder::new()
-        .name(thread_name.into())
-        .spawn(move || {
-            if let Err(e) = runtime.block_on(result.thread) {
-                warn!("error from runtime.block_on: {e:?}");
-            }
-        })
-        .unwrap();
-    let updater = EndpointKeyUpdater {
-        endpoints: result.endpoints.clone(),
-    };
-    Ok(SpawnServerResult {
-        endpoints: result.endpoints,
-        thread: handle,
-        key_updater: Arc::new(updater),
-    })
+    let stats = Arc::<StreamerStats>::default();
+
+    let SimpleQosQuicServerParams {
+        quic_server_params,
+        max_streams_per_second,
+    } = quic_server_params;
+
+    let simple_qos = Arc::new(SimpleQos::new(
+        max_streams_per_second,
+        quic_server_params.max_connections_per_peer,
+        quic_server_params.max_staked_connections,
+        quic_server_params.wait_for_chunk_timeout,
+        stats.clone(),
+        staked_nodes,
+        cancel.clone(),
+    ));
+
+    spawn_server_with_cancel_generic(
+        thread_name,
+        metrics_name,
+        stats,
+        sockets,
+        keypair,
+        packet_sender,
+        quic_server_params,
+        cancel,
+        simple_qos,
+    )
 }
 
 #[cfg(test)]

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -636,6 +636,7 @@ pub struct QuicServerParams {
     pub accumulator_channel_size: usize,
     pub num_threads: NonZeroUsize,
     pub max_streams_per_ms: u64,
+    pub max_streams_per_second: u64,
 }
 
 impl Default for QuicServerParams {
@@ -649,20 +650,6 @@ impl Default for QuicServerParams {
             accumulator_channel_size: DEFAULT_ACCUMULATOR_CHANNEL_SIZE,
             num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
             max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct SimpleQosQuicServerParams {
-    pub quic_server_params: QuicServerParams,
-    pub max_streams_per_second: u64,
-}
-
-impl Default for SimpleQosQuicServerParams {
-    fn default() -> Self {
-        SimpleQosQuicServerParams {
-            quic_server_params: QuicServerParams::default(),
             max_streams_per_second: DEFAULT_MAX_STREAMS_PER_MS * 1000,
         }
     }
@@ -786,7 +773,6 @@ pub fn spawn_server_with_cancel(
         quic_server_params.max_staked_connections,
         quic_server_params.max_unstaked_connections,
         quic_server_params.max_connections_per_peer,
-        quic_server_params.wait_for_chunk_timeout,
         stats.clone(),
         staked_nodes,
         cancel.clone(),
@@ -812,21 +798,15 @@ pub fn spawn_simple_qos_server_with_cancel(
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
     staked_nodes: Arc<RwLock<StakedNodes>>,
-    quic_server_params: SimpleQosQuicServerParams,
+    quic_server_params: QuicServerParams,
     cancel: CancellationToken,
 ) -> Result<SpawnServerResult, QuicServerError> {
     let stats = Arc::<StreamerStats>::default();
 
-    let SimpleQosQuicServerParams {
-        quic_server_params,
-        max_streams_per_second,
-    } = quic_server_params;
-
     let simple_qos = Arc::new(SimpleQos::new(
-        max_streams_per_second,
+        quic_server_params.max_streams_per_second,
         quic_server_params.max_connections_per_peer,
         quic_server_params.max_staked_connections,
-        quic_server_params.wait_for_chunk_timeout,
         stats.clone(),
         staked_nodes,
         cancel.clone(),
@@ -897,7 +877,7 @@ mod test {
     }
 
     fn setup_simple_qos_quic_server_with_params(
-        server_params: SimpleQosQuicServerParams,
+        server_params: QuicServerParams,
         staked_nodes: Arc<RwLock<StakedNodes>>,
     ) -> (
         std::thread::JoinHandle<()>,
@@ -1029,12 +1009,10 @@ mod test {
             HashMap::<Pubkey, u64>::default(), // overrides
         );
 
-        let server_params = SimpleQosQuicServerParams {
-            quic_server_params: QuicServerParams {
-                max_unstaked_connections: 0,
-                ..QuicServerParams::default_for_tests()
-            },
+        let server_params = QuicServerParams {
+            max_unstaked_connections: 0,
             max_streams_per_second: 20,
+            ..QuicServerParams::default_for_tests()
         };
         let (t, receiver, server_address, cancel) = setup_simple_qos_quic_server_with_params(
             server_params,

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -626,7 +626,6 @@ pub struct QuicServerParams {
     pub max_connections_per_peer: usize,
     pub max_staked_connections: usize,
     pub max_unstaked_connections: usize,
-    // pub max_streams_per_ms: u64,
     pub max_connections_per_ipaddr_per_min: u64,
     pub wait_for_chunk_timeout: Duration,
     pub accumulator_channel_size: usize,
@@ -645,6 +644,21 @@ impl Default for QuicServerParams {
             accumulator_channel_size: DEFAULT_ACCUMULATOR_CHANNEL_SIZE,
             num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
             max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SimpleQosQuicServerParams {
+    pub quic_server_params: QuicServerParams,
+    pub max_streams_per_second: u64,
+}
+
+impl Default for SimpleQosQuicServerParams {
+    fn default() -> Self {
+        SimpleQosQuicServerParams {
+            quic_server_params: QuicServerParams::default(),
+            max_streams_per_second: DEFAULT_MAX_STREAMS_PER_MS * 1000,
         }
     }
 }
@@ -717,6 +731,51 @@ pub fn spawn_server_with_cancel(
     let result = {
         let _guard = runtime.enter();
         crate::nonblocking::quic::spawn_server_with_cancel(
+            metrics_name,
+            sockets,
+            keypair,
+            packet_sender,
+            staked_nodes,
+            quic_server_params,
+            cancel,
+        )
+    }?;
+    let handle = thread::Builder::new()
+        .name(thread_name.into())
+        .spawn(move || {
+            if let Err(e) = runtime.block_on(result.thread) {
+                warn!("error from runtime.block_on: {e:?}");
+            }
+        })
+        .unwrap();
+    let updater = EndpointKeyUpdater {
+        endpoints: result.endpoints.clone(),
+    };
+    Ok(SpawnServerResult {
+        endpoints: result.endpoints,
+        thread: handle,
+        key_updater: Arc::new(updater),
+    })
+}
+
+/// Spawns a tokio runtime and a streamer instance inside it.
+pub fn spawn_simple_qos_server_with_cancel(
+    thread_name: &'static str,
+    metrics_name: &'static str,
+    sockets: impl IntoIterator<Item = UdpSocket>,
+    keypair: &Keypair,
+    packet_sender: Sender<PacketBatch>,
+    staked_nodes: Arc<RwLock<StakedNodes>>,
+    quic_server_params: SimpleQosQuicServerParams,
+    cancel: CancellationToken,
+) -> Result<SpawnServerResult, QuicServerError> {
+    let runtime = rt(
+        format!("{thread_name}Rt"),
+        quic_server_params.quic_server_params.num_threads,
+    );
+    let result = {
+        let _guard = runtime.enter();
+        crate::nonblocking::quic::spawn_simple_qos_server_with_cancel(
             metrics_name,
             sockets,
             keypair,

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -626,11 +626,12 @@ pub struct QuicServerParams {
     pub max_connections_per_peer: usize,
     pub max_staked_connections: usize,
     pub max_unstaked_connections: usize,
-    pub max_streams_per_ms: u64,
+    // pub max_streams_per_ms: u64,
     pub max_connections_per_ipaddr_per_min: u64,
     pub wait_for_chunk_timeout: Duration,
     pub accumulator_channel_size: usize,
     pub num_threads: NonZeroUsize,
+    pub max_streams_per_ms: u64,
 }
 
 impl Default for QuicServerParams {
@@ -639,11 +640,11 @@ impl Default for QuicServerParams {
             max_connections_per_peer: 1,
             max_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS,
             max_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS,
-            max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             accumulator_channel_size: DEFAULT_ACCUMULATOR_CHANNEL_SIZE,
             num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
+            max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
         }
     }
 }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -852,7 +852,9 @@ mod test {
         crate::nonblocking::{quic::test::*, testing_utilities::check_multiple_streams},
         crossbeam_channel::unbounded,
         solana_net_utils::sockets::bind_to_localhost_unique,
-        std::net::SocketAddr,
+        solana_pubkey::Pubkey,
+        solana_signer::Signer,
+        std::{collections::HashMap, net::SocketAddr},
     };
 
     fn rt_for_test() -> Runtime {
@@ -862,7 +864,10 @@ mod test {
         )
     }
 
-    fn setup_quic_server() -> (
+    fn setup_quic_server_with_params(
+        server_params: QuicServerParams,
+        staked_nodes: Arc<RwLock<StakedNodes>>,
+    ) -> (
         std::thread::JoinHandle<()>,
         crossbeam_channel::Receiver<PacketBatch>,
         SocketAddr,
@@ -872,7 +877,6 @@ mod test {
         let (sender, receiver) = unbounded();
         let keypair = Keypair::new();
         let server_address = s.local_addr().unwrap();
-        let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let cancel = CancellationToken::new();
         let SpawnServerResult {
             endpoints: _,
@@ -885,11 +889,21 @@ mod test {
             &keypair,
             sender,
             staked_nodes,
-            QuicServerParams::default_for_tests(),
+            server_params,
             cancel.clone(),
         )
         .unwrap();
         (t, receiver, server_address, cancel)
+    }
+
+    fn setup_quic_server() -> (
+        std::thread::JoinHandle<()>,
+        crossbeam_channel::Receiver<PacketBatch>,
+        SocketAddr,
+        CancellationToken,
+    ) {
+        let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
+        setup_quic_server_with_params(QuicServerParams::default_for_tests(), staked_nodes)
     }
 
     #[test]
@@ -961,6 +975,47 @@ mod test {
 
         let runtime = rt_for_test();
         runtime.block_on(check_multiple_writes(receiver, server_address, None));
+        cancel.cancel();
+        t.join().unwrap();
+    }
+
+    #[test]
+    fn test_quic_server_multiple_packets_with_simple_qos() {
+        // Send multiple writes from a staked node with SimpleStreamsPerSecond QoS mode
+        // with a super low staked client stake to ensure it can send all packets
+        // within the rate limit.
+        solana_logger::setup();
+        let client_keypair = Keypair::new();
+        let rich_node_keypair = Keypair::new();
+
+        let stakes = HashMap::from([
+            (client_keypair.pubkey(), 1_000), // very small staked node
+            (rich_node_keypair.pubkey(), 1_000_000_000),
+        ]);
+        let staked_nodes = StakedNodes::new(
+            Arc::new(stakes),
+            HashMap::<Pubkey, u64>::default(), // overrides
+        );
+
+        let server_params = QuicServerParams {
+            max_unstaked_connections: 0,
+            qos_mode: QosMode::SimpleStreamsPerSecond {
+                max_streams_per_second: 50,
+            },
+            ..QuicServerParams::default_for_tests()
+        };
+        let (t, receiver, server_address, cancel) =
+            setup_quic_server_with_params(server_params, Arc::new(RwLock::new(staked_nodes)));
+
+        let runtime = rt_for_test();
+        let num_expected_packets = 50;
+
+        runtime.block_on(check_multiple_packets(
+            receiver,
+            server_address,
+            Some(&client_keypair),
+            num_expected_packets,
+        ));
         cancel.cancel();
         t.join().unwrap();
     }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -63,9 +63,7 @@ use {
     solana_signer::Signer,
     solana_streamer::{
         nonblocking::{simple_qos::SimpleQosConfig, swqos::SwQosConfig},
-        quic::{
-            QuicStreamerConfig, SimpleQosQuicStreamerConfig, SwQosQuicStreamerConfig,
-        },
+        quic::{QuicStreamerConfig, SimpleQosQuicStreamerConfig, SwQosQuicStreamerConfig},
     },
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
     solana_turbine::{
@@ -954,7 +952,6 @@ pub fn execute(
             max_staked_connections: tpu_max_staked_connections.try_into().unwrap(),
             max_unstaked_connections: tpu_max_unstaked_connections.try_into().unwrap(),
             max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
-            coalesce: tpu_coalesce,
             num_threads: tpu_transaction_receive_threads,
             ..Default::default()
         },
@@ -967,7 +964,6 @@ pub fn execute(
             max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
             max_unstaked_connections: tpu_max_fwd_unstaked_connections.try_into().unwrap(),
             max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
-            coalesce: tpu_coalesce,
             num_threads: tpu_transaction_forward_receive_threads,
             ..Default::default()
         },
@@ -979,7 +975,6 @@ pub fn execute(
             max_connections_per_peer: 1,
             max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
             max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
-            coalesce: tpu_coalesce,
             num_threads: tpu_vote_transaction_receive_threads,
             ..Default::default()
         },

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -41,6 +41,7 @@ use {
             SchedulerPacing, Validator, ValidatorConfig, ValidatorError, ValidatorStartProgress,
             ValidatorTpuConfig,
         },
+        voting_service::MAX_VOTES_PER_SECOND,
     },
     solana_genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     solana_gossip::{
@@ -962,12 +963,18 @@ pub fn execute(
         ..Default::default()
     };
 
-    // Vote shares TPU forward's characteristics, except that we accept 1 connection
-    // per peer and no unstaked connections are accepted.
-    let mut vote_quic_server_config = tpu_fwd_quic_server_config.clone();
-    vote_quic_server_config.max_connections_per_peer = 1;
-    vote_quic_server_config.max_unstaked_connections = 0;
-    vote_quic_server_config.num_threads = tpu_vote_transaction_receive_threads;
+    let vote_quic_server_config = QuicServerParams {
+        max_connections_per_peer: 1,
+        max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
+        max_unstaked_connections: 0,
+        qos_mode: QosMode::SimpleStreamsPerSecond {
+            max_streams_per_second: MAX_VOTES_PER_SECOND,
+        },
+        max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
+        coalesce: tpu_coalesce,
+        num_threads: tpu_vote_transaction_receive_threads,
+        ..Default::default()
+    };
 
     let validator = match Validator::new(
         node,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -61,7 +61,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::{runtime_config::RuntimeConfig, snapshot_utils},
     solana_signer::Signer,
-    solana_streamer::quic::QuicServerParams,
+    solana_streamer::quic::QuicServerParams, SimpleQosQuicServerParams,
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
     solana_turbine::{
         broadcast_stage::BroadcastStageType,
@@ -963,17 +963,16 @@ pub fn execute(
         ..Default::default()
     };
 
-    let vote_quic_server_config = QuicServerParams {
-        max_connections_per_peer: 1,
-        max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
-        max_unstaked_connections: 0,
-        qos_mode: QosMode::SimpleStreamsPerSecond {
-            max_streams_per_second: MAX_VOTES_PER_SECOND,
+    let vote_quic_server_config = SimpleQosQuicServerParams {
+        quic_server_params: QuicServerParams {
+            max_connections_per_peer: 1,
+            max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
+            max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
+            coalesce: tpu_coalesce,
+            num_threads: tpu_vote_transaction_receive_threads,
+            ..Default::default()
         },
-        max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
-        coalesce: tpu_coalesce,
-        num_threads: tpu_vote_transaction_receive_threads,
-        ..Default::default()
+        max_streams_per_second: MAX_VOTES_PER_SECOND,
     };
 
     let validator = match Validator::new(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -61,7 +61,12 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::{runtime_config::RuntimeConfig, snapshot_utils},
     solana_signer::Signer,
-    solana_streamer::quic::QuicServerParams,
+    solana_streamer::{
+        nonblocking::{simple_qos::SimpleQosConfig, swqos::SwQosConfig},
+        quic::{
+            QuicStreamerConfig, SimpleQosQuicStreamerConfig, SwQosQuicStreamerConfig,
+        },
+    },
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
     solana_turbine::{
         broadcast_stage::BroadcastStageType,
@@ -943,33 +948,44 @@ pub fn execute(
     // the one pushed by bootstrap.
     node.info.hot_swap_pubkey(identity_keypair.pubkey());
 
-    let tpu_quic_server_config = QuicServerParams {
-        max_connections_per_peer: tpu_max_connections_per_peer.try_into().unwrap(),
-        max_staked_connections: tpu_max_staked_connections.try_into().unwrap(),
-        max_unstaked_connections: tpu_max_unstaked_connections.try_into().unwrap(),
-        max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
-        num_threads: tpu_transaction_receive_threads,
-        max_streams_per_ms,
-        ..Default::default()
+    let tpu_quic_server_config = SwQosQuicStreamerConfig {
+        quic_streamer_config: QuicStreamerConfig {
+            max_connections_per_peer: tpu_max_connections_per_peer.try_into().unwrap(),
+            max_staked_connections: tpu_max_staked_connections.try_into().unwrap(),
+            max_unstaked_connections: tpu_max_unstaked_connections.try_into().unwrap(),
+            max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
+            coalesce: tpu_coalesce,
+            num_threads: tpu_transaction_receive_threads,
+            ..Default::default()
+        },
+        qos_config: SwQosConfig { max_streams_per_ms },
     };
 
-    let tpu_fwd_quic_server_config = QuicServerParams {
-        max_connections_per_peer: tpu_max_connections_per_peer.try_into().unwrap(),
-        max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
-        max_unstaked_connections: tpu_max_fwd_unstaked_connections.try_into().unwrap(),
-        max_streams_per_ms,
-        max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
-        num_threads: tpu_transaction_forward_receive_threads,
-        ..Default::default()
+    let tpu_fwd_quic_server_config = SwQosQuicStreamerConfig {
+        quic_streamer_config: QuicStreamerConfig {
+            max_connections_per_peer: tpu_max_connections_per_peer.try_into().unwrap(),
+            max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
+            max_unstaked_connections: tpu_max_fwd_unstaked_connections.try_into().unwrap(),
+            max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
+            coalesce: tpu_coalesce,
+            num_threads: tpu_transaction_forward_receive_threads,
+            ..Default::default()
+        },
+        qos_config: SwQosConfig { max_streams_per_ms },
     };
 
-    let vote_quic_server_config = QuicServerParams {
-        max_connections_per_peer: 1,
-        max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
-        max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
-        num_threads: tpu_vote_transaction_receive_threads,
-        max_streams_per_second: MAX_VOTES_PER_SECOND,
-        ..Default::default()
+    let vote_quic_server_config = SimpleQosQuicStreamerConfig {
+        quic_streamer_config: QuicStreamerConfig {
+            max_connections_per_peer: 1,
+            max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
+            max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
+            coalesce: tpu_coalesce,
+            num_threads: tpu_vote_transaction_receive_threads,
+            ..Default::default()
+        },
+        qos_config: SimpleQosConfig {
+            max_streams_per_second: MAX_VOTES_PER_SECOND,
+        },
     };
 
     let validator = match Validator::new(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -36,12 +36,12 @@ use {
         repair::repair_handler::RepairHandlerType,
         snapshot_packager_service::SnapshotPackagerService,
         system_monitor_service::SystemMonitorService,
+        tpu::MAX_VOTES_PER_SECOND,
         validator::{
             is_snapshot_config_valid, BlockProductionMethod, BlockVerificationMethod,
             SchedulerPacing, Validator, ValidatorConfig, ValidatorError, ValidatorStartProgress,
             ValidatorTpuConfig,
         },
-        voting_service::MAX_VOTES_PER_SECOND,
     },
     solana_genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     solana_gossip::{

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -61,7 +61,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::{runtime_config::RuntimeConfig, snapshot_utils},
     solana_signer::Signer,
-    solana_streamer::quic::QuicServerParams, SimpleQosQuicServerParams,
+    solana_streamer::quic::QuicServerParams,
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
     solana_turbine::{
         broadcast_stage::BroadcastStageType,
@@ -963,16 +963,13 @@ pub fn execute(
         ..Default::default()
     };
 
-    let vote_quic_server_config = SimpleQosQuicServerParams {
-        quic_server_params: QuicServerParams {
-            max_connections_per_peer: 1,
-            max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
-            max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
-            coalesce: tpu_coalesce,
-            num_threads: tpu_vote_transaction_receive_threads,
-            ..Default::default()
-        },
+    let vote_quic_server_config = QuicServerParams {
+        max_connections_per_peer: 1,
+        max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
+        max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
+        num_threads: tpu_vote_transaction_receive_threads,
         max_streams_per_second: MAX_VOTES_PER_SECOND,
+        ..Default::default()
     };
 
     let validator = match Validator::new(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -946,9 +946,9 @@ pub fn execute(
         max_connections_per_peer: tpu_max_connections_per_peer.try_into().unwrap(),
         max_staked_connections: tpu_max_staked_connections.try_into().unwrap(),
         max_unstaked_connections: tpu_max_unstaked_connections.try_into().unwrap(),
-        max_streams_per_ms,
         max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
         num_threads: tpu_transaction_receive_threads,
+        max_streams_per_ms,
         ..Default::default()
     };
 

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -11,8 +11,11 @@ use {
     solana_perf::packet::PacketBatch,
     solana_quic_definitions::NotifyKeyUpdate,
     solana_streamer::{
-        nonblocking::quic::DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-        quic::{spawn_server_with_cancel, EndpointKeyUpdater, QuicServerParams},
+        nonblocking::{quic::DEFAULT_WAIT_FOR_CHUNK_TIMEOUT, swqos::SwQosConfig},
+        quic::{
+            spawn_server_with_cancel, EndpointKeyUpdater, QuicStreamerConfig,
+            SwQosQuicStreamerConfig,
+        },
         streamer::StakedNodes,
     },
     std::{
@@ -116,15 +119,20 @@ impl Vortexor {
         identity_keypair: &Keypair,
         cancel: CancellationToken,
     ) -> Self {
-        let mut quic_server_params = QuicServerParams {
-            max_connections_per_peer,
-            max_staked_connections: max_tpu_staked_connections,
-            max_unstaked_connections: max_tpu_unstaked_connections,
-            max_connections_per_ipaddr_per_min,
-            wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-            max_streams_per_ms,
-            ..Default::default()
+        let quic_server_params = SwQosQuicStreamerConfig {
+            quic_streamer_config: QuicStreamerConfig {
+                max_connections_per_peer,
+                max_staked_connections: max_tpu_staked_connections,
+                max_unstaked_connections: max_tpu_unstaked_connections,
+                max_connections_per_ipaddr_per_min,
+                wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
+                coalesce: tpu_coalesce,
+                ..Default::default()
+            },
+            qos_config: SwQosConfig { max_streams_per_ms },
         };
+
+        let mut quic_fwd_server_params = quic_server_params.clone();
 
         let TpuSockets {
             tpu_quic,
@@ -138,15 +146,20 @@ impl Vortexor {
             identity_keypair,
             tpu_sender.clone(),
             staked_nodes.clone(),
-            quic_server_params.clone(),
+            quic_server_params.quic_streamer_config,
+            quic_server_params.qos_config,
             cancel.clone(),
         )
         .unwrap();
 
         // Fot TPU forward -- we disallow unstaked connections. Allocate all connection resources
         // for staked connections:
-        quic_server_params.max_staked_connections = max_fwd_staked_connections;
-        quic_server_params.max_unstaked_connections = max_fwd_unstaked_connections;
+        quic_fwd_server_params
+            .quic_streamer_config
+            .max_staked_connections = max_fwd_staked_connections;
+        quic_fwd_server_params
+            .quic_streamer_config
+            .max_unstaked_connections = max_fwd_unstaked_connections;
         let tpu_fwd_result = spawn_server_with_cancel(
             "solVtxTpuFwd",
             "quic_vortexor_tpu_forwards",
@@ -154,7 +167,8 @@ impl Vortexor {
             identity_keypair,
             tpu_fwd_sender,
             staked_nodes.clone(),
-            quic_server_params,
+            quic_fwd_server_params.quic_streamer_config,
+            quic_fwd_server_params.qos_config,
             cancel.clone(),
         )
         .unwrap();

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -126,7 +126,6 @@ impl Vortexor {
                 max_unstaked_connections: max_tpu_unstaked_connections,
                 max_connections_per_ipaddr_per_min,
                 wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-                coalesce: tpu_coalesce,
                 ..Default::default()
             },
             qos_config: SwQosConfig { max_streams_per_ms },

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -120,9 +120,9 @@ impl Vortexor {
             max_connections_per_peer,
             max_staked_connections: max_tpu_staked_connections,
             max_unstaked_connections: max_tpu_unstaked_connections,
-            max_streams_per_ms,
             max_connections_per_ipaddr_per_min,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
+            max_streams_per_ms,
             ..Default::default()
         };
 

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -277,7 +277,8 @@ mod tests {
         },
         solana_signer::Signer,
         solana_streamer::{
-            quic::{spawn_server_with_cancel, QuicServerParams, SpawnServerResult},
+            nonblocking::swqos::SwQosConfig,
+            quic::{spawn_server_with_cancel, QuicStreamerConfig, SpawnServerResult},
             socket::SocketAddrSpace,
             streamer::StakedNodes,
         },
@@ -388,7 +389,8 @@ mod tests {
             &Keypair::new(),
             sender,
             staked_nodes,
-            QuicServerParams::default_for_tests(),
+            QuicStreamerConfig::default_for_tests(),
+            SwQosConfig::default(),
             cancel_token.clone(),
         )
         .unwrap();


### PR DESCRIPTION
#### Problem

Vote using QUIC requires a simpler QOS instead of stake weighted as we want to allow all staked nodes to be able to vote and there is no need to differentiate the count of votes per vote interval based on stakes.

#### Summary of Changes

1. Use a trait QosController to encapsulate different Qos Implementations -- declared in qos.rs
2. Logic specific to SWQOS is refactored to swqos.rs from quic.rs
3. Logic specific to simple QOS is implemented in simple_qos.rs
4. Added unit tests for testing simple QOS
5. Change votes QUIC serverice to use simple QOS.

There should be 0 impacts on existing SwQOS implementations as it is pure refactoring it.

I have annotated the code on major functions being refactored.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
