### PR TITLE
ibrl: remove packet batch sender thread from streamer

### DIFF
--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -64,7 +64,7 @@ pub struct BankingTracer {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "91baCBT3aY2nXSAuzY3S5dnMhWabVsHowgWqYPLjfyg7")
+    frozen_abi(digest = "9njKW2EBmvkBGCHPysxFxZzg1cXgmTxAUYZZiiqFhVHr")
 )]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TimedTracedEvent(pub std::time::SystemTime, pub TracedEvent);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -578,7 +578,6 @@ impl ValidatorTpuConfig {
         let tpu_quic_server_config = SwQosQuicStreamerConfig {
             quic_streamer_config: QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: 32,
-                accumulator_channel_size: 100_000, // smaller channel size for faster test
                 ..Default::default()
             },
             qos_config: SwQosConfig::default(),
@@ -588,7 +587,6 @@ impl ValidatorTpuConfig {
             quic_streamer_config: QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: 32,
                 max_unstaked_connections: 0,
-                accumulator_channel_size: 100_000, // smaller channel size for faster test
                 ..Default::default()
             },
             qos_config: SwQosConfig::default(),
@@ -599,7 +597,6 @@ impl ValidatorTpuConfig {
             quic_streamer_config: QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: 32,
                 max_unstaked_connections: 0,
-                accumulator_channel_size: 100_000, // smaller channel size for faster test
                 ..Default::default()
             },
             qos_config: SimpleQosConfig::default(),

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -466,6 +466,12 @@ fn sign_shreds_gpu(
         .map(|batch| match batch {
             PacketBatch::Pinned(batch) => Cow::Borrowed(batch),
             PacketBatch::Bytes(batch) => Cow::Owned(batch.to_pinned_packet_batch()),
+            PacketBatch::Single(packet) => {
+                // this is ugly, but unused (gpu code) and will be removed shortly in follow up PR
+                let mut batch = BytesPacketBatch::with_capacity(1);
+                batch.push(packet.clone());
+                Cow::Owned(batch.to_pinned_packet_batch())
+            }
         })
         .collect::<Vec<_>>();
     elems.extend(pinned_batches.iter().map(|batch| perf_libs::Elems {

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -9,7 +9,7 @@ use {
     solana_nohash_hasher::BuildNoHashHasher,
     solana_perf::{
         cuda_runtime::PinnedVec,
-        packet::{Packet, PacketBatch, PacketRef},
+        packet::{BytesPacketBatch, Packet, PacketBatch, PacketRef},
         perf_libs,
         recycler_cache::RecyclerCache,
         sigverify::{self, count_packets_in_batches, TxOffset},
@@ -308,6 +308,12 @@ pub fn verify_shreds_gpu(
         .map(|batch| match batch {
             PacketBatch::Pinned(batch) => Cow::Borrowed(batch),
             PacketBatch::Bytes(batch) => Cow::Owned(batch.to_pinned_packet_batch()),
+            PacketBatch::Single(packet) => {
+                // this is ugly, but unused (gpu code) and will be removed shortly in follow up PR
+                let mut batch = BytesPacketBatch::with_capacity(1);
+                batch.push(packet.clone());
+                Cow::Owned(batch.to_pinned_packet_batch())
+            }
         })
         .collect::<Vec<_>>();
     elems.extend(pinned_batches.iter().map(|batch| perf_libs::Elems {

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -153,6 +153,7 @@ impl BytesPacket {
 pub enum PacketBatch {
     Pinned(PinnedPacketBatch),
     Bytes(BytesPacketBatch),
+    Single(BytesPacket),
 }
 
 impl PacketBatch {
@@ -161,6 +162,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.first().map(PacketRef::from),
             Self::Bytes(batch) => batch.first().map(PacketRef::from),
+            Self::Single(packet) => Some(PacketRef::from(packet)),
         }
     }
 
@@ -169,6 +171,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.first_mut().map(PacketRefMut::from),
             Self::Bytes(batch) => batch.first_mut().map(PacketRefMut::from),
+            Self::Single(packet) => Some(PacketRefMut::from(packet)),
         }
     }
 
@@ -177,6 +180,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.is_empty(),
             Self::Bytes(batch) => batch.is_empty(),
+            Self::Single(_) => false,
         }
     }
 
@@ -185,6 +189,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.get(index).map(PacketRef::from),
             Self::Bytes(batch) => batch.get(index).map(PacketRef::from),
+            Self::Single(packet) => Some(PacketRef::from(packet)),
         }
     }
 
@@ -192,6 +197,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.get_mut(index).map(PacketRefMut::from),
             Self::Bytes(batch) => batch.get_mut(index).map(PacketRefMut::from),
+            Self::Single(packet) => Some(PacketRefMut::from(packet)),
         }
     }
 
@@ -199,6 +205,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => PacketBatchIter::Pinned(batch.iter()),
             Self::Bytes(batch) => PacketBatchIter::Bytes(batch.iter()),
+            Self::Single(packet) => PacketBatchIter::Bytes(core::array::from_ref(packet).iter()),
         }
     }
 
@@ -206,6 +213,9 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => PacketBatchIterMut::Pinned(batch.iter_mut()),
             Self::Bytes(batch) => PacketBatchIterMut::Bytes(batch.iter_mut()),
+            Self::Single(packet) => {
+                PacketBatchIterMut::Bytes(core::array::from_mut(packet).iter_mut())
+            }
         }
     }
 
