### PR TITLE
Factor out setting up FileCreator to agave-snaphsots::unarchive

### DIFF
--- a/snapshots/src/unarchive.rs
+++ b/snapshots/src/unarchive.rs
@@ -3,7 +3,7 @@ use {
         hardened_unpack::{self, UnpackError},
         ArchiveFormat, ArchiveFormatDecompressor,
     },
-    agave_fs::buffered_reader,
+    agave_fs::{buffered_reader, file_io::file_creator},
     bzip2::bufread::BzDecoder,
     crossbeam_channel::Sender,
     std::{
@@ -18,6 +18,11 @@ use {
 // Allows scheduling a large number of reads such that temporary disk access delays
 // shouldn't block decompression (unless read bandwidth is saturated).
 const MAX_SNAPSHOT_READER_BUF_SIZE: u64 = 128 * 1024 * 1024;
+// The buffer should be large enough to saturate write I/O bandwidth, while also accommodating:
+// - Many small files: each file consumes at least one write-capacity-sized chunk (0.5-1 MiB).
+// - Large files: their data may accumulate in backlog buffers while waiting for file open
+//   operations to complete.
+const MAX_UNPACK_WRITE_BUF_SIZE: usize = 512 * 1024 * 1024;
 
 /// Streams unpacked files across channel
 pub fn streaming_unarchive_snapshot(
@@ -30,15 +35,29 @@ pub fn streaming_unarchive_snapshot(
 ) -> JoinHandle<Result<(), UnpackError>> {
     let do_unpack = move |archive_path: &Path| {
         let archive_size = fs::metadata(archive_path)?.len() as usize;
+        // Bound the buffer based on available memlock budget (reader and writer might use it to
+        // register buffer in kernel) and input archive size (decompression multiplies content size,
+        // but buffering more than origin isn't necessary).
         let read_write_budget_size = (memlock_budget_size / 2).min(archive_size);
         let read_buf_size = MAX_SNAPSHOT_READER_BUF_SIZE.min(read_write_budget_size as u64);
         let decompressor = decompressed_tar_reader(archive_format, archive_path, read_buf_size)?;
+
+        let write_buf_size = MAX_UNPACK_WRITE_BUF_SIZE.min(read_write_budget_size);
+        let file_creator = file_creator(write_buf_size, move |file_path| {
+            let result = file_sender.send(file_path);
+            if let Err(err) = result {
+                panic!(
+                    "failed to send path '{}' from unpacker to rebuilder: {err}",
+                    err.0.display(),
+                );
+            }
+        })?;
+
         hardened_unpack::streaming_unpack_snapshot(
             decompressor,
-            read_write_budget_size,
+            file_creator,
             ledger_dir.as_path(),
             &account_paths,
-            &file_sender,
         )
     };
 
@@ -62,7 +81,16 @@ pub fn unpack_genesis_archive(
     fs::create_dir_all(destination_dir)?;
     let tar_bz2 = fs::File::open(archive_filename)?;
     let tar = BzDecoder::new(BufReader::new(tar_bz2));
-    hardened_unpack::unpack_genesis(tar, destination_dir, max_genesis_archive_unpacked_size)?;
+    let file_creator = file_creator(
+        0, /* don't provide memlock budget (forces sync IO), since genesis archives are small */
+        |_| {},
+    )?;
+    hardened_unpack::unpack_genesis(
+        tar,
+        file_creator,
+        destination_dir,
+        max_genesis_archive_unpacked_size,
+    )?;
     log::info!(
         "Extracted {:?} in {:?}",
         archive_filename,


### PR DESCRIPTION
#### Problem
Currently for snapshot unpacking file reader and file creator are set-up in different modules and functions, however they should be set-up together, since both require io-uring config that needs to be coordinated (e.g. splitting memlock budget between them).

#### Summary of Changes
* make `hardened_unpack` functions take `Box<dyn FileCreator>` (dynamic file created returned from `agave-fs::file_io`)
* move call to `file_creator` to `unarchive` mod, into the same functions that create decompressor / reader, such that their settings can be arranged in one place.

This will also allow creating shared io-uring backend (sqpoll) for both, which should speed up unpacking.