### PR TITLE
Refactor - Split `translate_and_update_accounts()` into two phases

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -755,11 +755,11 @@ pub mod apply_cost_tracker_during_replay {
 }
 
 pub mod stricter_abi_and_runtime_constraints {
-    solana_pubkey::declare_id!("CxeBn9PVeeXbmjbNwLv6U4C6svNxnC4JX6mfkvgeMocM");
+    solana_pubkey::declare_id!("sD3uVpaavUXQRvDXrMFCQ2CqLqnbz5mK8ttWNXbtD3r");
 }
 
 pub mod account_data_direct_mapping {
-    solana_pubkey::declare_id!("9s3RKimHWS44rJcJ9P1rwCmn2TvMqtZQBmz815ZUUHqJ");
+    solana_pubkey::declare_id!("DFN8MyKpQqFW31qczcahgnnxcAHQc6P94wtTEX5EP1RA");
 }
 
 pub mod add_set_tx_loaded_accounts_data_size_instruction {

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -822,18 +822,18 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
         // changes.
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
-        for translate_account in accounts.iter_mut() {
+        for translated_account in accounts.iter_mut() {
             let callee_account = instruction_context
-                .try_borrow_instruction_account(translate_account.index_in_caller)?;
+                .try_borrow_instruction_account(translated_account.index_in_caller)?;
             let update_caller = update_callee_account(
                 check_aligned,
-                &translate_account.caller_account,
+                &translated_account.caller_account,
                 callee_account,
                 stricter_abi_and_runtime_constraints,
                 account_data_direct_mapping,
             )?;
-            translate_account.update_caller_account_region =
-                translate_account.update_caller_account_info || update_caller;
+            translated_account.update_caller_account_region =
+                translated_account.update_caller_account_info || update_caller;
         }
     }
 
@@ -849,15 +849,15 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
     // CPI exit.
     //
     // Synchronize the callee's account changes so the caller can see them.
-    for translate_account in accounts.iter_mut() {
+    for translated_account in accounts.iter_mut() {
         let mut callee_account = instruction_context
-            .try_borrow_instruction_account(translate_account.index_in_caller)?;
-        if translate_account.update_caller_account_info {
+            .try_borrow_instruction_account(translated_account.index_in_caller)?;
+        if translated_account.update_caller_account_info {
             update_caller_account(
                 invoke_context,
                 memory_mapping,
                 check_aligned,
-                &mut translate_account.caller_account,
+                &mut translated_account.caller_account,
                 &mut callee_account,
                 stricter_abi_and_runtime_constraints,
                 account_data_direct_mapping,
@@ -866,14 +866,14 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
     }
 
     if stricter_abi_and_runtime_constraints {
-        for translate_account in accounts.iter() {
+        for translated_account in accounts.iter() {
             let mut callee_account = instruction_context
-                .try_borrow_instruction_account(translate_account.index_in_caller)?;
-            if translate_account.update_caller_account_region {
+                .try_borrow_instruction_account(translated_account.index_in_caller)?;
+            if translated_account.update_caller_account_region {
                 update_caller_account_region(
                     memory_mapping,
                     check_aligned,
-                    &translate_account.caller_account,
+                    &translated_account.caller_account,
                     &mut callee_account,
                     account_data_direct_mapping,
                 )?;

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -770,8 +770,6 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
     signers_seeds_len: u64,
     memory_mapping: &mut MemoryMapping,
 ) -> Result<u64, Error> {
-    let check_aligned = invoke_context.get_check_aligned();
-
     // CPI entry.
     //
     // Translate the inputs to the syscall and synchronize the caller's account
@@ -784,6 +782,11 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
         execute_time.stop();
         invoke_context.timings.execute_us += execute_time.as_us();
     }
+    let stricter_abi_and_runtime_constraints = invoke_context
+        .get_feature_set()
+        .stricter_abi_and_runtime_constraints;
+    let account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
+    let check_aligned = invoke_context.get_check_aligned();
 
     let instruction = S::translate_instruction(
         instruction_addr,
@@ -824,11 +827,6 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
     // CPI exit.
     //
     // Synchronize the callee's account changes so the caller can see them.
-    let stricter_abi_and_runtime_constraints = invoke_context
-        .get_feature_set()
-        .stricter_abi_and_runtime_constraints;
-    let account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
-
     for translate_account in accounts.iter_mut() {
         let mut callee_account = instruction_context
             .try_borrow_instruction_account(translate_account.index_in_caller)?;

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -580,7 +580,7 @@ pub fn translate_accounts_rust<'a>(
         check_aligned,
     )?;
 
-    translate_and_update_accounts(
+    translate_accounts_common(
         &account_info_keys,
         account_infos,
         account_infos_addr,
@@ -705,7 +705,7 @@ pub fn translate_accounts_c<'a>(
         check_aligned,
     )?;
 
-    translate_and_update_accounts(
+    translate_accounts_common(
         &account_info_keys,
         account_infos,
         account_infos_addr,
@@ -941,7 +941,7 @@ where
 }
 
 // Finish translating accounts and build TranslatedAccount from CallerAccount.
-fn translate_and_update_accounts<'a, T, F>(
+fn translate_accounts_common<'a, T, F>(
     account_info_keys: &[&Pubkey],
     account_infos: &[T],
     account_infos_addr: u64,


### PR DESCRIPTION
#### Problem

#8431 was reverted in #8542.

#### Summary of Changes

Same as #8431 but the code movement itself is now also feature gated behind `stricter_abi_and_runtime_constraints`.