### PR TITLE
Optimize stake_node map to use cheaper PubkeyHasher

### DIFF
--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -103,7 +103,7 @@ fn create_connection_cache(
     let (stake, total_stake) =
         find_node_activated_stake(rpc_client, client_node_id.pubkey()).unwrap_or_default();
     info!("Stake for specified client_node_id: {stake}, total stake: {total_stake}");
-    let stakes = HashMap::from([
+    let stakes = HashMap::from_iter([
         (client_node_id.pubkey(), stake),
         (Pubkey::new_unique(), total_stake - stake),
     ]);

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -229,7 +229,7 @@ fn main() -> Result<()> {
         let stake: u64 = 1024;
         let total_stake: u64 = 1024;
 
-        let stakes = HashMap::from([
+        let stakes = HashMap::from_iter([
             (identity_keypair.pubkey(), stake),
             (Pubkey::new_unique(), total_stake.saturating_sub(stake)),
         ]);

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -130,7 +130,7 @@ solana-packet = { workspace = true }
 solana-perf = { workspace = true }
 solana-poh = { workspace = true }
 solana-poh-config = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-quic-client = { workspace = true }
 solana-quic-definitions = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -42,7 +42,7 @@ use {
         packet::{Packet, PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
     },
     solana_pubkey::{Pubkey, PUBKEY_BYTES},
-    solana_runtime::bank_forks::SharableBanks,
+    solana_runtime::{bank_forks::SharableBanks, stakes::StakedNodesMap},
     solana_signature::{Signature, SIGNATURE_BYTES},
     solana_signer::Signer,
     solana_streamer::{
@@ -53,7 +53,7 @@ use {
     solana_time_utils::timestamp,
     std::{
         cmp::Reverse,
-        collections::{HashMap, HashSet},
+        collections::HashSet,
         net::{SocketAddr, UdpSocket},
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -544,7 +544,7 @@ impl ServeRepair {
 
     fn decode_request(
         remote_request: RemoteRequest,
-        epoch_staked_nodes: &Option<Arc<HashMap<Pubkey, u64>>>,
+        epoch_staked_nodes: &Option<Arc<StakedNodesMap>>,
         whitelist: &HashSet<Pubkey>,
         my_id: &Pubkey,
         socket_addr_space: &SocketAddrSpace,
@@ -616,7 +616,7 @@ impl ServeRepair {
 
     fn decode_requests(
         requests: Vec<RemoteRequest>,
-        epoch_staked_nodes: &Option<Arc<HashMap<Pubkey, u64>>>,
+        epoch_staked_nodes: &Option<Arc<StakedNodesMap>>,
         whitelist: &HashSet<Pubkey>,
         my_id: &Pubkey,
         socket_addr_space: &SocketAddrSpace,

--- a/gossip/benches/crds.rs
+++ b/gossip/benches/crds.rs
@@ -19,7 +19,8 @@ fn bench_find_old_labels(c: &mut Criterion) {
     std::iter::repeat_with(|| (CrdsValue::new_rand(&mut rng, None), rng.gen_range(0..now)))
         .take(50_000)
         .for_each(|(v, ts)| assert!(crds.insert(v, ts, GossipRoute::LocalMessage).is_ok()));
-    let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+    let mut stakes = HashMap::default();
+    stakes.insert(Pubkey::new_unique(), 1u64);
     let timeouts = CrdsTimeouts::new(
         Pubkey::new_unique(),
         CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, // default_timeout

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -64,7 +64,7 @@ use {
     },
     solana_pubkey::Pubkey,
     solana_rayon_threadlimit::get_thread_count,
-    solana_runtime::bank_forks::BankForks,
+    solana_runtime::{bank_forks::BankForks, stakes::StakedNodesMap},
     solana_sanitize::Sanitize,
     solana_signature::Signature,
     solana_signer::Signer,
@@ -222,7 +222,7 @@ impl ClusterInfo {
     fn refresh_push_active_set(
         &self,
         recycler: &PacketBatchRecycler,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
         gossip_validators: Option<&HashSet<Pubkey>>,
         sender: &impl ChannelSend<PacketBatch>,
     ) {
@@ -1233,7 +1233,7 @@ impl ClusterInfo {
         &self,
         thread_pool: &ThreadPool,
         gossip_validators: Option<&HashSet<Pubkey>>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
     ) -> impl Iterator<Item = (SocketAddr, Protocol)> {
         let now = timestamp();
         let keypair = self.keypair();
@@ -1284,7 +1284,7 @@ impl ClusterInfo {
     }
     fn new_push_requests(
         &self,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
     ) -> impl Iterator<Item = (SocketAddr, Protocol)> {
         let self_id = self.id();
         let (entries, push_messages, num_pushes) = {
@@ -1334,7 +1334,7 @@ impl ClusterInfo {
         &self,
         thread_pool: &ThreadPool,
         gossip_validators: Option<&HashSet<Pubkey>>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
         generate_pull_requests: bool,
     ) -> impl Iterator<Item = (SocketAddr, Protocol)> {
         self.trim_crds_table(CRDS_UNIQUE_PUBKEY_CAPACITY, stakes);
@@ -1357,7 +1357,7 @@ impl ClusterInfo {
         thread_pool: &ThreadPool,
         gossip_validators: Option<&HashSet<Pubkey>>,
         recycler: &PacketBatchRecycler,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
         sender: &impl ChannelSend<PacketBatch>,
         generate_pull_requests: bool,
     ) -> Result<(), GossipError> {
@@ -1412,7 +1412,7 @@ impl ClusterInfo {
         &self,
         thread_pool: &ThreadPool,
         epoch_duration: Duration,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
     ) {
         let self_pubkey = self.id();
         let timeouts = self
@@ -1428,7 +1428,7 @@ impl ClusterInfo {
 
     // Trims the CRDS table by dropping all values associated with the pubkeys
     // with the lowest stake, so that the number of unique pubkeys are bounded.
-    fn trim_crds_table(&self, cap: usize, stakes: &HashMap<Pubkey, u64>) {
+    fn trim_crds_table(&self, cap: usize, stakes: &StakedNodesMap) {
         if !self.gossip.crds.read().unwrap().should_trim(cap) {
             return;
         }
@@ -1547,7 +1547,7 @@ impl ClusterInfo {
             .unwrap()
     }
 
-    fn handle_batch_prune_messages(&self, messages: Vec<PruneData>, stakes: &HashMap<Pubkey, u64>) {
+    fn handle_batch_prune_messages(&self, messages: Vec<PruneData>, stakes: &StakedNodesMap) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_prune_messages_time);
         if messages.is_empty() {
             return;
@@ -1598,7 +1598,7 @@ impl ClusterInfo {
         requests: Vec<PullRequest>,
         thread_pool: &ThreadPool,
         recycler: &PacketBatchRecycler,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
         response_sender: &impl ChannelSend<PacketBatch>,
     ) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_pull_requests_time);
@@ -1677,7 +1677,7 @@ impl ClusterInfo {
         thread_pool: &ThreadPool,
         recycler: &PacketBatchRecycler,
         mut requests: Vec<PullRequest>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
     ) -> PinnedPacketBatch {
         const DEFAULT_EPOCH_DURATION_MS: u64 = DEFAULT_SLOTS_PER_EPOCH * DEFAULT_MS_PER_SLOT;
         let output_size_limit =
@@ -1776,7 +1776,7 @@ impl ClusterInfo {
     fn handle_batch_pull_responses(
         &self,
         responses: Vec<CrdsValue>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
         epoch_duration: Duration,
     ) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_pull_responses_time);
@@ -1868,7 +1868,7 @@ impl ClusterInfo {
         messages: Vec<(Pubkey, Vec<CrdsValue>)>,
         thread_pool: &ThreadPool,
         recycler: &PacketBatchRecycler,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
         response_sender: &impl ChannelSend<PacketBatch>,
     ) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_push_messages_time);
@@ -1903,7 +1903,7 @@ impl ClusterInfo {
         thread_pool: &ThreadPool,
         // Unique origin pubkeys of upserted CRDS values from push messages.
         origins: impl IntoIterator<Item = Pubkey>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
     ) -> Vec<(SocketAddr, Protocol /*::PruneMessage*/)> {
         let _st = ScopedTimer::from(&self.stats.generate_prune_messages);
         let self_pubkey = self.id();
@@ -1968,7 +1968,7 @@ impl ClusterInfo {
         thread_pool: &ThreadPool,
         recycler: &PacketBatchRecycler,
         response_sender: &impl ChannelSend<PacketBatch>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
         epoch_duration: Duration,
         should_check_duplicate_instance: bool,
     ) -> Result<(), GossipError> {
@@ -2131,7 +2131,7 @@ impl ClusterInfo {
             .add_relaxed(num_packets as u64);
         fn verify_packet(
             packet: PacketRef,
-            stakes: &HashMap<Pubkey, u64>,
+            stakes: &StakedNodesMap,
             stats: &GossipStats,
         ) -> Option<(SocketAddr, Protocol)> {
             let mut protocol: Protocol =
@@ -2615,7 +2615,7 @@ mod tests {
             &self,
             thread_pool: &ThreadPool,
             gossip_validators: Option<&HashSet<Pubkey>>,
-            stakes: &HashMap<Pubkey, u64>,
+            stakes: &StakedNodesMap,
         ) -> (
             Vec<(SocketAddr, Ping)>,     // Ping packets
             Vec<(SocketAddr, Protocol)>, // Pull requests
@@ -2657,7 +2657,8 @@ mod tests {
         });
         let entrypoint_pubkey = solana_pubkey::new_rand();
         let data = test_crds_values(entrypoint_pubkey);
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let mut stakes = HashMap::default();
+        stakes.insert(Pubkey::new_unique(), 1u64);
         let timeouts = CrdsTimeouts::new(
             cluster_info.id(),
             CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, // default_timeout
@@ -2795,17 +2796,17 @@ mod tests {
         cluster_info.gossip.refresh_push_active_set(
             &cluster_info.keypair(),
             cluster_info.my_shred_version(),
-            &HashMap::new(), // stakes
-            None,            // gossip validators
+            &HashMap::default(), // stakes
+            None,                // gossip validators
             &cluster_info.ping_cache,
             &mut Vec::new(), // pings
             &SocketAddrSpace::Unspecified,
         );
         let mut reqs = cluster_info.generate_new_gossip_requests(
             &thread_pool,
-            None,            // gossip_validators
-            &HashMap::new(), // stakes
-            true,            // generate_pull_requests
+            None,                // gossip_validators
+            &HashMap::default(), // stakes
+            true,                // generate_pull_requests
         );
         //assert none of the addrs are invalid.
         assert!(reqs.all(|(addr, _)| {
@@ -2934,7 +2935,7 @@ mod tests {
             Arc::new(keypair),
             SocketAddrSpace::Unspecified,
         );
-        let stakes = HashMap::<Pubkey, u64>::default();
+        let stakes = HashMap::default();
         cluster_info.ping_cache.lock().unwrap().mock_pong(
             *peer.pubkey(),
             peer.gossip().unwrap(),
@@ -2980,7 +2981,7 @@ mod tests {
                 cluster_info.my_shred_version(),
                 timestamp(),
                 None,
-                &HashMap::new(),
+                &HashMap::default(),
                 992, // max_bloom_filter_bytes
                 &cluster_info.ping_cache,
                 &mut pings,
@@ -3309,7 +3310,8 @@ mod tests {
         let entrypoint_pubkey = solana_pubkey::new_rand();
         let entrypoint = ContactInfo::new_localhost(&entrypoint_pubkey, timestamp());
         cluster_info.set_entrypoint(entrypoint.clone());
-        let (pings, pulls) = cluster_info.old_pull_requests(&thread_pool, None, &HashMap::new());
+        let stakes = HashMap::default();
+        let (pings, pulls) = cluster_info.old_pull_requests(&thread_pool, None, &stakes);
         assert!(pings.is_empty());
         assert_eq!(pulls.len(), MIN_NUM_BLOOM_FILTERS);
         for (addr, msg) in pulls {
@@ -3325,14 +3327,16 @@ mod tests {
         // now add this message back to the table and make sure after the next pull, the entrypoint is unset
         let entrypoint_crdsvalue = CrdsValue::new_unsigned(CrdsData::from(&entrypoint));
         let cluster_info = Arc::new(cluster_info);
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let mut stakes = HashMap::default();
+        stakes.insert(Pubkey::new_unique(), 1u64);
         let timeouts = cluster_info.gossip.make_timeouts(
             cluster_info.id(),
             &stakes,
             Duration::from_millis(cluster_info.gossip.pull.crds_timeout),
         );
         cluster_info.handle_pull_response(vec![entrypoint_crdsvalue], &timeouts);
-        let (pings, pulls) = cluster_info.old_pull_requests(&thread_pool, None, &HashMap::new());
+        let stakes = HashMap::default();
+        let (pings, pulls) = cluster_info.old_pull_requests(&thread_pool, None, &stakes);
         assert_eq!(pings.len(), 1);
         assert_eq!(pulls.len(), MIN_NUM_BLOOM_FILTERS);
         assert_eq!(*cluster_info.entrypoints.read().unwrap(), vec![entrypoint]);
@@ -3343,7 +3347,7 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let d = ContactInfo::new_localhost(&keypair.pubkey(), timestamp());
         let cluster_info = ClusterInfo::new(d.clone(), keypair, SocketAddrSpace::Unspecified);
-        let mut stakes = HashMap::new();
+        let mut stakes = StakedNodesMap::default();
 
         // no stake
         let id = Pubkey::from([1u8; 32]);
@@ -3392,7 +3396,7 @@ mod tests {
             .unwrap();
         cluster_info.set_entrypoint(entrypoint.clone());
 
-        let mut stakes = HashMap::new();
+        let mut stakes = HashMap::default();
 
         let other_node_pubkey = solana_pubkey::new_rand();
         let other_node = ContactInfo::new_localhost(&other_node_pubkey, timestamp());
@@ -3559,7 +3563,8 @@ mod tests {
         })
         .take(NO_ENTRIES)
         .collect();
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let mut stakes = HashMap::default();
+        stakes.insert(Pubkey::new_unique(), 1u64);
         let timeouts = CrdsTimeouts::new(
             cluster_info.id(),
             CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS * 4, // default_timeout

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -4,6 +4,7 @@ use {
     solana_clock::Slot,
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
+    solana_runtime::stakes::StakedNodesMap,
     solana_signature::Signature,
     std::{
         cmp::Reverse,
@@ -206,7 +207,7 @@ impl GossipStats {
 pub(crate) fn submit_gossip_stats(
     stats: &GossipStats,
     gossip: &CrdsGossip,
-    stakes: &HashMap<Pubkey, u64>,
+    stakes: &StakedNodesMap,
 ) {
     let (crds_stats, table_size, num_nodes, num_pubkeys, purged_values_size, failed_inserts_size) = {
         let gossip_crds = gossip.crds.read().unwrap();

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -45,6 +45,7 @@ use {
     solana_clock::Slot,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
+    solana_runtime::stakes::StakedNodesMap,
     std::{
         cmp::Ordering,
         collections::{hash_map, BTreeMap, HashMap, VecDeque},
@@ -633,7 +634,7 @@ impl Crds {
         // Set of pubkeys to never drop.
         // e.g. known validators, self pubkey, ...
         keep: &[Pubkey],
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
         now: u64,
     ) -> Result</*num purged:*/ usize, CrdsError> {
         if self.should_trim(cap) {
@@ -649,7 +650,7 @@ impl Crds {
         &mut self,
         size: usize,
         keep: &[Pubkey],
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
         now: u64,
     ) -> Result</*num purged:*/ usize, CrdsError> {
         if stakes.values().all(|&stake| stake == 0) {
@@ -886,7 +887,8 @@ mod tests {
             Ok(())
         );
         let pubkey = Pubkey::new_unique();
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let mut stakes = HashMap::default();
+        stakes.insert(Pubkey::new_unique(), 1u64);
         let epoch_duration = Duration::from_secs(48 * 3600);
         let timeouts = CrdsTimeouts::new(
             pubkey,
@@ -922,7 +924,8 @@ mod tests {
         let mut rng = thread_rng();
         let mut crds = Crds::default();
         let val = CrdsValue::new_rand(&mut rng, None);
-        let mut stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let mut stakes = HashMap::default();
+        stakes.insert(Pubkey::new_unique(), 1u64);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
             3,                              // default_timeout
@@ -981,7 +984,8 @@ mod tests {
             crds.insert(val.clone(), 1, GossipRoute::LocalMessage),
             Ok(_)
         );
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let mut stakes = HashMap::default();
+        stakes.insert(Pubkey::new_unique(), 1u64);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
             1,                              // default_timeout
@@ -1007,7 +1011,8 @@ mod tests {
             crds.insert(val.clone(), 1, GossipRoute::LocalMessage),
             Ok(())
         );
-        let mut stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let mut stakes = HashMap::default();
+        stakes.insert(Pubkey::new_unique(), 1u64);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
             0,                              // default_timeout
@@ -1395,7 +1400,8 @@ mod tests {
             crds.insert(val.clone(), 1, GossipRoute::LocalMessage),
             Ok(_)
         );
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let mut stakes = HashMap::default();
+        stakes.insert(Pubkey::new_unique(), 1u64);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
             1,                        // default_timeout

--- a/gossip/src/crds_filter.rs
+++ b/gossip/src/crds_filter.rs
@@ -1,7 +1,6 @@
 use {
     crate::{crds_data::CrdsData, crds_value::CrdsValue},
-    solana_pubkey::Pubkey,
-    std::collections::HashMap,
+    solana_runtime::stakes::StakedNodesMap,
 };
 
 pub(crate) enum GossipFilterDirection {
@@ -25,7 +24,7 @@ pub(crate) const MIN_STAKE_FOR_GOSSIP: u64 = solana_native_token::LAMPORTS_PER_S
 #[must_use]
 pub(crate) fn should_retain_crds_value(
     value: &CrdsValue,
-    stakes: &HashMap<Pubkey, u64>,
+    stakes: &StakedNodesMap,
     direction: GossipFilterDirection,
 ) -> bool {
     let retain_if_staked = || {

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -27,6 +27,7 @@ use {
     solana_keypair::Keypair,
     solana_ledger::shred::Shred,
     solana_pubkey::Pubkey,
+    solana_runtime::stakes::StakedNodesMap,
     solana_signer::Signer,
     solana_streamer::socket::SocketAddrSpace,
     solana_time_utils::timestamp,
@@ -62,7 +63,7 @@ impl CrdsGossip {
         &self,
         self_pubkey: &Pubkey,
         origins: I, // Unique pubkeys of crds values' owners.
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
     ) -> HashMap</*gossip peer:*/ Pubkey, /*origins:*/ Vec<Pubkey>>
     where
         I: IntoIterator<Item = Pubkey>,
@@ -74,7 +75,7 @@ impl CrdsGossip {
         &self,
         pubkey: &Pubkey, // This node.
         now: u64,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
         should_retain_crds_value: impl Fn(&CrdsValue) -> bool,
     ) -> (
         Vec<CrdsValue>, // unique CrdsValues pushed out to peers
@@ -163,7 +164,7 @@ impl CrdsGossip {
         origin: &[Pubkey],
         wallclock: u64,
         now: u64,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
     ) -> Result<(), CrdsGossipError> {
         if now > wallclock.saturating_add(self.push.prune_timeout) {
             Err(CrdsGossipError::PruneMessageTimeout)
@@ -181,7 +182,7 @@ impl CrdsGossip {
         &self,
         self_keypair: &Keypair,
         self_shred_version: u16,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
         gossip_validators: Option<&HashSet<Pubkey>>,
         ping_cache: &Mutex<PingCache>,
         pings: &mut Vec<(SocketAddr, Ping)>,
@@ -208,7 +209,7 @@ impl CrdsGossip {
         self_shred_version: u16,
         now: u64,
         gossip_validators: Option<&HashSet<Pubkey>>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
         bloom_size: usize,
         ping_cache: &Mutex<PingCache>,
         pings: &mut Vec<(SocketAddr, Ping)>,
@@ -288,7 +289,7 @@ impl CrdsGossip {
     pub fn make_timeouts<'a>(
         &self,
         self_pubkey: Pubkey,
-        stakes: &'a HashMap<Pubkey, u64>,
+        stakes: &'a StakedNodesMap,
         epoch_duration: Duration,
     ) -> CrdsTimeouts<'a> {
         self.pull.make_timeouts(self_pubkey, stakes, epoch_duration)
@@ -323,7 +324,7 @@ pub(crate) fn get_gossip_nodes<R: Rng>(
     verify_shred_version: impl Fn(/*shred_version:*/ u16) -> bool,
     crds: &RwLock<Crds>,
     gossip_validators: Option<&HashSet<Pubkey>>,
-    stakes: &HashMap<Pubkey, u64>,
+    stakes: &StakedNodesMap,
     socket_addr_space: &SocketAddrSpace,
 ) -> Vec<ContactInfo> {
     // Exclude nodes which have not been active for this long.
@@ -363,7 +364,7 @@ pub(crate) fn get_gossip_nodes<R: Rng>(
 // Dedups gossip addresses, keeping only the one with the highest stake.
 pub(crate) fn dedup_gossip_addresses(
     nodes: impl IntoIterator<Item = ContactInfo>,
-    stakes: &HashMap<Pubkey, u64>,
+    stakes: &StakedNodesMap,
 ) -> HashMap</*gossip:*/ SocketAddr, (/*stake:*/ u64, ContactInfo)> {
     nodes
         .into_iter()
@@ -439,9 +440,9 @@ mod test {
         let ping_cache = Mutex::new(ping_cache);
         crds_gossip.refresh_push_active_set(
             &keypair,
-            0,               // shred version
-            &HashMap::new(), // stakes
-            None,            // gossip validators
+            0,                   // shred version
+            &HashMap::default(), // stakes
+            None,                // gossip validators
             &ping_cache,
             &mut Vec::new(), // pings
             &SocketAddrSpace::Unspecified,
@@ -455,7 +456,7 @@ mod test {
             &[prune_pubkey],
             now,
             now,
-            &HashMap::<Pubkey, u64>::default(), // stakes
+            &HashMap::default(), // stakes
         );
         assert_eq!(res.err(), Some(CrdsGossipError::BadPruneDestination));
         //correct dest
@@ -466,7 +467,7 @@ mod test {
             &[prune_pubkey], // origins
             now,
             now,
-            &HashMap::<Pubkey, u64>::default(), // stakes
+            &HashMap::default(), // stakes
         );
         res.unwrap();
         //test timeout
@@ -478,7 +479,7 @@ mod test {
             &[prune_pubkey], // origins
             now,
             timeout,
-            &HashMap::<Pubkey, u64>::default(), // stakes
+            &HashMap::default(), // stakes
         );
         assert_eq!(res.err(), Some(CrdsGossipError::PruneMessageTimeout));
     }

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -8,7 +8,7 @@ use {
     solana_clock::{Epoch, Slot},
     solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
     solana_pubkey::Pubkey,
-    solana_runtime::bank_forks::BankForks,
+    solana_runtime::{bank_forks::BankForks, stakes::StakedNodesMap},
     std::{
         cmp::Reverse,
         collections::HashMap,
@@ -41,7 +41,7 @@ pub struct DuplicateShredHandler {
     bank_forks: Arc<RwLock<BankForks>>,
     // Cache information from root bank so we could function correctly without reading roots.
     cached_on_epoch: Epoch,
-    cached_staked_nodes: Arc<HashMap<Pubkey, u64>>,
+    cached_staked_nodes: Arc<StakedNodesMap>,
     cached_slots_in_epoch: u64,
     // Used to notify duplicate consensus state machine
     duplicate_slots_sender: Sender<Slot>,
@@ -85,7 +85,7 @@ impl DuplicateShredHandler {
             consumed: HashMap::<Slot, bool>::default(),
             last_root: 0,
             cached_on_epoch: 0,
-            cached_staked_nodes: Arc::new(HashMap::new()),
+            cached_staked_nodes: Arc::new(HashMap::default()),
             cached_slots_in_epoch: 0,
             blockstore,
             leader_schedule_cache,

--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -1,13 +1,12 @@
 use {
     solana_clock::{Epoch, DEFAULT_MS_PER_SLOT},
     solana_epoch_schedule::EpochSchedule,
-    solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank,
         bank_forks::{BankForks, ReadOnlyAtomicSlot},
+        stakes::StakedNodesMap,
     },
     std::{
-        collections::HashMap,
         sync::{Arc, RwLock},
         time::Duration,
     },
@@ -20,13 +19,13 @@ pub struct EpochSpecs {
     epoch_schedule: EpochSchedule,
     root: ReadOnlyAtomicSlot, // updated by bank-forks.
     bank_forks: Arc<RwLock<BankForks>>,
-    current_epoch_staked_nodes: Arc<HashMap<Pubkey, /*stake:*/ u64>>,
+    current_epoch_staked_nodes: Arc<StakedNodesMap>,
     epoch_duration: Duration,
 }
 
 impl EpochSpecs {
     #[inline]
-    pub fn current_epoch_staked_nodes(&mut self) -> &Arc<HashMap<Pubkey, /*stake:*/ u64>> {
+    pub fn current_epoch_staked_nodes(&mut self) -> &Arc<StakedNodesMap> {
         self.maybe_refresh();
         &self.current_epoch_staked_nodes
     }
@@ -87,6 +86,7 @@ mod tests {
     use {
         super::*,
         solana_clock::Slot,
+        solana_pubkey::Pubkey,
         solana_runtime::genesis_utils::{create_genesis_config, GenesisConfigInfo},
     };
 

--- a/gossip/src/received_cache.rs
+++ b/gossip/src/received_cache.rs
@@ -2,6 +2,7 @@ use {
     itertools::Itertools,
     lru::LruCache,
     solana_pubkey::Pubkey,
+    solana_runtime::stakes::StakedNodesMap,
     std::{cmp::Reverse, collections::HashMap},
 };
 
@@ -40,7 +41,7 @@ impl ReceivedCache {
         origin: Pubkey,  // CRDS value owner.
         stake_threshold: f64,
         min_ingress_nodes: usize,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
     ) -> impl Iterator<Item = Pubkey> {
         match self.0.peek_mut(&origin) {
             None => None,
@@ -96,7 +97,7 @@ impl ReceivedCacheEntry {
         origin: &Pubkey, // CRDS value owner.
         stake_threshold: f64,
         min_ingress_nodes: usize,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesMap,
     ) -> impl Iterator<Item = Pubkey> {
         debug_assert!((0.0..=1.0).contains(&stake_threshold));
         debug_assert!(self.num_upserts >= ReceivedCache::MIN_NUM_UPSERTS);

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -21,6 +21,7 @@ use {
     solana_keypair::Keypair,
     solana_pubkey::Pubkey,
     solana_rayon_threadlimit::get_thread_count,
+    solana_runtime::stakes::StakedNodesMap,
     solana_sha256_hasher::hash,
     solana_signer::Signer,
     solana_streamer::socket::SocketAddrSpace,
@@ -91,8 +92,8 @@ impl Deref for Network {
     }
 }
 
-fn stakes(network: &Network) -> HashMap<Pubkey, u64> {
-    let mut stakes = HashMap::new();
+fn stakes(network: &Network) -> StakedNodesMap {
+    let mut stakes = HashMap::default();
     for (key, Node { stake, .. }) in network.iter() {
         stakes.insert(*key, *stake);
     }
@@ -290,9 +291,9 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
     network_values.par_iter().for_each(|node| {
         node.gossip.refresh_push_active_set(
             &node.keypair,
-            0,               // shred version
-            &HashMap::new(), // stakes
-            None,            // gossip validators
+            0,                   // shred version
+            &HashMap::default(), // stakes
+            None,                // gossip validators
             &node.ping_cache,
             &mut Vec::new(), // pings
             &SocketAddrSpace::Unspecified,
@@ -462,9 +463,9 @@ fn network_run_push(
             network_values.par_iter().for_each(|node| {
                 node.gossip.refresh_push_active_set(
                     &node.keypair,
-                    0,               // shred version
-                    &HashMap::new(), // stakes
-                    None,            // gossip validators
+                    0,                   // shred version
+                    &HashMap::default(), // stakes
+                    None,                // gossip validators
                     &node.ping_cache,
                     &mut Vec::new(), // pings
                     &SocketAddrSpace::Unspecified,
@@ -534,7 +535,7 @@ fn network_run_pull(
                             0, // shred version.
                             now,
                             None,
-                            &HashMap::new(),
+                            &HashMap::default(),
                             992, // max_bloom_filter_bytes
                             from.ping_cache.deref(),
                             &mut pings,
@@ -790,15 +791,15 @@ fn test_prune_errors() {
     let ping_cache = new_ping_cache();
     crds_gossip.refresh_push_active_set(
         &keypair,
-        0,               // shred version
-        &HashMap::new(), // stakes
-        None,            // gossip validators
+        0,                   // shred version
+        &HashMap::default(), // stakes
+        None,                // gossip validators
         &ping_cache,
         &mut Vec::new(), // pings
         &SocketAddrSpace::Unspecified,
     );
     let now = timestamp();
-    let stakes = HashMap::<Pubkey, u64>::default();
+    let stakes = HashMap::default();
     //incorrect dest
     let mut res = crds_gossip.process_prune_msg(
         &id,                                      // self_pubkey

--- a/ledger/src/leader_schedule/identity_keyed.rs
+++ b/ledger/src/leader_schedule/identity_keyed.rs
@@ -3,6 +3,7 @@ use {
     itertools::Itertools,
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
+    solana_runtime::stakes::StakedNodesMap,
     std::{collections::HashMap, ops::Index},
 };
 
@@ -15,12 +16,7 @@ pub struct LeaderSchedule {
 
 impl LeaderSchedule {
     // Note: passing in zero stakers will cause a panic.
-    pub fn new(
-        epoch_staked_nodes: &HashMap<Pubkey, u64>,
-        epoch: Epoch,
-        len: u64,
-        repeat: u64,
-    ) -> Self {
+    pub fn new(epoch_staked_nodes: &StakedNodesMap, epoch: Epoch, len: u64, repeat: u64) -> Self {
         let keyed_stakes: Vec<_> = epoch_staked_nodes
             .iter()
             .map(|(pubkey, stake)| (pubkey, *stake))
@@ -83,7 +79,7 @@ mod tests {
     #[test]
     fn test_leader_schedule_basic() {
         let num_keys = 10;
-        let stakes: HashMap<_, _> = (0..num_keys)
+        let stakes: HashMap<_, _, _> = (0..num_keys)
             .map(|i| (solana_pubkey::new_rand(), i))
             .collect();
 
@@ -99,7 +95,7 @@ mod tests {
     #[test]
     fn test_repeated_leader_schedule() {
         let num_keys = 10;
-        let stakes: HashMap<_, _> = (0..num_keys)
+        let stakes: HashMap<_, _, _> = (0..num_keys)
             .map(|i| (solana_pubkey::new_rand(), i))
             .collect();
 
@@ -122,7 +118,7 @@ mod tests {
     fn test_repeated_leader_schedule_specific() {
         let alice_pubkey = solana_pubkey::new_rand();
         let bob_pubkey = solana_pubkey::new_rand();
-        let stakes: HashMap<_, _> = [(alice_pubkey, 2), (bob_pubkey, 1)].into_iter().collect();
+        let stakes: HashMap<_, _, _> = [(alice_pubkey, 2), (bob_pubkey, 1)].into_iter().collect();
 
         let epoch = 0;
         let len = 8;

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -36,8 +36,8 @@ use {
     solana_rent::Rent,
     solana_rpc_client::rpc_client::RpcClient,
     solana_runtime::genesis_utils::{
-        create_genesis_config_with_vote_accounts_and_cluster_type, GenesisConfigInfo,
-        ValidatorVoteKeypairs,
+        create_genesis_config_with_vote_accounts_and_cluster_type, stakes::StakedNodesMap,
+        GenesisConfigInfo, ValidatorVoteKeypairs,
     },
     solana_signer::{signers::Signers, Signer},
     solana_stake_interface::{
@@ -206,10 +206,12 @@ impl LocalCluster {
             }
 
             let total_stake = config.node_stakes.iter().sum::<u64>();
-            let stakes = HashMap::from([
+            let stakes = [
                 (client_keypair.pubkey(), stake),
                 (Pubkey::new_unique(), total_stake.saturating_sub(stake)),
-            ]);
+            ]
+            .into_iter()
+            .collect::<StakedNodesMap>();
             let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(
                 Arc::new(stakes),
                 HashMap::<Pubkey, u64>::default(), // overrides

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -52,7 +52,7 @@ use {
             calculate_stake_weighted_timestamp, MaxAllowableDrift,
             MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2,
         },
-        stakes::{SerdeStakesToStakeFormat, Stakes, StakesCache},
+        stakes::{SerdeStakesToStakeFormat, StakedNodesMap, Stakes, StakesCache},
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
@@ -119,7 +119,7 @@ use {
         invoke_context::BuiltinFunctionWithContext,
         loaded_programs::{ProgramCacheEntry, ProgramRuntimeEnvironments},
     },
-    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
+    solana_pubkey::Pubkey,
     solana_reward_info::RewardInfo,
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
@@ -931,7 +931,7 @@ struct VoteReward {
     vote_rewards: u64,
 }
 
-type VoteRewards = HashMap<Pubkey, VoteReward, PubkeyHasherBuilder>;
+type VoteRewards = HashMap<Pubkey, VoteReward, solana_pubkey::PubkeyHasherBuilder>;
 
 #[derive(Debug, Default)]
 pub struct NewBankOptions {
@@ -5014,11 +5014,11 @@ impl Bank {
     }
 
     /// Get the staked nodes map for the current Bank::epoch
-    pub fn current_epoch_staked_nodes(&self) -> Arc<HashMap<Pubkey, u64>> {
+    pub fn current_epoch_staked_nodes(&self) -> Arc<StakedNodesMap> {
         self.current_epoch_stakes().stakes().staked_nodes()
     }
 
-    pub fn epoch_staked_nodes(&self, epoch: Epoch) -> Option<Arc<HashMap<Pubkey, u64>>> {
+    pub fn epoch_staked_nodes(&self, epoch: Epoch) -> Option<Arc<StakedNodesMap>> {
         Some(self.epoch_stakes.get(&epoch)?.stakes().staked_nodes())
     }
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -12,7 +12,7 @@ use {
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::utils::create_account_shared_data,
     solana_clock::Epoch,
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_stake_interface::{
         program as stake_program,
         state::{Delegation, StakeActivationStatus},
@@ -30,6 +30,9 @@ use {
 mod serde_stakes;
 pub(crate) use serde_stakes::serialize_stake_accounts_to_delegation_format;
 pub use serde_stakes::SerdeStakesToStakeFormat;
+
+/// Mapping from node pubkey to total stake across all vote accounts.
+pub type StakedNodesMap = HashMap<Pubkey, u64, PubkeyHasherBuilder>;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -184,7 +187,7 @@ impl<T: Clone> Stakes<T> {
         &self.vote_accounts
     }
 
-    pub(crate) fn staked_nodes(&self) -> Arc<HashMap<Pubkey, u64>> {
+    pub(crate) fn staked_nodes(&self) -> Arc<StakedNodesMap> {
         self.vote_accounts.staked_nodes()
     }
 }

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -1,5 +1,5 @@
 use {
-    super::{StakeAccount, Stakes},
+    super::{StakeAccount, StakedNodesMap, Stakes},
     crate::stake_history::StakeHistory,
     im::HashMap as ImHashMap,
     serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer},
@@ -7,7 +7,7 @@ use {
     solana_pubkey::Pubkey,
     solana_stake_interface::state::Stake,
     solana_vote::vote_account::VoteAccounts,
-    std::{collections::HashMap, sync::Arc},
+    std::sync::Arc,
 };
 
 /// Wrapper struct with custom serialization to support serializing
@@ -28,7 +28,7 @@ impl SerdeStakesToStakeFormat {
         }
     }
 
-    pub fn staked_nodes(&self) -> Arc<HashMap<Pubkey, u64>> {
+    pub fn staked_nodes(&self) -> Arc<StakedNodesMap> {
         match self {
             Self::Stake(stakes) => stakes.staked_nodes(),
             Self::Account(stakes) => stakes.staked_nodes(),

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -49,7 +49,7 @@ solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true, features = ["agave-unstable-api"] }
 solana-packet = { workspace = true }
 solana-perf = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-quic-definitions = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }

--- a/streamer/examples/swqos.rs
+++ b/streamer/examples/swqos.rs
@@ -101,7 +101,7 @@ async fn main() -> anyhow::Result<()> {
 
     let staked_nodes = {
         let nodes = StakedNodes::new(
-            Arc::new(HashMap::new()),
+            Arc::new(HashMap::default()),
             load_staked_nodes_overrides(&cli.stake_amounts)?,
         );
         Arc::new(RwLock::new(nodes))

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1584,7 +1584,8 @@ pub mod test {
         agave_logger::setup();
 
         let client_keypair = Keypair::new();
-        let stakes = HashMap::from([(client_keypair.pubkey(), 100_000)]);
+        let mut stakes = HashMap::default();
+        stakes.insert(client_keypair.pubkey(), 100_000);
         let staked_nodes = StakedNodes::new(
             Arc::new(stakes),
             HashMap::<Pubkey, u64>::default(), // overrides
@@ -1620,7 +1621,8 @@ pub mod test {
         agave_logger::setup();
 
         let client_keypair = Keypair::new();
-        let stakes = HashMap::from([(client_keypair.pubkey(), 0)]);
+        let mut stakes = HashMap::default();
+        stakes.insert(client_keypair.pubkey(), 0);
         let staked_nodes = StakedNodes::new(
             Arc::new(stakes),
             HashMap::<Pubkey, u64>::default(), // overrides

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -16,7 +16,7 @@ use {
         BindIpAddrs, CurrentSocket, FixedSocketProvider, MultihomedSocketProvider, SocketProvider,
     },
     solana_packet::Packet,
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_time_utils::timestamp,
     std::{
         cmp::Reverse,
@@ -77,7 +77,7 @@ pub(crate) const SOCKET_READ_TIMEOUT: Duration = Duration::from_secs(1);
 // Total stake and nodes => stake map
 #[derive(Default)]
 pub struct StakedNodes {
-    stakes: Arc<HashMap<Pubkey, u64>>,
+    stakes: Arc<HashMap<Pubkey, u64, PubkeyHasherBuilder>>,
     overrides: HashMap<Pubkey, u64>,
     total_stake: u64,
     max_stake: u64,
@@ -431,7 +431,7 @@ impl StreamerSendStats {
 impl StakedNodes {
     /// Calculate the stake stats: return the new (total_stake, min_stake and max_stake) tuple
     fn calculate_stake_stats(
-        stakes: &Arc<HashMap<Pubkey, u64>>,
+        stakes: &Arc<HashMap<Pubkey, u64, PubkeyHasherBuilder>>,
         overrides: &HashMap<Pubkey, u64>,
     ) -> (u64, u64, u64) {
         let values = stakes
@@ -445,7 +445,10 @@ impl StakedNodes {
         (total_stake, min_stake, max_stake)
     }
 
-    pub fn new(stakes: Arc<HashMap<Pubkey, u64>>, overrides: HashMap<Pubkey, u64>) -> Self {
+    pub fn new(
+        stakes: Arc<HashMap<Pubkey, u64, PubkeyHasherBuilder>>,
+        overrides: HashMap<Pubkey, u64>,
+    ) -> Self {
         let (total_stake, min_stake, max_stake) = Self::calculate_stake_stats(&stakes, &overrides);
         Self {
             stakes,
@@ -480,7 +483,7 @@ impl StakedNodes {
     }
 
     // Update the stake map given a new stakes map
-    pub fn update_stake_map(&mut self, stakes: Arc<HashMap<Pubkey, u64>>) {
+    pub fn update_stake_map(&mut self, stakes: Arc<HashMap<Pubkey, u64, PubkeyHasherBuilder>>) {
         let (total_stake, min_stake, max_stake) =
             Self::calculate_stake_stats(&stakes, &self.overrides);
 

--- a/tps-client/src/utils.rs
+++ b/tps-client/src/utils.rs
@@ -2,7 +2,7 @@ use {
     log::{error, info},
     solana_client::connection_cache::ConnectionCache as ClientConnectionCache,
     solana_keypair::Keypair,
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_rpc_client::rpc_client::RpcClient,
     solana_signer::Signer,
     solana_streamer::streamer::StakedNodes,
@@ -113,13 +113,15 @@ fn create_connection_cache_with_client_socket_option(
     let (stake, total_stake) =
         find_node_activated_stake(rpc_client, client_node_id.pubkey()).unwrap_or_default();
     info!("Stake for specified client_node_id: {stake}, total stake: {total_stake}");
-    let stakes = HashMap::from([
+    let stakes = [
         (client_node_id.pubkey(), stake),
         (
             Pubkey::new_unique(),
             total_stake.checked_sub(stake).unwrap(),
         ),
-    ]);
+    ]
+    .into_iter()
+    .collect::<HashMap<_, _, PubkeyHasherBuilder>>();
     let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(
         Arc::new(stakes),
         HashMap::<Pubkey, u64>::default(), // overrides

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -408,7 +408,8 @@ async fn test_connection_pruned_and_reopened() {
 #[tokio::test]
 async fn test_staked_connection() {
     let stake_identity = Keypair::new();
-    let stakes = HashMap::from([(stake_identity.pubkey(), 100_000)]);
+    let mut stakes = HashMap::default();
+    stakes.insert(stake_identity.pubkey(), 100_000);
     let staked_nodes = StakedNodes::new(Arc::new(stakes), HashMap::<Pubkey, u64>::default());
 
     let SpawnTestServerResult {
@@ -706,7 +707,8 @@ async fn test_rate_limiting_establish_connection() {
 #[tokio::test]
 async fn test_update_identity() {
     let stake_identity = Keypair::new();
-    let stakes = HashMap::from([(stake_identity.pubkey(), 100_000)]);
+    let mut stakes = HashMap::default();
+    stakes.insert(stake_identity.pubkey(), 100_000);
     let staked_nodes = StakedNodes::new(Arc::new(stakes), HashMap::<Pubkey, u64>::default());
 
     let SpawnTestServerResult {

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -43,7 +43,7 @@ solana-net-utils = { workspace = true }
 solana-nohash-hasher = { workspace = true }
 solana-perf = { workspace = true }
 solana-poh = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-quic-client = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-rpc = { workspace = true }

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -145,7 +145,7 @@ pub fn main() {
     let sigverify_stage = Vortexor::create_sigverify_stage(tpu_receiver, non_vote_sender);
 
     // To be linked with StakedNodes service.
-    let stake_map = Arc::new(HashMap::new());
+    let stake_map = Arc::new(HashMap::default());
     let staked_nodes_overrides = HashMap::new();
 
     let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(

--- a/vortexor/src/stake_updater.rs
+++ b/vortexor/src/stake_updater.rs
@@ -5,7 +5,7 @@ use {
     crate::rpc_load_balancer::RpcLoadBalancer,
     log::{info, warn},
     solana_client::client_error,
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_streamer::streamer::StakedNodes,
     std::{
         collections::HashMap,
@@ -85,7 +85,7 @@ impl StakeUpdater {
                             vote_account.activated_stake,
                         ))
                     })
-                    .collect::<HashMap<Pubkey, u64>>(),
+                    .collect::<HashMap<Pubkey, u64, PubkeyHasherBuilder>>(),
             );
 
             *last_refresh = Some(Instant::now());

--- a/vortexor/tests/vortexor.rs
+++ b/vortexor/tests/vortexor.rs
@@ -58,7 +58,8 @@ async fn test_vortexor() {
     let tpu_address = tpu_sockets.tpu_quic[0].local_addr().unwrap();
     let tpu_fwd_address = tpu_sockets.tpu_quic_fwd[0].local_addr().unwrap();
 
-    let stakes = HashMap::from([(keypair.pubkey(), 10000)]);
+    let mut stakes = HashMap::default();
+    stakes.insert(keypair.pubkey(), 10000);
     let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(
         Arc::new(stakes),
         HashMap::<Pubkey, u64>::default(), // overrides

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -40,7 +40,7 @@ solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-packet = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-sdk-ids = { workspace = true }
 solana-serialize-utils = { workspace = true }
 solana-signature = { workspace = true }

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -61,7 +61,7 @@ solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rpc = { workspace = true }
 solana-runtime = { workspace = true }
 solana-signature = { workspace = true }

--- a/votor/src/staked_validators_cache.rs
+++ b/votor/src/staked_validators_cache.rs
@@ -103,7 +103,7 @@ impl StakedValidatorsCache {
                     "StakedValidatorsCache::get: unknown Bank::epoch_staked_nodes for epoch: \
                      {epoch}"
                 );
-                Arc::<HashMap<Pubkey, u64>>::default()
+                Arc::new(HashMap::default())
             });
 
         struct Node {


### PR DESCRIPTION
#### Problem

Default Hashmap for stake_node map is too expensive. We could optimize it to use cheaper PubkeyHasher.

#### Summary of Changes

- switch to use cheaper PubkeyHasher for stake_node HashMap

Benchmark shows 3x performance improvement.

```
test bench_staked_nodes_compute  ... bench:       4,471 ns/iter (+/- 201)  \\ this PR
test bench_staked_nodes_compute  ... bench:      12,917 ns/iter (+/- 80)  \\ before
```
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
