### PR TITLE
TPU: switch to QUIC votes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Release channels have their own copy of this changelog:
 * Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.
 #### Changes
 * `agave-validator exit` now saves bank state before exiting. This enables restarts from local state when snapshot generation is disabled.
+* Votes will be sent over QUIC by default. The old behavior is available via `--vote_use_quic false`.
 ### CLI
 #### Changes
 * Support Trezor hardware wallets using `usb://trezor`
@@ -68,6 +69,7 @@ without warning. From v4.0.0 onward, symbols in these crates will be unavailable
 
 #### Changes
 * The accounts index is now kept entirely in memory by default.
+* The votes are now transported over QUIC and not UDP. The old mode can be manually enabled with `--vote-use-quic false`.
 
 ## 3.0.0
 

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -25,7 +25,7 @@ use {
     solana_transaction_error::TransactionError, tokio::time::Duration,
 };
 
-pub const DEFAULT_VOTE_USE_QUIC: bool = false;
+pub const DEFAULT_VOTE_USE_QUIC: bool = true;
 
 /// The default connection count is set to 1 -- it should
 /// be sufficient for most use cases. Validators can use

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -156,6 +156,15 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .help(TransactionStructure::cli_message()),
         usage_warning: "Transaction structure is no longer configurable"
     );
+    add_arg!(
+        // deprecated in v4.0.0
+        Arg::with_name("vote_use_quic")
+            .long("vote-use-quic")
+            .takes_value(true)
+            .hidden(hidden_unless_forced())
+            .help("Controls if to use QUIC to send votes."),
+        usage_warning: "QUIC is used by default, submission of votes via UDP is deprecated."
+    );
     res
 }
 

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -722,14 +722,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Controls the rate of the clients connections per IpAddr per minute."),
     )
     .arg(
-        Arg::with_name("vote_use_quic")
-            .long("vote-use-quic")
-            .takes_value(true)
-            .default_value(&default_args.vote_use_quic)
-            .hidden(hidden_unless_forced())
-            .help("Controls if to use QUIC to send votes."),
-    )
-    .arg(
         Arg::with_name("tpu_max_connections_per_peer")
             .long("tpu-max-connections-per-peer")
             .takes_value(true)

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -63,6 +63,7 @@ use {
         nonblocking::{simple_qos::SimpleQosConfig, swqos::SwQosConfig},
         quic::{QuicStreamerConfig, SimpleQosQuicStreamerConfig, SwQosQuicStreamerConfig},
     },
+    solana_tpu_client::tpu_client::DEFAULT_VOTE_USE_QUIC,
     solana_turbine::{
         broadcast_stage::BroadcastStageType,
         xdp::{set_cpu_affinity, XdpConfig},
@@ -259,7 +260,14 @@ pub fn execute(
     let restricted_repair_only_mode = matches.is_present("restricted_repair_only_mode");
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
-    let vote_use_quic = value_t_or_exit!(matches, "vote_use_quic", bool);
+
+    let vote_use_quic = match matches.value_of("vote_use_quic") {
+        Some(v) => v.parse().expect("Invalid value in vote-use-quic"),
+        None => DEFAULT_VOTE_USE_QUIC,
+    };
+    if !vote_use_quic {
+        warn!("Submission of votes via UDP is deprecated.");
+    };
 
     let tpu_connection_pool_size = value_t_or_exit!(matches, "tpu_connection_pool_size", usize);
 


### PR DESCRIPTION
#### Problem

- Votes should not be sent via UDP: if a vote packet is lost, there is no way for the sender to know about it to retransmit.
- today we abuse gossip to eventually deliver the votes if they are lost, but it is both slow and inefficiemt.
- Streamer now has a simple QoS mode for vote transactions, which offers consistent TPS quotas for all staked nodes, tailored for vote ingestion
- QUIC offers improved security see https://github.com/solana-labs/solana/issues/22726

#### Summary of Changes

- Switch voting to QUIC by default, UDP voting still available if needed.
- Update changelog.