### PR TITLE
move rings to device.rs

### DIFF
--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        device::{DeviceQueue, NetworkDevice, QueueId, RingSizes, TxCompletionRing},
+        device::{DeviceQueue, NetworkDevice, QueueId, RingSizes, TxCompletionRing, TxRing},
         gre::{construct_gre_packet, gre_packet_size},
         netlink::MacAddress,
         packet::{
@@ -11,7 +11,7 @@ use {
         },
         route::NextHop,
         set_cpu_affinity,
-        socket::{Socket, Tx, TxRing},
+        socket::{Socket, Tx},
         umem::{Frame, OwnedUmem, PageAlignedMemory, Umem},
     },
     crossbeam_channel::{Receiver, Sender, TryRecvError},


### PR DESCRIPTION
#### Problem
`RxRing` and `TxRing`rings were defined in separate files from their complementary `RxFillRing` and `TxCompletionRing` rings, making the ring-related logic harder to reason about and maintain.

#### Summary of Changes
Moved `RxRing` and `TxRing` rings into device.rs alongside their complementary rings for better cohesion and organization.
