### PR TITLE
Moves bucket_map_holder{_stats} under accounts_index

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1,5 +1,7 @@
 mod account_map_entry;
 mod accounts_index_storage;
+mod bucket_map_holder;
+mod bucket_map_holder_stats;
 pub(crate) mod in_mem_accounts_index;
 mod iter;
 mod roots_tracker;
@@ -7,12 +9,13 @@ mod secondary;
 use {
     crate::{
         accounts_index::account_map_entry::SlotListWriteGuard, ancestors::Ancestors,
-        bucket_map_holder::Age, bucket_map_holder_stats::BucketMapHolderStats, contains::Contains,
-        is_zero_lamport::IsZeroLamport, pubkey_bins::PubkeyBinCalculator24,
+        contains::Contains, is_zero_lamport::IsZeroLamport, pubkey_bins::PubkeyBinCalculator24,
         rolling_bit_field::RollingBitField,
     },
     account_map_entry::{AccountMapEntry, PreAllocatedAccountMapEntry},
     accounts_index_storage::AccountsIndexStorage,
+    bucket_map_holder::Age,
+    bucket_map_holder_stats::BucketMapHolderStats,
     in_mem_accounts_index::{
         ExistedLocation, InMemAccountsIndex, InsertNewEntryResults, StartupStats,
     },
@@ -1745,11 +1748,8 @@ pub(crate) enum Startup {
 #[cfg(test)]
 pub mod tests {
     use {
-        super::*,
-        crate::{
-            accounts_index::account_map_entry::AccountMapEntryMeta,
-            bucket_map_holder::BucketMapHolder,
-        },
+        super::{bucket_map_holder::BucketMapHolder, *},
+        crate::accounts_index::account_map_entry::AccountMapEntryMeta,
         solana_account::{AccountSharedData, WritableAccount},
         solana_pubkey::PUBKEY_BYTES,
         spl_generic_token::{spl_token_ids, token::SPL_TOKEN_ACCOUNT_OWNER_OFFSET},

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -1,9 +1,9 @@
 use {
-    super::{AtomicRefCount, DiskIndexValue, IndexValue, RefCount, SlotList},
-    crate::{
+    super::{
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
-        is_zero_lamport::IsZeroLamport,
+        AtomicRefCount, DiskIndexValue, IndexValue, RefCount, SlotList,
     },
+    crate::is_zero_lamport::IsZeroLamport,
     solana_clock::Slot,
     std::{
         fmt::Debug,

--- a/accounts-db/src/accounts_index/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index/accounts_index_storage.rs
@@ -1,10 +1,10 @@
 use {
+    super::bucket_map_holder::BucketMapHolder,
     crate::{
         accounts_index::{
             self, in_mem_accounts_index::InMemAccountsIndex, AccountsIndexConfig, DiskIndexValue,
             IndexValue, Startup,
         },
-        bucket_map_holder::BucketMapHolder,
         waitable_condvar::WaitableCondvar,
     },
     std::{

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -1,10 +1,10 @@
 use {
+    super::bucket_map_holder_stats::BucketMapHolderStats,
     crate::{
         accounts_index::{
             in_mem_accounts_index::{InMemAccountsIndex, StartupStats},
             AccountsIndexConfig, DiskIndexValue, IndexLimitMb, IndexValue,
         },
-        bucket_map_holder_stats::BucketMapHolderStats,
         waitable_condvar::WaitableCondvar,
     },
     solana_bucket_map::bucket_map::{BucketMap, BucketMapConfig},

--- a/accounts-db/src/accounts_index/bucket_map_holder_stats.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder_stats.rs
@@ -1,7 +1,7 @@
 use {
-    crate::{
-        accounts_index::{in_mem_accounts_index::InMemAccountsIndex, DiskIndexValue, IndexValue},
-        bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
+    super::bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
+    crate::accounts_index::{
+        in_mem_accounts_index::InMemAccountsIndex, DiskIndexValue, IndexValue,
     },
     solana_clock::Slot,
     solana_time_utils::AtomicInterval,

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1,4 +1,8 @@
 use {
+    super::{
+        bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
+        bucket_map_holder_stats::BucketMapHolderStats,
+    },
     crate::{
         accounts_index::{
             account_map_entry::{
@@ -7,8 +11,6 @@ use {
             },
             DiskIndexValue, IndexValue, ReclaimsSlotList, RefCount, SlotList, UpsertReclaim,
         },
-        bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
-        bucket_map_holder_stats::BucketMapHolderStats,
         pubkey_bins::PubkeyBinCalculator24,
     },
     rand::{thread_rng, Rng},

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -29,8 +29,6 @@ pub mod append_vec;
 #[cfg(not(feature = "dev-context-only-utils"))]
 mod append_vec;
 pub mod blockhash_queue;
-mod bucket_map_holder;
-mod bucket_map_holder_stats;
 pub mod contains;
 pub mod is_loadable;
 mod is_zero_lamport;


### PR DESCRIPTION
#### Problem

The accounts-db crate's code is not well organized. The index is especially guilty. Many files should be under the accounts_index dir.


#### Summary of Changes

For this PR, move `bucket_map_holder` and `bucket_map_holder_stats` under `accounts_index`.