### PR TITLE
vote-program: deserialize, check initialized, then convert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11809,9 +11809,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "4.0.3"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6970d0b048a7b2c80203fe54e10e0cc6d52a88ef7115bb7214908415e33b930"
+checksum = "db6e123e16bfdd7a81d71b4c4699e0b29580b619f4cd2ef5b6aae1eb85e8979f"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -562,7 +562,7 @@ solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=3
 solana-validator-exit = "3.0.0"
 solana-version = { path = "version", version = "=3.1.0" }
 solana-vote = { path = "vote", version = "=3.1.0" }
-solana-vote-interface = "4.0.3"
+solana-vote-interface = "4.0.4"
 solana-vote-program = { path = "programs/vote", version = "=3.1.0", default-features = false }
 solana-wen-restart = { path = "wen-restart", version = "=3.1.0" }
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=3.1.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9929,9 +9929,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "4.0.3"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6970d0b048a7b2c80203fe54e10e0cc6d52a88ef7115bb7214908415e33b930"
+checksum = "db6e123e16bfdd7a81d71b4c4699e0b29580b619f4cd2ef5b6aae1eb85e8979f"
 dependencies = [
  "bincode",
  "cfg_eval",

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -874,6 +874,17 @@ impl VoteStateHandler {
         }
     }
 
