### PR TITLE
Sort in **descending** stake order

### DIFF
--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -301,7 +301,7 @@ impl VoteStorage {
                 }
             })
             .collect::<Vec<_>>();
-        pubkey_with_weight.sort_by(|(w1, _), (w2, _)| w1.partial_cmp(w2).unwrap());
+        pubkey_with_weight.sort_by(|(w1, _), (w2, _)| w2.partial_cmp(w1).unwrap());
         pubkey_with_weight.into_iter().map(|(_, pubkey)| pubkey)
     }
 


### PR DESCRIPTION
#### Problem
- stake-weighted sorting with some randomness was doing it backward
	- ignore randomness for now, assume rng always return 0.5
	- 2 nodes, stake=1, stake=2
	- weights = 0.5^(1/1) = 0.5
	- weights = 0.5^(1/2) = 0.707
	- node with stake 2 would come 2nd in list 

#### Summary of Changes
- reverse the sort comparison

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
