### PR TITLE
clippy: use io::Error::other instead of manually passing kind

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -148,9 +148,9 @@ pub fn load_validator_accounts(
             })?,
         ];
         let bls_pubkeys: Vec<BLSPubkey> = account_details.bls_pubkey.map_or(Ok(vec![]), |s| {
-            BLSPubkey::from_str(&s).map(|pk| vec![pk]).map_err(|err| {
-                io::Error::new(io::ErrorKind::Other, format!("Invalid BLS pubkey: {err}"))
-            })
+            BLSPubkey::from_str(&s)
+                .map(|pk| vec![pk])
+                .map_err(|err| io::Error::other(format!("Invalid BLS pubkey: {err}")))
         })?;
 
         add_validator_accounts(


### PR DESCRIPTION
#### Problem
Manual creation of `std::io::Error` of `Other` kind can be done instead with specialized constructor.
In rust 1.91 this triggers warnings (which we want to fix for https://github.com/anza-xyz/agave/issues/8117).

#### Summary of Changes
Use `Error::other()`
