### PR TITLE
Streamer: transition SimpleQos to TokenBucket

### DIFF
--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -56,4 +56,11 @@ pub(crate) trait QosController<C: ConnectionContext> {
     fn max_concurrent_connections(&self) -> usize;
 }
 
-pub trait QosConfig {}
+/// Marker trait to indicate what is the shared state for connections
+pub(crate) trait OpaqueStreamerCounter: Send + Sync + 'static {}
+
+#[cfg(test)]
+pub(crate) struct NullStreamerCounter;
+
+#[cfg(test)]
+impl OpaqueStreamerCounter for NullStreamerCounter {}

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{nonblocking::quic::ConnectionPeerType, quic::StreamerStats},
+    crate::{
+        nonblocking::{qos::OpaqueStreamerCounter, quic::ConnectionPeerType},
+        quic::StreamerStats,
+    },
     std::{
         cmp,
         sync::{
@@ -188,6 +191,8 @@ pub struct ConnectionStreamCounter {
     pub(crate) stream_count: AtomicU64,
     last_throttling_instant: RwLock<tokio::time::Instant>,
 }
+
+impl OpaqueStreamerCounter for ConnectionStreamCounter {}
 
 impl ConnectionStreamCounter {
     pub fn new() -> Self {


### PR DESCRIPTION
#### Problem

- SimpleQos can be even simpler
- Reworking SWQOS will make StreamThrottle obsolete anyway, and its complexity is overkill for SimpleQos

#### Summary of Changes

- Stop using old throttle logic, switch to simpler TokenBucket
- Update the quic.rs to be able to handle generic contexts (in prep for rework of swqos)