### PR TITLE
svm-fuzz-harness: refactor proto `bin` off of the workspace

### DIFF
--- a/svm-fuzz-harness/Cargo.toml
+++ b/svm-fuzz-harness/Cargo.toml
@@ -10,9 +10,6 @@ license = { workspace = true }
 edition = { workspace = true }
 publish = false
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-
 [[bin]]
 name = "test_exec_instr"
 path = "bin/test_exec_instr.rs"

--- a/svm-fuzz-harness/Cargo.toml
+++ b/svm-fuzz-harness/Cargo.toml
@@ -16,10 +16,9 @@ path = "bin/test_exec_instr.rs"
 required-features = ["fuzz"]
 
 [features]
-fuzz = ["dep:clap", "dep:prost", "dep:protosol", "dep:prost-build"]
-
-[features]
 agave-unstable-api = []
+dummy-for-ci-check = ["fuzz"]
+fuzz = ["dep:clap", "dep:prost", "dep:protosol", "dep:prost-build"]
 
 [dependencies]
 agave-feature-set = { workspace = true }

--- a/svm-fuzz-harness/Cargo.toml
+++ b/svm-fuzz-harness/Cargo.toml
@@ -16,6 +16,10 @@ crate-type = ["cdylib", "rlib"]
 [[bin]]
 name = "test_exec_instr"
 path = "bin/test_exec_instr.rs"
+required-features = ["fuzz"]
+
+[features]
+fuzz = ["dep:clap", "dep:prost", "dep:protosol", "dep:prost-build"]
 
 [features]
 agave-unstable-api = []
@@ -25,9 +29,9 @@ agave-feature-set = { workspace = true }
 agave-precompiles = { workspace = true }
 agave-syscalls = { workspace = true }
 bincode = { workspace = true }
-clap = { version = "4.5.2", features = ["derive"] }
-prost = { workspace = true }
-protosol = { git = "https://github.com/firedancer-io/protosol", tag = "v1.0.4" }
+clap = { version = "4.5.2", features = ["derive"], optional = true }
+prost = { workspace = true, optional = true }
+protosol = { git = "https://github.com/firedancer-io/protosol", tag = "v1.0.4", optional = true }
 solana-account = { workspace = true }
 solana-builtins = { workspace = true }
 solana-clock = { workspace = true, features = ["sysvar"] }
@@ -53,7 +57,7 @@ solana-transaction-context = { workspace = true }
 thiserror = { workspace = true }
 
 [build-dependencies]
-prost-build = { workspace = true }
+prost-build = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/svm-fuzz-harness/Makefile
+++ b/svm-fuzz-harness/Makefile
@@ -4,4 +4,5 @@ CARGO?=cargo
 test: | binaries
 
 binaries:
-	$(CARGO) build --manifest-path ./Cargo.toml --bins --release
+	$(CARGO) rustc --manifest-path ./Cargo.toml --lib --release --features fuzz --crate-type cdylib
+	$(CARGO) build --manifest-path ./Cargo.toml --bins --release --features fuzz

--- a/svm-fuzz-harness/bin/test_exec_instr.rs
+++ b/svm-fuzz-harness/bin/test_exec_instr.rs
@@ -2,7 +2,7 @@ use {
     clap::Parser,
     prost::Message,
     solana_svm_fuzz_harness::{
-        fixture::proto::InstrFixture as ProtoInstrFixture, instr::execute_instr_proto,
+        fixture::proto::InstrFixture as ProtoInstrFixture, fuzz::execute_instr_proto,
     },
     std::path::PathBuf,
 };

