### PR TITLE
Removing stored meta data from store tool

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -314,7 +314,7 @@ impl AccountsFile {
 
     /// Calculate the amount of storage required for an account with the passed
     /// in data_len
-    pub(crate) fn calculate_stored_size(&self, data_len: usize) -> usize {
+    pub fn calculate_stored_size(&self, data_len: usize) -> usize {
         match self {
             Self::AppendVec(_) => AppendVec::calculate_stored_size(data_len),
             Self::TieredStorage(ts) => ts


### PR DESCRIPTION
#### Problem
Store tool depends on scan_accounts_stored_meta which in turn means scan_accounts_stored_meta needs to be public for the accounts-db crate. This can and should be avoided.

#### Summary of Changes
- Changed store tool to not use stored meta 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
