### PR TITLE
replace protobuf-src by protoc-bin-vendored

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,15 +1121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "autotools"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8138adefca3e5d2e73bfba83bd6eeaf904b26a7ac1b4a19892cfe16cc7e1701"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5579,18 +5570,73 @@ dependencies = [
 name = "proto"
 version = "3.1.0"
 dependencies = [
- "protobuf-src",
+ "protoc-bin-vendored",
  "tonic-build",
 ]
 
 [[package]]
-name = "protobuf-src"
-version = "1.1.0+21.5"
+name = "protoc-bin-vendored"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
 dependencies = [
- "autotools",
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
 ]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "protosol"
@@ -10912,7 +10958,7 @@ dependencies = [
  "bs58",
  "enum-iterator",
  "prost",
- "protobuf-src",
+ "protoc-bin-vendored",
  "serde",
  "solana-account-decoder",
  "solana-hash",
@@ -11981,7 +12027,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "protobuf-src",
+ "protoc-bin-vendored",
  "rand 0.8.5",
  "rayon",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,7 +336,7 @@ proptest = "1.8"
 prost = "0.11.9"
 prost-build = "0.11.9"
 prost-types = "0.11.9"
-protobuf-src = "1.1.0"
+protoc-bin-vendored = "3.2.0"
 qstring = "0.7.2"
 qualifier_attr = { version = "0.2.2", default-features = false }
 quinn = "0.11.9"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -801,15 +801,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "autotools"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4586,13 +4577,68 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf-src"
-version = "1.1.0+21.5"
+name = "protoc-bin-vendored"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
 dependencies = [
- "autotools",
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
 ]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "qstring"
@@ -9335,7 +9381,7 @@ dependencies = [
  "bincode",
  "bs58",
  "prost",
- "protobuf-src",
+ "protoc-bin-vendored",
  "serde",
  "solana-account-decoder",
  "solana-hash",
@@ -10067,7 +10113,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "protobuf-src",
+ "protoc-bin-vendored",
  "rayon",
  "solana-clock",
  "solana-entry",

--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -18,4 +18,4 @@ tonic-build = { workspace = true }
 # windows users should install the protobuf compiler manually and set the PROTOC
 # envar to point to the installed binary
 [target."cfg(not(windows))".dependencies]
-protobuf-src = { workspace = true }
+protoc-bin-vendored = { workspace = true }

--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -14,8 +14,4 @@ agave-unstable-api = []
 
 [dependencies]
 tonic-build = { workspace = true }
-
-# windows users should install the protobuf compiler manually and set the PROTOC
-# envar to point to the installed binary
-[target."cfg(not(windows))".dependencies]
 protoc-bin-vendored = { workspace = true }

--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -13,5 +13,5 @@ edition = { workspace = true }
 agave-unstable-api = []
 
 [dependencies]
-tonic-build = { workspace = true }
 protoc-bin-vendored = { workspace = true }
+tonic-build = { workspace = true }

--- a/storage-bigtable/build-proto/src/main.rs
+++ b/storage-bigtable/build-proto/src/main.rs
@@ -1,8 +1,12 @@
-fn main() -> Result<(), std::io::Error> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     const PROTOC_ENVAR: &str = "PROTOC";
     if std::env::var(PROTOC_ENVAR).is_err() {
         #[cfg(not(windows))]
-        std::env::set_var(PROTOC_ENVAR, protobuf_src::protoc());
+        {
+            // Use vendored protoc to avoid building C++ protobuf via autotools
+            let protoc_path = protoc_bin_vendored::protoc_bin_path()?;
+            std::env::set_var(PROTOC_ENVAR, protoc_path);
+        }
     }
 
     let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -20,5 +24,7 @@ fn main() -> Result<(), std::io::Error> {
         .compile(
             &[googleapis.join("google/bigtable/v2/bigtable.proto")],
             &[googleapis],
-        )
+        )?;
+
+    Ok(())
 }

--- a/storage-bigtable/build-proto/src/main.rs
+++ b/storage-bigtable/build-proto/src/main.rs
@@ -1,12 +1,9 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     const PROTOC_ENVAR: &str = "PROTOC";
     if std::env::var(PROTOC_ENVAR).is_err() {
-        #[cfg(not(windows))]
-        {
-            // Use vendored protoc to avoid building C++ protobuf via autotools
-            let protoc_path = protoc_bin_vendored::protoc_bin_path()?;
-            std::env::set_var(PROTOC_ENVAR, protoc_path);
-        }
+        // Use vendored protoc to avoid building C++ protobuf via autotools
+        let protoc_path = protoc_bin_vendored::protoc_bin_path()?;
+        std::env::set_var(PROTOC_ENVAR, protoc_path);
     }
 
     let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -42,7 +42,7 @@ tonic-build = { workspace = true }
 # windows users should install the protobuf compiler manually and set the PROTOC
 # envar to point to the installed binary
 [target."cfg(not(windows))".build-dependencies]
-protobuf-src = { workspace = true }
+protoc-bin-vendored = { workspace = true }
 
 [dev-dependencies]
 enum-iterator = { workspace = true }

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -37,8 +37,8 @@ solana-transaction-error = { workspace = true }
 solana-transaction-status = { workspace = true }
 
 [build-dependencies]
-tonic-build = { workspace = true }
 protoc-bin-vendored = { workspace = true }
+tonic-build = { workspace = true }
 
 [dev-dependencies]
 enum-iterator = { workspace = true }

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -38,10 +38,6 @@ solana-transaction-status = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }
-
-# windows users should install the protobuf compiler manually and set the PROTOC
-# envar to point to the installed binary
-[target."cfg(not(windows))".build-dependencies]
 protoc-bin-vendored = { workspace = true }
 
 [dev-dependencies]

