### PR TITLE
refactor: votor unit tests: replace `assert!(...is_ok())` with `unwrap()`

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -729,27 +729,25 @@ mod tests {
         vote: Vote,
     ) {
         for rank in 0..6 {
-            assert!(pool
-                .add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    dummy_vote_message(validator_keypairs, &vote, rank),
-                    &mut vec![]
-                )
-                .is_ok());
-        }
-        assert!(pool
-            .add_message(
+            pool.add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                dummy_vote_message(validator_keypairs, &vote, 6),
-                &mut vec![]
+                dummy_vote_message(validator_keypairs, &vote, rank),
+                &mut vec![],
             )
-            .is_ok());
+            .unwrap();
+        }
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            dummy_vote_message(validator_keypairs, &vote, 6),
+            &mut vec![],
+        )
+        .unwrap();
         match vote {
             Vote::Notarize(vote) => assert_eq!(pool.highest_notarized_slot(), vote.slot),
             Vote::NotarizeFallback(vote) => assert_eq!(pool.highest_notarized_slot(), vote.slot),
@@ -769,16 +767,15 @@ mod tests {
     ) {
         for slot in start..=end {
             let vote = Vote::new_skip_vote(slot);
-            assert!(pool
-                .add_message(
-                    root_bank.epoch_schedule(),
-                    root_bank.epoch_stakes_map(),
-                    root_bank.slot(),
-                    &Pubkey::new_unique(),
-                    dummy_vote_message(keypairs, &vote, rank),
-                    &mut vec![]
-                )
-                .is_ok());
+            pool.add_message(
+                root_bank.epoch_schedule(),
+                root_bank.epoch_stakes_map(),
+                root_bank.slot(),
+                &Pubkey::new_unique(),
+                dummy_vote_message(keypairs, &vote, rank),
+                &mut vec![],
+            )
+            .unwrap();
         }
     }
 
@@ -1079,41 +1076,38 @@ mod tests {
             Vote::SkipFallback(_) => |pool: &ConsensusPool| pool.highest_skip_slot(),
         };
         let bank = bank_forks.read().unwrap().root_bank();
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, my_validator_ix),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            dummy_vote_message(&validator_keypairs, &vote, my_validator_ix),
+            &mut vec![],
+        )
+        .unwrap();
         let slot = vote.slot();
         assert!(highest_slot_fn(&pool) < slot);
         // Same key voting again shouldn't make a certificate
-        assert!(pool
-            .add_message(
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            dummy_vote_message(&validator_keypairs, &vote, my_validator_ix),
+            &mut vec![],
+        )
+        .unwrap();
+        assert!(highest_slot_fn(&pool) < slot);
+        for rank in 0..4 {
+            pool.add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, my_validator_ix),
-                &mut vec![]
+                dummy_vote_message(&validator_keypairs, &vote, rank),
+                &mut vec![],
             )
-            .is_ok());
-        assert!(highest_slot_fn(&pool) < slot);
-        for rank in 0..4 {
-            assert!(pool
-                .add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
-                    &mut vec![]
-                )
-                .is_ok());
+            .unwrap();
         }
         assert!(highest_slot_fn(&pool) < slot);
         let new_validator_ix = 6;
@@ -1282,16 +1276,15 @@ mod tests {
             let slot = (i as u64).saturating_add(16);
             let vote = Vote::new_skip_vote(slot);
             // These should not extend the skip range
-            assert!(pool
-                .add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, i),
-                    &mut vec![]
-                )
-                .is_ok());
+            pool.add_message(
+                bank.epoch_schedule(),
+                bank.epoch_stakes_map(),
+                bank.slot(),
+                &Pubkey::new_unique(),
+                dummy_vote_message(&validator_keypairs, &vote, i),
+                &mut vec![],
+            )
+            .unwrap();
         }
 
         assert_single_certificate_range(&pool, 15, 15);
