### PR TITLE
v3.1: Bump version to v3.1.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agave-cargo-registry"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "clap 2.33.3",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agave-fs"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
  "solana-clock",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "agave-install"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "atty",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "agave-io-uring"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "io-uring",
  "libc",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "agave-logger"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "env_logger",
  "libc",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "solana-frozen-abi",
@@ -251,11 +251,11 @@ dependencies = [
 
 [[package]]
 name = "agave-scheduler-bindings"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "agave-scheduling-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-scheduler-bindings",
  "agave-transaction-view",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "agave-snapshots"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-fs",
  "agave-logger",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-histogram"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "clap 2.33.3",
  "solana-version",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "agave-syscalls"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -323,7 +323,7 @@ dependencies = [
  "solana-bn254",
  "solana-clock",
  "solana-cpi",
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.0-beta.1",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "agave-thread-manager"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "affinity",
  "agave-thread-manager",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-transaction-view",
  "bincode",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "agave-validator"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-geyser-plugin-interface",
  "agave-logger",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "agave-verified-packet-receiver"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "assert_matches",
  "solana-perf",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "agave-votor"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "agave-votor-messages",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "agave-votor-messages"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "serde",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "agave-watchtower"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "clap 2.33.3",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-xdp-ebpf",
  "aya",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp-ebpf"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "aya",
  "aya-ebpf",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "gen-headers"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
  "regex",
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "gen-syscall-list"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "regex",
 ]
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "protobuf-src",
  "tonic-build",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "rbpf-cli"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "rdrand"
@@ -7079,7 +7079,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "Inflector",
  "assert_matches",
@@ -7122,7 +7122,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7148,7 +7148,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-cluster-bench"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "clap 2.33.3",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-fs",
  "agave-logger",
@@ -7330,7 +7330,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "borsh",
  "futures 0.3.31",
@@ -7360,7 +7360,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "serde",
  "solana-account",
@@ -7378,7 +7378,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7406,7 +7406,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-streamer"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "clap 3.2.23",
  "crossbeam-channel",
@@ -7418,7 +7418,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-vote"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -7476,7 +7476,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bencher",
  "bv",
@@ -7546,7 +7546,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-syscalls",
  "assert_matches",
@@ -7587,7 +7587,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program-tests"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -7607,7 +7607,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "bv",
@@ -7628,7 +7628,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -7647,7 +7647,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -7668,7 +7668,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-build-sbf"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "assert_cmd",
@@ -7690,7 +7690,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-test-sbf"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "cargo_metadata",
@@ -7702,7 +7702,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -7733,7 +7733,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -7766,7 +7766,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -7860,7 +7860,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -7873,7 +7873,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -7917,7 +7917,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7964,7 +7964,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client-test"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "futures-util",
@@ -8056,7 +8056,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "qualifier_attr",
  "solana-fee-structure",
@@ -8066,7 +8066,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8107,14 +8107,14 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-program-runtime",
 ]
 
 [[package]]
 name = "solana-compute-budget-program-bench"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "criterion",
@@ -8146,7 +8146,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "async-trait",
@@ -8171,7 +8171,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -8332,7 +8332,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8406,7 +8406,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -8441,7 +8441,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -8465,7 +8465,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-program-tests"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "assert_matches",
  "ed25519-dalek 1.0.1",
@@ -8481,7 +8481,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "agave-reserved-account-keys",
@@ -8600,7 +8600,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -8651,7 +8651,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -8729,7 +8729,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8810,7 +8810,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -8823,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -8853,7 +8853,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -9033,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keygen"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-votor-messages",
  "bs58",
