### PR TITLE
feat: upstream recent changes from `ConsensusPool` and `VotePool`

### DIFF
--- a/votor/src/consensus_pool/vote_pool.rs
+++ b/votor/src/consensus_pool/vote_pool.rs
@@ -1,164 +1,118 @@
 use {
-    crate::{common::Stake, consensus_pool::vote_certificate_builder::VoteCertificateBuilder},
+    crate::common::Stake,
     agave_votor_messages::consensus_message::VoteMessage,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
-    std::collections::{HashMap, HashSet},
+    std::collections::{BTreeMap, BTreeSet},
 };
 
-#[allow(dead_code)]
-#[derive(Debug)]
-pub(crate) struct VoteEntry {
-    pub(crate) transactions: Vec<VoteMessage>,
-    pub(crate) total_stake_by_key: Stake,
-}
-
-#[allow(dead_code)]
-impl VoteEntry {
-    pub fn new() -> Self {
-        Self {
-            transactions: Vec::new(),
-            total_stake_by_key: 0,
-        }
-    }
-}
-
-#[allow(dead_code)]
-pub(crate) trait VotePool {
-    fn total_stake(&self) -> Stake;
-    fn has_prev_validator_vote(&self, validator_vote_key: &Pubkey) -> bool;
-}
-
-#[allow(dead_code)]
 /// There are two types of vote pools:
 /// - SimpleVotePool: Tracks all votes of a specfic vote type made by validators for some slot N, but only one vote per block.
 /// - DuplicateBlockVotePool: Tracks all votes of a specfic vote type made by validators for some slot N,
 ///   but allows votes for different blocks by the same validator. Only relevant for VotePool's that are of type
 ///   Notarization or NotarizationFallback
