### PR TITLE
Support censor client by its pubkey

### DIFF
--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -64,7 +64,7 @@ pub struct BankingTracer {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "91baCBT3aY2nXSAuzY3S5dnMhWabVsHowgWqYPLjfyg7")
+    frozen_abi(digest = "AvmDYAAAAtex3Guupc9yQLDbySwydXRoWeZMhs961E7B")
 )]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TimedTracedEvent(pub std::time::SystemTime, pub TracedEvent);

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -224,6 +224,7 @@ impl Tpu {
             staked_nodes.clone(),
             vote_quic_server_config.quic_streamer_config,
             vote_quic_server_config.qos_config,
+            None,
             cancel.clone(),
         )
         .unwrap();

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3165,18 +3165,6 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
       "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA=="
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
     "node_modules/@slorber/static-site-generator-webpack-plugin": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@slorber/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.7.tgz",
@@ -3441,18 +3429,6 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-      "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -3476,18 +3452,6 @@
       "integrity": "sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
       }
     },
     "node_modules/@types/connect": {
@@ -3572,12 +3536,6 @@
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
       "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg=="
     },
-    "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-      "license": "MIT"
-    },
     "node_modules/@types/http-proxy": {
       "version": "1.17.9",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.9.tgz",
@@ -3616,15 +3574,6 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.11.1.tgz",
       "integrity": "sha512-DUlIj2nk0YnJdlWgsFuVKcX27MLW0KbKmGVoUHmFr+74FYYNUDAaj9ZqTADvsbE8rfxuVmSFc7KczYn5Y09ozg=="
-    },
-    "node_modules/@types/keyv": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
@@ -3709,15 +3658,6 @@
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router": "*"
-      }
-    },
-    "node_modules/@types/responselike": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/retry": {
@@ -4711,48 +4651,6 @@
       "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.6.0"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/call-bind": {
@@ -5865,33 +5763,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -5922,15 +5793,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/defer-to-connect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
@@ -6227,6 +6089,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
+    "node_modules/duplexer3": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
+      "integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -7743,31 +7611,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -8279,19 +8122,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "license": "MIT",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
       }
     },
     "node_modules/human-signals": {
@@ -9196,12 +9026,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "license": "MIT"
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -9252,13 +9076,29 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+    "node_modules/katex": {
+      "version": "0.16.25",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.25.tgz",
+      "integrity": "sha512-woHRUZ/iF23GBP1dkDQMh1QBad9dmr8/PAwNA54VrSOVYgI12MAcE14TqnDdQOdzyEonGzMepYnqBMYdsoAr8Q==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/kind-of": {
@@ -10106,15 +9946,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -10186,6 +10017,172 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/package-json/node_modules/@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json/node_modules/@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json/node_modules/cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/package-json/node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json/node_modules/decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/package-json/node_modules/defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "license": "MIT"
+    },
+    "node_modules/package-json/node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json/node_modules/got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/package-json/node_modules/got/node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/package-json/node_modules/json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
+      "license": "MIT"
+    },
+    "node_modules/package-json/node_modules/keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "node_modules/package-json/node_modules/normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/package-json/node_modules/p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json/node_modules/responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
+    "node_modules/package-json/node_modules/responselike/node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/package-json/node_modules/semver": {
@@ -11061,6 +11058,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prettier": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
@@ -11261,18 +11267,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -11850,24 +11844,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/rehype-katex/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
-    },
-    "node_modules/rehype-katex/node_modules/katex": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
-      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.19.0"
-      },
-      "bin": {
-        "katex": "cli.js"
-      }
-    },
     "node_modules/rehype-parse": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-7.0.1.tgz",
@@ -12190,12 +12166,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/resolve-alpn": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "license": "MIT"
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -12208,18 +12178,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
       "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
-    },
-    "node_modules/responselike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-      "license": "MIT",
-      "dependencies": {
-        "lowercase-keys": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -13635,6 +13593,15 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "node_modules/to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -14199,6 +14166,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prepend-http": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/use-composed-ref": {

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -325,6 +325,15 @@ pub fn resign_packet(packet: &mut PacketRefMut, keypair: &Keypair) -> Result<(),
 
             Ok(())
         }
+        PacketRefMut::WithClientId(packet) => {
+            let mut buffer = packet.buffer().to_vec();
+            let shred = get_shred_mut(&mut buffer).ok_or(Error::InvalidPacketSize)?;
+
+            resign_shred(shred, keypair)?;
+            packet.set_buffer(buffer);
+
+            Ok(())
+        }
     }
 }
 

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -308,6 +308,7 @@ pub fn verify_shreds_gpu(
         .map(|batch| match batch {
             PacketBatch::Pinned(batch) => Cow::Borrowed(batch),
             PacketBatch::Bytes(batch) => Cow::Owned(batch.to_pinned_packet_batch()),
+            PacketBatch::WithClientId(batch) => Cow::Owned(batch.to_pinned_packet_batch()),
         })
         .collect::<Vec<_>>();
     elems.extend(pinned_batches.iter().map(|batch| perf_libs::Elems {
@@ -460,6 +461,7 @@ fn sign_shreds_gpu(
         .map(|batch| match batch {
             PacketBatch::Pinned(batch) => Cow::Borrowed(batch),
             PacketBatch::Bytes(batch) => Cow::Owned(batch.to_pinned_packet_batch()),
+            PacketBatch::WithClientId(batch) => Cow::Owned(batch.to_pinned_packet_batch()),
         })
         .collect::<Vec<_>>();
     elems.extend(pinned_batches.iter().map(|batch| perf_libs::Elems {

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -153,6 +153,7 @@ impl BytesPacket {
 pub enum PacketBatch {
     Pinned(PinnedPacketBatch),
     Bytes(BytesPacketBatch),
+    WithClientId(BytesPacketBatchWithClientId), // Add this variant
 }
 
 impl PacketBatch {
@@ -161,6 +162,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.first().map(PacketRef::from),
             Self::Bytes(batch) => batch.first().map(PacketRef::from),
+            Self::WithClientId(batch) => batch.first().map(PacketRef::from),
         }
     }
 
@@ -169,6 +171,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.first_mut().map(PacketRefMut::from),
             Self::Bytes(batch) => batch.first_mut().map(PacketRefMut::from),
+            Self::WithClientId(batch) => batch.first_mut().map(PacketRefMut::from),
         }
     }
 
@@ -177,6 +180,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.is_empty(),
             Self::Bytes(batch) => batch.is_empty(),
+            Self::WithClientId(batch) => batch.is_empty(),
         }
     }
 
@@ -185,6 +189,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.get(index).map(PacketRef::from),
             Self::Bytes(batch) => batch.get(index).map(PacketRef::from),
+            Self::WithClientId(batch) => batch.get(index).map(PacketRef::from),
         }
     }
 
@@ -192,6 +197,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.get_mut(index).map(PacketRefMut::from),
             Self::Bytes(batch) => batch.get_mut(index).map(PacketRefMut::from),
+            Self::WithClientId(batch) => batch.get_mut(index).map(PacketRefMut::from),
         }
     }
 
