### PR TITLE
feat(scheduler-bindings): ExternalWorker::resolve_batch

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -727,6 +727,7 @@ mod external {
                     worker_to_pack,
                     allocator,
                     context.poh_recorder.read().unwrap().shared_leader_state(),
+                    context.bank_forks.read().unwrap().sharable_banks(),
                 );
 
                 worker_metrics.push(consume_worker.metrics_handle());

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -386,7 +386,7 @@ pub(crate) mod external {
                 .ok_or(ExternalConsumeWorkerError::AllocationFailure)?;
                 let response = WorkerToPackMessage {
                     batch: message.batch,
-                    processed: 1,
+                    processed: agave_scheduler_bindings::PROCESSED,
                     responses,
                 };
 
@@ -428,7 +428,7 @@ pub(crate) mod external {
 
             let response = WorkerToPackMessage {
                 batch: message.batch,
-                processed: 1,
+                processed: agave_scheduler_bindings::PROCESSED,
                 responses,
             };
 
@@ -573,7 +573,7 @@ pub(crate) mod external {
 
             let response_message = WorkerToPackMessage {
                 batch: message.batch,
-                processed: 1,
+                processed: agave_scheduler_bindings::PROCESSED,
                 responses: response_region,
             };
 
@@ -596,7 +596,7 @@ pub(crate) mod external {
         ) -> Result<(), ExternalConsumeWorkerError> {
             let invalid_message = WorkerToPackMessage {
                 batch: message.batch,
-                processed: 0,
+                processed: agave_scheduler_bindings::NOT_PROCESSED,
                 responses: TransactionResponseRegion {
                     tag: 0,
                     num_transaction_responses: 0,
@@ -678,13 +678,17 @@ pub(crate) mod external {
         ) -> Resolved {
             match resolving_result {
                 Ok(Some((resolved_pubkeys, min_alt_deactivation_slot))) => Resolved {
-                    success: 1,
+                    success: agave_scheduler_bindings::worker_message_types::RESOLVE_SUCCESS,
                     slot,
                     min_alt_deactivation_slot,
                     resolved_pubkeys,
                 },
                 _ => Resolved {
-                    success: u8::from(resolving_result.is_ok()),
+                    success: if resolving_result.is_ok() {
+                        agave_scheduler_bindings::worker_message_types::RESOLVE_SUCCESS
+                    } else {
+                        agave_scheduler_bindings::worker_message_types::RESOLVE_FAILURE
+                    },
                     slot,
                     min_alt_deactivation_slot: u64::MAX,
                     resolved_pubkeys: SharablePubkeys {
@@ -897,7 +901,7 @@ pub(crate) mod external {
             assert_eq!(
                 ExternalWorker::resolved_pubkeys_to_response(Err(()), TEST_SLOT),
                 Resolved {
-                    success: 0,
+                    success: agave_scheduler_bindings::worker_message_types::RESOLVE_FAILURE,
                     slot: TEST_SLOT,
                     min_alt_deactivation_slot: u64::MAX,
                     resolved_pubkeys: SharablePubkeys {
@@ -909,7 +913,7 @@ pub(crate) mod external {
             assert_eq!(
                 ExternalWorker::resolved_pubkeys_to_response(Ok(None), TEST_SLOT),
                 Resolved {
-                    success: 1,
+                    success: agave_scheduler_bindings::worker_message_types::RESOLVE_SUCCESS,
                     slot: TEST_SLOT,
                     min_alt_deactivation_slot: u64::MAX,
                     resolved_pubkeys: SharablePubkeys {
@@ -928,7 +932,7 @@ pub(crate) mod external {
                     TEST_SLOT
                 ),
                 Resolved {
-                    success: 1,
+                    success: agave_scheduler_bindings::worker_message_types::RESOLVE_SUCCESS,
                     slot: TEST_SLOT,
                     min_alt_deactivation_slot: 120,
                     resolved_pubkeys

--- a/scheduler-bindings/src/lib.rs
+++ b/scheduler-bindings/src/lib.rs
@@ -243,6 +243,11 @@ pub mod pack_message_flags {
     pub const RESOLVE: u16 = 1 << 1;
 }
 
+/// The message was processed.
+pub const PROCESSED: u8 = 1;
+/// The message was not processed.
+pub const NOT_PROCESSED: u8 = 0;
+
 /// Message: [Worker -> Pack]
 /// Message from worker threads in response to a [`PackToWorkerMessage`].
 #[cfg_attr(
@@ -258,11 +263,11 @@ pub struct WorkerToPackMessage {
     /// and is safe to do so - agave will hold no references to this memory
     /// after sending this message.
     pub batch: SharableTransactionBatchRegion,
-    /// `1` if the message was processed.
-    /// `0` if the message could not be processed. This will occur
+    /// [`PROCESSED`] if the message was processed.
+    /// [`NOT_PROCESSED`] if the message could not be processed. This will occur
     /// if the passed message was invalid, and could indicate an issue
     /// with the external pack process.
-    /// If `0`, the value of [`Self::responses`] is undefined.
+    /// If  [`NOT_PROCESSED`], the value of [`Self::responses`] is undefined.
     /// Other values should be considered invalid.
     pub processed: u8,
     /// Response per transaction in the batch.
@@ -401,6 +406,11 @@ pub mod worker_message_types {
     /// Tag indicating [`Resolved`] inner message.
     pub const RESOLVED: u8 = 1;
 
+    /// Resolving was successful.
+    pub const RESOLVE_SUCCESS: u8 = 1;
+    /// Resolving was unsuccessful.
+    pub const RESOLVE_FAILURE: u8 = 0;
+
     #[cfg_attr(
         feature = "dev-context-only-utils",
         derive(Debug, Clone, Copy, PartialEq, Eq)
@@ -408,7 +418,8 @@ pub mod worker_message_types {
     #[repr(C)]
     pub struct Resolved {
         /// Indicates if resolution was successful.
-        /// 0 = false, 1 = true.
+        /// [`RESOLVE_SUCCESS`] if resolving succeeded.
+        /// [`RESOLVE_FAILURE`] if resolved failed.
         /// Other values should be considered invalid.
         pub success: u8,
         /// Slot of the bank used for resolution.

--- a/scheduling-utils/src/responses_region.rs
+++ b/scheduling-utils/src/responses_region.rs
@@ -1,6 +1,6 @@
 use {
     agave_scheduler_bindings::{
-        worker_message_types::{ExecutionResponse, EXECUTION_RESPONSE},
+        worker_message_types::{ExecutionResponse, Resolved, EXECUTION_RESPONSE, RESOLVED},
         TransactionResponseRegion,
     },
     rts_alloc::Allocator,
@@ -13,6 +13,15 @@ pub fn execution_responses_from_iter(
 ) -> Option<TransactionResponseRegion> {
     // SAFETY: EXECUTION_RESPONSE -> ExecutionResponse
     unsafe { from_iterator(allocator, EXECUTION_RESPONSE, iter) }
+}
+
+/// Prepare a [`TransactionResponseRegion`] with [`Resolved`].
+pub fn resolve_responses_from_iter(
+    allocator: &Allocator,
+    iter: impl ExactSizeIterator<Item = Resolved>,
+) -> Option<TransactionResponseRegion> {
+    // SAFETY: RESOLVED -> Resolved
+    unsafe { from_iterator(allocator, RESOLVED, iter) }
 }
 
 /// Prepare a [`TransactionResponseRegion`] from an iterator.


### PR DESCRIPTION
#### Problem
- ATLs make it impossible for external scheduler to track locks if they cannot resolve keys

#### Summary of Changes
- Add support for `RESOLVE` flag so that external scheduler can use workers to resolve messages if necessary

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
