### PR TITLE
Remove Arc from leader_slots_map in LeaderSchedule

### DIFF
--- a/ledger/src/leader_schedule.rs
+++ b/ledger/src/leader_schedule.rs
@@ -39,9 +39,7 @@ pub trait LeaderScheduleVariant:
         pubkey: &Pubkey,
         offset: usize, // Starting index.
     ) -> Box<dyn Iterator<Item = usize> + '_> {
-        let index = self
-            .get_leader_slots_map()
-            .get(pubkey);
+        let index = self.get_leader_slots_map().get(pubkey);
         let num_slots = self.num_slots();
 
         match index {
@@ -55,7 +53,10 @@ pub trait LeaderScheduleVariant:
                 // for LeaderSchedule, where the schedule keeps repeating endlessly.
                 // The '%' returns where in a cycle we are and the '/' returns how many
                 // times the schedule is repeated.
-                Box::new((start_offset..=usize::MAX).map(move |k| index[k % size] + k / size * num_slots))
+                Box::new(
+                    (start_offset..=usize::MAX)
+                        .map(move |k| index[k % size] + k / size * num_slots),
+                )
             }
             _ => {
                 // Empty iterator for pubkeys not in schedule

--- a/ledger/src/leader_schedule.rs
+++ b/ledger/src/leader_schedule.rs
@@ -26,7 +26,7 @@ pub trait LeaderScheduleVariant:
     std::fmt::Debug + Send + Sync + Index<u64, Output = Pubkey>
 {
     fn get_slot_leaders(&self) -> &[Pubkey];
-    fn get_leader_slots_map(&self) -> &HashMap<Pubkey, Arc<Vec<usize>>>;
+    fn get_leader_slots_map(&self) -> &HashMap<Pubkey, Vec<usize>>;
 
     /// Get the vote account address for the given epoch slot index. This is
     /// guaranteed to be Some if the leader schedule is keyed by vote account
@@ -38,29 +38,31 @@ pub trait LeaderScheduleVariant:
         &self,
         pubkey: &Pubkey,
         offset: usize, // Starting index.
-    ) -> Box<dyn Iterator<Item = usize>> {
+    ) -> Box<dyn Iterator<Item = usize> + '_> {
         let index = self
             .get_leader_slots_map()
-            .get(pubkey)
-            .cloned()
-            .unwrap_or_default();
+            .get(pubkey);
         let num_slots = self.num_slots();
-        let size = index.len();
-        #[allow(clippy::reversed_empty_ranges)]
-        let range = if index.is_empty() {
-            1..=0 // Intentionally empty range of type RangeInclusive.
-        } else {
-            let offset = index
-                .binary_search(&(offset % num_slots))
-                .unwrap_or_else(identity)
-                + offset / num_slots * size;
-            offset..=usize::MAX
-        };
-        // The modular arithmetic here and above replicate Index implementation
-        // for LeaderSchedule, where the schedule keeps repeating endlessly.
-        // The '%' returns where in a cycle we are and the '/' returns how many
-        // times the schedule is repeated.
-        Box::new(range.map(move |k| index[k % size] + k / size * num_slots))
+
+        match index {
+            Some(index) if !index.is_empty() => {
+                let size = index.len();
+                let start_offset = index
+                    .binary_search(&(offset % num_slots))
+                    .unwrap_or_else(identity)
+                    + offset / num_slots * size;
+                // The modular arithmetic here and above replicate Index implementation
+                // for LeaderSchedule, where the schedule keeps repeating endlessly.
+                // The '%' returns where in a cycle we are and the '/' returns how many
+                // times the schedule is repeated.
+                Box::new((start_offset..=usize::MAX).map(move |k| index[k % size] + k / size * num_slots))
+            }
+            _ => {
+                // Empty iterator for pubkeys not in schedule
+                #[allow(clippy::reversed_empty_ranges)]
+                Box::new((1..=0).map(|_| 0))
+            }
+        }
     }
 
     fn num_slots(&self) -> usize {

--- a/ledger/src/leader_schedule/identity_keyed.rs
+++ b/ledger/src/leader_schedule/identity_keyed.rs
@@ -3,14 +3,14 @@ use {
     itertools::Itertools,
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
-    std::{collections::HashMap, ops::Index, sync::Arc},
+    std::{collections::HashMap, ops::Index},
 };
 
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct LeaderSchedule {
     slot_leaders: Vec<Pubkey>,
     // Inverted index from pubkeys to indices where they are the leader.
-    leader_slots_map: HashMap<Pubkey, Arc<Vec<usize>>>,
+    leader_slots_map: HashMap<Pubkey, Vec<usize>>,
 }
 
 impl LeaderSchedule {
@@ -36,15 +36,12 @@ impl LeaderSchedule {
         }
     }
 
-    fn invert_slot_leaders(slot_leaders: &[Pubkey]) -> HashMap<Pubkey, Arc<Vec<usize>>> {
+    fn invert_slot_leaders(slot_leaders: &[Pubkey]) -> HashMap<Pubkey, Vec<usize>> {
         slot_leaders
             .iter()
             .enumerate()
             .map(|(i, pk)| (*pk, i))
             .into_group_map()
-            .into_iter()
-            .map(|(k, v)| (k, Arc::new(v)))
-            .collect()
     }
 
     pub fn get_slot_leaders(&self) -> &[Pubkey] {
@@ -57,7 +54,7 @@ impl LeaderScheduleVariant for LeaderSchedule {
         &self.slot_leaders
     }
 
-    fn get_leader_slots_map(&self) -> &HashMap<Pubkey, Arc<Vec<usize>>> {
+    fn get_leader_slots_map(&self) -> &HashMap<Pubkey, Vec<usize>> {
         &self.leader_slots_map
     }
 }

--- a/ledger/src/leader_schedule/vote_keyed.rs
+++ b/ledger/src/leader_schedule/vote_keyed.rs
@@ -3,7 +3,7 @@ use {
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
     solana_vote::vote_account::VoteAccountsHashMap,
-    std::{collections::HashMap, ops::Index, sync::Arc},
+    std::{collections::HashMap, ops::Index},
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -80,7 +80,7 @@ impl LeaderScheduleVariant for LeaderSchedule {
         self.identity_keyed_leader_schedule.get_slot_leaders()
     }
 
-    fn get_leader_slots_map(&self) -> &HashMap<Pubkey, Arc<Vec<usize>>> {
+    fn get_leader_slots_map(&self) -> &HashMap<Pubkey, Vec<usize>> {
         self.identity_keyed_leader_schedule.get_leader_slots_map()
     }
 


### PR DESCRIPTION
#### Problem

The `leader_slots_map` in `LeaderSchedule` uses `HashMap<Pubkey, Arc<Vec<usize>>>`, but the `Arc` wrapping is unnecessary overhead.

The Arc was previously needed because `get_leader_upcoming_slots` returned a boxed iterator requiring ownership of the Vec. This forced cloning of the Arc on every call.

#### Summary of Changes

Changed `HashMap<Pubkey, Arc<Vec<usize>>>` to `HashMap<Pubkey, Vec<usize>>` in the leader schedule implementation.

By modifying `get_leader_upcoming_slots` to return a borrowed iterator (`Box<dyn Iterator + '_>`), and collecting the `Arc<LeaderSchedule>` references upfront in `next_leader_slot`, the schedules stay alive for the entire iterator chain, eliminating the need for Arc wrapping and avoiding intermediate Vec allocations.

Changes:
- Updated trait method signature and implementations
- Simplified `invert_slot_leaders` to return HashMap without Arc wrapping
- Modified `get_leader_upcoming_slots` to return borrowed iterator
- Collect leader schedules in `next_leader_slot` before creating iterators
- Removed Arc imports from identity_keyed and vote_keyed modules

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->