@@ -199,6 +205,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => PacketBatchIter::Pinned(batch.iter()),
             Self::Bytes(batch) => PacketBatchIter::Bytes(batch.iter()),
+            Self::WithClientId(batch) => PacketBatchIter::WithClientId(batch.iter()),
         }
     }
 
@@ -206,6 +213,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => PacketBatchIterMut::Pinned(batch.iter_mut()),
             Self::Bytes(batch) => PacketBatchIterMut::Bytes(batch.iter_mut()),
+            Self::WithClientId(batch) => PacketBatchIterMut::WithClientId(batch.iter_mut()),
         }
     }
 
@@ -215,6 +223,9 @@ impl PacketBatch {
                 PacketBatchParIter::Pinned(batch.par_iter().map(PacketRef::from))
             }
             Self::Bytes(batch) => PacketBatchParIter::Bytes(batch.par_iter().map(PacketRef::from)),
+            Self::WithClientId(batch) => {
+                PacketBatchParIter::WithClientId(batch.par_iter().map(PacketRef::from))
+            }
         }
     }
 
@@ -226,6 +237,9 @@ impl PacketBatch {
             Self::Bytes(batch) => {
                 PacketBatchParIterMut::Bytes(batch.par_iter_mut().map(PacketRefMut::from))
             }
+            Self::WithClientId(batch) => {
+                PacketBatchParIterMut::WithClientId(batch.par_iter_mut().map(PacketRefMut::from))
+            }
         }
     }
 
@@ -233,6 +247,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.len(),
             Self::Bytes(batch) => batch.len(),
+            Self::WithClientId(batch) => batch.len(),
         }
     }
 }
@@ -246,6 +261,11 @@ impl From<PinnedPacketBatch> for PacketBatch {
 impl From<BytesPacketBatch> for PacketBatch {
     fn from(batch: BytesPacketBatch) -> Self {
         Self::Bytes(batch)
+    }
+}
+impl From<BytesPacketBatchWithClientId> for PacketBatch {
+    fn from(batch: BytesPacketBatchWithClientId) -> Self {
+        Self::WithClientId(batch)
     }
 }
 
@@ -291,6 +311,7 @@ impl<'a> IntoParallelIterator for &'a mut PacketBatch {
 pub enum PacketRef<'a> {
     Packet(&'a Packet),
     Bytes(&'a BytesPacket),
+    WithClientId(&'a BytesPacketWithClientId),
 }
 
 impl PartialEq for PacketRef<'_> {
@@ -323,6 +344,12 @@ impl<'a> From<&'a mut BytesPacket> for PacketRef<'a> {
     }
 }
 
+impl<'a> From<&'a BytesPacketWithClientId> for PacketRef<'a> {
+    fn from(packet: &'a BytesPacketWithClientId) -> Self {
+        Self::WithClientId(packet)
+    }
+}
+
 impl<'a> PacketRef<'a> {
     pub fn data<I>(&self, index: I) -> Option<&'a <I as SliceIndex<[u8]>>::Output>
     where
@@ -331,6 +358,7 @@ impl<'a> PacketRef<'a> {
         match self {
             Self::Packet(packet) => packet.data(index),
             Self::Bytes(packet) => packet.data(index),
+            Self::WithClientId(packet) => packet.data(index),
         }
     }
 
@@ -339,6 +367,7 @@ impl<'a> PacketRef<'a> {
         match self {
             Self::Packet(packet) => packet.meta(),
             Self::Bytes(packet) => packet.meta(),
+            Self::WithClientId(packet) => packet.meta(),
         }
     }
 
@@ -350,6 +379,7 @@ impl<'a> PacketRef<'a> {
         match self {
             Self::Packet(packet) => packet.deserialize_slice(index),
             Self::Bytes(packet) => packet.deserialize_slice(index),
+            Self::WithClientId(packet) => packet.deserialize_slice(index),
         }
     }
 
@@ -370,6 +400,7 @@ impl<'a> PacketRef<'a> {
             // `BytesPacket` entirely and deal just with `Vec<BytesPacket>`
             // everywhere.
             Self::Bytes(packet) => packet.to_owned().to_owned(),
+            Self::WithClientId(packet) => packet.packet.to_owned().to_owned(),
         }
     }
 }
@@ -378,6 +409,7 @@ impl<'a> PacketRef<'a> {
 pub enum PacketRefMut<'a> {
     Packet(&'a mut Packet),
     Bytes(&'a mut BytesPacket),
+    WithClientId(&'a mut BytesPacketWithClientId),
 }
 
 impl<'a> PartialEq for PacketRefMut<'a> {
@@ -398,6 +430,12 @@ impl<'a> From<&'a mut BytesPacket> for PacketRefMut<'a> {
     }
 }
 
+impl<'a> From<&'a mut BytesPacketWithClientId> for PacketRefMut<'a> {
+    fn from(packet: &'a mut BytesPacketWithClientId) -> Self {
+        Self::WithClientId(packet)
+    }
+}
+
 impl PacketRefMut<'_> {
     pub fn data<I>(&self, index: I) -> Option<&<I as SliceIndex<[u8]>>::Output>
     where
@@ -406,6 +444,7 @@ impl PacketRefMut<'_> {
         match self {
             Self::Packet(packet) => packet.data(index),
             Self::Bytes(packet) => packet.data(index),
+            Self::WithClientId(packet) => packet.data(index),
         }
     }
 
@@ -414,6 +453,7 @@ impl PacketRefMut<'_> {
         match self {
             Self::Packet(packet) => packet.meta(),
             Self::Bytes(packet) => packet.meta(),
+            Self::WithClientId(packet) => packet.meta(),
         }
     }
 
@@ -422,6 +462,7 @@ impl PacketRefMut<'_> {
         match self {
             Self::Packet(packet) => packet.meta_mut(),
             Self::Bytes(packet) => packet.meta_mut(),
+            Self::WithClientId(packet) => packet.meta_mut(),
         }
     }
 
@@ -433,6 +474,7 @@ impl PacketRefMut<'_> {
         match self {
             Self::Packet(packet) => packet.deserialize_slice(index),
             Self::Bytes(packet) => packet.deserialize_slice(index),
+            Self::WithClientId(packet) => packet.deserialize_slice(index),
         }
     }
 
@@ -445,6 +487,7 @@ impl PacketRefMut<'_> {
                 packet.buffer_mut()[..size].copy_from_slice(src);
             }
             Self::Bytes(packet) => packet.copy_from_slice(src),
+            Self::WithClientId(packet) => packet.copy_from_slice(src),
         }
     }
 
@@ -453,6 +496,7 @@ impl PacketRefMut<'_> {
         match self {
             Self::Packet(packet) => PacketRef::Packet(packet),
             Self::Bytes(packet) => PacketRef::Bytes(packet),
+            Self::WithClientId(packet) => PacketRef::WithClientId(packet),
         }
     }
 }
