### PR TITLE
nit: refactor: remove accessor functions on simple vote types

### DIFF
--- a/votor-messages/src/vote.rs
+++ b/votor-messages/src/vote.rs
@@ -29,45 +29,45 @@ pub enum Vote {
 impl Vote {
     /// Create a new notarization vote
     pub fn new_notarization_vote(slot: Slot, block_id: Hash) -> Self {
-        Self::from(NotarizationVote::new(slot, block_id))
+        Self::from(NotarizationVote { slot, block_id })
     }
 
     /// Create a new finalization vote
     pub fn new_finalization_vote(slot: Slot) -> Self {
-        Self::from(FinalizationVote::new(slot))
+        Self::from(FinalizationVote { slot })
     }
 
     /// Create a new skip vote
     pub fn new_skip_vote(slot: Slot) -> Self {
-        Self::from(SkipVote::new(slot))
+        Self::from(SkipVote { slot })
     }
 
     /// Create a new notarization fallback vote
     pub fn new_notarization_fallback_vote(slot: Slot, block_id: Hash) -> Self {
-        Self::from(NotarizationFallbackVote::new(slot, block_id))
+        Self::from(NotarizationFallbackVote { slot, block_id })
     }
 
     /// Create a new skip fallback vote
     pub fn new_skip_fallback_vote(slot: Slot) -> Self {
-        Self::from(SkipFallbackVote::new(slot))
+        Self::from(SkipFallbackVote { slot })
     }
 
     /// The slot which was voted for
     pub fn slot(&self) -> Slot {
         match self {
-            Self::Notarize(vote) => vote.slot(),
-            Self::Finalize(vote) => vote.slot(),
-            Self::Skip(vote) => vote.slot(),
-            Self::NotarizeFallback(vote) => vote.slot(),
-            Self::SkipFallback(vote) => vote.slot(),
+            Self::Notarize(vote) => vote.slot,
+            Self::Finalize(vote) => vote.slot,
+            Self::Skip(vote) => vote.slot,
+            Self::NotarizeFallback(vote) => vote.slot,
+            Self::SkipFallback(vote) => vote.slot,
         }
     }
 
     /// The block id associated with the block which was voted for
     pub fn block_id(&self) -> Option<&Hash> {
         match self {
-            Self::Notarize(vote) => Some(vote.block_id()),
-            Self::NotarizeFallback(vote) => Some(vote.block_id()),
+            Self::Notarize(vote) => Some(&vote.block_id),
+            Self::NotarizeFallback(vote) => Some(&vote.block_id),
             Self::Finalize(_) | Self::Skip(_) | Self::SkipFallback(_) => None,
         }
     }
@@ -141,25 +141,10 @@ impl From<SkipFallbackVote> for Vote {
 )]
 #[derive(Clone, Copy, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct NotarizationVote {
-    slot: Slot,
-    block_id: Hash,
-}
-
-impl NotarizationVote {
-    /// Construct a notarization vote for `slot`
-    pub fn new(slot: Slot, block_id: Hash) -> Self {
-        Self { slot, block_id }
-    }
-
-    /// The slot to notarize
-    pub fn slot(&self) -> Slot {
-        self.slot
-    }
-
-    /// The block_id of the notarization slot
-    pub fn block_id(&self) -> &Hash {
-        &self.block_id
-    }
+    /// The slot this vote is cast for.
+    pub slot: Slot,
+    /// The block id this vote is for.
+    pub block_id: Hash,
 }
 
 /// A finalization vote
@@ -170,19 +155,8 @@ impl NotarizationVote {
 )]
 #[derive(Clone, Copy, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct FinalizationVote {
-    slot: Slot,
-}
-
-impl FinalizationVote {
-    /// Construct a finalization vote for `slot`
-    pub fn new(slot: Slot) -> Self {
-        Self { slot }
-    }
-
-    /// The slot to finalize
-    pub fn slot(&self) -> Slot {
-        self.slot
-    }
+    /// The slot this vote is cast for.
+    pub slot: Slot,
 }
 
 /// A skip vote
