### PR TITLE
Gossip: Fix off by one error in in `push_epoch_slots()`

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -695,17 +695,16 @@ impl ClusterInfo {
         let mut entries = Vec::default();
         let keypair = self.keypair();
         while !update.is_empty() {
-            let ix = epoch_slot_index % crds_data::MAX_EPOCH_SLOTS;
             let now = timestamp();
             let mut slots = if !reset {
-                self.lookup_epoch_slots(ix)
+                self.lookup_epoch_slots(epoch_slot_index)
             } else {
                 EpochSlots::new(self_pubkey, now)
             };
             let n = slots.fill(update, now);
             update = &update[n..];
             if n > 0 {
-                let epoch_slots = CrdsData::EpochSlots(ix, slots);
+                let epoch_slots = CrdsData::EpochSlots(epoch_slot_index, slots);
                 let entry = CrdsValue::new(epoch_slots, &keypair);
                 entries.push(entry);
             }


### PR DESCRIPTION
#### Problem
We have an off by one error in `push_epoch_slots` that causes us to push an epoch slot with index 0 twice in a row. This can happen when there is a large enough update that causes `epoch_slot_index` to wrap around back to 0.

#### Summary of Changes
The modulo here actually causes the bug here. Remove it and replace with the raw index value: `epoch_slot_index`

Solves issue: https://github.com/anza-xyz/agave/issues/8712