### PR TITLE
Move solana-logger back to agave as agave-logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
 name = "agave-cargo-registry"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "clap 2.33.3",
  "flate2",
  "hex",
@@ -92,7 +93,6 @@ dependencies = [
  "solana-cli-output",
  "solana-commitment-config",
  "solana-keypair",
- "solana-logger",
  "solana-pubkey",
  "solana-remote-wallet",
  "solana-rpc-client",
@@ -151,6 +151,7 @@ dependencies = [
 name = "agave-install"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "atty",
  "bincode",
  "bzip2",
@@ -172,7 +173,6 @@ dependencies = [
  "solana-config-interface",
  "solana-hash",
  "solana-keypair",
- "solana-logger",
  "solana-message",
  "solana-pubkey",
  "solana-rpc-client",
@@ -200,10 +200,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-logger"
+version = "3.1.0"
+dependencies = [
+ "env_logger",
+ "libc",
+ "log",
+ "signal-hook",
+]
+
+[[package]]
 name = "agave-precompiles"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "agave-precompiles",
  "bincode",
  "bytemuck",
@@ -217,7 +228,6 @@ dependencies = [
  "solana-ed25519-program",
  "solana-instruction",
  "solana-keccak-hasher",
- "solana-logger",
  "solana-message",
  "solana-precompile-error",
  "solana-pubkey",
@@ -264,6 +274,7 @@ name = "agave-snapshots"
 version = "3.1.0"
 dependencies = [
  "agave-fs",
+ "agave-logger",
  "assert_matches",
  "bzip2",
  "crossbeam-channel",
@@ -275,7 +286,6 @@ dependencies = [
  "solana-genesis-config",
  "solana-hash",
  "solana-lattice-hash",
- "solana-logger",
  "strum",
  "tar",
  "tempfile",
@@ -393,6 +403,7 @@ name = "agave-validator"
 version = "3.1.0"
 dependencies = [
  "agave-geyser-plugin-interface",
+ "agave-logger",
  "agave-snapshots",
  "assert_cmd",
  "chrono",
@@ -441,7 +452,6 @@ dependencies = [
  "solana-inflation",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-metrics",
  "solana-native-token",
  "solana-net-utils",
@@ -495,6 +505,7 @@ dependencies = [
 name = "agave-votor"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "agave-votor-messages",
  "anyhow",
  "bincode",
@@ -528,7 +539,6 @@ dependencies = [
  "solana-hash",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
@@ -556,19 +566,20 @@ dependencies = [
 name = "agave-votor-messages"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "serde",
  "solana-bls-signatures",
  "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-hash",
- "solana-logger",
 ]
 
 [[package]]
 name = "agave-watchtower"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "clap 2.33.3",
  "humantime",
  "log",
@@ -576,7 +587,6 @@ dependencies = [
  "solana-cli-config",
  "solana-cli-output",
  "solana-hash",
- "solana-logger",
  "solana-metrics",
  "solana-native-token",
  "solana-notifier",
@@ -6909,6 +6919,7 @@ dependencies = [
 name = "solana-accounts-cluster-bench"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "clap 2.33.3",
  "log",
  "rand 0.8.5",
@@ -6927,7 +6938,6 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-local-cluster",
- "solana-logger",
  "solana-measure",
  "solana-message",
  "solana-native-token",
@@ -6956,6 +6966,7 @@ name = "solana-accounts-db"
 version = "3.1.0"
 dependencies = [
  "agave-fs",
+ "agave-logger",
  "agave-reserved-account-keys",
  "ahash 0.8.11",
  "assert_matches",
@@ -7000,7 +7011,6 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-lattice-hash",
- "solana-logger",
  "solana-measure",
  "solana-message",
  "solana-metrics",
@@ -7179,6 +7189,7 @@ dependencies = [
 name = "solana-bench-vote"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "bincode",
  "clap 2.33.3",
  "crossbeam-channel",
@@ -7187,7 +7198,6 @@ dependencies = [
  "solana-connection-cache",
  "solana-hash",
  "solana-keypair",
- "solana-logger",
  "solana-message",
  "solana-net-utils",
  "solana-pubkey",
@@ -7368,6 +7378,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "bv",
  "bytemuck",
  "bytemuck_derive",
@@ -7379,7 +7390,6 @@ dependencies = [
  "rayon",
  "solana-bucket-map",
  "solana-clock",
- "solana-logger",
  "solana-measure",
  "solana-pubkey",
  "tempfile",
@@ -7429,6 +7439,7 @@ dependencies = [
 name = "solana-cargo-build-sbf"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "assert_cmd",
  "bzip2",
  "cargo_metadata",
@@ -7443,7 +7454,6 @@ dependencies = [
  "serial_test",
  "solana-file-download",
  "solana-keypair",
- "solana-logger",
  "tar",
 ]
 
@@ -7451,12 +7461,12 @@ dependencies = [
 name = "solana-cargo-test-sbf"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "cargo_metadata",
  "clap 3.2.23",
  "itertools 0.12.1",
  "log",
  "regex",
- "solana-logger",
 ]
 
 [[package]]
@@ -7527,6 +7537,7 @@ name = "solana-cli"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "agave-syscalls",
  "assert_matches",
  "bincode",
@@ -7571,7 +7582,6 @@ dependencies = [
  "solana-loader-v3-interface",
  "solana-loader-v4-interface",
  "solana-loader-v4-program",
- "solana-logger",
  "solana-message",
  "solana-native-token",
  "solana-nonce",
@@ -7724,6 +7734,7 @@ dependencies = [
 name = "solana-client-test"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "futures-util",
  "serde_json",
  "solana-client",
@@ -7731,7 +7742,6 @@ dependencies = [
  "solana-commitment-config",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-measure",
  "solana-merkle-tree",
  "solana-message",
@@ -7906,6 +7916,7 @@ dependencies = [
 name = "solana-connection-cache"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "async-trait",
  "bincode",
  "crossbeam-channel",
@@ -7917,7 +7928,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "solana-keypair",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
@@ -7933,6 +7943,7 @@ version = "3.1.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
+ "agave-logger",
  "agave-reserved-account-keys",
  "agave-scheduler-bindings",
  "agave-scheduling-utils",
@@ -8015,7 +8026,6 @@ dependencies = [
  "solana-keypair",
  "solana-ledger",
  "solana-loader-v3-interface",
- "solana-logger",
  "solana-measure",
  "solana-message",
  "solana-metrics",
@@ -8092,6 +8102,7 @@ name = "solana-cost-model"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "agave-reserved-account-keys",
  "ahash 0.8.11",
  "itertools 0.12.1",
@@ -8112,7 +8123,6 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
- "solana-logger",
  "solana-message",
  "solana-metrics",
  "solana-packet",
@@ -8240,6 +8250,7 @@ dependencies = [
 name = "solana-entry"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "agave-reserved-account-keys",
  "assert_matches",
  "bincode",
@@ -8255,7 +8266,6 @@ dependencies = [
  "solana-entry",
  "solana-hash",
  "solana-keypair",
- "solana-logger",
  "solana-measure",
  "solana-merkle-tree",
  "solana-message",
@@ -8359,6 +8369,7 @@ dependencies = [
 name = "solana-faucet"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "bincode",
  "clap 2.33.3",
  "crossbeam-channel",
@@ -8371,7 +8382,6 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
- "solana-logger",
  "solana-message",
  "solana-metrics",
  "solana-net-utils",
@@ -8489,6 +8499,7 @@ name = "solana-genesis"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "agave-snapshots",
  "base64 0.22.1",
  "bincode",
@@ -8514,7 +8525,6 @@ dependencies = [
  "solana-keypair",
  "solana-ledger",
  "solana-loader-v3-interface",
- "solana-logger",
  "solana-native-token",
  "solana-poh-config",
  "solana-pubkey",
@@ -8608,6 +8618,7 @@ name = "solana-gossip"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "anyhow",
  "arrayvec",
  "assert_matches",
@@ -8648,7 +8659,6 @@ dependencies = [
  "solana-hash",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-native-token",
@@ -8858,6 +8868,7 @@ name = "solana-ledger"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "agave-reserved-account-keys",
  "agave-snapshots",
  "anyhow",
@@ -8910,7 +8921,6 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-measure",
  "solana-message",
  "solana-metrics",
@@ -9036,6 +9046,7 @@ dependencies = [
 name = "solana-local-cluster"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "agave-snapshots",
  "assert_matches",
  "crossbeam-channel",
@@ -9064,7 +9075,6 @@ dependencies = [
  "solana-keypair",
  "solana-ledger",
  "solana-local-cluster",
- "solana-logger",
  "solana-message",
  "solana-native-token",
  "solana-net-utils",
@@ -9186,6 +9196,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 name = "solana-net-utils"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "anyhow",
  "bincode",
  "bytes",
@@ -9200,7 +9211,6 @@ dependencies = [
  "serde",
  "shuttle",
  "socket2 0.6.1",
- "solana-logger",
  "solana-net-utils",
  "solana-serde",
  "solana-svm-type-overrides",
@@ -9286,6 +9296,7 @@ dependencies = [
 name = "solana-perf"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "ahash 0.8.11",
  "assert_matches",
  "bencher",
@@ -9308,7 +9319,6 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-hash",
  "solana-keypair",
- "solana-logger",
  "solana-message",
  "solana-metrics",
  "solana-packet",
@@ -9334,6 +9344,7 @@ dependencies = [
 name = "solana-poh"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "arc-swap",
  "assert_matches",
  "bincode",
@@ -9349,7 +9360,6 @@ dependencies = [
  "solana-hash",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-perf",
@@ -9370,12 +9380,12 @@ dependencies = [
 name = "solana-poh-bench"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "clap 3.2.23",
  "log",
  "num_cpus",
  "rayon",
  "solana-entry",
- "solana-logger",
  "solana-measure",
  "solana-perf",
  "solana-sha256-hasher",
@@ -9587,6 +9597,7 @@ name = "solana-program-test"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "assert_matches",
  "async-trait",
  "base64 0.22.1",
@@ -9614,7 +9625,6 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-loader-v3-interface",
- "solana-logger",
  "solana-message",
  "solana-msg",
  "solana-native-token",
@@ -9690,6 +9700,7 @@ dependencies = [
 name = "solana-quic-client"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "async-lock",
  "async-trait",
  "crossbeam-channel",
@@ -9701,7 +9712,6 @@ dependencies = [
  "rustls 0.23.34",
  "solana-connection-cache",
  "solana-keypair",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
@@ -10022,6 +10032,7 @@ dependencies = [
 name = "solana-rpc-test"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "bincode",
  "bs58",
  "crossbeam-channel",
@@ -10037,7 +10048,6 @@ dependencies = [
  "solana-connection-cache",
  "solana-hash",
  "solana-keypair",
- "solana-logger",
  "solana-net-utils",
  "solana-pubkey",
  "solana-pubsub-client",
@@ -10062,6 +10072,7 @@ version = "3.1.0"
 dependencies = [
  "agave-feature-set",
  "agave-fs",
+ "agave-logger",
  "agave-precompiles",
  "agave-reserved-account-keys",
  "agave-snapshots",
@@ -10146,7 +10157,6 @@ dependencies = [
  "solana-lattice-hash",
  "solana-loader-v3-interface",
  "solana-loader-v4-interface",
- "solana-logger",
  "solana-measure",
  "solana-message",
  "solana-metrics",
@@ -10350,6 +10360,7 @@ dependencies = [
 name = "solana-send-transaction-service"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "async-trait",
  "crossbeam-channel",
  "itertools 0.12.1",
@@ -10362,7 +10373,6 @@ dependencies = [
  "solana-genesis-config",
  "solana-hash",
  "solana-keypair",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
@@ -10666,6 +10676,7 @@ dependencies = [
 name = "solana-streamer"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "anyhow",
  "arc-swap",
  "assert_matches",
@@ -10692,7 +10703,6 @@ dependencies = [
  "smallvec",
  "socket2 0.6.1",
  "solana-keypair",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
@@ -10717,6 +10727,7 @@ dependencies = [
 name = "solana-svm"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "agave-syscalls",
  "ahash 0.8.11",
  "assert_matches",
@@ -10749,7 +10760,6 @@ dependencies = [
  "solana-loader-v3-interface",
  "solana-loader-v4-interface",
  "solana-loader-v4-program",
- "solana-logger",
  "solana-message",
  "solana-native-token",
  "solana-nonce",
@@ -10819,6 +10829,7 @@ name = "solana-svm-test-harness"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "agave-precompiles",
  "agave-syscalls",
  "bincode",
@@ -10835,7 +10846,6 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-last-restart-slot",
- "solana-logger",
  "solana-precompile-error",
  "solana-program-runtime",
  "solana-pubkey",
@@ -11024,7 +11034,6 @@ dependencies = [
  "solana-keypair",
  "solana-ledger",
  "solana-loader-v3-interface",
- "solana-logger",
  "solana-message",
  "solana-native-token",
  "solana-net-utils",
@@ -11066,6 +11075,7 @@ dependencies = [
 name = "solana-tokens"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "assert_matches",
  "bincode",
  "chrono",
@@ -11086,7 +11096,6 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
- "solana-logger",
  "solana-message",
  "solana-native-token",
  "solana-program-error",
@@ -11257,6 +11266,7 @@ dependencies = [
 name = "solana-transaction-dos"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "bincode",
  "clap 2.33.3",
  "log",
@@ -11273,7 +11283,6 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-local-cluster",
- "solana-logger",
  "solana-measure",
  "solana-message",
  "solana-net-utils",
@@ -11395,6 +11404,7 @@ name = "solana-turbine"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "agave-votor",
  "agave-xdp",
  "assert_matches",
@@ -11422,7 +11432,6 @@ dependencies = [
  "solana-hash",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-native-token",
@@ -11487,6 +11496,7 @@ name = "solana-unified-scheduler-pool"
 version = "3.1.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
+ "agave-logger",
  "aquamarine",
  "assert_matches",
  "crossbeam-channel",
@@ -11503,7 +11513,6 @@ dependencies = [
  "solana-hash",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-metrics",
  "solana-poh",
  "solana-pubkey",
@@ -11547,6 +11556,7 @@ name = "solana-vortexor"
 version = "3.1.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
+ "agave-logger",
  "assert_matches",
  "bytes",
  "clap 4.5.31",
@@ -11577,7 +11587,6 @@ dependencies = [
  "solana-core",
  "solana-keypair",
  "solana-local-cluster",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-native-token",
@@ -11600,6 +11609,7 @@ dependencies = [
 name = "solana-vote"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "arbitrary",
  "bencher",
  "bincode",
@@ -11615,7 +11625,6 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
- "solana-logger",
  "solana-packet",
  "solana-pubkey",
  "solana-sdk-ids",
@@ -11665,6 +11674,7 @@ name = "solana-vote-program"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "assert_matches",
  "bincode",
  "criterion",
@@ -11682,7 +11692,6 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
- "solana-logger",
  "solana-metrics",
  "solana-packet",
  "solana-program-runtime",
@@ -11705,6 +11714,7 @@ dependencies = [
 name = "solana-wen-restart"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "agave-snapshots",
  "anyhow",
  "assert_matches",
@@ -11723,7 +11733,6 @@ dependencies = [
  "solana-hash",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-pubkey",
  "solana-runtime",
  "solana-shred-version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "lattice-hash",
     "ledger",
     "local-cluster",
+    "logger",
     "measure",
     "merkle-tree",
     "metrics",
@@ -186,6 +187,7 @@ agave-feature-set = { path = "feature-set", version = "=3.1.0", features = ["aga
 agave-fs = { path = "fs", version = "=3.1.0", features = ["agave-unstable-api"] }
 agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=3.1.0", features = ["agave-unstable-api"] }
 agave-io-uring = { path = "io-uring", version = "=3.1.0", features = ["agave-unstable-api"] }
+agave-logger = { path = "logger", version = "=3.1.0", features = ["agave-unstable-api"] }
 agave-precompiles = { path = "precompiles", version = "=3.1.0", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "reserved-account-keys", version = "=3.1.0", features = ["agave-unstable-api"] }
 agave-scheduler-bindings = { path = "scheduler-bindings", version = "=3.1.0", features = ["agave-unstable-api"] }
@@ -462,7 +464,6 @@ solana-loader-v3-interface = "6.1.0"
 solana-loader-v4-interface = "3.1.0"
 solana-loader-v4-program = { path = "programs/loader-v4", version = "=3.1.0", features = ["agave-unstable-api"] }
 solana-local-cluster = { path = "local-cluster", version = "=3.1.0", features = ["agave-unstable-api"] }
-solana-logger = "3.0.0"
 solana-measure = { path = "measure", version = "=3.1.0", features = ["agave-unstable-api"] }
 solana-merkle-tree = { path = "merkle-tree", version = "=3.1.0", features = ["agave-unstable-api"] }
 solana-message = "3.0.1"

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -16,6 +16,7 @@ agave-unstable-api = []
 dev-context-only-utils = []
 
 [dependencies]
+agave-logger = { workspace = true }
 clap = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
@@ -30,7 +31,6 @@ solana-gossip = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-message = { workspace = true, features = ["serde", "bincode", "blake3"] }
 solana-net-utils = { workspace = true }

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -1136,7 +1136,7 @@ fn run_accounts_bench(
 }
 
 fn main() {
-    solana_logger::setup_with_default("solana=info");
+    agave_logger::setup_with_default("solana=info");
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())
@@ -1458,7 +1458,7 @@ pub mod test {
 
     #[test]
     fn test_accounts_cluster_bench() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut validator_config = ValidatorConfig::default_for_test();
         initialize_and_add_secondary_indexes(&mut validator_config);
         let num_nodes = 1;
@@ -1508,7 +1508,7 @@ pub mod test {
 
     #[test]
     fn test_halt_accounts_creation_at_max() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut validator_config = ValidatorConfig::default_for_test();
         initialize_and_add_secondary_indexes(&mut validator_config);
         let num_nodes = 1;
@@ -1558,7 +1558,7 @@ pub mod test {
 
     #[test]
     fn test_create_then_reclaim_spl_token_accounts() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mint_keypair = Keypair::new();
         let mint_pubkey = mint_keypair.pubkey();
         let faucet_addr = run_local_faucet_for_tests(

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -104,6 +104,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
@@ -115,7 +116,6 @@ serde_bytes = { workspace = true }
 solana-accounts-db = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-compute-budget = { workspace = true }
 solana-instruction = { workspace = true }
-solana-logger = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-slot-history = { workspace = true }

--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -41,7 +41,7 @@ fn new_accounts_db(account_paths: Vec<PathBuf>) -> AccountsDb {
 
 #[bench]
 fn bench_delete_dependencies(bencher: &mut Bencher) {
-    solana_logger::setup();
+    agave_logger::setup();
     let accounts_db = new_accounts_db(vec![PathBuf::from("accounts_delete_deps")]);
     let accounts = Accounts::new(Arc::new(accounts_db));
     let mut old_pubkey = Pubkey::default();

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -234,7 +234,7 @@ mod tests {
         number_of_accounts_to_remove: usize,
         storage_access: StorageAccess,
     ) {
-        solana_logger::setup();
+        agave_logger::setup();
         let (storage, _temp_dirs) =
             create_storage_for_storage_reader(0, AccountsFileProvider::AppendVec, storage_access);
 

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1329,7 +1329,7 @@ mod tests {
 
     #[test]
     fn huge_clean() {
-        solana_logger::setup();
+        agave_logger::setup();
         let accounts_db = AccountsDb::new_single_for_tests();
         let accounts = Accounts::new(Arc::new(accounts_db));
         let mut old_pubkey = Pubkey::default();

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -972,7 +972,7 @@ fn test_account_grow() {
 
 #[test]
 fn test_lazy_gc_slot() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     // Only run this test with mark obsolete accounts disabled as garbage collection
     // is not lazy with mark obsolete accounts enabled
@@ -1027,7 +1027,7 @@ fn test_lazy_gc_slot() {
 
 #[test]
 fn test_clean_zero_lamport_and_dead_slot() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let accounts = AccountsDb::new_single_for_tests();
     let pubkey1 = solana_pubkey::new_rand();
@@ -1097,7 +1097,7 @@ fn test_clean_zero_lamport_and_dead_slot() {
 
 #[test]
 fn test_clean_dead_slot_with_obsolete_accounts() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     // This test is triggering a scenario in reclaim_accounts where the entire slot is reclaimed
     // When an entire slot is reclaimed, it normally unrefs the pubkeys, while when individual
@@ -1309,7 +1309,7 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
 
 #[test]
 fn test_shrink_zero_lamport_single_ref_account() {
-    solana_logger::setup();
+    agave_logger::setup();
     // note that 'None' checks the case based on the default value of `latest_full_snapshot_slot` in `AccountsDb`
     for latest_full_snapshot_slot in [None, Some(0), Some(1), Some(2)] {
         // store a zero and non-zero lamport account
@@ -1393,7 +1393,7 @@ fn test_shrink_zero_lamport_single_ref_account() {
 
 #[test]
 fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let accounts = AccountsDb::new_single_for_tests();
     let pubkey1 = solana_pubkey::new_rand();
@@ -1443,7 +1443,7 @@ fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
 
 #[test]
 fn test_clean_zero_lamport_and_old_roots() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let accounts = AccountsDb::new_single_for_tests();
     let pubkey = solana_pubkey::new_rand();
@@ -1483,7 +1483,7 @@ fn test_clean_zero_lamport_and_old_roots() {
 #[test_case(MarkObsoleteAccounts::Enabled)]
 #[test_case(MarkObsoleteAccounts::Disabled)]
 fn test_clean_old_with_normal_account(mark_obsolete_accounts: MarkObsoleteAccounts) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let accounts = AccountsDb::new_with_config(
         Vec::new(),
@@ -1521,7 +1521,7 @@ fn test_clean_old_with_normal_account(mark_obsolete_accounts: MarkObsoleteAccoun
 #[test_case(MarkObsoleteAccounts::Enabled)]
 #[test_case(MarkObsoleteAccounts::Disabled)]
 fn test_clean_old_with_zero_lamport_account(mark_obsolete_accounts: MarkObsoleteAccounts) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let accounts = AccountsDb::new_with_config(
         Vec::new(),
@@ -1567,7 +1567,7 @@ fn test_clean_old_with_zero_lamport_account(mark_obsolete_accounts: MarkObsolete
 fn test_clean_old_with_both_normal_and_zero_lamport_accounts(
     mark_obsolete_accounts: MarkObsoleteAccounts,
 ) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut accounts = AccountsDb {
         account_indexes: spl_token_mint_index_enabled(),
@@ -1718,7 +1718,7 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts(
 #[test_case(MarkObsoleteAccounts::Enabled)]
 #[test_case(MarkObsoleteAccounts::Disabled)]
 fn test_clean_max_slot_zero_lamport_account(mark_obsolete_accounts: MarkObsoleteAccounts) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let accounts = AccountsDb::new_with_config(
         Vec::new(),
@@ -1772,7 +1772,7 @@ fn assert_no_stores(accounts: &AccountsDb, slot: Slot) {
 
 #[test]
 fn test_accounts_db_purge_keep_live() {
-    solana_logger::setup();
+    agave_logger::setup();
     let some_lamport = 223;
     let zero_lamport = 0;
     let no_data = 0;
@@ -1854,7 +1854,7 @@ fn test_accounts_db_purge_keep_live() {
 
 #[test]
 fn test_accounts_db_purge1() {
-    solana_logger::setup();
+    agave_logger::setup();
     let some_lamport = 223;
     let zero_lamport = 0;
     let no_data = 0;
@@ -1954,7 +1954,7 @@ fn test_store_account_stress() {
 
 #[test]
 fn test_accountsdb_scan_accounts() {
-    solana_logger::setup();
+    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
     let key = Pubkey::default();
     let key0 = solana_pubkey::new_rand();
@@ -1999,7 +1999,7 @@ fn test_accountsdb_scan_accounts() {
 
 #[test]
 fn test_cleanup_key_not_removed() {
-    solana_logger::setup();
+    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
 
     let key = Pubkey::default();
@@ -2034,7 +2034,7 @@ fn test_cleanup_key_not_removed() {
 
 #[test]
 fn test_store_large_account() {
-    solana_logger::setup();
+    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
 
     let key = Pubkey::default();
@@ -2105,7 +2105,7 @@ pub static EPOCH_SCHEDULE: std::sync::LazyLock<EpochSchedule> =
 #[test]
 fn test_verify_bank_capitalization() {
     for pass in 0..2 {
-        solana_logger::setup();
+        agave_logger::setup();
         let db = AccountsDb::new_single_for_tests();
 
         let key = solana_pubkey::new_rand();
@@ -2144,7 +2144,7 @@ fn test_verify_bank_capitalization() {
 }
 #[test]
 fn test_storage_finder() {
-    solana_logger::setup();
+    agave_logger::setup();
     let db = AccountsDb {
         file_size: 16 * 1024,
         ..AccountsDb::new_single_for_tests()
@@ -2413,7 +2413,7 @@ fn test_shrink_all_slots_none() {
 
 #[test]
 fn test_shrink_candidate_slots() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut accounts = AccountsDb::new_single_for_tests();
 
@@ -2480,7 +2480,7 @@ fn test_shrink_candidate_slots() {
 /// bytes of the two remaining alive ancient accounts.
 #[test]
 fn test_shrink_candidate_slots_with_dead_ancient_account() {
-    solana_logger::setup();
+    agave_logger::setup();
     let epoch_schedule = EpochSchedule::default();
     let db = AccountsDb::new_single_for_tests();
     const ACCOUNT_DATA_SIZES: &[usize] = &[1000, 2000, 150];
@@ -2557,7 +2557,7 @@ fn test_shrink_candidate_slots_with_dead_ancient_account() {
 #[test]
 fn test_select_candidates_by_total_usage_no_candidates() {
     // no input candidates -- none should be selected
-    solana_logger::setup();
+    agave_logger::setup();
     let candidates = ShrinkCandidates::default();
     let db = AccountsDb::new_single_for_tests();
 
@@ -2572,7 +2572,7 @@ fn test_select_candidates_by_total_usage_no_candidates() {
 #[test_case(StorageAccess::File)]
 fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: StorageAccess) {
     // three candidates, one selected for shrink, one is put back to the candidate list and one is ignored
-    solana_logger::setup();
+    agave_logger::setup();
     let mut candidates = ShrinkCandidates::default();
     let db = AccountsDb::new_single_for_tests();
 
@@ -2639,7 +2639,7 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
 #[test_case(StorageAccess::File)]
 fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: StorageAccess) {
     // three candidates, 2 are selected for shrink, one is ignored
-    solana_logger::setup();
+    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
     let mut candidates = ShrinkCandidates::default();
 
@@ -2703,7 +2703,7 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
 #[test_case(StorageAccess::File)]
 fn test_select_candidates_by_total_usage_all_clean(storage_access: StorageAccess) {
     // 2 candidates, they must be selected to achieve the target alive ratio
-    solana_logger::setup();
+    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
     let mut candidates = ShrinkCandidates::default();
 
@@ -2752,7 +2752,7 @@ fn test_select_candidates_by_total_usage_all_clean(storage_access: StorageAccess
 
 #[test]
 fn test_delete_dependencies() {
-    solana_logger::setup();
+    agave_logger::setup();
     let accounts_index = AccountsIndex::<AccountInfo, AccountInfo>::default_for_tests();
     let key0 = Pubkey::new_from_array([0u8; 32]);
     let key1 = Pubkey::new_from_array([1u8; 32]);
@@ -2904,7 +2904,7 @@ fn test_account_balance_for_capitalization_native_program() {
 
 #[test]
 fn test_store_overhead() {
-    solana_logger::setup();
+    agave_logger::setup();
     let accounts = AccountsDb::new_single_for_tests();
     let account = AccountSharedData::default();
     let pubkey = solana_pubkey::new_rand();
@@ -2918,7 +2918,7 @@ fn test_store_overhead() {
 
 #[test]
 fn test_store_clean_after_shrink() {
-    solana_logger::setup();
+    agave_logger::setup();
     let accounts = AccountsDb::new_single_for_tests();
     let epoch_schedule = EpochSchedule::default();
 
@@ -2985,7 +2985,7 @@ fn test_wrapping_storage_id() {
 #[test]
 #[should_panic(expected = "We've run out of storage ids!")]
 fn test_reuse_storage_id() {
-    solana_logger::setup();
+    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
 
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
@@ -4412,7 +4412,7 @@ fn start_load_thread(
 
 #[test]
 fn test_load_account_and_cache_flush_race() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut db = AccountsDb::new_single_for_tests();
     db.load_delay = RACY_SLEEP_MS;
@@ -4723,7 +4723,7 @@ fn test_cache_flush_remove_unrooted_race_multiple_slots() {
 
 #[test]
 fn test_collect_uncleaned_slots_up_to_slot() {
-    solana_logger::setup();
+    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
 
     let slot1 = 11;
@@ -4753,7 +4753,7 @@ fn test_collect_uncleaned_slots_up_to_slot() {
 
 #[test]
 fn test_remove_uncleaned_slots_and_collect_pubkeys_up_to_slot() {
-    solana_logger::setup();
+    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
 
     let slot1 = 11;
@@ -4800,7 +4800,7 @@ fn test_remove_uncleaned_slots_and_collect_pubkeys_up_to_slot() {
 #[test_case(StorageAccess::Mmap)]
 #[test_case(StorageAccess::File)]
 fn test_shrink_productive(storage_access: StorageAccess) {
-    solana_logger::setup();
+    agave_logger::setup();
     let path = Path::new("");
     let file_size = 100;
     let slot = 11;
@@ -4836,7 +4836,7 @@ fn test_shrink_productive(storage_access: StorageAccess) {
 #[test_case(StorageAccess::Mmap)]
 #[test_case(StorageAccess::File)]
 fn test_is_candidate_for_shrink(storage_access: StorageAccess) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut accounts = AccountsDb::new_single_for_tests();
     let common_store_path = Path::new("");
@@ -5185,7 +5185,7 @@ define_accounts_db_test!(
 
 #[test]
 fn test_filter_zero_lamport_clean_for_incremental_snapshots() {
-    solana_logger::setup();
+    agave_logger::setup();
     let slot = 10;
 
     struct TestParameters {
@@ -5773,7 +5773,7 @@ define_accounts_db_test!(test_get_sorted_potential_ancient_slots, |db| {
 
 #[test]
 fn test_shrink_collect_simple() {
-    solana_logger::setup();
+    agave_logger::setup();
     let account_counts = [
         1,
         SHRINK_COLLECT_CHUNK_SIZE,
@@ -5973,7 +5973,7 @@ fn test_shrink_collect_simple() {
 
 #[test]
 fn test_shrink_collect_with_obsolete_accounts() {
-    solana_logger::setup();
+    agave_logger::setup();
     let account_count = 100;
     let pubkeys: Vec<_> = iter::repeat_with(Pubkey::new_unique)
         .take(account_count)
@@ -6266,7 +6266,7 @@ pub(crate) fn create_db_with_storages_and_index(
     num_slots: usize,
     account_data_size: Option<u64>,
 ) -> (AccountsDb, Slot) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let db = AccountsDb::new_single_for_tests();
 
@@ -6319,7 +6319,7 @@ fn get_one_ancient_append_vec_and_others(num_normal_slots: usize) -> (AccountsDb
 
 #[test]
 fn test_handle_dropped_roots_for_ancient() {
-    solana_logger::setup();
+    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
     db.handle_dropped_roots_for_ancient(std::iter::empty::<Slot>());
     let slot0 = 0;
@@ -6338,7 +6338,7 @@ fn insert_store(db: &AccountsDb, append_vec: Arc<AccountStorageEntry>) {
 #[test_case(StorageAccess::File)]
 #[should_panic(expected = "self.storage.remove")]
 fn test_handle_dropped_roots_for_ancient_assert(storage_access: StorageAccess) {
-    solana_logger::setup();
+    agave_logger::setup();
     let common_store_path = Path::new("");
     let store_file_size = 10_000;
     let entry = Arc::new(AccountStorageEntry::new(

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -2780,7 +2780,7 @@ pub mod tests {
 
     #[test]
     fn test_update_new_slot() {
-        solana_logger::setup();
+        agave_logger::setup();
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let ancestors = vec![(0, 0)].into_iter().collect();
@@ -3156,7 +3156,7 @@ pub mod tests {
 
     #[test]
     fn test_reclaim_older_items_in_slot_list() {
-        solana_logger::setup();
+        agave_logger::setup();
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<u64, u64>::default_for_tests();
         let mut gc = ReclaimsSlotList::new();
@@ -3249,7 +3249,7 @@ pub mod tests {
 
     #[test]
     fn test_reclaim_do_not_reclaim_cached_other_slot() {
-        solana_logger::setup();
+        agave_logger::setup();
         let key = solana_pubkey::new_rand();
         let index =
             AccountsIndex::<CacheableIndexValueTest, CacheableIndexValueTest>::default_for_tests();
@@ -3925,7 +3925,7 @@ pub mod tests {
 
     #[test]
     fn test_clean_rooted_entries_return() {
-        solana_logger::setup();
+        agave_logger::setup();
         let value = true;
         let key = solana_pubkey::new_rand();
         let key_unknown = solana_pubkey::new_rand();

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1536,7 +1536,7 @@ mod tests {
 
     #[test]
     fn test_update_slot_list_other_populate_reclaims() {
-        solana_logger::setup();
+        agave_logger::setup();
         let reclaim = UpsertReclaim::PopulateReclaims;
         let new_slot = 5;
         let info = 1;
@@ -1742,7 +1742,7 @@ mod tests {
 
     #[test]
     fn test_gather_possible_evictions() {
-        solana_logger::setup();
+        agave_logger::setup();
         let startup = false;
         let ref_count = 1;
         let map: HashMap<_, _> = (0..=255)
@@ -1799,7 +1799,7 @@ mod tests {
 
     #[test]
     fn test_should_evict_from_mem() {
-        solana_logger::setup();
+        agave_logger::setup();
         let bucket = new_for_test::<u64>();
         let mut startup = false;
         let mut current_age = 0;
@@ -1888,7 +1888,7 @@ mod tests {
 
     #[test]
     fn test_age() {
-        solana_logger::setup();
+        agave_logger::setup();
         let test = new_for_test::<u64>();
         assert!(test.get_should_age(test.storage.current_age()));
         assert_eq!(test.storage.count_buckets_flushed(), 0);
@@ -1911,7 +1911,7 @@ mod tests {
 
     #[test]
     fn test_update_slot_list_other_reclaim_old_slots() {
-        solana_logger::setup();
+        agave_logger::setup();
         let reclaim = UpsertReclaim::ReclaimOldSlots;
         let new_slot = 5;
         let info = 1;

--- a/accounts-db/src/ancestors.rs
+++ b/accounts-db/src/ancestors.rs
@@ -129,7 +129,7 @@ pub mod tests {
 
     #[test]
     fn test_ancestors_permutations() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut ancestors = Ancestors::default();
         let mut hash = HashMap::new();
 
@@ -194,7 +194,7 @@ pub mod tests {
 
     #[test]
     fn test_ancestors_smaller() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         for width in 0..34 {
             let mut hash = HashSet::new();

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1286,7 +1286,7 @@ pub mod tests {
         // n slots
         // m accounts per slot
         // divide into different ideal sizes so that we combine multiple slots sometimes and combine partial slots
-        solana_logger::setup();
+        agave_logger::setup();
         let total_accounts_per_storage = 10;
         let account_size = 184;
         for num_slots in 0..4 {
@@ -1394,7 +1394,7 @@ pub mod tests {
         // each account has different size
         // divide into different ideal sizes so that we combine multiple slots sometimes and combine partial slots
         // compare at end that all accounts are in result exactly once
-        solana_logger::setup();
+        agave_logger::setup();
         let total_accounts_per_storage = 10;
         let account_size = 184;
         for num_slots in 0..4 {
@@ -1630,7 +1630,7 @@ pub mod tests {
         // n storages
         // 1 account each
         // all accounts have 1 ref or all accounts have 2 refs
-        solana_logger::setup();
+        agave_logger::setup();
 
         let data_size = 48;
         let alive_bytes_per_slot = aligned_stored_size(data_size as usize) as u64;
@@ -2138,7 +2138,7 @@ pub mod tests {
 
     #[test]
     fn test_calc_accounts_to_combine_opposite() {
-        solana_logger::setup();
+        agave_logger::setup();
         // 1 storage
         // 2 accounts
         // 1 with 1 ref
@@ -2873,7 +2873,7 @@ pub mod tests {
 
     #[test]
     fn test_truncate_to_max_storages() {
-        solana_logger::setup();
+        agave_logger::setup();
         for filter in [false, true] {
             let ideal_storage_size_large = get_ancient_append_vec_capacity();
             let mut infos = create_test_infos(1);
@@ -3490,7 +3490,7 @@ pub mod tests {
         // NOTE: The recycler has been removed.  Creating this many extra storages is no longer
         // necessary, but also does no harm either.
         const MAX_RECYCLE_STORES: usize = 1000;
-        solana_logger::setup();
+        agave_logger::setup();
 
         // When we pack ancient append vecs, the packed append vecs are recycled first if possible. This means they aren't dropped directly.
         // This test tests that we are releasing Arc refcounts for storages when we pack them into ancient append vecs.

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1728,7 +1728,7 @@ pub mod tests {
         // So, the sanitizing on load behavior can be tested by capturing [u8] that would be created if such a write was possible (as it used to be).
         // The contents of [u8] written by an append vec cannot easily or reasonably change frequently since it has released a long time.
         /*
-            solana_logger::setup();
+            agave_logger::setup();
             // uncomment this code to generate the invalid append vec that will fail on load
             let file = get_append_vec_path("test_append");
             let path = &file.path;

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -383,7 +383,7 @@ pub mod tests {
 
     #[test]
     fn test_next_bucket_to_flush() {
-        solana_logger::setup();
+        agave_logger::setup();
         let bins = 4;
         let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         let visited = (0..bins)
@@ -406,7 +406,7 @@ pub mod tests {
 
     #[test]
     fn test_ages() {
-        solana_logger::setup();
+        agave_logger::setup();
         let bins = 4;
         let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         assert_eq!(0, test.current_age());
@@ -426,7 +426,7 @@ pub mod tests {
 
     #[test]
     fn test_age_increment() {
-        solana_logger::setup();
+        agave_logger::setup();
         let bins = 4;
         let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         for age in 0..513 {
@@ -447,7 +447,7 @@ pub mod tests {
 
     #[test]
     fn test_throttle() {
-        solana_logger::setup();
+        agave_logger::setup();
         let bins = 128;
         let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         let bins = test.bins as u64;
@@ -487,7 +487,7 @@ pub mod tests {
 
     #[test]
     fn test_age_time() {
-        solana_logger::setup();
+        agave_logger::setup();
         let bins = 1;
         let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         let threads = 2;
@@ -519,7 +519,7 @@ pub mod tests {
 
     #[test]
     fn test_age_broad() {
-        solana_logger::setup();
+        agave_logger::setup();
         let bins = 4;
         let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         assert_eq!(test.current_age(), 0);

--- a/accounts-db/src/rolling_bit_field.rs
+++ b/accounts-db/src/rolling_bit_field.rs
@@ -364,7 +364,7 @@ pub mod tests {
 
     #[test]
     fn test_get_all_less_than() {
-        solana_logger::setup();
+        agave_logger::setup();
         let len = 16;
         let mut bitfield = RollingBitField::new(len);
         assert!(bitfield.get_all_less_than(0).is_empty());
@@ -417,7 +417,7 @@ pub mod tests {
 
     #[test]
     fn test_bitfield_delete_non_excess() {
-        solana_logger::setup();
+        agave_logger::setup();
         let len = 16;
         let mut bitfield = RollingBitField::new(len);
         assert_eq!(bitfield.min(), None);
@@ -461,7 +461,7 @@ pub mod tests {
 
     #[test]
     fn test_bitfield_insert_excess() {
-        solana_logger::setup();
+        agave_logger::setup();
         let len = 16;
         let mut bitfield = RollingBitField::new(len);
 
@@ -493,7 +493,7 @@ pub mod tests {
 
     #[test]
     fn test_bitfield_permutations() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut bitfield = RollingBitField::new(2097152);
         let mut hash = HashSet::new();
 
@@ -593,7 +593,7 @@ pub mod tests {
 
     #[test]
     fn test_bitfield_insert_wide() {
-        solana_logger::setup();
+        agave_logger::setup();
         let width = 16;
         let start = 0;
         let mut tester = setup_wide(width, start);
@@ -612,7 +612,7 @@ pub mod tests {
 
     #[test]
     fn test_bitfield_insert_wide_before() {
-        solana_logger::setup();
+        agave_logger::setup();
         let width = 16;
         let start = 100;
         let mut bitfield = setup_wide(width, start).bitfield;
@@ -627,7 +627,7 @@ pub mod tests {
 
     #[test]
     fn test_bitfield_insert_wide_before_ok() {
-        solana_logger::setup();
+        agave_logger::setup();
         let width = 16;
         let start = 100;
         let mut bitfield = setup_wide(width, start).bitfield;
@@ -678,7 +678,7 @@ pub mod tests {
 
     #[test]
     fn test_bitfield_excess2() {
-        solana_logger::setup();
+        agave_logger::setup();
         let width = 16;
         let mut tester = setup_empty(width);
         let slot = 100;
@@ -712,7 +712,7 @@ pub mod tests {
 
     #[test]
     fn test_bitfield_excess() {
-        solana_logger::setup();
+        agave_logger::setup();
         // start at slot 0 or a separate, higher slot
         for width in [16, 4194304].iter() {
             let width = *width;
@@ -846,7 +846,7 @@ pub mod tests {
 
     #[test]
     fn test_bitfield_functionality() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         // bitfield sizes are powers of 2, cycle through values of 1, 2, 4, .. 2^9
         for power in 0..10 {
@@ -1009,7 +1009,7 @@ pub mod tests {
     #[test]
     fn test_bitfield_smaller() {
         // smaller bitfield, fewer entries, including 0
-        solana_logger::setup();
+        agave_logger::setup();
 
         for width in 0..34 {
             let mut bitfield = RollingBitField::new(4096);

--- a/banking-bench/Cargo.toml
+++ b/banking-bench/Cargo.toml
@@ -20,6 +20,7 @@ frozen-abi = []
 
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
+agave-logger = { workspace = true }
 assert_matches = { workspace = true }
 clap = { version = "3.1.8", features = ["derive", "cargo"] }
 crossbeam-channel = { workspace = true }
@@ -33,7 +34,6 @@ solana-gossip = { workspace = true }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
-solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-perf = { workspace = true }

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -233,7 +233,7 @@ impl PacketsPerIteration {
 
 #[allow(clippy::cognitive_complexity)]
 fn main() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let matches = Command::new(crate_name!())
         .about(crate_description!())

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -20,6 +20,7 @@ dummy-for-ci-check = []
 frozen-abi = []
 
 [dependencies]
+agave-logger = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -30,7 +31,6 @@ rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-
 solana-account = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
@@ -47,7 +47,6 @@ solana-gossip = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = "=3.0.0"
 solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-metrics = { workspace = true }

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -169,7 +169,7 @@ fn create_client(
 }
 
 fn main() {
-    solana_logger::setup_with_default_filter();
+    agave_logger::setup_with_default_filter();
     solana_metrics::set_panic_hook("bench-tps", /*version:*/ None);
 
     let matches = cli::build_args(solana_version::version!()).get_matches();

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -46,7 +46,7 @@ fn test_bench_tps_local_cluster(config: Config) {
         program_account(include_bytes!("fixtures/spl_instruction_padding.so")),
     )];
 
-    solana_logger::setup();
+    agave_logger::setup();
 
     let faucet_keypair = Keypair::new();
     let faucet_pubkey = faucet_keypair.pubkey();
@@ -107,7 +107,7 @@ fn test_bench_tps_local_cluster(config: Config) {
 }
 
 fn test_bench_tps_test_validator(config: Config) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();

--- a/bench-vote/Cargo.toml
+++ b/bench-vote/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 
 [dependencies]
+agave-logger = { workspace = true }
 bincode = { workspace = true }
 clap = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -23,7 +24,6 @@ solana-client = { workspace = true }
 solana-connection-cache = { workspace = true }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-message = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -184,7 +184,7 @@ fn main() -> Result<()> {
         )
         .get_matches();
 
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut num_sockets = 1usize;
     if let Some(n) = matches.value_of("num-recv-sockets") {

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -31,10 +31,10 @@ solana-pubkey = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 fs_extra = { workspace = true }
 rayon = { workspace = true }
 solana-bucket-map = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-logger = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 
 [[bench]]

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -1531,7 +1531,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "index asked to insert the same data twice")]
     fn test_occupy_if_matches_panic() {
-        solana_logger::setup();
+        agave_logger::setup();
         let random = 1;
         let k = Pubkey::from([1u8; 32]);
         let v = 12u64;
@@ -1565,7 +1565,7 @@ mod tests {
     #[should_panic(expected = "batch insertion can only occur prior to any deletes")]
     #[test]
     fn batch_insert_after_delete() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let tmpdir = tempdir().unwrap();
         let paths: Vec<PathBuf> = vec![tmpdir.path().to_path_buf()];

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn bucket_map_test_update_to_0_len() {
-        solana_logger::setup();
+        agave_logger::setup();
         let key = Pubkey::new_unique();
         let config = BucketMapConfig::new(1 << 1);
         let index = BucketMap::new(config);
@@ -390,7 +390,7 @@ mod tests {
     #[test]
     fn hashmap_compare() {
         use std::sync::Mutex;
-        solana_logger::setup();
+        agave_logger::setup();
         for mut use_batch_insert in [true, false] {
             let maps = (0..2)
                 .map(|max_buckets_pow2| {

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -628,7 +628,7 @@ mod test {
             count.clone(),
         )
         .is_none());
-        solana_logger::setup();
+        agave_logger::setup();
         for len in [0, 1, 47, 48, 49, 4097] {
             // create a zero len file. That will fail to load since it is too small.
             let path = tmpdir.path().join("small");

--- a/cargo-registry/Cargo.toml
+++ b/cargo-registry/Cargo.toml
@@ -20,6 +20,7 @@ remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
 remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
+agave-logger = { workspace = true }
 clap = { workspace = true }
 flate2 = { workspace = true }
 hex = { workspace = true }
@@ -34,7 +35,6 @@ solana-cli-config = { workspace = true }
 solana-cli-output = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-remote-wallet = { workspace = true }
 solana-rpc-client = { workspace = true, features = ["default"] }

--- a/cargo-registry/src/main.rs
+++ b/cargo-registry/src/main.rs
@@ -263,7 +263,7 @@ impl CargoRegistryService {
 
 #[tokio::main]
 async fn main() {
-    solana_logger::setup_with_default_filter();
+    agave_logger::setup_with_default_filter();
     let client = Arc::new(Client::new().expect("Failed to get RPC Client instance"));
 
     let bind_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), client.port);

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,7 @@ remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-logger = { workspace = true }
 agave-syscalls = { workspace = true }
 bincode = { workspace = true }
 bs58 = { workspace = true }
@@ -67,7 +68,6 @@ solana-keypair = "=3.0.1"
 solana-loader-v3-interface = { version = "=6.1.0", features = ["bincode"] }
 solana-loader-v4-interface = "=3.1.0"
 solana-loader-v4-program = { workspace = true }
-solana-logger = "=3.0.0"
 solana-message = "=3.0.1"
 solana-native-token = "=3.0.0"
 solana-nonce = "=3.0.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -243,7 +243,7 @@ pub fn parse_args<'a>(
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
-    solana_logger::setup_with_default("off");
+    agave_logger::setup_with_default("off");
     let matches = get_clap_app(
         crate_name!(),
         crate_description!(),

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -4532,7 +4532,7 @@ mod tests {
 
     #[test]
     fn test_cli_keypair_file() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let default_keypair = Keypair::new();
         let program_pubkey = Keypair::new();

--- a/cli/tests/cluster_query.rs
+++ b/cli/tests/cluster_query.rs
@@ -20,7 +20,7 @@ use {
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
 fn test_ping(compute_unit_price: Option<u64>) {
-    solana_logger::setup();
+    agave_logger::setup();
     let fee = FeeStructure::default().get_max_fee(1, 0);
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -215,7 +215,7 @@ fn test_nonce(seed: Option<String>, use_nonce_authority: bool, compute_unit_pric
 #[test]
 fn test_create_account_with_seed() {
     const ONE_SIG_FEE: u64 = 5000;
-    solana_logger::setup();
+    agave_logger::setup();
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet_with_unique_port_for_tests(mint_keypair);

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -97,7 +97,7 @@ fn expect_account_absent(rpc_client: &RpcClient, pubkey: Pubkey, absent_because:
 
 #[test]
 fn test_cli_program_deploy_non_upgradeable() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -301,7 +301,7 @@ fn test_cli_program_deploy_non_upgradeable() {
 
 #[test]
 fn test_cli_program_deploy_no_authority() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -403,7 +403,7 @@ fn test_cli_program_deploy_no_authority() {
 #[test_case(false, true; "Feature disabled, skip preflight")]
 #[test_case(false, false; "Feature disabled, don't skip preflight")]
 fn test_cli_program_deploy_feature(enable_feature: bool, skip_preflight: bool) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut program_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     program_path.push("tests");
@@ -522,7 +522,7 @@ fn test_cli_program_deploy_feature(enable_feature: bool, skip_preflight: bool) {
 #[test_case(true; "Feature enabled")]
 #[test_case(false; "Feature disabled")]
 fn test_cli_program_upgrade_with_feature(enable_feature: bool) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -687,7 +687,7 @@ fn test_cli_program_upgrade_with_feature(enable_feature: bool) {
 
 #[test]
 fn test_cli_program_deploy_with_authority() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -1082,7 +1082,7 @@ fn test_cli_program_deploy_with_authority() {
 #[test_case(true; "Skip preflight")]
 #[test_case(false; "Dont skip preflight")]
 fn test_cli_program_upgrade_auto_extend(skip_preflight: bool) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -1254,7 +1254,7 @@ fn test_cli_program_upgrade_auto_extend(skip_preflight: bool) {
 
 #[test]
 fn test_cli_program_close_program() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -1366,7 +1366,7 @@ fn test_cli_program_close_program() {
 
 #[test]
 fn test_cli_program_extend_program() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -1547,7 +1547,7 @@ fn test_cli_program_extend_program() {
 
 #[test]
 fn test_cli_program_migrate_program() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -1625,7 +1625,7 @@ fn test_cli_program_migrate_program() {
 
 #[test]
 fn test_cli_program_write_buffer() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -2013,7 +2013,7 @@ fn test_cli_program_write_buffer() {
 #[test_case(true; "Feature enabled")]
 #[test_case(false; "Feature disabled")]
 fn test_cli_program_write_buffer_feature(enable_feature: bool) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut program_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     program_path.push("tests");
@@ -2107,7 +2107,7 @@ fn test_cli_program_write_buffer_feature(enable_feature: bool) {
 
 #[test]
 fn test_cli_program_set_buffer_authority() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -2278,7 +2278,7 @@ fn test_cli_program_set_buffer_authority() {
 
 #[test]
 fn test_cli_program_mismatch_buffer_authority() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -2397,7 +2397,7 @@ fn test_cli_program_mismatch_buffer_authority() {
 #[test_case(true; "offline signer will be fee payer")]
 #[test_case(false; "online signer will be fee payer")]
 fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer: bool) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -2594,7 +2594,7 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
 
 #[test]
 fn test_cli_program_show() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
@@ -2790,7 +2790,7 @@ fn test_cli_program_show() {
 
 #[test]
 fn test_cli_program_dump() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -200,7 +200,7 @@ fn test_stake_delegation_force() {
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
 fn test_seed_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -295,7 +295,7 @@ fn test_seed_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) 
 
 #[test]
 fn test_stake_delegation_and_withdraw_available() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -464,7 +464,7 @@ fn test_stake_delegation_and_withdraw_available() {
 
 #[test]
 fn test_stake_delegation_and_withdraw_all() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -629,7 +629,7 @@ fn test_stake_delegation_and_withdraw_all() {
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
 fn test_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -721,7 +721,7 @@ fn test_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
 fn test_offline_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -881,7 +881,7 @@ fn test_offline_stake_delegation_and_deactivation(compute_unit_price: Option<u64
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
 fn test_nonced_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -1010,7 +1010,7 @@ fn test_nonced_stake_delegation_and_deactivation(compute_unit_price: Option<u64>
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
 fn test_stake_authorize(compute_unit_price: Option<u64>) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -1338,7 +1338,7 @@ fn test_stake_authorize(compute_unit_price: Option<u64>) {
 
 #[test]
 fn test_stake_authorize_with_fee_payer() {
-    solana_logger::setup();
+    agave_logger::setup();
     let fee_one_sig = FeeStructure::default().get_max_fee(1, 0);
     let fee_two_sig = FeeStructure::default().get_max_fee(2, 0);
 
@@ -1520,7 +1520,7 @@ fn test_stake_authorize_with_fee_payer() {
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
 fn test_stake_split(compute_unit_price: Option<u64>) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -1681,7 +1681,7 @@ fn test_stake_split(compute_unit_price: Option<u64>) {
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
 fn test_stake_set_lockup(compute_unit_price: Option<u64>) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -1969,7 +1969,7 @@ fn test_stake_set_lockup(compute_unit_price: Option<u64>) {
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
 fn test_offline_nonced_create_stake_account_and_withdraw(compute_unit_price: Option<u64>) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -2212,7 +2212,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw(compute_unit_price: Opt
 
 #[test]
 fn test_stake_checked_instructions() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -29,7 +29,7 @@ use {
 #[test_case(true; "Skip Preflight")]
 #[test_case(false; "Don`t skip Preflight")]
 fn test_transfer(skip_preflight: bool) {
-    solana_logger::setup();
+    agave_logger::setup();
     let fee_one_sig = FeeStructure::default().get_max_fee(1, 0);
     let fee_two_sig = FeeStructure::default().get_max_fee(2, 0);
     let mint_keypair = Keypair::new();
@@ -327,7 +327,7 @@ fn test_transfer(skip_preflight: bool) {
 
 #[test]
 fn test_transfer_multisession_signing() {
-    solana_logger::setup();
+    agave_logger::setup();
     let fee_one_sig = FeeStructure::default().get_max_fee(1, 0);
     let fee_two_sig = FeeStructure::default().get_max_fee(2, 0);
     let mint_keypair = Keypair::new();
@@ -477,7 +477,7 @@ fn test_transfer_multisession_signing() {
 #[test_case(None; "default")]
 #[test_case(Some(100_000); "with_compute_unit_price")]
 fn test_transfer_all(compute_unit_price: Option<u64>) {
-    solana_logger::setup();
+    agave_logger::setup();
     let lamports_per_signature = FeeStructure::default().get_max_fee(1, 0);
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -555,7 +555,7 @@ fn test_transfer_all(compute_unit_price: Option<u64>) {
 
 #[test]
 fn test_transfer_unfunded_recipient() {
-    solana_logger::setup();
+    agave_logger::setup();
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet_with_unique_port_for_tests(mint_keypair);
@@ -610,7 +610,7 @@ fn test_transfer_unfunded_recipient() {
 
 #[test]
 fn test_transfer_with_seed() {
-    solana_logger::setup();
+    agave_logger::setup();
     let fee = FeeStructure::default().get_max_fee(1, 0);
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();

--- a/cli/tests/validator_info.rs
+++ b/cli/tests/validator_info.rs
@@ -17,7 +17,7 @@ use {
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
 fn test_publish(compute_unit_price: Option<u64>) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -48,7 +48,7 @@ tokio = { workspace = true, features = ["full"] }
 tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
-solana-logger = { workspace = true }
+agave-logger = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -57,7 +57,7 @@ fn pubsub_addr() -> SocketAddr {
 
 #[test]
 fn test_rpc_client() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let alice = Keypair::new();
     let test_validator =

--- a/client-test/tests/send_and_confirm_transactions_in_parallel.rs
+++ b/client-test/tests/send_and_confirm_transactions_in_parallel.rs
@@ -36,7 +36,7 @@ fn create_messages(from: Pubkey, to: Pubkey) -> (Vec<Message>, u64) {
 
 #[test]
 fn test_send_and_confirm_transactions_in_parallel_without_tpu_client() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let alice = Keypair::new();
     let test_validator =
@@ -93,7 +93,7 @@ fn test_send_and_confirm_transactions_in_parallel_without_tpu_client() {
 
 #[test]
 fn test_send_and_confirm_transactions_in_parallel_with_tpu_client() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let alice = Keypair::new();
     let test_validator =

--- a/connection-cache/Cargo.toml
+++ b/connection-cache/Cargo.toml
@@ -31,6 +31,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 rand_chacha = { workspace = true }
-solana-logger = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -687,7 +687,7 @@ mod tests {
 
     #[test]
     fn test_connection_cache() {
-        solana_logger::setup();
+        agave_logger::setup();
         // Allow the test to run deterministically
         // with the same pseudorandom sequence between runs
         // and on different platforms - the cryptographic security

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -189,6 +189,7 @@ shaq = { workspace = true }
 sysctl = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 bencher = { workspace = true }
 criterion = { workspace = true }
@@ -205,7 +206,6 @@ solana-core = { path = ".", features = ["agave-unstable-api", "dev-context-only-
 solana-cost-model = { workspace = true, features = ["dev-context-only-utils"] }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
-solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-poh = { workspace = true, features = ["dev-context-only-utils"] }
 solana-program-binaries = { workspace = true }

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -139,7 +139,7 @@ fn bench_banking(
     tx_type: TransactionType,
     block_production_method: BlockProductionMethod,
 ) {
-    solana_logger::setup();
+    agave_logger::setup();
     let num_threads = BankingStage::default_num_workers();
     //   a multiple of packet chunk duplicates to avoid races
     const CHUNKS: usize = 8;

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -44,7 +44,7 @@ where
 }
 
 fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {
-    solana_logger::setup();
+    agave_logger::setup();
     let len = 30 * 1000;
     let chunk_size = 1024;
     let tx = test_tx();
@@ -161,7 +161,7 @@ fn bench_sigverify_stage_without_same_tx(bencher: &mut Bencher) {
 }
 
 fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
-    solana_logger::setup();
+    agave_logger::setup();
     trace!("start");
     let (packet_s, packet_r) = unbounded();
     let (verified_s, verified_r) = BankingTracer::channel_for_test();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -759,7 +759,7 @@ mod tests {
 
     #[test]
     fn test_banking_stage_tick() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             mut genesis_config, ..
         } = create_genesis_config(2);
@@ -834,7 +834,7 @@ mod tests {
 
     #[test]
     fn test_banking_stage_entries_only_central_scheduler() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -960,7 +960,7 @@ mod tests {
 
     #[test]
     fn test_banking_stage_entryfication() {
-        solana_logger::setup();
+        agave_logger::setup();
         // In this attack we'll demonstrate that a verifier can interpret the ledger
         // differently if either the server doesn't signal the ledger to add an
         // Entry OR if the verifier tries to parallelize across multiple Entries.
@@ -1072,7 +1072,7 @@ mod tests {
 
     #[test]
     fn test_bank_record_transactions() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo {
             genesis_config,
@@ -1134,7 +1134,7 @@ mod tests {
 
     #[test]
     fn test_vote_storage_full_send() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -637,7 +637,7 @@ mod tests {
 
     #[test]
     fn test_bank_process_and_record_transactions() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -739,7 +739,7 @@ mod tests {
 
     #[test]
     fn test_bank_nonce_update_blockhash_queried_before_transaction_record() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -822,7 +822,7 @@ mod tests {
 
     #[test]
     fn test_bank_process_and_record_transactions_all_unexecuted() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -886,7 +886,7 @@ mod tests {
     fn test_bank_process_and_record_transactions_cost_tracker(
         relax_intrabatch_account_locks: bool,
     ) {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -1036,7 +1036,7 @@ mod tests {
         relax_intrabatch_account_locks: bool,
         use_duplicate_transaction: bool,
     ) {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -1128,7 +1128,7 @@ mod tests {
 
     #[test]
     fn test_process_transactions_instruction_error() {
-        solana_logger::setup();
+        agave_logger::setup();
         let lamports = 10_000;
         let GenesisConfigInfo {
             genesis_config,
@@ -1192,7 +1192,7 @@ mod tests {
         relax_intrabatch_account_locks: bool,
         use_duplicate_transaction: bool,
     ) {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -1280,7 +1280,7 @@ mod tests {
 
     #[test]
     fn test_process_transactions_returns_unprocessed_txs() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -1355,7 +1355,7 @@ mod tests {
 
     #[test]
     fn test_write_persist_transaction_status() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             mut genesis_config,
             mint_keypair,
@@ -1463,7 +1463,7 @@ mod tests {
 
     #[test]
     fn test_write_persist_loaded_addresses() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -606,7 +606,7 @@ mod tests {
 
     #[test]
     fn test_compute_transaction_costs() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         // make a vec of txs
         let keypair = Keypair::new();
@@ -648,7 +648,7 @@ mod tests {
 
     #[test]
     fn test_select_transactions_per_cost() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
@@ -698,7 +698,7 @@ mod tests {
 
     #[test]
     fn test_update_and_remove_transaction_costs_committed() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
@@ -778,7 +778,7 @@ mod tests {
 
     #[test]
     fn test_update_and_remove_transaction_costs_not_committed() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
@@ -824,7 +824,7 @@ mod tests {
 
     #[test]
     fn test_update_and_remove_transaction_costs_mixed_execution() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -767,7 +767,7 @@ mod tests {
 
     #[test]
     fn test_max_vote_tx_fits() {
-        solana_logger::setup();
+        agave_logger::setup();
         let node_keypair = Keypair::new();
         let vote_keypair = Keypair::new();
         let tower_sync = TowerSync::new_from_slot(MAX_LOCKOUT_HISTORY as u64, Hash::default());
@@ -1503,7 +1503,7 @@ mod tests {
 
     #[test]
     fn test_verify_votes_empty() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);

--- a/core/src/cluster_slots_service/cluster_slots.rs
+++ b/core/src/cluster_slots_service/cluster_slots.rs
@@ -722,7 +722,7 @@ mod tests {
 
     #[test]
     fn test_best_peer_3() {
-        solana_logger::setup_with_default("info");
+        agave_logger::setup_with_default("info");
         let cs = ClusterSlots::default();
         let pk1 = Pubkey::new_unique();
         let pk2 = Pubkey::new_unique();

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -2572,7 +2572,7 @@ pub mod test {
 
     #[test]
     fn test_check_vote_threshold_no_skip_lockout_with_new_root() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut tower = Tower::new_for_tests(4, 0.67);
         let mut stakes = HashMap::new();
         for i in 0..(MAX_LOCKOUT_HISTORY as u64 + 1) {
@@ -2793,7 +2793,7 @@ pub mod test {
 
     #[test]
     fn test_check_vote_threshold_lockouts_not_updated() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut tower = Tower::new_for_tests(1, 0.67);
         let stakes = vec![(0, 1), (1, 2)].into_iter().collect();
         tower.record_vote(0, Hash::default());
@@ -3005,7 +3005,7 @@ pub mod test {
 
     #[test]
     fn test_switch_threshold_across_tower_reload() {
-        solana_logger::setup();
+        agave_logger::setup();
         // Init state
         let mut vote_simulator = VoteSimulator::new(2);
         let other_vote_account = vote_simulator.vote_pubkeys[1];
@@ -3262,7 +3262,7 @@ pub mod test {
 
     #[test]
     fn test_reconcile_blockstore_roots_with_tower_normal() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -3298,7 +3298,7 @@ pub mod test {
                     1) from external root (Tower(4))!?"
     )]
     fn test_reconcile_blockstore_roots_with_tower_panic_no_common_root() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -3326,7 +3326,7 @@ pub mod test {
 
     #[test]
     fn test_reconcile_blockstore_roots_with_tower_nop_no_parent() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -3352,7 +3352,7 @@ pub mod test {
 
     #[test]
     fn test_adjust_lockouts_after_replay_future_slots() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut tower = Tower::new_for_tests(10, 0.9);
         tower.record_vote(0, Hash::default());
         tower.record_vote(1, Hash::default());

--- a/core/src/mock_alpenglow_consensus.rs
+++ b/core/src/mock_alpenglow_consensus.rs
@@ -804,7 +804,7 @@ mod tests {
     fn test_mock_alpenglow_statemachine() {
         let test_timeout = Duration::from_secs(3);
         let max_slots = 5;
-        solana_logger::setup_with("trace");
+        agave_logger::setup_with("trace");
         let num_nodes = 10;
         let keypairs: Vec<Keypair> = (0..num_nodes).map(|_| Keypair::new()).collect();
         let peers: Vec<(Pubkey, UdpSocket)> = keypairs

--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -61,7 +61,7 @@ mod test {
     };
 
     fn run_test_sigverify_shred_cpu_repair(slot: Slot) {
-        solana_logger::setup();
+        agave_logger::setup();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let keypair = Keypair::new();
         let shred = Shredder::single_shred_for_tests(slot, &keypair);

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1813,7 +1813,7 @@ mod test {
 
     #[test]
     fn test_generate_repairs_for_wen_restart() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
         let max_repairs = 3;

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1772,7 +1772,7 @@ mod tests {
     /// test run_window_request responds with the right shred, and do not overrun
     pub fn run_highest_window_request(slot: Slot, num_slots: u64, nonce: Nonce) {
         let recycler = PacketBatchRecycler::default();
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let handler = StandardRepairHandler::new(blockstore.clone());
@@ -1825,7 +1825,7 @@ mod tests {
         let slot = 2;
         let nonce = 9;
         let recycler = PacketBatchRecycler::default();
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let handler = StandardRepairHandler::new(blockstore.clone());
@@ -1992,7 +1992,7 @@ mod tests {
     }
 
     pub fn run_orphan(slot: Slot, num_slots: u64, nonce: Nonce) {
-        solana_logger::setup();
+        agave_logger::setup();
         let recycler = PacketBatchRecycler::default();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
@@ -2046,7 +2046,7 @@ mod tests {
 
     #[test]
     fn run_orphan_corrupted_shred_size() {
-        solana_logger::setup();
+        agave_logger::setup();
         let recycler = PacketBatchRecycler::default();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
@@ -2102,7 +2102,7 @@ mod tests {
                 .unwrap()
         }
 
-        solana_logger::setup();
+        agave_logger::setup();
         let recycler = PacketBatchRecycler::default();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4990,7 +4990,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_dead_fork_invalid_slot_tick_count() {
-        solana_logger::setup();
+        agave_logger::setup();
         // Too many ticks per slot
         let res = check_dead_fork(|_keypair, bank| {
             let blockhash = bank.last_blockhash();
@@ -8199,7 +8199,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_replay_stage_last_vote_outside_slot_hashes() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ReplayBlockstoreComponents {
             cluster_info,
             poh_recorder,
@@ -8660,7 +8660,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_dumped_slot_not_causing_panic() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ReplayBlockstoreComponents {
             validator_node_to_vote_keys,
             leader_schedule_cache,
@@ -8956,7 +8956,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_tower_sync_from_bank_failed_switch() {
-        solana_logger::setup_with_default(
+        agave_logger::setup_with_default(
             "error,solana_core::replay_stage=info,solana_core::consensus=info",
         );
         /*
@@ -9037,7 +9037,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_tower_sync_from_bank_failed_lockout() {
-        solana_logger::setup_with_default(
+        agave_logger::setup_with_default(
             "error,solana_core::replay_stage=info,solana_core::consensus=info",
         );
         /*
@@ -9108,7 +9108,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_tower_adopt_from_bank_cache_only_computed() {
-        solana_logger::setup_with_default(
+        agave_logger::setup_with_default(
             "error,solana_core::replay_stage=info,solana_core::consensus=info",
         );
         /*
@@ -9241,7 +9241,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_initialize_progress_and_fork_choice_with_duplicates() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             mut genesis_config, ..
         } = create_genesis_config(123);
@@ -9365,7 +9365,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_skip_leader_slot_for_existing_slot() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ReplayBlockstoreComponents {
             blockstore,
@@ -9730,7 +9730,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_alpenglow_poh_migration_from_leader() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ReplayBlockstoreComponents {
             blockstore,
@@ -9849,7 +9849,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_alpenglow_poh_migration_from_replay() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ReplayBlockstoreComponents {
             blockstore,

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -455,7 +455,7 @@ mod tests {
 
     #[test]
     fn test_packet_discard() {
-        solana_logger::setup();
+        agave_logger::setup();
         let batch_size = 10;
         let mut batch = PinnedPacketBatch::with_capacity(batch_size);
         let packet = Packet::default();
@@ -498,7 +498,7 @@ mod tests {
     }
 
     fn test_sigverify_stage(use_same_tx: bool) {
-        solana_logger::setup();
+        agave_logger::setup();
         trace!("start");
         let (packet_s, packet_r) = unbounded();
         let (verified_s, verified_r) = BankingTracer::channel_for_test();

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -485,7 +485,7 @@ pub mod tests {
     };
 
     fn test_tvu_exit(enable_wen_restart: bool) {
-        solana_logger::setup();
+        agave_logger::setup();
         let leader = Node::new_localhost();
         let target1_keypair = Keypair::new();
         let target1 = Node::new_localhost_with_pubkey(&target1_keypair.pubkey());

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2905,7 +2905,7 @@ mod tests {
 
     #[test]
     fn validator_exit() {
-        solana_logger::setup();
+        agave_logger::setup();
         let leader_keypair = Keypair::new();
         let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
 
@@ -2951,7 +2951,7 @@ mod tests {
 
     #[test]
     fn test_should_cleanup_blockstore_incorrect_shred_versions() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
@@ -3086,7 +3086,7 @@ mod tests {
 
     #[test]
     fn test_cleanup_blockstore_incorrect_shred_versions() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let validator_config = ValidatorConfig::default_for_test();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -3182,7 +3182,7 @@ mod tests {
 
     #[test]
     fn test_wait_for_supermajority() {
-        solana_logger::setup();
+        agave_logger::setup();
         let node_keypair = Arc::new(Keypair::new());
         let cluster_info = ClusterInfo::new(
             ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
@@ -3329,7 +3329,7 @@ mod tests {
 
     #[test]
     fn test_poh_speed() {
-        solana_logger::setup();
+        agave_logger::setup();
         let poh_config = PohConfig {
             target_tick_duration: target_tick_duration(),
             // make PoH rate really fast to cause the panic condition
@@ -3346,7 +3346,7 @@ mod tests {
 
     #[test]
     fn test_poh_speed_no_hashes_per_tick() {
-        solana_logger::setup();
+        agave_logger::setup();
         let poh_config = PohConfig {
             target_tick_duration: target_tick_duration(),
             hashes_per_tick: None,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -157,7 +157,7 @@ fn run_bank_forks_snapshot_n<F>(last_slot: Slot, f: F, set_root_interval: u64)
 where
     F: Fn(&Bank, &Keypair),
 {
-    solana_logger::setup();
+    agave_logger::setup();
     // Set up snapshotting config
     let snapshot_test_config = SnapshotTestConfig::new(
         SnapshotInterval::Slots(NonZeroU64::new(set_root_interval).unwrap()),
@@ -263,7 +263,7 @@ fn goto_end_of_slot(bank: &Bank) {
 
 #[test]
 fn test_slots_to_snapshot() {
-    solana_logger::setup();
+    agave_logger::setup();
     let num_set_roots = MAX_CACHE_ENTRIES * 2;
 
     for add_root_interval in &[1, 3, 9] {
@@ -355,7 +355,7 @@ fn test_bank_forks_status_cache_snapshot() {
 
 #[test]
 fn test_bank_forks_incremental_snapshot() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     const SET_ROOT_INTERVAL: Slot = 2;
     const INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: Slot = SET_ROOT_INTERVAL * 2;
@@ -553,7 +553,7 @@ fn restore_from_snapshots_and_check_banks_are_equal(
 /// Spin up the background services fully then test taking & verifying snapshots
 #[test]
 fn test_snapshots_with_background_services() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     const SET_ROOT_INTERVAL_SLOTS: Slot = 2;
     const BANK_SNAPSHOT_INTERVAL_SLOTS: Slot = SET_ROOT_INTERVAL_SLOTS * 2;

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -51,7 +51,7 @@ use {
 
 #[test]
 fn test_scheduler_waited_by_drop_bank_service() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     static LOCK_TO_STALL: Mutex<()> = Mutex::new(());
 
@@ -206,7 +206,7 @@ fn test_scheduler_waited_by_drop_bank_service() {
 
 #[test]
 fn test_scheduler_producing_blocks() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -66,6 +66,7 @@ solana-transaction-error = { workspace = true }
 solana-vote-program = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 itertools = { workspace = true }
 rand = "0.8.5"
@@ -78,7 +79,6 @@ solana-compute-budget-program = { workspace = true }
 solana-cost-model = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-runtime-transaction = { workspace = true, features = [
     "dev-context-only-utils",

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -317,7 +317,7 @@ mod tests {
     };
 
     fn test_setup() -> (Keypair, Hash) {
-        solana_logger::setup();
+        agave_logger::setup();
         (Keypair::new(), Hash::new_unique())
     }
 

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -490,7 +490,7 @@ mod tests {
     }
 
     fn test_setup() -> Keypair {
-        solana_logger::setup();
+        agave_logger::setup();
         Keypair::new()
     }
 

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn test_vote_transaction_cost() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         // Create a sanitized vote transaction.
         let vote_transaction = RuntimeTransaction::try_create(
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn test_non_vote_transaction_cost() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         // Create a sanitized non-vote transaction.
         let non_vote_transaction = RuntimeTransaction::try_create(

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -115,6 +115,7 @@ name = "agave-ledger-tool"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "agave-reserved-account-keys",
  "agave-snapshots",
  "agave-syscalls",
@@ -159,7 +160,6 @@ dependencies = [
  "solana-keypair",
  "solana-ledger",
  "solana-loader-v3-interface",
- "solana-logger",
  "solana-measure",
  "solana-message",
  "solana-native-token",
@@ -192,6 +192,16 @@ dependencies = [
  "thiserror 2.0.17",
  "tikv-jemallocator",
  "tokio",
+]
+
+[[package]]
+name = "agave-logger"
+version = "3.1.0"
+dependencies = [
+ "env_logger",
+ "libc",
+ "log",
+ "signal-hook",
 ]
 
 [[package]]
@@ -345,6 +355,7 @@ dependencies = [
 name = "agave-votor"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "agave-votor-messages",
  "anyhow",
  "bincode",
@@ -375,7 +386,6 @@ dependencies = [
  "solana-hash",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-pubkey",
@@ -396,11 +406,11 @@ dependencies = [
 name = "agave-votor-messages"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "serde",
  "solana-bls-signatures",
  "solana-clock",
  "solana-hash",
- "solana-logger",
 ]
 
 [[package]]
@@ -6002,6 +6012,7 @@ name = "solana-banking-bench"
 version = "3.1.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
+ "agave-logger",
  "assert_matches",
  "clap 3.2.25",
  "crossbeam-channel",
@@ -6015,7 +6026,6 @@ dependencies = [
  "solana-hash",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-measure",
  "solana-message",
  "solana-perf",
@@ -6110,6 +6120,7 @@ name = "solana-bench-tps"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "chrono",
  "clap 2.34.0",
  "crossbeam-channel",
@@ -6139,7 +6150,6 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-local-cluster",
- "solana-logger",
  "solana-measure",
  "solana-message",
  "solana-metrics",
@@ -6843,6 +6853,7 @@ dependencies = [
 name = "solana-dos"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "bincode",
  "clap 3.2.25",
  "crossbeam-channel",
@@ -6860,7 +6871,6 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-local-cluster",
- "solana-logger",
  "solana-measure",
  "solana-message",
  "solana-net-utils",
@@ -6975,6 +6985,7 @@ dependencies = [
 name = "solana-faucet"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "bincode",
  "clap 2.34.0",
  "crossbeam-channel",
@@ -6986,7 +6997,6 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
- "solana-logger",
  "solana-message",
  "solana-metrics",
  "solana-net-utils",
@@ -7056,6 +7066,7 @@ name = "solana-genesis"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "agave-snapshots",
  "base64 0.22.1",
  "bincode",
@@ -7079,7 +7090,6 @@ dependencies = [
  "solana-keypair",
  "solana-ledger",
  "solana-loader-v3-interface",
- "solana-logger",
  "solana-native-token",
  "solana-poh-config",
  "solana-pubkey",
@@ -7161,6 +7171,7 @@ name = "solana-gossip"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "arrayvec",
  "assert_matches",
  "bincode",
@@ -7191,7 +7202,6 @@ dependencies = [
  "solana-hash",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-native-token",
@@ -7520,6 +7530,7 @@ dependencies = [
 name = "solana-local-cluster"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "agave-snapshots",
  "crossbeam-channel",
  "itertools 0.12.1",
@@ -7542,7 +7553,6 @@ dependencies = [
  "solana-hash",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-message",
  "solana-native-token",
  "solana-net-utils",
@@ -7577,19 +7587,6 @@ dependencies = [
  "strum",
  "tempfile",
  "trees",
-]
-
-[[package]]
-name = "solana-logger"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7421d1092680d72065edbf5c7605856719b021bf5f173656c71febcdd5d003"
-dependencies = [
- "env_logger",
- "lazy_static",
- "libc",
- "log",
- "signal-hook",
 ]
 
 [[package]]
@@ -7946,6 +7943,7 @@ name = "solana-program-test"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "assert_matches",
  "async-trait",
  "base64 0.22.1",
@@ -7972,7 +7970,6 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-loader-v3-interface",
- "solana-logger",
  "solana-message",
  "solana-msg",
  "solana-native-token",
@@ -9097,7 +9094,6 @@ dependencies = [
  "solana-keypair",
  "solana-ledger",
  "solana-loader-v3-interface",
- "solana-logger",
  "solana-message",
  "solana-native-token",
  "solana-net-utils",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -38,6 +38,7 @@ used_underscore_binding = "deny"
 [workspace.dependencies]
 agave-banking-stage-ingress-types = { path = "../banking-stage-ingress-types", version = "=3.1.0", features = ["agave-unstable-api"] }
 agave-feature-set = { path = "../feature-set", version = "=3.1.0", features = ["agave-unstable-api"] }
+agave-logger = { path = "../logger", version = "=3.1.0", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=3.1.0", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "../snapshots", version = "=3.1.0", features = ["agave-unstable-api"] }
 agave-syscalls = { path = "../syscalls", version = "=3.1.0", features = ["agave-unstable-api"] }
@@ -101,7 +102,6 @@ solana-keypair = "3.0.1"
 solana-ledger = { path = "../ledger", version = "=3.1.0", features = ["agave-unstable-api"] }
 solana-loader-v3-interface = "6.1.0"
 solana-local-cluster = { path = "../local-cluster", version = "=3.1.0", features = ["agave-unstable-api"] }
-solana-logger = "3.0.0"
 solana-measure = { path = "../measure", version = "=3.1.0", features = ["agave-unstable-api"] }
 solana-message = "3.0.1"
 solana-metrics = { path = "../metrics", version = "=3.1.0", features = ["agave-unstable-api"] }

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -20,6 +20,7 @@ dummy-for-ci-check = []
 frozen-abi = []
 
 [dependencies]
+agave-logger = { workspace = true }
 bincode = { workspace = true }
 clap = { version = "3.1.5", features = ["derive", "cargo"] }
 crossbeam-channel = { workspace = true }
@@ -35,7 +36,6 @@ solana-gossip = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = "=3.0.0"
 solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -760,7 +760,7 @@ fn run_dos<T: 'static + TpsClient + Send + Sync>(
 }
 
 fn main() {
-    solana_logger::setup_with_default_filter();
+    agave_logger::setup_with_default_filter();
     let mut cmd_params = build_cli_parameters();
 
     if !cmd_params.skip_gossip && cmd_params.shred_version.is_none() {
@@ -943,7 +943,7 @@ pub mod test {
 
     #[test]
     fn test_dos_random() {
-        solana_logger::setup();
+        agave_logger::setup();
         let num_nodes = 1;
         let cluster =
             LocalCluster::new_with_equal_stakes(num_nodes, 100, 3, SocketAddrSpace::Unspecified);
@@ -977,7 +977,7 @@ pub mod test {
 
     #[test]
     fn test_dos_without_blockhash() {
-        solana_logger::setup();
+        agave_logger::setup();
         let num_nodes = 1;
         let cluster =
             LocalCluster::new_with_equal_stakes(num_nodes, 100, 3, SocketAddrSpace::Unspecified);
@@ -1081,7 +1081,7 @@ pub mod test {
     }
 
     fn run_dos_with_blockhash_and_payer(tpu_use_quic: bool) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         // 1. Create faucet thread
         let faucet_keypair = Keypair::new();

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -46,12 +46,12 @@ solana-transaction-error = { workspace = true }
 wincode = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 assert_matches = { workspace = true }
 proptest = { workspace = true }
 solana-entry = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-message = { workspace = true }
 solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true }

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -1202,7 +1202,7 @@ mod tests {
 
     #[test]
     fn test_verify_slice1() {
-        solana_logger::setup();
+        agave_logger::setup();
         let thread_pool = thread_pool_for_tests();
 
         let zero = Hash::default();
@@ -1224,7 +1224,7 @@ mod tests {
 
     #[test]
     fn test_verify_slice_with_hashes1() {
-        solana_logger::setup();
+        agave_logger::setup();
         let thread_pool = thread_pool_for_tests();
 
         let zero = Hash::default();
@@ -1251,7 +1251,7 @@ mod tests {
 
     #[test]
     fn test_verify_slice_with_hashes_and_transactions() {
-        solana_logger::setup();
+        agave_logger::setup();
         let thread_pool = thread_pool_for_tests();
 
         let zero = Hash::default();
@@ -1404,7 +1404,7 @@ mod tests {
 
     #[test]
     fn test_poh_verify_fuzz() {
-        solana_logger::setup();
+        agave_logger::setup();
         for _ in 0..100 {
             let mut time = Measure::start("ticks");
             let num_ticks = thread_rng().gen_range(1..100);

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -25,6 +25,7 @@ agave-unstable-api = []
 dev-context-only-utils = []
 
 [dependencies]
+agave-logger = { workspace = true }
 bincode = { workspace = true }
 clap = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -36,7 +37,6 @@ solana-cli-output = { workspace = true }
 solana-hash = "=3.0.0"
 solana-instruction = "=3.0.0"
 solana-keypair = "=3.0.1"
-solana-logger = "=3.0.0"
 solana-message = "=3.0.1"
 solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -19,7 +19,7 @@ use {
 async fn main() {
     let default_keypair = solana_cli_config::Config::default().keypair_path;
 
-    solana_logger::setup_with_default_filter();
+    agave_logger::setup_with_default_filter();
     solana_metrics::set_panic_hook("faucet", /*version:*/ None);
     let matches = App::new(crate_name!())
         .about(crate_description!())

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -25,6 +25,7 @@ agave-unstable-api = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
@@ -48,7 +49,6 @@ solana-inflation = "=3.0.0"
 solana-keypair = "=3.0.1"
 solana-ledger = { workspace = true }
 solana-loader-v3-interface = "6.1.0"
-solana-logger = "=3.0.0"
 solana-native-token = "=3.0.0"
 solana-poh-config = "=3.0.0"
 solana-pubkey = { version = "=3.0.0", default-features = false }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -878,7 +878,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         }
     }
 
-    solana_logger::setup();
+    agave_logger::setup();
     create_new_ledger(
         &ledger_path,
         &genesis_config,

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -37,6 +37,7 @@ agave-unstable-api = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-logger = { workspace = true }
 arrayvec = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
@@ -73,7 +74,6 @@ solana-frozen-abi-macro = { version = "=3.0.1", optional = true, features = [
 solana-hash = "=3.0.0"
 solana-keypair = "=3.0.1"
 solana-ledger = { workspace = true, features = ["agave-unstable-api"] }
-solana-logger = "=3.0.0"
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-native-token = "=3.0.0"

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2647,7 +2647,7 @@ mod tests {
 
     #[test]
     fn test_handle_pull() {
-        solana_logger::setup();
+        agave_logger::setup();
         let cluster_info = Arc::new({
             let keypair = Arc::new(Keypair::new());
             let node = Node::new_localhost_with_pubkey(&keypair.pubkey());
@@ -3690,7 +3690,7 @@ mod tests {
 
     #[test]
     fn test_push_restart_heaviest_fork() {
-        solana_logger::setup();
+        agave_logger::setup();
         let keypair = Arc::new(Keypair::new());
         let pubkey = keypair.pubkey();
         let contact_info = ContactInfo::new_localhost(&pubkey, 0);
@@ -3764,7 +3764,7 @@ mod tests {
 
     #[test]
     fn test_contact_trace() {
-        solana_logger::setup();
+        agave_logger::setup();
         let keypair43 = Arc::new(
             Keypair::try_from(
                 [

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_handle_mixed_entries() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
@@ -381,7 +381,7 @@ mod tests {
 
     #[test]
     fn test_reject_abuses() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -375,7 +375,7 @@ fn get_gossip_address(matches: &ArgMatches, entrypoint_addr: Option<SocketAddr>)
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
-    solana_logger::setup_with_default_filter();
+    agave_logger::setup_with_default_filter();
 
     let matches = parse_matches();
     let socket_addr_space = SocketAddrSpace::new(matches.is_present("allow_private_addr"));

--- a/gossip/src/wire_format_tests.rs
+++ b/gossip/src/wire_format_tests.rs
@@ -40,7 +40,7 @@ mod tests {
     /// Export the "GOSSIP_WIRE_FORMAT_PACKETS" variable to run this test
     #[test]
     fn test_gossip_wire_format() {
-        solana_logger::setup();
+        agave_logger::setup();
         let path_base = match std::env::var_os("GOSSIP_WIRE_FORMAT_PACKETS") {
             Some(p) => PathBuf::from(p),
             None => {

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -712,7 +712,7 @@ fn test_star_network_push_ring_200() {
 #[ignore]
 #[serial]
 fn test_connected_staked_network() {
-    solana_logger::setup();
+    agave_logger::setup();
     let thread_pool = build_gossip_thread_pool();
     let stakes = [
         [1000; 2].to_vec(),
@@ -741,7 +741,7 @@ fn test_connected_staked_network() {
 #[test]
 #[ignore]
 fn test_star_network_large_pull() {
-    solana_logger::setup();
+    agave_logger::setup();
     let network = star_network_create(2000);
     let thread_pool = build_gossip_thread_pool();
     network_simulator_pull_only(&thread_pool, &network);
@@ -749,7 +749,7 @@ fn test_star_network_large_pull() {
 #[test]
 #[ignore]
 fn test_rstar_network_large_push() {
-    solana_logger::setup();
+    agave_logger::setup();
     let mut network = rstar_network_create(4000);
     let thread_pool = build_gossip_thread_pool();
     network_simulator(&thread_pool, &mut network, 0.9);
@@ -757,7 +757,7 @@ fn test_rstar_network_large_push() {
 #[test]
 #[ignore]
 fn test_ring_network_large_push() {
-    solana_logger::setup();
+    agave_logger::setup();
     let mut network = ring_network_create(4001);
     let thread_pool = build_gossip_thread_pool();
     network_simulator(&thread_pool, &mut network, 0.9);
@@ -765,7 +765,7 @@ fn test_ring_network_large_push() {
 #[test]
 #[ignore]
 fn test_star_network_large_push() {
-    solana_logger::setup();
+    agave_logger::setup();
     let mut network = star_network_create(4002);
     let thread_pool = build_gossip_thread_pool();
     network_simulator(&thread_pool, &mut network, 0.9);

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -155,7 +155,7 @@ fn retransmit_to(
 /// ring a -> b -> c -> d -> e -> a
 #[test]
 fn gossip_ring() {
-    solana_logger::setup();
+    agave_logger::setup();
     run_gossip_topo(40, |listen| {
         let num = listen.len();
         for n in 0..num {
@@ -173,7 +173,7 @@ fn gossip_ring() {
 #[test]
 #[ignore]
 fn gossip_ring_large() {
-    solana_logger::setup();
+    agave_logger::setup();
     run_gossip_topo(600, |listen| {
         let num = listen.len();
         for n in 0..num {
@@ -189,7 +189,7 @@ fn gossip_ring_large() {
 /// star a -> (b,c,d,e)
 #[test]
 fn gossip_star() {
-    solana_logger::setup();
+    agave_logger::setup();
     run_gossip_topo(10, |listen| {
         let num = listen.len();
         for n in 0..(num - 1) {
@@ -208,7 +208,7 @@ fn gossip_star() {
 /// rstar a <- (b,c,d,e)
 #[test]
 fn gossip_rstar() {
-    solana_logger::setup();
+    agave_logger::setup();
     run_gossip_topo(10, |listen| {
         let num = listen.len();
         let xd = {
@@ -227,7 +227,7 @@ fn gossip_rstar() {
 
 #[test]
 pub fn cluster_info_retransmit() {
-    solana_logger::setup();
+    agave_logger::setup();
     let exit = Arc::new(AtomicBool::new(false));
     trace!("c1:");
     let (c1, dr1, tn1) = test_node(exit.clone());
@@ -295,7 +295,7 @@ pub fn cluster_info_scale() {
             genesis_utils::{create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs},
         },
     };
-    solana_logger::setup();
+    agave_logger::setup();
     let exit = Arc::new(AtomicBool::new(false));
     let num_nodes: usize = std::env::var("NUM_NODES")
         .unwrap_or_else(|_| "10".to_string())

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 
 [dependencies]
+agave-logger = { workspace = true }
 atty = { workspace = true }
 bincode = { workspace = true }
 bzip2 = { workspace = true }
@@ -37,7 +38,6 @@ solana-clap-utils = { workspace = true }
 solana-config-interface = { version = "=2.0.0", features = ["bincode"] }
 solana-hash = "=3.0.0"
 solana-keypair = "=3.0.1"
-solana-logger = "=3.0.0"
 solana-message = "=3.0.1"
 solana-pubkey = { version = "=3.0.0", default-features = false }
 solana-rpc-client = { workspace = true }

--- a/install/src/lib.rs
+++ b/install/src/lib.rs
@@ -80,7 +80,7 @@ fn handle_init(matches: &ArgMatches<'_>, config_file: &str) -> Result<(), String
 }
 
 pub fn main() -> Result<(), String> {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
@@ -276,7 +276,7 @@ pub fn main() -> Result<(), String> {
 }
 
 pub fn main_init() -> Result<(), String> {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let matches = App::new("agave-install-init")
         .about("Initializes a new installation")

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -21,6 +21,7 @@ frozen-abi = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-logger = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-syscalls = { workspace = true }
@@ -63,7 +64,6 @@ solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils", "agave-unstable-api"] }
 solana-loader-v3-interface = { workspace = true }
-solana-logger = "=3.0.0"
 solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-native-token = { workspace = true }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -859,7 +859,7 @@ fn main() {
         unsafe { signal_hook::low_level::register(signal_hook::consts::SIGUSR1, || {}) }.unwrap();
     }
 
-    solana_logger::setup_with_default_filter();
+    agave_logger::setup_with_default_filter();
 
     let load_genesis_config_arg = load_genesis_arg();
     let accounts_db_config_args = accounts_db_args();

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -132,13 +132,13 @@ default-features = false
 features = ["lz4"]
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 bs58 = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }
 solana-account-decoder = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-ledger = { path = ".", features = ["dev-context-only-utils", "agave-unstable-api"] }
-solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-program-option = { workspace = true }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5281,7 +5281,7 @@ pub mod tests {
 
     #[test]
     fn test_create_new_ledger() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mint_total = 1_000_000_000_000;
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(mint_total);
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
@@ -5341,7 +5341,7 @@ pub mod tests {
 
     #[test]
     fn test_write_entries() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -6098,7 +6098,7 @@ pub mod tests {
 
     #[test]
     fn test_handle_chaining_missing_slots() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -6163,7 +6163,7 @@ pub mod tests {
     #[test]
     #[allow(clippy::cognitive_complexity)]
     pub fn test_forward_chaining_is_connected() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -6250,7 +6250,7 @@ pub mod tests {
                 .collect::<Vec<_>>()
         }
 
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -6334,7 +6334,7 @@ pub mod tests {
 
     #[test]
     fn test_set_and_chain_connected_on_root_and_next_slots() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -6959,7 +6959,7 @@ pub mod tests {
 
     #[test]
     fn test_should_insert_data_shred() {
-        solana_logger::setup();
+        agave_logger::setup();
         let entries = create_ticks(2000, 1, Hash::new_unique());
         let shredder = Shredder::new(0, 0, 1, 0).unwrap();
         let keypair = Keypair::new();
@@ -7606,7 +7606,7 @@ pub mod tests {
 
     #[test]
     fn test_insert_multiple_is_last() {
-        solana_logger::setup();
+        agave_logger::setup();
         let (shreds, _) = make_slot_entries(0, 0, 18);
         let num_shreds = shreds.len() as u64;
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -8656,7 +8656,7 @@ pub mod tests {
     }
 
     fn do_test_lowest_cleanup_slot_and_special_cfs(simulate_blockstore_cleanup_service: bool) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
@@ -10519,7 +10519,7 @@ pub mod tests {
     /// by producing valid shreds with overlapping fec_set_index ranges
     /// so that we fail the config check and mark the slot duplicate
     fn erasure_multiple_config() {
-        solana_logger::setup();
+        agave_logger::setup();
         let slot = 1;
         let num_txs = 20;
         // primary slot content

--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -280,7 +280,7 @@ mod tests {
     fn test_find_slots_to_clean() {
         // BlockstoreCleanupService::find_slots_to_clean() does not modify the
         // Blockstore, so we can make repeated calls on the same slots
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -353,7 +353,7 @@ mod tests {
 
     #[test]
     fn test_cleanup() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
         let (shreds, _) = make_many_slot_entries(0, 50, 5);
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_cleanup_speed() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1335,7 +1335,7 @@ pub mod tests {
 
     #[test]
     fn test_open_unknown_columns() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path();
@@ -1375,7 +1375,7 @@ pub mod tests {
 
     #[test]
     fn test_remove_deprecated_progam_costs_column_compat() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         fn is_program_costs_column_present(path: &Path) -> bool {
             DB::list_cf(&Options::default(), path)

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2455,7 +2455,7 @@ pub mod tests {
 
     // Intentionally make slot 1 faulty and ensure that processing sees it as dead
     fn do_test_process_blockstore_with_missing_hashes(blockstore_access_type: AccessType) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let hashes_per_tick = 2;
         let GenesisConfigInfo {
@@ -2511,7 +2511,7 @@ pub mod tests {
 
     #[test]
     fn test_process_blockstore_with_invalid_slot_tick_count() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
@@ -2573,7 +2573,7 @@ pub mod tests {
 
     #[test]
     fn test_process_blockstore_with_slot_with_trailing_entry() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo {
             mint_keypair,
@@ -2623,7 +2623,7 @@ pub mod tests {
 
     #[test]
     fn test_process_blockstore_with_incomplete_slot() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
@@ -2708,7 +2708,7 @@ pub mod tests {
 
     #[test]
     fn test_process_blockstore_with_two_forks_and_squash() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
@@ -2787,7 +2787,7 @@ pub mod tests {
 
     #[test]
     fn test_process_blockstore_with_two_forks() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
@@ -2877,7 +2877,7 @@ pub mod tests {
 
     #[test]
     fn test_process_blockstore_with_dead_slot() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
@@ -2924,7 +2924,7 @@ pub mod tests {
 
     #[test]
     fn test_process_blockstore_with_dead_child() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
@@ -2984,7 +2984,7 @@ pub mod tests {
 
     #[test]
     fn test_root_with_all_dead_children() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
@@ -3017,7 +3017,7 @@ pub mod tests {
 
     #[test]
     fn test_process_blockstore_epoch_boundary_root() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
@@ -3108,7 +3108,7 @@ pub mod tests {
 
     #[test]
     fn test_process_empty_entry_is_registered() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo {
             genesis_config,
@@ -3138,7 +3138,7 @@ pub mod tests {
 
     #[test]
     fn test_process_ledger_simple() {
-        solana_logger::setup();
+        agave_logger::setup();
         let leader_pubkey = solana_pubkey::new_rand();
         let mint = 100;
         let hashes_per_tick = 10;
@@ -3465,7 +3465,7 @@ pub mod tests {
 
     #[test]
     fn test_transaction_result_does_not_affect_bankhash() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -3640,7 +3640,7 @@ pub mod tests {
     fn test_process_entries_2nd_entry_collision_with_self_and_error(
         relax_intrabatch_account_locks: bool,
     ) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo {
             genesis_config,
@@ -3750,7 +3750,7 @@ pub mod tests {
     #[test_case(false; "old")]
     #[test_case(true; "simd83")]
     fn test_process_entry_duplicate_transaction(relax_intrabatch_account_locks: bool) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo {
             genesis_config,
@@ -4322,7 +4322,7 @@ pub mod tests {
     fn test_process_entries_stress() {
         // this test throws lots of rayon threads at process_entries()
         //  finds bugs in very low-layer stuff
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -4645,7 +4645,7 @@ pub mod tests {
         blockstore_root: Option<Slot>,
         blockstore_access_type: AccessType,
     ) {
-        solana_logger::setup();
+        agave_logger::setup();
         /*
             Build fork structure:
                  slot 0
@@ -5056,7 +5056,7 @@ pub mod tests {
     }
 
     fn do_test_schedule_batches_for_execution(should_succeed: bool) {
-        solana_logger::setup();
+        agave_logger::setup();
         let dummy_leader_pubkey = solana_pubkey::new_rand();
         let GenesisConfigInfo {
             genesis_config,
@@ -5162,7 +5162,7 @@ pub mod tests {
         tx_result: TxResult,
         poh_result: Result<Option<usize>>,
     ) {
-        solana_logger::setup();
+        agave_logger::setup();
         let dummy_leader_pubkey = solana_pubkey::new_rand();
         let GenesisConfigInfo {
             genesis_config,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -1111,7 +1111,7 @@ mod tests {
     #[test_case(true ; "last_in_slot")]
     #[test_case(false ; "not_last_in_slot")]
     fn test_should_discard_shred(is_last_in_slot: bool) {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut rng = rand::thread_rng();
         let slot = 18_291;
         let shreds = make_merkle_shreds_for_tests(
@@ -1375,7 +1375,7 @@ mod tests {
     #[test_case(true; "enforce_fixed_fec_set")]
     #[test_case(false ; "do_not_enforce_fixed_fec_set")]
     fn test_should_discard_shred_fec_set_checks(enforce_fixed_fec_set: bool) {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut rng = rand::thread_rng();
         let slot = 18_291;
         let shreds = make_merkle_shreds_for_tests(
@@ -1969,7 +1969,7 @@ mod tests {
 
     #[test]
     fn test_data_complete_shred_index_validation() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut rng = rand::thread_rng();
         let slot = 18_291;
         let shreds = make_merkle_shreds_for_tests(

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -546,7 +546,7 @@ mod tests {
     };
 
     fn run_test_sigverify_shred_cpu(slot: Slot) {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut packet = Packet::default();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
@@ -585,7 +585,7 @@ mod tests {
     }
 
     fn run_test_sigverify_shreds_cpu(thread_pool: &ThreadPool, slot: Slot) {
-        solana_logger::setup();
+        agave_logger::setup();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let keypair = Keypair::new();
         let batch = make_packet_batch(&keypair, slot);
@@ -619,7 +619,7 @@ mod tests {
     }
 
     fn run_test_sigverify_shreds_gpu(thread_pool: &ThreadPool, slot: Slot) {
-        solana_logger::setup();
+        agave_logger::setup();
         let recycler_cache = RecyclerCache::default();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
 

--- a/ledger/src/wire_format_tests.rs
+++ b/ledger/src/wire_format_tests.rs
@@ -65,7 +65,7 @@ mod tests {
     /// Export the "TURBINE_WIRE_FORMAT_PACKETS" env variable to run this test.
     #[test]
     fn test_turbine_wire_format() {
-        solana_logger::setup();
+        agave_logger::setup();
         let path_base = match std::env::var_os("TURBINE_WIRE_FORMAT_PACKETS") {
             Some(p) => PathBuf::from(p),
             None => {

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -17,6 +17,7 @@ agave-unstable-api = []
 dev-context-only-utils = ["solana-core/dev-context-only-utils"]
 
 [dependencies]
+agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 crossbeam-channel = { workspace = true }
 itertools = { workspace = true }
@@ -39,7 +40,6 @@ solana-hard-forks = { workspace = true }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
-solana-logger = { workspace = true }
 solana-message = { workspace = true }
 solana-native-token = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -305,7 +305,7 @@ pub fn run_cluster_partition<C>(
     ticks_per_slot: Option<u64>,
     additional_accounts: Vec<(Pubkey, AccountSharedData)>,
 ) {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     info!("PARTITION_TEST!");
     let num_nodes = partitions.len();
     let node_stakes: Vec<_> = partitions

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -108,7 +108,7 @@ use {
 #[test]
 #[serial]
 fn test_local_cluster_start_and_exit() {
-    solana_logger::setup();
+    agave_logger::setup();
     let num_nodes = 1;
     let cluster = LocalCluster::new_with_equal_stakes(
         num_nodes,
@@ -122,7 +122,7 @@ fn test_local_cluster_start_and_exit() {
 #[test]
 #[serial]
 fn test_local_cluster_start_and_exit_with_config() {
-    solana_logger::setup();
+    agave_logger::setup();
     const NUM_NODES: usize = 1;
     let mut config = ClusterConfig {
         validator_configs: make_identical_validator_configs(
@@ -142,7 +142,7 @@ fn test_local_cluster_start_and_exit_with_config() {
 #[test]
 #[serial]
 fn test_spend_and_verify_all_nodes_1() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     error!("test_spend_and_verify_all_nodes_1");
     let num_nodes = 1;
     let local = LocalCluster::new_with_equal_stakes(
@@ -164,7 +164,7 @@ fn test_spend_and_verify_all_nodes_1() {
 #[test]
 #[serial]
 fn test_spend_and_verify_all_nodes_2() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     error!("test_spend_and_verify_all_nodes_2");
     let num_nodes = 2;
     let local = LocalCluster::new_with_equal_stakes(
@@ -186,7 +186,7 @@ fn test_spend_and_verify_all_nodes_2() {
 #[test]
 #[serial]
 fn test_spend_and_verify_all_nodes_3() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     error!("test_spend_and_verify_all_nodes_3");
     let num_nodes = 3;
     let local = LocalCluster::new_with_equal_stakes(
@@ -208,7 +208,7 @@ fn test_spend_and_verify_all_nodes_3() {
 #[test]
 #[serial]
 fn test_local_cluster_signature_subscribe() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     let num_nodes = 2;
     let cluster = LocalCluster::new_with_equal_stakes(
         num_nodes,
@@ -291,7 +291,7 @@ fn test_local_cluster_signature_subscribe() {
 #[test]
 #[serial]
 fn test_two_unbalanced_stakes() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     error!("test_two_unbalanced_stakes");
     let validator_config = ValidatorConfig::default_for_test();
     let num_ticks_per_second = 100;
@@ -327,7 +327,7 @@ fn test_two_unbalanced_stakes() {
 #[test]
 #[serial]
 fn test_forwarding() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     // Set up a cluster where one node is never the leader, so all txs sent to this node
     // will be have to be forwarded in order to be confirmed
     let mut config = ClusterConfig {
@@ -370,7 +370,7 @@ fn test_forwarding() {
 #[test]
 #[serial]
 fn test_restart_node() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     error!("test_restart_node");
     let slots_per_epoch = MINIMUM_SLOTS_PER_EPOCH * 2;
     let ticks_per_slot = 16;
@@ -413,7 +413,7 @@ fn test_restart_node() {
 #[test]
 #[serial]
 fn test_mainnet_beta_cluster_type() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
 
     let mut config = ClusterConfig {
         cluster_type: ClusterType::MainnetBeta,
@@ -481,7 +481,7 @@ fn test_mainnet_beta_cluster_type() {
 #[test]
 #[serial]
 fn test_snapshot_download() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     // First set up the cluster with 1 node
     let snapshot_interval_slots = NonZeroU64::new(50).unwrap();
     let num_account_paths = 3;
@@ -556,7 +556,7 @@ fn test_snapshot_download() {
 #[test]
 #[serial]
 fn test_incremental_snapshot_download() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     // First set up the cluster with 1 node
     let incremental_snapshot_interval = 9;
     let full_snapshot_interval = incremental_snapshot_interval * 3;
@@ -729,7 +729,7 @@ fn test_incremental_snapshot_download() {
 #[test]
 #[serial]
 fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_startup() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     // If these intervals change, also make sure to change the loop timers accordingly.
     let incremental_snapshot_interval = 9;
     let full_snapshot_interval = incremental_snapshot_interval * 5;
@@ -1237,7 +1237,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 #[test]
 #[serial]
 fn test_snapshot_restart_tower() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     // First set up the cluster with 2 nodes
     let snapshot_interval_slots = NonZeroU64::new(10).unwrap();
     let num_account_paths = 2;
@@ -1310,7 +1310,7 @@ fn test_snapshot_restart_tower() {
 #[test]
 #[serial]
 fn test_snapshots_blockstore_floor() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     // First set up the cluster with 1 snapshotting leader
     let snapshot_interval_slots = NonZeroU64::new(100).unwrap();
     let num_account_paths = 4;
@@ -1423,7 +1423,7 @@ fn test_snapshots_blockstore_floor() {
 #[test]
 #[serial]
 fn test_snapshots_restart_validity() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     let snapshot_interval_slots = NonZeroU64::new(100).unwrap();
     let num_account_paths = 1;
     let mut snapshot_test_config =
@@ -1512,7 +1512,7 @@ fn test_snapshots_restart_validity() {
 #[allow(unused_attributes)]
 #[ignore]
 fn test_fail_entry_verification_leader() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     let leader_stake = (DUPLICATE_THRESHOLD * 100.0) as u64 + 1;
     let validator_stake1 = (100 - leader_stake) / 2;
     let validator_stake2 = 100 - leader_stake - validator_stake1;
@@ -1534,7 +1534,7 @@ fn test_fail_entry_verification_leader() {
 #[ignore]
 #[allow(unused_attributes)]
 fn test_fake_shreds_broadcast_leader() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     let node_stakes = vec![300, 100];
     let (cluster, _) = test_faulty_node(
         BroadcastStageType::BroadcastFakeShreds,
@@ -1552,7 +1552,7 @@ fn test_fake_shreds_broadcast_leader() {
 #[test]
 #[serial]
 fn test_wait_for_max_stake() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     let validator_config = ValidatorConfig::default_for_test();
     let slots_per_epoch = MINIMUM_SLOTS_PER_EPOCH;
     // Set this large enough to allow for skipped slots but still be able to
@@ -1610,7 +1610,7 @@ fn test_wait_for_max_stake() {
 // Test that when a leader is leader for banks B_i..B_{i+n}, and B_i is not
 // votable, then B_{i+1} still chains to B_i
 fn test_no_voting() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     let validator_config = ValidatorConfig {
         voting_disabled: true,
         ..ValidatorConfig::default_for_test()
@@ -1650,7 +1650,7 @@ fn test_no_voting() {
 #[test]
 #[serial]
 fn test_optimistic_confirmation_violation_detection() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     // First set up the cluster with 2 nodes
     let slots_per_epoch = 2048;
     let node_stakes = vec![50 * DEFAULT_NODE_STAKE, 51 * DEFAULT_NODE_STAKE];
@@ -1887,7 +1887,7 @@ fn test_optimistic_confirmation_violation_detection() {
 #[test]
 #[serial]
 fn test_validator_saves_tower() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
 
     let validator_config = ValidatorConfig {
         require_tower: true,
@@ -2037,7 +2037,7 @@ enum ClusterMode {
 }
 
 fn do_test_future_tower(cluster_mode: ClusterMode) {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
 
     // First set up the cluster with 4 nodes
     let slots_per_epoch = 2048;
@@ -2205,7 +2205,7 @@ fn restart_whole_cluster_after_hard_fork(
 #[test]
 #[serial]
 fn test_hard_fork_invalidates_tower() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
 
     // First set up the cluster with 2 nodes
     let slots_per_epoch = 2048;
@@ -2378,7 +2378,7 @@ fn create_snapshot_to_hard_fork(
 #[ignore]
 #[serial]
 fn test_hard_fork_with_gap_in_roots() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
 
     // First set up the cluster with 2 nodes
     let slots_per_epoch = 2048;
@@ -2545,7 +2545,7 @@ fn test_restart_tower_rollback() {
     // Test node crashing and failing to save its tower before restart
     // Cluster continues to make progress, this node is able to rejoin with
     // outdated tower post restart.
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
 
     // First set up the cluster with 2 nodes
     let slots_per_epoch = 2048;
@@ -2778,7 +2778,7 @@ fn test_rpc_block_subscribe() {
 #[serial]
 #[allow(unused_attributes)]
 fn test_oc_bad_signatures() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
 
     let total_stake = 100 * DEFAULT_NODE_STAKE;
     let leader_stake = (total_stake as f64 * VOTE_THRESHOLD_SIZE) as u64;
@@ -3150,7 +3150,7 @@ fn setup_transfer_scan_threads(
 }
 
 fn run_test_load_program_accounts(scan_commitment: CommitmentConfig) {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     // First set up the cluster with 2 nodes
     let slots_per_epoch = 2048;
     let node_stakes = vec![51 * DEFAULT_NODE_STAKE, 50 * DEFAULT_NODE_STAKE];
@@ -3265,7 +3265,7 @@ fn test_lockout_violation_without_tower() {
 //    `A` should not be able to generate a switching proof.
 //
 fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
-    solana_logger::setup_with("info");
+    agave_logger::setup_with("info");
 
     // First set up the cluster with 4 nodes
     let slots_per_epoch = 2048;
@@ -3545,7 +3545,7 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
 // stalling the network.
 
 fn test_fork_choice_refresh_old_votes() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     let max_switch_threshold_failure_pct = 1.0 - 2.0 * SWITCH_FORK_THRESHOLD;
     let total_stake = 100 * DEFAULT_NODE_STAKE;
     let max_failures_stake = (max_switch_threshold_failure_pct * total_stake as f64) as u64;
@@ -3942,7 +3942,7 @@ fn test_duplicate_shreds_broadcast_leader_ancestor_hashes() {
 }
 
 fn run_duplicate_shreds_broadcast_leader(vote_on_duplicate: bool) {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     // Create 4 nodes:
     // 1) Bad leader sending different versions of shreds to both of the other nodes
     // 2) 1 node who's voting behavior in gossip
@@ -4120,7 +4120,7 @@ fn run_duplicate_shreds_broadcast_leader(vote_on_duplicate: bool) {
 #[serial]
 #[ignore]
 fn test_switch_threshold_uses_gossip_votes() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     let total_stake = 100 * DEFAULT_NODE_STAKE;
 
     // Minimum stake needed to generate a switching proof
@@ -4449,7 +4449,7 @@ fn test_cluster_partition_1_1_1() {
 #[test]
 #[serial]
 fn test_leader_failure_4() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     error!("test_leader_failure_4");
     // Cluster needs a supermajority to remain even after taking 1 node offline,
     // so the minimum number of nodes for this test is 4.
@@ -4524,7 +4524,7 @@ fn test_leader_failure_4() {
 #[test]
 #[serial]
 fn test_slot_hash_expiry() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     solana_slot_hashes::set_entries_for_tests_only(64);
 
     let slots_per_epoch = 2048;
@@ -4740,7 +4740,7 @@ fn test_slot_hash_expiry() {
 #[serial]
 #[ignore]
 fn test_duplicate_with_pruned_ancestor() {
-    solana_logger::setup_with("info,solana_metrics=off");
+    agave_logger::setup_with("info,solana_metrics=off");
     solana_core::repair::duplicate_repair_status::set_ancestor_hash_repair_sample_size_for_tests_only(3);
 
     let majority_leader_stake = 10_000_000 * DEFAULT_NODE_STAKE;
@@ -4984,7 +4984,7 @@ fn test_duplicate_with_pruned_ancestor() {
 #[test]
 #[serial]
 fn test_boot_from_local_state() {
-    solana_logger::setup_with_default("error,local_cluster=info");
+    agave_logger::setup_with_default("error,local_cluster=info");
     const FULL_SNAPSHOT_INTERVAL: SnapshotInterval =
         SnapshotInterval::Slots(NonZeroU64::new(100).unwrap());
     const INCREMENTAL_SNAPSHOT_INTERVAL: SnapshotInterval =
@@ -5279,7 +5279,7 @@ fn test_boot_from_local_state() {
 #[test]
 #[serial]
 fn test_boot_from_local_state_missing_archive() {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     const FULL_SNAPSHOT_INTERVAL: SnapshotInterval =
         SnapshotInterval::Slots(NonZeroU64::new(20).unwrap());
     const INCREMENTAL_SNAPSHOT_INTERVAL: SnapshotInterval =
@@ -5454,7 +5454,7 @@ fn test_duplicate_shreds_switch_failure() {
         }
     }
 
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    agave_logger::setup_with_default(RUST_LOG_FILTER);
     let validator_keypairs = [
         "28bN3xyvrP4E8LwEgtLjhnkb7cY4amQb6DrYAbAYjgRV4GAGgkVM2K7wnxnAS7WDneuavza7x21MiafLu1HkwQt4",
         "2saHBBoTkLMmttmPQP8KfBkcCw45S5cwtV3wTdGCscRC8uxdgvHxpHiWXKx4LvJjNJtnNcbSv5NdheokFFqnNDt8",
@@ -5784,7 +5784,7 @@ fn test_duplicate_shreds_switch_failure() {
 #[serial]
 fn test_randomly_mixed_block_verification_methods_between_bootstrap_and_not() {
     // tailored logging just to see two block verification methods are working correctly
-    solana_logger::setup_with_default(
+    agave_logger::setup_with_default(
         "solana_metrics::metrics=warn,solana_core=warn,\
          solana_runtime::installed_scheduler_pool=trace,solana_ledger::blockstore_processor=debug,\
          info",
@@ -5817,7 +5817,7 @@ fn test_randomly_mixed_block_verification_methods_between_bootstrap_and_not() {
 #[ignore]
 #[serial]
 fn test_invalid_forks_persisted_on_restart() {
-    solana_logger::setup_with("info,solana_metrics=off,solana_ledger=off");
+    agave_logger::setup_with("info,solana_metrics=off,solana_ledger=off");
 
     let dup_slot = 10;
     let validator_keypairs = [

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "agave-logger"
+description = "Agave Logger"
+documentation = "https://docs.rs/agave-logger"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+name = "agave_logger"
+
+[features]
+agave-unstable-api = []
+
+[dependencies]
+env_logger = { workspace = true }
+log = { workspace = true }
+
+[target."cfg(unix)".dependencies]
+libc = { workspace = true }
+signal-hook = { workspace = true }

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -1,0 +1,138 @@
+//! The `logger` module configures `env_logger`
+#![cfg(feature = "agave-unstable-api")]
+use std::{
+    env,
+    sync::{Arc, LazyLock, RwLock},
+    thread::JoinHandle,
+};
+
+static LOGGER: LazyLock<Arc<RwLock<env_logger::Logger>>> =
+    LazyLock::new(|| Arc::new(RwLock::new(env_logger::Logger::from_default_env())));
+
+pub const DEFAULT_FILTER: &str = "solana=info,agave=info";
+
+struct LoggerShim {}
+
+impl log::Log for LoggerShim {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        LOGGER.read().unwrap().enabled(metadata)
+    }
+
+    fn log(&self, record: &log::Record) {
+        LOGGER.read().unwrap().log(record);
+    }
+
+    fn flush(&self) {}
+}
+
+fn replace_logger(logger: env_logger::Logger) {
+    log::set_max_level(logger.filter());
+    *LOGGER.write().unwrap() = logger;
+    let _ = log::set_boxed_logger(Box::new(LoggerShim {}));
+}
+
+// Configures logging with a specific filter overriding RUST_LOG.  _RUST_LOG is used instead
+// so if set it takes precedence.
+// May be called at any time to re-configure the log filter
+pub fn setup_with(filter: &str) {
+    let logger =
+        env_logger::Builder::from_env(env_logger::Env::new().filter_or("_RUST_LOG", filter))
+            .format_timestamp_nanos()
+            .build();
+    replace_logger(logger);
+}
+
+// Configures logging with a default filter if RUST_LOG is not set
+pub fn setup_with_default(filter: &str) {
+    let logger = env_logger::Builder::from_env(env_logger::Env::new().default_filter_or(filter))
+        .format_timestamp_nanos()
+        .build();
+    replace_logger(logger);
+}
+
+// Configures logging with the `DEFAULT_FILTER` if RUST_LOG is not set
+pub fn setup_with_default_filter() {
+    setup_with_default(DEFAULT_FILTER);
+}
+
+// Configures logging with the default filter "error" if RUST_LOG is not set
+pub fn setup() {
+    setup_with_default("error");
+}
+
+// Configures file logging with a default filter if RUST_LOG is not set
+pub fn setup_file_with_default(logfile: &str, filter: &str) {
+    use std::fs::OpenOptions;
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(logfile)
+        .unwrap();
+    let logger = env_logger::Builder::from_env(env_logger::Env::new().default_filter_or(filter))
+        .format_timestamp_nanos()
+        .target(env_logger::Target::Pipe(Box::new(file)))
+        .build();
+    replace_logger(logger);
+}
+
+#[cfg(unix)]
+fn redirect_stderr(filename: &str) {
+    use std::{fs::OpenOptions, os::unix::io::AsRawFd};
+    match OpenOptions::new().create(true).append(true).open(filename) {
+        Ok(file) => unsafe {
+            libc::dup2(file.as_raw_fd(), libc::STDERR_FILENO);
+        },
+        Err(err) => eprintln!("Unable to open {filename}: {err}"),
+    }
+}
+
+// Redirect stderr to a file with support for logrotate by sending a SIGUSR1 to the process.
+//
+// Upon success, future `log` macros and `eprintln!()` can be found in the specified log file.
+pub fn redirect_stderr_to_file(logfile: Option<String>) -> Option<JoinHandle<()>> {
+    // Default to RUST_BACKTRACE=1 for more informative validator logs
+    if env::var_os("RUST_BACKTRACE").is_none() {
+        env::set_var("RUST_BACKTRACE", "1")
+    }
+
+    match logfile {
+        None => {
+            setup_with_default_filter();
+            None
+        }
+        Some(logfile) => {
+            #[cfg(unix)]
+            {
+                use log::info;
+                let mut signals =
+                    signal_hook::iterator::Signals::new([signal_hook::consts::SIGUSR1])
+                        .unwrap_or_else(|err| {
+                            eprintln!("Unable to register SIGUSR1 handler: {err:?}");
+                            std::process::exit(1);
+                        });
+
+                setup_with_default_filter();
+                redirect_stderr(&logfile);
+                Some(
+                    std::thread::Builder::new()
+                        .name("solSigUsr1".into())
+                        .spawn(move || {
+                            for signal in signals.forever() {
+                                info!(
+                                    "received SIGUSR1 ({signal}), reopening log file: {logfile:?}",
+                                );
+                                redirect_stderr(&logfile);
+                            }
+                        })
+                        .unwrap(),
+                )
+            }
+            #[cfg(not(unix))]
+            {
+                println!("logrotate is not supported on this platform");
+                setup_file_with_default(&logfile, DEFAULT_FILTER);
+                None
+            }
+        }
+    }
+}

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
 
 [dev-dependencies]
-solana-logger = { workspace = true }
+agave-logger = { workspace = true }
 solana-net-utils = { path = ".", features = ["agave-unstable-api"] }
 
 [lints]

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -450,7 +450,7 @@ mod tests {
 
     #[test]
     fn test_bind_two_in_range_with_offset() {
-        solana_logger::setup();
+        agave_logger::setup();
         let config = SocketConfiguration::default();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let offset = 6;
@@ -486,7 +486,7 @@ mod tests {
 
     #[test]
     fn test_get_public_ip_addr_none() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let (pr_s, pr_e) = localhost_port_range_for_tests();
         let config = SocketConfiguration::default();
@@ -515,7 +515,7 @@ mod tests {
 
     #[test]
     fn test_get_public_ip_addr_reachable() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let port_range = localhost_port_range_for_tests();
         let config = SocketConfiguration::default();
@@ -555,7 +555,7 @@ mod tests {
 
     #[test]
     fn test_verify_ports_tcp_unreachable() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let port_range = localhost_port_range_for_tests();
         let config = SocketConfiguration::default();
@@ -578,7 +578,7 @@ mod tests {
 
     #[test]
     fn test_verify_ports_udp_unreachable() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let port_range = unique_port_range_for_tests(2);
         let config = SocketConfiguration::default();
@@ -604,7 +604,7 @@ mod tests {
 
     #[test]
     fn test_verify_many_ports_reachable() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let config = SocketConfiguration::default();
         let mut tcp_listeners = vec![];
@@ -657,7 +657,7 @@ mod tests {
     #[cfg(not(target_os = "macos"))]
     #[test]
     fn test_verify_udp_multiple_ips_reachable() {
-        solana_logger::setup();
+        agave_logger::setup();
         let config = SocketConfiguration::default();
         let ip_a = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let ip_b = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -78,10 +78,10 @@ libc = { workspace = true }
 nix = { workspace = true, features = ["user"] }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 assert_matches = { workspace = true }
 bencher = { workspace = true }
 rand_chacha = { workspace = true }
-solana-logger = { workspace = true }
 solana-perf = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 test-case = { workspace = true }
 

--- a/perf/benches/discard.rs
+++ b/perf/benches/discard.rs
@@ -10,7 +10,7 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 const NUM: usize = 1000;
 
 fn bench_discard(b: &mut Bencher) {
-    solana_logger::setup();
+    agave_logger::setup();
     let tx = test_tx();
     let num_packets = NUM;
 

--- a/perf/benches/recycler.rs
+++ b/perf/benches/recycler.rs
@@ -4,7 +4,7 @@ use {
 };
 
 fn bench_recycler(b: &mut Bencher) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let recycler: PacketBatchRecycler = Recycler::default();
 

--- a/perf/benches/reset.rs
+++ b/perf/benches/reset.rs
@@ -16,7 +16,7 @@ const N: usize = 1_000_000;
 // test bench_reset2 ... bench:     274,007 ns/iter (+/- 129,552)
 
 fn bench_reset1(b: &mut Bencher) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut v = Vec::with_capacity(N);
     v.resize_with(N, AtomicU64::default);
@@ -32,7 +32,7 @@ fn bench_reset1(b: &mut Bencher) {
 }
 
 fn bench_reset2(b: &mut Bencher) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut v = Vec::with_capacity(N);
     v.resize_with(N, AtomicU64::default);

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -115,7 +115,7 @@ fn bench_sigverify_high_packets_large_batch(b: &mut Bencher) {
 }
 
 fn bench_sigverify_uneven(b: &mut Bencher) {
-    solana_logger::setup();
+    agave_logger::setup();
     let simple_tx = test_tx();
     let multi_tx = test_multisig_tx();
     let mut tx;

--- a/perf/src/discard.rs
+++ b/perf/src/discard.rs
@@ -26,7 +26,7 @@ mod tests {
 
     #[test]
     fn test_batch_discard_random() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut batch = BytesPacketBatch::new();
         batch.resize(1, BytesPacket::new(Bytes::new(), Meta::default()));
         let batch = PacketBatch::from(batch);

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -865,7 +865,7 @@ mod tests {
 
     #[test]
     fn test_pubkey_too_small() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut tx = test_tx();
         let sig = tx.signatures[0];
         const NUM_SIG: usize = 18;
@@ -889,7 +889,7 @@ mod tests {
     fn test_pubkey_len() {
         // See that the verify cannot walk off the end of the packet
         // trying to index into the account_keys to access pubkey.
-        solana_logger::setup();
+        agave_logger::setup();
 
         const NUM_SIG: usize = 17;
         let keypair1 = Keypair::new();
@@ -1235,7 +1235,7 @@ mod tests {
 
     #[test]
     fn test_verify_multisig() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let tx = test_multisig_tx();
         let mut data = bincode::serialize(&tx).unwrap();
@@ -1273,7 +1273,7 @@ mod tests {
 
     #[test]
     fn test_verify_fuzz() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let tx = test_multisig_tx();
         let packet = BytesPacket::from_data(None, tx).unwrap();
@@ -1333,7 +1333,7 @@ mod tests {
 
     #[test]
     fn test_get_checked_scalar() {
-        solana_logger::setup();
+        agave_logger::setup();
         if perf_libs::api().is_none() {
             return;
         }
@@ -1368,7 +1368,7 @@ mod tests {
 
     #[test]
     fn test_ge_small_order() {
-        solana_logger::setup();
+        agave_logger::setup();
         if perf_libs::api().is_none() {
             return;
         }
@@ -1410,7 +1410,7 @@ mod tests {
 
     #[test]
     fn test_is_simple_vote_transaction() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut rng = rand::thread_rng();
 
         // transfer tx is not
@@ -1493,7 +1493,7 @@ mod tests {
 
     #[test]
     fn test_is_simple_vote_transaction_with_offsets() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut rng = rand::thread_rng();
 
         // batch of legacy messages

--- a/platform-tools-sdk/cargo-build-sbf/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/Cargo.toml
@@ -18,6 +18,7 @@ agave-unstable-api = []
 program = []
 
 [dependencies]
+agave-logger = { workspace = true }
 bzip2 = { workspace = true }
 cargo_metadata = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo", "env"] }
@@ -29,7 +30,6 @@ semver = { workspace = true }
 serde = { workspace = true }
 solana-file-download = "=3.1.0"
 solana-keypair = "=3.0.1"
-solana-logger = "=3.0.0"
 tar = { workspace = true }
 
 [dev-dependencies]

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -356,7 +356,7 @@ fn build_solana(config: Config, manifest_path: Option<PathBuf>) {
 }
 
 fn main() {
-    solana_logger::setup();
+    agave_logger::setup();
     let default_config = Config::default();
     let default_sbf_sdk = format!("{}", default_config.sbf_sdk.display());
 

--- a/platform-tools-sdk/cargo-test-sbf/Cargo.toml
+++ b/platform-tools-sdk/cargo-test-sbf/Cargo.toml
@@ -17,9 +17,9 @@ path = "src/main.rs"
 agave-unstable-api = []
 
 [dependencies]
+agave-logger = { workspace = true }
 cargo_metadata = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo"] }
 itertools = { workspace = true }
 log = { workspace = true, features = ["std"] }
 regex = { workspace = true }
-solana-logger = "=3.0.0"

--- a/platform-tools-sdk/cargo-test-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-test-sbf/src/main.rs
@@ -263,7 +263,7 @@ fn test_solana(config: Config, manifest_path: Option<PathBuf>) {
 }
 
 fn main() {
-    solana_logger::setup();
+    agave_logger::setup();
     let mut args = env::args().collect::<Vec<_>>();
     // When run as a cargo subcommand, the first program argument is the subcommand name.
     // Remove it

--- a/poh-bench/Cargo.toml
+++ b/poh-bench/Cargo.toml
@@ -16,12 +16,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 
 [dependencies]
+agave-logger = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo"] }
 log = { workspace = true }
 num_cpus = { workspace = true }
 rayon = { workspace = true }
 solana-entry = { workspace = true }
-solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-perf = { workspace = true }
 solana-sha256-hasher = { workspace = true }

--- a/poh-bench/src/main.rs
+++ b/poh-bench/src/main.rs
@@ -11,7 +11,7 @@ use {
 };
 
 fn main() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let matches = Command::new(crate_name!())
         .about(crate_description!())

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -42,13 +42,13 @@ solana-transaction = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
 solana-entry = { workspace = true, features = ["dev-context-only-utils"] }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-poh = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }

--- a/poh/benches/poh_verify.rs
+++ b/poh/benches/poh_verify.rs
@@ -20,7 +20,7 @@ const NUM_ENTRIES: usize = 800;
 
 #[bench]
 fn bench_poh_verify_ticks(bencher: &mut Bencher) {
-    solana_logger::setup();
+    agave_logger::setup();
     let thread_pool = entry::thread_pool_for_benches();
 
     let zero = Hash::default();

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -1522,7 +1522,7 @@ mod tests {
 
     #[test]
     fn test_reset_to_new_value() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
@@ -1605,7 +1605,7 @@ mod tests {
 
     #[test]
     fn test_poh_recorder_record_sets_start_slot() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
@@ -1693,7 +1693,7 @@ mod tests {
 
     #[test]
     fn test_reached_leader_tick() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         // Setup genesis.
         let GenesisConfigInfo {
@@ -1871,7 +1871,7 @@ mod tests {
 
     #[test]
     fn test_reached_leader_slot() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -651,7 +651,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_poh_service() {
-        solana_logger::setup();
+        agave_logger::setup();
         let GenesisConfigInfo {
             mut genesis_config, ..
         } = create_genesis_config(2);

--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -34,13 +34,13 @@ solana-secp256k1-program = { workspace = true, features = ["serde"] }
 solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 agave-precompiles = { path = ".", features = ["agave-unstable-api"] }
 bytemuck = { workspace = true }
 hex = { workspace = true }
 rand0-7 = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keccak-hasher = { workspace = true, features = ["sha3"] }
-solana-logger = { workspace = true }
 solana-secp256k1-program = { workspace = true, features = ["bincode"] }
 
 [lints]

--- a/precompiles/src/ed25519.rs
+++ b/precompiles/src/ed25519.rs
@@ -204,7 +204,7 @@ pub mod tests {
 
     #[test]
     fn test_invalid_offsets() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let mut instruction_data = vec![0u8; DATA_START];
         let offsets = Ed25519SignatureOffsets::default();
@@ -337,7 +337,7 @@ pub mod tests {
 
     #[test]
     fn test_ed25519() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let privkey = ed25519_dalek::Keypair::generate(&mut thread_rng());
         let message_arr = b"hello";
@@ -375,7 +375,7 @@ pub mod tests {
 
     #[test]
     fn test_offsets_to_ed25519_instruction() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let privkey = ed25519_dalek::Keypair::generate(&mut thread_rng());
         let messages: [&[u8]; 3] = [b"hello", b"IBRL", b"goodbye"];
@@ -444,7 +444,7 @@ pub mod tests {
 
     #[test]
     fn test_ed25519_malleability() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         // sig created via ed25519_dalek: both pass
         let privkey = ed25519_dalek::Keypair::generate(&mut thread_rng());

--- a/precompiles/src/secp256k1.rs
+++ b/precompiles/src/secp256k1.rs
@@ -152,7 +152,7 @@ pub mod tests {
 
     #[test]
     fn test_invalid_offsets() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let mut instruction_data = vec![0u8; DATA_START];
         let offsets = SecpSignatureOffsets::default();
@@ -282,7 +282,7 @@ pub mod tests {
 
     #[test]
     fn test_count_is_zero_but_sig_data_exists() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let mut instruction_data = vec![0u8; DATA_START];
         let offsets = SecpSignatureOffsets::default();
@@ -299,7 +299,7 @@ pub mod tests {
 
     #[test]
     fn test_secp256k1() {
-        solana_logger::setup();
+        agave_logger::setup();
         let offsets = SecpSignatureOffsets::default();
         assert_eq!(
             bincode::serialized_size(&offsets).unwrap() as usize,
@@ -342,7 +342,7 @@ pub mod tests {
     // Signatures are malleable.
     #[test]
     fn test_malleability() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let secret_key = libsecp256k1::SecretKey::random(&mut thread_rng());
         let public_key = libsecp256k1::PublicKey::from_secret_key(&secret_key);

--- a/precompiles/src/secp256r1.rs
+++ b/precompiles/src/secp256r1.rs
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn test_invalid_offsets() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let mut instruction_data = vec![0u8; DATA_START];
         let offsets = Secp256r1SignatureOffsets::default();
@@ -246,7 +246,7 @@ mod tests {
 
     #[test]
     fn test_invalid_signature_data_size() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         // Test data.len() < SIGNATURE_OFFSETS_START
         let small_data = vec![0u8; SIGNATURE_OFFSETS_START - 1];
@@ -358,7 +358,7 @@ mod tests {
 
     #[test]
     fn test_secp256r1() {
-        solana_logger::setup();
+        agave_logger::setup();
         let message_arr = b"hello";
         let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
         let signing_key = EcKey::generate(&group).unwrap();
@@ -405,7 +405,7 @@ mod tests {
 
     #[test]
     fn test_secp256r1_high_s() {
-        solana_logger::setup();
+        agave_logger::setup();
         let message_arr = b"hello";
         let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
         let signing_key = EcKey::generate(&group).unwrap();
@@ -461,7 +461,7 @@ mod tests {
     }
     #[test]
     fn test_new_secp256r1_instruction_31byte_components() {
-        solana_logger::setup();
+        agave_logger::setup();
         let message_arr = b"hello";
         let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
         let signing_key = EcKey::generate(&group).unwrap();

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -13,6 +13,7 @@ agave-unstable-api = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-logger = { workspace = true }
 assert_matches = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
@@ -39,7 +40,6 @@ solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-loader-v3-interface = { workspace = true }
-solana-logger = { workspace = true }
 solana-message = { workspace = true }
 solana-msg = { workspace = true }
 solana-native-token = { workspace = true }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -504,7 +504,7 @@ impl Default for ProgramTest {
     /// * the current working directory
     ///
     fn default() -> Self {
-        solana_logger::setup_with_default(
+        agave_logger::setup_with_default(
             "solana_sbpf::vm=debug,solana_runtime::message_processor=debug,\
              solana_runtime::system_instruction_processor=trace,solana_program_test=info",
         );

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -111,6 +111,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-logger"
+version = "3.1.0"
+dependencies = [
+ "env_logger",
+ "libc",
+ "log",
+ "signal-hook",
+]
+
+[[package]]
 name = "agave-precompiles"
 version = "3.1.0"
 dependencies = [
@@ -240,6 +250,7 @@ name = "agave-validator"
 version = "3.1.0"
 dependencies = [
  "agave-geyser-plugin-interface",
+ "agave-logger",
  "agave-snapshots",
  "chrono",
  "clap",
@@ -283,7 +294,6 @@ dependencies = [
  "solana-inflation",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-metrics",
  "solana-native-token",
  "solana-net-utils",
@@ -329,6 +339,7 @@ dependencies = [
 name = "agave-votor"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "agave-votor-messages",
  "anyhow",
  "bincode",
@@ -359,7 +370,6 @@ dependencies = [
  "solana-hash",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-pubkey",
@@ -380,11 +390,11 @@ dependencies = [
 name = "agave-votor-messages"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "serde",
  "solana-bls-signatures",
  "solana-clock",
  "solana-hash",
- "solana-logger",
 ]
 
 [[package]]
@@ -2089,14 +2099,14 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
+ "jiff",
  "log",
 ]
 
@@ -3241,6 +3251,30 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "jni"
@@ -4420,9 +4454,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -6786,6 +6829,7 @@ dependencies = [
 name = "solana-faucet"
 version = "3.1.0"
 dependencies = [
+ "agave-logger",
  "bincode",
  "clap",
  "crossbeam-channel",
@@ -6797,7 +6841,6 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
- "solana-logger",
  "solana-message",
  "solana-metrics",
  "solana-net-utils",
@@ -6950,6 +6993,7 @@ name = "solana-gossip"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "arrayvec",
  "assert_matches",
  "bincode",
@@ -6980,7 +7024,6 @@ dependencies = [
  "solana-hash",
  "solana-keypair",
  "solana-ledger",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-native-token",
@@ -7304,19 +7347,6 @@ dependencies = [
  "solana-svm-measure",
  "solana-svm-type-overrides",
  "solana-transaction-context",
-]
-
-[[package]]
-name = "solana-logger"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7421d1092680d72065edbf5c7605856719b021bf5f173656c71febcdd5d003"
-dependencies = [
- "env_logger",
- "lazy_static",
- "libc",
- "log",
- "signal-hook",
 ]
 
 [[package]]
@@ -7714,6 +7744,7 @@ name = "solana-program-test"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "assert_matches",
  "async-trait",
  "base64 0.22.1",
@@ -7740,7 +7771,6 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-loader-v3-interface",
- "solana-logger",
  "solana-message",
  "solana-msg",
  "solana-native-token",
@@ -8246,6 +8276,7 @@ name = "solana-sbf-programs"
 version = "3.1.0"
 dependencies = [
  "agave-feature-set",
+ "agave-logger",
  "agave-reserved-account-keys",
  "agave-syscalls",
  "agave-validator",
@@ -8279,7 +8310,6 @@ dependencies = [
  "solana-ledger",
  "solana-loader-v3-interface",
  "solana-loader-v4-interface",
- "solana-logger",
  "solana-measure",
  "solana-message",
  "solana-program",
@@ -9626,7 +9656,6 @@ dependencies = [
  "solana-keypair",
  "solana-ledger",
  "solana-loader-v3-interface",
- "solana-logger",
  "solana-message",
  "solana-native-token",
  "solana-net-utils",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -91,6 +91,7 @@ check-cfg = [
 
 [workspace.dependencies]
 agave-feature-set = { path = "../../feature-set", version = "=3.1.0" }
+agave-logger = { path = "../../logger", version = "=3.1.0" }
 agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=3.1.0" }
 agave-syscalls = { path = "../../syscalls", version = "=3.1.0" }
 agave-validator = { path = "../../validator", version = "=3.1.0" }
@@ -133,7 +134,6 @@ solana-instruction = "=3.0.0"
 solana-instructions-sysvar = "=3.0.0"
 solana-keccak-hasher = { version = "=3.0.0", features = ["sha3"] }
 solana-ledger = { path = "../../ledger", version = "=3.1.0" }
-solana-logger = "=3.0.0"
 solana-measure = { path = "../../measure", version = "=3.1.0" }
 solana-msg = "=3.0.0"
 solana-poseidon = { path = "../../poseidon/", version = "=3.1.0" }
@@ -185,6 +185,7 @@ frozen-abi = []
 
 [dev-dependencies]
 agave-feature-set = { workspace = true }
+agave-logger = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 agave-syscalls = { workspace = true }
 agave-validator = { workspace = true }
@@ -220,7 +221,6 @@ solana-keypair = "3.0.0"
 solana-ledger = { workspace = true }
 solana-loader-v3-interface = "6.1.0"
 solana-loader-v4-interface = "3.1.0"
-solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-message = "3.0.0"
 solana-program = { workspace = true }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -154,7 +154,7 @@ const LOADED_ACCOUNTS_DATA_SIZE_LIMIT_FOR_TEST: u32 = 64 * 1024 * 1024;
 #[test]
 #[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
 fn test_program_sbf_sanity() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut programs = Vec::new();
     #[cfg(feature = "sbf_c")]
@@ -262,7 +262,7 @@ fn test_program_sbf_sanity() {
 #[test]
 #[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
 fn test_program_sbf_loader_deprecated() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut programs = Vec::new();
     #[cfg(feature = "sbf_c")]
@@ -305,7 +305,7 @@ fn test_program_sbf_loader_deprecated() {
 #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: \
                            TransactionError(InstructionError(0, InvalidAccountData))")]
 fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -342,7 +342,7 @@ fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_duplicate_accounts() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut programs = Vec::new();
     #[cfg(feature = "sbf_c")]
@@ -449,7 +449,7 @@ fn test_program_sbf_duplicate_accounts() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_error_handling() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut programs = Vec::new();
     #[cfg(feature = "sbf_c")]
@@ -561,7 +561,7 @@ fn test_program_sbf_error_handling() {
 #[test]
 #[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
 fn test_return_data_and_log_data_syscall() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut programs = Vec::new();
     #[cfg(feature = "sbf_c")]
@@ -619,7 +619,7 @@ fn test_return_data_and_log_data_syscall() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_invoke_sanity() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     #[derive(Debug)]
     #[allow(dead_code)]
@@ -1297,7 +1297,7 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_ro_modify() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -1354,7 +1354,7 @@ fn test_program_sbf_ro_modify() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_call_depth() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -1392,7 +1392,7 @@ fn test_program_sbf_call_depth() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_compute_budget() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -1427,7 +1427,7 @@ fn test_program_sbf_compute_budget() {
 
 #[test]
 fn assert_instruction_count() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut programs = Vec::new();
     #[cfg(feature = "sbf_c")]
@@ -1523,7 +1523,7 @@ fn assert_instruction_count() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_instruction_introspection() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -1587,7 +1587,7 @@ fn test_program_sbf_instruction_introspection() {
 #[allow(clippy::arithmetic_side_effects)]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_r2_instruction_data_pointer(num_accounts: usize, input_data_len: usize) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -1688,7 +1688,7 @@ fn test_program_sbf_invoke_stable_genesis_and_bank() {
     // assert that the resulting bank hash matches with the expected value.
     // The assert check is commented out by default. Please refer to the last few lines
     // of the test to enable the assertion.
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -1864,7 +1864,7 @@ fn test_program_sbf_invoke_stable_genesis_and_bank() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_invoke_in_same_tx_as_deployment() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -1943,7 +1943,7 @@ fn test_program_sbf_invoke_in_same_tx_as_deployment() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_invoke_in_same_tx_as_redeployment() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -2049,7 +2049,7 @@ fn test_program_sbf_invoke_in_same_tx_as_redeployment() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_invoke_in_same_tx_as_undeployment() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -2129,7 +2129,7 @@ fn test_program_sbf_invoke_in_same_tx_as_undeployment() {
 #[test]
 #[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
 fn test_program_sbf_disguised_as_sbf_loader() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mut programs = Vec::new();
     #[cfg(feature = "sbf_c")]
@@ -2175,7 +2175,7 @@ fn test_program_sbf_disguised_as_sbf_loader() {
 #[cfg(feature = "sbf_c")]
 fn test_program_reads_from_program_account() {
     use solana_loader_v4_interface::state as loader_v4_state;
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -2209,7 +2209,7 @@ fn test_program_reads_from_program_account() {
 #[test]
 #[cfg(feature = "sbf_c")]
 fn test_program_sbf_c_dup() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -2245,7 +2245,7 @@ fn test_program_sbf_c_dup() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_upgrade() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -2330,7 +2330,7 @@ fn test_program_sbf_upgrade() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_upgrade_via_cpi() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -2445,7 +2445,7 @@ fn test_program_sbf_upgrade_via_cpi() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_ro_account_modify() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -2507,7 +2507,7 @@ fn test_program_sbf_ro_account_modify() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_realloc() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     const START_BALANCE: u64 = 100_000_000_000;
 
@@ -2930,7 +2930,7 @@ fn test_program_sbf_realloc() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_realloc_invoke() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     const START_BALANCE: u64 = 100_000_000_000;
 
@@ -3555,7 +3555,7 @@ fn test_program_sbf_realloc_invoke() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_processed_inner_instruction() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -3634,7 +3634,7 @@ fn test_program_sbf_processed_inner_instruction() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_fees() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let congestion_multiplier = 1;
 
@@ -3744,7 +3744,7 @@ fn test_program_fees() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_inner_instruction_alignment_checks() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -3782,7 +3782,7 @@ fn test_program_sbf_inner_instruction_alignment_checks() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_cpi_account_ownership_writability() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     for stricter_abi_and_runtime_constraints in [false, true] {
         let GenesisConfigInfo {
@@ -3978,7 +3978,7 @@ fn test_cpi_account_ownership_writability() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_cpi_account_data_updates() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     for (deprecated_callee, deprecated_caller, stricter_abi_and_runtime_constraints) in
         [false, true].into_iter().flat_map(move |z| {
@@ -4241,7 +4241,7 @@ fn test_cpi_account_data_updates() {
 #[test]
 #[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
 fn test_cpi_invalid_account_info_pointers() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -4329,7 +4329,7 @@ fn test_cpi_invalid_account_info_pointers() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_deplete_cost_meter_with_access_violation() {
-    solana_logger::setup();
+    agave_logger::setup();
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
@@ -4387,7 +4387,7 @@ fn test_deplete_cost_meter_with_access_violation() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_deplete_cost_meter_with_divide_by_zero() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -4432,7 +4432,7 @@ fn test_program_sbf_deplete_cost_meter_with_divide_by_zero() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_deny_access_beyond_current_length() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -4500,7 +4500,7 @@ fn test_deny_access_beyond_current_length() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_deny_executable_write() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -4555,7 +4555,7 @@ fn test_deny_executable_write() {
 #[test]
 fn test_update_callee_account() {
     // Test that fn update_callee_account() works and we are updating the callee account on CPI.
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -4828,7 +4828,7 @@ fn test_update_callee_account() {
 
 #[test]
 fn test_account_info_in_account() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -4900,7 +4900,7 @@ fn test_account_info_in_account() {
 
 #[test]
 fn test_account_info_rc_in_account() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -4993,7 +4993,7 @@ fn test_account_info_rc_in_account() {
 #[test]
 fn test_clone_account_data() {
     // Test cloning account data works as expect with
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -5131,7 +5131,7 @@ fn test_clone_account_data() {
 
 #[test]
 fn test_stack_heap_zeroed() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -5199,7 +5199,7 @@ fn test_stack_heap_zeroed() {
 fn test_function_call_args() {
     // This function tests edge compiler edge cases when calling functions with more than five
     // arguments and passing by value arguments with more than 16 bytes.
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -5341,7 +5341,7 @@ fn test_function_call_args() {
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_mem_syscalls_overlap_account_begin_or_end() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     for stricter_abi_and_runtime_constraints in [false, true] {
         let GenesisConfigInfo {

--- a/programs/sbf/tests/simulation.rs
+++ b/programs/sbf/tests/simulation.rs
@@ -21,7 +21,7 @@ use {
 
 #[test]
 fn test_no_panic_banks_client() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         genesis_config,
@@ -58,7 +58,7 @@ fn test_no_panic_banks_client() {
 
 #[test]
 fn test_no_panic_rpc_client() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let program_id = Pubkey::new_unique();
     let (test_validator, payer) = TestValidatorGenesis::default()

--- a/programs/sbf/tests/syscall_get_epoch_stake.rs
+++ b/programs/sbf/tests/syscall_get_epoch_stake.rs
@@ -23,7 +23,7 @@ use {
 
 #[test]
 fn test_syscall_get_epoch_stake() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     // Two vote accounts with stake.
     let stakes = vec![100_000_000, 500_000_000];

--- a/programs/sbf/tests/sysvar.rs
+++ b/programs/sbf/tests/sysvar.rs
@@ -25,7 +25,7 @@ use {
 
 #[test]
 fn test_sysvar_syscalls() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let GenesisConfigInfo {
         mut genesis_config,

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -62,13 +62,13 @@ solana-vote-interface = { workspace = true, features = ["bincode"] }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 solana-account = { workspace = true }
 solana-clock = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-instruction = { workspace = true }
-solana-logger = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -2057,7 +2057,7 @@ mod tests {
     #[test_case(false ; "VoteStateV3")]
     #[test_case(true ; "VoteStateV4")]
     fn test_vote_process_instruction(vote_state_v4_enabled: bool) {
-        solana_logger::setup();
+        agave_logger::setup();
         let instructions = create_account_with_config(
             &Pubkey::new_unique(),
             &Pubkey::new_unique(),

--- a/quic-client/Cargo.toml
+++ b/quic-client/Cargo.toml
@@ -37,8 +37,8 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 crossbeam-channel = { workspace = true }
-solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-packet = { workspace = true }
 solana-perf = { workspace = true }

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -65,7 +65,7 @@ mod tests {
             solana_connection_cache::client_connection::ClientConnection,
             solana_quic_client::quic_client::QuicClientConnection,
         };
-        solana_logger::setup();
+        agave_logger::setup();
         let (sender, receiver) = unbounded();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let (s, cancel, keypair) = server_args();
@@ -145,7 +145,7 @@ mod tests {
             solana_connection_cache::nonblocking::client_connection::ClientConnection,
             solana_quic_client::nonblocking::quic_client::QuicClientConnection,
         };
-        solana_logger::setup();
+        agave_logger::setup();
         let (sender, receiver) = unbounded();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let (s, cancel, keypair) = server_args();
@@ -201,7 +201,7 @@ mod tests {
             solana_connection_cache::client_connection::ClientConnection,
             solana_quic_client::quic_client::QuicClientConnection,
         };
-        solana_logger::setup();
+        agave_logger::setup();
 
         // Request Receiver
         let (sender, receiver) = unbounded();
@@ -313,7 +313,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_connection_close() {
-        solana_logger::setup();
+        agave_logger::setup();
         let (sender, receiver) = unbounded();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let (s, cancel, keypair) = server_args();

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -39,13 +39,13 @@ solana-transaction-status = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 solana-client = { workspace = true, features = ["dev-context-only-utils"] }
 solana-clock = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-connection-cache = { workspace = true }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-signature = { workspace = true }

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -65,7 +65,7 @@ fn post_rpc(request: Value, rpc_url: &str) -> Value {
 
 #[test]
 fn test_rpc_send_tx() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let alice = Keypair::new();
     let test_validator =
@@ -138,7 +138,7 @@ fn test_rpc_send_tx() {
 
 #[test]
 fn test_simulation_replaced_blockhash() -> ClientResult<()> {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let alice = Keypair::new();
     let validator = TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
@@ -183,7 +183,7 @@ fn test_simulation_replaced_blockhash() -> ClientResult<()> {
 
 #[test]
 fn test_rpc_invalid_requests() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let alice = Keypair::new();
     let test_validator =
@@ -216,7 +216,7 @@ fn test_rpc_invalid_requests() {
 
 #[test]
 fn test_rpc_slot_updates() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let test_validator =
         TestValidator::with_no_fees(Pubkey::new_unique(), None, SocketAddrSpace::Unspecified);
@@ -284,7 +284,7 @@ fn test_rpc_slot_updates() {
 
 #[test]
 fn test_rpc_subscriptions() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let alice = Keypair::new();
     let test_validator =
@@ -556,7 +556,7 @@ fn test_tpu_send_transaction_with_quic() {
 
 #[test]
 fn deserialize_rpc_error() -> ClientResult<()> {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let alice = Keypair::new();
     let validator = TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -192,6 +192,7 @@ thiserror = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 agave-transaction-view = { workspace = true }
 ed25519-dalek = { workspace = true }
 libsecp256k1 = { workspace = true }
@@ -201,7 +202,6 @@ rand_chacha = { workspace = true }
 solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
 solana-builtins = { workspace = true, features = ["dev-context-only-utils"] }
 solana-instruction-error = { workspace = true }
-solana-logger = { workspace = true }
 solana-program-binaries = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-runtime = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -773,7 +773,7 @@ mod tests {
     #[test]
     /// Test rewards computation and partitioned rewards distribution at the epoch boundary
     fn test_rewards_computation() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         // Delegations with sufficient stake to get rewards (2 SOL).
         let delegations_with_rewards = 100;
@@ -831,7 +831,7 @@ mod tests {
 
     #[test]
     fn test_rewards_point_calculation() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let expected_num_delegations = 100;
         let RewardBank { bank, .. } =
@@ -858,7 +858,7 @@ mod tests {
 
     #[test]
     fn test_rewards_point_calculation_empty() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         // bank with no rewards to distribute
         let (genesis_config, _mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
@@ -882,7 +882,7 @@ mod tests {
 
     #[test]
     fn test_calculate_stake_vote_rewards() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let expected_num_delegations = 1;
         let RewardBank {

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -688,7 +688,7 @@ mod tests {
     /// Test get_reward_distribution_num_blocks during normal epoch gives the expected result
     #[test]
     fn test_get_reward_distribution_num_blocks_normal() {
-        solana_logger::setup();
+        agave_logger::setup();
         let (mut genesis_config, _mint_keypair) =
             create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
         genesis_config.epoch_schedule = EpochSchedule::custom(432000, 432000, false);
@@ -743,7 +743,7 @@ mod tests {
 
     #[test]
     fn test_rewards_computation_and_partitioned_distribution_one_block() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let starting_slot = SLOTS_PER_EPOCH - 1;
         let (
@@ -828,7 +828,7 @@ mod tests {
     /// Test rewards computation and partitioned rewards distribution at the epoch boundary (two reward distribution blocks)
     #[test]
     fn test_rewards_computation_and_partitioned_distribution_two_blocks() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let starting_slot = SLOTS_PER_EPOCH - 1;
         let (

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -183,7 +183,7 @@ mod tests {
     #[test_case(StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_extra_fields_eof(storage_access: StorageAccess) {
-        solana_logger::setup();
+        agave_logger::setup();
         let (genesis_config, _) = create_genesis_config(500);
 
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn test_extra_fields_full_snapshot_archive() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let (mut genesis_config, _) = create_genesis_config(500);
         activate_all_features(&mut genesis_config);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -66,7 +66,6 @@ use {
         instruction::UpgradeableLoaderInstruction, state::UpgradeableLoaderState,
     },
     solana_loader_v4_interface::{instruction as loader_v4, state::LoaderV4State},
-    solana_logger,
     solana_message::{
         compiled_instruction::CompiledInstruction, Message, MessageHeader, SanitizedMessage,
     },
@@ -210,7 +209,7 @@ pub(in crate::bank) fn new_sanitized_message(message: Message) -> SanitizedMessa
 
 #[test]
 fn test_race_register_tick_freeze() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let (mut genesis_config, _) = create_genesis_config(50);
     genesis_config.ticks_per_slot = 1;
@@ -692,7 +691,7 @@ fn check_bank_update_vote_stake_rewards<F>(load_vote_and_stake_accounts: F)
 where
     F: Fn(&Bank) -> StakeDelegationsMap,
 {
-    solana_logger::setup();
+    agave_logger::setup();
 
     // create a bank that ticks really slowly...
     let bank0 = Arc::new(Bank::new_for_tests(&GenesisConfig {
@@ -943,7 +942,7 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
 
 #[test]
 fn test_bank_update_rewards_determinism() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     // The same reward should be distributed given same credits
     let expected_capitalization = do_test_bank_update_rewards_determinism();
@@ -969,7 +968,7 @@ fn test_purge_empty_accounts() {
     // When using the write cache, flushing is destructive/cannot be undone
     //  so we have to stop at various points and restart to actively test.
     for pass in 0..3 {
-        solana_logger::setup();
+        agave_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config_no_tx_fee(LAMPORTS_PER_SOL);
         let amount = genesis_config.rent.minimum_balance(0);
         let (mut bank, bank_forks) =
@@ -1182,7 +1181,7 @@ fn test_detect_failed_duplicate_transactions() {
 
 #[test]
 fn test_account_not_found() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(0);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let keypair = Keypair::new();
@@ -1271,7 +1270,7 @@ fn test_executed_transaction_count_post_bank_transaction_count_fix() {
 
 #[test]
 fn test_transfer_to_newb() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
@@ -1282,7 +1281,7 @@ fn test_transfer_to_newb() {
 
 #[test]
 fn test_transfer_to_sysvar() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
@@ -1368,7 +1367,7 @@ fn test_bank_withdraw_from_nonce_account() {
 
 #[test]
 fn test_bank_tx_fee() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let arbitrary_transfer_amount = 42_000;
     let mint = arbitrary_transfer_amount * 100;
@@ -1473,7 +1472,7 @@ fn test_bank_tx_fee() {
 
 #[test]
 fn test_bank_tx_compute_unit_fee() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let key = solana_pubkey::new_rand();
     let arbitrary_transfer_amount = 42;
@@ -1583,7 +1582,7 @@ fn test_bank_tx_compute_unit_fee() {
 
 #[test]
 fn test_bank_blockhash_fee_structure() {
-    //solana_logger::setup();
+    //agave_logger::setup();
 
     let leader = solana_pubkey::new_rand();
     let GenesisConfigInfo {
@@ -1645,7 +1644,7 @@ fn test_bank_blockhash_fee_structure() {
 
 #[test]
 fn test_bank_blockhash_compute_unit_fee_structure() {
-    //solana_logger::setup();
+    //agave_logger::setup();
 
     let leader = solana_pubkey::new_rand();
     let GenesisConfigInfo {
@@ -2429,7 +2428,7 @@ fn test_verify_hash_unfrozen() {
 
 #[test]
 fn test_verify_snapshot_bank() {
-    solana_logger::setup();
+    agave_logger::setup();
     let pubkey = solana_pubkey::new_rand();
     let (genesis_config, mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
@@ -2451,7 +2450,7 @@ fn test_verify_snapshot_bank() {
 // Test that two bank forks with the same transactions should not hash to the same value.
 #[test]
 fn test_bank_hash_same_transactions_different_fork() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
     let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     bank0.freeze();
@@ -2515,7 +2514,7 @@ fn test_hash_internal_state_order() {
 
 #[test]
 fn test_hash_internal_state_error() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
     let amount = genesis_config.rent.minimum_balance(0);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
@@ -2556,7 +2555,7 @@ fn test_bank_hash_internal_state_squash() {
 /// Verifies that last ids and accounts are correctly referenced from parent
 #[test]
 fn test_bank_squash() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config_no_tx_fee(2 * LAMPORTS_PER_SOL);
     let key1 = Keypair::new();
     let key2 = Keypair::new();
@@ -2645,7 +2644,7 @@ fn test_bank_get_account_in_parent_after_squash() {
 
 #[test]
 fn test_bank_get_account_in_parent_after_squash2() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
     let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
@@ -2772,7 +2771,7 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
 
 #[test]
 fn test_bank_update_sysvar_account() {
-    solana_logger::setup();
+    agave_logger::setup();
     // flushing the write cache is destructive, so test has to restart each time we flush and want to do 'illegal' operations once flushed
     for pass in 0..5 {
         use sysvar::clock::Clock;
@@ -3031,7 +3030,7 @@ fn test_bank_epoch_vote_accounts() {
 
 #[test]
 fn test_zero_signatures() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(500);
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.fee_rate_governor.lamports_per_signature = 2;
@@ -3551,7 +3550,7 @@ fn test_get_filtered_indexed_accounts() {
 
 #[test]
 fn test_status_cache_ancestors() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (parent, _bank_forks) = create_simple_test_arc_bank(500);
     let bank1 = Arc::new(new_from_parent(parent));
     let mut bank = bank1;
@@ -3864,7 +3863,7 @@ fn test_banks_leak() {
             );
         });
     }
-    solana_logger::setup();
+    agave_logger::setup();
     let (mut genesis_config, _) = create_genesis_config(100_000_000_000_000);
     add_lotsa_stake_accounts(&mut genesis_config);
     let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
@@ -4327,7 +4326,7 @@ fn test_nonce_transaction_with_tx_wide_caps() {
 
 #[test]
 fn test_nonce_authority() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (mut bank, _mint_keypair, custodian_keypair, nonce_keypair, bank_forks) =
         setup_nonce_with_bank(
             10_000_000,
@@ -4388,7 +4387,7 @@ fn test_nonce_authority() {
 
 #[test]
 fn test_nonce_payer() {
-    solana_logger::setup();
+    agave_logger::setup();
     let nonce_starting_balance = 250_000;
     let (mut bank, _mint_keypair, custodian_keypair, nonce_keypair, bank_forks) =
         setup_nonce_with_bank(
@@ -4452,7 +4451,7 @@ fn test_nonce_payer() {
 
 #[test]
 fn test_nonce_payer_tx_wide_cap() {
-    solana_logger::setup();
+    agave_logger::setup();
     let nonce_starting_balance =
         250_000 + FeeStructure::default().compute_fee_bins.last().unwrap().fee;
     let feature_set = FeatureSet::all_enabled();
@@ -4928,7 +4927,7 @@ fn test_transaction_with_program_ids_passed_to_programs() {
 
 #[test]
 fn test_account_ids_after_program_ids() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config_no_tx_fee_no_rent(500);
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
@@ -4997,7 +4996,7 @@ fn test_incinerator() {
 
 #[test]
 fn test_duplicate_account_key() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(500);
     let (bank, _bank_forks) = Bank::new_with_mockup_builtin_for_tests(
         &genesis_config,
@@ -5028,7 +5027,7 @@ fn test_duplicate_account_key() {
 
 #[test]
 fn test_process_transaction_with_too_many_account_locks() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(500);
     let (bank, _bank_forks) = Bank::new_with_mockup_builtin_for_tests(
         &genesis_config,
@@ -5063,7 +5062,7 @@ fn test_process_transaction_with_too_many_account_locks() {
 
 #[test]
 fn test_program_id_as_payer() {
-    solana_logger::setup();
+    agave_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(500);
     let mut bank = Bank::new_for_tests(&genesis_config);
 
@@ -5146,7 +5145,7 @@ fn test_ref_account_key_after_program_id() {
 
 #[test]
 fn test_fuzz_instructions() {
-    solana_logger::setup();
+    agave_logger::setup();
     use rand::{thread_rng, Rng};
     let bank = create_simple_test_bank(1_000_000_000);
 
@@ -5403,7 +5402,7 @@ fn test_same_program_id_uses_unique_executable_accounts() {
 
 #[test]
 fn test_clean_nonrooted() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000_000);
     let pubkey0 = Pubkey::from([0; 32]);
@@ -5476,7 +5475,7 @@ fn test_clean_nonrooted() {
 
 #[test]
 fn test_shrink_candidate_slots_cached() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000_000);
     let pubkey0 = solana_pubkey::new_rand();
@@ -5915,7 +5914,7 @@ fn test_add_precompiled_account_after_frozen() {
 
 #[test]
 fn test_reconfigure_token2_native_mint() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let genesis_config =
         create_genesis_config_with_leader(5, &solana_pubkey::new_rand(), 0).genesis_config;
@@ -5928,7 +5927,7 @@ fn test_reconfigure_token2_native_mint() {
 
 #[test]
 fn test_bank_load_program() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let (genesis_config, mint_keypair) = create_genesis_config_no_tx_fee(1_000_000_000);
     let bank = Bank::new_for_tests(&genesis_config);
@@ -7408,7 +7407,7 @@ fn test_store_scan_consistency<F>(
         ) + std::marker::Send
         + 'static,
 {
-    solana_logger::setup();
+    agave_logger::setup();
     // Set up initial bank
     let mut genesis_config =
         create_genesis_config_with_leader(10, &solana_pubkey::new_rand(), 374_999_998_287_840)
@@ -8458,7 +8457,7 @@ fn test_tx_log_order(relax_intrabatch_account_locks: bool) {
 
 #[test]
 fn test_tx_return_data() {
-    solana_logger::setup();
+    agave_logger::setup();
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
@@ -8654,7 +8653,7 @@ fn test_get_largest_accounts() {
 
 #[test]
 fn test_transfer_sysvar() {
-    solana_logger::setup();
+    agave_logger::setup();
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
@@ -8714,13 +8713,13 @@ fn test_transfer_sysvar() {
 
 #[test]
 fn test_clean_dropped_unrooted_frozen_banks() {
-    solana_logger::setup();
+    agave_logger::setup();
     do_test_clean_dropped_unrooted_banks(FreezeBank1::Yes);
 }
 
 #[test]
 fn test_clean_dropped_unrooted_unfrozen_banks() {
-    solana_logger::setup();
+    agave_logger::setup();
     do_test_clean_dropped_unrooted_banks(FreezeBank1::No);
 }
 
@@ -8831,7 +8830,7 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
 
 #[test]
 fn test_compute_budget_program_noop() {
-    solana_logger::setup();
+    agave_logger::setup();
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
@@ -8883,7 +8882,7 @@ fn test_compute_budget_program_noop() {
 
 #[test]
 fn test_compute_request_instruction() {
-    solana_logger::setup();
+    agave_logger::setup();
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
@@ -8935,7 +8934,7 @@ fn test_compute_request_instruction() {
 
 #[test]
 fn test_failed_compute_request_instruction() {
-    solana_logger::setup();
+    agave_logger::setup();
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
@@ -10893,7 +10892,7 @@ fn test_is_in_slot_hashes_history() {
 fn test_feature_activation_loaded_programs_cache_preparation_phase(
     formalize_loaded_transaction_data_size: bool,
 ) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     // Bank Setup
     let (genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
@@ -11006,7 +11005,7 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase(
 
 #[test]
 fn test_feature_activation_loaded_programs_epoch_transition() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     // Bank Setup
     let (mut genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
@@ -11211,7 +11210,7 @@ fn with_create_zero_lamport<F>(callback: F)
 where
     F: Fn(&Bank),
 {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let alice_keypair = Keypair::new();
     let bob_keypair = Keypair::new();
@@ -11691,7 +11690,7 @@ fn test_filter_program_errors_and_collect_fee_details() {
 
 #[test]
 fn test_deploy_last_epoch_slot() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     // Bank Setup
     let (mut genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
@@ -11792,7 +11791,7 @@ fn test_deploy_last_epoch_slot() {
 #[test_case(false; "informal_loaded_size")]
 #[test_case(true; "simd186_loaded_size")]
 fn test_loader_v3_to_v4_migration(formalize_loaded_transaction_data_size: bool) {
-    solana_logger::setup();
+    agave_logger::setup();
 
     // Bank Setup
     let (mut genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
@@ -12152,7 +12151,7 @@ fn test_blockhash_last_valid_block_height() {
 
 #[test]
 fn test_bank_epoch_stakes() {
-    solana_logger::setup();
+    agave_logger::setup();
     let num_of_nodes: u64 = 30;
     let stakes = (1..num_of_nodes.checked_add(1).expect("Shouldn't be big")).collect::<Vec<_>>();
     let voting_keypairs = stakes

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -832,7 +832,7 @@ mod tests {
 
     #[test]
     fn test_bank_forks_different_set_root() {
-        solana_logger::setup();
+        agave_logger::setup();
         let leader_keypair = Keypair::new();
         let GenesisConfigInfo {
             mut genesis_config,

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -414,7 +414,7 @@ pub(crate) mod tests {
     #[test_case(1; "single_vote_account")]
     #[test_case(2; "multiple_vote_accounts")]
     fn test_bls_pubkey_rank_map(num_vote_accounts_per_node: usize) {
-        solana_logger::setup();
+        agave_logger::setup();
         let num_nodes = 10;
         let num_vote_accounts = num_nodes * num_vote_accounts_per_node;
 

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -857,7 +857,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_normal_termination() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let bank = Arc::new(Bank::default_for_tests());
         let bank = BankWithScheduler::new(
@@ -875,7 +875,7 @@ mod tests {
 
     #[test]
     fn test_no_scheduler_termination() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let bank = Arc::new(Bank::default_for_tests());
         let bank = BankWithScheduler::new_without_scheduler(bank);
@@ -887,7 +887,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_termination_from_drop() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let bank = Arc::new(Bank::default_for_tests());
         let bank = BankWithScheduler::new(
@@ -899,7 +899,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_pause() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let bank = Arc::new(crate::bank::tests::create_simple_test_bank(42));
         let bank = BankWithScheduler::new(
@@ -920,7 +920,7 @@ mod tests {
     }
 
     fn do_test_schedule_execution(should_succeed: bool) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo {
             genesis_config,

--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn test_update_compute_unit_price() {
-        solana_logger::setup();
+        agave_logger::setup();
         let write_account_a = Pubkey::new_unique();
         let write_account_b = Pubkey::new_unique();
         let write_account_c = Pubkey::new_unique();

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -534,7 +534,7 @@ mod tests {
 
     #[test]
     fn test_prioritization_fee_cache_update() {
-        solana_logger::setup();
+        agave_logger::setup();
         let write_account_a = Pubkey::new_unique();
         let write_account_b = Pubkey::new_unique();
         let write_account_c = Pubkey::new_unique();
@@ -629,7 +629,7 @@ mod tests {
 
     #[test]
     fn test_get_prioritization_fees() {
-        solana_logger::setup();
+        agave_logger::setup();
         let write_account_a = Pubkey::new_unique();
         let write_account_b = Pubkey::new_unique();
         let write_account_c = Pubkey::new_unique();
@@ -881,7 +881,7 @@ mod tests {
     fn test_purge_duplicated_bank() {
         // duplicated bank can exists for same slot before OC.
         // prioritization_fee_cache should only have data from OC-ed bank
-        solana_logger::setup();
+        agave_logger::setup();
         let write_account_a = Pubkey::new_unique();
         let write_account_b = Pubkey::new_unique();
         let write_account_c = Pubkey::new_unique();

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -210,7 +210,7 @@ mod serde_snapshot_tests {
 
     #[test_case(StorageAccess::Mmap)]
     fn test_accounts_serialize(storage_access: StorageAccess) {
-        solana_logger::setup();
+        agave_logger::setup();
         let (_accounts_dir, paths) = get_temp_accounts_paths(4).unwrap();
         let accounts_db = AccountsDb::new_for_tests(paths);
         let accounts = Accounts::new(Arc::new(accounts_db));
@@ -270,7 +270,7 @@ mod serde_snapshot_tests {
     #[test_case(StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_remove_unrooted_slot_snapshot(storage_access: StorageAccess) {
-        solana_logger::setup();
+        agave_logger::setup();
         let unrooted_slot = 9;
         let unrooted_bank_id = 9;
         let db = AccountsDb::new_single_for_tests();
@@ -316,7 +316,7 @@ mod serde_snapshot_tests {
         mark_obsolete_accounts_restore: MarkObsoleteAccounts,
     ) {
         for pass in 0..2 {
-            solana_logger::setup();
+            agave_logger::setup();
             let accounts = AccountsDb::new_with_config(
                 Vec::new(),
                 AccountsDbConfig {
@@ -445,7 +445,7 @@ mod serde_snapshot_tests {
     #[test_case(StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_accounts_db_serialize_zero_and_free(storage_access: StorageAccess) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let some_lamport = 223;
         let zero_lamport = 0;
@@ -559,7 +559,7 @@ mod serde_snapshot_tests {
     #[test_case(StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_accounts_purge_chained_purge_before_snapshot_restore(storage_access: StorageAccess) {
-        solana_logger::setup();
+        agave_logger::setup();
         with_chained_zero_lamport_accounts(|accounts, current_slot| {
             // If there is no latest full snapshot, zero lamport accounts can be cleaned and
             // removed immediately. Set latest full snapshot slot to zero to avoid cleaning
@@ -578,7 +578,7 @@ mod serde_snapshot_tests {
     #[test_case(StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_accounts_purge_chained_purge_after_snapshot_restore(storage_access: StorageAccess) {
-        solana_logger::setup();
+        agave_logger::setup();
         with_chained_zero_lamport_accounts(|accounts, current_slot| {
             let accounts = reconstruct_accounts_db_via_serialization(
                 &accounts,
@@ -601,7 +601,7 @@ mod serde_snapshot_tests {
     #[test_case(StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_accounts_purge_long_chained_after_snapshot_restore(storage_access: StorageAccess) {
-        solana_logger::setup();
+        agave_logger::setup();
         let old_lamport = 223;
         let zero_lamport = 0;
         let no_data = 0;
@@ -675,7 +675,7 @@ mod serde_snapshot_tests {
     #[test_case(StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_accounts_clean_after_snapshot_restore_then_old_revives(storage_access: StorageAccess) {
-        solana_logger::setup();
+        agave_logger::setup();
         let old_lamport = 223;
         let zero_lamport = 0;
         let no_data = 0;
@@ -807,7 +807,7 @@ mod serde_snapshot_tests {
     #[test_case(StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_shrink_stale_slots_processed(storage_access: StorageAccess) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         for startup in &[false, true] {
             let accounts = AccountsDb::new_single_for_tests();

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -393,7 +393,7 @@ mod tests {
 
     #[test]
     fn test_minimization_get_vote_accounts() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let bootstrap_validator_pubkey = solana_pubkey::new_rand();
         let bootstrap_validator_stake_lamports = 30;
@@ -422,7 +422,7 @@ mod tests {
 
     #[test]
     fn test_minimization_get_stake_accounts() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let bootstrap_validator_pubkey = solana_pubkey::new_rand();
         let bootstrap_validator_stake_lamports = 30;
@@ -461,7 +461,7 @@ mod tests {
 
     #[test]
     fn test_minimization_get_owner_accounts() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let (genesis_config, _) = create_genesis_config(1_000_000);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
@@ -485,7 +485,7 @@ mod tests {
 
     #[test]
     fn test_minimization_add_programdata_accounts() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let (genesis_config, _) = create_genesis_config(1_000_000);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
@@ -531,7 +531,7 @@ mod tests {
 
     #[test]
     fn test_minimize_accounts_db() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let (genesis_config, _) = create_genesis_config(1_000_000);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -40,10 +40,10 @@ tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 solana-account = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-genesis-config = { workspace = true }
-solana-logger = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-nonce = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -635,7 +635,7 @@ mod test {
     }
 
     fn process_transactions<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let (mut genesis_config, mint_keypair) = create_genesis_config(4);
         genesis_config.fee_rate_governor = solana_fee_calculator::FeeRateGovernor::new(0, 0);
@@ -927,7 +927,7 @@ mod test {
     }
 
     fn retry_durable_nonce_transactions<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let (mut genesis_config, mint_keypair) = create_genesis_config(4);
         genesis_config.fee_rate_governor = solana_fee_calculator::FeeRateGovernor::new(0, 0);

--- a/snapshots/Cargo.toml
+++ b/snapshots/Cargo.toml
@@ -37,6 +37,6 @@ thiserror = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 assert_matches = { workspace = true }
-solana-logger = { workspace = true }
 tempfile = { workspace = true }

--- a/snapshots/src/hardened_unpack.rs
+++ b/snapshots/src/hardened_unpack.rs
@@ -603,7 +603,7 @@ mod tests {
 
     #[test]
     fn test_valid_snapshot_accounts() {
-        solana_logger::setup();
+        agave_logger::setup();
         assert!(is_valid_snapshot_archive_entry(
             &["accounts", "0.0"],
             tar::EntryType::Regular

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -63,9 +63,9 @@ tokio-util = { workspace = true, features = ["rt"] }
 x509-parser = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 anyhow = { workspace = true }
 assert_matches = { workspace = true }
 clap = { version = "4.5.31", features = ["cargo", "derive", "error-context"] }
-solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-streamer = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/streamer/examples/swqos.rs
+++ b/streamer/examples/swqos.rs
@@ -85,7 +85,7 @@ struct Cli {
 // number of threads as in fn default_num_tpu_transaction_forward_receive_threads
 #[tokio::main(flavor = "multi_thread", worker_threads = 16)]
 async fn main() -> anyhow::Result<()> {
-    solana_logger::setup();
+    agave_logger::setup();
     let cli = Cli::parse();
     let socket = bind_to_with_config(
         cli.bind_to.ip(),

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1772,7 +1772,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_quic_timeout() {
-        solana_logger::setup();
+        agave_logger::setup();
         let SpawnTestServerResult {
             join_handle,
             receiver,
@@ -1788,7 +1788,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_packet_batcher() {
-        solana_logger::setup();
+        agave_logger::setup();
         let (pkt_batch_sender, pkt_batch_receiver) = unbounded();
         let (ptk_sender, pkt_receiver) = unbounded();
         let cancel = CancellationToken::new();
@@ -1839,7 +1839,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_quic_stream_timeout() {
-        solana_logger::setup();
+        agave_logger::setup();
         let SpawnTestServerResult {
             join_handle,
             receiver,
@@ -1875,7 +1875,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_quic_server_block_multiple_connections() {
-        solana_logger::setup();
+        agave_logger::setup();
         let SpawnTestServerResult {
             join_handle,
             receiver,
@@ -1891,7 +1891,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_quic_server_multiple_connections_on_single_client_endpoint() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let SpawnTestServerResult {
             join_handle,
@@ -1974,7 +1974,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_quic_server_multiple_writes() {
-        solana_logger::setup();
+        agave_logger::setup();
         let SpawnTestServerResult {
             join_handle,
             receiver,
@@ -1989,7 +1989,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_quic_server_staked_connection_removal() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let client_keypair = Keypair::new();
         let stakes = HashMap::from([(client_keypair.pubkey(), 100_000)]);
@@ -2021,7 +2021,7 @@ pub mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_quic_server_zero_staked_connection_removal() {
         // In this test, the client has a pubkey, but is not in stake table.
-        solana_logger::setup();
+        agave_logger::setup();
 
         let client_keypair = Keypair::new();
         let stakes = HashMap::from([(client_keypair.pubkey(), 0)]);
@@ -2052,7 +2052,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_quic_server_unstaked_connection_removal() {
-        solana_logger::setup();
+        agave_logger::setup();
         let SpawnTestServerResult {
             join_handle,
             receiver,
@@ -2076,7 +2076,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_quic_server_unstaked_node_connect_failure() {
-        solana_logger::setup();
+        agave_logger::setup();
         let s = bind_to_localhost_unique().expect("should bind");
         let (sender, _) = unbounded();
         let keypair = Keypair::new();
@@ -2109,7 +2109,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_quic_server_multiple_streams() {
-        solana_logger::setup();
+        agave_logger::setup();
         let s = bind_to_localhost_unique().expect("should bind");
         let (sender, receiver) = unbounded();
         let keypair = Keypair::new();
@@ -2150,7 +2150,7 @@ pub mod test {
     #[test]
     fn test_prune_table_with_ip() {
         use std::net::Ipv4Addr;
-        solana_logger::setup();
+        agave_logger::setup();
         let cancel = CancellationToken::new();
         let mut table = ConnectionTable::new(ConnectionTableType::Unstaked, cancel);
         let mut num_entries = 5;
@@ -2204,7 +2204,7 @@ pub mod test {
 
     #[test]
     fn test_prune_table_with_unique_pubkeys() {
-        solana_logger::setup();
+        agave_logger::setup();
         let cancel = CancellationToken::new();
         let mut table = ConnectionTable::new(ConnectionTableType::Unstaked, cancel);
 
@@ -2243,7 +2243,7 @@ pub mod test {
 
     #[test]
     fn test_prune_table_with_non_unique_pubkeys() {
-        solana_logger::setup();
+        agave_logger::setup();
         let cancel = CancellationToken::new();
         let mut table = ConnectionTable::new(ConnectionTableType::Unstaked, cancel);
 
@@ -2310,7 +2310,7 @@ pub mod test {
     #[test]
     fn test_prune_table_random() {
         use std::net::Ipv4Addr;
-        solana_logger::setup();
+        agave_logger::setup();
         let cancel = CancellationToken::new();
         let mut table = ConnectionTable::new(ConnectionTableType::Unstaked, cancel);
 
@@ -2354,7 +2354,7 @@ pub mod test {
     #[test]
     fn test_remove_connections() {
         use std::net::Ipv4Addr;
-        solana_logger::setup();
+        agave_logger::setup();
         let cancel = CancellationToken::new();
         let mut table = ConnectionTable::new(ConnectionTableType::Unstaked, cancel);
 
@@ -2482,7 +2482,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_throttling_check_no_packet_drop() {
-        solana_logger::setup_with_default_filter();
+        agave_logger::setup_with_default_filter();
 
         let SpawnTestServerResult {
             join_handle,

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     pub fn packet_send_recv() {
-        solana_logger::setup();
+        agave_logger::setup();
         let recv_socket = bind_to_localhost_unique().expect("should bind - receiver");
         let addr = recv_socket.local_addr().unwrap();
         let send_socket = bind_to_localhost_unique().expect("should bind - sender");
@@ -391,7 +391,7 @@ mod tests {
 
     #[test]
     fn test_packet_resize() {
-        solana_logger::setup();
+        agave_logger::setup();
         let recv_socket = bind_to_localhost_unique().expect("should bind - receiver");
         let addr = recv_socket.local_addr().unwrap();
         let send_socket = bind_to_localhost_unique().expect("should bind - sender");

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -804,7 +804,7 @@ mod test {
 
     #[test]
     fn test_quic_timeout() {
-        solana_logger::setup();
+        agave_logger::setup();
         let (t, receiver, server_address, cancel) = setup_quic_server();
         let runtime = rt_for_test();
         runtime.block_on(check_timeout(receiver, server_address));
@@ -814,7 +814,7 @@ mod test {
 
     #[test]
     fn test_quic_server_block_multiple_connections() {
-        solana_logger::setup();
+        agave_logger::setup();
         let (t, _receiver, server_address, cancel) = setup_quic_server();
 
         let runtime = rt_for_test();
@@ -825,7 +825,7 @@ mod test {
 
     #[test]
     fn test_quic_server_multiple_streams() {
-        solana_logger::setup();
+        agave_logger::setup();
         let s = bind_to_localhost_unique().expect("should bind");
         let (sender, receiver) = unbounded();
         let keypair = Keypair::new();
@@ -859,7 +859,7 @@ mod test {
 
     #[test]
     fn test_quic_server_multiple_writes() {
-        solana_logger::setup();
+        agave_logger::setup();
         let (t, receiver, server_address, cancel) = setup_quic_server();
 
         let runtime = rt_for_test();
@@ -870,7 +870,7 @@ mod test {
 
     #[test]
     fn test_quic_server_unstaked_node_connect_failure() {
-        solana_logger::setup();
+        agave_logger::setup();
         let s = bind_to_localhost_unique().expect("should bind");
         let (sender, _) = unbounded();
         let keypair = Keypair::new();

--- a/svm-test-harness/Cargo.toml
+++ b/svm-test-harness/Cargo.toml
@@ -22,6 +22,7 @@ fuzz = ["dep:clap", "dep:prost", "dep:prost-build", "dep:protosol"]
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-logger = { workspace = true }
 agave-precompiles = { workspace = true }
 agave-syscalls = { workspace = true }
 bincode = { workspace = true }
@@ -37,7 +38,6 @@ solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true, features = ["serde"] }
 solana-last-restart-slot = { workspace = true, features = ["sysvar"] }
-solana-logger = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/svm-test-harness/src/fuzz.rs
+++ b/svm-test-harness/src/fuzz.rs
@@ -18,7 +18,7 @@ pub unsafe extern "C" fn sol_compat_init(_log_level: i32) {
     env::set_var("RAYON_NUM_THREADS", "1");
     if env::var("ENABLE_SOLANA_LOGGER").is_ok() {
         /* Pairs with RUST_LOG={trace,debug,info,etc} */
-        solana_logger::setup();
+        agave_logger::setup();
     }
 }
 

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -80,6 +80,7 @@ spl-generic-token = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 agave-syscalls = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
@@ -97,7 +98,6 @@ solana-ed25519-program = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-native-token = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-program-binaries = { workspace = true }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1268,7 +1268,7 @@ mod tests {
 
     #[test]
     fn test_instructions() {
-        solana_logger::setup();
+        agave_logger::setup();
         let instructions_key = solana_sdk_ids::sysvar::instructions::id();
         let keypair = Keypair::new();
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0, 1])];
@@ -1292,7 +1292,7 @@ mod tests {
 
     #[test]
     fn test_overrides() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut account_overrides = AccountOverrides::default();
         let slot_history_id = sysvar::slot_history::id();
         let account = AccountSharedData::new(42, 0, &Pubkey::default());

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -40,7 +40,6 @@ solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
 solana-loader-v3-interface = { workspace = true }
-solana-logger = "=3.0.0"
 solana-message = { workspace = true }
 solana-native-token = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -55,9 +55,9 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
-solana-logger = { workspace = true }
 solana-streamer = { workspace = true }
 solana-test-validator = { workspace = true }
 solana-transaction-error = { workspace = true }

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -1947,7 +1947,7 @@ mod tests {
 
     #[test]
     fn test_check_payer_balances_distribute_tokens_separate_payers() {
-        solana_logger::setup();
+        agave_logger::setup();
         let alice = Keypair::new();
         let test_validator = simple_test_validator(alice.pubkey());
         let url = test_validator.rpc_url();
@@ -2185,7 +2185,7 @@ mod tests {
 
     #[test]
     fn test_check_payer_balances_distribute_stakes_separate_payers() {
-        solana_logger::setup();
+        agave_logger::setup();
         let alice = Keypair::new();
         let test_validator = simple_test_validator(alice.pubkey());
         let url = test_validator.rpc_url();

--- a/tokens/tests/commands.rs
+++ b/tokens/tests/commands.rs
@@ -6,7 +6,7 @@ use {
 
 #[test]
 fn test_process_distribute_with_rpc_client() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let mint_keypair = Keypair::new();
     let test_validator =

--- a/transaction-dos/Cargo.toml
+++ b/transaction-dos/Cargo.toml
@@ -16,6 +16,7 @@ agave-unstable-api = []
 dev-context-only-utils = []
 
 [dependencies]
+agave-logger = { workspace = true }
 bincode = { workspace = true }
 clap = { workspace = true }
 log = { workspace = true }
@@ -29,7 +30,6 @@ solana-faucet = { workspace = true }
 solana-gossip = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -427,7 +427,7 @@ fn run_transactions_dos(
 }
 
 fn main() {
-    solana_logger::setup_with_default_filter();
+    agave_logger::setup_with_default_filter();
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())
@@ -678,7 +678,7 @@ pub mod test {
 
     #[test]
     fn test_tx_size() {
-        solana_logger::setup();
+        agave_logger::setup();
         let keypair = Keypair::new();
         let num_instructions = 20;
         let program_id = Pubkey::new_unique();
@@ -706,7 +706,7 @@ pub mod test {
     #[test]
     #[ignore]
     fn test_transaction_dos() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let validator_config = ValidatorConfig::default_for_test();
         let num_nodes = 1;

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -65,12 +65,12 @@ wincode = { workspace = true }
 caps = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 assert_matches = { workspace = true }
 bencher = { workspace = true }
 bs58 = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-ledger = { workspace = true, features = ["agave-unstable-api","dev-context-only-utils"] }
-solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-transaction = { workspace = true }

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -26,7 +26,7 @@ use {
 };
 
 fn broadcast_shreds_bench(b: &mut Bencher) {
-    solana_logger::setup();
+    agave_logger::setup();
     let leader_keypair = Arc::new(Keypair::new());
     let (quic_endpoint_sender, _quic_endpoint_receiver) =
         tokio::sync::mpsc::channel(/*capacity:*/ 128);

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -783,7 +783,7 @@ pub mod test {
 
     #[test]
     fn test_broadcast_ledger() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
 
         // Create the leader scheduler

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -817,7 +817,7 @@ mod test {
 
     #[test]
     fn entries_to_shreds_max() {
-        solana_logger::setup();
+        agave_logger::setup();
         let keypair = Keypair::new();
         let mut bs = StandardBroadcastRun::new(0);
         bs.slot = 1;

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -44,12 +44,12 @@ unwrap_none = { workspace = true }
 vec_extract_if_polyfill = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 assert_matches = { workspace = true }
 solana-clock = { workspace = true }
 solana-entry = { workspace = true }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-system-transaction = { workspace = true }
 test-case = { workspace = true }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -2808,7 +2808,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_pool_new() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
         let pool =
@@ -2824,7 +2824,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_spawn() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
         let pool =
@@ -2843,7 +2843,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_scheduler_drop_idle() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let _progress = sleepless_testing::setup(&[
             &TestCheckPoint::BeforeIdleSchedulerCleaned,
@@ -2907,7 +2907,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_drop_overgrown() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let _progress = sleepless_testing::setup(&[
             &TestCheckPoint::BeforeTrashedSchedulerCleaned,
@@ -2981,7 +2981,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_drop_stale() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let _progress = sleepless_testing::setup(&[
             &TestCheckPoint::BeforeTimeoutListenerTriggered,
@@ -3027,7 +3027,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_active_after_stale() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let _progress = sleepless_testing::setup(&[
             &TestCheckPoint::BeforeTimeoutListenerTriggered,
@@ -3117,7 +3117,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_pause_after_stale() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let _progress = sleepless_testing::setup(&[
             &TestCheckPoint::BeforeTimeoutListenerTriggered,
@@ -3162,7 +3162,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_remain_stale_after_error() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let _progress = sleepless_testing::setup(&[
             &TestCheckPoint::BeforeTimeoutListenerTriggered,
@@ -3250,7 +3250,7 @@ mod tests {
     }
 
     fn do_test_scheduler_drop_abort(abort_case: AbortCase) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let _progress = sleepless_testing::setup(match abort_case {
             AbortCase::Unhandled => &[
@@ -3334,7 +3334,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_drop_short_circuiting() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let _progress = sleepless_testing::setup(&[
             &TestCheckPoint::BeforeThreadManagerDrop,
@@ -3405,7 +3405,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_pool_filo() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
         let pool =
@@ -3434,7 +3434,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_pool_context_drop_unless_reinitialized() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
         let pool =
@@ -3453,7 +3453,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_pool_context_replace() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
         let pool =
@@ -3476,7 +3476,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_pool_install_into_bank_forks() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let bank = Bank::default_for_tests();
         let bank_forks = BankForks::new_rw_arc(bank);
@@ -3489,7 +3489,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_install_into_bank() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
@@ -3530,7 +3530,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_schedule_execution_success() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo {
             genesis_config,
@@ -3559,7 +3559,7 @@ mod tests {
     }
 
     fn do_test_scheduler_schedule_execution_failure(extra_tx_after_failure: bool) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let _progress = sleepless_testing::setup(&[
             &CheckPoint::TaskHandled(0),
@@ -3664,7 +3664,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "This panic should be propagated. (From: ")]
     fn test_scheduler_schedule_execution_panic() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         #[derive(Debug)]
         enum PanickingHanlderCheckPoint {
@@ -3749,7 +3749,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_execution_failure_short_circuiting() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let _progress = sleepless_testing::setup(&[
             &TestCheckPoint::BeforeNewTask,
@@ -3838,7 +3838,7 @@ mod tests {
     fn test_scheduler_schedule_execution_blocked_at_session_ending(
         scheduling_mode: SchedulingMode,
     ) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         const STALLED_TRANSACTION_INDEX: OrderedTaskId = 0;
         const BLOCKED_TRANSACTION_INDEX: OrderedTaskId = 1;
@@ -3992,7 +3992,7 @@ mod tests {
 
     #[test]
     fn test_block_production_scheduler_schedule_execution_retry() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         const ORIGINAL_TRANSACTION_INDEX: OrderedTaskId = 999;
         // This is 0 because it's the first task id assigned internally by BankingStageHelper
@@ -4098,7 +4098,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_mismatched_scheduling_context_race() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         #[derive(Debug)]
         struct TaskAndContextChecker;
@@ -4330,7 +4330,7 @@ mod tests {
     fn do_test_scheduler_schedule_execution_recent_blockhash_edge_case<
         const TRIGGER_RACE_CONDITION: bool,
     >() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo {
             genesis_config,
@@ -4418,7 +4418,7 @@ mod tests {
     // See comment in SchedulingStateMachine::create_task() for the justification of this test
     #[test]
     fn test_enfoced_get_account_locks_validation() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo {
             genesis_config,
@@ -4473,7 +4473,7 @@ mod tests {
         [false, true]
     )]
     fn test_task_handler_poh_recording(tx_result: TxResult, should_succeed_to_record_to_poh: bool) {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo {
             genesis_config,
@@ -4603,7 +4603,7 @@ mod tests {
 
     #[test]
     fn test_block_production_scheduler_schedule_execution_success() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo {
             genesis_config,
@@ -4660,7 +4660,7 @@ mod tests {
 
     #[test]
     fn test_block_production_scheduler_buffering_on_spawn() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let _progress = sleepless_testing::setup(&[
             &CheckPoint::NewBufferedTask(17),
@@ -4724,7 +4724,7 @@ mod tests {
 
     #[test]
     fn test_block_production_scheduler_buffering_before_new_session() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let _progress = sleepless_testing::setup(&[
             &CheckPoint::NewBufferedTask(18),
@@ -4797,7 +4797,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "register_banking_stage() isn't called yet")]
     fn test_block_production_scheduler_take_without_registering() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
         let pool =
@@ -4811,7 +4811,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "cannot take: Taken(0)")]
     fn test_block_production_scheduler_double_take_without_returning() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } =
             create_genesis_config_for_block_production(10_000);
@@ -4845,7 +4845,7 @@ mod tests {
 
     #[test]
     fn test_block_production_scheduler_drop_overgrown_on_returning() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } =
             create_genesis_config_for_block_production(10_000);
@@ -4922,7 +4922,7 @@ mod tests {
             }
         }
 
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } =
             create_genesis_config_for_block_production(10_000);
@@ -4984,7 +4984,7 @@ mod tests {
 
     #[test]
     fn test_block_production_scheduler_return_block_verification_scheduler_while_pooled() {
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo { genesis_config, .. } =
             create_genesis_config_for_block_production(10_000);
@@ -5032,7 +5032,7 @@ mod tests {
             }
         }
 
-        solana_logger::setup();
+        agave_logger::setup();
 
         let GenesisConfigInfo {
             genesis_config,

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -19,6 +19,7 @@ agave-unstable-api = []
 
 [dependencies]
 agave-geyser-plugin-interface = { workspace = true }
+agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
 clap = { workspace = true }
@@ -61,7 +62,6 @@ solana-hash = { workspace = true }
 solana-inflation = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
-solana-logger = "=3.0.0"
 solana-metrics = { workspace = true }
 solana-native-token = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -462,7 +462,7 @@ impl AdminRpc for AdminRpcImpl {
 
     fn set_log_filter(&self, filter: String) -> Result<()> {
         debug!("set_log_filter admin rpc request received");
-        solana_logger::setup_with(&filter);
+        agave_logger::setup_with(&filter);
         Ok(())
     }
 

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -1,4 +1,5 @@
 use {
+    agave_logger::redirect_stderr_to_file,
     agave_validator::{
         admin_rpc_service, cli, dashboard::Dashboard, ledger_lockfile, lock_ledger,
         println_name_value,
@@ -19,7 +20,6 @@ use {
     solana_faucet::faucet::{run_faucet, Faucet},
     solana_inflation::Inflation,
     solana_keypair::{read_keypair_file, write_keypair_file, Keypair},
-    solana_logger::redirect_stderr_to_file,
     solana_native_token::sol_str_to_lamports,
     solana_pubkey::Pubkey,
     solana_rent::Rent,

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1369,7 +1369,7 @@ mod tests {
 
     #[test]
     fn test_build_known_snapshot_hashes() {
-        solana_logger::setup();
+        agave_logger::setup();
         let full_snapshot_hash1 = (400_000, Hash::new_unique());
         let full_snapshot_hash2 = (400_000, Hash::new_unique());
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -6,6 +6,7 @@ use {
         commands::{run::args::RunArgs, FromClapArgMatches},
         ledger_lockfile, lock_ledger,
     },
+    agave_logger::redirect_stderr_to_file,
     agave_snapshots::{
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
@@ -52,7 +53,6 @@ use {
         blockstore_cleanup_service::{DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS},
         use_snapshot_archives_at_startup::{self, UseSnapshotArchivesAtStartup},
     },
-    solana_logger::redirect_stderr_to_file,
     solana_net_utils::multihomed_sockets::BindIpAddrs,
     solana_perf::recycler::enable_recycler_warming,
     solana_poh::poh_service,

--- a/vortexor/Cargo.toml
+++ b/vortexor/Cargo.toml
@@ -25,6 +25,7 @@ dev-context-only-utils = []
 
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
+agave-logger = { workspace = true }
 bytes = { workspace = true }
 clap = { version = "4.5.31", features = ["cargo", "derive", "error-context"] }
 crossbeam-channel = { workspace = true }
@@ -53,7 +54,6 @@ solana-clock = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-core = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -1,10 +1,10 @@
 use {
+    agave_logger::redirect_stderr_to_file,
     clap::{crate_name, Parser},
     crossbeam_channel::bounded,
     log::*,
     solana_core::banking_trace::BankingTracer,
     solana_keypair::read_keypair_file,
-    solana_logger::redirect_stderr_to_file,
     solana_net_utils::sockets::{bind_in_range_with_config, SocketConfiguration as SocketConfig},
     solana_quic_definitions::QUIC_PORT_OFFSET,
     solana_signer::Signer,
@@ -32,7 +32,7 @@ use {
 const DEFAULT_CHANNEL_SIZE: usize = 100_000;
 
 pub fn main() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let args = Cli::parse();
     let solana_version = solana_version::version!();

--- a/vortexor/tests/vortexor.rs
+++ b/vortexor/tests/vortexor.rs
@@ -39,7 +39,7 @@ use {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_vortexor() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     let bind_address = solana_net_utils::parse_host("127.0.0.1").expect("invalid bind_address");
     let keypair = Keypair::new();
@@ -98,7 +98,7 @@ fn get_server_urls(validator: &ClusterValidatorInfo) -> (Url, Url) {
 
 #[test]
 fn test_stake_update() {
-    solana_logger::setup();
+    agave_logger::setup();
 
     // Create a local cluster with 3 validators
     let default_node_stake = 10 * LAMPORTS_PER_SOL; // Define a default value for node stake

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -51,12 +51,12 @@ solana-vote-interface = { workspace = true, features = ["bincode"] }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 arbitrary = { workspace = true }
 bencher = { workspace = true }
 bincode = { workspace = true }
 rand = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true, features = ["bincode"] }

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -14,6 +14,7 @@ agave-unstable-api = []
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [dependencies]
+agave-logger = { workspace = true }
 serde = { workspace = true }
 solana-bls-signatures = { workspace = true, features = [
     "bytemuck", "solana-signer-derive",
@@ -26,7 +27,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-hash = { workspace = true, features = ["serde"] }
-solana-logger = { workspace = true }
 
 [lints]
 workspace = true

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -22,6 +22,7 @@ frozen-abi = [
 ]
 
 [dependencies]
+agave-logger = { workspace = true }
 agave-votor-messages = { workspace = true }
 anyhow = { workspace = true }
 bincode = { workspace = true }
@@ -58,7 +59,6 @@ solana-gossip = { workspace = true }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
-solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -1565,7 +1565,7 @@ mod tests {
 
     #[test]
     fn test_safe_to_notar() {
-        solana_logger::setup();
+        agave_logger::setup();
         let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
         let bank = bank_forks.read().unwrap().root_bank();
         let (my_vote_key, _, _) =

--- a/votor/src/consensus_pool/vote_pool.rs
+++ b/votor/src/consensus_pool/vote_pool.rs
@@ -187,7 +187,7 @@ mod test {
 
     #[test]
     fn test_notarization_fallback_pool() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut vote_pool = DuplicateBlockVotePool::new(3);
         let my_pubkey = Pubkey::new_unique();
 

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -517,7 +517,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_send_consensus_message() {
-        solana_logger::setup();
+        agave_logger::setup();
         let setup_result = setup(None);
 
         // validator 0 to 7 send Notarize on slot 2

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1427,7 +1427,7 @@ mod tests {
 
     #[test]
     fn test_received_finalized() {
-        solana_logger::setup();
+        agave_logger::setup();
         let test_context = EventHandlerTestContext::setup();
 
         let root_bank = test_context
@@ -1464,7 +1464,7 @@ mod tests {
 
     #[test]
     fn test_parent_ready_in_middle_of_window() {
-        solana_logger::setup();
+        agave_logger::setup();
         let test_context = EventHandlerTestContext::setup();
 
         // We just woke up and received finalize for slot 5
@@ -1503,7 +1503,7 @@ mod tests {
 
     #[test]
     fn test_received_standstill() {
-        solana_logger::setup();
+        agave_logger::setup();
         let test_context = EventHandlerTestContext::setup();
 
         // Send notarize vote for slot 1 then skip rest of the window
@@ -1549,7 +1549,7 @@ mod tests {
 
     #[test]
     fn test_received_set_identity() {
-        solana_logger::setup();
+        agave_logger::setup();
         let test_context = EventHandlerTestContext::setup();
         let old_identity = test_context.cluster_info.keypair().insecure_clone();
         let new_identity = Keypair::new();
@@ -1604,7 +1604,7 @@ mod tests {
     #[test_case("commitment_receiver")]
     #[test_case("own_vote_receiver")]
     fn test_channel_disconnection(channel_name: &str) {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut test_context = EventHandlerTestContext::setup();
         match channel_name {
             "bls_receiver" => {

--- a/votor/src/staked_validators_cache.rs
+++ b/votor/src/staked_validators_cache.rs
@@ -566,7 +566,7 @@ mod tests {
 
     #[test]
     fn test_alpenglow_port_override() {
-        solana_logger::setup();
+        agave_logger::setup();
         let (bank_forks, cluster_info, node_pubkeys) = create_bank_forks_and_cluster_info(3, 0, 1);
         let pubkey_b = node_pubkeys[1];
 

--- a/votor/src/vote_history_storage.rs
+++ b/votor/src/vote_history_storage.rs
@@ -176,7 +176,7 @@ mod test {
 
     #[test]
     fn test_file_vote_history_storage() {
-        solana_logger::setup();
+        agave_logger::setup();
         let tmp_dir = TempDir::new().unwrap();
         let storage = FileVoteHistoryStorage::new(tmp_dir.path().to_path_buf());
         let keypair = Keypair::new();

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -355,7 +355,7 @@ mod tests {
         bitmap: Vec::new(),
     }))]
     fn test_send_message(bls_op: BLSOp, expected_message: ConsensusMessage) {
-        solana_logger::setup();
+        agave_logger::setup();
         let (bls_sender, bls_receiver) = crossbeam_channel::unbounded();
         // Create listener thread on a random port we allocated and return SocketAddr to create VotingService
 

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -572,7 +572,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "The bank 0 doesn't have its own epoch_stakes for")]
     fn test_panic_on_future_slot() {
-        solana_logger::setup();
+        agave_logger::setup();
         let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
         // Create 10 node validatorvotekeypairs vec
         let validator_keypairs = (0..10)
@@ -589,7 +589,7 @@ mod tests {
 
     #[test]
     fn test_zero_staked_validator_fails_voting() {
-        solana_logger::setup();
+        agave_logger::setup();
         let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
         // Create 10 node validatorvotekeypairs vec
         let validator_keypairs = (0..10)

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 
 [dependencies]
+agave-logger = { workspace = true }
 clap = { workspace = true }
 humantime = { workspace = true }
 log = { workspace = true }
@@ -23,7 +24,6 @@ solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-cli-output = { workspace = true }
 solana-hash = "=3.0.0"
-solana-logger = "=3.0.0"
 solana-metrics = { workspace = true }
 solana-native-token = "=3.0.0"
 solana-notifier = { workspace = true }

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -452,7 +452,7 @@ fn validate_endpoints(
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
-    solana_logger::setup_with_default_filter();
+    agave_logger::setup_with_default_filter();
     solana_metrics::set_panic_hook("watchtower", /*version:*/ None);
 
     let config = get_config();

--- a/wen-restart/Cargo.toml
+++ b/wen-restart/Cargo.toml
@@ -49,6 +49,7 @@ prost-build = { workspace = true }
 protobuf-src = { workspace = true }
 
 [dev-dependencies]
+agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 assert_matches = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -57,7 +58,6 @@ serial_test = { workspace = true }
 solana-entry = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
-solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-signer = { workspace = true }
 solana-streamer = { workspace = true }

--- a/wen-restart/src/heaviest_fork_aggregate.rs
+++ b/wen-restart/src/heaviest_fork_aggregate.rs
@@ -208,7 +208,7 @@ mod tests {
     }
 
     fn test_aggregate_init() -> TestAggregateInitResult {
-        solana_logger::setup();
+        agave_logger::setup();
         let validator_voting_keypairs: Vec<_> = (0..TOTAL_VALIDATOR_COUNT)
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect();

--- a/wen-restart/src/last_voted_fork_slots_aggregate.rs
+++ b/wen-restart/src/last_voted_fork_slots_aggregate.rs
@@ -273,7 +273,7 @@ mod tests {
     }
 
     fn test_aggregate_init() -> TestAggregateInitResult {
-        solana_logger::setup();
+        agave_logger::setup();
         let validator_voting_keypairs: Vec<_> = (0..TOTAL_VALIDATOR_COUNT)
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect();
@@ -688,7 +688,7 @@ mod tests {
 
     #[test]
     fn test_aggregate_from_record_failures() {
-        solana_logger::setup();
+        agave_logger::setup();
         let mut test_state = test_aggregate_init();
         let last_vote_bankhash = Hash::new_unique();
         let mut last_voted_fork_slots_record = LastVotedForkSlotsRecord {

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -1954,7 +1954,7 @@ mod tests {
 
     #[test]
     fn test_wen_restart_divergence_across_epoch_boundary() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let test_state = wen_restart_test_init(&ledger_path);
         let last_vote_slot = test_state.last_voted_fork_slots[0];
@@ -2128,7 +2128,7 @@ mod tests {
 
     #[test]
     fn test_wen_restart_initialize() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let test_state = wen_restart_test_init(&ledger_path);
         let last_vote_bankhash = Hash::new_unique();
@@ -2690,7 +2690,7 @@ mod tests {
 
     #[test]
     fn test_increment_and_write_wen_restart_records() {
-        solana_logger::setup();
+        agave_logger::setup();
         let my_dir = TempDir::new().unwrap();
         let mut wen_restart_proto_path = my_dir.path().to_path_buf();
         wen_restart_proto_path.push("wen_restart_status.proto");
@@ -2927,7 +2927,7 @@ mod tests {
 
     #[test]
     fn test_find_heaviest_fork_failures() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let exit = Arc::new(AtomicBool::new(false));
         let test_state = wen_restart_test_init(&ledger_path);
@@ -3194,7 +3194,7 @@ mod tests {
 
     #[test]
     fn test_generate_snapshot() {
-        solana_logger::setup();
+        agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let test_state = wen_restart_test_init(&ledger_path);
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
#### Problem
The `solana-logger` crate should not have ever been moved to `solana-sdk` as it is mostly Agave specific (there are a few lingering references in `solana-sdk` that I'll look into separately)

#### Summary of Changes
Move the crate back to Agave and rename it to `agave-logger`