### PR TITLE
Remove no longer required test

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -86,7 +86,6 @@ use {
         bpf_loader, bpf_loader_upgradeable, ed25519_program, incinerator, native_loader,
         secp256k1_program,
     },
-    solana_sha256_hasher::hash,
     solana_signature::Signature,
     solana_signer::Signer,
     solana_stake_interface::{
@@ -202,41 +201,6 @@ pub(in crate::bank) fn create_genesis_config(lamports: u64) -> (GenesisConfig, K
 pub(in crate::bank) fn new_sanitized_message(message: Message) -> SanitizedMessage {
     SanitizedMessage::try_from_legacy_message(message, &ReservedAccountKeys::empty_key_set())
         .unwrap()
-}
-
-#[test]
-fn test_race_register_tick_freeze() {
-    solana_logger::setup();
-
-    let (mut genesis_config, _) = create_genesis_config(50);
-    genesis_config.ticks_per_slot = 1;
-    let p = solana_pubkey::new_rand();
-    let hash = hash(p.as_ref());
-
-    for _ in 0..1000 {
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
-        let bank0_ = bank0.clone();
-        let freeze_thread = Builder::new()
-            .name("freeze".to_string())
-            .spawn(move || loop {
-                if bank0_.is_complete() {
-                    assert_eq!(bank0_.last_blockhash(), hash);
-                    break;
-                }
-            })
-            .unwrap();
-
-        let bank0_ = bank0.clone();
-        let register_tick_thread = Builder::new()
-            .name("register_tick".to_string())
-            .spawn(move || {
-                bank0_.register_tick_for_test(&hash);
-            })
-            .unwrap();
-
-        register_tick_thread.join().unwrap();
-        freeze_thread.join().unwrap();
-    }
 }
 
 fn new_executed_processing_result(


### PR DESCRIPTION
#### Problem
- Test is of little value, and takes 120s to run, making running local tests time consuming.
- Test was introduced 6 years ago to ensure tick race condition does not occur: https://github.com/solana-labs/solana/pull/6799
- ~5 years ago, similar bug occurs, code is refactored: https://github.com/solana-labs/solana/pull/14101



#### Summary of Changes
- Removed the test
- With this test removed and https://github.com/anza-xyz/agave/pull/8585, all tests in runtime can run in 12s, greatly enhancing local dev experience. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
