### PR TITLE
Replay: remove double call to keypair read lock

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1104,10 +1104,12 @@ impl ReplayStage {
                                 ),
                             );
 
-                            if my_pubkey != cluster_info.id() {
-                                identity_keypair = cluster_info.keypair();
-                                let my_old_pubkey = my_pubkey;
-                                my_pubkey = identity_keypair.pubkey();
+                            let cluster_keypair = cluster_info.keypair();
+                            let cluster_pubkey = cluster_keypair.pubkey();
+                            if my_pubkey != cluster_pubkey {
+                                identity_keypair = cluster_keypair;
+                                let my_old_pubkey =
+                                    std::mem::replace(&mut my_pubkey, cluster_pubkey);
 
                                 // Load the new identity's tower
                                 tower = match Self::load_tower(

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2823,7 +2823,6 @@ fn test_oc_bad_signatures() {
     let client = cluster
         .build_validator_tpu_quic_client(cluster.entry_point_info.pubkey())
         .unwrap();
-    let cluster_funding_keypair = cluster.funding_keypair.insecure_clone();
     let voter_thread_sleep_ms: usize = 100;
     let num_votes_simulated = Arc::new(AtomicUsize::new(0));
     let gossip_voter = cluster_tests::start_gossip_voter(
@@ -2866,7 +2865,7 @@ fn test_oc_bad_signatures() {
                 );
                 LocalCluster::send_transaction_with_retries(
                     &client,
-                    &[&cluster_funding_keypair, &bad_authorized_signer_keypair],
+                    &[&node_keypair, &bad_authorized_signer_keypair],
                     &mut vote_tx,
                     5,
                 )


### PR DESCRIPTION
#### Problem
We grab the read lock on keypair and then immediately release it and grab it again if we are swapping identities.

#### Summary of Changes
Remove the double read lock. Just read once