@@ -460,6 +504,7 @@ impl PacketRefMut<'_> {
 pub enum PacketBatchIter<'a> {
     Pinned(std::slice::Iter<'a, Packet>),
     Bytes(std::slice::Iter<'a, BytesPacket>),
+    WithClientId(std::slice::Iter<'a, BytesPacketWithClientId>),
 }
 
 impl DoubleEndedIterator for PacketBatchIter<'_> {
@@ -467,6 +512,7 @@ impl DoubleEndedIterator for PacketBatchIter<'_> {
         match self {
             Self::Pinned(iter) => iter.next_back().map(PacketRef::Packet),
             Self::Bytes(iter) => iter.next_back().map(PacketRef::Bytes),
+            Self::WithClientId(iter) => iter.next_back().map(PacketRef::WithClientId),
         }
     }
 }
@@ -478,6 +524,7 @@ impl<'a> Iterator for PacketBatchIter<'a> {
         match self {
             Self::Pinned(iter) => iter.next().map(PacketRef::Packet),
             Self::Bytes(iter) => iter.next().map(PacketRef::Bytes),
+            Self::WithClientId(iter) => iter.next().map(PacketRef::WithClientId),
         }
     }
 }
@@ -485,6 +532,7 @@ impl<'a> Iterator for PacketBatchIter<'a> {
 pub enum PacketBatchIterMut<'a> {
     Pinned(std::slice::IterMut<'a, Packet>),
     Bytes(std::slice::IterMut<'a, BytesPacket>),
+    WithClientId(std::slice::IterMut<'a, BytesPacketWithClientId>),
 }
 
 impl DoubleEndedIterator for PacketBatchIterMut<'_> {
@@ -492,6 +540,7 @@ impl DoubleEndedIterator for PacketBatchIterMut<'_> {
         match self {
             Self::Pinned(iter) => iter.next_back().map(PacketRefMut::Packet),
             Self::Bytes(iter) => iter.next_back().map(PacketRefMut::Bytes),
+            Self::WithClientId(iter) => iter.next_back().map(PacketRefMut::WithClientId),
         }
     }
 }
@@ -503,12 +552,14 @@ impl<'a> Iterator for PacketBatchIterMut<'a> {
         match self {
             Self::Pinned(iter) => iter.next().map(PacketRefMut::Packet),
             Self::Bytes(iter) => iter.next().map(PacketRefMut::Bytes),
+            Self::WithClientId(iter) => iter.next().map(PacketRefMut::WithClientId),
         }
     }
 }
 
 type PacketParIter<'a> = rayon::slice::Iter<'a, Packet>;
 type BytesPacketParIter<'a> = rayon::slice::Iter<'a, BytesPacket>;
+type WithClientIdPacketParIter<'a> = rayon::slice::Iter<'a, BytesPacketWithClientId>;
 
 pub enum PacketBatchParIter<'a> {
     Pinned(
@@ -523,6 +574,12 @@ pub enum PacketBatchParIter<'a> {
             fn(<BytesPacketParIter<'a> as ParallelIterator>::Item) -> PacketRef<'a>,
         >,
     ),
+    WithClientId(
+        rayon::iter::Map<
+            WithClientIdPacketParIter<'a>,
+            fn(<WithClientIdPacketParIter<'a> as ParallelIterator>::Item) -> PacketRef<'a>,
+        >,
+    ),
 }
 
 impl<'a> ParallelIterator for PacketBatchParIter<'a> {
@@ -534,6 +591,7 @@ impl<'a> ParallelIterator for PacketBatchParIter<'a> {
         match self {
             Self::Pinned(iter) => iter.drive_unindexed(consumer),
             Self::Bytes(iter) => iter.drive_unindexed(consumer),
+            Self::WithClientId(iter) => iter.drive_unindexed(consumer),
         }
     }
 }
@@ -543,6 +601,7 @@ impl IndexedParallelIterator for PacketBatchParIter<'_> {
         match self {
             Self::Pinned(iter) => iter.len(),
             Self::Bytes(iter) => iter.len(),
+            Self::WithClientId(iter) => iter.len(),
         }
     }
 
@@ -550,6 +609,7 @@ impl IndexedParallelIterator for PacketBatchParIter<'_> {
         match self {
             Self::Pinned(iter) => iter.drive(consumer),
             Self::Bytes(iter) => iter.drive(consumer),
+            Self::WithClientId(iter) => iter.drive(consumer),
         }
     }
 
@@ -560,12 +620,14 @@ impl IndexedParallelIterator for PacketBatchParIter<'_> {
         match self {
             Self::Pinned(iter) => iter.with_producer(callback),
             Self::Bytes(iter) => iter.with_producer(callback),
+            Self::WithClientId(iter) => iter.with_producer(callback),
         }
     }
 }
 
 type PacketParIterMut<'a> = rayon::slice::IterMut<'a, Packet>;
 type BytesPacketParIterMut<'a> = rayon::slice::IterMut<'a, BytesPacket>;
+type WithClientIdPacketParIterMut<'a> = rayon::slice::IterMut<'a, BytesPacketWithClientId>;
 
 pub enum PacketBatchParIterMut<'a> {
     Pinned(
@@ -580,6 +642,12 @@ pub enum PacketBatchParIterMut<'a> {
             fn(<BytesPacketParIterMut<'a> as ParallelIterator>::Item) -> PacketRefMut<'a>,
         >,
     ),
+    WithClientId(
+        rayon::iter::Map<
+            WithClientIdPacketParIterMut<'a>,
+            fn(<WithClientIdPacketParIterMut<'a> as ParallelIterator>::Item) -> PacketRefMut<'a>,
+        >,
+    ),
 }
 
 impl<'a> ParallelIterator for PacketBatchParIterMut<'a> {
@@ -591,6 +659,7 @@ impl<'a> ParallelIterator for PacketBatchParIterMut<'a> {
         match self {
             Self::Pinned(iter) => iter.drive_unindexed(consumer),
             Self::Bytes(iter) => iter.drive_unindexed(consumer),
+            Self::WithClientId(iter) => iter.drive_unindexed(consumer),
         }
     }
 }
@@ -600,6 +669,7 @@ impl IndexedParallelIterator for PacketBatchParIterMut<'_> {
         match self {
             Self::Pinned(iter) => iter.len(),
             Self::Bytes(iter) => iter.len(),
+            Self::WithClientId(iter) => iter.len(),
         }
     }
 
@@ -607,6 +677,7 @@ impl IndexedParallelIterator for PacketBatchParIterMut<'_> {
         match self {
             Self::Pinned(iter) => iter.drive(consumer),
             Self::Bytes(iter) => iter.drive(consumer),
+            Self::WithClientId(iter) => iter.drive(consumer),
         }
     }
 
@@ -617,6 +688,7 @@ impl IndexedParallelIterator for PacketBatchParIterMut<'_> {
         match self {
             Self::Pinned(iter) => iter.with_producer(callback),
             Self::Bytes(iter) => iter.with_producer(callback),
+            Self::WithClientId(iter) => iter.with_producer(callback),
         }
     }
 }