@@ -1404,47 +1397,44 @@ mod tests {
         let bank = bank_forks.read().unwrap().root_bank();
         // 10% vote for skip 2
         let vote = Vote::new_skip_vote(2);
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 6),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            dummy_vote_message(&validator_keypairs, &vote, 6),
+            &mut vec![],
+        )
+        .unwrap();
         assert_eq!(pool.highest_skip_slot(), 2);
 
         assert_single_certificate_range(&pool, 2, 2);
         // 10% vote for skip 4
         let vote = Vote::new_skip_vote(4);
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 7),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            dummy_vote_message(&validator_keypairs, &vote, 7),
+            &mut vec![],
+        )
+        .unwrap();
         assert_eq!(pool.highest_skip_slot(), 4);
 
         assert_single_certificate_range(&pool, 2, 2);
         assert_single_certificate_range(&pool, 4, 4);
         // 10% vote for skip 3
         let vote = Vote::new_skip_vote(3);
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 8),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            dummy_vote_message(&validator_keypairs, &vote, 8),
+            &mut vec![],
+        )
+        .unwrap();
         assert_eq!(pool.highest_skip_slot(), 4);
         assert_single_certificate_range(&pool, 2, 4);
         assert!(pool.skip_certified(3));
@@ -1479,16 +1469,15 @@ mod tests {
         let bank = bank_forks.read().unwrap().root_bank();
         // Range expansion on a singleton vote should be ok
         let vote = Vote::new_skip_vote(1);
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 6),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            dummy_vote_message(&validator_keypairs, &vote, 6),
+            &mut vec![],
+        )
+        .unwrap();
         assert_eq!(pool.highest_skip_slot(), 1);
         add_skip_vote_range(
             &mut pool,
@@ -1517,16 +1506,15 @@ mod tests {
 
         // AlreadyExists, silently fail
         let vote = Vote::new_skip_vote(20);
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 6),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            dummy_vote_message(&validator_keypairs, &vote, 6),
+            &mut vec![],
+        )
+        .unwrap();
     }
 
     #[test]
@@ -1606,31 +1594,29 @@ mod tests {
         // Add a skip from myself.
         let vote = Vote::new_skip_vote(2);
         let mut new_events = vec![];
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &my_vote_key,
-                dummy_vote_message(&validator_keypairs, &vote, 0),
-                &mut new_events
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &my_vote_key,
+            dummy_vote_message(&validator_keypairs, &vote, 0),
+            &mut new_events,
+        )
+        .unwrap();
         assert!(new_events.is_empty());
 
         // 40% notarized, should succeed
         for rank in 1..5 {
             let vote = Vote::new_notarization_vote(2, block_id);
-            assert!(pool
-                .add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
-                    &mut new_events
-                )
-                .is_ok());
+            pool.add_message(
+                bank.epoch_schedule(),
+                bank.epoch_stakes_map(),
+                bank.slot(),
+                &Pubkey::new_unique(),
+                dummy_vote_message(&validator_keypairs, &vote, rank),
+                &mut new_events,
+            )
+            .unwrap();
         }
         assert_eq!(new_events.len(), 1);
         if let VotorEvent::SafeToNotar((event_slot, event_block_id)) = new_events[0] {
@@ -1648,47 +1634,44 @@ mod tests {
         // Add 20% notarize, but no vote from myself, should fail
         for rank in 1..3 {
             let vote = Vote::new_notarization_vote(3, block_id);
-            assert!(pool
-                .add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
-                    &mut new_events
-                )
-                .is_ok());
+            pool.add_message(
+                bank.epoch_schedule(),
+                bank.epoch_stakes_map(),
+                bank.slot(),
+                &Pubkey::new_unique(),
+                dummy_vote_message(&validator_keypairs, &vote, rank),
+                &mut new_events,
+            )
+            .unwrap();
         }
         assert!(new_events.is_empty());
 
         // Add a notarize from myself for some other block, but still not enough notar or skip, should fail.
         let vote = Vote::new_notarization_vote(3, Hash::new_unique());
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &my_vote_key,
-                dummy_vote_message(&validator_keypairs, &vote, 0),
-                &mut new_events
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &my_vote_key,
+            dummy_vote_message(&validator_keypairs, &vote, 0),
+            &mut new_events,
+        )
+        .unwrap();
         assert!(new_events.is_empty());
 
         // Now add 40% skip, should succeed
         // Funny thing is in this case we will also get SafeToSkip(3)
         for rank in 3..7 {
             let vote = Vote::new_skip_vote(3);
-            assert!(pool
-                .add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
-                    &mut new_events
-                )
-                .is_ok());
+            pool.add_message(
+                bank.epoch_schedule(),
+                bank.epoch_stakes_map(),
+                bank.slot(),
+                &Pubkey::new_unique(),
+                dummy_vote_message(&validator_keypairs, &vote, rank),
+                &mut new_events,
+            )
+            .unwrap();
         }
         assert_eq!(new_events.len(), 2);
         if let VotorEvent::SafeToSkip(event_slot) = new_events[0] {
@@ -1709,16 +1692,15 @@ mod tests {
         let duplicate_block_id = Hash::new_unique();
         for rank in 7..9 {
             let vote = Vote::new_notarization_vote(3, duplicate_block_id);
-            assert!(pool
-                .add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
-                    &mut new_events
-                )
-                .is_ok());
+            pool.add_message(
+                bank.epoch_schedule(),
+                bank.epoch_stakes_map(),
+                bank.slot(),
+                &Pubkey::new_unique(),
+                dummy_vote_message(&validator_keypairs, &vote, rank),
+                &mut new_events,
+            )
+            .unwrap();
         }
 
         assert_eq!(new_events.len(), 1);
@@ -1742,31 +1724,29 @@ mod tests {
         // Add a notarize from myself.
         let block_id = Hash::new_unique();
         let vote = Vote::new_notarization_vote(2, block_id);
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &my_vote_key,
-                dummy_vote_message(&validator_keypairs, &vote, 0),
-                &mut new_events
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &my_vote_key,
+            dummy_vote_message(&validator_keypairs, &vote, 0),
+            &mut new_events,
+        )
+        .unwrap();
         // Should still fail because there are no other votes.
         assert!(new_events.is_empty());
         // Add 50% skip, should succeed
         for rank in 1..6 {
             let vote = Vote::new_skip_vote(2);
-            assert!(pool
-                .add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
-                    &mut new_events
-                )
-                .is_ok());
+            pool.add_message(
+                bank.epoch_schedule(),
+                bank.epoch_stakes_map(),
+                bank.slot(),
+                &Pubkey::new_unique(),
+                dummy_vote_message(&validator_keypairs, &vote, rank),
+                &mut new_events,
+            )
+            .unwrap();
         }
         assert_eq!(new_events.len(), 1);
         if let VotorEvent::SafeToSkip(event_slot) = new_events[0] {
@@ -1777,16 +1757,15 @@ mod tests {
         new_events.clear();
         // Add 10% more notarize, will not send new SafeToSkip because the event was already sent
         let vote = Vote::new_notarization_vote(2, block_id);
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 6),
-                &mut new_events
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            dummy_vote_message(&validator_keypairs, &vote, 6),
+            &mut new_events,
+        )
+        .unwrap();
         assert!(new_events.is_empty());
     }
 
