### PR TITLE
poseidon: Avoid unnecessary collect and dereference in tests

### DIFF
--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -446,13 +446,10 @@ mod tests {
             ],
         ];
 
-        for (i, expected_hash) in expected_hashes.iter().enumerate() {
-            let inputs = vec![&input; i + 1]
-                .into_iter()
-                .map(|arr| &arr[..])
-                .collect::<Vec<_>>();
+        for (i, expected_hash) in expected_hashes.into_iter().enumerate() {
+            let inputs = vec![&input[..]; i + 1];
             let hash = hashv(Parameters::Bn254X5, Endianness::BigEndian, &inputs).unwrap();
-            assert_eq!(hash.to_bytes(), *expected_hash);
+            assert_eq!(hash.to_bytes(), expected_hash);
         }
     }
 }


### PR DESCRIPTION
#### Problem

The test was doing `map(|arr| &arr[..]).collect()`, which causes an unnecessary allocation. And then dereferencing `expected_hash` despite that place being the only use.

#### Summary of Changes

Instead, construct the vector containing slices from the start and use `into_iter` to iterate over owned expected hashes.
