### PR TITLE
feat(scheduler-bindings): external scheduler handshake thread

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,6 +39,9 @@ pub mod replay_stage;
 pub mod resource_limits;
 mod result;
 pub mod sample_performance_service;
+#[allow(dead_code)]
+#[cfg(unix)]
+mod scheduler_bindings_server;
 mod shred_fetch_stage;
 pub mod sigverify;
 pub mod sigverify_stage;

--- a/core/src/scheduler_bindings_server.rs
+++ b/core/src/scheduler_bindings_server.rs
@@ -1,0 +1,28 @@
+use {
+    crate::banking_stage::BankingControlMsg, agave_scheduling_utils::handshake, std::path::Path,
+    tokio::sync::mpsc,
+};
+
+pub(crate) fn spawn(path: &Path, session_sender: mpsc::Sender<BankingControlMsg>) {
+    // NB: Panic on start if we can't bind.
+    let mut listener = handshake::server::Server::new(path).unwrap();
+
+    std::thread::Builder::new()
+        .name("solBindingSrv".to_string())
+        .spawn(move || loop {
+            match listener.accept() {
+                Ok(session) => {
+                    if session_sender
+                        .blocking_send(BankingControlMsg::External { session })
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(err) => {
+                    error!("External scheduler handshake failed; err={err}")
+                }
+            };
+        })
+        .unwrap();
+}


### PR DESCRIPTION
#### Problem

- External schedulers must connect & configure their session via IPC (includes exchanging shared memory FDs).

#### Summary of Changes

- Spawn a dedicated thread to block on new scheduler connections.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
