### PR TITLE
Remove excess read lock calls on keypair

### DIFF
--- a/core/src/mock_alpenglow_consensus.rs
+++ b/core/src/mock_alpenglow_consensus.rs
@@ -477,7 +477,8 @@ impl MockAlpenglowConsensus {
         command: Receiver<SendCommand>,
     ) {
         let mut packet_buf = vec![0u8; MOCK_VOTE_PACKET_SIZE];
-        let id = cluster_info.id();
+        let self_keypair = cluster_info.keypair();
+        let id = self_keypair.pubkey();
         for command in command.iter() {
             let (slot, votor_msg) = match command {
                 SendCommand::Notarize(slot) => (slot, VotorMessageType::Notarize),
@@ -493,7 +494,7 @@ impl MockAlpenglowConsensus {
                 &mut packet_buf,
                 slot,
                 votor_msg,
-                cluster_info.keypair().as_ref(),
+                &self_keypair,
             );
 
             // prepare addresses to send the packets

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -654,7 +654,8 @@ impl ClusterInfo {
     // TODO: If two threads call into this function then epoch_slot_index has a
     // race condition and the threads will overwrite each other in crds table.
     pub fn push_epoch_slots(&self, mut update: &[Slot]) {
-        let self_pubkey = self.id();
+        let self_keypair = self.keypair();
+        let self_pubkey = self_keypair.pubkey();
         let current_slots: Vec<_> = {
             let gossip_crds =
                 self.time_gossip_read_lock("lookup_epoch_slots", &self.stats.epoch_slots_lookup);
@@ -692,7 +693,6 @@ impl ClusterInfo {
             None => 0,
         };
         let mut entries = Vec::default();
-        let keypair = self.keypair();
         while !update.is_empty() {
             let ix = epoch_slot_index % crds_data::MAX_EPOCH_SLOTS;
             let now = timestamp();
@@ -705,7 +705,7 @@ impl ClusterInfo {
             update = &update[n..];
             if n > 0 {
                 let epoch_slots = CrdsData::EpochSlots(ix, slots);
-                let entry = CrdsValue::new(epoch_slots, &keypair);
+                let entry = CrdsValue::new(epoch_slots, &self_keypair);
                 entries.push(entry);
             }
             epoch_slot_index += 1;
@@ -726,8 +726,9 @@ impl ClusterInfo {
         last_vote_bankhash: Hash,
     ) -> Result<(), RestartLastVotedForkSlotsError> {
         let now = timestamp();
+        let self_keypair = self.keypair();
         let last_voted_fork_slots = RestartLastVotedForkSlots::new(
-            self.id(),
+            self_keypair.pubkey(),
             now,
             fork,
             last_vote_bankhash,
@@ -735,7 +736,7 @@ impl ClusterInfo {
         )?;
         self.push_message(CrdsValue::new(
             CrdsData::RestartLastVotedForkSlots(last_voted_fork_slots),
-            &self.keypair(),
+            &self_keypair,
         ));
         Ok(())
     }
@@ -746,8 +747,9 @@ impl ClusterInfo {
         last_slot_hash: Hash,
         observed_stake: u64,
     ) {
+        let self_keypair = self.keypair();
         let restart_heaviest_fork = RestartHeaviestFork {
-            from: self.id(),
+            from: self_keypair.pubkey(),
             wallclock: timestamp(),
             last_slot,
             last_slot_hash,
@@ -756,7 +758,7 @@ impl ClusterInfo {
         };
         self.push_message(CrdsValue::new(
             CrdsData::RestartHeaviestFork(restart_heaviest_fork),
-            &self.keypair(),
+            &self_keypair,
         ));
     }
 
@@ -784,24 +786,25 @@ impl ClusterInfo {
             return Err(ClusterInfoError::TooManyIncrementalSnapshotHashes);
         }
 
+        let self_keypair = self.keypair();
         let message = CrdsData::SnapshotHashes(SnapshotHashes {
-            from: self.id(),
+            from: self_keypair.pubkey(),
             full,
             incremental,
             wallclock: timestamp(),
         });
-        self.push_message(CrdsValue::new(message, &self.keypair()));
+        self.push_message(CrdsValue::new(message, &self_keypair));
 
         Ok(())
     }
 
     pub fn push_vote_at_index(&self, vote: Transaction, vote_index: u8) {
         assert!(vote_index < MAX_VOTES);
-        let self_pubkey = self.id();
+        let self_keypair = self.keypair();
         let now = timestamp();
-        let vote = Vote::new(self_pubkey, vote, now).unwrap();
+        let vote = Vote::new(self_keypair.pubkey(), vote, now).unwrap();
         let vote = CrdsData::Vote(vote_index, vote);
-        let vote = CrdsValue::new(vote, &self.keypair());
+        let vote = CrdsValue::new(vote, &self_keypair);
         let mut gossip_crds = self.gossip.crds.write().unwrap();
         if let Err(err) = gossip_crds.insert(vote, now, GossipRoute::LocalMessage) {
             error!("push_vote failed: {err:?}");
@@ -1906,7 +1909,8 @@ impl ClusterInfo {
         stakes: &HashMap<Pubkey, u64>,
     ) -> Vec<(SocketAddr, Protocol /*::PruneMessage*/)> {
         let _st = ScopedTimer::from(&self.stats.generate_prune_messages);
-        let self_pubkey = self.id();
+        let self_keypair = self.keypair();
+        let self_pubkey = self_keypair.pubkey();
         // Obtain redundant gossip links which can be pruned.
         let prunes: HashMap</*gossip peer:*/ Pubkey, /*origins:*/ Vec<Pubkey>> = {
             let _st = ScopedTimer::from(&self.stats.prune_received_cache);
@@ -1938,7 +1942,6 @@ impl ClusterInfo {
         // Create and sign Protocol::PruneMessages.
         thread_pool.install(|| {
             let wallclock = timestamp();
-            let keypair = self.keypair();
             prunes
                 .into_par_iter()
                 .flat_map(|(destination, addr, prunes)| {
@@ -1954,7 +1957,7 @@ impl ClusterInfo {
                         destination,
                         wallclock,
                     };
-                    prune_data.sign(&keypair);
+                    prune_data.sign(&self_keypair);
                     let prune_message = Protocol::PruneMessage(self_pubkey, prune_data);
                     (addr, prune_message)
                 })
@@ -1973,7 +1976,8 @@ impl ClusterInfo {
         should_check_duplicate_instance: bool,
     ) -> Result<(), GossipError> {
         let _st = ScopedTimer::from(&self.stats.process_gossip_packets_time);
-        let self_pubkey = self.id();
+        let self_keypair = self.keypair();
+        let self_pubkey = self_keypair.pubkey();
         // Filter out values if the shred-versions are different.
         let self_shred_version = self.my_shred_version();
         {
@@ -2009,11 +2013,10 @@ impl ClusterInfo {
         };
         let mut pings = Vec::new();
         let mut rng = rand::thread_rng();
-        let keypair = self.keypair();
         let mut verify_gossip_addr = |value: &CrdsValue| {
             if verify_gossip_addr(
                 &mut rng,
-                &keypair,
+                &self_keypair,
                 value,
                 &self.socket_addr_space,
                 &self.ping_cache,

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -302,7 +302,7 @@ pub fn new_cluster_nodes<T: 'static>(
     stakes: &HashMap<Pubkey, u64>,
 ) -> ClusterNodes<T> {
     let self_pubkey = cluster_info.id();
-    let nodes = get_nodes(cluster_info, cluster_type, stakes);
+    let nodes = get_nodes(cluster_info, cluster_type, stakes, &self_pubkey);
     let index: HashMap<_, _> = nodes
         .iter()
         .enumerate()
@@ -329,15 +329,15 @@ fn get_nodes(
     cluster_info: &ClusterInfo,
     cluster_type: ClusterType,
     stakes: &HashMap<Pubkey, u64>,
+    self_pubkey: &Pubkey,
 ) -> Vec<Node> {
-    let self_pubkey = cluster_info.id();
     let should_dedup_tvu_addrs = match cluster_type {
         ClusterType::Development => false,
         ClusterType::Devnet | ClusterType::Testnet | ClusterType::MainnetBeta => true,
     };
     let mut nodes: Vec<Node> = std::iter::once({
         // The local node itself.
-        let stake = stakes.get(&self_pubkey).copied().unwrap_or_default();
+        let stake = stakes.get(self_pubkey).copied().unwrap_or_default();
         let node = ContactInfo::from(&cluster_info.my_contact_info());
         let node = NodeId::from(node);
         Node { node, stake }


### PR DESCRIPTION
#### Problem
We have even MORE places where we acquire the readlock on keypair multiple times back to back. This is unnecessary overhead.

#### Summary of Changes
Remove double read lock calls.
