### PR TITLE
Add mingw to the windows uname output list

### DIFF
--- a/scripts/generate-target-triple.sh
+++ b/scripts/generate-target-triple.sh
@@ -14,7 +14,7 @@ linux*)
 darwin*)
   export BUILD_TARGET_TRIPLE="$_arch-apple-darwin"
   ;;
-msys*)
+msys*|mingw*)
   export BUILD_TARGET_TRIPLE="$_arch-pc-windows-msvc"
   ;;
 *)


### PR DESCRIPTION
#### Problem
The [Publish Windows Tarball workflow](https://github.com/anza-xyz/agave/actions/workflows/publish-windows-tarball.yml) is failing on master. This is caused by `BUILD_TARGET_TRIPLE` not being populated

#### Summary of Changes
Include `mingw*` in the case list for uname output

Here's some debugging that shows the uname output
https://github.com/anza-xyz/agave/actions/runs/18953147250/job/54122848983#step:4:1126

And here's a workflow run that includes this change, with `TARGET` populated:
https://github.com/anza-xyz/agave/actions/runs/18953481337/job/54124084473#step:4:1130