--- a/svm-fuzz-harness/build.rs
+++ b/svm-fuzz-harness/build.rs
@@ -1,40 +1,44 @@
-use std::{env, fs, path::PathBuf};
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Get absolute proto dir from producer
-    let proto_dir = PathBuf::from(
-        env::var("DEP_PROTOSOL_PROTO_DIR")
-            .expect("protosol did not expose PROTO_DIR, did protosol build.rs run first?"),
-    );
+    // Only compile protobuf files when the fuzz feature is enabled.
+    #[cfg(feature = "fuzz")]
+    {
+        use std::{env, fs, path::PathBuf};
 
-    println!("cargo:rerun-if-env-changed=DEP_PROTOSOL_PROTO_DIR");
-    println!("cargo:rerun-if-changed={}", proto_dir.display());
+        // Get absolute proto dir from producer
+        let proto_dir = PathBuf::from(
+            env::var("DEP_PROTOSOL_PROTO_DIR")
+                .expect("protosol did not expose PROTO_DIR, did protosol build.rs run first?"),
+        );
 
-    // Collect absolute .proto paths
-    let mut proto_files = vec![];
-    for entry in fs::read_dir(&proto_dir)? {
-        let path = entry?.path();
-        if path.extension().and_then(|e| e.to_str()) == Some("proto") {
-            println!("cargo:rerun-if-changed={}", path.display());
-            proto_files.push(path);
+        println!("cargo:rerun-if-env-changed=DEP_PROTOSOL_PROTO_DIR");
+        println!("cargo:rerun-if-changed={}", proto_dir.display());
+
+        // Collect absolute .proto paths
+        let mut proto_files = vec![];
+        for entry in fs::read_dir(&proto_dir)? {
+            let path = entry?.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("proto") {
+                println!("cargo:rerun-if-changed={}", path.display());
+                proto_files.push(path);
+            }
         }
+
+        // Ensure deterministic order for rebuilds
+        proto_files.sort();
+
+        // Compile protos into Rust
+        let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+        let mut config = prost_build::Config::new();
+        config.out_dir(&out_dir);
+
+        config.compile_protos(
+            &proto_files
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>(),
+            &[proto_dir.to_str().unwrap()],
+        )?;
     }
-
-    // Ensure deterministic order for rebuilds
-    proto_files.sort();
-
-    // Compile protos into Rust
-    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
-    let mut config = prost_build::Config::new();
-    config.out_dir(&out_dir);
-
-    config.compile_protos(
-        &proto_files
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect::<Vec<_>>(),
-        &[proto_dir.to_str().unwrap()],
-    )?;
 
     Ok(())
 }

--- a/svm-fuzz-harness/src/fixture/account_state.rs
+++ b/svm-fuzz-harness/src/fixture/account_state.rs
@@ -1,3 +1,7 @@
+//! Account state conversions for protobuf support.
+
+#![cfg(feature = "fuzz")]
+
 use {
     super::{error::FixtureError, proto::AcctState as ProtoAccount},
     solana_account::Account,

--- a/svm-fuzz-harness/src/fixture/error.rs
+++ b/svm-fuzz-harness/src/fixture/error.rs
@@ -1,3 +1,7 @@
+//! Error types for fixture conversions.
+
+#![cfg(feature = "fuzz")]
+
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]

--- a/svm-fuzz-harness/src/fixture/feature_set.rs
+++ b/svm-fuzz-harness/src/fixture/feature_set.rs
@@ -1,3 +1,7 @@
+//! Feature set conversions for protobuf support.
+
+#![cfg(feature = "fuzz")]
+
 use {
     super::proto::FeatureSet as ProtoFeatureSet,
     agave_feature_set::{FeatureSet, FEATURE_NAMES},

--- a/svm-fuzz-harness/src/fixture/instr_context.rs
+++ b/svm-fuzz-harness/src/fixture/instr_context.rs
@@ -1,11 +1,7 @@
 //! Instruction context (input).
 
 use {
-    super::{error::FixtureError, proto::InstrContext as ProtoInstrContext},
-    agave_feature_set::FeatureSet,
-    solana_account::Account,
-    solana_instruction::AccountMeta,
-    solana_pubkey::Pubkey,
+    agave_feature_set::FeatureSet, solana_account::Account, solana_pubkey::Pubkey,
     solana_stable_layout::stable_instruction::StableInstruction,
 };
 
@@ -17,6 +13,13 @@ pub struct InstrContext {
     pub cu_avail: u64,
 }
 
+#[cfg(feature = "fuzz")]
+use {
+    super::{error::FixtureError, proto::InstrContext as ProtoInstrContext},
+    solana_instruction::AccountMeta,
+};
+
+#[cfg(feature = "fuzz")]
 impl TryFrom<ProtoInstrContext> for InstrContext {
     type Error = FixtureError;
 

--- a/svm-fuzz-harness/src/fixture/mod.rs
+++ b/svm-fuzz-harness/src/fixture/mod.rs
@@ -1,11 +1,16 @@
-//! Converts between Firedancer's protobuf payloads and Solana SDK types for
-//! use in Agave's SVM.
+//! Fixture types for SVM testing.
+//!
+//! This module provides native Rust types for testing program execution.
+//! When the `fuzz` feature is enabled, it also includes conversions
+//! between Firedancer's protobuf payloads and Solana SDK types.
 
 pub mod account_state;
 pub mod error;
 pub mod feature_set;
 pub mod instr_context;
 pub mod instr_effects;
+
+#[cfg(feature = "fuzz")]
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/org.solana.sealevel.v1.rs"));
 }

--- a/svm-fuzz-harness/src/fuzz.rs
+++ b/svm-fuzz-harness/src/fuzz.rs
@@ -1,0 +1,59 @@
+#![allow(clippy::missing_safety_doc)]
+
+use {
+    crate::{
+        fixture::{
+            instr_context::InstrContext,
+            proto::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
+        },
+        instr::execute_instr,
+    },
+    prost::Message,
+    std::{env, ffi::c_int},
+};
+
+#[no_mangle]
+pub unsafe extern "C" fn sol_compat_init(_log_level: i32) {
+    env::set_var("SOLANA_RAYON_THREADS", "1");
+    env::set_var("RAYON_NUM_THREADS", "1");
+    if env::var("ENABLE_SOLANA_LOGGER").is_ok() {
+        /* Pairs with RUST_LOG={trace,debug,info,etc} */
+        solana_logger::setup();
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sol_compat_fini() {}
+
+pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects> {
+    let Ok(instr_context) = InstrContext::try_from(input) else {
+        return None;
+    };
+    let instr_effects = execute_instr(instr_context);
+    instr_effects.map(Into::into)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sol_compat_instr_execute_v1(
+    out_ptr: *mut u8,
+    out_psz: *mut u64,
+    in_ptr: *mut u8,
+    in_sz: u64,
+) -> c_int {
+    let in_slice = std::slice::from_raw_parts(in_ptr, in_sz as usize);
+    let Ok(instr_context) = ProtoInstrContext::decode(in_slice) else {
+        return 0;
+    };
+    let Some(instr_effects) = execute_instr_proto(instr_context) else {
+        return 0;
+    };
+    let out_slice = std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize);
+    let out_vec = instr_effects.encode_to_vec();
+    if out_vec.len() > out_slice.len() {
+        return 0;
+    }
+    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
+    *out_psz = out_vec.len() as u64;
+
+    1
+}

--- a/svm-fuzz-harness/src/lib.rs
+++ b/svm-fuzz-harness/src/lib.rs
@@ -1,50 +1,9 @@
-#![allow(clippy::missing_safety_doc)]
+//! Solana SVM test harness.
 
 pub mod fixture;
 pub mod instr;
 pub mod program_cache;
 pub mod sysvar_cache;
 
-use {
-    fixture::proto::InstrContext as ProtoInstrContext,
-    prost::Message,
-    std::{env, ffi::c_int},
-};
-
-#[no_mangle]
-pub unsafe extern "C" fn sol_compat_init(_log_level: i32) {
-    env::set_var("SOLANA_RAYON_THREADS", "1");
-    env::set_var("RAYON_NUM_THREADS", "1");
-    if env::var("ENABLE_SOLANA_LOGGER").is_ok() {
-        /* Pairs with RUST_LOG={trace,debug,info,etc} */
-        solana_logger::setup();
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn sol_compat_fini() {}
-
-#[no_mangle]
-pub unsafe extern "C" fn sol_compat_instr_execute_v1(
-    out_ptr: *mut u8,
-    out_psz: *mut u64,
-    in_ptr: *mut u8,
-    in_sz: u64,
-) -> c_int {
-    let in_slice = std::slice::from_raw_parts(in_ptr, in_sz as usize);
-    let Ok(instr_context) = ProtoInstrContext::decode(in_slice) else {
-        return 0;
-    };
-    let Some(instr_effects) = instr::execute_instr_proto(instr_context) else {
-        return 0;
-    };
-    let out_slice = std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize);
-    let out_vec = instr_effects.encode_to_vec();
-    if out_vec.len() > out_slice.len() {
-        return 0;
-    }
-    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
-    *out_psz = out_vec.len() as u64;
-
-    1
-}
+#[cfg(feature = "fuzz")]
+pub mod fuzz;


### PR DESCRIPTION
#### Problem
We intend to use the `svm-fuzz-harness` crate as a lib-based entrypoint harness for testing single-instruction VM execution, in places such as `programs/sbf`. Additionally, all dependencies for the harness crate's binary entrypoints are pulled in whenever we compile the monorepo.

#### Summary of Changes
Refactor the harness crate to only offer the harness itself - which uses only types from the Solana SDK - for consumption by other crates as a test harness. Place anything only required for the `bin` target under the `fuzz` feature flag, and only compile with `fuzz` enabled specifically in the Makefile. Same thing goes for the `cdylib` lib target, which is only required for Firedancer's tooling so far.