### PR TITLE
clippy: fix mismatched_lifetime_syntaxes in tx-metadata

### DIFF
--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -104,11 +104,13 @@ impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
         self.transaction.num_instructions()
     }
 
-    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction> {
+    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
         self.transaction.instructions_iter()
     }
 
-    fn program_instructions_iter(&self) -> impl Iterator<Item = (&Pubkey, SVMInstruction)> + Clone {
+    fn program_instructions_iter(
+        &self,
+    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
         self.transaction.program_instructions_iter()
     }
 
@@ -116,7 +118,7 @@ impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
         self.transaction.static_account_keys()
     }
 
-    fn account_keys(&self) -> AccountKeys {
+    fn account_keys(&self) -> AccountKeys<'_> {
         self.transaction.account_keys()
     }
 
@@ -140,7 +142,9 @@ impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
         self.transaction.num_lookup_tables()
     }
 
-    fn message_address_table_lookups(&self) -> impl Iterator<Item = SVMMessageAddressTableLookup> {
+    fn message_address_table_lookups(
+        &self,
+    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
         self.transaction.message_address_table_lookups()
     }
 }

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -135,7 +135,7 @@ impl RuntimeTransaction<SanitizedTransaction> {
 
 impl TransactionWithMeta for RuntimeTransaction<SanitizedTransaction> {
     #[inline]
-    fn as_sanitized_transaction(&self) -> Cow<SanitizedTransaction> {
+    fn as_sanitized_transaction(&self) -> Cow<'_, SanitizedTransaction> {
         Cow::Borrowed(self)
     }
 

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -107,7 +107,7 @@ impl<D: TransactionData> RuntimeTransaction<ResolvedTransactionView<D>> {
 }
 
 impl<D: TransactionData> TransactionWithMeta for RuntimeTransaction<ResolvedTransactionView<D>> {
-    fn as_sanitized_transaction(&self) -> Cow<SanitizedTransaction> {
+    fn as_sanitized_transaction(&self) -> Cow<'_, SanitizedTransaction> {
         let VersionedTransaction {
             signatures,
             message,

--- a/runtime-transaction/src/transaction_with_meta.rs
+++ b/runtime-transaction/src/transaction_with_meta.rs
@@ -9,7 +9,7 @@ pub trait TransactionWithMeta: StaticMeta + SVMTransaction {
     /// Required to interact with geyser plugins.
     /// This function should not be used except for interacting with geyser.
     /// It may do numerous allocations that negatively impact performance.
-    fn as_sanitized_transaction(&self) -> Cow<SanitizedTransaction>;
+    fn as_sanitized_transaction(&self) -> Cow<'_, SanitizedTransaction>;
     /// Required to interact with several legacy interfaces that require
     /// `VersionedTransaction`. This should not be used unless necessary, as it
     /// performs numerous allocations that negatively impact performance.

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -172,7 +172,7 @@ impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {
         usize::from(self.view.num_instructions())
     }
 
-    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction> {
+    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
         self.view.instructions_iter()
     }
 
@@ -181,7 +181,7 @@ impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {
     ) -> impl Iterator<
         Item = (
             &solana_pubkey::Pubkey,
-            solana_svm_transaction::instruction::SVMInstruction,
+            solana_svm_transaction::instruction::SVMInstruction<'_>,
         ),
     > + Clone {
         self.view.program_instructions_iter()
@@ -191,7 +191,7 @@ impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {
         self.view.static_account_keys()
     }
 
-    fn account_keys(&self) -> AccountKeys {
+    fn account_keys(&self) -> AccountKeys<'_> {
         AccountKeys::new(
             self.view.static_account_keys(),
             self.resolved_addresses.as_ref(),
@@ -223,7 +223,9 @@ impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {
         usize::from(self.view.num_address_table_lookups())
     }
 
-    fn message_address_table_lookups(&self) -> impl Iterator<Item = SVMMessageAddressTableLookup> {
+    fn message_address_table_lookups(
+        &self,
+    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
         self.view.address_table_lookup_iter()
     }
 }

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -143,7 +143,7 @@ impl<const SANITIZED: bool, D: TransactionData> TransactionView<SANITIZED, D> {
 
     /// Return an iterator over the instructions in the transaction.
     #[inline]
-    pub fn instructions_iter(&self) -> InstructionsIterator {
+    pub fn instructions_iter(&self) -> InstructionsIterator<'_> {
         let data = self.data();
         // SAFETY: `frame` was created from `data`.
         unsafe { self.frame.instructions_iter(data) }
@@ -151,7 +151,7 @@ impl<const SANITIZED: bool, D: TransactionData> TransactionView<SANITIZED, D> {
 
     /// Return an iterator over the address table lookups in the transaction.
     #[inline]
-    pub fn address_table_lookup_iter(&self) -> AddressTableLookupIterator {
+    pub fn address_table_lookup_iter(&self) -> AddressTableLookupIterator<'_> {
         let data = self.data();
         // SAFETY: `frame` was created from `data`.
         unsafe { self.frame.address_table_lookup_iter(data) }
@@ -181,7 +181,7 @@ impl<D: TransactionData> TransactionView<true, D> {
     /// Return an iterator over the instructions paired with their program ids.
     pub fn program_instructions_iter(
         &self,
-    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction)> + Clone {
+    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
         self.instructions_iter().map(|ix| {
             let program_id_index = usize::from(ix.program_id_index);
             let program_id = &self.static_account_keys()[program_id_index];


### PR DESCRIPTION
#### Problem
According to newer clippy rules "the same lifetime is referred to in inconsistent ways, making the signature confusing"
This is a new lint mismatched_lifetime_syntaxes in rust 1.89 (which we want to fix for https://github.com/anza-xyz/agave/issues/8117).

#### Summary of Changes
Specify '_ explicitly on return types