@@ -1812,16 +1791,15 @@ mod tests {
     ) {
         let vote_1 = create_new_vote(vote_type_1, slot);
         let vote_2 = create_new_vote(vote_type_2, slot);
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(validator_keypairs, &vote_1, 0),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            dummy_vote_message(validator_keypairs, &vote_1, 0),
+            &mut vec![],
+        )
+        .unwrap();
         assert!(pool
             .add_message(
                 bank.epoch_schedule(),
@@ -1878,31 +1856,29 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(pool
-            .add_message(
-                root_bank.epoch_schedule(),
-                root_bank.epoch_stakes_map(),
-                root_bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_1.clone()),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            root_bank.epoch_schedule(),
+            root_bank.epoch_stakes_map(),
+            root_bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_1.clone()),
+            &mut vec![],
+        )
+        .unwrap();
         let cert_2 = Certificate {
             cert_type: CertificateType::FinalizeFast(2, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(pool
-            .add_message(
-                root_bank.epoch_schedule(),
-                root_bank.epoch_stakes_map(),
-                root_bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_2.clone()),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            root_bank.epoch_schedule(),
+            root_bank.epoch_stakes_map(),
+            root_bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_2.clone()),
+            &mut vec![],
+        )
+        .unwrap();
         assert!(pool.skip_certified(1));
         assert!(pool.is_finalized(2));
 
@@ -1962,31 +1938,29 @@ mod tests {
             bitmap: Vec::new(),
         };
         let bank = bank_forks.read().unwrap().root_bank();
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_3.clone()),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_3.clone()),
+            &mut vec![],
+        )
+        .unwrap();
         let cert_4 = Certificate {
             cert_type: CertificateType::Finalize(4),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_4.clone()),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_4.clone()),
+            &mut vec![],
+        )
+        .unwrap();
         // Should return both certificates
         let certs = pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 2);
