### PR TITLE
Use existing Ord implementation for PartialOrd instead of duplicating impl

### DIFF
--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -201,7 +201,7 @@ impl PartialEq for HeaviestSubtreeForkChoice {
 impl PartialOrd for HeaviestSubtreeForkChoice {
     // Sort by root
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.tree_root.cmp(&other.tree_root))
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
#### Problem
`PartialOrd` for `HeaviestSubtreeForkChoice` (test code) duplicates low level logic while it should re-use existing `Ord` implementation.

This is flagged by clippy 1.90 linter (as part of https://github.com/anza-xyz/agave/issues/8117 we should fix all the warnings)

#### Summary of Changes
Call `cmp` in `partial_cmp`
