### PR TITLE
Backport UiTransactionError to 2.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11348,6 +11348,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-commitment-config",
+ "solana-instruction",
  "solana-message",
  "solana-reward-info",
  "solana-signature",

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -257,7 +257,7 @@ fn write_transaction<W: io::Write>(
     }
 
     if let Some(transaction_status) = transaction_status {
-        write_status(w, &transaction_status.status, prefix)?;
+        write_status(w, &transaction_status.status.clone().map_err(Into::into), prefix)?;
         write_fees(w, transaction_status.fee, prefix)?;
         write_balances(w, transaction_status, prefix)?;
         write_compute_units_consumed(

--- a/transaction-status-client-types/Cargo.toml
+++ b/transaction-status-client-types/Cargo.toml
@@ -21,6 +21,7 @@ serde_derive = { workspace = true }
 serde_json = { workspace = true }
 solana-account-decoder-client-types = { workspace = true }
 solana-commitment-config = { workspace = true }
+solana-instruction = { workspace = true }
 solana-message = { workspace = true }
 solana-reward-info = { workspace = true, features = ["serde"] }
 solana-signature = { workspace = true, default-features = false }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -163,8 +163,8 @@ fn build_simple_ui_transaction_status_meta(
     show_rewards: bool,
 ) -> UiTransactionStatusMeta {
     UiTransactionStatusMeta {
-        err: meta.status.clone().err(),
-        status: meta.status,
+        err: meta.status.clone().map_err(Into::into).err(),
+        status: meta.status.map_err(Into::into),
         fee: meta.fee,
         pre_balances: meta.pre_balances,
         post_balances: meta.post_balances,
@@ -197,8 +197,8 @@ fn parse_ui_transaction_status_meta(
 ) -> UiTransactionStatusMeta {
     let account_keys = AccountKeys::new(static_keys, Some(&meta.loaded_addresses));
     UiTransactionStatusMeta {
-        err: meta.status.clone().err(),
-        status: meta.status,
+        err: meta.status.clone().map_err(Into::into).err(),
+        status: meta.status.map_err(Into::into),
         fee: meta.fee,
         pre_balances: meta.pre_balances,
         post_balances: meta.post_balances,


### PR DESCRIPTION
#### Problem

Developers on 2.x run into errors hitting RPC against 3.x network because of major breaking changes (expected). However, some developers may be slower to upgrade to 3.x libraries because other libraries like Anchor have not yet provided versions that support 3.x. In the meantime, this should unblock some of the developers still on 2.x waiting on the rest of the Solana dev ecosystem to update.

#### Summary of Changes

Backport `UiTransactionError` wrapper from `master` to deserialize `BorshIoError`

Fixes #8548