### PR TITLE
DEFAULT_MAX_QUIC_CONNECTIONS_PER_STAKED_PEER=16

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -40,7 +40,7 @@ use {
 pub const DEFAULT_MAX_QUIC_CONNECTIONS_PER_UNSTAKED_PEER: usize = 8;
 
 // allow multiple connections per ID for geo-distributed forwarders
-pub const DEFAULT_MAX_QUIC_CONNECTIONS_PER_STAKED_PEER: usize = 8;
+pub const DEFAULT_MAX_QUIC_CONNECTIONS_PER_STAKED_PEER: usize = 16;
 
 pub const DEFAULT_MAX_STAKED_CONNECTIONS: usize = 2000;
 


### PR DESCRIPTION
#### Problem

- DEFAULT_MAX_QUIC_CONNECTIONS_PER_STAKED_PEER is too low for some of the big RPC operators

#### Summary of Changes

- bump to 16 (we have enough space in staked connection table)