### PR TITLE
agave-xdp: add read() API to RxRing for descriptor consumption

### DIFF
--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -358,6 +358,117 @@ pub(crate) struct XdpDesc {
     pub(crate) options: u32,
 }
 
+pub struct TxRing<F: Frame> {
+    mmap: RingMmap<XdpDesc>,
+    producer: RingProducer,
+    size: u32,
+    fd: RawFd,
+    _frame: PhantomData<F>,
+}
+
+#[derive(Debug)]
+pub struct RingFull<F: Frame>(pub F);
+
+impl<F: Frame> TxRing<F> {
+    pub (crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            producer: RingProducer::new(mmap.producer, mmap.consumer, size),
+            mmap,
+            size,
+            fd,
+            _frame: PhantomData,
+        }
+    }
+
+    pub fn write(&mut self, frame: F, options: u32) -> Result<(), RingFull<F>> {
+        let Some(index) = self.producer.produce() else {
+            return Err(RingFull(frame));
+        };
+        let index = index & self.size.saturating_sub(1);
+        unsafe {
+            let desc = self.mmap.desc.add(index as usize);
+            desc.write(XdpDesc {
+                addr: frame.offset().0 as u64,
+                len: frame.len() as u32,
+                options,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn needs_wakeup(&self) -> bool {
+        unsafe { (*self.mmap.flags).load(Ordering::Relaxed) & XDP_RING_NEED_WAKEUP != 0 }
+    }
+
+    pub fn wake(&self) -> Result<u64, io::Error> {
+        let result = unsafe { sendto(self.fd, ptr::null(), 0, libc::MSG_DONTWAIT, ptr::null(), 0) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(result as u64)
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.size as usize
+    }
+
+    pub fn available(&self) -> usize {
+        self.producer.available() as usize
+    }
+
+    pub fn commit(&mut self) {
+        self.producer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.producer.sync(commit);
+    }
+}
+
+pub struct RxRing {
+    #[allow(dead_code)]
+    mmap: RingMmap<XdpDesc>,
+    consumer: RingConsumer,
+    size: u32,
+    #[allow(dead_code)]
+    fd: RawFd,
+}
+
+impl RxRing {
+    pub (crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            consumer: RingConsumer::new(mmap.producer, mmap.consumer),
+            mmap,
+            size,
+            fd,
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.size as usize
+    }
+
+    pub fn available(&self) -> usize {
+        self.consumer.available() as usize
+    }
+
+    pub fn commit(&mut self) {
+        self.consumer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.consumer.sync(commit);
+    }
+
+    pub fn read(&mut self) -> Option<XdpDesc> {
+        let index = self.consumer.consume()? & self.size.saturating_sub(1);
+        let desc = unsafe { ptr::read(self.mmap.desc.add(index as usize)) };
+        Some(desc)
+    }
+}
+
 pub struct TxCompletionRing {
     mmap: RingMmap<u64>,
     consumer: RingConsumer,

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -352,10 +352,10 @@ impl RingProducer {
 
 #[repr(C)]
 #[derive(Debug, Clone)]
-pub(crate) struct XdpDesc {
-    pub(crate) addr: u64,
-    pub(crate) len: u32,
-    pub(crate) options: u32,
+pub struct XdpDesc {
+    pub addr: u64,
+    pub len: u32,
+    pub options: u32,
 }
 
 pub struct TxCompletionRing {

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -6,7 +6,7 @@ use {
     },
     libc::{
         AF_INET, IF_NAMESIZE, SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, SYS_ioctl,
-        ifreq, mmap, munmap, socket, syscall, xdp_ring_offset,
+        XDP_RING_NEED_WAKEUP, ifreq, mmap, munmap, sendto, socket, syscall, xdp_ring_offset,
     },
     std::{
         ffi::{CStr, CString, c_char},
@@ -352,10 +352,123 @@ impl RingProducer {
 
 #[repr(C)]
 #[derive(Debug, Clone)]
-pub(crate) struct XdpDesc {
-    pub(crate) addr: u64,
-    pub(crate) len: u32,
-    pub(crate) options: u32,
+pub struct XdpDesc {
+    pub addr: u64,
+    pub len: u32,
+    pub options: u32,
+}
+
+pub struct TxRing<F: Frame> {
+    mmap: RingMmap<XdpDesc>,
+    producer: RingProducer,
+    size: u32,
+    fd: RawFd,
+    _frame: PhantomData<F>,
+}
+
+#[derive(Debug)]
+pub struct RingFull<F: Frame>(pub F);
+
+impl<F: Frame> TxRing<F> {
+    #[allow(dead_code)]
+    pub(crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            producer: RingProducer::new(mmap.producer, mmap.consumer, size),
+            mmap,
+            size,
+            fd,
+            _frame: PhantomData,
+        }
+    }
+
+    pub fn write(&mut self, frame: F, options: u32) -> Result<(), RingFull<F>> {
+        let Some(index) = self.producer.produce() else {
+            return Err(RingFull(frame));
+        };
+        let index = index & self.size.saturating_sub(1);
+        unsafe {
+            let desc = self.mmap.desc.add(index as usize);
+            desc.write(XdpDesc {
+                addr: frame.offset().0 as u64,
+                len: frame.len() as u32,
+                options,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn needs_wakeup(&self) -> bool {
+        unsafe { (*self.mmap.flags).load(Ordering::Relaxed) & XDP_RING_NEED_WAKEUP != 0 }
+    }
+
+    pub fn wake(&self) -> Result<u64, io::Error> {
+        let result = unsafe { sendto(self.fd, ptr::null(), 0, libc::MSG_DONTWAIT, ptr::null(), 0) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(result as u64)
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.size as usize
+    }
+
+    pub fn available(&self) -> usize {
+        self.producer.available() as usize
+    }
+
+    pub fn commit(&mut self) {
+        self.producer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.producer.sync(commit);
+    }
+}
+
+pub struct RxRing {
+    #[allow(dead_code)]
+    mmap: RingMmap<XdpDesc>,
+    consumer: RingConsumer,
+    size: u32,
+    #[allow(dead_code)]
+    fd: RawFd,
+}
+
+impl RxRing {
+    #[allow(dead_code)]
+    pub(crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            consumer: RingConsumer::new(mmap.producer, mmap.consumer),
+            mmap,
+            size,
+            fd,
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.size as usize
+    }
+
+    pub fn available(&self) -> usize {
+        self.consumer.available() as usize
+    }
+
+    pub fn commit(&mut self) {
+        self.consumer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.consumer.sync(commit);
+    }
+
+    pub fn read(&mut self) -> Option<XdpDesc> {
+        let index = self.consumer.consume()? & self.size.saturating_sub(1);
+        let desc = unsafe { ptr::read(self.mmap.desc.add(index as usize)) };
+        Some(desc)
+    }
 }
 
 pub struct TxCompletionRing {

--- a/xdp/src/socket.rs
+++ b/xdp/src/socket.rs
@@ -369,7 +369,6 @@ impl<F: Frame> TxRing<F> {
 }
 
 pub struct RxRing {
-    #[allow(dead_code)]
     mmap: RingMmap<XdpDesc>,
     consumer: RingConsumer,
     size: u32,
@@ -402,6 +401,16 @@ impl RxRing {
 
     pub fn sync(&mut self, commit: bool) {
         self.consumer.sync(commit);
+    }
+
+    /// Consumes a single descriptor from the ring.
+    ///
+    /// Returns `None` when no descriptor is available. Call [`RxRing::sync`] to
+    /// refresh the cached producer index before draining the ring.
+    pub fn read(&mut self) -> Option<XdpDesc> {
+        let index = self.consumer.consume()? & self.size.saturating_sub(1);
+        // Safety: index is masked to the ring size so the pointer is in bounds
+        Some(unsafe { ptr::read(self.mmap.desc.add(index as usize)) })
     }
 }
 

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        device::{DeviceQueue, NetworkDevice, QueueId, RingSizes, TxCompletionRing},
+        device::{DeviceQueue, NetworkDevice, QueueId, RingSizes, TxCompletionRing, TxRing},
         gre::{construct_gre_packet, gre_packet_size},
         netlink::MacAddress,
         packet::{
@@ -11,7 +11,7 @@ use {
         },
         route::NextHop,
         set_cpu_affinity,
-        socket::{Socket, Tx, TxRing},
+        socket::{Socket, Tx},
         umem::{Frame, OwnedUmem, PageAlignedMemory, Umem},
     },
     crossbeam_channel::{Receiver, Sender, TryRecvError},


### PR DESCRIPTION
#### Problem
Previously, `RxRing` lacked a dedicated method to read and consume descriptors efficiently from the RX ring buffer. 

#### Summary of Changes
Added a `read()` API to the `RxRing` type to support descriptor consumption.