### PR TITLE
Refactor - Removes existing entries in the same deployment slot

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -891,7 +891,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                         slot_versions.insert(index, Arc::clone(&entry));
                     }
                 }
-                // Remove existing entires in the same deployment slot unless they are for a different environment.
+                // Remove existing entries in the same deployment slot unless they are for a different environment.
                 // This overwrites the current status of a program in program management instructions.
                 slot_versions.retain(|existing| {
                     existing.deployment_slot != entry.deployment_slot

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1931,7 +1931,8 @@ mod tests {
 
     #[test]
     fn test_assign_program_removes_entries_in_same_slot() {
-        let mut cache = new_mock_cache::<TestForkGraph>();
+        let mut cache = ProgramCache::<TestForkGraph>::new(0, 0);
+        cache.environments.program_runtime_v1 = get_mock_env();
         let program_id = Pubkey::new_unique();
         let closed_other_slot = Arc::new(ProgramCacheEntry {
             program: ProgramCacheEntryType::Closed,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6270,17 +6270,11 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len(formalize_loaded_transaction_
             .read()
             .unwrap();
         let slot_versions = program_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
-        assert_eq!(slot_versions.len(), 2);
+        assert_eq!(slot_versions.len(), 1);
         assert_eq!(slot_versions[0].deployment_slot, bank.slot() - 1);
-        assert_eq!(slot_versions[0].effective_slot, bank.slot() - 1);
+        assert_eq!(slot_versions[0].effective_slot, bank.slot());
         assert!(matches!(
             slot_versions[0].program,
-            ProgramCacheEntryType::Closed,
-        ));
-        assert_eq!(slot_versions[1].deployment_slot, bank.slot() - 1);
-        assert_eq!(slot_versions[1].effective_slot, bank.slot());
-        assert!(matches!(
-            slot_versions[1].program,
             ProgramCacheEntryType::Loaded(_),
         ));
     }


### PR DESCRIPTION
#### Problem

In program management instructions a new cache entry is created, however before that happens the transaction itself loads the program about to be modified and thus also creates an entry for the previous state. Currently we ignore the old entry but we should just filter it out.

#### Summary of Changes

Removes existing entries in the same deployment slot (unless they are for a different environment) in `ProgramCache::assign_program()` and adjusts two affected tests.
