### PR TITLE
chore: Bump solana-sha256-hasher from 3.0.0 to 3.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10650,9 +10650,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sha256-hasher"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b912ba6f71cb202c0c3773ec77bf898fa9fe0c78691a2d6859b3b5b8954719"
+checksum = "b2ab77481366a966f895abbc11896d4803d285d258281a992ca89aca3ed0658c"
 dependencies = [
  "sha2 0.10.9",
  "solana-define-syscall 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -520,7 +520,7 @@ solana-send-transaction-service = { path = "send-transaction-service", version =
 solana-serde = "3.0.0"
 solana-serde-varint = "3.0.0"
 solana-serialize-utils = "3.1.0"
-solana-sha256-hasher = "3.0.0"
+solana-sha256-hasher = "3.0.1"
 solana-short-vec = "3.0.0"
 solana-shred-version = "3.0.0"
 solana-signature = { version = "3.1.0", default-features = false }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8894,9 +8894,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sha256-hasher"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b912ba6f71cb202c0c3773ec77bf898fa9fe0c78691a2d6859b3b5b8954719"
+checksum = "b2ab77481366a966f895abbc11896d4803d285d258281a992ca89aca3ed0658c"
 dependencies = [
  "sha2 0.10.9",
  "solana-define-syscall 3.0.0",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -88,7 +88,7 @@ solana-rpc-client = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sanitize = "=3.0.1"
 solana-serde-varint = "=3.0.0"
-solana-sha256-hasher = "=3.0.0"
+solana-sha256-hasher = "=3.0.1"
 solana-short-vec = "=3.0.0"
 solana-signature = { version = "=3.1.0", default-features = false }
 solana-signer = "=3.0.0"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9416,9 +9416,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sha256-hasher"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b912ba6f71cb202c0c3773ec77bf898fa9fe0c78691a2d6859b3b5b8954719"
+checksum = "b2ab77481366a966f895abbc11896d4803d285d258281a992ca89aca3ed0658c"
 dependencies = [
  "sha2 0.10.9",
  "solana-define-syscall 3.0.0",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -157,7 +157,7 @@ solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version
 solana-sbpf = "=0.13.0"
 solana-sdk-ids = "=3.0.0"
 solana-secp256k1-recover = "=3.0.0"
-solana-sha256-hasher = { version = "=3.0.0", features = ["sha2"] }
+solana-sha256-hasher = { version = "=3.0.1", features = ["sha2"] }
 solana-stake-interface = { version = "=2.0.1", features = ["bincode"] }
 solana-svm = { path = "../../svm", version = "=4.0.0-alpha.0" }
 solana-svm-callback = { path = "../../svm-callback", version = "=4.0.0-alpha.0" }


### PR DESCRIPTION
#### Problem
The 3.0.1 release includess a change to mitigate a compiler regression that caused regressions in Agave in PoH hashing; see https://github.com/anza-xyz/agave/issues/8894 for more details

#### Summary of Changes
Bump it

