### PR TITLE
agave-validator: move RpcBootstrapConfig clap args into config file

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -25,7 +25,6 @@ use {
     },
     solana_epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
     solana_faucet::faucet::{self, FAUCET_PORT},
-    solana_genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     solana_hash::Hash,
     solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE},
     solana_quic_definitions::QUIC_PORT_OFFSET,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -279,7 +279,6 @@ pub struct DefaultArgs {
     pub dynamic_port_range: String,
     pub ledger_path: String,
 
-    pub genesis_archive_unpacked_size: String,
     pub tower_storage: String,
     pub send_transaction_service_config: send_transaction_service::Config,
 
@@ -332,7 +331,6 @@ impl DefaultArgs {
             ledger_path: "ledger".to_string(),
             dynamic_port_range: format!("{}-{}", VALIDATOR_PORT_RANGE.0, VALIDATOR_PORT_RANGE.1),
             maximum_local_snapshot_age: "2500".to_string(),
-            genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE.to_string(),
             tower_storage: "file".to_string(),
             send_transaction_service_config: send_transaction_service::Config::default(),
             maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -231,18 +231,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Launch validator without voting"),
     )
     .arg(
-        Arg::with_name("check_vote_account")
-            .long("check-vote-account")
-            .takes_value(true)
-            .value_name("RPC_URL")
-            .requires("entrypoint")
-            .conflicts_with_all(&["no_voting"])
-            .help(
-                "Sanity check vote account state at startup. The JSON RPC endpoint at RPC_URL \
-                 must expose `--full-rpc-api`",
-            ),
-    )
-    .arg(
         Arg::with_name("restricted_repair_only_mode")
             .long("restricted-repair-only-mode")
             .takes_value(false)

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -234,12 +234,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("no_genesis_fetch")
-            .long("no-genesis-fetch")
-            .takes_value(false)
-            .help("Do not fetch genesis from the cluster"),
-    )
-    .arg(
         Arg::with_name("no_voting")
             .long("no-voting")
             .takes_value(false)

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -723,14 +723,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Log when transactions are processed which reference a given key."),
     )
     .arg(
-        Arg::with_name("only_known_rpc")
-            .alias("no-untrusted-rpc")
-            .long("only-known-rpc")
-            .takes_value(false)
-            .requires("known_validators")
-            .help("Use the RPC service of known validators only"),
-    )
-    .arg(
         Arg::with_name("repair_validators")
             .long("repair-validator")
             .validator(is_pubkey)

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -929,14 +929,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("max_genesis_archive_unpacked_size")
-            .long("max-genesis-archive-unpacked-size")
-            .value_name("NUMBER")
-            .takes_value(true)
-            .default_value(&default_args.genesis_archive_unpacked_size)
-            .help("maximum total uncompressed file size of downloaded genesis archive"),
-    )
-    .arg(
         Arg::with_name("wal_recovery_mode")
             .long("wal-recovery-mode")
             .value_name("MODE")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -420,12 +420,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Disable all snapshot generation"),
     )
     .arg(
-        Arg::with_name("no_incremental_snapshots")
-            .long("no-incremental-snapshots")
-            .takes_value(false)
-            .help("Disable incremental snapshots"),
-    )
-    .arg(
         Arg::with_name("snapshot_interval_slots")
             .long("snapshot-interval-slots")
             .alias("incremental-snapshot-interval-slots")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -225,15 +225,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Rendezvous with the cluster at this gossip entrypoint"),
     )
     .arg(
-        Arg::with_name("no_snapshot_fetch")
-            .long("no-snapshot-fetch")
-            .takes_value(false)
-            .help(
-                "Do not attempt to fetch a snapshot from the cluster, start from a local snapshot \
-                 if present",
-            ),
-    )
-    .arg(
         Arg::with_name("no_voting")
             .long("no-voting")
             .takes_value(false)

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1380,6 +1380,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
     .args(&json_rpc_config::args())
     .args(&rpc_bigtable_config::args())
     .args(&send_transaction_config::args())
+    .args(&rpc_bootstrap_config::args())
 }
 
 fn validators_set(

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -92,6 +92,10 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .takes_value(true)
             .default_value(&DEFAULT_MAX_GENESIS_ARCHIVE_UNPACKED_SIZE)
             .help("maximum total uncompressed file size of downloaded genesis archive"),
+        Arg::with_name("no_incremental_snapshots")
+            .long("no-incremental-snapshots")
+            .takes_value(false)
+            .help("Disable incremental snapshots"),
     ]
 }
 

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -3,8 +3,13 @@ use {
         bootstrap::RpcBootstrapConfig,
         commands::{FromClapArgMatches, Result},
     },
