### PR TITLE
Remove shrink size calculation from shrink test

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7356,19 +7356,6 @@ impl AccountsDb {
         }
     }
 
-    pub fn sizes_of_accounts_in_storage_for_tests(&self, slot: Slot) -> Vec<usize> {
-        let mut sizes = Vec::default();
-        if let Some(storage) = self.storage.get_slot_storage_entry(slot) {
-            storage
-                .accounts
-                .scan_accounts_stored_meta(|account| {
-                    sizes.push(account.stored_size());
-                })
-                .expect("must scan accounts storage");
-        }
-        sizes
-    }
-
     // With obsolete accounts marked, obsolete references are marked in the storage
     // and no longer need to be referenced. This leads to a static reference count
     // of 1. As referencing checking is common in tests, this test wrapper abstracts the behavior


### PR DESCRIPTION
#### Problem
Size calculation used in test_shrink_candidate_slots_cached is broken. It is intending to ensure that a given slot will be a shrink candidate if a pubkey of a given size is added to the slot. The current code should be fixed for a few reasons. 

1. It isn't actually looking at the shrink algorithm being used. The default right now is total space, which would mean any account0 size makes the slot valid for shrink (IE. putting size 0 for account0 still makes it valid for shrink).
2. The code is needlessly complex and not surprisingly incorrect. Right now the calculation sets pubkey0 size to 779081 bytes instead of the correct 38954 bytes because it attempts to make pubkey0 at least 80% of the slot, rather than 20% of the slot required to be valid for shrink.
3. It requires export of scan_accounts_stored_meta from the accounts db that do not need to be exported. Currently there are other uses, but they are all unnecessary. Further changes will make this private to the accounts_db. 
4. This is something that should be tested in the shrink library (the shrink size calculation) not in the bank. 

#### Summary of Changes
Remove the calculation and just use a static large value

Notes: Considered removing the entire test, since shrink should be mainly tested in accounts_db, but this is the only path that directly tests shrink on a bank.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
