### PR TITLE
 Use slice::from_ref instead of a slice of reference to cloned value

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -562,6 +562,7 @@ mod tests {
         solana_transaction_status::{TransactionStatusMeta, VersionedTransactionWithStatusMeta},
         std::{
             borrow::Cow,
+            slice,
             sync::{
                 atomic::{AtomicBool, AtomicU64},
                 Arc,
@@ -1558,7 +1559,7 @@ mod tests {
         let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
         let consumer_output =
-            consumer.process_and_record_transactions(&bank, &[sanitized_tx.clone()]);
+            consumer.process_and_record_transactions(&bank, slice::from_ref(&sanitized_tx));
         let CommitTransactionDetails::Committed {
             compute_units,
             loaded_accounts_data_size,

--- a/program-test/tests/cpi.rs
+++ b/program-test/tests/cpi.rs
@@ -12,6 +12,7 @@ use {
     solana_system_interface::{instruction as system_instruction, program as system_program},
     solana_sysvar::Sysvar,
     solana_transaction::Transaction,
+    std::slice,
 };
 
 // Process instruction to invoke into another program
@@ -31,7 +32,7 @@ fn invoker_process_instruction(
             &[0],
             vec![AccountMeta::new_readonly(*invoked_program_info.key, false)],
         ),
-        &[invoked_program_info.clone()],
+        slice::from_ref(invoked_program_info),
     )?;
     msg!("Processing invoker instruction after CPI");
     Ok(())
@@ -238,7 +239,7 @@ fn invoker_stack_height(
     let invoked_program_info = next_account_info(account_info_iter)?;
     invoke(
         &Instruction::new_with_bytes(*invoked_program_info.key, &[], vec![]),
-        &[invoked_program_info.clone()],
+        slice::from_ref(invoked_program_info),
     )?;
     msg!("Processing invoker instruction after CPI");
     Ok(())

--- a/program-test/tests/return_data.rs
+++ b/program-test/tests/return_data.rs
@@ -12,7 +12,7 @@ use {
     solana_signer::Signer,
     solana_transaction::Transaction,
     solana_transaction_context::TransactionReturnData,
-    std::str::from_utf8,
+    std::{slice, str::from_utf8},
 };
 
 // Process instruction to get return data from another program
@@ -30,7 +30,7 @@ fn get_return_data_process_instruction(
             accounts: vec![],
             data: input.to_vec(),
         },
-        &[invoked_program_info.clone()],
+        slice::from_ref(invoked_program_info),
     )?;
     let return_data = get_return_data().unwrap();
     msg!("Processing get_return_data instruction after CPI");

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -28,7 +28,7 @@ use {
     solana_transaction::Transaction,
     solana_transaction_error::TransactionError,
     solana_vote_program::vote_state,
-    std::convert::TryInto,
+    std::{convert::TryInto, slice},
 };
 
 // Use a big number to be sure that we get the right error
@@ -70,7 +70,7 @@ async fn clock_sysvar_updated_from_warp() {
 
     // Fail transaction
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction.clone()],
+        slice::from_ref(&instruction),
         Some(&context.payer.pubkey()),
         &[&context.payer],
         context.last_blockhash,

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -835,7 +835,7 @@ mod tests {
         solana_system_transaction as system_transaction,
         solana_transaction::sanitized::SanitizedTransaction,
         std::{
-            fs,
+            fs, slice,
             sync::{atomic::Ordering, Arc, RwLock},
         },
         test_case::test_case,
@@ -1445,7 +1445,7 @@ mod tests {
         )
         .unwrap();
         let deserialized_bank = bank_from_snapshot_archives(
-            &[accounts_dir.clone()],
+            slice::from_ref(&accounts_dir),
             bank_snapshots_dir.path(),
             &full_snapshot_archive_info,
             Some(&incremental_snapshot_archive_info),

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -51,7 +51,7 @@ use {
     solana_transaction::{sanitized::SanitizedTransaction, Transaction},
     solana_transaction_context::TransactionReturnData,
     solana_transaction_error::TransactionError,
-    std::{collections::HashMap, num::NonZeroU32, sync::atomic::Ordering},
+    std::{collections::HashMap, num::NonZeroU32, slice, sync::atomic::Ordering},
     test_case::test_case,
 };
 
@@ -1683,7 +1683,7 @@ fn simd83_nonce_reuse(fee_paying_nonce: bool) -> Vec<SvmTestEntry> {
         let mut test_entry = common_test_entry.clone();
 
         let first_transaction = Transaction::new_signed_with_payer(
-            &[withdraw_instruction.clone()],
+            slice::from_ref(&withdraw_instruction),
             Some(&fee_payer),
             &[&fee_payer_keypair],
             Hash::default(),
@@ -1711,7 +1711,7 @@ fn simd83_nonce_reuse(fee_paying_nonce: bool) -> Vec<SvmTestEntry> {
         let mut test_entry = common_test_entry.clone();
 
         let first_transaction = Transaction::new_signed_with_payer(
-            &[withdraw_instruction.clone()],
+            slice::from_ref(&withdraw_instruction),
             Some(&fee_payer),
             &[&fee_payer_keypair],
             Hash::default(),
@@ -1750,7 +1750,7 @@ fn simd83_nonce_reuse(fee_paying_nonce: bool) -> Vec<SvmTestEntry> {
         let mut test_entry = common_test_entry.clone();
 
         let first_transaction = Transaction::new_signed_with_payer(
-            &[withdraw_instruction.clone()],
+            slice::from_ref(&withdraw_instruction),
             Some(&fee_payer),
             &[&fee_payer_keypair],
             Hash::default(),
@@ -1796,7 +1796,7 @@ fn simd83_nonce_reuse(fee_paying_nonce: bool) -> Vec<SvmTestEntry> {
         let mut test_entry = common_test_entry.clone();
 
         let first_transaction = Transaction::new_signed_with_payer(
-            &[withdraw_instruction.clone()],
+            slice::from_ref(&withdraw_instruction),
             Some(&fee_payer),
             &[&fee_payer_keypair],
             Hash::default(),
@@ -1846,7 +1846,7 @@ fn simd83_nonce_reuse(fee_paying_nonce: bool) -> Vec<SvmTestEntry> {
         test_entry.add_initial_account(nonce_pubkey, &fake_nonce_account);
 
         let first_transaction = Transaction::new_signed_with_payer(
-            &[successful_noop_instruction.clone()],
+            slice::from_ref(&successful_noop_instruction),
             Some(&fee_payer),
             &[&fee_payer_keypair],
             Hash::default(),
@@ -2719,15 +2719,19 @@ fn program_cache_stats() {
     let mut system_tx_usage = 0;
     let mut successful_transfers = 0;
 
-    test_entry.push_transaction(make_transaction(&[succesful_noop_instruction.clone()]));
+    test_entry.push_transaction(make_transaction(slice::from_ref(
+        &succesful_noop_instruction,
+    )));
     noop_tx_usage += 1;
 
-    test_entry.push_transaction(make_transaction(&[succesful_transfer_instruction.clone()]));
+    test_entry.push_transaction(make_transaction(slice::from_ref(
+        &succesful_transfer_instruction,
+    )));
     system_tx_usage += 1;
     successful_transfers += 1;
 
     test_entry.push_transaction_with_status(
-        make_transaction(&[failing_transfer_instruction.clone()]),
+        make_transaction(slice::from_ref(&failing_transfer_instruction)),
         ExecutionStatus::ExecutedFailed,
     );
     system_tx_usage += 1;
@@ -2771,7 +2775,7 @@ fn program_cache_stats() {
 
     // nor does discard
     test_entry.transaction_batch.push(TransactionBatchItem {
-        transaction: make_transaction(&[succesful_transfer_instruction.clone()]),
+        transaction: make_transaction(slice::from_ref(&succesful_transfer_instruction)),
         check_result: Err(TransactionError::BlockhashNotFound),
         asserts: ExecutionStatus::Discarded.into(),
     });
@@ -2847,7 +2851,7 @@ fn program_cache_stats() {
     test_entry.drop_expected_account(buffer_address);
 
     test_entry.push_transaction_with_status(
-        make_transaction(&[succesful_noop_instruction.clone()]),
+        make_transaction(slice::from_ref(&succesful_noop_instruction)),
         ExecutionStatus::ExecutedFailed,
     );
     noop_tx_usage += 1;
@@ -2882,7 +2886,7 @@ fn program_cache_stats() {
     };
 
     test_entry.push_transaction_with_status(
-        make_transaction(&[succesful_noop_instruction.clone()]),
+        make_transaction(slice::from_ref(&succesful_noop_instruction)),
         ExecutionStatus::ExecutedFailed,
     );
     noop_tx_usage += 1;

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -1316,6 +1316,7 @@ mod tests {
         solana_streamer::socket::SocketAddrSpace,
         solana_test_validator::TestValidator,
         solana_transaction_status::TransactionConfirmationStatus,
+        std::slice,
     };
 
     fn one_signer_message(client: &RpcClient) -> Message {
@@ -2324,7 +2325,7 @@ mod tests {
         build_messages(
             &client,
             &mut db,
-            &[allocation.clone()],
+            slice::from_ref(&allocation),
             &args,
             Arc::new(AtomicBool::new(false)),
             &mut messages,
@@ -2443,7 +2444,7 @@ mod tests {
         send_messages(
             &client,
             &mut db,
-            &[allocation.clone()],
+            slice::from_ref(&allocation),
             &args,
             Arc::new(AtomicBool::new(false)),
             vec![message.clone()],


### PR DESCRIPTION
#### Problem
Rust toolchain 1.90 introduces some stricter lints and detects code that could be optimized, one of them is unnecessary clone for the purpose of creating a slice where `slice::from_ref` can be used

(as part of https://github.com/anza-xyz/agave/issues/8117 we should fix all the warnings)

#### Summary of Changes
Switch to `slice::from_ref` 
