### PR TITLE
xtask: add version bump command

### DIFF
--- a/ci/xtask/Cargo.lock
+++ b/ci/xtask/Cargo.lock
@@ -132,6 +132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,10 +161,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -197,6 +330,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +366,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -264,6 +409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +427,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -295,6 +456,12 @@ checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
@@ -335,10 +502,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -370,6 +580,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +621,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -412,6 +662,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tokio"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +703,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,10 +754,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "windows-link"
@@ -547,6 +877,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
 name = "xtask"
 version = "3.1.0"
 dependencies = [
@@ -554,5 +899,17 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
+ "pretty_assertions",
+ "semver",
+ "serial_test",
+ "tempfile",
  "tokio",
+ "toml_edit",
+ "walkdir",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -18,4 +18,12 @@ anyhow = "1.0.100"
 clap = { version = "4.5.31", features = ["derive"] }
 env_logger = "0.11.8"
 log = "0.4.28"
+semver = "1.0.27"
 tokio = { version = "1.48.0", features = ["full"] }
+toml_edit = { version = "0.23.7", features = ["serde"] }
+walkdir = "2.5.0"
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"
+serial_test = "3.2.0"
+tempfile = "3.23.0"

--- a/ci/xtask/src/commands.rs
+++ b/ci/xtask/src/commands.rs
@@ -1,1 +1,2 @@
+pub mod bump_version;
 pub mod hello;

--- a/ci/xtask/src/commands/bump_version.rs
+++ b/ci/xtask/src/commands/bump_version.rs
@@ -1,0 +1,212 @@
+use {
+    anyhow::{anyhow, Context, Result},
+    clap::{Args, ValueEnum},
+    log::{debug, info},
+    semver::Version,
+    std::{fmt, fs, process::Command},
+    toml_edit::{value, DocumentMut},
+};
+
+#[derive(Args)]
+pub struct BumpArgs {
+    #[arg(value_enum)]
+    pub level: BumpLevel,
+}
+
+#[derive(ValueEnum, Clone, Debug)]
+pub enum BumpLevel {
+    Major,
+    Minor,
+    Patch,
+}
+
+impl fmt::Display for BumpLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            BumpLevel::Major => "major",
+            BumpLevel::Minor => "minor",
+            BumpLevel::Patch => "patch",
+        };
+        write!(f, "{s}")
+    }
+}
+
+pub fn run(args: BumpArgs) -> Result<()> {
+    // get the current version
+    let current_version_str =
+        crate::common::get_current_version().context("failed to get current version")?;
+    let current_version = Version::parse(&current_version_str)?;
+
+    // bump the version
+    let new_version = bump_version(&args.level, &current_version);
+
+    // get all crates
+    let all_crates = crate::common::get_all_crates().context("failed to get all crates")?;
+
+    // update all cargo.toml
+    let all_cargo_tomls =
+        crate::common::find_all_cargo_tomls().context("failed to find all cargo.toml files")?;
+    info!("found {} cargo.toml files", all_cargo_tomls.len());
+    for cargo_toml in all_cargo_tomls {
+        info!("processing {}", cargo_toml.display());
+
+        // parse the cargo.toml file into a DocumentMut
+        let content = fs::read_to_string(&cargo_toml)
+            .context(format!("failed to read {}", cargo_toml.display()))?;
+        let mut doc = content
+            .parse::<DocumentMut>()
+            .context(format!("failed to parse {}", cargo_toml.display()))?;
+
+        // check if workspace.package.version is the same as the current version
+        if let Some(workspace_package_version_str) = doc
+            .get("workspace")
+            .and_then(|workspace| workspace.get("package"))
+            .and_then(|package| package.get("version"))
+            .and_then(|version| version.as_str())
+        {
+            if workspace_package_version_str == current_version.to_string() {
+                doc["workspace"]["package"]["version"] = value(new_version.to_string());
+                info!("  bumped workspace.package.version from {current_version} to {new_version}",);
+            }
+        }
+
+        // check if package.version is the same as the current version
+        if let Some(package_version_str) = doc
+            .get("package")
+            .and_then(|package| package.get("version"))
+            .and_then(|version| version.as_str())
+        {
+            if package_version_str == current_version.to_string() {
+                doc["package"]["version"] = value(new_version.to_string());
+                info!("  bumped package.version from {current_version} to {current_version}",);
+            }
+        }
+
+        // Update versions in [workspace.dependencies] if they match `current_version`
+        if let Some(dependencies) = doc
+            .get("workspace")
+            .and_then(|ws| ws.get("dependencies"))
+            .and_then(|deps| deps.as_table())
+        {
+            // Avoid borrowing `doc` while iterating
+            let keys: Vec<String> = dependencies.iter().map(|(k, _)| k.to_string()).collect();
+
+            for name in keys {
+                if all_crates.contains(&name) {
+                    if let Some(version) = doc["workspace"]["dependencies"]
+                        .get(&name)
+                        .and_then(|v| v.get("version"))
+                        .and_then(|v| v.as_str())
+                    {
+                        if !version.contains(&current_version.to_string()) {
+                            continue;
+                        }
+                        let old_version = version.to_string();
+                        let new_version = old_version
+                            .replace(&current_version.to_string(), &new_version.to_string());
+                        doc["workspace"]["dependencies"][&name]["version"] = value(&new_version);
+                        info!(
+                            "  bumped workspace.dependencies.{name}.version from {old_version} to \
+                             {new_version}",
+                        );
+                    }
+                }
+            }
+        }
+
+        // write the updated document back to the file
+        debug!("writing {}", cargo_toml.display());
+        fs::write(&cargo_toml, doc.to_string())
+            .context(format!("failed to write {}", cargo_toml.display()))?;
+    }
+
+    // update all Cargo.lock files
+    let all_cargo_locks =
+        crate::common::find_all_cargo_locks().context("failed to find all Cargo.lock files")?;
+    info!("found {} Cargo.lock files", all_cargo_locks.len());
+    for cargo_lock in all_cargo_locks {
+        let dir = cargo_lock.parent().context(format!(
+            "failed to get {}'s parent directory",
+            cargo_lock.display()
+        ))?;
+
+        info!("running `cargo tree` in {}", dir.display());
+        let output = Command::new("cargo")
+            .arg("tree")
+            .current_dir(dir)
+            .output()
+            .context(format!("failed to run `cargo tree` in {}", dir.display()))?;
+        if !output.status.success() {
+            return Err(anyhow!("{}", String::from_utf8_lossy(&output.stderr)));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn bump_version(level: &BumpLevel, current: &Version) -> Version {
+    let mut new_version = current.clone();
+    match level {
+        BumpLevel::Major => {
+            new_version.major = new_version.major.saturating_add(1);
+            new_version.minor = 0;
+            new_version.patch = 0;
+        }
+        BumpLevel::Minor => {
+            new_version.minor = new_version.minor.saturating_add(1);
+            new_version.patch = 0;
+        }
+        BumpLevel::Patch => {
+            new_version.patch = new_version.patch.saturating_add(1);
+        }
+    }
+
+    new_version
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bump_version() {
+        // bump major
+        {
+            assert_eq!(
+                bump_version(&BumpLevel::Major, &Version::parse("1.0.0").unwrap()),
+                Version::parse("2.0.0").unwrap()
+            );
+
+            assert_eq!(
+                bump_version(&BumpLevel::Major, &Version::parse("1.1.0").unwrap()),
+                Version::parse("2.0.0").unwrap()
+            );
+
+            assert_eq!(
+                bump_version(&BumpLevel::Major, &Version::parse("1.1.1").unwrap()),
+                Version::parse("2.0.0").unwrap()
+            );
+        }
+
+        // bump minor
+        {
+            assert_eq!(
+                bump_version(&BumpLevel::Minor, &Version::parse("1.0.0").unwrap()),
+                Version::parse("1.1.0").unwrap()
+            );
+
+            assert_eq!(
+                bump_version(&BumpLevel::Minor, &Version::parse("1.2.1").unwrap()),
+                Version::parse("1.3.0").unwrap()
+            );
+        }
+
+        // bump patch
+        {
+            assert_eq!(
+                bump_version(&BumpLevel::Patch, &Version::parse("1.0.0").unwrap()),
+                Version::parse("1.0.1").unwrap()
+            );
+        }
+    }
+}

--- a/ci/xtask/src/commands/bump_version.rs
+++ b/ci/xtask/src/commands/bump_version.rs
@@ -8,7 +8,7 @@ use {
 };
 
 #[derive(Args)]
-pub struct BumpArgs {
+pub struct CommandArgs {
     #[arg(value_enum)]
     pub level: BumpLevel,
 }
@@ -31,7 +31,7 @@ impl fmt::Display for BumpLevel {
     }
 }
 
-pub fn run(args: BumpArgs) -> Result<()> {
+pub fn run(args: CommandArgs) -> Result<()> {
     // get the current version
     let current_version_str =
         crate::common::get_current_version().context("failed to get current version")?;

--- a/ci/xtask/src/common.rs
+++ b/ci/xtask/src/common.rs
@@ -179,7 +179,7 @@ edition = { workspace = true }
 
         // test find_files_by_name for Cargo.toml
         {
-            let files = find_files_by_name("Cargo.toml").unwrap();
+            let files = find_all_cargo_tomls().unwrap();
             assert_eq!(files.len(), 3);
 
             let expected_files: HashSet<_> = [

--- a/ci/xtask/src/common.rs
+++ b/ci/xtask/src/common.rs
@@ -1,7 +1,7 @@
 use {
     anyhow::{anyhow, Result},
     std::{fs, path::PathBuf, process::Command},
-    toml_edit::ImDocument,
+    toml_edit::Document,
     walkdir::WalkDir,
 };
 
@@ -43,7 +43,7 @@ pub fn get_all_crates() -> Result<Vec<String>> {
     let mut crates = vec![];
     for cargo_toml in cargo_tomls {
         let content = fs::read_to_string(cargo_toml)?;
-        let doc = content.parse::<ImDocument<String>>()?;
+        let doc = content.parse::<Document<String>>()?;
         let Some(name) = doc
             .get("package")
             .and_then(|package| package.get("name"))
@@ -60,7 +60,7 @@ pub fn get_current_version() -> Result<String> {
     let git_root = get_git_root_path()?;
     let cargo_toml = git_root.join("Cargo.toml");
     let content = fs::read_to_string(cargo_toml)?;
-    let doc = content.parse::<ImDocument<String>>()?;
+    let doc = content.parse::<Document<String>>()?;
     let Some(version) = doc
         .get("workspace")
         .and_then(|workspace| workspace.get("package"))

--- a/ci/xtask/src/common.rs
+++ b/ci/xtask/src/common.rs
@@ -1,0 +1,223 @@
+use {
+    anyhow::{anyhow, Result},
+    std::{fs, path::PathBuf, process::Command},
+    toml_edit::ImDocument,
+    walkdir::WalkDir,
+};
+
+pub fn get_git_root_path() -> Result<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .map_err(|e| anyhow!("failed to get git root path, error: {e}"))?;
+    let root = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(PathBuf::from(root))
+}
+
+pub fn find_files_by_name(filename: &str) -> Result<Vec<PathBuf>> {
+    let git_root = get_git_root_path()?;
+    let mut results = vec![];
+
+    for entry in WalkDir::new(git_root)
+        .into_iter()
+        .filter_entry(|entry| !entry.path().components().any(|c| c.as_os_str() == "target"))
+        .filter_map(Result::ok)
+        .filter(|e| e.file_name() == filename)
+    {
+        results.push(entry.path().to_path_buf());
+    }
+
+    Ok(results)
+}
+
+pub fn find_all_cargo_tomls() -> Result<Vec<PathBuf>> {
+    find_files_by_name("Cargo.toml")
+}
+
+pub fn find_all_cargo_locks() -> Result<Vec<PathBuf>> {
+    find_files_by_name("Cargo.lock")
+}
+
+pub fn get_all_crates() -> Result<Vec<String>> {
+    let cargo_tomls = find_all_cargo_tomls()?;
+    let mut crates = vec![];
+    for cargo_toml in cargo_tomls {
+        let content = fs::read_to_string(cargo_toml)?;
+        let doc = content.parse::<ImDocument<String>>()?;
+        let Some(name) = doc
+            .get("package")
+            .and_then(|package| package.get("name"))
+            .and_then(|name| name.as_str())
+        else {
+            continue;
+        };
+        crates.push(name.to_string());
+    }
+    Ok(crates)
+}
+
+pub fn get_current_version() -> Result<String> {
+    let git_root = get_git_root_path()?;
+    let cargo_toml = git_root.join("Cargo.toml");
+    let content = fs::read_to_string(cargo_toml)?;
+    let doc = content.parse::<ImDocument<String>>()?;
+    let Some(version) = doc
+        .get("workspace")
+        .and_then(|workspace| workspace.get("package"))
+        .and_then(|package| package.get("version"))
+        .and_then(|version| version.as_str())
+    else {
+        return Err(anyhow!("failed to get version from Cargo.toml"));
+    };
+    Ok(version.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, pretty_assertions::assert_eq, serial_test::serial, std::collections::HashSet};
+
+    #[test]
+    #[serial] // std::env::set_current_dir will affect other tests
+    fn test_get_git_root_path() {
+        // create a temporary directory
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        // cd into the temporary directory and do git init
+        std::env::set_current_dir(temp_dir.path()).unwrap();
+        Command::new("git").args(["init"]).output().unwrap();
+
+        // call get_git_root_path should get the temporary directory
+        let root_path = get_git_root_path().unwrap();
+
+        // canonicalize the paths since macos may return a symlink
+        let canonicalized_root_path = fs::canonicalize(root_path).unwrap();
+        let canonicalized_temp_dir_path = fs::canonicalize(temp_dir.path()).unwrap();
+
+        assert_eq!(canonicalized_root_path, canonicalized_temp_dir_path);
+    }
+
+    #[test]
+    #[serial] // std::env::set_current_dir will affect other tests
+    fn test_workspace_functions() {
+        // $TEMPDIR
+        // |-- .git
+        // |-- Cargo.toml
+        // |-- Cargo.lock
+        // |-- foo
+        // |---- Cargo.toml
+        // |---- Cargo.lock
+        // |-- bar
+        // |---- Cargo.toml
+        // |---- Cargo.lock
+        let root_dir = tempfile::tempdir().unwrap();
+        let root_dir_path = root_dir.path();
+        std::env::set_current_dir(root_dir_path).unwrap();
+        Command::new("git").args(["init"]).output().unwrap();
+
+        // create the files
+        fs::write(
+            root_dir_path.join("Cargo.toml"),
+            r#"
+[workspace.package]
+version = "3.1.0"
+authors = ["Anza Maintainers <maintainers@anza.xyz>"]
+description = "Blockchain, Rebuilt for Scale"
+repository = "https://github.com/anza-xyz/agave"
+homepage = "https://anza.xyz/"
+license = "Apache-2.0"
+edition = "2021"
+
+[members]
+foo = { path = "foo" }
+bar = { path = "bar" }
+"#,
+        )
+        .unwrap();
+        fs::write(root_dir_path.join("Cargo.lock"), "").unwrap();
+        fs::create_dir_all(root_dir_path.join("foo")).unwrap();
+        fs::write(
+            root_dir_path.join("foo/Cargo.toml"),
+            r#"
+[package]
+name = "foo"
+documentation = "https://docs.rs/foo"
+version = { workspace = true }
+authors = { workspace = true }
+description = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+"#,
+        )
+        .unwrap();
+        fs::write(root_dir_path.join("foo/Cargo.lock"), "").unwrap();
+
+        fs::create_dir_all(root_dir_path.join("bar")).unwrap();
+        fs::write(
+            root_dir_path.join("bar/Cargo.toml"),
+            r#"
+[package]
+name = "bar"
+documentation = "https://docs.rs/bar"
+version = { workspace = true }
+authors = { workspace = true }
+description = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+"#,
+        )
+        .unwrap();
+        fs::write(root_dir_path.join("bar/Cargo.lock"), "").unwrap();
+
+        // test find_files_by_name for Cargo.toml
+        {
+            let files = find_files_by_name("Cargo.toml").unwrap();
+            assert_eq!(files.len(), 3);
+
+            let expected_files: HashSet<_> = [
+                fs::canonicalize(root_dir_path.join("Cargo.toml")).unwrap(),
+                fs::canonicalize(root_dir_path.join("foo/Cargo.toml")).unwrap(),
+                fs::canonicalize(root_dir_path.join("bar/Cargo.toml")).unwrap(),
+            ]
+            .iter()
+            .cloned()
+            .collect();
+
+            let actual_files: HashSet<_> = files.iter().cloned().collect();
+
+            assert_eq!(expected_files, actual_files);
+        }
+
+        // test find_files_by_name for Cargo.lock
+        {
+            let files = find_files_by_name("Cargo.lock").unwrap();
+            assert_eq!(files.len(), 3);
+
+            let expected_files: HashSet<_> = [
+                fs::canonicalize(root_dir_path.join("Cargo.lock")).unwrap(),
+                fs::canonicalize(root_dir_path.join("foo/Cargo.lock")).unwrap(),
+                fs::canonicalize(root_dir_path.join("bar/Cargo.lock")).unwrap(),
+            ]
+            .iter()
+            .cloned()
+            .collect();
+
+            let actual_files: HashSet<_> = files.iter().cloned().collect();
+
+            assert_eq!(expected_files, actual_files);
+        }
+
+        // test get_all_crates
+        {
+            let crates = get_all_crates().unwrap();
+            assert_eq!(crates.len(), 2);
+            let expected_crates: HashSet<String> =
+                ["foo", "bar"].iter().map(|s| s.to_string()).collect();
+            let actual_crates: HashSet<String> = crates.iter().map(|s| s.to_string()).collect();
+            assert_eq!(expected_crates, actual_crates);
+        }
+    }
+}

--- a/ci/xtask/src/common.rs
+++ b/ci/xtask/src/common.rs
@@ -198,7 +198,7 @@ edition = { workspace = true }
 
         // test find_files_by_name for Cargo.lock
         {
-            let files = find_files_by_name("Cargo.lock").unwrap();
+            let files = find_all_cargo_locks().unwrap();
             assert_eq!(files.len(), 3);
 
             let expected_files: HashSet<_> = [

--- a/ci/xtask/src/common.rs
+++ b/ci/xtask/src/common.rs
@@ -20,7 +20,12 @@ pub fn find_files_by_name(filename: &str) -> Result<Vec<PathBuf>> {
 
     for entry in WalkDir::new(git_root)
         .into_iter()
-        .filter_entry(|entry| !entry.path().components().any(|c| c.as_os_str() == "target"))
+        .filter_entry(|entry| {
+            !entry
+                .path()
+                .components()
+                .any(|c| c.as_os_str() == "target" || c.as_os_str() == ".git")
+        })
         .filter_map(Result::ok)
         .filter(|e| e.file_name() == filename)
     {

--- a/ci/xtask/src/common.rs
+++ b/ci/xtask/src/common.rs
@@ -224,5 +224,11 @@ edition = { workspace = true }
             let actual_crates: HashSet<String> = crates.iter().map(|s| s.to_string()).collect();
             assert_eq!(expected_crates, actual_crates);
         }
+
+        // test get_current_version
+        {
+            let version = get_current_version().unwrap();
+            assert_eq!(version, "3.1.0");
+        }
     }
 }

--- a/ci/xtask/src/main.rs
+++ b/ci/xtask/src/main.rs
@@ -22,7 +22,7 @@ enum Commands {
     #[command(about = "Hello")]
     Hello,
     #[command(about = "Bump version")]
-    BumpVersion(commands::bump_version::BumpArgs),
+    BumpVersion(commands::bump_version::CommandArgs),
 }
 
 #[derive(Args, Debug)]

--- a/ci/xtask/src/main.rs
+++ b/ci/xtask/src/main.rs
@@ -5,6 +5,7 @@ use {
 };
 
 mod commands;
+mod common;
 
 #[derive(Parser)]
 #[command(name = "xtask", about = "Build tasks", version)]
@@ -20,6 +21,8 @@ struct Xtask {
 enum Commands {
     #[command(about = "Hello")]
     Hello,
+    #[command(about = "Bump version")]
+    BumpVersion(commands::bump_version::BumpArgs),
 }
 
 #[derive(Args, Debug)]
@@ -55,6 +58,9 @@ async fn try_main() -> Result<()> {
     // run the command
     match xtask.command {
         Commands::Hello => commands::hello::run()?,
+        Commands::BumpVersion(args) => {
+            commands::bump_version::run(args)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
split from #6765 

#### Summary of Changes

```bash
> cargo xtask bump-version --help
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/xtask bump-version --help`
Bump version

Usage: xtask bump-version [OPTIONS] <LEVEL>

Arguments:
  <LEVEL>  [possible values: major, minor, patch]

Options:
  -v, --verbose  Enable verbose (debug) logging
  -h, --help     Print help
```

