### PR TITLE
Add --accounts-index-initial-accounts CLI option to Pre-allocate index HashMap

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -59,7 +59,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndex
     index_limit_mb: IndexLimitMb::InMemOnly,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
-    estimated_accounts: None,
+    initial_accounts: None,
 };
 pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIndexConfig {
     bins: Some(BINS_FOR_BENCHMARKS),
@@ -68,7 +68,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
     index_limit_mb: IndexLimitMb::InMemOnly,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
-    estimated_accounts: None,
+    initial_accounts: None,
 };
 pub type ScanResult<T> = Result<T, ScanError>;
 pub type SlotList<T> = SmallVec<[(Slot, T); 1]>;
@@ -244,7 +244,7 @@ pub struct AccountsIndexConfig {
     pub scan_results_limit_bytes: Option<usize>,
     /// Estimated total number of accounts, used to pre-allocate HashMap capacity
     /// per bin (divided by number of bins) to reduce resizing overhead.
-    pub estimated_accounts: Option<usize>,
+    pub initial_accounts: Option<usize>,
 }
 
 impl Default for AccountsIndexConfig {
@@ -256,7 +256,7 @@ impl Default for AccountsIndexConfig {
             index_limit_mb: IndexLimitMb::InMemOnly,
             ages_to_stay_in_cache: None,
             scan_results_limit_bytes: None,
-            estimated_accounts: None,
+            initial_accounts: None,
         }
     }
 }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -59,7 +59,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndex
     index_limit_mb: IndexLimitMb::InMemOnly,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
-    initial_accounts: None,
+    num_initial_accounts: None,
 };
 pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIndexConfig {
     bins: Some(BINS_FOR_BENCHMARKS),
@@ -68,7 +68,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
     index_limit_mb: IndexLimitMb::InMemOnly,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
-    initial_accounts: None,
+    num_initial_accounts: None,
 };
 pub type ScanResult<T> = Result<T, ScanError>;
 pub type SlotList<T> = SmallVec<[(Slot, T); 1]>;
@@ -244,7 +244,7 @@ pub struct AccountsIndexConfig {
     pub scan_results_limit_bytes: Option<usize>,
     /// Estimated total number of accounts, used to pre-allocate HashMap capacity
     /// per bin (divided by number of bins) to reduce resizing overhead.
-    pub initial_accounts: Option<usize>,
+    pub num_initial_accounts: Option<usize>,
 }
 
 impl Default for AccountsIndexConfig {
@@ -256,7 +256,7 @@ impl Default for AccountsIndexConfig {
             index_limit_mb: IndexLimitMb::InMemOnly,
             ages_to_stay_in_cache: None,
             scan_results_limit_bytes: None,
-            initial_accounts: None,
+            num_initial_accounts: None,
         }
     }
 }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -59,6 +59,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndex
     index_limit_mb: IndexLimitMb::InMemOnly,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
+    estimated_accounts: None,
 };
 pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIndexConfig {
     bins: Some(BINS_FOR_BENCHMARKS),
@@ -67,6 +68,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
     index_limit_mb: IndexLimitMb::InMemOnly,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
+    estimated_accounts: None,
 };
 pub type ScanResult<T> = Result<T, ScanError>;
 pub type SlotList<T> = SmallVec<[(Slot, T); 1]>;
