### PR TITLE
Optimize staked_nodes() for 3-4x performance improvement

### DIFF
--- a/vote/benches/vote_account.rs
+++ b/vote/benches/vote_account.rs
@@ -61,23 +61,20 @@ fn bench_staked_nodes_compute(b: &mut Bencher) {
     let mut rng = rand::thread_rng();
     let mut vote_accounts_map = HashMap::new();
 
-    // Create realistic scenario with 100 nodes, each with 3-5 vote accounts
-    // This simulates stake aggregation across multiple vote accounts per node
-    let node_count = 100;
+    // Create a scenario with ~400 vote accounts
+    // Each vote account has one node_pubkey and receives delegated stake
+    // The stake represents the total from multiple stake accounts delegating to it
+    let num_vote_accounts = 400;
 
-    for _ in 0..node_count {
-        let node_pubkey = Pubkey::new_unique();
-        let vote_accounts_per_node = rng.gen_range(3..=5);
-
-        for _ in 0..vote_accounts_per_node {
-            let (account, _) = new_rand_vote_account(&mut rng, Some(node_pubkey));
-            let vote_account = VoteAccount::try_from(account).unwrap();
-            let stake: u64 = rng.gen_range(1_000_000..100_000_000);
-            vote_accounts_map.insert(Pubkey::new_unique(), (stake, vote_account));
-        }
+    for _ in 0..num_vote_accounts {
+        let (account, _) = new_rand_vote_account(&mut rng, None);
+        let vote_account = VoteAccount::try_from(account).unwrap();
+        // Stake amount represents total delegated stake (from multiple stake accounts)
+        let stake: u64 = rng.gen_range(1_000_000..100_000_000);
+        vote_accounts_map.insert(Pubkey::new_unique(), (stake, vote_account));
     }
 
-    // Add some zero-stake accounts to test filtering
+    // Add some zero-stake accounts (vote accounts with no delegations)
     for _ in 0..50 {
         let (account, _) = new_rand_vote_account(&mut rng, None);
         let vote_account = VoteAccount::try_from(account).unwrap();

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -139,9 +139,14 @@ impl VoteAccounts {
     pub fn staked_nodes(&self) -> Arc<HashMap</*node_pubkey:*/ Pubkey, /*stake:*/ u64>> {
         self.staked_nodes
             .get_or_init(|| {
-                // Pre-allocate HashMap with estimated capacity to reduce reallocations
-                let mut staked_nodes =
-                    HashMap::with_capacity(self.vote_accounts.len().saturating_div(2));
+                // Count non-zero stake accounts for optimal capacity allocation
+                let non_zero_count = self
+                    .vote_accounts
+                    .values()
+                    .filter(|(stake, _)| *stake != 0)
+                    .count();
+
+                let mut staked_nodes = HashMap::with_capacity(non_zero_count);
 
                 for (stake, vote_account) in self.vote_accounts.values() {
                     if *stake != 0 {

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -1,6 +1,5 @@
 use {
     crate::vote_state_view::VoteStateView,
-    itertools::Itertools,
     serde::{
         de::{MapAccess, Visitor},
         ser::Serializer,
@@ -140,16 +139,20 @@ impl VoteAccounts {
     pub fn staked_nodes(&self) -> Arc<HashMap</*node_pubkey:*/ Pubkey, /*stake:*/ u64>> {
         self.staked_nodes
             .get_or_init(|| {
-                Arc::new(
-                    self.vote_accounts
-                        .values()
-                        .filter(|(stake, _)| *stake != 0u64)
-                        .map(|(stake, vote_account)| (*vote_account.node_pubkey(), stake))
-                        .into_grouping_map()
-                        .aggregate(|acc, _node_pubkey, stake| {
-                            Some(acc.unwrap_or_default() + stake)
-                        }),
-                )
+                // Pre-allocate HashMap with estimated capacity to reduce reallocations
+                let mut staked_nodes =
+                    HashMap::with_capacity(self.vote_accounts.len().saturating_div(2));
+
+                for (stake, vote_account) in self.vote_accounts.values() {
+                    if *stake != 0 {
+                        staked_nodes
+                            .entry(*vote_account.node_pubkey())
+                            .and_modify(|total_stake| *total_stake += stake)
+                            .or_insert(*stake);
+                    }
+                }
+
+                Arc::new(staked_nodes)
             })
             .clone()
     }

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -145,10 +145,7 @@ impl VoteAccounts {
 
                 for (stake, vote_account) in self.vote_accounts.values() {
                     if *stake != 0 {
-                        staked_nodes
-                            .entry(*vote_account.node_pubkey())
-                            .and_modify(|total_stake| *total_stake += stake)
-                            .or_insert(*stake);
+                        *staked_nodes.entry(*vote_account.node_pubkey()).or_default() += *stake;
                     }
                 }
 


### PR DESCRIPTION
## Problem

The `staked_nodes()` method in `VoteAccounts` was using itertools' `into_grouping_map().aggregate()` pattern, which creates intermediate allocations and adds unnecessary overhead for a hot path in validator operations.

## Summary of Changes

Replace the itertools grouping_map implementation with direct HashMap construction for better performance:

- **Remove** unused `itertools::Itertools` import
- **Optimize** stake aggregation using `entry().and_modify().or_insert()` 
- **Pre-allocate** HashMap with estimated capacity to reduce reallocations
- **Add** benchmark to measure and track performance

## Performance Impact

Benchmark with realistic scenario (400 validator nodes):

- **Before:** 27,206 ns/iter
- **After:** 12,586 ns/iter  
- **Improvement:** 2.16x speedup (53.7% faster)

Running on mainnet shows 3-4x Speedup

<img width="803" height="470" alt="image" src="https://github.com/user-attachments/assets/5bbc59ec-e686-4670-8672-ddcaf49fd6d1" />


<details>

<summary>log</summary>

```
[2025-10-16T16:01:25.813898562Z INFO  solana_metrics::metrics] datapoint: staked_nodes_timing num_vote_accounts=6755i old_impl_us=1057i new_impl_us=313i speedup_ratio=3.376996805111821
[2025-10-16T16:01:25.813904720Z INFO  solana_metrics::metrics] datapoint: staked_nodes_timing num_vote_accounts=6750i old_impl_us=864i new_impl_us=245i speedup_ratio=3.526530612244898
[2025-10-16T16:01:29.378669009Z INFO  solana_metrics::metrics] datapoint: staked_nodes_timing num_vote_accounts=6750i old_impl_us=662i new_impl_us=152i speedup_ratio=4.355263157894737
```
</details>


