### PR TITLE
ibrl: remove one of the two slot time governors to reduce poh recording time

### DIFF
--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -381,7 +381,6 @@ impl PohRecorder {
         let (poh_entry, tick_lock_contention_us) = measure_us!({
             let mut poh_l = self.poh.lock().unwrap();
             poh_l.tick()
-            poh_entry
         });
         self.metrics.tick_lock_contention_us += tick_lock_contention_us;
 

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -380,7 +380,7 @@ impl PohRecorder {
     pub(crate) fn tick(&mut self) {
         let (poh_entry, tick_lock_contention_us) = measure_us!({
             let mut poh_l = self.poh.lock().unwrap();
-            let poh_entry = poh_l.tick();
+            poh_l.tick()
             poh_entry
         });
         self.metrics.tick_lock_contention_us += tick_lock_contention_us;

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -180,7 +180,6 @@ pub struct PohRecorder {
     blockstore: Arc<Blockstore>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
     ticks_per_slot: u64,
-    target_ns_per_tick: u64,
     metrics: PohRecorderMetrics,
     delay_leader_block_for_pending_fork: bool,
     last_reported_slot_for_pending_fork: Arc<Mutex<Slot>>,
@@ -245,10 +244,6 @@ impl PohRecorder {
             tick_number,
         )));
 
-        let target_ns_per_tick = PohService::target_ns_per_tick(
-            ticks_per_slot,
-            poh_config.target_tick_duration.as_nanos() as u64,
-        );
         let (working_bank_sender, working_bank_receiver) = unbounded();
         let (leader_first_tick_height, leader_last_tick_height, grace_ticks) =
             Self::compute_leader_slot_tick_heights(next_leader_slot, ticks_per_slot);
@@ -268,7 +263,6 @@ impl PohRecorder {
                 blockstore,
                 leader_schedule_cache: leader_schedule_cache.clone(),
                 ticks_per_slot,
-                target_ns_per_tick,
                 metrics: PohRecorderMetrics::default(),
                 delay_leader_block_for_pending_fork,
                 last_reported_slot_for_pending_fork: Arc::default(),
@@ -384,15 +378,10 @@ impl PohRecorder {
 
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn tick(&mut self) {
-        let ((poh_entry, _target_time), tick_lock_contention_us) = measure_us!({
+        let (poh_entry, tick_lock_contention_us) = measure_us!({
             let mut poh_l = self.poh.lock().unwrap();
             let poh_entry = poh_l.tick();
-            let target_time = if poh_entry.is_some() {
-                Some(poh_l.target_poh_time(self.target_ns_per_tick))
-            } else {
-                None
-            };
-            (poh_entry, target_time)
+            poh_entry
         });
         self.metrics.tick_lock_contention_us += tick_lock_contention_us;
 

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -384,7 +384,7 @@ impl PohRecorder {
 
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn tick(&mut self) {
-        let ((poh_entry, target_time), tick_lock_contention_us) = measure_us!({
+        let ((poh_entry, _target_time), tick_lock_contention_us) = measure_us!({
             let mut poh_l = self.poh.lock().unwrap();
             let poh_entry = poh_l.tick();
             let target_time = if poh_entry.is_some() {
@@ -420,17 +420,6 @@ impl PohRecorder {
 
             let (_flush_res, flush_cache_and_tick_us) = measure_us!(self.flush_cache(true));
             self.metrics.flush_cache_tick_us += flush_cache_and_tick_us;
-
-            let (_, sleep_us) = measure_us!({
-                let target_time = target_time.unwrap();
-                // sleep is not accurate enough to get a predictable time.
-                // Kernel can not schedule the thread for a while.
-                while Instant::now() < target_time {
-                    // TODO: a caller could possibly desire to reset or record while we're spinning here
-                    std::hint::spin_loop();
-                }
-            });
-            self.metrics.total_sleep_us += sleep_us;
         }
     }
 


### PR DESCRIPTION
#### Problem
There are TWO mechanisms for controlling slot times in poh. The first is a busy loop on record_receiver
```rust
while ideal_time > Instant::now() {
    // check to see if a record request has been sent
    if let Ok(record) = record_receiver.try_recv() {
        // remember the record we just received as the next record to occur
        *next_record = Some(record);
        break;
    }
}
```
and the second is a busy loop that does nothing (the one removed in this PR)
```rust
let (_, sleep_us) = measure_us!({
    let target_time = target_time.unwrap();
    // sleep is not accurate enough to get a predictable time.
    // Kernel can not schedule the thread for a while.
    while Instant::now() < target_time {
        // TODO: a caller could possibly desire to reset or record while we're spinning here
        std::hint::spin_loop();
    }
});
self.metrics.total_sleep_us += sleep_us;
```
If stuck in this loop, transactions waiting to be recorded have to wait. so lets not do that, tyvm ibrl opos accelerate wagmi

#### Summary of Changes
do the 5 year old todo
