### PR TITLE
Moves accounts_index_storage::Startup to accounts_index

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -45,9 +45,8 @@ use {
         accounts_index::{
             in_mem_accounts_index::StartupStats, AccountSecondaryIndexes, AccountsIndex,
             AccountsIndexRootsStats, AccountsIndexScanResult, IndexKey, IsCached, ReclaimsSlotList,
-            RefCount, ScanConfig, ScanFilter, ScanResult, SlotList, UpsertReclaim,
+            RefCount, ScanConfig, ScanFilter, ScanResult, SlotList, Startup, UpsertReclaim,
         },
-        accounts_index_storage::Startup,
         accounts_update_notifier_interface::{AccountForGeyser, AccountsUpdateNotifier},
         active_stats::{ActiveStatItem, ActiveStats},
         ancestors::Ancestors,

--- a/accounts-db/src/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index_storage.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         accounts_index::{
             self, in_mem_accounts_index::InMemAccountsIndex, AccountsIndexConfig, DiskIndexValue,
-            IndexValue,
+            IndexValue, Startup,
         },
         bucket_map_holder::BucketMapHolder,
         waitable_condvar::WaitableCondvar,
@@ -106,27 +106,12 @@ impl BgThreads {
     }
 }
 
-/// modes the system can be in
-#[derive(Debug, Eq, PartialEq)]
-pub enum Startup {
-    /// not startup, but steady state execution
-    Normal,
-    /// startup (not steady state execution)
-    /// requesting 'startup'-like behavior where in-mem acct idx items are flushed asap
-    Startup,
-    /// startup (not steady state execution)
-    /// but also requesting additional threads to be running to flush the acct idx to disk asap
-    /// The idea is that the best perf to ssds will be with multiple threads,
-    ///  but during steady state, we can't allocate as many threads because we'd starve the rest of the system.
-    StartupWithExtraThreads,
-}
-
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexStorage<T, U> {
     /// startup=true causes:
     ///      in mem to act in a way that flushes to disk asap
     ///      also creates some additional bg threads to facilitate flushing to disk asap
     /// startup=false is 'normal' operation
-    pub fn set_startup(&self, startup: Startup) {
+    pub(crate) fn set_startup(&self, startup: Startup) {
         if startup == Startup::StartupWithExtraThreads && self.storage.is_disk_index_enabled() {
             // create some additional bg threads to help get things to the disk index asap
             *self.startup_worker_threads.lock().unwrap() = Some(BgThreads::new(


### PR DESCRIPTION
#### Problem

The accounts-db crate's code is not well organized. The index is especially guilty. Many files should be under the accounts_index dir.


#### Summary of Changes

For this PR, move `accounts_index_storage::Startup` into `accounts_index.rs`.