### PR TITLE
Run merge queue tasks with higher priority

### DIFF
--- a/.buildkite/pipeline-upload.sh
+++ b/.buildkite/pipeline-upload.sh
@@ -14,6 +14,7 @@ source ci/_
 if [[ $BUILDKITE_BRANCH == gh-readonly-queue* ]]; then
   # github merge queue
   cat <<EOF | tee /dev/tty | buildkite-agent pipeline upload
+priority: 10
 steps:
   - name: "sanity"
     command: "ci/docker-run-default-image.sh ci/test-sanity.sh"


### PR DESCRIPTION
#### Problem

Failures in the merge queue (that are not relevant to the issues with the code) are very annoying and quite costly: they affect all PR that are in the queue after.

#### Summary of Changes

Increase mergue queue jobs priority so they will be taken from the queue first: https://buildkite.com/docs/pipelines/configure/workflows/managing-priorities#prioritizing-whole-builds