### PR TITLE
chore(scheduler-bindings): log scheduler handover

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -485,8 +485,9 @@ impl BankingStage {
         // Shutdown all current threads.
         self.worker_exit_signal.store(true, Ordering::Relaxed);
         while let Some((name, res)) = self.threads.next().await {
-            if let Err(err) = res {
-                error!("Banking worker exited with error; name={name}; err={err:?}");
+            match res.unwrap() {
+                Ok(()) => info!("Banking worker exited cleanly; name={name}"),
+                Err(err) => error!("Banking worker exited with error; name={name}; err={err:?}"),
             }
         }
 
@@ -520,6 +521,8 @@ impl BankingStage {
 
             NamedTask::new(tokio::task::spawn_blocking(|| handle.join()), name)
         }));
+
+        info!("Scheduler spawned");
     }
 
     fn spawn_internal(
@@ -528,6 +531,7 @@ impl BankingStage {
         num_workers: NonZeroUsize,
         scheduler_config: SchedulerConfig,
     ) -> Vec<JoinHandle<()>> {
+        info!("Spawning internal scheduler");
         assert!(num_workers <= BankingStage::max_num_workers());
         let num_workers = num_workers.get();
 
@@ -694,6 +698,7 @@ mod external {
                 workers,
             }: AgaveSession,
         ) -> Vec<JoinHandle<()>> {
+            info!("Spawning external scheduler");
             static_assertions::const_assert!(
                 agave_scheduling_utils::handshake::MAX_WORKERS
                     == BankingStage::max_num_workers().get()


### PR DESCRIPTION
#### Problem

- It can be difficult to track which scheduler is currently active and whether it has successfully initialized,
- For development it can be difficult to track which workers have hung and are not exiting.

#### Summary of Changes

- Add logs around scheduler rotation.
- Add logs for woker exit successfully.
