### PR TITLE
Gossip: add `--advertised-ip` flag so you can NAT your validator in test clusters

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -770,13 +770,15 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("HOST")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
+                .hidden(hidden_unless_forced())
                 .help(
-                    "DNS name or IP address for this validator to advertise in gossip. This \
-                     address will be used as the target desination address for peers trying to \
-                     contact this node. [default: the first --bind-address, or ask --entrypoint \
-                     when --bind-address is not provided, or 127.0.0.1 when --entrypoint is not \
-                     provided]. Note: this argument cannot be used in a multihoming context (when \
-                     multiple --bind-address values are provided).",
+                    "Use when running a validator behind a NAT. DNS name or IP address for this \
+                     validator to advertise in gossip. This address will be used as the target \
+                     desination address for peers trying to contact this node. [default: the \
+                     first --bind-address, or ask --entrypoint when --bind-address is not \
+                     provided, or 127.0.0.1 when --entrypoint is not provided]. Note: this \
+                     argument cannot be used in a multihoming context (when multiple \
+                     --bind-address values are provided).",
                 ),
         )
         .arg(

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -765,6 +765,21 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 ),
         )
         .arg(
+            Arg::with_name("advertised_ip")
+                .long("advertised-ip")
+                .value_name("HOST")
+                .takes_value(true)
+                .validator(solana_net_utils::is_host)
+                .help(
+                    "DNS name or IP address for this validator to advertise in gossip. This \
+                     address will be used as the target desination address for peers trying to \
+                     contact this node. [default: the first --bind-address, or ask --entrypoint \
+                     when --bind-address is not provided, or 127.0.0.1 when --entrypoint is not \
+                     provided]. Note: this argument cannot be used in a multihoming context (when \
+                     multiple --bind-address values are provided).",
+                ),
+        )
+        .arg(
             Arg::with_name("clone_account")
                 .long("clone")
                 .short("c")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -227,6 +227,13 @@ pub fn execute(
         ))?;
     }
 
+    if bind_addresses.len() > 1 && matches.is_present("advertised_ip") {
+        Err(String::from(
+            "--advertised-ip cannot be used in a multihoming context. In multihoming, the \
+             validator will advertise the first --bind-address as this node's public IP address.",
+        ))?;
+    }
+
     let rpc_bind_address = if matches.is_present("rpc_bind_address") {
         solana_net_utils::parse_host(matches.value_of("rpc_bind_address").unwrap())
             .expect("invalid rpc_bind_address")
@@ -735,8 +742,18 @@ pub fn execute(
         })
         .transpose()?;
 
+    let advertised_ip = matches
+        .value_of("advertised_ip")
+        .map(|advertised_ip| {
+            solana_net_utils::parse_host(advertised_ip)
+                .map_err(|err| format!("failed to parse --advertised-ip: {err}"))
+        })
+        .transpose()?;
+
     let advertised_ip = if let Some(ip) = gossip_host {
         ip
+    } else if let Some(cli_ip) = advertised_ip {
+        cli_ip
     } else if !bind_addresses.active().is_unspecified() && !bind_addresses.active().is_loopback() {
         bind_addresses.active()
     } else if !entrypoint_addrs.is_empty() {


### PR DESCRIPTION
#### Problem
We removed `--gossip-host` cli arg in the past because
1) people kept misusing it (name makes no sense)
2) we thought no one ran a validator behind a nat

Turns out FD runs test clusters behind a NAT and want to be able to advertise one IP while binding to another IP

#### Summary of Changes
Add back in the `gossip-host` functionality but change the cli name to `--advertised-ip`. IMO this is a much more clear name for what the cli is requesting. It is requesting the ip you want to advertise. I also updated the cli description to make it even more clear.

`--advertised-ip` cannot be used in a multihoming context since I'm not sure how multihoming would even really work behind a NAT. FD team did not believe they needed this multihoming/NAT support anyway.