### PR TITLE
Validate and expire bp unified scheduler tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11709,6 +11709,7 @@ name = "solana-unified-scheduler-logic"
 version = "4.0.0-alpha.0"
 dependencies = [
  "assert_matches",
+ "solana-clock",
  "solana-instruction",
  "solana-message",
  "solana-pubkey",

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -172,10 +172,13 @@ impl Consumer {
         // Need to filter out transactions since they were sanitized earlier.
         // This means that the transaction may cross and epoch boundary (not allowed),
         //  or account lookup tables may have been closed.
-        let pre_results = txs
-            .iter()
-            .zip(max_ages)
-            .map(|(tx, max_age)| bank.resanitize_transaction_minimally(tx, max_age));
+        let pre_results = txs.iter().zip(max_ages).map(|(tx, max_age)| {
+            bank.resanitize_transaction_minimally(
+                tx,
+                max_age.sanitized_epoch,
+                max_age.alt_invalidation_slot,
+            )
+        });
         self.process_and_record_transactions_with_pre_results(bank, txs, pre_results)
     }
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -175,7 +175,7 @@ impl Consumer {
         let pre_results = txs
             .iter()
             .zip(max_ages)
-            .map(|(tx, max_age)| bank.resanitize_transaction_if_needed(tx, max_age));
+            .map(|(tx, max_age)| bank.resanitize_transaction_minimally(tx, max_age));
         self.process_and_record_transactions_with_pre_results(bank, txs, pre_results)
     }
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -172,29 +172,10 @@ impl Consumer {
         // Need to filter out transactions since they were sanitized earlier.
         // This means that the transaction may cross and epoch boundary (not allowed),
         //  or account lookup tables may have been closed.
-        let pre_results = txs.iter().zip(max_ages).map(|(tx, max_age)| {
-            // If the transaction was sanitized before this bank's epoch,
-            // additional checks are necessary.
-            if bank.epoch() != max_age.sanitized_epoch {
-                // Reserved key set may have changed, so we must verify that
-                // no writable keys are reserved.
-                bank.check_reserved_keys(tx)?;
-            }
-
-            if bank.slot() > max_age.alt_invalidation_slot {
-                // The address table lookup **may** have expired, but the
-                // expiration is not guaranteed since there may have been
-                // skipped slot.
-                // If the addresses still resolve here, then the transaction is still
-                // valid, and we can continue with processing.
-                // If they do not, then the ATL has expired and the transaction
-                // can be dropped.
-                let (_addresses, _deactivation_slot) =
-                    bank.load_addresses_from_ref(tx.message_address_table_lookups())?;
-            }
-
-            Ok(())
-        });
+        let pre_results = txs
+            .iter()
+            .zip(max_ages)
+            .map(|(tx, max_age)| bank.resanitize_transaction_if_needed(tx, max_age));
         self.process_and_record_transactions_with_pre_results(bank, txs, pre_results)
     }
 

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -1,8 +1,4 @@
-use {
-    crate::banking_stage::consumer::RetryableIndex,
-    solana_clock::{Epoch, Slot},
-    std::fmt::Display,
-};
+use {crate::banking_stage::consumer::RetryableIndex, std::fmt::Display};
 
 /// A unique identifier for a transaction batch.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -22,18 +18,7 @@ impl Display for TransactionBatchId {
 
 pub type TransactionId = usize;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct MaxAge {
-    pub sanitized_epoch: Epoch,
-    pub alt_invalidation_slot: Slot,
-}
-
-impl MaxAge {
-    pub const MAX: Self = Self {
-        sanitized_epoch: Epoch::MAX,
-        alt_invalidation_slot: Slot::MAX,
-    };
-}
+pub use solana_unified_scheduler_logic::MaxAge;
 
 /// Message: [Scheduler -> Worker]
 /// Transactions to be consumed (i.e. executed, recorded, and committed)

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -1,4 +1,8 @@
-use {crate::banking_stage::consumer::RetryableIndex, std::fmt::Display};
+use {
+    crate::banking_stage::consumer::RetryableIndex,
+    solana_clock::{Epoch, Slot},
+    std::fmt::Display,
+};
 
 /// A unique identifier for a transaction batch.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -18,7 +22,18 @@ impl Display for TransactionBatchId {
 
 pub type TransactionId = usize;
 
-pub use solana_unified_scheduler_logic::MaxAge;
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct MaxAge {
+    pub sanitized_epoch: Epoch,
+    pub alt_invalidation_slot: Slot,
+}
+
+impl MaxAge {
+    pub const MAX: Self = Self {
+        sanitized_epoch: Epoch::MAX,
+        alt_invalidation_slot: Slot::MAX,
+    };
+}
 
 /// Message: [Scheduler -> Worker]
 /// Transactions to be consumed (i.e. executed, recorded, and committed)

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -52,7 +52,6 @@ use {
         versioned::{sanitized::SanitizedVersionedTransaction, VersionedTransaction},
     },
     solana_transaction_error::AddressLoaderError,
-    solana_unified_scheduler_logic::MaxAge,
     solana_unified_scheduler_pool::{BankingStageHelper, DefaultSchedulerPool},
     std::{
         num::NonZeroUsize,
@@ -139,12 +138,8 @@ pub(crate) fn ensure_banking_stage_setup(
                         tx,
                         task_id,
                         packet.meta().size,
-                        MaxAge {
-                            sanitized_epoch: bank.epoch(),
-                            alt_invalidation_slot: estimate_last_valid_slot(
-                                bank.slot().min(deactivation_slot),
-                            ),
-                        },
+                        bank.epoch(),
+                        estimate_last_valid_slot(bank.slot().min(deactivation_slot)),
                     ))
                 });
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9727,6 +9727,7 @@ name = "solana-unified-scheduler-logic"
 version = "4.0.0-alpha.0"
 dependencies = [
  "assert_matches",
+ "solana-clock",
  "solana-pubkey",
  "solana-runtime-transaction",
  "solana-transaction",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10212,6 +10212,7 @@ name = "solana-unified-scheduler-logic"
 version = "4.0.0-alpha.0"
 dependencies = [
  "assert_matches",
+ "solana-clock",
  "solana-pubkey",
  "solana-runtime-transaction",
  "solana-transaction",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3046,7 +3046,7 @@ impl Bank {
         self.prepare_sanitized_batch(slice::from_ref(transaction))
     }
 
-    pub fn resanitize_transaction_if_needed(
+    pub fn resanitize_transaction_minimally(
         &self,
         transaction: &impl TransactionWithMeta,
         max_age: &MaxAge,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -166,6 +166,7 @@ use {
         transaction_accounts::KeyedAccountSharedData, TransactionReturnData,
     },
     solana_transaction_error::{TransactionError, TransactionResult as Result},
+    solana_unified_scheduler_logic::MaxAge,
     solana_vote::vote_account::{VoteAccount, VoteAccountsHashMap},
     std::{
         collections::{HashMap, HashSet},
@@ -3043,6 +3044,34 @@ impl Bank {
         transaction: &'a Tx,
     ) -> TransactionBatch<'a, 'a, Tx> {
         self.prepare_sanitized_batch(slice::from_ref(transaction))
+    }
+
+    pub fn resanitize_transaction_if_needed(
+        &self,
+        transaction: &impl TransactionWithMeta,
+        max_age: &MaxAge,
+    ) -> Result<()> {
+        // If the transaction was sanitized before this bank's epoch,
+        // additional checks are necessary.
+        if self.epoch() != max_age.sanitized_epoch {
+            // Reserved key set may have changed, so we must verify that
+            // no writable keys are reserved.
+            self.check_reserved_keys(transaction)?;
+        }
+
+        if self.slot() > max_age.alt_invalidation_slot {
+            // The address table lookup **may** have expired, but the
+            // expiration is not guaranteed since there may have been
+            // skipped slot.
+            // If the addresses still resolve here, then the transaction is still
+            // valid, and we can continue with processing.
+            // If they do not, then the ATL has expired and the transaction
+            // can be dropped.
+            let (_addresses, _deactivation_slot) =
+                self.load_addresses_from_ref(transaction.message_address_table_lookups())?;
+        }
+
+        Ok(())
     }
 
     /// Run transactions against a frozen bank without committing the results

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -166,7 +166,6 @@ use {
         transaction_accounts::KeyedAccountSharedData, TransactionReturnData,
     },
     solana_transaction_error::{TransactionError, TransactionResult as Result},
-    solana_unified_scheduler_logic::MaxAge,
     solana_vote::vote_account::{VoteAccount, VoteAccountsHashMap},
     std::{
         collections::{HashMap, HashSet},
@@ -3049,17 +3048,18 @@ impl Bank {
     pub fn resanitize_transaction_minimally(
         &self,
         transaction: &impl TransactionWithMeta,
-        max_age: &MaxAge,
+        sanitized_epoch: Epoch,
+        alt_invalidation_slot: Slot,
     ) -> Result<()> {
         // If the transaction was sanitized before this bank's epoch,
         // additional checks are necessary.
-        if self.epoch() != max_age.sanitized_epoch {
+        if self.epoch() != sanitized_epoch {
             // Reserved key set may have changed, so we must verify that
             // no writable keys are reserved.
             self.check_reserved_keys(transaction)?;
         }
 
-        if self.slot() > max_age.alt_invalidation_slot {
+        if self.slot() > alt_invalidation_slot {
             // The address table lookup **may** have expired, but the
             // expiration is not guaranteed since there may have been
             // skipped slot.

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -14,6 +14,7 @@ agave-unstable-api = []
 
 [dependencies]
 assert_matches = { workspace = true }
+solana-clock = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-transaction = { workspace = true }

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -107,6 +107,7 @@
 use {
     crate::utils::{ShortCounter, Token, TokenCell},
     assert_matches::assert_matches,
+    solana_clock::Slot,
     solana_pubkey::Pubkey,
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_transaction::sanitized::SanitizedTransaction,
@@ -452,6 +453,8 @@ const_assert_eq!(mem::size_of::<Task>(), 8);
 pub type BlockSize = usize;
 pub const NO_CONSUMED_BLOCK_SIZE: BlockSize = 0;
 
+pub const NO_LAST_RUNNABLE_SLOT: Slot = Slot::MAX;
+
 /// [`Token`] for [`UsageQueue`].
 type UsageQueueToken = Token<UsageQueueInner>;
 const_assert_eq!(mem::size_of::<UsageQueueToken>(), 0);
@@ -476,6 +479,7 @@ pub struct TaskInner {
     /// before running.
     blocked_usage_count: TokenCell<ShortCounter>,
     consumed_block_size: BlockSize,
+    last_runnable_slot: Slot,
 }
 
 impl TaskInner {
@@ -493,6 +497,14 @@ impl TaskInner {
 
     pub fn consumed_block_size(&self) -> BlockSize {
         self.consumed_block_size
+    }
+
+    pub fn last_runnable_slot(&self) -> Slot {
+        self.last_runnable_slot
+    }
+
+    pub fn is_runnable(&self, current_slot: Slot) -> bool {
+        current_slot <= self.last_runnable_slot
     }
 
     pub fn transaction(&self) -> &RuntimeTransaction<SanitizedTransaction> {
@@ -1254,6 +1266,7 @@ impl SchedulingStateMachine {
             transaction,
             task_id,
             NO_CONSUMED_BLOCK_SIZE,
+            NO_LAST_RUNNABLE_SLOT,
             usage_queue_loader,
         )
     }
@@ -1262,12 +1275,14 @@ impl SchedulingStateMachine {
         transaction: RuntimeTransaction<SanitizedTransaction>,
         task_id: OrderedTaskId,
         consumed_block_size: BlockSize,
+        last_runnable_slot: Slot,
         usage_queue_loader: &mut impl FnMut(Pubkey) -> UsageQueue,
     ) -> Task {
         Self::do_create_task(
             transaction,
             task_id,
             consumed_block_size,
+            last_runnable_slot,
             usage_queue_loader,
         )
     }
@@ -1276,6 +1291,7 @@ impl SchedulingStateMachine {
         transaction: RuntimeTransaction<SanitizedTransaction>,
         task_id: OrderedTaskId,
         consumed_block_size: BlockSize,
+        last_runnable_slot: Slot,
         usage_queue_loader: &mut impl FnMut(Pubkey) -> UsageQueue,
     ) -> Task {
         // It's crucial for tasks to be validated with
@@ -1332,6 +1348,7 @@ impl SchedulingStateMachine {
             lock_contexts,
             blocked_usage_count: TokenCell::new(ShortCounter::zero()),
             consumed_block_size,
+            last_runnable_slot,
         })
     }
 

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -1049,7 +1049,7 @@ impl TaskHandler for DefaultTaskHandler {
             }
             BlockProduction => {
                 if let Err(error) =
-                    bank.resanitize_transaction_if_needed(transaction, task.max_age())
+                    bank.resanitize_transaction_minimally(transaction, task.max_age())
                 {
                     *result = Err(error);
                     return;


### PR DESCRIPTION
#### Problem

bp unified scheduler code-path lacks any kinds of validation and expiration mechanism for incoming packets, which is untrusted by nature.

#### Summary of Changes

Introduce simplistic one, which just drops invalid packets/expired tasks.

This is similar to #7223, in impl sense and in the size of the patch, because both are just plumbing a tiny bit of information from the banking stage down to the unified scheduler main loop.