### PR TITLE
refactor: give certificate related types better names

### DIFF
--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -99,9 +99,9 @@ pub struct Certificate {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum ConsensusMessage {
-    /// Vote message.
+    /// A vote from a single party.
     Vote(VoteMessage),
-    /// Certificate message
+    /// A certificate aggregating votes from multiple parties.
     Certificate(Certificate),
 }
 

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -29,14 +29,14 @@ pub struct VoteMessage {
     pub rank: u16,
 }
 
+/// The different types of certificates and their relevant state.
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample, AbiEnumVisitor),
-    frozen_abi(digest = "APmpbbqEiJtCrxgjSs8FuMNcM1Qyzc5HtMW7KR79DGcF")
+    frozen_abi(digest = "8RmeGAzMoXh7ENiFCG1iHDh8ejokjR1hqJ2m4Ba7Uxgo")
 )]
-/// Certificate details
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
-pub enum Certificate {
+pub enum CertificateType {
     /// Finalize certificate
     Finalize(Slot),
     /// Fast finalize certificate
@@ -49,123 +49,60 @@ pub enum Certificate {
     Skip(Slot),
 }
 
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample, AbiEnumVisitor),
-    frozen_abi(digest = "3en2tmFekuD3SWbBnNPqeJSrxDeTJkKJe3CCimANrrpQ")
-)]
-/// Certificate type
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
-pub enum CertificateType {
-    /// Finalize certificate
-    Finalize,
-    /// Fast finalize certificate
-    FinalizeFast,
-    /// Notarize certificate
-    Notarize,
-    /// Notarize fallback certificate
-    NotarizeFallback,
-    /// Skip certificate
-    Skip,
-}
-
-impl Certificate {
-    /// Create a new certificate from a CertificateType, Slot, and Option<Hash>
-    pub fn new(certificate_type: CertificateType, slot: Slot, hash: Option<Hash>) -> Self {
-        match (certificate_type, hash) {
-            (CertificateType::Finalize, None) => Certificate::Finalize(slot),
-            (CertificateType::FinalizeFast, Some(hash)) => Certificate::FinalizeFast(slot, hash),
-            (CertificateType::Notarize, Some(hash)) => Certificate::Notarize(slot, hash),
-            (CertificateType::NotarizeFallback, Some(hash)) => {
-                Certificate::NotarizeFallback(slot, hash)
-            }
-            (CertificateType::Skip, None) => Certificate::Skip(slot),
-            _ => panic!("Invalid certificate type and hash combination"),
-        }
-    }
-
-    /// Get the certificate type
-    pub fn certificate_type(&self) -> CertificateType {
-        match self {
-            Certificate::Finalize(_) => CertificateType::Finalize,
-            Certificate::FinalizeFast(_, _) => CertificateType::FinalizeFast,
-            Certificate::Notarize(_, _) => CertificateType::Notarize,
-            Certificate::NotarizeFallback(_, _) => CertificateType::NotarizeFallback,
-            Certificate::Skip(_) => CertificateType::Skip,
-        }
-    }
-
+impl CertificateType {
     /// Get the slot of the certificate
     pub fn slot(&self) -> Slot {
         match self {
-            Certificate::Finalize(slot)
-            | Certificate::FinalizeFast(slot, _)
-            | Certificate::Notarize(slot, _)
-            | Certificate::NotarizeFallback(slot, _)
-            | Certificate::Skip(slot) => *slot,
+            Self::Finalize(slot)
+            | Self::FinalizeFast(slot, _)
+            | Self::Notarize(slot, _)
+            | Self::NotarizeFallback(slot, _)
+            | Self::Skip(slot) => *slot,
         }
-    }
-
-    /// Is this a fast finalize certificate?
-    pub fn is_fast_finalization(&self) -> bool {
-        matches!(self, Self::FinalizeFast(_, _))
-    }
-
-    /// Is this a finalize / fast finalize certificate?
-    pub fn is_finalization(&self) -> bool {
-        matches!(self, Self::Finalize(_) | Self::FinalizeFast(_, _))
-    }
-
-    /// Is this a notarize fallback certificate?
-    pub fn is_notarize_fallback(&self) -> bool {
-        matches!(self, Self::NotarizeFallback(_, _))
-    }
-
-    /// Is this a skip certificate?
-    pub fn is_skip(&self) -> bool {
-        matches!(self, Self::Skip(_))
     }
 
     /// Gets the block associated with this certificate, if present
     pub fn to_block(self) -> Option<Block> {
         match self {
-            Certificate::Finalize(_) | Certificate::Skip(_) => None,
-            Certificate::Notarize(slot, block_id)
-            | Certificate::NotarizeFallback(slot, block_id)
-            | Certificate::FinalizeFast(slot, block_id) => Some((slot, block_id)),
+            Self::Finalize(_) | Self::Skip(_) => None,
+            Self::Notarize(slot, block_id)
+            | Self::NotarizeFallback(slot, block_id)
+            | Self::FinalizeFast(slot, block_id) => Some((slot, block_id)),
         }
     }
 }
 
+/// The actual certificate with the aggregate signature and bitmap for which validators are included in the aggregate.
+/// BLS vote message, we need rank to look up pubkey
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "4pnAg6WpCFLfDL8w3uujV6k7uqw3RThCLQiD6whTxhbN")
+    frozen_abi(digest = "2jUyAYKXdK7gfncAx3JxhdUfA8DrkVkcbDB6J5tsiuEA")
 )]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-/// BLS vote message, we need rank to look up pubkey
-pub struct CertificateMessage {
-    /// The certificate
-    pub certificate: Certificate,
-    /// The signature
+pub struct Certificate {
+    /// The certificate type.
+    pub cert_type: CertificateType,
+    /// The aggregate signature.
     pub signature: BLSSignature,
-    /// The bitmap for validators, see solana-signer-store for encoding format
+    /// The bitmap for validators' signatures are included in the aggregate.
+    /// See solana-signer-store for encoding format.
     pub bitmap: Vec<u8>,
 }
 
+/// A consensus message sent between validators.
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample, AbiEnumVisitor),
-    frozen_abi(digest = "AusWCevDpUnnKrAjJg7NgsiZZn5pTXaLUghGfPHrsAFA")
+    frozen_abi(digest = "7r7dyUzmnYbxug6r7QkggXgBH5WUWvuC2Z9UcXLJfBgm")
 )]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
-/// BLS message data in Alpenglow
 pub enum ConsensusMessage {
-    /// Vote message, with the vote and the rank of the validator.
+    /// Vote message.
     Vote(VoteMessage),
     /// Certificate message
-    Certificate(CertificateMessage),
+    Certificate(Certificate),
 }
 
 impl ConsensusMessage {
@@ -175,19 +112,6 @@ impl ConsensusMessage {
             vote,
             signature,
             rank,
-        })
-    }
-
-    /// Create a new certificate message
-    pub fn new_certificate(
-        certificate: Certificate,
-        bitmap: Vec<u8>,
-        signature: BLSSignature,
-    ) -> Self {
-        Self::Certificate(CertificateMessage {
-            certificate,
-            signature,
-            bitmap,
         })
     }
 }

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -85,7 +85,7 @@ pub struct Certificate {
     pub cert_type: CertificateType,
     /// The aggregate signature.
     pub signature: BLSSignature,
-    /// The bitmap for validators' signatures are included in the aggregate.
+    /// A rank bitmap for validators' signatures included in the aggregate.
     /// See solana-signer-store for encoding format.
     pub bitmap: Vec<u8>,
 }

--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -1,5 +1,5 @@
 use {
-    agave_votor_messages::{consensus_message::Certificate, vote::Vote},
+    agave_votor_messages::{consensus_message::CertificateType, vote::Vote},
     std::time::Duration,
 };
 
