### PR TITLE
[syscalls] Remove `simplify_alt_bn128_syscall_error_codes` feature logic

### DIFF
--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1752,23 +1752,13 @@ declare_builtin_function!(
             })
             .collect::<Result<Vec<_>, Error>>()?;
 
-        let simplify_alt_bn128_syscall_error_codes = invoke_context
-            .get_feature_set()
-            .simplify_alt_bn128_syscall_error_codes;
-
-        let hash = match poseidon::hashv(parameters, endianness, inputs.as_slice()) {
-            Ok(hash) => hash,
-            Err(e) => {
-                return if simplify_alt_bn128_syscall_error_codes {
-                    Ok(1)
-                } else {
-                    Ok(e.into())
-                };
-            }
+        let Ok(hash) = poseidon::hashv(parameters, endianness, inputs.as_slice()) else {
+            return Ok(1);
         };
         hash_result.copy_from_slice(&hash.to_bytes());
 
         Ok(SUCCESS)
+
     }
 );
 
@@ -1845,69 +1835,35 @@ declare_builtin_function!(
             invoke_context.get_check_aligned(),
         )?;
 
-        let simplify_alt_bn128_syscall_error_codes = invoke_context
-            .get_feature_set()
-            .simplify_alt_bn128_syscall_error_codes;
-
         match op {
             ALT_BN128_G1_COMPRESS => {
-                let result_point = match alt_bn128_g1_compress(input) {
-                    Ok(result_point) => result_point,
-                    Err(e) => {
-                        return if simplify_alt_bn128_syscall_error_codes {
-                            Ok(1)
-                        } else {
-                            Ok(e.into())
-                        };
-                    }
+                let Ok(result_point) = alt_bn128_g1_compress(input) else {
+                    return Ok(1);
                 };
                 call_result.copy_from_slice(&result_point);
-                Ok(SUCCESS)
             }
             ALT_BN128_G1_DECOMPRESS => {
-                let result_point = match alt_bn128_g1_decompress(input) {
-                    Ok(result_point) => result_point,
-                    Err(e) => {
-                        return if simplify_alt_bn128_syscall_error_codes {
-                            Ok(1)
-                        } else {
-                            Ok(e.into())
-                        };
-                    }
+                let Ok(result_point) = alt_bn128_g1_decompress(input) else {
+                    return Ok(1);
                 };
                 call_result.copy_from_slice(&result_point);
-                Ok(SUCCESS)
             }
             ALT_BN128_G2_COMPRESS => {
-                let result_point = match alt_bn128_g2_compress(input) {
-                    Ok(result_point) => result_point,
-                    Err(e) => {
-                        return if simplify_alt_bn128_syscall_error_codes {
-                            Ok(1)
-                        } else {
-                            Ok(e.into())
-                        };
-                    }
+                let Ok(result_point) = alt_bn128_g2_compress(input) else {
+                    return Ok(1);
                 };
                 call_result.copy_from_slice(&result_point);
-                Ok(SUCCESS)
             }
             ALT_BN128_G2_DECOMPRESS => {
-                let result_point = match alt_bn128_g2_decompress(input) {
-                    Ok(result_point) => result_point,
-                    Err(e) => {
-                        return if simplify_alt_bn128_syscall_error_codes {
-                            Ok(1)
-                        } else {
-                            Ok(e.into())
-                        };
-                    }
+                let Ok(result_point) = alt_bn128_g2_decompress(input) else {
+                    return Ok(1);
                 };
                 call_result.copy_from_slice(&result_point);
-                Ok(SUCCESS)
             }
-            _ => Err(SyscallError::InvalidAttribute.into()),
+            _ => return Err(SyscallError::InvalidAttribute.into()),
         }
+
+        Ok(SUCCESS)
     }
 );
 

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1758,7 +1758,6 @@ declare_builtin_function!(
         hash_result.copy_from_slice(&hash.to_bytes());
 
         Ok(SUCCESS)
-
     }
 );
 


### PR DESCRIPTION
#### Summary of Changes
The `simplify_alt_bn128_syscall_error_codes` has been activated on all networks, so remove custom logic regarding the feature gate.

This is a follow-up to https://github.com/anza-xyz/agave/pull/7669. I missed removing this custom logic for the compression and poseidon syscalls (see https://github.com/anza-xyz/agave/pull/7669#issuecomment-3410479673).