### PR TITLE
fix(ledger-tool): correct stake formatting in graph labels

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -279,7 +279,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                         slot_stake_and_vote_count.get(&bank.slot())
                     {
                         format!(
-                            "\nvotes: {}, stake: {:.1} SOL ({:.1}%)",
+                            "\nvotes: {}, stake: {} SOL ({:.1}%)",
                             votes,
                             build_balance_message(*stake, false, false),
                             *stake as f64 / *total_stake as f64 * 100.,
@@ -397,7 +397,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
     // Annotate the final "..." node with absent vote and stake information
     if absent_votes > 0 {
         dot.push(format!(
-            r#"    "..."[label="...\nvotes: {}, stake: {:.1} SOL {:.1}%"];"#,
+            r#"    "..."[label="...\nvotes: {}, stake: {} SOL {:.1}%"];"#,
             absent_votes,
             build_balance_message(absent_stake, false, false),
             absent_stake as f64 / lowest_total_stake as f64 * 100.,


### PR DESCRIPTION
Replace String precision specifier {:.1} with {} for stake values in Graphviz labels to prevent truncation of the build_balance_message(...) output. We keep show_unit=false and manually append " SOL" to remain consistent with other usages. This ensures accurate, non-truncated SOL amounts in graph outputs and avoids any potential unit duplication.