### PR TITLE
Removes epoch warmup from VoteSimulator

### DIFF
--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -19,6 +19,7 @@ use {
     },
     crossbeam_channel::unbounded,
     solana_clock::Slot,
+    solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_runtime::{
@@ -392,6 +393,7 @@ pub fn initialize_state(
         vec![stake; validator_keypairs.len()],
     );
 
+    genesis_config.epoch_schedule = EpochSchedule::without_warmup();
     genesis_config.poh_config.hashes_per_tick = Some(2);
     let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     bank0.set_block_id(Some(Hash::new_unique()));


### PR DESCRIPTION
#### Problem

While working on https://github.com/anza-xyz/agave/pull/8617, I found out that VoteSimulator uses the default EpochSchedule, which includes warmup epochs. With PR 8617, this breaks `test_double_partition()` because it stores votes for more than 224 slots. And since those slots start at slot 0, combined with warmup epochs, it ends up spanning over 3 epochs, causing the test to panic (when combined with PR 8617).


#### Summary of Changes

Since VoteSimulator doesn't need warmup epochs, turn them off.