### PR TITLE
Fix - Reconfigure `ProgramRuntimeEnvironments` on epoch boundaries

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -546,8 +546,8 @@ impl Default for ProgramRuntimeEnvironments {
 /// Globally manages the transition between environments at the epoch boundary
 #[derive(Debug, Default)]
 pub struct EpochBoundaryPreparation {
-    /// The epoch of the last rerooting
-    pub latest_root_epoch: Epoch,
+    /// The epoch of the upcoming_environments
+    pub upcoming_epoch: Epoch,
     /// Anticipated replacement for `environments` at the next epoch
     ///
     /// This is `None` during most of an epoch, and only `Some` around the boundaries (at the end and beginning of an epoch).
@@ -559,9 +559,9 @@ pub struct EpochBoundaryPreparation {
 }
 
 impl EpochBoundaryPreparation {
-    pub fn new(root_epoch: Epoch) -> Self {
+    pub fn new(epoch: Epoch) -> Self {
         Self {
-            latest_root_epoch: root_epoch,
+            upcoming_epoch: epoch,
             upcoming_environments: None,
             programs_to_recompile: Vec::default(),
         }
@@ -572,16 +572,15 @@ impl EpochBoundaryPreparation {
         &self,
         epoch: Epoch,
     ) -> Option<ProgramRuntimeEnvironments> {
-        if epoch != self.latest_root_epoch {
+        if epoch == self.upcoming_epoch {
             return self.upcoming_environments.clone();
         }
         None
     }
 
     /// Before rerooting the blockstore this concludes the epoch boundary preparation
-    pub fn reroot(&mut self, new_root_epoch: Epoch) -> Option<ProgramRuntimeEnvironments> {
-        if self.latest_root_epoch != new_root_epoch {
-            self.latest_root_epoch = new_root_epoch;
+    pub fn reroot(&mut self, epoch: Epoch) -> Option<ProgramRuntimeEnvironments> {
+        if epoch == self.upcoming_epoch {
             if let Some(upcoming_environments) = self.upcoming_environments.take() {
                 self.programs_to_recompile.clear();
                 return Some(upcoming_environments);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1542,9 +1542,7 @@ impl Bank {
                     program_cache.assign_program(&upcoming_environments, key, recompiled);
                 }
             }
-        } else if self.epoch != epoch_boundary_preparation.latest_root_epoch
-            || slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch
-        {
+        } else if slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch {
             // Anticipate the upcoming program runtime environment for the next epoch,
             // so we can try to recompile loaded programs before the feature transition hits.
             let new_environments = self.create_program_runtime_environments(&upcoming_feature_set);
@@ -1559,6 +1557,7 @@ impl Bank {
             if changed_program_runtime_v2 {
                 upcoming_environments.program_runtime_v2 = new_environments.program_runtime_v2;
             }
+            epoch_boundary_preparation.upcoming_epoch = self.epoch.saturating_add(1);
             epoch_boundary_preparation.upcoming_environments = Some(upcoming_environments);
             epoch_boundary_preparation.programs_to_recompile = program_cache
                 .get_flattened_entries(changed_program_runtime_v1, changed_program_runtime_v2);
@@ -4129,7 +4128,7 @@ impl Bank {
             .epoch_boundary_preparation
             .write()
             .unwrap()
-            .latest_root_epoch = self.epoch;
+            .upcoming_epoch = self.epoch;
         self.transaction_processor.environments = environments;
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4123,10 +4123,17 @@ impl Bank {
         let (program_runtime_environment_v1, program_runtime_environment_v2) =
             self.create_program_runtime_environments(&self.feature_set);
         self.transaction_processor
-            .configure_program_runtime_environments(
-                program_runtime_environment_v1,
-                program_runtime_environment_v2,
-            );
+            .global_program_cache
+            .write()
+            .unwrap()
+            .latest_root_slot = self.slot;
+        self.transaction_processor
+            .epoch_boundary_preparation
+            .write()
+            .unwrap()
+            .latest_root_epoch = self.epoch;
+        self.transaction_processor.environments.program_runtime_v1 = program_runtime_environment_v1;
+        self.transaction_processor.environments.program_runtime_v2 = program_runtime_environment_v2;
     }
 
     fn create_program_runtime_environments(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1653,6 +1653,10 @@ impl Bank {
             },
             rewards_metrics,
         );
+
+        let new_environments = self.create_program_runtime_environments(&self.feature_set);
+        self.transaction_processor
+            .set_environments(new_environments);
     }
 
     pub fn byte_limit_for_scans(&self) -> Option<usize> {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11046,9 +11046,13 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
 
+    // Advance the bank to the end of the epoch to update the epoch_boundary_preparation.
+    goto_end_of_slot(bank.clone());
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 31);
+
     // Advance the bank to cross the epoch boundary and activate the feature.
     goto_end_of_slot(bank.clone());
-    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 32);
 
     // Load the program with the new environment.
     let transaction = Transaction::new(&signers, message.clone(), bank.last_blockhash());

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -805,11 +805,12 @@ mod tests {
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         let upcoming_environments = ProgramRuntimeEnvironments::default();
         let current_environments = batch_processor.environments.clone();
-        batch_processor
-            .epoch_boundary_preparation
-            .write()
-            .unwrap()
-            .upcoming_environments = Some(upcoming_environments.clone());
+        {
+            let mut epoch_boundary_preparation =
+                batch_processor.epoch_boundary_preparation.write().unwrap();
+            epoch_boundary_preparation.upcoming_epoch = 1;
+            epoch_boundary_preparation.upcoming_environments = Some(upcoming_environments.clone());
+        }
         mock_bank
             .account_shared_data
             .borrow_mut()

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -744,7 +744,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             })
             .collect();
 
-        let program_runtime_environments = self.get_environments_for_epoch(self.epoch);
         let mut count_hits_and_misses = true;
         loop {
             let (program_to_store, task_cookie, task_waiter) = {
@@ -784,7 +783,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 let mut global_program_cache = self.global_program_cache.write().unwrap();
                 // Submit our last completed loading task.
                 if global_program_cache.finish_cooperative_loading_task(
-                    &program_runtime_environments,
+                    program_runtime_environments_for_execution,
                     self.slot,
                     key,
                     program,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -379,15 +379,13 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .then(|| BalanceCollector::new_with_transaction_count(sanitized_txs.len()));
 
         // Create the batch-local program cache.
-        let program_runtime_environments_for_execution =
-            self.get_environments_for_epoch(self.epoch);
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(self.slot);
         let builtins = self.builtin_program_ids.read().unwrap().clone();
         let ((), program_cache_us) = measure_us!({
             self.replenish_program_cache(
                 &account_loader,
                 &builtins,
-                &program_runtime_environments_for_execution,
+                &environment.program_runtime_environments_for_execution,
                 &mut program_cache_for_tx_batch,
                 &mut execute_timings,
                 config.check_program_modification_slot,
@@ -470,7 +468,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         self.replenish_program_cache(
                             &account_loader,
                             &program_accounts_set,
-                            &program_runtime_environments_for_execution,
+                            &environment.program_runtime_environments_for_execution,
                             &mut program_cache_for_tx_batch,
                             &mut execute_timings,
                             config.check_program_modification_slot,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -261,7 +261,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .epoch_boundary_preparation
             .write()
             .unwrap()
-            .latest_root_epoch = processor.epoch;
+            .upcoming_epoch = processor.epoch;
         processor.environments.program_runtime_v1 =
             program_runtime_environment_v1.unwrap_or(empty_loader());
         processor.environments.program_runtime_v2 =

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -310,11 +310,21 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .unwrap()
             .upcoming_environments
         {
-            if self.environments.program_runtime_v1 == upcoming_environments.program_runtime_v1 {
+            if self.environments.program_runtime_v1 == upcoming_environments.program_runtime_v1
+                && !Arc::ptr_eq(
+                    &self.environments.program_runtime_v1,
+                    &upcoming_environments.program_runtime_v1,
+                )
+            {
                 self.environments.program_runtime_v1 =
                     upcoming_environments.program_runtime_v1.clone();
             }
-            if self.environments.program_runtime_v2 == upcoming_environments.program_runtime_v2 {
+            if self.environments.program_runtime_v2 == upcoming_environments.program_runtime_v2
+                && !Arc::ptr_eq(
+                    &self.environments.program_runtime_v2,
+                    &upcoming_environments.program_runtime_v2,
+                )
+            {
                 self.environments.program_runtime_v2 =
                     upcoming_environments.program_runtime_v2.clone();
             }

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -263,7 +263,12 @@ fn svm_concurrent() {
                     &*local_bank,
                     &th_txs,
                     check_results,
-                    &TransactionProcessingEnvironment::default(),
+                    &TransactionProcessingEnvironment {
+                        program_runtime_environments_for_execution: local_batch
+                            .environments
+                            .clone(),
+                        ..TransactionProcessingEnvironment::default()
+                    },
                     &processing_config,
                 );
 


### PR DESCRIPTION
#### Problem

Since #8471 we are not updating the `ProgramRuntimeEnvironments` anymore.

#### Summary of Changes

- Dissolves `TransactionBatchProcessor::configure_program_runtime_environments()`.
- Combines return values of `Bank::create_program_runtime_environments()`.
- Uses `program_runtime_environments_for_execution` parameter instead of `get_environments_for_epoch()` in `TransactionBatchProcessor::replenish_program_cache()`.
- Turns `EpochBoundaryPreparation::latest_root_epoch` into `EpochBoundaryPreparation::upcoming_epoch`.
- Reconfigures `ProgramRuntimeEnvironments` in `Bank::process_new_epoch()`:
  - First checks if the current environment changed and update it if so.
  - Then checks if the upcoming environment matches and uses that instead if possible.