### PR TITLE
Remove conditional_vis_mod! to make rustfmt aware of all modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,12 +1969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "conditional-mod"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67935045d95e19071aae6ee98d649f2a5593e510802040c622200c8d6666a9ca"
-
-[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8175,7 +8169,6 @@ dependencies = [
  "bytemuck",
  "bytes",
  "chrono",
- "conditional-mod",
  "criterion",
  "crossbeam-channel",
  "dashmap",
@@ -9135,7 +9128,6 @@ dependencies = [
  "bzip2",
  "chrono",
  "chrono-humanize",
- "conditional-mod",
  "criterion",
  "crossbeam-channel",
  "dashmap",
@@ -11670,7 +11662,6 @@ dependencies = [
  "bs58",
  "bytes",
  "caps",
- "conditional-mod",
  "crossbeam-channel",
  "futures 0.3.31",
  "itertools 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,8 +233,6 @@ cfg_eval = "0.1.2"
 chrono = { version = "0.4.42", default-features = false }
 chrono-humanize = "0.2.3"
 clap = "2.33.1"
-# Remove this dependency when procedural macros will support non-inline modules.
-conditional-mod = "0.1.0"
 console = "0.16.1"
 console_error_panic_hook = "0.1.7"
 console_log = "0.2.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -61,7 +61,6 @@ bs58 = { workspace = true }
 bytemuck = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
-conditional-mod = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api"] }
 derive_more = { workspace = true }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -24,7 +24,6 @@ use {
         validator::BlockProductionMethod,
     },
     agave_banking_stage_ingress_types::BankingPacketReceiver,
-    conditional_mod::conditional_vis_mod,
     crossbeam_channel::{unbounded, Receiver, Sender},
     histogram::Histogram,
     solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfoQuery},
@@ -67,14 +66,29 @@ pub mod vote_storage;
 
 mod consume_worker;
 mod vote_worker;
-conditional_vis_mod!(decision_maker, feature = "dev-context-only-utils", pub);
+
+#[cfg(feature = "dev-context-only-utils")]
+pub mod decision_maker;
+#[cfg(not(feature = "dev-context-only-utils"))]
+mod decision_maker;
+
 mod latest_validator_vote_packet;
 mod leader_slot_timing_metrics;
 mod read_write_account_set;
 mod vote_packet_receiver;
-conditional_vis_mod!(scheduler_messages, feature = "dev-context-only-utils", pub);
+
+#[cfg(feature = "dev-context-only-utils")]
+pub mod scheduler_messages;
+#[cfg(not(feature = "dev-context-only-utils"))]
+mod scheduler_messages;
+
 pub mod transaction_scheduler;
-conditional_vis_mod!(unified_scheduler, feature = "dev-context-only-utils", pub, pub(crate));
+
+#[cfg(feature = "dev-context-only-utils")]
+pub mod unified_scheduler;
+#[cfg(not(feature = "dev-context-only-utils"))]
+pub(crate) mod unified_scheduler;
+
 #[allow(dead_code)]
 #[cfg(unix)]
 mod progress_tracker;

--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -1,15 +1,44 @@
-use conditional_mod::conditional_vis_mod;
-
 mod batch_id_generator;
-conditional_vis_mod!(greedy_scheduler, feature = "dev-context-only-utils", pub, pub(crate));
+
+#[cfg(feature = "dev-context-only-utils")]
+pub mod greedy_scheduler;
+#[cfg(not(feature = "dev-context-only-utils"))]
+pub(crate) mod greedy_scheduler;
+
 mod in_flight_tracker;
-conditional_vis_mod!(prio_graph_scheduler, feature = "dev-context-only-utils", pub, pub(crate));
-conditional_vis_mod!(receive_and_buffer, feature = "dev-context-only-utils", pub, pub(crate));
-conditional_vis_mod!(scheduler, feature = "dev-context-only-utils", pub, pub(crate));
+
+#[cfg(feature = "dev-context-only-utils")]
+pub mod prio_graph_scheduler;
+#[cfg(not(feature = "dev-context-only-utils"))]
+pub(crate) mod prio_graph_scheduler;
+
+#[cfg(feature = "dev-context-only-utils")]
+pub mod receive_and_buffer;
+#[cfg(not(feature = "dev-context-only-utils"))]
+pub(crate) mod receive_and_buffer;
+
+#[cfg(feature = "dev-context-only-utils")]
+pub mod scheduler;
+#[cfg(not(feature = "dev-context-only-utils"))]
+pub(crate) mod scheduler;
+
 pub(crate) mod scheduler_common;
 pub mod scheduler_controller;
 pub(crate) mod scheduler_error;
-conditional_vis_mod!(scheduler_metrics, feature = "dev-context-only-utils", pub);
+
+#[cfg(feature = "dev-context-only-utils")]
+pub mod scheduler_metrics;
+#[cfg(not(feature = "dev-context-only-utils"))]
+mod scheduler_metrics;
+
 mod transaction_priority_id;
-conditional_vis_mod!(transaction_state, feature = "dev-context-only-utils", pub, pub(crate));
-conditional_vis_mod!(transaction_state_container, feature = "dev-context-only-utils", pub, pub(crate));
+
+#[cfg(feature = "dev-context-only-utils")]
+pub mod transaction_state;
+#[cfg(not(feature = "dev-context-only-utils"))]
+pub(crate) mod transaction_state;
+
+#[cfg(feature = "dev-context-only-utils")]
+pub mod transaction_state_container;
+#[cfg(not(feature = "dev-context-only-utils"))]
+pub(crate) mod transaction_state_container;

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -37,7 +37,6 @@ bytes = { workspace = true }
 bzip2 = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
 chrono-humanize = { workspace = true }
-conditional-mod = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api"] }
 eager = { workspace = true }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -35,7 +35,12 @@ pub mod leader_schedule_cache;
 pub mod leader_schedule_utils;
 pub mod next_slots_iterator;
 pub mod rooted_slot_iterator;
-conditional_mod::conditional_vis_mod!(shred, feature="agave-unstable-api", pub,pub(crate));
+
+#[cfg(feature = "agave-unstable-api")]
+pub mod shred;
+#[cfg(not(feature = "agave-unstable-api"))]
+pub(crate) mod shred;
+
 mod shredder;
 pub mod sigverify_shreds;
 pub mod slot_stats;

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -702,9 +702,9 @@ where
 {
     debug_assert!(root < max_slot);
     let Some(shred) = layout::get_shred(packet) else {
-            stats.index_overrun += 1;
-            return true;
-        };
+        stats.index_overrun += 1;
+        return true;
+    };
     match layout::get_version(shred) {
         None => {
             stats.index_overrun += 1;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1370,12 +1370,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "conditional-mod"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67935045d95e19071aae6ee98d649f2a5593e510802040c622200c8d6666a9ca"
-
-[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6435,7 +6429,6 @@ dependencies = [
  "bytemuck",
  "bytes",
  "chrono",
- "conditional-mod",
  "crossbeam-channel",
  "dashmap",
  "derive_more 2.0.1",
@@ -7150,7 +7143,6 @@ dependencies = [
  "bzip2",
  "chrono",
  "chrono-humanize",
- "conditional-mod",
  "crossbeam-channel",
  "dashmap",
  "eager",

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -68,7 +68,6 @@ caps = { workspace = true }
 assert_matches = { workspace = true }
 bencher = { workspace = true }
 bs58 = { workspace = true }
-conditional-mod = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-ledger = { workspace = true, features = ["agave-unstable-api","dev-context-only-utils"] }
 solana-logger = { workspace = true }


### PR DESCRIPTION
#### Problem

`rustfmt` does not recognize modules declared via macros such as `conditional_vis_mod!`.
As a result, these modules are silently skipped during formatting.

##### How to Reproduce

1. Close your IDE (or disable automatic formatting)
2. Manually break formatting in any file that is included via `conditional_vis_mod!`, for example: `core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs`
3. Run `./cargo nightly fmt -- --check`

You’ll see that rustfmt reports no changes - meaning it completely ignored that file

#### Summary of Changes

1. Removed the use of `conditional_vis_mod!`
2. Performed full formatting using: `./scripts/cargo-for-all-lock-files.sh -- +nightly-2025-02-16 fmt --all`

