### PR TITLE
votor update

### DIFF
--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -101,7 +101,6 @@ pub(crate) const DELTA_BLOCK: Duration = Duration::from_millis(400);
 /// Base timeout for when leader's first slice should arrive if they sent it immediately.
 pub(crate) const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
 
-#[cfg(test)]
 /// Timeout for standstill detection mechanism.
 pub(crate) const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);
 

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -52,7 +52,7 @@ pub(crate) struct ConsensusPoolContext {
     pub(crate) event_sender: VotorEventSender,
     pub(crate) commitment_sender: Sender<CommitmentAggregationData>,
 
-    delta_standstill: Duration,
+    pub(crate) delta_standstill: Duration,
 }
 
 pub(crate) struct ConsensusPoolService {

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -16,14 +16,11 @@ pub mod commitment;
 pub mod common;
 mod consensus_metrics;
 pub mod consensus_pool;
-#[allow(dead_code)]
 mod consensus_pool_service;
 pub mod event;
-#[allow(dead_code)]
 mod event_handler;
 pub mod root_utils;
 mod staked_validators_cache;
-#[allow(dead_code)]
 mod timer_manager;
 pub mod vote_history;
 pub mod vote_history_storage;

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -44,13 +44,17 @@
 use {
     crate::{
         commitment::CommitmentAggregationData,
-        consensus_pool_service::ConsensusPoolService,
+        common::DELTA_STANDSTILL,
+        consensus_metrics::ConsensusMetrics,
+        consensus_pool_service::{ConsensusPoolContext, ConsensusPoolService},
         event::{LeaderWindowInfo, VotorEventReceiver, VotorEventSender},
-        event_handler::EventHandler,
+        event_handler::{EventHandler, EventHandlerContext},
+        root_utils::RootContext,
         timer_manager::TimerManager,
         vote_history::VoteHistory,
         vote_history_storage::VoteHistoryStorage,
         voting_service::BLSOp,
+        voting_utils::VotingContext,
     },
     agave_votor_messages::consensus_message::ConsensusMessage,
     crossbeam_channel::{Receiver, Sender},
@@ -70,10 +74,12 @@ use {
         snapshot_controller::SnapshotController,
     },
     std::{
+        collections::HashMap,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc, Condvar, Mutex, RwLock,
         },
+        thread,
         time::Duration,
     },
 };