@@ -2001,16 +1975,15 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_5.clone()),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_5.clone()),
+            &mut vec![],
+        )
+        .unwrap();
 
         // Add Finalize cert on 5
         let cert_5_finalize = Certificate {
@@ -2018,16 +1991,15 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_5_finalize.clone()),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_5_finalize.clone()),
+            &mut vec![],
+        )
+        .unwrap();
 
         // Add FinalizeFast cert on 5
         let cert_5 = Certificate {
@@ -2035,16 +2007,15 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_5.clone()),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_5.clone()),
+            &mut vec![],
+        )
+        .unwrap();
         // Should return only FinalizeFast cert on 5
         let certs = pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 1);
@@ -2059,16 +2030,15 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_6.clone()),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_6.clone()),
+            &mut vec![],
+        )
+        .unwrap();
         // Should return certs on 5 and 6
         let certs = pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 2);
@@ -2083,32 +2053,30 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_6_finalize.clone()),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_6_finalize.clone()),
+            &mut vec![],
+        )
+        .unwrap();
         // Add a NotarizeFallback cert on 6
         let cert_6_notarize_fallback = Certificate {
             cert_type: CertificateType::NotarizeFallback(6, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_6_notarize_fallback.clone()),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_6_notarize_fallback.clone()),
+            &mut vec![],
+        )
+        .unwrap();
         // This should not be returned because 6 is the current highest finalized slot
         // only Notarize/Finalze/FinalizeFast should be returned
         let certs = pool.get_certs_for_standstill();
@@ -2124,16 +2092,15 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_7.clone()),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_7.clone()),
+            &mut vec![],
+        )
+        .unwrap();
         // Should return certs on 6 and 7
         let certs = pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 3);
@@ -2152,31 +2119,29 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_8_finalize),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_8_finalize),
+            &mut vec![],
+        )
+        .unwrap();
         let cert_8_notarize = Certificate {
             cert_type: CertificateType::Notarize(8, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(pool
-            .add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_8_notarize),
-                &mut vec![]
-            )
-            .is_ok());
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert_8_notarize),
+            &mut vec![],
+        )
+        .unwrap();
 
         // Should only return certs on 8 now
         let certs = pool.get_certs_for_standstill();
@@ -2201,16 +2166,15 @@ mod tests {
                 signature: BLSSignature::default(),
                 bitmap: Vec::new(),
             };
-            assert!(pool
-                .add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    ConsensusMessage::Certificate(cert),
-                    &mut events,
-                )
-                .is_ok());
+            pool.add_message(
+                bank.epoch_schedule(),
+                bank.epoch_stakes_map(),
+                bank.slot(),
+                &Pubkey::new_unique(),
+                ConsensusMessage::Certificate(cert),
+                &mut events,
+            )
+            .unwrap();
         }
         // events should now contain ParentReady for slot 4
         error!("Events: {events:?}");
@@ -2229,16 +2193,15 @@ mod tests {
                 signature: BLSSignature::default(),
                 bitmap: Vec::new(),
             };
-            assert!(pool
-                .add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    ConsensusMessage::Certificate(cert),
-                    &mut events,
-                )
-                .is_ok());
+            pool.add_message(
+                bank.epoch_schedule(),
+                bank.epoch_stakes_map(),
+                bank.slot(),
+                &Pubkey::new_unique(),
+                ConsensusMessage::Certificate(cert),
+                &mut events,
+            )
+            .unwrap();
         }
         // events should now contain ParentReady for slot 8
         error!("Events: {events:?}");
@@ -2257,24 +2220,7 @@ mod tests {
                 signature: BLSSignature::default(),
                 bitmap: Vec::new(),
             };
