### PR TITLE
rpc: track transaction status service health in getHealth rpc call

### DIFF
--- a/rpc-client-api/src/custom_error.rs
+++ b/rpc-client-api/src/custom_error.rs
@@ -28,6 +28,7 @@ pub const JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED: i64 = -32016;
 pub const JSON_RPC_SERVER_ERROR_EPOCH_REWARDS_PERIOD_ACTIVE: i64 = -32017;
 pub const JSON_RPC_SERVER_ERROR_SLOT_NOT_EPOCH_BOUNDARY: i64 = -32018;
 pub const JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE: i64 = -32019;
+pub const JSON_RPC_SERVER_ERROR_TRANSACTION_STATUS_BEHIND: i64 = -32020;
 
 #[derive(Error, Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -80,6 +81,8 @@ pub enum RpcCustomError {
     SlotNotEpochBoundary { slot: Slot },
     #[error("LongTermStorageUnreachable")]
     LongTermStorageUnreachable,
+    #[error("TransactionStatusBehind")]
+    TransactionStatusBehind { behind_by_slots: Slot },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -258,6 +261,13 @@ impl From<RpcCustomError> for Error {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE),
                 message: "Failed to query long-term storage; please try again".to_string(),
                 data: None,
+            },
+            RpcCustomError::TransactionStatusBehind { behind_by_slots } => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_TRANSACTION_STATUS_BEHIND),
+                message: format!("Transaction status is behind by {behind_by_slots} slots"),
+                data: Some(serde_json::json!({
+                    "behind_by_slots": behind_by_slots,
+                })),
             },
         }
     }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -454,8 +454,7 @@ impl JsonRpcRequestProcessor {
         let genesis_hash = bank.hash();
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().root_bank();
-        let blockstore: Arc<Blockstore> =
-            Arc::new(Blockstore::open(&get_tmp_ledger_path!()).unwrap());
+        let blockstore = Arc::new(Blockstore::open(&get_tmp_ledger_path!()).unwrap());
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(0));
         let exit = Arc::new(AtomicBool::new(false));
         let cluster_info = Arc::new({

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -454,7 +454,9 @@ impl JsonRpcRequestProcessor {
         let genesis_hash = bank.hash();
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().root_bank();
-        let blockstore = Arc::new(Blockstore::open(&get_tmp_ledger_path!()).unwrap());
+        let blockstore: Arc<Blockstore> =
+            Arc::new(Blockstore::open(&get_tmp_ledger_path!()).unwrap());
+        let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(0));
         let exit = Arc::new(AtomicBool::new(false));
         let cluster_info = Arc::new({
             let keypair = Arc::new(Keypair::new());
@@ -510,6 +512,7 @@ impl JsonRpcRequestProcessor {
                 blockstore,
                 0,
                 exit,
+                max_complete_transaction_status_slot.clone(),
             )),
             cluster_info,
             genesis_hash,
@@ -2816,6 +2819,12 @@ pub mod rpc_minimal {
                     num_slots_behind: Some(num_slots),
                 }
                 .into()),
+                RpcHealthStatus::TransactionStatusBehind { num_slots } => {
+                    Err(RpcCustomError::TransactionStatusBehind {
+                        behind_by_slots: num_slots,
+                    }
+                    .into())
+                }
             }
         }
 
@@ -3875,6 +3884,8 @@ pub mod rpc_full {
                             }
                             .into());
                         }
+                        // nothing to do for TransactionStatusBehind
+                        RpcHealthStatus::TransactionStatusBehind { .. } => (),
                     }
                 }
 

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -333,6 +333,7 @@ impl RpcRequestMiddleware {
             RpcHealthStatus::Ok => "ok",
             RpcHealthStatus::Behind { .. } => "behind",
             RpcHealthStatus::Unknown => "unknown",
+            RpcHealthStatus::TransactionStatusBehind { .. } => "transaction status behind",
         };
         info!("health check: {response}");
         response
@@ -595,6 +596,7 @@ impl JsonRpcService {
             Arc::clone(&blockstore),
             config.health_check_slot_distance,
             override_health_check,
+            max_complete_transaction_status_slot.clone(),
         ));
 
         let largest_accounts_cache = Arc::new(RwLock::new(LargestAccountsCache::new(


### PR DESCRIPTION
#### Problem

#6287 

#### Summary of Changes

check `max_complete_transaction_status_slot` in the getHealth RPC and use `health_check_slot_distance` as the threshold