### PR TITLE
Renames BucketMapHolderStats

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6608,7 +6608,7 @@ impl AccountsDb {
 
         {
             // Update the index stats now.
-            let index_stats = self.accounts_index.bucket_map_holder_stats();
+            let index_stats = self.accounts_index.stats();
 
             // stats for inserted entries that previously did *not* exist
             index_stats.inc_insert_count(total_accum.num_did_not_exist);
@@ -6838,7 +6838,7 @@ impl AccountsDb {
             .map(|bin| bin.capacity_for_startup())
             .sum();
         self.accounts_index
-            .bucket_map_holder_stats()
+            .stats()
             .capacity_in_mem
             .store(index_capacity, Ordering::Relaxed);
 

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1,11 +1,11 @@
 mod account_map_entry;
 mod accounts_index_storage;
 mod bucket_map_holder;
-mod bucket_map_holder_stats;
 pub(crate) mod in_mem_accounts_index;
 mod iter;
 mod roots_tracker;
 mod secondary;
+mod stats;
 use {
     crate::{
         accounts_index::account_map_entry::SlotListWriteGuard, ancestors::Ancestors,
@@ -15,7 +15,6 @@ use {
     account_map_entry::{AccountMapEntry, PreAllocatedAccountMapEntry},
     accounts_index_storage::AccountsIndexStorage,
     bucket_map_holder::Age,
-    bucket_map_holder_stats::BucketMapHolderStats,
     in_mem_accounts_index::{
         ExistedLocation, InMemAccountsIndex, InsertNewEntryResults, StartupStats,
     },
@@ -30,6 +29,7 @@ use {
     solana_clock::{BankId, Slot},
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
+    stats::Stats,
     std::{
         collections::{btree_map::BTreeMap, HashSet},
         fmt::Debug,
@@ -1003,7 +1003,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         rv.map(|index| slot_list.len() - 1 - index)
     }
 
-    pub(crate) fn bucket_map_holder_stats(&self) -> &BucketMapHolderStats {
+    pub(crate) fn stats(&self) -> &Stats {
         &self.storage.storage.stats
     }
 

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -1,5 +1,5 @@
 use {
-    super::bucket_map_holder_stats::BucketMapHolderStats,
+    super::stats::Stats,
     crate::{
         accounts_index::{
             in_mem_accounts_index::{InMemAccountsIndex, StartupStats},
@@ -47,7 +47,7 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     /// these items are expected to be flushed from the accounts write cache or otherwise modified before this age occurs
     pub future_age_to_flush_cached: AtomicAge,
 
-    pub stats: BucketMapHolderStats,
+    pub stats: Stats,
 
     age_timer: AtomicInterval,
 
@@ -224,7 +224,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             future_age_to_flush: AtomicAge::new(ages_to_stay_in_cache),
             // effectively age (0) - 1. So, the oldest possible age from 'now'
             future_age_to_flush_cached: AtomicAge::new(Age::MAX),
-            stats: BucketMapHolderStats::new(bins),
+            stats: Stats::new(bins),
             wait_dirty_or_aged: Arc::default(),
             next_bucket_to_flush: AtomicUsize::new(0),
             age_timer: AtomicInterval::default(),

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1,7 +1,7 @@
 use {
     super::{
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
-        bucket_map_holder_stats::BucketMapHolderStats,
+        stats::Stats,
     },
     crate::{
         accounts_index::{
@@ -1238,7 +1238,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 .collect();
 
             flush_stats.flush_update_us = flush_update_measure.end_as_us();
-            flush_stats.update_to_bucket_map_stats(self.stats());
+            flush_stats.update_to_stats(self.stats());
 
             let m = Measure::start("flush_evict");
             self.evict_from_cache(evictions_age, current_age, startup, ages_flushing_now);
@@ -1306,7 +1306,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         Self::update_stat(&stats.failed_to_evict, failed as u64);
     }
 
-    pub fn stats(&self) -> &BucketMapHolderStats {
+    pub fn stats(&self) -> &Stats {
         &self.storage.stats
     }
 
@@ -1350,7 +1350,7 @@ impl DiskFlushStats {
         Self::default()
     }
 
-    fn update_to_bucket_map_stats(&self, stats: &BucketMapHolderStats) {
+    fn update_to_stats(&self, stats: &Stats) {
         Self::update_stat(&stats.flush_update_us, self.flush_update_us);
         Self::update_stat(&stats.flush_should_evict_us, self.flush_should_evict_us);
         Self::update_stat(

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -15,15 +15,15 @@ use {
 const STATS_INTERVAL_MS: u64 = 10_000;
 
 #[derive(Debug, Default)]
-pub struct BucketMapHeldInMemStats {
+pub struct HeldInMemStats {
     pub ref_count: AtomicU64,
     pub slot_list_len: AtomicU64,
     pub slot_list_cached: AtomicU64,
 }
 
 #[derive(Debug, Default)]
-pub struct BucketMapHolderStats {
-    pub held_in_mem: BucketMapHeldInMemStats,
+pub struct Stats {
+    pub held_in_mem: HeldInMemStats,
     pub get_mem_us: AtomicU64,
     pub gets_from_mem: AtomicU64,
     pub get_missing_us: AtomicU64,
@@ -63,11 +63,11 @@ pub struct BucketMapHolderStats {
     pub flush_read_lock_us: AtomicU64,
 }
 
-impl BucketMapHolderStats {
-    pub fn new(bins: usize) -> BucketMapHolderStats {
-        BucketMapHolderStats {
+impl Stats {
+    pub fn new(bins: usize) -> Stats {
+        Stats {
             bins: bins as u64,
-            ..BucketMapHolderStats::default()
+            ..Stats::default()
         }
     }
 


### PR DESCRIPTION
#### Problem

The accounts-db crate's code is not well organized. The index is especially guilty. Many files should be under the accounts_index dir.


#### Summary of Changes

For this PR, rename `BucketMapHolderStats` to `Stats`.