### PR TITLE
clean up remaining vote state v4 TODOs

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -43,7 +43,7 @@ use {
     solana_signer::Signer,
     solana_stake_interface::state::StakeStateV2,
     solana_stake_program::stake_state,
-    solana_vote_program::vote_state::{self, VoteStateV3},
+    solana_vote_program::vote_state::{self, VoteStateV4},
     std::{
         collections::HashMap,
         error,
@@ -254,7 +254,7 @@ fn add_validator_accounts(
             identity_pubkey,
             identity_pubkey,
             commission,
-            rent.minimum_balance(VoteStateV3::size_of()).max(1),
+            rent.minimum_balance(VoteStateV4::size_of()).max(1),
         );
 
         genesis_config.add_account(
@@ -314,7 +314,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     // vote account
     let default_bootstrap_validator_lamports = &(500 * LAMPORTS_PER_SOL)
-        .max(rent.minimum_balance(VoteStateV3::size_of()))
+        .max(rent.minimum_balance(VoteStateV4::size_of()))
         .to_string();
     // stake account
     let default_bootstrap_validator_stake_lamports = &(LAMPORTS_PER_SOL / 2)
@@ -1322,10 +1322,10 @@ mod tests {
                 // check vote account
                 let vote_pk = b64_account.vote_account.parse().unwrap();
                 let vote_data = genesis_config.accounts[&vote_pk].data.clone();
-                let vote_state = VoteStateV3::deserialize(&vote_data).unwrap();
+                let vote_state = VoteStateV4::deserialize(&vote_data, &vote_pk).unwrap();
                 assert_eq!(vote_state.node_pubkey, identity_pk);
                 assert_eq!(vote_state.authorized_withdrawer, identity_pk);
-                let authorized_voters = vote_state.authorized_voters();
+                let authorized_voters = &vote_state.authorized_voters;
                 assert_eq!(authorized_voters.first().unwrap().1, &identity_pk);
 
                 // check stake account

--- a/program-test/tests/setup.rs
+++ b/program-test/tests/setup.rs
@@ -12,7 +12,7 @@ use {
     solana_transaction::Transaction,
     solana_vote_program::{
         vote_instruction,
-        vote_state::{self, VoteInit, VoteStateV3},
+        vote_state::{self, VoteInit, VoteStateV4},
     },
 };
 
@@ -54,7 +54,7 @@ pub async fn setup_vote(context: &mut ProgramTestContext) -> Pubkey {
         0,
         &system_program::id(),
     ));
-    let vote_lamports = Rent::default().minimum_balance(VoteStateV3::size_of());
+    let vote_lamports = Rent::default().minimum_balance(VoteStateV4::size_of());
     let vote_keypair = Keypair::new();
     let user_keypair = Keypair::new();
     instructions.append(&mut vote_instruction::create_account_with_config(
@@ -67,7 +67,7 @@ pub async fn setup_vote(context: &mut ProgramTestContext) -> Pubkey {
         },
         vote_lamports,
         vote_instruction::CreateVoteAccountConfig {
-            space: vote_state::VoteStateV3::size_of() as u64,
+            space: vote_state::VoteStateV4::size_of() as u64,
             ..vote_instruction::CreateVoteAccountConfig::default()
         },
     ));

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4588,7 +4588,7 @@ pub mod tests {
             EncodedConfirmedBlock, EncodedTransaction, EncodedTransactionWithStatusMeta,
             TransactionDetails,
         },
-        solana_vote_interface::state::VoteStateV3,
+        solana_vote_interface::state::VoteStateV4,
         solana_vote_program::{
             vote_instruction,
             vote_state::{TowerSync, VoteInit, VoteStateVersions, MAX_LOCKOUT_HISTORY},
@@ -5041,10 +5041,10 @@ pub mod tests {
             bank
         }
 
-        fn store_vote_account(&self, vote_pubkey: &Pubkey, vote_state: VoteStateV3) {
+        fn store_vote_account(&self, vote_pubkey: &Pubkey, vote_state: VoteStateV4) {
             let bank = self.working_bank();
-            let versioned = VoteStateVersions::new_v3(vote_state);
-            let space = VoteStateV3::size_of();
+            let versioned = VoteStateVersions::new_v4(vote_state);
+            let space = VoteStateV4::size_of();
             let balance = bank.get_minimum_balance_for_rent_exemption(space);
             let mut vote_account =
                 AccountSharedData::new(balance, space, &solana_vote_program::id());
@@ -7698,11 +7698,9 @@ pub mod tests {
         assert_eq!(bank.vote_accounts().len(), 1);
 
         // Create a vote account with no stake.
-        // TODO: Update this test to use `VoteStateV4` after vote program
-        // migration is complete. Currently using `VoteStateV3` because this
-        // test invokes the vote program which hasn't been migrated to v4 yet.
         let alice_vote_keypair = Keypair::new();
-        let alice_vote_state = VoteStateV3::new(
+        let alice_vote_state = VoteStateV4::new(
+            &alice_vote_keypair.pubkey(),
             &VoteInit {
                 node_pubkey: mint_keypair.pubkey(),
                 authorized_voter: alice_vote_keypair.pubkey(),

--- a/vote/benches/vote_account.rs
+++ b/vote/benches/vote_account.rs
@@ -43,8 +43,14 @@ fn bench_vote_account_try_from(b: &mut Bencher) {
         let vote_account = VoteAccount::try_from(account.clone()).unwrap();
         let vote_state_view = vote_account.vote_state_view();
         assert_eq!(&vote_state.node_pubkey, vote_state_view.node_pubkey());
-        assert_eq!(vote_state.inflation_rewards_commission_bps, vote_state_view.commission().into());
-        assert_eq!(vote_state.epoch_credits.len(), vote_state_view.num_epoch_credits());
+        assert_eq!(
+            vote_state.inflation_rewards_commission_bps,
+            vote_state_view.inflation_rewards_commission()
+        );
+        assert_eq!(
+            vote_state.epoch_credits.len(),
+            vote_state_view.num_epoch_credits()
+        );
         assert_eq!(vote_state.last_timestamp, vote_state_view.last_timestamp());
         assert_eq!(vote_state.root_slot, vote_state_view.root_slot());
     });

--- a/vote/benches/vote_account.rs
+++ b/vote/benches/vote_account.rs
@@ -4,13 +4,14 @@ use {
     solana_account::AccountSharedData,
     solana_pubkey::Pubkey,
     solana_vote::vote_account::VoteAccount,
-    solana_vote_interface::state::{VoteInit, VoteStateV3, VoteStateVersions},
+    solana_vote_interface::state::{VoteInit, VoteStateV4, VoteStateVersions},
 };
 
 fn new_rand_vote_account<R: Rng>(
     rng: &mut R,
     node_pubkey: Option<Pubkey>,
-) -> (AccountSharedData, VoteStateV3) {
+) -> (AccountSharedData, VoteStateV4) {
+    let vote_pubkey = Pubkey::new_unique();
     let vote_init = VoteInit {
         node_pubkey: node_pubkey.unwrap_or_else(Pubkey::new_unique),
         authorized_voter: Pubkey::new_unique(),
@@ -24,11 +25,10 @@ fn new_rand_vote_account<R: Rng>(
         leader_schedule_epoch: rng.gen(),
         unix_timestamp: rng.gen(),
     };
-    let mut vote_state = VoteStateV3::new(&vote_init, &clock);
-    vote_state.process_next_vote_slot(0, 0, 1);
+    let vote_state = VoteStateV4::new(&vote_pubkey, &vote_init, &clock);
     let account = AccountSharedData::new_data(
         rng.gen(), // lamports
-        &VoteStateVersions::new_v3(vote_state.clone()),
+        &VoteStateVersions::new_v4(vote_state.clone()),
         &solana_sdk_ids::vote::id(), // owner
     )
     .unwrap();
@@ -43,8 +43,8 @@ fn bench_vote_account_try_from(b: &mut Bencher) {
         let vote_account = VoteAccount::try_from(account.clone()).unwrap();
         let vote_state_view = vote_account.vote_state_view();
         assert_eq!(&vote_state.node_pubkey, vote_state_view.node_pubkey());
-        assert_eq!(vote_state.commission, vote_state_view.commission());
-        assert_eq!(vote_state.credits(), vote_state_view.credits());
+        assert_eq!(vote_state.inflation_rewards_commission_bps, vote_state_view.commission().into());
+        assert_eq!(vote_state.epoch_credits.len(), vote_state_view.num_epoch_credits());
         assert_eq!(vote_state.last_timestamp, vote_state_view.last_timestamp());
         assert_eq!(vote_state.root_slot, vote_state_view.root_slot());
     });

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -97,10 +97,11 @@ impl VoteAccount {
         use {
             rand::Rng as _,
             solana_clock::Clock,
-            solana_vote_interface::state::{VoteInit, VoteStateV3, VoteStateVersions},
+            solana_vote_interface::state::{VoteInit, VoteStateV4, VoteStateVersions},
         };
 
         let mut rng = rand::thread_rng();
+        let vote_pubkey = Pubkey::new_unique();
 
         let vote_init = VoteInit {
             node_pubkey: Pubkey::new_unique(),
@@ -115,10 +116,10 @@ impl VoteAccount {
             leader_schedule_epoch: rng.gen(),
             unix_timestamp: rng.gen(),
         };
-        let vote_state = VoteStateV3::new(&vote_init, &clock);
+        let vote_state = VoteStateV4::new(&vote_pubkey, &vote_init, &clock);
         let account = AccountSharedData::new_data(
             rng.gen(), // lamports
-            &VoteStateVersions::new_v3(vote_state.clone()),
+            &VoteStateVersions::new_v4(vote_state.clone()),
             &solana_sdk_ids::vote::id(), // owner
         )
         .unwrap();
@@ -454,7 +455,7 @@ mod tests {
         solana_account::WritableAccount,
         solana_clock::Clock,
         solana_pubkey::Pubkey,
-        solana_vote_interface::state::{VoteInit, VoteStateV3, VoteStateVersions},
+        solana_vote_interface::state::{VoteInit, VoteStateV4, VoteStateVersions},
         std::iter::repeat_with,
     };
 
@@ -462,6 +463,7 @@ mod tests {
         rng: &mut R,
         node_pubkey: Option<Pubkey>,
     ) -> AccountSharedData {
+        let vote_pubkey = Pubkey::new_unique();
         let vote_init = VoteInit {
             node_pubkey: node_pubkey.unwrap_or_else(Pubkey::new_unique),
             authorized_voter: Pubkey::new_unique(),
@@ -475,10 +477,10 @@ mod tests {
             leader_schedule_epoch: rng.gen(),
             unix_timestamp: rng.gen(),
         };
-        let vote_state = VoteStateV3::new(&vote_init, &clock);
+        let vote_state = VoteStateV4::new(&vote_pubkey, &vote_init, &clock);
         AccountSharedData::new_data(
             rng.gen(), // lamports
-            &VoteStateVersions::new_v3(vote_state.clone()),
+            &VoteStateVersions::new_v4(vote_state.clone()),
             &solana_sdk_ids::vote::id(), // owner
         )
         .unwrap()


### PR DESCRIPTION
#### Problem
As the title says, we left a few TODOs lying around from #8384 that can finally be addressed now that #8290 has landed.

#### Summary of Changes
Fix those TODOs by converting their callsites to `VoteStateV4`.