### PR TITLE
Include path of the archive in the unpacking error

### DIFF
--- a/snapshots/src/hardened_unpack.rs
+++ b/snapshots/src/hardened_unpack.rs
@@ -28,6 +28,8 @@ pub enum UnpackError {
     Io(#[from] std::io::Error),
     #[error("Archive error: {0}")]
     Archive(String),
+    #[error("Unpacking '{1}' failed: {0}")]
+    Unpack(Box<UnpackError>, PathBuf),
 }
 
 pub type Result<T> = std::result::Result<T, UnpackError>;

--- a/snapshots/src/unarchive.rs
+++ b/snapshots/src/unarchive.rs
@@ -25,22 +25,25 @@ pub fn streaming_unarchive_snapshot(
     archive_format: ArchiveFormat,
     memlock_budget_size: usize,
 ) -> JoinHandle<Result<(), UnpackError>> {
+    let do_unpack = move |archive_path: &Path| {
+        let archive_size = fs::metadata(archive_path)?.len() as usize;
+        let read_write_budget_size = (memlock_budget_size / 2).min(archive_size);
+        let read_buf_size = MAX_SNAPSHOT_READER_BUF_SIZE.min(read_write_budget_size as u64);
+        let decompressor = decompressed_tar_reader(archive_format, archive_path, read_buf_size)?;
+        hardened_unpack::streaming_unpack_snapshot(
+            decompressor,
+            read_write_budget_size,
+            ledger_dir.as_path(),
+            &account_paths,
+            &file_sender,
+        )
+    };
+
     thread::Builder::new()
         .name("solTarUnpack".to_string())
         .spawn(move || {
-            let archive_size = fs::metadata(&snapshot_archive_path)?.len() as usize;
-            let read_write_budget_size = (memlock_budget_size / 2).min(archive_size);
-            let read_buf_size = MAX_SNAPSHOT_READER_BUF_SIZE.min(read_write_budget_size as u64);
-            let decompressor =
-                decompressed_tar_reader(archive_format, snapshot_archive_path, read_buf_size)?;
-            hardened_unpack::streaming_unpack_snapshot(
-                decompressor,
-                read_write_budget_size,
-                ledger_dir.as_path(),
-                &account_paths,
-                &file_sender,
-            )?;
-            Ok(())
+            do_unpack(&snapshot_archive_path)
+                .map_err(|err| UnpackError::Unpack(Box::new(err), snapshot_archive_path))
         })
         .unwrap()
 }
@@ -51,12 +54,6 @@ fn decompressed_tar_reader(
     buf_size: u64,
 ) -> io::Result<ArchiveFormatDecompressor<impl BufRead>> {
     let buf_reader =
-        solana_accounts_db::large_file_buf_reader(archive_path.as_ref(), buf_size as usize)
-            .map_err(|err| {
-                io::Error::other(format!(
-                    "failed to open snapshot archive '{}': {err}",
-                    archive_path.as_ref().display(),
-                ))
-            })?;
+        solana_accounts_db::large_file_buf_reader(archive_path.as_ref(), buf_size as usize)?;
     ArchiveFormatDecompressor::new(archive_format, buf_reader)
 }


### PR DESCRIPTION
#### Problem
Path of the snapshot is not logged when unpack error happens

#### Summary of Changes
* move annotation of error with path from function creating decompressor to the whole unpacking function
* introduce separate Unpack error with variant adding path instead of using IO `other`
