### PR TITLE
Add client_id to getClusterNodes RPC response

### DIFF
--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -288,7 +288,7 @@ pub struct RpcContactInfo {
     pub feature_set: Option<u32>,
     /// Shred version
     pub shred_version: Option<u16>,
-    /// Client ID (0: SolanaLabs, 1: JitoLabs, 2: Firedancer, 3: Agave)
+    /// Client ID (0: SolanaLabs, 1: JitoLabs, 2: Firedancer, 3: Agave, 4: Paladin)
     pub client_id: Option<u16>,
 }
 

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -288,6 +288,8 @@ pub struct RpcContactInfo {
     pub feature_set: Option<u32>,
     /// Shred version
     pub shred_version: Option<u16>,
+    /// Client ID (0: SolanaLabs, 1: JitoLabs, 2: Firedancer, 3: Agave)
+    pub client_id: Option<u16>,
 }
 
 /// Map of leader base58 identity pubkeys to the slot indices relative to the first epoch slot

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -398,6 +398,7 @@ impl RpcSender for MockSender {
                 version: Some("1.0.0 c375ce1f".to_string()),
                 feature_set: None,
                 shred_version: None,
+                client_id: None,
             }])?,
             "getBlock" => serde_json::to_value(EncodedConfirmedBlock {
                 previous_blockhash: "mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B".to_string(),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3656,12 +3656,12 @@ pub mod rpc_full {
                             .map(|addr| socket_addr_space.check(&addr))
                             .unwrap_or_default()
                     {
-                        let (version, feature_set) = if let Some(version) =
+                        let (version, feature_set, client_id) = if let Some(version) =
                             cluster_info.get_node_version(contact_info.pubkey())
                         {
-                            (Some(version.to_string()), Some(version.feature_set))
+                            (Some(version.to_string()), Some(version.feature_set), Some(version.client))
                         } else {
-                            (None, None)
+                            (None, None, None)
                         };
                         Some(RpcContactInfo {
                             pubkey: contact_info.pubkey().to_string(),
@@ -3696,6 +3696,7 @@ pub mod rpc_full {
                             version,
                             feature_set,
                             shred_version: Some(my_shred_version),
+                            client_id,
                         })
                     } else {
                         None // Exclude spy nodes

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -37,7 +37,7 @@ pub struct Version {
     pub commit: u32,      // first 4 bytes of the sha1 commit hash
     pub feature_set: u32, // first 4 bytes of the FeatureSet identifier
     #[serde(with = "serde_varint")]
-    client: u16,
+    pub client: u16,
 }
 
 impl Version {


### PR DESCRIPTION
The `getClusterNodes` RPC method currently returns node information including version and feature set, but doesn't expose which client is running


Added `client_id` field to `RpcContactInfo` struct in `rpc-client-types/src/response.rs`
Updated `getClusterNodes` RPC handler in `rpc/src/rpc.rs` to populate `client_id` from the node's version info