### PR TITLE
feat(scheduler-bindings): add flag to reroute votes to external scheduler

### DIFF
--- a/scheduling-utils/src/handshake/mod.rs
+++ b/scheduling-utils/src/handshake/mod.rs
@@ -4,4 +4,4 @@ mod shared;
 #[cfg(test)]
 mod tests;
 
-pub use shared::{ClientLogon, MAX_WORKERS};
+pub use shared::{logon_flags, ClientLogon, MAX_WORKERS};

--- a/scheduling-utils/src/handshake/server.rs
+++ b/scheduling-utils/src/handshake/server.rs
@@ -185,6 +185,7 @@ impl Server {
 
         Ok((
             AgaveSession {
+                flags: logon.flags,
                 tpu_to_pack: AgaveTpuToPackSession {
                     allocator: tpu_to_pack_allocator,
                     producer: tpu_to_pack_queue,
@@ -339,6 +340,7 @@ impl Server {
 
 /// An initialized scheduling session.
 pub struct AgaveSession {
+    pub flags: u16,
     pub tpu_to_pack: AgaveTpuToPackSession,
     pub progress_tracker: shaq::Producer<ProgressMessage>,
     pub workers: Vec<AgaveWorkerSession>,

--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -24,6 +24,8 @@ pub struct ClientLogon {
     pub pack_to_worker_capacity: usize,
     /// The minimum capacity of the `worker_to_pack` queue in messages.
     pub worker_to_pack_capacity: usize,
+    /// Flags that control the behavior of the new scheduling session.
+    pub flags: u16,
     // NB: If adding more fields please ensure:
     // - The fields are zeroable.
     // - If possible the fields are backwards compatible:
@@ -43,4 +45,9 @@ impl ClientLogon {
         // - `Self` is valid for any byte pattern
         Some(unsafe { core::ptr::read_unaligned(buffer.as_ptr().cast()) })
     }
+}
+
+pub mod logon_flags {
+    /// Send the votes to the external scheduler instead of processing them internally.
+    pub const REROUTE_VOTES: u16 = 1 << 0;
 }

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -114,6 +114,7 @@ fn message_passing_on_all_queues() {
                 progress_tracker_capacity: 256,
                 pack_to_worker_capacity: 1024,
                 worker_to_pack_capacity: 1024,
+                flags: 0,
             },
             Duration::from_secs(1),
         )
@@ -195,6 +196,7 @@ fn accept_worker_count_max() {
                 progress_tracker_capacity: 256,
                 pack_to_worker_capacity: 1024,
                 worker_to_pack_capacity: 1024,
+                flags: 0,
             },
             Duration::from_secs(1),
         );
@@ -229,6 +231,7 @@ fn reject_worker_count_low() {
                 progress_tracker_capacity: 256,
                 pack_to_worker_capacity: 1024,
                 worker_to_pack_capacity: 1024,
+                flags: 0,
             },
             Duration::from_secs(1),
         );
@@ -266,6 +269,7 @@ fn reject_worker_count_high() {
                 progress_tracker_capacity: 256,
                 pack_to_worker_capacity: 1024,
                 worker_to_pack_capacity: 1024,
+                flags: 0,
             },
             Duration::from_secs(1),
         );


### PR DESCRIPTION
#### Problem

- External schedulers may wish to ensure they can build blocks deterministically. An internal vote worker prevents this while votes and user transactions share resource caps.

#### Summary of Changes

- Allow the external scheduler to specify when they wish to manage vote transactions.
