### PR TITLE
Adds rust-2024 lints to snapshots crate

### DIFF
--- a/snapshots/src/lib.rs
+++ b/snapshots/src/lib.rs
@@ -7,6 +7,15 @@
                 acknowledge use of an interface that may break without warning."
     )
 )]
+// Activate some of the Rust 2024 lints to make the future migration easier.
+#![warn(if_let_rescope)]
+#![warn(keyword_idents_2024)]
+#![warn(missing_unsafe_on_extern)]
+#![warn(rust_2024_guarded_string_incompatible_syntax)]
+#![warn(rust_2024_incompatible_pat)]
+#![warn(tail_expr_drop_order)]
+#![warn(unsafe_attr_outside_unsafe)]
+#![warn(unsafe_op_in_unsafe_fn)]
 
 mod archive;
 mod archive_format;


### PR DESCRIPTION
#### Problem

We want to update to rust 2024 edition (see #6203). But until then, we could still add 2024-incompatible code.


#### Summary of Changes

Add lints to the new snapshots crate for rust 2024.