### PR TITLE
XDP: Reduce frame count

### DIFF
--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -75,7 +75,7 @@ pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>>(
         RingSizes::default()
     });
 
-    let frame_count = (rx_size + tx_size) * 2;
+    let frame_count = rx_size + tx_size;
 
     // try to allocate huge pages first, then fall back to regular pages
     const HUGE_2MB: usize = 2 * 1024 * 1024;
@@ -93,7 +93,7 @@ pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>>(
         caps::raise(None, CapSet::Effective, cap).unwrap();
     }
 
-    let Ok((mut socket, tx)) = Socket::tx(queue, umem, zero_copy, tx_size * 2, tx_size) else {
+    let Ok((mut socket, tx)) = Socket::tx(queue, umem, zero_copy, tx_size, tx_size) else {
         panic!("failed to create AF_XDP socket on queue {queue_id:?}");
     };
 


### PR DESCRIPTION
#### Problem
High frame count is causing erratic xdp throughput due to an increase in cache misses. umem is larger -> driver has to touch more memory -> more cache misses.

#### Summary of Changes
Reduce frame count. 

With this change:
```
throughput: 2019629.41 pps | 22.62 Gbps
throughput: 2020814.40 pps | 22.63 Gbps
throughput: 2017774.21 pps | 22.60 Gbps
throughput: 2019690.23 pps | 22.62 Gbps
throughput: 2023983.49 pps | 22.67 Gbps
throughput: 2022319.43 pps | 22.65 Gbps
throughput: 2021539.85 pps | 22.64 Gbps
throughput: 2023270.17 pps | 22.66 Gbps
```
without this change:
```
throughput: 2025451.08 pps | 22.69 Gbps
throughput: 2028332.94 pps | 22.72 Gbps
throughput: 1614225.64 pps | 18.08 Gbps
throughput: 614477.00 pps | 6.88 Gbps
throughput: 1114294.41 pps | 12.48 Gbps
throughput: 2020585.78 pps | 22.63 Gbps
throughput: 2024045.53 pps | 22.67 Gbps
throughput: 2020720.39 pps | 22.63 Gbps
throughput: 2026861.62 pps | 22.70 Gbps
```
Tested on:
```
driver: mlx5_core
version: 6.8.0-85-generic
```