@@ -902,6 +974,251 @@ where
         .with_fixint_encoding()
         .allow_trailing_bytes()
         .deserialize_from(reader)
+}
+
+/// Enhanced version of BytesPacket with remote pubkey support
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BytesPacketWithClientId {
+    packet: BytesPacket,
+    remote_pubkey: Option<solana_pubkey::Pubkey>,
+}
+
+impl BytesPacketWithClientId {
+    pub fn new(packet: BytesPacket, remote_pubkey: Option<solana_pubkey::Pubkey>) -> Self {
+        Self {
+            packet,
+            remote_pubkey,
+        }
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn empty() -> Self {
+        Self {
+            packet: BytesPacket::empty(),
+            remote_pubkey: None,
+        }
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn from_bytes(dest: Option<&SocketAddr>, buffer: impl Into<Bytes>) -> Self {
+        Self {
+            packet: BytesPacket::from_bytes(dest, buffer),
+            remote_pubkey: None,
+        }
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn from_data<T>(dest: Option<&SocketAddr>, data: T) -> bincode::Result<Self>
+    where
+        T: solana_packet::Encode,
+    {
+        let packet = BytesPacket::from_data(dest, data)?;
+        Ok(Self::new(packet, None))
+    }
+
+    #[inline]
+    pub fn remote_pubkey(&self) -> Option<&solana_pubkey::Pubkey> {
+        self.remote_pubkey.as_ref()
+    }
+
+    #[inline]
+    pub fn set_remote_pubkey(&mut self, pubkey: Option<solana_pubkey::Pubkey>) {
+        self.remote_pubkey = pubkey;
+    }
+
+    /// Get the underlying BytesPacket
+    #[inline]
+    pub fn packet(&self) -> &BytesPacket {
+        &self.packet
+    }
+
+    /// Get mutable reference to the underlying BytesPacket
+    #[inline]
+    pub fn packet_mut(&mut self) -> &mut BytesPacket {
+        &mut self.packet
+    }
+
+    /// Convert to a regular BytesPacket (losing pubkey information)
+    pub fn into_bytes_packet(self) -> BytesPacket {
+        self.packet
+    }
+
+    /// Convert from a regular BytesPacket (no pubkey info)
+    pub fn from_bytes_packet(
+        packet: BytesPacket,
+        remote_pubkey: Option<solana_pubkey::Pubkey>,
+    ) -> Self {
+        Self {
+            packet,
+            remote_pubkey,
+        }
+    }
+}
+
+impl BytesPacketWithClientId {
+    #[inline]
+    pub fn data<I>(&self, index: I) -> Option<&<I as SliceIndex<[u8]>>::Output>
+    where
+        I: SliceIndex<[u8]>,
+    {
+        self.packet.data(index)
+    }
+
+    #[inline]
+    pub fn meta(&self) -> &Meta {
+        self.packet.meta()
+    }
+
+    #[inline]
+    pub fn meta_mut(&mut self) -> &mut Meta {
+        self.packet.meta_mut()
+    }
+
+    pub fn deserialize_slice<T, I>(&self, index: I) -> bincode::Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+        I: SliceIndex<[u8], Output = [u8]>,
+    {
+        self.packet.deserialize_slice(index)
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn copy_from_slice(&mut self, slice: &[u8]) {
+        self.packet.copy_from_slice(slice);
+    }
+
+    #[inline]
+    pub fn buffer(&self) -> &Bytes {
+        self.packet.buffer()
+    }
+
+    #[inline]
+    pub fn set_buffer(&mut self, buffer: impl Into<Bytes>) {
+        self.packet.set_buffer(buffer);
+    }
+
+    #[inline]
+    pub fn as_ref(&self) -> PacketRef<'_> {
+        PacketRef::Bytes(&self.packet)
+    }
+
+    #[inline]
+    pub fn as_mut(&mut self) -> PacketRefMut<'_> {
+        PacketRefMut::Bytes(&mut self.packet)
+    }
+}
+
+/// Enhanced version of BytesPacketBatch with remote pubkey support
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BytesPacketBatchWithClientId {
+    packets: Vec<BytesPacketWithClientId>,
+}
+
+impl BytesPacketBatchWithClientId {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        let packets = Vec::with_capacity(capacity);
+        Self { packets }
+    }
+
+    /// Convert to a regular BytesPacketBatch (losing pubkey information)
+    pub fn to_bytes_packet_batch(self) -> BytesPacketBatch {
+        let packets: Vec<BytesPacket> = self
+            .packets
+            .into_iter()
+            .map(|ep| ep.into_bytes_packet())
+            .collect();
+        BytesPacketBatch::from(packets)
+    }
+
+    /// Convert to PinnedPacketBatch for compatibility
+    pub fn to_pinned_packet_batch(&self) -> PinnedPacketBatch {
+        // Delegate to BytesPacketBatch implementation
+        let bytes_batch = self.clone().to_bytes_packet_batch();
+        bytes_batch.to_pinned_packet_batch()
+    }
+}
+
+impl Deref for BytesPacketBatchWithClientId {
+    type Target = Vec<BytesPacketWithClientId>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.packets
+    }
+}
+
+impl DerefMut for BytesPacketBatchWithClientId {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.packets
+    }
+}
+
+impl From<Vec<BytesPacketWithClientId>> for BytesPacketBatchWithClientId {
+    fn from(packets: Vec<BytesPacketWithClientId>) -> Self {
+        Self { packets }
+    }
+}
+
+impl FromIterator<BytesPacketWithClientId> for BytesPacketBatchWithClientId {
+    fn from_iter<T: IntoIterator<Item = BytesPacketWithClientId>>(iter: T) -> Self {
+        let packets = Vec::from_iter(iter);
+        Self { packets }
+    }
+}
+
+impl From<BytesPacketBatchWithClientId> for BytesPacketBatch {
+    fn from(enhanced_batch: BytesPacketBatchWithClientId) -> Self {
+        enhanced_batch.to_bytes_packet_batch()
+    }
+}
+
+// Iterator implementations
+impl<'a> IntoIterator for &'a BytesPacketBatchWithClientId {
+    type Item = &'a BytesPacketWithClientId;
+    type IntoIter = std::slice::Iter<'a, BytesPacketWithClientId>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.packets.iter()
+    }
+}
+
+impl IntoIterator for BytesPacketBatchWithClientId {
+    type Item = BytesPacketWithClientId;
+    type IntoIter = std::vec::IntoIter<BytesPacketWithClientId>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.packets.into_iter()
+    }
+}
+
+// Parallel iterator support
+impl<'a> IntoParallelIterator for &'a BytesPacketBatchWithClientId {
+    type Iter = rayon::slice::Iter<'a, BytesPacketWithClientId>;
+    type Item = &'a BytesPacketWithClientId;
+    fn into_par_iter(self) -> Self::Iter {
+        self.packets.par_iter()
+    }
+}
+
+impl<'a> IntoParallelIterator for &'a mut BytesPacketBatchWithClientId {
+    type Iter = rayon::slice::IterMut<'a, BytesPacketWithClientId>;
+    type Item = &'a mut BytesPacketWithClientId;
+    fn into_par_iter(self) -> Self::Iter {
+        self.packets.par_iter_mut()
+    }
+}
+
+impl IntoParallelIterator for BytesPacketBatchWithClientId {
+    type Iter = rayon::vec::IntoIter<BytesPacketWithClientId>;
+    type Item = BytesPacketWithClientId;
+    fn into_par_iter(self) -> Self::Iter {
+        self.packets.into_par_iter()
+    }
 }
 
 #[cfg(test)]

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -472,6 +472,7 @@ fn split_batches(batches: Vec<PacketBatch>) -> (Vec<BytesPacketBatch>, Vec<Pinne
         match batch {
             PacketBatch::Bytes(batch) => bytes_batches.push(batch),
             PacketBatch::Pinned(batch) => pinned_batches.push(batch),
+            PacketBatch::WithClientId(batch) => bytes_batches.push(batch.into()),
         }
     }
     (bytes_batches, pinned_batches)
