### PR TITLE
clippy: remove / allow dead code to conform with rust 1.90

### DIFF
--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -94,26 +94,6 @@ fn serialize_stake_accounts_to_stake_format<S: Serializer>(
     SerdeStakeAccountsToStakeFormat::from(stakes.clone()).serialize(serializer)
 }
 
-impl From<Stakes<Stake>> for SerdeStakesToDelegationFormat {
-    fn from(stakes: Stakes<Stake>) -> Self {
-        let Stakes {
-            vote_accounts,
-            stake_delegations,
-            unused,
-            epoch,
-            stake_history,
-        } = stakes;
-
-        Self {
-            vote_accounts,
-            stake_delegations: SerdeStakeMapToDelegationFormat(stake_delegations),
-            unused,
-            epoch,
-            stake_history,
-        }
-    }
-}
-
 impl From<Stakes<StakeAccount>> for SerdeStakeAccountsToDelegationFormat {
     fn from(stakes: Stakes<StakeAccount>) -> Self {
         let Stakes {
@@ -156,16 +136,6 @@ impl From<Stakes<StakeAccount>> for SerdeStakeAccountsToStakeFormat {
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Serialize)]
-struct SerdeStakesToDelegationFormat {
-    vote_accounts: VoteAccounts,
-    stake_delegations: SerdeStakeMapToDelegationFormat,
-    unused: u64,
-    epoch: Epoch,
-    stake_history: StakeHistory,
-}
-
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize)]
 struct SerdeStakeAccountsToDelegationFormat {
     vote_accounts: VoteAccounts,
     stake_delegations: SerdeStakeAccountMapToDelegationFormat,
@@ -182,21 +152,6 @@ struct SerdeStakeAccountsToStakeFormat {
     unused: u64,
     epoch: Epoch,
     stake_history: StakeHistory,
-}
-
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-struct SerdeStakeMapToDelegationFormat(ImHashMap<Pubkey, Stake>);
-impl Serialize for SerdeStakeMapToDelegationFormat {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut s = serializer.serialize_map(Some(self.0.len()))?;
-        for (pubkey, stake) in self.0.iter() {
-            s.serialize_entry(pubkey, &stake.delegation)?;
-        }
-        s.end()
-    }
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -13,6 +13,7 @@ pub(super) trait ListFrame {
     // ensure that after casting it won't have alignment issues, any heap
     // allocated fields, or any assumptions about endianness.
     #[cfg(test)]
+    #[allow(dead_code)]
     const ASSERT_ITEM_ALIGNMENT: ();
 
     fn len(&self) -> usize;

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -12,20 +12,6 @@ use {
     thiserror::Error,
 };
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(PartialEq, Eq, Debug, Default, Clone, Copy, Serialize, Deserialize)]
-pub(crate) enum BlockhashStatus {
-    /// No vote since restart
-    #[default]
-    Uninitialized,
-    /// Non voting validator
-    NonVoting,
-    /// Hot spare validator
-    HotSpare,
-    /// Successfully generated vote tx with blockhash
-    Blockhash(Slot, Hash),
-}
-
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub enum VoteHistoryVersions {
     Current(VoteHistory),


### PR DESCRIPTION
#### Problem
There are unused structs that newer clippy complains about.
A trait const is also flagged with warning.

(as part of https://github.com/anza-xyz/agave/issues/8117 we should fix all the warnings)

#### Summary of Changes
* Remove structs.
* allow dead code for trait const