+    agave_snapshots::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     clap::{value_t, Arg, ArgMatches},
+    std::sync::LazyLock,
 };
+
+static DEFAULT_MAX_GENESIS_ARCHIVE_UNPACKED_SIZE: LazyLock<String> =
+    LazyLock::new(|| MAX_GENESIS_ARCHIVE_UNPACKED_SIZE.to_string());
 
 #[cfg(test)]
 impl Default for RpcBootstrapConfig {
@@ -81,6 +86,12 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .takes_value(false)
             .requires("known_validators")
             .help("Use the RPC service of known validators only"),
+        Arg::with_name("max_genesis_archive_unpacked_size")
+            .long("max-genesis-archive-unpacked-size")
+            .value_name("NUMBER")
+            .takes_value(true)
+            .default_value(&DEFAULT_MAX_GENESIS_ARCHIVE_UNPACKED_SIZE)
+            .help("maximum total uncompressed file size of downloaded genesis archive"),
     ]
 }
 
@@ -239,5 +250,13 @@ mod tests {
                 expected_args,
             );
         }
+    }
+
+    #[test]
+    fn test_default_max_genesis_archive_unpacked_size_unchanged() {
+        assert_eq!(
+            *DEFAULT_MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+            (10 * 1024 * 1024).to_string()
+        );
     }
 }

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -3,7 +3,7 @@ use {
         bootstrap::RpcBootstrapConfig,
         commands::{FromClapArgMatches, Result},
     },
-    clap::{value_t, ArgMatches},
+    clap::{value_t, Arg, ArgMatches},
 };
 
 #[cfg(test)]
@@ -50,6 +50,10 @@ impl FromClapArgMatches for RpcBootstrapConfig {
             incremental_snapshot_fetch: !no_incremental_snapshots,
         })
     }
+}
+
+pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
+    vec![]
 }
 
 #[cfg(test)]

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -65,6 +65,16 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
                 "Do not attempt to fetch a snapshot from the cluster, start from a local snapshot \
                  if present",
             ),
+        Arg::with_name("check_vote_account")
+            .long("check-vote-account")
+            .takes_value(true)
+            .value_name("RPC_URL")
+            .requires("entrypoint")
+            .conflicts_with_all(&["no_voting"])
+            .help(
+                "Sanity check vote account state at startup. The JSON RPC endpoint at RPC_URL \
+                 must expose `--full-rpc-api`",
+            ),
     ]
 }
 

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -53,10 +53,19 @@ impl FromClapArgMatches for RpcBootstrapConfig {
 }
 
 pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
-    vec![Arg::with_name("no_genesis_fetch")
-        .long("no-genesis-fetch")
-        .takes_value(false)
-        .help("Do not fetch genesis from the cluster")]
+    vec![
+        Arg::with_name("no_genesis_fetch")
+            .long("no-genesis-fetch")
+            .takes_value(false)
+            .help("Do not fetch genesis from the cluster"),
+        Arg::with_name("no_snapshot_fetch")
+            .long("no-snapshot-fetch")
+            .takes_value(false)
+            .help(
+                "Do not attempt to fetch a snapshot from the cluster, start from a local snapshot \
+                 if present",
+            ),
+    ]
 }
 
 #[cfg(test)]

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -3,8 +3,8 @@ use {
         bootstrap::RpcBootstrapConfig,
         commands::{FromClapArgMatches, Result},
     },
-    agave_snapshots::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     clap::{value_t, Arg, ArgMatches},
+    solana_genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     std::sync::LazyLock,
 };
 

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -75,6 +75,12 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
                 "Sanity check vote account state at startup. The JSON RPC endpoint at RPC_URL \
                  must expose `--full-rpc-api`",
             ),
+        Arg::with_name("only_known_rpc")
+            .alias("no-untrusted-rpc")
+            .long("only-known-rpc")
+            .takes_value(false)
+            .requires("known_validators")
+            .help("Use the RPC service of known validators only"),
     ]
 }
 

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -53,7 +53,10 @@ impl FromClapArgMatches for RpcBootstrapConfig {
 }
 
 pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
-    vec![]
+    vec![Arg::with_name("no_genesis_fetch")
+        .long("no-genesis-fetch")
+        .takes_value(false)
+        .help("Do not fetch genesis from the cluster")]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Summary of Changes

- move RpcBootstrapConfig related clap args to config file
- move related default values to config file
