### PR TITLE
Resolve intermittent test failure in test_store_scan_consistency_root

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7683,13 +7683,17 @@ fn test_store_scan_consistency_unrooted() {
 
 #[test]
 fn test_store_scan_consistency_root() {
+    let (pruned_banks_sender, pruned_banks_receiver) = unbounded();
+    let pruned_banks_request_handler = PrunedBanksRequestHandler {
+        pruned_banks_receiver,
+    };
     test_store_scan_consistency(
-        |bank0,
-         bank_to_scan_sender,
-         _scan_finished_receiver,
-         pubkeys_to_modify,
-         program_id,
-         starting_lamports| {
+        move |bank0,
+              bank_to_scan_sender,
+              _scan_finished_receiver,
+              pubkeys_to_modify,
+              program_id,
+              starting_lamports| {
             let mut current_bank = bank0.clone();
             let mut prev_bank = bank0;
             loop {
@@ -7722,9 +7726,13 @@ fn test_store_scan_consistency_root() {
                     &solana_pubkey::new_rand(),
                     slot,
                 ));
+
+                // Move purge here so that Bank::drop()->purge_slots() doesn't race
+                // with clean. Simulates the call from AccountsBackgroundService
+                pruned_banks_request_handler.handle_request(&current_bank);
             }
         },
-        None,
+        Some(Box::new(SendDroppedBankCallback::new(pruned_banks_sender))),
         AcceptableScanResults::NoFailure,
     );
 }


### PR DESCRIPTION
#### Problem
There's a race condition between bank drop and process_dead_slots.

```
        // Remove dead slots from the accounts index root tracker
        self.remove_dead_slots_metadata(dead_slots.iter());

        clean_dead_slots.stop();
        let mut purge_removed_slots = Measure::start("reclaims::purge_removed_slots");
        self.purge_dead_slots_from_storage(dead_slots.iter(), purge_stats);
        purge_removed_slots.stop();
```

With a sleep added to make the issue more likely, this test fails every time. 
1. remove_dead_slots_metadata removes the slot from the alive roots list,
2. Bank Drop is called and attempts to purge its slot if its unrooted. In this case it sees that the account isn't on the alives root list and attempts to purge it
4. During the purge, there is nothing to reclaim, since it was already reclaimed by whatever is removing dead slots
purge_slot_storage fails because
```
        // After handling the reclaimed entries, this slot's
        // storage entries should be purged from self.storage
        assert!(
            self.storage.get_slot_storage_entry(remove_slot).is_none(),
            "slot {remove_slot} is not none"
        );
```
During normal operation this isn't an issue as the AccountsBackgroundService handles all Bank Drops, which is done in  the same thread as remove_dead_slots_metadata. 


#### Summary of Changes
- Copy fix from test_store_scan_consistency_unrooted
- Checked all other tests using test_store_scan_consistency_root with none, and did not see any failures. 
- It might make sense to always require a bank drop callback in Bank, but that is a separate refactor. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
