### PR TITLE
Remove `RwLock` on `Keypair` and switch to `Arcswap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8674,6 +8674,7 @@ dependencies = [
  "agave-feature-set",
  "agave-logger",
  "anyhow",
+ "arc-swap",
  "arrayvec",
  "assert_matches",
  "bincode",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7302,6 +7302,7 @@ version = "3.1.0"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
+ "arc-swap",
  "arrayvec",
  "assert_matches",
  "bincode",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -38,6 +38,7 @@ agave-unstable-api = []
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-logger = { workspace = true }
+arc-swap = { workspace = true }
 arrayvec = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7070,6 +7070,7 @@ version = "3.1.0"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
+ "arc-swap",
  "arrayvec",
  "assert_matches",
  "bincode",


### PR DESCRIPTION
Follow up to: https://github.com/anza-xyz/agave/pull/8546
#### Problem
We use an `RwLock` on `Keypair` in `ClusterInfo`. Calling `set_keypair` through the `AdminRpc` can cause the validator to hang due to lock contention. While this is fixed in https://github.com/anza-xyz/agave/pull/8546, there is no reason `Keypair` should be `RwLock`ed. 

#### Summary of Changes
Change `RwLock` to an `ArcSwap`
