### PR TITLE
Add `prerelease` command to increment-cargo-version.sh

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -18,8 +18,8 @@ is_crate_version_uploaded() {
   exit 0
 }
 
-semverParseInto "$CI_TAG" MAJOR MINOR PATCH SPECIAL
-expectedCrateVersion="$MAJOR.$MINOR.$PATCH$SPECIAL"
+semverParseInto "$CI_TAG" MAJOR MINOR PATCH PRERELEASE_STAGE PRERELEASE_NUMBER
+expectedCrateVersion="$MAJOR.$MINOR.$PATCH$PRERELEASE_STAGE.$PRERELEASE_NUMBER"
 
 [[ -n "$CRATES_IO_TOKEN" ]] || {
   echo CRATES_IO_TOKEN undefined

--- a/ci/semver_bash/semver.sh
+++ b/ci/semver_bash/semver.sh
@@ -1,30 +1,34 @@
 #!/usr/bin/env sh
 
 function semverParseInto() {
-    local RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
+    local RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)[.]\?\([0-9]*\)'
     #MAJOR
     eval $2=`echo $1 | sed -e "s#$RE#\1#"`
     #MINOR
     eval $3=`echo $1 | sed -e "s#$RE#\2#"`
     #MINOR
     eval $4=`echo $1 | sed -e "s#$RE#\3#"`
-    #SPECIAL
+    #PRERELEASE_STAGE
     eval $5=`echo $1 | sed -e "s#$RE#\4#"`
+    #PRERELEASE_NUMBER
+    eval $6=`echo $1 | sed -e "s#$RE#\5#"`
 }
 
 function semverEQ() {
     local MAJOR_A=0
     local MINOR_A=0
     local PATCH_A=0
-    local SPECIAL_A=0
+    local PRERELEASE_STAGE_A=0
+    local PRERELEASE_NUMBER_A=0
 
     local MAJOR_B=0
     local MINOR_B=0
     local PATCH_B=0
-    local SPECIAL_B=0
+    local PRERELEASE_STAGE_B=0
+    local PRERELEASE_NUMBER_B=0
 
-    semverParseInto $1 MAJOR_A MINOR_A PATCH_A SPECIAL_A
-    semverParseInto $2 MAJOR_B MINOR_B PATCH_B SPECIAL_B
+    semverParseInto $1 MAJOR_A MINOR_A PATCH_A PRERELEASE_STAGE_A PRERELEASE_NUMBER_A
+    semverParseInto $2 MAJOR_B MINOR_B PATCH_B PRERELEASE_STAGE_B PRERELEASE_NUMBER_B
 
     if [ $MAJOR_A -ne $MAJOR_B ]; then
         return 1
@@ -38,10 +42,13 @@ function semverEQ() {
         return 1
     fi
 
-    if [[ "_$SPECIAL_A" != "_$SPECIAL_B" ]]; then
+    if [[ "_$PRERELEASE_STAGE_A" != "_$PRERELEASE_STAGE_B" ]]; then
         return 1
     fi
 
+    if [[ "_$PRERELEASE_NUMBER_A" != "_$PRERELEASE_NUMBER_B" ]]; then
+        return 1
+    fi
 
     return 0
 
@@ -51,15 +58,17 @@ function semverLT() {
     local MAJOR_A=0
     local MINOR_A=0
     local PATCH_A=0
-    local SPECIAL_A=0
+    local PRERELEASE_STAGE_A=0
+    local PRERELEASE_NUMBER_A=0
 
     local MAJOR_B=0
     local MINOR_B=0
     local PATCH_B=0
-    local SPECIAL_B=0
+    local PRERELEASE_STAGE_B=0
+    local PRERELEASE_NUMBER_B=0
 
-    semverParseInto $1 MAJOR_A MINOR_A PATCH_A SPECIAL_A
-    semverParseInto $2 MAJOR_B MINOR_B PATCH_B SPECIAL_B
+    semverParseInto $1 MAJOR_A MINOR_A PATCH_A PRERELEASE_STAGE_A PRERELEASE_NUMBER_A
+    semverParseInto $2 MAJOR_B MINOR_B PATCH_B PRERELEASE_STAGE_B PRERELEASE_NUMBER_B
 
     if [ $MAJOR_A -lt $MAJOR_B ]; then
         return 0
@@ -68,23 +77,35 @@ function semverLT() {
     if [[ $MAJOR_A -le $MAJOR_B  && $MINOR_A -lt $MINOR_B ]]; then
         return 0
     fi
-    
+
     if [[ $MAJOR_A -le $MAJOR_B  && $MINOR_A -le $MINOR_B && $PATCH_A -lt $PATCH_B ]]; then
         return 0
     fi
 
-    if [[ "_$SPECIAL_A"  == "_" ]] && [[ "_$SPECIAL_B"  == "_" ]] ; then
+    if [[ "_$PRERELEASE_STAGE_A"  == "_" ]] && [[ "_$PRERELEASE_STAGE_B"  == "_" ]] ; then
         return 1
     fi
-    if [[ "_$SPECIAL_A"  == "_" ]] && [[ "_$SPECIAL_B"  != "_" ]] ; then
+    if [[ "_$PRERELEASE_STAGE_A"  == "_" ]] && [[ "_$PRERELEASE_STAGE_B"  != "_" ]] ; then
         return 1
     fi
-    if [[ "_$SPECIAL_A"  != "_" ]] && [[ "_$SPECIAL_B"  == "_" ]] ; then
+    if [[ "_$PRERELEASE_STAGE_A"  != "_" ]] && [[ "_$PRERELEASE_STAGE_B"  == "_" ]] ; then
         return 0
     fi
 
-    if [[ "_$SPECIAL_A" < "_$SPECIAL_B" ]]; then
+    if [[ "_$PRERELEASE_STAGE_A" < "_$PRERELEASE_STAGE_B" ]]; then
         return 0
+    fi
+
+    if [[ "$PRERELEASE_STAGE_A" == "$PRERELEASE_STAGE_B" ]]; then
+        if [[ "_$PRERELEASE_NUMBER_A"  == "_" ]] && [[ "_$PRERELEASE_NUMBER_B"  != "_" ]] ; then
+            return 1
+        fi
+        if [[ "_$PRERELEASE_NUMBER_A"  != "_" ]] && [[ "_$PRERELEASE_NUMBER_B"  == "_" ]] ; then
+            return 0
+        fi
+        if [[ $PRERELEASE_NUMBER_A -lt $PRERELEASE_NUMBER_B ]]; then
+            return 0
+        fi
     fi
 
     return 1
@@ -110,13 +131,14 @@ if [ "___semver.sh" == "___`basename $0`" ]; then
 MAJOR=0
 MINOR=0
 PATCH=0
-SPECIAL=""
+PRERELEASE_STAGE=""
+PRERELEASE_NUMBER=""
 
-semverParseInto $1 MAJOR MINOR PATCH SPECIAL
-echo "$1 -> M: $MAJOR m:$MINOR p:$PATCH s:$SPECIAL"
+semverParseInto $1 MAJOR MINOR PATCH PRERELEASE_STAGE PRERELEASE_NUMBER
+echo "$1 -> M: $MAJOR m:$MINOR p:$PATCH ps:$PRERELEASE_STAGE pn:$PRERELEASE_NUMBER"
 
-semverParseInto $2 MAJOR MINOR PATCH SPECIAL
-echo "$2 -> M: $MAJOR m:$MINOR p:$PATCH s:$SPECIAL"
+semverParseInto $2 MAJOR MINOR PATCH PRERELEASE_STAGE PRERELEASE_NUMBER
+echo "$2 -> M: $MAJOR m:$MINOR p:$PATCH ps:$PRERELEASE_STAGE pn:$PRERELEASE_NUMBER"
 
 semverEQ $1 $2
 echo "$1 == $2 -> $?."

--- a/ci/semver_bash/semver_test.sh
+++ b/ci/semver_bash/semver_test.sh
@@ -10,16 +10,32 @@ local D=R1.3.3
 local E=R1.3.2a
 local F=R1.3.2b
 local G=R1.2.3
+local H=R1.2.3-alpha
+local I=R1.2.3-beta.1
+local J=R1.2.3-alpha.1
+local K=R1.2.3-alpha.2
+local L=R1.2.3-alpha.11
+
+
+
 
 local MAJOR=0
 local MINOR=0
 local PATCH=0
-local SPECIAL=""
+local PRERELEASE_STAGE=""
+local PRERELEASE_NUMBER=""
 
-semverParseInto $A MAJOR MINOR PATCH SPECIAL
-echo "$A -> M:$MAJOR m:$MINOR p:$PATCH s:$SPECIAL. Expect M:1 m:3 p:2 s:"
-semverParseInto $E MAJOR MINOR PATCH SPECIAL
-echo "$E -> M:$MAJOR m:$MINOR p:$PATCH s:$SPECIAL. Expect M:1 m:3 p:2 s:a"
+echo "Parsing"
+semverParseInto $A MAJOR MINOR PATCH PRERELEASE_STAGE PRERELEASE_NUMBER
+echo "$A -> M:$MAJOR m:$MINOR p:$PATCH ps:$PRERELEASE_STAGE pn:$PRERELEASE_NUMBER. Expect M:1 m:3 p:2 ps: pn:"
+semverParseInto $E MAJOR MINOR PATCH PRERELEASE_STAGE PRERELEASE_NUMBER
+echo "$E -> M:$MAJOR m:$MINOR p:$PATCH ps:$PRERELEASE_STAGE pn:$PRERELEASE_NUMBER. Expect M:1 m:3 p:2 ps:a pn:"
+semverParseInto $H MAJOR MINOR PATCH PRERELEASE_STAGE PRERELEASE_NUMBER
+echo "$H -> M:$MAJOR m:$MINOR p:$PATCH ps:$PRERELEASE_STAGE pn:$PRERELEASE_NUMBER. Expect M:1 m:2 p:3 ps:-alpha pn:"
+semverParseInto $J MAJOR MINOR PATCH PRERELEASE_STAGE PRERELEASE_NUMBER
+echo "$J -> M:$MAJOR m:$MINOR p:$PATCH ps:$PRERELEASE_STAGE pn:$PRERELEASE_NUMBER. Expect M:1 m:2 p:3 ps:-alpha pn:1"
+
+echo ""
 
 echo "Equality comparisons"
 semverEQ $A $A
@@ -30,7 +46,7 @@ echo "$A < $A -> $?. Expect 1."
 
 semverGT $A $A
 echo "$A > $A -> $?. Expect 1."
-
+echo ""
 
 echo "Major number comparisons"
 semverEQ $A $B
@@ -50,7 +66,7 @@ echo "$B < $A -> $?. Expect 1."
 
 semverGT $B $A
 echo "$B > $A -> $?. Expect 0."
-
+echo ""
 
 echo "Minor number comparisons"
 semverEQ $A $C
@@ -70,6 +86,7 @@ echo "$C < $A -> $?. Expect 1."
 
 semverGT $C $A
 echo "$C > $A -> $?. Expect 0."
+echo ""
 
 echo "patch number comparisons"
 semverEQ $A $D
@@ -89,6 +106,7 @@ echo "$D < $A -> $?. Expect 1."
 
 semverGT $D $A
 echo "$D > $A -> $?. Expect 0."
+echo ""
 
 echo "special section vs no special comparisons"
 semverEQ $A $E
@@ -108,6 +126,7 @@ echo "$E < $A -> $?. Expect 0."
 
 semverGT $E $A
 echo "$E > $A -> $?. Expect 1."
+echo ""
 
 echo "special section vs special comparisons"
 semverEQ $E $F
@@ -127,6 +146,7 @@ echo "$F < $E -> $?. Expect 1."
 
 semverGT $F $E
 echo "$F > $E -> $?. Expect 0."
+echo ""
 
 echo "Minor and patch number comparisons"
 semverEQ $A $G
@@ -146,6 +166,142 @@ echo "$G < $A -> $?. Expect 0."
 
 semverGT $G $A
 echo "$G > $A -> $?. Expect 1."
+echo ""
+
+# local H=R1.2.3-alpha
+# local I=R1.2.3-beta.1
+# local J=R1.2.3-alpha.1
+# local K=R1.2.3-alpha.2
+# local L=R1.2.3-alpha.11
+
+# HJ
+# JK
+# JL
+# IK
+# IL
+
+
+echo "Different prerelease stages"
+semverEQ $H $I
+echo "$H == $I -> $?. Expect 1."
+
+semverLT $H $I
+echo "$H < $I -> $?. Expect 0."
+
+semverGT $H $I
+echo "$H > $I -> $?. Expect 1."
+
+semverEQ $I $H
+echo "$I == $H -> $?. Expect 1."
+
+semverLT $I $H
+echo "$I < $H -> $?. Expect 1."
+
+semverGT $I $H
+echo "$I > $H -> $?. Expect 0."
+echo ""
+
+# TODO this one reveals a bug
+echo "Same prerelease stage, one with number and one without"
+semverEQ $H $J
+echo "$H == $J -> $?. Expect 1."
+
+semverLT $H $J
+echo "$H < $J -> $?. Expect 1."
+
+semverGT $H $J
+echo "$H > $J -> $?. Expect 0."
+
+semverEQ $J $H
+echo "$J == $H -> $?. Expect 1."
+
+semverLT $J $H
+echo "$J < $H -> $?. Expect 0."
+
+semverGT $J $H
+echo "$J > $H -> $?. Expect 1."
+echo ""
+
+echo "Same except for prerelease number"
+semverEQ $J $K
+echo "$J == $K -> $?. Expect 1."
+
+semverLT $J $K
+echo "$J < $K -> $?. Expect 0."
+
+semverGT $J $K
+echo "$J > $K -> $?. Expect 1."
+
+semverEQ $K $J
+echo "$K == $J -> $?. Expect 1."
+
+semverLT $K $J
+echo "$K < $J -> $?. Expect 1."
+
+semverGT $K $J
+echo "$K > $J -> $?. Expect 0."
+echo ""
+
+echo "Same except for prerelease number"
+semverEQ $J $L
+echo "$J == $L -> $?. Expect 1."
+
+semverLT $J $L
+echo "$J < $L -> $?. Expect 0."
+
+semverGT $J $L
+echo "$J > $L -> $?. Expect 1."
+
+semverEQ $L $J
+echo "$L == $J -> $?. Expect 1."
+
+semverLT $L $J
+echo "$L < $J -> $?. Expect 1."
+
+semverGT $L $J
+echo "$L > $J -> $?. Expect 0."
+echo ""
+
+echo "Same except for prerelease number"
+semverEQ $I $K
+echo "$I == $K -> $?. Expect 1."
+
+semverLT $I $K
+echo "$I < $K -> $?. Expect 1."
+
+semverGT $I $K
+echo "$I > $K -> $?. Expect 0."
+
+semverEQ $K $I
+echo "$K == $I -> $?. Expect 1."
+
+semverLT $K $I
+echo "$K < $I -> $?. Expect 0."
+
+semverGT $K $I
+echo "$K > $I -> $?. Expect 1."
+echo ""
+
+echo "Same except for prerelease number"
+semverEQ $I $L
+echo "$I == $L -> $?. Expect 1."
+
+semverLT $I $L
+echo "$I < $L -> $?. Expect 1."
+
+semverGT $I $L
+echo "$I > $L -> $?. Expect 0."
+
+semverEQ $L $I
+echo "$L == $I -> $?. Expect 1."
+
+semverLT $L $I
+echo "$L < $I -> $?. Expect 0."
+
+semverGT $L $I
+echo "$L > $I -> $?. Expect 1."
+echo ""
+
 }
 
 semverTest

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -49,7 +49,11 @@ PRERELEASE_NUMBER=""
 semverParseInto "$(readCargoVariable version Cargo.toml)" MAJOR MINOR PATCH PRERELEASE_STAGE PRERELEASE_NUMBER
 [[ -n $MAJOR ]] || usage
 
-currentVersion="$MAJOR\.$MINOR\.$PATCH$PRERELEASE_STAGE.$PRERELEASE_NUMBER"
+prerelease=""
+if [[ -n $PRERELEASE_STAGE || -n $PRERELEASE_NUMBER ]]; then
+  prerelease="$PRERELEASE_STAGE.$PRERELEASE_NUMBER"
+fi
+currentVersion="$MAJOR\.$MINOR\.$PATCH$prerelease"
 
 bump=$1
 if [[ -z $bump ]]; then
@@ -139,7 +143,11 @@ esac
   fi
 )
 
-newVersion="$MAJOR.$MINOR.$PATCH$PRERELEASE_STAGE.$PRERELEASE_NUMBER"
+new_prerelease=""
+if [[ -n $PRERELEASE_STAGE || -n $PRERELEASE_NUMBER ]]; then
+  new_prerelease="$PRERELEASE_STAGE.$PRERELEASE_NUMBER"
+fi
+newVersion="$MAJOR.$MINOR.$PATCH$new_prerelease"
 echo "currentVersion: $currentVersion"
 echo "newVersion: $newVersion"
 

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -140,6 +140,8 @@ esac
 )
 
 newVersion="$MAJOR.$MINOR.$PATCH$PRERELEASE_STAGE.$PRERELEASE_NUMBER"
+echo "currentVersion: $currentVersion"
+echo "newVersion: $newVersion"
 
 # Update all the Cargo.toml files
 for Cargo_toml in "${Cargo_tomls[@]}"; do
@@ -151,6 +153,7 @@ for Cargo_toml in "${Cargo_tomls[@]}"; do
   # Set new crate version
   (
     set -x
+    echo "Cargo_toml: $Cargo_toml"
     sed -i "$Cargo_toml" -e "s/^version = \"$currentVersion\"$/version = \"$newVersion\"/"
   )
 

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -3,7 +3,7 @@ set -e
 
 usage() {
   cat <<EOF
-usage: $0 [major|minor|patch|-preXYZ]
+usage: $0 [major|minor|patch|prerelease|-preXYZ]
 
 Increments the Cargo.toml version.
 
@@ -58,21 +58,35 @@ if [[ -z $bump ]]; then
     bump=minor
   fi
 fi
-SPECIAL=""
 
 # Figure out what to increment
 case $bump in
+prerelease)
+  if [[ "$SPECIAL" == "-alpha" ]]; then
+    SPECIAL="-beta"
+  elif [[ "$SPECIAL" == "-beta" ]]; then
+    SPECIAL=""
+  else
+    echo "Error: Only '-alpha' and '-beta' prerelease can be bumped. Current prerelease value is: $SPECIAL"
+    exit 1
+  fi
+  ;;
 patch)
   PATCH=$((PATCH + 1))