@@ -650,6 +651,7 @@ pub fn ed25519_verify(
         .map(|batch| match batch {
             PacketBatch::Pinned(batch) => Cow::Borrowed(batch),
             PacketBatch::Bytes(batch) => Cow::Owned(batch.to_pinned_packet_batch()),
+            PacketBatch::WithClientId(batch) => Cow::Owned(batch.to_pinned_packet_batch()),
         })
         .collect::<Vec<_>>();
     for batch in pinned_batches.iter() {

--- a/streamer/src/nonblocking/mod.rs
+++ b/streamer/src/nonblocking/mod.rs
@@ -6,6 +6,7 @@ pub mod recvmmsg;
 pub mod sendmmsg;
 pub mod simple_qos;
 mod stream_throttle;
+pub mod streamer_feedback;
 pub mod swqos;
 #[cfg(feature = "dev-context-only-utils")]
 pub mod testing_utilities;

--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -1,6 +1,7 @@
 use {
     crate::nonblocking::quic::{ClientConnectionTracker, ConnectionPeerType},
     quinn::Connection,
+    solana_pubkey::Pubkey,
     std::future::Future,
     tokio_util::sync::CancellationToken,
 };
@@ -51,4 +52,8 @@ pub(crate) trait QosController<C: ConnectionContext> {
         context: &C,
         connection: Connection,
     ) -> impl Future<Output = usize> + Send;
+}
+
+pub(crate) trait QosControllerWithCensor {
+    async fn censor_client(&self, client: &Pubkey);
 }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1337,6 +1337,19 @@ impl ConnectionTable {
             0
         }
     }
