### PR TITLE
Refactor - `EpochBoundaryPreparation` structure

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -226,7 +226,7 @@ impl<'a> InvokeContext<'a> {
     pub fn get_environments_for_slot(
         &self,
         effective_slot: Slot,
-    ) -> Result<&ProgramRuntimeEnvironments, InstructionError> {
+    ) -> Result<ProgramRuntimeEnvironments, InstructionError> {
         let epoch_schedule = self.environment_config.sysvar_cache.get_epoch_schedule()?;
         let epoch = epoch_schedule.get_epoch(effective_slot);
         Ok(self

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1496,25 +1496,26 @@ impl Bank {
                 .checked_div(2)
                 .unwrap();
 
-        let mut program_cache = self
+        let program_cache = self
             .transaction_processor
             .global_program_cache
-            .write()
+            .read()
             .unwrap();
+        let mut epoch_boundary_preparation =
+            program_cache.epoch_boundary_preparation.write().unwrap();
 
-        if program_cache.upcoming_environments.is_some() {
-            if let Some((key, program_to_recompile)) = program_cache.programs_to_recompile.pop() {
-                let effective_epoch = program_cache.latest_root_epoch.saturating_add(1);
+        if let Some(upcoming_environments) =
+            epoch_boundary_preparation.upcoming_environments.as_ref()
+        {
+            let upcoming_environments = upcoming_environments.clone();
+            if let Some((key, program_to_recompile)) =
+                epoch_boundary_preparation.programs_to_recompile.pop()
+            {
+                drop(epoch_boundary_preparation);
                 drop(program_cache);
-                let environments_for_epoch = self
-                    .transaction_processor
-                    .global_program_cache
-                    .read()
-                    .unwrap()
-                    .get_environments_for_epoch(effective_epoch);
                 if let Some(recompiled) = load_program_with_pubkey(
                     self,
-                    &environments_for_epoch,
+                    &upcoming_environments,
                     &key,
                     self.slot,
                     &mut ExecuteTimings::default(),
@@ -1534,17 +1535,11 @@ impl Bank {
                     program_cache.assign_program(key, recompiled);
                 }
             }
-        } else if self.epoch != program_cache.latest_root_epoch
+        } else if self.epoch != epoch_boundary_preparation.latest_root_epoch
             || slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch
         {
             // Anticipate the upcoming program runtime environment for the next epoch,
             // so we can try to recompile loaded programs before the feature transition hits.
-            drop(program_cache);
-            let mut program_cache = self
-                .transaction_processor
-                .global_program_cache
-                .write()
-                .unwrap();
             let (program_runtime_environment_v1, program_runtime_environment_v2) =
                 self.create_program_runtime_environments(&upcoming_feature_set);
             let mut upcoming_environments = program_cache.environments.clone();
@@ -1558,10 +1553,10 @@ impl Bank {
             if changed_program_runtime_v2 {
                 upcoming_environments.program_runtime_v2 = program_runtime_environment_v2;
             }
-            program_cache.upcoming_environments = Some(upcoming_environments);
-            program_cache.programs_to_recompile = program_cache
+            epoch_boundary_preparation.upcoming_environments = Some(upcoming_environments);
+            epoch_boundary_preparation.programs_to_recompile = program_cache
                 .get_flattened_entries(changed_program_runtime_v1, changed_program_runtime_v2);
-            program_cache
+            epoch_boundary_preparation
                 .programs_to_recompile
                 .sort_by_cached_key(|(_id, program)| program.decayed_usage_counter(self.slot));
         }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -137,6 +137,9 @@ impl Bank {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
             self.slot,
             self.epoch,
+            self.transaction_processor
+                .epoch_boundary_preparation
+                .clone(),
             &self
                 .transaction_processor
                 .global_program_cache

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10955,14 +10955,14 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase(
         .global_program_cache
         .read()
         .unwrap()
-        .get_environments_for_epoch(0)
+        .get_environments_for_epoch(&bank.transaction_processor.epoch_boundary_preparation, 0)
         .program_runtime_v1;
     let upcoming_env = bank
         .transaction_processor
         .global_program_cache
         .read()
         .unwrap()
-        .get_environments_for_epoch(1)
+        .get_environments_for_epoch(&bank.transaction_processor.epoch_boundary_preparation, 1)
         .program_runtime_v1;
 
     // Advance the bank to recompile the program.
@@ -11073,12 +11073,19 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
 
     {
         // Prune for rerooting and thus finishing the recompilation phase.
+        let upcoming_environments = bank
+            .transaction_processor
+            .epoch_boundary_preparation
+            .write()
+            .unwrap()
+            .reroot(bank.epoch());
+        assert!(upcoming_environments.is_some());
         let mut program_cache = bank
             .transaction_processor
             .global_program_cache
             .write()
             .unwrap();
-        program_cache.prune(bank.slot(), bank.epoch());
+        program_cache.prune(bank.slot(), upcoming_environments);
 
         // Unload all (which is only the entry with the new environment)
         program_cache.sort_and_unload(percentage::Percentage::from(0));

--- a/svm-fuzz-harness/src/program_cache.rs
+++ b/svm-fuzz-harness/src/program_cache.rs
@@ -42,7 +42,6 @@ pub fn setup_program_cache(
 
     cache.set_slot_for_tests(slot);
     cache.environments = environments.clone();
-    cache.upcoming_environments = Some(environments);
 
     for builtin in BUILTINS {
         // Skip migrated builtins.

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -811,7 +811,7 @@ mod tests {
         let upcoming_environments = ProgramRuntimeEnvironments::default();
         let current_environments = {
             let global_program_cache = batch_processor.global_program_cache.read().unwrap();
-            global_program_cache
+            batch_processor
                 .epoch_boundary_preparation
                 .write()
                 .unwrap()

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -810,8 +810,12 @@ mod tests {
 
         let upcoming_environments = ProgramRuntimeEnvironments::default();
         let current_environments = {
-            let mut global_program_cache = batch_processor.global_program_cache.write().unwrap();
-            global_program_cache.upcoming_environments = Some(upcoming_environments.clone());
+            let global_program_cache = batch_processor.global_program_cache.read().unwrap();
+            global_program_cache
+                .epoch_boundary_preparation
+                .write()
+                .unwrap()
+                .upcoming_environments = Some(upcoming_environments.clone());
             global_program_cache.environments.clone()
         };
         mock_bank

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -156,6 +156,9 @@ pub struct TransactionBatchProcessor<FG: ForkGraph> {
     /// client code (e.g. Bank) and forwarded to process_message.
     sysvar_cache: RwLock<SysvarCache>,
 
+    /// Anticipates the environments of the upcoming epoch
+    pub epoch_boundary_preparation: Arc<RwLock<EpochBoundaryPreparation>>,
+
     /// Programs required for transaction batch processing
     pub global_program_cache: Arc<RwLock<ProgramCache<FG>>>,
 
@@ -182,10 +185,8 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
             slot: Slot::default(),
             epoch: Epoch::default(),
             sysvar_cache: RwLock::<SysvarCache>::default(),
-            global_program_cache: Arc::new(RwLock::new(ProgramCache::new(
-                Slot::default(),
-                Arc::new(RwLock::new(EpochBoundaryPreparation::default())),
-            ))),
+            epoch_boundary_preparation: Arc::new(RwLock::new(EpochBoundaryPreparation::default())),
+            global_program_cache: Arc::new(RwLock::new(ProgramCache::new(Slot::default()))),
             builtin_program_ids: RwLock::new(HashSet::new()),
             execution_cost: SVMTransactionExecutionCost::default(),
         }
@@ -208,10 +209,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         Self {
             slot,
             epoch,
-            global_program_cache: Arc::new(RwLock::new(ProgramCache::new(
-                slot,
-                epoch_boundary_preparation,
-            ))),
+            epoch_boundary_preparation,
+            global_program_cache: Arc::new(RwLock::new(ProgramCache::new(slot))),
             ..Self::default()
         }
     }
@@ -255,6 +254,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             slot,
             epoch,
             sysvar_cache: RwLock::<SysvarCache>::default(),
+            epoch_boundary_preparation: self.epoch_boundary_preparation.clone(),
             global_program_cache: self.global_program_cache.clone(),
             builtin_program_ids: RwLock::new(self.builtin_program_ids.read().unwrap().clone()),
             execution_cost: self.execution_cost,
@@ -276,8 +276,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let empty_loader = || Arc::new(BuiltinProgram::new_loader(VmConfig::default()));
 
         global_program_cache.latest_root_slot = self.slot;
-        global_program_cache
-            .epoch_boundary_preparation
+        self.epoch_boundary_preparation
             .write()
             .unwrap()
             .latest_root_epoch = self.epoch;
@@ -311,7 +310,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         self.global_program_cache
             .try_read()
             .ok()
-            .map(|cache| cache.get_environments_for_epoch(epoch))
+            .map(|cache| cache.get_environments_for_epoch(&self.epoch_boundary_preparation, epoch))
     }
 
     pub fn sysvar_cache(&self) -> RwLockReadGuard<SysvarCache> {
@@ -367,6 +366,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
                 self.slot,
                 self.epoch,
+                self.epoch_boundary_preparation.clone(),
                 &global_program_cache,
             );
             drop(global_program_cache);
@@ -779,7 +779,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     // Load, verify and compile one program.
                     let program = load_program_with_pubkey(
                         account_loader,
-                        &global_program_cache.get_environments_for_epoch(self.epoch),
+                        &global_program_cache.get_environments_for_epoch(
+                            &self.epoch_boundary_preparation,
+                            self.epoch,
+                        ),
                         &key,
                         self.slot,
                         execute_timings,
@@ -807,6 +810,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     *program_cache_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
                         self.slot,
                         self.epoch,
+                        self.epoch_boundary_preparation.clone(),
                         &global_program_cache,
                     );
                     program_cache_for_tx_batch.hit_max_limit = true;
@@ -1476,6 +1480,7 @@ mod tests {
             ProgramCacheForTxBatch::new_from_cache(
                 batch_processor.slot,
                 batch_processor.epoch,
+                batch_processor.epoch_boundary_preparation.clone(),
                 &global_program_cache,
             )
         };
@@ -1518,6 +1523,7 @@ mod tests {
                 ProgramCacheForTxBatch::new_from_cache(
                     batch_processor.slot,
                     batch_processor.epoch,
+                    batch_processor.epoch_boundary_preparation.clone(),
                     &global_program_cache,
                 )
             };
@@ -1891,6 +1897,7 @@ mod tests {
         let mut loaded_programs_for_tx_batch = ProgramCacheForTxBatch::new_from_cache(
             0,
             0,
+            batch_processor.epoch_boundary_preparation.clone(),
             &batch_processor.global_program_cache.read().unwrap(),
         );
         batch_processor

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -72,6 +72,7 @@ fn program_cache_execution(threads: usize) {
                     ProgramCacheForTxBatch::new_from_cache(
                         processor.slot,
                         processor.epoch,
+                        processor.epoch_boundary_preparation.clone(),
                         &global_program_cache,
                     )
                 };


### PR DESCRIPTION
#### Problem

Even after moving `LoadedPrograms::environments` into `TransactionBatchProcessor` computing the environments for a given epoch would still require locking `LoadedPrograms` because it also holds the upcoming environments. Thus, they should be separated into their own global structure which is never write locked by transaction processing.

#### Summary of Changes

- Factors the fields `latest_root_epoch`, `upcoming_environments` and `programs_to_recompile` of `ProgramCache` into `EpochBoundaryPreparation`.
- Moves `ProgramCache::epoch_boundary_preparation` into the `TransactionBatchProcessor`.
