### PR TITLE
Extract SnapshotVersion to agave-snapshots

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -14,7 +14,9 @@ use {
     },
     agave_feature_set::{self as feature_set, FeatureSet},
     agave_reserved_account_keys::ReservedAccountKeys,
-    agave_snapshots::{ArchiveFormat, DEFAULT_ARCHIVE_COMPRESSION, SUPPORTED_ARCHIVE_COMPRESSION},
+    agave_snapshots::{
+        ArchiveFormat, SnapshotVersion, DEFAULT_ARCHIVE_COMPRESSION, SUPPORTED_ARCHIVE_COMPRESSION,
+    },
     clap::{
         crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App,
         AppSettings, Arg, ArgMatches, SubCommand,
@@ -68,7 +70,6 @@ use {
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_bank_utils,
         snapshot_minimizer::SnapshotMinimizer,
-        snapshot_utils::SnapshotVersion,
     },
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_shred_version::compute_shred_version,

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -27,13 +27,13 @@ use {
         snapshot_utils::{
             self, get_highest_bank_snapshot, get_highest_full_snapshot_archive_info,
             get_highest_incremental_snapshot_archive_info, rebuild_storages_from_snapshot_dir,
-            verify_and_unarchive_snapshots, BankSnapshotInfo, SnapshotError, SnapshotVersion,
+            verify_and_unarchive_snapshots, BankSnapshotInfo, SnapshotError,
             StorageAndNextAccountsFileId, UnarchivedSnapshots, VerifyEpochStakesError,
             VerifySlotDeltasError, VerifySlotHistoryError,
         },
         status_cache,
     },
-    agave_snapshots::ArchiveFormat,
+    agave_snapshots::{ArchiveFormat, SnapshotVersion},
     log::*,
     solana_accounts_db::{
         accounts_db::{AccountsDbConfig, AtomicAccountsFileId},

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -1,6 +1,6 @@
 use {
-    crate::snapshot_utils::{self, SnapshotVersion},
-    agave_snapshots::{ArchiveFormat, SnapshotInterval, ZstdConfig},
+    crate::snapshot_utils,
+    agave_snapshots::{ArchiveFormat, SnapshotInterval, SnapshotVersion, ZstdConfig},
     std::{num::NonZeroUsize, path::PathBuf},
 };
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -19,7 +19,7 @@ use {
             get_slot_and_append_vec_id, SnapshotStorageRebuilder,
         },
     },
-    agave_snapshots::{ArchiveFormat, ArchiveFormatDecompressor},
+    agave_snapshots::{ArchiveFormat, ArchiveFormatDecompressor, SnapshotVersion},
     crossbeam_channel::{Receiver, Sender},
     log::*,
     regex::Regex,
@@ -38,7 +38,7 @@ use {
     std::{
         cmp::Ordering,
         collections::{HashMap, HashSet},
-        fmt, fs,
+        fs,
         io::{self, BufRead, BufReader, BufWriter, Error as IoError, Read, Seek, Write},
         mem,
         num::{NonZeroU64, NonZeroUsize},
@@ -73,7 +73,6 @@ pub const BANK_SNAPSHOTS_DIR: &str = "snapshots";
 pub const MAX_SNAPSHOT_DATA_FILE_SIZE: u64 = 32 * 1024 * 1024 * 1024; // 32 GiB
 const MAX_SNAPSHOT_VERSION_FILE_SIZE: u64 = 8; // byte
 const SNAPSHOT_FASTBOOT_VERSION: Version = Version::new(1, 0, 0);
-const VERSION_STRING_V1_2_0: &str = "1.2.0";
 pub const TMP_SNAPSHOT_ARCHIVE_PREFIX: &str = "tmp-snapshot-archive-";
 pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
     NonZeroU64::new(100_000).unwrap();
@@ -94,52 +93,6 @@ const MAX_SNAPSHOT_READER_BUF_SIZE: u64 = 128 * 1024 * 1024;
 // such that during unpacking large writes are mixed with file metadata operations
 // and towards the end of archive (sizes equalize) writes are >256KiB / file.
 const INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO: (usize, usize) = (4, 1);
-
-#[derive(Copy, Clone, Default, Eq, PartialEq, Debug)]
-pub enum SnapshotVersion {
-    #[default]
-    V1_2_0,
-}
-
-impl fmt::Display for SnapshotVersion {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(From::from(*self))
-    }
-}
-
-impl From<SnapshotVersion> for &'static str {
-    fn from(snapshot_version: SnapshotVersion) -> &'static str {
-        match snapshot_version {
-            SnapshotVersion::V1_2_0 => VERSION_STRING_V1_2_0,
-        }
-    }
-}
-
-impl FromStr for SnapshotVersion {
-    type Err = &'static str;
-
-    fn from_str(version_string: &str) -> std::result::Result<Self, Self::Err> {
-        // Remove leading 'v' or 'V' from slice
-        let version_string = if version_string
-            .get(..1)
-            .is_some_and(|s| s.eq_ignore_ascii_case("v"))
-        {
-            &version_string[1..]
-        } else {
-            version_string
-        };
-        match version_string {
-            VERSION_STRING_V1_2_0 => Ok(SnapshotVersion::V1_2_0),
-            _ => Err("unsupported snapshot version"),
-        }
-    }
-}
-
-impl SnapshotVersion {
-    pub fn as_str(self) -> &'static str {
-        <&str as From<Self>>::from(self)
-    }
-}
 
 /// Information about a bank snapshot. Namely the slot of the bank, the path to the snapshot, and
 /// the kind of the snapshot.