-            assert!(pool
-                .add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    ConsensusMessage::Certificate(cert),
-                    &mut events,
-                )
-                .is_ok());
-        }
-        let cert = Certificate {
-            cert_type: CertificateType::FinalizeFast(11, hash),
-            signature: BLSSignature::default(),
-            bitmap: Vec::new(),
-        };
-        assert!(pool
-            .add_message(
+            pool.add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
@@ -2282,7 +2228,22 @@ mod tests {
                 ConsensusMessage::Certificate(cert),
                 &mut events,
             )
-            .is_ok());
+            .unwrap();
+        }
+        let cert = Certificate {
+            cert_type: CertificateType::FinalizeFast(11, hash),
+            signature: BLSSignature::default(),
+            bitmap: Vec::new(),
+        };
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            ConsensusMessage::Certificate(cert),
+            &mut events,
+        )
+        .unwrap();
         // events should now contain ParentReady for slot 12
         error!("Events: {events:?}");
         assert!(events
@@ -2312,12 +2273,9 @@ mod tests {
 
         let signed_message = bincode::serialize(&vote).unwrap();
 
-        assert!(
-            vote_message
-                .signature
-                .verify(&bls_pubkey, &signed_message)
-                .is_ok(),
-            "BLS signature verification failed for VoteMessage"
-        );
+        vote_message
+            .signature
+            .verify(&bls_pubkey, &signed_message)
+            .expect("BLS signature verification failed for VoteMessage");
     }
 }

--- a/votor/src/staked_validators_cache.rs
+++ b/votor/src/staked_validators_cache.rs
@@ -273,12 +273,12 @@ mod tests {
                 .map(|(node_ix, pubkey)| {
                     let mut contact_info = ContactInfo::new(*pubkey, 0_u64, 0_u16);
 
-                    assert!(contact_info
+                    contact_info
                         .set_alpenglow((
                             Ipv4Addr::LOCALHOST,
-                            8080_u16.saturating_add(node_ix as u16)
+                            8080_u16.saturating_add(node_ix as u16),
                         ))
-                        .is_ok());
+                        .unwrap();
 
                     contact_info
                 });

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -508,9 +508,9 @@ mod test {
         vote_history.add_vote(vote_2);
 
         // Save to storage
-        assert!(vote_history
+        vote_history
             .save(&vote_history_storage, &node_keypair)
-            .is_ok());
+            .unwrap();
         // Restore from storage
         let restored_vote_history =
             VoteHistory::restore(&vote_history_storage, &node_keypair.pubkey())

--- a/votor/src/vote_history_storage.rs
+++ b/votor/src/vote_history_storage.rs
@@ -193,7 +193,7 @@ mod test {
         let mut vote_history = VoteHistory::new(pubkey, 0);
         let saved_vote_history = SavedVoteHistory::new(&vote_history, &keypair).unwrap();
         let saved_vote_history_versions = SavedVoteHistoryVersions::from(saved_vote_history);
-        assert!(storage.store(&saved_vote_history_versions).is_ok());
+        storage.store(&saved_vote_history_versions).unwrap();
         let restored_vote_history = storage.load(&pubkey).unwrap();
         assert_eq!(restored_vote_history.root(), 0);
 
@@ -202,7 +202,7 @@ mod test {
         vote_history.add_vote(Vote::new_skip_vote(2));
         let saved_vote_history = SavedVoteHistory::new(&vote_history, &keypair).unwrap();
         let saved_vote_history_versions = SavedVoteHistoryVersions::from(saved_vote_history);
-        assert!(storage.store(&saved_vote_history_versions).is_ok());
+        storage.store(&saved_vote_history_versions).unwrap();
         let restored_vote_history = storage.load(&pubkey).unwrap();
         assert_eq!(restored_vote_history.root(), 1);
         assert_eq!(
@@ -235,7 +235,7 @@ mod test {
         let saved_vote_history = SavedVoteHistory::new(&vote_history, &keypair).unwrap();
         let saved_vote_history_versions = SavedVoteHistoryVersions::from(saved_vote_history);
         // NullVoteHistoryStorage::save() always succeeds
-        assert!(storage.store(&saved_vote_history_versions).is_ok());
+        storage.store(&saved_vote_history_versions).unwrap();
         assert!(storage.load(&pubkey).is_err());
     }
 }

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -366,7 +366,7 @@ mod tests {
         let (_, validator_keypairs) = create_voting_service(bls_receiver, listener_addr);
 
         // Send a BLS message via the VotingService
-        assert!(bls_sender.send(bls_op).is_ok());
+        bls_sender.send(bls_op).unwrap();
 
         // Start a quick streamer to handle quick control packets
         let (sender, receiver) = crossbeam_channel::unbounded();


### PR DESCRIPTION
#### Problem

A bunch of test code is using `assert!(...is_ok())`.  When doing development, if one of these lines fails, we do not get to see what the actual error was just that it failed.

#### Summary of Changes

Replaces all occurrences with a simpler `unwrap()` which will also print an error message on failure.