### PR TITLE
slow partition tests

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2692,6 +2692,7 @@ fn run_test_load_program_accounts_partition(scan_commitment: CommitmentConfig) {
         on_partition_before_resolved,
         on_partition_resolved,
         None,
+        false,
         additional_accounts,
     );
 }
@@ -3842,6 +3843,7 @@ fn test_kill_heaviest_partition() {
         empty,
         on_partition_resolved,
         None,
+        true,
         vec![],
     )
 }
@@ -4423,6 +4425,7 @@ fn test_cluster_partition_1_1() {
         empty,
         on_partition_resolved,
         None,
+        false,
         vec![],
     )
 }
@@ -4442,6 +4445,7 @@ fn test_cluster_partition_1_1_1() {
         empty,
         on_partition_resolved,
         None,
+        false,
         vec![],
     )
 }


### PR DESCRIPTION
#### Problem
A few tests rely on `fn run_cluster_partition` to carry out the work of spinning up cluster, partitioning, and measuring things. However, we waste a bunch of time in this routine waiting for `spend_and_verify_all_nodes` to return success as an indicator that all nodes are caught up. This often takes a really long time because we see initial forking in the testing leading to 8 deep (256 slot) lockouts that take a couple minutes to resolve.

Example here: https://buildkite.com/anza/agave/builds/32748#019a157c-e488-4be4-90ab-85b4ec9f0820/88-1913

#### Summary of Changes

- Only allow bootstrap node to build blocks initially for some tests so there is effectively no partitioning during bootstrap. This is because nodes cannot build until they vote, and they cannot vote until they observe a block, so they will inherently be in sync with the bootstrap node.
- Set `wait_for_supermajority` to `None` when `no_wait_for_vote_to_start_leader` is `false`. This is because `wait_for_supermajority` will override `no_wait_for_vote_to_start_leader`, but `no_wait_for_vote_to_start_leader` provides stronger sync (less forking)