### PR TITLE
Update create_test_account/get_account_test to return pubkey rather than StoredMeta

### DIFF
--- a/accounts-db/benches/append_vec.rs
+++ b/accounts-db/benches/append_vec.rs
@@ -8,10 +8,11 @@ use {
         accounts_file::{StorageAccess, StoredAccountsInfo},
         append_vec::{
             test_utils::{create_test_account, get_append_vec_path},
-            AppendVec, StoredMeta,
+            AppendVec,
         },
     },
     solana_clock::Slot,
+    solana_pubkey::Pubkey,
     std::{
         sync::{Arc, Mutex},
         thread::{sleep, spawn},
@@ -29,11 +30,11 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 /// After the account is appended, the internal `current_len` is updated.
 fn append_account(
     vec: &AppendVec,
-    storage_meta: StoredMeta,
+    pubkey: Pubkey,
     account: &AccountSharedData,
 ) -> Option<StoredAccountsInfo> {
     let slot_ignored = Slot::MAX;
-    let accounts = [(&storage_meta.pubkey, account)];
+    let accounts = [(&pubkey, account)];
     let slice = &accounts[..];
     let storable_accounts = (slot_ignored, slice);
     vec.append_accounts(&storable_accounts, 0)
@@ -63,8 +64,8 @@ fn append_vec_append_mmap(bencher: &mut Bencher) {
 fn add_test_accounts(vec: &AppendVec, size: usize) -> Vec<(usize, usize)> {
     (0..size)
         .filter_map(|sample| {
-            let (meta, account) = create_test_account(sample);
-            append_account(vec, meta, &account).map(|info| (sample, info.offsets[0]))
+            let (pubkey, account) = create_test_account(sample);
+            append_account(vec, pubkey, &account).map(|info| (sample, info.offsets[0]))
         })
         .collect()
 }
@@ -78,7 +79,7 @@ fn append_vec_sequential_read(bencher: &mut Bencher, storage_access: StorageAcce
         let (sample, pos) = indexes.pop().unwrap();
         println!("reading pos {sample} {pos}");
         vec.get_stored_account_meta_callback(pos, |account| {
-            let (_meta, test) = create_test_account(sample);
+            let (_pubkey, test) = create_test_account(sample);
             assert_eq!(account.data(), test.data());
             indexes.push((sample, pos));
         });
@@ -104,7 +105,7 @@ fn append_vec_random_read(bencher: &mut Bencher, storage_access: StorageAccess) 
         let random_index: usize = thread_rng().gen_range(0..indexes.len());
         let (sample, pos) = &indexes[random_index];
         vec.get_stored_account_meta_callback(*pos, |account| {
-            let (_meta, test) = create_test_account(*sample);
+            let (_pubkey, test) = create_test_account(*sample);
             assert_eq!(account.data(), test.data());
         });
     });
@@ -133,8 +134,8 @@ fn append_vec_concurrent_append_read(bencher: &mut Bencher, storage_access: Stor
     let indexes1 = indexes.clone();
     spawn(move || loop {
         let sample = indexes1.lock().unwrap().len();
-        let (meta, account) = create_test_account(sample);
-        if let Some(info) = append_account(&vec1, meta, &account) {
+        let (pubkey, account) = create_test_account(sample);
+        if let Some(info) = append_account(&vec1, pubkey, &account) {
             indexes1.lock().unwrap().push((sample, info.offsets[0]))
         } else {
             break;
@@ -148,7 +149,7 @@ fn append_vec_concurrent_append_read(bencher: &mut Bencher, storage_access: Stor
         let random_index: usize = thread_rng().gen_range(0..len);
         let (sample, pos) = *indexes.lock().unwrap().get(random_index).unwrap();
         vec.get_stored_account_meta_callback(pos, |account| {
-            let (_meta, test) = create_test_account(sample);
+            let (_pubkey, test) = create_test_account(sample);
             assert_eq!(account.data(), test.data());
         });
     });
@@ -187,14 +188,14 @@ fn append_vec_concurrent_read_append(bencher: &mut Bencher, storage_access: Stor
             .get(random_index.checked_rem(len).unwrap())
             .unwrap();
         vec1.get_stored_account_meta_callback(pos, |account| {
-            let (_meta, test) = create_test_account(sample);
+            let (_pubkey, test) = create_test_account(sample);
             assert_eq!(account.data(), test.data());
         });
     });
     bencher.iter(|| {
         let sample: usize = thread_rng().gen_range(0..256);
-        let (meta, account) = create_test_account(sample);
-        if let Some(info) = append_account(&vec, meta, &account) {
+        let (pubkey, account) = create_test_account(sample);
+        if let Some(info) = append_account(&vec, pubkey, &account) {
             indexes.lock().unwrap().push((sample, info.offsets[0]))
         }
     });

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -910,7 +910,7 @@ impl AppendVec {
     pub fn get_account_test(
         &self,
         offset: usize,
-    ) -> Option<(StoredMeta, solana_account::AccountSharedData)> {
+    ) -> Option<(Pubkey, solana_account::AccountSharedData)> {
         let data_len = self.get_account_data_lens(&[offset]);
         let sizes: usize = data_len
             .iter()
@@ -923,8 +923,8 @@ impl AppendVec {
                 r2.as_ref().unwrap()
             ));
             assert_eq!(sizes, r_callback.stored_size());
-            let meta = r_callback.meta().clone();
-            Some((meta, r_callback.to_account_shared_data()))
+            let pubkey = r_callback.meta().pubkey;
+            Some((pubkey, r_callback.to_account_shared_data()))
         });
         if result.is_none() {
             assert!(self
@@ -1361,9 +1361,9 @@ pub mod tests {
     };
 
     impl AppendVec {
-        fn append_account_test(&self, data: &(StoredMeta, AccountSharedData)) -> Option<usize> {
+        fn append_account_test(&self, data: &(Pubkey, AccountSharedData)) -> Option<usize> {
             let slot_ignored = Slot::MAX;
-            let accounts = [(&data.0.pubkey, &data.1)];
+            let accounts = [(&data.0, &data.1)];
             let slice = &accounts[..];
             let storable_accounts = (slot_ignored, slice);
 

--- a/accounts-db/src/append_vec/test_utils.rs
+++ b/accounts-db/src/append_vec/test_utils.rs
@@ -1,7 +1,6 @@
 //! Helpers for AppendVec tests and benches
 #![cfg(feature = "dev-context-only-utils")]
 use {
-    super::StoredMeta,
     rand::{distributions::Alphanumeric, Rng},
     solana_account::AccountSharedData,
     solana_pubkey::Pubkey,
@@ -39,26 +38,16 @@ pub fn get_append_vec_path(path: &str) -> TempFile {
 
 /// return a test account.
 /// Note that `sample`=0 returns a fully default account with a default pubkey.
-pub fn create_test_account(sample: usize) -> (StoredMeta, AccountSharedData) {
+pub fn create_test_account(sample: usize) -> (Pubkey, AccountSharedData) {
     let data_len = sample % 256;
     let mut account = AccountSharedData::new(sample as u64, 0, &Pubkey::default());
     account.set_data_from_slice(&vec![data_len as u8; data_len]);
-    let stored_meta = StoredMeta {
-        write_version_obsolete: 0,
-        pubkey: Pubkey::default(),
-        data_len: data_len as u64,
-    };
-    (stored_meta, account)
+    (Pubkey::default(), account)
 }
 
 /// Create a test account for the given `data_len`.
 /// This is useful to create very large test account.
-pub fn create_test_account_with(data_len: usize) -> (StoredMeta, AccountSharedData) {
+pub fn create_test_account_with(data_len: usize) -> (Pubkey, AccountSharedData) {
     let account = AccountSharedData::new(100, data_len, &Pubkey::default());
-    let stored_meta = StoredMeta {
-        write_version_obsolete: 0,
-        pubkey: Pubkey::default(),
-        data_len: data_len as u64,
-    };
-    (stored_meta, account)
+    (Pubkey::default(), account)
 }


### PR DESCRIPTION
#### Problem
create_test_account/get_account_test return StoredMeta rather than pubkey, but none of the callers require StoredMeta.
StoredMeta shouldn't be public (even for dev_utils), and this gets the code closer to that.

#### Summary of Changes
- Return pubkey instead from create_test_account, get_account_test
- modify append_account_test to accept pubkey rather than StoredMeta
- Other changes to use pubkey directly rather than accessing it from StoredMeta

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
