### PR TITLE
remove public interfaces from `agave-unstable-api`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10167,7 +10167,6 @@ dependencies = [
  "solana-keypair",
  "solana-message",
  "solana-pubkey",
- "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-signature",
  "solana-signer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,7 +412,7 @@ solana-clap-v3-utils = { path = "clap-v3-utils", version = "=4.0.0-alpha.0", fea
 solana-cli = { path = "cli", version = "=4.0.0-alpha.0" }
 solana-cli-config = { path = "cli-config", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-cli-output = { path = "cli-output", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-solana-client = { path = "client", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
+solana-client = { path = "client", version = "=4.0.0-alpha.0" }
 solana-client-traits = "3.0.0"
 solana-clock = "3.0.0"
 solana-cluster-type = "3.0.0"
@@ -495,7 +495,7 @@ solana-program-pack = "3.0.0"
 solana-program-runtime = { path = "program-runtime", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-program-test = { path = "program-test", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-pubkey = { version = "3.0.0", default-features = false }
-solana-pubsub-client = { path = "pubsub-client", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
+solana-pubsub-client = { path = "pubsub-client", version = "=4.0.0-alpha.0" }
 solana-quic-client = { path = "quic-client", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-quic-definitions = "3.0.0"
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
@@ -503,10 +503,10 @@ solana-remote-wallet = { path = "remote-wallet", version = "=4.0.0-alpha.0", def
 solana-rent = "3.0.0"
 solana-reward-info = "3.0.0"
 solana-rpc = { path = "rpc", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-solana-rpc-client = { path = "rpc-client", version = "=4.0.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
-solana-rpc-client-api = { path = "rpc-client-api", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-solana-rpc-client-types = { path = "rpc-client-types", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
+solana-rpc-client = { path = "rpc-client", version = "=4.0.0-alpha.0", default-features = false }
+solana-rpc-client-api = { path = "rpc-client-api", version = "=4.0.0-alpha.0" }
+solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=4.0.0-alpha.0" }
+solana-rpc-client-types = { path = "rpc-client-types", version = "=4.0.0-alpha.0" }
 solana-runtime = { path = "runtime", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-sanitize = "3.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", vers
 agave-cargo-registry = { path = "cargo-registry", version = "=4.0.0-alpha.0" }
 agave-feature-set = { path = "feature-set", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 agave-fs = { path = "fs", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
+agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=4.0.0-alpha.0" }
 agave-io-uring = { path = "io-uring", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 agave-logger = { path = "logger", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 agave-precompiles = { path = "precompiles", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -410,7 +410,7 @@ solana-builtins-default-costs = { path = "builtins-default-costs", version = "=4
 solana-clap-utils = { path = "clap-utils", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-clap-v3-utils = { path = "clap-v3-utils", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-cli = { path = "cli", version = "=4.0.0-alpha.0" }
-solana-cli-config = { path = "cli-config", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
+solana-cli-config = { path = "cli-config", version = "=4.0.0-alpha.0" }
 solana-cli-output = { path = "cli-output", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-client = { path = "client", version = "=4.0.0-alpha.0" }
 solana-client-traits = "3.0.0"

--- a/cli-config/src/lib.rs
+++ b/cli-config/src/lib.rs
@@ -1,12 +1,3 @@
-#![cfg_attr(
-    not(feature = "agave-unstable-api"),
-    deprecated(
-        since = "3.1.0",
-        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
-                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
-                acknowledge use of an interface that may break without warning."
-    )
-)]
 //! Loading and saving the Solana CLI configuration file.
 //!
 //! The configuration file used by the Solana CLI includes information about the

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,12 +1,3 @@
-#![cfg_attr(
-    not(feature = "agave-unstable-api"),
-    deprecated(
-        since = "3.1.0",
-        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
-                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
-                acknowledge use of an interface that may break without warning."
-    )
-)]
 #![allow(clippy::arithmetic_side_effects)]
 
 pub mod client_option;

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -76,7 +76,7 @@ solana-accounts-db = { path = "../accounts-db", version = "=4.0.0-alpha.0", feat
 solana-bench-tps = { path = "../bench-tps", version = "=4.0.0-alpha.0" }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-clap-utils = { path = "../clap-utils", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-solana-cli-config = { path = "../cli-config", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
+solana-cli-config = { path = "../cli-config", version = "=4.0.0-alpha.0" }
 solana-cli-output = { path = "../cli-output", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-client = { path = "../client", version = "=4.0.0-alpha.0" }
 solana-clock = "3.0.0"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -78,7 +78,7 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=4.0.0
 solana-clap-utils = { path = "../clap-utils", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-cli-config = { path = "../cli-config", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-cli-output = { path = "../cli-output", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-solana-client = { path = "../client", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
+solana-client = { path = "../client", version = "=4.0.0-alpha.0" }
 solana-clock = "3.0.0"
 solana-cluster-type = "3.0.0"
 solana-commitment-config = "3.0.0"
@@ -116,9 +116,9 @@ solana-pubkey = { version = "3.0.0", default-features = false }
 solana-quic-client = { path = "../quic-client", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-rent = "3.0.0"
 solana-rpc = { path = "../rpc", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-solana-rpc-client = { path = "../rpc-client", version = "=4.0.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
-solana-rpc-client-api = { path = "../rpc-client-api", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-solana-rpc-client-nonce-utils = { path = "../rpc-client-nonce-utils", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
+solana-rpc-client = { path = "../rpc-client", version = "=4.0.0-alpha.0", default-features = false }
+solana-rpc-client-api = { path = "../rpc-client-api", version = "=4.0.0-alpha.0" }
+solana-rpc-client-nonce-utils = { path = "../rpc-client-nonce-utils", version = "=4.0.0-alpha.0" }
 solana-runtime = { path = "../runtime", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-sbpf = { version = "=0.13.0", default-features = false }

--- a/geyser-plugin-interface/src/lib.rs
+++ b/geyser-plugin-interface/src/lib.rs
@@ -1,10 +1,1 @@
-#![cfg_attr(
-    not(feature = "agave-unstable-api"),
-    deprecated(
-        since = "3.1.0",
-        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
-                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
-                acknowledge use of an interface that may break without warning."
-    )
-)]
 pub mod geyser_plugin_interface;

--- a/pubsub-client/src/lib.rs
+++ b/pubsub-client/src/lib.rs
@@ -1,12 +1,3 @@
-#![cfg_attr(
-    not(feature = "agave-unstable-api"),
-    deprecated(
-        since = "3.1.0",
-        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
-                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
-                acknowledge use of an interface that may break without warning."
-    )
-)]
 #![allow(clippy::arithmetic_side_effects)]
 
 pub mod nonblocking;

--- a/rpc-client-api/src/lib.rs
+++ b/rpc-client-api/src/lib.rs
@@ -1,12 +1,3 @@
-#![cfg_attr(
-    not(feature = "agave-unstable-api"),
-    deprecated(
-        since = "3.1.0",
-        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
-                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
-                acknowledge use of an interface that may break without warning."
-    )
-)]
 #![allow(clippy::arithmetic_side_effects)]
 
 pub mod client_error;

--- a/rpc-client-nonce-utils/src/lib.rs
+++ b/rpc-client-nonce-utils/src/lib.rs
@@ -1,12 +1,3 @@
-#![cfg_attr(
-    not(feature = "agave-unstable-api"),
-    deprecated(
-        since = "3.1.0",
-        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
-                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
-                acknowledge use of an interface that may break without warning."
-    )
-)]
 //! Durable transaction nonce helpers.
 
 pub mod blockhash_query;

--- a/rpc-client-types/src/lib.rs
+++ b/rpc-client-types/src/lib.rs
@@ -1,12 +1,3 @@
-#![cfg_attr(
-    not(feature = "agave-unstable-api"),
-    deprecated(
-        since = "3.1.0",
-        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
-                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
-                acknowledge use of an interface that may break without warning."
-    )
-)]
 #![allow(clippy::arithmetic_side_effects)]
 
 pub mod config;

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -62,7 +62,6 @@ jsonrpc-http-server = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-rpc-client = { path = ".", features = ["agave-unstable-api"] }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 static_assertions = { workspace = true }

--- a/rpc-client/src/lib.rs
+++ b/rpc-client/src/lib.rs
@@ -1,12 +1,3 @@
-#![cfg_attr(
-    not(feature = "agave-unstable-api"),
-    deprecated(
-        since = "3.1.0",
-        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
-                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
-                acknowledge use of an interface that may break without warning."
-    )
-)]
 #![allow(clippy::arithmetic_side_effects)]
 
 pub mod http_sender;


### PR DESCRIPTION
#### Problem
#8424 was sloppypaste (mostly `sed`) and included crates we commit to treating as public api

#### Summary of Changes
remove `agave-unstable-api` from `solana-cli-output`, `solana-client` (and it's constituents) and `agave-geyser-plugin-interface` crates