### PR TITLE
Fix - Environments filtering in `ProgramCache::extract()`

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -2679,7 +2679,7 @@ mod tests {
         let mut missing = get_entries_to_load(&cache, 22, &[program1]);
         let mut extracted = ProgramCacheForTxBatch::new(22);
         cache.extract(&mut missing, &mut extracted, &other_envs, true, true);
-        assert!(match_slot(&extracted, &program1, 10, 22));
+        assert!(match_missing(&missing, &program1, true));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Situations where an entry of a different environment is present but of the same environment is missing should be used as a hint to reload the program.

#### Summary of Changes

Once we encounter an almost matching entry which only has the wrong environment we narrow the search down to entries within the same deployment slot. If none is found we reload instead.