### PR TITLE
clippy: fix mismatched_lifetime_syntaxes in monorepo

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -917,7 +917,7 @@ impl AccountStorageEntry {
     }
 
     /// Locks obsolete accounts with a read lock and returns the the accounts with the guard
-    pub(crate) fn obsolete_accounts_read_lock(&self) -> RwLockReadGuard<ObsoleteAccounts> {
+    pub(crate) fn obsolete_accounts_read_lock(&self) -> RwLockReadGuard<'_, ObsoleteAccounts> {
         self.obsolete_accounts.read().unwrap()
     }
 

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -339,7 +339,7 @@ impl AccountsFile {
     }
 
     /// Returns the way to access this accounts file when archiving
-    pub fn internals_for_archive(&self) -> InternalsForArchive {
+    pub fn internals_for_archive(&self) -> InternalsForArchive<'_> {
         match self {
             Self::AppendVec(av) => av.internals_for_archive(),
             Self::TieredStorage(ts) => InternalsForArchive::Mmap(

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -159,7 +159,7 @@ impl ReadWriteState {
         }
     }
 
-    fn append_guard(&self) -> MutexGuard<()> {
+    fn append_guard(&self) -> MutexGuard<'_, ()> {
         match self {
             Self::ReadOnly => panic!("append not allowed in read-only state"),
             Self::Writable { append_lock } => append_lock.lock().unwrap(),
@@ -573,7 +573,7 @@ impl AppendVec {
     /// doesn't overrun the internal buffer. Otherwise return None.
     /// Also return the offset of the first byte after the requested data that
     /// falls on a 64-byte boundary.
-    fn get_slice(slice: ValidSlice, offset: usize, size: usize) -> Option<(&[u8], usize)> {
+    fn get_slice(slice: ValidSlice<'_>, offset: usize, size: usize) -> Option<(&[u8], usize)> {
         // SAFETY: Wrapping math is safe here because if `end` does wrap, the Range
         // parameter to `.get()` will be invalid, and `.get()` will correctly return None.
         let end = offset.wrapping_add(size);
@@ -638,7 +638,7 @@ impl AppendVec {
     /// Return a reference to the type at `offset` if its data doesn't overrun the internal buffer.
     /// Otherwise return None. Also return the offset of the first byte after the requested data
     /// that falls on a 64-byte boundary.
-    fn get_type<T>(slice: ValidSlice, offset: usize) -> Option<(&T, usize)> {
+    fn get_type<T>(slice: ValidSlice<'_>, offset: usize) -> Option<(&T, usize)> {
         let (data, next) = Self::get_slice(slice, offset, mem::size_of::<T>())?;
         let ptr = data.as_ptr().cast();
         //UNSAFE: The cast is safe because the slice is aligned and fits into the memory
@@ -1321,7 +1321,7 @@ impl AppendVec {
     }
 
     /// Returns the way to access this accounts file when archiving
-    pub(crate) fn internals_for_archive(&self) -> InternalsForArchive {
+    pub(crate) fn internals_for_archive(&self) -> InternalsForArchive<'_> {
         match &self.backing {
             AppendVecFileBacking::File(_file) => InternalsForArchive::FileIo(self.path()),
             // note this returns the entire mmap slice, even bytes that we consider invalid

--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -130,7 +130,7 @@ impl BlockhashQueue {
         note = "Please do not use, will no longer be available in the future"
     )]
     #[allow(deprecated)]
-    pub fn get_recent_blockhashes(&self) -> impl Iterator<Item = recent_blockhashes::IterItem> {
+    pub fn get_recent_blockhashes(&self) -> impl Iterator<Item = recent_blockhashes::IterItem<'_>> {
         (self.hashes).iter().map(|(k, v)| {
             recent_blockhashes::IterItem(v.hash_index, k, v.fee_calculator.lamports_per_signature)
         })

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -100,7 +100,7 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
         }
     }
 
-    fn get_write_bucket(&self) -> RwLockWriteGuard<Option<Bucket<T>>> {
+    fn get_write_bucket(&self) -> RwLockWriteGuard<'_, Option<Bucket<T>>> {
         let mut bucket = self.bucket.write().unwrap();
         if let Some(bucket) = bucket.as_mut() {
             bucket.handle_delayed_grows();

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -275,7 +275,9 @@ fn write_transaction<W: io::Write>(
     Ok(())
 }
 
-fn transform_lookups_to_unknown_keys(lookups: &[MessageAddressTableLookup]) -> Vec<AccountKeyType> {
+fn transform_lookups_to_unknown_keys(
+    lookups: &[MessageAddressTableLookup],
+) -> Vec<AccountKeyType<'_>> {
     let unknown_writable_keys = lookups
         .iter()
         .enumerate()

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -236,7 +236,7 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
         self.push_ids_into_queue(std::iter::once(priority_id)) > 0
     }
 
-    fn get_vacant_map_entry(&mut self) -> VacantEntry<TransactionState<Tx>> {
+    fn get_vacant_map_entry(&mut self) -> VacantEntry<'_, TransactionState<Tx>> {
         assert!(self.id_to_transaction_state.len() < self.id_to_transaction_state.capacity());
         self.id_to_transaction_state.vacant_entry()
     }

--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -848,7 +848,7 @@ impl HeaviestSubtreeForkChoice {
         }
     }
 
-    fn ancestor_iterator(&self, start_slot_hash_key: SlotHashKey) -> AncestorIterator {
+    fn ancestor_iterator(&self, start_slot_hash_key: SlotHashKey) -> AncestorIterator<'_> {
         AncestorIterator::new(start_slot_hash_key, &self.fork_infos)
     }
 

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -501,7 +501,7 @@ mod tests {
     fn simple_usage_cost_details(
         transaction: &WritableKeysTransaction,
         programs_execution_cost: u64,
-    ) -> UsageCostDetails<WritableKeysTransaction> {
+    ) -> UsageCostDetails<'_, WritableKeysTransaction> {
         UsageCostDetails {
             transaction,
             signature_cost: 0,
@@ -516,7 +516,7 @@ mod tests {
     fn simple_transaction_cost(
         transaction: &WritableKeysTransaction,
         programs_execution_cost: u64,
-    ) -> TransactionCost<WritableKeysTransaction> {
+    ) -> TransactionCost<'_, WritableKeysTransaction> {
         TransactionCost::Transaction(simple_usage_cost_details(
             transaction,
             programs_execution_cost,
@@ -525,7 +525,7 @@ mod tests {
 
     fn simple_vote_transaction_cost(
         transaction: &WritableKeysTransaction,
-    ) -> TransactionCost<WritableKeysTransaction> {
+    ) -> TransactionCost<'_, WritableKeysTransaction> {
         TransactionCost::SimpleVote { transaction }
     }
 

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -198,14 +198,18 @@ impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction
 
     fn instructions_iter(
         &self,
-    ) -> impl Iterator<Item = solana_svm_transaction::instruction::SVMInstruction> {
+    ) -> impl Iterator<Item = solana_svm_transaction::instruction::SVMInstruction<'_>> {
         core::iter::empty()
     }
 
     fn program_instructions_iter(
         &self,
-    ) -> impl Iterator<Item = (&Pubkey, solana_svm_transaction::instruction::SVMInstruction)> + Clone
-    {
+    ) -> impl Iterator<
+        Item = (
+            &Pubkey,
+            solana_svm_transaction::instruction::SVMInstruction<'_>,
+        ),
+    > + Clone {
         core::iter::empty()
     }
 
@@ -213,7 +217,7 @@ impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction
         &self.0
     }
 
-    fn account_keys(&self) -> solana_message::AccountKeys {
+    fn account_keys(&self) -> solana_message::AccountKeys<'_> {
         solana_message::AccountKeys::new(&self.0, None)
     }
 
@@ -240,7 +244,9 @@ impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction
     fn message_address_table_lookups(
         &self,
     ) -> impl Iterator<
-        Item = solana_svm_transaction::message_address_table_lookup::SVMMessageAddressTableLookup,
+        Item = solana_svm_transaction::message_address_table_lookup::SVMMessageAddressTableLookup<
+            '_,
+        >,
     > {
         core::iter::empty()
     }
@@ -289,7 +295,7 @@ impl solana_runtime_transaction::transaction_with_meta::TransactionWithMeta
     #[allow(refining_impl_trait)]
     fn as_sanitized_transaction(
         &self,
-    ) -> std::borrow::Cow<solana_transaction::sanitized::SanitizedTransaction> {
+    ) -> std::borrow::Cow<'_, solana_transaction::sanitized::SanitizedTransaction> {
         unimplemented!("WritableKeysTransaction::as_sanitized_transaction");
     }
 

--- a/install/src/update_manifest.rs
+++ b/install/src/update_manifest.rs
@@ -29,7 +29,7 @@ impl Signable for SignedUpdateManifest {
         self.account_pubkey
     }
 
-    fn signable_data(&self) -> Cow<[u8]> {
+    fn signable_data(&self) -> Cow<'_, [u8]> {
         Cow::Owned(bincode::serialize(&self.manifest).expect("serialize"))
     }
     fn get_signature(&self) -> Signature {

--- a/ledger/src/bit_vec.rs
+++ b/ledger/src/bit_vec.rs
@@ -255,7 +255,7 @@ impl<const NUM_BITS: usize> BitVec<NUM_BITS> {
     /// assert_eq!(bit_vec.range(..2).iter_ones().collect::<Vec<_>>(), [0, 1]);
     /// assert_eq!(bit_vec.range(1..).count_ones(), 1);
     /// ```
-    pub fn range(&self, bounds: impl RangeBounds<usize>) -> BitVecSlice<NUM_BITS> {
+    pub fn range(&self, bounds: impl RangeBounds<usize>) -> BitVecSlice<'_, NUM_BITS> {
         BitVecSlice::from_range_bounds(self, bounds)
     }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3025,7 +3025,10 @@ impl Blockstore {
     ///
     /// The function will return BlockstoreError::SlotCleanedUp if the input
     /// `slot` has already been cleaned-up.
-    fn check_lowest_cleanup_slot(&self, slot: Slot) -> Result<std::sync::RwLockReadGuard<Slot>> {
+    fn check_lowest_cleanup_slot(
+        &self,
+        slot: Slot,
+    ) -> Result<std::sync::RwLockReadGuard<'_, Slot>> {
         // lowest_cleanup_slot is the last slot that was not cleaned up by LedgerCleanupService
         let lowest_cleanup_slot = self.lowest_cleanup_slot.read().unwrap();
         if *lowest_cleanup_slot > 0 && *lowest_cleanup_slot >= slot {
@@ -3042,7 +3045,7 @@ impl Blockstore {
     /// This function ensures a consistent result by using lowest_cleanup_slot
     /// as the lower bound for reading columns that do not employ strong read
     /// consistency with slot-based delete_range.
-    fn ensure_lowest_cleanup_slot(&self) -> (std::sync::RwLockReadGuard<Slot>, Slot) {
+    fn ensure_lowest_cleanup_slot(&self) -> (std::sync::RwLockReadGuard<'_, Slot>, Slot) {
         let lowest_cleanup_slot = self.lowest_cleanup_slot.read().unwrap();
         let lowest_available_slot = (*lowest_cleanup_slot)
             .checked_add(1)

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -349,7 +349,7 @@ impl Rocks {
         &self,
         cf: &ColumnFamily,
         key: impl AsRef<[u8]>,
-    ) -> Result<Option<DBPinnableSlice>> {
+    ) -> Result<Option<DBPinnableSlice<'_>>> {
         let opt = self.db.get_pinned_cf(cf, key)?;
         Ok(opt)
     }
@@ -363,7 +363,7 @@ impl Rocks {
         &self,
         cf: &ColumnFamily,
         keys: I,
-    ) -> impl Iterator<Item = Result<Option<DBPinnableSlice>>>
+    ) -> impl Iterator<Item = Result<Option<DBPinnableSlice<'_>>>>
     where
         K: AsRef<[u8]> + 'a + ?Sized,
         I: IntoIterator<Item = &'a K>,
@@ -394,11 +394,11 @@ impl Rocks {
         &self,
         cf: &ColumnFamily,
         iterator_mode: RocksIteratorMode,
-    ) -> DBIterator {
+    ) -> DBIterator<'_> {
         self.db.iterator_cf(cf, iterator_mode)
     }
 
-    pub(crate) fn raw_iterator_cf(&self, cf: &ColumnFamily) -> Result<DBRawIterator> {
+    pub(crate) fn raw_iterator_cf(&self, cf: &ColumnFamily) -> Result<DBRawIterator<'_>> {
         Ok(self.db.raw_iterator_cf(cf))
     }
 

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -77,7 +77,7 @@ pub(crate) enum Shred {
 
 impl Shred {
     dispatch!(fn erasure_shard_index(&self) -> Result<usize, Error>);
-    dispatch!(fn erasure_shard_mut(&mut self) -> Result<PayloadMutGuard<Range<usize>>, Error>);
+    dispatch!(fn erasure_shard_mut(&mut self) -> Result<PayloadMutGuard<'_, Range<usize>>, Error>);
     dispatch!(fn merkle_node(&self) -> Result<Hash, Error>);
     dispatch!(fn sanitize(&self) -> Result<(), Error>);
     dispatch!(fn set_chained_merkle_root(&mut self, chained_merkle_root: &Hash) -> Result<(), Error>);
@@ -444,7 +444,7 @@ macro_rules! impl_merkle_shred {
         }
 
         // Returns the erasure coded slice as a mutable reference.
-        fn erasure_shard_mut(&mut self) -> Result<PayloadMutGuard<Range<usize>>, Error> {
+        fn erasure_shard_mut(&mut self) -> Result<PayloadMutGuard<'_, Range<usize>>, Error> {
             let offsets = self.erasure_shard_offsets()?;
             let payload_size = self.payload.len();
             self.payload

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -47,7 +47,7 @@ pub fn get_shred_mut(buffer: &mut [u8]) -> Option<&mut [u8]> {
 }
 
 #[inline]
-pub fn get_shred_and_repair_nonce(packet: PacketRef) -> Option<(&[u8], Option<Nonce>)> {
+pub fn get_shred_and_repair_nonce(packet: PacketRef<'_>) -> Option<(&[u8], Option<Nonce>)> {
     let data = packet.data(..)?;
     let shred = data.get(..get_shred_size(data)?)?;
     if !packet.meta().repair() {

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -139,7 +139,7 @@ impl MerkleTree {
         self.nodes.iter().last()
     }
 
-    pub fn find_path(&self, index: usize) -> Option<Proof> {
+    pub fn find_path(&self, index: usize) -> Option<Proof<'_>> {
         if index >= self.leaf_count {
             return None;
         }

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -209,7 +209,7 @@ impl PacketBatch {
         }
     }
 
-    pub fn par_iter(&self) -> PacketBatchParIter {
+    pub fn par_iter(&self) -> PacketBatchParIter<'_> {
         match self {
             Self::Pinned(batch) => {
                 PacketBatchParIter::Pinned(batch.par_iter().map(PacketRef::from))
@@ -218,7 +218,7 @@ impl PacketBatch {
         }
     }
 
-    pub fn par_iter_mut(&mut self) -> PacketBatchParIterMut {
+    pub fn par_iter_mut(&mut self) -> PacketBatchParIterMut<'_> {
         match self {
             Self::Pinned(batch) => {
                 PacketBatchParIterMut::Pinned(batch.par_iter_mut().map(PacketRefMut::from))

--- a/poh/src/poh_controller.rs
+++ b/poh/src/poh_controller.rs
@@ -116,7 +116,7 @@ pub struct PohServiceMessageReceiver {
 }
 
 impl PohServiceMessageReceiver {
-    pub(crate) fn try_recv(&self) -> Result<PohServiceMessageGuard, TryRecvError> {
+    pub(crate) fn try_recv(&self) -> Result<PohServiceMessageGuard<'_>, TryRecvError> {
         self.receiver
             .try_recv()
             .map(|message| PohServiceMessageGuard {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1932,7 +1932,7 @@ impl Bank {
         self.epoch_schedule().first_normal_epoch
     }
 
-    pub fn freeze_lock(&self) -> RwLockReadGuard<Hash> {
+    pub fn freeze_lock(&self) -> RwLockReadGuard<'_, Hash> {
         self.hash.read().unwrap()
     }
 
@@ -2936,7 +2936,7 @@ impl Bank {
     pub fn prepare_entry_batch(
         &self,
         txs: Vec<VersionedTransaction>,
-    ) -> Result<TransactionBatch<RuntimeTransaction<SanitizedTransaction>>> {
+    ) -> Result<TransactionBatch<'_, '_, RuntimeTransaction<SanitizedTransaction>>> {
         let enable_static_instruction_limit = self
             .feature_set
             .is_active(&agave_feature_set::static_instruction_limit::id());
@@ -5180,11 +5180,11 @@ impl Bank {
             .shrink_ancient_slots(self.epoch_schedule())
     }
 
-    pub fn read_cost_tracker(&self) -> LockResult<RwLockReadGuard<CostTracker>> {
+    pub fn read_cost_tracker(&self) -> LockResult<RwLockReadGuard<'_, CostTracker>> {
         self.cost_tracker.read()
     }
 
-    pub fn write_cost_tracker(&self) -> LockResult<RwLockWriteGuard<CostTracker>> {
+    pub fn write_cost_tracker(&self) -> LockResult<RwLockWriteGuard<'_, CostTracker>> {
         self.cost_tracker.write()
     }
 
@@ -5937,7 +5937,7 @@ impl Bank {
     pub fn prepare_batch_for_tests(
         &self,
         txs: Vec<Transaction>,
-    ) -> TransactionBatch<RuntimeTransaction<SanitizedTransaction>> {
+    ) -> TransactionBatch<'_, '_, RuntimeTransaction<SanitizedTransaction>> {
         let sanitized_txs = txs
             .into_iter()
             .map(RuntimeTransaction::from_transaction_for_tests)

--- a/runtime/src/read_optimized_dashmap.rs
+++ b/runtime/src/read_optimized_dashmap.rs
@@ -52,7 +52,7 @@ where
         self.inner.get(k).map(|v| ROValue::clone(&v))
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = DashmapIteratorItem<K, V, S>> {
+    pub fn iter(&self) -> impl Iterator<Item = DashmapIteratorItem<'_, K, V, S>> {
         self.inner.iter()
     }
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -62,7 +62,7 @@ impl StakesCache {
         Self(RwLock::new(stakes))
     }
 
-    pub(crate) fn stakes(&self) -> RwLockReadGuard<Stakes<StakeAccount>> {
+    pub(crate) fn stakes(&self) -> RwLockReadGuard<'_, Stakes<StakeAccount>> {
         self.0.read().unwrap()
     }
 

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -467,7 +467,7 @@ impl TransactionWithStatusMeta {
         }
     }
 
-    pub fn account_keys(&self) -> AccountKeys {
+    pub fn account_keys(&self) -> AccountKeys<'_> {
         match self {
             Self::MissingMetadata(tx) => AccountKeys::new(&tx.message.account_keys, None),
             Self::Complete(tx_with_meta) => tx_with_meta.account_keys(),
@@ -545,7 +545,7 @@ impl VersionedTransactionWithStatusMeta {
         })
     }
 
-    pub fn account_keys(&self) -> AccountKeys {
+    pub fn account_keys(&self) -> AccountKeys<'_> {
         AccountKeys::new(
             self.transaction.message.static_account_keys(),
             Some(&self.meta.loaded_addresses),

--- a/vote/src/vote_state_view.rs
+++ b/vote/src/vote_state_view.rs
@@ -177,13 +177,13 @@ impl VoteStateView {
         }
     }
 
-    fn inflation_rewards_commission_view(&self) -> CommissionView {
+    fn inflation_rewards_commission_view(&self) -> CommissionView<'_> {
         let offset = self.frame.offset(Field::Commission);
         // SAFETY: `frame` was created from `data`.
         CommissionView::new(self.frame.commission_frame(), &self.data[offset..])
     }
 
-    fn block_revenue_commission_view(&self) -> Option<CommissionView> {
+    fn block_revenue_commission_view(&self) -> Option<CommissionView<'_>> {
         let offset = self
             .frame
             .simd185_field_offset(Simd185Field::BlockRevenueCommission)?;
@@ -194,7 +194,7 @@ impl VoteStateView {
         ))
     }
 
-    fn pending_delegator_rewards_view(&self) -> Option<PendingDelegatorRewardsView> {
+    fn pending_delegator_rewards_view(&self) -> Option<PendingDelegatorRewardsView<'_>> {
         let offset = self
             .frame
             .simd185_field_offset(Simd185Field::PendingDelegatorRewards)?;
@@ -202,7 +202,7 @@ impl VoteStateView {
         Some(PendingDelegatorRewardsView::new(&self.data[offset..]))
     }
 
-    fn bls_pubkey_compressed_view(&self) -> Option<BlsPubkeyCompressedView> {
+    fn bls_pubkey_compressed_view(&self) -> Option<BlsPubkeyCompressedView<'_>> {
         let offset = self
             .frame
             .simd185_field_offset(Simd185Field::BlsPubkeyCompressed)?;
@@ -211,25 +211,25 @@ impl VoteStateView {
         Some(BlsPubkeyCompressedView::new(frame, &self.data[offset..]))
     }
 
-    fn votes_view(&self) -> ListView<VotesFrame> {
+    fn votes_view(&self) -> ListView<'_, VotesFrame> {
         let offset = self.frame.offset(Field::Votes);
         // SAFETY: `frame` was created from `data`.
         ListView::new(self.frame.votes_frame(), &self.data[offset..])
     }
 
-    fn root_slot_view(&self) -> RootSlotView {
+    fn root_slot_view(&self) -> RootSlotView<'_> {
         let offset = self.frame.offset(Field::RootSlot);
         // SAFETY: `frame` was created from `data`.
         RootSlotView::new(self.frame.root_slot_frame(), &self.data[offset..])
     }
 
-    fn authorized_voters_view(&self) -> ListView<AuthorizedVotersListFrame> {
+    fn authorized_voters_view(&self) -> ListView<'_, AuthorizedVotersListFrame> {
         let offset = self.frame.offset(Field::AuthorizedVoters);
         // SAFETY: `frame` was created from `data`.
         ListView::new(self.frame.authorized_voters_frame(), &self.data[offset..])
     }
 
-    fn epoch_credits_view(&self) -> ListView<EpochCreditsListFrame> {
+    fn epoch_credits_view(&self) -> ListView<'_, EpochCreditsListFrame> {
         let offset = self.frame.offset(Field::EpochCredits);
         // SAFETY: `frame` was created from `data`.
         ListView::new(self.frame.epoch_credits_frame(), &self.data[offset..])


### PR DESCRIPTION
#### Problem
According to newer clippy rules "the same lifetime is referred to in inconsistent ways, making the signature confusing"
This is a new lint `mismatched_lifetime_syntaxes` in rust 1.89 (which we want to fix for https://github.com/anza-xyz/agave/issues/8117).

#### Summary of Changes
Specify `'_` explicitly on return types

(this PR covers various crates, but for those covered by specific code-owners I've sent out separate PRs)