### PR TITLE
Remove stored meta from ancient append vec tests

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -23,8 +23,6 @@ mod geyser_plugin_utils;
 pub mod stats;
 pub mod tests;
 
-#[cfg(test)]
-use crate::append_vec::StoredAccountMeta;
 pub use accounts_db_config::{
     AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
 };
@@ -326,18 +324,18 @@ impl AccountFromStorage {
         self.data_len as usize
     }
     #[cfg(test)]
-    pub fn new(account: &StoredAccountMeta) -> Self {
+    pub(crate) fn new(offset: Offset, account: &StoredAccountInfoWithoutData) -> Self {
         // the id is irrelevant in this account info. This structure is only used DURING shrink operations.
         // In those cases, there is only 1 append vec id per slot when we read the accounts.
         // Any value of storage id in account info works fine when we want the 'normal' storage.
         let storage_id = 0;
         AccountFromStorage {
             index_info: AccountInfo::new(
-                StorageLocation::AppendVec(storage_id, account.offset()),
+                StorageLocation::AppendVec(storage_id, offset),
                 account.is_zero_lamport(),
             ),
             pubkey: *account.pubkey(),
-            data_len: account.data_len() as u64,
+            data_len: account.data_len as u64,
         }
     }
 }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1213,11 +1213,14 @@ pub mod tests {
     fn test_write_packed_storages_too_few_slots() {
         let (db, storages, slots, _infos) = get_sample_storages(1, None);
         let accounts_to_combine = AccountsToCombine::default();
+        let offset = 0;
         let account = storages
             .first()
             .unwrap()
             .accounts
-            .get_stored_account_meta_callback(0, |account| AccountFromStorage::new(&account))
+            .get_stored_account_without_data_callback(offset, |account| {
+                AccountFromStorage::new(offset, &account)
+            })
             .unwrap();
         let accounts = [&account];
 
@@ -3144,8 +3147,8 @@ pub mod tests {
                                 let mut accounts = Vec::default();
                                 storage
                                     .accounts
-                                    .scan_accounts_stored_meta(|account| {
-                                        accounts.push(AccountFromStorage::new(&account));
+                                    .scan_accounts_without_data(|offset, account| {
+                                        accounts.push(AccountFromStorage::new(offset, &account));
                                     })
                                     .expect("must scan accounts storage");
                                 (storage.slot(), accounts)
@@ -3577,11 +3580,12 @@ pub mod tests {
         let num_slots = 1;
         let data_size = None;
         let (_db, storages, _slots, _infos) = get_sample_storages(num_slots, data_size);
+        let offset = 0;
 
         storages[0]
             .accounts
-            .get_stored_account_meta_callback(0, |stored_account_meta| {
-                let account = AccountFromStorage::new(&stored_account_meta);
+            .get_stored_account_without_data_callback(offset, |stored_account| {
+                let account = AccountFromStorage::new(offset, &stored_account);
                 let slot = 1;
                 let capacity = 0;
                 for i in 0..4usize {


### PR DESCRIPTION
#### Problem
Ancient append vec tests use get_stored_account_meta_callback when data and metadata are not needed, requiring a dependency on StoredAccountMeta.  Switch to using get_stored_account_without_data_callback

#### Summary of Changes
- Switch tests to use get_stored_account_meta_callback
- Update AccountFromStorage new function to use StoredAccountInfoWithoutData and offset instead of StoredAccountMeta
- Test using scan_accounts_without_data is also effected due to change in AccountFromStorage new function. Update it to use scan_accounts_without_data

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
