### PR TITLE
Save obsolete accounts during fastboot save/restore

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -211,6 +211,21 @@ impl SnapshotPackagerService {
             start.elapsed(),
         );
 
+        info!("Saving obsolete accounts...");
+        let start = Instant::now();
+        let result = snapshot_utils::write_obsolete_accounts_to_snapshot(
+            &bank_snapshot_dir,
+            &state.snapshot_storages,
+            state.snapshot_slot,
+        );
+        if let Err(err) = result {
+            warn!("Failed to serialize obsolete accounts: {err}");
+            // If serializing the obsolete accounts failed, we do *NOT* want to mark the bank snapshot
+            // as loadable so return early.
+            return;
+        }
+        info!("Saving obsolete accounts... Done in {:?}", start.elapsed(),);
+
         let result = snapshot_utils::mark_bank_snapshot_as_loadable(&bank_snapshot_dir);
         if let Err(err) = result {
             warn!("Failed to mark bank snapshot as loadable: {err}");

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -224,7 +224,7 @@ impl SnapshotPackagerService {
             // as loadable so return early.
             return;
         }
-        info!("Saving obsolete accounts... Done in {:?}", start.elapsed(),);
+        info!("Saving obsolete accounts... Done in {:?}", start.elapsed());
 
         let result = snapshot_utils::mark_bank_snapshot_as_loadable(&bank_snapshot_dir);
         if let Err(err) = result {

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1637,7 +1637,7 @@ mod tests {
     fn test_fastboot_versioning() {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 3, true);
+        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 2, true);
 
         let snapshot_config = SnapshotConfig {
             bank_snapshots_dir: bank_snapshots_dir.as_ref().to_path_buf(),
@@ -1648,20 +1648,9 @@ mod tests {
 
         // Verify the snapshot is found with all files present
         let snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
-        assert_eq!(snapshot.slot, 3);
+        assert_eq!(snapshot.slot, 2);
 
-        // Test 1: Remove the storages flushed file
-        let storages_flushed_file = snapshot
-            .snapshot_dir
-            .join(snapshot_utils::SNAPSHOT_STORAGES_FLUSHED_FILENAME);
-        fs::remove_file(storages_flushed_file).unwrap();
-
-        // If the storages flushed file is removed, the version in the version file should be
-        // checked, and the snapshot should be found
-        let snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
-        assert_eq!(snapshot.slot, 3);
-
-        // Test 2: Modify the version in the fastboot version file to something newer
+        // Test 1: Modify the version in the fastboot version file to something newer
         // than current
         let complete_flag_file = snapshot
             .snapshot_dir
@@ -1672,29 +1661,19 @@ mod tests {
 
         fs::write(&complete_flag_file, new_version.to_string()).unwrap();
 
-        // With an invalid version and no flush file, the snapshot will be considered invalid
+        // With an invalid version, the snapshot will be considered invalid
         let new_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config);
         assert!(new_snapshot.is_none());
 
-        // Test 3: Remove the bank snapshot version file
+        // Test 2: Remove the bank snapshot version file
         let complete_flag_file = snapshot
             .snapshot_dir
             .join(snapshot_utils::SNAPSHOT_VERSION_FILENAME);
         fs::remove_file(complete_flag_file).unwrap();
 
-        // This will now find the previous entry in the directory, which is slot 2
+        // This will now find the previous entry in the directory, which is slot 1
         let snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
-        assert_eq!(snapshot.slot, 2);
-
-        // Test 4: Remove the fastboot version file
-        let fastboot_version_file = snapshot
-            .snapshot_dir
-            .join(snapshot_utils::SNAPSHOT_FASTBOOT_VERSION_FILENAME);
-        fs::remove_file(fastboot_version_file).unwrap();
-
-        // The flush file will still be found, making this a valid snapshot
-        let snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
-        assert_eq!(snapshot.slot, 2);
+        assert_eq!(snapshot.slot, 1);
     }
 
     #[test_case(false)]
@@ -1982,6 +1961,7 @@ mod tests {
     /// If zero lamport accounts are not handled correctly, Account1 or Account2 will come back
     /// failing the test
     #[test_case(MarkObsoleteAccounts::Disabled)]
+    #[test_case(MarkObsoleteAccounts::Enabled)]
     fn test_fastboot_handle_zero_lamport_accounts(mark_obsolete_accounts: MarkObsoleteAccounts) {
         let collector = Pubkey::new_unique();
         let key1 = Keypair::new();
@@ -2066,6 +2046,39 @@ mod tests {
 
         // Ensure the deserialized bank matches the original bank
         assert_eq!(*bank2, deserialized_bank);
+    }
+
+    /// Test that removing the obsolete accounts file causes fastboot to fail.
+    /// Fastboot requires obsolete accounts files in newer versions.
+    #[test]
+    #[should_panic(expected = "failed to read obsolete accounts file")]
+    fn test_fastboot_missing_obsolete_accounts() {
+        let genesis_config = GenesisConfig::default();
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 3, true);
+
+        let account_paths = &bank.rc.accounts.accounts_db.paths;
+        let bank_snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
+
+        // Remove the obsolete account file
+        let obsolete_accounts_file = bank_snapshot
+            .snapshot_dir
+            .join(snapshot_utils::SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME);
+        fs::remove_file(obsolete_accounts_file).unwrap();
+
+        bank_from_snapshot_dir(
+            account_paths,
+            &bank_snapshot,
+            &genesis_config,
+            &RuntimeConfig::default(),
+            None,
+            None,
+            false,
+            ACCOUNTS_DB_CONFIG_FOR_TESTING,
+            None,
+            Arc::default(),
+        )
+        .unwrap();
     }
 
     #[test_case(StorageAccess::Mmap)]

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1681,7 +1681,7 @@ mod tests {
             .join(snapshot_utils::SNAPSHOT_FASTBOOT_VERSION_FILENAME);
         fs::remove_file(fastboot_version_file).unwrap();
 
-        // The fastboot file is not found, no snapshot is found
+        // The fastboot file is not found, no loadable snapshot is found
         let snapshot = get_highest_loadable_bank_snapshot(&snapshot_config);
         assert!(snapshot.is_none());
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -82,9 +82,9 @@ pub const MAX_SNAPSHOT_DATA_FILE_SIZE: u64 = 32 * 1024 * 1024 * 1024; // 32 GiB
 const MAX_SNAPSHOT_VERSION_FILE_SIZE: u64 = 8; // byte
 
 // Snapshot Fastboot Version History
-// Legacy - No fastboot version file, uses storages flushed file to determine if snapshot is loadable
-// 1.0.0 - Initial version with version file. Backwards and forwards compatible with Legacy
-// 2.0.0 - Fastboot version file added, storages flushed file not written anymore
+// Legacy - No fastboot version file, storages flushed file presence determines if snapshot is loadable
+// 1.0.0 - Initial version file. Backwards and forwards compatible with Legacy.
+// 2.0.0 - Obsolete Accounts File added, storages flushed file not written anymore
 //         Snapshots created with version 2.0.0 will not fastboot to older versions
 //         Snapshots created with versions <2.0.0 will fastboot to version 2.0.0
 const SNAPSHOT_FASTBOOT_VERSION: Version = Version::new(2, 0, 0);

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -80,6 +80,13 @@ pub const SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME: &str = "full_snapshot_slot";
 pub const BANK_SNAPSHOTS_DIR: &str = "snapshots";
 pub const MAX_SNAPSHOT_DATA_FILE_SIZE: u64 = 32 * 1024 * 1024 * 1024; // 32 GiB
 const MAX_SNAPSHOT_VERSION_FILE_SIZE: u64 = 8; // byte
+
+// Snapshot Fastboot Version History
+// Legacy - No fastboot version file, uses storages flushed file to determine if snapshot is loadable
+// 1.0.0 - Initial version with version file. Backwards and forwards compatible with Legacy
+// 2.0.0 - Fastboot version file added, storages flushed file not written anymore
+//         Snapshots created with version 2.0.0 will not fastboot to older versions
+//         Snapshots created with versions <2.0.0 will fastboot to version 2.0.0
 const SNAPSHOT_FASTBOOT_VERSION: Version = Version::new(2, 0, 0);
 pub const TMP_SNAPSHOT_ARCHIVE_PREFIX: &str = "tmp-snapshot-archive-";
 pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
@@ -1920,24 +1927,21 @@ pub fn rebuild_storages_from_snapshot_dir(
     let accounts_hardlinks = bank_snapshot_dir.join(SNAPSHOT_ACCOUNTS_HARDLINKS);
     let account_run_paths: HashSet<_> = HashSet::from_iter(account_paths);
 
-    // Read out the obsolete accounts if fastboot_version is >= 2
-    let obsolete_accounts = if snapshot_info
+    // With fastboot_version >= 2, obsolete accounts are tracked and stored in the snapshot
+    // Even if obsolete accounts are not enabled, the snapshot may still contain obsolete accounts
+    // as the feature may have been enabled in previous validator runs.
+    let obsolete_accounts = snapshot_info
         .fastboot_version
         .as_ref()
         .is_some_and(|fastboot_version| fastboot_version.major >= 2)
-    {
-        Some(
-            deserialize_obsolete_accounts(bank_snapshot_dir, MAX_OBSOLETE_ACCOUNTS_FILE_SIZE)
-                .map_err(|err| {
-                    IoError::other(format!(
-                        "failed to read obsolete accounts file '{}': {err}",
-                        bank_snapshot_dir.display()
-                    ))
-                })?,
-        )
-    } else {
-        None
-    };
+        .then(|| deserialize_obsolete_accounts(bank_snapshot_dir, MAX_OBSOLETE_ACCOUNTS_FILE_SIZE))
+        .transpose()
+        .map_err(|err| {
+            IoError::other(format!(
+                "failed to read obsolete accounts file '{}': {err}",
+                bank_snapshot_dir.display()
+            ))
+        })?;
 
     let read_dir = fs::read_dir(&accounts_hardlinks).map_err(|err| {
         IoError::other(format!(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -511,17 +511,6 @@ pub fn execute(
         UseSnapshotArchivesAtStartup
     );
 
-    if mark_obsolete_accounts == MarkObsoleteAccounts::Enabled
-        && use_snapshot_archives_at_startup != UseSnapshotArchivesAtStartup::Always
-    {
-        Err(format!(
-            "The --accounts-db-mark-obsolete-accounts option requires the \
-             --use-snapshot-archives-at-startup option to be set to {}. Current value: {}",
-            UseSnapshotArchivesAtStartup::Always,
-            use_snapshot_archives_at_startup
-        ))?;
-    }
-
     let mut validator_config = ValidatorConfig {
         require_tower: matches.is_present("require_tower"),
         tower_storage,


### PR DESCRIPTION
#### Problem
Obsolete accounts are not saved during fastboot, so fastboot cannot be used when a validator is running with obsolete accounts enabled. 

#### Summary of Changes
- Save obsolete accounts during fastboot snapshot
- Allow fastboot with obsolete accounts
- Remove writing of storages flushed file and state complete file. This will cause fastbooting from this version to an older version to revert to archive boot. 

Flows verified:
3.0 -> 3.1 with obsolete accounts - Result: Fastboot
3.0 -> 3.1 without obsolete accounts - Result: Fastboot
3.1 with obsolete accounts -> 3.0 - Result: Load from Archives
3.1 without obsolete accounts -> 3.0 - Result: Loads from Archives
3.1 with obsolete accounts -> 3.1 without obsolete accounts - Result: Fastboot
3.1 with obsolete accounts -> 3.1 without obsolete accounts -> 3.1 with obsolete accounts - Result: Fastboot



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
