### PR TITLE
support simd83 in greedy scheduler

### DIFF
--- a/core/benches/scheduler.rs
+++ b/core/benches/scheduler.rs
@@ -215,6 +215,7 @@ fn timing_scheduler<T: ReceiveAndBuffer, S: Scheduler<T::Transaction>>(
                         .schedule(
                             black_box(&mut container),
                             u64::MAX, // no budget
+                            false,
                             bench_env.filter_1,
                             bench_env.filter_2,
                         )

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -77,6 +77,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
         &mut self,
         container: &mut S,
         budget: u64,
+        _relax_intrabatch_account_locks: bool,
         _pre_graph_filter: impl Fn(&[&Tx], &mut [bool]),
         pre_lock_filter: impl Fn(&TransactionState<Tx>) -> PreLockFilterAction,
     ) -> Result<SchedulingSummary, SchedulerError> {
@@ -426,6 +427,7 @@ mod test {
             scheduler.schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter
             ),
@@ -446,6 +448,7 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -468,6 +471,7 @@ mod test {
             .schedule(
                 &mut container,
                 0, // zero budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -494,6 +498,7 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -521,6 +526,7 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -548,6 +554,7 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -571,6 +578,7 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -591,6 +599,7 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -632,6 +641,7 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -669,6 +679,7 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -111,6 +111,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         &mut self,
         container: &mut S,
         budget: u64,
+        _relax_intrabatch_account_locks: bool,
         pre_graph_filter: impl Fn(&[&Tx], &mut [bool]),
         pre_lock_filter: impl Fn(&TransactionState<Tx>) -> PreLockFilterAction,
     ) -> Result<SchedulingSummary, SchedulerError> {
@@ -584,6 +585,7 @@ mod tests {
             scheduler.schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter
             ),
@@ -603,6 +605,7 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -624,6 +627,7 @@ mod tests {
             .schedule(
                 &mut container,
                 0, // zero budget. nothing should be scheduled
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -645,6 +649,7 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -667,6 +672,7 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -694,6 +700,7 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -740,6 +747,7 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -755,6 +763,7 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -774,6 +783,7 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -802,6 +812,7 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
+                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )

--- a/core/src/banking_stage/transaction_scheduler/scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler.rs
@@ -18,6 +18,7 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
         &mut self,
         container: &mut S,
         budget: u64,
+        relax_intrabatch_account_locks: bool,
         pre_graph_filter: impl Fn(&[&Tx], &mut [bool]),
         pre_lock_filter: impl Fn(&TransactionState<Tx>) -> PreLockFilterAction,
     ) -> Result<SchedulingSummary, SchedulerError>;

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -214,6 +214,8 @@ where
                 let (scheduling_summary, schedule_time_us) = measure_us!(self.scheduler.schedule(
                     &mut self.container,
                     scheduling_budget,
+                    bank.feature_set
+                        .is_active(&agave_feature_set::relax_intrabatch_account_locks::ID),
                     |txs, results| {
                         Self::pre_graph_filter(txs, results, bank, MAX_PROCESSING_AGE)
                     },


### PR DESCRIPTION
#### Problem
- Activation of simd83 not considered in greedy scheduler

#### Summary of Changes
- Don't split batches on conflict for greedy scheduler

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