+  if [[ "$SPECIAL" == "-alpha" ]]; then
+    SPECIAL="-beta"
+  fi
   ;;
 major)
   MAJOR=$((MAJOR+ 1))
   MINOR=0
   PATCH=0
+  SPECIAL="-alpha"
   ;;
 minor)
   MINOR=$((MINOR+ 1))
   PATCH=0
+  SPECIAL="-alpha"
   ;;
 dropspecial)
   ;;


### PR DESCRIPTION
#### Problem
The version bump script supports a prerelease suffix on the version number, but it is free-form.

#### Summary of Changes
We're planning to start using `-alpha` and `-beta` suffixes. This PR creates a new `prerelease` action and adds some version bump behavior to match our intended flow.

Here's the plan:
* manually add `-alpha` to master: `3.1.0` -> `3.1.0-alpha`. This will be a new PR created with `scripts/increment-cargo-version.sh -alpha`

After that, our branching process will continue as follows:
* Create `v3.1` branch and bump the version on that branch to `v3.1.0-beta`
* Patch bumps on `v3.1` will proceed with the `-beta` suffix until we're ready to recommend a release for mainnet-beta. At that point we drop the `-beta` suffix
* master will stay in `3.1.0-alpha` until we're ready to create the next major or minor version at which point we will bump to either `3.2.0-alpha` or `4.0.0-alpha`

