### PR TITLE
Simplify ListViewIter with ChunksExact

### DIFF
--- a/vote/src/vote_state_view/list_view.rs
+++ b/vote/src/vote_state_view/list_view.rs
@@ -1,4 +1,4 @@
-use super::field_frames::ListFrame;
+use {super::field_frames::ListFrame, std::slice::ChunksExact};
 
 pub(super) struct ListView<'a, F> {
     frame: F,
@@ -12,19 +12,9 @@ impl<'a, F: ListFrame> ListView<'a, F> {
         Self { frame, item_buffer }
     }
 
+    #[inline]
     pub(super) fn len(&self) -> usize {
         self.frame.len()
-    }
-
-    pub(super) fn into_iter(self) -> ListViewIter<'a, F>
-    where
-        Self: Sized,
-    {
-        ListViewIter {
-            index: 0,
-            rev_index: 0,
-            view: self,
-        }
     }
 
     pub(super) fn last(&self) -> Option<&F::Item> {
@@ -49,9 +39,8 @@ impl<'a, F: ListFrame> ListView<'a, F> {
 }
 
 pub(super) struct ListViewIter<'a, F> {
-    index: usize,
-    rev_index: usize,
-    view: ListView<'a, F>,
+    buffer: ChunksExact<'a, u8>,
+    frame: F,
 }
 
 impl<'a, F: ListFrame> Iterator for ListViewIter<'a, F>
@@ -59,19 +48,29 @@ where
     F::Item: 'a,
 {
     type Item = &'a F::Item;
+
     fn next(&mut self) -> Option<Self::Item> {
-        if self.index < self.view.len() {
-            let item = self.view.item(self.index);
-            self.index += 1;
-            item
-        } else {
-            None
-        }
+        let item_data = self.buffer.next()?;
+        // SAFETY: `item_data` is chunked by `self.frame.item_size()`
+        Some(unsafe { self.frame.read_item(item_data) })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.view.len().saturating_sub(self.index + self.rev_index);
-        (remaining, Some(remaining))
+        self.buffer.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.buffer.count()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let item_data = self.buffer.nth(n)?;
+        // SAFETY: `item_data` is chunked by `self.frame.item_size()`
+        Some(unsafe { self.frame.read_item(item_data) })
+    }
+
+    fn last(mut self) -> Option<Self::Item> {
+        self.next_back()
     }
 }
 
@@ -80,12 +79,170 @@ where
     F::Item: 'a,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.rev_index < self.view.len() {
