### PR TITLE
refactor: expect instead of unwrap in proof serialization

### DIFF
--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -58,7 +58,7 @@ pub mod zk_token_proof_state;
 #[cfg(not(target_os = "solana"))]
 pub use curve25519_dalek;
 
-/// Byte length of a compressed Ristretto point or scalar in Curve255519
+/// Byte length of a compressed Ristretto point or scalar in Curve25519
 const UNIT_LEN: usize = 32;
 /// Byte length of a compressed Ristretto point in Curve25519
 const RISTRETTO_POINT_LEN: usize = UNIT_LEN;

--- a/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/ciphertext_commitment_equality_proof.rs
@@ -211,12 +211,30 @@ impl CiphertextCommitmentEqualityProof {
     pub fn to_bytes(&self) -> [u8; CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_LEN] {
         let mut buf = [0_u8; CIPHERTEXT_COMMITMENT_EQUALITY_PROOF_LEN];
         let mut chunks = buf.chunks_mut(UNIT_LEN);
-        chunks.next().unwrap().copy_from_slice(self.Y_0.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.Y_1.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.Y_2.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.z_s.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.z_x.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.z_r.as_bytes());
+        chunks
+            .next()
+            .expect("ciphertext-commitment equality proof buffer has chunk for Y_0")
+            .copy_from_slice(self.Y_0.as_bytes());
+        chunks
+            .next()
+            .expect("ciphertext-commitment equality proof buffer has chunk for Y_1")
+            .copy_from_slice(self.Y_1.as_bytes());
+        chunks
+            .next()
+            .expect("ciphertext-commitment equality proof buffer has chunk for Y_2")
+            .copy_from_slice(self.Y_2.as_bytes());
+        chunks
+            .next()
+            .expect("ciphertext-commitment equality proof buffer has chunk for z_s")
+            .copy_from_slice(self.z_s.as_bytes());
+        chunks
+            .next()
+            .expect("ciphertext-commitment equality proof buffer has chunk for z_x")
+            .copy_from_slice(self.z_x.as_bytes());
+        chunks
+            .next()
+            .expect("ciphertext-commitment equality proof buffer has chunk for z_r")
+            .copy_from_slice(self.z_r.as_bytes());
         buf
     }
 

--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -396,35 +396,35 @@ impl FeeSigmaProof {
         let mut chunks = buf.chunks_mut(UNIT_LEN);
         chunks
             .next()
-            .unwrap()
+            .expect("fee proof buffer has chunk for Y_max_proof")
             .copy_from_slice(self.fee_max_proof.Y_max_proof.as_bytes());
         chunks
             .next()
-            .unwrap()
+            .expect("fee proof buffer has chunk for z_max_proof")
             .copy_from_slice(self.fee_max_proof.z_max_proof.as_bytes());
         chunks
             .next()
-            .unwrap()
+            .expect("fee proof buffer has chunk for c_max_proof")
             .copy_from_slice(self.fee_max_proof.c_max_proof.as_bytes());
         chunks
             .next()
-            .unwrap()
+            .expect("fee proof buffer has chunk for Y_delta")
             .copy_from_slice(self.fee_equality_proof.Y_delta.as_bytes());
         chunks
             .next()
-            .unwrap()
+            .expect("fee proof buffer has chunk for Y_claimed")
             .copy_from_slice(self.fee_equality_proof.Y_claimed.as_bytes());
         chunks
             .next()
-            .unwrap()
+            .expect("fee proof buffer has chunk for z_x")
             .copy_from_slice(self.fee_equality_proof.z_x.as_bytes());
         chunks
             .next()
-            .unwrap()
+            .expect("fee proof buffer has chunk for z_delta")
             .copy_from_slice(self.fee_equality_proof.z_delta.as_bytes());
         chunks
             .next()
-            .unwrap()
+            .expect("fee proof buffer has chunk for z_claimed")
             .copy_from_slice(self.fee_equality_proof.z_claimed.as_bytes());
         buf
     }

--- a/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof/handles_2.rs
+++ b/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof/handles_2.rs
@@ -204,11 +204,26 @@ impl GroupedCiphertext2HandlesValidityProof {
     pub fn to_bytes(&self) -> [u8; GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN] {
         let mut buf = [0_u8; GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_PROOF_LEN];
         let mut chunks = buf.chunks_mut(UNIT_LEN);
-        chunks.next().unwrap().copy_from_slice(self.Y_0.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.Y_1.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.Y_2.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.z_r.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.z_x.as_bytes());
+        chunks
+            .next()
+            .expect("grouped ciphertext proof buffer has chunk for Y_0")
+            .copy_from_slice(self.Y_0.as_bytes());
+        chunks
+            .next()
+            .expect("grouped ciphertext proof buffer has chunk for Y_1")
+            .copy_from_slice(self.Y_1.as_bytes());
+        chunks
+            .next()
+            .expect("grouped ciphertext proof buffer has chunk for Y_2")
+            .copy_from_slice(self.Y_2.as_bytes());
+        chunks
+            .next()
+            .expect("grouped ciphertext proof buffer has chunk for z_r")
+            .copy_from_slice(self.z_r.as_bytes());
+        chunks
+            .next()
+            .expect("grouped ciphertext proof buffer has chunk for z_x")
+            .copy_from_slice(self.z_x.as_bytes());
         buf
     }
 

--- a/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof/handles_3.rs
+++ b/zk-token-sdk/src/sigma_proofs/grouped_ciphertext_validity_proof/handles_3.rs
@@ -239,12 +239,30 @@ impl GroupedCiphertext3HandlesValidityProof {
     pub fn to_bytes(&self) -> [u8; GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN] {
         let mut buf = [0_u8; GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_PROOF_LEN];
         let mut chunks = buf.chunks_mut(UNIT_LEN);
-        chunks.next().unwrap().copy_from_slice(self.Y_0.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.Y_1.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.Y_2.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.Y_3.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.z_r.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.z_x.as_bytes());
+        chunks
+            .next()
+            .expect("grouped ciphertext proof buffer has chunk for Y_0")
+            .copy_from_slice(self.Y_0.as_bytes());
+        chunks
+            .next()
+            .expect("grouped ciphertext proof buffer has chunk for Y_1")
+            .copy_from_slice(self.Y_1.as_bytes());
+        chunks
+            .next()
+            .expect("grouped ciphertext proof buffer has chunk for Y_2")
+            .copy_from_slice(self.Y_2.as_bytes());
+        chunks
+            .next()
+            .expect("grouped ciphertext proof buffer has chunk for Y_3")
+            .copy_from_slice(self.Y_3.as_bytes());
+        chunks
+            .next()
+            .expect("grouped ciphertext proof buffer has chunk for z_r")
+            .copy_from_slice(self.z_r.as_bytes());
+        chunks
+            .next()
+            .expect("grouped ciphertext proof buffer has chunk for z_x")
+            .copy_from_slice(self.z_x.as_bytes());
         buf
     }
 

--- a/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
@@ -123,8 +123,14 @@ impl PubkeyValidityProof {
     pub fn to_bytes(&self) -> [u8; PUBKEY_VALIDITY_PROOF_LEN] {
         let mut buf = [0_u8; PUBKEY_VALIDITY_PROOF_LEN];
         let mut chunks = buf.chunks_mut(UNIT_LEN);
-        chunks.next().unwrap().copy_from_slice(self.Y.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.z.as_bytes());
+        chunks
+            .next()
+            .expect("pubkey validity proof buffer has chunk for Y")
+            .copy_from_slice(self.Y.as_bytes());
+        chunks
+            .next()
+            .expect("pubkey validity proof buffer has chunk for z")
+            .copy_from_slice(self.z.as_bytes());
         buf
     }
 

--- a/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
@@ -161,9 +161,18 @@ impl ZeroBalanceProof {
     pub fn to_bytes(&self) -> [u8; ZERO_BALANCE_PROOF_LEN] {
         let mut buf = [0_u8; ZERO_BALANCE_PROOF_LEN];
         let mut chunks = buf.chunks_mut(UNIT_LEN);
-        chunks.next().unwrap().copy_from_slice(self.Y_P.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.Y_D.as_bytes());
-        chunks.next().unwrap().copy_from_slice(self.z.as_bytes());
+        chunks
+            .next()
+            .expect("zero-balance proof buffer has chunk for Y_P")
+            .copy_from_slice(self.Y_P.as_bytes());
+        chunks
+            .next()
+            .expect("zero-balance proof buffer has chunk for Y_D")
+            .copy_from_slice(self.Y_D.as_bytes());
+        chunks
+            .next()
+            .expect("zero-balance proof buffer has chunk for z")
+            .copy_from_slice(self.z.as_bytes());
         buf
     }
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/range_proof.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/range_proof.rs
@@ -130,18 +130,33 @@ impl TryFrom<RangeProofU256> for decoded::RangeProof {
 #[cfg(not(target_os = "solana"))]
 fn copy_range_proof_modulo_inner_product_proof(proof: &decoded::RangeProof, buf: &mut [u8]) {
     let mut chunks = buf.chunks_mut(UNIT_LEN);
-    chunks.next().unwrap().copy_from_slice(proof.A.as_bytes());
-    chunks.next().unwrap().copy_from_slice(proof.S.as_bytes());
-    chunks.next().unwrap().copy_from_slice(proof.T_1.as_bytes());
-    chunks.next().unwrap().copy_from_slice(proof.T_2.as_bytes());
-    chunks.next().unwrap().copy_from_slice(proof.t_x.as_bytes());
     chunks
         .next()
-        .unwrap()
+        .expect("range proof buffer has chunk for A")
+        .copy_from_slice(proof.A.as_bytes());
+    chunks
+        .next()
+        .expect("range proof buffer has chunk for S")
+        .copy_from_slice(proof.S.as_bytes());
+    chunks
+        .next()
+        .expect("range proof buffer has chunk for T_1")
+        .copy_from_slice(proof.T_1.as_bytes());
+    chunks
+        .next()
+        .expect("range proof buffer has chunk for T_2")
+        .copy_from_slice(proof.T_2.as_bytes());
+    chunks
+        .next()
+        .expect("range proof buffer has chunk for t_x")
+        .copy_from_slice(proof.t_x.as_bytes());
+    chunks
+        .next()
+        .expect("range proof buffer has chunk for t_x_blinding")
         .copy_from_slice(proof.t_x_blinding.as_bytes());
     chunks
         .next()
-        .unwrap()
+        .expect("range proof buffer has chunk for e_blinding")
         .copy_from_slice(proof.e_blinding.as_bytes());
 }
 


### PR DESCRIPTION
#### Problem
Chained method calls were written in one line, making the code harder to read and review in diffs.

#### Summary of Changes

- Replaced unwrap() with expect("…") in serialization/deserialization:
- Formatted the code

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