--- a/storage-proto/build.rs
+++ b/storage-proto/build.rs
@@ -1,12 +1,9 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     const PROTOC_ENVAR: &str = "PROTOC";
     if std::env::var(PROTOC_ENVAR).is_err() {
-        #[cfg(not(windows))]
-        {
-            // Use vendored protoc to avoid building C++ protobuf via autotools
-            let protoc_path = protoc_bin_vendored::protoc_bin_path()?;
-            std::env::set_var(PROTOC_ENVAR, protoc_path);
-        }
+        // Use vendored protoc to avoid building C++ protobuf via autotools
+        let protoc_path = protoc_bin_vendored::protoc_bin_path()?;
+        std::env::set_var(PROTOC_ENVAR, protoc_path);
     }
 
     let proto_base_path = std::path::PathBuf::from("proto");

--- a/storage-proto/build.rs
+++ b/storage-proto/build.rs
@@ -1,8 +1,12 @@
-fn main() -> Result<(), std::io::Error> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     const PROTOC_ENVAR: &str = "PROTOC";
     if std::env::var(PROTOC_ENVAR).is_err() {
         #[cfg(not(windows))]
-        std::env::set_var(PROTOC_ENVAR, protobuf_src::protoc());
+        {
+            // Use vendored protoc to avoid building C++ protobuf via autotools
+            let protoc_path = protoc_bin_vendored::protoc_bin_path()?;
+            std::env::set_var(PROTOC_ENVAR, protoc_path);
+        }
     }
 
     let proto_base_path = std::path::PathBuf::from("proto");
@@ -29,5 +33,7 @@ fn main() -> Result<(), std::io::Error> {
             "InstructionErrorType",
             "#[cfg_attr(test, derive(enum_iterator::Sequence))]",
         )
-        .compile(&protos, &[proto_base_path])
+        .compile(&protos, &[proto_base_path])?;
+
+    Ok(())
 }

--- a/wen-restart/Cargo.toml
+++ b/wen-restart/Cargo.toml
@@ -42,10 +42,6 @@ solana-vote-program = { workspace = true }
 
 [build-dependencies]
 prost-build = { workspace = true }
-
-# windows users should install the protobuf compiler manually and set the PROTOC
-# envar to point to the installed binary
-[target."cfg(not(windows))".build-dependencies]
 protoc-bin-vendored = { workspace = true }
 
 [dev-dependencies]

--- a/wen-restart/Cargo.toml
+++ b/wen-restart/Cargo.toml
@@ -46,7 +46,7 @@ prost-build = { workspace = true }
 # windows users should install the protobuf compiler manually and set the PROTOC
 # envar to point to the installed binary
 [target."cfg(not(windows))".build-dependencies]
-protobuf-src = { workspace = true }
+protoc-bin-vendored = { workspace = true }
 
 [dev-dependencies]
 agave-snapshots = { workspace = true }

--- a/wen-restart/build.rs
+++ b/wen-restart/build.rs
@@ -1,12 +1,9 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     const PROTOC_ENVAR: &str = "PROTOC";
     if std::env::var(PROTOC_ENVAR).is_err() {
-        #[cfg(not(windows))]
-        {
-            // Use vendored protoc to avoid building C++ protobuf via autotools
-            let protoc_path = protoc_bin_vendored::protoc_bin_path()?;
-            std::env::set_var(PROTOC_ENVAR, protoc_path);
-        }
+        // Use vendored protoc to avoid building C++ protobuf via autotools
+        let protoc_path = protoc_bin_vendored::protoc_bin_path()?;
+        std::env::set_var(PROTOC_ENVAR, protoc_path);
     }
 
     let proto_base_path = std::path::PathBuf::from("proto");

--- a/wen-restart/build.rs
+++ b/wen-restart/build.rs
@@ -1,10 +1,12 @@
-use std::io::Result;
-
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     const PROTOC_ENVAR: &str = "PROTOC";
     if std::env::var(PROTOC_ENVAR).is_err() {
         #[cfg(not(windows))]
-        std::env::set_var(PROTOC_ENVAR, protobuf_src::protoc());
+        {
+            // Use vendored protoc to avoid building C++ protobuf via autotools
+            let protoc_path = protoc_bin_vendored::protoc_bin_path()?;
+            std::env::set_var(PROTOC_ENVAR, protoc_path);
+        }
     }
 
     let proto_base_path = std::path::PathBuf::from("proto");


### PR DESCRIPTION
#### Problem

We can skip building `protoc` and improve time required for compilation.

#### Summary of Changes

```
cpu: AMD EPYC 9275F 24-Core Processor

protoc-bin-vendored (5adf236811) (this PR)
$ time cargo build
real  1m17.736s
user  25m20.272s
sys 3m0.561s
$ time cargo build -j8
real  2m40.167s
user  16m21.509s
sys 2m6.206s

master (432c81404c)
$ time cargo build
real  1m24.308s
user  28m5.515s
sys 3m27.618s
$ time cargo build -j8
real  2m53.915s
user  17m57.676s
sys 2m22.308s
```