### PR TITLE
chore(stake): deprecate delegation_from and meta_from

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -24,6 +24,10 @@ pub fn stake_from<T: ReadableAccount + StateMut<StakeStateV2>>(account: &T) -> O
     from(account).and_then(|state: StakeStateV2| state.stake())
 }
 
+#[deprecated(
+    since = "2.2.0",
+    note = "Use `from(account).and_then(|state| state.delegation())` instead"
+)]
 pub fn delegation_from(account: &AccountSharedData) -> Option<Delegation> {
     from(account).and_then(|state: StakeStateV2| state.delegation())
 }
@@ -36,6 +40,10 @@ pub fn lockup_from<T: ReadableAccount + StateMut<StakeStateV2>>(account: &T) -> 
     from(account).and_then(|state: StakeStateV2| state.lockup())
 }
 
+#[deprecated(
+    since = "2.2.0",
+    note = "Use `from(account).and_then(|state| state.meta())` instead"
+)]
 pub fn meta_from(account: &AccountSharedData) -> Option<Meta> {
     from(account).and_then(|state: StakeStateV2| state.meta())
 }


### PR DESCRIPTION
Marked delegation_from and meta_from as deprecated with guidance to use from(account).and_then(|state| state.delegation()/meta()) because they are unused across the repository, appear to be legacy helpers inconsistent with neighboring generic helpers, and likely remain only for historical compatibility; deprecation preserves API stability while signaling maintainers and downstreams to migrate to the preferred access pattern.
