### PR TITLE
clippy: Fix 1.90 syntax and io:Error lints

### DIFF
--- a/core/src/repair/duplicate_repair_status.rs
+++ b/core/src/repair/duplicate_repair_status.rs
@@ -1130,7 +1130,7 @@ pub mod tests {
         let tree = test_setup
             .correct_ancestors_response
             .iter()
-            .fold(tr(request_slot + 1), |tree, (slot, _)| (tr(*slot) / tree));
+            .fold(tr(request_slot + 1), |tree, (slot, _)| tr(*slot) / tree);
         test_setup
             .blockstore
             .add_tree(tree, true, true, 2, Hash::default());
@@ -1165,7 +1165,7 @@ pub mod tests {
             .correct_ancestors_response
             .iter()
             .filter(|(slot, _)| *slot <= 92 || *slot % 2 == 1)
-            .fold(tr(request_slot), |tree, (slot, _)| (tr(*slot) / tree));
+            .fold(tr(request_slot), |tree, (slot, _)| tr(*slot) / tree);
         test_setup
             .blockstore
             .add_tree(tree, true, true, 2, Hash::default());
@@ -1210,7 +1210,7 @@ pub mod tests {
         let pruned_fork = [10, 11, 93, 94, 95, 96, 97, 98, 99]
             .iter()
             .rev()
-            .fold(tr(100), |tree, slot| (tr(*slot) / tree));
+            .fold(tr(100), |tree, slot| tr(*slot) / tree);
 
         test_setup
             .blockstore

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2580,12 +2580,9 @@ impl ReplayStage {
                 return GenerateVoteTxResult::Failed;
             }
         }
-        let vote_account = match bank.get_vote_account(vote_account_pubkey) {
-            None => {
-                warn!("Vote account {vote_account_pubkey} does not exist.  Unable to vote",);
-                return GenerateVoteTxResult::Failed;
-            }
-            Some(vote_account) => vote_account,
+        let Some(vote_account) = bank.get_vote_account(vote_account_pubkey) else {
+            warn!("Vote account {vote_account_pubkey} does not exist.  Unable to vote",);
+            return GenerateVoteTxResult::Failed;
         };
         let vote_state_view = vote_account.vote_state_view();
         if vote_state_view.node_pubkey() != &node_keypair.pubkey() {
@@ -2607,18 +2604,15 @@ impl ReplayStage {
             return GenerateVoteTxResult::Failed;
         };
 
-        let authorized_voter_keypair = match authorized_voter_keypairs
+        let Some(authorized_voter_keypair) = authorized_voter_keypairs
             .iter()
             .find(|keypair| &keypair.pubkey() == authorized_voter_pubkey)
-        {
-            None => {
-                warn!(
-                    "The authorized keypair {authorized_voter_pubkey} for vote account \
-                     {vote_account_pubkey} is not available.  Unable to vote"
-                );
-                return GenerateVoteTxResult::NonVoting;
-            }
-            Some(authorized_voter_keypair) => authorized_voter_keypair,
+        else {
+            warn!(
+                "The authorized keypair {authorized_voter_pubkey} for vote account \
+                 {vote_account_pubkey} is not available.  Unable to vote"
+            );
+            return GenerateVoteTxResult::NonVoting;
         };
 
         // Send our last few votes along with the new one

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7750,7 +7750,7 @@ pub mod tests {
                     .chain(
                         completed_data_end_indexes[i..=j]
                             .windows(2)
-                            .map(|end_indexes| (end_indexes[0] + 1..end_indexes[1] + 1)),
+                            .map(|end_indexes| end_indexes[0] + 1..end_indexes[1] + 1),
                     )
                     .collect::<Vec<_>>();
 

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -701,13 +701,10 @@ where
     P: Into<PacketRef<'a>>,
 {
     debug_assert!(root < max_slot);
-    let shred = match layout::get_shred(packet) {
-        None => {
+    let Some(shred) = layout::get_shred(packet) else {
             stats.index_overrun += 1;
             return true;
-        }
-        Some(shred) => shred,
-    };
+        };
     match layout::get_version(shred) {
         None => {
             stats.index_overrun += 1;

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -915,7 +915,7 @@ impl LocalCluster {
                                 } else {
                                     info!("node {node_pubkey} {stake_state:?} {vote_state:?}");
 
-                                    return Ok(());
+                                    Ok(())
                                 }
                             }
                             (None, _) => Err(Error::other("invalid stake account data")),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5682,7 +5682,7 @@ impl InvokeContextCallback for Bank {
     fn get_epoch_stake_for_vote_account(&self, vote_address: &Pubkey) -> u64 {
         self.get_current_epoch_vote_accounts()
             .get(vote_address)
-            .map(|(stake, _)| (*stake))
+            .map(|(stake, _)| *stake)
             .unwrap_or(0)
     }
 

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -347,7 +347,7 @@ pub(crate) mod tests {
             .map(|(node_pubkey, vote_accounts)| {
                 let mut vote_accounts = vote_accounts
                     .iter()
-                    .map(|v| (v.vote_account))
+                    .map(|v| v.vote_account)
                     .collect::<Vec<_>>();
                 vote_accounts.sort();
                 let node_vote_accounts = NodeVoteAccounts {

--- a/syscalls/src/sysvar.rs
+++ b/syscalls/src/sysvar.rs
@@ -241,10 +241,7 @@ declare_builtin_function!(
         let cache = invoke_context.get_sysvar_cache();
 
         // "`2` if the sysvar data is not present in the Sysvar Cache."
-        let sysvar_buf = match cache.sysvar_id_to_buffer(sysvar_id) {
-            None => return Ok(SYSVAR_NOT_FOUND),
-            Some(ref sysvar_buf) => sysvar_buf,
-        };
+        let Some(ref sysvar_buf) = cache.sysvar_id_to_buffer(sysvar_id) else { return Ok(SYSVAR_NOT_FOUND) };
 
         // "`1` if `offset + length` is greater than the length of the sysvar data."
         if let Some(sysvar_slice) = sysvar_buf.get(offset as usize..offset_length as usize) {

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -439,7 +439,7 @@ mod tests {
         // Make stake monotonic decreasing so rank is deterministic
         let stake = (0..validator_keypairs.len())
             .rev()
-            .map(|i| ((i.saturating_add(5).saturating_mul(100)) as u64))
+            .map(|i| (i.saturating_add(5).saturating_mul(100)) as u64)
             .collect::<Vec<_>>();
         let genesis = create_genesis_config_with_alpenglow_vote_accounts(
             1_000_000_000,

--- a/votor/src/vote_history_storage.rs
+++ b/votor/src/vote_history_storage.rs
@@ -108,8 +108,7 @@ pub struct NullVoteHistoryStorage {}
 
 impl VoteHistoryStorage for NullVoteHistoryStorage {
     fn load(&self, _node_pubkey: &Pubkey) -> Result<VoteHistory> {
-        Err(VoteHistoryError::IoError(io::Error::new(
-            io::ErrorKind::Other,
+        Err(VoteHistoryError::IoError(io::Error::other(
             "NullVoteHistoryStorage::load() not available",
         )))
     }

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -176,14 +176,11 @@ fn generate_vote_tx(vote: &Vote, bank: &Bank, context: &mut VotingContext) -> Ge
             );
             return GenerateVoteTxResult::HotSpare;
         }
-        let bls_pubkey_serialized = match vote_state_view.bls_pubkey_compressed() {
-            None => {
-                panic!(
-                    "No BLS pubkey in vote account {}",
-                    context.identity_keypair.pubkey()
-                );
-            }
-            Some(key) => key,
+        let Some(bls_pubkey_serialized) = vote_state_view.bls_pubkey_compressed() else {
+            panic!(
+                "No BLS pubkey in vote account {}",
+                context.identity_keypair.pubkey()
+            );
         };
         bls_pubkey_in_vote_account =
             (bincode::deserialize::<BLSPubkeyCompressed>(&bls_pubkey_serialized).unwrap())


### PR DESCRIPTION
#### Problem
Rust toolchain 1.90 introduces some stricter lints, the most basic ones are gathered in this PR commit-per-crate

(as part of https://github.com/anza-xyz/agave/issues/8117 we should fix all the warnings)

#### Summary of Changes
cargo +1.90.0 clippy --tests --fix -- -A mismatched_lifetime_syntaxes -A clippy::manual_is_multiple_of -A dangerous_implicit_autorefs
cargo +nightly-2025-02-16 fmt --al
hand pick semantically netural changes: syntax and io::Error API tweaks
