### PR TITLE
fix(tpu-to-pack): timeout to check exit flag

### DIFF
--- a/core/src/banking_stage/tpu_to_pack.rs
+++ b/core/src/banking_stage/tpu_to_pack.rs
@@ -16,6 +16,7 @@ use {
             Arc,
         },
         thread::JoinHandle,
+        time::Duration,
     },
 };
 
@@ -63,6 +64,7 @@ fn tpu_to_pack(
             recv(non_vote_receiver) -> msg => msg,
             recv(gossip_vote_receiver) -> msg => msg,
             recv(tpu_vote_receiver) -> msg => msg,
+            default(Duration::from_secs(1)) => continue,
         } {
             Ok(packet_batches) => packet_batches,
             Err(crossbeam_channel::RecvError) => {


### PR DESCRIPTION
#### Problem

- If there are no inbound votes/txs then the tpu to pack worker will block indefinitely and not exit.

#### Summary of Changes

- Add a 1s timeout to the select.
