### PR TITLE
set root infallible

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -587,7 +587,7 @@ mod tests {
             .root_slot
             .unwrap();
         for x in 0..root {
-            bank_forks.write().unwrap().set_root(x, None, None).unwrap();
+            bank_forks.write().unwrap().set_root(x, None, None);
         }
 
         // Add an additional bank/vote that will root slot 2
@@ -630,8 +630,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(root, None, Some(highest_super_majority_root))
-            .unwrap();
+            .set_root(root, None, Some(highest_super_majority_root));
         let highest_super_majority_root_bank =
             bank_forks.read().unwrap().get(highest_super_majority_root);
         assert!(highest_super_majority_root_bank.is_some());
@@ -714,8 +713,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(root, None, Some(highest_super_majority_root))
-            .unwrap();
+            .set_root(root, None, Some(highest_super_majority_root));
         let highest_super_majority_root_bank =
             bank_forks.read().unwrap().get(highest_super_majority_root);
         assert!(highest_super_majority_root_bank.is_some());

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -1914,7 +1914,7 @@ mod test {
         {
             let mut w_bank_forks = bank_forks.write().unwrap();
             w_bank_forks.insert(new_root_bank);
-            w_bank_forks.set_root(new_root_slot, None, None).unwrap();
+            w_bank_forks.set_root(new_root_slot, None, None);
         }
         popular_pruned_slot_pool.insert(dead_duplicate_confirmed_slot);
         assert!(!dead_slot_pool.is_empty());

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2412,9 +2412,7 @@ fn maybe_warp_slot(
             &Pubkey::default(),
             warp_slot,
         ));
-        bank_forks
-            .set_root(warp_slot, Some(snapshot_controller), Some(warp_slot))
-            .map_err(|err| err.to_string())?;
+        bank_forks.set_root(warp_slot, Some(snapshot_controller), Some(warp_slot));
         leader_schedule_cache.set_root(&bank_forks.root_bank());
 
         let full_snapshot_archive_info = match snapshot_bank_utils::bank_to_full_snapshot_archive(

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -248,7 +248,6 @@ impl VoteSimulator {
             &drop_bank_sender,
             &mut self.tbft_structs,
         )
-        .unwrap()
     }
 
     pub fn create_and_vote_new_branch(

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -200,8 +200,7 @@ where
             bank_forks
                 .write()
                 .unwrap()
-                .set_root(bank.slot(), Some(&snapshot_controller), None)
-                .unwrap();
+                .set_root(bank.slot(), Some(&snapshot_controller), None);
             snapshot_request_handler.handle_snapshot_requests(0);
         }
     }
@@ -296,11 +295,11 @@ fn test_slots_to_snapshot() {
                 .read()
                 .unwrap()
                 .prune_program_cache(current_bank.slot());
-            bank_forks
-                .write()
-                .unwrap()
-                .set_root(current_bank.slot(), Some(&snapshot_controller), None)
-                .unwrap();
+            bank_forks.write().unwrap().set_root(
+                current_bank.slot(),
+                Some(&snapshot_controller),
+                None,
+            );
         }
 
         let num_old_slots = num_set_roots * *add_root_interval - MAX_CACHE_ENTRIES + 1;
@@ -440,8 +439,7 @@ fn test_bank_forks_incremental_snapshot() {
             bank_forks
                 .write()
                 .unwrap()
-                .set_root(bank.slot(), Some(&snapshot_controller), None)
-                .unwrap();
+                .set_root(bank.slot(), Some(&snapshot_controller), None);
             snapshot_request_handler.handle_snapshot_requests(0);
         }
 
