### PR TITLE
Move snapshot_archive_info to agave-snapshots

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -35,7 +35,8 @@ use {
         tvu::{Tvu, TvuConfig, TvuSockets},
     },
     agave_snapshots::{
-        snapshot_config::SnapshotConfig, snapshot_hash::StartingSnapshotHashes, SnapshotInterval,
+        snapshot_archive_info::SnapshotArchiveInfoGetter as _, snapshot_config::SnapshotConfig,
+        snapshot_hash::StartingSnapshotHashes, SnapshotInterval,
     },
     anyhow::{anyhow, Context, Result},
     crossbeam_channel::{bounded, unbounded, Receiver},
@@ -126,7 +127,6 @@ use {
         dependency_tracker::DependencyTracker,
         prioritization_fee_cache::PrioritizationFeeCache,
         runtime_config::RuntimeConfig,
-        snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_bank_utils,
         snapshot_controller::SnapshotController,
         snapshot_utils::{self, clean_orphaned_account_snapshot_dirs},

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -2,7 +2,10 @@
 
 use {
     crate::snapshot_utils::create_tmp_accounts_dir_for_tests,
-    agave_snapshots::{paths as snapshot_paths, snapshot_config::SnapshotConfig, SnapshotInterval},
+    agave_snapshots::{
+        paths as snapshot_paths, snapshot_archive_info::FullSnapshotArchiveInfo,
+        snapshot_config::SnapshotConfig, SnapshotInterval,
+    },
     crossbeam_channel::unbounded,
     itertools::Itertools,
     log::{info, trace},
@@ -22,7 +25,6 @@ use {
         bank_forks::BankForks,
         genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo},
         runtime_config::RuntimeConfig,
-        snapshot_archive_info::FullSnapshotArchiveInfo,
         snapshot_bank_utils,
         snapshot_controller::SnapshotController,
         snapshot_utils,
@@ -681,7 +683,7 @@ fn test_snapshots_with_background_services() {
         // If a snapshot should be taken this slot, wait for it to complete
         if slot % FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS == 0 {
             let timer = Instant::now();
-            while snapshot_utils::get_highest_full_snapshot_archive_slot(
+            while snapshot_paths::get_highest_full_snapshot_archive_slot(
                 &snapshot_test_config
                     .snapshot_config
                     .full_snapshot_archives_dir,
@@ -699,7 +701,7 @@ fn test_snapshots_with_background_services() {
             && latest_full_snapshot_slot.is_some()
         {
             let timer = Instant::now();
-            while snapshot_utils::get_highest_incremental_snapshot_archive_slot(
+            while snapshot_paths::get_highest_incremental_snapshot_archive_slot(
                 &snapshot_test_config
                     .snapshot_config
                     .incremental_snapshot_archives_dir,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -1,7 +1,7 @@
 use {
     crate::LEDGER_TOOL_DIRECTORY,
     agave_snapshots::{
-        paths::BANK_SNAPSHOTS_DIR,
+        paths::{self as snapshot_paths, BANK_SNAPSHOTS_DIR},
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_hash::StartingSnapshotHashes,
     },
@@ -155,10 +155,10 @@ pub fn load_and_process_ledger(
             .map(PathBuf::from)
             .unwrap_or_else(|| snapshots_dir.clone());
         if let Some(full_snapshot_slot) =
-            snapshot_utils::get_highest_full_snapshot_archive_slot(&full_snapshot_archives_dir)
+            snapshot_paths::get_highest_full_snapshot_archive_slot(&full_snapshot_archives_dir)
         {
             let incremental_snapshot_slot =
-                snapshot_utils::get_highest_incremental_snapshot_archive_slot(
+                snapshot_paths::get_highest_incremental_snapshot_archive_slot(
                     &incremental_snapshot_archives_dir,
                     full_snapshot_slot,
                 )

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -15,7 +15,8 @@ use {
     agave_feature_set::{self as feature_set, FeatureSet},
     agave_reserved_account_keys::ReservedAccountKeys,
     agave_snapshots::{
-        ArchiveFormat, SnapshotVersion, DEFAULT_ARCHIVE_COMPRESSION, SUPPORTED_ARCHIVE_COMPRESSION,
+        snapshot_archive_info::SnapshotArchiveInfoGetter as _, ArchiveFormat, SnapshotVersion,
+        DEFAULT_ARCHIVE_COMPRESSION, SUPPORTED_ARCHIVE_COMPRESSION,
     },
     clap::{
         crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App,
@@ -67,7 +68,6 @@ use {
         bank_forks::BankForks,
         inflation_rewards::points::{InflationPointCalculationEvent, PointValue},
         installed_scheduler_pool::BankWithScheduler,
-        snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_bank_utils,
         snapshot_minimizer::SnapshotMinimizer,
     },

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -10,19 +10,17 @@ use {
     },
     agave_snapshots::{
         error::SnapshotError,
+        paths as snapshot_paths,
+        snapshot_archive_info::{
+            FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
+        },
         snapshot_config::SnapshotConfig,
         snapshot_hash::{FullSnapshotHash, IncrementalSnapshotHash, StartingSnapshotHashes},
     },
     log::*,
     solana_accounts_db::accounts_update_notifier_interface::AccountsUpdateNotifier,
     solana_genesis_config::GenesisConfig,
-    solana_runtime::{
-        bank_forks::BankForks,
-        snapshot_archive_info::{
-            FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
-        },
-        snapshot_bank_utils, snapshot_utils,
-    },
+    solana_runtime::{bank_forks::BankForks, snapshot_bank_utils, snapshot_utils},
     std::{
         path::PathBuf,
         result,
@@ -139,7 +137,7 @@ pub fn load_bank_forks(
         };
 
         let Some(full_snapshot_archive_info) =
-            snapshot_utils::get_highest_full_snapshot_archive_info(
+            snapshot_paths::get_highest_full_snapshot_archive_info(
                 &snapshot_config.full_snapshot_archives_dir,
             )
         else {
@@ -151,7 +149,7 @@ pub fn load_bank_forks(
         };
 
         let incremental_snapshot_archive_info =
-            snapshot_utils::get_highest_incremental_snapshot_archive_info(
+            snapshot_paths::get_highest_incremental_snapshot_archive_info(
                 &snapshot_config.incremental_snapshot_archives_dir,
                 full_snapshot_archive_info.slot(),
             );

--- a/local-cluster/src/local_cluster_snapshot_utils.rs
+++ b/local-cluster/src/local_cluster_snapshot_utils.rs
@@ -1,12 +1,12 @@
 use {
     crate::local_cluster::LocalCluster,
-    log::*,
-    solana_runtime::{
+    agave_snapshots::{
+        paths as snapshot_paths,
         snapshot_archive_info::{
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
         },
-        snapshot_utils,
     },
+    log::*,
     std::{
         path::Path,
         thread::sleep,
@@ -70,12 +70,12 @@ impl LocalCluster {
         max_wait_duration: Option<Duration>,
     ) -> NextSnapshotResult {
         let full_snapshot_slot =
-            snapshot_utils::get_highest_full_snapshot_archive_slot(&full_snapshot_archives_dir);
+            snapshot_paths::get_highest_full_snapshot_archive_slot(&full_snapshot_archives_dir);
         let last_slot = match next_snapshot_type {
             NextSnapshotType::FullSnapshot => full_snapshot_slot,
             NextSnapshotType::IncrementalAndFullSnapshot => {
                 full_snapshot_slot.and_then(|full_snapshot_slot| {
-                    snapshot_utils::get_highest_incremental_snapshot_archive_slot(
+                    snapshot_paths::get_highest_incremental_snapshot_archive_slot(
                         incremental_snapshot_archives_dir.as_ref().unwrap(),
                         full_snapshot_slot,
                     )
@@ -92,7 +92,7 @@ impl LocalCluster {
         let timer = Instant::now();
         let next_snapshot = loop {
             if let Some(full_snapshot_archive_info) =
-                snapshot_utils::get_highest_full_snapshot_archive_info(&full_snapshot_archives_dir)
+                snapshot_paths::get_highest_full_snapshot_archive_info(&full_snapshot_archives_dir)
             {
                 match next_snapshot_type {
                     NextSnapshotType::FullSnapshot => {
@@ -102,7 +102,7 @@ impl LocalCluster {
                     }
                     NextSnapshotType::IncrementalAndFullSnapshot => {
                         if let Some(incremental_snapshot_archive_info) =
-                            snapshot_utils::get_highest_incremental_snapshot_archive_info(
+                            snapshot_paths::get_highest_incremental_snapshot_archive_info(
                                 incremental_snapshot_archives_dir.as_ref().unwrap(),
                                 full_snapshot_archive_info.slot(),
                             )

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -7,7 +7,7 @@ use {
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
         parsed_token_accounts::*, rpc_cache::LargestAccountsCache, rpc_health::*,
     },
-    agave_snapshots::snapshot_config::SnapshotConfig,
+    agave_snapshots::{paths as snapshot_paths, snapshot_config::SnapshotConfig},
     base64::{prelude::BASE64_STANDARD, Engine},
     bincode::{config::Options, serialize},
     crossbeam_channel::{unbounded, Receiver, Sender},
@@ -70,7 +70,6 @@ use {
         commitment::{BlockCommitmentArray, BlockCommitmentCache},
         non_circulating_supply::{calculate_non_circulating_supply, NonCirculatingSupply},
         prioritization_fee_cache::PrioritizationFeeCache,
-        snapshot_utils,
     },
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_send_transaction_service::send_transaction_service::TransactionInfo,
@@ -2857,10 +2856,10 @@ pub mod rpc_minimal {
                 .unwrap();
 
             let full_snapshot_slot =
-                snapshot_utils::get_highest_full_snapshot_archive_slot(full_snapshot_archives_dir)
+                snapshot_paths::get_highest_full_snapshot_archive_slot(full_snapshot_archives_dir)
                     .ok_or(RpcCustomError::NoSnapshot)?;
             let incremental_snapshot_slot =
-                snapshot_utils::get_highest_incremental_snapshot_archive_slot(
+                snapshot_paths::get_highest_incremental_snapshot_archive_slot(
                     incremental_snapshot_archives_dir,
                     full_snapshot_slot,
                 );

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -9,7 +9,10 @@ use {
         rpc_cache::LargestAccountsCache,
         rpc_health::*,
     },
-    agave_snapshots::{paths as snapshot_paths, snapshot_config::SnapshotConfig, SnapshotInterval},
+    agave_snapshots::{
+        paths as snapshot_paths, snapshot_archive_info::SnapshotArchiveInfoGetter,
+        snapshot_config::SnapshotConfig, SnapshotInterval,
+    },
     crossbeam_channel::unbounded,
     jsonrpc_core::{futures::prelude::*, MetaIoHandler},
     jsonrpc_http_server::{
@@ -38,7 +41,6 @@ use {
         bank::Bank, bank_forks::BankForks, commitment::BlockCommitmentCache,
         non_circulating_supply::calculate_non_circulating_supply,
         prioritization_fee_cache::PrioritizationFeeCache,
-        snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_utils,
     },
     solana_send_transaction_service::{
         send_transaction_service::{self, SendTransactionService},
@@ -348,7 +350,7 @@ impl RequestMiddleware for RpcRequestMiddleware {
             {
                 // Convenience redirect to the latest snapshot
                 let full_snapshot_archive_info =
-                    snapshot_utils::get_highest_full_snapshot_archive_info(
+                    snapshot_paths::get_highest_full_snapshot_archive_info(
                         &snapshot_config.full_snapshot_archives_dir,
                     );
                 let snapshot_archive_info =
@@ -356,7 +358,7 @@ impl RequestMiddleware for RpcRequestMiddleware {
                         if request.uri().path() == FULL_SNAPSHOT_REQUEST_PATH {
                             Some(full_snapshot_archive_info.snapshot_archive_info().clone())
                         } else {
-                            snapshot_utils::get_highest_incremental_snapshot_archive_info(
+                            snapshot_paths::get_highest_incremental_snapshot_archive_info(
                                 &snapshot_config.incremental_snapshot_archives_dir,
                                 full_snapshot_archive_info.slot(),
                             )

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -31,7 +31,6 @@ mod read_optimized_dashmap;
 pub mod rent_collector;
 pub mod runtime_config;
 pub mod serde_snapshot;
-pub mod snapshot_archive_info;
 pub mod snapshot_bank_utils;
 pub mod snapshot_controller;
 pub mod snapshot_minimizer;

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -18,13 +18,9 @@ use {
         serde_snapshot::{
             self, reconstruct_bank_from_fields, SnapshotAccountsDbFields, SnapshotBankFields,
         },
-        snapshot_archive_info::{
-            FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
-        },
         snapshot_package::{SnapshotKind, SnapshotPackage},
         snapshot_utils::{
-            self, get_highest_bank_snapshot, get_highest_full_snapshot_archive_info,
-            get_highest_incremental_snapshot_archive_info, rebuild_storages_from_snapshot_dir,
+            self, get_highest_bank_snapshot, rebuild_storages_from_snapshot_dir,
             verify_and_unarchive_snapshots, BankSnapshotInfo, StorageAndNextAccountsFileId,
             UnarchivedSnapshots,
         },
@@ -35,7 +31,13 @@ use {
         error::{
             SnapshotError, VerifyEpochStakesError, VerifySlotDeltasError, VerifySlotHistoryError,
         },
-        paths as snapshot_paths,
+        paths::{
+            self as snapshot_paths, get_highest_full_snapshot_archive_info,
+            get_highest_incremental_snapshot_archive_info,
+        },
+        snapshot_archive_info::{
+            FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
+        },
         snapshot_config::SnapshotConfig,
         snapshot_hash::SnapshotHash,
         ArchiveFormat, SnapshotVersion,

--- a/snapshots/src/lib.rs
+++ b/snapshots/src/lib.rs
@@ -12,6 +12,7 @@ mod archive_format;
 pub mod error;
 pub mod hardened_unpack;
 pub mod paths;
+pub mod snapshot_archive_info;
 pub mod snapshot_config;
 pub mod snapshot_hash;
 mod snapshot_interval;

--- a/snapshots/src/snapshot_archive_info.rs
+++ b/snapshots/src/snapshot_archive_info.rs
@@ -1,9 +1,7 @@
 //! Information about snapshot archives
 
 use {
-    agave_snapshots::{
-        paths as snapshot_paths, snapshot_hash::SnapshotHash, ArchiveFormat, Result,
-    },
+    crate::{paths as snapshot_paths, snapshot_hash::SnapshotHash, ArchiveFormat, Result},
     solana_clock::Slot,
     std::{cmp::Ordering, path::PathBuf},
 };
@@ -71,7 +69,7 @@ impl FullSnapshotArchiveInfo {
         }))
     }
 
-    pub(crate) fn new(snapshot_archive_info: SnapshotArchiveInfo) -> Self {
+    pub fn new(snapshot_archive_info: SnapshotArchiveInfo) -> Self {
         Self(snapshot_archive_info)
     }
 }
@@ -125,7 +123,7 @@ impl IncrementalSnapshotArchiveInfo {
         ))
     }
 
-    pub(crate) fn new(base_slot: Slot, snapshot_archive_info: SnapshotArchiveInfo) -> Self {
+    pub fn new(base_slot: Slot, snapshot_archive_info: SnapshotArchiveInfo) -> Self {
         Self {
             base_slot,
             inner: snapshot_archive_info,

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1,4 +1,7 @@
 use {
+    agave_snapshots::{
+        paths as snapshot_paths, snapshot_archive_info::SnapshotArchiveInfoGetter as _,
+    },
     itertools::Itertools,
     log::*,
     rand::{seq::SliceRandom, thread_rng, Rng},
@@ -21,10 +24,7 @@ use {
     solana_metrics::datapoint_info,
     solana_pubkey::Pubkey,
     solana_rpc_client::rpc_client::RpcClient,
-    solana_runtime::{
-        snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_package::SnapshotKind,
-        snapshot_utils,
-    },
+    solana_runtime::snapshot_package::SnapshotKind,
     solana_signer::Signer,
     solana_streamer::socket::SocketAddrSpace,
     solana_vote_program::vote_state::VoteStateV4,
@@ -788,10 +788,10 @@ fn get_highest_local_snapshot_hash(
     incremental_snapshot_archives_dir: impl AsRef<Path>,
     incremental_snapshot_fetch: bool,
 ) -> Option<(Slot, Hash)> {
-    snapshot_utils::get_highest_full_snapshot_archive_info(full_snapshot_archives_dir)
+    snapshot_paths::get_highest_full_snapshot_archive_info(full_snapshot_archives_dir)
         .and_then(|full_snapshot_info| {
             if incremental_snapshot_fetch {
-                snapshot_utils::get_highest_incremental_snapshot_archive_info(
+                snapshot_paths::get_highest_incremental_snapshot_archive_info(
                     incremental_snapshot_archives_dir,
                     full_snapshot_info.slot(),
                 )
@@ -1131,7 +1131,7 @@ fn download_snapshots(
     }
 
     // Check and see if we've already got the full snapshot; if not, download it
-    if snapshot_utils::get_full_snapshot_archives(full_snapshot_archives_dir)
+    if snapshot_paths::get_full_snapshot_archives(full_snapshot_archives_dir)
         .into_iter()
         .any(|snapshot_archive| {
             snapshot_archive.slot() == full_snapshot_hash.0
@@ -1160,7 +1160,7 @@ fn download_snapshots(
     if bootstrap_config.incremental_snapshot_fetch {
         // Check and see if we've already got the incremental snapshot; if not, download it
         if let Some(incremental_snapshot_hash) = incremental_snapshot_hash {
-            if snapshot_utils::get_incremental_snapshot_archives(incremental_snapshot_archives_dir)
+            if snapshot_paths::get_incremental_snapshot_archives(incremental_snapshot_archives_dir)
                 .into_iter()
                 .any(|snapshot_archive| {
                     snapshot_archive.slot() == incremental_snapshot_hash.0

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -14,6 +14,12 @@ use {
             LastVotedForkSlotsRecord, State as RestartState, WenRestartProgress,
         },
     },
+    agave_snapshots::{
+        paths::{
+            get_highest_full_snapshot_archive_slot, get_highest_incremental_snapshot_archive_slot,
+        },
+        snapshot_archive_info::SnapshotArchiveInfoGetter,
+    },
     anyhow::Result,
     log::*,
     prost::Message,
@@ -35,15 +41,11 @@ use {
         accounts_background_service::AbsStatus,
         bank::Bank,
         bank_forks::BankForks,
-        snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_bank_utils::{
             bank_to_full_snapshot_archive, bank_to_incremental_snapshot_archive,
         },
         snapshot_controller::SnapshotController,
-        snapshot_utils::{
-            get_highest_full_snapshot_archive_slot, get_highest_incremental_snapshot_archive_slot,
-            purge_all_bank_snapshots,
-        },
+        snapshot_utils::purge_all_bank_snapshots,
     },
     solana_shred_version::compute_shred_version,
     solana_svm_timings::ExecuteTimings,


### PR DESCRIPTION
#### Problem
`snapshot_archive_info` in `runtime` doesn't have any dependencies on runtime components anymore and it is purely snapshot related, so should be in `agave-snapshots`.

#### Summary of Changes
* move module
* move functions from `snapshot_utils` that create archive info structs from paths to `agave_snapshot::paths`
* archive info `new` functions had to be elevated from `pub(crate)` to `pub` due to cross-crate usage
