### PR TITLE
docs: fix docs CI change detection, correct install anchor, and update macOS brew deps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,9 +37,10 @@ jobs:
       - name: Get file status
         run: |
           set +e
-          git diff --name-only $COMMIT_RANGE | grep \
-            -e '.github/workflows/docs.yml' \
-            -e 'docs/**'
+          # Match exactly the workflow file, or any path under docs/
+          git diff --name-only $COMMIT_RANGE | grep -E \
+            -e '^\.github/workflows/docs\.yml$' \
+            -e '^docs/'
           echo "FILE_CHANGED=$?" >> $GITHUB_ENV
 
       - name: Check

--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 There are multiple ways to install the Solana tools on your computer depending
 on your preferred workflow:
 
-- [Use the Solana Install Tool (Simplest option)](#use-solanas-install-tool)
+- [Use the Solana Install Tool (Simplest option)](#use-the-solana-install-tool)
 - [Download Prebuilt Binaries](#download-prebuilt-binaries)
 - [Build from Source](#build-from-source)
 - [Use Homebrew](#use-homebrew)
@@ -192,7 +192,7 @@ installation instruction for Homebrew if not already installed.
 Then, install build dependencies with `brew`:
 
 ```bash
-brew install pkg-config libudev protobuf llvm coreutils
+brew install pkg-config protobuf llvm coreutils
 ```
 
 Follow the instructions given at the end of the brew install command about


### PR DESCRIPTION
#### Problem

- Docs CI failed to detect changes due to grep using a glob-like pattern ('docs/**').

- TOC link in install.md used a non-standard anchor (#use-solanas-install-tool).

- macOS brew dependencies listed libudev, which doesn't exist on macOS.

#### Summary of Changes

- Use grep -E with '^.github/workflows/docs.yml$' and '^docs/' to detect changes.

- Update anchor to #use-the-solana-install-tool.

- Remove libudev from macOS Homebrew install line.

#### Impact

- Docs pipeline reliably builds on doc changes.

- Anchor link works after Docusaurus build.

- macOS install instructions won't mislead users.