### PR TITLE
svm-test-harness: refactor for entrypoint composability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10831,7 +10831,6 @@ dependencies = [
  "solana-clock",
  "solana-compute-budget",
  "solana-epoch-schedule",
- "solana-hash",
  "solana-instruction",
  "solana-instruction-error",
  "solana-last-restart-slot",

--- a/svm-test-harness/Cargo.toml
+++ b/svm-test-harness/Cargo.toml
@@ -33,7 +33,6 @@ solana-builtins = { workspace = true }
 solana-clock = { workspace = true, features = ["sysvar"] }
 solana-compute-budget = { workspace = true }
 solana-epoch-schedule = { workspace = true, features = ["sysvar"] }
-solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true, features = ["serde"] }
 solana-last-restart-slot = { workspace = true, features = ["sysvar"] }

--- a/svm-test-harness/src/instr.rs
+++ b/svm-test-harness/src/instr.rs
@@ -67,7 +67,7 @@ impl TransactionProcessingCallback for InstrContextCallback<'_> {
     }
 }
 
-fn create_invoke_context_fields(
+fn create_program_cache(
     input: &mut InstrContext,
     clock: &Clock,
     compute_budget: &ComputeBudget,
@@ -199,7 +199,7 @@ pub fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
     let rent = sysvar_cache.get_rent().unwrap();
 
     let (environments, mut program_cache) =
-        create_invoke_context_fields(&mut input, &clock, &compute_budget)?;
+        create_program_cache(&mut input, &clock, &compute_budget)?;
 
     let mut transaction_context =
         create_transaction_context(&input.accounts, &compute_budget, (*rent).clone());


### PR DESCRIPTION
Just some refactoring of the test harness to break a few things up. After this, I'll follow up with making some of these things inputs to the lib harness (not the protobuf-based harness) so we can provision custom test environment configs like compute budget and loaded program ELFs.