### PR TITLE
feat: accounts-index flush by threshold

### DIFF
--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -63,6 +63,15 @@ pub struct Stats {
     bins: u64,
     pub flush_should_evict_us: AtomicU64,
     pub flush_read_lock_us: AtomicU64,
+    // Max flush stats for 10s reporting interval
+    pub flush_max_total_entries_before: AtomicU64,
+    pub flush_max_num_flushed: AtomicU64,
+    pub flush_max_map_len_before: AtomicU64,
+    pub flush_max_map_capacity_before: AtomicU64,
+    pub flush_max_map_len_after: AtomicU64,
+    pub flush_max_map_capacity_after: AtomicU64,
+    pub flush_max_evicted: AtomicU64,
+    pub flush_max_total_entries_after: AtomicU64,
 }
 
 impl Stats {
@@ -150,6 +159,36 @@ impl Stats {
     pub fn remaining_until_next_interval(&self) -> u64 {
         self.last_time
             .remaining_until_next_interval(STATS_INTERVAL_MS)
+    }
+
+    /// Update flush stats with max values
+    pub fn update_flush_stats_max(
+        &self,
+        total_entries_before: usize,
+        num_flushed: usize,
+        map_len_before: usize,
+        map_capacity_before: usize,
+        map_len_after: usize,
+        map_capacity_after: usize,
+        evicted: usize,
+        total_entries_after: usize,
+    ) {
+        self.flush_max_total_entries_before
+            .fetch_max(total_entries_before as u64, Ordering::Relaxed);
+        self.flush_max_num_flushed
+            .fetch_max(num_flushed as u64, Ordering::Relaxed);
+        self.flush_max_map_len_before
+            .fetch_max(map_len_before as u64, Ordering::Relaxed);
+        self.flush_max_map_capacity_before
+            .fetch_max(map_capacity_before as u64, Ordering::Relaxed);
+        self.flush_max_map_len_after
+            .fetch_max(map_len_after as u64, Ordering::Relaxed);
+        self.flush_max_map_capacity_after
+            .fetch_max(map_capacity_after as u64, Ordering::Relaxed);
+        self.flush_max_evicted
+            .fetch_max(evicted as u64, Ordering::Relaxed);
+        self.flush_max_total_entries_after
+            .fetch_max(total_entries_after as u64, Ordering::Relaxed);
     }
 
     /// return min, max, sum, median of data
@@ -569,6 +608,49 @@ impl Stats {
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),
+                (
+                    "flush_max_total_entries_before",
+                    self.flush_max_total_entries_before
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_num_flushed",
+                    self.flush_max_num_flushed.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_len_before",
+                    self.flush_max_map_len_before.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_capacity_before",
+                    self.flush_max_map_capacity_before
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_len_after",
+                    self.flush_max_map_len_after.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_capacity_after",
+                    self.flush_max_map_capacity_after.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_evicted",
+                    self.flush_max_evicted.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_total_entries_after",
+                    self.flush_max_total_entries_after
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
             );
         } else {
             datapoint_info!(
@@ -635,6 +717,49 @@ impl Stats {
                 ("inserts", self.inserts.swap(0, Ordering::Relaxed), i64),
                 ("deletes", self.deletes.swap(0, Ordering::Relaxed), i64),
                 ("keys", self.keys.swap(0, Ordering::Relaxed), i64),
+                (
+                    "flush_max_total_entries_before",
+                    self.flush_max_total_entries_before
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_num_flushed",
+                    self.flush_max_num_flushed.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_len_before",
+                    self.flush_max_map_len_before.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_capacity_before",
+                    self.flush_max_map_capacity_before
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_len_after",
+                    self.flush_max_map_len_after.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_capacity_after",
+                    self.flush_max_map_capacity_after.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_evicted",
+                    self.flush_max_evicted.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_total_entries_after",
+                    self.flush_max_total_entries_after
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
             );
         }
     }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1116,6 +1116,20 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
+        Arg::with_name("accounts_index_limit_bytes")
+            .long("accounts-index-limit-bytes")
+            .value_name("BYTES")
+            .takes_value(true)
+            .requires("enable_accounts_disk_index")
+            .help("Flush accounts index to disk when memory usage exceeds this limit in bytes")
+            .long_help(
+                "Sets a memory size threshold for the in-memory accounts index. When the memory \
+                 usage of the index exceeds this limit (in bytes), it will flush to disk. This \
+                 provides a middle ground between pure in-memory (default) and always-on-disk \
+                 (--enable-accounts-disk-index) modes. Requires --enable-accounts-disk-index.",
+            ),
+    )
+    .arg(
         Arg::with_name("accounts_shrink_optimize_total_space")
             .long("accounts-shrink-optimize-total-space")
             .takes_value(true)

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -317,10 +317,14 @@ pub fn execute(
         accounts_index_config.num_initial_accounts = Some(num_initial_accounts);
     }
 
-    accounts_index_config.index_limit = if !matches.is_present("enable_accounts_disk_index") {
-        IndexLimit::InMemOnly
+    accounts_index_config.index_limit = if matches.is_present("enable_accounts_disk_index") {
+        if let Ok(limit_bytes) = value_t!(matches, "accounts_index_limit_bytes", u64) {
+            IndexLimit::Threshold(limit_bytes)
+        } else {
+            IndexLimit::Minimal
+        }
     } else {
-        IndexLimit::Minimal
+        IndexLimit::InMemOnly
     };
 
     {


### PR DESCRIPTION
#### Problem

Support accounts-index flush by threshold.


#### Summary of Changes

 - New IndexLimit::Threshold mode: Introduces configurable high/low water marks (75%/50%) for flushing entries to disk when memory pressure exceeds thresholds
  - Memory-based and entry-based limits: Supports both ThresholdLimit::Entries(n) and ThresholdLimit::MemoryMB(mb) configurations
  - Per-bin flush control: Each bin independently decides when to flush based on its entry count relative to the configured threshold
  - Enhanced flush stats: Adds detailed metrics tracking map size before/after flush, capacity, shrink operations, and eviction counts
  - CLI configuration: Adds --accounts-index-memory-limit-mb flag to validator and ledger-tool for easy threshold configuration



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
