### PR TITLE
agave-validator: move bigtable related args to the config file

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -287,10 +287,6 @@ pub struct DefaultArgs {
     pub rpc_threads: String,
     pub rpc_blocking_threads: String,
     pub rpc_niceness_adjustment: String,
-    pub rpc_bigtable_timeout: String,
-    pub rpc_bigtable_instance_name: String,
-    pub rpc_bigtable_app_profile_id: String,
-    pub rpc_bigtable_max_message_size: String,
     pub rpc_max_request_body_size: String,
 
     pub maximum_local_snapshot_age: String,
@@ -371,12 +367,6 @@ impl DefaultArgs {
             rpc_threads: num_cpus::get().to_string(),
             rpc_blocking_threads: 1.max(num_cpus::get() / 4).to_string(),
             rpc_niceness_adjustment: "0".to_string(),
-            rpc_bigtable_timeout: "30".to_string(),
-            rpc_bigtable_instance_name: solana_storage_bigtable::DEFAULT_INSTANCE_NAME.to_string(),
-            rpc_bigtable_app_profile_id: solana_storage_bigtable::DEFAULT_APP_PROFILE_ID
-                .to_string(),
-            rpc_bigtable_max_message_size: solana_storage_bigtable::DEFAULT_MAX_MESSAGE_SIZE
-                .to_string(),
             maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN
                 .to_string(),
             maximum_incremental_snapshot_archives_to_retain:

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -931,40 +931,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rpc_bigtable_timeout")
-            .long("rpc-bigtable-timeout")
-            .value_name("SECONDS")
-            .validator(is_parsable::<u64>)
-            .takes_value(true)
-            .default_value(&default_args.rpc_bigtable_timeout)
-            .help("Number of seconds before timing out RPC requests backed by BigTable"),
-    )
-    .arg(
-        Arg::with_name("rpc_bigtable_instance_name")
-            .long("rpc-bigtable-instance-name")
-            .takes_value(true)
-            .value_name("INSTANCE_NAME")
-            .default_value(&default_args.rpc_bigtable_instance_name)
-            .help("Name of the Bigtable instance to upload to"),
-    )
-    .arg(
-        Arg::with_name("rpc_bigtable_app_profile_id")
-            .long("rpc-bigtable-app-profile-id")
-            .takes_value(true)
-            .value_name("APP_PROFILE_ID")
-            .default_value(&default_args.rpc_bigtable_app_profile_id)
-            .help("Bigtable application profile id to use in requests"),
-    )
-    .arg(
-        Arg::with_name("rpc_bigtable_max_message_size")
-            .long("rpc-bigtable-max-message-size")
-            .value_name("BYTES")
-            .validator(is_parsable::<usize>)
-            .takes_value(true)
-            .default_value(&default_args.rpc_bigtable_max_message_size)
-            .help("Max encoding and decoding message size used in Bigtable Grpc client"),
-    )
-    .arg(
         Arg::with_name("rpc_send_transaction_retry_ms")
             .long("rpc-send-retry-ms")
             .value_name("MILLISECS")
@@ -1509,6 +1475,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
     )
     .args(&pub_sub_config::args())
     .args(&json_rpc_config::args(default_args))
+    .args(&rpc_bigtable_config::args())
 }
 
 fn validators_set(

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -66,11 +66,6 @@ pub(crate) fn args<'a>(default_args: &DefaultArgs) -> Vec<Arg<'_, 'a>> {
                 "Fetch historical transaction info from a BigTable instance as a fallback to \
                  local ledger data",
             ),
-        Arg::with_name("enable_bigtable_ledger_upload")
-            .long("enable-bigtable-ledger-upload")
-            .requires("enable_rpc_transaction_history")
-            .takes_value(false)
-            .help("Upload new confirmed blocks into a BigTable instance"),
         Arg::with_name("enable_extended_tx_metadata_storage")
             .long("enable-extended-tx-metadata-storage")
             .requires("enable_rpc_transaction_history")


### PR DESCRIPTION
#### Summary of Changes

move bigtable related args to the config file