### PR TITLE
Run test_scan_accounts_stored_meta_correctness() for both file and mmap

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1661,10 +1661,11 @@ pub mod tests {
     }
 
     /// Test that `scan_accounts_stored_meta` correctly reads back all accounts that were written.
-    #[test]
-    fn test_scan_accounts_stored_meta_correctness() {
+    #[test_case(StorageAccess::Mmap)]
+    #[test_case(StorageAccess::File)]
+    fn test_scan_accounts_stored_meta_correctness(storage_access: StorageAccess) {
         let (av_mmap, test_accounts, path) = rand_exhaustive_append_vec(100);
-        let av_file = AppendVec::new_from_file(&path.path, av_mmap.len(), StorageAccess::File)
+        let av_file = AppendVec::new_from_file(&path.path, av_mmap.len(), storage_access)
             .unwrap()
             .0;
         let mut reader = new_scan_accounts_reader();


### PR DESCRIPTION
#### Problem

`test_scan_accounts_stored_meta_correctness()` is only run for file io, but not mmap.


#### Summary of Changes

Run the test for both file io and mmap.