### PR TITLE
svm-fuzz-harness: update to use protosol crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,8 +5594,9 @@ dependencies = [
 
 [[package]]
 name = "protosol"
-version = "1.0.1"
-source = "git+https://github.com/firedancer-io/protosol?tag=v1.0.4#72fb79f2a24e60a55d392c386c1ac7c2d15c13a4"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e70d64aff3756d57a2b5e84ee2a01923f2a5350a51b93e8ec4631b817d8dcd"
 dependencies = [
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -337,6 +337,7 @@ prost = "0.11.9"
 prost-build = "0.11.9"
 prost-types = "0.11.9"
 protobuf-src = "1.1.0"
+protosol = "2.0.0"
 qstring = "0.7.2"
 qualifier_attr = { version = "0.2.2", default-features = false }
 quinn = "0.11.9"

--- a/svm-fuzz-harness/Cargo.toml
+++ b/svm-fuzz-harness/Cargo.toml
@@ -18,7 +18,7 @@ required-features = ["fuzz"]
 [features]
 agave-unstable-api = []
 dummy-for-ci-check = ["fuzz"]
-fuzz = ["dep:clap", "dep:prost", "dep:protosol", "dep:prost-build"]
+fuzz = ["dep:clap", "dep:prost", "dep:prost-build", "dep:protosol"]
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -27,7 +27,7 @@ agave-syscalls = { workspace = true }
 bincode = { workspace = true }
 clap = { version = "4.5.2", features = ["derive"], optional = true }
 prost = { workspace = true, optional = true }
-protosol = { git = "https://github.com/firedancer-io/protosol", tag = "v1.0.4", optional = true }
+protosol = { workspace = true, optional = true }
 solana-account = { workspace = true }
 solana-builtins = { workspace = true }
 solana-clock = { workspace = true, features = ["sysvar"] }

--- a/svm-fuzz-harness/src/fixture/account_state.rs
+++ b/svm-fuzz-harness/src/fixture/account_state.rs
@@ -56,7 +56,6 @@ impl From<(Pubkey, Account)> for ProtoAccount {
             lamports,
             data,
             executable,
-            seed_addr: None,
         }
     }
 }


### PR DESCRIPTION
#### Problem
FD published a crate to crates.io for `protosol`. We should use that instead of the git dependency.

#### Summary of Changes
Use the crates.io dependency instead of the git one.