@@ -215,6 +225,11 @@ impl PacketBatch {
                 PacketBatchParIter::Pinned(batch.par_iter().map(PacketRef::from))
             }
             Self::Bytes(batch) => PacketBatchParIter::Bytes(batch.par_iter().map(PacketRef::from)),
+            Self::Single(packet) => PacketBatchParIter::Bytes(
+                core::array::from_ref(packet)
+                    .par_iter()
+                    .map(PacketRef::from),
+            ),
         }
     }
 
@@ -226,6 +241,11 @@ impl PacketBatch {
             Self::Bytes(batch) => {
                 PacketBatchParIterMut::Bytes(batch.par_iter_mut().map(PacketRefMut::from))
             }
+            Self::Single(packet) => PacketBatchParIterMut::Bytes(
+                core::array::from_mut(packet)
+                    .par_iter_mut()
+                    .map(PacketRefMut::from),
+            ),
         }
     }
 
@@ -233,6 +253,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.len(),
             Self::Bytes(batch) => batch.len(),
+            Self::Single(_) => 1,
         }
     }
 }

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -189,7 +189,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.get(index).map(PacketRef::from),
             Self::Bytes(batch) => batch.get(index).map(PacketRef::from),
-            Self::Single(packet) => Some(PacketRef::from(packet)),
+            Self::Single(packet) => (index == 0).then_some(PacketRef::from(packet)),
         }
     }
 
@@ -197,7 +197,7 @@ impl PacketBatch {
         match self {
             Self::Pinned(batch) => batch.get_mut(index).map(PacketRefMut::from),
             Self::Bytes(batch) => batch.get_mut(index).map(PacketRefMut::from),
-            Self::Single(packet) => Some(PacketRefMut::from(packet)),
+            Self::Single(packet) => (index == 0).then_some(PacketRefMut::from(packet)),
         }
     }
 

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -472,6 +472,11 @@ fn split_batches(batches: Vec<PacketBatch>) -> (Vec<BytesPacketBatch>, Vec<Pinne
         match batch {
             PacketBatch::Bytes(batch) => bytes_batches.push(batch),
             PacketBatch::Pinned(batch) => pinned_batches.push(batch),
+            PacketBatch::Single(packet) => {
+                let mut batch = BytesPacketBatch::with_capacity(1);
+                batch.push(packet);
+                bytes_batches.push(batch);
+            }
         }
     }
     (bytes_batches, pinned_batches)
