### PR TITLE
ci: flag copied and renamed manifests for new crate check

### DIFF
--- a/ci/check-crates.sh
+++ b/ci/check-crates.sh
@@ -25,7 +25,7 @@ declare -A verified_crate_owners=(
 )
 
 # get Cargo.toml from git diff
-readarray -t files <<<"$(git diff "$COMMIT_RANGE" --diff-filter=AM --name-only | grep Cargo.toml)"
+readarray -t files <<<"$(git diff "$COMMIT_RANGE" --diff-filter=ACMR --name-only | grep Cargo.toml)"
 printf "%s\n" "${files[@]}"
 
 error_count=0


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/6782 moved a cargo manifest while renaming the crate. this series of actions was not flagged by ci/check-crates.sh, allowing the pr to be merged without first reserving the new name on crates.io

#### Summary of Changes
adds copied and renamed cargo manifests to crate check consideration