### PR TITLE
chore: Avoid dangerous-implicit-autoref

### DIFF
--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -287,8 +287,21 @@ impl TransactionAccounts {
     }
 
     pub(crate) fn len(&self) -> usize {
+        // RUST UPGRADE NOTE
+        //
+        // Rust 1.87.0 reports a `needless_borrow` warning
+        // Rust 1.88.0 reports a `dangerous_implicit_autorefs` warning if the
+        // recommendation given from Rust 1.87.0 is applied
+        //
+        // In order to facilitate upgrading to Rust >= 1.88.0, use the 1.88.0
+        // suggestion and ignore the warning given by 1.87.0. This comment and
+        // the `#[allow(clippy::needless_borrow)]` will be removed after the
+        // Rust version has advanced
+        #[allow(clippy::needless_borrow)]
         // SAFETY: The borrow is local to this function and is only reading length.
-        unsafe { (*self.shared_account_fields.get()).len() }
+        unsafe {
+            (&(*self.shared_account_fields.get())).len()
+        }
     }
 
     #[cfg(not(target_os = "solana"))]
@@ -342,16 +355,20 @@ impl TransactionAccounts {
             .ok_or(InstructionError::MissingAccount)?;
         borrow_counter.try_borrow_mut()?;
 
+        // See previous RUST UPGRADE NOTE in this file
+        #[allow(clippy::needless_borrow)]
         // SAFETY: The borrow counter guarantees this is the only mutable borrow of this account.
         // The unwrap is safe because accounts.len() == borrow_counters.len(), so the missing
         // account error should have been returned above.
         let svm_account = unsafe {
-            (*self.shared_account_fields.get())
+            (&mut (*self.shared_account_fields.get()))
                 .get_mut(index as usize)
                 .unwrap()
         };
+        // See previous RUST UPGRADE NOTE in this file
+        #[allow(clippy::needless_borrow)]
         let private_fields = unsafe {
-            (*self.private_account_fields.get())
+            (&mut (*self.private_account_fields.get()))
                 .get_mut(index as usize)
                 .unwrap()
         };
@@ -374,16 +391,20 @@ impl TransactionAccounts {
             .ok_or(InstructionError::MissingAccount)?;
         borrow_counter.try_borrow()?;
 
+        // See previous RUST UPGRADE NOTE in this file
+        #[allow(clippy::needless_borrow)]
         // SAFETY: The borrow counter guarantees there are no mutable borrow of this account.
         // The unwrap is safe because accounts.len() == borrow_counters.len(), so the missing
         // account error should have been returned above.
         let svm_account = unsafe {
-            (*self.shared_account_fields.get())
+            (&(*self.shared_account_fields.get()))
                 .get(index as usize)
                 .unwrap()
         };
+        // See previous RUST UPGRADE NOTE in this file
+        #[allow(clippy::needless_borrow)]
         let private_fields = unsafe {
-            (*self.private_account_fields.get())
+            (&(*self.private_account_fields.get()))
                 .get(index as usize)
                 .unwrap()
         };
@@ -460,9 +481,11 @@ impl TransactionAccounts {
     }
 
     pub(crate) fn account_key(&self, index: IndexOfAccount) -> Option<&Pubkey> {
+        // See previous RUST UPGRADE NOTE in this file
+        #[allow(clippy::needless_borrow)]
         // SAFETY: We never modify an account key, so returning a reference to it is safe.
         unsafe {
-            (*self.shared_account_fields.get())
+            (&(*self.shared_account_fields.get()))
                 .get(index as usize)
                 .map(|acc| &acc.key)
         }


### PR DESCRIPTION
#### Problem
Rust 1.88 raises this as a warning and suggests using a raw pointer method to to make the reference explicit. 

#### Summary of Changes
We need a reference to call function like .len(), so make the reference intentional. Without this, we get the following warning:
```
error: implicit autoref creates a reference to the dereference of a raw pointer
   --> transaction-context/src/transaction_accounts.rs:465:13
    |
465 | /             (*self.shared_account_fields.get())
466 | |                 .get(index as usize)
    | |____________________________________^
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
    = note: `-D dangerous-implicit-autorefs` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dangerous_implicit_autorefs)]`
help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
465 |             (&(*self.shared_account_fields.get()))
    |             ++                                   +
```
There is no change in behavior in this PR as far as I can tell; we were getting references before and still are. So, the safety warning that are present in the adjacent lines are presumed to still be correct

Progress towards https://github.com/anza-xyz/agave/issues/6850 (intermediate goal) and https://github.com/anza-xyz/agave/issues/8894 (end goal)