### PR TITLE
Deprecates `--accounts-db-access-storages-method mmap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Release channels have their own copy of this changelog:
 #### Changes
 ### Validator
 #### Breaking
+#### Deprecations
+* Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.
 
 ## 3.1.0
 ### RPC

--- a/accounts-db/benches/append_vec.rs
+++ b/accounts-db/benches/append_vec.rs
@@ -58,7 +58,11 @@ fn append_vec_append_file(bencher: &mut Bencher) {
 
 #[bench]
 fn append_vec_append_mmap(bencher: &mut Bencher) {
-    append_vec_append(bencher, StorageAccess::Mmap);
+    append_vec_append(
+        bencher,
+        #[allow(deprecated)]
+        StorageAccess::Mmap,
+    );
 }
 
 fn add_test_accounts(vec: &AppendVec, size: usize) -> Vec<(usize, usize)> {
@@ -93,7 +97,11 @@ fn append_vec_sequential_read_file(bencher: &mut Bencher) {
 
 #[bench]
 fn append_vec_sequential_read_mmap(bencher: &mut Bencher) {
-    append_vec_sequential_read(bencher, StorageAccess::Mmap);
+    append_vec_sequential_read(
+        bencher,
+        #[allow(deprecated)]
+        StorageAccess::Mmap,
+    );
 }
 
 fn append_vec_random_read(bencher: &mut Bencher, storage_access: StorageAccess) {
@@ -118,7 +126,11 @@ fn append_vec_random_read_file(bencher: &mut Bencher) {
 
 #[bench]
 fn append_vec_random_read_mmap(bencher: &mut Bencher) {
-    append_vec_random_read(bencher, StorageAccess::Mmap);
+    append_vec_random_read(
+        bencher,
+        #[allow(deprecated)]
+        StorageAccess::Mmap,
+    );
 }
 
 fn append_vec_concurrent_append_read(bencher: &mut Bencher, storage_access: StorageAccess) {
@@ -162,7 +174,11 @@ fn append_vec_concurrent_append_read_file(bencher: &mut Bencher) {
 
 #[bench]
 fn append_vec_concurrent_append_read_mmap(bencher: &mut Bencher) {
-    append_vec_concurrent_append_read(bencher, StorageAccess::Mmap);
+    append_vec_concurrent_append_read(
+        bencher,
+        #[allow(deprecated)]
+        StorageAccess::Mmap,
+    );
 }
 
 fn append_vec_concurrent_read_append(bencher: &mut Bencher, storage_access: StorageAccess) {
@@ -208,5 +224,9 @@ fn append_vec_concurrent_read_append_file(bencher: &mut Bencher) {
 
 #[bench]
 fn append_vec_concurrent_read_append_mmap(bencher: &mut Bencher) {
-    append_vec_concurrent_read_append(bencher, StorageAccess::Mmap);
+    append_vec_concurrent_read_append(
+        bencher,
+        #[allow(deprecated)]
+        StorageAccess::Mmap,
+    );
 }

--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -104,7 +104,11 @@ fn bench_write_accounts_file_file_io(c: &mut Criterion) {
 }
 
 fn bench_write_accounts_file_mmap(c: &mut Criterion) {
-    bench_write_accounts_file(c, StorageAccess::Mmap);
+    bench_write_accounts_file(
+        c,
+        #[allow(deprecated)]
+        StorageAccess::Mmap,
+    );
 }
 
 fn bench_scan_pubkeys(c: &mut Criterion) {
@@ -145,9 +149,14 @@ fn bench_scan_pubkeys(c: &mut Criterion) {
         // these new append vecs because that would cause double-free (or triple-free here).
         // Wrap the append vecs in ManuallyDrop to *not* remove the backing file on drop.
         let append_vec_mmap = ManuallyDrop::new(
-            AppendVec::new_from_file(append_vec.path(), append_vec.len(), StorageAccess::Mmap)
-                .unwrap()
-                .0,
+            AppendVec::new_from_file(
+                append_vec.path(),
+                append_vec.len(),
+                #[allow(deprecated)]
+                StorageAccess::Mmap,
+            )
+            .unwrap()
+            .0,
         );
         let append_vec_file = ManuallyDrop::new(
             AppendVec::new_from_file(append_vec.path(), append_vec.len(), StorageAccess::File)
@@ -230,9 +239,14 @@ fn bench_get_account_shared_data(c: &mut Criterion) {
         // these new append vecs because that would cause double-free (or triple-free here).
         // Wrap the append vecs in ManuallyDrop to *not* remove the backing file on drop.
         let append_vec_mmap = ManuallyDrop::new(
-            AppendVec::new_from_file(append_vec.path(), append_vec.len(), StorageAccess::Mmap)
-                .unwrap()
-                .0,
+            AppendVec::new_from_file(
+                append_vec.path(),
+                append_vec.len(),
+                #[allow(deprecated)]
+                StorageAccess::Mmap,
+            )
+            .unwrap()
+            .0,
         );
         let append_vec_file = ManuallyDrop::new(
             AppendVec::new_from_file(append_vec.path(), append_vec.len(), StorageAccess::File)

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -457,7 +457,7 @@ pub(crate) mod tests {
         test_case::test_case,
     };
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_shrink_in_progress(storage_access: StorageAccess) {
         // test that we check in order map then shrink_in_progress_map
@@ -552,7 +552,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(expected = "self.no_shrink_in_progress()")]
     fn test_get_slot_storage_entry_fail(storage_access: StorageAccess) {
@@ -565,7 +565,7 @@ pub(crate) mod tests {
         storage.get_slot_storage_entry(0);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(expected = "self.no_shrink_in_progress()")]
     fn test_all_slots_fail(storage_access: StorageAccess) {
@@ -578,7 +578,7 @@ pub(crate) mod tests {
         storage.all_slots();
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(expected = "self.no_shrink_in_progress()")]
     fn test_initialize_fail(storage_access: StorageAccess) {
@@ -591,7 +591,7 @@ pub(crate) mod tests {
         storage.initialize(AccountStorageMap::default());
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(
         expected = "shrink_can_be_active || self.shrink_in_progress_map.read().unwrap().is_empty()"
@@ -606,7 +606,7 @@ pub(crate) mod tests {
         storage.remove(&0, false);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(expected = "self.no_shrink_in_progress()")]
     fn test_iter_fail(storage_access: StorageAccess) {
@@ -619,7 +619,7 @@ pub(crate) mod tests {
         storage.iter();
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(expected = "self.no_shrink_in_progress()")]
     fn test_insert_fail(storage_access: StorageAccess) {
@@ -633,7 +633,7 @@ pub(crate) mod tests {
         storage.insert(0, sample);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(expected = "duplicate call")]
     fn test_shrinking_in_progress_fail3(storage_access: StorageAccess) {
@@ -649,7 +649,7 @@ pub(crate) mod tests {
         storage.shrinking_in_progress(0, sample);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(expected = "duplicate call")]
     fn test_shrinking_in_progress_fail4(storage_access: StorageAccess) {
@@ -662,7 +662,7 @@ pub(crate) mod tests {
         storage.shrinking_in_progress(0, sample);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_shrinking_in_progress_second_call(storage_access: StorageAccess) {
         // already called 'shrink_in_progress' on this slot, but it finished, so we succeed
@@ -695,7 +695,7 @@ pub(crate) mod tests {
         storage.shrinking_in_progress(slot, sample);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(expected = "no pre-existing storage for shrinking slot")]
     fn test_shrinking_in_progress_fail1(storage_access: StorageAccess) {
@@ -705,7 +705,7 @@ pub(crate) mod tests {
         storage.shrinking_in_progress(0, sample);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(expected = "no pre-existing storage for shrinking slot")]
     fn test_shrinking_in_progress_fail2(storage_access: StorageAccess) {
@@ -715,7 +715,7 @@ pub(crate) mod tests {
         storage.shrinking_in_progress(0, sample);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_missing(storage_access: StorageAccess) {
         // already called 'shrink_in_progress' on this slot, but it finished, so we succeed
@@ -755,7 +755,7 @@ pub(crate) mod tests {
         assert!(storage.get_account_storage_entry(slot, id).is_some());
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_get_if(storage_access: StorageAccess) {
         let storage = AccountStorage::default();
@@ -789,7 +789,7 @@ pub(crate) mod tests {
         assert_eq!(storage.get_if(|_, _| true).len(), ids.len());
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(expected = "self.no_shrink_in_progress()")]
     fn test_get_if_fail(storage_access: StorageAccess) {

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -161,7 +161,7 @@ mod tests {
         )
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(expected = "Obsolete accounts should be empty for TieredStorage")]
     fn test_account_storage_reader_tiered_storage_one_obsolete_account_should_panic(
@@ -193,7 +193,7 @@ mod tests {
         _ = AccountStorageReader::new(&storage, None).unwrap();
     }
 
-    #[test_case(AccountsFileProvider::AppendVec, StorageAccess::Mmap)]
+    #[test_case(AccountsFileProvider::AppendVec, #[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(AccountsFileProvider::AppendVec, StorageAccess::File)]
     #[test_case(AccountsFileProvider::HotStorage, StorageAccess::File)]
     fn test_account_storage_reader_no_obsolete_accounts(
@@ -223,12 +223,12 @@ mod tests {
     #[test_case(100, 0, StorageAccess::File)]
     #[test_case(100, 10, StorageAccess::File)]
     #[test_case(100, 100, StorageAccess::File)]
-    #[test_case(0, 0, StorageAccess::Mmap)]
-    #[test_case(1, 0, StorageAccess::Mmap)]
-    #[test_case(1, 1, StorageAccess::Mmap)]
-    #[test_case(100, 0, StorageAccess::Mmap)]
-    #[test_case(100, 10, StorageAccess::Mmap)]
-    #[test_case(100, 100, StorageAccess::Mmap)]
+    #[test_case(0, 0, #[allow(deprecated)] StorageAccess::Mmap)]
+    #[test_case(1, 0, #[allow(deprecated)] StorageAccess::Mmap)]
+    #[test_case(1, 1, #[allow(deprecated)] StorageAccess::Mmap)]
+    #[test_case(100, 0, #[allow(deprecated)] StorageAccess::Mmap)]
+    #[test_case(100, 10, #[allow(deprecated)] StorageAccess::Mmap)]
+    #[test_case(100, 100, #[allow(deprecated)] StorageAccess::Mmap)]
     fn test_account_storage_reader_with_obsolete_accounts(
         total_accounts: usize,
         number_of_accounts_to_remove: usize,
@@ -294,6 +294,7 @@ mod tests {
                 storage.accounts.internals_for_archive(),
                 InternalsForArchive::FileIo(_)
             )),
+            #[allow(deprecated)]
             StorageAccess::Mmap => assert!(matches!(
                 storage.accounts.internals_for_archive(),
                 InternalsForArchive::Mmap(_)
@@ -342,7 +343,7 @@ mod tests {
         }
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_account_storage_reader_filter_by_slot(storage_access: StorageAccess) {
         let (storage, _temp_dirs) =

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -2568,7 +2568,7 @@ fn test_select_candidates_by_total_usage_no_candidates() {
     assert_eq!(0, next_candidates.len());
 }
 
-#[test_case(StorageAccess::Mmap)]
+#[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
 #[test_case(StorageAccess::File)]
 fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: StorageAccess) {
     // three candidates, one selected for shrink, one is put back to the candidate list and one is ignored
@@ -2635,7 +2635,7 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
     assert!(next_candidates.contains(&store2_slot));
 }
 
-#[test_case(StorageAccess::Mmap)]
+#[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
 #[test_case(StorageAccess::File)]
 fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: StorageAccess) {
     // three candidates, 2 are selected for shrink, one is ignored
@@ -2699,7 +2699,7 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
     assert_eq!(0, next_candidates.len());
 }
 
-#[test_case(StorageAccess::Mmap)]
+#[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
 #[test_case(StorageAccess::File)]
 fn test_select_candidates_by_total_usage_all_clean(storage_access: StorageAccess) {
     // 2 candidates, they must be selected to achieve the target alive ratio
@@ -4797,7 +4797,7 @@ fn test_remove_uncleaned_slots_and_collect_pubkeys_up_to_slot() {
     assert!(candidates_contain(&pubkey3));
 }
 
-#[test_case(StorageAccess::Mmap)]
+#[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
 #[test_case(StorageAccess::File)]
 fn test_shrink_productive(storage_access: StorageAccess) {
     agave_logger::setup();
@@ -4833,7 +4833,7 @@ fn test_shrink_productive(storage_access: StorageAccess) {
     assert!(!AccountsDb::is_shrinking_productive(&store));
 }
 
-#[test_case(StorageAccess::Mmap)]
+#[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
 #[test_case(StorageAccess::File)]
 fn test_is_candidate_for_shrink(storage_access: StorageAccess) {
     agave_logger::setup();
@@ -6335,7 +6335,7 @@ fn insert_store(db: &AccountsDb, append_vec: Arc<AccountStorageEntry>) {
     db.storage.insert(append_vec.slot(), append_vec);
 }
 
-#[test_case(StorageAccess::Mmap)]
+#[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
 #[test_case(StorageAccess::File)]
 #[should_panic(expected = "self.storage.remove")]
 fn test_handle_dropped_roots_for_ancient_assert(storage_access: StorageAccess) {

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -49,6 +49,7 @@ pub enum AccountsFileError {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum StorageAccess {
     /// storages should be accessed by Mmap
+    #[deprecated(since = "4.0.0")]
     Mmap,
     /// storages should be accessed by File I/O
     /// ancient storages are created by 1-shot write to pack multiple accounts together more efficiently with new formats

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1535,7 +1535,11 @@ pub mod tests {
         // or all slots shrunk so no roots or storages should be removed
         for in_shrink_candidate_slots in [false, true] {
             for all_slots_shrunk in [false, true] {
-                for storage_access in [StorageAccess::Mmap, StorageAccess::File] {
+                for storage_access in [
+                    #[allow(deprecated)]
+                    StorageAccess::Mmap,
+                    StorageAccess::File,
+                ] {
                     for num_slots in 0..3 {
                         let (mut db, storages, slots, infos) = get_sample_storages(num_slots, None);
                         db.set_storage_access(storage_access);

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -290,6 +290,7 @@ impl AppendVec {
         data.flush().unwrap();
 
         let backing = match storage_access {
+            #[allow(deprecated)]
             StorageAccess::Mmap => {
                 //UNSAFE: Required to create a Mmap
                 let mmap = unsafe { MmapMut::map_mut(&data) };
@@ -483,9 +484,11 @@ impl AppendVec {
         Self::sanitize_len_and_size(current_len, file_size as usize)?;
 
         // AppendVec is in read-only mode, but mmap access requires file to be writable
+        #[allow(deprecated)]
+        let is_writable = storage_access == StorageAccess::Mmap;
         let data = OpenOptions::new()
             .read(true)
-            .write(storage_access == StorageAccess::Mmap)
+            .write(is_writable)
             .create(false)
             .open(&path)?;
 
@@ -1424,7 +1427,7 @@ pub mod tests {
         assert_eq!(&def1, &def2);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     #[should_panic(expected = "FileSizeTooSmall(0)")]
     fn test_append_vec_new_bad_size(storage_access: StorageAccess) {
@@ -1432,7 +1435,7 @@ pub mod tests {
         let _av = AppendVec::new(&path.path, true, 0, storage_access);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_append_vec_new_from_file_bad_size(storage_access: StorageAccess) {
         let file = get_append_vec_path("test_append_vec_new_from_file_bad_size");
@@ -1489,7 +1492,7 @@ pub mod tests {
         assert_matches!(result, Err(ref message) if message.to_string().contains("is larger than file size (1048576)"));
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_append_vec_one(storage_access: StorageAccess) {
         let path = get_append_vec_path("test_append");
@@ -1514,7 +1517,7 @@ pub mod tests {
         assert_eq!(av.get_account_test(index), None);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_append_vec_one_with_data(storage_access: StorageAccess) {
         let path = get_append_vec_path("test_append");
@@ -1531,7 +1534,7 @@ pub mod tests {
         truncate_and_test(av, index);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_remaining_bytes(storage_access: StorageAccess) {
         let path = get_append_vec_path("test_append");
@@ -1572,7 +1575,7 @@ pub mod tests {
         assert_eq!(av.remaining_bytes(), sz64 - u64_align!(av_len) as u64);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_append_vec_data(storage_access: StorageAccess) {
         let path = get_append_vec_path("test_append_data");
@@ -1656,6 +1659,7 @@ pub mod tests {
             &path.path,
             true,
             file_size,
+            #[allow(deprecated)]
             StorageAccess::Mmap,
         ));
         let slot = 42;
@@ -1784,7 +1788,7 @@ pub mod tests {
         }
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_append_vec_append_many(storage_access: StorageAccess) {
         let path = get_append_vec_path("test_append_many");
@@ -1835,7 +1839,7 @@ pub mod tests {
         trace!("sequential read time: {} ms", now.elapsed().as_millis());
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_new_from_file_crafted_zero_lamport_account(storage_access: StorageAccess) {
         // This test verifies that when we sanitize on load, that we fail sanitizing if we load an account with zero lamports that does not have all default value fields.
@@ -1908,7 +1912,7 @@ pub mod tests {
         assert_matches!(result, Err(ref message) if message.to_string().contains("incorrect layout/length/data"));
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_new_from_file_crafted_data_len(storage_access: StorageAccess) {
         let file = get_append_vec_path("test_new_from_file_crafted_data_len");
@@ -1944,7 +1948,7 @@ pub mod tests {
         assert_matches!(result, Err(ref message) if message.to_string().contains("incorrect layout/length/data"));
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_append_vec_reset(storage_access: StorageAccess) {
         let file = get_append_vec_path("test_append_vec_reset");
@@ -1957,7 +1961,7 @@ pub mod tests {
         assert_eq!(av.len(), 0);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_append_vec_flush(storage_access: StorageAccess) {
         let file = get_append_vec_path("test_append_vec_flush");
@@ -1975,7 +1979,7 @@ pub mod tests {
         assert_eq!(num_account, 1);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_append_vec_reopen_as_readonly(storage_access: StorageAccess) {
         let file = get_append_vec_path("test_append_vec_flush");
@@ -2001,7 +2005,7 @@ pub mod tests {
         }
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_new_from_file_too_large_data_len(storage_access: StorageAccess) {
         let file = get_append_vec_path("test_new_from_file_too_large_data_len");
@@ -2038,7 +2042,7 @@ pub mod tests {
         assert_matches!(result, Err(ref message) if message.to_string().contains("incorrect layout/length/data"));
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_new_from_file_crafted_executable(storage_access: StorageAccess) {
         let file = get_append_vec_path("test_new_from_crafted_executable");
@@ -2109,7 +2113,7 @@ pub mod tests {
         assert_eq!(mem::size_of::<AccountMeta>(), 0x38);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_get_account_shared_data_from_truncated_file(storage_access: StorageAccess) {
         let file = get_append_vec_path("test_get_account_shared_data_from_truncated_file");
@@ -2142,7 +2146,7 @@ pub mod tests {
         assert!(result.is_none()); // Expect None to be returned.
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_get_account_sizes(storage_access: StorageAccess) {
         const NUM_ACCOUNTS: usize = 37;
@@ -2270,14 +2274,14 @@ pub mod tests {
     }
 
     /// Test `scan_pubkey` for a valid account storage.
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_scan_pubkeys(storage_access: StorageAccess) {
         test_scan_pubkeys_helper(storage_access, |_, size| size);
     }
 
     /// Test `scan_pubkey` for storage with incomplete account meta data.
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_scan_pubkeys_incomplete_data(storage_access: StorageAccess) {
         test_scan_pubkeys_helper(storage_access, |path, size| {
@@ -2294,7 +2298,7 @@ pub mod tests {
     }
 
     /// Test `scan_pubkey` for storage which is missing the last account data
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_scan_pubkeys_missing_account_data(storage_access: StorageAccess) {
         test_scan_pubkeys_helper(storage_access, |path, size| {
@@ -2369,14 +2373,14 @@ pub mod tests {
         )
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_scan_stored_accounts_no_data(storage_access: StorageAccess) {
         test_scan_stored_accounts_no_data_helper(storage_access, |_, size| size);
     }
 
     /// Test `scan_stored_accounts_no_data` for storage with incomplete account meta data.
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_scan_stored_accounts_no_data_incomplete_data(storage_access: StorageAccess) {
         test_scan_stored_accounts_no_data_helper(storage_access, |path, size| {
@@ -2393,7 +2397,7 @@ pub mod tests {
     }
 
     /// Test `scan_stored_accounts_no_data` for storage which is missing the last account data
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_scan_stored_accounts_no_data_missing_account_data(storage_access: StorageAccess) {
         test_scan_stored_accounts_no_data_helper(storage_access, |path, size| {
@@ -2467,14 +2471,14 @@ pub mod tests {
     }
 
     /// Test `scan_accounts_stored_meta` for a normal/good storage.
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_scan_accounts_stored_meta(storage_access: StorageAccess) {
         test_scan_accounts_stored_meta_helper(storage_access, |_, size| size);
     }
 
     /// Test `scan_accounts_stored_meta` for a storage with incomplete account meta data.
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_scan_accounts_stored_meta_incomplete_meta_data(storage_access: StorageAccess) {
         test_scan_accounts_stored_meta_helper(storage_access, |path, size| {
@@ -2491,7 +2495,7 @@ pub mod tests {
     }
 
     /// Test `scan_accounts_stored_meta` for a storage that is missing the last account data.
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_scan_accounts_stored_meta_missing_account_data(storage_access: StorageAccess) {
         test_scan_accounts_stored_meta_helper(storage_access, |path, size| {
@@ -2536,7 +2540,7 @@ pub mod tests {
     // Test to make sure that `is_dirty` is tracked properly
     // * `reopen_as_readonly()` moves `is_dirty`
     // * `flush()` clears `is_dirty`
-    #[test_matrix([false, true], [StorageAccess::Mmap, StorageAccess::File])]
+    #[test_matrix([false, true], [#[allow(deprecated)] StorageAccess::Mmap, StorageAccess::File])]
     fn test_is_dirty(begins_dirty: bool, storage_access: StorageAccess) {
         let file = get_append_vec_path("test_is_dirty");
 

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -1,6 +1,7 @@
 use {
     crate::LEDGER_TOOL_DIRECTORY,
     clap::{value_t, value_t_or_exit, values_t, values_t_or_exit, Arg, ArgMatches},
+    log::*,
     solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
     solana_accounts_db::{
         accounts_db::{AccountsDbConfig, DEFAULT_MEMLOCK_BUDGET_SIZE},
@@ -271,7 +272,11 @@ pub fn get_accounts_db_config(
     let storage_access = arg_matches
         .value_of("accounts_db_access_storages_method")
         .map(|method| match method {
-            "mmap" => StorageAccess::Mmap,
+            "mmap" => {
+                warn!("Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.");
+                #[allow(deprecated)]
+                StorageAccess::Mmap
+            }
             "file" => StorageAccess::File,
             _ => {
                 // clap will enforce one of the above values is given

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -79,7 +79,7 @@ mod tests {
 
     /// Test roundtrip serialize/deserialize of a bank
     #[test_matrix(
-        [StorageAccess::Mmap, StorageAccess::File]
+        [#[allow(deprecated)] StorageAccess::Mmap, StorageAccess::File]
     )]
     fn test_serialize_bank_snapshot(storage_access: StorageAccess) {
         let (mut genesis_config, _) = create_genesis_config(500);
@@ -180,7 +180,7 @@ mod tests {
         bank.flush_accounts_cache_slot_for_tests()
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_extra_fields_eof(storage_access: StorageAccess) {
         agave_logger::setup();

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -208,7 +208,7 @@ mod serde_snapshot_tests {
         }
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     fn test_accounts_serialize(storage_access: StorageAccess) {
         agave_logger::setup();
         let (_accounts_dir, paths) = get_temp_accounts_paths(4).unwrap();
@@ -267,7 +267,7 @@ mod serde_snapshot_tests {
         assert_eq!(accounts_hash, daccounts_hash);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_remove_unrooted_slot_snapshot(storage_access: StorageAccess) {
         agave_logger::setup();
@@ -306,7 +306,7 @@ mod serde_snapshot_tests {
     }
 
     #[test_matrix(
-        [StorageAccess::File, StorageAccess::Mmap],
+        [StorageAccess::File, #[allow(deprecated)] StorageAccess::Mmap],
         [MarkObsoleteAccounts::Enabled, MarkObsoleteAccounts::Disabled],
         [MarkObsoleteAccounts::Enabled, MarkObsoleteAccounts::Disabled]
     )]
@@ -442,7 +442,7 @@ mod serde_snapshot_tests {
         }
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_accounts_db_serialize_zero_and_free(storage_access: StorageAccess) {
         agave_logger::setup();
@@ -556,7 +556,7 @@ mod serde_snapshot_tests {
         assert_eq!(calculated_capitalization, expected_capitalization);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_accounts_purge_chained_purge_before_snapshot_restore(storage_access: StorageAccess) {
         agave_logger::setup();
@@ -575,7 +575,7 @@ mod serde_snapshot_tests {
         });
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_accounts_purge_chained_purge_after_snapshot_restore(storage_access: StorageAccess) {
         agave_logger::setup();
@@ -598,7 +598,7 @@ mod serde_snapshot_tests {
         });
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_accounts_purge_long_chained_after_snapshot_restore(storage_access: StorageAccess) {
         agave_logger::setup();
@@ -672,7 +672,7 @@ mod serde_snapshot_tests {
         accounts.assert_load_account(current_slot, purged_pubkey2, 0);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_accounts_clean_after_snapshot_restore_then_old_revives(storage_access: StorageAccess) {
         agave_logger::setup();
@@ -804,7 +804,7 @@ mod serde_snapshot_tests {
         accounts.assert_load_account(current_slot, dummy_pubkey, dummy_lamport);
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_shrink_stale_slots_processed(storage_access: StorageAccess) {
         agave_logger::setup();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1521,7 +1521,7 @@ mod tests {
         );
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_bank_fields_from_snapshot(storage_access: StorageAccess) {
         let collector = Pubkey::new_unique();
@@ -1820,7 +1820,7 @@ mod tests {
     ///     - remove Account2's reference back to slot 2 by transferring from the mint to Account2
     ///     - take a full snap shot
     ///     - verify that recovery from full snapshot does not bring account1 back to life
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_snapshots_handle_zero_lamport_accounts(storage_access: StorageAccess) {
         let collector = Pubkey::new_unique();
@@ -2082,7 +2082,7 @@ mod tests {
         .unwrap();
     }
 
-    #[test_case(StorageAccess::Mmap)]
+    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_bank_from_snapshot_dir(storage_access: StorageAccess) {
         let genesis_config = GenesisConfig::default();

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -404,7 +404,11 @@ pub fn execute(
     let storage_access = matches
         .value_of("accounts_db_access_storages_method")
         .map(|method| match method {
-            "mmap" => StorageAccess::Mmap,
+            "mmap" => {
+                warn!("Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.");
+                #[allow(deprecated)]
+                StorageAccess::Mmap
+            }
             "file" => StorageAccess::File,
             _ => {
                 // clap will enforce one of the above values is given


### PR DESCRIPTION
#### Problem

Mmap-ing in general should be avoided for performance. We currently allow using mmaps for append vec storage access.


#### Summary of Changes

Historically, we've still allowed mmap because RPCs saw perf regressions when using file-io. After talking with RPCs running v3.0, they have said the perf regressions using file-io are now gone.

Deprecate `--accounts-db-access-storages-method mmap`.