### PR TITLE
Skip adding useless uncleaned pubkeys

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5050,6 +5050,19 @@ impl AccountsDb {
         // Safe because queries to the index will be reading updates from later roots.
         self.purge_slot_cache_pubkeys(slot, pubkeys, is_dead_slot);
 
+        // Use ReclaimOldSlots to reclaim old slots if marking obsolete accounts and cleaning
+        // Cleaning is enabled if `should_flush_f` is Some.
+        // should_flush_f is set to None when
+        // 1) There's an ongoing scan to avoid reclaiming accounts being scanned.
+        // 2) The slot is > max_clean_root to prevent unrooted slots from reclaiming rooted versions.
+        let reclaim_method = if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled
+            && should_flush_f.is_some()
+        {
+            UpsertReclaim::ReclaimOldSlots
+        } else {
+            UpsertReclaim::IgnoreReclaims
+        };
+
         if !is_dead_slot {
             // This ensures that all updates are written to an AppendVec, before any
             // updates to the index happen, so anybody that sees a real entry in the index,
@@ -5059,19 +5072,6 @@ impl AccountsDb {
                 flush_stats.num_bytes_flushed.0,
                 "flush_slot_cache",
             );
-
-            // Use ReclaimOldSlots to reclaim old slots if marking obsolete accounts and cleaning
-            // Cleaning is enabled if `should_flush_f` is Some.
-            // should_flush_f is set to None when
-            // 1) There's an ongoing scan to avoid reclaiming accounts being scanned.
-            // 2) The slot is > max_clean_root to prevent unrooted slots from reclaiming rooted versions.
-            let reclaim_method = if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled
-                && should_flush_f.is_some()
-            {
-                UpsertReclaim::ReclaimOldSlots
-            } else {
-                UpsertReclaim::IgnoreReclaims
-            };
 
             let (store_accounts_timing_inner, store_accounts_total_inner_us) = measure_us!(self
                 ._store_accounts_frozen(
@@ -5097,21 +5097,20 @@ impl AccountsDb {
 
         // Add `accounts` to uncleaned_pubkeys since they were written to storage
         // and should be visited by `clean`.
-        // If obsolete accounts were marked, accounts were already cleaned,
+        // If old slots were reclaimed, accounts were already cleaned,
         // but zero lamports need to be visited during clean for full removal.
-        if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled && should_flush_f.is_some()
-        {
+        if reclaim_method == UpsertReclaim::ReclaimOldSlots {
             self.uncleaned_pubkeys.entry(slot).or_default().extend(
                 accounts
                     .into_iter()
-                    .filter(|(_pubkey, account)| account.lamports() == 0)
+                    .filter(|(_pubkey, account)| account.is_zero_lamport())
                     .map(|(pubkey, _account)| pubkey),
             );
         } else {
             self.uncleaned_pubkeys
                 .entry(slot)
                 .or_default()
-                .extend(accounts.iter().map(|(pubkey, _account)| **pubkey));
+                .extend(accounts.into_iter().map(|(pubkey, _account)| *pubkey));
         }
 
         flush_stats


### PR DESCRIPTION
#### Problem
- At the end of flush_rooted_accounts_cache all accounts that were modified in the slot are added to the uncleaned pubkeys list. However, with obsolete accounts enabled and marked, this is not needed unless the accounts are zero lamports. Only zero lamport accounts need to be revisited by clean. 

#### Summary of Changes
- Only add zero lamport accounts to the uncleaned pubkey list at the end of flush_rooted_accounts_cache.

The time to collect the delta list goes down significantly. In all the following graphs, the blue validator is running obsolete accounts, while the other two validators are edge canaries. At roughly 18:20 an epoch transition occurs leading to increased clean activity. The blue validator is originally running with this code, but switches to run baseline at 19:20. 

Collecting delta pubkeys (which pulls from the uncleaned pubkey list) is significantly faster
<img width="1709" height="407" alt="image" src="https://github.com/user-attachments/assets/30bd8a83-82ee-457a-abd6-890183db9268" />

Total clean time: Shows similar reduction:
<img width="1709" height="407" alt="image" src="https://github.com/user-attachments/assets/739cb158-181c-489b-8ba3-330560caf4b7" />


Total flush time shows no degradation:
<img width="1709" height="407" alt="image" src="https://github.com/user-attachments/assets/609328b6-26e6-42ef-9578-654003a07c9b" />


#### Testing Notes
- Tested against mainnet for 1 month, saw no issues. 
Guaranteed that existing unit tests already adequately covers this scenario, so no need to add new tests. If the obsolete account switch is removed, it results in 14 test failures due to keys not being cleaned properly. This verifies that there is existing test coverage for this scenario, and that the problem statement is correct: WIth obsolete accounts enabled and marked, these pubkeys do not need to be cleaned. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
