### PR TITLE
nit: rename `VoteCertificateBuilder` to `CertificateBuilder`

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -7,10 +7,10 @@ use {
             MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES,
         },
         consensus_pool::{
+            certificate_builder::{CertificateBuilder, CertificateError},
             parent_ready_tracker::ParentReadyTracker,
             slot_stake_counters::SlotStakeCounters,
             stats::ConsensusPoolStats,
-            vote_certificate_builder::{CertificateError, VoteCertificateBuilder},
             vote_pool::{DuplicateBlockVotePool, SimpleVotePool, VotePool},
         },
         event::VotorEvent,
@@ -33,10 +33,10 @@ use {
     thiserror::Error,
 };
 
+mod certificate_builder;
 pub mod parent_ready_tracker;
 mod slot_stake_counters;
 mod stats;
-mod vote_certificate_builder;
 mod vote_pool;
 
 pub type PoolId = (Slot, VoteType);
@@ -211,7 +211,7 @@ impl ConsensusPool {
             if accumulated_stake as f64 / (total_stake as f64) < limit {
                 continue;
             }
-            let mut cert_builder = VoteCertificateBuilder::new(cert_type);
+            let mut cert_builder = CertificateBuilder::new(cert_type);
             vote_types.iter().for_each(|vote_type| {
                 if let Some(vote_pool) = self.vote_pools.get(&(slot, *vote_type)) {
                     match vote_pool {

--- a/votor/src/consensus_pool/certificate_builder.rs
+++ b/votor/src/consensus_pool/certificate_builder.rs
@@ -31,7 +31,7 @@ pub enum CertificateError {
 
 /// A builder for creating a `CertificateMessage` by efficiently aggregating BLS signatures.
 #[derive(Clone)]
-pub struct VoteCertificateBuilder {
+pub struct CertificateBuilder {
     cert_type: CertificateType,
     signature: SignatureProjective,
     // For some certificates we need two bitmaps, for example, NotarizeFallback
@@ -46,7 +46,7 @@ pub struct VoteCertificateBuilder {
     input_bitmap_2: BitVec<u8, Lsb0>,
 }
 
-impl VoteCertificateBuilder {
+impl CertificateBuilder {
     pub fn new(cert_type: CertificateType) -> Self {
         Self {
             cert_type,
@@ -139,7 +139,7 @@ mod tests {
     fn test_normal_build() {
         let hash = Hash::new_unique();
         let cert_type = CertificateType::NotarizeFallback(1, hash);
-        let mut builder = VoteCertificateBuilder::new(cert_type);
+        let mut builder = CertificateBuilder::new(cert_type);
         // Test building the certificate from Notarize and NotarizeFallback votes
         // Create Notarize on validator 1, 4, 6
         let vote = Vote::new_notarization_vote(1, hash);
@@ -197,7 +197,7 @@ mod tests {
         }
 
         // Build a new certificate with only Notarize votes, we should get Base2 encoding
-        let mut builder = VoteCertificateBuilder::new(cert_type);
+        let mut builder = CertificateBuilder::new(cert_type);
         builder
             .aggregate(&messages_1)
             .expect("Failed to aggregate notarization votes");
@@ -216,7 +216,7 @@ mod tests {
 
         // Base2 encoding only applies when the first bitmap is non-empty, if we build another
         // certificate with only NotarizeFallback votes, we should still get Base3 encoding
-        let mut builder = VoteCertificateBuilder::new(cert_type);
+        let mut builder = CertificateBuilder::new(cert_type);
         builder
             .aggregate(&messages_2)
             .expect("Failed to aggregate notarization fallback votes");
@@ -239,7 +239,7 @@ mod tests {
     fn test_builder_with_errors() {
         let hash = Hash::new_unique();
         let cert_type = CertificateType::NotarizeFallback(1, hash);
-        let mut builder = VoteCertificateBuilder::new(cert_type);
+        let mut builder = CertificateBuilder::new(cert_type);
 
         // Test with a rank that exceeds the maximum allowed
         let vote = Vote::new_notarization_vote(1, hash);
@@ -278,7 +278,7 @@ mod tests {
             signature: signature.into(),
             rank: 1,
         }];
-        let mut builder = VoteCertificateBuilder::new(cert_type);
+        let mut builder = CertificateBuilder::new(cert_type);
         builder
             .aggregate(&messages_1)
             .expect("Failed to aggregate notarization votes");
@@ -325,7 +325,7 @@ mod tests {
 
         // 2. Generation: Aggregate votes and build the certificate. This will
         // use base2 encoding because it only contains one type of vote.
-        let mut builder = VoteCertificateBuilder::new(cert_type);
+        let mut builder = CertificateBuilder::new(cert_type);
         builder
             .aggregate(&vote_messages)
             .expect("Failed to aggregate votes");
@@ -389,7 +389,7 @@ mod tests {
 
         // 2. Generation: Aggregate votes. Because there are two vote types, this will use
         //    base3 encoding.
-        let mut builder = VoteCertificateBuilder::new(cert_type);
+        let mut builder = CertificateBuilder::new(cert_type);
         builder
             .aggregate(&all_vote_messages)
             .expect("Failed to aggregate votes");


### PR DESCRIPTION
#### Problem

The `Vote` prefix in the struct name feels superfluous as there are just `Certificate`s.


#### Summary of Changes

- renames the struct to remove the `Vote` prefix
- This PR is split out from https://github.com/anza-xyz/agave/pull/8700 to make reviewing easier.