### PR TITLE
agave-validator: move json_rpc_config default definitions

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -274,7 +274,6 @@ pub struct DefaultArgs {
     pub tower_storage: String,
     pub send_transaction_service_config: send_transaction_service::Config,
 
-    pub rpc_blocking_threads: String,
     pub rpc_niceness_adjustment: String,
     pub rpc_max_request_body_size: String,
 
@@ -330,7 +329,6 @@ impl DefaultArgs {
             genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE.to_string(),
             tower_storage: "file".to_string(),
             send_transaction_service_config: send_transaction_service::Config::default(),
-            rpc_blocking_threads: 1.max(num_cpus::get() / 4).to_string(),
             rpc_niceness_adjustment: "0".to_string(),
             maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN
                 .to_string(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -29,7 +29,6 @@ use {
     solana_hash::Hash,
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
     solana_quic_definitions::QUIC_PORT_OFFSET,
-    solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,
     solana_send_transaction_service::send_transaction_service::{self},
     solana_streamer::quic::{
         DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER,
@@ -274,8 +273,6 @@ pub struct DefaultArgs {
     pub tower_storage: String,
     pub send_transaction_service_config: send_transaction_service::Config,
 
-    pub rpc_max_request_body_size: String,
-
     pub maximum_local_snapshot_age: String,
     pub maximum_full_snapshot_archives_to_retain: String,
     pub maximum_incremental_snapshot_archives_to_retain: String,
@@ -365,7 +362,6 @@ impl DefaultArgs {
             tpu_max_fwd_unstaked_connections: 0.to_string(),
             tpu_max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS.to_string(),
             num_quic_endpoints: DEFAULT_QUIC_ENDPOINTS.to_string(),
-            rpc_max_request_body_size: MAX_REQUEST_BODY_SIZE.to_string(),
             banking_trace_dir_byte_limit: BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT.to_string(),
             block_production_pacing_fill_time_millis: BankingStage::default_fill_time_millis()
                 .to_string(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -274,7 +274,6 @@ pub struct DefaultArgs {
     pub tower_storage: String,
     pub send_transaction_service_config: send_transaction_service::Config,
 
-    pub rpc_niceness_adjustment: String,
     pub rpc_max_request_body_size: String,
 
     pub maximum_local_snapshot_age: String,
@@ -329,7 +328,6 @@ impl DefaultArgs {
             genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE.to_string(),
             tower_storage: "file".to_string(),
             send_transaction_service_config: send_transaction_service::Config::default(),
-            rpc_niceness_adjustment: "0".to_string(),
             maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN
                 .to_string(),
             maximum_incremental_snapshot_archives_to_retain:

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -30,7 +30,6 @@ use {
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
     solana_quic_definitions::QUIC_PORT_OFFSET,
     solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,
-    solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS,
     solana_send_transaction_service::send_transaction_service::{self},
     solana_streamer::quic::{
         DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER,
@@ -275,7 +274,6 @@ pub struct DefaultArgs {
     pub tower_storage: String,
     pub send_transaction_service_config: send_transaction_service::Config,
 
-    pub rpc_max_multiple_accounts: String,
     pub rpc_threads: String,
     pub rpc_blocking_threads: String,
     pub rpc_niceness_adjustment: String,
@@ -331,7 +329,6 @@ impl DefaultArgs {
             dynamic_port_range: format!("{}-{}", VALIDATOR_PORT_RANGE.0, VALIDATOR_PORT_RANGE.1),
             maximum_local_snapshot_age: "2500".to_string(),
             genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE.to_string(),
-            rpc_max_multiple_accounts: MAX_MULTIPLE_ACCOUNTS.to_string(),
             tower_storage: "file".to_string(),
             send_transaction_service_config: send_transaction_service::Config::default(),
             rpc_threads: num_cpus::get().to_string(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -274,7 +274,6 @@ pub struct DefaultArgs {
     pub tower_storage: String,
     pub send_transaction_service_config: send_transaction_service::Config,
 
-    pub rpc_threads: String,
     pub rpc_blocking_threads: String,
     pub rpc_niceness_adjustment: String,
     pub rpc_max_request_body_size: String,
@@ -331,7 +330,6 @@ impl DefaultArgs {
             genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE.to_string(),
             tower_storage: "file".to_string(),
             send_transaction_service_config: send_transaction_service::Config::default(),
-            rpc_threads: num_cpus::get().to_string(),
             rpc_blocking_threads: 1.max(num_cpus::get() / 4).to_string(),
             rpc_niceness_adjustment: "0".to_string(),
             maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -30,7 +30,7 @@ use {
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
     solana_quic_definitions::QUIC_PORT_OFFSET,
     solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,
-    solana_rpc_client_api::request::{DELINQUENT_VALIDATOR_SLOT_DISTANCE, MAX_MULTIPLE_ACCOUNTS},
+    solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS,
     solana_send_transaction_service::send_transaction_service::{self},
     solana_streamer::quic::{
         DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE, DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER,
@@ -272,7 +272,6 @@ pub struct DefaultArgs {
     pub ledger_path: String,
 
     pub genesis_archive_unpacked_size: String,
-    pub health_check_slot_distance: String,
     pub tower_storage: String,
     pub send_transaction_service_config: send_transaction_service::Config,
 
@@ -333,7 +332,6 @@ impl DefaultArgs {
             maximum_local_snapshot_age: "2500".to_string(),
             genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE.to_string(),
             rpc_max_multiple_accounts: MAX_MULTIPLE_ACCOUNTS.to_string(),
-            health_check_slot_distance: DELINQUENT_VALIDATOR_SLOT_DISTANCE.to_string(),
             tower_storage: "file".to_string(),
             send_transaction_service_config: send_transaction_service::Config::default(),
             rpc_threads: num_cpus::get().to_string(),

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1431,6 +1431,9 @@ mod tests {
             let entrypoints = vec![];
             let known_validators = None;
 
+            let json_rpc_config =
+                crate::commands::run::args::json_rpc_config::tests::default_json_rpc_config();
+
             RunArgs {
                 identity_keypair,
                 ledger_path,
@@ -1440,27 +1443,7 @@ mod tests {
                 socket_addr_space: SocketAddrSpace::Global,
                 rpc_bootstrap_config: RpcBootstrapConfig::default(),
                 blockstore_options: BlockstoreOptions::default(),
-                json_rpc_config: JsonRpcConfig {
-                    health_check_slot_distance: json_rpc_config::DEFAULT_HEALTH_CHECK_SLOT_DISTANCE
-                        .parse()
-                        .unwrap(),
-                    max_multiple_accounts: Some(
-                        json_rpc_config::DEFAULT_MAX_MULTIPLE_ACCOUNTS
-                            .parse()
-                            .unwrap(),
-                    ),
-                    rpc_threads: json_rpc_config::DEFAULT_RPC_THREADS.parse().unwrap(),
-                    rpc_blocking_threads: json_rpc_config::DEFAULT_RPC_BLOCKING_THREADS
-                        .parse()
-                        .unwrap(),
-                    rpc_niceness_adj: json_rpc_config::DEFAULT_RPC_NICENESS_ADJ.parse().unwrap(),
-                    max_request_body_size: Some(
-                        json_rpc_config::DEFAULT_RPC_MAX_REQUEST_BODY_SIZE
-                            .parse()
-                            .unwrap(),
-                    ),
-                    ..JsonRpcConfig::default()
-                },
+                json_rpc_config,
                 pub_sub_config: PubSubConfig {
                     worker_threads: 4,
                     notification_threads: None,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1380,7 +1380,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .args(&pub_sub_config::args())
-    .args(&json_rpc_config::args(default_args))
+    .args(&json_rpc_config::args())
     .args(&rpc_bigtable_config::args())
     .args(&send_transaction_config::args())
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1453,6 +1453,7 @@ mod tests {
                     rpc_blocking_threads: json_rpc_config::DEFAULT_RPC_BLOCKING_THREADS
                         .parse()
                         .unwrap(),
+                    rpc_niceness_adj: json_rpc_config::DEFAULT_RPC_NICENESS_ADJ.parse().unwrap(),
                     max_request_body_size: Some(
                         json_rpc_config::DEFAULT_RPC_MAX_REQUEST_BODY_SIZE
                             .parse()

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1416,7 +1416,6 @@ mod tests {
         super::*,
         crate::cli::thread_args::thread_args,
         scopeguard::defer,
-        solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,
         std::{
             fs,
             net::{IpAddr, Ipv4Addr},
@@ -1442,11 +1441,23 @@ mod tests {
                 rpc_bootstrap_config: RpcBootstrapConfig::default(),
                 blockstore_options: BlockstoreOptions::default(),
                 json_rpc_config: JsonRpcConfig {
-                    health_check_slot_distance: 128,
-                    max_multiple_accounts: Some(100),
-                    rpc_threads: num_cpus::get(),
-                    rpc_blocking_threads: 1.max(num_cpus::get() / 4),
-                    max_request_body_size: Some(MAX_REQUEST_BODY_SIZE),
+                    health_check_slot_distance: json_rpc_config::DEFAULT_HEALTH_CHECK_SLOT_DISTANCE
+                        .parse()
+                        .unwrap(),
+                    max_multiple_accounts: Some(
+                        json_rpc_config::DEFAULT_MAX_MULTIPLE_ACCOUNTS
+                            .parse()
+                            .unwrap(),
+                    ),
+                    rpc_threads: json_rpc_config::DEFAULT_RPC_THREADS.parse().unwrap(),
+                    rpc_blocking_threads: json_rpc_config::DEFAULT_RPC_BLOCKING_THREADS
+                        .parse()
+                        .unwrap(),
+                    max_request_body_size: Some(
+                        json_rpc_config::DEFAULT_RPC_MAX_REQUEST_BODY_SIZE
+                            .parse()
+                            .unwrap(),
+                    ),
                     ..JsonRpcConfig::default()
                 },
                 pub_sub_config: PubSubConfig {

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -472,4 +472,13 @@ mod tests {
             "DEFAULT_RPC_THREADS changed"
         );
     }
+
+    #[test]
+    fn test_default_rpc_blocking_threads_unchanged() {
+        assert_eq!(
+            DEFAULT_RPC_BLOCKING_THREADS.to_string(),
+            (1.max(num_cpus::get() / 4)).to_string(),
+            "DEFAULT_RPC_BLOCKING_THREADS changed"
+        );
+    }
 }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -450,8 +450,7 @@ mod tests {
     #[test]
     fn test_default_health_check_slot_distance_unchanged() {
         assert_eq!(
-            *DEFAULT_HEALTH_CHECK_SLOT_DISTANCE,
-            "128",
+            *DEFAULT_HEALTH_CHECK_SLOT_DISTANCE, "128",
             "DEFAULT_HEALTH_CHECK_SLOT_DISTANCE changed"
         );
     }
@@ -459,8 +458,7 @@ mod tests {
     #[test]
     fn test_default_max_multiple_accounts_unchanged() {
         assert_eq!(
-            *DEFAULT_MAX_MULTIPLE_ACCOUNTS,
-            "100",
+            *DEFAULT_MAX_MULTIPLE_ACCOUNTS, "100",
             "DEFAULT_MAX_MULTIPLE_ACCOUNTS changed"
         );
     }
@@ -494,8 +492,7 @@ mod tests {
     #[test]
     fn test_default_rpc_max_request_body_size_unchanged() {
         assert_eq!(
-            *DEFAULT_RPC_MAX_REQUEST_BODY_SIZE,
-            "51200",
+            *DEFAULT_RPC_MAX_REQUEST_BODY_SIZE, "51200",
             "DEFAULT_RPC_MAX_REQUEST_BODY_SIZE changed"
         );
     }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -7,7 +7,9 @@ use {
     std::sync::LazyLock,
 };
 
-pub(crate) const DEFAULT_HEALTH_CHECK_SLOT_DISTANCE: &str = "128"; // solana_rpc_client_api::request::DELINQUENT_VALIDATOR_SLOT_DISTANCE
+pub(crate) static DEFAULT_HEALTH_CHECK_SLOT_DISTANCE: LazyLock<String> = LazyLock::new(|| {
+    solana_rpc_client_api::request::DELINQUENT_VALIDATOR_SLOT_DISTANCE.to_string()
+});
 pub(crate) const DEFAULT_MAX_MULTIPLE_ACCOUNTS: &str = "100"; // solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS
 pub(crate) static DEFAULT_RPC_THREADS: LazyLock<String> =
     LazyLock::new(|| num_cpus::get().to_string());
@@ -91,7 +93,7 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .long("health-check-slot-distance")
             .value_name("SLOT_DISTANCE")
             .takes_value(true)
-            .default_value(DEFAULT_HEALTH_CHECK_SLOT_DISTANCE)
+            .default_value(&DEFAULT_HEALTH_CHECK_SLOT_DISTANCE)
             .help(
                 "Report this validator as healthy if its latest replayed optimistically confirmed \
                  slot is within the specified number of slots from the cluster's latest \
@@ -441,5 +443,14 @@ mod tests {
                 expected_args,
             );
         }
+    }
+
+    #[test]
+    fn test_default_health_check_slot_distance_unchanged() {
+        assert_eq!(
+            DEFAULT_HEALTH_CHECK_SLOT_DISTANCE.to_string(),
+            "128",
+            "DEFAULT_HEALTH_CHECK_SLOT_DISTANCE changed"
+        );
     }
 }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -9,6 +9,8 @@ use {
     solana_rpc::rpc::{JsonRpcConfig, RpcBigtableConfig},
 };
 
+const DEFAULT_HEALTH_CHECK_SLOT_DISTANCE: &str = "128"; // solana_rpc_client_api::request::DELINQUENT_VALIDATOR_SLOT_DISTANCE
+
 impl FromClapArgMatches for JsonRpcConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         let rpc_bigtable_config = if matches.is_present("enable_rpc_bigtable_ledger_storage")
@@ -84,7 +86,7 @@ pub(crate) fn args<'a>(default_args: &DefaultArgs) -> Vec<Arg<'_, 'a>> {
             .long("health-check-slot-distance")
             .value_name("SLOT_DISTANCE")
             .takes_value(true)
-            .default_value(&default_args.health_check_slot_distance)
+            .default_value(&DEFAULT_HEALTH_CHECK_SLOT_DISTANCE)
             .help(
                 "Report this validator as healthy if its latest replayed optimistically confirmed \
                  slot is within the specified number of slots from the cluster's latest \

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -463,4 +463,13 @@ mod tests {
             "DEFAULT_MAX_MULTIPLE_ACCOUNTS changed"
         );
     }
+
+    #[test]
+    fn test_default_rpc_threads_unchanged() {
+        assert_eq!(
+            DEFAULT_RPC_THREADS.to_string(),
+            num_cpus::get().to_string(),
+            "DEFAULT_RPC_THREADS changed"
+        );
+    }
 }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -91,7 +91,7 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .long("health-check-slot-distance")
             .value_name("SLOT_DISTANCE")
             .takes_value(true)
-            .default_value(&DEFAULT_HEALTH_CHECK_SLOT_DISTANCE)
+            .default_value(DEFAULT_HEALTH_CHECK_SLOT_DISTANCE)
             .help(
                 "Report this validator as healthy if its latest replayed optimistically confirmed \
                  slot is within the specified number of slots from the cluster's latest \
@@ -105,7 +105,7 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .long("rpc-max-multiple-accounts")
             .value_name("MAX ACCOUNTS")
             .takes_value(true)
-            .default_value(&DEFAULT_MAX_MULTIPLE_ACCOUNTS)
+            .default_value(DEFAULT_MAX_MULTIPLE_ACCOUNTS)
             .help(
                 "Override the default maximum accounts accepted by the getMultipleAccounts JSON \
                  RPC method",
@@ -144,7 +144,7 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .value_name("ADJUSTMENT")
             .takes_value(true)
             .validator(solana_perf::thread::is_niceness_adjustment_valid)
-            .default_value(&DEFAULT_RPC_NICENESS_ADJ)
+            .default_value(DEFAULT_RPC_NICENESS_ADJ)
             .help(
                 "Add this value to niceness of RPC threads. Negative value increases priority, \
                  positive value decreases priority.",
@@ -163,7 +163,7 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .value_name("BYTES")
             .takes_value(true)
             .validator(is_parsable::<usize>)
-            .default_value(&DEFAULT_RPC_MAX_REQUEST_BODY_SIZE)
+            .default_value(DEFAULT_RPC_MAX_REQUEST_BODY_SIZE)
             .help("The maximum request body size accepted by rpc service"),
     ]
 }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -16,6 +16,7 @@ static DEFAULT_RPC_THREADS: LazyLock<String> = LazyLock::new(|| num_cpus::get().
 static DEFAULT_RPC_BLOCKING_THREADS: LazyLock<String> =
     LazyLock::new(|| (1.max(num_cpus::get() / 4)).to_string());
 const DEFAULT_RPC_NICENESS_ADJ: &str = "0";
+const DEFAULT_RPC_MAX_REQUEST_BODY_SIZE: &str = "51200"; // solana_rpc::rpc::MAX_REQUEST_BODY_SIZE = 50 * (1 << 10) = 51200
 
 impl FromClapArgMatches for JsonRpcConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
@@ -164,7 +165,7 @@ pub(crate) fn args<'a>(default_args: &DefaultArgs) -> Vec<Arg<'_, 'a>> {
             .value_name("BYTES")
             .takes_value(true)
             .validator(is_parsable::<usize>)
-            .default_value(&default_args.rpc_max_request_body_size)
+            .default_value(&DEFAULT_RPC_MAX_REQUEST_BODY_SIZE)
             .help("The maximum request body size accepted by rpc service"),
     ]
 }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -481,4 +481,12 @@ mod tests {
             "DEFAULT_RPC_BLOCKING_THREADS changed"
         );
     }
+
+    #[test]
+    fn test_default_rpc_niceness_adj_unchanged() {
+        assert_eq!(
+            DEFAULT_RPC_NICENESS_ADJ, "0",
+            "DEFAULT_RPC_NICENESS_ADJ changed"
+        );
+    }
 }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        cli::DefaultArgs,
-        commands::{FromClapArgMatches, Result},
-    },
+    crate::commands::{FromClapArgMatches, Result},
     clap::{value_t, Arg, ArgMatches},
     solana_accounts_db::accounts_index::AccountSecondaryIndexes,
     solana_clap_utils::input_validators::is_parsable,
@@ -58,7 +55,7 @@ impl FromClapArgMatches for JsonRpcConfig {
     }
 }
 
-pub(crate) fn args<'a>(default_args: &DefaultArgs) -> Vec<Arg<'_, 'a>> {
+pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
     vec![
         Arg::with_name("enable_rpc_transaction_history")
             .long("enable-rpc-transaction-history")

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -15,6 +15,7 @@ const DEFAULT_MAX_MULTIPLE_ACCOUNTS: &str = "100"; // solana_rpc_client_api::req
 static DEFAULT_RPC_THREADS: LazyLock<String> = LazyLock::new(|| num_cpus::get().to_string());
 static DEFAULT_RPC_BLOCKING_THREADS: LazyLock<String> =
     LazyLock::new(|| (1.max(num_cpus::get() / 4)).to_string());
+const DEFAULT_RPC_NICENESS_ADJ: &str = "0";
 
 impl FromClapArgMatches for JsonRpcConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
@@ -144,7 +145,7 @@ pub(crate) fn args<'a>(default_args: &DefaultArgs) -> Vec<Arg<'_, 'a>> {
             .value_name("ADJUSTMENT")
             .takes_value(true)
             .validator(solana_perf::thread::is_niceness_adjustment_valid)
-            .default_value(&default_args.rpc_niceness_adjustment)
+            .default_value(&DEFAULT_RPC_NICENESS_ADJ)
             .help(
                 "Add this value to niceness of RPC threads. Negative value increases priority, \
                  positive value decreases priority.",

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -7,10 +7,12 @@ use {
     solana_accounts_db::accounts_index::AccountSecondaryIndexes,
     solana_clap_utils::input_validators::is_parsable,
     solana_rpc::rpc::{JsonRpcConfig, RpcBigtableConfig},
+    std::sync::LazyLock,
 };
 
 const DEFAULT_HEALTH_CHECK_SLOT_DISTANCE: &str = "128"; // solana_rpc_client_api::request::DELINQUENT_VALIDATOR_SLOT_DISTANCE
 const DEFAULT_MAX_MULTIPLE_ACCOUNTS: &str = "100"; // solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS
+static DEFAULT_RPC_THREADS: LazyLock<String> = LazyLock::new(|| num_cpus::get().to_string());
 
 impl FromClapArgMatches for JsonRpcConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
@@ -111,7 +113,7 @@ pub(crate) fn args<'a>(default_args: &DefaultArgs) -> Vec<Arg<'_, 'a>> {
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)
-            .default_value(&default_args.rpc_threads)
+            .default_value(&DEFAULT_RPC_THREADS)
             .help("Number of threads to use for servicing RPC requests"),
         Arg::with_name("rpc_blocking_threads")
             .long("rpc-blocking-threads")

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -7,17 +7,16 @@ use {
     std::sync::LazyLock,
 };
 
-pub(crate) static DEFAULT_HEALTH_CHECK_SLOT_DISTANCE: LazyLock<String> = LazyLock::new(|| {
+static DEFAULT_HEALTH_CHECK_SLOT_DISTANCE: LazyLock<String> = LazyLock::new(|| {
     solana_rpc_client_api::request::DELINQUENT_VALIDATOR_SLOT_DISTANCE.to_string()
 });
-pub(crate) static DEFAULT_MAX_MULTIPLE_ACCOUNTS: LazyLock<String> =
+static DEFAULT_MAX_MULTIPLE_ACCOUNTS: LazyLock<String> =
     LazyLock::new(|| solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS.to_string());
-pub(crate) static DEFAULT_RPC_THREADS: LazyLock<String> =
-    LazyLock::new(|| num_cpus::get().to_string());
-pub(crate) static DEFAULT_RPC_BLOCKING_THREADS: LazyLock<String> =
+static DEFAULT_RPC_THREADS: LazyLock<String> = LazyLock::new(|| num_cpus::get().to_string());
+static DEFAULT_RPC_BLOCKING_THREADS: LazyLock<String> =
     LazyLock::new(|| (1.max(num_cpus::get() / 4)).to_string());
-pub(crate) const DEFAULT_RPC_NICENESS_ADJ: &str = "0";
-pub(crate) static DEFAULT_RPC_MAX_REQUEST_BODY_SIZE: LazyLock<String> =
+const DEFAULT_RPC_NICENESS_ADJ: &str = "0";
+static DEFAULT_RPC_MAX_REQUEST_BODY_SIZE: LazyLock<String> =
     LazyLock::new(|| solana_rpc::rpc::MAX_REQUEST_BODY_SIZE.to_string());
 
 impl FromClapArgMatches for JsonRpcConfig {

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -7,13 +7,14 @@ use {
     std::sync::LazyLock,
 };
 
-const DEFAULT_HEALTH_CHECK_SLOT_DISTANCE: &str = "128"; // solana_rpc_client_api::request::DELINQUENT_VALIDATOR_SLOT_DISTANCE
-const DEFAULT_MAX_MULTIPLE_ACCOUNTS: &str = "100"; // solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS
-static DEFAULT_RPC_THREADS: LazyLock<String> = LazyLock::new(|| num_cpus::get().to_string());
-static DEFAULT_RPC_BLOCKING_THREADS: LazyLock<String> =
+pub(crate) const DEFAULT_HEALTH_CHECK_SLOT_DISTANCE: &str = "128"; // solana_rpc_client_api::request::DELINQUENT_VALIDATOR_SLOT_DISTANCE
+pub(crate) const DEFAULT_MAX_MULTIPLE_ACCOUNTS: &str = "100"; // solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS
+pub(crate) static DEFAULT_RPC_THREADS: LazyLock<String> =
+    LazyLock::new(|| num_cpus::get().to_string());
+pub(crate) static DEFAULT_RPC_BLOCKING_THREADS: LazyLock<String> =
     LazyLock::new(|| (1.max(num_cpus::get() / 4)).to_string());
-const DEFAULT_RPC_NICENESS_ADJ: &str = "0";
-const DEFAULT_RPC_MAX_REQUEST_BODY_SIZE: &str = "51200"; // solana_rpc::rpc::MAX_REQUEST_BODY_SIZE = 50 * (1 << 10) = 51200
+pub(crate) const DEFAULT_RPC_NICENESS_ADJ: &str = "0";
+pub(crate) const DEFAULT_RPC_MAX_REQUEST_BODY_SIZE: &str = "51200"; // solana_rpc::rpc::MAX_REQUEST_BODY_SIZE = 50 * (1 << 10) = 51200
 
 impl FromClapArgMatches for JsonRpcConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -10,7 +10,8 @@ use {
 pub(crate) static DEFAULT_HEALTH_CHECK_SLOT_DISTANCE: LazyLock<String> = LazyLock::new(|| {
     solana_rpc_client_api::request::DELINQUENT_VALIDATOR_SLOT_DISTANCE.to_string()
 });
-pub(crate) const DEFAULT_MAX_MULTIPLE_ACCOUNTS: &str = "100"; // solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS
+pub(crate) static DEFAULT_MAX_MULTIPLE_ACCOUNTS: LazyLock<String> =
+    LazyLock::new(|| solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS.to_string());
 pub(crate) static DEFAULT_RPC_THREADS: LazyLock<String> =
     LazyLock::new(|| num_cpus::get().to_string());
 pub(crate) static DEFAULT_RPC_BLOCKING_THREADS: LazyLock<String> =
@@ -107,7 +108,7 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .long("rpc-max-multiple-accounts")
             .value_name("MAX ACCOUNTS")
             .takes_value(true)
-            .default_value(DEFAULT_MAX_MULTIPLE_ACCOUNTS)
+            .default_value(&DEFAULT_MAX_MULTIPLE_ACCOUNTS)
             .help(
                 "Override the default maximum accounts accepted by the getMultipleAccounts JSON \
                  RPC method",
@@ -451,6 +452,15 @@ mod tests {
             DEFAULT_HEALTH_CHECK_SLOT_DISTANCE.to_string(),
             "128",
             "DEFAULT_HEALTH_CHECK_SLOT_DISTANCE changed"
+        );
+    }
+
+    #[test]
+    fn test_default_max_multiple_accounts_unchanged() {
+        assert_eq!(
+            DEFAULT_MAX_MULTIPLE_ACCOUNTS.to_string(),
+            "100",
+            "DEFAULT_MAX_MULTIPLE_ACCOUNTS changed"
         );
     }
 }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -173,7 +173,7 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(super) mod tests {
     #[cfg(not(target_os = "linux"))]
     use crate::commands::run::args::tests::verify_args_struct_by_command_run_is_error_with_identity_setup;
     use {
@@ -188,6 +188,18 @@ mod tests {
             num::NonZeroUsize,
         },
     };
+
+    pub fn default_json_rpc_config() -> JsonRpcConfig {
+        JsonRpcConfig {
+            health_check_slot_distance: DEFAULT_HEALTH_CHECK_SLOT_DISTANCE.parse().unwrap(),
+            max_multiple_accounts: Some(DEFAULT_MAX_MULTIPLE_ACCOUNTS.parse().unwrap()),
+            rpc_threads: DEFAULT_RPC_THREADS.parse().unwrap(),
+            rpc_blocking_threads: DEFAULT_RPC_BLOCKING_THREADS.parse().unwrap(),
+            rpc_niceness_adj: DEFAULT_RPC_NICENESS_ADJ.parse().unwrap(),
+            max_request_body_size: Some(DEFAULT_RPC_MAX_REQUEST_BODY_SIZE.parse().unwrap()),
+            ..JsonRpcConfig::default()
+        }
+    }
 
     #[test]
     fn verify_args_struct_by_command_run_with_enable_rpc_transaction_history() {

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -10,6 +10,7 @@ use {
 };
 
 const DEFAULT_HEALTH_CHECK_SLOT_DISTANCE: &str = "128"; // solana_rpc_client_api::request::DELINQUENT_VALIDATOR_SLOT_DISTANCE
+const DEFAULT_MAX_MULTIPLE_ACCOUNTS: &str = "100"; // solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS
 
 impl FromClapArgMatches for JsonRpcConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
@@ -100,7 +101,7 @@ pub(crate) fn args<'a>(default_args: &DefaultArgs) -> Vec<Arg<'_, 'a>> {
             .long("rpc-max-multiple-accounts")
             .value_name("MAX ACCOUNTS")
             .takes_value(true)
-            .default_value(&default_args.rpc_max_multiple_accounts)
+            .default_value(&DEFAULT_MAX_MULTIPLE_ACCOUNTS)
             .help(
                 "Override the default maximum accounts accepted by the getMultipleAccounts JSON \
                  RPC method",

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -450,7 +450,7 @@ mod tests {
     #[test]
     fn test_default_health_check_slot_distance_unchanged() {
         assert_eq!(
-            DEFAULT_HEALTH_CHECK_SLOT_DISTANCE.to_string(),
+            *DEFAULT_HEALTH_CHECK_SLOT_DISTANCE,
             "128",
             "DEFAULT_HEALTH_CHECK_SLOT_DISTANCE changed"
         );
@@ -459,7 +459,7 @@ mod tests {
     #[test]
     fn test_default_max_multiple_accounts_unchanged() {
         assert_eq!(
-            DEFAULT_MAX_MULTIPLE_ACCOUNTS.to_string(),
+            *DEFAULT_MAX_MULTIPLE_ACCOUNTS,
             "100",
             "DEFAULT_MAX_MULTIPLE_ACCOUNTS changed"
         );
@@ -468,7 +468,7 @@ mod tests {
     #[test]
     fn test_default_rpc_threads_unchanged() {
         assert_eq!(
-            DEFAULT_RPC_THREADS.to_string(),
+            *DEFAULT_RPC_THREADS,
             num_cpus::get().to_string(),
             "DEFAULT_RPC_THREADS changed"
         );
@@ -477,7 +477,7 @@ mod tests {
     #[test]
     fn test_default_rpc_blocking_threads_unchanged() {
         assert_eq!(
-            DEFAULT_RPC_BLOCKING_THREADS.to_string(),
+            *DEFAULT_RPC_BLOCKING_THREADS,
             (1.max(num_cpus::get() / 4)).to_string(),
             "DEFAULT_RPC_BLOCKING_THREADS changed"
         );
@@ -494,7 +494,7 @@ mod tests {
     #[test]
     fn test_default_rpc_max_request_body_size_unchanged() {
         assert_eq!(
-            DEFAULT_RPC_MAX_REQUEST_BODY_SIZE.to_string(),
+            *DEFAULT_RPC_MAX_REQUEST_BODY_SIZE,
             "51200",
             "DEFAULT_RPC_MAX_REQUEST_BODY_SIZE changed"
         );

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -17,7 +17,8 @@ pub(crate) static DEFAULT_RPC_THREADS: LazyLock<String> =
 pub(crate) static DEFAULT_RPC_BLOCKING_THREADS: LazyLock<String> =
     LazyLock::new(|| (1.max(num_cpus::get() / 4)).to_string());
 pub(crate) const DEFAULT_RPC_NICENESS_ADJ: &str = "0";
-pub(crate) const DEFAULT_RPC_MAX_REQUEST_BODY_SIZE: &str = "51200"; // solana_rpc::rpc::MAX_REQUEST_BODY_SIZE = 50 * (1 << 10) = 51200
+pub(crate) static DEFAULT_RPC_MAX_REQUEST_BODY_SIZE: LazyLock<String> =
+    LazyLock::new(|| solana_rpc::rpc::MAX_REQUEST_BODY_SIZE.to_string());
 
 impl FromClapArgMatches for JsonRpcConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
@@ -166,7 +167,7 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .value_name("BYTES")
             .takes_value(true)
             .validator(is_parsable::<usize>)
-            .default_value(DEFAULT_RPC_MAX_REQUEST_BODY_SIZE)
+            .default_value(&DEFAULT_RPC_MAX_REQUEST_BODY_SIZE)
             .help("The maximum request body size accepted by rpc service"),
     ]
 }
@@ -487,6 +488,15 @@ mod tests {
         assert_eq!(
             DEFAULT_RPC_NICENESS_ADJ, "0",
             "DEFAULT_RPC_NICENESS_ADJ changed"
+        );
+    }
+
+    #[test]
+    fn test_default_rpc_max_request_body_size_unchanged() {
+        assert_eq!(
+            DEFAULT_RPC_MAX_REQUEST_BODY_SIZE.to_string(),
+            "51200",
+            "DEFAULT_RPC_MAX_REQUEST_BODY_SIZE changed"
         );
     }
 }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -449,27 +449,17 @@ mod tests {
 
     #[test]
     fn test_default_health_check_slot_distance_unchanged() {
-        assert_eq!(
-            *DEFAULT_HEALTH_CHECK_SLOT_DISTANCE, "128",
-            "DEFAULT_HEALTH_CHECK_SLOT_DISTANCE changed"
-        );
+        assert_eq!(*DEFAULT_HEALTH_CHECK_SLOT_DISTANCE, "128");
     }
 
     #[test]
     fn test_default_max_multiple_accounts_unchanged() {
-        assert_eq!(
-            *DEFAULT_MAX_MULTIPLE_ACCOUNTS, "100",
-            "DEFAULT_MAX_MULTIPLE_ACCOUNTS changed"
-        );
+        assert_eq!(*DEFAULT_MAX_MULTIPLE_ACCOUNTS, "100");
     }
 
     #[test]
     fn test_default_rpc_threads_unchanged() {
-        assert_eq!(
-            *DEFAULT_RPC_THREADS,
-            num_cpus::get().to_string(),
-            "DEFAULT_RPC_THREADS changed"
-        );
+        assert_eq!(*DEFAULT_RPC_THREADS, num_cpus::get().to_string());
     }
 
     #[test]
@@ -477,23 +467,16 @@ mod tests {
         assert_eq!(
             *DEFAULT_RPC_BLOCKING_THREADS,
             (1.max(num_cpus::get() / 4)).to_string(),
-            "DEFAULT_RPC_BLOCKING_THREADS changed"
         );
     }
 
     #[test]
     fn test_default_rpc_niceness_adj_unchanged() {
-        assert_eq!(
-            DEFAULT_RPC_NICENESS_ADJ, "0",
-            "DEFAULT_RPC_NICENESS_ADJ changed"
-        );
+        assert_eq!(DEFAULT_RPC_NICENESS_ADJ, "0");
     }
 
     #[test]
     fn test_default_rpc_max_request_body_size_unchanged() {
-        assert_eq!(
-            *DEFAULT_RPC_MAX_REQUEST_BODY_SIZE, "51200",
-            "DEFAULT_RPC_MAX_REQUEST_BODY_SIZE changed"
-        );
+        assert_eq!(*DEFAULT_RPC_MAX_REQUEST_BODY_SIZE, "51200");
     }
 }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -13,6 +13,8 @@ use {
 const DEFAULT_HEALTH_CHECK_SLOT_DISTANCE: &str = "128"; // solana_rpc_client_api::request::DELINQUENT_VALIDATOR_SLOT_DISTANCE
 const DEFAULT_MAX_MULTIPLE_ACCOUNTS: &str = "100"; // solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS
 static DEFAULT_RPC_THREADS: LazyLock<String> = LazyLock::new(|| num_cpus::get().to_string());
+static DEFAULT_RPC_BLOCKING_THREADS: LazyLock<String> =
+    LazyLock::new(|| (1.max(num_cpus::get() / 4)).to_string());
 
 impl FromClapArgMatches for JsonRpcConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
@@ -132,7 +134,7 @@ pub(crate) fn args<'a>(default_args: &DefaultArgs) -> Vec<Arg<'_, 'a>> {
                     })
             })
             .takes_value(true)
-            .default_value(&default_args.rpc_blocking_threads)
+            .default_value(&DEFAULT_RPC_BLOCKING_THREADS)
             .help(
                 "Number of blocking threads to use for servicing CPU bound RPC requests (eg \
                  getMultipleAccounts)",

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -488,6 +488,6 @@ pub(super) mod tests {
 
     #[test]
     fn test_default_rpc_max_request_body_size_unchanged() {
-        assert_eq!(*DEFAULT_RPC_MAX_REQUEST_BODY_SIZE, "51200");
+        assert_eq!(*DEFAULT_RPC_MAX_REQUEST_BODY_SIZE, 51_200.to_string());
     }
 }


### PR DESCRIPTION
#### Problem

a follow-up to https://github.com/anza-xyz/agave/pull/8429

#### Summary of Changes

move them