### PR TITLE
Use bencher crate for append_vec benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7136,6 +7136,7 @@ dependencies = [
  "agave-reserved-account-keys",
  "ahash 0.8.11",
  "assert_matches",
+ "bencher",
  "bincode",
  "blake3",
  "bv",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -107,6 +107,7 @@ thiserror = { workspace = true }
 agave-logger = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 assert_matches = { workspace = true }
+bencher = { workspace = true }
 criterion = { workspace = true }
 libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }
@@ -146,6 +147,10 @@ harness = false
 
 [[bench]]
 name = "bench_lock_accounts"
+harness = false
+
+[[bench]]
+name = "append_vec"
 harness = false
 
 [lints]

--- a/accounts-db/benches/append_vec.rs
+++ b/accounts-db/benches/append_vec.rs
@@ -1,7 +1,5 @@
-#![feature(test)]
-extern crate test;
-
 use {
+    bencher::{benchmark_group, benchmark_main, Bencher},
     rand::{thread_rng, Rng},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::{
@@ -18,7 +16,6 @@ use {
         thread::{sleep, spawn},
         time::Duration,
     },
-    test::Bencher,
 };
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
@@ -51,12 +48,10 @@ fn append_vec_append(bencher: &mut Bencher, storage_access: StorageAccess) {
     });
 }
 
-#[bench]
 fn append_vec_append_file(bencher: &mut Bencher) {
     append_vec_append(bencher, StorageAccess::File);
 }
 
-#[bench]
 fn append_vec_append_mmap(bencher: &mut Bencher) {
     append_vec_append(
         bencher,
@@ -90,12 +85,10 @@ fn append_vec_sequential_read(bencher: &mut Bencher, storage_access: StorageAcce
     });
 }
 
-#[bench]
 fn append_vec_sequential_read_file(bencher: &mut Bencher) {
     append_vec_sequential_read(bencher, StorageAccess::File);
 }
 
-#[bench]
 fn append_vec_sequential_read_mmap(bencher: &mut Bencher) {
     append_vec_sequential_read(
         bencher,
@@ -119,12 +112,10 @@ fn append_vec_random_read(bencher: &mut Bencher, storage_access: StorageAccess) 
     });
 }
 
-#[bench]
 fn append_vec_random_read_file(bencher: &mut Bencher) {
     append_vec_random_read(bencher, StorageAccess::File);
 }
 
-#[bench]
 fn append_vec_random_read_mmap(bencher: &mut Bencher) {
     append_vec_random_read(
         bencher,
@@ -167,12 +158,10 @@ fn append_vec_concurrent_append_read(bencher: &mut Bencher, storage_access: Stor
     });
 }
 
-#[bench]
 fn append_vec_concurrent_append_read_file(bencher: &mut Bencher) {
     append_vec_concurrent_append_read(bencher, StorageAccess::File);
 }
 
-#[bench]
 fn append_vec_concurrent_append_read_mmap(bencher: &mut Bencher) {
     append_vec_concurrent_append_read(
         bencher,
@@ -217,12 +206,10 @@ fn append_vec_concurrent_read_append(bencher: &mut Bencher, storage_access: Stor
     });
 }
 
-#[bench]
 fn append_vec_concurrent_read_append_file(bencher: &mut Bencher) {
     append_vec_concurrent_read_append(bencher, StorageAccess::File);
 }
 
-#[bench]
 fn append_vec_concurrent_read_append_mmap(bencher: &mut Bencher) {
     append_vec_concurrent_read_append(
         bencher,
@@ -230,3 +217,18 @@ fn append_vec_concurrent_read_append_mmap(bencher: &mut Bencher) {
         StorageAccess::Mmap,
     );
 }
+
+benchmark_group!(
+    benches,
+    append_vec_append_file,
+    append_vec_append_mmap,
+    append_vec_sequential_read_file,
+    append_vec_sequential_read_mmap,
+    append_vec_random_read_file,
+    append_vec_random_read_mmap,
+    append_vec_concurrent_append_read_file,
+    append_vec_concurrent_append_read_mmap,
+    append_vec_concurrent_read_append_file,
+    append_vec_concurrent_read_append_mmap,
+);
+benchmark_main!(benches);


### PR DESCRIPTION
#### Problem
Use of stable toolchain (same as for production code) for all codebase is much preferred to using nightly. To achieve that it's necessary switch benchmarks to use one of the benchmarking frameworks that works in stable - criterion or bencher.

#### Summary of Changes
Switch `append_vec` benchmark to `bencher` crate.

Note:
Both of benchmarking crates use different heuristics for selecting number of iterations to yield results, usually they are much more sensitive to variance in benchmark timing than built-in unstable `#[bench]` utility. 

This is in particular visible for benchmarks doing IO, so longer benchmark runs are to be expected. `append_vec` bench is suffering from this problem, however it seems criterion is way worse here than `bencher`, as `criterion` will run for tens of minutes, while `bencher` "only" for 1 minute compared to 20 seconds on master:

PR:
```
running 10 tests
test append_vec_append_file                 ... bench:         747 ns/iter (+/- 32)
test append_vec_append_mmap                 ... bench:          64 ns/iter (+/- 5)
test append_vec_concurrent_append_read_file ... bench:       2,496 ns/iter (+/- 1,604)
test append_vec_concurrent_append_read_mmap ... bench:         322 ns/iter (+/- 259)
test append_vec_concurrent_read_append_file ... bench:      54,985 ns/iter (+/- 106,222)
test append_vec_concurrent_read_append_mmap ... bench:     100,482 ns/iter (+/- 18,469,329)
test append_vec_random_read_file            ... bench:         909 ns/iter (+/- 85,864)
test append_vec_random_read_mmap            ... bench:         123 ns/iter (+/- 20,897)
test append_vec_sequential_read_file        ... bench:         550 ns/iter (+/- 126,268)
test append_vec_sequential_read_mmap        ... bench:         101 ns/iter (+/- 10,125)

test result: ok. 0 passed; 0 failed; 0 ignored; 10 measured

real 1m2,757s
user 4m17,459s
sys 3m49,555s
```

master:
```
running 10 tests
test append_vec_append_file                 ... bench:         783.17 ns/iter (+/- 153.33)
test append_vec_append_mmap                 ... bench:          59.40 ns/iter (+/- 7.36)
test append_vec_concurrent_append_read_file ... bench:         382.14 ns/iter (+/- 81.10)
test append_vec_concurrent_append_read_mmap ... bench:          65.63 ns/iter (+/- 14.97)
test append_vec_concurrent_read_append_file ... bench:          94.21 ns/iter (+/- 38.90)
test append_vec_concurrent_read_append_mmap ... bench:         285.98 ns/iter (+/- 110.86)
test append_vec_random_read_file            ... bench:         610.74 ns/iter (+/- 33.86)
test append_vec_random_read_mmap            ... bench:          89.12 ns/iter (+/- 16.03)
test append_vec_sequential_read_file        ... bench:         463.55 ns/iter (+/- 25.45)
test append_vec_sequential_read_mmap        ... bench:         147.23 ns/iter (+/- 10.31)

test result: ok. 0 passed; 0 failed; 0 ignored; 10 measured; 0 filtered out; finished in 18.99s


real 0m19,444s
user 0m20,041s
sys 0m9,949s
```