### PR TITLE
introduce scripts/cargo-for-all-workspace.sh

### DIFF
--- a/scripts/cargo-for-all-workspaces.sh
+++ b/scripts/cargo-for-all-workspaces.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+scripts_base="$(dirname "$0")"
+cargo_for_all_lock_files="$scripts_base"/cargo-for-all-lock-files.sh
+
+"$cargo_for_all_lock_files" --only-workspaces "${@}"


### PR DESCRIPTION
#### Problem
we frequently need to run a cargo command on each workspace in the monorepo. cargo-for-all-lock-files.sh has been our go to for this for years, but recently we have added several standalone crates that are neither themselves workspaces, nor members of another workspace.

#### Summary of Changes
* adds a --only-workspaces flag to scripts/cargo-for-all-lock-files.sh
* adds scripts/cargo-for-all-workspaces.sh as a convenience wrapper around the former
