### PR TITLE
Update Rust to 1.89.0

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2025-05-09
+  nightly_version=2025-06-23
 fi
 
 

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2025-02-16
+  nightly_version=2025-03-29
 fi
 
 

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2025-03-29
+  nightly_version=2025-05-09
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.88.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.89.0"


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/issues/8894

#### Summary of Changes
Per the issue above, advance the Rust version directly from 1.86 to 1.89. This PR will have intermediate PR's for each major version, but these will be squashed as we don't want an intermediate state in master where the perf regression is reintroduced

I am looking to have intermediate green CI runs for each bump; progress here:
- [x] 1.87.0 (https://buildkite.com/anza/agave/builds/33962)
- [x] 1.88.0 (https://buildkite.com/anza/agave/builds/34031)
- [x] 1.89.0 (final state of this PR)