### PR TITLE
clippy: fix mismatched_lifetime_syntaxes in svm

### DIFF
--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1499,7 +1499,7 @@ mod tests {
             }
         }
 
-        fn caller_account(&mut self) -> CallerAccount {
+        fn caller_account(&mut self) -> CallerAccount<'_> {
             let data = if self.stricter_abi_and_runtime_constraints {
                 &mut []
             } else {
@@ -1528,7 +1528,7 @@ mod tests {
     }
 
     impl MockAccountInfo<'_> {
-        fn new(key: Pubkey, account: &AccountSharedData) -> MockAccountInfo {
+        fn new(key: Pubkey, account: &AccountSharedData) -> MockAccountInfo<'_> {
             MockAccountInfo {
                 key,
                 is_signer: false,

--- a/svm-transaction/src/svm_message.rs
+++ b/svm-transaction/src/svm_message.rs
@@ -47,17 +47,19 @@ pub trait SVMMessage: Debug {
     fn num_instructions(&self) -> usize;
 
     /// Return an iterator over the instructions in the message.
-    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction>;
+    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>>;
 
     /// Return an iterator over the instructions in the message, paired with
     /// the pubkey of the program.
-    fn program_instructions_iter(&self) -> impl Iterator<Item = (&Pubkey, SVMInstruction)> + Clone;
+    fn program_instructions_iter(
+        &self,
+    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone;
 
     /// Return the list of static account keys.
     fn static_account_keys(&self) -> &[Pubkey];
 
     /// Return the account keys.
-    fn account_keys(&self) -> AccountKeys;
+    fn account_keys(&self) -> AccountKeys<'_>;
 
     /// Return the fee-payer
     fn fee_payer(&self) -> &Pubkey;
@@ -138,7 +140,9 @@ pub trait SVMMessage: Debug {
     fn num_lookup_tables(&self) -> usize;
 
     /// Get message address table lookups used in the message
-    fn message_address_table_lookups(&self) -> impl Iterator<Item = SVMMessageAddressTableLookup>;
+    fn message_address_table_lookups(
+        &self,
+    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>>;
 }
 
 fn default_precompile_signature_count<'a>(

--- a/svm-transaction/src/svm_message/sanitized_message.rs
+++ b/svm-transaction/src/svm_message/sanitized_message.rs
@@ -26,13 +26,15 @@ impl SVMMessage for SanitizedMessage {
         SanitizedMessage::instructions(self).len()
     }
 
-    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction> {
+    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
         SanitizedMessage::instructions(self)
             .iter()
             .map(SVMInstruction::from)
     }
 
-    fn program_instructions_iter(&self) -> impl Iterator<Item = (&Pubkey, SVMInstruction)> + Clone {
+    fn program_instructions_iter(
+        &self,
+    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
         SanitizedMessage::program_instructions_iter(self)
             .map(|(pubkey, ix)| (pubkey, SVMInstruction::from(ix)))
     }
@@ -41,7 +43,7 @@ impl SVMMessage for SanitizedMessage {
         SanitizedMessage::static_account_keys(self)
     }
 
-    fn account_keys(&self) -> AccountKeys {
+    fn account_keys(&self) -> AccountKeys<'_> {
         SanitizedMessage::account_keys(self)
     }
 
@@ -65,7 +67,9 @@ impl SVMMessage for SanitizedMessage {
         SanitizedMessage::message_address_table_lookups(self).len()
     }
 
-    fn message_address_table_lookups(&self) -> impl Iterator<Item = SVMMessageAddressTableLookup> {
+    fn message_address_table_lookups(
+        &self,
+    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
         SanitizedMessage::message_address_table_lookups(self)
             .iter()
             .map(SVMMessageAddressTableLookup::from)

--- a/svm-transaction/src/svm_message/sanitized_transaction.rs
+++ b/svm-transaction/src/svm_message/sanitized_transaction.rs
@@ -26,11 +26,13 @@ impl SVMMessage for SanitizedTransaction {
         SVMMessage::num_instructions(SanitizedTransaction::message(self))
     }
 
-    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction> {
+    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
         SVMMessage::instructions_iter(SanitizedTransaction::message(self))
     }
 
-    fn program_instructions_iter(&self) -> impl Iterator<Item = (&Pubkey, SVMInstruction)> + Clone {
+    fn program_instructions_iter(
+        &self,
+    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
         SVMMessage::program_instructions_iter(SanitizedTransaction::message(self))
     }
 
@@ -38,7 +40,7 @@ impl SVMMessage for SanitizedTransaction {
         SVMMessage::static_account_keys(SanitizedTransaction::message(self))
     }
 
-    fn account_keys(&self) -> AccountKeys {
+    fn account_keys(&self) -> AccountKeys<'_> {
         SVMMessage::account_keys(SanitizedTransaction::message(self))
     }
 
@@ -62,7 +64,9 @@ impl SVMMessage for SanitizedTransaction {
         SVMMessage::num_lookup_tables(SanitizedTransaction::message(self))
     }
 
-    fn message_address_table_lookups(&self) -> impl Iterator<Item = SVMMessageAddressTableLookup> {
+    fn message_address_table_lookups(
+        &self,
+    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
         SVMMessage::message_address_table_lookups(SanitizedTransaction::message(self))
     }
 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -341,7 +341,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .unwrap_or_else(|| self.environments.clone())
     }
 
-    pub fn sysvar_cache(&self) -> RwLockReadGuard<SysvarCache> {
+    pub fn sysvar_cache(&self) -> RwLockReadGuard<'_, SysvarCache> {
         self.sysvar_cache.read().unwrap()
     }
 

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -212,7 +212,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
     pub fn get_instruction_context_at_index_in_trace(
         &self,
         index_in_trace: usize,
-    ) -> Result<InstructionContext, InstructionError> {
+    ) -> Result<InstructionContext<'_, '_>, InstructionError> {
         let instruction = self
             .instruction_trace
             .get(index_in_trace)
@@ -232,7 +232,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
     pub fn get_instruction_context_at_nesting_level(
         &self,
         nesting_level: usize,
-    ) -> Result<InstructionContext, InstructionError> {
+    ) -> Result<InstructionContext<'_, '_>, InstructionError> {
         let index_in_trace = *self
             .instruction_stack
             .get(nesting_level)
@@ -254,7 +254,9 @@ impl<'ix_data> TransactionContext<'ix_data> {
     }
 
     /// Returns a view on the current instruction
-    pub fn get_current_instruction_context(&self) -> Result<InstructionContext, InstructionError> {
+    pub fn get_current_instruction_context(
+        &self,
+    ) -> Result<InstructionContext<'_, '_>, InstructionError> {
         let level = self
             .get_instruction_stack_height()
             .checked_sub(1)
@@ -265,7 +267,9 @@ impl<'ix_data> TransactionContext<'ix_data> {
     /// Returns a view on the next instruction. This function assumes it has already been
     /// configured with the correct values in `prepare_next_instruction` or
     /// `prepare_next_top_level_instruction`
-    pub fn get_next_instruction_context(&self) -> Result<InstructionContext, InstructionError> {
+    pub fn get_next_instruction_context(
+        &self,
+    ) -> Result<InstructionContext<'_, '_>, InstructionError> {
         let index_in_trace = self
             .instruction_trace
             .len()
@@ -481,7 +485,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
     }
 
     /// Take ownership of the instruction trace
-    pub fn take_instruction_trace(&mut self) -> Vec<InstructionFrame> {
+    pub fn take_instruction_trace(&mut self) -> Vec<InstructionFrame<'_>> {
         // The last frame is a placeholder for the next instruction to be executed, so it
         // is empty.
         self.instruction_trace.pop();
@@ -642,7 +646,7 @@ impl<'a> InstructionContext<'a, '_> {
     pub fn try_borrow_instruction_account(
         &self,
         index_in_instruction: IndexOfAccount,
-    ) -> Result<BorrowedInstructionAccount, InstructionError> {
+    ) -> Result<BorrowedInstructionAccount<'_, '_>, InstructionError> {
         let instruction_account = *self
             .instruction_accounts
             .get(index_in_instruction as usize)

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -335,7 +335,7 @@ impl TransactionAccounts {
     pub(crate) fn try_borrow_mut(
         &self,
         index: IndexOfAccount,
-    ) -> Result<AccountRefMut, InstructionError> {
+    ) -> Result<AccountRefMut<'_>, InstructionError> {
         let borrow_counter = self
             .borrow_counters
             .get(index as usize)
@@ -367,7 +367,7 @@ impl TransactionAccounts {
         })
     }
 
-    pub fn try_borrow(&self, index: IndexOfAccount) -> Result<AccountRef, InstructionError> {
+    pub fn try_borrow(&self, index: IndexOfAccount) -> Result<AccountRef<'_>, InstructionError> {
         let borrow_counter = self
             .borrow_counters
             .get(index as usize)


### PR DESCRIPTION
#### Problem
According to newer clippy rules "the same lifetime is referred to in inconsistent ways, making the signature confusing"
This is a new lint mismatched_lifetime_syntaxes in rust 1.89 (which we want to fix for https://github.com/anza-xyz/agave/issues/8117).

#### Summary of Changes
Specify '_ explicitly on return types