### PR TITLE
Gossip: wrapping add on epoch_slot_index

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -708,7 +708,7 @@ impl ClusterInfo {
                 let entry = CrdsValue::new(epoch_slots, &keypair);
                 entries.push(entry);
             }
-            epoch_slot_index += 1;
+            epoch_slot_index = epoch_slot_index.wrapping_add(1);
             reset = true;
         }
         let mut gossip_crds = self.gossip.crds.write().unwrap();


### PR DESCRIPTION
#### Problem
When pushing epoch slots, `epoch_slot_index` can overflow. Normally this is fine, but with `debug_assertions` this will panic. 

#### Summary of Changes
Just wrapping add `epcoh_slot_index`. 

NOTE: There is an off by one bug here. But it has been around a while, so I am not fixing it in this PR. I will follow up with a PR that fixes the bug brought up here: https://github.com/anza-xyz/agave/issues/8712
