### PR TITLE
feat(scheduler-bindings): add `BankingStage::spawn_external_threads`

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -28,12 +28,6 @@ pub enum ConsumeWorkerError<Tx> {
     Send(#[from] SendError<FinishedConsumeWork<Tx>>),
 }
 
-#[derive(Debug, Error)]
-pub enum ExternalConsumeWorkerError {
-    #[error("Sender disconnected")]
-    SenderDisconnected,
-}
-
 enum ProcessingStatus<Tx> {
     Processed,
     /// Work could not be processed due to lack of bank.
@@ -177,8 +171,9 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
     }
 }
 
+#[allow(dead_code)]
 #[cfg(unix)]
-mod external {
+pub(crate) mod external {
     use {
         super::*,
         agave_scheduler_bindings::{
@@ -189,6 +184,12 @@ mod external {
         agave_transaction_view::resolved_transaction_view::ResolvedTransactionView,
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     };
+
+    #[derive(Debug, Error)]
+    pub enum ExternalConsumeWorkerError {
+        #[error("Sender disconnected")]
+        SenderDisconnected,
+    }
 
     pub(crate) struct ExternalWorker {
         exit: Arc<AtomicBool>,

--- a/core/src/banking_stage/tpu_to_pack.rs
+++ b/core/src/banking_stage/tpu_to_pack.rs
@@ -4,6 +4,7 @@
 use {
     agave_banking_stage_ingress_types::BankingPacketReceiver,
     agave_scheduler_bindings::{tpu_message_flags, SharableTransactionRegion, TpuToPackMessage},
+    agave_scheduling_utils::handshake::server::AgaveTpuToPackSession,
     rts_alloc::Allocator,
     solana_packet::PacketFlags,
     solana_perf::packet::PacketBatch,
@@ -28,8 +29,10 @@ pub struct BankingPacketReceivers {
 pub fn spawn(
     exit: Arc<AtomicBool>,
     receivers: BankingPacketReceivers,
-    allocator: rts_alloc::Allocator,
-    producer: shaq::Producer<TpuToPackMessage>,
+    AgaveTpuToPackSession {
+        allocator,
+        producer,
+    }: AgaveTpuToPackSession,
 ) -> JoinHandle<()> {
     std::thread::Builder::new()
         .name("solTpu2Pack".to_string())

--- a/scheduling-utils/src/handshake/mod.rs
+++ b/scheduling-utils/src/handshake/mod.rs
@@ -4,4 +4,4 @@ mod shared;
 #[cfg(test)]
 mod tests;
 
-pub use shared::ClientLogon;
+pub use shared::{ClientLogon, MAX_WORKERS};

--- a/scheduling-utils/src/handshake/server.rs
+++ b/scheduling-utils/src/handshake/server.rs
@@ -198,7 +198,7 @@ impl Server {
             AgaveSession {
                 tpu_to_pack: AgaveTpuToPackSession {
                     allocator: tpu_to_pack_allocator,
-                    queue: tpu_to_pack_queue,
+                    producer: tpu_to_pack_queue,
                 },
                 progress_tracker,
                 workers,
@@ -299,7 +299,7 @@ pub struct AgaveSession {
 /// Shared memory objects for the tpu to pack worker.
 pub struct AgaveTpuToPackSession {
     pub allocator: Allocator,
-    pub queue: shaq::Producer<TpuToPackMessage>,
+    pub producer: shaq::Producer<TpuToPackMessage>,
 }
 
 /// Shared memory objects for a single banking worker.

--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -1,7 +1,8 @@
+pub const MAX_WORKERS: usize = 64;
+
 pub(crate) const VERSION: u64 = 1;
 pub(crate) const LOGON_SUCCESS: u8 = 0x01;
 pub(crate) const LOGON_FAILURE: u8 = 0x02;
-pub(crate) const MAX_WORKERS: usize = 64;
 pub(crate) const MAX_ALLOCATOR_HANDLES: usize = 128;
 pub(crate) const GLOBAL_ALLOCATORS: usize = 1;
 

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -60,9 +60,9 @@ fn message_passing_on_all_queues() {
         let mut session = server.accept().unwrap();
 
         // Send a tpu_to_pack message.
-        let mut slot = session.tpu_to_pack.queue.reserve().unwrap();
+        let mut slot = session.tpu_to_pack.producer.reserve().unwrap();
         unsafe { *slot.as_mut() = tpu_to_pack };
-        session.tpu_to_pack.queue.commit();
+        session.tpu_to_pack.producer.commit();
 
         // Send a progress_tracker message.
         let mut slot = session.progress_tracker.reserve().unwrap();

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -786,7 +786,7 @@ impl AdminRpc for AdminRpcImpl {
             };
 
             banking_stage
-                .spawn_threads(
+                .spawn_internal_threads(
                     block_production_method,
                     num_workers,
                     SchedulerConfig { scheduler_pacing },


### PR DESCRIPTION
#### Problem

- The external consume worker is currently unused.

#### Summary of Changes

- Add banking stage entry point that can be used to switch to an external scheduler + worker threads. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
