### PR TITLE
Remove get_stored_account_meta_callback

### DIFF
--- a/accounts-db/benches/append_vec.rs
+++ b/accounts-db/benches/append_vec.rs
@@ -78,7 +78,7 @@ fn append_vec_sequential_read(bencher: &mut Bencher, storage_access: StorageAcce
     bencher.iter(|| {
         let (sample, pos) = indexes.pop().unwrap();
         println!("reading pos {sample} {pos}");
-        vec.get_stored_account_meta_callback(pos, |account| {
+        vec.get_stored_account_callback(pos, |account| {
             let (_pubkey, test) = create_test_account(sample);
             assert_eq!(account.data(), test.data());
             indexes.push((sample, pos));
@@ -104,7 +104,7 @@ fn append_vec_random_read(bencher: &mut Bencher, storage_access: StorageAccess) 
     bencher.iter(|| {
         let random_index: usize = thread_rng().gen_range(0..indexes.len());
         let (sample, pos) = &indexes[random_index];
-        vec.get_stored_account_meta_callback(*pos, |account| {
+        vec.get_stored_account_callback(*pos, |account| {
             let (_pubkey, test) = create_test_account(*sample);
             assert_eq!(account.data(), test.data());
         });
@@ -148,7 +148,7 @@ fn append_vec_concurrent_append_read(bencher: &mut Bencher, storage_access: Stor
         let len = indexes.lock().unwrap().len();
         let random_index: usize = thread_rng().gen_range(0..len);
         let (sample, pos) = *indexes.lock().unwrap().get(random_index).unwrap();
-        vec.get_stored_account_meta_callback(pos, |account| {
+        vec.get_stored_account_callback(pos, |account| {
             let (_pubkey, test) = create_test_account(sample);
             assert_eq!(account.data(), test.data());
         });
@@ -187,7 +187,7 @@ fn append_vec_concurrent_read_append(bencher: &mut Bencher, storage_access: Stor
             .unwrap()
             .get(random_index.checked_rem(len).unwrap())
             .unwrap();
-        vec1.get_stored_account_meta_callback(pos, |account| {
+        vec1.get_stored_account_callback(pos, |account| {
             let (_pubkey, test) = create_test_account(sample);
             assert_eq!(account.data(), test.data());
         });

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -207,24 +207,6 @@ impl AccountsFile {
         }
     }
 
-    /// calls `callback` with the account located at the specified index offset.
-    ///
-    /// Prefer get_stored_account_callback() when possible, as it does not contain file format
-    /// implementation details, and thus potentially can read less and be faster.
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn get_stored_account_meta_callback<Ret>(
-        &self,
-        offset: usize,
-        callback: impl for<'local> FnMut(StoredAccountMeta<'local>) -> Ret,
-    ) -> Option<Ret> {
-        match self {
-            Self::AppendVec(av) => av.get_stored_account_meta_callback(offset, callback),
-            Self::TieredStorage(_) => {
-                unimplemented!("StoredAccountMeta is only implemented for AppendVec")
-            }
-        }
-    }
-
     /// return an `AccountSharedData` for an account at `offset`, if any.  Otherwise return None.
     pub(crate) fn get_account_shared_data(&self, offset: usize) -> Option<AccountSharedData> {
         match self {


### PR DESCRIPTION
#### Problem
- Function requires exporting internals that do not need to be exported

#### Summary of Changes
- Change remaining callers to get_stored_account_callback
- Remove function

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
