### PR TITLE
slow partition test

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2653,7 +2653,7 @@ fn run_test_load_program_accounts_partition(scan_commitment: CommitmentConfig) {
     let exit = Arc::new(AtomicBool::new(false));
 
     let (t_update, t_scan, additional_accounts) = setup_transfer_scan_threads(
-        1000,
+        100,
         exit.clone(),
         scan_commitment,
         update_client_receiver,


### PR DESCRIPTION
#### Problem
`test_run_test_load_program_accounts_partition_root` is running extremely slow in CI and causing timeout issues. See https://buildkite.com/anza/agave/builds/32576#019a0df9-0cd9-4b7f-a6ca-11bfb782b9d8 for example

The slow part appears to be landing 2k transactions (confirmed this takes multiple minutes on my bench. My hunch is that this is due to unstaked connection TPS throttling

#### Summary of Changes
Decrease the number of sends from 2k to 200