### PR TITLE
Makes scan_accounts_stored_meta() private to the append vec module

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "dev-context-only-utils")]
-use crate::append_vec::{self, StoredAccountMeta};
 use {
     crate::{
         account_info::{AccountInfo, Offset},
@@ -270,25 +268,6 @@ impl AccountsFile {
                 if let Some(reader) = ts.reader() {
                     reader.scan_accounts(callback)?;
                 }
-            }
-        }
-        Ok(())
-    }
-
-    /// Iterate over all accounts and call `callback` with each account.
-    ///
-    /// Prefer scan_accounts() when possible, as it does not contain file format
-    /// implementation details, and thus potentially can read less and be faster.
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn scan_accounts_stored_meta(
-        &self,
-        callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
-    ) -> Result<()> {
-        let mut reader = append_vec::new_scan_accounts_reader();
-        match self {
-            Self::AppendVec(av) => av.scan_accounts_stored_meta(&mut reader, callback)?,
-            Self::TieredStorage(_) => {
-                unimplemented!("StoredAccountMeta is only implemented for AppendVec")
             }
         }
         Ok(())

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1010,7 +1010,7 @@ impl AppendVec {
     /// Prefer scan_accounts() when possible, as it does not contain file format
     /// implementation details, and thus potentially can read less and be faster.
     #[allow(clippy::blocks_in_conditions)]
-    pub(crate) fn scan_accounts_stored_meta<'a>(
+    fn scan_accounts_stored_meta<'a>(
         &'a self,
         reader: &mut impl RequiredLenBufFileRead<'a>,
         mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
@@ -1073,6 +1073,19 @@ impl AppendVec {
             }
         }
         Ok(())
+    }
+
+    /// Scans accounts with StoredAccountMeta
+    ///
+    /// Only intended to be called by agave-store-tool.
+    /// Refer to `scan_accounts_stored_meta` for further documentation.
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn scan_accounts_stored_meta_for_store_tool(
+        &self,
+        callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
+    ) -> Result<()> {
+        let mut reader = new_scan_accounts_reader();
+        self.scan_accounts_stored_meta(&mut reader, callback)
     }
 
     /// Calculate the amount of storage required for an account with the passed

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -6,7 +6,7 @@ use {
     },
     rayon::prelude::*,
     solana_account::ReadableAccount,
-    solana_accounts_db::accounts_file::{AccountsFile, StorageAccess},
+    solana_accounts_db::append_vec::AppendVec,
     solana_pubkey::Pubkey,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     std::{
@@ -109,24 +109,12 @@ fn cmd_search(
 }
 
 fn do_inspect(file: impl AsRef<Path>, verbose: bool) -> Result<(), String> {
-    let file_size = fs::metadata(&file)
-        .map_err(|err| {
-            format!(
-                "failed to get file metadata '{}': {err}",
-                file.as_ref().display(),
-            )
-        })?
-        .len() as usize;
-
-    let (storage, _size) =
-        AccountsFile::new_from_file(file.as_ref(), file_size, StorageAccess::default()).map_err(
-            |err| {
-                format!(
-                    "failed to open account storage file '{}': {err}",
-                    file.as_ref().display(),
-                )
-            },
-        )?;
+    let storage = AppendVec::new_for_store_tool(file.as_ref()).map_err(|err| {
+        format!(
+            "failed to open account storage file '{}': {err}",
+            file.as_ref().display(),
+        )
+    })?;
     // By default, when the storage is dropped, the backing file will be removed.
     // We do not want to remove the backing file here in the store-tool, so prevent dropping.
     let storage = ManuallyDrop::new(storage);
@@ -138,7 +126,7 @@ fn do_inspect(file: impl AsRef<Path>, verbose: bool) -> Result<(), String> {
     let mut stored_accounts_size = Saturating(0);
     let mut lamports = Saturating(0);
     storage
-        .scan_accounts_stored_meta(|account| {
+        .scan_accounts_stored_meta_for_store_tool(|account| {
             if verbose {
                 println!("{account:?}");
             } else {
@@ -198,23 +186,12 @@ fn do_search(
         )
     })?;
     files.par_iter().for_each(|file| {
-        let file_size = match fs::metadata(file) {
-            Ok(metadata) => metadata.len() as usize,
-            Err(err) => {
-                eprintln!("failed to get storage metadata '{}': {err}", file.display(),);
-                return;
-            }
-        };
-        let Ok((storage, _size)) =
-            AccountsFile::new_from_file(file, file_size, StorageAccess::default()).inspect_err(
-                |err| {
-                    eprintln!(
-                        "failed to open account storage file '{}': {err}",
-                        file.display(),
-                    )
-                },
+        let Ok(storage) = AppendVec::new_for_store_tool(file).inspect_err(|err| {
+            eprintln!(
+                "failed to open account storage file '{}': {err}",
+                file.display(),
             )
-        else {
+        }) else {
             return;
         };
         // By default, when the storage is dropped, the backing file will be removed.
@@ -223,7 +200,7 @@ fn do_search(
 
         let file_name = Path::new(file.file_name().expect("path is a file"));
         storage
-            .scan_accounts_stored_meta(|account| {
+            .scan_accounts_stored_meta_for_store_tool(|account| {
                 if addresses.contains(account.pubkey()) {
                     if verbose {
                         println!("storage: {}, {account:?}", file_name.display());


### PR DESCRIPTION
#### Problem

We want to remove uses of StoredAccountMeta from everywhere outside of the append vec module. We currently use `scan_accounts_stored_meta()` in AccountsFile for agave-store-tool though.

#### Summary of Changes

Update agave-store-tool to call AppendVec methods instead of AccountsFile, which then lets us make `scan_accounts_stored_meta()` private to append vec.