### PR TITLE
Update tiered_storage create_test_accounts API to match append_vec API

### DIFF
--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -351,13 +351,8 @@ mod tests {
             .map(|size| create_test_account(*size))
             .collect();
 
-        let account_refs: Vec<_> = accounts
-            .iter()
-            .map(|account| (&account.0.pubkey, &account.1))
-            .collect();
-
         // Slot information is not used here
-        let storable_accounts = (Slot::MAX, &account_refs[..]);
+        let storable_accounts = (Slot::MAX, &accounts[..]);
 
         let temp_dir = tempdir().unwrap();
         let tiered_storage_path = temp_dir.path().join(path_suffix);

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -1462,13 +1462,8 @@ mod tests {
             .map(|size| create_test_account(*size))
             .collect();
 
-        let account_refs: Vec<_> = accounts
-            .iter()
-            .map(|account| (&account.0.pubkey, &account.1))
-            .collect();
-
         // Slot information is not used here
-        let storable_accounts = (Slot::MAX, &account_refs[..]);
+        let storable_accounts = (Slot::MAX, &accounts[..]);
 
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("test_write_account_and_index_blocks");

--- a/accounts-db/src/tiered_storage/test_utils.rs
+++ b/accounts-db/src/tiered_storage/test_utils.rs
@@ -3,7 +3,7 @@
 use {
     super::footer::TieredStorageFooter,
     crate::{
-        account_storage::stored_account_info::StoredAccountInfo, append_vec::StoredMeta,
+        account_storage::stored_account_info::StoredAccountInfo,
         tiered_storage::hot::RENT_EXEMPT_RENT_EPOCH,
     },
     solana_account::{Account, AccountSharedData, ReadableAccount},
@@ -16,7 +16,7 @@ use {
 ///
 /// When the seed is zero, then a zero-lamport test account will be
 /// created.
-pub(super) fn create_test_account(seed: u64) -> (StoredMeta, AccountSharedData) {
+pub(super) fn create_test_account(seed: u64) -> (Pubkey, AccountSharedData) {
     let data_byte = seed as u8;
     let owner_byte = u8::MAX - data_byte;
     let account = Account {
@@ -31,13 +31,7 @@ pub(super) fn create_test_account(seed: u64) -> (StoredMeta, AccountSharedData) 
             RENT_EXEMPT_RENT_EPOCH
         },
     };
-
-    let stored_meta = StoredMeta {
-        write_version_obsolete: u64::MAX,
-        pubkey: Pubkey::new_unique(),
-        data_len: seed,
-    };
-    (stored_meta, AccountSharedData::from(account))
+    (Pubkey::new_unique(), AccountSharedData::from(account))
 }
 
 pub(super) fn verify_test_account(


### PR DESCRIPTION
#### Problem
- both tierd_storage and append_vecs have create_test_account functions to create test accounts
- APIs no longer match
- Append vec API was updated here: https://github.com/anza-xyz/agave/pull/8583

#### Summary of Changes
- Apply the same update to tiered storage test_utils
- Update callers

Note: The functions could probably be combined, but that would be a separate refactor. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
