### PR TITLE
changelog: Add note about --replay-slots-concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Release channels have their own copy of this changelog:
   * `--no-check-vote-account`
   * `--no-rocksdb-compaction`, `--rocksdb-compaction-interval-slots`, `--rocksdb-max-compaction-jitter-slots`
   * `--replay-slots-concurrently`
+    * Use `--replay-forks-threads` with a value of `4` to match preexisting behavior
   * `--rpc-pubsub-max-connections`, `--rpc-pubsub-max-fragment-size`, `--rpc-pubsub-max-in-buffer-capacity`, `--rpc-pubsub-max-out-buffer-capacity`, `--enable-cpi-and-log-storage`, `--minimal-rpc-api`
   * `--skip-poh-verify`
 * Deprecated snapshot archive formats have been removed and are no longer loadable.


### PR DESCRIPTION
#### Problem
We removed a bunch of deprecated arguments in `v3.0` (https://github.com/anza-xyz/agave/pull/6551). Many of those were complete removals. However, `--replay-slot-concurrently` was renamed & had a slight change in behavior on how to use the arg (boolean ==> integer)

#### Summary of Changes
Add a note about how to use the new flag to match old behavior