### PR TITLE
vm, cpi: make order of checks consistent in both ABIs

### DIFF
--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -370,8 +370,6 @@ impl<'a> CallerAccount<'a> {
                     return Err(Box::new(CpiError::InvalidPointer));
                 }
             }
-            let ref_to_len_in_vm =
-                translate_type_mut_for_cpi::<u64>(memory_mapping, vm_len_addr, false)?;
             let vm_data_addr = data.as_ptr() as u64;
             let serialized_data = CallerAccount::get_serialized_data(
                 memory_mapping,
@@ -380,6 +378,8 @@ impl<'a> CallerAccount<'a> {
                 stricter_abi_and_runtime_constraints,
                 account_data_direct_mapping,
             )?;
+            let ref_to_len_in_vm =
+                translate_type_mut_for_cpi::<u64>(memory_mapping, vm_len_addr, false)?;
             (serialized_data, vm_data_addr, ref_to_len_in_vm)
         };
 


### PR DESCRIPTION
#### Problem
The order of CPI checks and memory address translations is different between the Rust and C ABIs. This makes implementing CPIs in other clients more complicated than it needs to be, because now we have to structure our logic differently depending on which ABI is being invoked.

#### Summary of Changes
Move the translation of `ref_to_len_in_vm` field after the translation of the caller account's serialized data in `CallerAccount::from_account_info`. This makes the behaviour of `CallerAccount::from_account_info` consistent with `CallerAccount::from_sol_account_info`, so the checks happen in the same order in both ABIs.

This does not need a feature gate as it is not a consensus-breaking change - it does not change whether a transaction will succeed or fail, just which error code will be thrown.