@@ -678,8 +676,7 @@ fn test_snapshots_with_background_services() {
             bank_forks
                 .write()
                 .unwrap()
-                .set_root(slot, Some(&snapshot_controller), None)
-                .unwrap();
+                .set_root(slot, Some(&snapshot_controller), None);
         }
 
         // If a snapshot should be taken this slot, wait for it to complete

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -176,8 +176,7 @@ fn test_scheduler_waited_by_drop_bank_service() {
             &mut Vec::new(),
             &drop_bank_sender1,
             &mut tbft_structs,
-        )
-        .unwrap();
+        );
     }
 
     // Receive pruned banks from the above handle_new_root

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -304,9 +304,9 @@ mod tests {
             let mut bank_forks = bank_forks_arc.write().unwrap();
             let bank0 = bank_forks.get(0).unwrap();
             bank_forks.insert(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 9));
-            bank_forks.set_root(9, None, None).unwrap();
+            bank_forks.set_root(9, None, None);
         }
-        blockstore.set_roots([0, 9].iter()).unwrap();
+        assert!(blockstore.set_roots([0, 9].iter()).is_ok());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(
             &bank_forks_arc.read().unwrap().working_bank(),
         ));
@@ -396,7 +396,7 @@ mod tests {
             let mut bank_forks = bank_forks_arc.write().unwrap();
             let bank0 = bank_forks.get(0).unwrap();
             bank_forks.insert(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 9));
