### PR TITLE
tpu-client-next: consolidate worker error logging

### DIFF
--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -7,7 +7,7 @@ use {
     super::leader_updater::LeaderUpdater,
     crate::{
         connection_worker::DEFAULT_MAX_CONNECTION_HANDSHAKE_TIMEOUT,
-        logging::{debug, warn},
+        logging::debug,
         quic_networking::{
             create_client_config, create_client_endpoint, QuicClientCertificate, QuicError,
         },
@@ -338,23 +338,13 @@ impl WorkersBroadcaster for NonblockingBroadcaster {
         for new_leader in leaders {
             let send_res =
                 workers.try_send_transactions_to_address(new_leader, transaction_batch.clone());
-            match send_res {
-                Ok(()) => (),
-                Err(WorkersCacheError::WorkerNotFound) => {
-                    warn!("No existing worker for {new_leader:?}, skip sending to this leader.");
-                }
-                Err(WorkersCacheError::ShutdownError) => {
-                    debug!("Connection to {new_leader} was closed, worker cache shutdown");
-                }
-                Err(WorkersCacheError::ReceiverDropped) => {
-                    // Remove the worker from the cache, if the peer has disconnected.
+            if let Err(err) = send_res {
+                debug!("Failed to send transactions to {new_leader:?}, worker send error: {err}.");
+                if err == WorkersCacheError::ReceiverDropped {
+                    // Remove the worker from the cache if the peer has disconnected.
                     if let Some(pop_worker) = workers.pop(*new_leader) {
                         shutdown_worker(pop_worker)
                     }
-                }
-                Err(err) => {
-                    warn!("Connection to {new_leader} was closed, worker error: {err}");
-                    // If we have failed to send batch, it will be dropped.
                 }
             }
         }


### PR DESCRIPTION
#### Problem

In the default broadcaster used in tpu-client-next non-critical errors reported with too high log level and the error message is off.
When client broadcasts transaction batch to the next `Fanout::send` leaders, some leader's workers might not be able to accept new transactions to send. This is not critical, because this default broadcaster only tries to send transaction batch, without giving a guarantees that transaction batch will be delivered to any of them. If this default behaviour is not what user needs, he/she should implement a custom broadcaster. To address the question why some `ConnectionWorker` might have full channel: the inflow of transactions is too high and the worker is not able to handle them or problems with connections (trying to reestablish and not pulling the channel).

See discussion on [discord](https://discord.com/channels/428295358100013066/689412830075551748/1430141234881757194)

#### Summary of Changes



