### PR TITLE
test: only activate direct mapping with stricter ABI constraints enabled

### DIFF
--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1362,7 +1362,7 @@ mod tests {
             rc::Rc,
             slice,
         },
-        test_case::test_matrix,
+        test_case::case,
     };
 
     macro_rules! mock_invoke_context {
@@ -1389,6 +1389,7 @@ mod tests {
                 .collect::<Vec<KeyedAccountSharedData>>();
             let mut feature_set = SVMFeatureSet::all_enabled();
             feature_set.stricter_abi_and_runtime_constraints = false;
+            feature_set.account_data_direct_mapping = false;
             let feature_set = &feature_set;
             with_mock_invoke_context_with_feature_set!(
                 $invoke_context,
@@ -1981,8 +1982,13 @@ mod tests {
         assert_eq!(caller_account.serialized_data, account.data());
     }
 
-    #[test_matrix([false, true])]
-    fn test_update_caller_account_lamports_owner(stricter_abi_and_runtime_constraints: bool) {
+    #[case(false, false)]
+    #[case(true, false)]
+    #[case(true, true)]
+    fn test_update_caller_account_lamports_owner(
+        stricter_abi_and_runtime_constraints: bool,
+        account_data_direct_mapping: bool,
+    ) {
         let transaction_accounts = transaction_with_one_writable_instruction_account(vec![]);
         let account = transaction_accounts[1].1.clone();
         mock_invoke_context!(
@@ -2028,7 +2034,7 @@ mod tests {
             &mut caller_account,
             &mut callee_account,
             stricter_abi_and_runtime_constraints,
-            stricter_abi_and_runtime_constraints,
+            account_data_direct_mapping,
         )
         .unwrap();
 
@@ -2165,8 +2171,13 @@ mod tests {
         assert_eq!(data_len, 0);
     }
 
-    #[test_matrix([false, true])]
-    fn test_update_callee_account_lamports_owner(stricter_abi_and_runtime_constraints: bool) {
+    #[case(false, false)]
+    #[case(true, false)]
+    #[case(true, true)]
+    fn test_update_callee_account_lamports_owner(
+        stricter_abi_and_runtime_constraints: bool,
+        account_data_direct_mapping: bool,
+    ) {
         let transaction_accounts = transaction_with_one_writable_instruction_account(vec![]);
         let account = transaction_accounts[1].1.clone();
 
@@ -2194,7 +2205,7 @@ mod tests {
             &caller_account,
             callee_account,
             stricter_abi_and_runtime_constraints,
-            true, // account_data_direct_mapping
+            account_data_direct_mapping,
         )
         .unwrap();
 
@@ -2203,8 +2214,13 @@ mod tests {
         assert_eq!(caller_account.owner, callee_account.get_owner());
     }
 
-    #[test_matrix([false, true])]
-    fn test_update_callee_account_data_writable(stricter_abi_and_runtime_constraints: bool) {
+    #[case(false, false)]
+    #[case(true, false)]
+    #[case(true, true)]
+    fn test_update_callee_account_data_writable(
+        stricter_abi_and_runtime_constraints: bool,
+        account_data_direct_mapping: bool,
+    ) {
         let transaction_accounts =
             transaction_with_one_writable_instruction_account(b"foobar".to_vec());
         let account = transaction_accounts[1].1.clone();
@@ -2247,7 +2263,7 @@ mod tests {
                 &caller_account,
                 callee_account,
                 stricter_abi_and_runtime_constraints,
-                true, // account_data_direct_mapping
+                account_data_direct_mapping,
             )
             .unwrap(),
             stricter_abi_and_runtime_constraints,
@@ -2264,7 +2280,7 @@ mod tests {
                 &caller_account,
                 callee_account,
                 stricter_abi_and_runtime_constraints,
-                true, // account_data_direct_mapping
+                account_data_direct_mapping,
             )
             .unwrap(),
             stricter_abi_and_runtime_constraints,
@@ -2282,7 +2298,7 @@ mod tests {
             &caller_account,
             callee_account,
             stricter_abi_and_runtime_constraints,
-            true, // account_data_direct_mapping
+            account_data_direct_mapping,
         )
         .unwrap();
         borrow_instruction_account!(callee_account, invoke_context, 0);
@@ -2295,7 +2311,7 @@ mod tests {
             &caller_account,
             callee_account,
             stricter_abi_and_runtime_constraints,
-            true, // account_data_direct_mapping
+            account_data_direct_mapping,
         );
         if stricter_abi_and_runtime_constraints {
             assert_matches!(
@@ -2307,8 +2323,13 @@ mod tests {
         }
     }
 
-    #[test_matrix([false, true])]
-    fn test_update_callee_account_data_readonly(stricter_abi_and_runtime_constraints: bool) {
+    #[case(false, false)]
+    #[case(true, false)]
+    #[case(true, true)]
+    fn test_update_callee_account_data_readonly(
+        stricter_abi_and_runtime_constraints: bool,
+        account_data_direct_mapping: bool,
+    ) {
         let transaction_accounts =
             transaction_with_one_readonly_instruction_account(b"foobar".to_vec());
         let account = transaction_accounts[1].1.clone();
@@ -2351,7 +2372,7 @@ mod tests {
                 &caller_account,
                 callee_account,
                 stricter_abi_and_runtime_constraints,
-                true, // account_data_direct_mapping
+                account_data_direct_mapping,
             ),
             Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::AccountDataSizeChanged
         );
@@ -2367,7 +2388,7 @@ mod tests {
                 &caller_account,
                 callee_account,
                 stricter_abi_and_runtime_constraints,
-                true, // account_data_direct_mapping
+                account_data_direct_mapping,
             ),
             Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::AccountDataSizeChanged
         );

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -2663,6 +2663,7 @@ fn test_program_sbf_realloc() {
         // disable when needed
         if !stricter_abi_and_runtime_constraints {
             feature_set.deactivate(&feature_set::stricter_abi_and_runtime_constraints::id());
+            feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let mut bank_client = BankClient::new_shared(bank.clone());
@@ -3932,6 +3933,7 @@ fn test_cpi_account_ownership_writability() {
         let mut feature_set = FeatureSet::all_enabled();
         if !stricter_abi_and_runtime_constraints {
             feature_set.deactivate(&feature_set::stricter_abi_and_runtime_constraints::id());
+            feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
 
         bank.feature_set = Arc::new(feature_set);
@@ -4133,6 +4135,7 @@ fn test_cpi_account_data_updates() {
         let mut feature_set = FeatureSet::all_enabled();
         if !stricter_abi_and_runtime_constraints {
             feature_set.deactivate(&feature_set::stricter_abi_and_runtime_constraints::id());
+            feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
 
         bank.feature_set = Arc::new(feature_set);
@@ -4584,6 +4587,7 @@ fn test_deny_access_beyond_current_length() {
         // disable when needed
         if !stricter_abi_and_runtime_constraints {
             feature_set.deactivate(&feature_set::stricter_abi_and_runtime_constraints::id());
+            feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let mut bank_client = BankClient::new_shared(bank);
@@ -4652,6 +4656,7 @@ fn test_deny_executable_write() {
         // disable when needed
         if !stricter_abi_and_runtime_constraints {
             feature_set.deactivate(&feature_set::stricter_abi_and_runtime_constraints::id());
+            feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let mut bank_client = BankClient::new_shared(bank);
@@ -4707,6 +4712,7 @@ fn test_update_callee_account() {
         // disable when needed
         if !stricter_abi_and_runtime_constraints {
             feature_set.deactivate(&feature_set::stricter_abi_and_runtime_constraints::id());
+            feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let mut bank_client = BankClient::new_shared(bank.clone());
@@ -4991,6 +4997,7 @@ fn test_account_info_in_account() {
             // disable when needed
             if !stricter_abi_and_runtime_constraints {
                 feature_set.deactivate(&feature_set::stricter_abi_and_runtime_constraints::id());
+                feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
             }
 
             let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
@@ -5052,6 +5059,7 @@ fn test_account_info_rc_in_account() {
         // disable when needed
         if !stricter_abi_and_runtime_constraints {
             feature_set.deactivate(&feature_set::stricter_abi_and_runtime_constraints::id());
+            feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
 
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
@@ -5142,6 +5150,7 @@ fn test_clone_account_data() {
     let feature_set = Arc::make_mut(&mut bank.feature_set);
 
     feature_set.deactivate(&feature_set::stricter_abi_and_runtime_constraints::id());
+    feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
 
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
     let mut bank_client = BankClient::new_shared(bank.clone());
@@ -5491,6 +5500,7 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
         let mut feature_set = FeatureSet::all_enabled();
         if !stricter_abi_and_runtime_constraints {
             feature_set.deactivate(&feature_set::stricter_abi_and_runtime_constraints::id());
+            feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
 
         let account_keypair = Keypair::new();


### PR DESCRIPTION
#### Problem
Some tests and helpers are activating direct mapping without `stricter_abi_and_runtime_constraints`. This potentially masks undesired behavior in tests as the feature activation ordering isn't planned to have direct mapping without first activating `stricter_abi_and_runtime_constraints`.

#### Summary of Changes
Disable direct mapping in tests that disable `stricter_abi_and_runtime_constraints`.

Optionally, `FeatureSet::deactivate` could be aware of dependent features to prevent regressions or debug assertions could be added `debug_assert!(!direct_mapping || stricter_abi_and_runtime_constraints)`

cc @Lichtso 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
