### PR TITLE
suppress erroneous lints related to nested deprecation blocks

### DIFF
--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -33,6 +33,7 @@ where
     T: FromStr,
     T::Err: Display,
 {
+    #[allow(deprecated)]
     is_parsable_generic::<T, &str>(string)
 }
 
@@ -66,6 +67,7 @@ where
     note = "please use `clap::value_parser!(Pubkey)` instead"
 )]
 pub fn is_pubkey(string: &str) -> Result<(), String> {
+    #[allow(deprecated)]
     is_parsable_generic::<Pubkey, _>(string)
 }
 
@@ -78,6 +80,7 @@ pub fn is_hash<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
+    #[allow(deprecated)]
     is_parsable_generic::<Hash, _>(string)
 }
 
@@ -106,6 +109,7 @@ pub fn is_keypair_or_ask_keyword<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
+    #[allow(deprecated)]
     if string.as_ref() == ASK_KEYWORD {
         return Ok(());
     }
@@ -121,13 +125,16 @@ where
             `SignerSourceParserBuilder::default().allow_prompt().allow_legacy().build()` instead"
 )]
 pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
+    #[allow(deprecated)]
     if string == ASK_KEYWORD {
         return Ok(());
     }
-    match SignerSource::parse(string)
+    #[allow(deprecated)]
+    let signer_source_kind = SignerSource::parse(string)
         .map_err(|err| format!("{err}"))?
