### PR TITLE
fix: replace panic-prone unwrap() with safe get_transaction_error()

### DIFF
--- a/banks-client/src/error.rs
+++ b/banks-client/src/error.rs
@@ -31,11 +31,12 @@ pub enum BanksClientError {
 }
 
 impl BanksClientError {
-    pub fn unwrap(&self) -> TransactionError {
+    /// Safely extract TransactionError if present, returns None for other error types
+    pub fn get_transaction_error(&self) -> Option<TransactionError> {
         match self {
             BanksClientError::TransactionError(err)
-            | BanksClientError::SimulationError { err, .. } => err.clone(),
-            _ => panic!("unexpected transport error"),
+            | BanksClientError::SimulationError { err, .. } => Some(err.clone()),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
Remove the dangerous unwrap() method from BanksClientError that could cause panics for non-transaction errors. 

Replace it with a safe get_transaction_error() method that returns Option<TransactionError>, following the same pattern used in rpc-client-api. 

This prevents unexpected program termination while maintaining the same functionality for extracting transaction errors.