### PR TITLE
clippy: Address clone_ref_to_slice_refs instances

### DIFF
--- a/programs/sbf/rust/instruction_introspection/src/lib.rs
+++ b/programs/sbf/rust/instruction_introspection/src/lib.rs
@@ -51,7 +51,7 @@ fn process_instruction(
                 &[instruction_data[0], instruction_data[1], 1],
                 vec![AccountMeta::new_readonly(instructions::id(), false)],
             ),
-            &[instructions_account.clone()],
+            std::slice::from_ref(instructions_account),
         )?;
     }
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -879,25 +879,30 @@ fn test_program_sbf_invoke_sanity() {
         do_invoke_success(
             TEST_MAX_ACCOUNT_INFOS_OK,
             &[],
-            &[invoked_program_id.clone()],
+            std::slice::from_ref(&invoked_program_id),
             &bank,
         );
 
         do_invoke_success(
             TEST_CU_USAGE_MINIMUM,
             &[],
-            &[noop_program_id.clone()],
+            std::slice::from_ref(&noop_program_id),
             &bank,
         );
 
         do_invoke_success(
             TEST_CU_USAGE_BASELINE,
             &[],
-            &[noop_program_id.clone()],
+            std::slice::from_ref(&noop_program_id),
             &bank,
         );
 
-        do_invoke_success(TEST_CU_USAGE_MAX, &[], &[noop_program_id.clone()], &bank);
+        do_invoke_success(
+            TEST_CU_USAGE_MAX,
+            &[],
+            std::slice::from_ref(&noop_program_id),
+            &bank,
+        );
 
         let bank = bank_with_feature_deactivated(
             &bank_forks,
@@ -912,7 +917,7 @@ fn test_program_sbf_invoke_sanity() {
         do_invoke_success(
             TEST_MAX_ACCOUNT_INFOS_OK_BEFORE_SIMD_0339,
             &[],
-            &[invoked_program_id.clone()],
+            std::slice::from_ref(&invoked_program_id),
             &bank,
         );
 
@@ -928,7 +933,7 @@ fn test_program_sbf_invoke_sanity() {
         do_invoke_success(
             TEST_MAX_ACCOUNT_INFOS_OK_BEFORE_INCREASE_TX_ACCOUNT_LOCK_BEFORE_SIMD_0339,
             &[],
-            &[invoked_program_id.clone()],
+            std::slice::from_ref(&invoked_program_id),
             &bank,
         );
         let bank = bank_with_feature_activated(
@@ -1014,7 +1019,7 @@ fn test_program_sbf_invoke_sanity() {
         do_invoke_failure_test_local(
             TEST_PRIVILEGE_ESCALATION_SIGNER,
             TransactionError::InstructionError(0, InstructionError::PrivilegeEscalation),
-            &[invoked_program_id.clone()],
+            std::slice::from_ref(&invoked_program_id),
             None,
             &bank,
         );
@@ -1022,7 +1027,7 @@ fn test_program_sbf_invoke_sanity() {
         do_invoke_failure_test_local(
             TEST_PRIVILEGE_ESCALATION_WRITABLE,
             TransactionError::InstructionError(0, InstructionError::PrivilegeEscalation),
-            &[invoked_program_id.clone()],
+            std::slice::from_ref(&invoked_program_id),
             None,
             &bank,
         );
@@ -1177,7 +1182,7 @@ fn test_program_sbf_invoke_sanity() {
         do_invoke_failure_test_local(
             TEST_RETURN_ERROR,
             TransactionError::InstructionError(0, InstructionError::Custom(42)),
-            &[invoked_program_id.clone()],
+            std::slice::from_ref(&invoked_program_id),
             None,
             &bank,
         );
@@ -1185,7 +1190,7 @@ fn test_program_sbf_invoke_sanity() {
         do_invoke_failure_test_local(
             TEST_PRIVILEGE_DEESCALATION_ESCALATION_SIGNER,
             TransactionError::InstructionError(0, InstructionError::PrivilegeEscalation),
-            &[invoked_program_id.clone()],
+            std::slice::from_ref(&invoked_program_id),
             None,
             &bank,
         );
@@ -1193,7 +1198,7 @@ fn test_program_sbf_invoke_sanity() {
         do_invoke_failure_test_local(
             TEST_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE,
             TransactionError::InstructionError(0, InstructionError::PrivilegeEscalation),
-            &[invoked_program_id.clone()],
+            std::slice::from_ref(&invoked_program_id),
             None,
             &bank,
         );
@@ -1201,7 +1206,7 @@ fn test_program_sbf_invoke_sanity() {
         do_invoke_failure_test_local_with_compute_check(
             TEST_WRITABLE_DEESCALATION_WRITABLE,
             TransactionError::InstructionError(0, InstructionError::ReadonlyDataModified),
-            &[invoked_program_id.clone()],
+            std::slice::from_ref(&invoked_program_id),
             None,
             true, // should_deplete_compute_meter
             &bank,
@@ -1268,7 +1273,7 @@ fn test_program_sbf_invoke_sanity() {
         do_invoke_failure_test_local(
             TEST_DUPLICATE_PRIVILEGE_ESCALATION_SIGNER,
             TransactionError::InstructionError(0, InstructionError::PrivilegeEscalation),
-            &[invoked_program_id.clone()],
+            std::slice::from_ref(&invoked_program_id),
             None,
             &bank,
         );
@@ -1276,7 +1281,7 @@ fn test_program_sbf_invoke_sanity() {
         do_invoke_failure_test_local(
             TEST_DUPLICATE_PRIVILEGE_ESCALATION_WRITABLE,
             TransactionError::InstructionError(0, InstructionError::PrivilegeEscalation),
-            &[invoked_program_id.clone()],
+            std::slice::from_ref(&invoked_program_id),
             None,
             &bank,
         );


### PR DESCRIPTION
#### Problem
We want to advance to Rust 1.89.0; running `clippy` with 1.89.0 yields the following:
```
error: this call to `clone` can be replaced with `std::slice::from_ref`
   --> tests/programs.rs:882:13
    |
882 |             &[invoked_program_id.clone()],
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&invoked_program_id)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cloned_ref_to_slice_refs
    = note: `-D clippy::cloned-ref-to-slice-refs` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::cloned_ref_to_slice_refs)]`
```

#### Summary of Changes
Apply the suggested change; progress towards https://github.com/anza-xyz/agave/issues/8894