### PR TITLE
fix(scheduler-bindings): delete old IPC file before binding

### DIFF
--- a/core/src/scheduler_bindings_server.rs
+++ b/core/src/scheduler_bindings_server.rs
@@ -5,6 +5,7 @@ use {
 
 pub(crate) fn spawn(path: &Path, session_sender: mpsc::Sender<BankingControlMsg>) {
     // NB: Panic on start if we can't bind.
+    let _ = std::fs::remove_file(path);
     let mut listener = handshake::server::Server::new(path).unwrap();
 
     std::thread::Builder::new()


### PR DESCRIPTION
#### Problem

- On exit, the validator leaves around the IPC file. On subsequent startup binding fails due to the pre-existing file.

#### Summary of Changes

- Remove the file (ignoring errors) before trying to bind.
