### PR TITLE
Add timing instrumentation for staked_nodes() optimization [TEST-DON"T MERGE]

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Edit",
+      "Bash",
+      "Read",
+      "mcp__github__*",
+      "Fetch"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash",
+      "Fetch",
+      "mcp__github",
+      "mcp__sequential-thinking__sequentialthinking"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Agave is a Rust workspace of validator, client, and tooling crates. Core execution lives in `runtime/` and `core/`, networking flows through `rpc/`, `banks-server/`, and `banks-client/`, and user-facing binaries ship from `cli/` and `cli-config/`. Shared SDK code is in `sdk/`, on-chain examples and SBF helpers live in `programs/`, `cargo-build-sbf/`, and `cargo-test-sbf/`. Reference material sits in `docs/`, automation resides in `scripts/` and `ci/`, and each crate carries unit tests beside `src/` plus broader scenarios under `tests/` or `benches/` (for example `runtime/tests/`, `local-cluster/tests/`).
+
+## Build, Test, and Development Commands
+- `./cargo build --workspace` compiles every crate using the pinned toolchain in `rust-toolchain.toml`.
+- `./cargo test --workspace --all-features` runs the suite; narrow scope with `-p <crate>` during iteration.
+- `./cargo clippy --workspace --all-targets` enforces lint policy and must be clean before review.
+- `cargo fmt --all` (or `./cargo fmt`) applies the shared `rustfmt.toml` formatting.
+
+## Coding Style & Naming Conventions
+Follow the defaults captured in `rustfmt.toml`: four-space indentation, 100-column targets, trailing commas on multiline structures, and `snake_case` paths. Types and traits use `UpperCamelCase`; constants use `SCREAMING_SNAKE_CASE`. Prefer `expect("context")` over bare `unwrap()`, keep error messages actionable, and hide consensus-affecting work behind feature gates named after the tracking issue.
+
+## Testing Guidelines
+Unit tests rely on Rust’s built-in harness; add them beside the code path they protect. Integration and validator flows belong in dedicated crates such as `program-test/` or `local-cluster/`. Generate coverage with `scripts/coverage.sh` and attach notable deltas when coverage shifts. Benchmarks that require nightly must run via `cargo +nightly bench`, with summaries linked in the PR when performance is impacted.
+
+## Commit & Pull Request Guidelines
+Write imperative, single-line commit titles (`Add vote packet filter`). Keep commits review-sized and avoid mixing refactors with behaviour changes. Open draft PRs to trigger CI, then provide a concise problem statement, proposed changes list, test evidence, and relevant metrics or benchmarks. Link issues, refresh `CHANGELOG.md` when user-facing, and document feature gating or SIMD references for consensus changes.
+
+## Security & Configuration Tips
+Report vulnerabilities through the channel defined in `SECURITY.md` before disclosure. For reproducible validator builds, follow `docs/src/cli/install.md` and the perf-library scripts under `scripts/`. Store validator keys outside the repository and prefer hardware or `remote-wallet/` tooling for signing. Monitor `metrics/` and `watchtower/` outputs after enabling new gates to catch regressions quickly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,144 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Agave is the Anza-maintained Solana validator client implementation, written in Rust. It's a high-performance blockchain architecture with extensive testing, benchmarking, and optimization focus.
+
+## Build Commands
+
+```bash
+# Debug build (not suitable for production)
+./cargo build
+
+# Full build with all features
+cargo build --workspace --all-targets --features dummy-for-ci-check,frozen-abi
+
+# Release build (for production use)
+cargo build --release
+```
+
+## Testing Commands
+
+```bash
+# Run all tests
+./cargo test
+
+# Run specific workspace tests
+cargo test --workspace --exclude <package>
+
+# Run tests with all features
+cargo test --all-features
+
+# Run benchmarks (requires nightly)
+cargo +nightly bench
+```
+
+## Linting and Code Quality
+
+```bash
+# Run clippy (use the provided script for CI compliance)
+./scripts/cargo-clippy.sh
+
+# Manual clippy with all CI flags
+cargo +nightly clippy --workspace --all-targets --features dummy-for-ci-check,frozen-abi -- \
+  --deny=warnings \
+  --deny=clippy::default_trait_access \
+  --deny=clippy::arithmetic_side_effects \
+  --deny=clippy::manual_let_else \
+  --deny=clippy::uninlined-format-args \
+  --deny=clippy::used_underscore_binding
+
+# Format code
+cargo fmt --all
+
+# Check code coverage
+./scripts/coverage.sh
+```
+
+## Architecture Overview
+
+### Core Components
+
+- **`core/`** - Main validator implementation containing banking stage, consensus, TPU (Transaction Processing Unit), TVU (Transaction Validation Unit), and networking components
+- **`validator/`** - Validator entry point and CLI interface
+- **`runtime/`** - Transaction processing runtime and account management
+- **`ledger/`** - Blockchain storage and ledger management
+- **`accounts-db/`** - Account storage and indexing system
+- **`svm/`** - Solana Virtual Machine components
+- **`rpc/`** - JSON RPC server implementation
+- **`streamer/`** - Network packet streaming and processing
+- **`turbine/`** - Block propagation protocol
+- **`gossip/`** - Cluster information and gossip protocol
+
+### Key Architectural Patterns
+
+- **Banking Stage**: Central transaction processing pipeline with parallel execution
+- **TPU/TVU Split**: Transaction Processing Unit handles new transactions, Transaction Validation Unit handles block validation
+- **Pipelining**: Extensive use of multi-stage pipelines for performance
+- **QUIC**: Modern transport protocol for improved networking
+- **Proof of History (PoH)**: Built-in time source for transaction ordering
+
+### Programs and Interfaces
+
+- **`programs/`** - Built-in Solana programs (system, vote, stake, compute budget, etc.)
+- **`syscalls/`** - System call interface for on-chain programs
+- **`builtins/`** - Built-in program implementations
+
+## Development Guidelines
+
+### Pull Request Process
+
+- Keep PRs under 1,000 lines for functional changes
+- Use Draft PRs to run CI before requesting review
+- All changes require 90%+ test coverage
+- Benchmark performance-impacting changes
+- Follow existing code conventions and patterns
+
+### Code Standards
+
+- Use `rustfmt` for formatting (latest version)
+- All code must pass `clippy` with the repository's strict settings
+- Variable names should be spelled out, not abbreviated
+- Function names use `<verb>_<subject>` pattern
+- Test functions start with `test_`, benchmarks with `bench_`
+
+### Testing Requirements
+
+- Unit tests for all new functionality
+- Integration tests for complex flows
+- Stress testing for performance-critical paths
+- All tests must be deterministic and fast
+
+### Development Workflow
+
+1. Build understanding by reading surrounding code and imports
+2. Follow existing patterns and conventions in the module
+3. Run tests frequently during development
+4. Use provided scripts for consistent tooling
+5. Benchmark any performance-sensitive changes
+
+## Special Files and Tools
+
+- **`Cargo.toml`** - Workspace configuration with 140+ crates
+- **`clippy.toml`** - Clippy configuration with custom rules and disallowed methods
+- **`scripts/`** - Utility scripts for development and deployment
+- **`ci/`** - Continuous integration configuration
+- **`docs/`** - Technical documentation and design proposals
+
+## Performance Focus
+
+This codebase prioritizes performance with:
+- Extensive benchmarking requirements
+- Custom memory management patterns
+- SIMD optimizations where applicable
+- Careful attention to allocation patterns
+- Profile-guided optimization support
+
+## Security Considerations
+
+- Consensus-breaking changes require feature gates and SIMDs (Solana Improvement Documents)
+- Never use `unwrap()` without proof it cannot panic; prefer `expect()` with clear messages
+- Follow secure coding practices for financial software
+- All network-facing code undergoes security review

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11792,6 +11792,7 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-logger",
+ "solana-metrics",
  "solana-packet",
  "solana-pubkey",
  "solana-sdk-ids",

--- a/accounts-db/.claude/settings.local.json
+++ b/accounts-db/.claude/settings.local.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(//home/sol/src/agave/**)",
+      "Read(//home/sol/src/agave/**)",
+      "Read(//home/sol/src/**)",
+      "Bash(./cargo --help)",
+      "Bash(./cargo build -p solana-accounts-db)",
+      "Bash(gh:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/accounts-db/CLAUDE.md
+++ b/accounts-db/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the `accounts-db` crate within the Agave (Solana) blockchain validator implementation. This crate handles persistent storage and management of account data, implementing a high-performance accounts database with concurrent reads and sequential writes.
+
+## Build Commands
+
+The project uses a custom `cargo` wrapper script located at `../../cargo`. All cargo commands should be executed from the root Agave directory (`../../`):
+
+```bash
+# Build the accounts-db crate
+../../cargo build -p solana-accounts-db
+
+# Build with release optimizations
+../../cargo build -p solana-accounts-db --release
+
+# Run tests for this crate specifically  
+../../cargo test -p solana-accounts-db
+
+# Run a specific test
+../../cargo test -p solana-accounts-db test_name
+
+# Run benchmarks (requires nightly rust)
+../../cargo +nightly bench -p solana-accounts-db
+
+# Check for clippy linting issues
+../../cargo clippy -p solana-accounts-db
+
+# Format code
+../../cargo fmt -p solana-accounts-db
+```
+
+## Architecture Overview
+
+### Core Components
+
+- **AccountsDb** (`src/accounts_db.rs`): Main database implementation providing account storage, indexing, and retrieval
+- **AccountsIndex** (`src/accounts_index.rs`): In-memory index mapping account pubkeys to storage locations
+- **AccountStorage** (`src/account_storage.rs`): Manages individual storage files (AppendVecs and TieredStorage)
+- **AppendVec** (`src/append_vec.rs`): Legacy append-only storage format for accounts
+- **TieredStorage** (`src/tiered_storage/`): Next-generation storage format with better compression and read performance
+
+### Storage Architecture
+
+The accounts database uses a multi-layered storage approach:
+
+1. **Memory Cache** (`accounts_cache.rs`): Recently accessed accounts kept in memory
+2. **Storage Files**: Persistent storage using either AppendVec or TieredStorage formats
+3. **Index**: Maps account pubkeys to their storage locations and metadata
+
+### Key Features
+
+- **Concurrent Access**: Supports many concurrent readers with single-threaded writes
+- **Memory Mapping**: Storage files are memory-mapped for efficient access
+- **Compression**: TieredStorage provides LZ4 compression for space efficiency
+- **Background Processing**: Cleaning, shrinking, and compaction run in background threads
+
+## Development Features
+
+The crate supports conditional compilation features:
+- `dev-context-only-utils`: Enables development and testing utilities (required for tests)
+- `frozen-abi`: Enables ABI freezing for production builds
+
+## Testing
+
+Tests are organized in several files:
+- Unit tests are colocated with source files
+- Integration tests in `tests/` directory  
+- Comprehensive test suite in `src/accounts_db/tests.rs`
+
+The crate uses criterion for benchmarking performance-critical code paths.
+
+## Important Implementation Details
+
+- **Write Versioning**: Uses atomic write version counter for ordering commits across the entire database
+- **Slot-Based Storage**: Each AppendVec stores accounts for a single slot only
+- **Background Cleaning**: Removes outdated account versions and reclaims space
+- **Memory Management**: Careful memory mapping and cleanup to handle large datasets efficiently
+
+## Clippy Configuration
+
+The project uses custom clippy rules defined in `../../clippy.toml` which disallow certain networking methods and deprecated macros. Always run clippy before submitting changes.

--- a/clippy.sh
+++ b/clippy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cargo +nightly-2025-02-16 clippy --workspace --all-targets --features dummy-for-ci-check,frozen-abi -- --deny=warnings --deny=clippy::default_trait_access --deny=clippy::arithmetic_side_effects --deny=clippy::manual_let_else --deny=clippy::used_underscore_binding

--- a/runtime/.claude/settings.local.json
+++ b/runtime/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(//home/sol/src/agave/**)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/runtime/CLAUDE.md
+++ b/runtime/CLAUDE.md
@@ -1,0 +1,127 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the `runtime` crate within the Agave (Solana) blockchain validator implementation. The runtime crate provides the core execution environment for processing transactions and managing blockchain state. It implements the Bank, which is the central component responsible for transaction processing, account management, and state transitions in the Solana validator.
+
+## Build Commands
+
+The project uses a custom `cargo` wrapper script located at `../cargo`. All cargo commands should be executed from the root Agave directory (`../`):
+
+```bash
+# Build the runtime crate
+../cargo build -p solana-runtime
+
+# Build with release optimizations
+../cargo build -p solana-runtime --release
+
+# Run tests for this crate specifically  
+../cargo test -p solana-runtime
+
+# Run a specific test
+../cargo test -p solana-runtime test_name
+
+# Run benchmarks (requires nightly rust)
+../cargo +nightly bench -p solana-runtime
+
+# Check for clippy linting issues
+../cargo clippy -p solana-runtime
+
+# Format code
+../cargo fmt -p solana-runtime
+```
+
+## Architecture Overview
+
+### Core Components
+
+- **Bank** (`src/bank.rs`): The central transaction processing engine that tracks client accounts and program execution state
+- **BankForks** (`src/bank_forks.rs`): DAG structure managing multiple bank checkpoints representing different blockchain forks
+- **AccountsBackgroundService** (`src/accounts_background_service.rs`): Background service for cleaning up dead slots and managing account storage
+- **SnapshotUtils** (`src/snapshot_utils.rs`): Utilities for creating, managing, and restoring blockchain state snapshots
+- **PrioritizationFee** (`src/prioritization_fee.rs` & `prioritization_fee_cache.rs`): Transaction fee prioritization and caching mechanisms
+- **EpochStakes** (`src/epoch_stakes.rs`): Management of validator stake information across epochs
+
+### Transaction Processing Architecture
+
+The runtime follows this high-level transaction processing flow:
+
+1. **Transaction Entry**: Transactions enter through `Bank::process_transactions`
+2. **Account Loading**: References are loaded from the accounts database 
+3. **Program Execution**: Programs are loaded and executed via InvokeContext
+4. **State Storage**: Results are committed back to account storage
+5. **Status Tracking**: Transaction status can be queried via `get_signature_status`
+
+### Bank Lifecycle
+
+Banks progress through distinct lifecycle stages:
+
+1. **Open**: Newly created bank accepting transactions
+2. **Complete**: All transactions for the slot have been applied  
+3. **Frozen**: No more transactions accepted, rent applied, sysvars updated
+4. **Rooted**: Finalized state that cannot be removed from the chain
+
+### Key Features
+
+- **Fork Management**: BankForks maintains a DAG of bank checkpoints for handling blockchain forks
+- **Snapshot System**: Complete state snapshots for fast bootstrap and recovery
+- **Background Processing**: Dedicated service for account cleanup and maintenance
+- **Fee Prioritization**: Advanced fee caching and prioritization for transaction ordering
+- **Stake Management**: Comprehensive validator stake tracking across epochs
+- **Dependency Tracking**: Transaction dependency resolution for parallel execution
+
+## Development Features
+
+The crate supports conditional compilation features:
+- `dev-context-only-utils`: Enables development and testing utilities (required for tests)
+- `frozen-abi`: Enables ABI freezing for production builds
+
+## Testing
+
+Tests are organized across several locations:
+- Unit tests colocated with source files
+- Integration tests in module subdirectories
+- Benchmarks in `benches/` directory using criterion
+
+## Important Implementation Details
+
+- **Single Leader Processing**: Each bank processes transactions for a single slot from a single leader
+- **Parent Relationships**: All banks except genesis point to a parent bank
+- **Concurrent Access**: Supports concurrent reads while maintaining single-threaded writes
+- **State Consistency**: Careful synchronization ensures consistent state across concurrent operations
+- **Memory Management**: Efficient memory usage patterns for handling large blockchain state
+
+### Snapshot Architecture
+
+The runtime implements a comprehensive snapshot system:
+- **Full Snapshots**: Complete blockchain state at specific slots
+- **Incremental Snapshots**: Delta changes since the last full snapshot
+- **Archive Management**: Compressed snapshot storage and retrieval
+- **Rebuilding**: Ability to reconstruct account storage from snapshots
+
+### Background Services
+
+- **Account Cleanup**: Removes outdated account versions and reclaims space
+- **Snapshot Creation**: Periodic state snapshots for recovery and bootstrapping  
+- **Stats Collection**: Performance metrics and monitoring data
+
+## Performance Considerations
+
+- **Parallel Transaction Processing**: Uses dependency tracking for concurrent execution
+- **Memory Mapping**: Efficient account storage access via memory-mapped files
+- **Caching**: Aggressive caching of frequently accessed data
+- **Background Operations**: Non-blocking maintenance operations
+
+## Clippy Configuration
+
+The project uses custom clippy rules defined in `../clippy.toml`. Always run clippy before submitting changes to ensure code quality and consistency.
+
+## Dependencies
+
+The crate has extensive dependencies on other Solana components:
+- `solana-accounts-db`: Account storage and indexing
+- `solana-svm`: Solana Virtual Machine for program execution  
+- `solana-program-runtime`: Runtime environment for on-chain programs
+- `solana-unified-scheduler-logic`: Advanced transaction scheduling

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -38,6 +38,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
+solana-metrics = { workspace = true }
 solana-packet = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }


### PR DESCRIPTION

#### Problem

This commit adds datapoint metrics to compare the performance of the
old itertools implementation versus the new manual HashMap implementation
of staked_nodes().

The instrumentation runs both implementations and reports:
- num_vote_accounts: Number of vote accounts being processed
- old_impl_us: Time taken by itertools grouping_map (microseconds)
- new_impl_us: Time taken by manual HashMap (microseconds)
- speedup_ratio: Performance improvement ratio

This allows gathering real-world performance data from mainnet to
validate the optimization before merging.

Metrics are reported via datapoint_info! with the name "staked_nodes_timing".




#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
