### PR TITLE
Revert "Pass SlotListWriteGuard instead of &mut to it for slot list updates"

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1485,7 +1485,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     /// Returns true if the slot list was completely purged (is empty at the end).
     fn purge_older_root_entries(
         &self,
-        mut slot_list: SlotListWriteGuard<T>,
+        slot_list: &mut SlotListWriteGuard<T>,
         reclaims: &mut ReclaimsSlotList<T>,
         max_clean_root_inclusive: Option<Slot>,
     ) -> bool {
@@ -1498,7 +1498,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             let roots_tracker = &self.roots_tracker.read().unwrap();
             newest_root_in_slot_list = Self::get_newest_root_in_slot_list(
                 &roots_tracker.alive_roots,
-                &slot_list,
+                slot_list,
                 max_clean_root_inclusive,
             );
             max_clean_root_inclusive.unwrap_or_else(|| roots_tracker.alive_roots.max_inclusive())
@@ -1532,9 +1532,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     ) -> bool {
         let mut is_slot_list_empty = false;
         let missing_in_accounts_index = self
-            .slot_list_mut(pubkey, |slot_list| {
-                is_slot_list_empty =
-                    self.purge_older_root_entries(slot_list, reclaims, max_clean_root_inclusive);
+            .slot_list_mut(pubkey, |mut slot_list| {
+                is_slot_list_empty = self.purge_older_root_entries(
+                    &mut slot_list,
+                    reclaims,
+                    max_clean_root_inclusive,
+                );
             })
             .is_none();
 
@@ -3377,10 +3380,10 @@ pub mod tests {
             1,
             AccountMapEntryMeta::default(),
         );
-        let mut reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(entry.slot_list_write_lock(), &mut reclaims, None));
-        assert!(reclaims.is_empty());
         let mut slot_list = entry.slot_list_write_lock();
+        let mut reclaims = ReclaimsSlotList::new();
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, None));
+        assert!(reclaims.is_empty());
         assert_eq!(
             slot_list.clone_list(),
             SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
@@ -3392,9 +3395,8 @@ pub mod tests {
         // Note 2 is not a root
         index.add_root(5);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, None));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, None));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
-        let mut slot_list = entry.slot_list_write_lock();
         assert_eq!(
             slot_list.clone_list(),
             SlotList::from_iter([(5, true), (9, true)])
@@ -3403,9 +3405,8 @@ pub mod tests {
         slot_list.assign([(1 as Slot, true), (2, true), (5, true), (9, true)]);
         index.add_root(6);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, None));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, None));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
-        let mut slot_list = entry.slot_list_write_lock();
         assert_eq!(
             slot_list.clone_list(),
             SlotList::from_iter([(5, true), (9, true)])
@@ -3415,9 +3416,8 @@ pub mod tests {
         // outcome
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, Some(6)));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(6)));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
-        let mut slot_list = entry.slot_list_write_lock();
         assert_eq!(
             slot_list.clone_list(),
             SlotList::from_iter([(5, true), (9, true)])
@@ -3426,9 +3426,8 @@ pub mod tests {
         // Pass a max root, earlier slots should be reclaimed
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, Some(5)));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(5)));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
-        let mut slot_list = entry.slot_list_write_lock();
         assert_eq!(
             slot_list.clone_list(),
             SlotList::from_iter([(5, true), (9, true)])
@@ -3438,9 +3437,8 @@ pub mod tests {
         // so nothing will be purged
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, Some(2)));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(2)));
         assert!(reclaims.is_empty());
-        let mut slot_list = entry.slot_list_write_lock();
         assert_eq!(
             slot_list.clone_list(),
             SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
@@ -3450,9 +3448,8 @@ pub mod tests {
         // so nothing will be purged
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, Some(1)));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(1)));
         assert!(reclaims.is_empty());
-        let mut slot_list = entry.slot_list_write_lock();
         assert_eq!(
             slot_list.clone_list(),
             SlotList::from_iter([(1, true), (2, true), (5, true), (9, true)])
@@ -3462,11 +3459,11 @@ pub mod tests {
         // some of the roots in the list, shouldn't return those smaller roots
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsSlotList::new();
-        assert!(!index.purge_older_root_entries(slot_list, &mut reclaims, Some(7)));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(7)));
         assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
         assert_eq!(
-            entry.slot_list_read_lock().as_ref(),
-            &[(5, true), (9, true)]
+            slot_list.clone_list(),
+            SlotList::from_iter([(5, true), (9, true)])
         );
     }
 