--- a/snapshots/src/lib.rs
+++ b/snapshots/src/lib.rs
@@ -2,5 +2,8 @@
 
 mod archive_format;
 mod snapshot_interval;
+mod snapshot_version;
 
-pub use {archive_format::*, snapshot_interval::SnapshotInterval};
+pub use {
+    archive_format::*, snapshot_interval::SnapshotInterval, snapshot_version::SnapshotVersion,
+};

--- a/snapshots/src/snapshot_version.rs
+++ b/snapshots/src/snapshot_version.rs
@@ -1,0 +1,49 @@
+use std::{fmt, str::FromStr};
+
+const VERSION_STRING_V1_2_0: &str = "1.2.0";
+
+#[derive(Copy, Clone, Default, Eq, PartialEq, Debug)]
+pub enum SnapshotVersion {
+    #[default]
+    V1_2_0,
+}
+
+impl fmt::Display for SnapshotVersion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(From::from(*self))
+    }
+}
+
+impl From<SnapshotVersion> for &'static str {
+    fn from(snapshot_version: SnapshotVersion) -> &'static str {
+        match snapshot_version {
+            SnapshotVersion::V1_2_0 => VERSION_STRING_V1_2_0,
+        }
+    }
+}
+
+impl FromStr for SnapshotVersion {
+    type Err = &'static str;
+
+    fn from_str(version_string: &str) -> Result<Self, Self::Err> {
+        // Remove leading 'v' or 'V' from slice
+        let version_string = if version_string
+            .get(..1)
+            .is_some_and(|s| s.eq_ignore_ascii_case("v"))
+        {
+            &version_string[1..]
+        } else {
+            version_string
+        };
+        match version_string {
+            VERSION_STRING_V1_2_0 => Ok(SnapshotVersion::V1_2_0),
+            _ => Err("unsupported snapshot version"),
+        }
+    }
+}
+
+impl SnapshotVersion {
+    pub fn as_str(self) -> &'static str {
+        <&str as From<Self>>::from(self)
+    }
+}

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1,6 +1,6 @@
 use {
     crate::commands,
-    agave_snapshots::DEFAULT_ARCHIVE_COMPRESSION,
+    agave_snapshots::{SnapshotVersion, DEFAULT_ARCHIVE_COMPRESSION},
     clap::{crate_description, crate_name, App, AppSettings, Arg, ArgMatches, SubCommand},
     solana_accounts_db::{
         accounts_db::{
@@ -26,7 +26,7 @@ use {
     solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,
     solana_rpc_client_api::request::{DELINQUENT_VALIDATOR_SLOT_DISTANCE, MAX_MULTIPLE_ACCOUNTS},
     solana_runtime::snapshot_utils::{
-        SnapshotVersion, DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+        DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
         DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
         DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -4,7 +4,7 @@ use {
         cli::{hash_validator, port_range_validator, port_validator, DefaultArgs},
         commands::{FromClapArgMatches, Result},
     },
-    agave_snapshots::SUPPORTED_ARCHIVE_COMPRESSION,
+    agave_snapshots::{SnapshotVersion, SUPPORTED_ARCHIVE_COMPRESSION},
     clap::{values_t, App, Arg, ArgMatches},
     solana_accounts_db::utils::create_and_canonicalize_directory,
     solana_clap_utils::{
@@ -26,7 +26,6 @@ use {
     solana_ledger::{blockstore_options::BlockstoreOptions, use_snapshot_archives_at_startup},
     solana_pubkey::Pubkey,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
-    solana_runtime::snapshot_utils::SnapshotVersion,
     solana_send_transaction_service::send_transaction_service::{
         Config as SendTransactionServiceConfig, MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
     },

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -6,7 +6,7 @@ use {
         commands::{run::args::RunArgs, FromClapArgMatches},
         ledger_lockfile, lock_ledger,
     },
-    agave_snapshots::{ArchiveFormat, SnapshotInterval},
+    agave_snapshots::{ArchiveFormat, SnapshotInterval, SnapshotVersion},
     clap::{crate_name, value_t, value_t_or_exit, values_t, values_t_or_exit, ArgMatches},
     crossbeam_channel::unbounded,
     log::*,
@@ -57,7 +57,7 @@ use {
     solana_runtime::{
         runtime_config::RuntimeConfig,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
-        snapshot_utils::{self, SnapshotVersion, BANK_SNAPSHOTS_DIR},
+        snapshot_utils::{self, BANK_SNAPSHOTS_DIR},
     },
     solana_signer::Signer,
     solana_streamer::quic::{QuicServerParams, DEFAULT_TPU_COALESCE},


### PR DESCRIPTION
#### Problem
`SnapshotVersion` is placed in snapshot_utils and imported from there in several places in code. It has no dependencies on other types / crate and can be moved to agave-snapshots

#### Summary of Changes
Move type into new module in `agave-snapshots`
