### PR TITLE
Removes StoredAccountMeta from comments

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -298,8 +298,7 @@ struct LoadAccountsIndexForShrink<'a, T: ShrinkCollectRefs<'a>> {
     all_are_zero_lamports: bool,
 }
 
-/// reference an account found during scanning a storage. This is a byval struct to replace
-/// `StoredAccountMeta`
+/// reference an account found during scanning a storage.
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct AccountFromStorage {
     pub index_info: AccountInfo,
@@ -625,7 +624,7 @@ pub enum LoadHint {
 
 #[derive(Debug)]
 pub enum LoadedAccountAccessor<'a> {
-    // StoredAccountMeta can't be held directly here due to its lifetime dependency to
+    // StoredAccountInfo can't be held directly here due to its lifetime dependency on
     // AccountStorageEntry
     Stored(Option<(Arc<AccountStorageEntry>, usize)>),
     // None value in Cached variant means the cache was flushed

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -2086,14 +2086,14 @@ fn test_hash_stored_account() {
             .0
             .checksum(),
         expected_account_hash,
-        "StoredAccountMeta's data layout might be changed; update hashing if needed."
+        "StoredAccountInfo's data layout might be changed; update hashing if needed."
     );
     assert_eq!(
         AccountsDb::lt_hash_account(&account, stored_account.pubkey())
             .0
             .checksum(),
         expected_account_hash,
-        "Account-based hashing must be consistent with StoredAccountMeta-based one."
+        "Account-based hashing must be consistent with StoredAccountInfo-based one."
     );
 }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1131,9 +1131,7 @@ impl AppendVec {
     }
 
     /// iterate over all pubkeys and call `callback`.
-    /// This iteration does not deserialize and populate each field in `StoredAccountMeta`.
-    /// `data` is completely ignored, for example.
-    /// Also, no references have to be maintained/returned from an iterator function.
+    /// no references have to be maintained/returned from an iterator function.
     /// This fn can operate on a batch of data at once.
     pub fn scan_pubkeys(&self, mut callback: impl FnMut(&Pubkey)) -> Result<()> {
         self.scan_stored_accounts_no_data(|account| {

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -603,8 +603,7 @@ pub mod tests {
                     let source_slot = starting_slot % max_slots;
 
                     let storage = setup_sample_storage(&db, source_slot);
-                    // since we're no longer storing `StoredAccountMeta`, we have to actually store the
-                    // accounts so they can be looked up later in `db`
+                    // store the accounts so they can be looked up later in `db`
                     if let Some(offsets) = storage
                         .accounts
                         .write_accounts(&(source_slot, &three[..]), 0)
@@ -736,8 +735,7 @@ pub mod tests {
                                     let range = overall_index..(overall_index + count);
                                     let mut result =
                                         raw2_accounts_from_storage[range.clone()].to_vec();
-                                    // since we're no longer storing `StoredAccountMeta`, we have to actually store the
-                                    // accounts so they can be looked up later in `db`
+                                    // store the accounts so they can be looked up later in `db`
                                     let storage = setup_sample_storage(&db, slot);
                                     if let Some(offsets) = storage
                                         .accounts


### PR DESCRIPTION
#### Problem

We're trying to remove StoredAccountMeta from everywhere outside of the append vec module. To do that, I often grep for "StoredAccountMeta". This string shows up in comments as well as actual code, which is sometimes a false positive. Those comments can be updated.


#### Summary of Changes

Update comments that mention StoredAccountMeta unnecessarily.