### PR TITLE
chore: Address mismatched_lifetime_syntaxes warnings

### DIFF
--- a/cost-model/benches/cost_tracker.rs
+++ b/cost-model/benches/cost_tracker.rs
@@ -45,7 +45,7 @@ fn setup(num_transactions: usize, contentious_transactions: bool) -> BenchSetup 
 
 fn get_costs(
     transactions: &[WritableKeysTransaction],
-) -> Vec<TransactionCost<WritableKeysTransaction>> {
+) -> Vec<TransactionCost<'_, WritableKeysTransaction>> {
     transactions
         .iter()
         .map(|transaction| {

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -253,7 +253,7 @@ impl<'a, 'b> LazyAnalysis<'a, 'b> {
         }
     }
 
-    fn analyze(&mut self) -> &Analysis {
+    fn analyze(&mut self) -> &Analysis<'_> {
         if let Some(ref analysis) = self.analysis {
             return analysis;
         }


### PR DESCRIPTION
#### Problem
The following warning is present when running with Rust 1.89.0:
```
error: lifetime flowing from input to output with different syntax can be confusing
  --> cost-model/benches/cost_tracker.rs:47:19
   |
47 |     transactions: &[WritableKeysTransaction],
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ this lifetime flows to the output
48 | ) -> Vec<TransactionCost<WritableKeysTransaction>> {
   |          ---------------------------------------- the lifetime gets resolved as `'_`
   |
   = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
48 | ) -> Vec<TransactionCost<'_, WritableKeysTransaction>> {
   |                          +++
```

#### Summary of Changes
Apply the suggested change to the two relevant locations.

Part of https://github.com/anza-xyz/agave/issues/8894