### PR TITLE
feat(scheduler-bindings): ExternalWorker skeleton loop

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -64,6 +64,7 @@ pub mod leader_slot_metrics;
 pub mod qos_service;
 pub mod vote_storage;
 
+#[allow(dead_code)]
 mod consume_worker;
 mod vote_worker;
 

--- a/scheduler-bindings/src/lib.rs
+++ b/scheduler-bindings/src/lib.rs
@@ -94,10 +94,8 @@ pub struct SharablePubkeys {
 /// 4. External pack process frees all transaction memory pointed to by the
 ///    [`SharableTransactionRegion`] in the batch, then frees the memory for
 ///    the array of [`SharableTransactionRegion`].
-#[cfg_attr(
-    feature = "dev-context-only-utils",
-    derive(Debug, Clone, Copy, PartialEq, Eq)
-)]
+#[cfg_attr(feature = "dev-context-only-utils", derive(Debug, PartialEq, Eq))]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct SharableTransactionBatchRegion {
     /// Number of transactions in the batch.


### PR DESCRIPTION
#### Problem
- Need worker to process messages for external scheduler

#### Summary of Changes
- Add skeleton for processing messages from external scheduler
  - Do not support any flags => always responds with message consistent with external sending an invalid message

#### Plan
- (This PR) Add loop logic for external worker
- Add support for executing batches
- Add support for resolving batches

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
