### PR TITLE
Socket wakeup

### DIFF
--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -430,6 +430,18 @@ impl<F: Frame> RxFillRing<F> {
     pub fn sync(&mut self, commit: bool) {
         self.producer.sync(commit);
     }
+
+    pub fn needs_wakeup(&self) -> bool {
+        unsafe { (*self.mmap.flags).load(Ordering::Relaxed) & XDP_RING_NEED_WAKEUP != 0 }
+    }
+
+    pub fn wake(&self) -> Result<u64, io::Error> {
+        let result = unsafe { sendto(self._fd, ptr::null(), 0, libc::MSG_DONTWAIT, ptr::null(), 0) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(result as u64)
+    }
 }
 
 pub struct RingMmap<T> {

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -6,7 +6,7 @@ use {
     },
     libc::{
         AF_INET, IF_NAMESIZE, SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, SYS_ioctl,
-        ifreq, mmap, munmap, socket, syscall, xdp_ring_offset,
+        XDP_RING_NEED_WAKEUP, ifreq, mmap, munmap, sendto, socket, syscall, xdp_ring_offset,
     },
     std::{
         ffi::{CStr, CString, c_char},
@@ -393,7 +393,7 @@ pub struct RxFillRing<F: Frame> {
     mmap: RingMmap<u64>,
     producer: RingProducer,
     size: u32,
-    _fd: RawFd,
+    fd: RawFd,
     _frame: PhantomData<F>,
 }
 
@@ -404,7 +404,7 @@ impl<F: Frame> RxFillRing<F> {
             producer: RingProducer::new(mmap.producer, mmap.consumer, size),
             mmap,
             size,
-            _fd: fd,
+            fd,
             _frame: PhantomData,
         }
     }
@@ -429,6 +429,18 @@ impl<F: Frame> RxFillRing<F> {
 
     pub fn sync(&mut self, commit: bool) {
         self.producer.sync(commit);
+    }
+
+    pub fn needs_wakeup(&self) -> bool {
+        unsafe { (*self.mmap.flags).load(Ordering::Relaxed) & XDP_RING_NEED_WAKEUP != 0 }
+    }
+
+    pub fn wake(&self) -> Result<u64, io::Error> {
+        let result = unsafe { sendto(self.fd, ptr::null(), 0, libc::MSG_DONTWAIT, ptr::null(), 0) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(result as u64)
     }
 }
 

--- a/xdp/src/socket.rs
+++ b/xdp/src/socket.rs
@@ -262,10 +262,31 @@ pub struct Tx<F: Frame> {
     pub ring: Option<TxRing<F>>,
 }
 
+impl<F: Frame> Tx<F> {
+    pub(crate) fn needs_wakeup(&self) -> bool {
+        self.ring.as_ref().unwrap().needs_wakeup()
+    }
+
+    pub(crate) fn wake(&self) -> Result<u64, io::Error> {
+        self.ring.as_ref().unwrap().wake()
+    }
+}
+
 pub struct Rx<F: Frame> {
     pub fill: RxFillRing<F>,
     pub ring: Option<RxRing>,
 }
+
+impl<F: Frame> Rx<F> {
+    pub(crate) fn needs_wakeup(&self) -> bool {
+        self.fill.needs_wakeup()
+    }
+
+    pub(crate) fn wake(&self) -> Result<u64, io::Error> {
+        self.fill.wake()
+    }
+}
+
 
 pub struct TxRing<F: Frame> {
     mmap: RingMmap<XdpDesc>,

--- a/xdp/src/socket.rs
+++ b/xdp/src/socket.rs
@@ -295,9 +295,33 @@ pub struct Tx<F: Frame> {
     pub ring: Option<TxRing<F>>,
 }
 
+impl<F: Frame> Tx<F> {
+    #[allow(dead_code)]
+    pub(crate) fn needs_wakeup(&self) -> bool {
+        self.ring.as_ref().unwrap().needs_wakeup()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn wake(&self) -> Result<u64, io::Error> {
+        self.ring.as_ref().unwrap().wake()
+    }
+}
+
 pub struct Rx<F: Frame> {
     pub fill: RxFillRing<F>,
     pub ring: Option<RxRing>,
+}
+
+impl<F: Frame> Rx<F> {
+    #[allow(dead_code)]
+    pub(crate) fn needs_wakeup(&self) -> bool {
+        self.fill.needs_wakeup()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn wake(&self) -> Result<u64, io::Error> {
+        self.fill.wake()
+    }
 }
 
 pub struct TxRing<F: Frame> {


### PR DESCRIPTION
#### Problem
`RxFillRing` did not previously expose a wakeup helper, making it difficult to notify the kernel when descriptors were replenished.  
Additionally, higher-level `Socket` abstractions (`Rx` and `Tx`) lacked methods to access these wakeup mechanisms.

#### Summary of Changes
- Added  `wake()` and `needs_wakeup()` helpers to `RxFillRing`
- Exposed `wake()` and `needs_wakeup()` helpers to `Rx` and `Tx` handle types.
- Forwarded wakeup calls from these handles to their corresponding ring implementations:
  - `Rx` now delegates to `RxFillRing`'s `wake()` and `needs_wakeup()`.
  - `Tx` now delegates to `TxRing`'s `wake()` and `needs_wakeup()`.
- Enables socket-level wakeup control, simplifying integration with event loops and poll-based I/O.

