### PR TITLE
Use read lock for accessing slot list when possible in tests

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1630,7 +1630,7 @@ mod tests {
                         &mut reclaims,
                         reclaim,
                     );
-                    let mut slot_list = entry.slot_list_write_lock().clone_list();
+                    let mut slot_list = entry.slot_list_read_lock().clone_list();
 
                     // calculate expected reclaims
                     let mut expected_reclaims = ReclaimsSlotList::new();
@@ -2008,7 +2008,7 @@ mod tests {
                         &mut reclaims,
                         reclaim,
                     );
-                    let mut slot_list = entry.slot_list_write_lock().clone_list();
+                    let mut slot_list = entry.slot_list_read_lock().clone_list();
 
                     // calculate expected reclaims
                     let mut expected_reclaims = ReclaimsSlotList::new();


### PR DESCRIPTION
#### Problem
Tests that only grab lock to read list clone are using write lock.

#### Summary of Changes
Change to read lock.
