### PR TITLE
Move set_perms from accounts-db hardened_unpack to file_io

### DIFF
--- a/accounts-db/src/file_io.rs
+++ b/accounts-db/src/file_io.rs
@@ -1,9 +1,9 @@
 //! File i/o helper functions.
 use std::{
-    fs::{File, OpenOptions},
+    fs::{self, File, OpenOptions},
     io::{self, BufWriter, Write},
     ops::Range,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
@@ -168,11 +168,23 @@ impl<'a> SyncIoFileCreator<'a> {
     }
 }
 
-#[cfg(not(unix))]
-pub(super) fn set_file_readonly(path: &std::path::Path, readonly: bool) -> io::Result<()> {
-    let mut perm = std::fs::metadata(path)?.permissions();
-    perm.set_readonly(readonly);
-    std::fs::set_permissions(path, perm)
+/// Update permissions mode of an existing directory or file path
+///
+/// Note: on-non Unix platforms, this functions only updates readonly mode.
+pub fn set_path_permissions(dst: &Path, mode: u32) -> io::Result<()> {
+    let perm;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        perm = fs::Permissions::from_mode(mode);
+    }
+    #[cfg(not(unix))]
+    {
+        let mut current_perm = fs::metadata(path)?.permissions();
+        current_perm.set_readonly(mode & 0o200 == 0);
+        perm = current_perm;
+    }
+    fs::set_permissions(dst, perm)
 }
 
 impl FileCreator for SyncIoFileCreator<'_> {
@@ -194,8 +206,9 @@ impl FileCreator for SyncIoFileCreator<'_> {
         io::copy(contents, &mut file_buf)?;
         file_buf.flush()?;
 
+        // On unix the file was opened with proper permissions, only update the mode on non-unix
         #[cfg(not(unix))]
-        set_file_readonly(&path, mode & 0o200 == 0)?;
+        set_path_permissions(&path, mode)?;
 
         self.file_complete(path);
         Ok(())

--- a/accounts-db/src/file_io.rs
+++ b/accounts-db/src/file_io.rs
@@ -171,7 +171,7 @@ impl<'a> SyncIoFileCreator<'a> {
 /// Update permissions mode of an existing directory or file path
 ///
 /// Note: on-non Unix platforms, this functions only updates readonly mode.
-pub fn set_path_permissions(dst: &Path, mode: u32) -> io::Result<()> {
+pub fn set_path_permissions(path: &Path, mode: u32) -> io::Result<()> {
     let perm;
     #[cfg(unix)]
     {
@@ -184,7 +184,7 @@ pub fn set_path_permissions(dst: &Path, mode: u32) -> io::Result<()> {
         current_perm.set_readonly(mode & 0o200 == 0);
         perm = current_perm;
     }
-    fs::set_permissions(dst, perm)
+    fs::set_permissions(path, perm)
 }
 
 impl FileCreator for SyncIoFileCreator<'_> {


### PR DESCRIPTION
#### Problem
* `set_perms` in hardened_unpack is calling `crate::file_io::set_file_readonly` for a non-unix platforms which introduces a bit weird dependency (i.e. windows-only API)
* the `set_file_readonly` call actually ignores the `mode`, which matches the way we currently call `set_perms` in hardened_unpack (set files as writable, I suppose for mmap functionality), but we could as well follow the passed mode
* `set_file_readonly` is used in both file_io and hardened_unpack, but those calls can be replaced with a call to more generic set path permissions function

#### Summary of Changes
* move `set_perms` to file_io as `set_path_permissions`
* remove `set_file_readonly` and replace calls with `set_path_permissions`

Note: this PR will be useful for cleaner change when extracting hardened_unpack into dedicated agave-snapshots crate (https://github.com/anza-xyz/agave/pull/8428)