+    /// Deserialize a vote account and coerce it to v3 (done internally by the
+    /// `VoteStateV3::deserialize` API).
+    pub fn deserialize_v3(
+        vote_account: &BorrowedInstructionAccount,
+    ) -> Result<Self, InstructionError> {
+        let vote_state = VoteStateV3::deserialize(vote_account.get_data())?;
+        Ok(Self {
+            target_state: TargetVoteState::V3(vote_state),
+        })
+    }
+
     pub fn init_vote_account_state(
         vote_account: &mut BorrowedInstructionAccount,
         vote_init: &VoteInit,

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -32,7 +32,7 @@ use {
 // TODO: Change me once the program has full v4 feature gate support.
 pub(crate) const TEMP_HARDCODED_TARGET_VERSION: VoteStateTargetVersion = VoteStateTargetVersion::V3;
 
-fn verify_and_get_vote_state_handler(
+fn get_vote_state_handler_checked(
     vote_account: &BorrowedInstructionAccount,
     target_version: VoteStateTargetVersion,
 ) -> Result<VoteStateHandler, InstructionError> {
@@ -890,7 +890,7 @@ pub fn process_vote_with_account<S: std::hash::BuildHasher>(
     vote: &Vote,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = verify_and_get_vote_state_handler(vote_account, target_version)?;
+    let mut vote_state = get_vote_state_handler_checked(vote_account, target_version)?;
 
     let authorized_voter = vote_state.get_and_update_authorized_voter(clock.epoch)?;
     verify_authorized_signer(&authorized_voter, signers)?;
@@ -914,7 +914,7 @@ pub fn process_vote_state_update<S: std::hash::BuildHasher>(
     vote_state_update: VoteStateUpdate,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = verify_and_get_vote_state_handler(vote_account, target_version)?;
+    let mut vote_state = get_vote_state_handler_checked(vote_account, target_version)?;
 
     let authorized_voter = vote_state.get_and_update_authorized_voter(clock.epoch)?;
     verify_authorized_signer(&authorized_voter, signers)?;
@@ -965,7 +965,7 @@ pub fn process_tower_sync<S: std::hash::BuildHasher>(
     tower_sync: TowerSync,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = verify_and_get_vote_state_handler(vote_account, target_version)?;
+    let mut vote_state = get_vote_state_handler_checked(vote_account, target_version)?;
 
     let authorized_voter = vote_state.get_and_update_authorized_voter(clock.epoch)?;
     verify_authorized_signer(&authorized_voter, signers)?;

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -32,17 +32,20 @@ use {
 // TODO: Change me once the program has full v4 feature gate support.
 pub(crate) const TEMP_HARDCODED_TARGET_VERSION: VoteStateTargetVersion = VoteStateTargetVersion::V3;
 
+// Deserialize the vote account, check if it's initialized, then convert to the
+// target using the `VoteStateHandler` constructor, returning the initialized
+// `VoteStateHandler`.
 fn get_vote_state_handler_checked(
     vote_account: &BorrowedInstructionAccount,
     target_version: VoteStateTargetVersion,
 ) -> Result<VoteStateHandler, InstructionError> {
-    let vote_state = VoteStateHandler::deserialize_and_convert(vote_account, target_version)?;
+    let versioned = VoteStateVersions::deserialize(vote_account.get_data())?;
 
-    if vote_state.is_uninitialized() {
+    if versioned.is_uninitialized() {
         return Err(InstructionError::UninitializedAccount);
     }
 
-    Ok(vote_state)
+    VoteStateHandler::new_from_versioned(versioned, vote_account.get_key(), target_version)
 }
 
 /// Checks the proposed vote state with the current and

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -693,7 +693,7 @@ pub fn authorize<S: std::hash::BuildHasher>(
     signers: &HashSet<Pubkey, S>,
     clock: &Clock,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = VoteStateHandler::deserialize_and_convert(vote_account, target_version)?;
+    let mut vote_state = get_vote_state_handler_checked(vote_account, target_version)?;
 
     match vote_authorize {
         VoteAuthorize::Voter => {
@@ -734,7 +734,7 @@ pub fn update_validator_identity<S: std::hash::BuildHasher>(
     node_pubkey: &Pubkey,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = VoteStateHandler::deserialize_and_convert(vote_account, target_version)?;
+    let mut vote_state = get_vote_state_handler_checked(vote_account, target_version)?;
 
     // current authorized withdrawer must say "yay"
     verify_authorized_signer(vote_state.authorized_withdrawer(), signers)?;
@@ -759,7 +759,7 @@ pub fn update_commission<S: std::hash::BuildHasher>(
     epoch_schedule: &EpochSchedule,
     clock: &Clock,
 ) -> Result<(), InstructionError> {
-    let vote_state_result = VoteStateHandler::deserialize_and_convert(vote_account, target_version);
+    let vote_state_result = get_vote_state_handler_checked(vote_account, target_version);
     let enforce_commission_update_rule = if let Ok(decoded_vote_state) = &vote_state_result {
         commission > decoded_vote_state.commission()
     } else {
@@ -820,7 +820,7 @@ pub fn withdraw<S: std::hash::BuildHasher>(
 ) -> Result<(), InstructionError> {
     let mut vote_account =
         instruction_context.try_borrow_instruction_account(vote_account_index)?;
-    let vote_state = VoteStateHandler::deserialize_and_convert(&vote_account, target_version)?;
+    let vote_state = get_vote_state_handler_checked(&vote_account, target_version)?;
 
     verify_authorized_signer(vote_state.authorized_withdrawer(), signers)?;
 
@@ -1217,7 +1217,7 @@ mod tests {
 
         // Convert the vote state to current as would occur during vote instructions
         let converted_vote_state =
-            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version).unwrap();
+            get_vote_state_handler_checked(&borrowed_account, target_version).unwrap();
 
         // Check to make sure that the vote_state is unchanged
         assert!(vote_state == converted_vote_state);
@@ -1251,7 +1251,7 @@ mod tests {
 
         // Convert the vote state to current as would occur during vote instructions
         let converted_vote_state =
-            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version).unwrap();
+            get_vote_state_handler_checked(&borrowed_account, target_version).unwrap();
 
         // Check to make sure that the vote_state is unchanged
         assert!(vote_state == converted_vote_state);
@@ -1287,7 +1287,7 @@ mod tests {
 
         // Convert the vote state to current as would occur during vote instructions
         let converted_vote_state =
-            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version).unwrap();
+            get_vote_state_handler_checked(&borrowed_account, target_version).unwrap();
 
         // Check to make sure that the vote_state is unchanged
         assert_eq!(vote_state, converted_vote_state);
@@ -1384,7 +1384,7 @@ mod tests {
 
         // Increase commission in first half of epoch -- allowed
         assert_eq!(
-            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version)
+            get_vote_state_handler_checked(&borrowed_account, target_version)
                 .unwrap()
                 .commission(),
             10
@@ -1401,7 +1401,7 @@ mod tests {
             Ok(())
         );
         assert_eq!(
-            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version)
+            get_vote_state_handler_checked(&borrowed_account, target_version)
                 .unwrap()
                 .commission(),
             11
@@ -1420,7 +1420,7 @@ mod tests {
             Err(_)
         );
         assert_eq!(
-            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version)
+            get_vote_state_handler_checked(&borrowed_account, target_version)
                 .unwrap()
                 .commission(),
             11
@@ -1439,14 +1439,14 @@ mod tests {
             Ok(())
         );
         assert_eq!(
-            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version)
+            get_vote_state_handler_checked(&borrowed_account, target_version)
                 .unwrap()
                 .commission(),
             10
         );
 
         assert_eq!(
-            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version)
+            get_vote_state_handler_checked(&borrowed_account, target_version)
                 .unwrap()
                 .commission(),
             10
@@ -1464,7 +1464,7 @@ mod tests {
             Ok(())
         );
         assert_eq!(
-            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version)
+            get_vote_state_handler_checked(&borrowed_account, target_version)
                 .unwrap()
                 .commission(),
             9


### PR DESCRIPTION
#### Problem
As per the amendment to SIMD-0185 in https://github.com/solana-foundation/solana-improvement-documents/pull/369, when the vote state v4 feature gate is active, the Vote program must adjust the way it handles its "deserialize and convert" workflow.

With the vote state v4 feature disabled, a handful of program instructions call `VoteStateV3::deserialize`, which coerces the underlying vote state to v3, before checking its initialization status. These instructions are:
* `Authorize*`
* `UpdateValidatorIdentity`
* `UpdateCommission`
* `Withdraw`

Only when the vote state v4 feature is enabled should the behavior change to "deserialize -> check initialized -> convert", as per https://github.com/solana-foundation/solana-improvement-documents/pull/369.

#### Summary of Changes
First, refactors the `verify_and_get_vote_state_handler` helper to deserialize as `VoteStateVersions` first, then check for initialization, then convert to v3 or v4.

Then, configures instructions that did not previously call this helper (`Authorize*`, `UpdateValidatorIdentity`, `UpdateCommission`, `Withdraw`) to conditionally call it based on the feature status.