@@ -650,6 +655,12 @@ pub fn ed25519_verify(
         .map(|batch| match batch {
             PacketBatch::Pinned(batch) => Cow::Borrowed(batch),
             PacketBatch::Bytes(batch) => Cow::Owned(batch.to_pinned_packet_batch()),
+            PacketBatch::Single(packet) => {
+                // this is ugly, but unused (gpu code) and will be removed shortly in follow up PR
+                let mut batch = BytesPacketBatch::with_capacity(1);
+                batch.push(packet.clone());
+                Cow::Owned(batch.to_pinned_packet_batch())
+            }
         })
         .collect::<Vec<_>>();
     for batch in pinned_batches.iter() {

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -5,35 +5,32 @@ use {
             qos::{ConnectionContext, QosController},
             stream_throttle::ConnectionStreamCounter,
         },
-        quic::{configure_server, QuicServerError, QuicStreamerConfig, StreamerStats},
+        quic::{QuicServerError, QuicStreamerConfig, StreamerStats, configure_server},
         streamer::StakedNodes,
     },
     bytes::{BufMut, Bytes, BytesMut},
-    crossbeam_channel::{bounded, Receiver, Sender, TryRecvError, TrySendError},
-    futures::{stream::FuturesUnordered, Future, StreamExt as _},
+    crossbeam_channel::{Sender, TrySendError},
+    futures::{Future, StreamExt as _, stream::FuturesUnordered},
     indexmap::map::{Entry, IndexMap},
     quinn::{Accept, Connecting, Connection, Endpoint, EndpointConfig, TokioRuntime},
-    rand::{thread_rng, Rng},
+    rand::{Rng, thread_rng},
     smallvec::SmallVec,
     solana_keypair::Keypair,
     solana_measure::measure::Measure,
     solana_net_utils::token_bucket::TokenBucket,
     solana_packet::{Meta, PACKET_DATA_SIZE},
-    solana_perf::packet::{BytesPacket, BytesPacketBatch, PacketBatch, PACKETS_PER_BATCH},
+    solana_perf::packet::{BytesPacket, BytesPacketBatch, PacketBatch},
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_tls_utils::get_pubkey_from_tls_certificate,
     solana_transaction_metrics_tracker::signature_if_should_track_packet,
     std::{
-        array,
-        fmt,
+        array, fmt,
         iter::repeat_with,
         net::{IpAddr, SocketAddr, UdpSocket},
         pin::Pin,
-        // CAUTION: be careful not to introduce any awaits while holding an RwLock.
         sync::{
-            atomic::{AtomicU64, Ordering},
-            Arc, RwLock,
+            Arc, RwLock, atomic::{AtomicU64, Ordering}
         },
         task::Poll,
         time::{Duration, Instant},
@@ -47,9 +44,7 @@ use {
         // but if we do, the scope of the RwLock must always be a subset of the async Mutex
         // (i.e. lock order is always async Mutex -> RwLock). Also, be careful not to
         // introduce any other awaits while holding the RwLock.
-        select,
-        task::{self, JoinHandle},
-        time::timeout,
+        select, task::JoinHandle, time::timeout
     },
     tokio_util::{sync::CancellationToken, task::TaskTracker},
 };
@@ -158,15 +153,6 @@ where
             .map_err(QuicServerError::EndpointFailed)
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let (packet_batch_sender, packet_batch_receiver) =
-        bounded(quic_server_params.accumulator_channel_size);
-    task::spawn_blocking({
-        let cancel = cancel.clone();
-        let stats = stats.clone();
-        move || {
-            run_packet_batch_sender(packet_sender, packet_batch_receiver, stats, cancel);
-        }
-    });
 
     let max_concurrent_connections = quic_server_params.max_concurrent_connections();
     let handle = tokio::spawn({
@@ -176,7 +162,7 @@ where
             let tasks = run_server(
                 name,
                 endpoints.clone(),
-                packet_batch_sender,
+                packet_sender,
                 stats.clone(),
                 quic_server_params,
                 cancel,
@@ -245,7 +231,7 @@ impl ClientConnectionTracker {
 async fn run_server<Q, C>(
     name: &'static str,
     endpoints: Vec<Endpoint>,
-    packet_batch_sender: Sender<PacketAccumulator>,
+    packet_batch_sender: Sender<PacketBatch>,
     stats: Arc<StreamerStats>,
     quic_server_params: QuicStreamerConfig,
     cancel: CancellationToken,
@@ -444,7 +430,7 @@ async fn setup_connection<Q, C>(
     rate_limiter: Arc<ConnectionRateLimiter>,
     overall_connection_rate_limiter: Arc<TokenBucket>,
     client_connection_tracker: ClientConnectionTracker,
-    packet_sender: Sender<PacketAccumulator>,
+    packet_sender: Sender<PacketBatch>,
     stats: Arc<StreamerStats>,
     server_params: Arc<QuicStreamerConfig>,
     qos: Arc<Q>,
@@ -563,129 +549,6 @@ fn handle_connection_error(e: quinn::ConnectionError, stats: &StreamerStats, fro
     }
 }
 
-// Holder(s) of the Sender<PacketAccumulator> on the other end should not
-// wait for this function to exit
-fn run_packet_batch_sender(
-    packet_sender: Sender<PacketBatch>,
-    packet_receiver: Receiver<PacketAccumulator>,
-    stats: Arc<StreamerStats>,
-    cancel: CancellationToken,
-) {
-    let mut channel_disconnected = false;
-    trace!("enter packet_batch_sender");
-    loop {
-        let mut packet_perf_measure: Vec<([u8; 64], Instant)> = Vec::default();
-        let mut packet_batch = BytesPacketBatch::with_capacity(PACKETS_PER_BATCH);
-        let mut total_bytes: usize = 0;
-
-        stats
-            .total_packet_batches_allocated
-            .fetch_add(1, Ordering::Relaxed);
-        stats
-            .total_packets_allocated
-            .fetch_add(PACKETS_PER_BATCH, Ordering::Relaxed);
-
-        loop {
-            if cancel.is_cancelled() || channel_disconnected {
-                return;
-            }
-            if !packet_batch.is_empty() {
-                let len = packet_batch.len();
-                track_streamer_fetch_packet_performance(&packet_perf_measure, &stats);
-
-                if let Err(e) = packet_sender.try_send(packet_batch.into()) {
-                    stats
-                        .total_packet_batch_send_err
-                        .fetch_add(1, Ordering::Relaxed);
-                    trace!("Send error: {e}");
-
-                    // The downstream channel is disconnected, this error is not recoverable.
-                    if matches!(e, TrySendError::Disconnected(_)) {
-                        cancel.cancel();
-                        return;
-                    }
-                } else {
-                    stats
-                        .total_packet_batches_sent
-                        .fetch_add(1, Ordering::Relaxed);
-
-                    stats
-                        .total_packets_sent_to_consumer
-                        .fetch_add(len, Ordering::Relaxed);
-
-                    stats
-                        .total_bytes_sent_to_consumer
-                        .fetch_add(total_bytes, Ordering::Relaxed);
-
-                    trace!("Sent {len} packet batch");
-                }
-                break;
-            }
-
-            // On the first receive, we block on recv not to use excessive CPU when the channel is idle.
-            // This will not block the exit as the channel will be dropped on the sender's side.
-            //
-            // On subsequent receives, we call try_recv, so that we do not get blocked waiting for packets
-            // when we already have something in the batch.
-            //
-            // For setting channel_disconnected, we can ignore TryRecvError::Disconnected on try_recv and
-            // set it on the next iteration (if we don't exit early anyway from cancel token)
-            let mut first = true;
-            let mut recv = || {
-                if first {
-                    first = false;
-                    // recv is only an error if empty and disconnected
-                    packet_receiver.recv().map_err(|_| {
-                        channel_disconnected = true;
-                        TryRecvError::Disconnected
-                    })
-                } else {
-                    packet_receiver.try_recv()
-                }
-            };
-            while let Ok(mut packet_accumulator) = recv() {
-                // 86% of transactions/packets come in one chunk. In that case,
-                // we can just move the chunk to the `Packet` and no copy is
-                // made.
-                // 14% of them come in multiple chunks. In that case, we copy
-                // them into one `Bytes` buffer. We make a copy once, with
-                // intention to not do it again.
-                let num_chunks = packet_accumulator.chunks.len();
-                let mut packet = if packet_accumulator.chunks.len() == 1 {
-                    BytesPacket::new(
-                        packet_accumulator.chunks.pop().expect("expected one chunk"),
-                        packet_accumulator.meta,
-                    )
-                } else {
-                    let size: usize = packet_accumulator.chunks.iter().map(Bytes::len).sum();
-                    let mut buf = BytesMut::with_capacity(size);
-                    for chunk in packet_accumulator.chunks {
-                        buf.put_slice(&chunk);
-                    }
-                    BytesPacket::new(buf.freeze(), packet_accumulator.meta)
-                };
-
-                total_bytes += packet.meta().size;
-
-                if let Some(signature) = signature_if_should_track_packet(&packet).ok().flatten() {
-                    packet_perf_measure.push((*signature, packet_accumulator.start_time));
-                    // we set the PERF_TRACK_PACKET on
-                    packet.meta_mut().set_track_performance(true);
-                }
-                packet_batch.push(packet);
-                stats
-                    .total_chunks_processed_by_batcher
-                    .fetch_add(num_chunks, Ordering::Relaxed);
-
-                // prevent getting stuck in loop
-                if packet_batch.len() >= PACKETS_PER_BATCH {
-                    break;
-                }
-            }
-        }
-    }
-}
-
 fn track_streamer_fetch_packet_performance(
     packet_perf_measure: &[([u8; 64], Instant)],
     stats: &StreamerStats,
@@ -716,7 +579,7 @@ fn track_streamer_fetch_packet_performance(
 }
 
 async fn handle_connection<Q, C>(
-    packet_sender: Sender<PacketAccumulator>,
+    packet_sender: Sender<PacketBatch>,
     connection: Connection,
     stats: Arc<StreamerStats>,
     wait_for_chunk_timeout: Duration,
@@ -862,7 +725,7 @@ enum StreamState {
 fn handle_chunks(
     chunks: impl ExactSizeIterator<Item = Bytes>,
     accum: &mut PacketAccumulator,
-    packet_sender: &Sender<PacketAccumulator>,
+    packet_sender: &Sender<PacketBatch>,
     stats: &StreamerStats,
     peer_type: ConnectionPeerType,
 ) -> Result<StreamState, ()> {
@@ -904,9 +767,39 @@ fn handle_chunks(
 
     // done receiving chunks
     let bytes_sent = accum.meta.size;
-    let chunks_sent = accum.chunks.len();
 
-    if let Err(err) = packet_sender.try_send(accum.clone()) {
+    //
+    // 86% of transactions/packets come in one chunk. In that case,
+    // we can just move the chunk to the `Packet` and no copy is
+    // made.
+    // 14% of them come in multiple chunks. In that case, we copy
+    // them into one `Bytes` buffer. We make a copy once, with
+    // intention to not do it again.
+    let mut packet = if accum.chunks.len() == 1 {
+        BytesPacket::new(
+            accum.chunks.pop().expect("expected one chunk"),
+            accum.meta.clone(),
+        )
+    } else {
+        let size: usize = accum.chunks.iter().map(Bytes::len).sum();
+        let mut buf = BytesMut::with_capacity(size);
+        for chunk in &accum.chunks {
+            buf.put_slice(chunk);
+        }
+        BytesPacket::new(buf.freeze(), accum.meta.clone())
+    };
+
+    let packet_size = packet.meta().size;
+
+    let mut packet_perf_measure = None;
+    if let Some(signature) = signature_if_should_track_packet(&packet).ok().flatten() {
+        packet_perf_measure = Some((*signature, accum.start_time));
+        // we set the PERF_TRACK_PACKET on
+        packet.meta_mut().set_track_performance(true);
+    }
+    let packet_batch = PacketBatch::Bytes(BytesPacketBatch::from(vec![packet]));
+
+    if let Err(err) = packet_sender.try_send(packet_batch) {
         stats
             .total_handle_chunk_to_packet_batcher_send_err
             .fetch_add(1, Ordering::Relaxed);
@@ -924,15 +817,25 @@ fn handle_chunks(
         }
         trace!("packet batch send error {err:?}");
     } else {
+        if let Some(ppm) = &packet_perf_measure {
+            track_streamer_fetch_packet_performance(core::array::from_ref(ppm), stats);
+        }
+        // stats
+        //     .total_packets_sent_for_batching
+        //     .fetch_add(1, Ordering::Relaxed);
+        // stats
+        //     .total_bytes_sent_for_batching
+        //     .fetch_add(bytes_sent, Ordering::Relaxed);
+        // stats
+        //     .total_chunks_sent_for_batching
+        //     .fetch_add(chunks_sent, Ordering::Relaxed);
+
         stats
-            .total_packets_sent_for_batching
+            .total_bytes_sent_to_consumer
+            .fetch_add(packet_size, Ordering::Relaxed);
+        stats
+            .total_packets_sent_to_consumer
             .fetch_add(1, Ordering::Relaxed);
-        stats
-            .total_bytes_sent_for_batching
-            .fetch_add(bytes_sent, Ordering::Relaxed);
-        stats
-            .total_chunks_sent_for_batching
-            .fetch_add(chunks_sent, Ordering::Relaxed);
 
         match peer_type {
             ConnectionPeerType::Unstaked => {
@@ -1394,51 +1297,6 @@ pub mod test {
         check_timeout(receiver, server_address).await;
         cancel.cancel();
         join_handle.await.unwrap();
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_packet_batcher() {
-        agave_logger::setup();
-        let (pkt_batch_sender, pkt_batch_receiver) = unbounded();
-        let (ptk_sender, pkt_receiver) = unbounded();
-        let cancel = CancellationToken::new();
-        let stats = Arc::new(StreamerStats::default());
-
-        let handle = task::spawn_blocking({
-            let cancel = cancel.clone();
-            move || {
-                run_packet_batch_sender(pkt_batch_sender, pkt_receiver, stats, cancel);
-            }
-        });
-
-        let num_packets = 1000;
-
-        for _i in 0..num_packets {
-            let mut meta = Meta::default();
-            let bytes = Bytes::from("Hello world");
-            let size = bytes.len();
-            meta.size = size;
-            let packet_accum = PacketAccumulator {
-                meta,
-                chunks: smallvec::smallvec![bytes],
-                start_time: Instant::now(),
-            };
-            ptk_sender.send(packet_accum).unwrap();
-        }
-        let mut i = 0;
-        let start = Instant::now();
-        while i < num_packets && start.elapsed().as_secs() < 2 {
-            if let Ok(batch) = pkt_batch_receiver.try_recv() {
-                i += batch.len();
-            } else {
-                sleep(Duration::from_millis(1)).await;
-            }
-        }
-        assert_eq!(i, num_packets);
-        cancel.cancel();
-        // Explicit drop to wake up packet_batch_sender
-        drop(ptk_sender);
-        handle.await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -823,15 +823,6 @@ fn handle_chunks(
         if let Some(ppm) = &packet_perf_measure {
             track_streamer_fetch_packet_performance(core::array::from_ref(ppm), stats);
         }
-        // stats
-        //     .total_packets_sent_for_batching
-        //     .fetch_add(1, Ordering::Relaxed);
-        // stats
-        //     .total_bytes_sent_for_batching
-        //     .fetch_add(bytes_sent, Ordering::Relaxed);
-        // stats
-        //     .total_chunks_sent_for_batching
-        //     .fetch_add(chunks_sent, Ordering::Relaxed);
 
         stats
             .total_bytes_sent_to_consumer

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -5,15 +5,15 @@ use {
             qos::{ConnectionContext, QosController},
             stream_throttle::ConnectionStreamCounter,
         },
-        quic::{QuicServerError, QuicStreamerConfig, StreamerStats, configure_server},
+        quic::{configure_server, QuicServerError, QuicStreamerConfig, StreamerStats},
         streamer::StakedNodes,
     },
     bytes::{BufMut, Bytes, BytesMut},
     crossbeam_channel::{Sender, TrySendError},
-    futures::{Future, StreamExt as _, stream::FuturesUnordered},
+    futures::{stream::FuturesUnordered, Future, StreamExt as _},
     indexmap::map::{Entry, IndexMap},
     quinn::{Accept, Connecting, Connection, Endpoint, EndpointConfig, TokioRuntime},
-    rand::{Rng, thread_rng},
+    rand::{thread_rng, Rng},
     smallvec::SmallVec,
     solana_keypair::Keypair,
     solana_measure::measure::Measure,
@@ -30,7 +30,8 @@ use {
         net::{IpAddr, SocketAddr, UdpSocket},
         pin::Pin,
         sync::{
-            Arc, RwLock, atomic::{AtomicU64, Ordering}
+            atomic::{AtomicU64, Ordering},
+            Arc, RwLock,
         },
         task::Poll,
         time::{Duration, Instant},
@@ -44,7 +45,9 @@ use {
         // but if we do, the scope of the RwLock must always be a subset of the async Mutex
         // (i.e. lock order is always async Mutex -> RwLock). Also, be careful not to
         // introduce any other awaits while holding the RwLock.
-        select, task::JoinHandle, time::timeout
+        select,
+        task::JoinHandle,
+        time::timeout,
     },
     tokio_util::{sync::CancellationToken, task::TaskTracker},
 };

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -804,17 +804,17 @@ fn handle_chunks(
 
     if let Err(err) = packet_sender.try_send(packet_batch) {
         stats
-            .total_handle_chunk_to_packet_batcher_send_err
+            .total_handle_chunk_to_packet_send_err
             .fetch_add(1, Ordering::Relaxed);
         match err {
             TrySendError::Full(_) => {
                 stats
-                    .total_handle_chunk_to_packet_batcher_send_full_err
+                    .total_handle_chunk_to_packet_send_full_err
                     .fetch_add(1, Ordering::Relaxed);
             }
             TrySendError::Disconnected(_) => {
                 stats
-                    .total_handle_chunk_to_packet_batcher_send_disconnected_err
+                    .total_handle_chunk_to_packet_send_disconnected_err
                     .fetch_add(1, Ordering::Relaxed);
             }
         }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -19,7 +19,7 @@ use {
     solana_measure::measure::Measure,
     solana_net_utils::token_bucket::TokenBucket,
     solana_packet::{Meta, PACKET_DATA_SIZE},
-    solana_perf::packet::{BytesPacket, BytesPacketBatch, PacketBatch},
+    solana_perf::packet::{BytesPacket, PacketBatch},
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_tls_utils::get_pubkey_from_tls_certificate,
@@ -797,7 +797,7 @@ fn handle_chunks(
         // we set the PERF_TRACK_PACKET on
         packet.meta_mut().set_track_performance(true);
     }
-    let packet_batch = PacketBatch::Bytes(BytesPacketBatch::from(vec![packet]));
+    let packet_batch = PacketBatch::Single(packet);
 
     if let Err(err) = packet_sender.try_send(packet_batch) {
         stats

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -163,8 +163,6 @@ pub struct StreamerStats {
     pub(crate) active_streams: AtomicUsize,
     pub(crate) total_new_streams: AtomicUsize,
     pub(crate) invalid_stream_size: AtomicUsize,
-    pub(crate) total_packets_allocated: AtomicUsize,
-    pub(crate) total_packet_batches_allocated: AtomicUsize,
     pub(crate) total_staked_chunks_received: AtomicUsize,
     pub(crate) total_unstaked_chunks_received: AtomicUsize,
     pub(crate) total_packet_batch_send_err: AtomicUsize,
@@ -374,17 +372,6 @@ impl StreamerStats {
             (
                 "invalid_stream_size",
                 self.invalid_stream_size.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "packets_allocated",
-                self.total_packets_allocated.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "packet_batches_allocated",
-                self.total_packet_batches_allocated
-                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -165,10 +165,9 @@ pub struct StreamerStats {
     pub(crate) invalid_stream_size: AtomicUsize,
     pub(crate) total_staked_chunks_received: AtomicUsize,
     pub(crate) total_unstaked_chunks_received: AtomicUsize,
-    pub(crate) total_packet_batch_send_err: AtomicUsize,
-    pub(crate) total_handle_chunk_to_packet_batcher_send_err: AtomicUsize,
-    pub(crate) total_handle_chunk_to_packet_batcher_send_full_err: AtomicUsize,
-    pub(crate) total_handle_chunk_to_packet_batcher_send_disconnected_err: AtomicUsize,
+    pub(crate) total_handle_chunk_to_packet_send_err: AtomicUsize,
+    pub(crate) total_handle_chunk_to_packet_send_full_err: AtomicUsize,
+    pub(crate) total_handle_chunk_to_packet_send_disconnected_err: AtomicUsize,
     pub(crate) total_packet_batches_none: AtomicUsize,
     pub(crate) total_packets_sent_to_consumer: AtomicUsize,
     pub(crate) total_bytes_sent_to_consumer: AtomicUsize,
@@ -415,25 +414,20 @@ impl StreamerStats {
                 i64
             ),
             (
-                "packet_batch_send_error",
-                self.total_packet_batch_send_err.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "handle_chunk_to_packet_batcher_send_error",
-                self.total_handle_chunk_to_packet_batcher_send_err
+                "total_handle_chunk_to_packet_send_err",
+                self.total_handle_chunk_to_packet_send_err
                     .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
-                "handle_chunk_to_packet_batcher_send_full_err",
-                self.total_handle_chunk_to_packet_batcher_send_full_err
+                "total_handle_chunk_to_packet_send_full_err",
+                self.total_handle_chunk_to_packet_send_full_err
                     .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
-                "handle_chunk_to_packet_batcher_send_disconnected_err",
-                self.total_handle_chunk_to_packet_batcher_send_disconnected_err
+                "total_handle_chunk_to_packet_send_disconnected_err",
+                self.total_handle_chunk_to_packet_send_disconnected_err
                     .swap(0, Ordering::Relaxed),
                 i64
             ),

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -75,9 +75,6 @@ pub struct SpawnServerResult {
     pub key_updater: Arc<EndpointKeyUpdater>,
 }
 
-/// Controls the the channel size for the PacketBatch coalesce
-pub(crate) const DEFAULT_ACCUMULATOR_CHANNEL_SIZE: usize = 250_000;
-
 /// Returns default server configuration along with its PEM certificate chain.
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
 pub(crate) fn configure_server(
@@ -174,11 +171,7 @@ pub struct StreamerStats {
     pub(crate) total_handle_chunk_to_packet_batcher_send_err: AtomicUsize,
     pub(crate) total_handle_chunk_to_packet_batcher_send_full_err: AtomicUsize,
     pub(crate) total_handle_chunk_to_packet_batcher_send_disconnected_err: AtomicUsize,
-    pub(crate) total_packet_batches_sent: AtomicUsize,
     pub(crate) total_packet_batches_none: AtomicUsize,
-    pub(crate) total_packets_sent_for_batching: AtomicUsize,
-    pub(crate) total_bytes_sent_for_batching: AtomicUsize,
-    pub(crate) total_chunks_sent_for_batching: AtomicUsize,
     pub(crate) total_packets_sent_to_consumer: AtomicUsize,
     pub(crate) total_bytes_sent_to_consumer: AtomicUsize,
     pub(crate) total_chunks_processed_by_batcher: AtomicUsize,
@@ -395,12 +388,6 @@ impl StreamerStats {
                 i64
             ),
             (
-                "packets_sent_for_batching",
-                self.total_packets_sent_for_batching
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
                 "staked_packets_sent_for_batching",
                 self.total_staked_packets_sent_for_batching
                     .swap(0, Ordering::Relaxed),
@@ -409,18 +396,6 @@ impl StreamerStats {
             (
                 "unstaked_packets_sent_for_batching",
                 self.total_unstaked_packets_sent_for_batching
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "bytes_sent_for_batching",
-                self.total_bytes_sent_for_batching
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "chunks_sent_for_batching",
-                self.total_chunks_sent_for_batching
                     .swap(0, Ordering::Relaxed),
                 i64
             ),
@@ -473,11 +448,6 @@ impl StreamerStats {
                 "handle_chunk_to_packet_batcher_send_disconnected_err",
                 self.total_handle_chunk_to_packet_batcher_send_disconnected_err
                     .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "packet_batches_sent",
-                self.total_packet_batches_sent.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
@@ -607,7 +577,6 @@ pub struct QuicStreamerConfig {
     pub max_unstaked_connections: usize,
     pub max_connections_per_ipaddr_per_min: u64,
     pub wait_for_chunk_timeout: Duration,
-    pub accumulator_channel_size: usize,
     pub num_threads: NonZeroUsize,
 }
 
@@ -632,7 +601,6 @@ impl Default for QuicStreamerConfig {
             max_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-            accumulator_channel_size: DEFAULT_ACCUMULATOR_CHANNEL_SIZE,
             num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
         }
     }
@@ -646,9 +614,6 @@ impl QuicStreamerConfig {
     pub fn default_for_tests() -> Self {
         // Shrink the channel size to avoid a massive allocation for tests
         Self {
-            accumulator_channel_size: 100_000,
-            max_connections_per_unstaked_peer: 1,
-            max_connections_per_staked_peer: 1,
             num_threads: Self::DEFAULT_NUM_SERVER_THREADS_FOR_TEST,
             ..Self::default()
         }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -593,8 +593,9 @@ impl QuicStreamerConfig {
 
     #[cfg(feature = "dev-context-only-utils")]
     pub fn default_for_tests() -> Self {
-        // Shrink the channel size to avoid a massive allocation for tests
         Self {
+            max_connections_per_unstaked_peer: 1,
+            max_connections_per_staked_peer: 1,
             num_threads: Self::DEFAULT_NUM_SERVER_THREADS_FOR_TEST,
             ..Self::default()
         }


### PR DESCRIPTION
#### Problem
#8356 removed the coalescing in the tpu, which removes the need for a batching thread. now, any batching is done by sigverify.

#### Summary of Changes
removes packet batch sender, sending from streamer to sigverify directly. Introduces a `PacketBatch::Single(BytesPacket)` and moves aggregation/batching to sigverify

this also removes 3 threads from the validator (quic tpu, quic tpu fwd, quic tpu vote). 