@@ -240,6 +242,9 @@ pub struct AccountsIndexConfig {
     pub index_limit_mb: IndexLimitMb,
     pub ages_to_stay_in_cache: Option<Age>,
     pub scan_results_limit_bytes: Option<usize>,
+    /// Estimated total number of accounts, used to pre-allocate HashMap capacity
+    /// per bin (divided by number of bins) to reduce resizing overhead and overallocations.
+    pub estimated_accounts: Option<usize>,
 }
 
 impl Default for AccountsIndexConfig {
@@ -251,6 +256,7 @@ impl Default for AccountsIndexConfig {
             index_limit_mb: IndexLimitMb::InMemOnly,
             ages_to_stay_in_cache: None,
             scan_results_limit_bytes: None,
+            estimated_accounts: None,
         }
     }
 }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -242,8 +242,7 @@ pub struct AccountsIndexConfig {
     pub index_limit_mb: IndexLimitMb,
     pub ages_to_stay_in_cache: Option<Age>,
     pub scan_results_limit_bytes: Option<usize>,
-    /// Estimated total number of accounts, used to pre-allocate HashMap capacity
-    /// per bin (divided by number of bins) to reduce resizing overhead.
+    /// Initial number of accounts, used to pre-allocate HashMap capacity
     pub num_initial_accounts: Option<usize>,
 }
 

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -243,7 +243,7 @@ pub struct AccountsIndexConfig {
     pub ages_to_stay_in_cache: Option<Age>,
     pub scan_results_limit_bytes: Option<usize>,
     /// Estimated total number of accounts, used to pre-allocate HashMap capacity
-    /// per bin (divided by number of bins) to reduce resizing overhead and overallocations.
+    /// per bin (divided by number of bins) to reduce resizing overhead.
     pub estimated_accounts: Option<usize>,
 }
 

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -242,7 +242,7 @@ pub struct AccountsIndexConfig {
     pub index_limit_mb: IndexLimitMb,
     pub ages_to_stay_in_cache: Option<Age>,
     pub scan_results_limit_bytes: Option<usize>,
-    /// Initial number of accounts, used to pre-allocate HashMap capacity
+    /// Initial number of accounts, used to pre-allocate HashMap capacity at startup.
     pub num_initial_accounts: Option<usize>,
 }
 

--- a/accounts-db/src/accounts_index/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index/accounts_index_storage.rs
@@ -154,8 +154,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexStorage<
 
         let storage = Arc::new(BucketMapHolder::new(bins, config, num_flush_threads.get()));
 
+        let num_initial_accounts = config.num_initial_accounts;
         let in_mem: Box<_> = (0..bins)
