### PR TITLE
xdp: tx_loop: change MAX_TIMEOUTS to 1

### DIFF
--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -118,7 +118,7 @@ pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>>(
     // How long we sleep waiting to receive shreds from the channel.
     const RECV_TIMEOUT: Duration = Duration::from_nanos(1000);
 
-    const MAX_TIMEOUTS: usize = 500;
+    const MAX_TIMEOUTS: usize = 1;
 
     // We try to collect _at least_ BATCH_SIZE packets before queueing into the NIC. This is to
     // avoid introducing too much per-packet overhead and giving the NIC time to complete work


### PR DESCRIPTION
Once upon a time we used to spin without sleeping, and we flushed batches after 500 empty spins on the receive channel. Then we added sleeping to save CPU but kept MAX_TIMEOUTS too high.

When load is relatively low - like during banking - this can lead to a non-full batch to be held for up to 500ms, which can cause slots to be skipped.

Fix by bringing MAX_TIMEOUTS to 1 which means that during banking we'll hold shreds for up to 1ms.