### PR TITLE
xtask: introduce xtask

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
 [target.x86_64-unknown-linux-gnu]
 # When building for linux, target the minimal supported CPU
 rustflags = ["-Ctarget-cpu=x86-64-v2"]
+
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14058,6 +14058,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask"
+version = "3.1.0"
+dependencies = [
+ "anyhow",
+ "clap 4.5.31",
+ "env_logger",
+ "log",
+ "tokio",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ members = [
     "watchtower",
     "wen-restart",
     "xdp",
+    "xtask",
     "zk-token-sdk",
 ]
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "xtask"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { version = "4.5.31", features = ["derive"] }
+env_logger = { workspace = true }
+log = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -1,0 +1,1 @@
+pub mod hello;

--- a/xtask/src/commands/hello.rs
+++ b/xtask/src/commands/hello.rs
@@ -1,0 +1,10 @@
+use {
+    anyhow::Result,
+    log::{debug, info},
+};
+
+pub fn run() -> Result<()> {
+    debug!("DEBUG MODE");
+    info!("Hello!");
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,61 @@
+use {
+    anyhow::Result,
+    clap::{Args, Parser, Subcommand},
+    log::error,
+};
+
+mod commands;
+
+#[derive(Parser)]
+#[command(name = "xtask", about = "Build tasks", version)]
+struct Xtask {
+    #[command(flatten)]
+    pub global: GlobalOptions,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    #[command(about = "Hello")]
+    Hello,
+}
+
+#[derive(Args, Debug)]
+pub struct GlobalOptions {
+    /// Enable verbose (debug) logging
+    #[arg(short, long, global = true)]
+    pub verbose: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(err) = try_main().await {
+        error!("Error: {err}");
+        for (i, cause) in err.chain().skip(1).enumerate() {
+            error!("  {}: {}", i.saturating_add(1), cause);
+        }
+        std::process::exit(1);
+    }
+}
+
+async fn try_main() -> Result<()> {
+    // parse the command line arguments
+    let xtask = Xtask::parse();
+
+    // set the log level
+    if xtask.global.verbose {
+        std::env::set_var("RUST_LOG", "debug");
+    } else {
+        std::env::set_var("RUST_LOG", "info");
+    }
+    env_logger::init();
+
+    // run the command
+    match xtask.command {
+        Commands::Hello => commands::hello::run()?,
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
split from #6765 

#### Summary of Changes

introduce xtask with a hello command. some use cases:

```bash
> cargo xtask --help
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/xtask --help`
Build tasks

Usage: xtask [OPTIONS] <COMMAND>

Commands:
  hello  Hello
  help   Print this message or the help of the given subcommand(s)

Options:
  -v, --verbose  Enable verbose (debug) logging
  -h, --help     Print help
  -V, --version  Print version
```

```bash
> cargo xtask hello
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/xtask hello`
[2025-10-16T16:27:38Z INFO  xtask::commands::hello] Hello!
```

```
> cargo xtask hello -v
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/xtask hello -v`
[2025-10-16T16:27:40Z DEBUG xtask::commands::hello] DEBUG MODE
[2025-10-16T16:27:40Z INFO  xtask::commands::hello] Hello!
```