### PR TITLE
CI: limit windows targets

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -66,6 +66,7 @@ jobs:
         run: |
           echo "PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           echo "OPENSSL_SRC_PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          echo "SOLANA_CLI_ONLY=1" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - shell: bash
         run: |

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,15 @@ humantime = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
 pretty-hex = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "rustls-tls-native-roots", "json"] }
+reqwest = { workspace = true, features = [
+    "blocking",
+    "brotli",
+    "deflate",
+    "gzip",
+    "rustls-tls",
+    "rustls-tls-native-roots",
+    "json",
+] }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -107,13 +115,15 @@ tiny-bip39 = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 solana-client = { workspace = true, features = ["dev-context-only-utils"] }
-solana-faucet = { workspace = true, features = ["dev-context-only-utils"] }
 solana-nonce-account = { workspace = true }
 solana-presigner = { workspace = true }
-solana-rpc = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-solana-streamer = { workspace = true }
-solana-test-validator = { workspace = true }
 solana-tps-client = { workspace = true, features = ["dev-context-only-utils"] }
 tempfile = { workspace = true }
 test-case = { workspace = true }
+
+[target."cfg(unix)".dev-dependencies]
+solana-faucet = { workspace = true, features = ["dev-context-only-utils"] }
+solana-rpc = { workspace = true }
+solana-streamer = { workspace = true }
+solana-test-validator = { workspace = true }

--- a/cli/tests/address_lookup_table.rs
+++ b/cli/tests/address_lookup_table.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 use {
     solana_cli::{
         address_lookup_table::{

--- a/cli/tests/cluster_query.rs
+++ b/cli/tests/cluster_query.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 use {
     solana_cli::{
         check_balance,

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 #![allow(clippy::arithmetic_side_effects)]
 use {
     solana_cli::{

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 #![allow(clippy::arithmetic_side_effects)]
 // REMOVE once https://github.com/rust-lang/rust-clippy/issues/11153 is fixed
 #![allow(clippy::items_after_test_module)]

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 #![allow(clippy::arithmetic_side_effects)]
 use {
     solana_cli::cli::{process_command, CliCommand, CliConfig},

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 #![allow(clippy::arithmetic_side_effects)]
 use {
     assert_matches::assert_matches,

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 #![allow(clippy::arithmetic_side_effects)]
 use {
     solana_cli::{

--- a/cli/tests/validator_info.rs
+++ b/cli/tests/validator_info.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 use {
     serde_json::json,
     solana_cli::{

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 #![allow(clippy::arithmetic_side_effects)]
 use {
     solana_account::ReadableAccount,

--- a/scripts/cargo-clippy-nightly.sh
+++ b/scripts/cargo-clippy-nightly.sh
@@ -22,12 +22,25 @@ source "$here/../ci/rust-version.sh" nightly
 # Similarly, nightly is desired to run clippy over all of bench files because
 # the bench itself isn't stabilized yet...
 #   ref: https://github.com/rust-lang/rust/issues/66287
-"$here/cargo-for-all-lock-files.sh" -- \
-  "+${rust_nightly}" clippy \
-  --workspace --all-targets --features dummy-for-ci-check,frozen-abi -- \
-  --deny=warnings \
-  --deny=clippy::default_trait_access \
-  --deny=clippy::arithmetic_side_effects \
-  --deny=clippy::manual_let_else \
-  --deny=clippy::uninlined-format-args \
-  --deny=clippy::used_underscore_binding
+if [[ -n "${SOLANA_CLI_ONLY+x}" ]]; then
+  cargo \
+    "+${rust_nightly}" clippy \
+    --workspace --bin solana --bin solana-keygen \
+    --features dummy-for-ci-check,frozen-abi -- \
+    --deny=warnings \
+    --deny=clippy::default_trait_access \
+    --deny=clippy::arithmetic_side_effects \
+    --deny=clippy::manual_let_else \
+    --deny=clippy::uninlined-format-args \
+    --deny=clippy::used_underscore_binding
+else
+  "$here/cargo-for-all-lock-files.sh" -- \
+    "+${rust_nightly}" clippy \
+    --workspace --all-targets --features dummy-for-ci-check,frozen-abi -- \
+    --deny=warnings \
+    --deny=clippy::default_trait_access \
+    --deny=clippy::arithmetic_side_effects \
+    --deny=clippy::manual_let_else \
+    --deny=clippy::uninlined-format-args \
+    --deny=clippy::used_underscore_binding
+fi

--- a/scripts/cargo-clippy-nightly.sh
+++ b/scripts/cargo-clippy-nightly.sh
@@ -25,7 +25,14 @@ source "$here/../ci/rust-version.sh" nightly
 if [[ -n "${SOLANA_CLI_ONLY+x}" ]]; then
   cargo \
     "+${rust_nightly}" clippy \
-    --workspace --bin solana --bin solana-keygen \
+    --workspace \
+    --bin solana \
+    --bin solana-keygen \
+    --bin agave-install \
+    --bin cargo-build-sbf \
+    --bin cargo-test-sbf \
+    --bin solana-stake-accounts \
+    --bin solana-tokens \
     --features dummy-for-ci-check,frozen-abi -- \
     --deny=warnings \
     --deny=clippy::default_trait_access \


### PR DESCRIPTION
#### Problem
- Windows build is incredibly slow (49m on my latest PR)
- Windows support is annoying in validator/core where we have some stuff that we don't care to support windows on
  - No reasonable operator is going to run on windows 

#### Summary of Changes
- Windows CI only builds solana-cli, solana-keygen
- cli integration tests marked as unix-only
  - This is to avoid TestValidator dependence for windows

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
