### PR TITLE
Cleanup derive attributes to list all traits in one place

### DIFF
--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -70,9 +70,8 @@ impl fmt::Display for UiTransactionEncoding {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Copy, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Default)]
 pub enum TransactionDetails {
     #[default]
     Full,


### PR DESCRIPTION
#### Problem
Derives are listed in two separate attributes (introduced in clippy fix https://github.com/anza-xyz/agave/pull/8792)

#### Summary of Changes
Coalesce into one
