### PR TITLE
ci: add workspace key to xtask

### DIFF
--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0"
 edition = "2021"
 publish = false
 
+# Prevents auto-detection of parent workspace (ie. git worktrees).
+[workspace]
+
 [features]
 agave-unstable-api = []
 dummy-for-ci-check = []


### PR DESCRIPTION
#### Problem
For any devs who use git worktrees in Agave this new setup for the `xtask` dir, which is excluded from the workspace, can cause trouble with checks like `cargo sort`.

I have a few scripts that mimick CI and run a few checks, which broke from this setup.

#### Summary of Changes
Unless I'm missing something, the simplest fix is to just add a `[workspace]` key to the `xtask` crate so jobs like `cargo sort` don't walk upwards into the worktree root.