### PR TITLE
clippy: remove unused log::* import

### DIFF
--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -1,6 +1,6 @@
 //! The error that can be produced from Blockstore operations.
 
-use {agave_snapshots::hardened_unpack::UnpackError, log::*, solana_clock::Slot, thiserror::Error};
+use {agave_snapshots::hardened_unpack::UnpackError, solana_clock::Slot, thiserror::Error};
 
 #[derive(Error, Debug)]
 pub enum BlockstoreError {


### PR DESCRIPTION
#### Problem
Newer rust toolchains detect that * imports are unused and `log::*` gets flagged.

#### Summary of Changes
Remove unused import.
