### PR TITLE
Reduces MAX_LEADER_SCHEDULE_STAKES to 3

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -212,7 +212,7 @@ pub(crate) mod tests;
 
 pub const SECONDS_PER_YEAR: f64 = 365.25 * 24.0 * 60.0 * 60.0;
 
-pub const MAX_LEADER_SCHEDULE_STAKES: Epoch = 5;
+pub const MAX_LEADER_SCHEDULE_STAKES: Epoch = 3;
 
 pub type BankStatusCache = StatusCache<Result<()>>;
 #[cfg_attr(


### PR DESCRIPTION
#### Problem

Snapshotting a bank is slow, and the serialized file is large.

The `Bank::epoch_stakes` field is constrained by the `MAX_LEADER_SCHEDULE_STAKES` constant for the number of epochs to store.

We currently store 5 epochs (and 6 epochs until https://github.com/anza-xyz/agave/pull/8584), but this number was arbitrarily chosen[^1].

The epoch stakes is serialized into the bank snapshot, so its size directly impacts the time to snapshot a bank, and also the size of the resulting serialized file.

The serialized bank file on mnb is around 1 GB today, and much of that is epoch stakes. We don't need 5 epochs-worth.

[^1]: Here's its origin: https://github.com/solana-labs/solana/pull/7668#discussion_r363019651.


#### Summary of Changes

Change the number of epochs to 3.

Why 3?

Minimally the retransmit and broadcast code needs to support receiving shreds on either side of an epoch. And that code sets its cap to be the same as `MAX_LEADER_SCHEDULE_STAKES`. It needs >= 2 epochs. We could change the retransmit/broadcast constants to hardcode 2, but I'm trying to make a smaller change here.

So then why not 2?

Mainly just to cover any unknown unknowns. With 3, then we'd have the stakes for calculating the leader schedule of the next epoch, the current epoch, and the previous epoch. Maybe we don't need the previous epoch? I think we can revisit that in a future PR.


#### Results

The serialized bank snapshot file decreased on my dev box from over 1 GB to 600 MB:

<img width="919" height="362" alt="Screenshot 2025-10-22 at 10 19 53 AM" src="https://github.com/user-attachments/assets/84f11967-5d4a-445c-9fe1-8c1865c1f4f9" />


Bank serialization time decreased on my dev box from ~3 seconds to ~1.8 seconds:

<img width="922" height="357" alt="Screenshot 2025-10-22 at 9 33 27 AM" src="https://github.com/user-attachments/assets/4fa37ba1-4496-4f80-a3ff-c2688b3b3ce5" />


And some knock-on effects, such as purging old bank snapshot files, also got faster:

<img width="921" height="356" alt="Screenshot 2025-10-22 at 9 33 49 AM" src="https://github.com/user-attachments/assets/a27d3753-6407-4e4a-9d44-fa13cd292e25" />
