### PR TITLE
clippy: derive Default impl for enums instead of manual impl

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1524,18 +1524,13 @@ impl fmt::Display for CliStakeState {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Default)]
 pub enum CliStakeType {
     Stake,
     RewardsPool,
+    #[default]
     Uninitialized,
     Initialized,
-}
-
-impl Default for CliStakeType {
-    fn default() -> Self {
-        Self::Uninitialized
-    }
 }
 
 #[derive(Serialize, Deserialize)]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -485,8 +485,9 @@ impl ValidatorConfig {
 // `ValidatorStartProgress` contains status information that is surfaced to the node operator over
 // the admin RPC channel to help them to follow the general progress of node startup without
 // having to watch log messages.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub enum ValidatorStartProgress {
+    #[default]
     Initializing, // Catch all, default state
     SearchingForRpcService,
     DownloadingSnapshot {
@@ -510,12 +511,6 @@ pub enum ValidatorStartProgress {
     // `Running` is the terminal state once the validator fully starts and all services are
     // operational
     Running,
-}
-
-impl Default for ValidatorStartProgress {
-    fn default() -> Self {
-        Self::Initializing
-    }
 }
 
 struct BlockstoreRootScan {

--- a/gossip/src/deprecated.rs
+++ b/gossip/src/deprecated.rs
@@ -4,17 +4,12 @@ use {
 };
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
 enum CompressionType {
+    #[default]
     Uncompressed,
     GZip,
     BZip2,
-}
-
-impl Default for CompressionType {
-    fn default() -> Self {
-        Self::Uncompressed
-    }
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -114,18 +114,13 @@ impl LedgerColumnOptions {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum BlockstoreCompressionType {
+    #[default]
     None,
     Snappy,
     Lz4,
     Zlib,
-}
-
-impl Default for BlockstoreCompressionType {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 impl BlockstoreCompressionType {

--- a/remote-wallet/src/locator.rs
+++ b/remote-wallet/src/locator.rs
@@ -8,16 +8,11 @@ use {
     uriparse::{URIReference, URIReferenceBuilder, URIReferenceError},
 };
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum Manufacturer {
+    #[default]
     Unknown,
     Ledger,
-}
-
-impl Default for Manufacturer {
-    fn default() -> Self {
-        Self::Unknown
-    }
 }
 
 const MANUFACTURER_UNKNOWN: &str = "unknown";

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -363,18 +363,13 @@ pub type TransactionBalances = Vec<Vec<u64>>;
 
 pub type PreCommitResult<'a> = Result<Option<RwLockReadGuard<'a, Hash>>>;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
 pub enum TransactionLogCollectorFilter {
     All,
     AllWithVotes,
+    #[default]
     None,
     OnlyMentionedAddresses,
-}
-
-impl Default for TransactionLogCollectorFilter {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 #[derive(Debug, Default)]

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -72,17 +72,13 @@ impl fmt::Display for UiTransactionEncoding {
 
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum TransactionDetails {
+    #[default]
     Full,
     Signatures,
     None,
     Accounts,
-}
-
-impl Default for TransactionDetails {
-    fn default() -> Self {
-        Self::Full
-    }
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
#### Problem
Manual implementation of `Default` trait is used in places where a derive can do the same job.
In rust 1.91 this triggers warnings (which we want to fix for https://github.com/anza-xyz/agave/issues/8117).

#### Summary of Changes
Update enums to use `derive(Default)` with `#[default]` market on specific enum variant