@@ -195,19 +169,8 @@ impl FinalizationVote {
 )]
 #[derive(Clone, Copy, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct SkipVote {
-    pub(crate) slot: Slot,
-}
-
-impl SkipVote {
-    /// Construct a skip vote for `slot`
-    pub fn new(slot: Slot) -> Self {
-        Self { slot }
-    }
-
-    /// The slot to skip
-    pub fn slot(&self) -> Slot {
-        self.slot
-    }
+    /// The slot this vote is cast for.
+    pub slot: Slot,
 }
 
 /// A notarization fallback vote
@@ -218,25 +181,10 @@ impl SkipVote {
 )]
 #[derive(Clone, Copy, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct NotarizationFallbackVote {
-    slot: Slot,
-    block_id: Hash,
-}
-
-impl NotarizationFallbackVote {
-    /// Construct a notarization vote for `slot`
-    pub fn new(slot: Slot, block_id: Hash) -> Self {
-        Self { slot, block_id }
-    }
-
-    /// The slot to notarize
-    pub fn slot(&self) -> Slot {
-        self.slot
-    }
-
-    /// The block_id of the notarization slot
-    pub fn block_id(&self) -> &Hash {
-        &self.block_id
-    }
+    /// The slot this vote is cast for.
+    pub slot: Slot,
+    /// The block id this vote is for.
+    pub block_id: Hash,
 }
 
 /// A skip fallback vote
@@ -247,17 +195,6 @@ impl NotarizationFallbackVote {
 )]
 #[derive(Clone, Copy, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct SkipFallbackVote {
-    pub(crate) slot: Slot,
-}
-
-impl SkipFallbackVote {
-    /// Construct a skip fallback vote for `slot`
-    pub fn new(slot: Slot) -> Self {
-        Self { slot }
-    }
-
-    /// The slot to skip
-    pub fn slot(&self) -> Slot {
-        self.slot
-    }
+    /// The slot this vote is cast for.
+    pub slot: Slot,
 }

--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -70,19 +70,16 @@ pub const fn certificate_limits_and_vote_types(
 pub fn vote_to_certificate_ids(vote: &Vote) -> Vec<CertificateType> {
     match vote {
         Vote::Notarize(vote) => vec![
-            CertificateType::Notarize(vote.slot(), *vote.block_id()),
-            CertificateType::NotarizeFallback(vote.slot(), *vote.block_id()),
-            CertificateType::FinalizeFast(vote.slot(), *vote.block_id()),
+            CertificateType::Notarize(vote.slot, vote.block_id),
+            CertificateType::NotarizeFallback(vote.slot, vote.block_id),
+            CertificateType::FinalizeFast(vote.slot, vote.block_id),
         ],
         Vote::NotarizeFallback(vote) => {
-            vec![CertificateType::NotarizeFallback(
-                vote.slot(),
-                *vote.block_id(),
-            )]
+            vec![CertificateType::NotarizeFallback(vote.slot, vote.block_id)]
         }
-        Vote::Finalize(vote) => vec![CertificateType::Finalize(vote.slot())],
-        Vote::Skip(vote) => vec![CertificateType::Skip(vote.slot())],
-        Vote::SkipFallback(vote) => vec![CertificateType::Skip(vote.slot())],
+        Vote::Finalize(vote) => vec![CertificateType::Finalize(vote.slot)],
+        Vote::Skip(vote) => vec![CertificateType::Skip(vote.slot)],
+        Vote::SkipFallback(vote) => vec![CertificateType::Skip(vote.slot)],
     }
 }
 

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -744,11 +744,11 @@ mod tests {
             )
             .is_ok());
         match vote {
-            Vote::Notarize(vote) => assert_eq!(pool.highest_notarized_slot(), vote.slot()),
-            Vote::NotarizeFallback(vote) => assert_eq!(pool.highest_notarized_slot(), vote.slot()),
-            Vote::Skip(vote) => assert_eq!(pool.highest_skip_slot(), vote.slot()),
-            Vote::SkipFallback(vote) => assert_eq!(pool.highest_skip_slot(), vote.slot()),
-            Vote::Finalize(vote) => assert_eq!(pool.highest_finalized_slot(), vote.slot()),
+            Vote::Notarize(vote) => assert_eq!(pool.highest_notarized_slot(), vote.slot),
+            Vote::NotarizeFallback(vote) => assert_eq!(pool.highest_notarized_slot(), vote.slot),
+            Vote::Skip(vote) => assert_eq!(pool.highest_skip_slot(), vote.slot),
+            Vote::SkipFallback(vote) => assert_eq!(pool.highest_skip_slot(), vote.slot),
+            Vote::Finalize(vote) => assert_eq!(pool.highest_finalized_slot(), vote.slot),
         }
     }
 

