### PR TITLE
logger: Update functions to take PathBuf/Path

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -118,13 +118,7 @@ fn main() {
         let _ = fs::remove_file(&validator_log_symlink);
         symlink::symlink_file(&validator_log_with_timestamp, &validator_log_symlink).unwrap();
 
-        Some(
-            ledger_path
-                .join(validator_log_with_timestamp)
-                .into_os_string()
-                .into_string()
-                .unwrap(),
-        )
+        Some(ledger_path.join(validator_log_with_timestamp))
     } else {
         None
     };

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -112,12 +112,9 @@ pub fn execute(
     let identity_keypair = Arc::new(run_args.identity_keypair);
 
     let logfile = run_args.logfile;
-    let logfile = if logfile == "-" {
-        None
-    } else {
-        println!("log file: {logfile}");
-        Some(logfile)
-    };
+    if let Some(logfile) = logfile.as_ref() {
+        println!("log file: {}", logfile.display());
+    }
     let use_progress_bar = logfile.is_none();
     let _logger_thread = redirect_stderr_to_file(logfile);
 

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -23,6 +23,7 @@ use {
         collections::HashMap,
         env,
         net::{IpAddr, SocketAddr},
+        path::PathBuf,
         sync::{atomic::AtomicBool, Arc, RwLock},
     },
     tokio_util::sync::CancellationToken,
@@ -54,7 +55,7 @@ pub fn main() {
             None
         } else {
             println!("log file: {logfile}");
-            Some(logfile)
+            Some(PathBuf::from(logfile))
         }
     };
     let _logger_thread = redirect_stderr_to_file(logfile);


### PR DESCRIPTION
Using these types is more proper than the current use of String and &str in the arguments