@@ -51,35 +51,38 @@ pub const fn conflicting_types(vote_type: VoteType) -> &'static [VoteType] {
 ///
 /// Must be in sync with `vote_to_certificate_ids`
 pub const fn certificate_limits_and_vote_types(
-    cert_type: Certificate,
+    cert_type: &CertificateType,
 ) -> (f64, &'static [VoteType]) {
     match cert_type {
-        Certificate::Notarize(_, _) => (0.6, &[VoteType::Notarize]),
-        Certificate::NotarizeFallback(_, _) => {
+        CertificateType::Notarize(_, _) => (0.6, &[VoteType::Notarize]),
+        CertificateType::NotarizeFallback(_, _) => {
             (0.6, &[VoteType::Notarize, VoteType::NotarizeFallback])
         }
-        Certificate::FinalizeFast(_, _) => (0.8, &[VoteType::Notarize]),
-        Certificate::Finalize(_) => (0.6, &[VoteType::Finalize]),
-        Certificate::Skip(_) => (0.6, &[VoteType::Skip, VoteType::SkipFallback]),
+        CertificateType::FinalizeFast(_, _) => (0.8, &[VoteType::Notarize]),
+        CertificateType::Finalize(_) => (0.6, &[VoteType::Finalize]),
+        CertificateType::Skip(_) => (0.6, &[VoteType::Skip, VoteType::SkipFallback]),
     }
 }
 
 /// Lookup from `Vote` to the `CertificateId`s the vote accounts for
 ///
 /// Must be in sync with `certificate_limits_and_vote_types` and `VoteType::get_type`
-pub fn vote_to_certificate_ids(vote: &Vote) -> Vec<Certificate> {
+pub fn vote_to_certificate_ids(vote: &Vote) -> Vec<CertificateType> {
     match vote {
         Vote::Notarize(vote) => vec![
-            Certificate::Notarize(vote.slot(), *vote.block_id()),
-            Certificate::NotarizeFallback(vote.slot(), *vote.block_id()),
-            Certificate::FinalizeFast(vote.slot(), *vote.block_id()),
+            CertificateType::Notarize(vote.slot(), *vote.block_id()),
+            CertificateType::NotarizeFallback(vote.slot(), *vote.block_id()),
+            CertificateType::FinalizeFast(vote.slot(), *vote.block_id()),
         ],
         Vote::NotarizeFallback(vote) => {
-            vec![Certificate::NotarizeFallback(vote.slot(), *vote.block_id())]
+            vec![CertificateType::NotarizeFallback(
+                vote.slot(),
+                *vote.block_id(),
+            )]
         }
-        Vote::Finalize(vote) => vec![Certificate::Finalize(vote.slot())],
-        Vote::Skip(vote) => vec![Certificate::Skip(vote.slot())],
-        Vote::SkipFallback(vote) => vec![Certificate::Skip(vote.slot())],
+        Vote::Finalize(vote) => vec![CertificateType::Finalize(vote.slot())],
+        Vote::Skip(vote) => vec![CertificateType::Skip(vote.slot())],
+        Vote::SkipFallback(vote) => vec![CertificateType::Skip(vote.slot())],
     }
 }
 

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -16,9 +16,7 @@ use {
         event::VotorEvent,
     },
     agave_votor_messages::{
-        consensus_message::{
-            Block, Certificate, CertificateMessage, CertificateType, ConsensusMessage, VoteMessage,
-        },
+        consensus_message::{Block, Certificate, CertificateType, ConsensusMessage, VoteMessage},
         vote::Vote,
     },
     log::{error, trace},
@@ -64,7 +62,7 @@ pub enum AddVoteError {
     ChannelDisconnected(String),
 
     #[error("Voting Service queue full")]
-    VotingServiceChannelFull,
+    VotingServiceQueueFull,
 
     #[error("Invalid rank: {0}")]
     InvalidRank(u16),
@@ -105,7 +103,7 @@ pub struct ConsensusPool {
     // Vote pools to do bean counting for votes.
     vote_pools: BTreeMap<PoolId, VotePool>,
     /// Completed certificates
-    completed_certificates: BTreeMap<Certificate, Arc<CertificateMessage>>,
+    completed_certificates: BTreeMap<CertificateType, Arc<Certificate>>,
     /// Tracks slots which have reached the parent ready condition:
     /// - They have a potential parent block with a NotarizeFallback certificate
     /// - All slots from the parent have a Skip certificate
@@ -186,16 +184,16 @@ impl ConsensusPool {
         block_id: Option<Hash>,
         events: &mut Vec<VotorEvent>,
         total_stake: Stake,
-    ) -> Result<Vec<Arc<CertificateMessage>>, AddVoteError> {
+    ) -> Result<Vec<Arc<Certificate>>, AddVoteError> {
         let slot = vote.slot();
         let mut new_certificates_to_send = Vec::new();
-        for cert_id in vote_to_certificate_ids(vote) {
+        for cert_type in vote_to_certificate_ids(vote) {
             // If the certificate is already complete, skip it
-            if self.completed_certificates.contains_key(&cert_id) {
+            if self.completed_certificates.contains_key(&cert_type) {
                 continue;
             }
             // Otherwise check whether the certificate is complete
-            let (limit, vote_types) = certificate_limits_and_vote_types(cert_id);
+            let (limit, vote_types) = certificate_limits_and_vote_types(&cert_type);
             let accumulated_stake = vote_types
                 .iter()
                 .filter_map(|vote_type| {
@@ -204,7 +202,7 @@ impl ConsensusPool {
                         VotePool::DuplicateBlockVotePool(pool) => {
                             pool.total_stake_by_block_id(block_id.as_ref().expect(
                                 "Duplicate block pool for {vote_type:?} expects a block id for \
-                                 certificate {cert_id:?}",
+                                 certificate {cert_type:?}",
                             ))
                         }
                     })
@@ -213,28 +211,24 @@ impl ConsensusPool {
             if accumulated_stake as f64 / (total_stake as f64) < limit {
                 continue;
             }
-            let mut vote_certificate_builder = VoteCertificateBuilder::new(cert_id);
+            let mut cert_builder = VoteCertificateBuilder::new(cert_type);
             vote_types.iter().for_each(|vote_type| {
                 if let Some(vote_pool) = self.vote_pools.get(&(slot, *vote_type)) {
                     match vote_pool {
                         VotePool::SimpleVotePool(pool) => {
-                            vote_certificate_builder.aggregate(pool.votes()).unwrap();
+                            cert_builder.aggregate(pool.votes()).unwrap();
                         }
                         VotePool::DuplicateBlockVotePool(pool) => {
-                            if let Some(votes) = pool.votes(block_id.as_ref().expect(
-                                "Duplicate block pool for {vote_type:?} expects a block id for \
-                                 certificate {cert_id:?}",
-                            )) {
-                                vote_certificate_builder.aggregate(votes).unwrap();
+                            if let Some(votes) = pool.votes(block_id.as_ref().unwrap()) {
+                                cert_builder.aggregate(votes).unwrap();
                             }
                         }
                     };
                 }
             });
-            let new_cert = Arc::new(vote_certificate_builder.build()?);
-            self.insert_certificate(cert_id, new_cert.clone(), events);
-            self.stats
-                .incr_cert_type(new_cert.certificate.certificate_type(), true);
+            let new_cert = Arc::new(cert_builder.build()?);
+            self.insert_certificate(cert_type, new_cert.clone(), events);
+            self.stats.incr_cert_type(&new_cert.cert_type, true);
             new_certificates_to_send.push(new_cert);
         }
         Ok(new_certificates_to_send)
@@ -278,19 +272,19 @@ impl ConsensusPool {
 
     fn insert_certificate(
         &mut self,
-        cert_id: Certificate,
-        cert: Arc<CertificateMessage>,
+        cert_type: CertificateType,
+        cert: Arc<Certificate>,
         events: &mut Vec<VotorEvent>,
     ) {
-        trace!("{}: Inserting certificate {:?}", self.my_pubkey, cert_id);
-        self.completed_certificates.insert(cert_id, cert);
-        match cert_id {
-            Certificate::NotarizeFallback(slot, block_id) => {
+        trace!("{}: Inserting certificate {:?}", self.my_pubkey, cert_type);
+        self.completed_certificates.insert(cert_type, cert.clone());
+        match cert_type {
+            CertificateType::NotarizeFallback(slot, block_id) => {
                 self.parent_ready_tracker
                     .add_new_notar_fallback_or_stronger((slot, block_id), events);
             }
-            Certificate::Skip(slot) => self.parent_ready_tracker.add_new_skip(slot, events),
-            Certificate::Notarize(slot, block_id) => {
+            CertificateType::Skip(slot) => self.parent_ready_tracker.add_new_skip(slot, events),
+            CertificateType::Notarize(slot, block_id) => {
                 events.push(VotorEvent::BlockNotarized((slot, block_id)));
                 self.parent_ready_tracker
                     .add_new_notar_fallback_or_stronger((slot, block_id), events);
@@ -306,7 +300,7 @@ impl ConsensusPool {
                     }
                 }
             }
-            Certificate::Finalize(slot) => {
+            CertificateType::Finalize(slot) => {
                 if let Some(block) = self.get_notarized_block(slot) {
                     events.push(VotorEvent::Finalized(block, false));
                     if self
@@ -320,7 +314,7 @@ impl ConsensusPool {
                     self.highest_finalized_slot = Some(slot);
                 }
             }
-            Certificate::FinalizeFast(slot, block_id) => {
+            CertificateType::FinalizeFast(slot, block_id) => {
                 events.push(VotorEvent::Finalized((slot, block_id), true));
                 self.parent_ready_tracker
                     .add_new_notar_fallback_or_stronger((slot, block_id), events);
@@ -337,7 +331,7 @@ impl ConsensusPool {
         }
     }
 
-    /// Adds the new vote the the certificate pool. If a new certificate is created
+    /// Adds the new vote the the consensus pool. If a new certificate is created
     /// as a result of this, send it via the `self.certificate_sender`
     ///
     /// Any new votor events that are a result of adding this new vote will be added
@@ -353,7 +347,7 @@ impl ConsensusPool {
         my_vote_pubkey: &Pubkey,
         message: ConsensusMessage,
         events: &mut Vec<VotorEvent>,
-    ) -> Result<(Option<Slot>, Vec<Arc<CertificateMessage>>), AddVoteError> {
+    ) -> Result<(Option<Slot>, Vec<Arc<Certificate>>), AddVoteError> {
         let current_highest_finalized_slot = self.highest_finalized_slot;
         let new_certficates_to_send = match message {
             ConsensusMessage::Vote(vote_message) => self.add_vote(
@@ -364,9 +358,7 @@ impl ConsensusPool {
                 vote_message,
                 events,
             )?,
-            ConsensusMessage::Certificate(certificate_message) => {
-                self.add_certificate(root_slot, &certificate_message, events)?
-            }
+            ConsensusMessage::Certificate(cert) => self.add_certificate(root_slot, cert, events)?,
         };
         // If we have a new highest finalized slot, return it
         let new_finalized_slot = if self.highest_finalized_slot > current_highest_finalized_slot {
@@ -385,7 +377,7 @@ impl ConsensusPool {
         my_vote_pubkey: &Pubkey,
         vote_message: VoteMessage,
         events: &mut Vec<VotorEvent>,
-    ) -> Result<Vec<Arc<CertificateMessage>>, AddVoteError> {
+    ) -> Result<Vec<Arc<Certificate>>, AddVoteError> {
         let vote = &vote_message.vote;
         let rank = vote_message.rank;
         let vote_slot = vote.slot();
@@ -405,7 +397,7 @@ impl ConsensusPool {
         }
         let block_id = vote.block_id().map(|block_id| {
             if !matches!(vote, Vote::Notarize(_) | Vote::NotarizeFallback(_)) {
-                panic!("expected Notarize or NotarizeFallback vote");
+                panic!("expected Notarize/ NotarizeFallback/ Genesis vote");
             }
             *block_id
         });
@@ -449,34 +441,33 @@ impl ConsensusPool {
     fn add_certificate(
         &mut self,
         root_slot: Slot,
-        certificate_message: &CertificateMessage,
+        cert: Certificate,
         events: &mut Vec<VotorEvent>,
-    ) -> Result<Vec<Arc<CertificateMessage>>, AddVoteError> {
-        let certificate_id = certificate_message.certificate;
+    ) -> Result<Vec<Arc<Certificate>>, AddVoteError> {
+        let cert_type = cert.cert_type;
         self.stats.incoming_certs = self.stats.incoming_certs.saturating_add(1);
-        if certificate_id.slot() < root_slot {
+        if cert_type.slot() < root_slot {
             self.stats.out_of_range_certs = self.stats.out_of_range_certs.saturating_add(1);
             return Err(AddVoteError::UnrootedSlot);
         }
-        if self.completed_certificates.contains_key(&certificate_id) {
+        if self.completed_certificates.contains_key(&cert_type) {
             self.stats.exist_certs = self.stats.exist_certs.saturating_add(1);
             return Ok(vec![]);
         }
-        let new_certificate = Arc::new(certificate_message.clone());
-        self.insert_certificate(certificate_id, new_certificate.clone(), events);
+        let cert = Arc::new(cert);
+        self.insert_certificate(cert_type, cert.clone(), events);
 
-        self.stats
-            .incr_cert_type(certificate_id.certificate_type(), false);
+        self.stats.incr_cert_type(&cert_type, false);
 
-        Ok(vec![new_certificate])
+        Ok(vec![cert])
     }
 
     /// Get the notarized block in `slot`
     pub fn get_notarized_block(&self, slot: Slot) -> Option<Block> {
         self.completed_certificates
             .iter()
-            .find_map(|(cert_id, _)| match cert_id {
-                Certificate::Notarize(s, block_id) if slot == *s => Some((*s, *block_id)),
+            .find_map(|(cert_type, _)| match cert_type {
+                CertificateType::Notarize(s, block_id) if slot == *s => Some((*s, *block_id)),
                 _ => None,
             })
     }
@@ -486,9 +477,9 @@ impl ConsensusPool {
         // Return the max of CertificateType::Notarize and CertificateType::NotarizeFallback
         self.completed_certificates
             .iter()
-            .filter_map(|(cert_id, _)| match cert_id {
-                Certificate::Notarize(s, _) => Some(s),
-                Certificate::NotarizeFallback(s, _) => Some(s),
+            .filter_map(|(cert_type, _)| match cert_type {
+                CertificateType::Notarize(s, _) => Some(s),
+                CertificateType::NotarizeFallback(s, _) => Some(s),
                 _ => None,
             })
             .max()
@@ -500,8 +491,8 @@ impl ConsensusPool {
     fn highest_skip_slot(&self) -> Slot {
         self.completed_certificates
             .iter()
-            .filter_map(|(cert_id, _)| match cert_id {
-                Certificate::Skip(s) => Some(s),
+            .filter_map(|(cert_type, _)| match cert_type {
+                CertificateType::Skip(s) => Some(s),
                 _ => None,
             })
             .max()
@@ -512,9 +503,9 @@ impl ConsensusPool {
     pub fn highest_finalized_slot(&self) -> Slot {
         self.completed_certificates
             .iter()
-            .filter_map(|(cert_id, _)| match cert_id {
-                Certificate::Finalize(s) => Some(s),
-                Certificate::FinalizeFast(s, _) => Some(s),
+            .filter_map(|(cert_type, _)| match cert_type {
+                CertificateType::Finalize(s) => Some(s),
+                CertificateType::FinalizeFast(s, _) => Some(s),
                 _ => None,
             })
             .max()
@@ -524,8 +515,8 @@ impl ConsensusPool {
 
     /// Checks if any block in the slot `s` is finalized
     pub fn is_finalized(&self, slot: Slot) -> bool {
-        self.completed_certificates.keys().any(|cert_id| {
-            matches!(cert_id, Certificate::Finalize(s) | Certificate::FinalizeFast(s, _) if *s == slot)
+        self.completed_certificates.keys().any(|cert_type| {
+            matches!(cert_type, CertificateType::Finalize(s) | CertificateType::FinalizeFast(s, _) if *s == slot)
         })
     }
 
@@ -533,15 +524,15 @@ impl ConsensusPool {
     /// the size of the certificate
     #[cfg(test)]
     pub fn slot_has_notarized_fallback(&self, slot: Slot) -> bool {
-        self.completed_certificates
-            .iter()
-            .any(|(cert_id, _)| matches!(cert_id, Certificate::NotarizeFallback(s,_) if *s == slot))
+        self.completed_certificates.iter().any(
+            |(cert_type, _)| matches!(cert_type, CertificateType::NotarizeFallback(s,_) if *s == slot),
+        )
     }
 
     /// Checks if `slot` has a `Skip` certificate
     pub fn skip_certified(&self, slot: Slot) -> bool {
         self.completed_certificates
-            .contains_key(&Certificate::Skip(slot))
+            .contains_key(&CertificateType::Skip(slot))
     }
 
     #[cfg(test)]
@@ -557,9 +548,9 @@ impl ConsensusPool {
         first_alpenglow_slot: Slot,
     ) -> bool {
         // TODO: for GCE tests we WFSM on 1 so slot 1 is exempt
-        let needs_notarization_certificate = parent_slot >= first_alpenglow_slot && parent_slot > 1;
+        let needs_notar_cert = parent_slot >= first_alpenglow_slot && parent_slot > 1;
 
-        if needs_notarization_certificate
+        if needs_notar_cert
             && !self.slot_has_notarized_fallback(parent_slot)
             && !self.is_finalized(parent_slot)
         {
@@ -567,13 +558,13 @@ impl ConsensusPool {
             return false;
         }
 
-        let needs_skip_certificate =
+        let needs_skip_cert =
             // handles cases where we are entering the alpenglow epoch, where the first
             // slot in the epoch will pass my_leader_slot == parent_slot
             my_leader_slot != first_alpenglow_slot &&
             my_leader_slot != parent_slot.saturating_add(1);
 
-        if needs_skip_certificate {
+        if needs_skip_cert {
             let begin_skip_slot = first_alpenglow_slot.max(parent_slot.saturating_add(1));
             for slot in begin_skip_slot..my_leader_slot {
                 if !self.skip_certified(slot) {
@@ -593,12 +584,12 @@ impl ConsensusPool {
     pub fn prune_old_state(&mut self, root_slot: Slot) {
         // `completed_certificates`` now only contains entries >= `slot`
         self.completed_certificates
-            .retain(|cert_id, _| match cert_id {
-                Certificate::Finalize(s)
-                | Certificate::FinalizeFast(s, _)
-                | Certificate::Notarize(s, _)
-                | Certificate::NotarizeFallback(s, _)
-                | Certificate::Skip(s) => s >= &root_slot,
+            .retain(|cert_type, _| match cert_type {
+                CertificateType::Finalize(s)
+                | CertificateType::FinalizeFast(s, _)
+                | CertificateType::Notarize(s, _)
+                | CertificateType::NotarizeFallback(s, _)
+                | CertificateType::Skip(s) => s >= &root_slot,
             });
         self.vote_pools = self.vote_pools.split_off(&(root_slot, VoteType::Finalize));
         self.slot_stake_counters_map = self.slot_stake_counters_map.split_off(&root_slot);
@@ -617,31 +608,33 @@ impl ConsensusPool {
         self.stats.maybe_report();
     }
 
-    pub fn get_certs_for_standstill(&self) -> Vec<Arc<CertificateMessage>> {
+    pub fn get_certs_for_standstill(&self) -> Vec<Arc<Certificate>> {
         let (highest_finalized_with_notarize_slot, has_fast_finalize) =
             self.highest_finalized_with_notarize.unwrap_or((0, false));
         self.completed_certificates
             .iter()
-            .filter_map(|(cert_id, cert)| {
+            .filter_map(|(cert_type, cert)| {
                 let cert_to_send = match (
-                    cert_id.slot().cmp(&highest_finalized_with_notarize_slot),
-                    cert_id.certificate_type(),
+                    cert_type.slot().cmp(&highest_finalized_with_notarize_slot),
+                    cert_type,
                     has_fast_finalize,
                 ) {
                     (Ordering::Greater, _, _)
                     | (
                         Ordering::Equal,
-                        CertificateType::Finalize | CertificateType::Notarize,
+                        CertificateType::Finalize(_) | CertificateType::Notarize(_, _),
                         false,
                     )
-                    | (Ordering::Equal, CertificateType::FinalizeFast, true) => Some(cert.clone()),
-                    (Ordering::Equal, CertificateType::FinalizeFast, false) => {
+                    | (Ordering::Equal, CertificateType::FinalizeFast(_, _), true) => {
+                        Some(cert.clone())
+                    }
+                    (Ordering::Equal, CertificateType::FinalizeFast(_, _), false) => {
                         panic!("Should not happen while certificate pool is single threaded")
                     }
                     _ => None,
                 };
                 if cert_to_send.is_some() {
-                    trace!("{}: Refreshing certificate {:?}", self.my_pubkey, cert_id);
+                    trace!("{}: Refreshing certificate {:?}", self.my_pubkey, cert_type);
                 }
                 cert_to_send
             })
@@ -653,9 +646,7 @@ impl ConsensusPool {
 mod tests {
     use {
         super::*,
-        agave_votor_messages::consensus_message::{
-            CertificateType, VoteMessage, BLS_KEYPAIR_DERIVE_SEED,
-        },
+        agave_votor_messages::consensus_message::{VoteMessage, BLS_KEYPAIR_DERIVE_SEED},
         solana_bls_signatures::{
             keypair::Keypair as BLSKeypair, Pubkey as BLSPubkey, Signature as BLSSignature,
             VerifiableSignature,
@@ -1030,14 +1021,14 @@ mod tests {
         assert!(pool.make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot));
     }
 
-    #[test_case(Vote::new_finalization_vote(5), vec![CertificateType::Finalize])]
-    #[test_case(Vote::new_notarization_vote(6, Hash::new_unique()), vec![CertificateType::Notarize, CertificateType::NotarizeFallback])]
-    #[test_case(Vote::new_notarization_fallback_vote(7, Hash::new_unique()), vec![CertificateType::NotarizeFallback])]
-    #[test_case(Vote::new_skip_vote(8), vec![CertificateType::Skip])]
-    #[test_case(Vote::new_skip_fallback_vote(9), vec![CertificateType::Skip])]
+    #[test_case(Vote::new_finalization_vote(5), vec![CertificateType::Finalize(5)])]
+    #[test_case(Vote::new_notarization_vote(6, Hash::default()), vec![CertificateType::Notarize(6, Hash::default()), CertificateType::NotarizeFallback(6, Hash::default())])]
+    #[test_case(Vote::new_notarization_fallback_vote(7, Hash::default()), vec![CertificateType::NotarizeFallback(7, Hash::default())])]
+    #[test_case(Vote::new_skip_vote(8), vec![CertificateType::Skip(8)])]
+    #[test_case(Vote::new_skip_fallback_vote(9), vec![CertificateType::Skip(9)])]
     fn test_add_vote_and_create_new_certificate_with_types(
         vote: Vote,
-        expected_certificate_types: Vec<CertificateType>,
+        expected_cert_types: Vec<CertificateType>,
     ) {
         let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
         let my_validator_ix = 5;
@@ -1103,9 +1094,9 @@ mod tests {
             assert!(new_finalized_slot.is_none());
         }
         // Assert certs_to_send contains the expected certificate types
-        for cert_type in expected_certificate_types {
+        for expected_cert_type in expected_cert_types {
             assert!(certs_to_send.iter().any(|cert| {
-                cert.certificate.certificate_type() == cert_type && cert.certificate.slot() == slot
+                cert.cert_type == expected_cert_type && cert.cert_type.slot() == slot
             }));
         }
         assert_eq!(highest_slot_fn(&pool), slot);
@@ -1126,32 +1117,30 @@ mod tests {
         }
     }
 
-    #[test_case(CertificateType::Finalize, Vote::new_finalization_vote(5))]
+    #[test_case(CertificateType::Finalize(5), Vote::new_finalization_vote(5))]
     #[test_case(
-        CertificateType::FinalizeFast,
-        Vote::new_notarization_vote(6, Hash::new_unique())
+        CertificateType::FinalizeFast(6, Hash::default()),
+        Vote::new_notarization_vote(6, Hash::default())
     )]
     #[test_case(
-        CertificateType::Notarize,
-        Vote::new_notarization_vote(6, Hash::new_unique())
+        CertificateType::Notarize(6, Hash::default()),
+        Vote::new_notarization_vote(6, Hash::default())
     )]
     #[test_case(
-        CertificateType::NotarizeFallback,
-        Vote::new_notarization_fallback_vote(7, Hash::new_unique())
+        CertificateType::NotarizeFallback(7, Hash::default()),
+        Vote::new_notarization_fallback_vote(7, Hash::default())
     )]
-    #[test_case(CertificateType::Skip, Vote::new_skip_vote(8))]
-    fn test_add_certificate_with_types(certificate_type: CertificateType, vote: Vote) {
+    #[test_case(CertificateType::Skip(8), Vote::new_skip_vote(8))]
+    fn test_add_certificate_with_types(cert_type: CertificateType, vote: Vote) {
         let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
 
-        let certificate = Certificate::new(certificate_type, vote.slot(), vote.block_id().copied());
-
-        let certificate_message = CertificateMessage {
-            certificate,
+        let cert = Certificate {
+            cert_type,
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
         let bank = bank_forks.read().unwrap().root_bank();
-        let message = ConsensusMessage::Certificate(certificate_message.clone());
+        let message = ConsensusMessage::Certificate(cert.clone());
         // Add the certificate to the pool
         let (new_finalized_slot, certs_to_send) = pool
             .add_message(
@@ -1164,15 +1153,15 @@ mod tests {
             )
             .unwrap();
         // Because this is the first certificate of this type, it should be sent out.
-        if certificate_type == CertificateType::Finalize
-            || certificate_type == CertificateType::FinalizeFast
+        if matches!(cert_type, CertificateType::Finalize(_))
+            || matches!(cert_type, CertificateType::FinalizeFast(_, _))
         {
-            assert_eq!(new_finalized_slot, Some(certificate.slot()));
+            assert_eq!(new_finalized_slot, Some(cert_type.slot()));
         } else {
             assert!(new_finalized_slot.is_none());
         }
         assert_eq!(certs_to_send.len(), 1);
-        assert_eq!(*certs_to_send[0], certificate_message);
+        assert_eq!(*certs_to_send[0], cert);
 
         // Adding the cert again will not trigger another send
         let (new_finalized_slot, certs_to_send) = pool
@@ -1202,7 +1191,7 @@ mod tests {
                 .unwrap();
             assert!(!certs_to_send
                 .iter()
-                .any(|cert| { cert.certificate.certificate_type() == certificate_type }));
+                .any(|cert| { cert.cert_type == cert_type }));
         }
     }
 
@@ -1845,8 +1834,8 @@ mod tests {
 
         let root_bank = bank_forks.read().unwrap().root_bank();
         // Add a skip cert on slot 1 and finalize cert on slot 2
-        let cert_1 = CertificateMessage {
-            certificate: Certificate::new(CertificateType::Skip, 1, None),
+        let cert_1 = Certificate {
+            cert_type: CertificateType::Skip(1),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -1860,12 +1849,8 @@ mod tests {
                 &mut vec![]
             )
             .is_ok());
-        let cert_2 = CertificateMessage {
-            certificate: Certificate::new(
-                CertificateType::FinalizeFast,
-                2,
-                Some(Hash::new_unique()),
-            ),
+        let cert_2 = Certificate {
+            cert_type: CertificateType::FinalizeFast(2, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -1906,10 +1891,9 @@ mod tests {
             .is_err());
 
         // Send a cert on slot 2, it should be rejected
-        let certificate = Certificate::new(CertificateType::Notarize, 2, Some(Hash::new_unique()));
-
-        let cert = ConsensusMessage::Certificate(CertificateMessage {
-            certificate,
+        let cert_type = CertificateType::Notarize(2, Hash::new_unique());
+        let cert = ConsensusMessage::Certificate(Certificate {
+            cert_type,
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         });
@@ -1933,12 +1917,8 @@ mod tests {
         assert!(pool.get_certs_for_standstill().is_empty());
 
         // Add notar-fallback cert on 3 and finalize cert on 4
-        let cert_3 = CertificateMessage {
-            certificate: Certificate::new(
-                CertificateType::NotarizeFallback,
-                3,
-                Some(Hash::new_unique()),
-            ),
+        let cert_3 = Certificate {
+            cert_type: CertificateType::NotarizeFallback(3, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -1953,8 +1933,8 @@ mod tests {
                 &mut vec![]
             )
             .is_ok());
-        let cert_4 = CertificateMessage {
-            certificate: Certificate::new(CertificateType::Finalize, 4, None),
+        let cert_4 = Certificate {
+            cert_type: CertificateType::Finalize(4),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -1971,14 +1951,14 @@ mod tests {
         // Should return both certificates
         let certs = pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 2);
-        assert!(certs.iter().any(|cert| cert.certificate.slot() == 3
-            && cert.certificate.certificate_type() == CertificateType::NotarizeFallback));
-        assert!(certs.iter().any(|cert| cert.certificate.slot() == 4
-            && cert.certificate.certificate_type() == CertificateType::Finalize));
+        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 3
+            && matches!(cert.cert_type, CertificateType::NotarizeFallback(_, _))));
+        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 4
+            && matches!(cert.cert_type, CertificateType::Finalize(_))));
 
         // Add Notarize cert on 5
-        let cert_5 = CertificateMessage {
-            certificate: Certificate::new(CertificateType::Notarize, 5, Some(Hash::new_unique())),
+        let cert_5 = Certificate {
+            cert_type: CertificateType::Notarize(5, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -1994,8 +1974,8 @@ mod tests {
             .is_ok());
 
         // Add Finalize cert on 5
-        let cert_5_finalize = CertificateMessage {
-            certificate: Certificate::new(CertificateType::Finalize, 5, None),
+        let cert_5_finalize = Certificate {
+            cert_type: CertificateType::Finalize(5),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -2011,12 +1991,8 @@ mod tests {
             .is_ok());
 
         // Add FinalizeFast cert on 5
-        let cert_5 = CertificateMessage {
-            certificate: Certificate::new(
-                CertificateType::FinalizeFast,
-                5,
-                Some(Hash::new_unique()),
-            ),
+        let cert_5 = Certificate {
+            cert_type: CertificateType::FinalizeFast(5, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -2034,13 +2010,13 @@ mod tests {
         let certs = pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 1);
         assert!(
-            certs[0].certificate.slot() == 5
-                && certs[0].certificate.certificate_type() == CertificateType::FinalizeFast
+            certs[0].cert_type.slot() == 5
+                && matches!(certs[0].cert_type, CertificateType::FinalizeFast(_, _))
         );
 
         // Now add Notarize cert on 6
-        let cert_6 = CertificateMessage {
-            certificate: Certificate::new(CertificateType::Notarize, 6, Some(Hash::new_unique())),
+        let cert_6 = Certificate {
+            cert_type: CertificateType::Notarize(6, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -2057,14 +2033,14 @@ mod tests {
         // Should return certs on 5 and 6
         let certs = pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 2);
-        assert!(certs.iter().any(|cert| cert.certificate.slot() == 5
-            && cert.certificate.certificate_type() == CertificateType::FinalizeFast));
-        assert!(certs.iter().any(|cert| cert.certificate.slot() == 6
-            && cert.certificate.certificate_type() == CertificateType::Notarize));
+        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 5
+            && matches!(cert.cert_type, CertificateType::FinalizeFast(_, _))));
+        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 6
+            && matches!(cert.cert_type, CertificateType::Notarize(_, _))));
 
         // Add another Finalize cert on 6
-        let cert_6_finalize = CertificateMessage {
-            certificate: Certificate::new(CertificateType::Finalize, 6, None),
+        let cert_6_finalize = Certificate {
+            cert_type: CertificateType::Finalize(6),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -2079,12 +2055,8 @@ mod tests {
             )
             .is_ok());
         // Add a NotarizeFallback cert on 6
-        let cert_6_notarize_fallback = CertificateMessage {
-            certificate: Certificate::new(
-                CertificateType::NotarizeFallback,
-                6,
-                Some(Hash::new_unique()),
-            ),
+        let cert_6_notarize_fallback = Certificate {
+            cert_type: CertificateType::NotarizeFallback(6, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -2102,14 +2074,14 @@ mod tests {
         // only Notarize/Finalze/FinalizeFast should be returned
         let certs = pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 2);
-        assert!(certs.iter().any(|cert| cert.certificate.slot() == 6
-            && cert.certificate.certificate_type() == CertificateType::Finalize));
-        assert!(certs.iter().any(|cert| cert.certificate.slot() == 6
-            && cert.certificate.certificate_type() == CertificateType::Notarize));
+        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 6
+            && matches!(cert.cert_type, CertificateType::Finalize(_))));
+        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 6
+            && matches!(cert.cert_type, CertificateType::Notarize(_, _))));
 
         // Add another skip on 7
-        let cert_7 = CertificateMessage {
-            certificate: Certificate::new(CertificateType::Skip, 7, None),
+        let cert_7 = Certificate {
+            cert_type: CertificateType::Skip(7),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -2126,16 +2098,18 @@ mod tests {
         // Should return certs on 6 and 7
         let certs = pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 3);
-        assert!(certs.iter().any(|cert| cert.certificate.slot() == 6
-            && cert.certificate.certificate_type() == CertificateType::Finalize));
-        assert!(certs.iter().any(|cert| cert.certificate.slot() == 6
-            && cert.certificate.certificate_type() == CertificateType::Notarize));
-        assert!(certs.iter().any(|cert| cert.certificate.slot() == 7
-            && cert.certificate.certificate_type() == CertificateType::Skip));
+        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 6
+            && matches!(cert.cert_type, CertificateType::Finalize(_))));
+        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 6
+            && matches!(cert.cert_type, CertificateType::Notarize(_, _))));
+        assert!(certs
+            .iter()
+            .any(|cert| cert.cert_type.slot() == 7
+                && matches!(cert.cert_type, CertificateType::Skip(_))));
 
         // Add Finalize then Notarize cert on 8
-        let cert_8_finalize = CertificateMessage {
-            certificate: Certificate::new(CertificateType::Finalize, 8, None),
+        let cert_8_finalize = Certificate {
+            cert_type: CertificateType::Finalize(8),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -2149,8 +2123,8 @@ mod tests {
                 &mut vec![]
             )
             .is_ok());
-        let cert_8_notarize = CertificateMessage {
-            certificate: Certificate::new(CertificateType::Notarize, 8, Some(Hash::new_unique())),
+        let cert_8_notarize = Certificate {
+            cert_type: CertificateType::Notarize(8, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
@@ -2168,10 +2142,10 @@ mod tests {
         // Should only return certs on 8 now
         let certs = pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 2);
-        assert!(certs.iter().any(|cert| cert.certificate.slot() == 8
-            && cert.certificate.certificate_type() == CertificateType::Finalize));
-        assert!(certs.iter().any(|cert| cert.certificate.slot() == 8
-            && cert.certificate.certificate_type() == CertificateType::Notarize));
+        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 8
+            && matches!(cert.cert_type, CertificateType::Finalize(_))));
+        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 8
+            && matches!(cert.cert_type, CertificateType::Notarize(_, _))));
     }
 
     #[test]
@@ -2183,8 +2157,8 @@ mod tests {
         // Add a notarization cert on slot 1 to 3
         let hash = Hash::new_unique();
         for slot in 1..=3 {
-            let cert = CertificateMessage {
-                certificate: Certificate::new(CertificateType::Notarize, slot, Some(hash)),
+            let cert = Certificate {
+                cert_type: CertificateType::Notarize(slot, hash),
                 signature: BLSSignature::default(),
                 bitmap: Vec::new(),
             };
@@ -2211,8 +2185,8 @@ mod tests {
 
         // Also works if we add FinalizeFast for slot 4 to 7
         for slot in 4..=7 {
-            let cert = CertificateMessage {
-                certificate: Certificate::new(CertificateType::FinalizeFast, slot, Some(hash)),
+            let cert = Certificate {
+                cert_type: CertificateType::FinalizeFast(slot, hash),
                 signature: BLSSignature::default(),
                 bitmap: Vec::new(),
             };
@@ -2239,8 +2213,8 @@ mod tests {
 
         // NotarizeFallback on slot 8 to 10 and FinalizeFast on slot 11
         for slot in 8..=10 {
-            let cert = CertificateMessage {
-                certificate: Certificate::new(CertificateType::NotarizeFallback, slot, Some(hash)),
+            let cert = Certificate {
+                cert_type: CertificateType::NotarizeFallback(slot, hash),
                 signature: BLSSignature::default(),
                 bitmap: Vec::new(),
             };
@@ -2255,8 +2229,8 @@ mod tests {
                 )
                 .is_ok());
         }
-        let cert = CertificateMessage {
-            certificate: Certificate::new(CertificateType::FinalizeFast, 11, Some(hash)),
+        let cert = Certificate {
+            cert_type: CertificateType::FinalizeFast(11, hash),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };

--- a/votor/src/consensus_pool/stats.rs
+++ b/votor/src/consensus_pool/stats.rs
@@ -19,7 +19,7 @@ struct CertificateStats {
 
 impl CertificateStats {
     /// Increments the stats associated with the certificate type by one.
-    fn increment(&mut self, cert_type: &CertificateType) {
+    fn record(&mut self, cert_type: &CertificateType) {
         match cert_type {
             CertificateType::Finalize(_) => self.finalize = self.finalize.saturating_add(1),
             CertificateType::FinalizeFast(_, _) => {
@@ -33,8 +33,8 @@ impl CertificateStats {
         }
     }
 
-    /// Records the certificate related statistics.
-    fn record(&self, header: &'static str) {
+    /// Submits the certificate related statistics.
+    fn submit(&self, header: &'static str) {
         datapoint_info!(
             header,
             ("finalize", self.finalize, i64),
@@ -100,9 +100,9 @@ impl ConsensusPoolStats {
 
     pub fn incr_cert_type(&mut self, cert_type: &CertificateType, is_generated: bool) {
         if is_generated {
-            self.new_certs_generated.increment(cert_type);
+            self.new_certs_generated.record(cert_type);
         } else {
-            self.new_certs_ingested.increment(cert_type);
+            self.new_certs_ingested.record(cert_type);
         };
     }
 
@@ -166,9 +166,9 @@ impl ConsensusPoolStats {
         );
 
         self.new_certs_generated
-            .record("consensus_pool_generated_certs");
+            .submit("consensus_pool_generated_certs");
         self.new_certs_ingested
-            .record("consensus_pool_ingested_certs");
+            .submit("consensus_pool_ingested_certs");
     }
 
     pub fn maybe_report(&mut self) {

--- a/votor/src/consensus_pool/stats.rs
+++ b/votor/src/consensus_pool/stats.rs
@@ -1,6 +1,3 @@
-#![allow(dead_code)]
-// TODO(wen): remove allow(dead_code) when consensus_pool is fully integrated
-
 use {
     crate::common::VoteType,
     agave_votor_messages::consensus_message::CertificateType,
@@ -10,7 +7,45 @@ use {
 
 const STATS_REPORT_INTERVAL: Duration = Duration::from_secs(10);
 
-#[derive(Debug)]
+/// Struct to hold stats for different certificate types.
+#[derive(Default)]
+struct CertificateStats {
+    finalize: u64,
+    finalize_fast: u64,
+    notarize: u64,
+    notarize_fallback: u64,
+    skip: u64,
+}
+
+impl CertificateStats {
+    /// Increments the stats associated with the certificate type by one.
+    fn increment(&mut self, cert_type: &CertificateType) {
+        match cert_type {
+            CertificateType::Finalize(_) => self.finalize = self.finalize.saturating_add(1),
+            CertificateType::FinalizeFast(_, _) => {
+                self.finalize_fast = self.finalize_fast.saturating_add(1)
+            }
+            CertificateType::Notarize(_, _) => self.notarize = self.notarize.saturating_add(1),
+            CertificateType::NotarizeFallback(_, _) => {
+                self.notarize_fallback = self.notarize_fallback.saturating_add(1)
+            }
+            CertificateType::Skip(_) => self.skip = self.skip.saturating_add(1),
+        }
+    }
+
+    /// Records the certificate related statistics.
+    fn record(&self, header: &'static str) {
+        datapoint_info!(
+            header,
+            ("finalize", self.finalize, i64),
+            ("finalize_fast", self.finalize_fast, i64),
+            ("notarize", self.notarize, i64),
+            ("notarize_fallback", self.notarize_fallback, i64),
+            ("skip", self.skip, i64),
+        )
+    }
+}
+
 pub(crate) struct ConsensusPoolStats {
     pub(crate) conflicting_votes: u32,
     pub(crate) event_safe_to_notarize: u32,
@@ -22,8 +57,8 @@ pub(crate) struct ConsensusPoolStats {
     pub(crate) out_of_range_certs: u32,
     pub(crate) out_of_range_votes: u32,
 
-    pub(crate) new_certs_generated: Vec<u32>,
-    pub(crate) new_certs_ingested: Vec<u32>,
+    new_certs_generated: CertificateStats,
+    new_certs_ingested: CertificateStats,
     pub(crate) ingested_votes: Vec<u32>,
 
     pub(crate) last_request_time: Instant,
@@ -38,7 +73,6 @@ impl Default for ConsensusPoolStats {
 impl ConsensusPoolStats {
     pub fn new() -> Self {
         let num_vote_types = (VoteType::SkipFallback as usize).saturating_add(1);
-        let num_cert_types = (CertificateType::Skip as usize).saturating_add(1);
         Self {
             conflicting_votes: 0,
             event_safe_to_notarize: 0,
@@ -50,8 +84,8 @@ impl ConsensusPoolStats {
             out_of_range_certs: 0,
             out_of_range_votes: 0,
 
-            new_certs_ingested: vec![0; num_cert_types],
-            new_certs_generated: vec![0; num_cert_types],
+            new_certs_ingested: CertificateStats::default(),
+            new_certs_generated: CertificateStats::default(),
             ingested_votes: vec![0; num_vote_types],
 
             last_request_time: Instant::now(),
@@ -64,15 +98,12 @@ impl ConsensusPoolStats {
         self.ingested_votes[index] = self.ingested_votes[index].saturating_add(1);
     }
 
-    pub fn incr_cert_type(&mut self, cert_type: CertificateType, is_generated: bool) {
-        let index = cert_type as usize;
-        let array = if is_generated {
-            &mut self.new_certs_generated
+    pub fn incr_cert_type(&mut self, cert_type: &CertificateType, is_generated: bool) {
+        if is_generated {
+            self.new_certs_generated.increment(cert_type);
         } else {
-            &mut self.new_certs_ingested
+            self.new_certs_ingested.increment(cert_type);
         };
-
-        array[index] = array[index].saturating_add(1);
     }
 
     fn report(&self) {
@@ -134,93 +165,10 @@ impl ConsensusPoolStats {
             ),
         );
 
-        datapoint_info!(
-            "certfificate_pool_ingested_certs",
-            (
-                "finalize",
-                *self
-                    .new_certs_ingested
-                    .get(CertificateType::Finalize as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-            (
-                "finalize_fast",
-                *self
-                    .new_certs_ingested
-                    .get(CertificateType::FinalizeFast as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-            (
-                "notarize",
-                *self
-                    .new_certs_ingested
-                    .get(CertificateType::Notarize as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-            (
-                "notarize_fallback",
-                *self
-                    .new_certs_ingested
-                    .get(CertificateType::NotarizeFallback as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-            (
-                "skip",
-                *self
-                    .new_certs_ingested
-                    .get(CertificateType::Skip as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-        );
-
-        datapoint_info!(
-            "consensus_pool_generated_certs",
-            (
-                "finalize",
-                *self
-                    .new_certs_generated
-                    .get(CertificateType::Finalize as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-            (
-                "finalize_fast",
-                *self
-                    .new_certs_generated
-                    .get(CertificateType::FinalizeFast as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-            (
-                "notarize",
-                *self
-                    .new_certs_generated
-                    .get(CertificateType::Notarize as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-            (
-                "notarize_fallback",
-                *self
-                    .new_certs_generated
-                    .get(CertificateType::NotarizeFallback as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-            (
-                "skip",
-                *self
-                    .new_certs_generated
-                    .get(CertificateType::Skip as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-        );
+        self.new_certs_generated
+            .record("consensus_pool_generated_certs");
+        self.new_certs_ingested
+            .record("consensus_pool_ingested_certs");
     }
 
     pub fn maybe_report(&mut self) {

--- a/votor/src/consensus_pool/vote_certificate_builder.rs
+++ b/votor/src/consensus_pool/vote_certificate_builder.rs
@@ -3,7 +3,7 @@ use {
     agave_votor_messages::consensus_message::{Certificate, CertificateType, VoteMessage},
     bitvec::prelude::*,
     solana_bls_signatures::{BlsError, SignatureProjective},
-    solana_signer_store::{encode_base2, encode_base3, DecodeError, EncodeError},
+    solana_signer_store::{decode, encode_base2, encode_base3, DecodeError, Decoded, EncodeError},
     thiserror::Error,
 };
 
@@ -44,6 +44,31 @@ pub struct VoteCertificateBuilder {
     // will be empty.
     input_bitmap_1: BitVec<u8, Lsb0>,
     input_bitmap_2: BitVec<u8, Lsb0>,
+}
+
+impl TryFrom<Certificate> for VoteCertificateBuilder {
+    type Error = CertificateError;
+
+    fn try_from(cert: Certificate) -> Result<Self, Self::Error> {
+        let projective_signature = SignatureProjective::try_from(cert.signature)?;
+        let decoded_bitmap =
+            decode(&cert.bitmap, MAXIMUM_VALIDATORS).map_err(CertificateError::DecodeError)?;
+        let (mut input_bitmap_1, mut input_bitmap_2) = match decoded_bitmap {
+            Decoded::Base2(bitmap) => (
+                bitmap,
+                BitVec::<u8, Lsb0>::repeat(false, MAXIMUM_VALIDATORS),
+            ),
+            Decoded::Base3(bitmap1, bitmap2) => (bitmap1, bitmap2),
+        };
+        input_bitmap_1.resize(MAXIMUM_VALIDATORS, false);
+        input_bitmap_2.resize(MAXIMUM_VALIDATORS, false);
+        Ok(VoteCertificateBuilder {
+            cert_type: cert.cert_type,
+            signature: projective_signature,
+            input_bitmap_1,
+            input_bitmap_2,
+        })
+    }
 }
 
 impl VoteCertificateBuilder {
@@ -294,6 +319,19 @@ mod tests {
             builder.build(),
             Err(CertificateError::EncodeError(
                 EncodeError::InvalidBitCombination
+            ))
+        );
+
+        // Test decoding error
+        let corrupt_certificate_message = Certificate {
+            cert_type: CertificateType::NotarizeFallback(1, hash),
+            signature: signature.into(),
+            bitmap: vec![0xFF; 100], // Corrupted bitmap
+        };
+        assert_eq!(
+            VoteCertificateBuilder::try_from(corrupt_certificate_message).err(),
+            Some(CertificateError::DecodeError(
+                DecodeError::UnsupportedEncoding
             ))
         );
     }

--- a/votor/src/consensus_pool/vote_certificate_builder.rs
+++ b/votor/src/consensus_pool/vote_certificate_builder.rs
@@ -1,9 +1,9 @@
 use {
     crate::common::{certificate_limits_and_vote_types, VoteType},
-    agave_votor_messages::consensus_message::{Certificate, CertificateMessage, VoteMessage},
+    agave_votor_messages::consensus_message::{Certificate, CertificateType, VoteMessage},
     bitvec::prelude::*,
     solana_bls_signatures::{BlsError, SignatureProjective},
-    solana_signer_store::{decode, encode_base2, encode_base3, DecodeError, Decoded, EncodeError},
+    solana_signer_store::{encode_base2, encode_base3, DecodeError, EncodeError},
     thiserror::Error,
 };
 
@@ -29,12 +29,10 @@ pub enum CertificateError {
     ValidatorDoesNotExist(u16),
 }
 
-// TODO(wen): remove dead_code when we migrate consensus_pool
-#[allow(dead_code)]
 /// A builder for creating a `CertificateMessage` by efficiently aggregating BLS signatures.
 #[derive(Clone)]
 pub struct VoteCertificateBuilder {
-    certificate: Certificate,
+    cert_type: CertificateType,
     signature: SignatureProjective,
     // For some certificates we need two bitmaps, for example, NotarizeFallback
     // certificates have Notarize and NotarizeFallback votes, so we need two bitmaps
@@ -48,36 +46,10 @@ pub struct VoteCertificateBuilder {
     input_bitmap_2: BitVec<u8, Lsb0>,
 }
 
-impl TryFrom<CertificateMessage> for VoteCertificateBuilder {
-    type Error = CertificateError;
-
-    fn try_from(message: CertificateMessage) -> Result<Self, Self::Error> {
-        let projective_signature = SignatureProjective::try_from(message.signature)?;
-        let decoded_bitmap =
-            decode(&message.bitmap, MAXIMUM_VALIDATORS).map_err(CertificateError::DecodeError)?;
-        let (mut input_bitmap_1, mut input_bitmap_2) = match decoded_bitmap {
-            Decoded::Base2(bitmap) => (
-                bitmap,
-                BitVec::<u8, Lsb0>::repeat(false, MAXIMUM_VALIDATORS),
-            ),
-            Decoded::Base3(bitmap1, bitmap2) => (bitmap1, bitmap2),
-        };
-        input_bitmap_1.resize(MAXIMUM_VALIDATORS, false);
-        input_bitmap_2.resize(MAXIMUM_VALIDATORS, false);
-        Ok(VoteCertificateBuilder {
-            certificate: message.certificate,
-            signature: projective_signature,
-            input_bitmap_1,
-            input_bitmap_2,
-        })
-    }
-}
-
-#[allow(dead_code)]
 impl VoteCertificateBuilder {
-    pub fn new(certificate_id: Certificate) -> Self {
+    pub fn new(cert_type: CertificateType) -> Self {
         Self {
-            certificate: certificate_id,
+            cert_type,
             signature: SignatureProjective::identity(),
             input_bitmap_1: BitVec::repeat(false, MAXIMUM_VALIDATORS),
             input_bitmap_2: BitVec::repeat(false, MAXIMUM_VALIDATORS),
@@ -90,7 +62,7 @@ impl VoteCertificateBuilder {
             return Ok(());
         }
 
-        let vote_types = certificate_limits_and_vote_types(self.certificate).1;
+        let vote_types = certificate_limits_and_vote_types(&self.cert_type).1;
         for vote_message in messages {
             let rank = vote_message.rank as usize;
             if MAXIMUM_VALIDATORS <= rank {
@@ -111,7 +83,7 @@ impl VoteCertificateBuilder {
             .aggregate_with(messages.iter().map(|m| &m.signature))?)
     }
 
-    pub fn build(self) -> Result<CertificateMessage, CertificateError> {
+    pub fn build(self) -> Result<Certificate, CertificateError> {
         let mut input_bitmap_1 = self.input_bitmap_1;
         let mut input_bitmap_2 = self.input_bitmap_2;
 
@@ -139,8 +111,8 @@ impl VoteCertificateBuilder {
             // If we only have one bitmap, use Base2 encoding
             encode_base2(&input_bitmap_1).map_err(CertificateError::EncodeError)?
         };
-        Ok(CertificateMessage {
-            certificate: self.certificate,
+        Ok(Certificate {
+            cert_type: self.cert_type,
             signature: self.signature.into(),
             bitmap,
         })
@@ -152,7 +124,7 @@ mod tests {
     use {
         super::*,
         agave_votor_messages::{
-            consensus_message::{Certificate, CertificateType, VoteMessage},
+            consensus_message::{CertificateType, VoteMessage},
             vote::Vote,
         },
         solana_bls_signatures::{
@@ -160,13 +132,14 @@ mod tests {
             Signature as BLSSignature, SignatureProjective, VerifiablePubkey,
         },
         solana_hash::Hash,
+        solana_signer_store::{decode, Decoded},
     };
 
     #[test]
     fn test_normal_build() {
         let hash = Hash::new_unique();
-        let certificate = Certificate::new(CertificateType::NotarizeFallback, 1, Some(hash));
-        let mut builder = VoteCertificateBuilder::new(certificate);
+        let cert_type = CertificateType::NotarizeFallback(1, hash);
+        let mut builder = VoteCertificateBuilder::new(cert_type);
         // Test building the certificate from Notarize and NotarizeFallback votes
         // Create Notarize on validator 1, 4, 6
         let vote = Vote::new_notarization_vote(1, hash);
@@ -205,11 +178,9 @@ mod tests {
             .aggregate(&messages_2)
             .expect("Failed to aggregate notarization fallback votes");
 
-        let certificate_message = builder.build().expect("Failed to build certificate");
-        assert_eq!(certificate_message.certificate, certificate);
-        match decode(&certificate_message.bitmap, MAXIMUM_VALIDATORS)
-            .expect("Failed to decode bitmap")
-        {
+        let cert = builder.build().expect("Failed to build certificate");
+        assert_eq!(cert.cert_type, cert_type);
+        match decode(&cert.bitmap, MAXIMUM_VALIDATORS).expect("Failed to decode bitmap") {
             Decoded::Base3(bitmap1, bitmap2) => {
                 assert_eq!(bitmap1.len(), 8);
                 assert_eq!(bitmap2.len(), 8);
@@ -226,15 +197,13 @@ mod tests {
         }
 
         // Build a new certificate with only Notarize votes, we should get Base2 encoding
-        let mut builder = VoteCertificateBuilder::new(certificate);
+        let mut builder = VoteCertificateBuilder::new(cert_type);
         builder
             .aggregate(&messages_1)
             .expect("Failed to aggregate notarization votes");
-        let certificate_message = builder.build().expect("Failed to build certificate");
-        assert_eq!(certificate_message.certificate, certificate);
-        match decode(&certificate_message.bitmap, MAXIMUM_VALIDATORS)
-            .expect("Failed to decode bitmap")
-        {
+        let cert = builder.build().expect("Failed to build certificate");
+        assert_eq!(cert.cert_type, cert_type);
+        match decode(&cert.bitmap, MAXIMUM_VALIDATORS).expect("Failed to decode bitmap") {
             Decoded::Base2(bitmap1) => {
                 assert_eq!(bitmap1.len(), 7);
                 for i in rank_1 {
@@ -247,15 +216,13 @@ mod tests {
 
         // Base2 encoding only applies when the first bitmap is non-empty, if we build another
         // certificate with only NotarizeFallback votes, we should still get Base3 encoding
-        let mut builder = VoteCertificateBuilder::new(certificate);
+        let mut builder = VoteCertificateBuilder::new(cert_type);
         builder
             .aggregate(&messages_2)
             .expect("Failed to aggregate notarization fallback votes");
-        let certificate_message = builder.build().expect("Failed to build certificate");
-        assert_eq!(certificate_message.certificate, certificate);
-        match decode(&certificate_message.bitmap, MAXIMUM_VALIDATORS)
-            .expect("Failed to decode bitmap")
-        {
+        let cert = builder.build().expect("Failed to build certificate");
+        assert_eq!(cert.cert_type, cert_type);
+        match decode(&cert.bitmap, MAXIMUM_VALIDATORS).expect("Failed to decode bitmap") {
             Decoded::Base3(bitmap1, bitmap2) => {
                 assert_eq!(bitmap1.count_ones(), 0);
                 assert_eq!(bitmap2.len(), 8);
@@ -271,8 +238,8 @@ mod tests {
     #[test]
     fn test_builder_with_errors() {
         let hash = Hash::new_unique();
-        let certificate = Certificate::new(CertificateType::NotarizeFallback, 1, Some(hash));
-        let mut builder = VoteCertificateBuilder::new(certificate);
+        let cert_type = CertificateType::NotarizeFallback(1, hash);
+        let mut builder = VoteCertificateBuilder::new(cert_type);
 
         // Test with a rank that exceeds the maximum allowed
         let vote = Vote::new_notarization_vote(1, hash);
@@ -311,7 +278,7 @@ mod tests {
             signature: signature.into(),
             rank: 1,
         }];
-        let mut builder = VoteCertificateBuilder::new(certificate);
+        let mut builder = VoteCertificateBuilder::new(cert_type);
         builder
             .aggregate(&messages_1)
             .expect("Failed to aggregate notarization votes");
@@ -329,26 +296,13 @@ mod tests {
                 EncodeError::InvalidBitCombination
             ))
         );
-
-        // Test decoding error
-        let corrupt_certificate_message = CertificateMessage {
-            certificate: Certificate::new(CertificateType::NotarizeFallback, 1, Some(hash)),
-            signature: signature.into(),
-            bitmap: vec![0xFF; 100], // Corrupted bitmap
-        };
-        assert_eq!(
-            VoteCertificateBuilder::try_from(corrupt_certificate_message).err(),
-            Some(CertificateError::DecodeError(
-                DecodeError::UnsupportedEncoding
-            ))
-        );
     }
 
     #[test]
     fn test_certificate_verification_base2_encoding() {
         let slot = 10;
         let hash = Hash::new_unique();
-        let certificate_id = Certificate::new(CertificateType::Notarize, slot, Some(hash));
+        let cert_type = CertificateType::Notarize(slot, hash);
 
         // 1. Setup: Create keypairs and a single vote object.
         // All validators will sign the same message, resulting in a single bitmap.
@@ -371,7 +325,7 @@ mod tests {
 
         // 2. Generation: Aggregate votes and build the certificate. This will
         // use base2 encoding because it only contains one type of vote.
-        let mut builder = VoteCertificateBuilder::new(certificate_id);
+        let mut builder = VoteCertificateBuilder::new(cert_type);
         builder
             .aggregate(&vote_messages)
             .expect("Failed to aggregate votes");
@@ -396,7 +350,7 @@ mod tests {
         let hash = Hash::new_unique();
         // A NotarizeFallback certificate can be composed of both Notarize and NotarizeFallback
         // votes.
-        let certificate_id = Certificate::new(CertificateType::NotarizeFallback, slot, Some(hash));
+        let cert_type = CertificateType::NotarizeFallback(slot, hash);
 
         // 1. Setup: Create two groups of validators signing two different vote types.
         let mut all_vote_messages = Vec::new();
@@ -435,7 +389,7 @@ mod tests {
 
         // 2. Generation: Aggregate votes. Because there are two vote types, this will use
         //    base3 encoding.
-        let mut builder = VoteCertificateBuilder::new(certificate_id);
+        let mut builder = VoteCertificateBuilder::new(cert_type);
         builder
             .aggregate(&all_vote_messages)
             .expect("Failed to aggregate votes");

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -5,7 +5,7 @@ use {
         staked_validators_cache::StakedValidatorsCache,
         vote_history_storage::{SavedVoteHistoryVersions, VoteHistoryStorage},
     },
-    agave_votor_messages::consensus_message::{CertificateMessage, ConsensusMessage},
+    agave_votor_messages::consensus_message::{Certificate, ConsensusMessage},
     bincode::serialize,
     crossbeam_channel::Receiver,
     solana_client::connection_cache::ConnectionCache,
@@ -45,7 +45,7 @@ pub enum BLSOp {
         saved_vote_history: SavedVoteHistoryVersions,
     },
     PushCertificate {
-        certificate: Arc<CertificateMessage>,
+        certificate: Arc<Certificate>,
     },
 }
 
@@ -234,7 +234,7 @@ impl VotingService {
                 );
             }
             BLSOp::PushCertificate { certificate } => {
-                let vote_slot = certificate.certificate.slot();
+                let vote_slot = certificate.cert_type.slot();
                 let message = ConsensusMessage::Certificate((*certificate).clone());
                 Self::broadcast_consensus_message(
                     vote_slot,
@@ -261,9 +261,7 @@ mod tests {
             NullVoteHistoryStorage, SavedVoteHistory, SavedVoteHistoryVersions,
         },
         agave_votor_messages::{
-            consensus_message::{
-                Certificate, CertificateMessage, CertificateType, ConsensusMessage, VoteMessage,
-            },
+            consensus_message::{Certificate, CertificateType, ConsensusMessage, VoteMessage},
             vote::Vote,
         },
         solana_bls_signatures::Signature as BLSSignature,
@@ -344,13 +342,13 @@ mod tests {
         rank: 1,
     }))]
     #[test_case(BLSOp::PushCertificate {
-        certificate: Arc::new(CertificateMessage {
-            certificate: Certificate::new(CertificateType::Skip, 5, None),
+        certificate: Arc::new(Certificate {
+            cert_type: CertificateType::Skip(5),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         }),
-    }, ConsensusMessage::Certificate(CertificateMessage {
-        certificate: Certificate::new(CertificateType::Skip, 5, None),
+    }, ConsensusMessage::Certificate(Certificate {
+        cert_type: CertificateType::Skip(5),
         signature: BLSSignature::default(),
         bitmap: Vec::new(),
     }))]


### PR DESCRIPTION
#### Problem

Currently, we have `CertificateType`, `Certificate`, and `CertificateMessage`.  Intuitively, we would expect `Certificate` to contain the signature and the bitmap which is not in the `Certificate`. but in the `CertificateMessage` instead.  This setup doesn't feel intuitive.

#### Summary of Changes

- gets rid of `CertificateType`
- renames `Certificate` to `CertificateType`
- renames `CertificateMessage` to `Certificate`
- also removes some associated dead code.

Related PR in alpenglow repo is https://github.com/anza-xyz/alpenglow/pull/549