+
+    // Remove all connections, Returns number of connections that were removed
+    pub(crate) fn remove_connection_by_key(&mut self, key: ConnectionTableKey) -> usize {
+        if let Entry::Occupied(mut e) = self.table.entry(key) {
+            let e_ref = e.get_mut();
+            let connections_removed = e_ref.len();
+            e.swap_remove_entry();
+            self.total_size = self.total_size.saturating_sub(connections_removed);
+            connections_removed
+        } else {
+            0
+        }
+    }
 }
 
 struct EndpointAccept<'a> {

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -190,10 +190,7 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
     ) -> impl Future<Output = Option<CancellationToken>> + Send {
         async move {
             if let Some(feedback_manager) = &*self.feedback_manager.read().await {
-                let remote_pubkey = match conn_context.remote_pubkey() {
-                    Some(pubkey) => pubkey,
-                    None => return None,
-                };
+                let remote_pubkey = conn_context.remote_pubkey()?;
                 if feedback_manager.is_client_censored(&remote_pubkey).await {
                     debug!(
                         "Rejecting connection from censored client {}",
@@ -320,7 +317,7 @@ impl QosControllerWithCensor for SimpleQos {
     /// Censor a client connection, remove all connections
     async fn censor_client(&self, client: &Pubkey) {
         let mut connection_table = self.staked_connection_table.lock().await;
-        let client = ConnectionTableKey::Pubkey(client.clone());
+        let client = ConnectionTableKey::Pubkey(*client);
         connection_table.remove_connection_by_key(client);
     }
 }

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -27,7 +27,7 @@ use {
         },
     },
     tokio::{
-        sync::{Mutex, MutexGuard},
+        sync::{Mutex, MutexGuard, RwLock as TokioRwLock},
         task,
     },
     tokio_util::sync::CancellationToken,
@@ -53,6 +53,7 @@ pub struct SimpleQos {
     stats: Arc<StreamerStats>,
     staked_connection_table: Arc<Mutex<ConnectionTable>>,
     staked_nodes: Arc<RwLock<StakedNodes>>,
+    feedback_manager: TokioRwLock<Option<Arc<FeedbackManager<Self>>>>,
 }
 
 impl SimpleQos {
@@ -75,16 +76,20 @@ impl SimpleQos {
                 ConnectionTableType::Staked,
                 cancel.clone(),
             ))),
+            feedback_manager: TokioRwLock::new(None),
         });
+        let qos_copy = qos.clone();
         if let Some(feedback_receiver) = feedback_receiver {
             let qos_clone = qos.clone();
 
             task::spawn(async move {
-                let feedback_manager = FeedbackManager::new(qos_clone);
+                let feedback_manager = Arc::new(FeedbackManager::new(qos_clone));
+                let mut qos_feedback_manager = qos.feedback_manager.write().await;
+                *qos_feedback_manager = Some(feedback_manager.clone());
                 run_feedback_receiver(feedback_manager, feedback_receiver, cancel).await;
             });
         }
-        qos
+        qos_copy
     }
 
     fn cache_new_connection(
@@ -184,6 +189,22 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
         conn_context: &mut SimpleQosConnectionContext,
     ) -> impl Future<Output = Option<CancellationToken>> + Send {
         async move {
+            if let Some(feedback_manager) = &*self.feedback_manager.read().await {
+                let remote_pubkey = match conn_context.remote_pubkey() {
+                    Some(pubkey) => pubkey,
+                    None => return None,
+                };
+                if feedback_manager.is_client_censored(&remote_pubkey).await {
+                    debug!(
+                        "Rejecting connection from censored client {}",
+                        connection.remote_address()
+                    );
+                    self.stats
+                        .num_censored_clients
+                        .fetch_add(1, Ordering::Relaxed);
+                    return None;
+                }
+            }
             const PRUNE_RANDOM_SAMPLE_SIZE: usize = 2;
             match conn_context.peer_type() {
                 ConnectionPeerType::Staked(stake) => {
@@ -295,6 +316,15 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
     }
 }
 
+impl QosControllerWithCensor for SimpleQos {
+    /// Censor a client connection, remove all connections
+    async fn censor_client(&self, client: &Pubkey) {
+        let mut connection_table = self.staked_connection_table.lock().await;
+        let client = ConnectionTableKey::Pubkey(client.clone());
+        connection_table.remove_connection_by_key(client);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
@@ -400,6 +430,7 @@ mod tests {
             100, // max_staked_connections
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -453,6 +484,7 @@ mod tests {
             100, // max_staked_connections
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -530,6 +562,7 @@ mod tests {
             100, // max_staked_connections
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -586,6 +619,7 @@ mod tests {
             100, // max_staked_connections
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -625,6 +659,7 @@ mod tests {
             100, // max_staked_connections
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -667,6 +702,7 @@ mod tests {
             100, // max_staked_connections
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -725,6 +761,7 @@ mod tests {
             100, // max_staked_connections
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -788,6 +825,7 @@ mod tests {
             1,  // max_staked_connections (set to 1 to trigger pruning)
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -857,6 +895,7 @@ mod tests {
             1,  // max_staked_connections (set to 1)
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -917,6 +956,7 @@ mod tests {
             100, // max_staked_connections
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -980,6 +1020,7 @@ mod tests {
             100, // max_staked_connections
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -1042,6 +1083,7 @@ mod tests {
             100, // max_staked_connections
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -1104,6 +1146,7 @@ mod tests {
             100, // max_staked_connections
             stats.clone(),
             staked_nodes,
+            None,
             cancel.clone(),
         );
 
@@ -1134,14 +1177,5 @@ mod tests {
         // The function should complete (may or may not sleep depending on current throttling state)
         // We just verify it doesn't panic and completes successfully
         assert!(elapsed < std::time::Duration::from_secs(1)); // Should not take too long
-    }
-}
-
-impl QosControllerWithCensor for SimpleQos {
-    /// Censor a client connection, remove all connections
-    async fn censor_client(&self, client: &Pubkey) {
-        let mut connection_table = self.staked_connection_table.lock().await;
-        let client = ConnectionTableKey::Pubkey(client.clone());
-        connection_table.remove_connection_by_key(client);
     }
 }

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -79,11 +79,9 @@ impl SimpleQos {
         if let Some(feedback_receiver) = feedback_receiver {
             let qos_clone = qos.clone();
 
-            task::spawn_blocking({
-                move || {
-                    let feedback_manager = FeedbackManager::new(qos_clone);
-                    run_feedback_receiver(feedback_manager, feedback_receiver, cancel);
-                }
+            task::spawn(async move {
+                let feedback_manager = FeedbackManager::new(qos_clone);
+                run_feedback_receiver(feedback_manager, feedback_receiver, cancel).await;
             });
         }
         qos

--- a/streamer/src/nonblocking/streamer_feedback.rs
+++ b/streamer/src/nonblocking/streamer_feedback.rs
@@ -78,7 +78,7 @@ where
 
                 let cleanup_result = Self::cleanup_expired_clients(&censored_client).await;
                 if let Err(e) = cleanup_result {
-                    warn!("Error during client cleanup: {}", e);
+                    warn!("Error during client cleanup: {e}");
                 }
             }
         })
@@ -130,7 +130,7 @@ where
             }
 
             if actually_removed > 0 {
-                info!("Cleaned up {} expired censored clients", actually_removed);
+                info!("Cleaned up {actually_removed} expired censored clients");
             }
 
             actually_removed
@@ -167,13 +167,13 @@ where
         {
             let mut censored_client = self.censored_client.write().await;
             censored_client.insert(
-                client.clone(),
+                *client,
                 ClientCensorInfo {
                     censored_time: Instant::now(),
                     censor_duration: duration,
                 },
             );
-            debug!("Censoring client: {}", client);
+            debug!("Censoring client: {client}");
             drop(censored_client);
         }
         self.qos.censor_client(client).await;

--- a/streamer/src/nonblocking/streamer_feedback.rs
+++ b/streamer/src/nonblocking/streamer_feedback.rs
@@ -173,7 +173,7 @@ where
                     censor_duration: duration,
                 },
             );
-            debug!("Censoring client: {client}");
+            debug!("Censoring client: {}", client);
             drop(censored_client);
         }
         self.qos.censor_client(client).await;

--- a/streamer/src/nonblocking/streamer_feedback.rs
+++ b/streamer/src/nonblocking/streamer_feedback.rs
@@ -11,17 +11,24 @@ use {
     tokio_util::sync::CancellationToken,
 };
 
+pub const DEFAULT_CENSOR_CLEANUP_INTERVAL: Duration = Duration::from_secs(30);
+
 /// Feedback sent to the QUIC streamer by consumers.
 /// This can support different type of receivers.
 pub enum StreamerFeedback {
-    // Censor the pubkey
-    CensorClient(Pubkey),
+    /// Censor the pubkey for an optional duration
+    /// If duration is None, censor indefinitely, unless
+    /// it is uncensored later explicitly. If duration is Some,
+    /// censor for that duration and the censor will be removed
+    /// automatically.
+    CensorClient((Pubkey, Option<Duration>)),
     // Uncensor the pubkey
     UncensorClient(Pubkey),
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)] // Add Clone here
 struct ClientCensorInfo {
     censored_time: Instant,
+    censor_duration: Option<Duration>,
 }
 
 pub(crate) struct FeedbackManager<Q>
@@ -30,6 +37,7 @@ where
 {
     censored_client: Arc<RwLock<HashMap<Pubkey, ClientCensorInfo>>>,
     qos: Arc<Q>,
+    cleanup_handle: tokio::task::JoinHandle<()>, // Store handle to cancel if needed
 }
 
 impl<Q> FeedbackManager<Q>
@@ -37,16 +45,136 @@ where
     Q: QosControllerWithCensor,
 {
     pub(crate) fn new(qos: Arc<Q>) -> Self {
+        Self::new_with_cleanup_interval(qos, DEFAULT_CENSOR_CLEANUP_INTERVAL)
+    }
+
+    pub(crate) fn new_with_cleanup_interval(qos: Arc<Q>, cleanup_interval: Duration) -> Self {
+        let censored_client = Arc::new(RwLock::new(HashMap::new()));
+
+        // Start the cleanup task
+        let cleanup_handle = Self::start_cleanup_task(censored_client.clone(), cleanup_interval);
+
         Self {
-            censored_client: Arc::new(RwLock::new(HashMap::new())),
+            censored_client,
             qos,
+            cleanup_handle,
         }
+    }
+
+    // Start the background cleanup task and return the handle
+    fn start_cleanup_task(
+        censored_client: Arc<RwLock<HashMap<Pubkey, ClientCensorInfo>>>,
+        cleanup_interval: Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(cleanup_interval);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            loop {
+                interval.tick().await;
+
+                let cleanup_result = Self::cleanup_expired_clients(&censored_client).await;
+                if let Err(e) = cleanup_result {
+                    warn!("Error during client cleanup: {}", e);
+                }
+            }
+        })
+    }
+
+    // Enhanced cleanup with error handling and statistics
+    async fn cleanup_expired_clients(
+        censored_client: &Arc<RwLock<HashMap<Pubkey, ClientCensorInfo>>>,
+    ) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+        let now = Instant::now();
+        let mut clients_to_remove = Vec::new();
+
+        // First pass: identify expired clients
+        {
+            let censored_map = censored_client.read().await;
+            for (pubkey, info) in censored_map.iter() {
+                if let Some(duration) = info.censor_duration {
+                    if now.duration_since(info.censored_time) >= duration {
+                        // Clone both the pubkey and the info to avoid borrowing issues
+                        clients_to_remove.push((*pubkey, info.clone())); // *pubkey dereferences to Pubkey (which is Copy)
+                    }
+                }
+            }
+        } // censored_map is dropped here, but we've cloned the data we need
+
+        // Second pass: remove expired clients
+        let removed_count = if !clients_to_remove.is_empty() {
+            let mut censored_map = censored_client.write().await;
+            let mut actually_removed = 0;
+
+            for (pubkey, original_info) in &clients_to_remove {
+                // Double-check the client is still expired (in case it was updated between reads)
+                if let Some(current_info) = censored_map.get(pubkey) {
+                    if let Some(duration) = current_info.censor_duration {
+                        if now.duration_since(current_info.censored_time) >= duration {
+                            censored_map.remove(pubkey);
+                            actually_removed += 1;
+
+                            debug!(
+                                "Auto-uncensored expired client: {} (censored for {:?}, duration: {:?})",
+                                pubkey,
+                                now.duration_since(original_info.censored_time),
+                                original_info.censor_duration
+                            );
+                        }
+                    }
+                }
+            }
+
+            if actually_removed > 0 {
+                info!("Cleaned up {} expired censored clients", actually_removed);
+            }
+
+            actually_removed
+        } else {
+            0
+        };
+
+        Ok(removed_count)
+    }
+
+    // Add method to get statistics about censored clients
+    pub(crate) async fn get_censor_stats(&self) -> CensorStats {
+        let censored_map = self.censored_client.read().await;
+        let now = Instant::now();
+
+        let mut indefinite_count = 0;
+        let mut temporary_count = 0;
+        let mut expired_count = 0;
+
+        for info in censored_map.values() {
+            if let Some(duration) = info.censor_duration {
+                if now.duration_since(info.censored_time) >= duration {
+                    expired_count += 1;
+                } else {
+                    temporary_count += 1;
+                }
+            } else {
+                indefinite_count += 1;
+            }
+        }
+
+        CensorStats {
+            total_censored: censored_map.len(),
+            indefinite_count,
+            temporary_count,
+            expired_count, // These should be cleaned up soon
+        }
+    }
+
+    // Add method to manually trigger cleanup (useful for testing)
+    pub(crate) async fn cleanup_now(&self) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+        Self::cleanup_expired_clients(&self.censored_client).await
     }
 
     pub(crate) async fn handle_feedback(&self, feedback: StreamerFeedback) {
         match feedback {
-            StreamerFeedback::CensorClient(address) => {
-                self.censor_client(&address).await;
+            StreamerFeedback::CensorClient((address, duration)) => {
+                self.censor_client(&address, duration).await;
             }
             StreamerFeedback::UncensorClient(address) => {
                 self.uncensor_client(&address).await;
@@ -65,13 +193,14 @@ where
         }
     }
 
-    pub(crate) async fn censor_client(&self, client: &Pubkey) {
+    pub(crate) async fn censor_client(&self, client: &Pubkey, duration: Option<Duration>) {
         {
             let mut censored_client = self.censored_client.write().await;
             censored_client.insert(
                 client.clone(),
                 ClientCensorInfo {
                     censored_time: Instant::now(),
+                    censor_duration: duration,
                 },
             );
             debug!("Censoring client: {}", client);
@@ -113,5 +242,24 @@ pub(crate) async fn run_feedback_receiver<Q>(
                 }
             },
         }
+    }
+}
+
+// Statistics structure
+#[derive(Debug, Clone)]
+pub struct CensorStats {
+    pub total_censored: usize,
+    pub indefinite_count: usize,
+    pub temporary_count: usize,
+    pub expired_count: usize, // Should be 0 if cleanup is working properly
+}
+
+// Clean shutdown support
+impl<Q> Drop for FeedbackManager<Q>
+where
+    Q: QosControllerWithCensor,
+{
+    fn drop(&mut self) {
+        self.cleanup_handle.abort(); // Cancel the cleanup task when FeedbackManager is dropped
     }
 }

--- a/streamer/src/nonblocking/streamer_feedback.rs
+++ b/streamer/src/nonblocking/streamer_feedback.rs
@@ -166,11 +166,6 @@ where
         }
     }
 
-    // Add method to manually trigger cleanup (useful for testing)
-    pub(crate) async fn cleanup_now(&self) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
-        Self::cleanup_expired_clients(&self.censored_client).await
-    }
-
     pub(crate) async fn handle_feedback(&self, feedback: StreamerFeedback) {
         match feedback {
             StreamerFeedback::CensorClient((address, duration)) => {

--- a/streamer/src/nonblocking/streamer_feedback.rs
+++ b/streamer/src/nonblocking/streamer_feedback.rs
@@ -1,0 +1,102 @@
+use {
+    crate::nonblocking::qos::QosControllerWithCensor,
+    crossbeam_channel::{Receiver},
+    solana_pubkey::Pubkey,
+    std::{
+        collections::HashMap,
+        sync::{Arc, RwLock},
+        time::{Duration, Instant},
+    },
+    tokio_util::{sync::CancellationToken},
+};
+
+/// Feedback sent to the QUIC streamer by consumers.
+/// This can support different type of receivers.
+pub enum StreamerFeedback {
+    // Censor the pubkey
+    CensorClient(Pubkey),
+}
+
+struct ClientCensorInfo {
+    censored_time: Instant,
+}
+
+pub(crate) struct FeedbackManager<Q>
+where
+    Q: QosControllerWithCensor,
+{
+    censored_client: RwLock<HashMap<Pubkey, ClientCensorInfo>>,
+    qos: Arc<Q>,
+}
+
+impl<Q> FeedbackManager<Q>
+where
+    Q: QosControllerWithCensor,
+{
+    pub(crate) fn new(qos: Arc<Q>) -> Self {
+        Self {
+            censored_client: RwLock::new(HashMap::new()),
+            qos,
+        }
+    }
+
+    pub(crate) fn handle_feedback(&self, feedback: StreamerFeedback) {
+        match feedback {
+            StreamerFeedback::CensorClient(address) => {
+                let mut censored_client: std::sync::RwLockWriteGuard<
+                    '_,
+                    HashMap<Pubkey, ClientCensorInfo>,
+                > = self.censored_client.write().unwrap();
+                censored_client.insert(
+                    address,
+                    ClientCensorInfo {
+                        censored_time: Instant::now(),
+                    },
+                );
+                self.qos.censor_client(&address);
+            }
+        }
+    }
+
+    pub(crate) fn uncensor_client(&self, client: &Pubkey) {
+        let mut censored_client: std::sync::RwLockWriteGuard<
+            '_,
+            HashMap<Pubkey, ClientCensorInfo>,
+        > = self.censored_client.write().unwrap();
+        censored_client.remove(client);
+    }
+
+    pub(crate) async fn censor_client(&self, client: &Pubkey) {
+        self.qos.censor_client(client).await;
+    }
+}
+
+pub(crate) fn run_feedback_receiver<Q>(
+    feedback_manager: FeedbackManager<Q>,
+    feedback_receiver: Receiver<StreamerFeedback>,
+    cancel: CancellationToken,
+) where
+    Q: QosControllerWithCensor,
+{
+    let feedback_timeout = Duration::from_secs(1);
+    info!("Running feedback receiver");
+    loop {
+        if cancel.is_cancelled() {
+            return;
+        }
+        let feedback = feedback_receiver.recv_timeout(feedback_timeout);
+        match feedback {
+            Ok(feedback) => {
+                feedback_manager.handle_feedback(feedback);
+            }
+            Err(error) => match error {
+                crossbeam_channel::RecvTimeoutError::Timeout => {
+                    continue;
+                }
+                crossbeam_channel::RecvTimeoutError::Disconnected => {
+                    break;
+                }
+            },
+        }
+    }
+}

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -649,6 +649,8 @@ pub struct QuicStreamerConfig {
     pub wait_for_chunk_timeout: Duration,
     pub accumulator_channel_size: usize,
     pub num_threads: NonZeroUsize,
+    /// Controls if to send the client Id (client's public key) along with packet batches.
+    pub send_client_id: bool,
 }
 
 #[derive(Clone)]
@@ -704,6 +706,7 @@ impl Default for QuicStreamerConfig {
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             accumulator_channel_size: DEFAULT_ACCUMULATOR_CHANNEL_SIZE,
             num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
+            send_client_id: false, // Default to false for backward compatibility
         }
     }
 }
@@ -726,6 +729,12 @@ impl QuicStreamerConfig {
         let conns = self.max_staked_connections + self.max_unstaked_connections;
         conns + conns / 4
     }
+
+    // Add convenience method
+    pub fn with_client_id(mut self, include_client_id: bool) -> Self {
+        self.send_client_id = include_client_id;
+        self
+    }
 }
 
 #[allow(deprecated)]
@@ -739,6 +748,7 @@ impl From<&QuicServerParams> for QuicStreamerConfig {
             wait_for_chunk_timeout: params.wait_for_chunk_timeout,
             accumulator_channel_size: params.accumulator_channel_size,
             num_threads: params.num_threads,
+            send_client_id: false,
         }
     }
 }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -4,7 +4,7 @@ use {
             qos::{ConnectionContext, QosController},
             quic::{ALPN_TPU_PROTOCOL_ID, DEFAULT_WAIT_FOR_CHUNK_TIMEOUT},
             simple_qos::{SimpleQos, SimpleQosConfig},
-            streamer_feedback::StreamerFeedback,
+            streamer_feedback::{CensoringStats, StreamerFeedback},
             swqos::{SwQos, SwQosConfig},
         },
         streamer::StakedNodes,
@@ -227,6 +227,7 @@ pub struct StreamerStats {
     pub(crate) outstanding_incoming_connection_attempts: AtomicUsize,
     pub(crate) total_incoming_connection_attempts: AtomicUsize,
     pub(crate) quic_endpoints_count: AtomicUsize,
+    pub(crate) censoring_stats: Option<CensoringStats>,
 }
 
 impl StreamerStats {
@@ -236,6 +237,16 @@ impl StreamerStats {
             let process_sampled_packets_us_hist = metrics.clone();
             metrics.clear();
             process_sampled_packets_us_hist
+        };
+
+        // Helper function to get censoring stat or 0
+        let censoring_stat = |field: &dyn Fn(&CensoringStats) -> usize| -> i64 {
+            self.censoring_stats.as_ref().map(field).unwrap_or(0) as i64
+        };
+
+        // Helper function to get and reset censoring stat or 0
+        let censoring_stat_swap = |field: &dyn Fn(&CensoringStats) -> usize| -> i64 {
+            self.censoring_stats.as_ref().map(field).unwrap_or(0) as i64
         };
 
         datapoint_info!(
@@ -598,6 +609,53 @@ impl StreamerStats {
                 "refused_connections_too_many_open_connections",
                 self.refused_connections_too_many_open_connections
                     .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            // Censoring stats - always included, 0 if not available
+            (
+                "total_censored_clients",
+                censoring_stat(&|stats| stats.total_censored.load(Ordering::Relaxed)),
+                i64
+            ),
+            (
+                "indefinite_censored_clients",
+                censoring_stat(&|stats| stats.indefinite_count.load(Ordering::Relaxed)),
+                i64
+            ),
+            (
+                "temporary_censored_clients",
+                censoring_stat(&|stats| stats.temporary_count.load(Ordering::Relaxed)),
+                i64
+            ),
+            (
+                "expired_censored_clients",
+                censoring_stat(&|stats| stats.expired_count.load(Ordering::Relaxed)),
+                i64
+            ),
+            (
+                "total_censored_events",
+                censoring_stat_swap(&|stats| stats
+                    .total_censored_events
+                    .swap(0, Ordering::Relaxed)),
+                i64
+            ),
+            (
+                "total_uncensored_events",
+                censoring_stat_swap(&|stats| stats
+                    .total_uncensored_events
+                    .swap(0, Ordering::Relaxed)),
+                i64
+            ),
+            (
+                "auto_cleanup_runs",
+                censoring_stat_swap(&|stats| stats.auto_cleanup_runs.swap(0, Ordering::Relaxed)),
+                i64
+            ),
+            (
+                "clients_auto_uncensored",
+                censoring_stat_swap(&|stats| stats
+                    .clients_auto_uncensored
+                    .swap(0, Ordering::Relaxed)),
                 i64
             ),
         );

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -937,6 +937,7 @@ pub fn spawn_server_with_cancel(
 }
 
 /// Spawns a tokio runtime and a streamer instance inside it.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_simple_qos_server_with_cancel(
     thread_name: &'static str,
     metrics_name: &'static str,

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -183,6 +183,7 @@ pub struct StreamerStats {
     pub(crate) total_stream_read_errors: AtomicUsize,
     pub(crate) total_stream_read_timeouts: AtomicUsize,
     pub(crate) num_evictions_staked: AtomicUsize,
+    pub(crate) num_censored_clients: AtomicUsize,
     pub(crate) num_evictions_unstaked: AtomicUsize,
     pub(crate) connection_added_from_staked_peer: AtomicUsize,
     pub(crate) connection_added_from_unstaked_peer: AtomicUsize,
@@ -994,6 +995,7 @@ mod test {
             staked_nodes,
             server_params.quic_streamer_config,
             server_params.qos_config,
+            None,
             cancel.clone(),
         )
         .unwrap();


### PR DESCRIPTION
#### Problem
Alpenglow requires sending the pubkey of the client for QUIC connection to the consumer and supports censoring a client using the key if the consumer determines the client is misbehaving.

#### Summary of Changes

1. Enhanced PacketBatch with new variant WithClientId.
2. Enhanced SimplqQOS to support sending consumer with WithClientId packet batch.
3. Support receiving feedback from consumer for SimpleQOS.
4. Support censoring the client with censor internal.
5. Support uncensoring a client after the specified censorship interval.


Testing for now.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
