### PR TITLE
Refactor: external worker separate channel from struct

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -742,7 +742,6 @@ mod external {
                 let consume_worker = ExternalWorker::new(
                     id,
                     self.worker_exit_signal.clone(),
-                    pack_to_worker,
                     Consumer::new(
                         self.committer.clone(),
                         self.transaction_recorder.clone(),
@@ -760,7 +759,7 @@ mod external {
                     Builder::new()
                         .name(format!("solECoWorker{id:02}"))
                         .spawn(move || {
-                            let _ = consume_worker.run();
+                            let _ = consume_worker.run(pack_to_worker);
                         })
                         .unwrap(),
                 );


### PR DESCRIPTION
#### Problem
- Was using unsafe `try_read_ptr` then immediately `as_ref`-ing. We can use the safe alternative.

#### Summary of Changes
- Use `try_read` instead of `try_read_ptr`
- To get around borrow-checker, separated receiver from the rest of the struct

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
