### PR TITLE
Refactor system instructions test

### DIFF
--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -259,21 +259,21 @@ mod test {
     pub const WITHDRAW_TO_ACCOUNT_INDEX: IndexOfAccount = 1;
 
     macro_rules! push_instruction_context {
-        ($invoke_context:expr, $transaction_context:ident, $instruction_context:ident, $instruction_accounts:ident) => {
+        ($invoke_context:expr, $instruction_context:ident, $instruction_accounts:ident) => {
             $invoke_context
                 .transaction_context
                 .configure_next_instruction_for_tests(2, $instruction_accounts, vec![])
                 .unwrap();
             $invoke_context.push().unwrap();
-            let $transaction_context = &$invoke_context.transaction_context;
-            let $instruction_context = $transaction_context
+            let transaction_context = &$invoke_context.transaction_context;
+            let $instruction_context = transaction_context
                 .get_current_instruction_context()
                 .unwrap();
         };
     }
 
     macro_rules! prepare_mockup {
-        ($invoke_context:ident, $instruction_accounts:ident, $rent:ident) => {
+        ($invoke_context:ident, $instruction_accounts:ident, $rent:ident, $transaction_context:ident) => {
             let $rent = Rent {
                 lamports_per_byte_year: 42,
                 ..Rent::default()
@@ -291,7 +291,7 @@ mod test {
                 InstructionAccount::new(0, true, true),
                 InstructionAccount::new(1, false, true),
             ];
-            with_mock_invoke_context!($invoke_context, transaction_context, transaction_accounts);
+            with_mock_invoke_context!($invoke_context, $transaction_context, transaction_accounts);
         };
     }
 
@@ -312,13 +312,13 @@ mod test {
 
     #[test]
     fn expected_behavior() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -405,13 +405,13 @@ mod test {
 
     #[test]
     fn nonce_inx_initialized_account_not_signer_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -436,13 +436,13 @@ mod test {
 
     #[test]
     fn nonce_inx_too_early_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -457,13 +457,13 @@ mod test {
 
     #[test]
     fn nonce_inx_uninitialized_account_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -476,13 +476,13 @@ mod test {
 
     #[test]
     fn nonce_inx_independent_nonce_authority_ok() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -503,13 +503,13 @@ mod test {
 
     #[test]
     fn nonce_inx_no_nonce_authority_sig_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -527,13 +527,13 @@ mod test {
 
     #[test]
     fn withdraw_inx_unintialized_acc_ok() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -574,13 +574,13 @@ mod test {
 
     #[test]
     fn withdraw_inx_unintialized_acc_unsigned_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -608,13 +608,13 @@ mod test {
 
     #[test]
     fn withdraw_inx_unintialized_acc_insuff_funds_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -639,13 +639,13 @@ mod test {
 
     #[test]
     fn withdraw_inx_uninitialized_acc_two_withdraws_ok() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -709,13 +709,13 @@ mod test {
 
     #[test]
     fn withdraw_inx_initialized_acc_two_withdraws_ok() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -798,13 +798,13 @@ mod test {
 
     #[test]
     fn withdraw_inx_initialized_acc_nonce_too_early_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -833,13 +833,13 @@ mod test {
 
     #[test]
     fn withdraw_inx_initialized_acc_insuff_funds_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -865,13 +865,13 @@ mod test {
 
     #[test]
     fn withdraw_inx_initialized_acc_insuff_rent_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -897,13 +897,13 @@ mod test {
 
     #[test]
     fn withdraw_inx_overflow() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -929,13 +929,13 @@ mod test {
 
     #[test]
     fn initialize_inx_ok() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -961,13 +961,13 @@ mod test {
 
     #[test]
     fn initialize_inx_initialized_account_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -982,13 +982,13 @@ mod test {
 
     #[test]
     fn initialize_inx_uninitialized_acc_insuff_funds_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -1002,13 +1002,13 @@ mod test {
 
     #[test]
     fn authorize_inx_ok() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -1032,13 +1032,13 @@ mod test {
 
     #[test]
     fn authorize_inx_uninitialized_state_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -1055,13 +1055,13 @@ mod test {
 
     #[test]
     fn authorize_inx_bad_authority_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -1077,13 +1077,13 @@ mod test {
 
     #[test]
     fn verify_nonce_ok() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -1096,14 +1096,14 @@ mod test {
         let authorized = *nonce_account.get_key();
         initialize_nonce_account(&mut nonce_account, &authorized, &rent, &invoke_context).unwrap();
         drop(nonce_account);
+        let blockhash = invoke_context.environment_config.blockhash;
         assert_matches!(
             verify_nonce_account(
                 &transaction_context
                     .accounts()
                     .try_borrow(NONCE_ACCOUNT_INDEX)
                     .unwrap(),
-                DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash)
-                    .as_hash(),
+                DurableNonce::from_blockhash(&blockhash).as_hash(),
             ),
             Some(_)
         );
@@ -1111,13 +1111,13 @@ mod test {
 
     #[test]
     fn verify_nonce_bad_acc_state_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            _instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, _instruction_context, instruction_accounts);
         assert_eq!(
             verify_nonce_account(
                 &transaction_context
@@ -1132,13 +1132,13 @@ mod test {
 
     #[test]
     fn verify_nonce_bad_query_hash_fail() {
-        prepare_mockup!(invoke_context, instruction_accounts, rent);
-        push_instruction_context!(
+        prepare_mockup!(
             invoke_context,
-            transaction_context,
-            instruction_context,
-            instruction_accounts
+            instruction_accounts,
+            rent,
+            transaction_context
         );
+        push_instruction_context!(invoke_context, instruction_context, instruction_accounts);
         let mut nonce_account = instruction_context
             .try_borrow_instruction_account(NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -1158,14 +1158,14 @@ mod test {
         .unwrap();
         set_invoke_context_blockhash!(invoke_context, 1);
         drop(nonce_account);
+        let blockhash = invoke_context.environment_config.blockhash;
         assert_eq!(
             verify_nonce_account(
                 &transaction_context
                     .accounts()
                     .try_borrow(NONCE_ACCOUNT_INDEX)
                     .unwrap(),
-                DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash)
-                    .as_hash(),
+                DurableNonce::from_blockhash(&blockhash).as_hash(),
             ),
             None
         );


### PR DESCRIPTION
#### Problem

This PR comes from this comment: https://github.com/anza-xyz/agave/pull/8372#discussion_r2417499921. We want to avoid a test-only function to convert `TransactionAccountView` into `AccountSharedData`. In order to avoid cluttering the original PR, I am opening this one to refactor the tests and avoid the extra function there.

Since the function `verify_nonce_account` is used only after the transaction has successfully completed, we can use the result from `deconstruct_without_keys` for comparison. This setting does not require an extra function nor any new modifications in #8372.

#### Summary of Changes

1. Add `transaction_context` to `prepare_mockup` and remove it from `push_instruction_context`.
2. Make borrow checker happy in two cases, by not using `invoke_context` again.
3. Use `deconstruct_without_keys` in tests that need `verify_nonce_account`.