### PR TITLE
Move path related functions to agave-snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "log",
  "lz4",
  "rand 0.8.5",
+ "regex",
  "semver 1.0.27",
  "solana-accounts-db",
  "solana-clock",

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,6 +1,9 @@
 mod snapshot_gossip_manager;
 use {
-    agave_snapshots::{snapshot_config::SnapshotConfig, snapshot_hash::StartingSnapshotHashes},
+    agave_snapshots::{
+        paths as snapshot_paths, snapshot_config::SnapshotConfig,
+        snapshot_hash::StartingSnapshotHashes,
+    },
     snapshot_gossip_manager::SnapshotGossipManager,
     solana_accounts_db::accounts_db::AccountStorageEntry,
     solana_clock::Slot,
@@ -188,7 +191,7 @@ impl SnapshotPackagerService {
         }
         info!("Flushing account storages... Done in {:?}", start.elapsed());
 
-        let bank_snapshot_dir = snapshot_utils::get_bank_snapshot_dir(
+        let bank_snapshot_dir = snapshot_paths::get_bank_snapshot_dir(
             &snapshot_config.bank_snapshots_dir,
             state.snapshot_slot,
         );

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::snapshot_utils::create_tmp_accounts_dir_for_tests,
-    agave_snapshots::{snapshot_config::SnapshotConfig, SnapshotInterval},
+    agave_snapshots::{paths as snapshot_paths, snapshot_config::SnapshotConfig, SnapshotInterval},
     crossbeam_channel::unbounded,
     itertools::Itertools,
     log::{info, trace},
@@ -118,7 +118,7 @@ fn restore_from_snapshot(
     let old_bank_forks = old_bank_forks.read().unwrap();
     let old_last_bank = old_bank_forks.get(old_last_slot).unwrap();
 
-    let full_snapshot_archive_path = snapshot_utils::build_full_snapshot_archive_path(
+    let full_snapshot_archive_path = snapshot_paths::build_full_snapshot_archive_path(
         &snapshot_config.full_snapshot_archives_dir,
         old_last_bank.slot(),
         &old_last_bank.get_snapshot_hash(),

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "log",
  "lz4",
  "rand 0.8.5",
+ "regex",
  "semver",
  "solana-accounts-db",
  "solana-clock",

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -9,7 +9,9 @@
 )]
 pub use solana_file_download::DownloadProgressRecord;
 use {
-    agave_snapshots::{snapshot_hash::SnapshotHash, ArchiveFormat, ZstdConfig},
+    agave_snapshots::{
+        paths as snapshot_paths, snapshot_hash::SnapshotHash, ArchiveFormat, ZstdConfig,
+    },
     log::*,
     solana_clock::Slot,
     solana_file_download::{download_file, DownloadProgressCallbackOption},
@@ -67,7 +69,7 @@ pub fn download_snapshot_archive(
     );
 
     let snapshot_archives_remote_dir =
-        snapshot_utils::build_snapshot_archives_remote_dir(match snapshot_kind {
+        snapshot_paths::build_snapshot_archives_remote_dir(match snapshot_kind {
             SnapshotKind::FullSnapshot => full_snapshot_archives_dir,
             SnapshotKind::IncrementalSnapshot(_) => incremental_snapshot_archives_dir,
         });
@@ -80,14 +82,14 @@ pub fn download_snapshot_archive(
         ArchiveFormat::TarLz4,
     ] {
         let destination_path = match snapshot_kind {
-            SnapshotKind::FullSnapshot => snapshot_utils::build_full_snapshot_archive_path(
+            SnapshotKind::FullSnapshot => snapshot_paths::build_full_snapshot_archive_path(
                 &snapshot_archives_remote_dir,
                 desired_snapshot_hash.0,
                 &desired_snapshot_hash.1,
                 archive_format,
             ),
             SnapshotKind::IncrementalSnapshot(base_slot) => {
-                snapshot_utils::build_incremental_snapshot_archive_path(
+                snapshot_paths::build_incremental_snapshot_archive_path(
                     &snapshot_archives_remote_dir,
                     base_slot,
                     desired_snapshot_hash.0,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -1,6 +1,7 @@
 use {
     crate::LEDGER_TOOL_DIRECTORY,
     agave_snapshots::{
+        paths::BANK_SNAPSHOTS_DIR,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_hash::StartingSnapshotHashes,
     },
@@ -37,7 +38,7 @@ use {
         bank_forks::BankForks,
         prioritization_fee_cache::PrioritizationFeeCache,
         snapshot_controller::SnapshotController,
-        snapshot_utils::{self, clean_orphaned_account_snapshot_dirs, BANK_SNAPSHOTS_DIR},
+        snapshot_utils::{self, clean_orphaned_account_snapshot_dirs},
     },
     solana_transaction::versioned::VersionedTransaction,
     solana_unified_scheduler_pool::DefaultSchedulerPool,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -5,7 +5,7 @@ use {
         integration_tests::DEFAULT_NODE_STAKE,
         validator_configs::*,
     },
-    agave_snapshots::snapshot_config::SnapshotConfig,
+    agave_snapshots::{paths::BANK_SNAPSHOTS_DIR, snapshot_config::SnapshotConfig},
     itertools::izip,
     log::*,
     solana_account::{Account, AccountSharedData, ReadableAccount},
@@ -35,12 +35,9 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_rpc_client::rpc_client::RpcClient,
-    solana_runtime::{
-        genesis_utils::{
-            create_genesis_config_with_vote_accounts_and_cluster_type, GenesisConfigInfo,
-            ValidatorVoteKeypairs,
-        },
-        snapshot_utils::BANK_SNAPSHOTS_DIR,
+    solana_runtime::genesis_utils::{
+        create_genesis_config_with_vote_accounts_and_cluster_type, GenesisConfigInfo,
+        ValidatorVoteKeypairs,
     },
     solana_signer::{signers::Signers, Signer},
     solana_stake_interface::{

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
-    agave_snapshots::{snapshot_config::SnapshotConfig, SnapshotInterval},
+    agave_snapshots::{paths as snapshot_paths, snapshot_config::SnapshotConfig, SnapshotInterval},
     assert_matches::assert_matches,
     crossbeam_channel::{unbounded, Receiver},
     gag::BufferRedirect,
@@ -69,11 +69,8 @@ use {
         response::RpcSignatureResult,
     },
     solana_runtime::{
-        commitment::VOTE_THRESHOLD_SIZE,
-        snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_bank_utils,
-        snapshot_package::SnapshotKind,
-        snapshot_utils::{self, BANK_SNAPSHOTS_DIR},
+        commitment::VOTE_THRESHOLD_SIZE, snapshot_archive_info::SnapshotArchiveInfoGetter,
+        snapshot_bank_utils, snapshot_package::SnapshotKind, snapshot_utils,
     },
     solana_signer::Signer,
     solana_stake_interface::{self as stake, state::NEW_WARMUP_COOLDOWN_RATE},
@@ -937,8 +934,8 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 
     let copy_files_with_remote = |from: &Path, to: &Path| {
         copy_files(from, to);
-        let remote_from = snapshot_utils::build_snapshot_archives_remote_dir(from);
-        let remote_to = snapshot_utils::build_snapshot_archives_remote_dir(to);
+        let remote_from = snapshot_paths::build_snapshot_archives_remote_dir(from);
+        let remote_to = snapshot_paths::build_snapshot_archives_remote_dir(to);
         let _ = fs::create_dir_all(&remote_from);
         let _ = fs::create_dir_all(&remote_to);
         copy_files(&remote_from, &remote_to);
@@ -946,7 +943,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 
     let delete_files_with_remote = |from: &Path| {
         delete_files(from);
-        let remote_dir = snapshot_utils::build_snapshot_archives_remote_dir(from);
+        let remote_dir = snapshot_paths::build_snapshot_archives_remote_dir(from);
         let _ = fs::create_dir_all(&remote_dir);
         delete_files(&remote_dir);
     };
@@ -1278,7 +1275,7 @@ fn test_snapshot_restart_tower() {
     );
 
     // Copy archive to validator's snapshot output directory
-    let validator_archive_path = snapshot_utils::build_full_snapshot_archive_path(
+    let validator_archive_path = snapshot_paths::build_full_snapshot_archive_path(
         validator_snapshot_test_config
             .full_snapshot_archives_dir
             .keep(),
@@ -1348,7 +1345,7 @@ fn test_snapshots_blockstore_floor() {
     };
 
     // Copy archive to validator's snapshot output directory
-    let validator_archive_path = snapshot_utils::build_full_snapshot_archive_path(
+    let validator_archive_path = snapshot_paths::build_full_snapshot_archive_path(
         validator_snapshot_test_config
             .full_snapshot_archives_dir
             .keep(),
@@ -2320,7 +2317,7 @@ fn test_run_test_load_program_accounts_root() {
 fn create_simple_snapshot_config(ledger_path: &Path) -> SnapshotConfig {
     SnapshotConfig {
         full_snapshot_archives_dir: ledger_path.to_path_buf(),
-        bank_snapshots_dir: ledger_path.join(BANK_SNAPSHOTS_DIR),
+        bank_snapshots_dir: ledger_path.join(snapshot_paths::BANK_SNAPSHOTS_DIR),
         ..SnapshotConfig::default()
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "log",
  "lz4",
  "rand 0.8.5",
+ "regex",
  "semver",
  "solana-accounts-db",
  "solana-clock",

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -9,7 +9,7 @@ use {
         rpc_cache::LargestAccountsCache,
         rpc_health::*,
     },
-    agave_snapshots::{snapshot_config::SnapshotConfig, SnapshotInterval},
+    agave_snapshots::{paths as snapshot_paths, snapshot_config::SnapshotConfig, SnapshotInterval},
     crossbeam_channel::unbounded,
     jsonrpc_core::{futures::prelude::*, MetaIoHandler},
     jsonrpc_http_server::{
@@ -141,11 +141,11 @@ impl RpcRequestMiddleware {
         Self {
             ledger_path,
             full_snapshot_archive_path_regex: Regex::new(
-                snapshot_utils::FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX,
+                snapshot_paths::FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX,
             )
             .unwrap(),
             incremental_snapshot_archive_path_regex: Regex::new(
-                snapshot_utils::INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX,
+                snapshot_paths::INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX,
             )
             .unwrap(),
             snapshot_config,
@@ -239,7 +239,7 @@ impl RpcRequestMiddleware {
             local_path
         } else {
             // remote snapshot archive path
-            snapshot_utils::build_snapshot_archives_remote_dir(root).join(stem)
+            snapshot_paths::build_snapshot_archives_remote_dir(root).join(stem)
         };
         (
             path,

--- a/runtime/src/snapshot_archive_info.rs
+++ b/runtime/src/snapshot_archive_info.rs
@@ -1,8 +1,9 @@
 //! Information about snapshot archives
 
 use {
-    crate::snapshot_utils,
-    agave_snapshots::{snapshot_hash::SnapshotHash, ArchiveFormat, Result},
+    agave_snapshots::{
+        paths as snapshot_paths, snapshot_hash::SnapshotHash, ArchiveFormat, Result,
+    },
     solana_clock::Slot,
     std::{cmp::Ordering, path::PathBuf},
 };
@@ -31,7 +32,7 @@ pub trait SnapshotArchiveInfoGetter {
         self.snapshot_archive_info()
             .path
             .parent()
-            .is_some_and(|p| p.ends_with(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR))
+            .is_some_and(|p| p.ends_with(snapshot_paths::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR))
     }
 }
 
@@ -58,9 +59,9 @@ pub struct FullSnapshotArchiveInfo(SnapshotArchiveInfo);
 impl FullSnapshotArchiveInfo {
     /// Parse the path to a full snapshot archive and return a new `FullSnapshotArchiveInfo`
     pub fn new_from_path(path: PathBuf) -> Result<Self> {
-        let filename = snapshot_utils::path_to_file_name_str(path.as_path())?;
+        let filename = snapshot_paths::path_to_file_name_str(path.as_path())?;
         let (slot, hash, archive_format) =
-            snapshot_utils::parse_full_snapshot_archive_filename(filename)?;
+            snapshot_paths::parse_full_snapshot_archive_filename(filename)?;
 
         Ok(Self::new(SnapshotArchiveInfo {
             path,
@@ -109,9 +110,9 @@ pub struct IncrementalSnapshotArchiveInfo {
 impl IncrementalSnapshotArchiveInfo {
     /// Parse the path to an incremental snapshot archive and return a new `IncrementalSnapshotArchiveInfo`
     pub fn new_from_path(path: PathBuf) -> Result<Self> {
-        let filename = snapshot_utils::path_to_file_name_str(path.as_path())?;
+        let filename = snapshot_paths::path_to_file_name_str(path.as_path())?;
         let (base_slot, slot, hash, archive_format) =
-            snapshot_utils::parse_incremental_snapshot_archive_filename(filename)?;
+            snapshot_paths::parse_incremental_snapshot_archive_filename(filename)?;
 
         Ok(Self::new(
             base_slot,

--- a/snapshots/Cargo.toml
+++ b/snapshots/Cargo.toml
@@ -27,6 +27,7 @@ crossbeam-channel = { workspace = true }
 log = { workspace = true }
 lz4 = { workspace = true }
 rand = { workspace = true }
+regex = { workspace = true }
 semver = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-clock = { workspace = true }

--- a/snapshots/src/lib.rs
+++ b/snapshots/src/lib.rs
@@ -11,6 +11,7 @@
 mod archive_format;
 pub mod error;
 pub mod hardened_unpack;
+pub mod paths;
 pub mod snapshot_config;
 pub mod snapshot_hash;
 mod snapshot_interval;

--- a/snapshots/src/paths.rs
+++ b/snapshots/src/paths.rs
@@ -1,0 +1,299 @@
+use {
+    crate::{error::SnapshotError, snapshot_hash::SnapshotHash, ArchiveFormat, Result},
+    regex::Regex,
+    solana_clock::Slot,
+    solana_hash::Hash,
+    std::{
+        path::{Path, PathBuf},
+        sync::LazyLock,
+    },
+};
+
+pub const SNAPSHOT_STATUS_CACHE_FILENAME: &str = "status_cache";
+pub const SNAPSHOT_VERSION_FILENAME: &str = "version";
+pub const SNAPSHOT_FASTBOOT_VERSION_FILENAME: &str = "fastboot_version";
+/// No longer checked in version v3.1. Can be removed in v3.2
+pub const SNAPSHOT_STATE_COMPLETE_FILENAME: &str = "state_complete";
+pub const SNAPSHOT_STORAGES_FLUSHED_FILENAME: &str = "storages_flushed";
+pub const SNAPSHOT_ACCOUNTS_HARDLINKS: &str = "accounts_hardlinks";
+pub const SNAPSHOT_ARCHIVE_DOWNLOAD_DIR: &str = "remote";
+pub const SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME: &str = "obsolete_accounts";
+/// No longer checked in version v3.1. Can be removed in v3.2
+pub const SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME: &str = "full_snapshot_slot";
+/// When a snapshot is taken of a bank, the state is serialized under this directory.
+/// Specifically in `BANK_SNAPSHOTS_DIR/SLOT/`.
+/// This is also where the bank state is located in the snapshot archive.
+pub const BANK_SNAPSHOTS_DIR: &str = "snapshots";
+pub const TMP_SNAPSHOT_ARCHIVE_PREFIX: &str = "tmp-snapshot-archive-";
+pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str =
+    r"^snapshot-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar\.zst|tar\.lz4)$";
+pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^incremental-snapshot-(?P<base>[[:digit:]]+)-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar\.zst|tar\.lz4)$";
+
+/// Get the `&str` from a `&Path`
+pub fn path_to_file_name_str(path: &Path) -> Result<&str> {
+    path.file_name()
+        .ok_or_else(|| SnapshotError::PathToFileNameError(path.to_path_buf()))?
+        .to_str()
+        .ok_or_else(|| SnapshotError::FileNameToStrError(path.to_path_buf()))
+}
+
+pub fn build_snapshot_archives_remote_dir(snapshot_archives_dir: impl AsRef<Path>) -> PathBuf {
+    snapshot_archives_dir
+        .as_ref()
+        .join(SNAPSHOT_ARCHIVE_DOWNLOAD_DIR)
+}
+
+/// Build the full snapshot archive path from its components: the snapshot archives directory, the
+/// snapshot slot, the accounts hash, and the archive format.
+pub fn build_full_snapshot_archive_path(
+    full_snapshot_archives_dir: impl AsRef<Path>,
+    slot: Slot,
+    hash: &SnapshotHash,
+    archive_format: ArchiveFormat,
+) -> PathBuf {
+    full_snapshot_archives_dir.as_ref().join(format!(
+        "snapshot-{}-{}.{}",
+        slot,
+        hash.0,
+        archive_format.extension(),
+    ))
+}
+
+/// Build the incremental snapshot archive path from its components: the snapshot archives
+/// directory, the snapshot base slot, the snapshot slot, the accounts hash, and the archive
+/// format.
+pub fn build_incremental_snapshot_archive_path(
+    incremental_snapshot_archives_dir: impl AsRef<Path>,
+    base_slot: Slot,
+    slot: Slot,
+    hash: &SnapshotHash,
+    archive_format: ArchiveFormat,
+) -> PathBuf {
+    incremental_snapshot_archives_dir.as_ref().join(format!(
+        "incremental-snapshot-{}-{}-{}.{}",
+        base_slot,
+        slot,
+        hash.0,
+        archive_format.extension(),
+    ))
+}
+
+/// Parse a full snapshot archive filename into its Slot, Hash, and Archive Format
+pub fn parse_full_snapshot_archive_filename(
+    archive_filename: &str,
+) -> Result<(Slot, SnapshotHash, ArchiveFormat)> {
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX).unwrap());
+
+    let do_parse = || {
+        RE.captures(archive_filename).and_then(|captures| {
+            let slot = captures
+                .name("slot")
+                .map(|x| x.as_str().parse::<Slot>())?
+                .ok()?;
+            let hash = captures
+                .name("hash")
+                .map(|x| x.as_str().parse::<Hash>())?
+                .ok()?;
+            let archive_format = captures
+                .name("ext")
+                .map(|x| x.as_str().parse::<ArchiveFormat>())?
+                .ok()?;
+
+            Some((slot, SnapshotHash(hash), archive_format))
+        })
+    };
+
+    do_parse().ok_or_else(|| {
+        SnapshotError::ParseSnapshotArchiveFileNameError(archive_filename.to_string())
+    })
+}
+
+/// Parse an incremental snapshot archive filename into its base Slot, actual Slot, Hash, and Archive Format
+pub fn parse_incremental_snapshot_archive_filename(
+    archive_filename: &str,
+) -> Result<(Slot, Slot, SnapshotHash, ArchiveFormat)> {
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX).unwrap());
+
+    let do_parse = || {
+        RE.captures(archive_filename).and_then(|captures| {
+            let base_slot = captures
+                .name("base")
+                .map(|x| x.as_str().parse::<Slot>())?
+                .ok()?;
+            let slot = captures
+                .name("slot")
+                .map(|x| x.as_str().parse::<Slot>())?
+                .ok()?;
+            let hash = captures
+                .name("hash")
+                .map(|x| x.as_str().parse::<Hash>())?
+                .ok()?;
+            let archive_format = captures
+                .name("ext")
+                .map(|x| x.as_str().parse::<ArchiveFormat>())?
+                .ok()?;
+
+            Some((base_slot, slot, SnapshotHash(hash), archive_format))
+        })
+    };
+
+    do_parse().ok_or_else(|| {
+        SnapshotError::ParseSnapshotArchiveFileNameError(archive_filename.to_string())
+    })
+}
+
+/// Returns the file name of the bank snapshot for `slot`
+pub fn get_snapshot_file_name(slot: Slot) -> String {
+    slot.to_string()
+}
+
+/// Constructs the path to the bank snapshot directory for `slot` within `bank_snapshots_dir`
+pub fn get_bank_snapshot_dir(bank_snapshots_dir: impl AsRef<Path>, slot: Slot) -> PathBuf {
+    bank_snapshots_dir
+        .as_ref()
+        .join(get_snapshot_file_name(slot))
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::ZstdConfig};
+
+    #[test]
+    fn test_parse_full_snapshot_archive_filename() {
+        assert_eq!(
+            parse_full_snapshot_archive_filename(&format!(
+                "snapshot-43-{}.tar.zst",
+                Hash::default()
+            ))
+            .unwrap(),
+            (
+                43,
+                SnapshotHash(Hash::default()),
+                ArchiveFormat::TarZstd {
+                    config: ZstdConfig::default(),
+                }
+            )
+        );
+        assert_eq!(
+            parse_full_snapshot_archive_filename(&format!(
+                "snapshot-45-{}.tar.lz4",
+                Hash::default()
+            ))
+            .unwrap(),
+            (45, SnapshotHash(Hash::default()), ArchiveFormat::TarLz4)
+        );
+
+        assert!(parse_full_snapshot_archive_filename("invalid").is_err());
+        assert!(
+            parse_full_snapshot_archive_filename("snapshot-bad!slot-bad!hash.bad!ext").is_err()
+        );
+
+        assert!(
+            parse_full_snapshot_archive_filename("snapshot-12345678-bad!hash.bad!ext").is_err()
+        );
+        assert!(parse_full_snapshot_archive_filename(&format!(
+            "snapshot-12345678-{}.bad!ext",
+            Hash::new_unique()
+        ))
+        .is_err());
+        assert!(
+            parse_full_snapshot_archive_filename("snapshot-12345678-bad!hash.tar.zst").is_err()
+        );
+
+        assert!(parse_full_snapshot_archive_filename(&format!(
+            "snapshot-bad!slot-{}.bad!ext",
+            Hash::new_unique()
+        ))
+        .is_err());
+        assert!(parse_full_snapshot_archive_filename(&format!(
+            "snapshot-12345678-{}.bad!ext",
+            Hash::new_unique()
+        ))
+        .is_err());
+        assert!(parse_full_snapshot_archive_filename(&format!(
+            "snapshot-bad!slot-{}.tar.zst",
+            Hash::new_unique()
+        ))
+        .is_err());
+
+        assert!(
+            parse_full_snapshot_archive_filename("snapshot-bad!slot-bad!hash.tar.zst").is_err()
+        );
+        assert!(
+            parse_full_snapshot_archive_filename("snapshot-12345678-bad!hash.tar.zst").is_err()
+        );
+        assert!(parse_full_snapshot_archive_filename(&format!(
+            "snapshot-bad!slot-{}.tar.zst",
+            Hash::new_unique()
+        ))
+        .is_err());
+    }
+
+    #[test]
+    fn test_parse_incremental_snapshot_archive_filename() {
+        assert_eq!(
+            parse_incremental_snapshot_archive_filename(&format!(
+                "incremental-snapshot-43-234-{}.tar.zst",
+                Hash::default()
+            ))
+            .unwrap(),
+            (
+                43,
+                234,
+                SnapshotHash(Hash::default()),
+                ArchiveFormat::TarZstd {
+                    config: ZstdConfig::default(),
+                }
+            )
+        );
+        assert_eq!(
+            parse_incremental_snapshot_archive_filename(&format!(
+                "incremental-snapshot-45-456-{}.tar.lz4",
+                Hash::default()
+            ))
+            .unwrap(),
+            (
+                45,
+                456,
+                SnapshotHash(Hash::default()),
+                ArchiveFormat::TarLz4
+            )
+        );
+
+        assert!(parse_incremental_snapshot_archive_filename("invalid").is_err());
+        assert!(parse_incremental_snapshot_archive_filename(&format!(
+            "snapshot-42-{}.tar.zst",
+            Hash::new_unique()
+        ))
+        .is_err());
+        assert!(parse_incremental_snapshot_archive_filename(
+            "incremental-snapshot-bad!slot-bad!slot-bad!hash.bad!ext"
+        )
+        .is_err());
+
+        assert!(parse_incremental_snapshot_archive_filename(&format!(
+            "incremental-snapshot-bad!slot-56785678-{}.tar.zst",
+            Hash::new_unique()
+        ))
+        .is_err());
+
+        assert!(parse_incremental_snapshot_archive_filename(&format!(
+            "incremental-snapshot-12345678-bad!slot-{}.tar.zst",
+            Hash::new_unique()
+        ))
+        .is_err());
+
+        assert!(parse_incremental_snapshot_archive_filename(
+            "incremental-snapshot-12341234-56785678-bad!HASH.tar.zst"
+        )
+        .is_err());
+
+        assert!(parse_incremental_snapshot_archive_filename(&format!(
+            "incremental-snapshot-12341234-56785678-{}.bad!ext",
+            Hash::new_unique()
+        ))
+        .is_err());
+    }
+}

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1,7 +1,9 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
     agave_feature_set::{alpenglow, raise_cpi_nesting_limit_to_8, FeatureSet, FEATURE_NAMES},
-    agave_snapshots::{snapshot_config::SnapshotConfig, SnapshotInterval},
+    agave_snapshots::{
+        paths::BANK_SNAPSHOTS_DIR, snapshot_config::SnapshotConfig, SnapshotInterval,
+    },
     base64::{prelude::BASE64_STANDARD, Engine},
     crossbeam_channel::Receiver,
     log::*,
@@ -50,7 +52,6 @@ use {
         bank_forks::BankForks,
         genesis_utils::{self, create_genesis_config_with_leader_ex_no_features},
         runtime_config::RuntimeConfig,
-        snapshot_utils::BANK_SNAPSHOTS_DIR,
     },
     solana_sdk_ids::address_lookup_table,
     solana_signer::Signer,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -8,6 +8,7 @@ use {
     },
     agave_logger::redirect_stderr_to_file,
     agave_snapshots::{
+        paths::BANK_SNAPSHOTS_DIR,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         ArchiveFormat, SnapshotInterval, SnapshotVersion,
     },
@@ -57,10 +58,7 @@ use {
     solana_perf::recycler::enable_recycler_warming,
     solana_poh::poh_service,
     solana_pubkey::Pubkey,
-    solana_runtime::{
-        runtime_config::RuntimeConfig,
-        snapshot_utils::{self, BANK_SNAPSHOTS_DIR},
-    },
+    solana_runtime::{runtime_config::RuntimeConfig, snapshot_utils},
     solana_signer::Signer,
     solana_streamer::quic::{QuicServerParams, DEFAULT_TPU_COALESCE},
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -1410,6 +1410,7 @@ mod tests {
     use {
         crate::wen_restart::{tests::wen_restart_proto::LastVotedForkSlotsAggregateFinal, *},
         agave_snapshots::{
+            paths::build_incremental_snapshot_archive_path,
             snapshot_config::{SnapshotConfig, SnapshotUsage},
             snapshot_hash::SnapshotHash,
         },
@@ -1439,7 +1440,6 @@ mod tests {
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
             },
             snapshot_bank_utils::bank_to_full_snapshot_archive,
-            snapshot_utils::build_incremental_snapshot_archive_path,
         },
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,


### PR DESCRIPTION
#### Problem
Obtaining and parsing paths for snapshot related files is a shared functionality for lots of snapshot related code and modules. It should be moved to agave-snapshots.

#### Summary of Changes
* introduce `paths` module in `agave-snapshots`
* move path related functions from `snapshot_utils` to `agave_snapshots::paths`