### PR TITLE
ledger: Build the grouped slot leaders manually

### DIFF
--- a/leader-schedule/Cargo.toml
+++ b/leader-schedule/Cargo.toml
@@ -24,14 +24,13 @@ agave-random = { workspace = true }
 itertools = { workspace = true }
 rand_chacha = { workspace = true }
 solana-clock = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-vote = { workspace = true }
 
 [dev-dependencies]
 bs58 = { workspace = true, features = ["alloc"] }
 rand = { workspace = true }
 sha2 = { workspace = true }
-solana-pubkey = { workspace = true, features = ["rand"] }
 solana-vote = { path = "../vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
 test-case = { workspace = true }
 

--- a/leader-schedule/src/vote_keyed.rs
+++ b/leader-schedule/src/vote_keyed.rs
@@ -1,8 +1,7 @@
 use {
     super::{SlotLeader, stake_weighted_slot_leaders},
-    itertools::Itertools,
     solana_clock::Epoch,
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_vote::vote_account::VoteAccountsHashMap,
     std::{collections::HashMap, iter, num::NonZeroUsize, ops::Index},
 };
@@ -11,7 +10,7 @@ use {
 pub struct LeaderSchedule {
     slot_leaders: Vec<SlotLeader>,
     // Inverted index from leader id to indices where they are the leader.
-    leader_slots_map: HashMap<Pubkey, Vec<usize>>,
+    leader_slots_map: HashMap<Pubkey, Vec<usize>, PubkeyHasherBuilder>,
     repeat: NonZeroUsize,
 }
 
@@ -47,11 +46,18 @@ impl LeaderSchedule {
             })
             .collect();
         let slot_leaders = stake_weighted_slot_leaders(slot_leader_stakes, epoch, len, repeat);
-        Self::new_from_schedule(slot_leaders, repeat)
+        Self {
+            leader_slots_map: Self::invert_slot_leaders(
+                &slot_leaders,
+                Some(vote_accounts_map.len()),
+            ),
+            slot_leaders,
+            repeat,
+        }
     }
 
     pub fn new_from_schedule(slot_leaders: Vec<SlotLeader>, repeat: NonZeroUsize) -> Self {
-        let leader_slots_map = Self::invert_slot_leaders(&slot_leaders);
+        let leader_slots_map = Self::invert_slot_leaders(&slot_leaders, None);
         Self {
             slot_leaders,
             leader_slots_map,
@@ -59,12 +65,23 @@ impl LeaderSchedule {
         }
     }
 
-    fn invert_slot_leaders(slot_leaders: &[SlotLeader]) -> HashMap<Pubkey, Vec<usize>> {
-        slot_leaders
-            .iter()
-            .enumerate()
-            .map(|(i, leader)| (leader.id, i))
-            .into_group_map()
+    fn invert_slot_leaders(
+        slot_leaders: &[SlotLeader],
+        nodes_len: Option<usize>,
+    ) -> HashMap<Pubkey, Vec<usize>, PubkeyHasherBuilder> {
+        let mut grouped_slot_leaders = match nodes_len {
+            Some(nodes_len) => {
+                HashMap::with_capacity_and_hasher(nodes_len, PubkeyHasherBuilder::default())
+            }
+            None => HashMap::with_hasher(PubkeyHasherBuilder::default()),
+        };
+        for (slot, leader) in slot_leaders.iter().enumerate() {
+            grouped_slot_leaders
+                .entry(leader.id)
+                .and_modify(|slots: &mut Vec<usize>| slots.push(slot))
+                .or_insert(vec![slot]);
+        }
+        grouped_slot_leaders
     }
 
     pub fn get_slot_leaders(&self) -> impl Iterator<Item = &SlotLeader> {

--- a/leader-schedule/src/vote_keyed.rs
+++ b/leader-schedule/src/vote_keyed.rs
@@ -73,7 +73,7 @@ impl LeaderSchedule {
             Some(nodes_len) => {
                 HashMap::with_capacity_and_hasher(nodes_len, PubkeyHasherBuilder::default())
             }
-            None => HashMap::with_hasher(PubkeyHasherBuilder::default()),
+            None => HashMap::default(),
         };
         for (slot, leader) in slot_leaders.iter().enumerate() {
             grouped_slot_leaders

--- a/leader-schedule/src/vote_keyed.rs
+++ b/leader-schedule/src/vote_keyed.rs
@@ -75,11 +75,11 @@ impl LeaderSchedule {
             }
             None => HashMap::default(),
         };
-        for (slot, leader) in slot_leaders.iter().enumerate() {
+        for (index, leader) in slot_leaders.iter().enumerate() {
             grouped_slot_leaders
                 .entry(leader.id)
-                .and_modify(|slots: &mut Vec<_>| slots.push(slot))
-                .or_insert(vec![slot]);
+                .and_modify(|indices: &mut Vec<_>| indices.push(index))
+                .or_insert(vec![index]);
         }
         grouped_slot_leaders
     }

--- a/leader-schedule/src/vote_keyed.rs
+++ b/leader-schedule/src/vote_keyed.rs
@@ -78,7 +78,7 @@ impl LeaderSchedule {
         for (slot, leader) in slot_leaders.iter().enumerate() {
             grouped_slot_leaders
                 .entry(leader.id)
-                .and_modify(|slots: &mut Vec<usize>| slots.push(slot))
+                .and_modify(|slots: &mut Vec<_>| slots.push(slot))
                 .or_insert(vec![slot]);
         }
         grouped_slot_leaders


### PR DESCRIPTION
#### Problem

Building them with `itertools::into_group_map` takes 20.9ms.


<img width="1905" height="708" alt="before" src="https://github.com/user-attachments/assets/fc6eb2a3-441e-4102-8604-45bf5f368284" />

#### Summary of Changes

Building them manually with a pre-allocated hash map, using pubkey hasher, takes 5.2ms.

<img width="1902" height="731" alt="after_1" src="https://github-production-user-asset-6210df.s3.amazonaws.com/34685103/500555538-c05deaaf-9de3-4964-9e16-9a849bf3dae7.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20260325%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260325T113406Z&X-Amz-Expires=300&X-Amz-Signature=c1b4aaa622b061f9bad828af49e82aef2afa62945e5240a6285dfa69dd77f750&X-Amz-SignedHeaders=host" />

Ref: #8280
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
