### PR TITLE
Refactor - Move `ProgramCache::environments` to `TransactionBatchProcessor`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -488,7 +488,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
 
     // Adding `DELAY_VISIBILITY_SLOT_OFFSET` to slots to accommodate for delay visibility of the program
     let mut program_cache_for_tx_batch =
-        bank.new_program_cache_for_tx_batch_for_slot(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
+        ProgramCacheForTxBatch::new(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
     for key in cached_account_keys {
         program_cache_for_tx_batch.replenish(
             key,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -917,6 +917,13 @@ pub fn mock_process_instruction_with_feature_set<
         *loader_id,
         Arc::new(ProgramCacheEntry::new_builtin(0, 0, builtin_function)),
     );
+    program_cache_for_tx_batch.set_slot_for_tests(
+        invoke_context
+            .get_sysvar_cache()
+            .get_clock()
+            .map(|clock| clock.slot)
+            .unwrap_or(1),
+    );
     invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
     pre_adjustments(&mut invoke_context);
     invoke_context

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -9,7 +9,6 @@ use {
         sysvar_cache::SysvarCache,
     },
     solana_account::{create_account_shared_data_for_test, AccountSharedData},
-    solana_clock::Slot,
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
     solana_instruction::{error::InstructionError, AccountMeta, Instruction},
@@ -140,6 +139,8 @@ pub struct EnvironmentConfig<'a> {
     pub blockhash_lamports_per_signature: u64,
     epoch_stake_callback: &'a dyn InvokeContextCallback,
     feature_set: &'a SVMFeatureSet,
+    pub program_runtime_environments_for_execution: &'a ProgramRuntimeEnvironments,
+    pub program_runtime_environments_for_deployment: &'a ProgramRuntimeEnvironments,
     sysvar_cache: &'a SysvarCache,
 }
 impl<'a> EnvironmentConfig<'a> {
@@ -148,6 +149,8 @@ impl<'a> EnvironmentConfig<'a> {
         blockhash_lamports_per_signature: u64,
         epoch_stake_callback: &'a dyn InvokeContextCallback,
         feature_set: &'a SVMFeatureSet,
+        program_runtime_environments_for_execution: &'a ProgramRuntimeEnvironments,
+        program_runtime_environments_for_deployment: &'a ProgramRuntimeEnvironments,
         sysvar_cache: &'a SysvarCache,
     ) -> Self {
         Self {
@@ -155,6 +158,8 @@ impl<'a> EnvironmentConfig<'a> {
             blockhash_lamports_per_signature,
             epoch_stake_callback,
             feature_set,
+            program_runtime_environments_for_execution,
+            program_runtime_environments_for_deployment,
             sysvar_cache,
         }
     }
@@ -221,17 +226,6 @@ impl<'a> InvokeContext<'a> {
             syscall_context: Vec::new(),
             register_traces: Vec::new(),
         }
-    }
-
-    pub fn get_environments_for_slot(
-        &self,
-        effective_slot: Slot,
-    ) -> Result<ProgramRuntimeEnvironments, InstructionError> {
-        let epoch_schedule = self.environment_config.sysvar_cache.get_epoch_schedule()?;
-        let epoch = epoch_schedule.get_epoch(effective_slot);
-        Ok(self
-            .program_cache_for_tx_batch
-            .get_environments_for_epoch(epoch))
     }
 
     /// Push a stack frame onto the invocation stack
@@ -566,8 +560,8 @@ impl<'a> InvokeContext<'a> {
         let empty_memory_mapping =
             MemoryMapping::new(Vec::new(), &mock_config, SBPFVersion::V0).unwrap();
         let mut vm = EbpfVm::new(
-            self.program_cache_for_tx_batch
-                .environments
+            self.environment_config
+                .program_runtime_environments_for_execution
                 .program_runtime_v2
                 .clone(),
             SBPFVersion::V0,
@@ -648,6 +642,11 @@ impl<'a> InvokeContext<'a> {
     /// Get the current feature set.
     pub fn get_feature_set(&self) -> &SVMFeatureSet {
         self.environment_config.feature_set
+    }
+
+    pub fn get_program_runtime_environments_for_deployment(&self) -> &ProgramRuntimeEnvironments {
+        self.environment_config
+            .program_runtime_environments_for_deployment
     }
 
     pub fn is_stake_raise_minimum_delegation_to_1_sol_active(&self) -> bool {
@@ -782,7 +781,7 @@ macro_rules! with_mock_invoke_context_with_feature_set {
                 __private::{Hash, ReadableAccount, Rent, TransactionContext},
                 execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
                 invoke_context::{EnvironmentConfig, InvokeContext},
-                loaded_programs::ProgramCacheForTxBatch,
+                loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments},
                 sysvar_cache::SysvarCache,
             },
         };
@@ -817,11 +816,14 @@ macro_rules! with_mock_invoke_context_with_feature_set {
                 }
             }
         });
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockInvokeContextCallback {},
             $feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -730,10 +730,6 @@ impl ProgramCacheForTxBatch {
         }
     }
 
-    pub fn new_from_cache<FG: ForkGraph>(slot: Slot, _cache: &ProgramCache<FG>) -> Self {
-        Self::new(slot)
-    }
-
     /// Refill the cache with a single entry. It's typically called during transaction loading, and
     /// transaction processing (for program management instructions).
     /// It replaces the existing entry (if any) with the provided entry. The return value contains

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1696,7 +1696,6 @@ mod test_utils {
     use {
         super::*, agave_syscalls::create_program_runtime_environment_v1,
         solana_account::ReadableAccount, solana_loader_v4_interface::state::LoaderV4State,
-        solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
         solana_sdk_ids::loader_v4,
     };
 
@@ -1752,9 +1751,6 @@ mod test_utils {
                     program_runtime_environment.clone(),
                     false,
                 ) {
-                    invoke_context
-                        .program_cache_for_tx_batch
-                        .set_slot_for_tests(DELAY_VISIBILITY_SLOT_OFFSET);
                     invoke_context
                         .program_cache_for_tx_batch
                         .store_modified_entry(*pubkey, Arc::new(loaded_program));
@@ -3993,6 +3989,9 @@ mod tests {
         invoke_context
             .program_cache_for_tx_batch
             .replenish(program_id, Arc::new(program));
+        invoke_context
+            .program_cache_for_tx_batch
+            .set_slot_for_tests(2);
 
         assert_matches!(
             deploy_test_program(&mut invoke_context, program_id,),
@@ -4032,6 +4031,9 @@ mod tests {
         invoke_context
             .program_cache_for_tx_batch
             .replenish(program_id, Arc::new(program));
+        invoke_context
+            .program_cache_for_tx_batch
+            .set_slot_for_tests(2);
 
         let program_id2 = Pubkey::new_unique();
         assert_matches!(

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -195,18 +195,17 @@ pub fn deploy_program(
 #[macro_export]
 macro_rules! deploy_program {
     ($invoke_context:expr, $program_id:expr, $loader_key:expr, $account_size:expr, $programdata:expr, $deployment_slot:expr $(,)?) => {
-        let environments = $invoke_context
-            .get_environments_for_slot($deployment_slot.saturating_add(
-                solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
-            ))
-            .map_err(|_err| {
-                // This will never fail since the epoch schedule is already configured.
-                InstructionError::ProgramEnvironmentSetupFailure
-            })?;
+        assert_eq!(
+            $deployment_slot,
+            $invoke_context.program_cache_for_tx_batch.slot()
+        );
         let load_program_metrics = $crate::deploy_program(
             $invoke_context.get_log_collector(),
             $invoke_context.program_cache_for_tx_batch,
-            environments.program_runtime_v1.clone(),
+            $invoke_context
+                .get_program_runtime_environments_for_deployment()
+                .program_runtime_v1
+                .clone(),
             $program_id,
             $loader_key,
             $account_size,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4091,8 +4091,8 @@ impl Bank {
             self.create_program_runtime_environments(&self.feature_set);
         self.transaction_processor
             .configure_program_runtime_environments(
-                Some(program_runtime_environment_v1),
-                Some(program_runtime_environment_v2),
+                program_runtime_environment_v1,
+                program_runtime_environment_v2,
             );
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -188,7 +188,7 @@ use {
     },
     solana_nonce as nonce,
     solana_nonce_account::{get_system_account_kind, SystemAccountKind},
-    solana_program_runtime::{loaded_programs::ProgramCacheForTxBatch, sysvar_cache::SysvarCache},
+    solana_program_runtime::sysvar_cache::SysvarCache,
 };
 pub use {partitioned_epoch_rewards::KeyedRewardsAndNumPartitions, solana_reward_info::RewardType};
 
@@ -5917,17 +5917,6 @@ impl Bank {
             .accounts
             .accounts_db
             .calculate_accounts_lt_hash_at_startup_from_index(&self.ancestors, self.slot)
-    }
-
-    pub fn new_program_cache_for_tx_batch_for_slot(&self, slot: Slot) -> ProgramCacheForTxBatch {
-        ProgramCacheForTxBatch::new_from_cache(
-            slot,
-            &self
-                .transaction_processor
-                .global_program_cache
-                .read()
-                .unwrap(),
-        )
     }
 
     pub fn get_transaction_processor(&self) -> &TransactionBatchProcessor<BankForks> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3257,11 +3257,23 @@ impl Bank {
 
         let (blockhash, blockhash_lamports_per_signature) =
             self.last_blockhash_and_lamports_per_signature();
+        let effective_epoch_of_deployments =
+            self.epoch_schedule().get_epoch(self.slot.saturating_add(
+                solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
+            ));
         let processing_environment = TransactionProcessingEnvironment {
             blockhash,
             blockhash_lamports_per_signature,
             epoch_total_stake: self.get_current_epoch_total_stake(),
             feature_set: self.feature_set.runtime_features(),
+            program_runtime_environments_for_execution: self
+                .transaction_processor
+                .get_environments_for_epoch(self.epoch)
+                .unwrap(),
+            program_runtime_environments_for_deployment: self
+                .transaction_processor
+                .get_environments_for_epoch(effective_epoch_of_deployments)
+                .unwrap(),
             rent: self.rent_collector.rent.clone(),
         };
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5922,10 +5922,6 @@ impl Bank {
     pub fn new_program_cache_for_tx_batch_for_slot(&self, slot: Slot) -> ProgramCacheForTxBatch {
         ProgramCacheForTxBatch::new_from_cache(
             slot,
-            self.epoch_schedule.get_epoch(slot),
-            self.transaction_processor
-                .epoch_boundary_preparation
-                .clone(),
             &self
                 .transaction_processor
                 .global_program_cache

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -134,14 +134,7 @@ impl Bank {
         let elf = &programdata[progradata_metadata_size..];
         // Set up the two `LoadedProgramsForTxBatch` instances, as if
         // processing a new transaction batch.
-        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
-            self.slot,
-            &self
-                .transaction_processor
-                .global_program_cache
-                .read()
-                .unwrap(),
-        );
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(self.slot);
         let program_runtime_environments = self
             .transaction_processor
             .get_environments_for_epoch(self.epoch)

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -136,10 +136,6 @@ impl Bank {
         // processing a new transaction batch.
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
             self.slot,
-            self.epoch,
-            self.transaction_processor
-                .epoch_boundary_preparation
-                .clone(),
             &self
                 .transaction_processor
                 .global_program_cache

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -146,6 +146,10 @@ impl Bank {
                 .read()
                 .unwrap(),
         );
+        let program_runtime_environments = self
+            .transaction_processor
+            .get_environments_for_epoch(self.epoch)
+            .unwrap();
 
         // Configure a dummy `InvokeContext` from the runtime's current
         // environment, as well as the two `ProgramCacheForTxBatch`
@@ -181,6 +185,8 @@ impl Bank {
                     0,
                     &MockCallback {},
                     &feature_set,
+                    &program_runtime_environments,
+                    &program_runtime_environments,
                     &sysvar_cache,
                 ),
                 None,
@@ -188,19 +194,10 @@ impl Bank {
                 compute_budget.to_cost(),
             );
 
-            let environments = dummy_invoke_context
-                .get_environments_for_slot(self.slot.saturating_add(
-                    solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
-                ))
-                .map_err(|_err| {
-                    // This will never fail since the epoch schedule is already configured.
-                    InstructionError::ProgramEnvironmentSetupFailure
-                })?;
-
             let load_program_metrics = solana_bpf_loader_program::deploy_program(
                 dummy_invoke_context.get_log_collector(),
                 dummy_invoke_context.program_cache_for_tx_batch,
-                environments.program_runtime_v1.clone(),
+                program_runtime_environments.program_runtime_v1.clone(),
                 program_id,
                 &bpf_loader_upgradeable::id(),
                 data_len,

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -137,8 +137,7 @@ impl Bank {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(self.slot);
         let program_runtime_environments = self
             .transaction_processor
-            .get_environments_for_epoch(self.epoch)
-            .unwrap();
+            .get_environments_for_epoch(self.epoch);
 
         // Configure a dummy `InvokeContext` from the runtime's current
         // environment, as well as the two `ProgramCacheForTxBatch`
@@ -202,7 +201,10 @@ impl Bank {
             .global_program_cache
             .write()
             .unwrap()
-            .merge(&program_cache_for_tx_batch.drain_modified_entries());
+            .merge(
+                &self.transaction_processor.environments,
+                &program_cache_for_tx_batch.drain_modified_entries(),
+            );
 
         Ok(())
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10947,17 +10947,11 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase(
     let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 16);
     let current_env = bank
         .transaction_processor
-        .global_program_cache
-        .read()
-        .unwrap()
-        .get_environments_for_epoch(&bank.transaction_processor.epoch_boundary_preparation, 0)
+        .get_environments_for_epoch(0)
         .program_runtime_v1;
     let upcoming_env = bank
         .transaction_processor
-        .global_program_cache
-        .read()
-        .unwrap()
-        .get_environments_for_epoch(&bank.transaction_processor.epoch_boundary_preparation, 1)
+        .get_environments_for_epoch(1)
         .program_runtime_v1;
 
     // Advance the bank to recompile the program.

--- a/svm-test-harness/src/program_cache.rs
+++ b/svm-test-harness/src/program_cache.rs
@@ -2,12 +2,8 @@ use {
     agave_feature_set::{
         enable_loader_v4, zk_elgamal_proof_program_enabled, zk_token_sdk_enabled, FeatureSet,
     },
-    agave_syscalls::create_program_runtime_environment_v1,
     solana_builtins::BUILTINS,
-    solana_compute_budget::compute_budget::ComputeBudget,
-    solana_program_runtime::loaded_programs::{
-        ProgramCacheEntry, ProgramCacheForTxBatch, ProgramRuntimeEnvironments,
-    },
+    solana_program_runtime::loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
     solana_pubkey::Pubkey,
     std::sync::Arc,
 };
@@ -20,28 +16,9 @@ const MIGRATED_BUILTINS: &[Pubkey] = &[
     solana_sdk_ids::stake::id(),
 ];
 
-pub fn setup_program_cache(
-    feature_set: &FeatureSet,
-    compute_budget: &ComputeBudget,
-    slot: u64,
-) -> ProgramCacheForTxBatch {
+pub fn setup_program_cache(feature_set: &FeatureSet, slot: u64) -> ProgramCacheForTxBatch {
     let mut cache = ProgramCacheForTxBatch::default();
-
-    let environments = ProgramRuntimeEnvironments {
-        program_runtime_v1: Arc::new(
-            create_program_runtime_environment_v1(
-                &feature_set.runtime_features(),
-                &compute_budget.to_budget(),
-                false, /* deployment */
-                false, /* debugging_features */
-            )
-            .unwrap(),
-        ),
-        ..ProgramRuntimeEnvironments::default()
-    };
-
     cache.set_slot_for_tests(slot);
-    cache.environments = environments.clone();
 
     for builtin in BUILTINS {
         // Skip migrated builtins.

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -95,7 +95,9 @@ mod tests {
             declare_process_instruction,
             execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
             invoke_context::EnvironmentConfig,
-            loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
+            loaded_programs::{
+                ProgramCacheEntry, ProgramCacheForTxBatch, ProgramRuntimeEnvironments,
+            },
             sysvar_cache::SysvarCache,
         },
         solana_pubkey::Pubkey,
@@ -219,11 +221,14 @@ mod tests {
         ));
         let sysvar_cache = SysvarCache::default();
         let feature_set = SVMFeatureSet::all_enabled();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -273,11 +278,14 @@ mod tests {
                 ),
             ]),
         ));
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -317,11 +325,14 @@ mod tests {
                 ),
             ]),
         ));
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -450,11 +461,14 @@ mod tests {
         ));
         let sysvar_cache = SysvarCache::default();
         let feature_set = SVMFeatureSet::all_enabled();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -489,11 +503,14 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -525,11 +542,14 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -673,11 +693,14 @@ mod tests {
             }
         }
         let feature_set = SVMFeatureSet::all_enabled();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -511,7 +511,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(50).unwrap(),
+            &batch_processor.get_environments_for_epoch(50),
             &key,
             500,
             &mut ExecuteTimings::default(),
@@ -534,7 +534,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20).unwrap(),
+            &batch_processor.get_environments_for_epoch(20),
             &key,
             0, // Slot 0
             &mut ExecuteTimings::default(),
@@ -547,7 +547,6 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
                     .get_environments_for_epoch(20)
-                    .unwrap()
                     .program_runtime_v1,
             ),
         );
@@ -569,7 +568,7 @@ mod tests {
         // This should return an error
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20).unwrap(),
+            &batch_processor.get_environments_for_epoch(20),
             &key,
             200,
             &mut ExecuteTimings::default(),
@@ -581,7 +580,6 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
                     .get_environments_for_epoch(20)
-                    .unwrap()
                     .program_runtime_v1,
             ),
         );
@@ -597,7 +595,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20).unwrap(),
+            &batch_processor.get_environments_for_epoch(20),
             &key,
             200,
             &mut ExecuteTimings::default(),
@@ -651,7 +649,7 @@ mod tests {
         // This should return an error
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(0).unwrap(),
+            &batch_processor.get_environments_for_epoch(0),
             &key1,
             0,
             &mut ExecuteTimings::default(),
@@ -663,7 +661,6 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
                     .get_environments_for_epoch(0)
-                    .unwrap()
                     .program_runtime_v1,
             ),
         );
@@ -689,7 +686,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20).unwrap(),
+            &batch_processor.get_environments_for_epoch(20),
             &key1,
             200,
             &mut ExecuteTimings::default(),
@@ -739,7 +736,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(0).unwrap(),
+            &batch_processor.get_environments_for_epoch(0),
             &key,
             0,
             &mut ExecuteTimings::default(),
@@ -751,7 +748,6 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
                     .get_environments_for_epoch(0)
-                    .unwrap()
                     .program_runtime_v1,
             ),
         );
@@ -773,7 +769,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20).unwrap(),
+            &batch_processor.get_environments_for_epoch(20),
             &key,
             200,
             &mut ExecuteTimings::default(),
