### PR TITLE
tests: programs/sbf: use svm-test-harness in `test_program_sbf_sanity`

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -32,7 +32,7 @@ cargo_build_sbf_sanity() {
   done
   popd
 
-  cargo test --features=sbf_rust --test programs test_program_sbf_sanity
+  SBF_OUT_DIR=target/deploy cargo test --features=sbf_rust --test programs test_program_sbf_sanity
   popd
 }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8587,6 +8587,7 @@ dependencies = [
  "solana-svm-callback",
  "solana-svm-feature-set",
  "solana-svm-log-collector",
+ "solana-svm-test-harness",
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
@@ -9736,6 +9737,38 @@ dependencies = [
 [[package]]
 name = "solana-svm-measure"
 version = "4.0.0-alpha.0"
+
+[[package]]
+name = "solana-svm-test-harness"
+version = "4.0.0-alpha.0"
+dependencies = [
+ "agave-feature-set",
+ "agave-logger",
+ "agave-precompiles",
+ "agave-syscalls",
+ "bincode",
+ "solana-account",
+ "solana-builtins",
+ "solana-clock",
+ "solana-compute-budget",
+ "solana-epoch-schedule",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-last-restart-slot",
+ "solana-precompile-error",
+ "solana-program-runtime",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-stable-layout",
+ "solana-svm",
+ "solana-svm-callback",
+ "solana-svm-log-collector",
+ "solana-svm-timings",
+ "solana-sysvar-id",
+ "solana-transaction-context",
+ "thiserror 2.0.17",
+]
 
 [[package]]
 name = "solana-svm-timings"

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -163,6 +163,7 @@ solana-svm = { path = "../../svm", version = "=4.0.0-alpha.0" }
 solana-svm-callback = { path = "../../svm-callback", version = "=4.0.0-alpha.0" }
 solana-svm-feature-set = { path = "../../svm-feature-set", version = "=4.0.0-alpha.0" }
 solana-svm-log-collector = { path = "../../svm-log-collector", version = "=4.0.0-alpha.0" }
+solana-svm-test-harness = { path = "../../svm-test-harness", version = "=4.0.0-alpha.0" }
 solana-svm-timings = { path = "../../svm-timings", version = "=4.0.0-alpha.0" }
 solana-svm-transaction = { path = "../../svm-transaction", version = "=4.0.0-alpha.0" }
 solana-svm-type-overrides = { path = "../../svm-type-overrides", version = "=4.0.0-alpha.0" }
@@ -243,6 +244,7 @@ solana-svm = { workspace = true }
 solana-svm-callback = { workspace = true }
 solana-svm-feature-set = { workspace = true }
 solana-svm-log-collector = { workspace = true }
+solana-svm-test-harness = { workspace = true }
 solana-svm-timings = { workspace = true }
 solana-svm-transaction = { workspace = true }
 solana-svm-type-overrides = { workspace = true }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -71,6 +71,16 @@ use {
     },
     test_case::test_matrix,
 };
+#[cfg(all(
+    any(feature = "sbf_c", feature = "sbf_rust"),
+    not(feature = "sbf_sanity_list")
+))]
+use {
+    solana_account::Account,
+    solana_program_runtime::sysvar_cache::SysvarCache,
+    solana_sdk_ids::sysvar::rent,
+    solana_svm_test_harness::{self as harness, fixture::instr_context::InstrContext},
+};
 
 #[cfg(feature = "sbf_rust")]
 fn process_transaction_and_record_inner(
@@ -226,31 +236,75 @@ fn test_program_sbf_sanity() {
     for program in programs.iter() {
         println!("Test program: {:?}", program.0);
 
-        let GenesisConfigInfo {
-            genesis_config,
-            mint_keypair,
-            ..
-        } = create_genesis_config(50);
+        let program_elf = harness::file::load_program_elf(program.0);
+        let program_id = Pubkey::new_unique();
 
-        let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-        let mut bank_client = BankClient::new_shared(bank);
-        let authority_keypair = Keypair::new();
+        let feature_set = FeatureSet::all_enabled();
 
-        // Call user program
-        let (_bank, program_id) = load_program_of_loader_v4(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
-            program.0,
-        );
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
 
         let account_metas = vec![
-            AccountMeta::new(mint_keypair.pubkey(), true),
-            AccountMeta::new(Keypair::new().pubkey(), false),
+            AccountMeta::new(pubkey1, true),
+            AccountMeta::new(pubkey2, false),
         ];
         let instruction = Instruction::new_with_bytes(program_id, &[1], account_metas);
-        let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
+
+        let accounts = vec![
+            (
+                program_id,
+                Account {
+                    owner: bpf_loader_upgradeable::id(),
+                    ..Default::default() // <-- Stubbed
+                },
+            ),
+            (pubkey1, Account::default()),
+            (pubkey2, Account::default()),
+        ];
+
+        let compute_budget = ComputeBudget::new_with_defaults(false, false);
+
+        let mut program_cache =
+            harness::program_cache::new_with_builtins(&feature_set, /* slot */ 0);
+        harness::program_cache::add_program(
+            &mut program_cache,
+            &program_id,
+            &bpf_loader_upgradeable::id(),
+            &program_elf,
+            &feature_set,
+            &compute_budget,
+        );
+
+        let mut sysvar_cache = SysvarCache::default();
+        sysvar_cache.fill_missing_entries(|pubkey, callbackback| {
+            if pubkey == &rent::id() {
+                // Add the default Rent sysvar.
+                let rent = Rent::default();
+                let rent_data = bincode::serialize(&rent).unwrap();
+                callbackback(&rent_data);
+            }
+        });
+
+        let context = InstrContext {
+            feature_set,
+            accounts,
+            instruction: instruction.into(),
+            cu_avail: compute_budget.compute_unit_limit,
+        };
+
+        let effects = harness::instr::execute_instr(
+            context,
+            &compute_budget,
+            &mut program_cache,
+            &sysvar_cache,
+        )
+        .unwrap();
+
+        let result = match effects.result {
+            Some(err) => Err(err),
+            None => Ok(()),
+        };
+
         if program.1 {
             assert!(result.is_ok(), "{result:?}");
         } else {

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -254,7 +254,7 @@ fn test_program_sbf_sanity() {
             (
                 program_id,
                 Account {
-                    owner: bpf_loader_upgradeable::id(),
+                    owner: loader_v4::id(),
                     ..Default::default() // <-- Stubbed
                 },
             ),
@@ -269,7 +269,7 @@ fn test_program_sbf_sanity() {
         harness::program_cache::add_program(
             &mut program_cache,
             &program_id,
-            &bpf_loader_upgradeable::id(),
+            &loader_v4::id(),
             &program_elf,
             &feature_set,
             &compute_budget,


### PR DESCRIPTION
#### Problem
We need to refactor the tests in programs/sbf to stop using Bank, etc. in order to free up our dependency graph for the coming SVM repo split.

#### Summary of Changes
Start the refactoring by converting the `test_program_sbf_sanity` tests to use the new `svm-test-harness` lib.