### PR TITLE
nit: refactor: consensus_pool remove some unnecessary `pub`

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -43,7 +43,7 @@ type PoolId = (Slot, VoteType);
 
 /// Different failure cases from calling `add_vote()`.
 #[derive(Debug, Error)]
-pub(crate) enum AddVoteError {
+enum AddVoteError {
     #[error("Conflicting vote type: {0:?} vs existing {1:?} for slot: {2} pubkey: {3}")]
     ConflictingVoteType(VoteType, VoteType, Slot, Pubkey),
     #[error("Epoch stakes missing for epoch: {0}")]
@@ -58,7 +58,7 @@ pub(crate) enum AddVoteError {
 
 /// Different failure cases from calling `add_certificate()`.
 #[derive(Debug, Error)]
-pub(crate) enum AddCertError {
+enum AddCertError {
     #[error("Unrooted slot")]
     UnrootedSlot,
 }


### PR DESCRIPTION
#### Problem

Some error types do not need to be `pub`.  Was identified in https://github.com/anza-xyz/agave/pull/8776#discussion_r2486644478 but that PR merged before I was able to fix it.

#### Summary of Changes

Removes the unnecessary `pub`s.