### PR TITLE
Add allow deprecated to get_max_age

### DIFF
--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -140,6 +140,7 @@ impl BlockhashQueue {
         since = "2.0.0",
         note = "Please use `solana_clock::MAX_PROCESSING_AGE`"
     )]
+    #[allow(deprecated)]
     pub fn get_max_age(&self) -> usize {
         self.max_age
     }

--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -140,8 +140,8 @@ impl BlockhashQueue {
         since = "2.0.0",
         note = "Please use `solana_clock::MAX_PROCESSING_AGE`"
     )]
-    #[allow(deprecated)]
     pub fn get_max_age(&self) -> usize {
+        #[allow(deprecated)]
         self.max_age
     }
 }


### PR DESCRIPTION
#### Problem
- AccountsDB doesn't build with cargo build when built alone due to
```
error: use of deprecated field `blockhash_queue::BlockhashQueue::max_age`: This crate has been marked for formal inclusion in the Agave Unstable API. From v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to acknowledge use of an interface that may break without warning.
   --> accounts-db/src/blockhash_queue.rs:144:9
    |
144 |         self.max_age
    |         ^^^^^^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(deprecated)]`

error: could not compile `solana-accounts-db` (lib) due to 1 previous error
```
- Oddly the error message is not as expected
```
    #[deprecated(
        since = "2.0.0",
        note = "Please use `solana_clock::MAX_PROCESSING_AGE`"
    )]
```

#### Summary of Changes
- Given that the entire crate (accounts-db) will be marked unstable in 4.0.0, it seems a safe workaround to allow the function as all other functions in this crate are also allowed.
- If there are better ideas, let's implement them instead. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
