### PR TITLE
Only pre-allocate in-memory accounts index when disk index is disabled

### DIFF
--- a/accounts-db/src/accounts_index/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index/accounts_index_storage.rs
@@ -1,7 +1,7 @@
 use {
     super::{
         bucket_map_holder::BucketMapHolder, in_mem_accounts_index::InMemAccountsIndex,
-        AccountsIndexConfig, DiskIndexValue, IndexValue, Startup,
+        AccountsIndexConfig, DiskIndexValue, IndexLimitMb, IndexValue, Startup,
     },
     crate::{accounts_index, waitable_condvar::WaitableCondvar},
     std::{
@@ -151,7 +151,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexStorage<
 
         let storage = Arc::new(BucketMapHolder::new(bins, config, num_flush_threads.get()));
 
-        let num_initial_accounts = config.num_initial_accounts;
+        let num_initial_accounts = match config.index_limit_mb {
+            IndexLimitMb::InMemOnly => config.num_initial_accounts,
+            _ => None,
+        };
         let in_mem: Box<_> = (0..bins)
             .map(|bin| Arc::new(InMemAccountsIndex::new(&storage, bin, num_initial_accounts)))
             .collect();
@@ -163,5 +166,72 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexStorage<
             startup_worker_threads: Mutex::default(),
             exit,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::accounts_index::BINS_FOR_TESTING};
+
+    /// Test when index_limit_mb is InMemOnly, num_initial_accounts should be passed through
+    #[test]
+    fn test_num_initial_accounts_in_mem_only() {
+        let config = AccountsIndexConfig {
+            index_limit_mb: IndexLimitMb::InMemOnly,
+            num_initial_accounts: Some(1000),
+            ..AccountsIndexConfig::default()
+        };
+
+        let exit = Arc::new(AtomicBool::default());
+        let storage = AccountsIndexStorage::<u64, u64>::new(BINS_FOR_TESTING, &config, exit);
+
+        // Verify that the in-memory map was created with capacity
+        let map_capacity = storage.in_mem[0].map_internal_capacity();
+        assert!(
+            map_capacity > 0,
+            "Expected non-zero capacity with InMemOnly and num_initial_accounts set, got {}",
+            map_capacity
+        );
+    }
+
+    /// Test when index_limit_mb is not InMemOnly (e.g., Minimal), num_initial_accounts should be None
+    #[test]
+    fn test_num_initial_accounts_minimal() {
+        let config = AccountsIndexConfig {
+            index_limit_mb: IndexLimitMb::Minimal,
+            num_initial_accounts: Some(1000),
+            ..AccountsIndexConfig::default()
+        };
+
+        let exit = Arc::new(AtomicBool::default());
+        let storage = AccountsIndexStorage::<u64, u64>::new(BINS_FOR_TESTING, &config, exit);
+
+        // Verify that the in-memory map was created without preallocation
+        let map_capacity = storage.in_mem[0].map_internal_capacity();
+        assert_eq!(
+            map_capacity, 0,
+            "Expected zero capacity with Minimal index_limit_mb even with num_initial_accounts set, got {}",
+            map_capacity
+        );
+    }
+
+    /// Test when num_initial_accounts is None, even with InMemOnly, capacity should be 0
+    #[test]
+    fn test_num_initial_accounts_none_in_mem_only() {
+        let config = AccountsIndexConfig {
+            index_limit_mb: IndexLimitMb::InMemOnly,
+            num_initial_accounts: None,
+            ..AccountsIndexConfig::default()
+        };
+
+        let exit = Arc::new(AtomicBool::default());
+        let storage = AccountsIndexStorage::<u64, u64>::new(BINS_FOR_TESTING, &config, exit);
+
+        let map_capacity = storage.in_mem[0].map_internal_capacity();
+        assert_eq!(
+            map_capacity, 0,
+            "Expected zero capacity with None num_initial_accounts, got {}",
+            map_capacity
+        );
     }
 }

