### PR TITLE
streamer: remove redundant zero assignments for msghdr

### DIFF
--- a/streamer/src/msghdr.rs
+++ b/streamer/src/msghdr.rs
@@ -20,8 +20,10 @@ pub(crate) fn create_msghdr(
     msg_hdr.msg_namelen = msg_namelen;
     msg_hdr.msg_iov = iov.as_mut_ptr();
     msg_hdr.msg_iovlen = 1;
-    msg_hdr.msg_control = ptr::null::<libc::c_void>() as *mut _;
-    msg_hdr.msg_controllen = 0;
-    msg_hdr.msg_flags = 0;
+    // Fields below are already zero-initialized by zeroed().
+    // msg_hdr.msg_control = ptr::null::<libc::c_void>() as *mut _;
+    // msg_hdr.msg_controllen = 0;
+    // msg_hdr.msg_flags = 0;
+    
     msg_hdr
 }

--- a/streamer/src/msghdr.rs
+++ b/streamer/src/msghdr.rs
@@ -4,7 +4,6 @@ use {
     libc::{iovec, msghdr, sockaddr_storage, socklen_t},
     std::{
         mem::{zeroed, MaybeUninit},
-        ptr,
     },
 };
 
@@ -24,6 +23,5 @@ pub(crate) fn create_msghdr(
     // msg_hdr.msg_control = ptr::null::<libc::c_void>() as *mut _;
     // msg_hdr.msg_controllen = 0;
     // msg_hdr.msg_flags = 0;
-    
     msg_hdr
 }


### PR DESCRIPTION
Remove redundant assignments to msg_control, msg_controllen, and msg_flags

These fields are already zero-initialized by zeroed(). The original assignments 
are retained as comments for clarity.