### PR TITLE
Refactor - `ProgramRuntimeEnvironments` in `EnvironmentConfig`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -488,7 +488,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
 
     // Adding `DELAY_VISIBILITY_SLOT_OFFSET` to slots to accommodate for delay visibility of the program
     let mut program_cache_for_tx_batch =
-        bank.new_program_cache_for_tx_batch_for_slot(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
+        ProgramCacheForTxBatch::new(bank.slot() + DELAY_VISIBILITY_SLOT_OFFSET);
     for key in cached_account_keys {
         program_cache_for_tx_batch.replenish(
             key,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -226,7 +226,7 @@ impl<'a> InvokeContext<'a> {
     pub fn get_environments_for_slot(
         &self,
         effective_slot: Slot,
-    ) -> Result<&ProgramRuntimeEnvironments, InstructionError> {
+    ) -> Result<ProgramRuntimeEnvironments, InstructionError> {
         let epoch_schedule = self.environment_config.sysvar_cache.get_epoch_schedule()?;
         let epoch = epoch_schedule.get_epoch(effective_slot);
         Ok(self

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -917,6 +917,13 @@ pub fn mock_process_instruction_with_feature_set<
         *loader_id,
         Arc::new(ProgramCacheEntry::new_builtin(0, 0, builtin_function)),
     );
+    program_cache_for_tx_batch.set_slot_for_tests(
+        invoke_context
+            .get_sysvar_cache()
+            .get_clock()
+            .map(|clock| clock.slot)
+            .unwrap_or(1),
+    );
     invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
     pre_adjustments(&mut invoke_context);
     invoke_context

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -9,7 +9,6 @@ use {
         sysvar_cache::SysvarCache,
     },
     solana_account::{create_account_shared_data_for_test, AccountSharedData},
-    solana_clock::Slot,
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
     solana_instruction::{error::InstructionError, AccountMeta, Instruction},
@@ -140,6 +139,8 @@ pub struct EnvironmentConfig<'a> {
     pub blockhash_lamports_per_signature: u64,
     epoch_stake_callback: &'a dyn InvokeContextCallback,
     feature_set: &'a SVMFeatureSet,
+    pub program_runtime_environments_for_execution: &'a ProgramRuntimeEnvironments,
+    pub program_runtime_environments_for_deployment: &'a ProgramRuntimeEnvironments,
     sysvar_cache: &'a SysvarCache,
 }
 impl<'a> EnvironmentConfig<'a> {
@@ -148,6 +149,8 @@ impl<'a> EnvironmentConfig<'a> {
         blockhash_lamports_per_signature: u64,
         epoch_stake_callback: &'a dyn InvokeContextCallback,
         feature_set: &'a SVMFeatureSet,
+        program_runtime_environments_for_execution: &'a ProgramRuntimeEnvironments,
+        program_runtime_environments_for_deployment: &'a ProgramRuntimeEnvironments,
         sysvar_cache: &'a SysvarCache,
     ) -> Self {
         Self {
@@ -155,6 +158,8 @@ impl<'a> EnvironmentConfig<'a> {
             blockhash_lamports_per_signature,
             epoch_stake_callback,
             feature_set,
+            program_runtime_environments_for_execution,
+            program_runtime_environments_for_deployment,
             sysvar_cache,
         }
     }
@@ -221,17 +226,6 @@ impl<'a> InvokeContext<'a> {
             syscall_context: Vec::new(),
             register_traces: Vec::new(),
         }
-    }
-
-    pub fn get_environments_for_slot(
-        &self,
-        effective_slot: Slot,
-    ) -> Result<ProgramRuntimeEnvironments, InstructionError> {
-        let epoch_schedule = self.environment_config.sysvar_cache.get_epoch_schedule()?;
-        let epoch = epoch_schedule.get_epoch(effective_slot);
-        Ok(self
-            .program_cache_for_tx_batch
-            .get_environments_for_epoch(epoch))
     }
 
     /// Push a stack frame onto the invocation stack
@@ -566,8 +560,8 @@ impl<'a> InvokeContext<'a> {
         let empty_memory_mapping =
             MemoryMapping::new(Vec::new(), &mock_config, SBPFVersion::V0).unwrap();
         let mut vm = EbpfVm::new(
-            self.program_cache_for_tx_batch
-                .environments
+            self.environment_config
+                .program_runtime_environments_for_execution
                 .program_runtime_v2
                 .clone(),
             SBPFVersion::V0,
@@ -648,6 +642,11 @@ impl<'a> InvokeContext<'a> {
     /// Get the current feature set.
     pub fn get_feature_set(&self) -> &SVMFeatureSet {
         self.environment_config.feature_set
+    }
+
+    pub fn get_program_runtime_environments_for_deployment(&self) -> &ProgramRuntimeEnvironments {
+        self.environment_config
+            .program_runtime_environments_for_deployment
     }
 
     pub fn is_stake_raise_minimum_delegation_to_1_sol_active(&self) -> bool {
@@ -782,7 +781,7 @@ macro_rules! with_mock_invoke_context_with_feature_set {
                 __private::{Hash, ReadableAccount, Rent, TransactionContext},
                 execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
                 invoke_context::{EnvironmentConfig, InvokeContext},
-                loaded_programs::ProgramCacheForTxBatch,
+                loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments},
                 sysvar_cache::SysvarCache,
             },
         };
@@ -817,11 +816,14 @@ macro_rules! with_mock_invoke_context_with_feature_set {
                 }
             }
         });
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockInvokeContextCallback {},
             $feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -730,10 +730,6 @@ impl ProgramCacheForTxBatch {
         }
     }
 
-    pub fn new_from_cache<FG: ForkGraph>(slot: Slot, _cache: &ProgramCache<FG>) -> Self {
-        Self::new(slot)
-    }
-
     /// Refill the cache with a single entry. It's typically called during transaction loading, and
     /// transaction processing (for program management instructions).
     /// It replaces the existing entry (if any) with the provided entry. The return value contains

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1687,7 +1687,6 @@ mod test_utils {
     use {
         super::*, agave_syscalls::create_program_runtime_environment_v1,
         solana_account::ReadableAccount, solana_loader_v4_interface::state::LoaderV4State,
-        solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
         solana_sdk_ids::loader_v4,
     };
 
@@ -1743,9 +1742,6 @@ mod test_utils {
                     program_runtime_environment.clone(),
                     false,
                 ) {
-                    invoke_context
-                        .program_cache_for_tx_batch
-                        .set_slot_for_tests(DELAY_VISIBILITY_SLOT_OFFSET);
                     invoke_context
                         .program_cache_for_tx_batch
                         .store_modified_entry(*pubkey, Arc::new(loaded_program));
@@ -3984,6 +3980,9 @@ mod tests {
         invoke_context
             .program_cache_for_tx_batch
             .replenish(program_id, Arc::new(program));
+        invoke_context
+            .program_cache_for_tx_batch
+            .set_slot_for_tests(2);
 
         assert_matches!(
             deploy_test_program(&mut invoke_context, program_id,),
@@ -4023,6 +4022,9 @@ mod tests {
         invoke_context
             .program_cache_for_tx_batch
             .replenish(program_id, Arc::new(program));
+        invoke_context
+            .program_cache_for_tx_batch
+            .set_slot_for_tests(2);
 
         let program_id2 = Pubkey::new_unique();
         assert_matches!(

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -186,18 +186,17 @@ pub fn deploy_program(
 #[macro_export]
 macro_rules! deploy_program {
     ($invoke_context:expr, $program_id:expr, $loader_key:expr, $account_size:expr, $programdata:expr, $deployment_slot:expr $(,)?) => {
-        let environments = $invoke_context
-            .get_environments_for_slot($deployment_slot.saturating_add(
-                solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
-            ))
-            .map_err(|_err| {
-                // This will never fail since the epoch schedule is already configured.
-                InstructionError::ProgramEnvironmentSetupFailure
-            })?;
+        assert_eq!(
+            $deployment_slot,
+            $invoke_context.program_cache_for_tx_batch.slot()
+        );
         let load_program_metrics = $crate::deploy_program(
             $invoke_context.get_log_collector(),
             $invoke_context.program_cache_for_tx_batch,
-            environments.program_runtime_v1.clone(),
+            $invoke_context
+                .get_program_runtime_environments_for_deployment()
+                .program_runtime_v1
+                .clone(),
             $program_id,
             $loader_key,
             $account_size,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -188,7 +188,7 @@ use {
     },
     solana_nonce as nonce,
     solana_nonce_account::{get_system_account_kind, SystemAccountKind},
-    solana_program_runtime::{loaded_programs::ProgramCacheForTxBatch, sysvar_cache::SysvarCache},
+    solana_program_runtime::sysvar_cache::SysvarCache,
 };
 pub use {partitioned_epoch_rewards::KeyedRewardsAndNumPartitions, solana_reward_info::RewardType};
 
@@ -5905,17 +5905,6 @@ impl Bank {
             .accounts
             .accounts_db
             .calculate_accounts_lt_hash_at_startup_from_index(&self.ancestors, self.slot)
-    }
-
-    pub fn new_program_cache_for_tx_batch_for_slot(&self, slot: Slot) -> ProgramCacheForTxBatch {
-        ProgramCacheForTxBatch::new_from_cache(
-            slot,
-            &self
-                .transaction_processor
-                .global_program_cache
-                .read()
-                .unwrap(),
-        )
     }
 
     pub fn get_transaction_processor(&self) -> &TransactionBatchProcessor<BankForks> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5910,10 +5910,6 @@ impl Bank {
     pub fn new_program_cache_for_tx_batch_for_slot(&self, slot: Slot) -> ProgramCacheForTxBatch {
         ProgramCacheForTxBatch::new_from_cache(
             slot,
-            self.epoch_schedule.get_epoch(slot),
-            self.transaction_processor
-                .epoch_boundary_preparation
-                .clone(),
             &self
                 .transaction_processor
                 .global_program_cache

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1496,25 +1496,26 @@ impl Bank {
                 .checked_div(2)
                 .unwrap();
 
-        let mut program_cache = self
+        let program_cache = self
             .transaction_processor
             .global_program_cache
-            .write()
+            .read()
             .unwrap();
+        let mut epoch_boundary_preparation =
+            program_cache.epoch_boundary_preparation.write().unwrap();
 
-        if program_cache.upcoming_environments.is_some() {
-            if let Some((key, program_to_recompile)) = program_cache.programs_to_recompile.pop() {
-                let effective_epoch = program_cache.latest_root_epoch.saturating_add(1);
+        if let Some(upcoming_environments) =
+            epoch_boundary_preparation.upcoming_environments.as_ref()
+        {
+            let upcoming_environments = upcoming_environments.clone();
+            if let Some((key, program_to_recompile)) =
+                epoch_boundary_preparation.programs_to_recompile.pop()
+            {
+                drop(epoch_boundary_preparation);
                 drop(program_cache);
-                let environments_for_epoch = self
-                    .transaction_processor
-                    .global_program_cache
-                    .read()
-                    .unwrap()
-                    .get_environments_for_epoch(effective_epoch);
                 if let Some(recompiled) = load_program_with_pubkey(
                     self,
-                    &environments_for_epoch,
+                    &upcoming_environments,
                     &key,
                     self.slot,
                     &mut ExecuteTimings::default(),
@@ -1534,17 +1535,11 @@ impl Bank {
                     program_cache.assign_program(key, recompiled);
                 }
             }
-        } else if self.epoch != program_cache.latest_root_epoch
+        } else if self.epoch != epoch_boundary_preparation.latest_root_epoch
             || slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch
         {
             // Anticipate the upcoming program runtime environment for the next epoch,
             // so we can try to recompile loaded programs before the feature transition hits.
-            drop(program_cache);
-            let mut program_cache = self
-                .transaction_processor
-                .global_program_cache
-                .write()
-                .unwrap();
             let (program_runtime_environment_v1, program_runtime_environment_v2) =
                 self.create_program_runtime_environments(&upcoming_feature_set);
             let mut upcoming_environments = program_cache.environments.clone();
@@ -1558,10 +1553,10 @@ impl Bank {
             if changed_program_runtime_v2 {
                 upcoming_environments.program_runtime_v2 = program_runtime_environment_v2;
             }
-            program_cache.upcoming_environments = Some(upcoming_environments);
-            program_cache.programs_to_recompile = program_cache
+            epoch_boundary_preparation.upcoming_environments = Some(upcoming_environments);
+            epoch_boundary_preparation.programs_to_recompile = program_cache
                 .get_flattened_entries(changed_program_runtime_v1, changed_program_runtime_v2);
-            program_cache
+            epoch_boundary_preparation
                 .programs_to_recompile
                 .sort_by_cached_key(|(_id, program)| program.decayed_usage_counter(self.slot));
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3255,11 +3255,23 @@ impl Bank {
 
         let (blockhash, blockhash_lamports_per_signature) =
             self.last_blockhash_and_lamports_per_signature();
+        let effective_epoch_of_deployments =
+            self.epoch_schedule().get_epoch(self.slot.saturating_add(
+                solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
+            ));
         let processing_environment = TransactionProcessingEnvironment {
             blockhash,
             blockhash_lamports_per_signature,
             epoch_total_stake: self.get_current_epoch_total_stake(),
             feature_set: self.feature_set.runtime_features(),
+            program_runtime_environments_for_execution: self
+                .transaction_processor
+                .get_environments_for_epoch(self.epoch)
+                .unwrap(),
+            program_runtime_environments_for_deployment: self
+                .transaction_processor
+                .get_environments_for_epoch(effective_epoch_of_deployments)
+                .unwrap(),
             rent: self.rent_collector.rent.clone(),
         };
 

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -137,6 +137,9 @@ impl Bank {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
             self.slot,
             self.epoch,
+            self.transaction_processor
+                .epoch_boundary_preparation
+                .clone(),
             &self
                 .transaction_processor
                 .global_program_cache

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -134,14 +134,7 @@ impl Bank {
         let elf = &programdata[progradata_metadata_size..];
         // Set up the two `LoadedProgramsForTxBatch` instances, as if
         // processing a new transaction batch.
-        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
-            self.slot,
-            &self
-                .transaction_processor
-                .global_program_cache
-                .read()
-                .unwrap(),
-        );
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(self.slot);
         let program_runtime_environments = self
             .transaction_processor
             .get_environments_for_epoch(self.epoch)

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -136,10 +136,6 @@ impl Bank {
         // processing a new transaction batch.
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
             self.slot,
-            self.epoch,
-            self.transaction_processor
-                .epoch_boundary_preparation
-                .clone(),
             &self
                 .transaction_processor
                 .global_program_cache

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -146,6 +146,10 @@ impl Bank {
                 .read()
                 .unwrap(),
         );
+        let program_runtime_environments = self
+            .transaction_processor
+            .get_environments_for_epoch(self.epoch)
+            .unwrap();
 
         // Configure a dummy `InvokeContext` from the runtime's current
         // environment, as well as the two `ProgramCacheForTxBatch`
@@ -181,6 +185,8 @@ impl Bank {
                     0,
                     &MockCallback {},
                     &feature_set,
+                    &program_runtime_environments,
+                    &program_runtime_environments,
                     &sysvar_cache,
                 ),
                 None,
@@ -188,19 +194,10 @@ impl Bank {
                 compute_budget.to_cost(),
             );
 
-            let environments = dummy_invoke_context
-                .get_environments_for_slot(self.slot.saturating_add(
-                    solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
-                ))
-                .map_err(|_err| {
-                    // This will never fail since the epoch schedule is already configured.
-                    InstructionError::ProgramEnvironmentSetupFailure
-                })?;
-
             let load_program_metrics = solana_bpf_loader_program::deploy_program(
                 dummy_invoke_context.get_log_collector(),
                 dummy_invoke_context.program_cache_for_tx_batch,
-                environments.program_runtime_v1.clone(),
+                program_runtime_environments.program_runtime_v1.clone(),
                 program_id,
                 &bpf_loader_upgradeable::id(),
                 data_len,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10955,14 +10955,14 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase(
         .global_program_cache
         .read()
         .unwrap()
-        .get_environments_for_epoch(0)
+        .get_environments_for_epoch(&bank.transaction_processor.epoch_boundary_preparation, 0)
         .program_runtime_v1;
     let upcoming_env = bank
         .transaction_processor
         .global_program_cache
         .read()
         .unwrap()
-        .get_environments_for_epoch(1)
+        .get_environments_for_epoch(&bank.transaction_processor.epoch_boundary_preparation, 1)
         .program_runtime_v1;
 
     // Advance the bank to recompile the program.
@@ -11073,12 +11073,19 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
 
     {
         // Prune for rerooting and thus finishing the recompilation phase.
+        let upcoming_environments = bank
+            .transaction_processor
+            .epoch_boundary_preparation
+            .write()
+            .unwrap()
+            .reroot(bank.epoch());
+        assert!(upcoming_environments.is_some());
         let mut program_cache = bank
             .transaction_processor
             .global_program_cache
             .write()
             .unwrap();
-        program_cache.prune(bank.slot(), bank.epoch());
+        program_cache.prune(bank.slot(), upcoming_environments);
 
         // Unload all (which is only the entry with the new environment)
         program_cache.sort_and_unload(percentage::Percentage::from(0));

--- a/svm-fuzz-harness/src/instr.rs
+++ b/svm-fuzz-harness/src/instr.rs
@@ -12,6 +12,7 @@ use {
         proto::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
     },
     agave_precompiles::{get_precompile, is_precompile},
+    agave_syscalls::create_program_runtime_environment_v1,
     solana_account::AccountSharedData,
     solana_compute_budget::compute_budget::{ComputeBudget, SVMTransactionExecutionCost},
     solana_hash::Hash,
@@ -20,7 +21,7 @@ use {
     solana_precompile_error::PrecompileError,
     solana_program_runtime::{
         invoke_context::{EnvironmentConfig, InvokeContext},
-        loaded_programs::ProgramCacheForTxBatch,
+        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments},
         sysvar_cache::SysvarCache,
     },
     solana_pubkey::Pubkey,
@@ -32,7 +33,7 @@ use {
         transaction_accounts::KeyedAccountSharedData, IndexOfAccount, InstructionAccount,
         TransactionContext,
     },
-    std::collections::HashSet,
+    std::{collections::HashSet, sync::Arc},
 };
 
 /// Implement the callback trait so that the SVM API can be used to load
@@ -77,6 +78,7 @@ fn create_invoke_context_fields(
 ) -> Option<(
     TransactionContext,
     SysvarCache,
+    ProgramRuntimeEnvironments,
     ProgramCacheForTxBatch,
     Hash,
     u64,
@@ -117,11 +119,22 @@ fn create_invoke_context_fields(
         compute_budget.max_instruction_trace_length,
     );
 
+    let environments = ProgramRuntimeEnvironments {
+        program_runtime_v1: Arc::new(
+            create_program_runtime_environment_v1(
+                &input.feature_set.runtime_features(),
+                &compute_budget.to_budget(),
+                false, /* deployment */
+                false, /* debugging_features */
+            )
+            .unwrap(),
+        ),
+        ..ProgramRuntimeEnvironments::default()
+    };
+
     // Set up the program cache, which will include all builtins by default.
     let mut program_cache =
-        crate::program_cache::setup_program_cache(&input.feature_set, &compute_budget, clock.slot);
-
-    let environments = program_cache.environments.clone();
+        crate::program_cache::setup_program_cache(&input.feature_set, clock.slot);
 
     #[allow(deprecated)]
     let (blockhash, lamports_per_signature) = sysvar_cache
@@ -174,6 +187,7 @@ fn create_invoke_context_fields(
     Some((
         transaction_context,
         sysvar_cache,
+        environments,
         program_cache,
         blockhash,
         lamports_per_signature,
@@ -207,6 +221,7 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
     let (
         mut transaction_context,
         sysvar_cache,
+        environments,
         mut program_cache,
         blockhash,
         lamports_per_signature,
@@ -224,6 +239,8 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
             lamports_per_signature,
             &callback,
             &runtime_features,
+            &environments,
+            &environments,
             &sysvar_cache,
         );
 

--- a/svm-fuzz-harness/src/program_cache.rs
+++ b/svm-fuzz-harness/src/program_cache.rs
@@ -42,7 +42,6 @@ pub fn setup_program_cache(
 
     cache.set_slot_for_tests(slot);
     cache.environments = environments.clone();
-    cache.upcoming_environments = Some(environments);
 
     for builtin in BUILTINS {
         // Skip migrated builtins.

--- a/svm-fuzz-harness/src/program_cache.rs
+++ b/svm-fuzz-harness/src/program_cache.rs
@@ -2,12 +2,8 @@ use {
     agave_feature_set::{
         enable_loader_v4, zk_elgamal_proof_program_enabled, zk_token_sdk_enabled, FeatureSet,
     },
-    agave_syscalls::create_program_runtime_environment_v1,
     solana_builtins::BUILTINS,
-    solana_compute_budget::compute_budget::ComputeBudget,
-    solana_program_runtime::loaded_programs::{
-        ProgramCacheEntry, ProgramCacheForTxBatch, ProgramRuntimeEnvironments,
-    },
+    solana_program_runtime::loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
     solana_pubkey::Pubkey,
     std::sync::Arc,
 };
@@ -20,28 +16,9 @@ const MIGRATED_BUILTINS: &[Pubkey] = &[
     solana_sdk_ids::stake::id(),
 ];
 
-pub fn setup_program_cache(
-    feature_set: &FeatureSet,
-    compute_budget: &ComputeBudget,
-    slot: u64,
-) -> ProgramCacheForTxBatch {
+pub fn setup_program_cache(feature_set: &FeatureSet, slot: u64) -> ProgramCacheForTxBatch {
     let mut cache = ProgramCacheForTxBatch::default();
-
-    let environments = ProgramRuntimeEnvironments {
-        program_runtime_v1: Arc::new(
-            create_program_runtime_environment_v1(
-                &feature_set.runtime_features(),
-                &compute_budget.to_budget(),
-                false, /* deployment */
-                false, /* debugging_features */
-            )
-            .unwrap(),
-        ),
-        ..ProgramRuntimeEnvironments::default()
-    };
-
     cache.set_slot_for_tests(slot);
-    cache.environments = environments.clone();
 
     for builtin in BUILTINS {
         // Skip migrated builtins.

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -95,7 +95,9 @@ mod tests {
             declare_process_instruction,
             execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
             invoke_context::EnvironmentConfig,
-            loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
+            loaded_programs::{
+                ProgramCacheEntry, ProgramCacheForTxBatch, ProgramRuntimeEnvironments,
+            },
             sysvar_cache::SysvarCache,
         },
         solana_pubkey::Pubkey,
@@ -219,11 +221,14 @@ mod tests {
         ));
         let sysvar_cache = SysvarCache::default();
         let feature_set = SVMFeatureSet::all_enabled();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -273,11 +278,14 @@ mod tests {
                 ),
             ]),
         ));
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -317,11 +325,14 @@ mod tests {
                 ),
             ]),
         ));
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -450,11 +461,14 @@ mod tests {
         ));
         let sysvar_cache = SysvarCache::default();
         let feature_set = SVMFeatureSet::all_enabled();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -489,11 +503,14 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -525,11 +542,14 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -673,11 +693,14 @@ mod tests {
             }
         }
         let feature_set = SVMFeatureSet::all_enabled();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -811,7 +811,7 @@ mod tests {
         let upcoming_environments = ProgramRuntimeEnvironments::default();
         let current_environments = {
             let global_program_cache = batch_processor.global_program_cache.read().unwrap();
-            global_program_cache
+            batch_processor
                 .epoch_boundary_preparation
                 .write()
                 .unwrap()

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -810,8 +810,12 @@ mod tests {
 
         let upcoming_environments = ProgramRuntimeEnvironments::default();
         let current_environments = {
-            let mut global_program_cache = batch_processor.global_program_cache.write().unwrap();
-            global_program_cache.upcoming_environments = Some(upcoming_environments.clone());
+            let global_program_cache = batch_processor.global_program_cache.read().unwrap();
+            global_program_cache
+                .epoch_boundary_preparation
+                .write()
+                .unwrap()
+                .upcoming_environments = Some(upcoming_environments.clone());
             global_program_cache.environments.clone()
         };
         mock_bank

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -156,6 +156,9 @@ pub struct TransactionBatchProcessor<FG: ForkGraph> {
     /// client code (e.g. Bank) and forwarded to process_message.
     sysvar_cache: RwLock<SysvarCache>,
 
+    /// Anticipates the environments of the upcoming epoch
+    pub epoch_boundary_preparation: Arc<RwLock<EpochBoundaryPreparation>>,
+
     /// Programs required for transaction batch processing
     pub global_program_cache: Arc<RwLock<ProgramCache<FG>>>,
 
@@ -182,10 +185,8 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
             slot: Slot::default(),
             epoch: Epoch::default(),
             sysvar_cache: RwLock::<SysvarCache>::default(),
-            global_program_cache: Arc::new(RwLock::new(ProgramCache::new(
-                Slot::default(),
-                Arc::new(RwLock::new(EpochBoundaryPreparation::default())),
-            ))),
+            epoch_boundary_preparation: Arc::new(RwLock::new(EpochBoundaryPreparation::default())),
+            global_program_cache: Arc::new(RwLock::new(ProgramCache::new(Slot::default()))),
             builtin_program_ids: RwLock::new(HashSet::new()),
             execution_cost: SVMTransactionExecutionCost::default(),
         }
@@ -208,10 +209,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         Self {
             slot,
             epoch,
-            global_program_cache: Arc::new(RwLock::new(ProgramCache::new(
-                slot,
-                epoch_boundary_preparation,
-            ))),
+            epoch_boundary_preparation,
+            global_program_cache: Arc::new(RwLock::new(ProgramCache::new(slot))),
             ..Self::default()
         }
     }
@@ -255,6 +254,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             slot,
             epoch,
             sysvar_cache: RwLock::<SysvarCache>::default(),
+            epoch_boundary_preparation: self.epoch_boundary_preparation.clone(),
             global_program_cache: self.global_program_cache.clone(),
             builtin_program_ids: RwLock::new(self.builtin_program_ids.read().unwrap().clone()),
             execution_cost: self.execution_cost,
@@ -276,8 +276,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let empty_loader = || Arc::new(BuiltinProgram::new_loader(VmConfig::default()));
 
         global_program_cache.latest_root_slot = self.slot;
-        global_program_cache
-            .epoch_boundary_preparation
+        self.epoch_boundary_preparation
             .write()
             .unwrap()
             .latest_root_epoch = self.epoch;
@@ -311,7 +310,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         self.global_program_cache
             .try_read()
             .ok()
-            .map(|cache| cache.get_environments_for_epoch(epoch))
+            .map(|cache| cache.get_environments_for_epoch(&self.epoch_boundary_preparation, epoch))
     }
 
     pub fn sysvar_cache(&self) -> RwLockReadGuard<SysvarCache> {
@@ -367,6 +366,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
                 self.slot,
                 self.epoch,
+                self.epoch_boundary_preparation.clone(),
                 &global_program_cache,
             );
             drop(global_program_cache);
@@ -779,7 +779,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     // Load, verify and compile one program.
                     let program = load_program_with_pubkey(
                         account_loader,
-                        &global_program_cache.get_environments_for_epoch(self.epoch),
+                        &global_program_cache.get_environments_for_epoch(
+                            &self.epoch_boundary_preparation,
+                            self.epoch,
+                        ),
                         &key,
                         self.slot,
                         execute_timings,
@@ -807,6 +810,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     *program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
                         self.slot,
                         self.epoch,
+                        self.epoch_boundary_preparation.clone(),
                         &global_program_cache,
                     );
                     program_cache_for_tx_batch.hit_max_limit = true;
@@ -1476,6 +1480,7 @@ mod tests {
             ProgramCacheForTxBatch::new_from_cache(
                 batch_processor.slot,
                 batch_processor.epoch,
+                batch_processor.epoch_boundary_preparation.clone(),
                 &global_program_cache,
             )
         };
@@ -1518,6 +1523,7 @@ mod tests {
                 ProgramCacheForTxBatch::new_from_cache(
                     batch_processor.slot,
                     batch_processor.epoch,
+                    batch_processor.epoch_boundary_preparation.clone(),
                     &global_program_cache,
                 )
             };
@@ -1891,6 +1897,7 @@ mod tests {
         let mut loaded_programs_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
             0,
             0,
+            batch_processor.epoch_boundary_preparation.clone(),
             &batch_processor.global_program_cache.read().unwrap(),
         );
         batch_processor

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -38,6 +38,7 @@ use {
         loaded_programs::{
             EpochBoundaryPreparation, ForkGraph, ProgramCache, ProgramCacheEntry,
             ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
+            ProgramRuntimeEnvironments,
         },
         solana_sbpf::{program::BuiltinProgram, vm::Config as VmConfig},
         sysvar_cache::SysvarCache,
@@ -135,6 +136,11 @@ pub struct TransactionProcessingEnvironment {
     pub epoch_total_stake: u64,
     /// Runtime feature set to use for the transaction batch.
     pub feature_set: SVMFeatureSet,
+    /// The current ProgramRuntimeEnvironments derived from the SVMFeatureSet.
+    pub program_runtime_environments_for_execution: ProgramRuntimeEnvironments,
+    /// Depending on the next slot this is either the current or the upcoming
+    /// ProgramRuntimeEnvironments.
+    pub program_runtime_environments_for_deployment: ProgramRuntimeEnvironments,
     /// Rent calculator to use for the transaction batch.
     pub rent: Rent,
 }
@@ -302,11 +308,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
     /// Returns the current environments depending on the given epoch
     /// Returns None if the call could result in a deadlock
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn get_environments_for_epoch(
-        &self,
-        epoch: Epoch,
-    ) -> Option<solana_program_runtime::loaded_programs::ProgramRuntimeEnvironments> {
+    pub fn get_environments_for_epoch(&self, epoch: Epoch) -> Option<ProgramRuntimeEnvironments> {
         self.global_program_cache
             .try_read()
             .ok()

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -895,6 +895,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 environment.blockhash_lamports_per_signature,
                 callback,
                 &environment.feature_set,
+                &environment.program_runtime_environments_for_execution,
+                &environment.program_runtime_environments_for_deployment,
                 sysvar_cache,
             ),
             log_collector.clone(),

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -72,6 +72,7 @@ fn program_cache_execution(threads: usize) {
                     ProgramCacheForTxBatch::new_from_cache(
                         processor.slot,
                         processor.epoch,
+                        processor.epoch_boundary_preparation.clone(),
                         &global_program_cache,
                     )
                 };

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -67,10 +67,7 @@ fn program_cache_execution(threads: usize) {
                     &feature_set,
                     0,
                 );
-                let mut result = {
-                    let global_program_cache = processor.global_program_cache.read().unwrap();
-                    ProgramCacheForTxBatch::new_from_cache(processor.slot, &global_program_cache)
-                };
+                let mut result = ProgramCacheForTxBatch::new(processor.slot);
                 let program_runtime_environments_for_execution = processor
                     .get_environments_for_epoch(processor.epoch)
                     .unwrap();

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -69,16 +69,15 @@ fn program_cache_execution(threads: usize) {
                 );
                 let mut result = {
                     let global_program_cache = processor.global_program_cache.read().unwrap();
-                    ProgramCacheForTxBatch::new_from_cache(
-                        processor.slot,
-                        processor.epoch,
-                        processor.epoch_boundary_preparation.clone(),
-                        &global_program_cache,
-                    )
+                    ProgramCacheForTxBatch::new_from_cache(processor.slot, &global_program_cache)
                 };
+                let program_runtime_environments_for_execution = processor
+                    .get_environments_for_epoch(processor.epoch)
+                    .unwrap();
                 processor.replenish_program_cache(
                     &account_loader,
                     &maps,
+                    &program_runtime_environments_for_execution,
                     &mut result,
                     &mut ExecuteTimings::default(),
                     false,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -158,6 +158,12 @@ impl SvmTestEnvironment<'_> {
             blockhash: LAST_BLOCKHASH,
             feature_set: test_entry.feature_set,
             blockhash_lamports_per_signature: LAMPORTS_PER_SIGNATURE,
+            program_runtime_environments_for_execution: batch_processor
+                .get_environments_for_epoch(EXECUTION_EPOCH)
+                .unwrap(),
+            program_runtime_environments_for_deployment: batch_processor
+                .get_environments_for_epoch(EXECUTION_EPOCH)
+                .unwrap(),
             ..TransactionProcessingEnvironment::default()
         };
 

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -4770,11 +4770,14 @@ mod tests {
 
         with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
         let feature_set = SVMFeatureSet::default();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
 
@@ -4832,11 +4835,14 @@ mod tests {
 
         with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
         let feature_set = SVMFeatureSet::default();
+        let program_runtime_environments = ProgramRuntimeEnvironments::default();
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
+            &program_runtime_environments,
+            &program_runtime_environments,
             &sysvar_cache,
         );
 


### PR DESCRIPTION
#### Problem

#8412 was reverted. #8537 fixes the reasons for the revert.

#### Summary of Changes

- Adds `TransactionProcessingEnvironment::program_runtime_environments`.
- Adds `EnvironmentConfig::program_runtime_environments`.
- Removes `ProgramCacheForTxBatch::environments` and `ProgramCacheForTxBatch::upcoming_environments`.
- Adds `missing set_slot_for_tests()`.
- Removes `ProgramCacheForTxBatch::new_from_cache()`.