### PR TITLE
Gossip: Remove leaky `RwLockReadGuard` around `Arc<Keypair>`

### DIFF
--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -257,7 +257,7 @@ impl AncestorHashesService {
                 let mut stats = AncestorHashesResponsesStats::default();
                 let mut packet_threshold = DynamicPacketToProcessThreshold::default();
                 while !exit.load(Ordering::Relaxed) {
-                    let keypair = cluster_info.keypair().clone();
+                    let keypair = cluster_info.keypair();
                     let result = Self::process_new_packets_from_channel(
                         &ancestor_hashes_request_statuses,
                         &response_receiver,
@@ -722,7 +722,7 @@ impl AncestorHashesService {
         // Keep around the last second of requests in the throttler.
         request_throttle.retain(|request_time| *request_time > (timestamp() - 1000));
 
-        let identity_keypair: &Keypair = &repair_info.cluster_info.keypair().clone();
+        let identity_keypair: &Keypair = &repair_info.cluster_info.keypair();
 
         let number_of_allowed_requests =
             MAX_ANCESTOR_HASHES_SLOT_REQUESTS_PER_SECOND.saturating_sub(request_throttle.len());

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1643,7 +1643,7 @@ mod test {
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let cluster_slots = ClusterSlots::default_for_tests();
         let cluster_info = Arc::new(new_test_cluster_info());
-        let identity_keypair = cluster_info.keypair().clone();
+        let identity_keypair = cluster_info.keypair();
         let serve_repair = {
             ServeRepair::new(
                 cluster_info,

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -665,7 +665,7 @@ impl ServeRepair {
         let socket_addr_space = *self.cluster_info.socket_addr_space();
         let root_bank = self.sharable_banks.root();
         let epoch_staked_nodes = root_bank.epoch_staked_nodes(root_bank.epoch());
-        let identity_keypair = self.cluster_info.keypair().clone();
+        let identity_keypair = self.cluster_info.keypair();
         let my_id = identity_keypair.pubkey();
 
         let max_buffered_packets = if !self.repair_whitelist.read().unwrap().is_empty() {
@@ -996,7 +996,7 @@ impl ServeRepair {
         stats: &mut ServeRepairStats,
         data_budget: &DataBudget,
     ) {
-        let identity_keypair = self.cluster_info.keypair().clone();
+        let identity_keypair = self.cluster_info.keypair();
         let mut pending_pings = Vec::default();
 
         for RepairRequestWithMeta {
@@ -1488,7 +1488,7 @@ mod tests {
             bank_forks,
             Arc::new(RwLock::new(HashSet::default())),
         );
-        let keypair = cluster_info.keypair().clone();
+        let keypair = cluster_info.keypair();
         let repair_peer_id = solana_pubkey::new_rand();
         let repair_request = ShredRepairType::Orphan(123);
 
@@ -1527,7 +1527,7 @@ mod tests {
         let cluster_info = Arc::new(new_test_cluster_info());
         let repair_peer_id = solana_pubkey::new_rand();
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let keypair = cluster_info.keypair().clone();
+        let keypair = cluster_info.keypair();
 
         let mut bank = Bank::new_for_tests(&genesis_config);
         bank.feature_set = Arc::new(FeatureSet::all_enabled());
@@ -1574,7 +1574,7 @@ mod tests {
             bank_forks,
             Arc::new(RwLock::new(HashSet::default())),
         );
-        let keypair = cluster_info.keypair().clone();
+        let keypair = cluster_info.keypair();
         let repair_peer_id = solana_pubkey::new_rand();
 
         let slot = 50;
@@ -1889,7 +1889,7 @@ mod tests {
             bank_forks,
             Arc::new(RwLock::new(HashSet::default())),
         );
-        let identity_keypair = cluster_info.keypair().clone();
+        let identity_keypair = cluster_info.keypair();
         let mut outstanding_requests = OutstandingShredRepairs::default();
         let (repair_request_quic_sender, _) = tokio::sync::mpsc::channel(/*buffer:*/ 128);
         let rv = serve_repair.repair_request(
@@ -2192,7 +2192,7 @@ mod tests {
         let contact_info3 = ContactInfo::new_localhost(&solana_pubkey::new_rand(), timestamp());
         cluster_info.insert_info(contact_info2.clone());
         cluster_info.insert_info(contact_info3.clone());
-        let identity_keypair = cluster_info.keypair().clone();
+        let identity_keypair = cluster_info.keypair();
         let serve_repair = ServeRepair::new_for_test(
             cluster_info,
             bank_forks,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -652,7 +652,7 @@ impl ReplayStage {
             let verify_recyclers = VerifyRecyclers::default();
             let _exit = Finalizer::new(exit.clone());
 
-            let mut identity_keypair = cluster_info.keypair().clone();
+            let mut identity_keypair = cluster_info.keypair();
             let mut my_pubkey = identity_keypair.pubkey();
             if !is_alpenglow_migration_complete && my_pubkey != tower.node_pubkey {
                 // set-identity was called during the startup procedure, ensure the tower is consistent
@@ -1105,7 +1105,7 @@ impl ReplayStage {
                             );
 
                             if my_pubkey != cluster_info.id() {
-                                identity_keypair = cluster_info.keypair().clone();
+                                identity_keypair = cluster_info.keypair();
                                 let my_old_pubkey = my_pubkey;
                                 my_pubkey = identity_keypair.pubkey();
 
@@ -7714,7 +7714,7 @@ pub(crate) mod tests {
         let has_new_vote_been_rooted = false;
         let mut tracked_vote_transactions = vec![];
 
-        let identity_keypair = cluster_info.keypair().clone();
+        let identity_keypair = cluster_info.keypair();
         let my_vote_keypair = vec![Arc::new(
             validator_keypairs.remove(&my_pubkey).unwrap().vote_keypair,
         )];
@@ -8227,7 +8227,7 @@ pub(crate) mod tests {
         let has_new_vote_been_rooted = false;
         let mut tracked_vote_transactions = vec![];
 
-        let identity_keypair = cluster_info.keypair().clone();
+        let identity_keypair = cluster_info.keypair();
         let my_vote_keypair = vec![Arc::new(
             validator_keypairs.remove(&my_pubkey).unwrap().vote_keypair,
         )];

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -394,7 +394,7 @@ impl ShredFetchStage {
 
 impl RepairContext {
     fn keypair(&self) -> Arc<Keypair> {
-        self.cluster_info.keypair().clone()
+        self.cluster_info.keypair()
     }
 }
 

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -226,7 +226,7 @@ impl ClusterInfo {
         sender: &impl ChannelSend<PacketBatch>,
     ) {
         let shred_version = self.my_contact_info.read().unwrap().shred_version();
-        let self_keypair: Arc<Keypair> = self.keypair().clone();
+        let self_keypair = self.keypair();
         let mut pings = Vec::new();
         self.gossip.refresh_push_active_set(
             &self_keypair,
@@ -384,8 +384,8 @@ impl ClusterInfo {
         self.keypair.read().unwrap().pubkey()
     }
 
-    pub fn keypair(&self) -> RwLockReadGuard<Arc<Keypair>> {
-        self.keypair.read().unwrap()
+    pub fn keypair(&self) -> Arc<Keypair> {
+        self.keypair.read().unwrap().clone()
     }
 
     pub fn set_keypair(&self, new_keypair: Arc<Keypair>) {
@@ -1163,7 +1163,7 @@ impl ClusterInfo {
     }
 
     fn refresh_my_gossip_contact_info(&self) {
-        let keypair: Arc<Keypair> = self.keypair().clone();
+        let keypair = self.keypair();
         let node = {
             let mut node = self.my_contact_info.write().unwrap();
             node.set_wallclock(timestamp());
@@ -1841,7 +1841,7 @@ impl ClusterInfo {
         response_sender: &impl ChannelSend<PacketBatch>,
     ) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_ping_messages_time);
-        let keypair: Arc<Keypair> = self.keypair().clone();
+        let keypair = self.keypair();
         let pongs = pings.into_iter().map(|(addr, ping)| {
             let pong = Pong::new(&ping, &keypair);
             (addr, Protocol::PongMessage(pong))
@@ -1938,7 +1938,7 @@ impl ClusterInfo {
         // Create and sign Protocol::PruneMessages.
         thread_pool.install(|| {
             let wallclock = timestamp();
-            let keypair: Arc<Keypair> = self.keypair().clone();
+            let keypair = self.keypair();
             prunes
                 .into_par_iter()
                 .flat_map(|(destination, addr, prunes)| {
@@ -2009,7 +2009,7 @@ impl ClusterInfo {
         };
         let mut pings = Vec::new();
         let mut rng = rand::thread_rng();
-        let keypair: Arc<Keypair> = self.keypair().clone();
+        let keypair = self.keypair();
         let mut verify_gossip_addr = |value: &CrdsValue| {
             if verify_gossip_addr(
                 &mut rng,

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -105,7 +105,7 @@ pub fn spawn_shred_sigverify(
             }
             // We can't store the keypair outside the loop
             // because the identity might be hot swapped.
-            let keypair: Arc<Keypair> = cluster_info.keypair().clone();
+            let keypair = cluster_info.keypair();
             match run_shred_sigverify(
                 &thread_pool,
                 &keypair,


### PR DESCRIPTION
This is PR fixes the deadlock issue brought up here: https://github.com/anza-xyz/agave/issues/8485

Solution initially proposed by @diman-io here: https://github.com/anza-xyz/agave/issues/8485#issuecomment-3414206409

Location of reentry lock identified by @steviez here: https://github.com/anza-xyz/agave/issues/8485#issuecomment-3420555953

#### Problem
We are leaking a read lock every time we try and get our keypair. This can result in the validator hanging if you consistently call `set-identity` `AdminRpc` endpoint. 

#### Summary of Changes
Don't leak the read lock. Just clone the `Arc`, release the read lock, and return `Arc<Keypair>`

This was tested on a staked testnet node. Swapped identities multiple times from staked to unstaked and unstaked to staked. No issues. 

There will be 2 follow up PRs to this:
1) Follow up PR (https://github.com/anza-xyz/agave/pull/8539) will switch `RwLock` around `Arc<Keypair>` to an `ArcSwap<Arc<Keypair>>`. There is no reason we should be using an `RwLock` here. 

2) In the current code we acquire the read lock wayyy to frequently in some places. As a follow up to (1), we will reduce calls to acquire the keypair.