### PR TITLE
ci: use protected environment in GitHub Actions

### DIFF
--- a/.github/workflows/add-team-to-ghsa.yml
+++ b/.github/workflows/add-team-to-ghsa.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   add-team-to-ghsa:
     if: github.repository == 'anza-xyz/agave'
+    environment: protected
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,6 +9,7 @@ jobs:
     if: github.repository == 'anza-xyz/agave'
     name: benchmark
     runs-on: benchmark
+    environment: protected
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -103,6 +103,7 @@ jobs:
       github.repository == 'anza-xyz/agave' &&
       github.event_name == 'push'
     runs-on: ubuntu-22.04
+    environment: protected
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/publish-windows-tarball.yml
+++ b/.github/workflows/publish-windows-tarball.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   windows-build:
     runs-on: windows-2022
+    environment: protected
     outputs:
       tag: ${{ steps.build.outputs.tag }}
       channel: ${{ steps.build.outputs.channel }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   trigger-buildkite-pipeline:
     if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
+    environment: protected
     steps:
       - name: Trigger a Buildkite Build
         uses: "buildkite/trigger-pipeline-action@v2.4.1"
@@ -42,6 +43,7 @@ jobs:
   version-bump:
     if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
+    environment: protected
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
#### Problem

the current secrets are available to all branches, which is too broad and could lead to accidental misuse

#### Summary of Changes

restrict secret access by using a protected environment limited to selected branches

---

the plan:

1. set up protected secrets
2. merge this PR
3. bp to v2.3 (for flexibility), v3.0 and v3.1
4. add one more step when cutting a new branch
5. remove existing repository level secrets 