### PR TITLE
Pin spl-token-cli version to v5.4.0

### DIFF
--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,5 +1,5 @@
 # populate this on the stable branch
-splTokenCliVersion=
+splTokenCliVersion=5.4.0
 
 maybeSplTokenCliVersionArg=
 if [[ -n "$splTokenCliVersion" ]]; then


### PR DESCRIPTION
#### Problem
v3.0 is now the stable branch. Pinning spl-token-cli to v5.4.0
