### PR TITLE
Use shared sqpoll for snapshot unpack file reader and creator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,7 +308,7 @@ hyper-proxy = "0.9.1"
 im = "15.1.0"
 indexmap = "2.12.1"
 indicatif = "0.18.3"
-io-uring = "0.7.11"
+io-uring = { version = "0.7.11", features = ["io_safety"] }
 itertools = "0.14.0"
 jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
     "unprefixed_malloc_on_supported_platforms",

--- a/fs/src/buffered_reader.rs
+++ b/fs/src/buffered_reader.rs
@@ -14,7 +14,10 @@
 //! When reading full accounts data whose sizes exceed the small stack buffer, the `BufReaderWithOverflow`
 //! should be used, which supports dynamically allocated buffer for preparing contiguous data slices.
 use {
-    crate::file_io::{read_into_buffer, read_more_buffer},
+    crate::{
+        file_io::{read_into_buffer, read_more_buffer},
+        io_setup::IoSetupState,
+    },
     std::{
         fs::File,
         io::{self, BufRead},
@@ -386,18 +389,25 @@ impl<R: BufRead> RequiredLenBufRead for BufReaderWithOverflow<R> {
 
 /// Open file at `path` with buffering reader using `buf_size` memory and doing
 /// read-ahead IO reads (if `io_uring` is supported by the platform)
-pub fn large_file_buf_reader(path: &Path, buf_size: usize) -> io::Result<impl BufRead + use<>> {
+pub fn large_file_buf_reader(
+    path: &Path,
+    buf_size: usize,
+    io_setup: &IoSetupState,
+) -> io::Result<impl BufRead + use<>> {
     #[cfg(target_os = "linux")]
     {
         assert!(agave_io_uring::io_uring_supported());
         use crate::io_uring::sequential_file_reader::SequentialFileReaderBuilder;
 
-        SequentialFileReaderBuilder::new().build(path, buf_size)
+        SequentialFileReaderBuilder::new()
+            .shared_sqpoll(io_setup.shared_sqpoll_fd())
+            .build(path, buf_size)
     }
     #[cfg(not(target_os = "linux"))]
     {
         use std::io::BufReader;
         let file = File::open(path)?;
+        let _ = io_setup;
         Ok(BufReader::with_capacity(buf_size, file))
     }
 }

--- a/fs/src/io_setup.rs
+++ b/fs/src/io_setup.rs
@@ -1,0 +1,107 @@
+use std::io;
+#[cfg(target_os = "linux")]
+use {
+    crate::io_uring::sqpoll::SharedSqPoll,
+    std::os::fd::{AsFd as _, BorrowedFd},
+};
+
+/// State used by IO utilities for managing shared resources and configuration during setup.
+///
+/// This may include io_uring file descriptors, flag whether to register memory buffers in kernel,
+/// and other resources that need to be accessed by multiple functions performing IO operations
+/// such that they can efficiently cooperate with each other.
+///
+/// This is achieved by creating `IoSetupState` at the beginning of the processing setup and
+/// passing its reference to IO utilities that need sharing / customized options.
+///
+/// Note: the state needs to live only during creation of the IO utilities, not during their usage,
+/// so it's generally advisable to drop it after setup is done such that e.g. init-only squeue is
+/// released.
+#[derive(Default)]
+pub struct IoSetupState {
+    #[cfg(target_os = "linux")]
+    shared_sqpoll: Option<SharedSqPoll>,
+}
+
+impl IoSetupState {
+    /// Enables shared io-uring worker pool and sqpoll based kernel thread.
+    ///
+    /// The sqpoll thread will drain submission queues from all io-uring instances created
+    /// through builder obtained from `create_io_uring_builder()` with FD obtained from
+    /// `shared_sqpoll_fd()` after this call.
+    pub fn with_shared_sqpoll(self) -> io::Result<Self> {
+        Ok(Self {
+            #[cfg(target_os = "linux")]
+            shared_sqpoll: Some(SharedSqPoll::new()?),
+        })
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn shared_sqpoll_fd(&self) -> Option<BorrowedFd<'_>> {
+        self.shared_sqpoll.as_ref().map(|s| s.as_fd())
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            file_io::FileCreator,
+            io_uring::{
+                file_creator::IoUringFileCreator,
+                sequential_file_reader::SequentialFileReaderBuilder,
+            },
+        },
+        rand::RngCore,
+        std::{
+            fs::File,
+            io::{Cursor, Read},
+            sync::{Arc, RwLock},
+        },
+    };
+
+    #[test]
+    fn test_shared_sqpoll_read_and_create() {
+        let io_setup = &IoSetupState::default().with_shared_sqpoll().unwrap();
+
+        let read_bytes = RwLock::new(vec![]);
+        let read_bytes_ref = &read_bytes;
+        let mut file_creator = IoUringFileCreator::with_buffer_capacity(
+            1 << 20,
+            io_setup.shared_sqpoll_fd(),
+            move |path| {
+                let mut reader = SequentialFileReaderBuilder::new()
+                    .shared_sqpoll(io_setup.shared_sqpoll_fd())
+                    .build(path, 1 << 20)
+                    .unwrap();
+                reader
+                    .read_to_end(read_bytes_ref.write().unwrap().as_mut())
+                    .unwrap();
+            },
+        )
+        .unwrap();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dir_handle = Arc::new(File::open(temp_dir.path()).unwrap());
+        let mut write_bytes = vec![0; 2 << 20];
+        rand::rng().fill_bytes(&mut write_bytes);
+
+        let file_path1 = temp_dir.path().join("test-1.txt");
+        let file_path2 = temp_dir.path().join("test-2.txt");
+        for path in [file_path1, file_path2] {
+            let dir_handle = dir_handle.clone();
+            file_creator
+                .schedule_create_at_dir(path, 0o644, dir_handle, &mut Cursor::new(&write_bytes))
+                .unwrap();
+        }
+        file_creator.drain().unwrap();
+        drop(file_creator);
+
+        // After drain all the callbacks that read data into `read_bytes` should be done.
+        let read_bytes = read_bytes.into_inner().unwrap();
+        // Expect atomically appended two copies, each from different file.
+        assert_eq!(&read_bytes[..write_bytes.len()], &write_bytes);
+        assert_eq!(&read_bytes[write_bytes.len()..], &write_bytes);
+    }
+}

--- a/fs/src/io_uring/mod.rs
+++ b/fs/src/io_uring/mod.rs
@@ -4,6 +4,7 @@ pub mod dir_remover;
 pub mod file_creator;
 pub mod memory;
 pub mod sequential_file_reader;
+pub(crate) mod sqpoll;
 
 // Based on Linux <uapi/linux/ioprio.h>
 const IO_PRIO_CLASS_SHIFT: u16 = 13;

--- a/fs/src/io_uring/sqpoll.rs
+++ b/fs/src/io_uring/sqpoll.rs
@@ -1,0 +1,46 @@
+use std::{
+    io,
+    os::fd::{AsFd, AsRawFd as _, BorrowedFd},
+    time::Duration,
+};
+
+const SQPOLL_IDLE_WAIT_TIME: Duration = Duration::from_millis(50);
+
+/// Mechanism for sharing a kernel worker pool and submission queue kernel polling thread
+///
+/// A single `SharedSqPoll` instance should be created and file descriptor obtained through
+/// `as_fd()` can be then passed to io-uring utilities that should create io_uring builder using
+/// `io_uring_builder_with(shared_sqpoll_fd)`.
+pub struct SharedSqPoll {
+    /// The io_uring instance used as root defining the kernel worker pool such that
+    /// other io_uring instances can attach to its file descriptor.
+    sqpoll_io_uring: io_uring::IoUring,
+}
+
+impl SharedSqPoll {
+    pub fn new() -> io::Result<Self> {
+        let shared_sqpoll_io_uring = io_uring::IoUring::builder()
+            .setup_sqpoll(SQPOLL_IDLE_WAIT_TIME.as_millis() as u32)
+            .build(1)?;
+        Ok(Self {
+            sqpoll_io_uring: shared_sqpoll_io_uring,
+        })
+    }
+}
+
+impl AsFd for SharedSqPoll {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.sqpoll_io_uring.as_fd()
+    }
+}
+
+/// Return new io-uring builder that is attached to shared worker pool (if provided).
+pub fn io_uring_builder_with(shared_sqpoll_fd: Option<BorrowedFd>) -> io_uring::Builder {
+    let mut builder = io_uring::IoUring::builder();
+    if let Some(fd) = shared_sqpoll_fd {
+        builder
+            .setup_attach_wq(fd.as_raw_fd())
+            .setup_sqpoll(SQPOLL_IDLE_WAIT_TIME.as_millis() as u32);
+    }
+    builder
+}

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -19,4 +19,5 @@ pub mod buffered_reader;
 pub mod buffered_writer;
 pub mod dirs;
 pub mod file_io;
+pub mod io_setup;
 mod io_uring;

--- a/snapshots/src/hardened_unpack.rs
+++ b/snapshots/src/hardened_unpack.rs
@@ -452,7 +452,7 @@ fn is_valid_genesis_archive_entry<'a>(
 mod tests {
     use {
         super::*,
-        agave_fs::file_io::file_creator,
+        agave_fs::{file_io::file_creator, io_setup::IoSetupState},
         assert_matches::assert_matches,
         std::io::BufReader,
         tar::{Builder, Header},
@@ -699,7 +699,7 @@ mod tests {
     }
 
     fn finalize_and_unpack_snapshot(archive: tar::Builder<Vec<u8>>) -> Result<()> {
-        let file_creator = file_creator(256, |_| {})?;
+        let file_creator = file_creator(256, &IoSetupState::default(), |_| {})?;
         with_finalize_and_unpack(archive, move |a, b| {
             unpack_snapshot_with_processors(a, file_creator, b, &[PathBuf::new()], |_, _| {})
                 .map(|_| ())
@@ -707,7 +707,7 @@ mod tests {
     }
 
     fn finalize_and_unpack_genesis(archive: tar::Builder<Vec<u8>>) -> Result<()> {
-        let file_creator = file_creator(0, |_| {})?;
+        let file_creator = file_creator(0, &IoSetupState::default(), |_| {})?;
         with_finalize_and_unpack(archive, move |a, b| {
             unpack_genesis(a, file_creator, b, MAX_GENESIS_SIZE_FOR_TESTS)
         })
@@ -990,7 +990,7 @@ mod tests {
         archive.append(&header, data).unwrap();
         let result = with_finalize_and_unpack(archive, |ar, tmp| {
             let tmp_path_buf = tmp.to_path_buf();
-            let file_creator = file_creator(256, move |path| {
+            let file_creator = file_creator(256, &IoSetupState::default(), move |path| {
                 assert_eq!(path, tmp_path_buf.join("accounts_dest/123.456"))
             })
             .expect("must make file_creator");


### PR DESCRIPTION
#### Problem
Snapshot unpacking is only done at startup and its basically the only computation happening at that time. IO uring utilities for disk read and write are using batched submission, which makes them occasionally waste CPU on syscalls and may delay submission of work to kernel causing wait times.
The above can be remedied by enabling sqpoll for io-urings they use. 

#### Summary of Changes
* create `IoBackend` util that can be used to create shared sqpoll io-uring (and in future other resources that need sharing / split among io-urings, e.g. memlock budget)
* pass `IoBackend` as extra parameter for creating `large_file_buffered_reader` and `file_creator`
* enable sqpoll with shared kernel thread and workers among snapshot unpacking reader and writer

##### Performance metrics
On some runs walltimes are equivalent, however with the PR we are able to get the write buffers submitted to kernel faster as shown with file-creator stats

master:
```
files creation stats - large buf headroom: 51659, no buf count: 17995, avg pending writes at no buf: 54871952
snapshot untar took 95.5s
```
PR:
```
files creation stats - large buf headroom: 427215, no buf count: 140, avg pending writes at no buf: 137237414
snapshot untar took 95.4s
```

On a different set of runs (interleaved PR/master with validator running in background) I'm seeing PR getting better / more consistent timing while master varies to slower timing:
```
PR:
snapshot untar took 98.7s
snapshot untar took 97.7s
snapshot untar took 108.3s
snapshot untar took 96.6s

master:
snapshot untar took 104.2s
snapshot untar took 105.3s
snapshot untar took 104.9s
snapshot untar took 105.9s
```