### PR TITLE
Adds rust-2024 lints to fs crate

### DIFF
--- a/fs/src/buffered_reader.rs
+++ b/fs/src/buffered_reader.rs
@@ -47,12 +47,12 @@ impl<const N: usize> Stack<N> {
 
     #[inline(always)]
     unsafe fn as_slice(&self) -> &[u8] {
-        slice::from_raw_parts(self.0.as_ptr() as *const u8, N)
+        unsafe { slice::from_raw_parts(self.0.as_ptr() as *const u8, N) }
     }
 
     #[inline(always)]
     unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
-        slice::from_raw_parts_mut(self.0.as_mut_ptr() as *mut u8, N)
+        unsafe { slice::from_raw_parts_mut(self.0.as_mut_ptr() as *mut u8, N) }
     }
 }
 

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -1,3 +1,13 @@
+// Activate some of the Rust 2024 lints to make the future migration easier.
+#![warn(if_let_rescope)]
+#![warn(keyword_idents_2024)]
+#![warn(missing_unsafe_on_extern)]
+#![warn(rust_2024_guarded_string_incompatible_syntax)]
+#![warn(rust_2024_incompatible_pat)]
+#![warn(tail_expr_drop_order)]
+#![warn(unsafe_attr_outside_unsafe)]
+#![warn(unsafe_op_in_unsafe_fn)]
+
 pub mod buffered_reader;
 pub mod dirs;
 pub mod file_io;


### PR DESCRIPTION
#### Problem

We want to update to rust 2024 edition (see #6203). But until then, we could still add 2024-incompatible code.


#### Summary of Changes

Add lints to the new fs crate for rust 2024.