### PR TITLE
Changes needed for new version numbers

### DIFF
--- a/ci/semver_bash/semver.sh
+++ b/ci/semver_bash/semver.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 function semverParseInto() {
-    local RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
+    local RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([\.0-9A-Za-z-]*\)'
     #MAJOR
     eval $2=`echo $1 | sed -e "s#$RE#\1#"`
     #MINOR
@@ -68,7 +68,6 @@ function semverLT() {
     if [[ $MAJOR_A -le $MAJOR_B  && $MINOR_A -lt $MINOR_B ]]; then
         return 0
     fi
-    
     if [[ $MAJOR_A -le $MAJOR_B  && $MINOR_A -le $MINOR_B && $PATCH_A -lt $PATCH_B ]]; then
         return 0
     fi

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -93,7 +93,7 @@ check)
   exit 0
   ;;
 -*)
-  if [[ $1 =~ ^-[A-Za-z0-9]*$ ]]; then
+  if [[ $1 =~ ^-[\.A-Za-z0-9]*$ ]]; then
     SPECIAL="$1"
   else
     echo "Error: Unsupported characters found in $1"


### PR DESCRIPTION
#### Problem
The current scripts don't support `.` in the prerelease part of the version number

#### Summary of Changes
Update the regexes

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
