### PR TITLE
feat: various improvements to `CertificateBuilder`

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -10,7 +10,6 @@ use {
             parent_ready_tracker::ParentReadyTracker,
             slot_stake_counters::SlotStakeCounters,
             stats::ConsensusPoolStats,
-            vote_certificate_builder::{CertificateError, VoteCertificateBuilder},
             vote_pool::{DuplicateBlockVotePool, SimpleVotePool, VotePool},
         },
         event::VotorEvent,
@@ -19,6 +18,7 @@ use {
         consensus_message::{Block, Certificate, CertificateType, ConsensusMessage, VoteMessage},
         vote::Vote,
     },
+    certificate_builder::{BuildError as CertificateBuilderError, CertificateBuilder},
     log::{error, trace},
     solana_clock::{Epoch, Slot},
     solana_epoch_schedule::EpochSchedule,
@@ -33,10 +33,10 @@ use {
     thiserror::Error,
 };
 
+mod certificate_builder;
 pub mod parent_ready_tracker;
 mod slot_stake_counters;
 mod stats;
-mod vote_certificate_builder;
 mod vote_pool;
 
 pub type PoolId = (Slot, VoteType);
@@ -55,8 +55,8 @@ pub enum AddVoteError {
     #[error("Slot in the future")]
     SlotInFuture,
 
-    #[error("Certificate error: {0}")]
-    Certificate(#[from] CertificateError),
+    #[error("Certificate builder error: {0}")]
+    CertificateBuilder(#[from] CertificateBuilderError),
 
     #[error("{0} channel disconnected")]
     ChannelDisconnected(String),
@@ -211,7 +211,7 @@ impl ConsensusPool {
             if accumulated_stake as f64 / (total_stake as f64) < limit {
                 continue;
             }
-            let mut cert_builder = VoteCertificateBuilder::new(cert_type);
+            let mut cert_builder = CertificateBuilder::new(cert_type);
             vote_types.iter().for_each(|vote_type| {
                 if let Some(vote_pool) = self.vote_pools.get(&(slot, *vote_type)) {
                     match vote_pool {


### PR DESCRIPTION
#### Problem

- The current certificate builder is not capable of producing certificates for rewards because it combines skip and skip fallback votes into a single signature aggregate.  If we want to be able to reuse the builder without having to re-aggregate the votes into it, we will need to track skip and skip fallback votes separately.
- The logic in `VoteCertificateBuilder::build` is a bit obtuse.  In the scenario with a single bitmap, the actual operation is pretty straightforward.
- `VoteCertificateBuilder::aggregate` is silently ignoring potential bugs if there are somehow more than 2 types of bitmaps needed


#### Summary of Changes

- Splits out building of different certificates allowing us to enforce proper checks i.e. whether or not there should be one or more bitmaps and one or more signature aggregates.
- tracks the signature aggregate for skip certificates separately so that we can reuse the builder for skip reward certificates without having re-aggregate skip votes into it.  
- renames the builder to `CertificateBuilder` as the `Vote` prefix seems redundant.
- improves error handling: `aggregate` and `build` functions returns separate error types which means that they can be minimised to the minimum set of errors that can actually happen when calling these functions.
- improves documentation in various places.
