### PR TITLE
Xsk map in `socket.rs`

### DIFF
--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -5,8 +5,7 @@ use {
         umem::{Frame, FrameOffset},
     },
     libc::{
-        ifreq, mmap, munmap, socket, syscall, xdp_ring_offset, SYS_ioctl, AF_INET, IF_NAMESIZE,
-        SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM,
+        ifreq, mmap, munmap, sendto, socket, syscall, xdp_ring_offset, SYS_ioctl, AF_INET, IF_NAMESIZE, SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, XDP_RING_NEED_WAKEUP
     },
     std::{
         ffi::{c_char, CStr, CString},
@@ -350,6 +349,111 @@ pub(crate) struct XdpDesc {
     pub(crate) addr: u64,
     pub(crate) len: u32,
     pub(crate) options: u32,
+}
+
+pub struct TxRing<F: Frame> {
+    mmap: RingMmap<XdpDesc>,
+    producer: RingProducer,
+    size: u32,
+    fd: RawFd,
+    _frame: PhantomData<F>,
+}
+
+#[derive(Debug)]
+pub struct RingFull<F: Frame>(pub F);
+
+impl<F: Frame> TxRing<F> {
+    pub (crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            producer: RingProducer::new(mmap.producer, mmap.consumer, size),
+            mmap,
+            size,
+            fd,
+            _frame: PhantomData,
+        }
+    }
+
+    pub fn write(&mut self, frame: F, options: u32) -> Result<(), RingFull<F>> {
+        let Some(index) = self.producer.produce() else {
+            return Err(RingFull(frame));
+        };
+        let index = index & self.size.saturating_sub(1);
+        unsafe {
+            let desc = self.mmap.desc.add(index as usize);
+            desc.write(XdpDesc {
+                addr: frame.offset().0 as u64,
+                len: frame.len() as u32,
+                options,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn needs_wakeup(&self) -> bool {
+        unsafe { (*self.mmap.flags).load(Ordering::Relaxed) & XDP_RING_NEED_WAKEUP != 0 }
+    }
+
+    pub fn wake(&self) -> Result<u64, io::Error> {
+        let result = unsafe { sendto(self.fd, ptr::null(), 0, libc::MSG_DONTWAIT, ptr::null(), 0) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(result as u64)
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.size as usize
+    }
+
+    pub fn available(&self) -> usize {
+        self.producer.available() as usize
+    }
+
+    pub fn commit(&mut self) {
+        self.producer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.producer.sync(commit);
+    }
+}
+
+pub struct RxRing {
+    #[allow(dead_code)]
+    mmap: RingMmap<XdpDesc>,
+    consumer: RingConsumer,
+    size: u32,
+    #[allow(dead_code)]
+    fd: RawFd,
+}
+
+impl RxRing {
+    pub (crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            consumer: RingConsumer::new(mmap.producer, mmap.consumer),
+            mmap,
+            size,
+            fd,
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.size as usize
+    }
+
+    pub fn available(&self) -> usize {
+        self.consumer.available() as usize
+    }
+
+    pub fn commit(&mut self) {
+        self.consumer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.consumer.sync(commit);
+    }
 }
 
 pub struct TxCompletionRing {

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        device::{NetworkDevice, QueueId, RingSizes},
+        device::{NetworkDevice, QueueId, RingSizes, TxRing},
         netlink::MacAddress,
         packet::{
             write_eth_header, write_ip_header, write_udp_header, ETH_HEADER_SIZE, IP_HEADER_SIZE,
@@ -10,7 +10,7 @@ use {
         },
         route::Router,
         set_cpu_affinity,
-        socket::{Socket, Tx, TxRing},
+        socket::{Socket, Tx},
         umem::{Frame as _, PageAlignedMemory, SliceUmem, SliceUmemFrame, Umem as _},
     },
     caps::{


### PR DESCRIPTION
#### Problem
AF_XDP sockets lacked xsks_map registration, preventing eBPF programs from redirecting packets to user space on the receive side.

#### Summary of Changes
Added `register_in_xskmap(&self, bpf: &mut Ebpf)` in `Socket<U: Umem>` type to register AF_XDP socket fds in xsks_map using their queue IDs, enabling proper packet redirection for RX paths.