### PR TITLE
Simplify InMemAccountsIndex eviction code

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -881,7 +881,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// Skip entries with ref_count != 1 since they will be rejected later anyway
     fn gather_possible_evictions<'a>(
         iter: impl Iterator<Item = (&'a Pubkey, &'a Box<AccountMapEntry<T>>)>,
-        possible_evictions: &mut Vec<(Pubkey, bool)>,
+        possible_evictions: &mut Vec<(Pubkey, /*is_dirty*/ bool)>,
         startup: bool,
         current_age: Age,
         ages_flushing_now: Age,


### PR DESCRIPTION
#### Problem

`InMemAccountsIndex` has two unnecessary layers of abstraction for managing evictions:

1. **PossibleEvictions** - A caching struct that always operates with size 1 (`new(1)`, `reset(1)`, `insert(0, ...)`). Only one `FlushScanResult` is ever created and used at a time, making the caching unnecessary.

2. **FlushScanResult** - A wrapper struct around a single `Vec<(Pubkey, bool)>` with no additional functionality.

#### Summary of change

- Remove `PossibleEvictions` struct and its field from `InMemAccountsIndex`
- Remove `FlushScanResult` struct  
- Create the evictions vec locally in `flush_scan` and return it directly as `Vec<(Pubkey, bool)>`
- Update `gather_possible_evictions` to work with the vec directly

**Net result**: 79 lines of code removed, simpler and more direct eviction logic.

