### PR TITLE
svm-test-harness: refactor for test env setup

### DIFF
--- a/svm-test-harness/src/file.rs
+++ b/svm-test-harness/src/file.rs
@@ -1,0 +1,80 @@
+//! Module for loading files from local filesystem.
+//!
+//! When compiling a Solana program with `cargo build-sbf`, the environment
+//! variable `SBF_OUT_DIR` defaults to `target/deploy` and the compiled program
+//! ELF file is written to `target/deploy/program_name.so`.
+//!
+//! As a result, the default search paths for ELF files are:
+//!
+//! * `tests/fixtures`
+//! * `BPF_OUT_DIR`
+//! * `SBF_OUT_DIR`
+//! * The current working directory
+//!
+//! Since these functions are intended for the local filesystem and for testing
+//! purposes, they will panic if the file is not found or if there is an
+//! error reading the file.
+
+use std::{
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+fn default_shared_object_dirs() -> Vec<PathBuf> {
+    let mut search_path = vec![PathBuf::from("tests/fixtures")];
+
+    if let Ok(bpf_out_dir) = std::env::var("BPF_OUT_DIR") {
+        search_path.push(PathBuf::from(bpf_out_dir));
+    }
+
+    if let Ok(sbf_out_dir) = std::env::var("SBF_OUT_DIR") {
+        search_path.push(PathBuf::from(sbf_out_dir));
+    }
+
+    if let Ok(dir) = std::env::current_dir() {
+        search_path.push(dir);
+    }
+
+    search_path
+}
+
+fn find_file(filename: &str) -> Option<PathBuf> {
+    for dir in default_shared_object_dirs() {
+        let candidate = dir.join(filename);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Read the contents of a file into a `Vec<u8>`.
+pub fn read_file<P: AsRef<Path>>(path: P) -> Vec<u8> {
+    let path = path.as_ref();
+    let mut file = File::open(path)
+        .unwrap_or_else(|e| panic!("Failed to open file {}: {}", path.display(), e));
+
+    let mut file_data = Vec::new();
+    file.read_to_end(&mut file_data)
+        .unwrap_or_else(|e| panic!("Failed to read file {}: {}", path.display(), e));
+    file_data
+}
+
+/// Load a program ELF file from the local filesystem by program name.
+///
+/// The program ELF file is expected to be located in one of the default search
+/// paths:
+///
+/// * `tests/fixtures`
+/// * `BPF_OUT_DIR`
+/// * `SBF_OUT_DIR`
+/// * The current working directory
+///
+/// The name of the program ELF file is expected to be `{program_name}.so`.
+pub fn load_program_elf(program_name: &str) -> Vec<u8> {
+    let file_name = format!("{program_name}.so");
+    let program_file = find_file(&file_name)
+        .unwrap_or_else(|| panic!("Failed to find program ELF file: {file_name}"));
+    read_file(program_file)
+}

--- a/svm-test-harness/src/fuzz.rs
+++ b/svm-test-harness/src/fuzz.rs
@@ -9,9 +9,11 @@ use {
         instr::execute_instr,
     },
     agave_feature_set::{increase_cpi_account_info_limit, raise_cpi_nesting_limit_to_8},
+    agave_syscalls::create_program_runtime_environment_v1,
     prost::Message,
     solana_compute_budget::compute_budget::ComputeBudget,
-    std::{env, ffi::c_int},
+    solana_program_runtime::loaded_programs::ProgramRuntimeEnvironments,
+    std::{env, ffi::c_int, sync::Arc},
 };
 
 #[no_mangle]
@@ -41,6 +43,7 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects
         budget.compute_unit_limit = instr_context.cu_avail;
         budget
     };
+
     // When testing with protobuf, we fill the sysvar cache from input accounts.
     let sysvar_cache = {
         let mut cache = solana_program_runtime::sysvar_cache::SysvarCache::default();
@@ -48,7 +51,40 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects
         cache
     };
 
-    let instr_effects = execute_instr(instr_context, &compute_budget, &sysvar_cache);
+    // When testing with protobuf, we fill the program cache from input accounts.
+    let mut program_cache = {
+        let slot = sysvar_cache.get_clock().unwrap().slot;
+        let environments = ProgramRuntimeEnvironments {
+            program_runtime_v1: Arc::new(
+                create_program_runtime_environment_v1(
+                    &instr_context.feature_set.runtime_features(),
+                    &compute_budget.to_budget(),
+                    false, /* deployment */
+                    false, /* debugging_features */
+                )
+                .unwrap(),
+            ),
+            ..ProgramRuntimeEnvironments::default()
+        };
+
+        let mut cache = crate::program_cache::new_with_builtins(&instr_context.feature_set, slot);
+        crate::program_cache::fill_from_accounts(
+            &mut cache,
+            &environments,
+            &instr_context.accounts,
+            slot,
+        )
+        .unwrap();
+
+        cache
+    };
+
+    let instr_effects = execute_instr(
+        instr_context,
+        &compute_budget,
+        &mut program_cache,
+        &sysvar_cache,
+    );
     instr_effects.map(Into::into)
 }
 

