### PR TITLE
refactor: use `ClusterInfo` instead of storing and updating pubkey

### DIFF
--- a/votor/src/consensus_pool/parent_ready_tracker.rs
+++ b/votor/src/consensus_pool/parent_ready_tracker.rs
@@ -16,8 +16,8 @@ use {
     crate::{common::MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE, event::VotorEvent},
     agave_votor_messages::consensus_message::Block,
     solana_clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
-    solana_pubkey::Pubkey,
-    std::collections::HashMap,
+    solana_gossip::cluster_info::ClusterInfo,
+    std::{collections::HashMap, sync::Arc},
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -27,10 +27,8 @@ pub enum BlockProductionParent {
     Parent(Block),
 }
 
-#[derive(Clone, Debug, Default)]
 pub struct ParentReadyTracker {
-    /// Our pubkey for logging
-    my_pubkey: Pubkey,
+    cluster_info: Arc<ClusterInfo>,
 
     /// Parent ready status for each slot
     slot_statuses: HashMap<Slot, ParentReadyStatus>,
@@ -58,7 +56,7 @@ struct ParentReadyStatus {
 
 impl ParentReadyTracker {
     /// Creates a new tracker with the root bank as implicitely notarized fallback
-    pub fn new(my_pubkey: Pubkey, root_block @ (root_slot, _): Block) -> Self {
+    pub fn new(cluster_info: Arc<ClusterInfo>, root_block @ (root_slot, _): Block) -> Self {
         let mut slot_statuses = HashMap::new();
         slot_statuses.insert(
             root_slot,
@@ -77,7 +75,7 @@ impl ParentReadyTracker {
             },
         );
         Self {
-            my_pubkey,
+            cluster_info,
             slot_statuses,
             root: root_slot,
             highest_with_parent_ready: root_slot.saturating_add(1),
@@ -100,7 +98,7 @@ impl ParentReadyTracker {
         }
         trace!(
             "{}: Adding new notar fallback for {block:?}",
-            self.my_pubkey
+            self.cluster_info.id()
         );
         status.notar_fallbacks.push(block);
         assert!(status.notar_fallbacks.len() <= MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE);
@@ -109,7 +107,7 @@ impl ParentReadyTracker {
         for s in slot.saturating_add(1).. {
             trace!(
                 "{}: Adding new parent ready for {s} parent {block:?}",
-                self.my_pubkey
+                self.cluster_info.id()
             );
             let status = self.slot_statuses.entry(s).or_default();
             if !status.parents_ready.contains(&block) {
@@ -138,7 +136,7 @@ impl ParentReadyTracker {
             return;
         }
 
-        trace!("{}: Adding new skip for {slot:?}", self.my_pubkey);
+        trace!("{}: Adding new skip for {slot:?}", self.cluster_info.id());
         let status = self.slot_statuses.entry(slot).or_default();
         status.skip = true;
 
@@ -177,7 +175,7 @@ impl ParentReadyTracker {
         for s in future_slots {
             trace!(
                 "{}: Adding new parent ready for {s} parents {potential_parents:?}",
-                self.my_pubkey,
+                self.cluster_info.id(),
             );
             let status = self.slot_statuses.entry(s).or_default();
             for &block in &potential_parents {
@@ -232,29 +230,30 @@ impl ParentReadyTracker {
         self.root = root;
         self.slot_statuses.retain(|&s, _| s >= root);
     }
-
-    /// Updates the pubkey. Note that the pubkey is used for logging purposes only.
-    pub fn update_pubkey(&mut self, new_pubkey: Pubkey) {
-        self.my_pubkey = new_pubkey;
-    }
-
-    #[cfg(test)]
-    pub(crate) fn my_pubkey(&self) -> Pubkey {
-        self.my_pubkey
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use {
         super::*, itertools::Itertools, solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
-        solana_hash::Hash, solana_pubkey::Pubkey,
+        solana_gossip::contact_info::ContactInfo, solana_hash::Hash, solana_keypair::Keypair,
+        solana_signer::Signer, solana_streamer::socket::SocketAddrSpace,
     };
+
+    fn new_cluster_info() -> Arc<ClusterInfo> {
+        let keypair = Keypair::new();
+        let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
+        Arc::new(ClusterInfo::new(
+            contact_info,
+            Arc::new(keypair),
+            SocketAddrSpace::Unspecified,
+        ))
+    }
 
     #[test]
     fn basic() {
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), genesis);
         let mut events = vec![];
 
         for i in 1..2 * NUM_CONSECUTIVE_LEADER_SLOTS {
@@ -268,7 +267,7 @@ mod tests {
     #[test]
     fn skips() {
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), genesis);
         let mut events = vec![];
         let block = (1, Hash::new_unique());
 
@@ -285,7 +284,7 @@ mod tests {
     #[test]
     fn out_of_order() {
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), genesis);
         let mut events = vec![];
         let block = (1, Hash::new_unique());
 
@@ -305,7 +304,7 @@ mod tests {
     fn snapshot_wfsm() {
         let root_slot = 2147;
         let root_block = (root_slot, Hash::new_unique());
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), root_block);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), root_block);
         let mut events = vec![];
 
         assert!(tracker.parent_ready(root_slot + 1, root_block));
@@ -332,7 +331,7 @@ mod tests {
     #[test]
     fn highest_parent_ready_out_of_order() {
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), genesis);
         let mut events = vec![];
         assert_eq!(tracker.highest_parent_ready(), 1);
 
@@ -354,7 +353,7 @@ mod tests {
     #[test]
     fn missed_window() {
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), genesis);
         let mut events = vec![];
         assert_eq!(tracker.highest_parent_ready(), 1);
         assert_eq!(
@@ -384,7 +383,7 @@ mod tests {
     #[test]
     fn pick_more_skips() {
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), genesis);
         let mut events = vec![];
 
         for i in 1..=10 {

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -183,7 +183,8 @@ impl ConsensusPoolService {
         let mut events = vec![];
         let mut my_pubkey = ctx.cluster_info.id();
         let root_bank = ctx.sharable_banks.root();
-        let mut consensus_pool = ConsensusPool::new_from_root_bank(my_pubkey, &root_bank);
+        let mut consensus_pool =
+            ConsensusPool::new_from_root_bank(ctx.cluster_info.clone(), &root_bank);
 
         // Wait until migration has completed
         info!("{my_pubkey}: Consensus pool loop initialized, waiting for Alpenglow migration");
@@ -209,7 +210,6 @@ impl ConsensusPoolService {
             let new_pubkey = ctx.cluster_info.id();
             if my_pubkey != new_pubkey {
                 my_pubkey = new_pubkey;
-                consensus_pool.update_pubkey(my_pubkey);
                 info!("Consensus pool pubkey updated to {my_pubkey}");
             }
 
@@ -388,10 +388,9 @@ impl ConsensusPoolService {
             }
             BlockProductionParent::ParentNotReady => {
                 // This can't happen, place holder depending on how we hook up optimistic
-                return Err(ConsensusPoolServiceError::FailedToAddBlockEvent(format!(
-                    "Must have a block production parent: {:#?}",
-                    consensus_pool.parent_ready_tracker
-                )));
+                return Err(ConsensusPoolServiceError::FailedToAddBlockEvent(
+                    "Must have a block production parent".to_string(),
+                ));
             }
             BlockProductionParent::Parent(parent_block) => {
                 events.push(VotorEvent::ProduceWindow(LeaderWindowInfo {


### PR DESCRIPTION
#### Problem

`ConsensusPool` and `ParentReadyTracker` are storing the node's pubkey for logging purposes.  This also requires code to update the pubkey when they change.  We already have a handy struct `ClusterInfo` that can be used to get the current pubkey.

#### Summary of Changes

Updates `ConsensusPool` and `ParentReadyTracker` to use `ClusterInfo` instead.  This allows us to simplify some related code as well.