### PR TITLE
clippy: use std::ptr::with_exposed_provenance_mut instead of transmute

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -72,6 +72,7 @@ use {
         mem::transmute,
         panic::AssertUnwindSafe,
         path::{Path, PathBuf},
+        ptr,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc, RwLock,
@@ -114,7 +115,7 @@ fn get_invoke_context<'a, 'b>() -> &'a mut InvokeContext<'b, 'b> {
         Some(val) => val,
         None => panic!("Invoke context not set!"),
     });
-    unsafe { transmute::<usize, &mut InvokeContext>(ptr) }
+    unsafe { &mut *ptr::with_exposed_provenance_mut(ptr) }
 }
 
 pub fn invoke_builtin_function(


### PR DESCRIPTION
#### Problem
Using `transmute` to convert `usize` to mut ref in rust 1.91 triggers warnings (which we want to fix for https://github.com/anza-xyz/agave/issues/8117):

```
warning: transmuting an integer to a pointer creates a pointer without provenance
   --> program-test/src/lib.rs:117:14
    |
117 |     unsafe { transmute::<usize, &mut InvokeContext>(ptr) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
    = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
    = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
    = note: `#[warn(integer_to_ptr_transmutes)]` on by default
help: use `std::ptr::with_exposed_provenance_mut` instead to use a previously exposed provenance
```

#### Summary of Changes
Convert from `usize` to `&mut InvokeContext` using specialized `std::ptr::with_exposed_provenance_mut`