-            bank_forks.set_root(9, None, None).unwrap();
+            bank_forks.set_root(9, None, None);
         }
         blockstore.set_roots([0, 9].iter()).unwrap();
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(

--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -173,11 +173,7 @@ mod tests {
             &root_bank,
         );
         // root is updated but epoch still the same.
-        bank_forks
-            .write()
-            .unwrap()
-            .set_root(17, None, None)
-            .unwrap();
+        bank_forks.write().unwrap().set_root(17, None, None);
         let root_bank = bank_forks.read().unwrap().get(17).unwrap();
         verify_epoch_specs(
             &mut epoch_specs,
@@ -186,11 +182,7 @@ mod tests {
             &root_bank,
         );
         // root is updated but epoch still the same.
-        bank_forks
-            .write()
-            .unwrap()
-            .set_root(19, None, None)
-            .unwrap();
+        bank_forks.write().unwrap().set_root(19, None, None);
         let root_bank = bank_forks.read().unwrap().get(19).unwrap();
         verify_epoch_specs(
             &mut epoch_specs,
@@ -199,11 +191,7 @@ mod tests {
             &root_bank,
         );
         // root is updated to a new epoch.
-        bank_forks
-            .write()
-            .unwrap()
-            .set_root(37, None, None)
-            .unwrap();
+        bank_forks.write().unwrap().set_root(37, None, None);
         let root_bank = bank_forks.read().unwrap().get(37).unwrap();
         verify_epoch_specs(
             &mut epoch_specs,
@@ -212,11 +200,7 @@ mod tests {
             &root_bank,
         );
         // root is updated but epoch still the same.
-        bank_forks
-            .write()
-            .unwrap()
-            .set_root(59, None, None)
-            .unwrap();
+        bank_forks.write().unwrap().set_root(59, None, None);
         let root_bank = bank_forks.read().unwrap().get(59).unwrap();
         verify_epoch_specs(
             &mut epoch_specs,
@@ -225,11 +209,7 @@ mod tests {
             &root_bank,
         );
         // root is updated to a new epoch.
-        bank_forks
-            .write()
-            .unwrap()
-            .set_root(97, None, None)
-            .unwrap();
+        bank_forks.write().unwrap().set_root(97, None, None);
         let root_bank = bank_forks.read().unwrap().get(97).unwrap();
         verify_epoch_specs(
             &mut epoch_specs,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -30,7 +30,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank::{Bank, PreCommitResult, TransactionBalancesSet},
-        bank_forks::{BankForks, SetRootError},
+        bank_forks::BankForks,
         bank_utils,
         commitment::VOTE_THRESHOLD_SIZE,
         dependency_tracker::DependencyTracker,
@@ -817,9 +817,6 @@ pub enum BlockstoreProcessorError {
 
     #[error("root bank with mismatched capitalization at {0}")]
     RootBankWithMismatchedCapitalization(Slot),
-
-    #[error("set root error {0}")]
-    SetRootError(#[from] SetRootError),
 
     #[error("incomplete final fec set")]
     IncompleteFinalFecSet,
@@ -2074,7 +2071,7 @@ fn load_frozen_forks(
                 let _ = bank_forks
                     .write()
                     .unwrap()
-                    .set_root(root, snapshot_controller, None)?;
+                    .set_root(root, snapshot_controller, None);
                 m.stop();
                 set_root_us += m.as_us();
 
@@ -4284,7 +4281,7 @@ pub mod tests {
             &mut ExecuteTimings::default(),
         )
         .unwrap();
-        bank_forks.write().unwrap().set_root(1, None, None).unwrap();
+        bank_forks.write().unwrap().set_root(1, None, None);
 
         let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank1);
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1162,13 +1162,11 @@ impl ProgramTestContext {
                 .clone_without_scheduler()
         };
 
-        bank_forks
-            .set_root(
-                pre_warp_slot,
-                None, // snapshots are disabled
-                Some(pre_warp_slot),
-            )
-            .unwrap();
+        bank_forks.set_root(
+            pre_warp_slot,
+            None, // snapshots are disabled
+            Some(pre_warp_slot),
+        );
 
         // warp_bank is frozen so go forward to get unfrozen bank at warp_slot
         bank_forks.insert(Bank::new_from_parent(
@@ -1209,13 +1207,11 @@ impl ProgramTestContext {
         bank.fill_bank_with_ticks_for_tests();
         let pre_warp_slot = bank.slot();
 
-        bank_forks
-            .set_root(
-                pre_warp_slot,
-                None, // snapshot_controller
-                Some(pre_warp_slot),
-            )
-            .unwrap();
+        bank_forks.set_root(
+            pre_warp_slot,
+            None, // snapshot_controller
+            Some(pre_warp_slot),
+        );
 
         // warp_bank is frozen so go forward to get unfrozen bank at warp_slot
         let warp_slot = pre_warp_slot + 1;

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -641,7 +641,7 @@ mod tests {
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
         let bank7 = Bank::new_from_parent(bank5, &Pubkey::default(), 7);
         bank_forks.write().unwrap().insert(bank7);
-        bank_forks.write().unwrap().set_root(7, None, None).unwrap();
+        bank_forks.write().unwrap().set_root(7, None, None);
         OptimisticallyConfirmedBankTracker::process_notification(
             (
                 BankNotification::OptimisticallyConfirmed(6),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5008,8 +5008,7 @@ pub mod tests {
                 self.bank_forks
                     .write()
                     .unwrap()
-                    .set_root(*root, None, Some(0))
-                    .unwrap();
+                    .set_root(*root, None, Some(0));
                 let block_time = self
                     .bank_forks
                     .read()

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -4,7 +4,6 @@ use {
             SnapshotRequest, SnapshotRequestKind, SnapshotRequestSender,
         },
         bank::{Bank, SquashTiming},
-        bank_forks::SetRootError,
         snapshot_config::SnapshotConfig,
     },
     agave_snapshots::SnapshotInterval,
@@ -60,11 +59,7 @@ impl SnapshotController {
         self.latest_abs_request_slot.store(slot, Ordering::Relaxed);
     }
 
-    pub fn handle_new_roots(
-        &self,
-        root: Slot,
-        banks: &[&Arc<Bank>],
-    ) -> Result<(bool, SquashTiming, u64), SetRootError> {
+    pub fn handle_new_roots(&self, root: Slot, banks: &[&Arc<Bank>]) -> (bool, SquashTiming, u64) {
         let mut is_root_bank_squashed = false;
         let mut squash_timing = SquashTiming::default();
         let mut total_snapshot_ms = 0;
@@ -123,7 +118,7 @@ impl SnapshotController {
             }
         }
 
-        Ok((is_root_bank_squashed, squash_timing, total_snapshot_ms))
+        (is_root_bank_squashed, squash_timing, total_snapshot_ms)
     }
 
     /// Returns the intervals, in slots, for sending snapshot requests

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -13,7 +13,6 @@ use {
     parking_lot::RwLock,
     solana_clock::Slot,
     solana_pubkey::Pubkey,
-    solana_runtime::bank_forks::SetRootError,
     solana_votor_messages::consensus_message::Block,
     std::{
         collections::{BTreeMap, BTreeSet},
@@ -51,9 +50,6 @@ enum EventLoopError {
 
     #[error("Error generating and inserting vote")]
     VotingError(#[from] VoteError),
-
-    #[error("Unable to set root")]
-    SetRootError(#[from] SetRootError),
 
     #[error("Set identity error")]
     SetIdentityError(#[from] VoteHistoryError),

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -9,8 +9,7 @@ use {
         rpc_subscriptions::RpcSubscriptions,
     },
     solana_runtime::{
-        bank_forks::{BankForks, SetRootError},
-        installed_scheduler_pool::BankWithScheduler,
+        bank_forks::BankForks, installed_scheduler_pool::BankWithScheduler,
         snapshot_controller::SnapshotController,
     },
     std::sync::{Arc, RwLock},
@@ -50,8 +49,7 @@ pub fn check_and_handle_new_root<CB>(
     rpc_subscriptions: Option<&RpcSubscriptions>,
     my_pubkey: &Pubkey,
     callback: CB,
-) -> Result<(), SetRootError>
-where
+) where
     CB: FnOnce(&BankForks),
 {
     // get the root bank before squash
@@ -89,7 +87,7 @@ where
         highest_super_majority_root,
         drop_bank_sender,
         callback,
-    )?;
+    );
     blockstore.slots_stats.mark_rooted(new_root);
     if let Some(rpc_subscriptions) = rpc_subscriptions {
         rpc_subscriptions.notify_roots(rooted_slots);
@@ -116,7 +114,6 @@ where
         }
     }
     info!("{my_pubkey}: new root {new_root}");
-    Ok(())
 }
 
 /// Sets the bank forks root:
@@ -130,8 +127,7 @@ pub fn set_bank_forks_root<CB>(
     highest_super_majority_root: Option<Slot>,
     drop_bank_sender: &Sender<Vec<BankWithScheduler>>,
     callback: CB,
-) -> Result<(), SetRootError>
-where
+) where
     CB: FnOnce(&BankForks),
 {
     bank_forks.read().unwrap().prune_program_cache(new_root);
@@ -139,7 +135,7 @@ where
         new_root,
         snapshot_controller,
         highest_super_majority_root,
-    )?;
+    );
 
     drop_bank_sender
         .send(removed_banks)
@@ -147,5 +143,4 @@ where
 
     let r_bank_forks = bank_forks.read().unwrap();
     callback(&r_bank_forks);
-    Ok(())
 }

--- a/wen-restart/src/last_voted_fork_slots_aggregate.rs
+++ b/wen-restart/src/last_voted_fork_slots_aggregate.rs
@@ -286,7 +286,7 @@ mod tests {
         let bank0 = bank_forks.read().unwrap().root_bank();
         let bank1 = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        assert!(bank_forks.write().unwrap().set_root(1, None, None).is_ok());
+        bank_forks.write().unwrap().set_root(1, None, None);
         let root_bank = bank_forks.read().unwrap().root_bank();
         let root_slot = root_bank.slot();
         let last_voted_fork_slots = vec![


### PR DESCRIPTION
#### Problem
We've been passing Result through a big nest of set/check root calls but it seems like we don't need to do this at all anymore.

#### Summary of Changes

- Don't return Result for all the various "set root" related functions
- Remove a bunch of `.unwrap()` calls from tests