### PR TITLE
Remove dead TieredReadableFile::new_writable()

### DIFF
--- a/accounts-db/src/tiered_storage/file.rs
+++ b/accounts-db/src/tiered_storage/file.rs
@@ -43,15 +43,6 @@ impl TieredReadableFile {
         Ok(file)
     }
 
-    pub fn new_writable(file_path: impl AsRef<Path>) -> io::Result<Self> {
-        Ok(Self(
-            OpenOptions::new()
-                .create_new(true)
-                .write(true)
-                .open(file_path)?,
-        ))
-    }
-
     fn check_magic_number(&self) -> TieredStorageResult<()> {
         self.seek_from_end(-(std::mem::size_of::<TieredStorageMagicNumber>() as i64))?;
         let mut magic_number = TieredStorageMagicNumber::zeroed();


### PR DESCRIPTION
This method opened files with write-only permissions but returned a readable wrapper, which would cause read operations to fail (e.g., EBADF). The codepath is unused across the repository and contradicts the API design where writes go through TieredWritableFile and finalized files are read via TieredReadableFile.
Eliminating it prevents misuse and aligns the file API with documented behavior and footer/magic-number workflow.