### PR TITLE
tests: streamer swqos tester log absolute time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10909,6 +10909,7 @@ dependencies = [
  "arc-swap",
  "assert_matches",
  "bytes",
+ "chrono",
  "clap 4.5.31",
  "crossbeam-channel",
  "dashmap",

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -66,6 +66,7 @@ x509-parser = { workspace = true }
 agave-logger = { workspace = true }
 anyhow = { workspace = true }
 assert_matches = { workspace = true }
+chrono = { workspace = true, features = ["now"] }
 clap = { version = "4.5.31", features = ["cargo", "derive", "error-context"] }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-streamer = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }


### PR DESCRIPTION
#### Problem

- Streamer test tooling (swqos.rs) logs time relative to start, this leads to offsets when parsing w.r.t client-side logs

#### Summary of Changes

- Make it log in time relative to solana epoch.
