### PR TITLE
change ios stable build runner to use latest macos

### DIFF
--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-13
+          - macos-latest
         target:
           - aarch64-apple-ios
           - x86_64-apple-ios


### PR DESCRIPTION
#### Problem

macOS 13 runner images are being deprecated and have started to [fail](https://github.com/anza-xyz/agave/actions/runs/19079844943/job/54508658573) during our CI runs

#### Summary of Changes

Change the ios build CI job to use `macos-latest`

Closes https://github.com/anza-xyz/devops/issues/898

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