@@ -807,17 +803,13 @@ mod tests {
         let mut account_data = AccountSharedData::default();
         account_data.set_owner(bpf_loader::id());
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-
         let upcoming_environments = ProgramRuntimeEnvironments::default();
-        let current_environments = {
-            let global_program_cache = batch_processor.global_program_cache.read().unwrap();
-            batch_processor
-                .epoch_boundary_preparation
-                .write()
-                .unwrap()
-                .upcoming_environments = Some(upcoming_environments.clone());
-            global_program_cache.environments.clone()
-        };
+        let current_environments = batch_processor.environments.clone();
+        batch_processor
+            .epoch_boundary_preparation
+            .write()
+            .unwrap()
+            .upcoming_environments = Some(upcoming_environments.clone());
         mock_bank
             .account_shared_data
             .borrow_mut()
@@ -826,9 +818,7 @@ mod tests {
         for is_upcoming_env in [false, true] {
             let result = load_program_with_pubkey(
                 &mock_bank,
-                &batch_processor
-                    .get_environments_for_epoch(is_upcoming_env as u64)
-                    .unwrap(),
+                &batch_processor.get_environments_for_epoch(is_upcoming_env as u64),
                 &key,
                 200,
                 &mut ExecuteTimings::default(),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "dev-context-only-utils")]
-use qualifier_attr::{field_qualifiers, qualifiers};
 use {
     crate::{
         account_loader::{
@@ -40,7 +38,6 @@ use {
             ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
             ProgramRuntimeEnvironments,
         },
-        solana_sbpf::{program::BuiltinProgram, vm::Config as VmConfig},
         sysvar_cache::SysvarCache,
     },
     solana_pubkey::Pubkey,
@@ -59,8 +56,13 @@ use {
         collections::HashSet,
         fmt::{Debug, Formatter},
         rc::Rc,
-        sync::Weak,
     },
+};
+#[cfg(feature = "dev-context-only-utils")]
+use {
+    qualifier_attr::{field_qualifiers, qualifiers},
+    solana_program_runtime::solana_sbpf::{program::BuiltinProgram, vm::Config as VmConfig},
+    std::sync::Weak,
 };
 
 /// A list of log messages emitted during a transaction
@@ -233,6 +235,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     ///
     /// The cache will still not contain any builtin programs. It's advisable to
     /// call `add_builtin` to add the required builtins before using the processor.
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn new(
         slot: Slot,
         epoch: Epoch,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -38,6 +38,7 @@ use {
         loaded_programs::{
             EpochBoundaryPreparation, ForkGraph, ProgramCache, ProgramCacheEntry,
             ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
+            ProgramRuntimeEnvironments,
         },
         solana_sbpf::{program::BuiltinProgram, vm::Config as VmConfig},
         sysvar_cache::SysvarCache,
@@ -135,6 +136,11 @@ pub struct TransactionProcessingEnvironment {
     pub epoch_total_stake: u64,
     /// Runtime feature set to use for the transaction batch.
     pub feature_set: SVMFeatureSet,
+    /// The current ProgramRuntimeEnvironments derived from the SVMFeatureSet.
+    pub program_runtime_environments_for_execution: ProgramRuntimeEnvironments,
+    /// Depending on the next slot this is either the current or the upcoming
+    /// ProgramRuntimeEnvironments.
+    pub program_runtime_environments_for_deployment: ProgramRuntimeEnvironments,
     /// Rent calculator to use for the transaction batch.
     pub rent: Rent,
 }
@@ -302,11 +308,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
     /// Returns the current environments depending on the given epoch
     /// Returns None if the call could result in a deadlock
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn get_environments_for_epoch(
-        &self,
-        epoch: Epoch,
-    ) -> Option<solana_program_runtime::loaded_programs::ProgramRuntimeEnvironments> {
+    pub fn get_environments_for_epoch(&self, epoch: Epoch) -> Option<ProgramRuntimeEnvironments> {
         self.global_program_cache
             .try_read()
             .ok()

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -895,6 +895,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 environment.blockhash_lamports_per_signature,
                 callback,
                 &environment.feature_set,
+                &environment.program_runtime_environments_for_execution,
+                &environment.program_runtime_environments_for_deployment,
                 sysvar_cache,
             ),
             log_collector.clone(),

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -68,9 +68,8 @@ fn program_cache_execution(threads: usize) {
                     0,
                 );
                 let mut result = ProgramCacheForTxBatch::new(processor.slot);
-                let program_runtime_environments_for_execution = processor
-                    .get_environments_for_epoch(processor.epoch)
-                    .unwrap();
+                let program_runtime_environments_for_execution =
+                    processor.get_environments_for_epoch(processor.epoch);
                 processor.replenish_program_cache(
                     &account_loader,
                     &maps,

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -67,10 +67,7 @@ fn program_cache_execution(threads: usize) {
                     &feature_set,
                     0,
                 );
-                let mut result = {
-                    let global_program_cache = processor.global_program_cache.read().unwrap();
-                    ProgramCacheForTxBatch::new_from_cache(processor.slot, &global_program_cache)
-                };
+                let mut result = ProgramCacheForTxBatch::new(processor.slot);
                 let program_runtime_environments_for_execution = processor
                     .get_environments_for_epoch(processor.epoch)
                     .unwrap();

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -69,16 +69,15 @@ fn program_cache_execution(threads: usize) {
                 );
                 let mut result = {
                     let global_program_cache = processor.global_program_cache.read().unwrap();
-                    ProgramCacheForTxBatch::new_from_cache(
-                        processor.slot,
-                        processor.epoch,
-                        processor.epoch_boundary_preparation.clone(),
-                        &global_program_cache,
-                    )
+                    ProgramCacheForTxBatch::new_from_cache(processor.slot, &global_program_cache)
                 };
+                let program_runtime_environments_for_execution = processor
+                    .get_environments_for_epoch(processor.epoch)
+                    .unwrap();
                 processor.replenish_program_cache(
                     &account_loader,
                     &maps,
+                    &program_runtime_environments_for_execution,
                     &mut result,
                     &mut ExecuteTimings::default(),
                     false,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -158,6 +158,12 @@ impl SvmTestEnvironment<'_> {
             blockhash: LAST_BLOCKHASH,
             feature_set: test_entry.feature_set,
             blockhash_lamports_per_signature: LAMPORTS_PER_SIGNATURE,
+            program_runtime_environments_for_execution: batch_processor
+                .get_environments_for_epoch(EXECUTION_EPOCH)
+                .unwrap(),
+            program_runtime_environments_for_deployment: batch_processor
+                .get_environments_for_epoch(EXECUTION_EPOCH)
+                .unwrap(),
             ..TransactionProcessingEnvironment::default()
         };
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -159,11 +159,9 @@ impl SvmTestEnvironment<'_> {
             feature_set: test_entry.feature_set,
             blockhash_lamports_per_signature: LAMPORTS_PER_SIGNATURE,
             program_runtime_environments_for_execution: batch_processor
-                .get_environments_for_epoch(EXECUTION_EPOCH)
-                .unwrap(),
+                .get_environments_for_epoch(EXECUTION_EPOCH),
             program_runtime_environments_for_deployment: batch_processor
-                .get_environments_for_epoch(EXECUTION_EPOCH)
-                .unwrap(),
+                .get_environments_for_epoch(EXECUTION_EPOCH),
             ..TransactionProcessingEnvironment::default()
         };
 
@@ -312,7 +310,7 @@ impl SvmTestEnvironment<'_> {
                         .global_program_cache
                         .write()
                         .unwrap()
-                        .merge(programs_modified_by_tx);
+                        .merge(&self.batch_processor.environments, programs_modified_by_tx);
                 }
             }
         }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -4734,11 +4734,14 @@ mod tests {
 
         with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
         let feature_set = SVMFeatureSet::default();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
 
@@ -4796,11 +4799,14 @@ mod tests {
 
         with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
         let feature_set = SVMFeatureSet::default();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
 


### PR DESCRIPTION
#### Problem

`ProgramCache::environments` should not be global but individual per `TransactionBatchProcessor`.

#### Summary of Changes

- Removes `ProgramCache::get_environments_for_epoch()`.
- Moves `ProgramCache::environments` to `TransactionBatchProcessor`.
- Removes `TransactionBatchProcessor::configure_program_runtime_environments_inner()`.
- Removes the `Option<>` around parameters of `TransactionBatchProcessor::configure_program_runtime_environments()`.
- Marks `TransactionBatchProcessor::new()` as `dev-context-only-utils`.