### PR TITLE
streamer: API cleanup

### DIFF
--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -19,8 +19,8 @@ use {
         nonblocking::swqos::SwQosConfig,
         packet::PacketBatchRecycler,
         quic::{
-            spawn_server_with_cancel, QuicStreamerConfig, DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER,
-            DEFAULT_MAX_STAKED_CONNECTIONS,
+            spawn_stake_wighted_qos_server, QuicStreamerConfig,
+            DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER, DEFAULT_MAX_STAKED_CONNECTIONS,
         },
         streamer::{receiver, PacketBatchReceiver, StakedNodes, StreamerReceiveStats},
     },
@@ -276,7 +276,7 @@ fn main() -> Result<()> {
             let (s_reader, r_reader) = unbounded();
             read_channels.push(r_reader);
 
-            let server = spawn_server_with_cancel(
+            let server = spawn_stake_wighted_qos_server(
                 "solRcvrBenVote",
                 "bench_vote_metrics",
                 read_sockets,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -51,8 +51,8 @@ use {
     },
     solana_streamer::{
         quic::{
-            spawn_server_with_cancel, spawn_simple_qos_server_with_cancel,
-            SimpleQosQuicStreamerConfig, SpawnServerResult, SwQosQuicStreamerConfig,
+            spawn_simple_qos_server, spawn_stake_wighted_qos_server, SimpleQosQuicStreamerConfig,
+            SpawnServerResult, SwQosQuicStreamerConfig,
         },
         streamer::StakedNodes,
     },
@@ -217,7 +217,7 @@ impl Tpu {
             endpoints: _,
             thread: tpu_vote_quic_t,
             key_updater: vote_streamer_key_updater,
-        } = spawn_simple_qos_server_with_cancel(
+        } = spawn_simple_qos_server(
             "solQuicTVo",
             "quic_streamer_tpu_vote",
             tpu_vote_quic_sockets,
@@ -236,7 +236,7 @@ impl Tpu {
                 endpoints: _,
                 thread: tpu_quic_t,
                 key_updater,
-            } = spawn_server_with_cancel(
+            } = spawn_stake_wighted_qos_server(
                 "solQuicTpu",
                 "quic_streamer_tpu",
                 transactions_quic_sockets,
@@ -259,7 +259,7 @@ impl Tpu {
                 endpoints: _,
                 thread: tpu_forwards_quic_t,
                 key_updater: forwards_key_updater,
-            } = spawn_server_with_cancel(
+            } = spawn_stake_wighted_qos_server(
                 "solQuicTpuFwd",
                 "quic_streamer_tpu_forwards",
                 transactions_forwards_quic_sockets,

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -12,7 +12,7 @@ mod tests {
         solana_perf::packet::PacketBatch,
         solana_quic_client::nonblocking::quic_client::{QuicClient, QuicLazyInitializedEndpoint},
         solana_streamer::{
-            nonblocking::swqos::SwQosConfig,
+            nonblocking::{quic::SpawnNonBlockingServerResult, swqos::SwQosConfig},
             quic::{QuicStreamerConfig, SpawnServerResult},
             streamer::StakedNodes,
         },
@@ -74,7 +74,7 @@ mod tests {
             endpoints: _,
             thread: t,
             key_updater: _,
-        } = solana_streamer::quic::spawn_server_with_cancel(
+        } = solana_streamer::quic::spawn_stake_wighted_qos_server(
             "solQuicTest",
             "quic_streamer_test",
             vec![s.try_clone().unwrap()],
@@ -151,12 +151,12 @@ mod tests {
         let (sender, receiver) = unbounded();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let (s, cancel, keypair) = server_args();
-        let solana_streamer::nonblocking::quic::SpawnNonBlockingServerResult {
+        let SpawnNonBlockingServerResult {
             endpoints: _,
             stats: _,
             thread: t,
             max_concurrent_connections: _,
-        } = solana_streamer::nonblocking::quic::spawn_server_with_cancel(
+        } = solana_streamer::nonblocking::testing_utilities::spawn_stake_weighted_qos_server(
             "quic_streamer_test",
             vec![s.try_clone().unwrap()],
             &keypair,
@@ -214,7 +214,7 @@ mod tests {
             endpoints: request_recv_endpoints,
             thread: request_recv_thread,
             key_updater: _,
-        } = solana_streamer::quic::spawn_server_with_cancel(
+        } = solana_streamer::quic::spawn_stake_wighted_qos_server(
             "solQuicTest",
             "quic_streamer_test",
             [request_recv_socket.try_clone().unwrap()],
@@ -239,7 +239,7 @@ mod tests {
             endpoints: mut response_recv_endpoints,
             thread: response_recv_thread,
             key_updater: _,
-        } = solana_streamer::quic::spawn_server_with_cancel(
+        } = solana_streamer::quic::spawn_stake_wighted_qos_server(
             "solQuicTest",
             "quic_streamer_test",
             [response_recv_socket],
@@ -327,7 +327,7 @@ mod tests {
             stats: _,
             thread: t,
             max_concurrent_connections: _,
-        } = solana_streamer::nonblocking::quic::spawn_server_with_cancel(
+        } = solana_streamer::nonblocking::testing_utilities::spawn_stake_weighted_qos_server(
             "quic_streamer_test",
             vec![s.try_clone().unwrap()],
             &keypair,

--- a/streamer/examples/swqos.rs
+++ b/streamer/examples/swqos.rs
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
         stats,
         thread: run_thread,
         max_concurrent_connections: _,
-    } = solana_streamer::nonblocking::quic::spawn_stake_weighted_qos_server(
+    } = solana_streamer::nonblocking::testing_utilities::spawn_stake_weighted_qos_server(
         "quic_streamer_test",
         [socket.try_clone()?],
         &keypair,

--- a/streamer/examples/swqos.rs
+++ b/streamer/examples/swqos.rs
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
         stats,
         thread: run_thread,
         max_concurrent_connections: _,
-    } = solana_streamer::nonblocking::quic::spawn_server_with_cancel(
+    } = solana_streamer::nonblocking::quic::spawn_stake_weighted_qos_server(
         "quic_streamer_test",
         [socket.try_clone()?],
         &keypair,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1185,9 +1185,12 @@ impl Future for EndpointAccept<'_> {
 pub mod test {
     use {
         super::*,
-        crate::nonblocking::testing_utilities::{
-            check_multiple_streams, get_client_config, make_client_endpoint, setup_quic_server,
-            SpawnTestServerResult,
+        crate::nonblocking::{
+            swqos::SwQosConfig,
+            testing_utilities::{
+                check_multiple_streams, get_client_config, make_client_endpoint, setup_quic_server,
+                spawn_stake_weighted_qos_server, SpawnTestServerResult,
+            },
         },
         assert_matches::assert_matches,
         crossbeam_channel::{unbounded, Receiver},

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -13,7 +13,7 @@ use {
     solana_streamer::{
         nonblocking::{quic::DEFAULT_WAIT_FOR_CHUNK_TIMEOUT, swqos::SwQosConfig},
         quic::{
-            spawn_server_with_cancel, EndpointKeyUpdater, QuicStreamerConfig,
+            spawn_stake_wighted_qos_server, EndpointKeyUpdater, QuicStreamerConfig,
             SwQosQuicStreamerConfig,
         },
         streamer::StakedNodes,
@@ -138,7 +138,7 @@ impl Vortexor {
             tpu_quic_fwd,
         } = tpu_sockets;
 
-        let tpu_result = spawn_server_with_cancel(
+        let tpu_result = spawn_stake_wighted_qos_server(
             "solVtxTpu",
             "quic_vortexor_tpu",
             tpu_quic,
@@ -159,7 +159,7 @@ impl Vortexor {
         quic_fwd_server_params
             .quic_streamer_config
             .max_unstaked_connections = max_fwd_unstaked_connections;
-        let tpu_fwd_result = spawn_server_with_cancel(
+        let tpu_fwd_result = spawn_stake_wighted_qos_server(
             "solVtxTpuFwd",
             "quic_vortexor_tpu_forwards",
             tpu_quic_fwd,

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -278,7 +278,7 @@ mod tests {
         solana_signer::Signer,
         solana_streamer::{
             nonblocking::swqos::SwQosConfig,
-            quic::{spawn_server_with_cancel, QuicStreamerConfig, SpawnServerResult},
+            quic::{spawn_stake_wighted_qos_server, QuicStreamerConfig, SpawnServerResult},
             socket::SocketAddrSpace,
             streamer::StakedNodes,
         },
@@ -382,7 +382,7 @@ mod tests {
         let SpawnServerResult {
             thread: quic_server_thread,
             ..
-        } = spawn_server_with_cancel(
+        } = spawn_stake_wighted_qos_server(
             "AlpenglowLocalClusterTest",
             "quic_streamer_test",
             [socket],


### PR DESCRIPTION
#### Problem

- Streamer has a lot of deprecated functions 
- Some functions accumulated name suffixes like 'spawn_server_with_cancel_and_qos' due to API changes

#### Summary of Changes

- rm deprecated
- Condense the names of functions that are still in use
- no functional changes