-        .kind
-    {
+        .kind;
+    match signer_source_kind {
+        #[allow(deprecated)]
         SignerSourceKind::Prompt => Ok(()),
         _ => Err(format!(
             "Unable to parse input as `prompt:` URI scheme or `ASK` keyword: {string}"
@@ -243,7 +250,9 @@ pub fn is_url_or_moniker<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
-    match url::Url::parse(&normalize_to_url_if_moniker(string.as_ref())) {
+    #[allow(deprecated)]
+    let normalized = normalize_to_url_if_moniker(string.as_ref());
+    match url::Url::parse(&normalized) {
         Ok(url) => {
             if url.has_host() {
                 Ok(())
@@ -274,6 +283,7 @@ pub fn is_epoch<T>(epoch: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
+    #[allow(deprecated)]
     is_parsable_generic::<Epoch, _>(epoch)
 }
 
@@ -285,6 +295,7 @@ pub fn is_slot<T>(slot: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
+    #[allow(deprecated)]
     is_parsable_generic::<Slot, _>(slot)
 }
 
@@ -313,6 +324,7 @@ pub fn is_port<T>(port: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
+    #[allow(deprecated)]
     is_parsable_generic::<u16, _>(port)
 }
 

--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -81,11 +81,9 @@ pub fn no_passphrase_arg<'a>() -> Arg<'a> {
 
 #[deprecated(since = "2.0.0", note = "Please use `try_get_language` instead")]
 pub fn acquire_language(matches: &ArgMatches) -> Language {
-    match matches
-        .get_one::<String>(LANGUAGE_ARG.name)
-        .unwrap()
-        .as_str()
-    {
+    #[allow(deprecated)]
+    let language_name = LANGUAGE_ARG.name;
+    match matches.get_one::<String>(language_name).unwrap().as_str() {
         "english" => Language::English,
         "chinese-simplified" => Language::ChineseSimplified,
         "chinese-traditional" => Language::ChineseTraditional,

--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -1,11 +1,12 @@
+#[allow(deprecated)]
+use solana_faucet::{
+    faucet::{run_faucet, Faucet, FAUCET_PORT},
+    socketaddr,
+};
 use {
     clap::{crate_description, crate_name, values_t, App, Arg},
     log::*,
     solana_clap_utils::input_parsers::{lamports_of_sol, value_of},
-    solana_faucet::{
-        faucet::{run_faucet, Faucet, FAUCET_PORT},
-        socketaddr,
-    },
     solana_keypair::read_keypair_file,
     std::{
         collections::HashSet,
@@ -81,23 +82,31 @@ async fn main() {
         .into_iter()
         .collect();
 
+    #[allow(deprecated)]
     let faucet_addr = socketaddr!(Ipv4Addr::UNSPECIFIED, FAUCET_PORT);
 
-    let faucet = Arc::new(Mutex::new(Faucet::new_with_allowed_ips(
-        faucet_keypair,
-        time_slice,
-        per_time_cap,
-        per_request_cap,
-        allowed_ips,
-    )));
+    let faucet = Arc::new(Mutex::new(
+        #[allow(deprecated)]
+        Faucet::new_with_allowed_ips(
+            faucet_keypair,
+            time_slice,
+            per_time_cap,
+            per_request_cap,
+            allowed_ips,
+        ),
+    ));
 
     let faucet1 = faucet.clone();
     thread::spawn(move || loop {
-        let time = faucet1.lock().unwrap().time_slice;
-        thread::sleep(time);
-        debug!("clearing ip cache");
-        faucet1.lock().unwrap().clear_caches();
+        #[allow(deprecated)]
+        {
+            let time = faucet1.lock().unwrap().time_slice;
+            thread::sleep(time);
+            debug!("clearing ip cache");
+            faucet1.lock().unwrap().clear_caches();
+        }
     });
 
+    #[allow(deprecated)]
     run_faucet(faucet, faucet_addr, None).await;
 }

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -327,14 +327,17 @@ pub fn run_local_faucet_with_port(
 ) {
     thread::spawn(move || {
         let faucet_addr = socketaddr!(Ipv4Addr::UNSPECIFIED, port);
-        let faucet = Arc::new(Mutex::new(Faucet::new(
-            faucet_keypair,
-            time_input,
-            per_time_cap,
-            per_request_cap,
-        )));
-        let runtime = Runtime::new().unwrap();
-        runtime.block_on(run_faucet(faucet, faucet_addr, Some(sender)));
+        #[allow(deprecated)]
+        {
+            let faucet = Arc::new(Mutex::new(Faucet::new(
+                faucet_keypair,
+                time_input,
+                per_time_cap,
+                per_request_cap,
+            )));
+            let runtime = Runtime::new().unwrap();
+            runtime.block_on(run_faucet(faucet, faucet_addr, Some(sender)));
+        }
     });
 }
 

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -79,13 +79,16 @@ pub(crate) const IP_ECHO_SERVER_RESPONSE_LENGTH: usize = HEADER_LENGTH + 23;
     note = "Use `get_public_ip_addr_with_binding` instead"
 )]
 pub fn get_public_ip_addr(ip_echo_server_addr: &SocketAddr) -> Result<IpAddr, String> {
-    let fut = ip_echo_server_request(*ip_echo_server_addr, IpEchoServerMessage::default());
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| e.to_string())?;
-    let resp = rt.block_on(fut).map_err(|e| e.to_string())?;
-    Ok(resp.address)
+    #[allow(deprecated)]
+    {
+        let fut = ip_echo_server_request(*ip_echo_server_addr, IpEchoServerMessage::default());
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| e.to_string())?;
+        let resp = rt.block_on(fut).map_err(|e| e.to_string())?;
+        Ok(resp.address)
+    }
 }
 
 /// Determine the public IP address of this machine by asking an ip_echo_server at the given
@@ -461,8 +464,11 @@ pub fn bind_to_with_config_non_blocking(
 )]
 /// binds both a UdpSocket and a TcpListener
 pub fn bind_common(ip_addr: IpAddr, port: u16) -> io::Result<(UdpSocket, TcpListener)> {
-    let config = sockets::SocketConfiguration::default();
-    sockets::bind_common_with_config(ip_addr, port, config)
+    #[allow(deprecated)]
+    {
+        let config = sockets::SocketConfiguration::default();
+        sockets::bind_common_with_config(ip_addr, port, config)
+    }
 }
 
 #[deprecated(

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -217,7 +217,17 @@ pub fn bind_in_range_with_config(
 }
 
 #[deprecated(since = "3.0.0", note = "Please bind to specific ports instead")]
+#[allow(deprecated)]
 pub fn bind_with_any_port_with_config(
+    ip_addr: IpAddr,
+    config: SocketConfiguration,
+) -> io::Result<UdpSocket> {
+    _bind_with_any_port_with_config(ip_addr, config)
+}
+
+// this private method works around a cargo bug involving nested deprecations
+// remove it with the above deprecated public method
+fn _bind_with_any_port_with_config(
     ip_addr: IpAddr,
     config: SocketConfiguration,
 ) -> io::Result<UdpSocket> {

--- a/rayon-threadlimit/src/lib.rs
+++ b/rayon-threadlimit/src/lib.rs
@@ -36,5 +36,6 @@ pub fn get_thread_count() -> usize {
             similar instead"
 )]
 pub fn get_max_thread_count() -> usize {
+    #[allow(deprecated)]
     get_thread_count().saturating_mul(2)
 }


### PR DESCRIPTION
#### Problem
after introduction of `agave-unstable-api` in #8424, developer workflows that involved building single crates from within their containing directories began to raise deprecation lints, despite dependencies being appropriately declared. this appears to be an issue with cargo related to nested deprecation blocks as all instances were on previously deprecated symbols within now globaly deprecated crates.

#### Summary of Changes
apply deprecation allowances on the smallest effective context

---

this is a backportable stopgap as many of the effected locations were long past due for removal  and those that weren't are now since master is on 4.0