### PR TITLE
vote-program: vote-state: remove create account helpers

### DIFF
--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -82,10 +82,12 @@ impl StakeReward {
         let validator_staking_keypair = Keypair::new();
         let validator_voting_keypair = Keypair::new();
 
-        let validator_vote_account = vote_state::create_account(
-            &validator_voting_keypair.pubkey(),
+        let validator_vote_account = vote_state::create_v4_account_with_authorized(
             &validator_pubkey,
-            10,
+            &validator_voting_keypair.pubkey(),
+            &validator_voting_keypair.pubkey(),
+            None,
+            1000,
             validator_stake_lamports,
         );
 

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -416,18 +416,38 @@ mod tests {
 
         let sk1 = solana_pubkey::new_rand();
         let pk1 = solana_pubkey::new_rand();
-        let mut vote_account1 =
-            vote_state::create_account(&pk1, &solana_pubkey::new_rand(), 0, 100);
+        let mut vote_account1 = vote_state::create_v4_account_with_authorized(
+            &solana_pubkey::new_rand(),
+            &pk1,
+            &pk1,
+            None,
+            0,
+            100,
+        );
         let stake_account1 =
             stake_state::create_account(&sk1, &pk1, &vote_account1, &genesis_config.rent, 100);
         let sk2 = solana_pubkey::new_rand();
         let pk2 = solana_pubkey::new_rand();
-        let mut vote_account2 = vote_state::create_account(&pk2, &solana_pubkey::new_rand(), 0, 50);
+        let mut vote_account2 = vote_state::create_v4_account_with_authorized(
+            &solana_pubkey::new_rand(),
+            &pk2,
+            &pk2,
+            None,
+            0,
+            50,
+        );
         let stake_account2 =
             stake_state::create_account(&sk2, &pk2, &vote_account2, &genesis_config.rent, 50);
         let sk3 = solana_pubkey::new_rand();
         let pk3 = solana_pubkey::new_rand();
-        let mut vote_account3 = vote_state::create_account(&pk3, &solana_pubkey::new_rand(), 0, 1);
+        let mut vote_account3 = vote_state::create_v4_account_with_authorized(
+            &solana_pubkey::new_rand(),
+            &pk3,
+            &pk3,
+            None,
+            0,
+            1,
+        );
         let stake_account3 = stake_state::create_account(
             &sk3,
             &pk3,
@@ -437,7 +457,14 @@ mod tests {
         );
         let sk4 = solana_pubkey::new_rand();
         let pk4 = solana_pubkey::new_rand();
-        let mut vote_account4 = vote_state::create_account(&pk4, &solana_pubkey::new_rand(), 0, 1);
+        let mut vote_account4 = vote_state::create_v4_account_with_authorized(
+            &solana_pubkey::new_rand(),
+            &pk4,
+            &pk4,
+            None,
+            0,
+            1,
+        );
         let stake_account4 = stake_state::create_account(
             &sk4,
             &pk4,

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -249,11 +249,12 @@ fn add_validator_accounts(
             AccountSharedData::new(lamports, 0, &system_program::id()),
         );
 
-        let vote_account = vote_state::create_account_with_authorized(
+        let vote_account = vote_state::create_v4_account_with_authorized(
             identity_pubkey,
             identity_pubkey,
             identity_pubkey,
-            commission,
+            None,
+            u16::from(commission) * 100,
             rent.minimum_balance(VoteStateV4::size_of()).max(1),
         );
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2334,11 +2334,12 @@ fn main() {
                                 ),
                             );
 
-                            let vote_account = vote_state::create_account_with_authorized(
+                            let vote_account = vote_state::create_v4_account_with_authorized(
                                 identity_pubkey,
                                 identity_pubkey,
                                 identity_pubkey,
-                                100,
+                                None,
+                                10000,
                                 rent.minimum_balance(VoteStateV4::size_of()).max(1),
                             );
 

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -220,7 +220,14 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
     let vote_address = Pubkey::new_unique();
     let node_address = Pubkey::new_unique();
 
-    let vote_account = vote_state::create_account(&vote_address, &node_address, 0, 1_000_000_000);
+    let vote_account = vote_state::create_v4_account_with_authorized(
+        &node_address,
+        &vote_address,
+        &vote_address,
+        None,
+        0,
+        1_000_000_000,
+    );
     program_test.add_account(vote_address, vote_account.clone().into());
 
     // create stake accounts with 0.9 sol to test min-stake filtering

--- a/programs/sbf/tests/syscall_get_epoch_stake.rs
+++ b/programs/sbf/tests/syscall_get_epoch_stake.rs
@@ -17,7 +17,7 @@ use {
     solana_signer::Signer,
     solana_transaction::Transaction,
     solana_vote::vote_account::VoteAccount,
-    solana_vote_program::vote_state::create_account_with_authorized,
+    solana_vote_program::vote_state::create_v4_account_with_authorized,
     std::collections::HashMap,
 };
 
@@ -50,10 +50,11 @@ fn test_syscall_get_epoch_stake() {
             .map(|keypair| {
                 let node_id = keypair.node_keypair.pubkey();
                 let authorized_voter = keypair.vote_keypair.pubkey();
-                let vote_account = VoteAccount::try_from(create_account_with_authorized(
+                let vote_account = VoteAccount::try_from(create_v4_account_with_authorized(
                     &node_id,
                     &authorized_voter,
                     &node_id,
+                    None,
                     0,
                     100,
                 ))

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -19,7 +19,7 @@ use {
         vote_instruction::VoteInstruction,
         vote_processor::Entrypoint,
         vote_state::{
-            create_account, create_account_with_authorized, TowerSync, Vote, VoteAuthorize,
+            create_v4_account_with_authorized, TowerSync, Vote, VoteAuthorize,
             VoteAuthorizeCheckedWithSeedArgs, VoteAuthorizeWithSeedArgs, VoteInit, VoteStateUpdate,
             VoteStateV3, VoteStateVersions, MAX_LOCKOUT_HISTORY,
         },
@@ -133,7 +133,14 @@ fn create_test_account() -> (Pubkey, AccountSharedData) {
     let vote_pubkey = solana_pubkey::new_rand();
     (
         vote_pubkey,
-        create_account(&vote_pubkey, &solana_pubkey::new_rand(), 0, balance),
+        create_v4_account_with_authorized(
+            &solana_pubkey::new_rand(),
+            &vote_pubkey,
+            &vote_pubkey,
+            None,
+            0,
+            balance,
+        ),
     )
 }
 
@@ -146,10 +153,11 @@ fn create_test_account_with_authorized() -> (Pubkey, Pubkey, Pubkey, AccountShar
         vote_pubkey,
         authorized_voter,
         authorized_withdrawer,
-        create_account_with_authorized(
+        create_v4_account_with_authorized(
             &solana_pubkey::new_rand(),
             &authorized_voter,
             &authorized_withdrawer,
+            None,
             0,
             100,
         ),
@@ -716,10 +724,11 @@ impl BenchAuthorizeWithSeed {
             &withdrawer_owner,
         )
         .unwrap();
-        let vote_account = create_account_with_authorized(
+        let vote_account = create_v4_account_with_authorized(
             &Pubkey::new_unique(),
             &authorized_voter,
             &authorized_withdrawer,
+            None,
             0,
             100,
         );
@@ -804,10 +813,11 @@ impl BenchAuthorizeCheckedWithSeed {
             &withdrawer_owner,
         )
         .unwrap();
-        let vote_account = create_account_with_authorized(
+        let vote_account = create_v4_account_with_authorized(
             &Pubkey::new_unique(),
             &authorized_voter,
             &authorized_withdrawer,
+            None,
             0,
             100,
         );

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1060,10 +1060,6 @@ fn do_process_tower_sync(
     )
 }
 
-// This function is used:
-// a. In many tests.
-// b. In the genesis tool that initializes a cluster to create the bootstrap validator.
-// c. In the ledger tool when creating bootstrap vote accounts.
 #[cfg(test)]
 pub fn create_account_with_authorized(
     node_pubkey: &Pubkey,

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1064,6 +1064,7 @@ fn do_process_tower_sync(
 // a. In many tests.
 // b. In the genesis tool that initializes a cluster to create the bootstrap validator.
 // c. In the ledger tool when creating bootstrap vote accounts.
+#[cfg(test)]
 pub fn create_account_with_authorized(
     node_pubkey: &Pubkey,
     authorized_voter: &Pubkey,
@@ -1117,16 +1118,6 @@ pub fn create_v4_account_with_authorized(
     .unwrap();
 
     vote_account
-}
-
-// create_account() should be removed, use create_account_with_authorized() instead
-pub fn create_account(
-    vote_pubkey: &Pubkey,
-    node_pubkey: &Pubkey,
-    commission: u8,
-    lamports: u64,
-) -> AccountSharedData {
-    create_account_with_authorized(node_pubkey, vote_pubkey, vote_pubkey, commission, lamports)
 }
 
 #[allow(clippy::arithmetic_side_effects)]

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1316,14 +1316,35 @@ mod tests {
         let mut accumulator2 = RewardsAccumulator::default();
 
         let vote_pubkey_a = Pubkey::new_unique();
-        let vote_account_a =
-            vote_state::create_account(&vote_pubkey_a, &Pubkey::new_unique(), 20, 100);
+        let node_pubkey_a = Pubkey::new_unique();
+        let vote_account_a = vote_state::create_v4_account_with_authorized(
+            &node_pubkey_a,
+            &vote_pubkey_a,
+            &vote_pubkey_a,
+            None,
+            2000,
+            100,
+        );
         let vote_pubkey_b = Pubkey::new_unique();
-        let vote_account_b =
-            vote_state::create_account(&vote_pubkey_b, &Pubkey::new_unique(), 20, 100);
+        let node_pubkey_b = Pubkey::new_unique();
+        let vote_account_b = vote_state::create_v4_account_with_authorized(
+            &node_pubkey_b,
+            &vote_pubkey_b,
+            &vote_pubkey_b,
+            None,
+            2000,
+            100,
+        );
         let vote_pubkey_c = Pubkey::new_unique();
-        let vote_account_c =
-            vote_state::create_account(&vote_pubkey_c, &Pubkey::new_unique(), 20, 100);
+        let node_pubkey_c = Pubkey::new_unique();
+        let vote_account_c = vote_state::create_v4_account_with_authorized(
+            &node_pubkey_c,
+            &vote_pubkey_c,
+            &vote_pubkey_c,
+            None,
+            2000,
+            100,
+        );
 
         accumulator1.add_reward(
             vote_pubkey_a,

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -405,8 +405,14 @@ mod tests {
         let validator_pubkey = Pubkey::new_unique();
         let validator_vote_pubkey = Pubkey::new_unique();
 
-        let validator_vote_account =
-            vote_state::create_account(&validator_vote_pubkey, &validator_pubkey, 10, 20);
+        let validator_vote_account = vote_state::create_v4_account_with_authorized(
+            &validator_pubkey,
+            &validator_vote_pubkey,
+            &validator_vote_pubkey,
+            None,
+            1000,
+            20,
+        );
 
         for stake_reward in rewards.iter() {
             // store account in Bank, since distribution now checks for account existence

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -238,14 +238,10 @@ impl VersionedEpochStakes {
 #[cfg(test)]
 pub(crate) mod tests {
     use {
-        super::*,
-        solana_account::AccountSharedData,
+        super::*, solana_account::AccountSharedData,
         solana_bls_signatures::keypair::Keypair as BLSKeypair,
         solana_vote::vote_account::VoteAccount,
-        solana_vote_program::vote_state::{
-            create_account_with_authorized, create_v4_account_with_authorized,
-        },
-        std::iter,
+        solana_vote_program::vote_state::create_v4_account_with_authorized, std::iter,
         test_case::test_case,
     };
 
@@ -286,10 +282,11 @@ pub(crate) mod tests {
                                 100,
                             )
                         } else {
-                            create_account_with_authorized(
+                            create_v4_account_with_authorized(
                                 &node_id,
                                 &authorized_voter,
                                 &node_id,
+                                None,
                                 0,
                                 100,
                             )

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -176,24 +176,24 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
 
         // Create accounts
         let node_account = Account::new(VALIDATOR_LAMPORTS, 0, &system_program::id());
-        let vote_account = if is_alpenglow {
+        let bls_pubkey_compressed = if is_alpenglow {
             let bls_keypair = BLSKeypair::derive_from_signer(
                 &validator_voting_keypairs.borrow().vote_keypair,
                 BLS_KEYPAIR_DERIVE_SEED,
             )
             .unwrap();
-            let bls_pubkey_compressed = bls_pubkey_to_compressed_bytes(&bls_keypair.public);
-            vote_state::create_v4_account_with_authorized(
-                &node_pubkey,
-                &vote_pubkey,
-                &vote_pubkey,
-                Some(bls_pubkey_compressed),
-                0,
-                *stake,
-            )
+            Some(bls_pubkey_to_compressed_bytes(&bls_keypair.public))
         } else {
-            vote_state::create_account(&vote_pubkey, &node_pubkey, 0, *stake)
+            None
         };
+        let vote_account = vote_state::create_v4_account_with_authorized(
+            &node_pubkey,
+            &vote_pubkey,
+            &vote_pubkey,
+            bls_pubkey_compressed,
+            0,
+            *stake,
+        );
         let stake_account = Account::from(stake_state::create_account(
             &stake_pubkey,
             &vote_pubkey,
@@ -339,23 +339,14 @@ pub fn create_genesis_config_with_leader_ex_no_features(
     cluster_type: ClusterType,
     mut initial_accounts: Vec<(Pubkey, AccountSharedData)>,
 ) -> GenesisConfig {
-    let validator_vote_account = if let Some(bls_pubkey_compressed) = validator_bls_pubkey {
-        vote_state::create_v4_account_with_authorized(
-            validator_pubkey,
-            validator_vote_account_pubkey,
-            validator_vote_account_pubkey,
-            Some(bls_pubkey_compressed),
-            0,
-            validator_stake_lamports,
-        )
-    } else {
-        vote_state::create_account(
-            validator_vote_account_pubkey,
-            validator_pubkey,
-            0,
-            validator_stake_lamports,
-        )
-    };
+    let validator_vote_account = vote_state::create_v4_account_with_authorized(
+        validator_pubkey,
+        validator_vote_account_pubkey,
+        validator_vote_account_pubkey,
+        validator_bls_pubkey,
+        0,
+        validator_stake_lamports,
+    );
 
     let validator_stake_account = stake_state::create_account(
         validator_stake_account_pubkey,

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -523,8 +523,15 @@ pub(crate) mod tests {
         stake: u64,
     ) -> ((Pubkey, AccountSharedData), (Pubkey, AccountSharedData)) {
         let vote_pubkey = solana_pubkey::new_rand();
-        let vote_account =
-            vote_state::create_account(&vote_pubkey, &solana_pubkey::new_rand(), 0, 1);
+        let node_pubkey = solana_pubkey::new_rand();
+        let vote_account = vote_state::create_v4_account_with_authorized(
+            &node_pubkey,
+            &vote_pubkey,
+            &vote_pubkey,
+            None,
+            0,
+            1,
+        );
         let stake_pubkey = solana_pubkey::new_rand();
         (
             (vote_pubkey, vote_account),
@@ -541,10 +548,18 @@ pub(crate) mod tests {
         vote_pubkey: &Pubkey,
         stake_pubkey: &Pubkey,
     ) -> AccountSharedData {
+        let node_pubkey = solana_pubkey::new_rand();
         stake_state::create_account(
             stake_pubkey,
             vote_pubkey,
-            &vote_state::create_account(vote_pubkey, &solana_pubkey::new_rand(), 0, 1),
+            &vote_state::create_v4_account_with_authorized(
+                &node_pubkey,
+                vote_pubkey,
+                vote_pubkey,
+                None,
+                0,
+                1,
+            ),
             &Rent::free(),
             stake,
         )

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -195,14 +195,18 @@ mod tests {
     #[test]
     fn test_serde_stakes_to_stake_format() {
         let mut stake_delegations = ImHashMap::new();
+        let vote_pubkey = Pubkey::new_unique();
+        let node_pubkey = Pubkey::new_unique();
         stake_delegations.insert(
             Pubkey::new_unique(),
             StakeAccount::try_from(stake_state::create_account(
                 &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
-                &vote_state::create_account(
-                    &Pubkey::new_unique(),
-                    &Pubkey::new_unique(),
+                &vote_pubkey,
+                &vote_state::create_v4_account_with_authorized(
+                    &node_pubkey,
+                    &vote_pubkey,
+                    &vote_pubkey,
+                    None,
                     0,
                     1_000_000_000,
                 ),
@@ -262,10 +266,15 @@ mod tests {
         });
         for _ in 0..rng.gen_range(5usize..10) {
             let vote_pubkey = solana_pubkey::new_rand();
-            let vote_account = vote_state::create_account(
+            let node_pubkey = solana_pubkey::new_rand();
+            let commission = rng.gen_range(0..101);
+            let commission_bps = commission * 100;
+            let vote_account = vote_state::create_v4_account_with_authorized(
+                &node_pubkey,
                 &vote_pubkey,
-                &solana_pubkey::new_rand(),  // node_pubkey
-                rng.gen_range(0..101),       // commission
+                &vote_pubkey,
+                None,
+                commission_bps,
                 rng.gen_range(0..1_000_000), // lamports
             );
             stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);

--- a/wen-restart/src/last_voted_fork_slots_aggregate.rs
+++ b/wen-restart/src/last_voted_fork_slots_aggregate.rs
@@ -257,7 +257,7 @@ mod tests {
         solana_signer::Signer,
         solana_time_utils::timestamp,
         solana_vote::vote_account::VoteAccount,
-        solana_vote_program::vote_state::create_account_with_authorized,
+        solana_vote_program::vote_state::create_v4_account_with_authorized,
     };
 
     const TOTAL_VALIDATOR_COUNT: u16 = 10;
@@ -779,10 +779,11 @@ mod tests {
                     authorized_voter,
                     (
                         stake,
-                        VoteAccount::try_from(create_account_with_authorized(
+                        VoteAccount::try_from(create_v4_account_with_authorized(
                             &node_id,
                             &authorized_voter,
                             &node_id,
+                            None,
                             0,
                             100,
                         ))

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -1444,7 +1444,7 @@ mod tests {
         solana_time_utils::timestamp,
         solana_vote::vote_account::VoteAccount,
         solana_vote_interface::state::{TowerSync, Vote},
-        solana_vote_program::vote_state::create_account_with_authorized,
+        solana_vote_program::vote_state::create_v4_account_with_authorized,
         std::{fs::remove_file, sync::Arc, thread::Builder},
         tempfile::TempDir,
     };
@@ -1985,10 +1985,11 @@ mod tests {
                     authorized_voter,
                     (
                         stake,
-                        VoteAccount::try_from(create_account_with_authorized(
+                        VoteAccount::try_from(create_v4_account_with_authorized(
                             &node_id,
                             &authorized_voter,
                             &node_id,
+                            None,
                             0,
                             100,
                         ))


### PR DESCRIPTION
#### Problem
These helpers serve to create v3 vote state, but we actually want to encourage use of `VoteStateV4` now, since it's soon to be considered the "current" version. In all of the callsites outside of the Vote program, the usage of `VoteStateV4::deserialize` means all vote state versions besides v1 are supported, so we can preemptively update the account creation sites to use v4.

#### Summary of Changes
Similar to #8384, update all callsites that use the v3 account creation helpers from `vote_state` to use their v4 counterparts. Also makes those v3 versions private and handles things like genesis account creation for all versions.