-            .map(|bin| Arc::new(InMemAccountsIndex::new(&storage, bin)))
+            .map(|bin| Arc::new(InMemAccountsIndex::new(&storage, bin, num_initial_accounts)))
             .collect();
 
         Self {

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -177,8 +177,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let lowest_pubkey = bin_calc.lowest_pubkey_from_bin(bin);
         let highest_pubkey = bin_calc.highest_pubkey_from_bin(bin);
 
-        let map_internal = if let Some(estimated_total) = storage.estimated_accounts {
-            let capacity_per_bin = estimated_total / storage.bins;
+        let map_internal = if let Some(initial_accounts) = storage.initial_accounts {
+            let capacity_per_bin = initial_accounts / storage.bins;
             RwLock::new(HashMap::with_capacity_and_hasher(
                 capacity_per_bin,
                 ahash::RandomState::default(),

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -177,7 +177,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let lowest_pubkey = bin_calc.lowest_pubkey_from_bin(bin);
         let highest_pubkey = bin_calc.highest_pubkey_from_bin(bin);
 
-        // Pre-allocate HashMap capacity based on estimated accounts divided by bins
         let map_internal = if let Some(estimated_total) = storage.estimated_accounts {
             let capacity_per_bin = estimated_total / storage.bins;
             RwLock::new(HashMap::with_capacity_and_hasher(

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -2251,9 +2251,7 @@ mod tests {
     fn test_new_with_num_initial_accounts(num_initial_accounts: Option<usize>) {
         let config = AccountsIndexConfig::default();
 
-        // Test with different bin counts: 2, 4, 8
         let bin_counts = [2, 4, 8];
-        let mut total_capacities = Vec::new();
 
         for bin_count in bin_counts {
             let holder = Arc::new(BucketMapHolder::new(bin_count, &config, 1));
@@ -2265,10 +2263,8 @@ mod tests {
                 total_capacity += accounts_index.map_internal.read().unwrap().capacity();
             }
 
-            total_capacities.push(total_capacity);
-
-            if num_initial_accounts.is_some() {
-                assert!(total_capacity > num_initial_accounts.unwrap());
+            if let Some(num_initial_accounts) = num_initial_accounts {
+                assert!(total_capacity > num_initial_accounts);
             } else {
                 assert_eq!(total_capacity, 0);
             }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -177,7 +177,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let lowest_pubkey = bin_calc.lowest_pubkey_from_bin(bin);
         let highest_pubkey = bin_calc.highest_pubkey_from_bin(bin);
 
-        let map_internal = if let Some(initial_accounts) = storage.initial_accounts {
+        let map_internal = if let Some(initial_accounts) = storage.num_initial_accounts {
             let capacity_per_bin = initial_accounts / storage.bins;
             RwLock::new(HashMap::with_capacity_and_hasher(
                 capacity_per_bin,

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -177,8 +177,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let lowest_pubkey = bin_calc.lowest_pubkey_from_bin(bin);
         let highest_pubkey = bin_calc.highest_pubkey_from_bin(bin);
 
-        let map_internal = if let Some(initial_accounts) = storage.num_initial_accounts {
-            let capacity_per_bin = initial_accounts / storage.bins;
+        let map_internal = if let Some(num_initial_accounts) = storage.num_initial_accounts {
+            let capacity_per_bin = num_initial_accounts / storage.bins;
             RwLock::new(HashMap::with_capacity_and_hasher(
                 capacity_per_bin,
                 ahash::RandomState::default(),

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -171,13 +171,17 @@ struct FlushScanResult {
 }
 
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T, U> {
-    pub fn new(storage: &Arc<BucketMapHolder<T, U>>, bin: usize) -> Self {
+    pub fn new(
+        storage: &Arc<BucketMapHolder<T, U>>,
+        bin: usize,
+        num_initial_accounts: Option<usize>,
+    ) -> Self {
         let num_ages_to_distribute_flushes = Age::MAX - storage.ages_to_stay_in_cache;
         let bin_calc = PubkeyBinCalculator24::new(storage.bins);
         let lowest_pubkey = bin_calc.lowest_pubkey_from_bin(bin);
         let highest_pubkey = bin_calc.highest_pubkey_from_bin(bin);
 
-        let map_internal = if let Some(num_initial_accounts) = storage.num_initial_accounts {
+        let map_internal = if let Some(num_initial_accounts) = num_initial_accounts {
             let capacity_per_bin = num_initial_accounts / storage.bins;
             RwLock::new(HashMap::with_capacity_and_hasher(
                 capacity_per_bin,
@@ -1423,7 +1427,7 @@ mod tests {
             1,
         ));
         let bin = 0;
-        InMemAccountsIndex::new(&holder, bin)
+        InMemAccountsIndex::new(&holder, bin, None)
     }
 
     fn new_disk_buckets_for_test<T: IndexValue>() -> InMemAccountsIndex<T, T> {
@@ -1433,7 +1437,7 @@ mod tests {
         };
         let holder = Arc::new(BucketMapHolder::new(BINS_FOR_TESTING, &config, 1));
         let bin = 0;
-        let bucket = InMemAccountsIndex::new(&holder, bin);
+        let bucket = InMemAccountsIndex::new(&holder, bin, None);
         assert!(bucket.storage.is_disk_index_enabled());
         bucket
     }
@@ -2240,105 +2244,20 @@ mod tests {
         assert_eq!(len, 2);
     }
 
-    #[test]
-    fn test_new_with_initial_accounts_pre_allocation() {
-        // Test that initial_accounts is used to pre-allocate HashMap capacity
-        let num_initial_accounts = 10000;
-        let config = AccountsIndexConfig {
-            num_initial_accounts: Some(num_initial_accounts),
-            ..Default::default()
-        };
+    #[test_case(Some(10000);  "with pre-allocation")]
+    #[test_case(None; "without pre-allocation")]
+    fn test_new_with_num_initial_accounts(num_initial_accounts: Option<usize>) {
+        let config = AccountsIndexConfig::default();
         let holder = Arc::new(BucketMapHolder::new(BINS_FOR_TESTING, &config, 1));
         let bin = 0;
-        let accounts_index = InMemAccountsIndex::<u64, u64>::new(&holder, bin);
+        let accounts_index =
+            InMemAccountsIndex::<u64, u64>::new(&holder, bin, num_initial_accounts);
 
-        // Verify the index was created successfully with pre-allocated capacity
-        assert_eq!(
-            accounts_index.storage.num_initial_accounts,
-            Some(num_initial_accounts)
-        );
-
-        // Verify the HashMap was pre-allocated with the expected capacity per bin
-        // HashMap with ahash allocates space based on load factor (typically 7/8 = 0.875)
-        // The actual capacity reported is: next_power_of_two(requested / 0.875) * 0.875
-        let expected_capacity_per_bin = num_initial_accounts / BINS_FOR_TESTING; // 5000
-        let actual_capacity = accounts_index.map_internal.read().unwrap().capacity();
-
-        // Calculate the expected capacity considering the load factor
-        // For ahash HashMap, capacity = (next_power_of_two(requested / 0.875)) * 0.875
-        let with_load_factor = (expected_capacity_per_bin as f64 / 0.875).ceil() as usize; // 5715
-        let expected_actual_capacity = with_load_factor.next_power_of_two() * 7 / 8; // 7168
-
-        assert_eq!(
-            actual_capacity, expected_actual_capacity,
-            "HashMap capacity mismatch. Requested per bin: {}, Expected capacity: {}, Actual: {}",
-            expected_capacity_per_bin, expected_actual_capacity, actual_capacity
-        );
-
-        // Verify basic operations work correctly with pre-allocated map
-        let pubkey = solana_pubkey::new_rand();
-        let slot = 0;
-        let mut callback_called = false;
-        accounts_index.get_or_create_index_entry_for_pubkey(&pubkey, |entry| {
-            assert_eq!(entry.slot_list_lock_read_len(), 0);
-            InMemAccountsIndex::<u64, u64>::cache_entry_at_slot(entry, (slot, 42));
-            callback_called = true;
-        });
-        assert!(callback_called);
-
-        // Verify the entry was inserted successfully
-        let mut found = false;
-        accounts_index.get_only_in_mem(&pubkey, false, |entry| {
-            found = entry.is_some();
-        });
-        assert!(found);
-    }
-
-    #[test]
-    fn test_new_without_initial_accounts_uses_default() {
-        // Test that when initial_accounts is None, default HashMap is used
-        let config = AccountsIndexConfig {
-            num_initial_accounts: None,
-            ..Default::default()
-        };
-        let holder = Arc::new(BucketMapHolder::new(BINS_FOR_TESTING, &config, 1));
-        let bin = 0;
-        let accounts_index = InMemAccountsIndex::<u64, u64>::new(&holder, bin);
-
-        // Verify the index was created with no pre-allocation
-        assert_eq!(accounts_index.storage.num_initial_accounts, None);
-
-        // Verify the HashMap starts with default capacity (0 for empty HashMap)
         let initial_capacity = accounts_index.map_internal.read().unwrap().capacity();
-        assert_eq!(
-            initial_capacity, 0,
-            "HashMap should have 0 capacity when not pre-allocated, got {}",
-            initial_capacity
-        );
-
-        // Verify basic operations still work correctly
-        let pubkey = solana_pubkey::new_rand();
-        let slot = 0;
-        let mut callback_called = false;
-        accounts_index.get_or_create_index_entry_for_pubkey(&pubkey, |entry| {
-            assert_eq!(entry.slot_list_lock_read_len(), 0);
-            InMemAccountsIndex::<u64, u64>::cache_entry_at_slot(entry, (slot, 42));
-            callback_called = true;
-        });
-        assert!(callback_called);
-
-        // Verify the entry was inserted successfully
-        let mut found = false;
-        accounts_index.get_only_in_mem(&pubkey, false, |entry| {
-            found = entry.is_some();
-        });
-        assert!(found);
-
-        // After insertion, capacity should have grown
-        let capacity_after_insert = accounts_index.map_internal.read().unwrap().capacity();
-        assert!(
-            capacity_after_insert > 0,
-            "HashMap capacity should be > 0 after insertion"
-        );
+        if num_initial_accounts.is_some() {
+            assert!(initial_capacity > 0);
+        } else {
+            assert_eq!(initial_capacity, 0);
+        }
     }
 }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -2255,11 +2255,11 @@ mod tests {
         let bin_counts = [2, 4, 8];
         let mut total_capacities = Vec::new();
 
-        for bins in bin_counts {
-            let holder = Arc::new(BucketMapHolder::new(bins, &config, 1));
+        for bin_count in bin_counts {
+            let holder = Arc::new(BucketMapHolder::new(bin_count, &config, 1));
             let mut total_capacity = 0;
 
-            for bin in 0..bins {
+            for bin in 0..bin_count {
                 let accounts_index =
                     InMemAccountsIndex::<u64, u64>::new(&holder, bin, num_initial_accounts);
                 total_capacity += accounts_index.map_internal.read().unwrap().capacity();
@@ -2268,18 +2268,9 @@ mod tests {
             total_capacities.push(total_capacity);
 
             if num_initial_accounts.is_some() {
-                assert!(total_capacity > 0);
+                assert!(total_capacity > num_initial_accounts.unwrap());
             } else {
                 assert_eq!(total_capacity, 0);
-            }
-        }
-
-        // Verify that total capacity across all bins is the same
-        // regardless of bin count
-        if num_initial_accounts.is_some() {
-            let first_total = total_capacities[0];
-            for &total in &total_capacities[1..] {
-                assert_eq!(total, first_total);
             }
         }
     }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -176,8 +176,20 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let bin_calc = PubkeyBinCalculator24::new(storage.bins);
         let lowest_pubkey = bin_calc.lowest_pubkey_from_bin(bin);
         let highest_pubkey = bin_calc.highest_pubkey_from_bin(bin);
+
+        // Pre-allocate HashMap capacity based on estimated accounts divided by bins
+        let map_internal = if let Some(estimated_total) = storage.estimated_accounts {
+            let capacity_per_bin = estimated_total / storage.bins;
+            RwLock::new(HashMap::with_capacity_and_hasher(
+                capacity_per_bin,
+                ahash::RandomState::default(),
+            ))
+        } else {
+            RwLock::default()
+        };
+
         Self {
-            map_internal: RwLock::default(),
+            map_internal,
             storage: Arc::clone(storage),
             _bin: bin,
             lowest_pubkey,

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -61,9 +61,6 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     /// how many ages should elapse from the last time an item is used where the item will remain in the cache
     pub ages_to_stay_in_cache: Age,
 
-    /// initial number of accounts, used to pre-allocate the in-mem index
-    pub(crate) num_initial_accounts: Option<usize>,
-
     /// startup is a special time for flush to focus on moving everything to disk as fast and efficiently as possible
     /// with less thread count limitations. LRU and access patterns are not important. Freeing memory
     /// and writing to disk in parallel are.
@@ -220,7 +217,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         Self {
             disk,
             ages_to_stay_in_cache,
-            num_initial_accounts: config.num_initial_accounts,
             count_buckets_flushed: AtomicUsize::default(),
             // age = 0
             age: AtomicAge::default(),

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -62,7 +62,7 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     pub ages_to_stay_in_cache: Age,
 
     /// estimated total number of accounts for calculating per-bin HashMap capacity
-    pub(crate) estimated_accounts: Option<usize>,
+    pub(crate) initial_accounts: Option<usize>,
 
     /// startup is a special time for flush to focus on moving everything to disk as fast and efficiently as possible
     /// with less thread count limitations. LRU and access patterns are not important. Freeing memory
@@ -220,7 +220,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         Self {
             disk,
             ages_to_stay_in_cache,
-            estimated_accounts: config.estimated_accounts,
+            initial_accounts: config.initial_accounts,
             count_buckets_flushed: AtomicUsize::default(),
             // age = 0
             age: AtomicAge::default(),

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -61,8 +61,8 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     /// how many ages should elapse from the last time an item is used where the item will remain in the cache
     pub ages_to_stay_in_cache: Age,
 
-    /// estimated total number of accounts for calculating per-bin HashMap capacity
-    pub(crate) initial_accounts: Option<usize>,
+    /// initial number of accounts, used to pre-allocate the in-mem index
+    pub(crate) num_initial_accounts: Option<usize>,
 
     /// startup is a special time for flush to focus on moving everything to disk as fast and efficiently as possible
     /// with less thread count limitations. LRU and access patterns are not important. Freeing memory
@@ -220,7 +220,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         Self {
             disk,
             ages_to_stay_in_cache,
-            initial_accounts: config.initial_accounts,
+            num_initial_accounts: config.initial_accounts,
             count_buckets_flushed: AtomicUsize::default(),
             // age = 0
             age: AtomicAge::default(),

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -220,7 +220,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         Self {
             disk,
             ages_to_stay_in_cache,
-            num_initial_accounts: config.initial_accounts,
+            num_initial_accounts: config.num_initial_accounts,
             count_buckets_flushed: AtomicUsize::default(),
             // age = 0
             age: AtomicAge::default(),

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -61,6 +61,9 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     /// how many ages should elapse from the last time an item is used where the item will remain in the cache
     pub ages_to_stay_in_cache: Age,
 
+    /// estimated total number of accounts for calculating per-bin HashMap capacity
+    pub(crate) estimated_accounts: Option<usize>,
+
     /// startup is a special time for flush to focus on moving everything to disk as fast and efficiently as possible
     /// with less thread count limitations. LRU and access patterns are not important. Freeing memory
     /// and writing to disk in parallel are.
@@ -217,6 +220,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         Self {
             disk,
             ages_to_stay_in_cache,
+            estimated_accounts: config.estimated_accounts,
             count_buckets_flushed: AtomicUsize::default(),
             // age = 0
             age: AtomicAge::default(),

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -53,16 +53,13 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .validator(is_pow2)
             .takes_value(true)
             .help("Number of bins to divide the accounts index into"),
-        Arg::with_name("estimated_accounts")
-            .long("estimated-accounts")
+        Arg::with_name("accounts_index_initial_accounts")
+            .long("accounts-index-initial-accounts")
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)
-            .help(
-                "Estimated total number of accounts in the ledger. Used to pre-allocate HashMap \
-                 capacity in the accounts index (divided by number of bins). Helps reduce memory \
-                 allocations and overallocations during initialization and runtime.",
-            ),
+            .help("Pre-allocate the accounts index, assuming this many number of accounts")
+            .hidden(hidden_unless_forced()),
         Arg::with_name("enable_accounts_disk_index")
             .long("enable-accounts-disk-index")
             .help("Enables the disk-based accounts index")
@@ -252,7 +249,7 @@ pub fn get_accounts_db_config(
     let ledger_tool_ledger_path = ledger_path.join(LEDGER_TOOL_DIRECTORY);
 
     let accounts_index_bins = value_t!(arg_matches, "accounts_index_bins", usize).ok();
-    let estimated_accounts = value_t!(arg_matches, "estimated_accounts", usize).ok();
+    let initial_accounts = value_t!(arg_matches, "accounts_index_initial_accounts", usize).ok();
     let accounts_index_index_limit_mb = if !arg_matches.is_present("enable_accounts_disk_index") {
         IndexLimitMb::InMemOnly
     } else {
@@ -264,7 +261,7 @@ pub fn get_accounts_db_config(
         .unwrap_or_else(|| vec![ledger_tool_ledger_path.join("accounts_index")]);
     let accounts_index_config = AccountsIndexConfig {
         bins: accounts_index_bins,
-        estimated_accounts,
+        initial_accounts,
         index_limit_mb: accounts_index_index_limit_mb,
         drives: Some(accounts_index_drives),
         ..AccountsIndexConfig::default()

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -249,7 +249,8 @@ pub fn get_accounts_db_config(
     let ledger_tool_ledger_path = ledger_path.join(LEDGER_TOOL_DIRECTORY);
 
     let accounts_index_bins = value_t!(arg_matches, "accounts_index_bins", usize).ok();
-    let num_initial_accounts = value_t!(arg_matches, "accounts_index_initial_accounts_count", usize).ok();
+    let num_initial_accounts =
+        value_t!(arg_matches, "accounts_index_initial_accounts_count", usize).ok();
     let accounts_index_index_limit_mb = if !arg_matches.is_present("enable_accounts_disk_index") {
         IndexLimitMb::InMemOnly
     } else {

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -58,7 +58,7 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)
-            .help("Pre-allocate the accounts index, assuming this many number of accounts")
+            .help("Pre-allocate the accounts index, assuming this many accounts")
             .hidden(hidden_unless_forced()),
         Arg::with_name("enable_accounts_disk_index")
             .long("enable-accounts-disk-index")

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -53,8 +53,8 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .validator(is_pow2)
             .takes_value(true)
             .help("Number of bins to divide the accounts index into"),
-        Arg::with_name("accounts_index_initial_accounts")
-            .long("accounts-index-initial-accounts")
+        Arg::with_name("accounts_index_initial_accounts_count")
+            .long("accounts-index-initial-accounts-count")
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)
@@ -249,7 +249,7 @@ pub fn get_accounts_db_config(
     let ledger_tool_ledger_path = ledger_path.join(LEDGER_TOOL_DIRECTORY);
 
     let accounts_index_bins = value_t!(arg_matches, "accounts_index_bins", usize).ok();
-    let num_initial_accounts = value_t!(arg_matches, "accounts_index_initial_accounts", usize).ok();
+    let num_initial_accounts = value_t!(arg_matches, "accounts_index_initial_accounts_count", usize).ok();
     let accounts_index_index_limit_mb = if !arg_matches.is_present("enable_accounts_disk_index") {
         IndexLimitMb::InMemOnly
     } else {

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -249,7 +249,7 @@ pub fn get_accounts_db_config(
     let ledger_tool_ledger_path = ledger_path.join(LEDGER_TOOL_DIRECTORY);
 
     let accounts_index_bins = value_t!(arg_matches, "accounts_index_bins", usize).ok();
-    let initial_accounts = value_t!(arg_matches, "accounts_index_initial_accounts", usize).ok();
+    let num_initial_accounts = value_t!(arg_matches, "accounts_index_initial_accounts", usize).ok();
     let accounts_index_index_limit_mb = if !arg_matches.is_present("enable_accounts_disk_index") {
         IndexLimitMb::InMemOnly
     } else {
@@ -261,7 +261,7 @@ pub fn get_accounts_db_config(
         .unwrap_or_else(|| vec![ledger_tool_ledger_path.join("accounts_index")]);
     let accounts_index_config = AccountsIndexConfig {
         bins: accounts_index_bins,
-        initial_accounts,
+        num_initial_accounts,
         index_limit_mb: accounts_index_index_limit_mb,
         drives: Some(accounts_index_drives),
         ..AccountsIndexConfig::default()

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -53,6 +53,16 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .validator(is_pow2)
             .takes_value(true)
             .help("Number of bins to divide the accounts index into"),
+        Arg::with_name("estimated_accounts")
+            .long("estimated-accounts")
+            .value_name("NUMBER")
+            .validator(is_parsable::<usize>)
+            .takes_value(true)
+            .help(
+                "Estimated total number of accounts in the ledger. Used to pre-allocate HashMap \
+                 capacity in the accounts index (divided by number of bins). Helps reduce memory \
+                 allocations and overallocations during initialization and runtime.",
+            ),
         Arg::with_name("enable_accounts_disk_index")
             .long("enable-accounts-disk-index")
             .help("Enables the disk-based accounts index")
@@ -242,6 +252,7 @@ pub fn get_accounts_db_config(
     let ledger_tool_ledger_path = ledger_path.join(LEDGER_TOOL_DIRECTORY);
 
     let accounts_index_bins = value_t!(arg_matches, "accounts_index_bins", usize).ok();
+    let estimated_accounts = value_t!(arg_matches, "estimated_accounts", usize).ok();
     let accounts_index_index_limit_mb = if !arg_matches.is_present("enable_accounts_disk_index") {
         IndexLimitMb::InMemOnly
     } else {
@@ -253,6 +264,7 @@ pub fn get_accounts_db_config(
         .unwrap_or_else(|| vec![ledger_tool_ledger_path.join("accounts_index")]);
     let accounts_index_config = AccountsIndexConfig {
         bins: accounts_index_bins,
+        estimated_accounts,
         index_limit_mb: accounts_index_index_limit_mb,
         drives: Some(accounts_index_drives),
         ..AccountsIndexConfig::default()

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1183,7 +1183,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(is_parsable::<usize>)
             .takes_value(true)
             .help("Pre-allocate the accounts index, assuming this many number of accounts")
-            .hidden(..),
+            .hidden(hidden_unless_forced()),
     )
     .arg(
         Arg::with_name("accounts_index_path")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1182,7 +1182,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)
-            .help("Pre-allocate the accounts index, assuming this many number of accounts")
+            .help("Pre-allocate the accounts index, assuming this many accounts")
             .hidden(hidden_unless_forced()),
     )
     .arg(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1177,8 +1177,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Number of bins to divide the accounts index into"),
     )
     .arg(
-        Arg::with_name("accounts_index_initial_accounts")
-            .long("accounts-index-initial-accounts")
+        Arg::with_name("accounts_index_initial_accounts_count")
+            .long("accounts-index-initial-accounts-count")
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1177,6 +1177,18 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Number of bins to divide the accounts index into"),
     )
     .arg(
+        Arg::with_name("estimated_accounts")
+            .long("estimated-accounts")
+            .value_name("NUMBER")
+            .validator(is_parsable::<usize>)
+            .takes_value(true)
+            .help(
+                "Estimated total number of accounts in the ledger. Used to pre-allocate HashMap \
+                 capacity in the accounts index (divided by number of bins). Helps reduce memory \
+                 allocations and overallocations during initialization and runtime.",
+            ),
+    )
+    .arg(
         Arg::with_name("accounts_index_path")
             .long("accounts-index-path")
             .value_name("PATH")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1177,16 +1177,13 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Number of bins to divide the accounts index into"),
     )
     .arg(
-        Arg::with_name("estimated_accounts")
-            .long("estimated-accounts")
+        Arg::with_name("accounts_index_initial_accounts")
+            .long("accounts-index-initial-accounts")
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)
-            .help(
-                "Estimated total number of accounts in the ledger. Used to pre-allocate HashMap \
-                 capacity in the accounts index (divided by number of bins). Helps reduce memory \
-                 allocations and overallocations during initialization and runtime.",
-            ),
+            .help("Pre-allocate the accounts index, assuming this many number of accounts")
+            .hidden(..),
     )
     .arg(
         Arg::with_name("accounts_index_path")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -319,8 +319,8 @@ pub fn execute(
     if let Ok(bins) = value_t!(matches, "accounts_index_bins", usize) {
         accounts_index_config.bins = Some(bins);
     }
-    if let Ok(estimated_accounts) = value_t!(matches, "estimated_accounts", usize) {
-        accounts_index_config.estimated_accounts = Some(estimated_accounts);
+    if let Ok(initial_accounts) = value_t!(matches, "accounts_index_initial_accounts", usize) {
+        accounts_index_config.initial_accounts = Some(initial_accounts);
     }
 
     accounts_index_config.index_limit_mb = if !matches.is_present("enable_accounts_disk_index") {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -319,6 +319,9 @@ pub fn execute(
     if let Ok(bins) = value_t!(matches, "accounts_index_bins", usize) {
         accounts_index_config.bins = Some(bins);
     }
+    if let Ok(estimated_accounts) = value_t!(matches, "estimated_accounts", usize) {
+        accounts_index_config.estimated_accounts = Some(estimated_accounts);
+    }
 
     accounts_index_config.index_limit_mb = if !matches.is_present("enable_accounts_disk_index") {
         IndexLimitMb::InMemOnly

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -319,8 +319,8 @@ pub fn execute(
     if let Ok(bins) = value_t!(matches, "accounts_index_bins", usize) {
         accounts_index_config.bins = Some(bins);
     }
-    if let Ok(initial_accounts) = value_t!(matches, "accounts_index_initial_accounts", usize) {
-        accounts_index_config.initial_accounts = Some(initial_accounts);
+    if let Ok(num_initial_accounts) = value_t!(matches, "accounts_index_initial_accounts", usize) {
+        accounts_index_config.num_initial_accounts = Some(num_initial_accounts);
     }
 
     accounts_index_config.index_limit_mb = if !matches.is_present("enable_accounts_disk_index") {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -319,7 +319,9 @@ pub fn execute(
     if let Ok(bins) = value_t!(matches, "accounts_index_bins", usize) {
         accounts_index_config.bins = Some(bins);
     }
-    if let Ok(num_initial_accounts) = value_t!(matches, "accounts_index_initial_accounts", usize) {
+    if let Ok(num_initial_accounts) =
+        value_t!(matches, "accounts_index_initial_accounts_count", usize)
+    {
         accounts_index_config.num_initial_accounts = Some(num_initial_accounts);
     }
 


### PR DESCRIPTION
#### Problem

HashMap over-allocation during accounts index initialization causes significant performance overhead during startup. The accounts index HashMap bins start with default capacity and must resize multiple times as accounts are loaded, causing:
- Slower startup times (additional ~20 seconds)
- 2x slower insertion operations
- Unnecessary memory allocations and rehashing

#### Summary of Changes

Adds a new `--accounts-index-initial-accounts` CLI flag to both `agave-validator` and `agave-ledger-tool` that allows users to specify the total estimated number of accounts in the ledger. The accounts index uses this to pre-allocate HashMap capacity per bin (total / bins), reducing memory allocation overhead during initialization and runtime.

**Performance Improvements:**

### Before
- Generate Index Time: 79,025,725 μs (~79 seconds)
- Insertion Time: 1,411,455,030 μs (~1,411 seconds)

### After
- Generate Index Time: 59,959,734 μs (~60 seconds) - **~20 seconds saved (~24% faster)**
- Insertion Time: 742,284,644 μs (~742 seconds) - **~50% reduction**

**Implementation Details:**
- Added `estimated_accounts` field to `AccountsIndexConfig`
- Modified `InMemAccountsIndex::new()` to calculate per-bin capacity by dividing total accounts by number of bins
- Added `--estimated-accounts` CLI flag to validator and ledger-tool
- HashMap capacity is pre-allocated based on the estimate, reducing resize operations

**Usage:**

```bash
# Validator
agave-validator --accounts-index-initial-accounts 100000000

# Ledger tool
agave-ledger-tool --ledger /path/to/ledger --accounts-index-initial-accounts 100000000 verify
```

**Note on Memory Usage:**

While this significantly improves startup time and insertion performance, memory usage remains similar due to Rust's HashMap internally rounding capacity up to the next power of 2. Future optimizations could address this by adjusting the capacity calculation strategy.