### PR TITLE
runtime: Remove redundant DCOU attribute

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5914,7 +5914,6 @@ impl Bank {
     }
 
     /// Prepare a transaction batch from a list of legacy transactions. Used for tests only.
-    #[cfg(feature = "dev-context-only-utils")]
     pub fn prepare_batch_for_tests(
         &self,
         txs: Vec<Transaction>,


### PR DESCRIPTION
#### Problem

`Bank::prepare_batch_for_tests` was tagged with DCOU attribute, even though the the entire `impl` block is already DCOU.

#### Summary of Changes

Remove the redundant attribute.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
