### PR TITLE
agave-validator: move SendTransactionService args into config file

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -44,7 +44,7 @@ use {
 pub mod thread_args;
 use {
     solana_core::banking_stage::BankingStage,
-    thread_args::{thread_args, DefaultThreadArgs},
+    thread_args::{DefaultThreadArgs, thread_args},
 };
 
 // The default minimal snapshot download speed (bytes/second)
@@ -278,7 +278,6 @@ pub struct DefaultArgs {
     pub send_transaction_service_config: send_transaction_service::Config,
 
     pub rpc_max_multiple_accounts: String,
-    pub rpc_send_transaction_retry_ms: String,
     pub rpc_send_transaction_leader_forward_count: String,
     pub rpc_send_transaction_service_max_retries: String,
     pub rpc_send_transaction_batch_size: String,
@@ -345,9 +344,6 @@ impl DefaultArgs {
             tower_storage: "file".to_string(),
             etcd_domain_name: "localhost".to_string(),
             send_transaction_service_config: send_transaction_service::Config::default(),
-            rpc_send_transaction_retry_ms: default_send_transaction_service_config
-                .retry_rate_ms
-                .to_string(),
             rpc_send_transaction_leader_forward_count: default_send_transaction_service_config
                 .leader_forward_count
                 .to_string(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -280,7 +280,6 @@ pub struct DefaultArgs {
     pub rpc_max_multiple_accounts: String,
     pub rpc_send_transaction_leader_forward_count: String,
     pub rpc_send_transaction_service_max_retries: String,
-    pub rpc_send_transaction_batch_size: String,
     pub rpc_send_transaction_retry_pool_max_size: String,
     pub rpc_threads: String,
     pub rpc_blocking_threads: String,
@@ -349,9 +348,6 @@ impl DefaultArgs {
                 .to_string(),
             rpc_send_transaction_service_max_retries: default_send_transaction_service_config
                 .service_max_retries
-                .to_string(),
-            rpc_send_transaction_batch_size: default_send_transaction_service_config
-                .batch_size
                 .to_string(),
             rpc_send_transaction_retry_pool_max_size: default_send_transaction_service_config
                 .retry_pool_max_size

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -279,7 +279,6 @@ pub struct DefaultArgs {
 
     pub rpc_max_multiple_accounts: String,
     pub rpc_send_transaction_leader_forward_count: String,
-    pub rpc_send_transaction_retry_pool_max_size: String,
     pub rpc_threads: String,
     pub rpc_blocking_threads: String,
     pub rpc_niceness_adjustment: String,
@@ -344,9 +343,6 @@ impl DefaultArgs {
             send_transaction_service_config: send_transaction_service::Config::default(),
             rpc_send_transaction_leader_forward_count: default_send_transaction_service_config
                 .leader_forward_count
-                .to_string(),
-            rpc_send_transaction_retry_pool_max_size: default_send_transaction_service_config
-                .retry_pool_max_size
                 .to_string(),
             rpc_threads: num_cpus::get().to_string(),
             rpc_blocking_threads: 1.max(num_cpus::get() / 4).to_string(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -279,7 +279,6 @@ pub struct DefaultArgs {
 
     pub rpc_max_multiple_accounts: String,
     pub rpc_send_transaction_retry_ms: String,
-    pub rpc_send_transaction_batch_ms: String,
     pub rpc_send_transaction_leader_forward_count: String,
     pub rpc_send_transaction_service_max_retries: String,
     pub rpc_send_transaction_batch_size: String,
@@ -348,9 +347,6 @@ impl DefaultArgs {
             send_transaction_service_config: send_transaction_service::Config::default(),
             rpc_send_transaction_retry_ms: default_send_transaction_service_config
                 .retry_rate_ms
-                .to_string(),
-            rpc_send_transaction_batch_ms: default_send_transaction_service_config
-                .batch_send_rate_ms
                 .to_string(),
             rpc_send_transaction_leader_forward_count: default_send_transaction_service_config
                 .leader_forward_count

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -44,7 +44,7 @@ use {
 pub mod thread_args;
 use {
     solana_core::banking_stage::BankingStage,
-    thread_args::{DefaultThreadArgs, thread_args},
+    thread_args::{thread_args, DefaultThreadArgs},
 };
 
 // The default minimal snapshot download speed (bytes/second)
@@ -278,7 +278,6 @@ pub struct DefaultArgs {
     pub send_transaction_service_config: send_transaction_service::Config,
 
     pub rpc_max_multiple_accounts: String,
-    pub rpc_send_transaction_leader_forward_count: String,
     pub rpc_threads: String,
     pub rpc_blocking_threads: String,
     pub rpc_niceness_adjustment: String,
@@ -328,8 +327,6 @@ pub struct DefaultArgs {
 
 impl DefaultArgs {
     pub fn new() -> Self {
-        let default_send_transaction_service_config = send_transaction_service::Config::default();
-
         DefaultArgs {
             bind_address: "0.0.0.0".to_string(),
             ledger_path: "ledger".to_string(),
@@ -341,9 +338,6 @@ impl DefaultArgs {
             tower_storage: "file".to_string(),
             etcd_domain_name: "localhost".to_string(),
             send_transaction_service_config: send_transaction_service::Config::default(),
-            rpc_send_transaction_leader_forward_count: default_send_transaction_service_config
-                .leader_forward_count
-                .to_string(),
             rpc_threads: num_cpus::get().to_string(),
             rpc_blocking_threads: 1.max(num_cpus::get() / 4).to_string(),
             rpc_niceness_adjustment: "0".to_string(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -279,7 +279,6 @@ pub struct DefaultArgs {
 
     pub rpc_max_multiple_accounts: String,
     pub rpc_send_transaction_leader_forward_count: String,
-    pub rpc_send_transaction_service_max_retries: String,
     pub rpc_send_transaction_retry_pool_max_size: String,
     pub rpc_threads: String,
     pub rpc_blocking_threads: String,
@@ -345,9 +344,6 @@ impl DefaultArgs {
             send_transaction_service_config: send_transaction_service::Config::default(),
             rpc_send_transaction_leader_forward_count: default_send_transaction_service_config
                 .leader_forward_count
-                .to_string(),
-            rpc_send_transaction_service_max_retries: default_send_transaction_service_config
-                .service_max_retries
                 .to_string(),
             rpc_send_transaction_retry_pool_max_size: default_send_transaction_service_config
                 .retry_pool_max_size

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -27,7 +27,7 @@ use {
     solana_pubkey::Pubkey,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_send_transaction_service::send_transaction_service::{
-        Config as SendTransactionServiceConfig, MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
+        Config as SendTransactionServiceConfig, MAX_TRANSACTION_BATCH_SIZE,
     },
     solana_signer::Signer,
     solana_streamer::socket::SocketAddrSpace,
@@ -937,16 +937,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(is_parsable::<u64>)
             .default_value(&default_args.rpc_send_transaction_retry_ms)
             .help("The rate at which transactions sent via rpc service are retried."),
-    )
-    .arg(
-        Arg::with_name("rpc_send_transaction_batch_ms")
-            .long("rpc-send-batch-ms")
-            .value_name("MILLISECS")
-            .hidden(hidden_unless_forced())
-            .takes_value(true)
-            .validator(|s| is_within_range(s, 1..=MAX_BATCH_SEND_RATE_MS))
-            .default_value(&default_args.rpc_send_transaction_batch_ms)
-            .help("The rate at which transactions sent via rpc service are sent in batch."),
     )
     .arg(
         Arg::with_name("rpc_send_transaction_leader_forward_count")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -972,16 +972,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("The maximum size of transactions retry pool."),
     )
     .arg(
-        Arg::with_name("rpc_send_transaction_tpu_peer")
-            .long("rpc-send-transaction-tpu-peer")
-            .takes_value(true)
-            .number_of_values(1)
-            .multiple(true)
-            .value_name("HOST:PORT")
-            .validator(solana_net_utils::is_host_port)
-            .help("Peer(s) to broadcast transactions to instead of the current leader"),
-    )
-    .arg(
         Arg::with_name("rpc_send_transaction_also_leader")
             .long("rpc-send-transaction-also-leader")
             .requires("rpc_send_transaction_tpu_peer")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -930,15 +930,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rpc_send_transaction_retry_ms")
-            .long("rpc-send-retry-ms")
-            .value_name("MILLISECS")
-            .takes_value(true)
-            .validator(is_parsable::<u64>)
-            .default_value(&default_args.rpc_send_transaction_retry_ms)
-            .help("The rate at which transactions sent via rpc service are retried."),
-    )
-    .arg(
         Arg::with_name("rpc_send_transaction_leader_forward_count")
             .long("rpc-send-leader-count")
             .value_name("NUMBER")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -928,18 +928,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rpc_send_transaction_leader_forward_count")
-            .long("rpc-send-leader-count")
-            .value_name("NUMBER")
-            .takes_value(true)
-            .validator(is_parsable::<u64>)
-            .default_value(&default_args.rpc_send_transaction_leader_forward_count)
-            .help(
-                "The number of upcoming leaders to which to forward transactions sent via rpc \
-                 service.",
-            ),
-    )
-    .arg(
         Arg::with_name("geyser_plugin_config")
             .long("geyser-plugin-config")
             .alias("accountsdb-plugin-config")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -26,9 +26,7 @@ use {
     solana_ledger::{blockstore_options::BlockstoreOptions, use_snapshot_archives_at_startup},
     solana_pubkey::Pubkey,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
-    solana_send_transaction_service::send_transaction_service::{
-        Config as SendTransactionServiceConfig, MAX_TRANSACTION_BATCH_SIZE,
-    },
+    solana_send_transaction_service::send_transaction_service::Config as SendTransactionServiceConfig,
     solana_signer::Signer,
     solana_streamer::socket::SocketAddrSpace,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
@@ -963,16 +961,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
                 "The maximum number of transaction broadcast retries, regardless of requested \
                  value.",
             ),
-    )
-    .arg(
-        Arg::with_name("rpc_send_transaction_batch_size")
-            .long("rpc-send-batch-size")
-            .value_name("NUMBER")
-            .hidden(hidden_unless_forced())
-            .takes_value(true)
-            .validator(|s| is_within_range(s, 1..=MAX_TRANSACTION_BATCH_SIZE))
-            .default_value(&default_args.rpc_send_transaction_batch_size)
-            .help("The size of transactions to be sent in batch."),
     )
     .arg(
         Arg::with_name("rpc_send_transaction_retry_pool_max_size")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -940,18 +940,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rpc_send_transaction_service_max_retries")
-            .long("rpc-send-service-max-retries")
-            .value_name("NUMBER")
-            .takes_value(true)
-            .validator(is_parsable::<usize>)
-            .default_value(&default_args.rpc_send_transaction_service_max_retries)
-            .help(
-                "The maximum number of transaction broadcast retries, regardless of requested \
-                 value.",
-            ),
-    )
-    .arg(
         Arg::with_name("rpc_send_transaction_retry_pool_max_size")
             .long("rpc-send-transaction-retry-pool-max-size")
             .value_name("NUMBER")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1475,6 +1475,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
     .args(&pub_sub_config::args())
     .args(&json_rpc_config::args(default_args))
     .args(&rpc_bigtable_config::args())
+    .args(&send_transaction_config::args())
 }
 
 fn validators_set(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -940,15 +940,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rpc_send_transaction_retry_pool_max_size")
-            .long("rpc-send-transaction-retry-pool-max-size")
-            .value_name("NUMBER")
-            .takes_value(true)
-            .validator(is_parsable::<usize>)
-            .default_value(&default_args.rpc_send_transaction_retry_pool_max_size)
-            .help("The maximum size of transactions retry pool."),
-    )
-    .arg(
         Arg::with_name("rpc_send_transaction_also_leader")
             .long("rpc-send-transaction-also-leader")
             .requires("rpc_send_transaction_tpu_peer")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -940,14 +940,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rpc_send_transaction_also_leader")
-            .long("rpc-send-transaction-also-leader")
-            .requires("rpc_send_transaction_tpu_peer")
-            .help(
-                "With `--rpc-send-transaction-tpu-peer HOST:PORT`, also send to the current leader",
-            ),
-    )
-    .arg(
         Arg::with_name("geyser_plugin_config")
             .long("geyser-plugin-config")
             .alias("accountsdb-plugin-config")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -940,17 +940,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rpc_send_transaction_default_max_retries")
-            .long("rpc-send-default-max-retries")
-            .value_name("NUMBER")
-            .takes_value(true)
-            .validator(is_parsable::<usize>)
-            .help(
-                "The maximum number of transaction broadcast retries when unspecified by the \
-                 request, otherwise retried until expiration.",
-            ),
-    )
-    .arg(
         Arg::with_name("rpc_send_transaction_service_max_retries")
             .long("rpc-send-service-max-retries")
             .value_name("NUMBER")

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -477,7 +477,10 @@ mod tests {
 
     #[test]
     fn test_default_rpc_send_transaction_retry_pool_max_size_unchanged() {
-        assert_eq!(*DEFAULT_RPC_SEND_TRANSACTION_RETRY_POOL_MAX_SIZE, "10000");
+        assert_eq!(
+            *DEFAULT_RPC_SEND_TRANSACTION_RETRY_POOL_MAX_SIZE,
+            10_000.to_string()
+        );
     }
 
     #[test]

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -129,6 +129,15 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .value_name("HOST:PORT")
             .validator(solana_net_utils::is_host_port)
             .help("Peer(s) to broadcast transactions to instead of the current leader"),
+        Arg::with_name("rpc_send_transaction_default_max_retries")
+            .long("rpc-send-default-max-retries")
+            .value_name("NUMBER")
+            .takes_value(true)
+            .validator(is_parsable::<usize>)
+            .help(
+                "The maximum number of transaction broadcast retries when unspecified by the \
+                 request, otherwise retried until expiration.",
+            ),
     ]
 }
 

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -165,6 +165,12 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .validator(is_parsable::<usize>)
             .default_value(&DEFAULT_RPC_SEND_TRANSACTION_RETRY_POOL_MAX_SIZE)
             .help("The maximum size of transactions retry pool."),
+        Arg::with_name("rpc_send_transaction_also_leader")
+            .long("rpc-send-transaction-also-leader")
+            .requires("rpc_send_transaction_tpu_peer")
+            .help(
+                "With `--rpc-send-transaction-tpu-peer HOST:PORT`, also send to the current leader",
+            ),
     ]
 }
 

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -121,6 +121,14 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .validator(|s| is_within_range(s, VALID_RANGE_RPC_SEND_TRANSACTION_BATCH_SIZE))
             .default_value(&DEFAULT_RPC_SEND_TRANSACTION_BATCH_SIZE)
             .help("The size of transactions to be sent in batch."),
+        Arg::with_name("rpc_send_transaction_tpu_peer")
+            .long("rpc-send-transaction-tpu-peer")
+            .takes_value(true)
+            .number_of_values(1)
+            .multiple(true)
+            .value_name("HOST:PORT")
+            .validator(solana_net_utils::is_host_port)
+            .help("Peer(s) to broadcast transactions to instead of the current leader"),
     ]
 }
 

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -42,6 +42,11 @@ static DEFAULT_RPC_SEND_TRANSACTION_RETRY_POOL_MAX_SIZE: LazyLock<String> = Lazy
         .retry_pool_max_size
         .to_string()
 });
+static DEFAULT_RPC_SEND_TRANSACTION_LEADER_FORWARD_COUNT: LazyLock<String> = LazyLock::new(|| {
+    SendTransactionServiceConfig::default()
+        .leader_forward_count
+        .to_string()
+});
 
 impl FromClapArgMatches for SendTransactionServiceConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
@@ -170,6 +175,16 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .requires("rpc_send_transaction_tpu_peer")
             .help(
                 "With `--rpc-send-transaction-tpu-peer HOST:PORT`, also send to the current leader",
+            ),
+        Arg::with_name("rpc_send_transaction_leader_forward_count")
+            .long("rpc-send-leader-count")
+            .value_name("NUMBER")
+            .takes_value(true)
+            .validator(is_parsable::<u64>)
+            .default_value(&DEFAULT_RPC_SEND_TRANSACTION_LEADER_FORWARD_COUNT)
+            .help(
+                "The number of upcoming leaders to which to forward transactions sent via rpc \
+                 service.",
             ),
     ]
 }
@@ -463,5 +478,10 @@ mod tests {
     #[test]
     fn test_default_rpc_send_transaction_retry_pool_max_size_unchanged() {
         assert_eq!(*DEFAULT_RPC_SEND_TRANSACTION_RETRY_POOL_MAX_SIZE, "10000");
+    }
+
+    #[test]
+    fn test_default_rpc_send_transaction_leader_forward_count_unchanged() {
+        assert_eq!(*DEFAULT_RPC_SEND_TRANSACTION_LEADER_FORWARD_COUNT, "2");
     }
 }

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -37,6 +37,11 @@ static DEFAULT_RPC_SEND_TRANSACTION_SERVICE_MAX_RETRIES: LazyLock<String> = Lazy
         .service_max_retries
         .to_string()
 });
+static DEFAULT_RPC_SEND_TRANSACTION_RETRY_POOL_MAX_SIZE: LazyLock<String> = LazyLock::new(|| {
+    SendTransactionServiceConfig::default()
+        .retry_pool_max_size
+        .to_string()
+});
 
 impl FromClapArgMatches for SendTransactionServiceConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
@@ -153,6 +158,13 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
                 "The maximum number of transaction broadcast retries, regardless of requested \
                  value.",
             ),
+        Arg::with_name("rpc_send_transaction_retry_pool_max_size")
+            .long("rpc-send-transaction-retry-pool-max-size")
+            .value_name("NUMBER")
+            .takes_value(true)
+            .validator(is_parsable::<usize>)
+            .default_value(&DEFAULT_RPC_SEND_TRANSACTION_RETRY_POOL_MAX_SIZE)
+            .help("The maximum size of transactions retry pool."),
     ]
 }
 
@@ -440,5 +452,10 @@ mod tests {
             *DEFAULT_RPC_SEND_TRANSACTION_SERVICE_MAX_RETRIES,
             usize::MAX.to_string()
         );
+    }
+
+    #[test]
+    fn test_default_rpc_send_transaction_retry_pool_max_size_unchanged() {
+        assert_eq!(*DEFAULT_RPC_SEND_TRANSACTION_RETRY_POOL_MAX_SIZE, "10000");
     }
 }

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -32,6 +32,11 @@ static DEFAULT_RPC_SEND_TRANSACTION_BATCH_SIZE: LazyLock<String> = LazyLock::new
         .batch_size
         .to_string()
 });
+static DEFAULT_RPC_SEND_TRANSACTION_SERVICE_MAX_RETRIES: LazyLock<String> = LazyLock::new(|| {
+    SendTransactionServiceConfig::default()
+        .service_max_retries
+        .to_string()
+});
 
 impl FromClapArgMatches for SendTransactionServiceConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
@@ -137,6 +142,16 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .help(
                 "The maximum number of transaction broadcast retries when unspecified by the \
                  request, otherwise retried until expiration.",
+            ),
+        Arg::with_name("rpc_send_transaction_service_max_retries")
+            .long("rpc-send-service-max-retries")
+            .value_name("NUMBER")
+            .takes_value(true)
+            .validator(is_parsable::<usize>)
+            .default_value(&DEFAULT_RPC_SEND_TRANSACTION_SERVICE_MAX_RETRIES)
+            .help(
+                "The maximum number of transaction broadcast retries, regardless of requested \
+                 value.",
             ),
     ]
 }
@@ -417,5 +432,13 @@ mod tests {
     #[test]
     fn test_valid_range_rpc_send_transaction_batch_size_unchanged() {
         assert_eq!(VALID_RANGE_RPC_SEND_TRANSACTION_BATCH_SIZE, 1..=10_000);
+    }
+
+    #[test]
+    fn test_default_rpc_send_transaction_service_max_retries_unchanged() {
+        assert_eq!(
+            *DEFAULT_RPC_SEND_TRANSACTION_SERVICE_MAX_RETRIES,
+            usize::MAX.to_string()
+        );
     }
 }

--- a/validator/src/commands/run/args/send_transaction_config.rs
+++ b/validator/src/commands/run/args/send_transaction_config.rs
@@ -1,6 +1,6 @@
 use {
     crate::commands::{Error, FromClapArgMatches, Result},
-    clap::{value_t, ArgMatches},
+    clap::{value_t, Arg, ArgMatches},
     solana_send_transaction_service::send_transaction_service::{
         Config as SendTransactionServiceConfig, MAX_TRANSACTION_SENDS_PER_SECOND,
     },
@@ -67,6 +67,10 @@ impl FromClapArgMatches for SendTransactionServiceConfig {
             leader_forward_count,
         })
     }
+}
+
+pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
+    vec![]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Summary of Changes

- move clap definitions
- move default values
- add tests for ensuring validator's behavior