### PR TITLE
Improves accuracy of index mem usage stat

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -881,10 +881,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         }
     }
 
-    /// assumes 1 entry in the slot list. Ignores overhead of the HashMap and such
-    pub const fn approx_size_of_one_entry() -> usize {
-        // with only one entry in the slot list, it is stored inline in the SmallVec
-        size_of::<Pubkey>() + size_of::<AccountMapEntry<T>>()
+    /// The footprint of a single element in the in-mem hashmap
+    pub const fn size_of_uninitialized() -> usize {
+        size_of::<Pubkey>() + size_of::<Box<AccountMapEntry<T>>>()
+    }
+
+    /// The size of an index value, with only a single entry in the slot list
+    pub const fn size_of_single_entry() -> usize {
+        size_of::<AccountMapEntry<T>>()
     }
 
     fn should_evict_based_on_age(


### PR DESCRIPTION
#### Problem

The accounts index stat for the estimate of in-mem usage isn't very accurate, since it doesn't include the overhead of the hashmap's spare capacity.

We can manually handle this in the metrics dashboards, but then it becomes challenging if these values change between agave versions, as then the metrics dashboards need to have different constants, which is kind of a pain.


#### Summary of Changes

Update the index metric to account for the overhead of the hashmap's spare capacity too.



Here's my dev box running this PR. The blue line is the "estimate_mem_bytes" metric, which this PR changes. The purple line is my manual calculation of the mem usage. Blue on the left doesn't include the spare capacity, whereas blue on the right does (and has the expected same value as the purple).
<img width="922" height="487" alt="Screenshot 2025-10-30 at 11 42 24 AM" src="https://github.com/user-attachments/assets/3b4acb68-8edf-44ad-9d19-66961a5190b5" />