### PR TITLE
Gossip: Fail Deserialization Early

### DIFF
--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -258,14 +258,13 @@ impl AccountsHashes {
 type LegacySnapshotHashes = AccountsHashes;
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct SnapshotHashes {
     pub from: Pubkey,
     pub full: (Slot, Hash),
     pub incremental: Vec<(Slot, Hash)>,
     pub wallclock: u64,
 }
-reject_deserialize!(SnapshotHashes, "SnapshotHashes is deprecated");
 
 impl Sanitize for SnapshotHashes {
     fn sanitize(&self) -> Result<(), SanitizeError> {
@@ -654,14 +653,11 @@ mod test {
         let bytes = bincode::serialize(&accounts_hashes).unwrap();
         assert!(bincode::deserialize::<CrdsData>(&bytes[..]).is_err());
 
-        // SnapshotHashes
-        let snapshot_hashes = CrdsData::SnapshotHashes(SnapshotHashes {
-            from: keypair.pubkey(),
-            full: (0, Hash::new_unique()),
-            incremental: vec![(0, Hash::new_unique())],
-            wallclock: timestamp(),
-        });
-        let bytes = bincode::serialize(&snapshot_hashes).unwrap();
+        // LegacySnapshotHashes
+        let legacy_snapshot_hashes = CrdsData::LegacySnapshotHashes(
+            LegacySnapshotHashes::new_rand(&mut rng, Some(keypair.pubkey())),
+        );
+        let bytes = bincode::serialize(&legacy_snapshot_hashes).unwrap();
         assert!(bincode::deserialize::<CrdsData>(&bytes[..]).is_err());
 
         // LowestSlot(1, ...)

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 use crate::contact_info::{sanitize_socket, ContactInfo, Error, Protocol, SOCKET_ADDR_UNSPECIFIED};
 use {
-    crate::crds_data::MAX_WALLCLOCK,
-    serde::{Deserialize, Serialize},
+    crate::crds_data::{reject_deserialize, MAX_WALLCLOCK},
+    serde::Serialize,
     solana_pubkey::Pubkey,
     solana_sanitize::{Sanitize, SanitizeError},
     solana_streamer::socket::SocketAddrSpace,
@@ -11,7 +11,7 @@ use {
 
 /// Structure representing a node on the network
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub(crate) struct LegacyContactInfo {
     id: Pubkey,
     /// gossip address
@@ -39,6 +39,7 @@ pub(crate) struct LegacyContactInfo {
     /// node shred version
     shred_version: u16,
 }
+reject_deserialize!(LegacyContactInfo, "LegacyContactInfo is deprecated");
 
 impl Sanitize for LegacyContactInfo {
     fn sanitize(&self) -> std::result::Result<(), SanitizeError> {


### PR DESCRIPTION
#### Problem
We deserialize and then sig verify. But sigverify is expensive. So let's just fail deserialization on the deprecated gossip message types

#### Summary of Changes
Fail Deserialization on deprecated gossip message types

