### PR TITLE
Updates static assertions for CLUSTER_NODES_CACHES_NUM_EPOCH_CAP

### DIFF
--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -32,7 +32,6 @@ use {
         socket::SocketAddrSpace,
     },
     solana_time_utils::{timestamp, AtomicInterval},
-    static_assertions::const_assert_eq,
     std::{
         collections::{HashMap, HashSet},
         net::{SocketAddr, UdpSocket},
@@ -54,7 +53,14 @@ pub(crate) mod broadcast_utils;
 mod fail_entry_verification_broadcast_run;
 pub(crate) mod standard_broadcast_run;
 
-const_assert_eq!(CLUSTER_NODES_CACHE_NUM_EPOCH_CAP, 5);
+const _: () = const {
+    // From https://github.com/anza-xyz/agave/pull/1735#discussion_r1644899183:
+    // 1. There must be at least two epochs because near an epoch boundary you might receive
+    //    shreds from the other side of the epoch boundary.
+    // 2. It does not make sense to have capacity more than the number of epoch-stakes in Bank.
+    assert!(CLUSTER_NODES_CACHE_NUM_EPOCH_CAP >= 2);
+    assert!(CLUSTER_NODES_CACHE_NUM_EPOCH_CAP <= MAX_LEADER_SCHEDULE_STAKES as usize);
+};
 const CLUSTER_NODES_CACHE_NUM_EPOCH_CAP: usize = MAX_LEADER_SCHEDULE_STAKES as usize;
 const CLUSTER_NODES_CACHE_TTL: Duration = Duration::from_secs(5);
 

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -35,7 +35,6 @@ use {
         socket::SocketAddrSpace,
     },
     solana_time_utils::timestamp,
-    static_assertions::const_assert_eq,
     std::{
         borrow::Cow,
         collections::{HashMap, HashSet},
@@ -58,7 +57,14 @@ const DEDUPER_RESET_CYCLE: Duration = Duration::from_secs(5 * 60);
 // Minimum number of shreds to use rayon parallel iterators.
 const PAR_ITER_MIN_NUM_SHREDS: usize = 2;
 
-const_assert_eq!(CLUSTER_NODES_CACHE_NUM_EPOCH_CAP, 5);
+const _: () = const {
+    // From https://github.com/anza-xyz/agave/pull/1735#discussion_r1644899183:
+    // 1. There must be at least two epochs because near an epoch boundary you might receive
+    //    shreds from the other side of the epoch boundary.
+    // 2. It does not make sense to have capacity more than the number of epoch-stakes in Bank.
+    assert!(CLUSTER_NODES_CACHE_NUM_EPOCH_CAP >= 2);
+    assert!(CLUSTER_NODES_CACHE_NUM_EPOCH_CAP <= MAX_LEADER_SCHEDULE_STAKES as usize);
+};
 const CLUSTER_NODES_CACHE_NUM_EPOCH_CAP: usize = MAX_LEADER_SCHEDULE_STAKES as usize;
 const CLUSTER_NODES_CACHE_TTL: Duration = Duration::from_secs(5);
 


### PR DESCRIPTION
#### Problem

We'd like to reduce the number of epochs in `MAX_LEADER_SCHEDULE_STAKES`, but this constant is required to be a specific value by `CLUSTER_NODES_CACHES_NUM_EPOCH_CAP` in retransmit/broadcast.

(Why do we want to reduce the number of epochs in `MAX_LEADER_SCHEDULE_STAKES`? Good question! This is because the epoch stakes cache is serialized into the snapshot, and is by far the largest component—both in size and time. We don't need all the epochs either.

Note that `MAX_LEADER_SCHEDULE_STAKES = 5` was arbitrarily chosen. Here's its origin: https://github.com/solana-labs/solana/pull/7668#discussion_r363019651.

Also note that we used to actually store 6 epochs in the cache. That was changed to 5 in https://github.com/anza-xyz/agave/pull/8584.)


#### Summary of Changes

Update the static assertions for `CLUSTER_NODES_CACHES_NUM_EPOCH_CAP` to not require a specific value for `MAX_LEADER_SCHEDULE_STAKES`. Instead, assert the range in which it is valid.