### PR TITLE
Move default config values to snapshot_config

### DIFF
--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -1,8 +1,19 @@
 use {
-    crate::snapshot_utils,
     agave_snapshots::{ArchiveFormat, SnapshotInterval, SnapshotVersion, ZstdConfig},
-    std::{num::NonZeroUsize, path::PathBuf},
+    std::{
+        num::{NonZeroU64, NonZeroUsize},
+        path::PathBuf,
+    },
 };
+
+pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
+    NonZeroU64::new(100_000).unwrap();
+pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
+    NonZeroU64::new(100).unwrap();
+pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
+    NonZeroUsize::new(2).unwrap();
+pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
+    NonZeroUsize::new(4).unwrap();
 
 /// Snapshot configuration and runtime information
 #[derive(Clone, Debug)]
@@ -47,10 +58,10 @@ impl Default for SnapshotConfig {
         Self {
             usage: SnapshotUsage::LoadAndGenerate,
             full_snapshot_archive_interval: SnapshotInterval::Slots(
-                snapshot_utils::DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+                DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
             ),
             incremental_snapshot_archive_interval: SnapshotInterval::Slots(
-                snapshot_utils::DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+                DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
             ),
             full_snapshot_archives_dir: PathBuf::default(),
             incremental_snapshot_archives_dir: PathBuf::default(),
@@ -59,10 +70,9 @@ impl Default for SnapshotConfig {
                 config: ZstdConfig::default(),
             },
             snapshot_version: SnapshotVersion::default(),
-            maximum_full_snapshot_archives_to_retain:
-                snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             maximum_incremental_snapshot_archives_to_retain:
-                snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             packager_thread_niceness_adj: 0,
         }
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -43,7 +43,7 @@ use {
         fs,
         io::{self, BufRead, BufReader, BufWriter, Error as IoError, Read, Seek, Write},
         mem,
-        num::{NonZeroU64, NonZeroUsize},
+        num::NonZeroUsize,
         ops::RangeInclusive,
         path::{Path, PathBuf},
         process::ExitStatus,
@@ -82,14 +82,6 @@ pub const MAX_SNAPSHOT_DATA_FILE_SIZE: u64 = 32 * 1024 * 1024 * 1024; // 32 GiB
 const MAX_SNAPSHOT_VERSION_FILE_SIZE: u64 = 8; // byte
 const SNAPSHOT_FASTBOOT_VERSION: Version = Version::new(1, 0, 0);
 pub const TMP_SNAPSHOT_ARCHIVE_PREFIX: &str = "tmp-snapshot-archive-";
-pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
-    NonZeroU64::new(100_000).unwrap();
-pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
-    NonZeroU64::new(100).unwrap();
-pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
-    NonZeroUsize::new(2).unwrap();
-pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
-    NonZeroUsize::new(4).unwrap();
 pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str =
     r"^snapshot-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar\.zst|tar\.lz4)$";
 pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^incremental-snapshot-(?P<base>[[:digit:]]+)-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar\.zst|tar\.lz4)$";
@@ -2600,6 +2592,10 @@ pub fn create_tmp_accounts_dir_for_tests() -> (TempDir, PathBuf) {
 mod tests {
     use {
         super::*,
+        crate::snapshot_config::{
+            DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        },
         agave_snapshots::ZstdConfig,
         assert_matches::assert_matches,
         bincode::{deserialize_from, serialize_into},

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -25,7 +25,7 @@ use {
     solana_quic_definitions::QUIC_PORT_OFFSET,
     solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,
     solana_rpc_client_api::request::{DELINQUENT_VALIDATOR_SLOT_DISTANCE, MAX_MULTIPLE_ACCOUNTS},
-    solana_runtime::snapshot_utils::{
+    solana_runtime::snapshot_config::{
         DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
         DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
         DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,


### PR DESCRIPTION
#### Problem
`snapshot_config` depends on constants that are directly used and related to config and which utils could easily import from config

#### Summary of Changes
* Move default values for config to `snapshot_config`
* update all uses

(this change will allow a cleaner move of `snapshot_config` to new `agave-snapshots` crate added in https://github.com/anza-xyz/agave/pull/8382)