### PR TITLE
clippy: Address manual_let_else instances

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,16 +24,13 @@ use {
 fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error>> {
     let parse_args = match matches.subcommand() {
         ("config", Some(matches)) => {
-            let config_file = match matches.value_of("config_file") {
-                None => {
-                    println!(
-                        "{} Either provide the `--config` arg or ensure home directory exists to \
-                         use the default config location",
-                        style("No config file found.").bold()
-                    );
-                    return Ok(false);
-                }
-                Some(config_file) => config_file,
+            let Some(config_file) = matches.value_of("config_file") else {
+                println!(
+                    "{} Either provide the `--config` arg or ensure home directory exists to use \
+                     the default config location",
+                    style("No config file found.").bold()
+                );
+                return Ok(false);
             };
             let mut config = Config::load(config_file).unwrap_or_default();
 


### PR DESCRIPTION
#### Problem
Rust 1.89 clippy doesn't like this block:
```
--> cli/src/main.rs:27:13

27 | /             let config_file = match matches.value_of("config_file") {
28 | |                 None => {
29 | |                     println!(
30 | |                         "{} Either provide the `--config` arg or ensure home directory exists to \
...  |
36 | |                 Some(config_file) => config_file,
37 | |             };
   | |______________^

= help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else
```
#### Summary of Changes
Apply the suggestion:
```
= note: requested on the command line with `-D clippy::manual-let-else`
help: consider writing

27 ~             let Some(config_file) = matches.value_of("config_file") else {
28 +                     println!(
29 +                         "{} Either provide the `--config` arg or ensure home directory exists to \
30 +                          use the default config location",
31 +                         style("No config file found.").bold()
32 +                     );
33 +                     return Ok(false);
34 +                 };
```

Work towards resolving https://github.com/anza-xyz/agave/issues/8894