--- a/votor/src/consensus_pool/slot_stake_counters.rs
+++ b/votor/src/consensus_pool/slot_stake_counters.rs
@@ -49,7 +49,7 @@ impl SlotStakeCounters {
             Vote::Notarize(vote) => {
                 let old_entry_stake = self
                     .notarize_entry_total
-                    .insert(*vote.block_id(), entry_stake)
+                    .insert(vote.block_id, entry_stake)
                     .unwrap_or(0);
                 self.notarize_total = self
                     .notarize_total
@@ -89,7 +89,7 @@ impl SlotStakeCounters {
         // but not to notarize b. Moreover:
         // notar(b) >= 40% or (skip(s) + notar(b) >= 60% and notar(b) >= 20%)
         if let Some(Vote::Notarize(my_vote)) = self.my_first_vote.as_ref() {
-            if my_vote.block_id() == block_id {
+            if &my_vote.block_id == block_id {
                 return false; // I voted for the same block, no need to send NotarizeFallback
             }
         }

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -167,34 +167,31 @@ impl VoteHistory {
         // in final version
         match vote {
             Vote::Notarize(vote) => {
-                assert!(self.voted.insert(vote.slot()));
-                assert!(self
-                    .voted_notar
-                    .insert(vote.slot(), *vote.block_id())
-                    .is_none());
+                assert!(self.voted.insert(vote.slot));
+                assert!(self.voted_notar.insert(vote.slot, vote.block_id).is_none());
             }
             Vote::Finalize(vote) => {
-                assert!(!self.skipped(vote.slot()));
-                self.its_over.insert(vote.slot());
+                assert!(!self.skipped(vote.slot));
+                self.its_over.insert(vote.slot);
             }
             Vote::Skip(vote) => {
-                self.voted.insert(vote.slot());
-                self.skipped.insert(vote.slot());
+                self.voted.insert(vote.slot);
+                self.skipped.insert(vote.slot);
             }
             Vote::NotarizeFallback(vote) => {
-                assert!(self.voted(vote.slot()));
-                assert!(!self.its_over(vote.slot()));
-                self.skipped.insert(vote.slot());
+                assert!(self.voted(vote.slot));
+                assert!(!self.its_over(vote.slot));
+                self.skipped.insert(vote.slot);
                 self.voted_notar_fallback
-                    .entry(vote.slot())
+                    .entry(vote.slot)
                     .or_default()
-                    .insert(*vote.block_id());
+                    .insert(vote.block_id);
             }
             Vote::SkipFallback(vote) => {
-                assert!(self.voted(vote.slot()));
-                assert!(!self.its_over(vote.slot()));
-                self.skipped.insert(vote.slot());
-                self.voted_skip_fallback.insert(vote.slot());
+                assert!(self.voted(vote.slot));
+                assert!(!self.its_over(vote.slot));
+                self.skipped.insert(vote.slot);
+                self.voted_skip_fallback.insert(vote.slot);
             }
         }
         self.votes_cast.entry(vote.slot()).or_default().push(vote);


### PR DESCRIPTION
#### Problem

The various vote structs are fairly simple structs and having accessors on them just makes the code more verbose and does not offer any practical benefit.

#### Summary of Changes

- Makes the fields in the various vote structs public
- removes the various accessor functions
- also removes the constructors which are not needed if the fields are public
