### PR TITLE
A private package for making RPC subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3119,6 +3119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4259,6 +4265,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3f48dc3e6b8bd21e15436c1ddd0bc22a6a54e8ec46fedd6adf3425f396ec6a"
+dependencies = [
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "jsonrpsee-ws-client",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf36eb27f8e13fa93dcb50ccb44c417e25b818cfa1a481b5470cd07b19c60b98"
+dependencies = [
+ "base64 0.22.1",
+ "futures-util",
+ "http 1.1.0",
+ "jsonrpsee-core",
+ "pin-project",
+ "rustls 0.23.32",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.5.3",
+ "soketto 0.8.1",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-util 0.7.16",
+ "tracing",
+ "url 2.5.7",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
+dependencies = [
+ "async-trait",
+ "futures-timer",
+ "futures-util",
+ "http 1.1.0",
+ "jsonrpsee-types",
+ "pin-project",
+ "rustc-hash 2.0.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
+dependencies = [
+ "http 1.1.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
+dependencies = [
+ "http 1.1.0",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "tower 0.5.2",
+ "url 2.5.7",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5204,22 +5292,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5609,7 +5697,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls 0.23.32",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.1",
  "slab",
  "thiserror 2.0.17",
  "tinyvec",
@@ -6193,6 +6281,7 @@ version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6234,6 +6323,27 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.32",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.6",
+ "security-framework 3.2.0",
+ "security-framework-sys",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be59af91596cac372a6942530653ad0c3a246cdd491aaa9dcaee47f88d67d5a0"
@@ -6249,7 +6359,7 @@ dependencies = [
  "rustls-webpki 0.103.6",
  "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 1.0.2",
  "windows-sys 0.59.0",
 ]
 
@@ -6851,6 +6961,21 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha-1 0.9.8",
+]
+
+[[package]]
+name = "soketto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures 0.3.31",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
 ]
 
 [[package]]
@@ -7899,7 +8024,7 @@ dependencies = [
  "solana-version",
  "systemstat",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -9863,8 +9988,8 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
- "tungstenite",
+ "tokio-tungstenite 0.28.0",
+ "tungstenite 0.28.0",
  "url 2.5.7",
 ]
 
@@ -9991,7 +10116,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "soketto",
+ "soketto 0.7.1",
  "solana-account",
  "solana-account-decoder",
  "solana-accounts-db",
@@ -10195,6 +10320,17 @@ dependencies = [
  "solana-version",
  "spl-generic-token",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "solana-rpc-internal"
+version = "3.1.0"
+dependencies = [
+ "jsonrpsee",
+ "serde",
+ "serde_json",
+ "tokio",
+ "ws-mock",
 ]
 
 [[package]]
@@ -12870,6 +13006,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.27.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -12880,7 +13028,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
- "tungstenite",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.8",
 ]
 
@@ -13156,6 +13304,23 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.9.0",
+ "sha1",
+ "thiserror 2.0.17",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"
@@ -13525,6 +13690,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.2",
 ]
 
 [[package]]
@@ -14016,6 +14190,19 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "ws-mock"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f30585bdd4b173e94be8f51bb563f95e4c694743e65c36e4a00ff5bc53b387a"
+dependencies = [
+ "futures-util",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.27.0",
+ "tracing",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ members = [
     "rpc-client-api",
     "rpc-client-nonce-utils",
     "rpc-client-types",
+    "rpc-internal",
     "rpc-test",
     "runtime",
     "runtime-transaction",
@@ -297,6 +298,7 @@ jsonrpc-derive = "18.0.0"
 jsonrpc-http-server = "18.0.0"
 jsonrpc-ipc-server = "18.0.0"
 jsonrpc-pubsub = "18.0.0"
+jsonrpsee = "0.26.0"
 lazy-lru = "0.1.3"
 libc = "0.2.177"
 libloading = "0.7.4"
@@ -499,6 +501,7 @@ solana-rpc-client = { path = "rpc-client", version = "=3.1.0", default-features 
 solana-rpc-client-api = { path = "rpc-client-api", version = "=3.1.0" }
 solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=3.1.0" }
 solana-rpc-client-types = { path = "rpc-client-types", version = "=3.1.0" }
+solana-rpc-internal = { path = "rpc-internal", version = "=3.1.0" }
 solana-runtime = { path = "runtime", version = "=3.1.0" }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=3.1.0" }
 solana-sanitize = "3.0.1"
@@ -614,6 +617,7 @@ wasm-bindgen = "0.2"
 winapi = "0.3.8"
 wincode = { version = "0.1.2", features = ["derive", "solana-short-vec"] }
 winreg = "0.50"
+ws-mock = "0.3.2"
 x509-parser = "0.14.0"
 zeroize = { version = "1.8", default-features = false }
 zstd = "0.13.3"

--- a/rpc-internal/Cargo.toml
+++ b/rpc-internal/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "solana-rpc-internal"
+description = "Private utilities for making RPC requests and subscriptions"
+publish = false
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+subscriptions = ["jsonrpsee/ws-client"]
+
+[dependencies]
+jsonrpsee = { workspace = true, optional = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+tokio = { workspace = true }
+ws-mock = { workspace = true }
+
+[lints]
+workspace = true

--- a/rpc-internal/src/lib.rs
+++ b/rpc-internal/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod subscriptions;

--- a/rpc-internal/src/subscriptions.rs
+++ b/rpc-internal/src/subscriptions.rs
@@ -1,0 +1,201 @@
+#![cfg(feature = "subscriptions")]
+
+use {
+    jsonrpsee::{
+        core::{
+            client::{async_client::Client, Subscription, SubscriptionClientT},
+            traits::ToRpcParams,
+            ClientError,
+        },
+        ws_client::{PingConfig, WsClientBuilder},
+    },
+    serde::de::DeserializeOwned,
+    std::ops::{Deref, DerefMut},
+};
+
+pub struct SubscriptionWithClient<T: DeserializeOwned> {
+    _client: Client,
+    subscription: Subscription<T>,
+}
+
+impl<T: DeserializeOwned> Deref for SubscriptionWithClient<T> {
+    type Target = Subscription<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.subscription
+    }
+}
+
+impl<T: DeserializeOwned> DerefMut for SubscriptionWithClient<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.subscription
+    }
+}
+
+impl<T: DeserializeOwned> SubscriptionWithClient<T> {
+    pub async fn unsubscribe(self) -> Result<(), ClientError> {
+        self.subscription.unsubscribe().await
+    }
+}
+
+pub async fn subscribe<Notif, Params>(
+    url: &str,
+    method: &str,
+    params: Params,
+) -> Result<SubscriptionWithClient<Notif>, ClientError>
+where
+    Params: ToRpcParams + Send,
+    Notif: DeserializeOwned,
+{
+    let client = WsClientBuilder::default()
+        .enable_ws_ping(PingConfig::default())
+        .max_buffer_capacity_per_subscription(
+            // Gets us as close to 'unbounded' as is possible with `tokio::sync::mpsc::channel`.
+            2_305_843_009_213_693_951usize, /* Semaphore::MAX_PERMITS */
+        )
+        .build(url)
+        .await?;
+    let subscription = client
+        .subscribe(
+            format!("{method}Subscribe").as_str(),
+            params,
+            format!("{method}Unsubscribe").as_str(),
+        )
+        .await?;
+    Ok(SubscriptionWithClient {
+        _client: client,
+        subscription,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        crate::subscriptions::{subscribe, SubscriptionWithClient},
+        serde_json::json,
+        ws_mock::{
+            matchers::JsonPartial,
+            ws_mock_server::{WsMock, WsMockServer},
+        },
+    };
+
+    #[tokio::test]
+    async fn test_sends_subscribe_message() {
+        let server = WsMockServer::start().await;
+
+        WsMock::new()
+            .matcher(JsonPartial::new(json!({ "method": "slotSubscribe" })))
+            .respond_with(
+                json!({ "jsonrpc": "2.0", "id": 0, "result": 123 })
+                    .to_string()
+                    .into(),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let _subscription: SubscriptionWithClient<()> =
+            subscribe(&server.uri().await, "slot", vec![] as Vec<()>)
+                .await
+                .expect("Failed to establish subscription");
+
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn test_unsubscribes_from_received_subscription_id() {
+        let server = WsMockServer::start().await;
+
+        WsMock::new()
+            .matcher(JsonPartial::new(json!({ "method": "slotSubscribe" })))
+            .respond_with(
+                json!({ "jsonrpc": "2.0", "id": 0, "result": 123 })
+                    .to_string()
+                    .into(),
+            )
+            .mount(&server)
+            .await;
+
+        let subscription: SubscriptionWithClient<()> =
+            subscribe(&server.uri().await, "slot", vec![] as Vec<()>)
+                .await
+                .expect("Failed to establish subscription");
+
+        WsMock::new()
+            .matcher(JsonPartial::new(json!({ "method": "slotUnsubscribe" })))
+            .respond_with(
+                json!({ "jsonrpc": "2.0", "id": 1, "result": true })
+                    .to_string()
+                    .into(),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        subscription
+            .unsubscribe()
+            .await
+            .expect("Failed to unsubscribe");
+
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn test_receives_notifications() {
+        let server = WsMockServer::start().await;
+
+        WsMock::new()
+            .matcher(JsonPartial::new(json!({ "method": "slotSubscribe" })))
+            .respond_with(
+                json!({ "jsonrpc": "2.0", "id": 0, "result": 123 })
+                    .to_string()
+                    .into(),
+            )
+            .respond_with(
+                json!({
+                    "jsonrpc": "2.0",
+                    "method": "slotNotification",
+                    "params": { "result": "foo", "subscription": 123 }
+                })
+                .to_string()
+                .into(),
+            )
+            .respond_with(
+                json!({
+                    "jsonrpc": "2.0",
+                    "method": "slotNotification",
+                    "params": { "result": "bar", "subscription": 123 }
+                })
+                .to_string()
+                .into(),
+            )
+            .respond_with(
+                json!({
+                    "jsonrpc": "2.0",
+                    "method": "slotNotification",
+                    "params": { "result": "baz", "subscription": 123 }
+                })
+                .to_string()
+                .into(),
+            )
+            .mount(&server)
+            .await;
+
+        let mut subscription: SubscriptionWithClient<String> =
+            subscribe(&server.uri().await, "slot", vec![] as Vec<()>)
+                .await
+                .expect("Failed to establish subscription");
+
+        let mut notifications = vec![];
+        for _ in 0..3 {
+            let notification = subscription
+                .next()
+                .await
+                .expect("Received no notification")
+                .unwrap();
+            notifications.push(notification);
+        }
+
+        assert_eq!(notifications, vec!["foo", "bar", "baz"]);
+    }
+}


### PR DESCRIPTION
#### Problem

The idea is to replace `solana_pubsub_client` for internal usage with this lightweight subscriber that implements only JSON-RPC WebSockets.

#### Summary of Changes

Added a JSON-RPC WebSockets client and tests for subscribing, unsubscribing, and receiving notifications.