### PR TITLE
Fix - #8476

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -847,7 +847,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         &self,
         epoch: Epoch,
     ) -> Option<ProgramRuntimeEnvironments> {
-        if epoch == self.latest_root_epoch {
+        if epoch != self.latest_root_epoch {
             return self.upcoming_environments.clone();
         }
         None

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5919,7 +5919,7 @@ impl Bank {
     ) -> Option<Arc<ProgramCacheEntry>> {
         let environments = self
             .transaction_processor
-            .get_environments_for_epoch(effective_epoch)?;
+            .get_environments_for_epoch(effective_epoch);
         load_program_with_pubkey(
             self,
             &environments,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -507,7 +507,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(50).unwrap(),
+            &batch_processor.get_environments_for_epoch(50),
             &key,
             500,
             &mut ExecuteTimings::default(),
@@ -530,7 +530,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20).unwrap(),
+            &batch_processor.get_environments_for_epoch(20),
             &key,
             0, // Slot 0
             &mut ExecuteTimings::default(),
@@ -543,7 +543,6 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
                     .get_environments_for_epoch(20)
-                    .unwrap()
                     .program_runtime_v1,
             ),
         );
@@ -565,7 +564,7 @@ mod tests {
         // This should return an error
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20).unwrap(),
+            &batch_processor.get_environments_for_epoch(20),
             &key,
             200,
             &mut ExecuteTimings::default(),
@@ -577,7 +576,6 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
                     .get_environments_for_epoch(20)
-                    .unwrap()
                     .program_runtime_v1,
             ),
         );
@@ -593,7 +591,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20).unwrap(),
+            &batch_processor.get_environments_for_epoch(20),
             &key,
             200,
             &mut ExecuteTimings::default(),
@@ -647,7 +645,7 @@ mod tests {
         // This should return an error
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(0).unwrap(),
+            &batch_processor.get_environments_for_epoch(0),
             &key1,
             0,
             &mut ExecuteTimings::default(),
@@ -659,7 +657,6 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
                     .get_environments_for_epoch(0)
-                    .unwrap()
                     .program_runtime_v1,
             ),
         );
@@ -685,7 +682,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20).unwrap(),
+            &batch_processor.get_environments_for_epoch(20),
             &key1,
             200,
             &mut ExecuteTimings::default(),
@@ -735,7 +732,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(0).unwrap(),
+            &batch_processor.get_environments_for_epoch(0),
             &key,
             0,
             &mut ExecuteTimings::default(),
@@ -747,7 +744,6 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(
                 batch_processor
                     .get_environments_for_epoch(0)
-                    .unwrap()
                     .program_runtime_v1,
             ),
         );
@@ -769,7 +765,7 @@ mod tests {
 
         let result = load_program_with_pubkey(
             &mock_bank,
-            &batch_processor.get_environments_for_epoch(20).unwrap(),
+            &batch_processor.get_environments_for_epoch(20),
             &key,
             200,
             &mut ExecuteTimings::default(),
@@ -818,9 +814,7 @@ mod tests {
         for is_upcoming_env in [false, true] {
             let result = load_program_with_pubkey(
                 &mock_bank,
-                &batch_processor
-                    .get_environments_for_epoch(is_upcoming_env as u64)
-                    .unwrap(),
+                &batch_processor.get_environments_for_epoch(is_upcoming_env as u64),
                 &key,
                 200,
                 &mut ExecuteTimings::default(),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -37,7 +37,7 @@ use {
         invoke_context::{EnvironmentConfig, InvokeContext},
         loaded_programs::{
             ForkGraph, ProgramCache, ProgramCacheEntry, ProgramCacheForTxBatch,
-            ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
+            ProgramCacheMatchCriteria, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
         },
         solana_sbpf::{program::BuiltinProgram, vm::Config as VmConfig},
         sysvar_cache::SysvarCache,
@@ -293,16 +293,11 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     }
 
     /// Returns the current environments depending on the given epoch
-    /// Returns None if the call could result in a deadlock
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn get_environments_for_epoch(
-        &self,
-        epoch: Epoch,
-    ) -> Option<solana_program_runtime::loaded_programs::ProgramRuntimeEnvironments> {
+    pub fn get_environments_for_epoch(&self, epoch: Epoch) -> ProgramRuntimeEnvironments {
         self.global_program_cache
             .try_read()
-            .ok()
-            .map(|cache| cache.get_environments_for_epoch(epoch))
+            .unwrap()
+            .get_environments_for_epoch(epoch)
     }
 
     pub fn sysvar_cache(&self) -> RwLockReadGuard<SysvarCache> {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -295,7 +295,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     /// Returns the current environments depending on the given epoch
     pub fn get_environments_for_epoch(&self, epoch: Epoch) -> ProgramRuntimeEnvironments {
         self.global_program_cache
-            .try_read()
+            .read()
             .unwrap()
             .get_environments_for_epoch(epoch)
     }


### PR DESCRIPTION
#### Problem

#8412 was reverted in #8476 because it used `TransactionBatchProcessor::get_environments_for_epoch()` which was previously only used in the CLI and tests, and used `try_read()` instead of `read()` (since #1621). This means it fails when locked writable already and then propagates that failure outwards. Because of that the shuttle tests ignored this error silently.

#### Summary of Changes

Please see the commit messages for details.