-            let item = self.view.item(self.view.len() - self.rev_index - 1);
-            self.rev_index += 1;
-            item
-        } else {
-            None
+        let item_data = self.buffer.next_back()?;
+        // SAFETY: `item_data` is chunked by `self.frame.item_size()`
+        Some(unsafe { self.frame.read_item(item_data) })
+    }
+}
+
+impl<'a, F: ListFrame> IntoIterator for ListView<'a, F>
+where
+    F::Item: 'a,
+{
+    type Item = &'a F::Item;
+    type IntoIter = ListViewIter<'a, F>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let item_size = self.frame.item_size();
+        let total_bytes = self.frame.len() * item_size;
+        let slice = &self.item_buffer[..total_bytes];
+        ListViewIter {
+            buffer: slice.chunks_exact(item_size),
+            frame: self.frame,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::field_frames::{LandedVotesListFrame, LockoutListFrame},
+        *,
+    };
+
+    fn build_lockout_buffer(len: usize, make: impl Fn(usize) -> (u64, u32)) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(size_of::<u64>() + len * 12);
+        buf.extend_from_slice(&(len as u64).to_le_bytes());
+        for i in 0..len {
+            let (slot, count) = make(i);
+            buf.extend_from_slice(&slot.to_le_bytes());
+            buf.extend_from_slice(&count.to_le_bytes());
+        }
+        buf
+    }
+
+    fn build_landed_buffer(len: usize, make: impl Fn(usize) -> (u8, u64, u32)) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(size_of::<u64>() + len * 13);
+        buf.extend_from_slice(&(len as u64).to_le_bytes());
+        for i in 0..len {
+            let (latency, slot, count) = make(i);
+            buf.push(latency);
+            buf.extend_from_slice(&slot.to_le_bytes());
+            buf.extend_from_slice(&count.to_le_bytes());
+        }
+        buf
+    }
+
+    #[test]
+    fn iter_lockout_forward_and_rev() {
+        let len = 5usize;
+        let buffer = build_lockout_buffer(len, |i| (i as u64, (10 + i) as u32));
+        let frame = LockoutListFrame { len: len as u8 };
+        let view = ListView::new(frame, &buffer);
+
+        let forward: Vec<(u64, u32)> = view
+            .into_iter()
+            .map(|it| (it.slot(), it.confirmation_count()))
+            .collect();
+        assert_eq!(
+            forward,
+            (0..len)
+                .map(|i| (i as u64, (10 + i) as u32))
+                .collect::<Vec<_>>()
+        );
+
+        let view = ListView::new(frame, &buffer);
+        let rev: Vec<(u64, u32)> = view
+            .into_iter()
+            .rev()
+            .map(|it| (it.slot(), it.confirmation_count()))
+            .collect();
+        assert_eq!(
+            rev,
+            (0..len)
+                .rev()
+                .map(|i| (i as u64, (10 + i) as u32))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn iter_lockout_mixed_front_back() {
+        let len = 5usize;
+        let buffer = build_lockout_buffer(len, |i| (i as u64, (100 + i) as u32));
+        let frame = LockoutListFrame { len: len as u8 };
+        let mut it = ListView::new(frame, &buffer).into_iter();
+
+        let out = [
+            (it.next().map(|x| (x.slot(), x.confirmation_count()))).unwrap(), // 0
+            (it.next_back().map(|x| (x.slot(), x.confirmation_count()))).unwrap(), // 4
+            (it.next().map(|x| (x.slot(), x.confirmation_count()))).unwrap(), // 1
+            (it.next_back().map(|x| (x.slot(), x.confirmation_count()))).unwrap(), // 3
+            (it.next().map(|x| (x.slot(), x.confirmation_count()))).unwrap(), // 2
+        ];
+        assert!(it.next().is_none());
+
+        let expected = [
+            (0u64, 100u32),
+            (4u64, 104u32),
+            (1u64, 101u32),
+            (3u64, 103u32),
+            (2u64, 102u32),
+        ];
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn iter_landed_stride_and_rev() {
+        let len = 4usize;
+        let buffer =
+            build_landed_buffer(len, |i| ((200 + i) as u8, (10 + i) as u64, (20 + i) as u32));
+        let frame = LandedVotesListFrame { len: len as u8 };
+
+        // Forward
+        let view = ListView::new(frame, &buffer);
+        let fwd: Vec<(u64, u32)> = view
+            .into_iter()
+            .map(|it| (it.slot(), it.confirmation_count()))
+            .collect();
+        assert_eq!(
+            fwd,
+            (0..len)
+                .map(|i| ((10 + i) as u64, (20 + i) as u32))
+                .collect::<Vec<_>>()
+        );
+
+        // Reverse
+        let view = ListView::new(frame, &buffer);
+        let rev: Vec<(u64, u32)> = view
+            .into_iter()
+            .rev()
+            .map(|it| (it.slot(), it.confirmation_count()))
+            .collect();
+        assert_eq!(
+            rev,
+            (0..len)
+                .rev()
+                .map(|i| ((10 + i) as u64, (20 + i) as u32))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn size_hint_decreases() {
+        let len = 3usize;
+        let buffer = build_lockout_buffer(len, |i| (i as u64, i as u32));
+        let frame = LockoutListFrame { len: len as u8 };
+        let mut it = ListView::new(frame, &buffer).into_iter();
+
+        assert_eq!(it.size_hint(), (3, Some(3)));
+        assert!(it.next().is_some());
+        assert_eq!(it.size_hint(), (2, Some(2)));
+        assert!(it.next_back().is_some());
+        assert_eq!(it.size_hint(), (1, Some(1)));
+        assert!(it.next().is_some());
+        assert_eq!(it.size_hint(), (0, Some(0)));
+        assert!(it.next().is_none());
+        assert!(it.next_back().is_none());
     }
 }


### PR DESCRIPTION
#### Problem
`ListViewIter` performs manual bookkeeping with `index` and `rev_index` to manage progress through the iterator. `Iterator` and `DoubleEndedIterator` implementations only consider `index` and `rev_index`, respectively, which leads to incorrect iteration when using both `next` and `next_back` on the same iterator.

Additionally, `next` and `next_back` perform a bounds check before calling `view.item(index)`, which performs its own bound checking, resulting in duplicated bounds checks on each iteration.

#### Summary of Changes

This refactors `ListViewIter` to hold a `std::slice::ChunksExact`, which efficiently implements the manual bookkeeping that is currently in use by shrinking its internal slice on each iteration. This makes `Iterator` and `DoubleEndedIterator` implementations trivial, as they simply delegate iterator progress to `std::slice::ChunksExact` and perform the read on the byte chunk. This also gives us the optimized implementations for `count`, `size_hint`, `nth`, and `last` for free.

Also included tests, which exercise this behavior. Current implementation fails the tests that exercise `next` and `next_back` together.