### PR TITLE
Remove redundant sanitize() call in parse_turbine

### DIFF
--- a/ledger/src/wire_format_tests.rs
+++ b/ledger/src/wire_format_tests.rs
@@ -11,9 +11,6 @@ mod tests {
     fn parse_turbine(bytes: &[u8]) -> anyhow::Result<Shred> {
         let shred = Shred::new_from_serialized_shred(bytes.to_owned())
             .map_err(|_e| anyhow::anyhow!("Can not deserialize"))?;
-        shred
-            .sanitize()
-            .map_err(|_e| anyhow::anyhow!("Failed sanitize"))?;
         Ok(shred)
     }
 


### PR DESCRIPTION
The Shred constructed via new_from_serialized_shred() is already sanitized internally by the Merkle variants’ from_payload() (which call sanitize()). Calling sanitize() again in parse_turbine duplicated validation and added unnecessary overhead. This change removes the extra call to align with common usage across the codebase and avoid redundant work.