### PR TITLE
runtime: Add `Bank::new_from_parent_with_bank_forks`, reduce repetition

### DIFF
--- a/core/tests/scheduler_cost_adjustment.rs
+++ b/core/tests/scheduler_cost_adjustment.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 use {
     solana_account::{Account, ReadableAccount},
-    solana_clock::{Slot, MAX_PROCESSING_AGE},
+    solana_clock::MAX_PROCESSING_AGE,
     solana_compute_budget::compute_budget_limits::MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
     solana_compute_budget_interface::ComputeBudgetInstruction,
     solana_cost_model::cost_model::CostModel,
@@ -13,7 +13,7 @@ use {
     solana_native_token::LAMPORTS_PER_SOL,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
-    solana_runtime::{bank::Bank, bank_forks::BankForks},
+    solana_runtime::bank::Bank,
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk_ids::{bpf_loader_upgradeable, secp256k1_program},
     solana_signer::Signer,
@@ -22,22 +22,7 @@ use {
     solana_system_interface::instruction as system_instruction,
     solana_transaction::Transaction,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
-    std::sync::{Arc, RwLock},
 };
-
-fn new_bank_from_parent_with_bank_forks(
-    bank_forks: &RwLock<BankForks>,
-    parent: Arc<Bank>,
-    collector_id: &Pubkey,
-    slot: Slot,
-) -> Arc<Bank> {
-    let bank = Bank::new_from_parent(parent, collector_id, slot);
-    bank_forks
-        .write()
-        .unwrap()
-        .insert(bank)
-        .clone_without_scheduler()
-}
 
 #[derive(Debug, Eq, PartialEq)]
 struct TestResult {
@@ -78,7 +63,7 @@ impl TestSetup {
     fn execute_test_transaction(&mut self, ixs: &[Instruction]) -> TestResult {
         let root_bank = Bank::new_for_tests(&self.genesis_config);
         let (bank, bank_forks) = root_bank.wrap_with_bank_forks_for_tests();
-        let bank = new_bank_from_parent_with_bank_forks(
+        let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank,
             &Pubkey::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5862,6 +5862,20 @@ impl Bank {
         )
     }
 
+    pub fn new_from_parent_with_bank_forks(
+        bank_forks: &RwLock<BankForks>,
+        parent: Arc<Bank>,
+        collector_id: &Pubkey,
+        slot: Slot,
+    ) -> Arc<Self> {
+        let bank = Bank::new_from_parent(parent, collector_id, slot);
+        bank_forks
+            .write()
+            .unwrap()
+            .insert(bank)
+            .clone_without_scheduler()
+    }
+
     /// Prepare a transaction batch from a list of legacy transactions. Used for tests only.
     #[cfg(feature = "dev-context-only-utils")]
     pub fn prepare_batch_for_tests(

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -389,10 +389,7 @@ pub enum CacheValue {
 mod tests {
     use {
         super::*,
-        crate::{
-            bank::tests::new_bank_from_parent_with_bank_forks, runtime_config::RuntimeConfig,
-            snapshot_bank_utils, snapshot_utils,
-        },
+        crate::{runtime_config::RuntimeConfig, snapshot_bank_utils, snapshot_utils},
         agave_snapshots::snapshot_config::SnapshotConfig,
         solana_account::{ReadableAccount as _, WritableAccount as _},
         solana_accounts_db::{
@@ -506,7 +503,7 @@ mod tests {
 
         let bank = {
             let slot = bank.slot() + 1;
-            new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot)
+            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot)
         };
 
         // send from account 2 to account 1; account 1 stays alive, account 2 ends up dead
@@ -753,7 +750,7 @@ mod tests {
         for _ in 0..7 {
             let slot = bank.slot() + 1;
             bank =
-                new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
+                Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
             for _ in 0..13 {
                 bank.register_unique_recent_blockhash_for_test();
                 // note: use a random pubkey here to ensure accounts
@@ -807,7 +804,7 @@ mod tests {
         for _ in 0..9 {
             let slot = bank.slot() + 1;
             bank =
-                new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
+                Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
             for _ in 0..3 {
                 bank.register_unique_recent_blockhash_for_test();
                 bank.transfer(amount, &mint_keypair, &pubkey::new_rand())
@@ -833,7 +830,7 @@ mod tests {
         for i in 0..num_accounts {
             let slot = bank.slot() + 1;
             bank =
-                new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
+                Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
             bank.register_unique_recent_blockhash_for_test();
 
             // transfer into the accounts so they start with a non-zero balance
@@ -915,7 +912,7 @@ mod tests {
         let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
         let slot = bank.slot() + 1;
-        bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
+        bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
 
         // These are the two accounts *currently* added to the bank during Bank::new().
         // More accounts could be added later, so if the test fails, inspect the actual cache
@@ -956,7 +953,7 @@ mod tests {
         for _ in 0..3 {
             let slot = bank.slot() + 1;
             bank =
-                new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
+                Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
             bank.register_unique_recent_blockhash_for_test();
             bank.transfer(amount, &mint_keypair, &pubkey::new_rand())
                 .unwrap();

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -391,10 +391,7 @@ pub(crate) mod tests {
         super::*,
         crate::bank::{
             test_utils::goto_end_of_slot,
-            tests::{
-                create_genesis_config, create_simple_test_bank,
-                new_bank_from_parent_with_bank_forks,
-            },
+            tests::{create_genesis_config, create_simple_test_bank},
             Bank,
         },
         agave_feature_set::FeatureSet,
@@ -1216,7 +1213,7 @@ pub(crate) mod tests {
 
         // Advance to the next epoch without activating the feature.
         let mut first_slot_in_next_epoch = slots_per_epoch + 1;
-        let bank = new_bank_from_parent_with_bank_forks(
+        let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank,
             &Pubkey::default(),
@@ -1239,7 +1236,7 @@ pub(crate) mod tests {
         goto_end_of_slot(bank.clone());
         first_slot_in_next_epoch += slots_per_epoch;
         let migration_slot = first_slot_in_next_epoch;
-        let bank = new_bank_from_parent_with_bank_forks(
+        let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank,
             &Pubkey::default(),
@@ -1255,7 +1252,7 @@ pub(crate) mod tests {
         goto_end_of_slot(bank.clone());
         let next_slot = bank.slot() + 1;
         let bank =
-            new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), next_slot);
+            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), next_slot);
 
         // Successfully invoke the new BPF builtin program.
         bank.process_transaction(&Transaction::new(
@@ -1286,7 +1283,7 @@ pub(crate) mod tests {
         // Simulate crossing another epoch boundary for a new bank.
         goto_end_of_slot(bank.clone());
         first_slot_in_next_epoch += slots_per_epoch;
-        let bank = new_bank_from_parent_with_bank_forks(
+        let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank,
             &Pubkey::default(),
@@ -1369,7 +1366,7 @@ pub(crate) mod tests {
         // Advance the bank to cross the epoch boundary and activate the
         // feature.
         goto_end_of_slot(bank.clone());
-        let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
+        let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
 
         // Assert the feature _was_ activated but the program was not migrated.
         assert!(bank.feature_set.is_active(feature_id));
@@ -1386,7 +1383,7 @@ pub(crate) mod tests {
 
         // Simulate crossing an epoch boundary again.
         goto_end_of_slot(bank.clone());
-        let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 96);
+        let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 96);
 
         // Again, assert the feature is still active and the program still was
         // not migrated.
@@ -1473,7 +1470,7 @@ pub(crate) mod tests {
         // Simulate crossing an epoch boundary for a new bank.
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         goto_end_of_slot(bank.clone());
-        let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
+        let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
 
         // Assert the feature is active but the builtin was not migrated.
         assert!(bank.feature_set.is_active(feature_id));

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -370,7 +370,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            bank::tests::{create_genesis_config, new_bank_from_parent_with_bank_forks},
+            bank::tests::create_genesis_config,
             bank_forks::BankForks,
             genesis_utils::{
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
@@ -579,7 +579,7 @@ mod tests {
         // Advance some num slots; usually to the next epoch boundary to update
         // EpochStakes
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-        let bank = new_bank_from_parent_with_bank_forks(
+        let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank,
             &Pubkey::default(),
@@ -757,7 +757,7 @@ mod tests {
         // simulate block progress
         for slot in starting_slot..=(2 * SLOTS_PER_EPOCH) + 2 {
             let pre_cap = previous_bank.capitalization();
-            let curr_bank = new_bank_from_parent_with_bank_forks(
+            let curr_bank = Bank::new_from_parent_with_bank_forks(
                 bank_forks.as_ref(),
                 previous_bank.clone(),
                 &Pubkey::default(),
@@ -850,7 +850,7 @@ mod tests {
             let pre_epoch_rewards: solana_sysvar::epoch_rewards::EpochRewards =
                 solana_account::from_account(&pre_sysvar_account).unwrap_or_default();
             let pre_distributed_rewards = pre_epoch_rewards.distributed_rewards;
-            let curr_bank = new_bank_from_parent_with_bank_forks(
+            let curr_bank = Bank::new_from_parent_with_bank_forks(
                 bank_forks.as_ref(),
                 previous_bank.clone(),
                 &Pubkey::default(),
@@ -990,7 +990,7 @@ mod tests {
         let transfer_amount = 5_000;
 
         for slot in 1..=num_slots_in_epoch + 2 {
-            let bank = new_bank_from_parent_with_bank_forks(
+            let bank = Bank::new_from_parent_with_bank_forks(
                 bank_forks.as_ref(),
                 previous_bank.clone(),
                 &Pubkey::default(),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -167,20 +167,6 @@ impl VoteReward {
     }
 }
 
-pub(in crate::bank) fn new_bank_from_parent_with_bank_forks(
-    bank_forks: &RwLock<BankForks>,
-    parent: Arc<Bank>,
-    collector_id: &Pubkey,
-    slot: Slot,
-) -> Arc<Bank> {
-    let bank = Bank::new_from_parent(parent, collector_id, slot);
-    bank_forks
-        .write()
-        .unwrap()
-        .insert(bank)
-        .clone_without_scheduler()
-}
-
 fn create_genesis_config_no_tx_fee_no_rent(lamports: u64) -> (GenesisConfig, Keypair) {
     // genesis_util creates config with no tx fee and no rent
     let genesis_config_info = solana_runtime::genesis_utils::create_genesis_config(lamports);
@@ -579,7 +565,7 @@ pub(in crate::bank) fn new_from_parent_next_epoch(
         epoch = parent.epoch_schedule().get_epoch(slot);
     }
 
-    new_bank_from_parent_with_bank_forks(bank_forks, parent, &Pubkey::default(), slot)
+    Bank::new_from_parent_with_bank_forks(bank_forks, parent, &Pubkey::default(), slot)
 }
 
 #[test]
@@ -1247,7 +1233,7 @@ fn test_executed_transaction_count_post_bank_transaction_count_fix() {
     assert_eq!(bank.executed_transaction_count(), 2);
     assert_eq!(bank.transaction_error_count(), 1);
 
-    let bank2 = new_bank_from_parent_with_bank_forks(
+    let bank2 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank,
         &Pubkey::default(),
@@ -1435,7 +1421,7 @@ fn test_bank_tx_fee() {
     );
 
     // Verify that an InstructionError collects fees, too
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
     let mut tx = system_transaction::transfer(&mint_keypair, &key, 1, bank.last_blockhash());
     // Create a bogus instruction to system_program to cause an instruction error
     tx.message.instructions[0].data[0] = 40;
@@ -1545,7 +1531,7 @@ fn test_bank_tx_compute_unit_fee() {
     );
 
     // Verify that an InstructionError collects fees, too
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
     let mut tx = system_transaction::transfer(&mint_keypair, &key, 1, bank.last_blockhash());
     // Create a bogus instruction to system_program to cause an instruction error
     tx.message.instructions[0].data[0] = 40;
@@ -1601,13 +1587,13 @@ fn test_bank_blockhash_fee_structure() {
     let cheap_lamports_per_signature = bank.get_lamports_per_signature();
     assert_eq!(cheap_lamports_per_signature, 0);
 
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
     goto_end_of_slot(bank.clone());
     let expensive_blockhash = bank.last_blockhash();
     let expensive_lamports_per_signature = bank.get_lamports_per_signature();
     assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
 
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
 
     // Send a transfer using cheap_blockhash
     let key = solana_pubkey::new_rand();
@@ -1663,13 +1649,13 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
     let cheap_lamports_per_signature = bank.get_lamports_per_signature();
     assert_eq!(cheap_lamports_per_signature, 0);
 
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
     goto_end_of_slot(bank.clone());
     let expensive_blockhash = bank.last_blockhash();
     let expensive_lamports_per_signature = bank.get_lamports_per_signature();
     assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
 
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
 
     // Send a transfer using cheap_blockhash
     let key = solana_pubkey::new_rand();
@@ -2225,7 +2211,7 @@ fn new_from_parent(parent: Arc<Bank>) -> Bank {
 
 fn new_from_parent_with_fork_next_slot(parent: Arc<Bank>, fork: &RwLock<BankForks>) -> Arc<Bank> {
     let slot = parent.slot() + 1;
-    new_bank_from_parent_with_bank_forks(fork, parent, &Pubkey::default(), slot)
+    Bank::new_from_parent_with_bank_forks(fork, parent, &Pubkey::default(), slot)
 }
 
 /// Verify that the parent's vector is computed correctly
@@ -2353,7 +2339,7 @@ fn test_bank_hash_internal_state_verify() {
 
         let bank0_state = bank0.hash_internal_state();
         // Checkpointing should result in a new state while freezing the parent
-        let bank2 = new_bank_from_parent_with_bank_forks(
+        let bank2 = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank0.clone(),
             &solana_pubkey::new_rand(),
@@ -2373,7 +2359,7 @@ fn test_bank_hash_internal_state_verify() {
             add_root_and_flush_write_cache(&bank2);
             assert!(bank2.verify_accounts(VerifyAccountsHashConfig::default_for_test(), None));
         }
-        let bank3 = new_bank_from_parent_with_bank_forks(
+        let bank3 = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank0.clone(),
             &solana_pubkey::new_rand(),
@@ -2459,7 +2445,7 @@ fn test_bank_hash_same_transactions_different_fork() {
     let pubkey = solana_pubkey::new_rand();
     let amount = genesis_config.rent.minimum_balance(0);
 
-    let bank1 = new_bank_from_parent_with_bank_forks(
+    let bank1 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
         &Pubkey::default(),
@@ -2468,7 +2454,7 @@ fn test_bank_hash_same_transactions_different_fork() {
     bank1.transfer(amount, &mint_keypair, &pubkey).unwrap();
     bank1.freeze();
 
-    let bank2 = new_bank_from_parent_with_bank_forks(
+    let bank2 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
         &Pubkey::default(),
@@ -2656,7 +2642,7 @@ fn test_bank_get_account_in_parent_after_squash2() {
         .unwrap();
     assert_eq!(bank0.get_balance(&key1.pubkey()), amount);
 
-    let bank1 = new_bank_from_parent_with_bank_forks(
+    let bank1 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
         &Pubkey::default(),
@@ -2665,7 +2651,7 @@ fn test_bank_get_account_in_parent_after_squash2() {
     bank1
         .transfer(3 * amount, &mint_keypair, &key1.pubkey())
         .unwrap();
-    let bank2 = new_bank_from_parent_with_bank_forks(
+    let bank2 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
         &Pubkey::default(),
@@ -2675,7 +2661,7 @@ fn test_bank_get_account_in_parent_after_squash2() {
         .transfer(2 * amount, &mint_keypair, &key1.pubkey())
         .unwrap();
 
-    let bank3 = new_bank_from_parent_with_bank_forks(
+    let bank3 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank1.clone(),
         &Pubkey::default(),
@@ -2692,7 +2678,7 @@ fn test_bank_get_account_in_parent_after_squash2() {
     bank3.squash();
     assert_eq!(bank1.get_balance(&key1.pubkey()), 4 * amount);
 
-    let bank4 = new_bank_from_parent_with_bank_forks(
+    let bank4 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank3.clone(),
         &Pubkey::default(),
@@ -2704,7 +2690,7 @@ fn test_bank_get_account_in_parent_after_squash2() {
     assert_eq!(bank4.get_balance(&key1.pubkey()), 8 * amount);
     assert_eq!(bank3.get_balance(&key1.pubkey()), 4 * amount);
     bank4.squash();
-    let bank5 = new_bank_from_parent_with_bank_forks(
+    let bank5 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank4.clone(),
         &Pubkey::default(),
@@ -2712,7 +2698,7 @@ fn test_bank_get_account_in_parent_after_squash2() {
     );
     bank5.squash();
     let bank6 =
-        new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank5, &Pubkey::default(), 6);
+        Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank5, &Pubkey::default(), 6);
     bank6.squash();
 
     // This picks up the values from 4 which is the highest root:
@@ -2738,7 +2724,7 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
     assert_eq!(account.lamports(), amount);
     assert_eq!(slot, 0);
 
-    let bank2 = new_bank_from_parent_with_bank_forks(
+    let bank2 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank1.clone(),
         &Pubkey::default(),
@@ -2762,7 +2748,7 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
     bank1.squash();
 
     let bank3 =
-        new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &Pubkey::default(), 3);
+        Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &Pubkey::default(), 3);
     assert_eq!(
         None,
         bank3.get_account_modified_since_parent_with_fixed_root(&pubkey)
@@ -3112,14 +3098,14 @@ fn test_bank_inherit_tx_count() {
     let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     // Bank 1
-    let bank1 = new_bank_from_parent_with_bank_forks(
+    let bank1 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
         &solana_pubkey::new_rand(),
         1,
     );
     // Bank 2
-    let bank2 = new_bank_from_parent_with_bank_forks(
+    let bank2 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
         &solana_pubkey::new_rand(),
@@ -3153,7 +3139,7 @@ fn test_bank_inherit_tx_count() {
     assert_eq!(bank1.transaction_count(), 1);
     assert_eq!(bank1.non_vote_transaction_count_since_restart(), 1);
 
-    let bank6 = new_bank_from_parent_with_bank_forks(
+    let bank6 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank1.clone(),
         &solana_pubkey::new_rand(),
@@ -4971,7 +4957,7 @@ fn test_incinerator() {
     let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     // Move to the first normal slot so normal rent behaviour applies
-    let bank = new_bank_from_parent_with_bank_forks(
+    let bank = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0,
         &Pubkey::default(),
@@ -5933,8 +5919,8 @@ fn test_bank_load_program() {
     let bank = Bank::new_for_tests(&genesis_config);
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
     goto_end_of_slot(bank.clone());
-    let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 42);
-    let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 50);
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 42);
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 50);
 
     let program_key = solana_pubkey::new_rand();
     let programdata_key = solana_pubkey::new_rand();
@@ -8351,7 +8337,7 @@ fn test_vote_epoch_panic() {
     ));
     assert!(result.is_ok());
 
-    let _bank = new_bank_from_parent_with_bank_forks(
+    let _bank = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank,
         &mint_keypair.pubkey(),
@@ -8771,7 +8757,7 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
 
     let slot = 1;
     let bank1 =
-        new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0.clone(), &collector, slot);
+        Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0.clone(), &collector, slot);
     add_root_and_flush_write_cache(&bank0);
     bank1
         .transfer(amount, &mint_keypair, &key1.pubkey())
@@ -8784,7 +8770,7 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
     }
 
     let slot = slot + 1;
-    let bank2 = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+    let bank2 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
     bank2
         .transfer(amount * 2, &mint_keypair, &key2.pubkey())
         .unwrap();
@@ -10732,7 +10718,7 @@ fn test_accounts_data_size_from_genesis() {
     // Create accounts over a number of banks and ensure the accounts data size remains correct
     for _ in 0..10 {
         let slot = bank.slot() + 1;
-        bank = new_bank_from_parent_with_bank_forks(
+        bank = Bank::new_from_parent_with_bank_forks(
             bank_forks.as_ref(),
             bank,
             &Pubkey::default(),
@@ -10943,7 +10929,7 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase(
 
     // Advance the bank to middle of epoch to start the recompilation phase.
     goto_end_of_slot(bank.clone());
-    let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 16);
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 16);
     let current_env = bank
         .transaction_processor
         .get_environments_for_epoch(0)
@@ -10989,7 +10975,7 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase(
 
     // Advance the bank to cross the epoch boundary and activate the feature.
     goto_end_of_slot(bank.clone());
-    let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
 
     // Load the program with the new environment.
     let transaction = Transaction::new(&signers, message, bank.last_blockhash());
@@ -11053,7 +11039,7 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
 
     // Advance the bank to cross the epoch boundary and activate the feature.
     goto_end_of_slot(bank.clone());
-    let bank = new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
 
     // Load the program with the new environment.
     let transaction = Transaction::new(&signers, message.clone(), bank.last_blockhash());
@@ -11126,7 +11112,7 @@ fn test_verify_accounts() {
     // make some banks, do some transactions, ensure there's some zero-lamport accounts
     for _ in 0..4 {
         let slot = bank.slot() + 1;
-        bank = new_bank_from_parent_with_bank_forks(
+        bank = Bank::new_from_parent_with_bank_forks(
             bank_forks.as_ref(),
             bank,
             &Pubkey::new_unique(),
@@ -11238,17 +11224,17 @@ where
 
     // create the next bank in the current epoch
     let slot = bank.slot() + 1;
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
 
     // create the next bank where we will store a zero-lamport account to be cleaned
     let slot = bank.slot() + 1;
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
     let account = AccountSharedData::new(0, len1, &program);
     bank.store_account(&bob_pubkey, &account);
 
     // transfer some to bogus pubkey just to make previous bank (=slot) really cleanable
     let slot = bank.slot() + 1;
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
     let bank_client = BankClient::new_shared(bank.clone());
     bank_client
         .transfer_and_confirm(
@@ -11260,13 +11246,13 @@ where
 
     // super fun time; callback chooses to .clean_accounts() or not
     let slot = bank.slot() + 1;
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
     callback(&bank);
 
     // create a normal account at the same pubkey as the zero-lamports account
     let lamports = genesis_config.rent.minimum_balance(len2);
     let slot = bank.slot() + 1;
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
     let bank_client = BankClient::new_shared(bank);
     let ix = system_instruction::create_account(
         &alice_pubkey,
@@ -11703,7 +11689,7 @@ fn test_deploy_last_epoch_slot() {
     // go to the last slot in the epoch
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
     let slots_in_epoch = bank.epoch_schedule().get_slots_in_epoch(0);
-    let bank = new_bank_from_parent_with_bank_forks(
+    let bank = Bank::new_from_parent_with_bank_forks(
         &bank_forks,
         bank,
         &Pubkey::default(),
@@ -11775,8 +11761,12 @@ fn test_deploy_last_epoch_slot() {
     goto_end_of_slot(bank.clone());
 
     // go to the first slot in the new epoch
-    let bank =
-        new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slots_in_epoch);
+    let bank = Bank::new_from_parent_with_bank_forks(
+        &bank_forks,
+        bank,
+        &Pubkey::default(),
+        slots_in_epoch,
+    );
     eprintln!("now at slot {} epoch {}", bank.slot(), bank.epoch());
 
     let instruction = Instruction::new_with_bytes(program_keypair.pubkey(), &[], Vec::new());
@@ -11939,7 +11929,7 @@ fn test_loader_v3_to_v4_migration(formalize_loaded_transaction_data_size: bool) 
         TransactionError::InstructionError(0, InstructionError::InvalidArgument)
     );
 
-    let bank = new_bank_from_parent_with_bank_forks(
+    let bank = Bank::new_from_parent_with_bank_forks(
         &bank_forks,
         bank.clone(),
         &Pubkey::default(),
@@ -12065,7 +12055,7 @@ fn test_loader_v3_to_v4_migration(formalize_loaded_transaction_data_size: bool) 
             Ok(()),
         ),
     ] {
-        let bank = new_bank_from_parent_with_bank_forks(
+        let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank.clone(),
             &Pubkey::default(),
@@ -12088,7 +12078,7 @@ fn test_loader_v3_to_v4_migration(formalize_loaded_transaction_data_size: bool) 
 
         goto_end_of_slot(bank.clone());
         let bank =
-            new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), next_slot);
+            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), next_slot);
         next_slot += 1;
 
         let instruction = Instruction::new_with_bytes(program_keypair.pubkey(), &[], Vec::new());

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -814,7 +814,6 @@ mod tests {
         super::*,
         crate::{
             bank::{tests::create_simple_test_bank, BankTestConfig},
-            bank_forks::BankForks,
             snapshot_utils::{
                 clean_orphaned_account_snapshot_dirs, create_tmp_accounts_dir_for_tests,
                 get_bank_snapshot_dir, get_bank_snapshots, get_highest_bank_snapshot,
@@ -840,7 +839,7 @@ mod tests {
         solana_transaction::sanitized::SanitizedTransaction,
         std::{
             fs, slice,
-            sync::{atomic::Ordering, Arc, RwLock},
+            sync::{atomic::Ordering, Arc},
         },
         test_case::test_case,
     };
@@ -874,20 +873,6 @@ mod tests {
         }
 
         Arc::into_inner(bank).unwrap()
-    }
-
-    fn new_bank_from_parent_with_bank_forks(
-        bank_forks: &RwLock<BankForks>,
-        parent: Arc<Bank>,
-        collector_id: &Pubkey,
-        slot: Slot,
-    ) -> Arc<Bank> {
-        let bank = Bank::new_from_parent(parent, collector_id, slot);
-        bank_forks
-            .write()
-            .unwrap()
-            .insert(bank)
-            .clone_without_scheduler()
     }
 
     /// Test roundtrip of bank to a full snapshot, then back again.  This test creates the simplest
@@ -975,7 +960,7 @@ mod tests {
         // Create a new slot, and invalidate the account for key1 in slot0
         let slot = 1;
         let bank1 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
         bank1
             .transfer(LAMPORTS_PER_SOL, &key3, &key1.pubkey())
             .unwrap();
@@ -1044,7 +1029,7 @@ mod tests {
 
         let slot = 1;
         let bank1 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
         bank1
             .transfer(3 * LAMPORTS_PER_SOL, &mint_keypair, &key3.pubkey())
             .unwrap();
@@ -1058,7 +1043,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank2 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
         bank2
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1066,7 +1051,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank3 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
         bank3
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1074,7 +1059,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank4 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
         bank4
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1149,7 +1134,7 @@ mod tests {
 
         let slot = 1;
         let bank1 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
         bank1
             .transfer(3 * LAMPORTS_PER_SOL, &mint_keypair, &key3.pubkey())
             .unwrap();
@@ -1180,7 +1165,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank2 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
         bank2
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1188,7 +1173,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank3 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
         bank3
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1196,7 +1181,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank4 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
         bank4
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1256,7 +1241,7 @@ mod tests {
 
         let slot = 1;
         let bank1 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
         bank1
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1287,7 +1272,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank2 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
         bank2
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1295,7 +1280,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank3 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
         bank3
             .transfer(2 * LAMPORTS_PER_SOL, &mint_keypair, &key2.pubkey())
             .unwrap();
@@ -1303,7 +1288,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank4 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
         bank4
             .transfer(3 * LAMPORTS_PER_SOL, &mint_keypair, &key3.pubkey())
             .unwrap();
@@ -1394,7 +1379,7 @@ mod tests {
 
         let slot = 1;
         let bank1 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
         bank1
             .transfer(lamports_to_transfer, &key2, &key1.pubkey())
             .unwrap();
@@ -1413,7 +1398,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank2 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
         let blockhash = bank2.last_blockhash();
         let tx = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
             &key1,
@@ -1472,7 +1457,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank3 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
         // Update Account2 so that it no longer holds a reference to slot2
         bank3
             .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
@@ -1481,7 +1466,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank4 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
         bank4.fill_bank_with_ticks_for_tests();
 
         // Ensure account1 has been cleaned/purged from everywhere
@@ -1546,7 +1531,7 @@ mod tests {
 
         let slot = 1;
         let bank1 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
         bank1.fill_bank_with_ticks_for_tests();
 
         let all_snapshots_dir = tempfile::TempDir::new().unwrap();
@@ -1565,7 +1550,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank2 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
         bank2
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1867,7 +1852,7 @@ mod tests {
 
         let slot = 1;
         let bank1 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
         bank1
             .transfer(lamports_to_transfer, &key2, &key1.pubkey())
             .unwrap();
@@ -1883,7 +1868,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank2 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
         let blockhash = bank2.last_blockhash();
         let tx = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
             &key1,
@@ -1906,7 +1891,7 @@ mod tests {
 
         let slot = slot + 1;
         let bank3 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
         // Update Account2 so that it no longer holds a reference to slot2
         bank3
             .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
@@ -2010,7 +1995,7 @@ mod tests {
         // In slot 1 transfer from key1 to key2, such that key1 becomes zero lamport
         let slot = 1;
         let bank1 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
         bank1.transfer(lamports, &key1, &key2.pubkey()).unwrap();
         assert_eq!(bank1.get_balance(&key1.pubkey()), 0,);
         bank1.fill_bank_with_ticks_for_tests();
@@ -2018,7 +2003,7 @@ mod tests {
         // In slot 2 transfer into key2 to mint such that key2 becomes zero lamport
         let slot = slot + 1;
         let bank2 =
-            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
         bank2.transfer(lamports * 2, &key2, &mint.pubkey()).unwrap();
         bank2.fill_bank_with_ticks_for_tests();
         assert_eq!(bank2.get_balance(&key2.pubkey()), 0);


### PR DESCRIPTION
#### Problem

Multiple crates were defining `new_bank_from_parent_with_bank_forks` function with exactly the same code.

#### Summary of Changes

To reduce repetition, move that code to a DCOU method `Bank::new_from_parent_with_bank_forks` and use it instead.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
