### PR TITLE
validator: Organize blockstore related args

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -297,7 +297,6 @@ pub struct DefaultArgs {
     pub snapshot_zstd_compression_level: String,
 
     pub rocksdb_shred_compaction: String,
-    pub rocksdb_perf_sample_interval: String,
 
     pub accounts_shrink_optimize_total_space: String,
     pub accounts_shrink_ratio: String,
@@ -350,7 +349,6 @@ impl DefaultArgs {
             contact_debug_interval: "120000".to_string(),
             snapshot_version: SnapshotVersion::default(),
             rocksdb_shred_compaction: "level".to_string(),
-            rocksdb_perf_sample_interval: "0".to_string(),
             accounts_shrink_optimize_total_space: DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE
                 .to_string(),
             accounts_shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_RATIO.to_string(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -297,7 +297,6 @@ pub struct DefaultArgs {
     pub snapshot_zstd_compression_level: String,
 
     pub rocksdb_shred_compaction: String,
-    pub rocksdb_ledger_compression: String,
     pub rocksdb_perf_sample_interval: String,
 
     pub accounts_shrink_optimize_total_space: String,
@@ -351,7 +350,6 @@ impl DefaultArgs {
             contact_debug_interval: "120000".to_string(),
             snapshot_version: SnapshotVersion::default(),
             rocksdb_shred_compaction: "level".to_string(),
-            rocksdb_ledger_compression: "none".to_string(),
             rocksdb_perf_sample_interval: "0".to_string(),
             accounts_shrink_optimize_total_space: DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE
                 .to_string(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -296,8 +296,6 @@ pub struct DefaultArgs {
     pub snapshot_archive_format: String,
     pub snapshot_zstd_compression_level: String,
 
-    pub rocksdb_shred_compaction: String,
-
     pub accounts_shrink_optimize_total_space: String,
     pub accounts_shrink_ratio: String,
     pub tpu_connection_pool_size: String,
@@ -348,7 +346,6 @@ impl DefaultArgs {
             snapshot_zstd_compression_level: "1".to_string(), // level 1 is optimized for speed
             contact_debug_interval: "120000".to_string(),
             snapshot_version: SnapshotVersion::default(),
-            rocksdb_shred_compaction: "level".to_string(),
             accounts_shrink_optimize_total_space: DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE
                 .to_string(),
             accounts_shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_RATIO.to_string(),

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -19,7 +19,6 @@ pub struct DefaultThreadArgs {
     pub rayon_global_threads: String,
     pub replay_forks_threads: String,
     pub replay_transactions_threads: String,
-    pub rocksdb_compaction_threads: String,
     pub rocksdb_flush_threads: String,
     pub tpu_transaction_forward_receive_threads: String,
     pub tpu_transaction_receive_threads: String,
@@ -44,7 +43,6 @@ impl Default for DefaultThreadArgs {
             replay_forks_threads: ReplayForksThreadsArg::bounded_default().to_string(),
             replay_transactions_threads: ReplayTransactionsThreadsArg::bounded_default()
                 .to_string(),
-            rocksdb_compaction_threads: RocksdbCompactionThreadsArg::bounded_default().to_string(),
             rocksdb_flush_threads: RocksdbFlushThreadsArg::bounded_default().to_string(),
             tpu_transaction_forward_receive_threads:
                 TpuTransactionForwardReceiveThreadArgs::bounded_default().to_string(),
@@ -69,7 +67,6 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
         new_thread_arg::<RayonGlobalThreadsArg>(&defaults.rayon_global_threads),
         new_thread_arg::<ReplayForksThreadsArg>(&defaults.replay_forks_threads),
         new_thread_arg::<ReplayTransactionsThreadsArg>(&defaults.replay_transactions_threads),
-        new_thread_arg::<RocksdbCompactionThreadsArg>(&defaults.rocksdb_compaction_threads),
         new_thread_arg::<RocksdbFlushThreadsArg>(&defaults.rocksdb_flush_threads),
         new_thread_arg::<TpuTransactionForwardReceiveThreadArgs>(
             &defaults.tpu_transaction_forward_receive_threads,
@@ -313,17 +310,6 @@ impl ThreadArg for ReplayTransactionsThreadsArg {
 
     fn default() -> usize {
         num_cpus::get()
-    }
-}
-
-pub struct RocksdbCompactionThreadsArg;
-impl ThreadArg for RocksdbCompactionThreadsArg {
-    const NAME: &'static str = "rocksdb_compaction_threads";
-    const LONG_NAME: &'static str = "rocksdb-compaction-threads";
-    const HELP: &'static str = "Number of threads to use for rocksdb (Blockstore) compactions";
-
-    fn default() -> usize {
-        solana_ledger::blockstore::default_num_compaction_threads().get()
     }
 }
 

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -78,7 +78,7 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
     ]
 }
 
-fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
+pub(crate) fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
     Arg::with_name(T::NAME)
         .long(T::LONG_NAME)
         .takes_value(true)

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -19,7 +19,6 @@ pub struct DefaultThreadArgs {
     pub rayon_global_threads: String,
     pub replay_forks_threads: String,
     pub replay_transactions_threads: String,
-    pub rocksdb_flush_threads: String,
     pub tpu_transaction_forward_receive_threads: String,
     pub tpu_transaction_receive_threads: String,
     pub tpu_vote_transaction_receive_threads: String,
@@ -43,7 +42,6 @@ impl Default for DefaultThreadArgs {
             replay_forks_threads: ReplayForksThreadsArg::bounded_default().to_string(),
             replay_transactions_threads: ReplayTransactionsThreadsArg::bounded_default()
                 .to_string(),
-            rocksdb_flush_threads: RocksdbFlushThreadsArg::bounded_default().to_string(),
             tpu_transaction_forward_receive_threads:
                 TpuTransactionForwardReceiveThreadArgs::bounded_default().to_string(),
             tpu_transaction_receive_threads: TpuTransactionReceiveThreads::bounded_default()
@@ -67,7 +65,6 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
         new_thread_arg::<RayonGlobalThreadsArg>(&defaults.rayon_global_threads),
         new_thread_arg::<ReplayForksThreadsArg>(&defaults.replay_forks_threads),
         new_thread_arg::<ReplayTransactionsThreadsArg>(&defaults.replay_transactions_threads),
-        new_thread_arg::<RocksdbFlushThreadsArg>(&defaults.rocksdb_flush_threads),
         new_thread_arg::<TpuTransactionForwardReceiveThreadArgs>(
             &defaults.tpu_transaction_forward_receive_threads,
         ),
@@ -310,17 +307,6 @@ impl ThreadArg for ReplayTransactionsThreadsArg {
 
     fn default() -> usize {
         num_cpus::get()
-    }
-}
-
-pub struct RocksdbFlushThreadsArg;
-impl ThreadArg for RocksdbFlushThreadsArg {
-    const NAME: &'static str = "rocksdb_flush_threads";
-    const LONG_NAME: &'static str = "rocksdb-flush-threads";
-    const HELP: &'static str = "Number of threads to use for rocksdb (Blockstore) memtable flushes";
-
-    fn default() -> usize {
-        solana_ledger::blockstore::default_num_flush_threads().get()
     }
 }
 

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -584,19 +584,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rocksdb_perf_sample_interval")
-            .hidden(hidden_unless_forced())
-            .long("rocksdb-perf-sample-interval")
-            .value_name("ROCKS_PERF_SAMPLE_INTERVAL")
-            .takes_value(true)
-            .validator(is_parsable::<usize>)
-            .default_value(&default_args.rocksdb_perf_sample_interval)
-            .help(
-                "Controls how often RocksDB read/write performance samples are collected. Perf \
-                 samples are collected in 1 / ROCKS_PERF_SAMPLE_INTERVAL sampling rate.",
-            ),
-    )
-    .arg(
         Arg::with_name("skip_startup_ledger_verification")
             .long("skip-startup-ledger-verification")
             .takes_value(false)

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1341,6 +1341,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
     .args(&rpc_bigtable_config::args())
     .args(&send_transaction_config::args())
     .args(&rpc_bootstrap_config::args())
+    .args(&blockstore_options::args())
 }
 
 fn validators_set(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -572,18 +572,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Keep this amount of shreds in root slots."),
     )
     .arg(
-        Arg::with_name("rocksdb_shred_compaction")
-            .long("rocksdb-shred-compaction")
-            .value_name("ROCKSDB_COMPACTION_STYLE")
-            .takes_value(true)
-            .possible_values(&["level"])
-            .default_value(&default_args.rocksdb_shred_compaction)
-            .help(
-                "Controls how RocksDB compacts shreds. *WARNING*: You will lose your Blockstore \
-                 data when you switch between options.",
-            ),
-    )
-    .arg(
         Arg::with_name("skip_startup_ledger_verification")
             .long("skip-startup-ledger-verification")
             .takes_value(false)

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -584,19 +584,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("rocksdb_ledger_compression")
-            .hidden(hidden_unless_forced())
-            .long("rocksdb-ledger-compression")
-            .value_name("COMPRESSION_TYPE")
-            .takes_value(true)
-            .possible_values(&["none", "lz4", "snappy", "zlib"])
-            .default_value(&default_args.rocksdb_ledger_compression)
-            .help(
-                "The compression algorithm that is used to compress transaction status data. \
-                 Turning on compression can save ~10% of the ledger size.",
-            ),
-    )
-    .arg(
         Arg::with_name("rocksdb_perf_sample_interval")
             .hidden(hidden_unless_forced())
             .long("rocksdb-perf-sample-interval")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -562,16 +562,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Output snapshot version"),
     )
     .arg(
-        Arg::with_name("limit_ledger_size")
-            .long("limit-ledger-size")
-            .value_name("SHRED_COUNT")
-            .takes_value(true)
-            .min_values(0)
-            .max_values(1)
-            /* .default_value() intentionally not used here! */
-            .help("Keep this amount of shreds in root slots."),
-    )
-    .arg(
         Arg::with_name("skip_startup_ledger_verification")
             .long("skip-startup-ledger-verification")
             .takes_value(false)

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -923,19 +923,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("wal_recovery_mode")
-            .long("wal-recovery-mode")
-            .value_name("MODE")
-            .takes_value(true)
-            .possible_values(&[
-                "tolerate_corrupted_tail_records",
-                "absolute_consistency",
-                "point_in_time",
-                "skip_any_corrupted_record",
-            ])
-            .help("Mode to recovery the ledger db write ahead log."),
-    )
-    .arg(
         Arg::with_name("poh_pinned_cpu_core")
             .hidden(hidden_unless_forced())
             .long("experimental-poh-pinned-cpu-core")

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -134,6 +134,14 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
                 "Controls how RocksDB compacts shreds. *WARNING*: You will lose your Blockstore \
                  data when you switch between options.",
             ),
+        Arg::with_name("limit_ledger_size")
+            .long("limit-ledger-size")
+            .value_name("SHRED_COUNT")
+            .takes_value(true)
+            .min_values(0)
+            .max_values(1)
+            /* .default_value() intentionally not used here! */
+            .help("Keep this amount of shreds in root slots."),
     ]
 }
 

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -3,7 +3,7 @@ use {
         cli::thread_args::{RocksdbCompactionThreadsArg, RocksdbFlushThreadsArg, ThreadArg},
         commands::{FromClapArgMatches, Result},
     },
-    clap::{value_t, ArgMatches},
+    clap::{value_t, Arg, ArgMatches},
     solana_ledger::blockstore_options::{
         AccessType, BlockstoreCompressionType, BlockstoreOptions, BlockstoreRecoveryMode,
         LedgerColumnOptions,
@@ -37,7 +37,7 @@ impl FromClapArgMatches for BlockstoreOptions {
             rocks_perf_sample_interval: value_t!(matches, "rocksdb_perf_sample_interval", usize)?,
         };
 
-        let rocksdb_compaction_threads =
+        let rocksdb_compaction_threads: std::num::NonZero<usize> =
             value_t!(matches, RocksdbCompactionThreadsArg::NAME, NonZeroUsize)?;
 
         let rocksdb_flush_threads = value_t!(matches, RocksdbFlushThreadsArg::NAME, NonZeroUsize)?;
@@ -51,6 +51,10 @@ impl FromClapArgMatches for BlockstoreOptions {
             num_rocksdb_flush_threads: rocksdb_flush_threads,
         })
     }
+}
+
+pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
+    vec![]
 }
 
 #[cfg(test)]

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -54,7 +54,17 @@ impl FromClapArgMatches for BlockstoreOptions {
 }
 
 pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
-    vec![]
+    vec![Arg::with_name("wal_recovery_mode")
+        .long("wal-recovery-mode")
+        .value_name("MODE")
+        .takes_value(true)
+        .possible_values(&[
+            "tolerate_corrupted_tail_records",
+            "absolute_consistency",
+            "point_in_time",
+            "skip_any_corrupted_record",
+        ])
+        .help("Mode to recovery the ledger db write ahead log.")]
 }
 
 #[cfg(test)]

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -4,7 +4,7 @@ use {
         commands::{FromClapArgMatches, Result},
     },
     clap::{value_t, Arg, ArgMatches},
-    solana_clap_utils::hidden_unless_forced,
+    solana_clap_utils::{hidden_unless_forced, input_validators::is_parsable},
     solana_ledger::blockstore_options::{
         AccessType, BlockstoreCompressionType, BlockstoreOptions, BlockstoreRecoveryMode,
         LedgerColumnOptions,
@@ -13,6 +13,7 @@ use {
 };
 
 const DEFAULT_ROCKSDB_LEDGER_COMPRESSION: &str = "none";
+const DEFAULT_ROCKSDB_PERF_SAMPLE_INTERVAL: &str = "0";
 
 impl FromClapArgMatches for BlockstoreOptions {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
@@ -79,6 +80,17 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .help(
                 "The compression algorithm that is used to compress transaction status data. \
                  Turning on compression can save ~10% of the ledger size.",
+            ),
+        Arg::with_name("rocksdb_perf_sample_interval")
+            .hidden(hidden_unless_forced())
+            .long("rocksdb-perf-sample-interval")
+            .value_name("ROCKS_PERF_SAMPLE_INTERVAL")
+            .takes_value(true)
+            .validator(is_parsable::<usize>)
+            .default_value(DEFAULT_ROCKSDB_PERF_SAMPLE_INTERVAL)
+            .help(
+                "Controls how often RocksDB read/write performance samples are collected. Perf \
+                 samples are collected in 1 / ROCKS_PERF_SAMPLE_INTERVAL sampling rate.",
             ),
     ]
 }
@@ -233,5 +245,10 @@ mod tests {
     #[test]
     fn test_default_rocksdb_ledger_compression_unchanged() {
         assert_eq!(DEFAULT_ROCKSDB_LEDGER_COMPRESSION, "none");
+    }
+
+    #[test]
+    fn test_default_rocksdb_perf_sample_interval_unchanged() {
+        assert_eq!(DEFAULT_ROCKSDB_PERF_SAMPLE_INTERVAL, "0");
     }
 }

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -29,6 +29,7 @@ static DEFAULT_ROCKSDB_FLUSH_THREADS: LazyLock<String> = LazyLock::new(|| {
         .get()
         .to_string()
 });
+const DEFAULT_ROCKSDB_SHRED_COMPACTION: &str = "level";
 
 impl FromClapArgMatches for BlockstoreOptions {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
@@ -123,6 +124,16 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .validator(|num| is_within_range(num, VALID_RANGE_ROCKSDB_FLUSH_THREADS.clone()))
             .hidden(hidden_unless_forced())
             .help("Number of threads to use for rocksdb (Blockstore) memtable flushes"),
+        Arg::with_name("rocksdb_shred_compaction")
+            .long("rocksdb-shred-compaction")
+            .value_name("ROCKSDB_COMPACTION_STYLE")
+            .takes_value(true)
+            .possible_values(&["level"])
+            .default_value(DEFAULT_ROCKSDB_SHRED_COMPACTION)
+            .help(
+                "Controls how RocksDB compacts shreds. *WARNING*: You will lose your Blockstore \
+                 data when you switch between options.",
+            ),
     ]
 }
 
@@ -313,5 +324,10 @@ mod tests {
             *VALID_RANGE_ROCKSDB_FLUSH_THREADS,
             RangeInclusive::new(1, num_cpus::get()),
         );
+    }
+
+    #[test]
+    fn test_default_rocksdb_shred_compaction_unchanged() {
+        assert_eq!(DEFAULT_ROCKSDB_SHRED_COMPACTION, "level");
     }
 }


### PR DESCRIPTION
#### Summary of Changes

- move BlockstoreOptions related args to config file
- move `rocksdb_compaction_threads` and `rocksdb_flush_threads` from `thread_args` to config file