Here's an example of how this might look for the next couple of branches:
```
master:     3.1.0-alpha --> ... 4.0.0-alpha -> ... -> 4.1.0-alpha
                    \                   \
                     \                   4.0.0-beta -> 4.0.1-beta -> ... -> 4.0.6-beta -> 4.0.6 -> 4.0.7
                      \
                       3.1.0-beta -> 3.1.1-beta -> ... -> 3.1.5-beta -> 3.1.5 -> 3.1.6
```

Rules that are enforced in this code change:
* Bumping `major` or `minor` resets prerelease to `-alpha`
* Bumping `patch` while the prelrease is `-alpha` will automatically bump the prerelease to `-beta`

I tested the following scenarios:
```
Description                         Initial Version     Command run                                        Expected Version     Result
add -alpha                          3.1.0               scripts/increment-cargo-version.sh -alpha       => 3.1.0-alpha          OK
    bump prerelease from 0.alpha    3.1.0-alpha         scripts/increment-cargo-version.sh prerelease   => 3.1.0-beta           OK
bump patch from 0.alpha             3.1.0-alpha         scripts/increment-cargo-version.sh patch        => 3.1.1-beta           OK
bump patch from 1.beta              3.1.1-beta          scripts/increment-cargo-version.sh patch        => 3.1.2-beta           OK
bump prerelease from 2.beta         3.1.2-beta          scripts/increment-cargo-version.sh prerelease   => 3.1.2                OK
    bump prerelease                 3.1.2               scripts/increment-cargo-version.sh prerelease   => error                OK
    bump patch                      3.1.2               scripts/increment-cargo-version.sh patch        => 3.1.3                OK
    bump minor                      3.1.2               scripts/increment-cargo-version.sh minor        => 3.2.0-alpha          OK
    bump major                      3.1.2               scripts/increment-cargo-version.sh major        => 4.0.0-alpha          OK
```


This is one of the changes required for https://github.com/anza-xyz/agave/issues/8606. I'm working on other changes to the release workflow that will make use of this change