### PR TITLE
test fix: keep connection alive

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1890,7 +1890,7 @@ pub mod test {
 
         let SpawnTestServerResult {
             join_handle,
-            receiver: _,
+            receiver,
             server_address,
             stats,
             cancel,
@@ -1957,6 +1957,11 @@ pub mod test {
         assert!(start.elapsed().as_secs() < 1);
 
         cancel.cancel();
+        // Explicitly drop receiver here so that it doesn't get implicitly
+        // dropped earlier. This is necessary to ensure the server stays alive
+        // and doesn't issue a cancel to kill the connection earlier than
+        // expected.
+        drop(receiver);
         join_handle.await.unwrap();
     }
 


### PR DESCRIPTION
#### Problem
`test_quic_server_multiple_connections_on_single_client_endpoint` is flaky in CI. For example, see https://buildkite.com/anza/agave/builds/31839#0199de40-d9cd-4a5d-b814-1a48e19f8d23

We rely on [this receiver](https://github.com/anza-xyz/agave/blob/master/streamer/src/nonblocking/quic.rs#L1893) being alive to keep the server alive, but we don't use the receiver so we drop it immediately.

There seems to be some timing/coalesce variance that will occasionally cause the following sequence to happen:

1. server tries to send
2. recognizes channel is disconnected because receiver dropped
3. calls cancel on the cancellation token
4. connection gets dropped

This can then lead to multiple different failure modes in this test (and maybe others) depending on exact timing:

1. We might jump up to 2 removed connections and spin forever in [this loop](https://github.com/anza-xyz/agave/blob/master/streamer/src/nonblocking/quic.rs#L1938-L1941) because we're explicitly waiting for 1 removed connection
2. We might try and [write to the connection](https://github.com/anza-xyz/agave/blob/master/streamer/src/nonblocking/quic.rs#L1944), fail, try to unwrap the error, and panic

I'm guessing #8025 is what caused this issue to start popping up

#### Summary of Changes
Explicitly drop the receiver at the end of the test to prevent dropping it earlier