### PR TITLE
docs: Add step to update CODEOWNERS in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -104,6 +104,7 @@ Alternatively use the Github UI.
 ### Miscellaneous Clean up
 
 1. Pin the spl-token-cli version in the newly promoted stable branch by setting `splTokenCliVersion` in scripts/spl-token-cli-version.sh to the latest release that depends on the stable branch (usually this will be the latest spl-token-cli release).
+1. Update [CODEOWNERS](https://github.com/anza-xyz/agave/blob/master/.github/CODEOWNERS) to `* @anza-xyz/backport-reviewers` on the new branch.
 1. Update [mergify.yml](https://github.com/anza-xyz/agave/blob/master/.mergify.yml) to add backport actions for the new branch and remove actions for the obsolete branch.
 1. Adjust the [Github backport labels](https://github.com/anza-xyz/agave/labels) to add the new branch label and remove the label for the obsolete branch.
 1. Announce on Discord #development that the release branch exists so people know to use the new backport labels.


### PR DESCRIPTION
#### Problem
Release branches should have `backport-reviewers` as the only CODEOWNER and manual process will ensure relevant experts weigh in on PR's

#### Summary of Changes
Add the reminder in the loose TODO list
