### PR TITLE
Use .keys() instead of .iter().map(..strip values)

### DIFF
--- a/svm-test-harness/src/fixture/feature_set.rs
+++ b/svm-test-harness/src/fixture/feature_set.rs
@@ -23,8 +23,8 @@ const fn feature_u64(feature: &Pubkey) -> u64 {
 
 static INDEXED_FEATURES: LazyLock<HashMap<u64, Pubkey>> = LazyLock::new(|| {
     FEATURE_NAMES
-        .iter()
-        .map(|(pubkey, _)| (feature_u64(pubkey), *pubkey))
+        .keys()
+        .map(|pubkey| (feature_u64(pubkey), *pubkey))
         .collect()
 });
 


### PR DESCRIPTION
#### Problem
Iteration over hashmap to extract keys should be done by `keys()` API

(as part of https://github.com/anza-xyz/agave/issues/8117 we should fix all the warnings)

#### Summary of Changes
Use .keys() instead of .iter().map(..strip values)
