### PR TITLE
Enable CompletedDataIndexesV2

### DIFF
--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -215,9 +215,9 @@ impl From<SlotMetaV2> for SlotMetaV1 {
 // pub type CompletedDataIndexes = CompletedDataIndexesV1;
 // pub type SlotMetaFallback = SlotMetaV2;
 // ```
-pub type SlotMeta = SlotMetaV1;
-pub type CompletedDataIndexes = CompletedDataIndexesV1;
-pub type SlotMetaFallback = SlotMetaV2;
+pub type SlotMeta = SlotMetaV2;
+pub type CompletedDataIndexes = CompletedDataIndexesV2;
+pub type SlotMetaFallback = SlotMetaV1;
 
 // Serde implementation of serialize and deserialize for Option<u64>
 // where None is represented as u64::MAX; for backward compatibility.


### PR DESCRIPTION
#### Problem
Follow up on #6047

`CompletedDataIndexes` is a `BTreeSet`, which is slow to deserialize. #6047 added `CompletedDataIndexesV2` and `SlotMetaV2` (which replaces the `BTreeSet` with a `BitVec`), and included support for reading `SlotMetaV2` as a fallback in the `columns::SlotMeta` deserialize implementation.

https://github.com/anza-xyz/agave/blob/faa41c9974243c41a1ddb40abdf09063fc4a44e6/ledger/src/blockstore/column.rs#L739-L762

#### Summary of Changes

#6047 was included in 2.3.0, so we can enable `SlotMetaV2` as the default. In the event of a downgrade, versions >2.3.0 can read the `SlotMetaV2` format. This enables `SlotMetaV2` as the default.
