### PR TITLE
Remove shrink_to_fit from InMemAccountsIndex eviction

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1247,9 +1247,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     occupied.remove();
                 }
             }
-            if map.capacity() > 2 * map.len() {
-                map.shrink_to_fit();
-            }
             let capacity_post = map.capacity();
             drop(map);
             stats.update_in_mem_capacity(capacity_pre, capacity_post);

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1247,7 +1247,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     occupied.remove();
                 }
             }
-            if map.is_empty() {
+            if map.capacity() > 2 * map.len() {
                 map.shrink_to_fit();
             }
             let capacity_post = map.capacity();


### PR DESCRIPTION
#### Problem

shrink_to_fit from InMemAccountsIndex eviction is unnecessary.

The shrink_to_fit operation adds unnecessary overhead, and the freed capacity
is likely to be reused during subsequent cache insertions.

#### Summary of Changes

Remove shrink_to_fit from InMemAccountsIndex eviction


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
