### PR TITLE
Remove usages of `to_account_shared_data`

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -7,7 +7,7 @@ use {
     dashmap::DashMap,
     rand::Rng,
     rayon::iter::{IntoParallelRefIterator, ParallelIterator},
-    solana_account::{Account, AccountSharedData, ReadableAccount},
+    solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::{
         account_info::{AccountInfo, StorageLocation},
         accounts::{AccountAddressFilter, Accounts},
@@ -80,11 +80,7 @@ where
         .take(num_keys)
         .collect();
     let accounts_data: Vec<_> = std::iter::repeat_n(
-        Account {
-            lamports: 1,
-            ..Default::default()
-        }
-        .to_account_shared_data(),
+        AccountSharedData::new(1, 0, &Pubkey::new_from_array([0u8; 32])),
         num_keys,
     )
     .collect();

--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -3,13 +3,13 @@ use {
     criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::{
-        account_info::create_account_shared_data,
         accounts_file::StorageAccess,
         append_vec::{self, AppendVec},
         tiered_storage::{
             file::TieredReadableFile,
             hot::{HotStorageReader, HotStorageWriter, RENT_EXEMPT_RENT_EPOCH},
         },
+        utils::create_account_shared_data,
     },
     solana_clock::Slot,
     solana_pubkey::Pubkey,

--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -3,6 +3,7 @@ use {
     criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::{
+        account_info::create_account_shared_data,
         accounts_file::StorageAccess,
         append_vec::{self, AppendVec},
         tiered_storage::{
@@ -258,7 +259,9 @@ fn bench_get_account_shared_data(c: &mut Criterion) {
             |b| {
                 b.iter_with_large_drop(|| {
                     _ = append_vec_mmap
-                        .get_stored_account_callback(0, |account| account.to_account_shared_data())
+                        .get_stored_account_callback(0, |account| {
+                            create_account_shared_data(&account)
+                        })
                         .unwrap();
                 });
             },
@@ -280,7 +283,9 @@ fn bench_get_account_shared_data(c: &mut Criterion) {
             |b| {
                 b.iter_with_large_drop(|| {
                     _ = append_vec_file
-                        .get_stored_account_callback(0, |account| account.to_account_shared_data())
+                        .get_stored_account_callback(0, |account| {
+                            create_account_shared_data(&account)
+                        })
                         .unwrap();
                 });
             },

--- a/accounts-db/src/account_info.rs
+++ b/accounts-db/src/account_info.rs
@@ -10,7 +10,18 @@ use {
         is_zero_lamport::IsZeroLamport,
     },
     modular_bitfield::prelude::*,
+    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
 };
+
+pub fn create_account_shared_data(account: &impl ReadableAccount) -> AccountSharedData {
+    AccountSharedData::create(
+        account.lamports(),
+        account.data().to_vec(),
+        *account.owner(),
+        account.executable(),
+        account.rent_epoch(),
+    )
+}
 
 /// offset within an append vec to account data
 pub type Offset = usize;

--- a/accounts-db/src/account_info.rs
+++ b/accounts-db/src/account_info.rs
@@ -10,18 +10,7 @@ use {
         is_zero_lamport::IsZeroLamport,
     },
     modular_bitfield::prelude::*,
-    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
 };
-
-pub fn create_account_shared_data(account: &impl ReadableAccount) -> AccountSharedData {
-    AccountSharedData::create(
-        account.lamports(),
-        account.data().to_vec(),
-        *account.owner(),
-        account.executable(),
-        account.rent_epoch(),
-    )
-}
 
 /// offset within an append vec to account data
 pub type Offset = usize;

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -30,7 +30,7 @@ pub use accounts_db_config::{
 use qualifier_attr::qualifiers;
 use {
     crate::{
-        account_info::{AccountInfo, Offset, StorageLocation},
+        account_info::{create_account_shared_data, AccountInfo, Offset, StorageLocation},
         account_storage::{
             stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
             AccountStorage, AccountStoragesOrderer, ShrinkInProgress,
@@ -733,7 +733,7 @@ impl LoadedAccount<'_> {
 
     pub fn take_account(&self) -> AccountSharedData {
         match self {
-            LoadedAccount::Stored(stored_account) => stored_account.to_account_shared_data(),
+            LoadedAccount::Stored(stored_account) => create_account_shared_data(stored_account),
             LoadedAccount::Cached(cached_account) => match cached_account {
                 Cow::Owned(cached_account) => cached_account.account.clone(),
                 Cow::Borrowed(cached_account) => cached_account.account.clone(),
@@ -5976,7 +5976,7 @@ impl AccountsDb {
             .map(|index| {
                 let txn = txs.map(|txs| *txs.get(index).expect("txs must be present if provided"));
                 accounts_and_meta_to_store.account_default_if_zero_lamport(index, |account| {
-                    let account_shared_data = account.to_account_shared_data();
+                    let account_shared_data = account.take_account();
                     let pubkey = account.pubkey();
                     let account_info =
                         AccountInfo::new(StorageLocation::Cached, account.is_zero_lamport());

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -30,7 +30,7 @@ pub use accounts_db_config::{
 use qualifier_attr::qualifiers;
 use {
     crate::{
-        account_info::{create_account_shared_data, AccountInfo, Offset, StorageLocation},
+        account_info::{AccountInfo, Offset, StorageLocation},
         account_storage::{
             stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
             AccountStorage, AccountStoragesOrderer, ShrinkInProgress,
@@ -59,7 +59,8 @@ use {
         partitioned_rewards::PartitionedEpochRewardsConfig,
         read_only_accounts_cache::ReadOnlyAccountsCache,
         storable_accounts::{StorableAccounts, StorableAccountsBySlot},
-        u64_align, utils,
+        u64_align,
+        utils::{self, create_account_shared_data},
     },
     dashmap::{DashMap, DashSet},
     log::*,

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -29,11 +29,11 @@ pub mod tests {
     use {
         super::*,
         crate::{
-            account_info::create_account_shared_data,
             accounts_db::{AccountsDbConfig, MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING},
             accounts_update_notifier_interface::{
                 AccountForGeyser, AccountsUpdateNotifier, AccountsUpdateNotifierInterface,
             },
+            utils::create_account_shared_data,
         },
         dashmap::DashMap,
         solana_account::ReadableAccount as _,

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -29,6 +29,7 @@ pub mod tests {
     use {
         super::*,
         crate::{
+            account_info::create_account_shared_data,
             accounts_db::{AccountsDbConfig, MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING},
             accounts_update_notifier_interface::{
                 AccountForGeyser, AccountsUpdateNotifier, AccountsUpdateNotifierInterface,
@@ -87,7 +88,7 @@ pub mod tests {
             self.accounts_notified
                 .entry(*account.pubkey)
                 .or_default()
-                .push((slot, write_version, account.to_account_shared_data()));
+                .push((slot, write_version, create_account_shared_data(account)));
         }
 
         fn notify_end_of_restore_from_snapshot(&self) {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -2075,7 +2075,7 @@ fn test_hash_stored_account() {
         executable,
         rent_epoch,
     };
-    let account = stored_account.to_account_shared_data();
+    let account = create_account_shared_data(&stored_account);
 
     let expected_account_hash = LtHashChecksum([
         160, 29, 105, 138, 56, 166, 40, 55, 224, 231, 29, 208, 68, 46, 190, 89, 141, 20, 65, 86,
@@ -6097,7 +6097,7 @@ fn get_all_accounts_from_storages<'a>(
             storage
                 .accounts
                 .scan_accounts(&mut reader, |_offset, account| {
-                    vec.push((*account.pubkey(), account.to_account_shared_data()));
+                    vec.push((*account.pubkey(), create_account_shared_data(&account)));
                 })
                 .expect("must scan accounts storage");
             // make sure scan_pubkeys results match

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1111,7 +1111,7 @@ pub mod tests {
     use {
         super::*,
         crate::{
-            account_info::{create_account_shared_data, AccountInfo, StorageLocation},
+            account_info::{AccountInfo, StorageLocation},
             accounts_db::{
                 tests::{
                     append_single_account_with_default_hash, compare_all_accounts,
@@ -1127,6 +1127,7 @@ pub mod tests {
             },
             append_vec::{self, aligned_stored_size},
             storable_accounts::StorableAccountsBySlot,
+            utils::create_account_shared_data,
         },
         rand::seq::SliceRandom as _,
         solana_account::{AccountSharedData, ReadableAccount, WritableAccount},

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1111,7 +1111,7 @@ pub mod tests {
     use {
         super::*,
         crate::{
-            account_info::{AccountInfo, StorageLocation},
+            account_info::{create_account_shared_data, AccountInfo, StorageLocation},
             accounts_db::{
                 tests::{
                     append_single_account_with_default_hash, compare_all_accounts,
@@ -2049,7 +2049,7 @@ pub mod tests {
             assert_eq!(
                 one_ref_accounts_account_shared_data
                     .iter()
-                    .map(|meta| meta.to_account_shared_data())
+                    .map(create_account_shared_data)
                     .collect::<Vec<_>>(),
                 vec![account_with_1_ref]
             );
@@ -2128,7 +2128,7 @@ pub mod tests {
                 .accounts
                 .get_stored_account_callback(0, |account| {
                     assert_eq!(account.pubkey(), pk_with_2_refs);
-                    account.to_account_shared_data()
+                    create_account_shared_data(&account)
                 })
                 .unwrap();
             assert_eq!(account, account_shared_data_with_2_refs);
@@ -2242,7 +2242,7 @@ pub mod tests {
             assert_eq!(
                 one_ref_accounts_account_shared_data
                     .iter()
-                    .map(|meta| meta.to_account_shared_data())
+                    .map(create_account_shared_data)
                     .collect::<Vec<_>>(),
                 vec![account_with_1_ref]
             );
@@ -2276,7 +2276,7 @@ pub mod tests {
             let accounts_shrunk_same_slot = storage
                 .accounts
                 .get_stored_account_callback(0, |account| {
-                    (*account.pubkey(), account.to_account_shared_data())
+                    (*account.pubkey(), create_account_shared_data(&account))
                 })
                 .unwrap();
             let mut reader = append_vec::new_scan_accounts_reader();
@@ -3230,7 +3230,7 @@ pub mod tests {
                                 .new_storage()
                                 .accounts
                                 .scan_accounts(&mut reader, |_offset, meta| {
-                                    two.push((*meta.pubkey(), meta.to_account_shared_data()));
+                                    two.push((*meta.pubkey(), create_account_shared_data(&meta)));
                                 })
                                 .expect("must scan accounts storage");
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -13,7 +13,7 @@ pub use meta::{AccountMeta, StoredAccountMeta, StoredMeta};
 use meta::{AccountMeta, StoredAccountMeta, StoredMeta};
 use {
     crate::{
-        account_info::Offset,
+        account_info::{create_account_shared_data, Offset},
         account_storage::stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
         accounts_file::{InternalsForArchive, StorageAccess, StoredAccountsInfo},
         buffered_reader::{
@@ -839,7 +839,7 @@ impl AppendVec {
         match &self.backing {
             AppendVecFileBacking::Mmap(_) => self
                 .get_stored_account_meta_callback(offset, |account| {
-                    account.to_account_shared_data()
+                    create_account_shared_data(&account)
                 }),
             AppendVecFileBacking::File(file) => {
                 let mut buf = MaybeUninit::<[u8; PAGE_SIZE]>::uninit();
@@ -867,7 +867,7 @@ impl AppendVec {
                         stored_size,
                     };
                     // data is within `buf`, so just allocate a new vec for data
-                    account.to_account_shared_data()
+                    create_account_shared_data(&account)
                 } else {
                     // not enough was read from file to get `data`
                     assert!(data_len <= MAX_PERMITTED_DATA_LENGTH, "{data_len}");
@@ -915,7 +915,7 @@ impl AppendVec {
             ));
             assert_eq!(sizes, r_callback.stored_size());
             let pubkey = r_callback.meta().pubkey;
-            Some((pubkey, r_callback.to_account_shared_data()))
+            Some((pubkey, create_account_shared_data(&r_callback)))
         });
         if result.is_none() {
             assert!(self
@@ -1657,7 +1657,7 @@ pub mod tests {
             let mut index = 0;
             av.scan_accounts_stored_meta(&mut reader, |v| {
                 let (pubkey, account) = &test_accounts[index];
-                let recovered = v.to_account_shared_data();
+                let recovered = create_account_shared_data(&v);
                 assert_eq!(&recovered, account);
                 assert_eq!(v.pubkey(), pubkey);
                 index += 1;
@@ -1709,7 +1709,7 @@ pub mod tests {
         let now = Instant::now();
         av.scan_accounts_stored_meta(&mut reader, |v| {
             let account = create_test_account(sample + 1);
-            let recovered = v.to_account_shared_data();
+            let recovered = create_account_shared_data(&v);
             assert_eq!(recovered, account.1);
             sample += 1;
         })

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -13,7 +13,7 @@ pub use meta::{AccountMeta, StoredAccountMeta, StoredMeta};
 use meta::{AccountMeta, StoredAccountMeta, StoredMeta};
 use {
     crate::{
-        account_info::{create_account_shared_data, Offset},
+        account_info::Offset,
         account_storage::stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
         accounts_file::{InternalsForArchive, StorageAccess, StoredAccountsInfo},
         buffered_reader::{
@@ -24,6 +24,7 @@ use {
         is_zero_lamport::IsZeroLamport,
         storable_accounts::StorableAccounts,
         u64_align,
+        utils::create_account_shared_data,
     },
     log::*,
     memmap2::MmapMut,

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -1,6 +1,7 @@
 //! trait for abstracting underlying storage of pubkey and account pairs to be written
 use {
     crate::{
+        account_info::create_account_shared_data,
         account_storage::stored_account_info::StoredAccountInfo,
         accounts_db::{AccountFromStorage, AccountStorageEntry, AccountsDb},
         is_zero_lamport::IsZeroLamport,
@@ -46,6 +47,15 @@ impl<'a> AccountForStorage<'a> {
             AccountForStorage::StoredAccountInfo(account) => account.pubkey(),
         }
     }
+
+    pub fn take_account(&self) -> AccountSharedData {
+        match self {
+            AccountForStorage::AddressAndAccount((_pubkey, account)) => {
+                create_account_shared_data(&**account)
+            }
+            AccountForStorage::StoredAccountInfo(account) => create_account_shared_data(&**account),
+        }
+    }
 }
 
 impl ReadableAccount for AccountForStorage<'_> {
@@ -80,12 +90,7 @@ impl ReadableAccount for AccountForStorage<'_> {
         }
     }
     fn to_account_shared_data(&self) -> AccountSharedData {
-        match self {
-            AccountForStorage::AddressAndAccount((_pubkey, account)) => {
-                account.to_account_shared_data()
-            }
-            AccountForStorage::StoredAccountInfo(account) => account.to_account_shared_data(),
-        }
+        self.take_account()
     }
 }
 

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -50,10 +50,8 @@ impl<'a> AccountForStorage<'a> {
 
     pub fn take_account(&self) -> AccountSharedData {
         match self {
-            AccountForStorage::AddressAndAccount((_pubkey, account)) => {
-                create_account_shared_data(&**account)
-            }
-            AccountForStorage::StoredAccountInfo(account) => create_account_shared_data(&**account),
+            AccountForStorage::AddressAndAccount((_pubkey, account)) => (*account).clone(),
+            AccountForStorage::StoredAccountInfo(account) => create_account_shared_data(*account),
         }
     }
 }

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -1,10 +1,10 @@
 //! trait for abstracting underlying storage of pubkey and account pairs to be written
 use {
     crate::{
-        account_info::create_account_shared_data,
         account_storage::stored_account_info::StoredAccountInfo,
         accounts_db::{AccountFromStorage, AccountStorageEntry, AccountsDb},
         is_zero_lamport::IsZeroLamport,
+        utils::create_account_shared_data,
     },
     solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::{Epoch, Slot},

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -178,7 +178,7 @@ mod tests {
         file::TieredStorageMagicNumber,
         footer::TieredStorageFooter,
         hot::HOT_FORMAT,
-        solana_account::{AccountSharedData, ReadableAccount},
+        solana_account::AccountSharedData,
         solana_clock::Slot,
         solana_pubkey::Pubkey,
         solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
@@ -371,7 +371,7 @@ mod tests {
         let mut expected_accounts_map = HashMap::new();
         for i in 0..num_accounts {
             storable_accounts.account_default_if_zero_lamport(i, |account| {
-                expected_accounts_map.insert(*account.pubkey(), account.to_account_shared_data());
+                expected_accounts_map.insert(*account.pubkey(), account.take_account());
             });
         }
 

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -1489,7 +1489,7 @@ mod tests {
                     storable_accounts.account_default_if_zero_lamport(i, |account| {
                         verify_test_account(
                             &stored_account,
-                            &account.to_account_shared_data(),
+                            &account.take_account(),
                             account.pubkey(),
                         );
                     });
@@ -1512,7 +1512,7 @@ mod tests {
                     storable_accounts.account_default_if_zero_lamport(offset, |account| {
                         verify_test_account(
                             &stored_account,
-                            &account.to_account_shared_data(),
+                            &account.take_account(),
                             account.pubkey(),
                         );
                     });
@@ -1526,11 +1526,7 @@ mod tests {
         hot_storage
             .scan_accounts(|_offset, stored_account| {
                 storable_accounts.account_default_if_zero_lamport(i, |account| {
-                    verify_test_account(
-                        &stored_account,
-                        &account.to_account_shared_data(),
-                        account.pubkey(),
-                    );
+                    verify_test_account(&stored_account, &account.take_account(), account.pubkey());
                 });
                 i += 1;
             })

--- a/accounts-db/src/utils.rs
+++ b/accounts-db/src/utils.rs
@@ -2,6 +2,7 @@
 use {crate::io_uring::dir_remover::RingDirRemover, agave_io_uring::io_uring_supported};
 use {
     log::*,
+    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_measure::measure_time,
     std::{
         collections::HashSet,
@@ -212,6 +213,18 @@ pub fn create_and_canonicalize_directories(
 pub fn create_and_canonicalize_directory(directory: impl AsRef<Path>) -> io::Result<PathBuf> {
     fs::create_dir_all(&directory)?;
     fs::canonicalize(directory)
+}
+
+/// Creates a new AccountSharedData structure for anything that implements ReadableAccount.
+/// This function implies data copies.
+pub fn create_account_shared_data(account: &impl ReadableAccount) -> AccountSharedData {
+    AccountSharedData::create(
+        account.lamports(),
+        account.data().to_vec(),
+        *account.owner(),
+        account.executable(),
+        account.rent_epoch(),
+    )
 }
 
 #[cfg(test)]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -74,6 +74,7 @@ use {
         AccountSharedData, InheritableAccountFields, ReadableAccount, WritableAccount,
     },
     solana_accounts_db::{
+        account_info::create_account_shared_data,
         account_locks::validate_account_locks,
         accounts::{AccountAddressFilter, Accounts, PubkeyAccountSlot},
         accounts_db::{AccountStorageEntry, AccountsDb, AccountsDbConfig},
@@ -2566,7 +2567,8 @@ impl Bank {
                 self.get_account(pubkey).is_none(),
                 "{pubkey} repeated in genesis config"
             );
-            self.store_account(pubkey, &account.to_account_shared_data());
+            let account_shared_data = create_account_shared_data(account);
+            self.store_account(pubkey, &account_shared_data);
             self.capitalization.fetch_add(account.lamports(), Relaxed);
             self.accounts_data_size_initial += account.data().len() as u64;
         }
@@ -2576,7 +2578,8 @@ impl Bank {
                 self.get_account(pubkey).is_none(),
                 "{pubkey} repeated in genesis config"
             );
-            self.store_account(pubkey, &account.to_account_shared_data());
+            let account_shared_data = create_account_shared_data(account);
+            self.store_account(pubkey, &account_shared_data);
             self.accounts_data_size_initial += account.data().len() as u64;
         }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -74,7 +74,6 @@ use {
         AccountSharedData, InheritableAccountFields, ReadableAccount, WritableAccount,
     },
     solana_accounts_db::{
-        account_info::create_account_shared_data,
         account_locks::validate_account_locks,
         accounts::{AccountAddressFilter, Accounts, PubkeyAccountSlot},
         accounts_db::{AccountStorageEntry, AccountsDb, AccountsDbConfig},
@@ -84,6 +83,7 @@ use {
         ancestors::{Ancestors, AncestorsForSerialization},
         blockhash_queue::BlockhashQueue,
         storable_accounts::StorableAccounts,
+        utils::create_account_shared_data,
     },
     solana_builtins::{BUILTINS, STATELESS_BUILTINS},
     solana_clock::{

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -10,7 +10,7 @@ use {
     rayon::{prelude::*, ThreadPool},
     serde::{Deserialize, Serialize},
     solana_account::{AccountSharedData, ReadableAccount},
-    solana_accounts_db::account_info::create_account_shared_data,
+    solana_accounts_db::utils::create_account_shared_data,
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
     solana_stake_interface::state::{Delegation, StakeActivationStatus},

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -10,6 +10,7 @@ use {
     rayon::{prelude::*, ThreadPool},
     serde::{Deserialize, Serialize},
     solana_account::{AccountSharedData, ReadableAccount},
+    solana_accounts_db::account_info::create_account_shared_data,
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
     solana_stake_interface::state::{Delegation, StakeActivationStatus},
@@ -93,7 +94,7 @@ impl StakesCache {
         debug_assert_ne!(account.lamports(), 0u64);
         if solana_vote_program::check_id(owner) {
             if VoteStateVersions::is_correct_size_and_initialized(account.data()) {
-                match VoteAccount::try_from(account.to_account_shared_data()) {
+                match VoteAccount::try_from(create_account_shared_data(account)) {
                     Ok(vote_account) => {
                         // drop the old account after releasing the lock
                         let _old_vote_account = {
@@ -121,7 +122,7 @@ impl StakesCache {
                 };
             };
         } else if solana_stake_program::check_id(owner) {
-            match StakeAccount::try_from(account.to_account_shared_data()) {
+            match StakeAccount::try_from(create_account_shared_data(account)) {
                 Ok(stake_account) => {
                     let mut stakes = self.0.write().unwrap();
                     stakes.upsert_stake_delegation(


### PR DESCRIPTION
#### Problem

The `ReadableAccount` trait is coupled to `AccountSharedData` in that one of its methods imply one can transform the underlying data structure into AccountSharedData. Program-runtime wants to adopt a program friendly account structure that implements ReadableAccount, but does not allow the conversion, so removing `to_account_shared_data` from the trait is an understandable path forward.

According to the discussion in https://github.com/anza-xyz/solana-sdk/pull/386, I'll first remove usages from the monorepo, then mark the function as deprecated in the SDK and bump the monorepo dependency, and lastly completely remove it from the SDK.

#### Summary of Changes

Remove all usages of `to_account_shared_data` from the monorepo and replace it by `create_account_shared_data`, which belongs in `accounts-db`.

