### PR TITLE
refactor: fix some fragile code in `CertificateBuilder`

### DIFF
--- a/votor/src/consensus_pool/certificate_builder.rs
+++ b/votor/src/consensus_pool/certificate_builder.rs
@@ -22,7 +22,9 @@ pub(super) enum AggregateError {
     #[error("BLS error: {0}")]
     Bls(#[from] BlsError),
     #[error("Validator does not exist for given rank: {0}")]
-    ValidatorDoesNotExist(u16),
+    InvalidRank(u16),
+    #[error("Validator already included")]
+    ValidatorAlreadyIncluded,
 }
 
 /// Different types of errors that can be returned from the [`CertificateBuilder::build()`] function.
@@ -32,8 +34,18 @@ pub enum BuildError {
     Bls(#[from] BlsError),
     #[error("Encoding failed: {0:?}")]
     Encode(EncodeError),
-    #[error("Validator does not exist for given rank: {0}")]
-    ValidatorDoesNotExist(u16),
+}
+
+/// Looks up the bit at `rank` in `bitmap` and sets it to true.
+fn try_set_bitmap(bitmap: &mut BitVec<u8, Lsb0>, rank: u16) -> Result<(), AggregateError> {
+    let mut ptr = bitmap
+        .get_mut(rank as usize)
+        .ok_or(AggregateError::InvalidRank(rank))?;
+    if *ptr {
+        return Err(AggregateError::ValidatorAlreadyIncluded);
+    }
+    *ptr = true;
+    Ok(())
 }
 
 /// A builder for creating a `CertificateMessage` by efficiently aggregating BLS signatures.
@@ -65,23 +77,16 @@ impl CertificateBuilder {
 
     /// Aggregates a slice of `VoteMessage`s into the builder.
     pub fn aggregate(&mut self, messages: &[VoteMessage]) -> Result<(), AggregateError> {
-        if messages.is_empty() {
-            return Ok(());
-        }
-
         let vote_types = certificate_limits_and_vote_types(&self.cert_type).1;
         for vote_message in messages {
-            let rank = vote_message.rank as usize;
-            if MAXIMUM_VALIDATORS <= rank {
-                return Err(AggregateError::ValidatorDoesNotExist(vote_message.rank));
-            }
+            let rank = vote_message.rank;
 
             let current_vote_type = VoteType::get_type(&vote_message.vote);
 
             if current_vote_type == vote_types[0] {
-                self.input_bitmap_1.set(rank, true);
+                try_set_bitmap(&mut self.input_bitmap_1, rank)?;
             } else if vote_types.len() == 2 && current_vote_type == vote_types[1] {
-                self.input_bitmap_2.set(rank, true);
+                try_set_bitmap(&mut self.input_bitmap_2, rank)?;
             }
         }
 
@@ -101,13 +106,8 @@ impl CertificateBuilder {
             .last_one()
             .map_or(0, |i| i.saturating_add(1));
         let new_length = last_one_1.max(last_one_2);
-        if new_length > MAXIMUM_VALIDATORS {
-            error!(
-                "Bitmap length exceeds maximum allowed: {MAXIMUM_VALIDATORS} should be caught \
-                 during aggregation"
-            );
-            return Err(BuildError::ValidatorDoesNotExist(new_length as u16));
-        }
+        // checks in `aggregate()` guarantee that this assertion is valid
+        assert!(new_length <= MAXIMUM_VALIDATORS);
 
         input_bitmap_1.resize(new_length, false);
         input_bitmap_2.resize(new_length, false);
@@ -261,9 +261,7 @@ mod tests {
         };
         assert_eq!(
             builder.aggregate(&[message_out_of_bounds]),
-            Err(AggregateError::ValidatorDoesNotExist(
-                rank_out_of_bounds as u16
-            ))
+            Err(AggregateError::InvalidRank(rank_out_of_bounds as u16))
         );
 
         // Test bls error


### PR DESCRIPTION
## Problem

#### Fragile code in `CertificateBuilder::aggregate()`:
- We are allowing the same rank to be aggregated multiple times which will break verification.  This was not a problem yet because the vote pool was dropping duplicates.
- the check for ensuring that we are setting a valid rank in the bitmap is away from updating the rank.  

#### Unnecessary check for empty messages in `CertificateBuilder::aggregate()`.
- the rest of the function is a NOP if messages are empty

#### Unnecessary error in `CertificateBuilder::build()`:
- `aggregate()` guarantees that `new_length` will not exceed `MAXIMUM_VALIDATORS`.

#### `AggregateError::ValidatorDoesNotExist` does not seem to be correct
- we cannot deduce that the validator does not exist, simply that the rank is invalid.

## Summary of Changes

- introduces a check to ensure that we do not set the same rank multiple times
- combines updating the bitmap with checking for length
- removes unnecessary check for empty messages in `aggregate()`
- converts the error check in `build` with an assert.
- Renames `AggregateError::ValidatorDoesNotExist`  to `AggregateError::InvalidRank` 