### PR TITLE
feat(svm): support `drop_on_failure` and `all_or_nothing` processing

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3092,6 +3092,8 @@ impl Bank {
                     enable_return_data_recording: true,
                     enable_transaction_balance_recording: true,
                 },
+                drop_on_failure: false,
+                all_or_nothing: false,
             },
         );
 
@@ -3826,6 +3828,8 @@ impl Bank {
                 log_messages_bytes_limit,
                 limit_to_load_programs: false,
                 recording_config,
+                drop_on_failure: false,
+                all_or_nothing: false,
             },
         );
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -9,7 +9,6 @@ use {
         },
         rollback_accounts::RollbackAccounts,
         transaction_error_metrics::TransactionErrorMetrics,
-        transaction_execution_result::ExecutedTransaction,
     },
     ahash::{AHashMap, AHashSet},
     solana_account::{
@@ -276,23 +275,6 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
         }
     }
 
-    pub(crate) fn update_accounts_for_executed_tx(
-        &mut self,
-        message: &impl SVMMessage,
-        executed_transaction: &ExecutedTransaction,
-    ) {
-        if executed_transaction.was_successful() {
-            self.update_accounts_for_successful_tx(
-                message,
-                &executed_transaction.loaded_transaction.accounts,
-            );
-        } else {
-            self.update_accounts_for_failed_tx(
-                &executed_transaction.loaded_transaction.rollback_accounts,
-            );
-        }
-    }
-
     pub(crate) fn update_accounts_for_failed_tx(&mut self, rollback_accounts: &RollbackAccounts) {
         for (account_address, account) in rollback_accounts {
             self.loaded_accounts
@@ -300,7 +282,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
         }
     }
 
-    fn update_accounts_for_successful_tx(
+    pub(crate) fn update_accounts_for_successful_tx(
         &mut self,
         message: &impl SVMMessage,
         transaction_accounts: &[KeyedAccountSharedData],


### PR DESCRIPTION
#### Problem

- Supporting Jito bundles requires drop on failure + all or nothing for a given bundle (maps into 1 batch in our model).
- Supporting Paladin P3 TXs requires drop on failure.

#### Summary of Changes

- Add the two flags to `TransactionProcessingConfig`.
- Fail processing with `TransactionError::CommitCancelled` when execution would violate the flags.