### PR TITLE
Revert "Use read lock for accessing slot list when possible in tests"

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1630,7 +1630,7 @@ mod tests {
                         &mut reclaims,
                         reclaim,
                     );
-                    let mut slot_list = entry.slot_list_read_lock().clone_list();
+                    let mut slot_list = entry.slot_list_write_lock().clone_list();
 
                     // calculate expected reclaims
                     let mut expected_reclaims = ReclaimsSlotList::new();
@@ -2008,7 +2008,7 @@ mod tests {
                         &mut reclaims,
                         reclaim,
                     );
-                    let mut slot_list = entry.slot_list_read_lock().clone_list();
+                    let mut slot_list = entry.slot_list_write_lock().clone_list();
 
                     // calculate expected reclaims
                     let mut expected_reclaims = ReclaimsSlotList::new();


### PR DESCRIPTION
https://github.com/anza-xyz/agave/pull/8409 should be reverted (scans might be relying on locked slot_list len and ref_count to be consistent), this PR should allow a clean revert.

Reverts anza-xyz/agave#8466