### PR TITLE
broadcast_metrics: actually update is_xdp

### DIFF
--- a/turbine/src/broadcast_stage/broadcast_metrics.rs
+++ b/turbine/src/broadcast_stage/broadcast_metrics.rs
@@ -35,6 +35,7 @@ pub struct TransmitShredsStats {
 
 impl BroadcastStats for TransmitShredsStats {
     fn update(&mut self, new_stats: &TransmitShredsStats) {
+        self.is_xdp = new_stats.is_xdp;
         self.transmit_elapsed += new_stats.transmit_elapsed;
         self.send_mmsg_elapsed += new_stats.send_mmsg_elapsed;
         self.send_quic_elapsed += new_stats.send_quic_elapsed;


### PR DESCRIPTION
This should have gone in ef61532782e98e0694555bf0e3b830ebe81cc43d oops.