@@ -9090,7 +9090,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -9104,7 +9104,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -9259,7 +9259,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "log",
@@ -9284,7 +9284,7 @@ dependencies = [
 
 [[package]]
 name = "solana-local-cluster"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "agave-snapshots",
@@ -9354,11 +9354,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "fast-math",
  "hex",
@@ -9388,7 +9388,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bencher",
  "crossbeam-channel",
@@ -9422,7 +9422,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-net-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "anyhow",
@@ -9480,7 +9480,7 @@ dependencies = [
 
 [[package]]
 name = "solana-notifier"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
  "reqwest 0.12.24",
@@ -9522,7 +9522,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "ahash 0.8.11",
@@ -9570,7 +9570,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "arc-swap",
@@ -9606,7 +9606,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh-bench"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "clap 3.2.23",
@@ -9632,7 +9632,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-bn254 0.5.0",
@@ -9710,7 +9710,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-binaries"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "serde",
@@ -9772,7 +9772,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "assert_matches",
  "base64 0.22.1",
@@ -9824,7 +9824,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -9902,7 +9902,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -9928,7 +9928,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "async-lock",
@@ -9971,7 +9971,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
  "num_cpus",
@@ -9980,7 +9980,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "assert_matches",
  "console 0.16.1",
@@ -10028,7 +10028,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -10136,7 +10136,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -10183,7 +10183,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -10203,7 +10203,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "anyhow",
  "clap 2.33.3",
@@ -10232,7 +10232,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -10259,7 +10259,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-test"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -10297,7 +10297,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-fs",
@@ -10447,7 +10447,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -10585,7 +10585,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "async-trait",
@@ -10757,7 +10757,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-accounts"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "clap 2.33.3",
  "solana-account",
@@ -10812,7 +10812,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -10833,7 +10833,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -10876,7 +10876,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "bs58",
@@ -10901,7 +10901,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "anyhow",
@@ -10952,7 +10952,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "agave-syscalls",
@@ -11028,7 +11028,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -11038,22 +11038,22 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-svm-test-harness"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -11089,7 +11089,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-timings"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -11098,7 +11098,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -11114,7 +11114,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "futures 0.3.31",
  "rand 0.8.5",
@@ -11138,7 +11138,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -11233,7 +11233,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -11289,7 +11289,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
 name = "solana-tls-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "rustls 0.23.34",
  "solana-keypair",
@@ -11300,7 +11300,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tokens"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "assert_matches",
@@ -11349,7 +11349,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tps-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
  "solana-account",
@@ -11381,7 +11381,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -11413,7 +11413,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -11469,7 +11469,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -11491,7 +11491,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-dos"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -11542,7 +11542,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -11560,7 +11560,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -11605,7 +11605,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -11628,7 +11628,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -11690,7 +11690,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -11705,7 +11705,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "assert_matches",
  "solana-instruction",
@@ -11720,7 +11720,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-logger",
@@ -11766,7 +11766,7 @@ checksum = "c5d2face763df5afeaa9509b9019968860e69cc1531ec8b4a2e6c7b702204d5a"
 
 [[package]]
 name = "solana-version"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -11780,7 +11780,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vortexor"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-logger",
@@ -11834,7 +11834,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "arbitrary",
@@ -11898,7 +11898,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -11939,7 +11939,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "agave-snapshots",
@@ -11976,7 +11976,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -11993,7 +11993,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program-tests"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bytemuck",
  "solana-account",
@@ -12049,7 +12049,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -12066,7 +12066,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -12082,7 +12082,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.0-beta.1",
  "solana-derivation-path",
  "solana-instruction",
  "solana-keypair",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 description = "Blockchain, Rebuilt for Scale"
 repository = "https://github.com/anza-xyz/agave"
@@ -182,26 +182,26 @@ used_underscore_binding = "deny"
 [workspace.dependencies]
 Inflector = "0.11.4"
 aes-gcm-siv = "0.11.1"
-agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-cargo-registry = { path = "cargo-registry", version = "=3.1.0-beta.0" }
-agave-feature-set = { path = "feature-set", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-fs = { path = "fs", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=3.1.0-beta.0" }
-agave-io-uring = { path = "io-uring", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-logger = { path = "logger", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-precompiles = { path = "precompiles", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "reserved-account-keys", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-scheduler-bindings = { path = "scheduler-bindings", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-scheduling-utils = { path = "scheduling-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-snapshots = { path = "snapshots", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-syscalls = { path = "syscalls", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-thread-manager = { path = "thread-manager", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-transaction-view = { path = "transaction-view", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-verified-packet-receiver = { path = "verified-packet-receiver", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-votor = { path = "votor", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-votor-messages = { path = "votor-messages", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-xdp = { path = "xdp", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-xdp-ebpf = { path = "xdp-ebpf", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-cargo-registry = { path = "cargo-registry", version = "=3.1.0-beta.1" }
+agave-feature-set = { path = "feature-set", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-fs = { path = "fs", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=3.1.0-beta.1" }
+agave-io-uring = { path = "io-uring", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-logger = { path = "logger", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-precompiles = { path = "precompiles", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "reserved-account-keys", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-scheduler-bindings = { path = "scheduler-bindings", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-scheduling-utils = { path = "scheduling-utils", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-snapshots = { path = "snapshots", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-syscalls = { path = "syscalls", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-thread-manager = { path = "thread-manager", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-transaction-view = { path = "transaction-view", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-verified-packet-receiver = { path = "verified-packet-receiver", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-votor = { path = "votor", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-votor-messages = { path = "votor-messages", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-xdp = { path = "xdp", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-xdp-ebpf = { path = "xdp-ebpf", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 ahash = "0.8.11"
 anyhow = "1.0.100"
 aquamarine = "0.6.0"
@@ -386,70 +386,70 @@ smpl_jwt = "0.7.1"
 socket2 = "0.6.1"
 soketto = "0.7"
 solana-account = "3.2.0"
-solana-account-decoder = { path = "account-decoder", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-account-decoder = { path = "account-decoder", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-account-info = "3.0.0"
-solana-accounts-db = { path = "accounts-db", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-accounts-db = { path = "accounts-db", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-address = "1.0.0"
 solana-address-lookup-table-interface = "3.0.0"
 solana-atomic-u64 = "3.0.0"
-solana-banks-client = { path = "banks-client", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-banks-interface = { path = "banks-interface", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-banks-server = { path = "banks-server", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-banks-client = { path = "banks-client", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-banks-interface = { path = "banks-interface", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-banks-server = { path = "banks-server", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-big-mod-exp = "3.0.0"
 solana-bincode = "3.0.0"
 solana-blake3-hasher = "3.0.0"
-solana-bloom = { path = "bloom", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-bloom = { path = "bloom", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-bls-signatures = { version = "1.0.0", features = ["serde"] }
 solana-bn254 = "3.1.2"
 solana-borsh = "3.0.0"
-solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-bucket-map = { path = "bucket_map", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-builtins = { path = "builtins", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-builtins-default-costs = { path = "builtins-default-costs", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-clap-utils = { path = "clap-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-clap-v3-utils = { path = "clap-v3-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-cli = { path = "cli", version = "=3.1.0-beta.0" }
-solana-cli-config = { path = "cli-config", version = "=3.1.0-beta.0" }
-solana-cli-output = { path = "cli-output", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-client = { path = "client", version = "=3.1.0-beta.0" }
+solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-bucket-map = { path = "bucket_map", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-builtins = { path = "builtins", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-builtins-default-costs = { path = "builtins-default-costs", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-clap-utils = { path = "clap-utils", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-clap-v3-utils = { path = "clap-v3-utils", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-cli = { path = "cli", version = "=3.1.0-beta.1" }
+solana-cli-config = { path = "cli-config", version = "=3.1.0-beta.1" }
+solana-cli-output = { path = "cli-output", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-client = { path = "client", version = "=3.1.0-beta.1" }
 solana-client-traits = "3.0.0"
 solana-clock = "3.0.0"
 solana-cluster-type = "3.0.0"
 solana-commitment-config = "3.0.0"
-solana-compute-budget = { path = "compute-budget", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-compute-budget = { path = "compute-budget", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-compute-budget-interface = "3.0.0"
-solana-compute-budget-program = { path = "programs/compute-budget", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-compute-budget-program = { path = "programs/compute-budget", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-config-interface = "2.0.0"
-solana-connection-cache = { path = "connection-cache", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
-solana-core = { path = "core", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-cost-model = { path = "cost-model", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-connection-cache = { path = "connection-cache", version = "=3.1.0-beta.1", default-features = false, features = ["agave-unstable-api"] }
+solana-core = { path = "core", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-cost-model = { path = "cost-model", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-cpi = "3.0.0"
-solana-curve25519 = { path = "curves/curve25519", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-curve25519 = { path = "curves/curve25519", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-define-syscall = "3.0.0"
 solana-derivation-path = "3.0.0"
-solana-download-utils = { path = "download-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-download-utils = { path = "download-utils", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-ed25519-program = "3.0.0"
-solana-entry = { path = "entry", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-entry = { path = "entry", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-epoch-info = "3.0.0"
 solana-epoch-rewards = "3.0.0"
 solana-epoch-rewards-hasher = "3.0.0"
 solana-epoch-schedule = "3.0.0"
 solana-example-mocks = "3.0.0"
-solana-faucet = { path = "faucet", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-faucet = { path = "faucet", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-feature-gate-interface = "3.0.0"
-solana-fee = { path = "fee", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-fee = { path = "fee", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-fee-calculator = "3.0.0"
 solana-fee-structure = "3.0.0"
 solana-file-download = "3.1.0"
 solana-frozen-abi = "3.0.1"
 solana-frozen-abi-macro = "3.0.1"
-solana-genesis = { path = "genesis", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-genesis = { path = "genesis", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-genesis-config = "3.0.0"
-solana-genesis-utils = { path = "genesis-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-gossip = { path = "gossip", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-genesis-utils = { path = "genesis-utils", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-gossip = { path = "gossip", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-hard-forks = "3.0.0"
 solana-hash = "3.0.0"
 solana-inflation = "3.0.0"
@@ -459,56 +459,56 @@ solana-instructions-sysvar = "3.0.0"
 solana-keccak-hasher = "3.0.0"
 solana-keypair = "3.0.1"
 solana-last-restart-slot = "3.0.0"
-solana-lattice-hash = { path = "lattice-hash", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-ledger = { path = "ledger", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-lattice-hash = { path = "lattice-hash", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-ledger = { path = "ledger", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-loader-v2-interface = "3.0.0"
 solana-loader-v3-interface = "6.1.0"
 solana-loader-v4-interface = "3.1.0"
-solana-loader-v4-program = { path = "programs/loader-v4", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-local-cluster = { path = "local-cluster", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-measure = { path = "measure", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-merkle-tree = { path = "merkle-tree", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-loader-v4-program = { path = "programs/loader-v4", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-local-cluster = { path = "local-cluster", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-measure = { path = "measure", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-merkle-tree = { path = "merkle-tree", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-message = "3.0.1"
-solana-metrics = { path = "metrics", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-metrics = { path = "metrics", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-msg = "3.0.0"
 solana-native-token = "3.0.0"
-solana-net-utils = { path = "net-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-net-utils = { path = "net-utils", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-nohash-hasher = "0.2.1"
 solana-nonce = "3.0.0"
 solana-nonce-account = "3.0.0"
-solana-notifier = { path = "notifier", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-notifier = { path = "notifier", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-offchain-message = "3.0.0"
 solana-packet = "3.0.0"
-solana-perf = { path = "perf", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-poh = { path = "poh", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-perf = { path = "perf", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-poh = { path = "poh", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-poh-config = "3.0.0"
-solana-poseidon = { path = "poseidon", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-poseidon = { path = "poseidon", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-precompile-error = "3.0.0"
 solana-presigner = "3.0.0"
 solana-program = { version = "3.0.0", default-features = false }
-solana-program-binaries = { path = "program-binaries", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-program-binaries = { path = "program-binaries", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-program-entrypoint = "3.1.0"
 solana-program-error = "3.0.0"
 solana-program-memory = "3.0.0"
 solana-program-option = "3.0.0"
 solana-program-pack = "3.0.0"
-solana-program-runtime = { path = "program-runtime", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-program-test = { path = "program-test", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-program-runtime = { path = "program-runtime", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-program-test = { path = "program-test", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-pubkey = { version = "3.0.0", default-features = false }
-solana-pubsub-client = { path = "pubsub-client", version = "=3.1.0-beta.0" }
-solana-quic-client = { path = "quic-client", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-pubsub-client = { path = "pubsub-client", version = "=3.1.0-beta.1" }
+solana-quic-client = { path = "quic-client", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-quic-definitions = "3.0.0"
-solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-remote-wallet = { path = "remote-wallet", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
+solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-remote-wallet = { path = "remote-wallet", version = "=3.1.0-beta.1", default-features = false, features = ["agave-unstable-api"] }
 solana-rent = "3.0.0"
 solana-reward-info = "3.0.0"
-solana-rpc = { path = "rpc", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-rpc-client = { path = "rpc-client", version = "=3.1.0-beta.0", default-features = false }
-solana-rpc-client-api = { path = "rpc-client-api", version = "=3.1.0-beta.0" }
-solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=3.1.0-beta.0" }
-solana-rpc-client-types = { path = "rpc-client-types", version = "=3.1.0-beta.0" }
-solana-runtime = { path = "runtime", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-runtime-transaction = { path = "runtime-transaction", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-rpc = { path = "rpc", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-rpc-client = { path = "rpc-client", version = "=3.1.0-beta.1", default-features = false }
+solana-rpc-client-api = { path = "rpc-client-api", version = "=3.1.0-beta.1" }
+solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=3.1.0-beta.1" }
+solana-rpc-client-types = { path = "rpc-client-types", version = "=3.1.0-beta.1" }
+solana-runtime = { path = "runtime", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-runtime-transaction = { path = "runtime-transaction", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-sanitize = "3.0.1"
 solana-sbpf = { version = "=0.13.0", default-features = false }
 solana-sdk-ids = "3.0.0"
@@ -517,7 +517,7 @@ solana-secp256k1-recover = "3.0.0"
 solana-secp256r1-program = "3.0.0"
 solana-seed-derivable = "3.0.0"
 solana-seed-phrase = "3.0.0"
-solana-send-transaction-service = { path = "send-transaction-service", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-send-transaction-service = { path = "send-transaction-service", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-serde = "3.0.0"
 solana-serde-varint = "3.0.0"
 solana-serialize-utils = "3.1.0"
@@ -531,50 +531,50 @@ solana-slot-hashes = "3.0.0"
 solana-slot-history = "3.0.0"
 solana-stable-layout = "3.0.0"
 solana-stake-interface = { version = "2.0.1" }
-solana-stake-program = { path = "programs/stake", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-storage-bigtable = { path = "storage-bigtable", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-storage-proto = { path = "storage-proto", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-streamer = { path = "streamer", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm = { path = "svm", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-callback = { path = "svm-callback", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-feature-set = { path = "svm-feature-set", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-log-collector = { path = "svm-log-collector", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-measure = { path = "svm-measure", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-test-harness = { path = "svm-test-harness", version = "=3.1.0-beta.0" }
-solana-svm-timings = { path = "svm-timings", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-transaction = { path = "svm-transaction", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-type-overrides = { path = "svm-type-overrides", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-stake-program = { path = "programs/stake", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-storage-bigtable = { path = "storage-bigtable", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-storage-proto = { path = "storage-proto", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-streamer = { path = "streamer", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-svm = { path = "svm", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-svm-callback = { path = "svm-callback", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-svm-feature-set = { path = "svm-feature-set", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-svm-log-collector = { path = "svm-log-collector", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-svm-measure = { path = "svm-measure", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-svm-test-harness = { path = "svm-test-harness", version = "=3.1.0-beta.1" }
+solana-svm-timings = { path = "svm-timings", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-svm-transaction = { path = "svm-transaction", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-svm-type-overrides = { path = "svm-type-overrides", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-system-interface = "2.0"
-solana-system-program = { path = "programs/system", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-system-program = { path = "programs/system", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-system-transaction = "3.0.0"
 solana-sysvar = "3.0.0"
 solana-sysvar-id = "3.0.0"
-solana-test-validator = { path = "test-validator", version = "=3.1.0-beta.0" }
+solana-test-validator = { path = "test-validator", version = "=3.1.0-beta.1" }
 solana-time-utils = "3.0.0"
-solana-tls-utils = { path = "tls-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-tps-client = { path = "tps-client", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-tpu-client = { path = "tpu-client", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
-solana-tpu-client-next = { path = "tpu-client-next", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-tls-utils = { path = "tls-utils", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-tps-client = { path = "tps-client", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-tpu-client = { path = "tpu-client", version = "=3.1.0-beta.1", default-features = false, features = ["agave-unstable-api"] }
+solana-tpu-client-next = { path = "tpu-client-next", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-transaction = "3.0.1"
-solana-transaction-context = { path = "transaction-context", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-context = { path = "transaction-context", version = "=3.1.0-beta.1", features = ["agave-unstable-api", "bincode"] }
 solana-transaction-error = "3.0.0"
-solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-transaction-status = { path = "transaction-status", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-turbine = { path = "turbine", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-udp-client = { path = "udp-client", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-transaction-status = { path = "transaction-status", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-turbine = { path = "turbine", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-udp-client = { path = "udp-client", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-validator-exit = "3.0.0"
-solana-version = { path = "version", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-vote = { path = "vote", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-version = { path = "version", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-vote = { path = "vote", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-vote-interface = "4.0.4"
-solana-vote-program = { path = "programs/vote", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
-solana-wen-restart = { path = "wen-restart", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-vote-program = { path = "programs/vote", version = "=3.1.0-beta.1", default-features = false, features = ["agave-unstable-api"] }
+solana-wen-restart = { path = "wen-restart", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-zk-sdk = "4.0.0"
-solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-zk-token-sdk = { path = "zk-token-sdk", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-zk-token-sdk = { path = "zk-token-sdk", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 spl-associated-token-account-interface = "2.0.0"
 spl-generic-token = "2.0.0"
 spl-memo-interface = "2.0.0"

--- a/ci/xtask/Cargo.lock
+++ b/ci/xtask/Cargo.lock
@@ -893,7 +893,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "xtask"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 description = "Blockchain, Rebuilt for Scale"
 repository = "https://github.com/anza-xyz/agave"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agave-fs"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
  "solana-clock",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "agave-io-uring"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "io-uring",
  "libc",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agave-ledger-tool"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "agave-logger"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "env_logger",
  "libc",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey",
@@ -236,11 +236,11 @@ dependencies = [
 
 [[package]]
 name = "agave-scheduler-bindings"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "agave-scheduling-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-scheduler-bindings",
  "agave-transaction-view",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "agave-snapshots"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-fs",
  "bincode",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-tool"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "clap 2.34.0",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "agave-syscalls"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "libsecp256k1",
@@ -310,7 +310,7 @@ dependencies = [
  "solana-bn254",
  "solana-clock",
  "solana-cpi",
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.0-beta.1",
  "solana-hash",
  "solana-instruction",
  "solana-keccak-hasher",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "agave-verified-packet-receiver"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-perf",
  "solana-streamer",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "agave-votor"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "agave-votor-messages",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "agave-votor-messages"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "serde",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-xdp-ebpf",
  "aya",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp-ebpf"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "aya",
  "aya-ebpf",
@@ -6097,7 +6097,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -6137,7 +6137,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6161,7 +6161,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-fs",
  "ahash 0.8.12",
@@ -6273,7 +6273,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banking-bench"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-logger",
@@ -6309,7 +6309,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "borsh",
  "futures 0.3.31",
@@ -6335,7 +6335,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "serde",
  "solana-account",
@@ -6353,7 +6353,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -6381,7 +6381,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-tps"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -6481,7 +6481,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bv",
  "fnv",
@@ -6541,7 +6541,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -6568,7 +6568,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bv",
  "bytemuck",
@@ -6585,7 +6585,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -6604,7 +6604,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -6621,7 +6621,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "dirs-next",
  "serde",
@@ -6661,7 +6661,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -6701,7 +6701,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6802,7 +6802,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -6810,7 +6810,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -6840,7 +6840,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -6864,7 +6864,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6885,7 +6885,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -7028,7 +7028,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -7082,7 +7082,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -7117,7 +7117,7 @@ dependencies = [
 
 [[package]]
 name = "solana-dos"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -7160,7 +7160,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -7184,7 +7184,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -7261,7 +7261,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -7311,7 +7311,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -7353,7 +7353,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -7443,7 +7443,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -7473,7 +7473,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -7660,7 +7660,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -7670,7 +7670,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -7813,7 +7813,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
  "solana-account",
@@ -7835,7 +7835,7 @@ dependencies = [
 
 [[package]]
 name = "solana-local-cluster"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "agave-snapshots",
@@ -7898,11 +7898,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -7931,7 +7931,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -7960,7 +7960,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-net-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -8081,7 +8081,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "arc-swap",
  "core_affinity",
@@ -8114,7 +8114,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-bn254 0.5.0",
@@ -8146,7 +8146,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-binaries"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "serde",
@@ -8206,7 +8206,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8249,7 +8249,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8322,7 +8322,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -8346,7 +8346,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -8383,7 +8383,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
  "num_cpus",
@@ -8391,7 +8391,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "console 0.16.1",
  "dialoguer",
@@ -8435,7 +8435,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -8520,7 +8520,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8558,7 +8558,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -8577,7 +8577,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -8592,7 +8592,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -8617,7 +8617,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-fs",
@@ -8753,7 +8753,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -8875,7 +8875,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -9054,7 +9054,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -9075,7 +9075,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "bs58",
@@ -9137,7 +9137,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -9183,7 +9183,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -9225,7 +9225,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -9235,22 +9235,22 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-svm-timings"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -9259,7 +9259,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -9271,7 +9271,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -9293,7 +9293,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "log",
@@ -9374,7 +9374,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -9430,7 +9430,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
 name = "solana-tls-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "rustls 0.23.34",
  "solana-keypair",
@@ -9441,7 +9441,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tps-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
  "solana-account",
@@ -9472,7 +9472,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -9504,7 +9504,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "log",
@@ -9551,7 +9551,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "serde",
@@ -9578,7 +9578,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9592,7 +9592,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -9633,7 +9633,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9655,7 +9655,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-votor",
@@ -9709,7 +9709,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -9723,7 +9723,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -9735,7 +9735,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -9775,7 +9775,7 @@ checksum = "c5d2face763df5afeaa9509b9019968860e69cc1531ec8b4a2e6c7b702204d5a"
 
 [[package]]
 name = "solana-version"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -9787,7 +9787,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "itertools 0.12.1",
@@ -9840,7 +9840,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -9870,7 +9870,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-snapshots",
  "anyhow",
@@ -9898,7 +9898,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -9950,7 +9950,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -9965,7 +9965,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -9981,7 +9981,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.0-beta.1",
  "solana-derivation-path",
  "solana-instruction",
  "solana-pubkey",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 description = "Blockchain, Rebuilt for Scale"
 repository = "https://github.com/anza-xyz/agave"
@@ -36,12 +36,12 @@ manual_let_else = "deny"
 used_underscore_binding = "deny"
 
 [workspace.dependencies]
-agave-banking-stage-ingress-types = { path = "../banking-stage-ingress-types", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-feature-set = { path = "../feature-set", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-logger = { path = "../logger", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-snapshots = { path = "../snapshots", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-syscalls = { path = "../syscalls", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+agave-banking-stage-ingress-types = { path = "../banking-stage-ingress-types", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-feature-set = { path = "../feature-set", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-logger = { path = "../logger", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-snapshots = { path = "../snapshots", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+agave-syscalls = { path = "../syscalls", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 ahash = "0.8.11"
 assert_cmd = "2.0"
 assert_matches = "1.5.0"
@@ -71,82 +71,82 @@ serde_yaml = "0.9.34"
 serial_test = "2.0.0"
 signal-hook = "0.3.18"
 solana-account = "3.2.0"
-solana-account-decoder = { path = "../account-decoder", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-accounts-db = { path = "../accounts-db", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-bench-tps = { path = "../bench-tps", version = "=3.1.0-beta.0" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-clap-utils = { path = "../clap-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-cli-config = { path = "../cli-config", version = "=3.1.0-beta.0" }
-solana-cli-output = { path = "../cli-output", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-client = { path = "../client", version = "=3.1.0-beta.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-accounts-db = { path = "../accounts-db", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-bench-tps = { path = "../bench-tps", version = "=3.1.0-beta.1" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-clap-utils = { path = "../clap-utils", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-cli-config = { path = "../cli-config", version = "=3.1.0-beta.1" }
+solana-cli-output = { path = "../cli-output", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-client = { path = "../client", version = "=3.1.0-beta.1" }
 solana-clock = "3.0.0"
 solana-cluster-type = "3.0.0"
 solana-commitment-config = "3.0.0"
-solana-compute-budget = { path = "../compute-budget", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-compute-budget = { path = "../compute-budget", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-compute-budget-interface = "3.0.0"
-solana-connection-cache = { path = "../connection-cache", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
-solana-core = { path = "../core", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-cost-model = { path = "../cost-model", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-entry = { path = "../entry", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-faucet = { path = "../faucet", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-connection-cache = { path = "../connection-cache", version = "=3.1.0-beta.1", default-features = false, features = ["agave-unstable-api"] }
+solana-core = { path = "../core", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-cost-model = { path = "../cost-model", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-entry = { path = "../entry", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-faucet = { path = "../faucet", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-feature-gate-interface = "3.0.0"
 solana-fee-calculator = "3.0.0"
-solana-genesis = { path = "../genesis", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-genesis = { path = "../genesis", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-genesis-config = "3.0.0"
-solana-genesis-utils = { path = "../genesis-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-gossip = { path = "../gossip", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-genesis-utils = { path = "../genesis-utils", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-gossip = { path = "../gossip", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-hash = "3.0.0"
 solana-inflation = "3.0.0"
 solana-instruction = "3.0.0"
 solana-keypair = "3.0.1"
-solana-ledger = { path = "../ledger", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-ledger = { path = "../ledger", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-loader-v3-interface = "6.1.0"
-solana-local-cluster = { path = "../local-cluster", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-measure = { path = "../measure", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-local-cluster = { path = "../local-cluster", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-measure = { path = "../measure", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-message = "3.0.1"
-solana-metrics = { path = "../metrics", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-metrics = { path = "../metrics", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-native-token = "3.0.0"
-solana-net-utils = { path = "../net-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-net-utils = { path = "../net-utils", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-nonce = "3.0.0"
-solana-perf = { path = "../perf", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-poh = { path = "../poh", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-program-runtime = { path = "../program-runtime", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-perf = { path = "../perf", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-poh = { path = "../poh", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-program-runtime = { path = "../program-runtime", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-pubkey = { version = "3.0.0", default-features = false }
-solana-quic-client = { path = "../quic-client", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-quic-client = { path = "../quic-client", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-rent = "3.0.0"
-solana-rpc = { path = "../rpc", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-rpc-client = { path = "../rpc-client", version = "=3.1.0-beta.0", default-features = false }
-solana-rpc-client-api = { path = "../rpc-client-api", version = "=3.1.0-beta.0" }
-solana-rpc-client-nonce-utils = { path = "../rpc-client-nonce-utils", version = "=3.1.0-beta.0" }
-solana-runtime = { path = "../runtime", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-runtime-transaction = { path = "../runtime-transaction", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-rpc = { path = "../rpc", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-rpc-client = { path = "../rpc-client", version = "=3.1.0-beta.1", default-features = false }
+solana-rpc-client-api = { path = "../rpc-client-api", version = "=3.1.0-beta.1" }
+solana-rpc-client-nonce-utils = { path = "../rpc-client-nonce-utils", version = "=3.1.0-beta.1" }
+solana-runtime = { path = "../runtime", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-runtime-transaction = { path = "../runtime-transaction", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-sbpf = { version = "=0.13.0", default-features = false }
 solana-sdk-ids = "3.0.0"
 solana-shred-version = "3.0.0"
 solana-signature = { version = "3.1.0", default-features = false }
 solana-signer = "3.0.0"
 solana-stake-interface = { version = "2.0.1" }
-solana-stake-program = { path = "../programs/stake", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-streamer = { path = "../streamer", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-callback = { path = "../svm-callback", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-feature-set = { path = "../svm-feature-set", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-log-collector = { path = "../svm-log-collector", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-type-overrides = { path = "../svm-type-overrides", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-stake-program = { path = "../programs/stake", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-streamer = { path = "../streamer", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-svm-callback = { path = "../svm-callback", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-svm-feature-set = { path = "../svm-feature-set", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-svm-log-collector = { path = "../svm-log-collector", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-svm-type-overrides = { path = "../svm-type-overrides", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
 solana-system-interface = "2.0"
 solana-system-transaction = "3.0.0"
-solana-test-validator = { path = "../test-validator", version = "=3.1.0-beta.0" }
+solana-test-validator = { path = "../test-validator", version = "=3.1.0-beta.1" }
 solana-time-utils = "3.0.0"
-solana-tps-client = { path = "../tps-client", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-tpu-client = { path = "../tpu-client", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
+solana-tps-client = { path = "../tps-client", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-tpu-client = { path = "../tpu-client", version = "=3.1.0-beta.1", default-features = false, features = ["agave-unstable-api"] }
 solana-transaction = "3.0.1"
-solana-transaction-context = { path = "../transaction-context", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "bincode"] }
-solana-transaction-status = { path = "../transaction-status", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-version = { path = "../version", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-vote = { path = "../vote", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-vote-program = { path = "../programs/vote", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
+solana-transaction-context = { path = "../transaction-context", version = "=3.1.0-beta.1", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-status = { path = "../transaction-status", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-version = { path = "../version", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-vote = { path = "../vote", version = "=3.1.0-beta.1", features = ["agave-unstable-api"] }
+solana-vote-program = { path = "../programs/vote", version = "=3.1.0-beta.1", default-features = false, features = ["agave-unstable-api"] }
 tempfile = "3.23.0"
 thiserror = "2.0.17"
 tokio = "1.48.0"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noop"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "package-metadata"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 description = "Solana SBF test program with tools version in package metadata"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-metadata"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 description = "Solana SBF test program with tools version in workspace metadata"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agave-fs"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
  "solana-clock",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "agave-io-uring"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "io-uring",
  "libc",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agave-logger"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "env_logger",
  "libc",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey",
@@ -151,11 +151,11 @@ dependencies = [
 
 [[package]]
 name = "agave-scheduler-bindings"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "agave-scheduling-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-scheduler-bindings",
  "agave-transaction-view",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "agave-snapshots"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-fs",
  "bincode",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "agave-syscalls"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "libsecp256k1 0.6.0",
@@ -211,7 +211,7 @@ dependencies = [
  "solana-bn254",
  "solana-clock",
  "solana-cpi",
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.0-beta.1",
  "solana-hash",
  "solana-instruction",
  "solana-keccak-hasher",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "agave-validator"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-geyser-plugin-interface",
  "agave-logger",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "agave-verified-packet-receiver"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-perf",
  "solana-streamer",
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "agave-votor"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "agave-votor-messages",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "agave-votor-messages"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "serde",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-xdp-ebpf",
  "aya",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp-ebpf"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "aya",
  "aya-ebpf",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6100,7 +6100,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-fs",
  "ahash 0.8.11",
@@ -6212,7 +6212,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "borsh",
  "futures 0.3.31",
@@ -6238,7 +6238,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "serde",
  "solana-account",
@@ -6256,7 +6256,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -6317,7 +6317,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bv",
  "fnv",
@@ -6377,7 +6377,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -6404,7 +6404,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bv",
  "bytemuck",
@@ -6421,7 +6421,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -6440,7 +6440,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -6457,7 +6457,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "chrono",
  "clap",
@@ -6485,7 +6485,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "dirs-next",
  "serde",
@@ -6497,7 +6497,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -6537,7 +6537,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6638,7 +6638,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -6676,7 +6676,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -6700,7 +6700,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6721,7 +6721,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -6864,7 +6864,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -6918,7 +6918,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -6953,7 +6953,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -6977,7 +6977,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -7085,7 +7085,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -7135,7 +7135,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -7219,7 +7219,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -7249,7 +7249,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -7437,7 +7437,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -7447,7 +7447,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -7590,7 +7590,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
  "solana-account",
@@ -7612,11 +7612,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -7645,7 +7645,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -7674,7 +7674,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-net-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7756,7 +7756,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -7787,7 +7787,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "arc-swap",
  "core_affinity",
@@ -7820,7 +7820,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-bn254 0.5.0",
@@ -7899,7 +7899,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-binaries"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "serde",
@@ -7961,7 +7961,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8004,7 +8004,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8077,7 +8077,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -8101,7 +8101,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -8138,7 +8138,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
  "num_cpus",
@@ -8146,7 +8146,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "console 0.16.1",
  "dialoguer",
@@ -8190,7 +8190,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -8275,7 +8275,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8313,7 +8313,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -8332,7 +8332,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -8347,7 +8347,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -8372,7 +8372,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-fs",
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -8534,7 +8534,7 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbf-programs"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8607,7 +8607,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-program-entrypoint",
  "solana-sbf-rust-128bit-dep",
@@ -8615,11 +8615,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit-dep"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-sbf-rust-account-mem"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8630,7 +8630,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-account-mem-deprecated"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-program",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alloc"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-msg",
  "solana-program",
@@ -8651,7 +8651,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "array-bytes",
  "solana-bn254",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128-compression"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "array-bytes",
  "solana-bn254",
@@ -8671,7 +8671,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-big-mod-exp"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "array-bytes",
  "serde",
@@ -8683,7 +8683,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-args"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "borsh",
  "solana-account-info",
@@ -8695,7 +8695,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-depth"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-msg",
  "solana-program",
@@ -8705,7 +8705,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-caller-access"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8718,16 +8718,16 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-curve25519"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.0-beta.1",
  "solana-msg",
  "solana-program-entrypoint",
 ]
 
 [[package]]
 name = "solana-sbf-rust-custom-heap"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8738,7 +8738,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-dep-crate"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "byteorder 1.5.0",
  "solana-program-entrypoint",
@@ -8746,7 +8746,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-deprecated-loader"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8762,7 +8762,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-divide-by-zero"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8772,7 +8772,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-dup-accounts"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-error-handling"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "num-derive",
  "num-traits",
@@ -8799,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-external-spend"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8809,7 +8809,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-get-minimum-delegation"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8821,7 +8821,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-inner_instruction_alignment_check"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8834,7 +8834,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-instruction-introspection"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8849,7 +8849,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8868,7 +8868,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-error"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-ok"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8892,7 +8892,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-return"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8904,11 +8904,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-dep"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-sbf-rust-invoked"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8924,7 +8924,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoked-dep"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
@@ -8932,7 +8932,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-iter"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-program",
  "solana-program-entrypoint",
@@ -8940,7 +8940,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-log-data"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-program",
@@ -8952,7 +8952,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-many-args"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-msg",
  "solana-program",
@@ -8962,7 +8962,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-many-args-dep"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-msg",
  "solana-program",
@@ -8970,7 +8970,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-mem"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8982,11 +8982,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-mem-dep"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-sbf-rust-membuiltins"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-program-entrypoint",
  "solana-sbf-rust-mem-dep",
@@ -8994,7 +8994,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-noop"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -9004,7 +9004,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-panic"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9015,7 +9015,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-param-passing"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-program",
  "solana-program-entrypoint",
@@ -9024,11 +9024,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-param-passing-dep"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-sbf-rust-poseidon"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "array-bytes",
  "solana-msg",
@@ -9038,7 +9038,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-r2-instruction-data-pointer"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-cpi",
  "solana-program-entrypoint",
@@ -9046,7 +9046,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-rand"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "getrandom 0.2.10",
  "rand 0.8.5",
@@ -9059,7 +9059,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9073,7 +9073,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-dep"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
@@ -9081,7 +9081,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -9097,11 +9097,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke-dep"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-sbf-rust-remaining-compute-units"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-ro-account_modify"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-ro-modify"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9139,7 +9139,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sanity"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9152,7 +9152,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-secp256k1-recover"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "libsecp256k1 0.7.0",
  "sha3",
@@ -9165,7 +9165,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sha"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "blake3",
  "sha2 0.10.9",
@@ -9180,7 +9180,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sibling-inner-instructions"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -9192,7 +9192,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sibling-instructions"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -9205,7 +9205,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-simulation"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-clock",
@@ -9218,7 +9218,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-spoof1"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -9232,7 +9232,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-spoof1-system"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -9242,7 +9242,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sysvar"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "solana-account-info",
@@ -9260,7 +9260,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-upgradeable"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9272,7 +9272,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-upgraded"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9284,7 +9284,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-syscall-get-epoch-stake"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9391,7 +9391,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -9568,7 +9568,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -9589,7 +9589,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -9628,7 +9628,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "bs58",
@@ -9651,7 +9651,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -9697,7 +9697,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "ahash 0.8.11",
  "log",
@@ -9739,7 +9739,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -9749,22 +9749,22 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 
 [[package]]
 name = "solana-svm-timings"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -9773,7 +9773,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -9785,7 +9785,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -9807,7 +9807,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "log",
@@ -9890,7 +9890,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -9946,7 +9946,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
 name = "solana-tls-utils"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "rustls 0.23.34",
  "solana-keypair",
@@ -9957,7 +9957,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -9989,7 +9989,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "log",
@@ -10036,7 +10036,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -10064,7 +10064,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10078,7 +10078,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -10119,7 +10119,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10141,7 +10141,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "agave-votor",
@@ -10195,7 +10195,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -10209,7 +10209,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -10221,7 +10221,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -10261,7 +10261,7 @@ checksum = "c5d2face763df5afeaa9509b9019968860e69cc1531ec8b4a2e6c7b702204d5a"
 
 [[package]]
 name = "solana-version"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -10273,7 +10273,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "bincode",
  "itertools 0.12.1",
@@ -10326,7 +10326,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -10357,7 +10357,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-snapshots",
  "anyhow",
@@ -10385,7 +10385,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -10437,7 +10437,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -10452,7 +10452,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -10468,7 +10468,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.0-beta.1",
  "solana-derivation-path",
  "solana-instruction",
  "solana-pubkey",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -73,7 +73,7 @@ members = [
     "rust/upgraded",
 ]
 [workspace.package]
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
@@ -90,11 +90,11 @@ check-cfg = [
 ]
 
 [workspace.dependencies]
-agave-feature-set = { path = "../../feature-set", version = "=3.1.0-beta.0" }
-agave-logger = { path = "../../logger", version = "=3.1.0-beta.0" }
-agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=3.1.0-beta.0" }
-agave-syscalls = { path = "../../syscalls", version = "=3.1.0-beta.0" }
-agave-validator = { path = "../../validator", version = "=3.1.0-beta.0" }
+agave-feature-set = { path = "../../feature-set", version = "=3.1.0-beta.1" }
+agave-logger = { path = "../../logger", version = "=3.1.0-beta.1" }
+agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=3.1.0-beta.1" }
+agave-syscalls = { path = "../../syscalls", version = "=3.1.0-beta.1" }
+agave-validator = { path = "../../validator", version = "=3.1.0-beta.1" }
 array-bytes = "=1.4.1"
 bincode = { version = "1.1.4", default-features = false }
 blake3 = "1.0.0"
@@ -114,64 +114,64 @@ serde = { version = "1.0.112", features = ["derive"] }
 serde_json = "1.0.56"
 sha2 = "0.10.8"
 sha3 = "0.10.8"
-solana-account-decoder = { path = "../../account-decoder", version = "=3.1.0-beta.0" }
+solana-account-decoder = { path = "../../account-decoder", version = "=3.1.0-beta.1" }
 solana-account-info = "=3.0.0"
-solana-accounts-db = { path = "../../accounts-db", version = "=3.1.0-beta.0" }
+solana-accounts-db = { path = "../../accounts-db", version = "=3.1.0-beta.1" }
 solana-big-mod-exp = "=3.0.0"
 solana-blake3-hasher = { version = "=3.0.0", features = ["blake3"] }
 solana-bn254 = "=3.1.2"
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=3.1.0-beta.0" }
-solana-cli-output = { path = "../../cli-output", version = "=3.1.0-beta.0" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=3.1.0-beta.1" }
+solana-cli-output = { path = "../../cli-output", version = "=3.1.0-beta.1" }
 solana-clock = { version = "=3.0.0", features = ["serde", "sysvar"] }
-solana-compute-budget = { path = "../../compute-budget", version = "=3.1.0-beta.0" }
-solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=3.1.0-beta.0" }
+solana-compute-budget = { path = "../../compute-budget", version = "=3.1.0-beta.1" }
+solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=3.1.0-beta.1" }
 solana-cpi = "=3.0.0"
-solana-curve25519 = { path = "../../curves/curve25519", version = "=3.1.0-beta.0" }
+solana-curve25519 = { path = "../../curves/curve25519", version = "=3.1.0-beta.1" }
 solana-define-syscall = "=3.0.0"
-solana-fee = { path = "../../fee", version = "=3.1.0-beta.0" }
+solana-fee = { path = "../../fee", version = "=3.1.0-beta.1" }
 solana-hash = { version = "=3.0.0", features = ["bytemuck", "serde", "std"] }
 solana-instruction = "=3.0.0"
 solana-instructions-sysvar = "=3.0.0"
 solana-keccak-hasher = { version = "=3.0.0", features = ["sha3"] }
-solana-ledger = { path = "../../ledger", version = "=3.1.0-beta.0" }
-solana-measure = { path = "../../measure", version = "=3.1.0-beta.0" }
+solana-ledger = { path = "../../ledger", version = "=3.1.0-beta.1" }
+solana-measure = { path = "../../measure", version = "=3.1.0-beta.1" }
 solana-msg = "=3.0.0"
-solana-poseidon = { path = "../../poseidon/", version = "=3.1.0-beta.0" }
+solana-poseidon = { path = "../../poseidon/", version = "=3.1.0-beta.1" }
 solana-program = "=3.0.0"
 solana-program-entrypoint = "=3.1.0"
 solana-program-error = "=3.0.0"
 solana-program-memory = "=3.0.0"
-solana-program-runtime = { path = "../../program-runtime", version = "=3.1.0-beta.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=3.1.0-beta.1" }
 solana-pubkey = { version = "=3.0.0", default-features = false }
-solana-runtime = { path = "../../runtime", version = "=3.1.0-beta.0" }
-solana-runtime-transaction = { path = "../../runtime-transaction", version = "=3.1.0-beta.0" }
-solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-invoke-dep = { path = "rust/invoke_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-invoked-dep = { path = "rust/invoked_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-r2-instruction-data-pointer = { path = "rust/r2_instruction_data_pointer", version = "=3.1.0-beta.0" }
-solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=3.1.0-beta.0" }
+solana-runtime = { path = "../../runtime", version = "=3.1.0-beta.1" }
+solana-runtime-transaction = { path = "../../runtime-transaction", version = "=3.1.0-beta.1" }
+solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=3.1.0-beta.1" }
+solana-sbf-rust-invoke-dep = { path = "rust/invoke_dep", version = "=3.1.0-beta.1" }
+solana-sbf-rust-invoked-dep = { path = "rust/invoked_dep", version = "=3.1.0-beta.1" }
+solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=3.1.0-beta.1" }
+solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=3.1.0-beta.1" }
+solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=3.1.0-beta.1" }
+solana-sbf-rust-r2-instruction-data-pointer = { path = "rust/r2_instruction_data_pointer", version = "=3.1.0-beta.1" }
+solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=3.1.0-beta.1" }
+solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=3.1.0-beta.1" }
 solana-sbpf = "=0.13.0"
 solana-sdk-ids = "=3.0.0"
 solana-secp256k1-recover = "=3.0.0"
 solana-sha256-hasher = { version = "=3.0.0", features = ["sha2"] }
 solana-stake-interface = { version = "=2.0.1", features = ["bincode"] }
-solana-svm = { path = "../../svm", version = "=3.1.0-beta.0" }
-solana-svm-callback = { path = "../../svm-callback", version = "=3.1.0-beta.0" }
-solana-svm-feature-set = { path = "../../svm-feature-set", version = "=3.1.0-beta.0" }
-solana-svm-log-collector = { path = "../../svm-log-collector", version = "=3.1.0-beta.0" }
-solana-svm-timings = { path = "../../svm-timings", version = "=3.1.0-beta.0" }
-solana-svm-transaction = { path = "../../svm-transaction", version = "=3.1.0-beta.0" }
-solana-svm-type-overrides = { path = "../../svm-type-overrides", version = "=3.1.0-beta.0" }
+solana-svm = { path = "../../svm", version = "=3.1.0-beta.1" }
+solana-svm-callback = { path = "../../svm-callback", version = "=3.1.0-beta.1" }
+solana-svm-feature-set = { path = "../../svm-feature-set", version = "=3.1.0-beta.1" }
+solana-svm-log-collector = { path = "../../svm-log-collector", version = "=3.1.0-beta.1" }
+solana-svm-timings = { path = "../../svm-timings", version = "=3.1.0-beta.1" }
+solana-svm-transaction = { path = "../../svm-transaction", version = "=3.1.0-beta.1" }
+solana-svm-type-overrides = { path = "../../svm-type-overrides", version = "=3.1.0-beta.1" }
 solana-system-interface = { version = "=2.0", features = ["bincode"] }
 solana-sysvar = "=3.0.0"
-solana-transaction-context = { path = "../../transaction-context", version = "=3.1.0-beta.0" }
-solana-transaction-status = { path = "../../transaction-status", version = "=3.1.0-beta.0" }
-solana-vote = { path = "../../vote", version = "=3.1.0-beta.0" }
-solana-vote-program = { path = "../../programs/vote", version = "=3.1.0-beta.0" }
+solana-transaction-context = { path = "../../transaction-context", version = "=3.1.0-beta.1" }
+solana-transaction-status = { path = "../../transaction-status", version = "=3.1.0-beta.1" }
+solana-vote = { path = "../../vote", version = "=3.1.0-beta.1" }
+solana-vote-program = { path = "../../programs/vote", version = "=3.1.0-beta.1" }
 test-case = "3.3.1"
 thiserror = "1.0"
 

--- a/svm/tests/example-programs/clock-sysvar/Cargo.toml
+++ b/svm/tests/example-programs/clock-sysvar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock-sysvar-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/hello-solana/Cargo.toml
+++ b/svm/tests/example-programs/hello-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-solana-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/simple-transfer/Cargo.toml
+++ b/svm/tests/example-programs/simple-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-transfer-program"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/transfer-from-account/Cargo.toml
+++ b/svm/tests/example-programs/transfer-from-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-from-account"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/write-to-account/Cargo.toml
+++ b/svm/tests/example-programs/write-to-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-to-account"
-version = "3.1.0-beta.0"
+version = "3.1.0-beta.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
#### Problem
Bumping the version number manually for now. I'm working on automation to handle this

Nothing in the commit other than the version change:
```
$ glol -2
06de7a92cb 2025-11-05 13:01:00 -0600  (HEAD -> v3.1_version_bump, willhickey/v3.1_version_bump)  will.hickey@anza.xyz Bump prerelease suffix to -beta.1
db914777eb 2025-11-05 09:55:24 -0600  (agave/v3.1, v3.1)  37929162+mergify[bot]@users.noreply.github.com v3.1: suppress erroneous lints related to nested deprecation blocks (backport of #8899) (#8905)
$ git diff v3.1..HEAD  | grep -vE "^ |^@@ |^--- |^\+\+\+ |^index |^diff |^-( \")?(solana|agave).*3.1.0-beta.0|^\+( \")?(solana|agave).*3.1.0-beta.1|^-version|^\+version"
$
```