### PR TITLE
Implement size_hint for ListViewIter

### DIFF
--- a/vote/src/vote_state_view/list_view.rs
+++ b/vote/src/vote_state_view/list_view.rs
@@ -68,6 +68,11 @@ where
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.view.len().saturating_sub(self.index + self.rev_index);
+        (remaining, Some(remaining))
+    }
 }
 
 impl<'a, F: ListFrame> DoubleEndedIterator for ListViewIter<'a, F>


### PR DESCRIPTION
#### Problem

`ListViewIter` doesn't implement `size_hint`, which means building collections from it can't preallocate destination memory.

This is part of the `collect_vote_lockouts` perf improvements. 
https://github.com/anza-xyz/agave/blob/3e7bb4a162422552a95c7d5a444564a9428f5d75/core/src/consensus.rs#L428
`TowerVoteState::from` builds its internal `VecDeque` from `ListViewIter`, which as stated above cannot preallocate due to lack of a `size_hint`. This accounts for roughly 25% of execution time:

<img width="1986" height="1147" alt="image" src="https://github.com/user-attachments/assets/8f31ea41-716c-40d7-af9e-fa9718b9df54" />


#### Summary of Changes

This implements `size_hint` for `ListViewIter` so that creating collections from it can properly preallocate.

<img width="1776" height="1356" alt="image" src="https://github.com/user-attachments/assets/d40db807-a998-4270-a5a9-a2558d880aa5" />
