### PR TITLE
ci: move stable-sbf artifact to target dir

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -17,10 +17,10 @@ cargo_build_sbf_sanity() {
 
   pushd programs/sbf
   # Generate the sanity programs list
-  if [ ! -f sanity_programs.txt ]; then
+  if [ ! -f target/sanity_programs.txt ]; then
     cargo test --features="sbf_rust,sbf_sanity_list" --test programs test_program_sbf_sanity
   fi
-  mapfile -t rust_programs < <(cat sanity_programs.txt)
+  mapfile -t rust_programs < <(cat target/sanity_programs.txt)
 
   pushd rust
   # This is done in a loop to mock how developers invoke `cargo-build-sbf`

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -214,7 +214,8 @@ fn test_program_sbf_sanity() {
         // cargo-build-sbf and ensure it is working correctly.
         use std::{env, fs::File, io::Write};
         let current_dir = env::current_dir().unwrap();
-        let mut file = File::create(current_dir.join("sanity_programs.txt")).unwrap();
+        let mut file =
+            File::create(current_dir.join("target").join("sanity_programs.txt")).unwrap();
         for program in programs.iter() {
             writeln!(file, "{}", program.0.trim_start_matches("solana_sbf_rust_"))
                 .expect("Failed to write to file");


### PR DESCRIPTION
#### Problem
ci stable-sbf step leaves the file `programs/sbf/sanity_programs.txt` in the work tree, polluting `git status` output

#### Summary of Changes
move it to the workspace target directory, which is already under gitignore and cleaned up with `cargo clean`