### PR TITLE
docs: Add step to update CHANGELOG.md in RELEASE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -312,15 +312,3 @@ makes the feature code complete.
 * Link to any relevant feature gate issues or SIMDs.
 * If you add entries on multiple branches use the same wording if possible.
 This simplifies the process of diffing between versions of the log.
-
-## Maintaining This Changelog
-### When creating a new release branch:
-* Commit to master updating the changelog:
-  * Update the edge, beta, and stable links
-  * Create new section: `vx.y+1.0 - Unreleased`
-  * Remove `Unreleased` annotation from vx.y.0 section.
-* Create vx.y branch starting at that commit.
-* Commit to `vx.y` updating the changelog:
-  * Remove the `vx.y+1.0 - Unreleased` section
-  * Remove the channel links
-* Tag vx.y.0 on the new branch

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -101,9 +101,17 @@ Alternatively use the Github UI.
     ci/channel-info.sh
     ```
 
+### Update the Changelog
+
+Create a PR that makes the following updates to [CHANGELOG.md](https://github.com/anza-xyz/agave/blob/master/CHANGELOG.md) in master:
+* Advance the channel links with the newly created branch becoming beta.
+* Add a new section `X.Y.0-Unreleased` for the new master version.
+* Remove the `Unreleased` annotation for the section that has now become beta.
+
 ### Miscellaneous Clean up
 
 1. Pin the spl-token-cli version in the newly promoted stable branch by setting `splTokenCliVersion` in scripts/spl-token-cli-version.sh to the latest release that depends on the stable branch (usually this will be the latest spl-token-cli release).
+1. Update [CHANGELOG.md](https://github.com/anza-xyz/agave/blob/master/CHANGELOG.md) to remove the channel links on the new branch. Additionally, remove any wording about the new branch being unreleased.
 1. Update [CODEOWNERS](https://github.com/anza-xyz/agave/blob/master/.github/CODEOWNERS) to `* @anza-xyz/backport-reviewers` on the new branch.
 1. Update [mergify.yml](https://github.com/anza-xyz/agave/blob/master/.mergify.yml) to add backport actions for the new branch and remove actions for the obsolete branch.
 1. Adjust the [Github backport labels](https://github.com/anza-xyz/agave/labels) to add the new branch label and remove the label for the obsolete branch.


### PR DESCRIPTION
#### Problem
This is a recurring step that should happen for every release.

#### Summary of Changes
Document the step so there is less chance of it being forgotten.

In the future, potentially aspire to an automated GH action and/or CI enforcement (ie https://github.com/anza-xyz/agave/pull/8829#pullrequestreview-3412368897)