### PR TITLE
feat(scheduler-bindings): huge pages; queue sizes in items

### DIFF
--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -12,18 +12,18 @@ pub(crate) const GLOBAL_ALLOCATORS: usize = 1;
 pub struct ClientLogon {
     /// The number of Agave worker threads that will be spawned to handle packing requests.
     pub worker_count: usize,
-    /// The allocator file size in bytes, this is shared by all allocator handles.
+    /// The minimum allocator file size in bytes, this is shared by all allocator handles.
     pub allocator_size: usize,
     /// The number of [`rts_alloc::Allocator`] handles the external process is requesting.
     pub allocator_handles: usize,
-    /// The size of the `tpu_to_pack` queue in bytes.
-    pub tpu_to_pack_size: usize,
-    /// The size of the `progress_tracker` queue in bytes.
-    pub progress_tracker_size: usize,
-    /// The size of the `pack_to_worker` queue in bytes.
-    pub pack_to_worker_size: usize,
-    /// The size of the `worker_to_pack` queue in bytes.
-    pub worker_to_pack_size: usize,
+    /// The minimum capacity of the `tpu_to_pack` queue in messages.
+    pub tpu_to_pack_capacity: usize,
+    /// The minimum capacity of the `progress_tracker` queue in messages.
+    pub progress_tracker_capacity: usize,
+    /// The minimum capacity of the `pack_to_worker` queue in messages.
+    pub pack_to_worker_capacity: usize,
+    /// The minimum capacity of the `worker_to_pack` queue in messages.
+    pub worker_to_pack_capacity: usize,
     // NB: If adding more fields please ensure:
     // - The fields are zeroable.
     // - If possible the fields are backwards compatible:

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -110,10 +110,10 @@ fn message_passing_on_all_queues() {
                 worker_count: 4,
                 allocator_size: 1024 * 1024 * 1024,
                 allocator_handles: 3,
-                tpu_to_pack_size: 65536 * 1024,
-                progress_tracker_size: 16 * 1024,
-                pack_to_worker_size: 1024 * 1024,
-                worker_to_pack_size: 1024 * 1024,
+                tpu_to_pack_capacity: 65536,
+                progress_tracker_capacity: 256,
+                pack_to_worker_capacity: 1024,
+                worker_to_pack_capacity: 1024,
             },
             Duration::from_secs(1),
         )
@@ -191,10 +191,10 @@ fn accept_worker_count_max() {
                 worker_count: MAX_WORKERS,
                 allocator_size: 1024 * 1024 * 1024,
                 allocator_handles: 3,
-                tpu_to_pack_size: 65536 * 1024,
-                progress_tracker_size: 16 * 1024,
-                pack_to_worker_size: 1024 * 1024,
-                worker_to_pack_size: 1024 * 1024,
+                tpu_to_pack_capacity: 65536,
+                progress_tracker_capacity: 256,
+                pack_to_worker_capacity: 1024,
+                worker_to_pack_capacity: 1024,
             },
             Duration::from_secs(1),
         );
@@ -225,10 +225,10 @@ fn reject_worker_count_low() {
                 worker_count: 0,
                 allocator_size: 1024 * 1024 * 1024,
                 allocator_handles: 3,
-                tpu_to_pack_size: 65536 * 1024,
-                progress_tracker_size: 16 * 1024,
-                pack_to_worker_size: 1024 * 1024,
-                worker_to_pack_size: 1024 * 1024,
+                tpu_to_pack_capacity: 65536,
+                progress_tracker_capacity: 256,
+                pack_to_worker_capacity: 1024,
+                worker_to_pack_capacity: 1024,
             },
             Duration::from_secs(1),
         );
@@ -262,10 +262,10 @@ fn reject_worker_count_high() {
                 worker_count: 100,
                 allocator_size: 1024 * 1024 * 1024,
                 allocator_handles: 3,
-                tpu_to_pack_size: 65536 * 1024,
-                progress_tracker_size: 16 * 1024,
-                pack_to_worker_size: 1024 * 1024,
-                worker_to_pack_size: 1024 * 1024,
+                tpu_to_pack_capacity: 65536,
+                progress_tracker_capacity: 256,
+                pack_to_worker_capacity: 1024,
+                worker_to_pack_capacity: 1024,
             },
             Duration::from_secs(1),
         );
@@ -273,40 +273,6 @@ fn reject_worker_count_high() {
             panic!();
         };
         assert_eq!(reason, "Worker count; count=100");
-    });
-
-    client_handle.join().unwrap();
-    server_handle.join().unwrap();
-}
-
-#[test]
-fn reject_invalid_queue_size() {
-    let ipc = NamedTempFile::new().unwrap();
-    std::fs::remove_file(ipc.path()).unwrap();
-    let mut server = Server::new(ipc.path()).unwrap();
-
-    let server_handle = std::thread::spawn(move || {
-        let res = server.accept();
-        assert!(matches!(res, Err(AgaveHandshakeError::Shaq(_))));
-    });
-    let client_handle = std::thread::spawn(move || {
-        let res = connect(
-            ipc,
-            ClientLogon {
-                worker_count: 4,
-                allocator_size: 1024 * 1024 * 1024,
-                allocator_handles: 3,
-                tpu_to_pack_size: 0,
-                progress_tracker_size: 16 * 1024,
-                pack_to_worker_size: 1024 * 1024,
-                worker_to_pack_size: 1024 * 1024,
-            },
-            Duration::from_secs(1),
-        );
-        let Err(ClientHandshakeError::Rejected(reason)) = res else {
-            panic!();
-        };
-        assert_eq!(reason, "Shaq; err=InvalidBufferSize");
     });
 
     client_handle.join().unwrap();


### PR DESCRIPTION
#### Problem

- Allocators and queues could benefit from huge pages if available but currently do not take advantage of them.
- Queue sizes in bytes are confusing to users trying to set a minimum message capacity.

#### Summary of Changes

- First try to map using huge pages, falling back to regular pages on failure.
- Specify queues sizes in terms of messages, this also makes it easier to manage the page alignment requirements.
