### PR TITLE
Remove unused pub functions in accounts-db

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -245,10 +245,6 @@ impl AccountsCache {
         }
     }
 
-    pub fn contains_any_slots(&self, max_slot_inclusive: Slot) -> bool {
-        self.cache.iter().any(|e| e.key() <= &max_slot_inclusive)
-    }
-
     pub fn cached_frozen_slots(&self) -> Vec<Slot> {
         self.cache
             .iter()

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1708,14 +1708,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         stats.roots_range = Some(roots_tracker.alive_roots.range_width());
     }
 
-    pub fn min_alive_root(&self) -> Option<Slot> {
-        self.roots_tracker.read().unwrap().min_alive_root()
-    }
-
-    pub fn num_alive_roots(&self) -> usize {
-        self.roots_tracker.read().unwrap().alive_roots.len()
-    }
-
     pub fn all_alive_roots(&self) -> Vec<Slot> {
         let tracker = self.roots_tracker.read().unwrap();
         tracker.alive_roots.get_all()

--- a/accounts-db/src/accounts_index/roots_tracker.rs
+++ b/accounts-db/src/accounts_index/roots_tracker.rs
@@ -1,4 +1,4 @@
-use {crate::rolling_bit_field::RollingBitField, solana_clock::Slot};
+use crate::rolling_bit_field::RollingBitField;
 
 #[derive(Debug)]
 pub struct RootsTracker {
@@ -23,9 +23,5 @@ impl RootsTracker {
         Self {
             alive_roots: RollingBitField::new(max_width),
         }
-    }
-
-    pub fn min_alive_root(&self) -> Option<Slot> {
-        self.alive_roots.min()
     }
 }


### PR DESCRIPTION
#### Problem
A few unused functions marked as `pub`  in accounts-db

#### Summary of Changes
Remove them.

(not sure if that is the kind of breaking change that we want to avoid or first mark with deprecations... I noticed some other unused pub functions that are marked as deprecated long time ago)