### PR TITLE
Move creation of tar Archive for reading as private code in hardened_unpack

### DIFF
--- a/snapshots/src/unarchive.rs
+++ b/snapshots/src/unarchive.rs
@@ -10,7 +10,6 @@ use {
         path::{Path, PathBuf},
         thread::{self, JoinHandle},
     },
-    tar::Archive,
 };
 
 // Allows scheduling a large number of reads such that temporary disk access delays
@@ -35,7 +34,7 @@ pub fn streaming_unarchive_snapshot(
             let decompressor =
                 decompressed_tar_reader(archive_format, snapshot_archive_path, read_buf_size)?;
             hardened_unpack::streaming_unpack_snapshot(
-                Archive::new(decompressor),
+                decompressor,
                 read_write_budget_size,
                 ledger_dir.as_path(),
                 &account_paths,


### PR DESCRIPTION
#### Problem
`hardened_unpack` API requires caller to create `tar::Archive` and provide that as input. This is unnecessarily exposing implementation detail on how tar is unpacked, while `io::Read` with tar contents would be sufficient.

#### Summary of Changes
Make public function in `hardened_unpack` receive `impl io::Read` as input of the archive contents (caller might then decide how that data is constructed, e.g. selecting decompressor or read implementation).