### PR TITLE
clippy: allow large enum variant for vote enums to conform with rust 1.90

### DIFF
--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -644,6 +644,7 @@ pub enum VoteStateTargetVersion {
     // New vote state versions will be added here...
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq)]
 enum TargetVoteState {
     V3(VoteStateV3),

--- a/vote/src/vote_state_view/frame_v4.rs
+++ b/vote/src/vote_state_view/frame_v4.rs
@@ -131,6 +131,7 @@ mod tests {
         std::collections::VecDeque,
     };
 
+    #[allow(clippy::large_enum_variant)]
     #[derive(Debug, Clone, Deserialize, Serialize)]
     enum TestVoteStateVersions {
         V0_23_5,


### PR DESCRIPTION
#### Problem
error: large size difference between variants

(as part of https://github.com/anza-xyz/agave/issues/8117 we should fix all the warnings)

#### Summary of Changes
add clippy allow for specific enums