### PR TITLE
clippy: use array instead of vec! in tests

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -841,7 +841,7 @@ mod tests {
                 ..Message::default()
             };
 
-            let txs = vec![new_sanitized_tx(&[&keypair], message, Hash::default())];
+            let txs = [new_sanitized_tx(&[&keypair], message, Hash::default())];
             let results = accounts.lock_accounts(
                 txs.iter(),
                 vec![Ok(()); txs.len()].into_iter(),
@@ -868,7 +868,7 @@ mod tests {
                 ..Message::default()
             };
 
-            let txs = vec![new_sanitized_tx(&[&keypair], message, Hash::default())];
+            let txs = [new_sanitized_tx(&[&keypair], message, Hash::default())];
             let results = accounts.lock_accounts(
                 txs.iter(),
                 vec![Ok(()); txs.len()].into_iter(),
@@ -943,7 +943,7 @@ mod tests {
             instructions,
         );
         let tx1 = new_sanitized_tx(&[&keypair1], message, Hash::default());
-        let txs = vec![tx0, tx1];
+        let txs = [tx0, tx1];
         let results1 = accounts.lock_accounts(
             txs.iter(),
             vec![Ok(()); txs.len()].into_iter(),
@@ -1042,7 +1042,7 @@ mod tests {
         let accounts_clone = accounts_arc.clone();
         let exit_clone = exit.clone();
         thread::spawn(move || loop {
-            let txs = vec![writable_tx.clone()];
+            let txs = [writable_tx.clone()];
             let results = accounts_clone.clone().lock_accounts(
                 txs.iter(),
                 vec![Ok(()); txs.len()].into_iter(),
@@ -1061,7 +1061,7 @@ mod tests {
         });
         let counter_clone = counter;
         for _ in 0..5 {
-            let txs = vec![readonly_tx.clone()];
+            let txs = [readonly_tx.clone()];
             let results = accounts_arc.clone().lock_accounts(
                 txs.iter(),
                 vec![Ok(()); txs.len()].into_iter(),
@@ -1200,7 +1200,7 @@ mod tests {
             instructions,
         );
         let tx2 = new_sanitized_tx(&[&keypair3], message, Hash::default());
-        let txs = vec![tx0, tx1, tx2];
+        let txs = [tx0, tx1, tx2];
 
         let qos_results = vec![
             Ok(()),

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -623,7 +623,7 @@ mod tests {
                 None,
             ),
         );
-        let txs = vec![transfer_tx.clone(), vote_tx.clone(), vote_tx, transfer_tx];
+        let txs = [transfer_tx.clone(), vote_tx.clone(), vote_tx, transfer_tx];
 
         let qos_service = QosService::new(1);
         let txs_costs = qos_service.compute_transaction_costs(
@@ -670,7 +670,7 @@ mod tests {
             CostModel::calculate_cost(&transfer_tx, &FeatureSet::all_enabled()).sum();
         let vote_tx_cost = CostModel::calculate_cost(&vote_tx, &FeatureSet::all_enabled()).sum();
         // make a vec of txs
-        let txs = vec![transfer_tx.clone(), vote_tx.clone(), transfer_tx, vote_tx];
+        let txs = [transfer_tx.clone(), vote_tx.clone(), transfer_tx, vote_tx];
 
         let qos_service = QosService::new(1);
         let txs_costs = qos_service.compute_transaction_costs(

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -604,7 +604,7 @@ pub(crate) mod tests {
                 None
             }
         };
-        let test_cases = vec![
+        let test_cases = [
             (
                 new_rand_data_shred(&mut rng, next_shred_index, &shredder, &leader, true),
                 new_rand_data_shred(
@@ -1118,8 +1118,7 @@ pub(crate) mod tests {
         let coding_shred_different_retransmitter =
             Shred::new_from_serialized_shred(coding_shred_different_retransmitter_payload).unwrap();
 
-        let test_cases = vec![
-            // Same data shred from different retransmitter
+        let test_cases = [
             (data_shred, data_shred_different_retransmitter),
             // Same coding shred from different retransmitter
             (coding_shred, coding_shred_different_retransmitter),

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -228,7 +228,7 @@ mod test {
             SocketAddr::from((Ipv4Addr::LOCALHOST, 3333)),
             SocketAddr::from((Ipv4Addr::LOCALHOST, 3333 + QUIC_PORT_OFFSET)),
         );
-        let recent_peers: HashMap<_, _> = vec![
+        let recent_peers: HashMap<_, _> = [
             (
                 validator_vote_keypairs0.node_keypair.pubkey(),
                 validator0_socket,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1073,7 +1073,7 @@ fn test_one_source_two_tx_one_batch() {
 
     let t1 = system_transaction::transfer(&mint_keypair, &key1, amount, genesis_config.hash());
     let t2 = system_transaction::transfer(&mint_keypair, &key2, amount, genesis_config.hash());
-    let txs = vec![t1.clone(), t2.clone()];
+    let txs = [t1.clone(), t2.clone()];
     let res = bank.process_transactions(txs.iter());
 
     assert_eq!(res.len(), 2);
@@ -1708,7 +1708,7 @@ fn test_debits_before_credits() {
         2 * LAMPORTS_PER_SOL,
         genesis_config.hash(),
     );
-    let txs = vec![tx0, tx1];
+    let txs = [tx0, tx1];
     let results = bank.process_transactions(txs.iter());
     assert!(results[0].is_err());
 
@@ -1791,7 +1791,7 @@ fn test_readonly_accounts(relax_intrabatch_account_locks: bool) {
         &[&payer1, &authorized_voter],
         bank.last_blockhash(),
     );
-    let txs = vec![tx0, tx1];
+    let txs = [tx0, tx1];
     let results = bank.process_transactions(txs.iter());
 
     // If multiple transactions attempt to read the same account, they should succeed.
@@ -1812,7 +1812,7 @@ fn test_readonly_accounts(relax_intrabatch_account_locks: bool) {
         1,
         bank.last_blockhash(),
     );
-    let txs = vec![tx0, tx1];
+    let txs = [tx0, tx1];
     let results = bank.process_transactions(txs.iter());
     // Whether an account can be locked as read-only and writable at the same time depends on features.
     assert_eq!(results[0], Ok(()));
@@ -8989,7 +8989,7 @@ fn test_failed_compute_request_instruction() {
         ],
         Some(&payer1_keypair.pubkey()),
     );
-    let txs = vec![
+    let txs = [
         Transaction::new(&[&payer0_keypair], message0, bank.last_blockhash()),
         Transaction::new(&[&payer1_keypair], message1, bank.last_blockhash()),
     ];

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -548,7 +548,7 @@ mod tests {
         // [9,      b, c          ]  -->  [5,     5,         5,         9        ]
         // [2,   a,    c          ]  -->  [2,     2,         5,         2        ]
         //
-        let txs = vec![
+        let txs = [
             build_sanitized_transaction_for_test(5, &write_account_a, &write_account_b),
             build_sanitized_transaction_for_test(9, &write_account_b, &write_account_c),
             build_sanitized_transaction_for_test(2, &write_account_a, &write_account_c),
@@ -592,7 +592,7 @@ mod tests {
         sync_update(
             &prioritization_fee_cache,
             bank1.clone(),
-            vec![build_sanitized_transaction_for_test(
+            [build_sanitized_transaction_for_test(
                 1,
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
@@ -603,7 +603,7 @@ mod tests {
 
         // add slot 2 entry to cache, but not finalize it
         let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 2));
-        let txs = vec![build_sanitized_transaction_for_test(
+        let txs = [build_sanitized_transaction_for_test(
             1,
             &Pubkey::new_unique(),
             &Pubkey::new_unique(),
@@ -614,7 +614,7 @@ mod tests {
         sync_update(
             &prioritization_fee_cache,
             bank3.clone(),
-            vec![build_sanitized_transaction_for_test(
+            [build_sanitized_transaction_for_test(
                 1,
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
@@ -667,7 +667,7 @@ mod tests {
 
         // Assert after add one transaction for slot 1
         {
-            let txs = vec![
+            let txs = [
                 build_sanitized_transaction_for_test(2, &write_account_a, &write_account_b),
                 build_sanitized_transaction_for_test(
                     1,
@@ -730,7 +730,7 @@ mod tests {
 
         // Assert after add one transaction for slot 2
         {
-            let txs = vec![
+            let txs = [
                 build_sanitized_transaction_for_test(4, &write_account_b, &write_account_c),
                 build_sanitized_transaction_for_test(
                     3,
@@ -804,7 +804,7 @@ mod tests {
 
         // Assert after add one transaction for slot 3
         {
-            let txs = vec![
+            let txs = [
                 build_sanitized_transaction_for_test(6, &write_account_a, &write_account_c),
                 build_sanitized_transaction_for_test(
                     5,
@@ -899,7 +899,7 @@ mod tests {
 
         // Assert after add transactions for bank1 of slot 1
         {
-            let txs = vec![
+            let txs = [
                 build_sanitized_transaction_for_test(2, &write_account_a, &write_account_b),
                 build_sanitized_transaction_for_test(
                     1,
@@ -912,7 +912,7 @@ mod tests {
 
         // Assert after add transactions for bank2 of slot 1
         {
-            let txs = vec![
+            let txs = [
                 build_sanitized_transaction_for_test(4, &write_account_b, &write_account_c),
                 build_sanitized_transaction_for_test(
                     3,


### PR DESCRIPTION
#### Problem
Some tests used `vec![some, values]` in places where `[some, values]` can be used.
In rust 1.91 this triggers warnings (which we want to fix for https://github.com/anza-xyz/agave/issues/8117).

#### Summary of Changes
Update tests to use array syntax instead of constructing vectors.
