### PR TITLE
SIMD-0334: fix alt_bn128 pairing length check

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1181,7 +1181,7 @@ pub mod deprecate_rent_exemption_threshold {
 
 pub mod poseidon_enforce_padding {
     solana_pubkey::declare_id!("poUdAqRXXsNmfqAZ6UqpjbeYgwBygbfQLEvWSqVhSnb");
-
+}
 
 pub mod fix_alt_bn128_pairing_length_check {
     solana_pubkey::declare_id!("bnYzodLwmybj7e1HAe98yZrdJTd7we69eMMLgCXqKZm");

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -171,6 +171,8 @@ impl FeatureSet {
             increase_cpi_account_info_limit: self.is_active(&increase_cpi_account_info_limit::id()),
             vote_state_v4: self.is_active(&vote_state_v4::id()),
             poseidon_enforce_padding: self.is_active(&poseidon_enforce_padding::id()),
+            fix_alt_bn128_pairing_length_check: self
+                .is_active(&fix_alt_bn128_pairing_length_check::id()),
         }
     }
 }
@@ -1179,6 +1181,10 @@ pub mod deprecate_rent_exemption_threshold {
 
 pub mod poseidon_enforce_padding {
     solana_pubkey::declare_id!("poUdAqRXXsNmfqAZ6UqpjbeYgwBygbfQLEvWSqVhSnb");
+
+
+pub mod fix_alt_bn128_pairing_length_check {
+    solana_pubkey::declare_id!("bnYzodLwmybj7e1HAe98yZrdJTd7we69eMMLgCXqKZm");
 }
 
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
@@ -2123,6 +2129,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             poseidon_enforce_padding::id(),
             "SIMD-0359: Enforce padding in Poseidon hash inputs",
+        ),
+        (
+            fix_alt_bn128_pairing_length_check::id(),
+            "SIMD-0334: Fix alt_bn128_pairing length check",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -50,6 +50,7 @@ pub struct SVMFeatureSet {
     pub increase_cpi_account_info_limit: bool,
     pub vote_state_v4: bool,
     pub poseidon_enforce_padding: bool,
+    pub fix_alt_bn128_pairing_length_check: bool,
 }
 
 impl SVMFeatureSet {
@@ -96,6 +97,7 @@ impl SVMFeatureSet {
             increase_cpi_account_info_limit: true,
             vote_state_v4: true,
             poseidon_enforce_padding: true,
+            fix_alt_bn128_pairing_length_check: true,
         }
     }
 }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1633,7 +1633,14 @@ declare_builtin_function!(
                 )
             }
             ALT_BN128_PAIRING_BE => {
-                alt_bn128_versioned_pairing(VersionedPairing::V0, input, Endianness::BE)
+                let version = if invoke_context
+                    .get_feature_set()
+                    .fix_alt_bn128_pairing_length_check {
+                    VersionedPairing::V1
+                } else {
+                    VersionedPairing::V0
+                };
+                alt_bn128_versioned_pairing(version, input, Endianness::BE)
             }
             _ => {
                 return Err(SyscallError::InvalidAttribute.into());


### PR DESCRIPTION
#### Problem
The alt_bn128_pairing syscall takes a byte slice as input, interprets the bytes as an array of pairs of g1 and g2 points on bn128 elliptic curve, and applies a pairing operation. If the byte slice input has an improper length, the function should terminate early. Specifically, if the byte slice length is not a multiple of 192 (the sum of the lengths of g1 and g2 points), the function should terminate early with an error.

However, the current code does not perform this check correctly.

#### Summary of Changes
The fix was made on the solana-sdk side https://github.com/anza-xyz/solana-sdk/pull/324 and shipped with solana-bn254 v3.1. The changes themselves are pretty minimal since all the changes are scoped in the versioned [enum](https://github.com/anza-xyz/solana-sdk/blob/master/bn254/src/pairing.rs#L45).

solana-bn254 v3.1 contains an implementation of simd-0284 as well. I made changes for simd-0334 first since it is slightly easier to add. I'll add simd-0284 as an immediate follow-up to this PR.

All credits go to @LStan.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