--- a/accounts-db/src/accounts_index/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index/accounts_index_storage.rs
@@ -185,12 +185,10 @@ mod tests {
         let exit = Arc::new(AtomicBool::default());
         let storage = AccountsIndexStorage::<u64, u64>::new(BINS_FOR_TESTING, &config, exit);
 
-        // Verify that the in-memory map was created with capacity
         let map_capacity = storage.in_mem[0].map_internal_capacity();
         assert!(
             map_capacity > 0,
-            "Expected non-zero capacity with InMemOnly and num_initial_accounts set, got {}",
-            map_capacity
+            "Expected non-zero capacity with InMemOnly and num_initial_accounts set, got {map_capacity}"
         );
     }
 
@@ -206,12 +204,10 @@ mod tests {
         let exit = Arc::new(AtomicBool::default());
         let storage = AccountsIndexStorage::<u64, u64>::new(BINS_FOR_TESTING, &config, exit);
 
-        // Verify that the in-memory map was created without preallocation
         let map_capacity = storage.in_mem[0].map_internal_capacity();
         assert_eq!(
             map_capacity, 0,
-            "Expected zero capacity with Minimal index_limit_mb even with num_initial_accounts set, got {}",
-            map_capacity
+            "Expected zero capacity with Minimal index_limit_mb even with num_initial_accounts set, got {map_capacity}"
         );
     }
 
@@ -230,8 +226,7 @@ mod tests {
         let map_capacity = storage.in_mem[0].map_internal_capacity();
         assert_eq!(
             map_capacity, 0,
-            "Expected zero capacity with None num_initial_accounts, got {}",
-            map_capacity
+            "Expected zero capacity with None num_initial_accounts, got {map_capacity}"
         );
     }
 }

--- a/accounts-db/src/accounts_index/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index/accounts_index_storage.rs
@@ -188,7 +188,8 @@ mod tests {
         let map_capacity = storage.in_mem[0].map_internal_capacity();
         assert!(
             map_capacity > 0,
-            "Expected non-zero capacity with InMemOnly and num_initial_accounts set, got {map_capacity}"
+            "Expected non-zero capacity with InMemOnly and num_initial_accounts set, got \
+             {map_capacity}"
         );
     }
 
@@ -207,7 +208,8 @@ mod tests {
         let map_capacity = storage.in_mem[0].map_internal_capacity();
         assert_eq!(
             map_capacity, 0,
-            "Expected zero capacity with Minimal index_limit_mb even with num_initial_accounts set, got {map_capacity}"
+            "Expected zero capacity with Minimal index_limit_mb even with num_initial_accounts \
+             set, got {map_capacity}"
         );
     }
 

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -241,6 +241,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn map_internal_capacity(&self) -> usize {
+        self.map_internal.read().unwrap().capacity()
+    }
+
     /// return all keys in this bin
     pub fn keys(&self) -> Vec<Pubkey> {
         Self::update_stat(&self.stats().keys, 1);

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -55,6 +55,7 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .help("Number of bins to divide the accounts index into"),
         Arg::with_name("accounts_index_initial_accounts_count")
             .long("accounts-index-initial-accounts-count")
+            .conflicts_with("enable_accounts_disk_index")
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1179,6 +1179,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
     .arg(
         Arg::with_name("accounts_index_initial_accounts_count")
             .long("accounts-index-initial-accounts-count")
+            .conflicts_with("enable_accounts_disk_index")
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)


### PR DESCRIPTION
#### Problem

We don't want to preallocate in-memory index when disk index is enabled.  Preallocate in-memory index should only be used for in-memory only index. 

#### Summary of Changes

- Modified `AccountsIndexStorage::new()` to conditionally set `num_initial_accounts` based on `index_limit_mb` mode. Preallocation now only occurs when `IndexLimitMb::InMemOnly` is configured.

- Added `conflicts_with` constraint to prevent `--accounts-index-initial-accounts-count` from being used with `--enable-accounts-disk-index`, making the incompatibility explicit at the CLI level.

- Added tests to cover: 
  - Preallocation occurs correctly with `InMemOnly` mode
  - Preallocation is skipped with `Minimal` (disk-backed) mode
  - No preallocation when `num_initial_accounts` is `None`
  
- Added `map_internal_capacity()` test helper method for verifying HashMap capacity in tests.