@@ -140,6 +146,124 @@ pub struct Votor {
 }
 
 impl Votor {
+    pub fn new(config: VotorConfig) -> Self {
+        let VotorConfig {
+            exit,
+            vote_account,
+            wait_to_vote_slot,
+            wait_for_vote_to_start_leader,
+            vote_history,
+            vote_history_storage,
+            authorized_voter_keypairs,
+            blockstore,
+            bank_forks,
+            cluster_info,
+            leader_schedule_cache,
+            rpc_subscriptions,
+            snapshot_controller,
+            bls_sender,
+            commitment_sender,
+            drop_bank_sender,
+            bank_notification_sender,
+            leader_window_notifier,
+            event_sender,
+            event_receiver,
+            own_vote_sender,
+            consensus_message_receiver: bls_receiver,
+        } = config;
+
+        let start = Arc::new((Mutex::new(false), Condvar::new()));
+
+        let identity_keypair = cluster_info.keypair().clone();
+        let has_new_vote_been_rooted = !wait_for_vote_to_start_leader;
+
+        // Get the sharable root bank
+        let sharable_banks = bank_forks.read().unwrap().sharable_banks();
+
+        let shared_context = SharedContext {
+            blockstore: blockstore.clone(),
+            bank_forks: bank_forks.clone(),
+            cluster_info: cluster_info.clone(),
+            rpc_subscriptions,
+            leader_window_notifier,
+            vote_history_storage,
+        };
+
+        let consensus_metrics = Arc::new(PlRwLock::new(ConsensusMetrics::new(
+            sharable_banks.root().epoch(),
+        )));
+        let voting_context = VotingContext {
+            vote_history,
+            vote_account_pubkey: vote_account,
+            identity_keypair: identity_keypair.clone(),
+            authorized_voter_keypairs,
+            derived_bls_keypairs: HashMap::new(),
+            has_new_vote_been_rooted,
+            own_vote_sender,
+            bls_sender: bls_sender.clone(),
+            commitment_sender: commitment_sender.clone(),
+            wait_to_vote_slot,
+            sharable_banks: sharable_banks.clone(),
+            consensus_metrics: consensus_metrics.clone(),
+        };
+
+        let root_context = RootContext {
+            leader_schedule_cache: leader_schedule_cache.clone(),
+            snapshot_controller,
+            bank_notification_sender,
+            drop_bank_sender,
+        };
+
+        let timer_manager = Arc::new(PlRwLock::new(TimerManager::new(
+            event_sender.clone(),
+            exit.clone(),
+            consensus_metrics,
+        )));
+
+        let event_handler_context = EventHandlerContext {
+            exit: exit.clone(),
+            start: start.clone(),
+            event_receiver,
+            timer_manager: Arc::clone(&timer_manager),
+            shared_context,
+            voting_context,
+            root_context,
+        };
+
+        let consensus_pool_context = ConsensusPoolContext {
+            exit: exit.clone(),
+            start: start.clone(),
+            cluster_info: cluster_info.clone(),
+            my_vote_pubkey: vote_account,
+            blockstore,
+            sharable_banks,
+            leader_schedule_cache,
+            consensus_message_receiver: bls_receiver,
+            bls_sender,
+            event_sender,
+            commitment_sender,
+            delta_standstill: DELTA_STANDSTILL,
+        };
+
+        let event_handler = EventHandler::new(event_handler_context);
+        let consensus_pool_service = ConsensusPoolService::new(consensus_pool_context);
+
+        Self {
+            start,
+            event_handler,
+            consensus_pool_service,
+            timer_manager,
+        }
+    }
+
+    pub fn start_migration(&self) {
+        // TODO: evaluate once we have actual migration logic
+        let (lock, cvar) = &*self.start;
+        let mut started = lock.lock().unwrap();
+        *started = true;
+        cvar.notify_all();
+    }
+
     pub(crate) fn wait_for_migration_or_exit(
         exit: &AtomicBool,
         (lock, cvar): &(Mutex<bool>, Condvar),
@@ -154,5 +278,25 @@ impl Votor {
             // isn't delayed a lot.
             (started, _) = cvar.wait_timeout(started, Duration::from_secs(1)).unwrap();
         }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.consensus_pool_service.join()?;
+
+        // Loop till we manage to unwrap the Arc and then we can join.
+        let mut timer_manager = self.timer_manager;
+        loop {
+            match Arc::try_unwrap(timer_manager) {
+                Ok(manager) => {
+                    manager.into_inner().join();
+                    break;
+                }
+                Err(m) => {
+                    timer_manager = m;
+                    thread::sleep(Duration::from_millis(1));
+                }
+            }
+        }
+        self.event_handler.join()
     }
 }

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -169,7 +169,7 @@ impl Votor {
             event_sender,
             event_receiver,
             own_vote_sender,
-            consensus_message_receiver: bls_receiver,
+            consensus_message_receiver,
         } = config;
 
         let start = Arc::new((Mutex::new(false), Condvar::new()));
@@ -238,7 +238,7 @@ impl Votor {
             blockstore,
             sharable_banks,
             leader_schedule_cache,
-            consensus_message_receiver: bls_receiver,
+            consensus_message_receiver,
             bls_sender,
             event_sender,
             commitment_sender,


### PR DESCRIPTION
#### Problem
Need to upstream major votor crate changes: `consensus_pool_service`, `event_handler`, `votor`

These changes are large and extremely hard to review in one shot, so attempt to break up the PRs to make them digestible. This PR focuses on adding `votor`. Future PRs will build out metrics

See https://github.com/anza-xyz/agave/pull/8237 for a larger lens into the overall changes that are planned to come in.

#### Summary of Changes

- build out `Votor impl` (not actually active yet)
- undead some things now that we in theory create those services (except we don't because `Votor` isn't actually created)
- expose `delta_standstill`