@@ -3697,8 +3694,8 @@ pub mod tests {
         // was outdated by the update in the later slot, the primary account key is still alive,
         // so both secondary keys will still be kept alive.
         index.add_root(later_slot);
-        index.slot_list_mut(&account_key, |slot_list| {
-            index.purge_older_root_entries(slot_list, &mut ReclaimsSlotList::new(), None)
+        index.slot_list_mut(&account_key, |mut slot_list| {
+            index.purge_older_root_entries(&mut slot_list, &mut ReclaimsSlotList::new(), None)
         });
 
         check_secondary_index_mapping_correct(

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -602,10 +602,16 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         reclaims: &mut ReclaimsSlotList<T>,
         reclaim: UpsertReclaim,
     ) -> usize {
-        let slot_list = current.slot_list_write_lock();
+        let mut slot_list = current.slot_list_write_lock();
         let (slot, new_entry) = new_value;
-        let (ref_count_change, slot_list_len) =
-            Self::update_slot_list(slot_list, slot, new_entry, other_slot, reclaims, reclaim);
+        let (ref_count_change, slot_list_len) = Self::update_slot_list(
+            &mut slot_list,
+            slot,
+            new_entry,
+            other_slot,
+            reclaims,
+            reclaim,
+        );
 
         match ref_count_change.cmp(&0) {
             cmp::Ordering::Equal => {
@@ -635,7 +641,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// The reference count change is the number of entries added (1) - the number of uncached
     /// entries removed or replaced
     fn update_slot_list(
-        mut slot_list: SlotListWriteGuard<T>,
+        slot_list: &mut SlotListWriteGuard<T>,
         slot: Slot,
         account_info: T,
         other_slot: Option<Slot>,
@@ -1505,10 +1511,11 @@ mod tests {
         for other_slot in [Some(new_slot), Some(unique_other_slot), None] {
             let mut reclaims = ReclaimsSlotList::new();
             let entry = AccountMapEntry::empty_for_tests();
+            let mut slot_list = entry.slot_list_write_lock();
             // upserting into empty slot_list, so always addref
             assert_eq!(
                 InMemAccountsIndex::<u64, u64>::update_slot_list(
-                    entry.slot_list_write_lock(),
+                    &mut slot_list,
                     new_slot,
                     info,
                     other_slot,
@@ -1518,7 +1525,7 @@ mod tests {
                 (1, 1),
                 "other_slot: {other_slot:?}"
             );
-            assert_eq!(entry.slot_list_read_lock().as_ref(), &[at_new_slot]);
+            assert_eq!(slot_list.clone_list(), SlotList::from([at_new_slot]));
             assert!(reclaims.is_empty());
         }
 
@@ -1528,7 +1535,7 @@ mod tests {
             1,
             AccountMapEntryMeta::default(),
         );
-        let slot_list = entry.slot_list_write_lock();
+        let mut slot_list = entry.slot_list_write_lock();
         let expected_reclaims = ReclaimsSlotList::from(slot_list.as_ref());
         let other_slot = Some(unique_other_slot);
         let mut reclaims = ReclaimsSlotList::new();
@@ -1537,7 +1544,7 @@ mod tests {
             // but, it DOES contain an entry at other_slot, so we do NOT add-ref. The assumption is that 'other_slot' is going away
             // and that the previously held add-ref is now used by 'new_slot'
             InMemAccountsIndex::<u64, u64>::update_slot_list(
-                slot_list,
+                &mut slot_list,
                 new_slot,
                 info,
                 other_slot,
@@ -1547,8 +1554,7 @@ mod tests {
             (0, 1),
             "other_slot: {other_slot:?}"
         );
-        let slot_list = entry.slot_list_read_lock();
-        assert_eq!(slot_list.as_ref(), &[at_new_slot]);
+        assert_eq!(slot_list.clone_list(), SlotList::from([at_new_slot]));
         assert_eq!(reclaims, expected_reclaims);
 
         // nothing will exist at this slot
@@ -1617,20 +1623,20 @@ mod tests {
                         1,
                         AccountMapEntryMeta::default(),
                     );
-                    let slot_list = entry.slot_list_write_lock();
+                    let mut slot_list = entry.slot_list_write_lock();
                     let mut expected = slot_list.clone_list();
                     let original = slot_list.clone_list();
                     let mut reclaims = ReclaimsSlotList::new();
 
                     let (result, _len) = InMemAccountsIndex::<u64, u64>::update_slot_list(
-                        slot_list,
+                        &mut slot_list,
                         new_slot,
                         info,
                         other_slot,
                         &mut reclaims,
                         reclaim,
                     );
-                    let mut slot_list = entry.slot_list_write_lock().clone_list();
+                    let mut slot_list = slot_list.clone_list();
 
                     // calculate expected reclaims
                     let mut expected_reclaims = ReclaimsSlotList::new();
@@ -1877,10 +1883,11 @@ mod tests {
         for other_slot in [Some(new_slot), Some(unique_other_slot), None] {
             let mut reclaims = ReclaimsSlotList::new();
             let entry = AccountMapEntry::empty_for_tests();
+            let mut slot_list = entry.slot_list_write_lock();
             // upserting into empty slot_list, so always addref
             assert_eq!(
                 InMemAccountsIndex::<u64, u64>::update_slot_list(
-                    entry.slot_list_write_lock(),
+                    &mut slot_list,
                     new_slot,
                     info,
                     other_slot,
@@ -1890,7 +1897,7 @@ mod tests {
                 (1, 1),
                 "other_slot: {other_slot:?}"
             );
-            assert_eq!(entry.slot_list_read_lock().as_ref(), &[at_new_slot]);
+            assert_eq!(slot_list.clone_list(), SlotList::from([at_new_slot]));
             assert!(reclaims.is_empty());
         }
 
@@ -1900,7 +1907,7 @@ mod tests {
             1,
             AccountMapEntryMeta::default(),
         );
-        let slot_list = entry.slot_list_write_lock();
+        let mut slot_list = entry.slot_list_write_lock();
         let expected_reclaims = ReclaimsSlotList::from(slot_list.as_ref());
         let other_slot = Some(unique_other_slot);
         let mut reclaims = ReclaimsSlotList::new();
@@ -1909,7 +1916,7 @@ mod tests {
             // but, it DOES contain an entry at other_slot, so we do NOT add-ref. The assumption is that 'other_slot' is going away
             // and that the previously held add-ref is now used by 'new_slot'
             InMemAccountsIndex::<u64, u64>::update_slot_list(
-                slot_list,
+                &mut slot_list,
                 new_slot,
                 info,
                 other_slot,
@@ -1919,8 +1926,7 @@ mod tests {
             (0, 1),
             "other_slot: {other_slot:?}"
         );
-        let slot_list = entry.slot_list_read_lock();
-        assert_eq!(slot_list.as_ref(), &[at_new_slot]);
+        assert_eq!(slot_list.clone_list(), SlotList::from([at_new_slot]));
         assert_eq!(reclaims, expected_reclaims);
 
         // nothing will exist at this slot
@@ -1995,20 +2001,20 @@ mod tests {
                         1,
                         AccountMapEntryMeta::default(),
                     );
-                    let slot_list = entry.slot_list_write_lock();
+                    let mut slot_list = entry.slot_list_write_lock();
                     let mut expected = slot_list.clone_list();
                     let original = slot_list.clone_list();
                     let mut reclaims = ReclaimsSlotList::new();
 
                     let (result, _len) = InMemAccountsIndex::<u64, u64>::update_slot_list(
-                        slot_list,
+                        &mut slot_list,
                         new_slot,
                         info,
                         other_slot,
                         &mut reclaims,
                         reclaim,
                     );
-                    let mut slot_list = entry.slot_list_write_lock().clone_list();
+                    let mut slot_list = slot_list.clone_list();
 
                     // calculate expected reclaims
                     let mut expected_reclaims = ReclaimsSlotList::new();
@@ -2061,12 +2067,13 @@ mod tests {
             1,
             AccountMapEntryMeta::default(),
         );
+        let mut slot_list = entry.slot_list_write_lock();
         let mut reclaims = ReclaimsSlotList::new();
         let new_info = 1;
 
         // Attempt to update the slot list with a duplicate slot, which should trigger the panic
         InMemAccountsIndex::<u64, u64>::update_slot_list(
-            entry.slot_list_write_lock(),
+            &mut slot_list,
             new_slot,
             new_info,
             Some(slot_to_replace),


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/8409 changed the scope of the lock guard such that modifying entry ref_count is no longer done while holding the write lock.
There is no consistent pattern of reading ref count only under slot list lock, but at least one place - scans might be relying on locked slot_list len and ref_count to be consistent: https://github.com/anza-xyz/agave/blob/6bef121d88425f567ff5281c0e275a418a2af5e6/accounts-db/src/accounts_index.rs#L1068-L1069
Making it 100% correct might need other changes in how ref_count is updated, but no need to make it worse.

#### Summary of Changes
Reverts anza-xyz/agave#8409