### PR TITLE
test_bank_forks_new_rw_arc_memory_leak should test hard fork count, rather than looping until OOM

### DIFF
--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -729,10 +729,9 @@ mod tests {
 
     #[test]
     fn test_bank_forks_new_rw_arc_memory_leak() {
-        for _ in 0..1000 {
-            let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-            BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
-        }
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        assert_eq!(Arc::strong_count(&bank_forks), 1);
     }
 
     #[test]

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -727,6 +727,22 @@ mod tests {
         solana_vote_program::vote_state::BlockTimestamp,
     };
 
+    // This test verifies that BankForks::new_rw_arc() doesn't create a reference cycle.
+    //
+    // Before PR #1893, there was a cycle:
+    //   Arc<RwLock<BankForks>> → Bank → ProgramCache → Arc<RwLock<BankForks>>
+    //
+    // This happened because new_rw_arc() called:
+    //   root_bank.set_fork_graph_in_program_cache(bank_forks.clone())
+    //
+    // The fix changed it to use a Weak reference:
+    //   root_bank.set_fork_graph_in_program_cache(Arc::downgrade(&bank_forks))
+    //
+    // Breaking the cycle:
+    //   Arc<RwLock<BankForks>> → Bank → ProgramCache → Weak<RwLock<BankForks>>
+    //
+    // Without the fix: strong_count == 2 (the clone creates an extra strong ref)
+    // With the fix: strong_count == 1 (only the returned Arc holds a strong ref)
     #[test]
     fn test_bank_forks_new_rw_arc_memory_leak() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);


### PR DESCRIPTION
#### Problem
test_bank_forks_new_rw_arc_memory_leak is attempting to loop until OOM by creating bank_forks. This is indeterminate based on system settings. Tested the original commit (prior to the test introduction) and did not OOM on my system. 

#### Summary of Changes
- Change test to count the hard forks of the data structure. This test failed on the original commit (IE It reproduced the issue this test is trying to catch). 
- Test now runs in 100ms instead of 112s and is more effective at catching the intended issue

Note: this test + one other cause the runtime tests to take 120s instead of 11s, impeding local development

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
