### PR TITLE
load prog test slow

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3152,7 +3152,7 @@ fn run_test_load_program_accounts(scan_commitment: CommitmentConfig) {
     .take(node_stakes.len())
     .collect();
 
-    let num_starting_accounts = 1000;
+    let num_starting_accounts = 100;
     let exit = Arc::new(AtomicBool::new(false));
     let (update_client_sender, update_client_receiver) = unbounded();
     let (scan_client_sender, scan_client_receiver) = unbounded();


### PR DESCRIPTION
#### Problem
Same as #8629 . 2k transfers takes a lonnnnggggg time and doesn't provide any additional explicit test coverage.

#### Summary of Changes
Reduce transfers from 2k to 200 for `test_run_test_load_program_accounts_root`