--- a/svm-test-harness/src/fuzz.rs
+++ b/svm-test-harness/src/fuzz.rs
@@ -41,8 +41,14 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects
         budget.compute_unit_limit = instr_context.cu_avail;
         budget
     };
+    // When testing with protobuf, we fill the sysvar cache from input accounts.
+    let sysvar_cache = {
+        let mut cache = solana_program_runtime::sysvar_cache::SysvarCache::default();
+        crate::sysvar_cache::fill_from_accounts(&mut cache, &instr_context.accounts);
+        cache
+    };
 
-    let instr_effects = execute_instr(instr_context, &compute_budget);
+    let instr_effects = execute_instr(instr_context, &compute_budget, &sysvar_cache);
     instr_effects.map(Into::into)
 }
 

--- a/svm-test-harness/src/instr.rs
+++ b/svm-test-harness/src/instr.rs
@@ -8,7 +8,6 @@ use {
     agave_precompiles::{get_precompile, is_precompile},
     agave_syscalls::create_program_runtime_environment_v1,
     solana_account::{Account, AccountSharedData},
-    solana_clock::Clock,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_instruction::AccountMeta,
     solana_instruction_error::InstructionError,
@@ -21,14 +20,14 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_stable_layout::stable_vec::StableVec,
-    solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
+    solana_svm_callback::InvokeContextCallback,
     solana_svm_log_collector::LogCollector,
     solana_svm_timings::ExecuteTimings,
     solana_transaction_context::{
         transaction_accounts::KeyedAccountSharedData, IndexOfAccount, InstructionAccount,
         TransactionContext,
     },
-    std::{collections::HashSet, sync::Arc},
+    std::sync::Arc,
 };
 
 /// Implement the callback trait so that the SVM API can be used to load
@@ -56,92 +55,6 @@ impl InvokeContextCallback for InstrContextCallback<'_> {
             Err(PrecompileError::InvalidPublicKey)
         }
     }