-pub(crate) enum VotePoolType {
+pub(super) enum VotePool {
     SimpleVotePool(SimpleVotePool),
     DuplicateBlockVotePool(DuplicateBlockVotePool),
 }
 
-pub(crate) struct SimpleVotePool {
-    /// Tracks all votes of a specfic vote type made by validators for some slot N.
-    pub(crate) vote_entry: VoteEntry,
-    prev_voted_validators: HashSet<Pubkey>,
+#[derive(Default)]
+pub(super) struct SimpleVotePool {
+    votes: Vec<VoteMessage>,
+    total_stake: Stake,
+    prev_voted_validators: BTreeSet<Pubkey>,
 }
 
-#[allow(dead_code)]
 impl SimpleVotePool {
-    pub fn new() -> Self {
-        Self {
-            vote_entry: VoteEntry::new(),
-            prev_voted_validators: HashSet::new(),
-        }
-    }
-
-    pub fn add_vote(
+    pub(super) fn add_vote(
         &mut self,
-        validator_vote_key: &Pubkey,
+        validator_vote_key: Pubkey,
         validator_stake: Stake,
-        transaction: &VoteMessage,
+        vote: VoteMessage,
     ) -> Option<Stake> {
-        if self.prev_voted_validators.contains(validator_vote_key) {
+        if !self.prev_voted_validators.insert(validator_vote_key) {
             return None;
         }
-        self.prev_voted_validators.insert(*validator_vote_key);
-        self.vote_entry.transactions.push(*transaction);
-        self.vote_entry.total_stake_by_key = self
-            .vote_entry
-            .total_stake_by_key
-            .saturating_add(validator_stake);
-        Some(self.vote_entry.total_stake_by_key)
+        self.votes.push(vote);
+        self.total_stake = self.total_stake.saturating_add(validator_stake);
+        Some(self.total_stake)
     }
 
-    pub fn add_to_certificate(&self, output: &mut VoteCertificateBuilder) {
-        output
-            .aggregate(&self.vote_entry.transactions)
-            .expect("Incoming vote message signatures are assumed to be valid")
+    pub(super) fn votes(&self) -> &[VoteMessage] {
+        &self.votes
     }
-}
 
-impl VotePool for SimpleVotePool {
-    fn total_stake(&self) -> Stake {
-        self.vote_entry.total_stake_by_key
+    pub(super) fn total_stake(&self) -> Stake {
+        self.total_stake
     }
-    fn has_prev_validator_vote(&self, validator_vote_key: &Pubkey) -> bool {
+
+    pub(super) fn has_prev_validator_vote(&self, validator_vote_key: &Pubkey) -> bool {
         self.prev_voted_validators.contains(validator_vote_key)
     }
 }
 
-pub(crate) struct DuplicateBlockVotePool {
-    max_entries_per_pubkey: usize,
-    pub(crate) votes: HashMap<Hash, VoteEntry>,
-    total_stake: Stake,
-    prev_voted_block_ids: HashMap<Pubkey, Vec<Hash>>,
+#[derive(Default)]
+struct VoteEntry {
+    votes: Vec<VoteMessage>,
+    total_stake_by_key: Stake,
 }
 
-#[allow(dead_code)]
+pub(super) struct DuplicateBlockVotePool {
+    max_entries_per_pubkey: usize,
+    vote_entries: BTreeMap<Hash, VoteEntry>,
+    prev_voted_block_ids: BTreeMap<Pubkey, BTreeSet<Hash>>,
+}
+
 impl DuplicateBlockVotePool {
-    pub fn new(max_entries_per_pubkey: usize) -> Self {
+    pub(super) fn new(max_entries_per_pubkey: usize) -> Self {
         Self {
             max_entries_per_pubkey,
-            votes: HashMap::new(),
-            total_stake: 0,
-            prev_voted_block_ids: HashMap::new(),
+            vote_entries: BTreeMap::new(),
+            prev_voted_block_ids: BTreeMap::new(),
         }
     }
 
-    pub fn add_vote(
+    pub(super) fn add_vote(
         &mut self,
-        validator_vote_key: &Pubkey,
-        voted_block_id: Hash,
-        transaction: &VoteMessage,
+        validator_vote_key: Pubkey,
         validator_stake: Stake,
+        vote: VoteMessage,
     ) -> Option<Stake> {
+        let block_id = *vote.vote.block_id().unwrap();
         // Check whether the validator_vote_key already used the same voted_block_id or exceeded max_entries_per_pubkey
         // If so, return false, otherwise add the voted_block_id to the prev_votes
         let prev_voted_block_ids = self
             .prev_voted_block_ids
-            .entry(*validator_vote_key)
+            .entry(validator_vote_key)
             .or_default();
-        if prev_voted_block_ids.contains(&voted_block_id) {
+        if prev_voted_block_ids.contains(&block_id)
+            || prev_voted_block_ids.len() >= self.max_entries_per_pubkey
+        {
             return None;
         }
-        let inserted_first_time = prev_voted_block_ids.is_empty();
-        if prev_voted_block_ids.len() >= self.max_entries_per_pubkey {
-            return None;
-        }
-        prev_voted_block_ids.push(voted_block_id);
+        prev_voted_block_ids.insert(block_id);
 
-        let vote_entry = self
-            .votes
-            .entry(voted_block_id)
-            .or_insert_with(VoteEntry::new);
-        vote_entry.transactions.push(*transaction);
+        let vote_entry = self.vote_entries.entry(block_id).or_default();
+        vote_entry.votes.push(vote);
         vote_entry.total_stake_by_key = vote_entry
             .total_stake_by_key
             .saturating_add(validator_stake);
-
-        if inserted_first_time {
-            self.total_stake = self.total_stake.saturating_add(validator_stake);
-        }
         Some(vote_entry.total_stake_by_key)
     }
 
-    pub fn total_stake_by_block_id(&self, block_id: &Hash) -> Stake {
-        self.votes
+    pub(super) fn total_stake_by_block_id(&self, block_id: &Hash) -> Stake {
+        self.vote_entries
             .get(block_id)
             .map_or(0, |vote_entries| vote_entries.total_stake_by_key)
     }
 
-    pub fn add_to_certificate(&self, block_id: &Hash, output: &mut VoteCertificateBuilder) {
-        if let Some(vote_entries) = self.votes.get(block_id) {
-            output
-                .aggregate(&vote_entries.transactions)
-                .expect("Incoming vote message signatures are assumed to be valid")
-        }
+    pub(super) fn votes(&self, block_id: &Hash) -> Option<&[VoteMessage]> {
+        self.vote_entries
+            .get(block_id)
+            .map(|entry| entry.votes.as_slice())
     }
 
-    pub fn has_prev_validator_vote_for_block(
+    pub(super) fn has_prev_validator_vote_for_block(
         &self,
         validator_vote_key: &Pubkey,
         block_id: &Hash,
@@ -167,13 +121,8 @@ impl DuplicateBlockVotePool {
             .get(validator_vote_key)
             .is_some_and(|vs| vs.contains(block_id))
     }
-}
 
-impl VotePool for DuplicateBlockVotePool {
-    fn total_stake(&self) -> Stake {
-        self.total_stake
-    }
-    fn has_prev_validator_vote(&self, validator_vote_key: &Pubkey) -> bool {
+    pub(super) fn has_prev_validator_vote(&self, validator_vote_key: &Pubkey) -> bool {
         self.prev_voted_block_ids.contains_key(validator_vote_key)
     }
 }
@@ -188,25 +137,25 @@ mod test {
 
     #[test]
     fn test_skip_vote_pool() {
-        let mut vote_pool = SimpleVotePool::new();
+        let mut vote_pool = SimpleVotePool::default();
         let vote = Vote::new_skip_vote(5);
-        let transaction = VoteMessage {
+        let vote_message = VoteMessage {
             vote,
             signature: BLSSignature::default(),
             rank: 1,
         };
         let my_pubkey = Pubkey::new_unique();
 
-        assert_eq!(vote_pool.add_vote(&my_pubkey, 10, &transaction), Some(10));
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote_message), Some(10));
         assert_eq!(vote_pool.total_stake(), 10);
 
         // Adding the same key again should fail
-        assert_eq!(vote_pool.add_vote(&my_pubkey, 10, &transaction), None);
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote_message), None);
         assert_eq!(vote_pool.total_stake(), 10);
 
         // Adding a different key should succeed
         let new_pubkey = Pubkey::new_unique();
-        assert_eq!(vote_pool.add_vote(&new_pubkey, 60, &transaction), Some(70));
+        assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote_message), Some(70));
         assert_eq!(vote_pool.total_stake(), 70);
     }
 
@@ -216,39 +165,23 @@ mod test {
         let my_pubkey = Pubkey::new_unique();
         let block_id = Hash::new_unique();
         let vote = Vote::new_notarization_vote(3, block_id);
-        let transaction = VoteMessage {
+        let vote = VoteMessage {
             vote,
             signature: BLSSignature::default(),
             rank: 1,
         };
-        assert_eq!(
-            vote_pool.add_vote(&my_pubkey, block_id, &transaction, 10),
-            Some(10)
-        );
-        assert_eq!(vote_pool.total_stake(), 10);
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), Some(10));
         assert_eq!(vote_pool.total_stake_by_block_id(&block_id), 10);
 
         // Adding the same key again should fail
-        assert_eq!(
-            vote_pool.add_vote(&my_pubkey, block_id, &transaction, 10),
-            None
-        );
-        assert_eq!(vote_pool.total_stake(), 10);
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), None);
 
         // Adding a different bankhash should fail
-        assert_eq!(
-            vote_pool.add_vote(&my_pubkey, block_id, &transaction, 10),
-            None
-        );
-        assert_eq!(vote_pool.total_stake(), 10);
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), None);
 
         // Adding a different key should succeed
         let new_pubkey = Pubkey::new_unique();
-        assert_eq!(
-            vote_pool.add_vote(&new_pubkey, block_id, &transaction, 60),
-            Some(70)
-        );
-        assert_eq!(vote_pool.total_stake(), 70);
+        assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote), Some(70));
         assert_eq!(vote_pool.total_stake_by_block_id(&block_id), 70);
     }
 
@@ -256,56 +189,52 @@ mod test {
     fn test_notarization_fallback_pool() {
         solana_logger::setup();
         let mut vote_pool = DuplicateBlockVotePool::new(3);
-        let vote = Vote::new_notarization_fallback_vote(7, Hash::new_unique());
-        let transaction = VoteMessage {
-            vote,
-            signature: BLSSignature::default(),
-            rank: 1,
-        };
         let my_pubkey = Pubkey::new_unique();
 
-        let block_ids: Vec<Hash> = (0..4).map(|_| Hash::new_unique()).collect();
+        let votes = (0..4)
+            .map(|_| {
+                let vote = Vote::new_notarization_fallback_vote(7, Hash::new_unique());
+                VoteMessage {
+                    vote,
+                    signature: BLSSignature::default(),
+                    rank: 1,
+                }
+            })
+            .collect::<Vec<_>>();
 
         // Adding the first 3 votes should succeed, but total_stake should remain at 10
-        for block_id in &block_ids[0..3] {
+        for vote in votes.iter().take(3).cloned() {
+            assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), Some(10));
             assert_eq!(
-                vote_pool.add_vote(&my_pubkey, *block_id, &transaction, 10),
-                Some(10)
+                vote_pool.total_stake_by_block_id(vote.vote.block_id().unwrap()),
+                10
             );
-            assert_eq!(vote_pool.total_stake(), 10);
-            assert_eq!(vote_pool.total_stake_by_block_id(block_id), 10);
         }
         // Adding the 4th vote should fail
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, votes[3]), None);
         assert_eq!(
-            vote_pool.add_vote(&my_pubkey, block_ids[3], &transaction, 10),
-            None
+            vote_pool.total_stake_by_block_id(votes[3].vote.block_id().unwrap()),
+            0
         );
-        assert_eq!(vote_pool.total_stake(), 10);
-        assert_eq!(vote_pool.total_stake_by_block_id(&block_ids[3]), 0);
 
         // Adding a different key should succeed
         let new_pubkey = Pubkey::new_unique();
-        for block_id in &block_ids[1..3] {
+        for vote in votes.iter().skip(1).take(2).cloned() {
+            assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote), Some(70));
             assert_eq!(
-                vote_pool.add_vote(&new_pubkey, *block_id, &transaction, 60),
-                Some(70)
+                vote_pool.total_stake_by_block_id(vote.vote.block_id().unwrap()),
+                70
             );
-            assert_eq!(vote_pool.total_stake(), 70);
-            assert_eq!(vote_pool.total_stake_by_block_id(block_id), 70);
         }
 
         // The new key only added 2 votes, so adding block_ids[3] should succeed
+        assert_eq!(vote_pool.add_vote(new_pubkey, 60, votes[3]), Some(60));
         assert_eq!(
-            vote_pool.add_vote(&new_pubkey, block_ids[3], &transaction, 60),
-            Some(60)
+            vote_pool.total_stake_by_block_id(votes[3].vote.block_id().unwrap()),
+            60
         );
-        assert_eq!(vote_pool.total_stake(), 70);
-        assert_eq!(vote_pool.total_stake_by_block_id(&block_ids[3]), 60);
 
         // Now if adding the same key again, it should fail
-        assert_eq!(
-            vote_pool.add_vote(&new_pubkey, block_ids[0], &transaction, 60),
-            None
-        );
+        assert_eq!(vote_pool.add_vote(new_pubkey, 60, votes[0]), None);
     }
 }

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -132,7 +132,7 @@ impl ConsensusPoolService {
     fn process_consensus_message(
         ctx: &mut ConsensusPoolContext,
         my_pubkey: &Pubkey,
-        message: &ConsensusMessage,
+        message: ConsensusMessage,
         consensus_pool: &mut ConsensusPool,
         events: &mut Vec<VotorEvent>,
         standstill_timer: &mut Instant,
@@ -247,7 +247,7 @@ impl ConsensusPoolService {
                 match Self::process_consensus_message(
                     ctx,
                     &my_pubkey,
-                    &message,
+                    message,
                     &mut consensus_pool,
                     &mut events,
                     &mut standstill_timer,
@@ -275,7 +275,7 @@ impl ConsensusPoolService {
         root_bank: &Bank,
         my_pubkey: &Pubkey,
         my_vote_pubkey: &Pubkey,
-        message: &ConsensusMessage,
+        message: ConsensusMessage,
         consensus_pool: &mut ConsensusPool,
         votor_events: &mut Vec<VotorEvent>,
         commitment_sender: &Sender<CommitmentAggregationData>,


### PR DESCRIPTION
#### Problem

Need to stream major changes in `ConsensusPool` and `VotePool` from the alpenglow repo to this repo.

Also see https://github.com/anza-xyz/alpenglow/pull/550 and https://github.com/anza-xyz/alpenglow/pull/551 for how the changes were made in the alpenglow repo.


#### Summary of Changes

- Removes the `VotePool` trait
- Renames the `VotePoolType` to `VotePool`
- Restricts the visibility of various types to the minimum needed.
- vote pools do not need to know about the certificate builder
- renames some variables in simple pool and uses API to reduce amount of code
- prev_voted_block_ids in duplicate pool uses a btreeset instead of vec to make lookups cheaper
- duplicate pool's tracking of total stake is not needed by production code
- various APIs were taking a vote message and fields derived from it, passing just vote message
