### PR TITLE
Move MAX_GENESIS_ARCHIVE_UNPACKED_SIZE from accounts-db to ledger

### DIFF
--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -45,7 +45,6 @@ const MAX_SNAPSHOT_ARCHIVE_UNPACKED_APPARENT_SIZE: u64 = 64 * 1024 * 1024 * 1024
 const MAX_SNAPSHOT_ARCHIVE_UNPACKED_ACTUAL_SIZE: u64 = 4 * 1024 * 1024 * 1024 * 1024;
 
 const MAX_SNAPSHOT_ARCHIVE_UNPACKED_COUNT: u64 = 5_000_000;
-pub const MAX_GENESIS_ARCHIVE_UNPACKED_SIZE: u64 = 10 * 1024 * 1024; // 10 MiB
 const MAX_GENESIS_ARCHIVE_UNPACKED_COUNT: u64 = 100;
 
 // The buffer should be large enough to saturate write I/O bandwidth, while also accommodating:
@@ -814,9 +813,7 @@ mod tests {
     }
 
     fn finalize_and_unpack_genesis(archive: tar::Builder<Vec<u8>>) -> Result<()> {
-        with_finalize_and_unpack(archive, |a, b| {
-            unpack_genesis(a, b, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE)
-        })
+        with_finalize_and_unpack(archive, |a, b| unpack_genesis(a, b, 1024))
     }
 
     #[test]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -39,9 +39,7 @@ use {
     solana_accounts_db::{
         accounts_db::{AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_TESTING},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
-        hardened_unpack::{
-            open_genesis_config, OpenGenesisConfigError, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-        },
+        hardened_unpack::{open_genesis_config, OpenGenesisConfigError},
         utils::move_and_async_delete_path_contents,
     },
     solana_client::{
@@ -80,6 +78,7 @@ use {
         blockstore_processor::{self, TransactionStatusSender},
         entry_notifier_interface::EntryNotifierArc,
         entry_notifier_service::{EntryNotifierSender, EntryNotifierService},
+        genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         leader_schedule::FixedSchedule,
         leader_schedule_cache::LeaderScheduleCache,
         use_snapshot_archives_at_startup::UseSnapshotArchivesAtStartup,

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -7,7 +7,6 @@ use {
     clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg, ArgMatches},
     itertools::Itertools,
     solana_account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
-    solana_accounts_db::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     solana_clap_utils::{
         input_parsers::{
             cluster_type_of, pubkey_of, pubkeys_of, unix_timestamp_from_rfc3339_datetime,
@@ -31,7 +30,10 @@ use {
     solana_genesis_config::GenesisConfig,
     solana_inflation::Inflation,
     solana_keypair::{read_keypair_file, Keypair},
-    solana_ledger::{blockstore::create_new_ledger, blockstore_options::LedgerColumnOptions},
+    solana_ledger::{
+        blockstore::create_new_ledger, blockstore_options::LedgerColumnOptions,
+        genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+    },
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_native_token::LAMPORTS_PER_SOL,
     solana_poh_config::PohConfig,

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -346,7 +346,7 @@ pub fn hardforks_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<Slot>> {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_accounts_db::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE};
+    use {super::*, solana_ledger::genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE};
 
     #[test]
     fn test_max_genesis_archive_unpacked_size_constant() {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -50,6 +50,7 @@ use {
         blockstore_processor::{
             ProcessSlotCallback, TransactionStatusMessage, TransactionStatusSender,
         },
+        genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     },
     solana_measure::{measure::Measure, measure_time},
     solana_message::SimpleAddressLoader,
@@ -1778,7 +1779,7 @@ fn main() {
                     create_new_ledger(
                         &output_directory,
                         &genesis_config,
-                        solana_accounts_db::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+                        MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
                         LedgerColumnOptions::default(),
                     )
                     .unwrap_or_else(|err| {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4963,7 +4963,7 @@ macro_rules! create_new_tmp_ledger {
         $crate::blockstore::create_new_ledger_from_name(
             $crate::tmp_ledger_name!(),
             $genesis_config,
-            $crate::macro_reexports::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+            $crate::genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
             $crate::blockstore_options::LedgerColumnOptions::default(),
         )
     };
@@ -4990,7 +4990,7 @@ macro_rules! create_new_tmp_ledger_auto_delete {
         $crate::blockstore::create_new_ledger_from_name_auto_delete(
             $crate::tmp_ledger_name!(),
             $genesis_config,
-            $crate::macro_reexports::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+            $crate::genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
             $crate::blockstore_options::LedgerColumnOptions::default(),
         )
     };
@@ -5270,7 +5270,9 @@ pub mod tests {
     use {
         super::*,
         crate::{
-            genesis_utils::{create_genesis_config, GenesisConfigInfo},
+            genesis_utils::{
+                create_genesis_config, GenesisConfigInfo, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+            },
             leader_schedule::{FixedSchedule, IdentityKeyedLeaderSchedule},
             shred::{max_ticks_per_n_shreds, MAX_DATA_SHREDS_PER_SLOT},
         },
@@ -5279,9 +5281,7 @@ pub mod tests {
         crossbeam_channel::unbounded,
         rand::{seq::SliceRandom, thread_rng},
         solana_account_decoder::parse_token::UiTokenAmount,
-        solana_accounts_db::hardened_unpack::{
-            open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-        },
+        solana_accounts_db::hardened_unpack::open_genesis_config,
         solana_clock::{DEFAULT_MS_PER_SLOT, DEFAULT_TICKS_PER_SLOT},
         solana_entry::entry::{next_entry, next_entry_mut},
         solana_hash::Hash,

--- a/ledger/src/genesis_utils.rs
+++ b/ledger/src/genesis_utils.rs
@@ -6,6 +6,8 @@ use {
     solana_runtime::genesis_utils::create_genesis_config_with_leader_with_mint_keypair,
 };
 
+pub const MAX_GENESIS_ARCHIVE_UNPACKED_SIZE: u64 = 10 * 1024 * 1024; // 10 MiB
+
 // same as genesis_config::create_genesis_config, but with bootstrap_validator staking logic
 //  for the core crate tests
 pub fn create_genesis_config(mint_lamports: u64) -> GenesisConfigInfo {

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -48,9 +48,4 @@ extern crate log;
 #[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
 
-#[doc(hidden)]
-pub mod macro_reexports {
-    pub use solana_accounts_db::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE;
-}
-
 mod wire_format_tests;

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -8,7 +8,6 @@ use {
     solana_account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
     solana_accounts_db::{
         accounts_db::AccountsDbConfig, accounts_index::AccountsIndexConfig,
-        hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         utils::create_accounts_run_and_snapshot_dirs,
     },
     solana_cli_output::CliAccount,
@@ -35,7 +34,7 @@ use {
     solana_keypair::{read_keypair_file, write_keypair_file, Keypair},
     solana_ledger::{
         blockstore::create_new_ledger, blockstore_options::LedgerColumnOptions,
-        create_new_tmp_ledger,
+        create_new_tmp_ledger, genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     },
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_message::Message,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2,11 +2,8 @@ use {
     crate::commands,
     agave_snapshots::DEFAULT_ARCHIVE_COMPRESSION,
     clap::{crate_description, crate_name, App, AppSettings, Arg, ArgMatches, SubCommand},
-    solana_accounts_db::{
-        accounts_db::{
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO,
-        },
-        hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+    solana_accounts_db::accounts_db::{
+        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO,
     },
     solana_clap_utils::{
         hidden_unless_forced,
@@ -21,6 +18,7 @@ use {
     solana_epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
     solana_faucet::faucet::{self, FAUCET_PORT},
     solana_hash::Hash,
+    solana_ledger::genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
     solana_quic_definitions::QUIC_PORT_OFFSET,
     solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -15,7 +15,6 @@ use {
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig, MarkObsoleteAccounts},
         accounts_file::StorageAccess,
         accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig, IndexLimitMb, ScanFilter},
-        hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         utils::{
             create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories,
             create_and_canonicalize_directory,
@@ -47,6 +46,7 @@ use {
     solana_keypair::Keypair,
     solana_ledger::{
         blockstore_cleanup_service::{DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS},
+        genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         use_snapshot_archives_at_startup::{self, UseSnapshotArchivesAtStartup},
     },
     solana_logger::redirect_stderr_to_file,

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -1410,7 +1410,6 @@ mod tests {
     use {
         crate::wen_restart::{tests::wen_restart_proto::LastVotedForkSlotsAggregateFinal, *},
         crossbeam_channel::unbounded,
-        solana_accounts_db::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         solana_entry::entry::create_ticks,
         solana_gossip::{
             cluster_info::ClusterInfo,
@@ -1426,6 +1425,7 @@ mod tests {
             blockstore::{create_new_ledger, entries_to_test_shreds, Blockstore},
             blockstore_options::LedgerColumnOptions,
             blockstore_processor::{fill_blockstore_slot_with_ticks, test_process_blockstore},
+            genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
             get_tmp_ledger_path_auto_delete,
         },
         solana_pubkey::Pubkey,


### PR DESCRIPTION
#### Problem
MAX_GENESIS_ARCHIVE_UNPACKED_SIZE constant is defined in code that should mostly perform untar operation and it's way high-level / business logic related to be there.
And it's used only in test that could as well use / test for tigher value.

The constant is used across several crates, but most of those are in `ledger` / `ledger-tool`

#### Summary of Changes
Move to `ledger/genesis_utils.rs`

(test for hitting max size when unpacking will come separately - right now no test is actually reliant on the constant)