-}
-
-impl TransactionProcessingCallback for InstrContextCallback<'_> {
-    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, u64)> {
-        self.0
-            .accounts
-            .iter()
-            .find(|(found_pubkey, _)| *found_pubkey == *pubkey)
-            .map(|(_, account)| (AccountSharedData::from(account.clone()), 0u64))
-    }
-}
-
-fn create_program_cache(
-    input: &mut InstrContext,
-    clock: &Clock,
-    compute_budget: &ComputeBudget,
-) -> Option<(ProgramRuntimeEnvironments, ProgramCacheForTxBatch)> {
-    if !input
-        .accounts
-        .iter()
-        .any(|(pubkey, _)| pubkey == &input.instruction.program_id)
-    {
-        input.accounts.push((
-            input.instruction.program_id,
-            AccountSharedData::default().into(),
-        ));
-    }
-
-    let environments = ProgramRuntimeEnvironments {
-        program_runtime_v1: Arc::new(
-            create_program_runtime_environment_v1(
-                &input.feature_set.runtime_features(),
-                &compute_budget.to_budget(),
-                false, /* deployment */
-                false, /* debugging_features */
-            )
-            .unwrap(),
-        ),
-        ..ProgramRuntimeEnvironments::default()
-    };
-
-    // Set up the program cache, which will include all builtins by default.
-    let mut program_cache =
-        crate::program_cache::setup_program_cache(&input.feature_set, clock.slot);
-
-    let mut newly_loaded_programs = HashSet::<Pubkey>::new();
-
-    for acc in &input.accounts {
-        // FD rejects duplicate account loads
-        if !newly_loaded_programs.insert(acc.0) {
-            return None;
-        }
-
-        if program_cache.find(&acc.0).is_none() {
-            // load_program_with_pubkey expects the owner to be one of the bpf loader
-            if !solana_sdk_ids::loader_v4::check_id(&acc.1.owner)
-                && !solana_sdk_ids::bpf_loader_deprecated::check_id(&acc.1.owner)
-                && !solana_sdk_ids::bpf_loader::check_id(&acc.1.owner)
-                && !solana_sdk_ids::bpf_loader_upgradeable::check_id(&acc.1.owner)
-            {
-                continue;
-            }
-            // https://github.com/anza-xyz/agave/blob/af6930da3a99fd0409d3accd9bbe449d82725bd6/svm/src/program_loader.rs#L124
-            /* pub fn load_program_with_pubkey<CB: TransactionProcessingCallback, FG: ForkGraph>(
-                callbacks: &CB,
-                program_cache: &ProgramCache<FG>,
-                pubkey: &Pubkey,
-                slot: Slot,
-                effective_epoch: Epoch,
-                epoch_schedule: &EpochSchedule,
-                reload: bool,
-            ) -> Option<Arc<ProgramCacheEntry>> { */
-            if let Some(loaded_program) = solana_svm::program_loader::load_program_with_pubkey(
-                &InstrContextCallback(input),
-                &environments,
-                &acc.0,
-                clock.slot,
-                &mut ExecuteTimings::default(),
-                false,
-            ) {
-                program_cache.replenish(acc.0, loaded_program);
-            }
-        }
-    }
-
-    Some((environments, program_cache))
 }
 
 fn create_instruction_accounts(
@@ -186,6 +99,7 @@ fn create_transaction_context(
 pub fn execute_instr(
     mut input: InstrContext,
     compute_budget: &ComputeBudget,
+    program_cache: &mut ProgramCacheForTxBatch,
     sysvar_cache: &SysvarCache,
 ) -> Option<InstrEffects> {
     let mut compute_units_consumed = 0;
@@ -194,11 +108,32 @@ pub fn execute_instr(
     let log_collector = LogCollector::new_ref();
     let runtime_features = input.feature_set.runtime_features();
 
-    let clock = sysvar_cache.get_clock().unwrap();
     let rent = sysvar_cache.get_rent().unwrap();
 
-    let (environments, mut program_cache) =
-        create_program_cache(&mut input, &clock, compute_budget)?;
+    // Add default account for the program being invoked if not already present.
+    if !input
+        .accounts
+        .iter()
+        .any(|(pubkey, _)| pubkey == &input.instruction.program_id)
+    {
+        input.accounts.push((
+            input.instruction.program_id,
+            AccountSharedData::default().into(),
+        ));
+    }
+
+    let environments = ProgramRuntimeEnvironments {
+        program_runtime_v1: Arc::new(
+            create_program_runtime_environment_v1(
+                &input.feature_set.runtime_features(),
+                &compute_budget.to_budget(),
+                false, /* deployment */
+                false, /* debugging_features */
+            )
+            .unwrap(),
+        ),
+        ..ProgramRuntimeEnvironments::default()
+    };
 
     let mut transaction_context =
         create_transaction_context(&input.accounts, compute_budget, (*rent).clone());
@@ -222,7 +157,7 @@ pub fn execute_instr(
 
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
-            &mut program_cache,
+            program_cache,
             EnvironmentConfig::new(
                 blockhash,
                 blockhash_lamports_per_signature,
@@ -311,10 +246,12 @@ mod tests {
         let to_pubkey = Pubkey::new_from_array([2u8; 32]);
 
         let cu_avail = 10000u64;
+        let slot = 10;
+        let feature_set = FeatureSet::default();
 
         // Create Clock sysvar
         let clock = solana_clock::Clock {
-            slot: 10,
+            slot,
             ..Default::default()
         };
         let clock_data = bincode::serialize(&clock).unwrap();
@@ -325,7 +262,7 @@ mod tests {
 
         // Build the instruction context.
         let context = InstrContext {
-            feature_set: FeatureSet::default(),
+            feature_set: feature_set.clone(),
             accounts: vec![
                 (
                     from_pubkey,
@@ -414,8 +351,32 @@ mod tests {
         let mut sysvar_cache = SysvarCache::default();
         crate::sysvar_cache::fill_from_accounts(&mut sysvar_cache, &context.accounts);
 
+        // Create Program Cache
+        let mut program_cache = crate::program_cache::new_with_builtins(&feature_set, slot);
+
+        let environments = ProgramRuntimeEnvironments {
+            program_runtime_v1: Arc::new(
+                create_program_runtime_environment_v1(
+                    &feature_set.runtime_features(),
+                    &compute_budget.to_budget(),
+                    false, /* deployment */
+                    false, /* debugging_features */
+                )
+                .unwrap(),
+            ),
+            ..ProgramRuntimeEnvironments::default()
+        };
+
+        crate::program_cache::fill_from_accounts(
+            &mut program_cache,
+            &environments,
+            &context.accounts,
+            slot,
+        )
+        .unwrap();
+
         // Execute the instruction.
-        let effects = execute_instr(context, &compute_budget, &sysvar_cache)
+        let effects = execute_instr(context, &compute_budget, &mut program_cache, &sysvar_cache)
             .expect("Instruction execution should succeed");
 
         // Verify the results.

--- a/svm-test-harness/src/lib.rs
+++ b/svm-test-harness/src/lib.rs
@@ -1,5 +1,6 @@
 //! Solana SVM test harness.
 
+pub mod file;
 pub mod fixture;
 pub mod instr;
 pub mod program_cache;

--- a/svm-test-harness/src/program_cache.rs
+++ b/svm-test-harness/src/program_cache.rs
@@ -4,28 +4,14 @@ use {
     },
     solana_builtins::BUILTINS,
     solana_program_runtime::loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
-    solana_pubkey::Pubkey,
     std::sync::Arc,
 };
-
-// These programs have been migrated to Core BPF, and therefore should not be
-// included in the fuzzing harness.
-const MIGRATED_BUILTINS: &[Pubkey] = &[
-    solana_sdk_ids::address_lookup_table::id(),
-    solana_sdk_ids::config::id(),
-    solana_sdk_ids::stake::id(),
-];
 
 pub fn setup_program_cache(feature_set: &FeatureSet, slot: u64) -> ProgramCacheForTxBatch {
     let mut cache = ProgramCacheForTxBatch::default();
     cache.set_slot_for_tests(slot);
 
     for builtin in BUILTINS {
-        // Skip migrated builtins.
-        if MIGRATED_BUILTINS.contains(&builtin.program_id) {
-            continue;
-        }
-
         // Only activate feature-gated builtins if the feature is active.
         if builtin.program_id == solana_sdk_ids::loader_v4::id()
             && !feature_set.is_active(&enable_loader_v4::id())

--- a/svm-test-harness/src/program_cache.rs
+++ b/svm-test-harness/src/program_cache.rs
@@ -2,12 +2,20 @@ use {
     agave_feature_set::{
         enable_loader_v4, zk_elgamal_proof_program_enabled, zk_token_sdk_enabled, FeatureSet,
     },
+    solana_account::{Account, AccountSharedData},
     solana_builtins::BUILTINS,
-    solana_program_runtime::loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
-    std::sync::Arc,
+    solana_instruction_error::InstructionError,
+    solana_program_runtime::loaded_programs::{
+        ProgramCacheEntry, ProgramCacheForTxBatch, ProgramRuntimeEnvironments,
+    },
+    solana_pubkey::Pubkey,
+    solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
+    solana_svm_timings::ExecuteTimings,
+    std::{collections::HashSet, sync::Arc},
 };
 
-pub fn setup_program_cache(feature_set: &FeatureSet, slot: u64) -> ProgramCacheForTxBatch {
+/// Create a new `ProgramCacheForTxBatch` instance with all builtins from `solana-builtins`.
+pub fn new_with_builtins(feature_set: &FeatureSet, slot: u64) -> ProgramCacheForTxBatch {
     let mut cache = ProgramCacheForTxBatch::default();
     cache.set_slot_for_tests(slot);
 
@@ -40,4 +48,67 @@ pub fn setup_program_cache(feature_set: &FeatureSet, slot: u64) -> ProgramCacheF
     }
 
     cache
+}
+
+/// Populate a `ProgramCacheForTxBatch` via `load_program_with_pubkey` from any program accounts.
+pub fn fill_from_accounts(
+    program_cache: &mut ProgramCacheForTxBatch,
+    environments: &ProgramRuntimeEnvironments,
+    accounts: &[(Pubkey, Account)],
+    slot: u64,
+) -> Result<(), InstructionError> {
+    let mut newly_loaded_programs = HashSet::<Pubkey>::new();
+
+    for acc in accounts {
+        // FD rejects duplicate account loads
+        if !newly_loaded_programs.insert(acc.0) {
+            return Err(InstructionError::UnsupportedProgramId);
+        }
+
+        if program_cache.find(&acc.0).is_none() {
+            // load_program_with_pubkey expects the owner to be one of the bpf loader
+            if !solana_sdk_ids::loader_v4::check_id(&acc.1.owner)
+                && !solana_sdk_ids::bpf_loader_deprecated::check_id(&acc.1.owner)
+                && !solana_sdk_ids::bpf_loader::check_id(&acc.1.owner)
+                && !solana_sdk_ids::bpf_loader_upgradeable::check_id(&acc.1.owner)
+            {
+                continue;
+            }
+            // https://github.com/anza-xyz/agave/blob/af6930da3a99fd0409d3accd9bbe449d82725bd6/svm/src/program_loader.rs#L124
+            /* pub fn load_program_with_pubkey<CB: TransactionProcessingCallback, FG: ForkGraph>(
+                callbacks: &CB,
+                program_cache: &ProgramCache<FG>,
+                pubkey: &Pubkey,
+                slot: Slot,
+                effective_epoch: Epoch,
+                epoch_schedule: &EpochSchedule,
+                reload: bool,
+            ) -> Option<Arc<ProgramCacheEntry>> { */
+            if let Some(loaded_program) = solana_svm::program_loader::load_program_with_pubkey(
+                &FillFromAccountsCallback(accounts),
+                environments,
+                &acc.0,
+                slot,
+                &mut ExecuteTimings::default(),
+                false,
+            ) {
+                program_cache.replenish(acc.0, loaded_program);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+struct FillFromAccountsCallback<'a>(&'a [(Pubkey, Account)]);
+
+impl InvokeContextCallback for FillFromAccountsCallback<'_> {}
+
+impl TransactionProcessingCallback for FillFromAccountsCallback<'_> {
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, u64)> {
+        self.0
+            .iter()
+            .find(|(found_pubkey, _)| *found_pubkey == *pubkey)
+            .map(|(_, account)| (AccountSharedData::from(account.clone()), 0u64))
+    }
 }

--- a/svm-test-harness/src/program_cache.rs
+++ b/svm-test-harness/src/program_cache.rs
@@ -60,13 +60,16 @@ pub fn add_program(
     elf: &[u8],
     feature_set: &FeatureSet,
     compute_budget: &ComputeBudget,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let program_runtime_environment = Arc::new(create_program_runtime_environment_v1(
-        &feature_set.runtime_features(),
-        &compute_budget.to_budget(),
-        false, /* reject_deployment_of_broken_elfs */
-        false, /* debugging_features */
-    )?);
+) {
+    let program_runtime_environment = Arc::new(
+        create_program_runtime_environment_v1(
+            &feature_set.runtime_features(),
+            &compute_budget.to_budget(),
+            false, /* reject_deployment_of_broken_elfs */
+            false, /* debugging_features */
+        )
+        .unwrap(),
+    );
 
     let entry = ProgramCacheEntry::new(
         loader_key,
@@ -76,11 +79,10 @@ pub fn add_program(
         elf,
         elf.len(),
         &mut LoadProgramMetrics::default(),
-    )?;
+    )
+    .unwrap();
 
     cache.replenish(*program_id, Arc::new(entry));
-
-    Ok(())
 }
 
 /// Populate a `ProgramCacheForTxBatch` via `load_program_with_pubkey` from any program accounts.

--- a/svm-test-harness/src/sysvar_cache.rs
+++ b/svm-test-harness/src/sysvar_cache.rs
@@ -4,16 +4,13 @@ use {
     solana_pubkey::Pubkey,
 };
 
-pub fn setup_sysvar_cache(input_accounts: &[(Pubkey, Account)]) -> SysvarCache {
-    let mut sysvar_cache = SysvarCache::default();
-
+/// Populate a `SysvarCache` via `fill_missing_entries` from any sysvar accounts.
+pub fn fill_from_accounts(sysvar_cache: &mut SysvarCache, accounts: &[(Pubkey, Account)]) {
     sysvar_cache.fill_missing_entries(|pubkey, callbackback| {
-        if let Some(account) = input_accounts.iter().find(|(key, _)| key == pubkey) {
+        if let Some(account) = accounts.iter().find(|(key, _)| key == pubkey) {
             if account.1.lamports() > 0 {
                 callbackback(account.1.data());
             }
         }
     });
-
-    sysvar_cache
 }


### PR DESCRIPTION
Refactors the test harness again after #8669 to allow unit tests that use the internal `execute_instr` harness to customize the test environment, including adding programs to the cache and configuring sysvars.

Note that this does not modify the way the protobuf/fuzzing entrypoint works. It simply moves all fuzzing-related behavior outward to the `execute_instr_proto` harness, and allows tests (like those within `programs/sbf`) to customize the test environment when invoking the inner `execute_instr` directly.
