### PR TITLE
clippy: Address mut_from_ref instances

### DIFF
--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -579,6 +579,7 @@ fn translate_string_and_do(
 }
 
 // Do not use this directly
+#[allow(clippy::mut_from_ref)]
 fn translate_type_mut<'a, T>(
     memory_mapping: &'a MemoryMapping,
     vm_addr: u64,
@@ -587,6 +588,7 @@ fn translate_type_mut<'a, T>(
     translate_type_inner!(memory_mapping, AccessType::Store, vm_addr, T, check_aligned)
 }
 // Do not use this directly
+#[allow(clippy::mut_from_ref)]
 fn translate_slice_mut<'a, T>(
     memory_mapping: &'a MemoryMapping,
     vm_addr: u64,


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/issues/6850

Running `clippy` with Rust 1.88.0 yields the following:
```
error: mutable borrow from immutable input(s)
   --> syscalls/src/lib.rs:586:13
    |
586 | ) -> Result<&'a mut T, Error> {
    |             ^^^^^^^^^
    |
note: immutable borrow here
   --> syscalls/src/lib.rs:583:21
    |
583 |     memory_mapping: &'a MemoryMapping,
    |                     ^^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mut_from_ref
    = note: `#[deny(clippy::mut_from_ref)]` on by default
```

#### Summary of Changes
Apply a `#[allow(clippy::mut_from_ref)]` guard to these two function. As @Lichtso responded below:

> Clippy does not understand that address comes from an u64, nof a reference. Also, changing the mapped data does not influence the mapping.

Progress towards https://github.com/anza-xyz/agave/issues/6850 (intermediate goal) and https://github.com/anza-xyz/agave/issues/8894 (end goal)
