### PR TITLE
Bump modular-bitfield to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4644,9 +4644,9 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0d5274763b5572c8f29dadb5cd0bc59de64c805de433c1b556075f733b0a1a"
+checksum = "47a586be3f2f7e70a9d302c621447dba612d42069f3901258b2cf8ce96d855b1"
 dependencies = [
  "modular-bitfield-impl",
  "static_assertions",
@@ -4654,9 +4654,9 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield-impl"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eec4327f127d4d18c54c8bfbf7b05d74cc9a1befdcc6283a241238ffbc84c6"
+checksum = "8462d3cc74eaf4194f6c0bd7b18c6f3fa6293297f4bdb60fe4c4b022ea366e12"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,7 @@ memoffset = "0.9"
 merlin = { version = "3", default-features = false }
 min-max-heap = "1.3.0"
 mockall = "0.11.4"
-modular-bitfield = "0.12.0"
+modular-bitfield = "0.13.0"
 nix = "0.30.1"
 num-bigint = "0.4.6"
 num-derive = "0.4"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -3781,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0d5274763b5572c8f29dadb5cd0bc59de64c805de433c1b556075f733b0a1a"
+checksum = "47a586be3f2f7e70a9d302c621447dba612d42069f3901258b2cf8ce96d855b1"
 dependencies = [
  "modular-bitfield-impl",
  "static_assertions",
@@ -3791,9 +3791,9 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield-impl"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eec4327f127d4d18c54c8bfbf7b05d74cc9a1befdcc6283a241238ffbc84c6"
+checksum = "8462d3cc74eaf4194f6c0bd7b18c6f3fa6293297f4bdb60fe4c4b022ea366e12"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
#### Problem
New version of modular-bitfield was released and now it includes a fix for warning we are observing during cargo clippy +1.90 checks (https://github.com/anza-xyz/agave/issues/8117#issuecomment-3343931008)

#### Summary of Changes
From [release notes](https://github.com/modular-bitfield/modular-bitfield/releases/tag/v0.13.0):
* Breaking changes
  * The MSRV is now 1.76. This is not currently a hard requirement of modular-bitfield itself but is instead the path of least resistance due to changes to underlying dev-dependencies, so please open a ticket if you really need support for an even older version of Rust.
  * From<[u8; {n}]> (when conversions are guaranteed) and TryFrom<[u8; {n}]> traits are now automatically derived by #[bitfield]. This will conflict with any manual implementations of the same trait, but you wrote those implementations to do this thing anyway, right? (https://github.com/modular-bitfield/modular-bitfield/issues/120)
  * The BitfieldSpecifier alias, which was deprecated in v0.12, is removed.
* Enhancements
  * Diagnostic messages around invalid bit counts have been improved.
  * Minor documentation improvements for the Specifier trait.
* Bug fixes
  * Unnecessary brackets in the generated output which were triggering new Clippy lints in Rust 1.90+ have been fixed. (https://github.com/modular-bitfield/modular-bitfield/issues/130)
   * Unnecessary identity operations in the generated output which were triggering Clippy lints in some cases have been fixed. (https://github.com/modular-bitfield/modular-bitfield/issues/131)
