### PR TITLE
streamer: track max open connections for metrics 

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -512,10 +512,16 @@ pub(crate) fn update_open_connections_stat(
         stats
             .open_staked_connections
             .store(connection_table.table_size(), Ordering::Relaxed);
+        stats
+            .peak_open_staked_connections
+            .fetch_max(connection_table.table_size(), Ordering::Relaxed);
     } else {
         stats
             .open_unstaked_connections
             .store(connection_table.table_size(), Ordering::Relaxed);
+        stats
+            .peak_open_unstaked_connections
+            .fetch_max(connection_table.table_size(), Ordering::Relaxed);
     }
 }
 

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -221,6 +221,8 @@ pub struct StreamerStats {
     pub(crate) open_connections: AtomicUsize,
     pub(crate) open_staked_connections: AtomicUsize,
     pub(crate) open_unstaked_connections: AtomicUsize,
+    pub(crate) peak_open_staked_connections: AtomicUsize,
+    pub(crate) peak_open_unstaked_connections: AtomicUsize,
     pub(crate) refused_connections_too_many_open_connections: AtomicUsize,
     pub(crate) outstanding_incoming_connection_attempts: AtomicUsize,
     pub(crate) total_incoming_connection_attempts: AtomicUsize,
@@ -583,13 +585,19 @@ impl StreamerStats {
                 i64
             ),
             (
-                "open_staked_connections",
-                self.open_staked_connections.load(Ordering::Relaxed),
+                "peak_open_staked_connections",
+                self.peak_open_staked_connections.swap(
+                    self.open_staked_connections.load(Ordering::Relaxed),
+                    Ordering::Relaxed
+                ),
                 i64
             ),
             (
-                "open_unstaked_connections",
-                self.open_unstaked_connections.load(Ordering::Relaxed),
+                "peak_open_unstaked_connections",
+                self.peak_open_unstaked_connections.swap(
+                    self.open_unstaked_connections.load(Ordering::Relaxed),
+                    Ordering::Relaxed
+                ),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem

- Streamer tracks current open connections in stats, so we observe how many are open at the moment of sampling
- Sampling happens every 2 seconds, so many connections are likely to have been closed, making the metric misleading

#### Summary of Changes

- Switch to fetch_max, thus keeping track of peak connection count in the sampling interval
- Rename metrics to avoid confusion