### PR TITLE
ci: Update the ios GH build runner

### DIFF
--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-13
+          - macos-15
         target:
           - aarch64-apple-ios
           - x86_64-apple-ios


### PR DESCRIPTION
#### Problem
Use macos-15 as macos-13 is deprecated and set for removal in a month.

Current builds failed due to brownout and linked https://github.com/actions/runner-images/issues/13046