### PR TITLE
clippy: fix mismatched_lifetime_syntaxes in networking

### DIFF
--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -41,7 +41,7 @@ impl Signable for CrdsValue {
         self.pubkey()
     }
 
-    fn signable_data(&self) -> Cow<[u8]> {
+    fn signable_data(&self) -> Cow<'static, [u8]> {
         Cow::Owned(serialize(&self.data).expect("failed to serialize CrdsData"))
     }
 

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -94,7 +94,7 @@ impl<const N: usize> Signable for Ping<N> {
     }
 
     #[inline]
-    fn signable_data(&self) -> Cow<[u8]> {
+    fn signable_data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(&self.token)
     }
 
@@ -140,7 +140,7 @@ impl Signable for Pong {
         self.from
     }
 
-    fn signable_data(&self) -> Cow<[u8]> {
+    fn signable_data(&self) -> Cow<'static, [u8]> {
         Cow::Owned(self.hash.as_ref().into())
     }
 

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -103,7 +103,7 @@ impl Protocol {
 }
 
 impl PruneData {
-    fn signable_data_without_prefix(&self) -> Cow<[u8]> {
+    fn signable_data_without_prefix(&self) -> Cow<'static, [u8]> {
         #[derive(Serialize)]
         struct SignData<'a> {
             pubkey: &'a Pubkey,
@@ -120,7 +120,7 @@ impl PruneData {
         Cow::Owned(serialize(&data).expect("should serialize PruneData"))
     }
 
-    fn signable_data_with_prefix(&self) -> Cow<[u8]> {
+    fn signable_data_with_prefix(&self) -> Cow<'static, [u8]> {
         #[derive(Serialize)]
         struct SignDataWithPrefix<'a> {
             prefix: &'a [u8],
@@ -199,7 +199,7 @@ impl Signable for PruneData {
         self.pubkey
     }
 
-    fn signable_data(&self) -> Cow<[u8]> {
+    fn signable_data(&self) -> Cow<'static, [u8]> {
         // Continue to return signable data without a prefix until cluster has upgraded
         self.signable_data_without_prefix()
     }

--- a/quic-client/src/quic_client.rs
+++ b/quic-client/src/quic_client.rs
@@ -47,7 +47,7 @@ impl AsyncTaskSemaphore {
     /// When returned, the lock has been locked and usage count has been
     /// incremented. When the returned MutexGuard is dropped the lock is dropped
     /// without decrementing the usage count.
-    pub fn acquire(&self) -> MutexGuard<u64> {
+    pub fn acquire(&self) -> MutexGuard<'_, u64> {
         let mut count = self.counter.lock().unwrap();
         *count += 1;
         while *count > self.permits {

--- a/rpc-client-types/src/filter.rs
+++ b/rpc-client-types/src/filter.rs
@@ -154,7 +154,7 @@ impl Memcmp {
         self.offset
     }
 
-    pub fn bytes(&self) -> Option<Cow<Vec<u8>>> {
+    pub fn bytes(&self) -> Option<Cow<'_, Vec<u8>>> {
         use MemcmpEncodedBytes::*;
         match &self.bytes {
             Base58(bytes) => bs58::decode(bytes).into_vec().ok().map(Cow::Owned),


### PR DESCRIPTION
#### Problem
According to newer clippy rules "the same lifetime is referred to in inconsistent ways, making the signature confusing"
This is a new lint mismatched_lifetime_syntaxes in rust 1.89 (which we want to fix for https://github.com/anza-xyz/agave/issues/8117).

#### Summary of Changes
Specify '_ explicitly on return types