### PR TITLE
clippy: allow mut_from_ref for translate_*_mut to conform with rust 1.90

### DIFF
--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -575,6 +575,7 @@ fn translate_string_and_do(
 }
 
 // Do not use this directly
+#[allow(clippy::mut_from_ref)]
 fn translate_type_mut<'a, T>(
     memory_mapping: &'a MemoryMapping,
     vm_addr: u64,
@@ -583,6 +584,7 @@ fn translate_type_mut<'a, T>(
     translate_type_inner!(memory_mapping, AccessType::Store, vm_addr, T, check_aligned)
 }
 // Do not use this directly
+#[allow(clippy::mut_from_ref)]
 fn translate_slice_mut<'a, T>(
     memory_mapping: &'a MemoryMapping,
     vm_addr: u64,


### PR DESCRIPTION
#### Problem
The functions seem to be inherently unsafe by design, however newer clippy flags it with warnings.

(as part of https://github.com/anza-xyz/agave/issues/8117 we should fix all the warnings)

#### Summary of Changes
Disable warning per function.
