### PR TITLE
fix(cli): false positive tx view deprecation warning

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -222,7 +222,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .value_name("STRUCT")
             .takes_value(true)
             .possible_values(TransactionStructure::cli_names())
-            .default_value(TransactionStructure::default().into())
             .help(TransactionStructure::cli_message()),
         usage_warning: "Transaction structure is no longer configurable"
     );

--- a/validator/src/commands/manage_block_production/mod.rs
+++ b/validator/src/commands/manage_block_production/mod.rs
@@ -64,7 +64,6 @@ pub fn command(default_args: &DefaultArgs) -> App<'_, '_> {
                 .value_name("STRUCT")
                 .takes_value(true)
                 .possible_values(TransactionStructure::cli_names())
-                .default_value(TransactionStructure::default().into())
                 .help(TransactionStructure::cli_message()),
         )
         .arg(


### PR DESCRIPTION
#### Problem

- Due to the default value, all `manage-block-production` commands will trigger deprecation warnings.

#### Summary of Changes

- Remove default value from clap and simply rely on validator's unwrap_or_default() call.