### PR TITLE
Bump solana-accounts crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6877,9 +6877,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e5a5c395c41a30f0e36fa487b8cda3280f0d9e4c7b461c0881fa23564f4c28"
+checksum = "014dcb9293341241dd153b35f89ea906e4170914f4a347a95e7fb07ade47cd6f"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -6891,7 +6891,6 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-instruction-error",
- "solana-logger",
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-sysvar",
@@ -9169,19 +9168,6 @@ dependencies = [
  "strum",
  "tempfile",
  "trees",
-]
-
-[[package]]
-name = "solana-logger"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7421d1092680d72065edbf5c7605856719b021bf5f173656c71febcdd5d003"
-dependencies = [
- "env_logger",
- "lazy_static",
- "libc",
- "log",
- "signal-hook",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -383,7 +383,7 @@ smallvec = { version = "1.15.1", default-features = false, features = ["union"] 
 smpl_jwt = "0.7.1"
 socket2 = "0.6.1"
 soketto = "0.7"
-solana-account = "3.1.0"
+solana-account = "3.2.0"
 solana-account-decoder = { path = "account-decoder", version = "=3.1.0", features = ["agave-unstable-api"] }
 solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=3.1.0", features = ["agave-unstable-api"] }
 solana-account-info = "3.0.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,7 +44,7 @@ reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-solana-account = "=3.1.0"
+solana-account = "=3.2.0"
 solana-account-decoder = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }
 solana-borsh = "=3.0.0"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -5905,9 +5905,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e5a5c395c41a30f0e36fa487b8cda3280f0d9e4c7b461c0881fa23564f4c28"
+checksum = "014dcb9293341241dd153b35f89ea906e4170914f4a347a95e7fb07ade47cd6f"
 dependencies = [
  "bincode",
  "qualifier_attr",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -70,7 +70,7 @@ serde_json = "1.0.145"
 serde_yaml = "0.9.34"
 serial_test = "2.0.0"
 signal-hook = "0.3.18"
-solana-account = "3.1.0"
+solana-account = "3.2.0"
 solana-account-decoder = { path = "../account-decoder", version = "=3.1.0", features = ["agave-unstable-api"] }
 solana-accounts-db = { path = "../accounts-db", version = "=3.1.0", features = ["agave-unstable-api"] }
 solana-bench-tps = { path = "../bench-tps", version = "=3.1.0" }

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -34,7 +34,7 @@ itertools = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-solana-account = "=3.1.0"
+solana-account = "=3.2.0"
 solana-bls-signatures = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5833,9 +5833,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e5a5c395c41a30f0e36fa487b8cda3280f0d9e4c7b461c0881fa23564f4c28"
+checksum = "014dcb9293341241dd153b35f89ea906e4170914f4a347a95e7fb07ade47cd6f"
 dependencies = [
  "bincode",
  "qualifier_attr",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -197,7 +197,7 @@ itertools = { workspace = true }
 log = { workspace = true }
 miow = { workspace = true }
 net2 = { workspace = true }
-solana-account = "3.0.0"
+solana-account = "3.2.0"
 solana-account-decoder = { workspace = true }
 solana-account-info = "3.0.0"
 solana-accounts-db = { workspace = true }


### PR DESCRIPTION
#### Problem

We have deprecated `to_account_shared_data` in https://github.com/anza-xyz/solana-sdk/pull/407 and removed its usage in https://github.com/anza-xyz/agave/pull/8668, but we haven't yet bumped the crate to prevent new call sites in the monorepo.

#### Summary of Changes

Bump the crate to v3.2.0, which brings https://github.com/anza-xyz/solana-sdk/pull/407.

