### PR TITLE
add cpu-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-cpu-utils"
+version = "4.2.0-alpha.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "agave-feature-set"
 version = "4.2.0-alpha.0"
 dependencies = [
@@ -339,6 +346,7 @@ dependencies = [
 name = "agave-validator"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-cpu-utils",
  "agave-logger",
  "agave-snapshots",
  "agave-votor",
@@ -349,7 +357,6 @@ dependencies = [
  "chrono",
  "clap 2.33.3",
  "console 0.16.3",
- "core_affinity",
  "crossbeam-channel",
  "fd-lock",
  "indicatif",
@@ -531,13 +538,13 @@ dependencies = [
 name = "agave-xdp"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-cpu-utils",
  "agave-xdp-ebpf",
  "arc-swap",
  "arrayvec",
  "aya",
  "bytes",
  "caps",
- "core_affinity",
  "crossbeam-channel",
  "libc",
  "log",
@@ -2018,17 +2025,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core_affinity"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
-dependencies = [
- "libc",
- "num_cpus",
- "winapi",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -9207,12 +9203,12 @@ dependencies = [
 name = "solana-poh"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-cpu-utils",
  "agave-logger",
  "agave-votor-messages",
  "arc-swap",
  "assert_matches",
  "bincode",
- "core_affinity",
  "criterion",
  "crossbeam-channel",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "connection-cache",
     "core",
     "cost-model",
+    "cpu-utils",
     "download-utils",
     "entry",
     "faucet",
@@ -170,6 +171,7 @@ collapsible_if = "allow"
 Inflector = "0.11.4"
 agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 agave-bls-cert-verify = { path = "bls-cert-verify", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
+agave-cpu-utils = { path = "cpu-utils", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 agave-feature-set = { path = "feature-set", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 agave-fs = { path = "fs", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=4.2.0-alpha.0" }
@@ -223,7 +225,6 @@ chrono-humanize = "0.2.3"
 clap = { version = "2.33.1", default-features = false, features = ["suggestions"] }
 console = "0.16.3"
 const_format = "0.2.36"
-core_affinity = "0.8.3"
 criterion = "0.8.2"
 crossbeam-channel = "0.5.15"
 csv = "1.4.0"

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -363,7 +363,7 @@ pub struct ValidatorConfig {
     pub no_os_cpu_stats_reporting: bool,
     pub no_os_disk_stats_reporting: bool,
     pub enforce_ulimit_nofile: bool,
-    pub poh_pinned_cpu_core: usize,
+    pub poh_pinned_cpu_core: Option<usize>,
     pub poh_hashes_per_batch: u64,
     pub process_ledger_before_services: bool,
     pub accounts_db_config: AccountsDbConfig,

--- a/cpu-utils/Cargo.toml
+++ b/cpu-utils/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "agave-cpu-utils"
+description = "Agave CPU Utils"
+version = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = true
+
+[features]
+agave-unstable-api = []
+
+[dependencies]
+libc = { workspace = true }

--- a/cpu-utils/src/affinity.rs
+++ b/cpu-utils/src/affinity.rs
@@ -1,0 +1,145 @@
+//! Core CPU affinity operations.
+
+use std::{io, mem, ops::Deref};
+
+const CPU_SETSIZE: usize = libc::CPU_SETSIZE as usize;
+
+/// Identifies a logical CPU (hardware thread) by its kernel-assigned ID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CpuId(usize);
+
+impl CpuId {
+    pub fn new(cpu: usize) -> io::Result<Self> {
+        if cpu < CPU_SETSIZE {
+            Ok(Self(cpu))
+        } else {
+            Err(io::Error::from_raw_os_error(libc::EINVAL))
+        }
+    }
+}
+
+impl Deref for CpuId {
+    type Target = usize;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Set CPU affinity for a thread.
+///
+/// Restricts the thread to run only on the specified CPUs.
+///
+/// # Arguments
+/// * `thread_id` - Thread ID to set affinity for. `None` means the calling thread.
+/// * `cpus` - CPU IDs to bind the thread to. Can be any iterable collection.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use agave_cpu_utils::*;
+/// # fn main() -> std::io::Result<()> {
+/// // Pin current thread to CPU 0
+/// set_cpu_affinity(None, [CpuId::new(0)?])?;
+///
+/// // Pin current thread to multiple CPUs
+/// set_cpu_affinity(None, [CpuId::new(0)?, CpuId::new(1)?, CpuId::new(2)?])?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::InvalidInput`] if any CPU ID is too large for `cpu_set_t`.
+/// Returns [`io::Error`] if the system call fails, including offline CPUs or CPUs
+/// disallowed by the task's hard cpuset/cgroup.
+pub fn set_cpu_affinity(
+    thread_id: Option<libc::pid_t>,
+    cpus: impl IntoIterator<Item = CpuId>,
+) -> io::Result<()> {
+    // safety: cpu_set_t is a POD type, zero-initialization is standard
+    let mut cpu_set: libc::cpu_set_t = unsafe { mem::zeroed() };
+
+    for cpu in cpus {
+        // safety: CpuId values are constructed only after validating cpu < CPU_SETSIZE.
+        unsafe { libc::CPU_SET(*cpu, &mut cpu_set) };
+    }
+
+    let tid = thread_id.unwrap_or(0);
+
+    // safety: sched_setaffinity is safe with valid parameters
+    let result =
+        unsafe { libc::sched_setaffinity(tid, mem::size_of::<libc::cpu_set_t>(), &cpu_set) };
+
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
+}
+
+/// Get the CPU affinity mask for a thread.
+///
+/// Returns a sorted vector of CPU IDs that the thread is allowed to run on.
+///
+/// # Arguments
+/// * `thread_id` - Thread ID to query. `None` means the calling thread.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use agave_cpu_utils::*;
+/// # fn main() -> std::io::Result<()> {
+/// let cpus = cpu_affinity(None)?;
+/// println!("Thread can run on CPUs: {:?}", cpus);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Errors
+///
+/// Returns [`io::Error`] if the system call fails.
+pub fn cpu_affinity(thread_id: Option<libc::pid_t>) -> io::Result<Vec<CpuId>> {
+    // safety: cpu_set_t is a POD type, zero-initialization is standard
+    let mut cpu_set: libc::cpu_set_t = unsafe { mem::zeroed() };
+
+    let tid = thread_id.unwrap_or(0);
+
+    // safety: sched_getaffinity is safe with valid parameters
+    let result =
+        unsafe { libc::sched_getaffinity(tid, mem::size_of::<libc::cpu_set_t>(), &mut cpu_set) };
+
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut cpus = Vec::new();
+    for cpu in 0..CPU_SETSIZE {
+        // safety: cpu < CPU_SETSIZE by construction
+        if unsafe { libc::CPU_ISSET(cpu, &cpu_set) } {
+            cpus.push(CpuId::new(cpu)?);
+        }
+    }
+
+    Ok(cpus)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cpu_id_validation() {
+        let result = CpuId::new(CPU_SETSIZE);
+        assert_eq!(result.unwrap_err().raw_os_error(), Some(libc::EINVAL));
+    }
+
+    #[test]
+    fn test_cpu_affinity_returns_sorted() {
+        let cpus = cpu_affinity(None).expect("failed to query current CPU affinity");
+        assert!(
+            cpus.windows(2).all(|window| *window[0] <= *window[1]),
+            "cpu_affinity should return sorted CPU list"
+        );
+    }
+}

--- a/cpu-utils/src/lib.rs
+++ b/cpu-utils/src/lib.rs
@@ -1,0 +1,26 @@
+#![cfg(all(feature = "agave-unstable-api", target_os = "linux"))]
+
+//! CPU affinity utilities for Linux systems.
+//!
+//! This crate provides safe Rust bindings for setting CPU affinity and querying
+//! the current task affinity mask. Useful for performance-critical applications
+//! that need precise control over thread placement.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use agave_cpu_utils::*;
+//!
+//! # fn main() -> std::io::Result<()> {
+//! let allowed = cpu_affinity(None)?;
+//! if let Some(&cpu) = allowed.first() {
+//!     set_cpu_affinity(None, [cpu])?;
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+
+mod affinity;
+
+pub use affinity::{CpuId, cpu_affinity, set_cpu_affinity};

--- a/cpu-utils/tests/integration_test.rs
+++ b/cpu-utils/tests/integration_test.rs
@@ -1,0 +1,77 @@
+#![cfg(all(feature = "agave-unstable-api", target_os = "linux"))]
+
+//! Integration tests for agave-cpu-utils
+//!
+//! These tests require a Linux system.
+//! Tests that modify CPU affinity spawn dedicated threads to avoid affecting the
+//! test harness.
+
+use {
+    agave_cpu_utils::{CpuId, cpu_affinity, set_cpu_affinity},
+    std::{io, thread},
+};
+
+fn current_affinity() -> Vec<CpuId> {
+    cpu_affinity(None).expect("failed to query current CPU affinity")
+}
+
+fn handle_affinity_result(result: io::Result<()>, test_name: &str) {
+    match result {
+        Ok(()) => {}
+        Err(e) => panic!("{test_name}: unexpected error: {e:?}"),
+    }
+}
+
+#[test]
+fn test_set_and_get_affinity() {
+    let affinity = current_affinity();
+    let cpu = affinity
+        .first()
+        .copied()
+        .expect("current CPU affinity mask should not be empty");
+
+    let result = thread::spawn(move || {
+        set_cpu_affinity(None, [cpu])?;
+        let affinity = cpu_affinity(None)?;
+        assert_eq!(affinity, vec![cpu]);
+        Ok::<(), io::Error>(())
+    })
+    .join()
+    .expect("Thread panicked");
+
+    handle_affinity_result(result, "test_set_and_get_affinity");
+}
+
+#[test]
+fn test_affinity_with_multiple_cpus() {
+    let available = current_affinity();
+    if available.len() < 2 {
+        eprintln!(
+            "Skipping test_affinity_with_multiple_cpus: current CPU affinity mask has fewer than \
+             2 CPUs"
+        );
+        return;
+    }
+    let (cpu0, cpu1) = (available[0], available[1]);
+
+    let result = thread::spawn(move || {
+        set_cpu_affinity(None, [cpu0, cpu1])?;
+        let affinity = cpu_affinity(None)?;
+        assert_eq!(affinity, vec![cpu0, cpu1]);
+        Ok::<(), io::Error>(())
+    })
+    .join()
+    .expect("Thread panicked");
+
+    handle_affinity_result(result, "test_affinity_with_multiple_cpus");
+}
+
+#[test]
+fn test_invalid_cpu_index_rejected() {
+    assert_eq!(
+        CpuId::new(libc::CPU_SETSIZE as usize)
+            .unwrap_err()
+            .raw_os_error(),
+        Some(libc::EINVAL)
+    );
+}

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -77,6 +77,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-cpu-utils"
+version = "4.2.0-alpha.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "agave-feature-set"
 version = "4.2.0-alpha.0"
 dependencies = [
@@ -411,13 +418,13 @@ dependencies = [
 name = "agave-xdp"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-cpu-utils",
  "agave-xdp-ebpf",
  "arc-swap",
  "arrayvec",
  "aya",
  "bytes",
  "caps",
- "core_affinity",
  "crossbeam-channel",
  "libc",
  "log",
@@ -1707,17 +1714,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core_affinity"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
-dependencies = [
- "libc",
- "num_cpus",
- "winapi",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -7798,9 +7794,9 @@ dependencies = [
 name = "solana-poh"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-cpu-utils",
  "agave-votor-messages",
  "arc-swap",
- "core_affinity",
  "crossbeam-channel",
  "log",
  "qualifier_attr",

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -22,9 +22,9 @@ dev-context-only-utils = []
 shuttle-test = ["dep:shuttle"]
 
 [dependencies]
+agave-cpu-utils = { workspace = true }
 agave-votor-messages = { workspace = true }
 arc-swap = { workspace = true }
-core_affinity = { workspace = true }
 crossbeam-channel = { workspace = true }
 log = { workspace = true }
 qualifier_attr = { workspace = true }

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -1,5 +1,7 @@
 //! The `poh_service` module implements a service that records the passing of
 //! "ticks", a measure of time in the PoH stream
+#[cfg(target_os = "linux")]
+use agave_cpu_utils::{CpuId, set_cpu_affinity};
 use {
     crate::{
         poh_controller::{PohServiceMessage, PohServiceMessageGuard, PohServiceMessageReceiver},
@@ -37,7 +39,10 @@ const TARGET_HASH_BATCH_TIME_US: u64 = 50;
 pub const DEFAULT_HASHES_PER_BATCH: u64 =
     TARGET_HASH_BATCH_TIME_US * DEFAULT_HASHES_PER_SECOND / 1_000_000;
 
-pub const DEFAULT_PINNED_CPU_CORE: usize = 0;
+#[cfg(target_os = "linux")]
+pub const DEFAULT_PINNED_CPU_CORE: Option<usize> = Some(0);
+#[cfg(not(target_os = "linux"))]
+pub const DEFAULT_PINNED_CPU_CORE: Option<usize> = None;
 
 const TARGET_SLOT_ADJUSTMENT_NS: u64 = 50_000_000;
 
@@ -100,7 +105,7 @@ impl PohService {
         poh_config: &PohConfig,
         poh_exit: Arc<AtomicBool>,
         ticks_per_slot: u64,
-        pinned_cpu_core: usize,
+        pinned_cpu_core: Option<usize>,
         hashes_per_batch: u64,
         mut record_receiver: RecordReceiver,
         poh_service_receiver: PohServiceMessageReceiver,
@@ -109,6 +114,8 @@ impl PohService {
     ) -> Self {
         migration_status.set_poh_service_started();
         let poh_config = poh_config.clone();
+        #[cfg(not(target_os = "linux"))]
+        let _ = pinned_cpu_core;
         let tick_producer = Builder::new()
             .name("solPohTickProd".to_string())
             .spawn(move || {
@@ -144,11 +151,18 @@ impl PohService {
                         )
                     }
                 } else {
-                    // PoH service runs in a tight loop, generating hashes as fast as possible.
-                    // Let's dedicate one of the CPU cores to this thread so that it can gain
-                    // from cache performance.
-                    if let Some(cores) = core_affinity::get_core_ids() {
-                        core_affinity::set_for_current(cores[pinned_cpu_core]);
+                    #[cfg(target_os = "linux")]
+                    if let Some(pinned_cpu_core) = pinned_cpu_core {
+                        // PoH service runs in a tight loop, generating hashes as fast as possible.
+                        // Let's dedicate one of the CPU cores to this thread so that it can gain
+                        // from cache performance.
+                        let pinned_cpu = CpuId::new(pinned_cpu_core).unwrap();
+                        set_cpu_affinity(None, [pinned_cpu]).unwrap_or_else(|e| {
+                            panic!(
+                                "Failed to set CPU affinity for POH service to CPU \
+                                 {pinned_cpu_core}: {e:?}. This is critical for performance."
+                            )
+                        });
                     }
                     Self::tick_producer(
                         poh_recorder,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -77,6 +77,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-cpu-utils"
+version = "4.2.0-alpha.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "agave-feature-set"
 version = "4.2.0-alpha.0"
 dependencies = [
@@ -253,6 +260,7 @@ dependencies = [
 name = "agave-validator"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-cpu-utils",
  "agave-logger",
  "agave-snapshots",
  "agave-votor",
@@ -261,7 +269,6 @@ dependencies = [
  "chrono",
  "clap",
  "console 0.16.3",
- "core_affinity",
  "crossbeam-channel",
  "fd-lock",
  "indicatif",
@@ -399,13 +406,13 @@ dependencies = [
 name = "agave-xdp"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-cpu-utils",
  "agave-xdp-ebpf",
  "arc-swap",
  "arrayvec",
  "aya",
  "bytes",
  "caps",
- "core_affinity",
  "crossbeam-channel",
  "libc",
  "log",
@@ -1636,17 +1643,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core_affinity"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
-dependencies = [
- "libc",
- "num_cpus",
- "winapi",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -7569,9 +7565,9 @@ dependencies = [
 name = "solana-poh"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-cpu-utils",
  "agave-votor-messages",
  "arc-swap",
- "core_affinity",
  "crossbeam-channel",
  "log",
  "qualifier_attr",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -18,6 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 
 [dependencies]
+agave-cpu-utils = { workspace = true }
 agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor = { workspace = true }
@@ -25,7 +26,6 @@ agave-xdp = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
 clap = { workspace = true }
 console = { workspace = true }
-core_affinity = { workspace = true }
 crossbeam-channel = { workspace = true }
 fd-lock = { workspace = true }
 indicatif = { workspace = true }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -867,18 +867,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .hidden(hidden_unless_forced())
             .long("experimental-poh-pinned-cpu-core")
             .takes_value(true)
-            .value_name("CPU_CORE_INDEX")
-            .validator(|s| {
-                let core_index = usize::from_str(&s).map_err(|e| e.to_string())?;
-                let max_index = core_affinity::get_core_ids()
-                    .map(|cids| cids.len() - 1)
-                    .unwrap_or(0);
-                if core_index > max_index {
-                    return Err(format!("core index must be in the range [0, {max_index}]"));
-                }
-                Ok(())
-            })
-            .help("EXPERIMENTAL: Specify which CPU core PoH is pinned to"),
+            .value_name("CPU_ID")
+            .validator(|s| usize::from_str(&s).map(|_| ()).map_err(|e| e.to_string()))
+            .help("Specify which CPU core PoH is pinned to"),
     )
     .arg(
         Arg::with_name("poh_hashes_per_batch")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -12,7 +12,6 @@ use {
         snapshot_config::{SnapshotConfig, SnapshotUsage},
     },
     agave_votor::vote_history_storage,
-    agave_xdp::{set_cpu_affinity, transmitter::XdpConfig},
     clap::{ArgMatches, crate_name, value_t, value_t_or_exit, values_t, values_t_or_exit},
     crossbeam_channel::unbounded,
     log::*,
@@ -29,9 +28,7 @@ use {
             create_and_canonicalize_directory,
         },
     },
-    solana_clap_utils::input_parsers::{
-        keypair_of, keypairs_of, parse_cpu_ranges, pubkey_of, value_of, values_of,
-    },
+    solana_clap_utils::input_parsers::{keypair_of, keypairs_of, pubkey_of, value_of, values_of},
     solana_clock::{DEFAULT_SLOTS_PER_EPOCH, Slot},
     solana_core::{
         banking_stage::transaction_scheduler::scheduler_controller::SchedulerConfig,
@@ -84,6 +81,8 @@ use {
         sync::{Arc, RwLock, atomic::AtomicBool},
     },
 };
+#[cfg(target_os = "linux")]
+use {agave_xdp::transmitter::XdpConfig, solana_clap_utils::input_parsers::parse_cpu_ranges};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Operation {
@@ -164,7 +163,7 @@ pub fn execute(
             Err(format!("invalid entrypoint address: {addr}"))?;
         }
     }
-
+    #[cfg(target_os = "linux")]
     let xdp_transmit_config = if let Some(xdp_cpu_cores) = matches
         .value_of("xdp_cpu_cores")
         .or_else(|| matches.value_of("experimental_retransmit_xdp_cpu_cores"))
@@ -412,21 +411,12 @@ pub fn execute(
     #[cfg(not(target_os = "linux"))]
     let xdp_transmit_setup = None;
 
-    let reserved = xdp_transmit_config
-        .map(|xdp| xdp.cpus.clone())
-        .unwrap_or_default()
-        .iter()
-        .cloned()
-        .collect::<HashSet<_>>();
-    if !reserved.is_empty() {
-        let available = core_affinity::get_core_ids()
-            .unwrap_or_default()
-            .into_iter()
-            .map(|core_id| core_id.id)
-            .collect::<HashSet<_>>();
-        let available = available.difference(&reserved);
-        set_cpu_affinity(available.into_iter().copied()).unwrap();
-    }
+    #[cfg(target_os = "linux")]
+    let poh_pinned_cpu_core =
+        value_of(matches, "poh_pinned_cpu_core").or(poh_service::DEFAULT_PINNED_CPU_CORE);
+
+    #[cfg(not(target_os = "linux"))]
+    let poh_pinned_cpu_core = None;
 
     solana_core::validator::report_target_features();
 
@@ -804,8 +794,7 @@ pub fn execute(
         // The validator needs to open many files, check that the process has
         // permission to do so in order to fail quickly and give a direct error
         enforce_ulimit_nofile: true,
-        poh_pinned_cpu_core: value_of(matches, "poh_pinned_cpu_core")
-            .unwrap_or(poh_service::DEFAULT_PINNED_CPU_CORE),
+        poh_pinned_cpu_core,
         poh_hashes_per_batch: value_of(matches, "poh_hashes_per_batch")
             .unwrap_or(poh_service::DEFAULT_HASHES_PER_BATCH),
         process_ledger_before_services: matches.is_present("process_ledger_before_services"),

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -12,6 +12,7 @@ publish = true
 agave-unstable-api = []
 
 [dependencies]
+agave-cpu-utils = { workspace = true }
 arc-swap = { workspace = true }
 bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -24,7 +25,6 @@ agave-xdp-ebpf = { workspace = true }
 arrayvec = { workspace = true }
 aya = { workspace = true }
 caps = { workspace = true }
-core_affinity = { workspace = true }
 
 [lints]
 workspace = true

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -31,51 +31,6 @@ pub mod transmitter;
 pub use program::load_xdp_program;
 use std::{io, net::Ipv4Addr};
 
-#[cfg(target_os = "linux")]
-pub fn set_cpu_affinity(cpus: impl IntoIterator<Item = usize>) -> Result<(), io::Error> {
-    unsafe {
-        let mut cpu_set = std::mem::zeroed();
-
-        for cpu in cpus {
-            libc::CPU_SET(cpu, &mut cpu_set);
-        }
-
-        let result = libc::sched_setaffinity(
-            0,
-            std::mem::size_of::<libc::cpu_set_t>(),
-            &cpu_set as *const libc::cpu_set_t,
-        );
-        if result != 0 {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(())
-        }
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-pub fn set_cpu_affinity(_cpus: impl IntoIterator<Item = usize>) -> Result<(), io::Error> {
-    unimplemented!()
-}
-
-#[cfg(target_os = "linux")]
-pub fn get_cpu() -> Result<usize, io::Error> {
-    unsafe {
-        let result = libc::sched_getcpu();
-        if result < 0 {
-            assert_eq!(result, -1);
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(result as usize)
-        }
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-pub fn get_cpu() -> Result<usize, io::Error> {
-    unimplemented!()
-}
-
 /// Returns the IPv4 address of the specified network interface.
 ///
 /// If the interface is part of a bonded interface, returns the master's IPv4 address.

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -16,10 +16,10 @@ use {
         load_xdp_program,
         route::{RouteTable, Router, RoutingTables},
         route_monitor::RouteMonitor,
-        set_cpu_affinity,
         tx_loop::{TxLoop, TxLoopBuilder, TxLoopConfigBuilder, TxPacket},
         umem::{OwnedUmem, PageAlignedMemory},
     },
+    agave_cpu_utils::{CpuId, cpu_affinity, set_cpu_affinity},
     arc_swap::ArcSwap,
     arrayvec::ArrayVec,
     aya::Ebpf,
@@ -251,32 +251,33 @@ impl TransmitterBuilder {
         tx_loop_config_builder.zero_copy(zero_copy);
         let tx_loop_config = tx_loop_config_builder.build_with_src_device(&dev);
 
-        let reserved_cores = cpus.iter().cloned().collect::<HashSet<_>>();
-        let available_cores = core_affinity::get_core_ids()
-            .expect("linux provide affine cores")
+        let reserved_cores = cpus
+            .iter()
+            .copied()
+            .map(CpuId::new)
+            .collect::<io::Result<HashSet<_>>>()?;
+        let unreserved_cores = cpu_affinity(None)?
             .into_iter()
-            .map(|core_affinity::CoreId { id }| id)
-            .collect::<HashSet<_>>();
-        let unreserved_cores = available_cores
-            .difference(&reserved_cores)
-            .cloned()
+            .filter(|core| !reserved_cores.contains(core))
             .collect::<Vec<_>>();
 
-        let tx_loop_builders = cpus
-            .into_iter()
-            .zip(std::iter::repeat_with(|| tx_loop_config.clone()))
-            .enumerate()
-            .map(|(i, (cpu_id, config))| {
-                // since we aren't necessarily allocating from the thread that we intend to run on,
-                // temporarily switch to the target cpu for each TxLoop to ensure that the Umem region
-                // is allocated to the correct numa node
-                set_cpu_affinity([cpu_id]).unwrap();
-                let tx_loop_builder = TxLoopBuilder::new(cpu_id, QueueId(i as u64), config, &dev);
-                // migrate main thread back off of the last xdp reserved cpu
-                set_cpu_affinity(unreserved_cores.clone()).unwrap();
-                tx_loop_builder
-            })
-            .collect::<Vec<_>>();
+        if unreserved_cores.is_empty() {
+            return Err("all CPUs are reserved; no CPU available for the main thread".into());
+        }
+
+        let mut tx_loop_builders = Vec::with_capacity(cpus.len());
+        for (i, cpu_id) in cpus.into_iter().enumerate() {
+            // since we aren't necessarily allocating from the thread that we intend to run on,
+            // temporarily switch to the target cpu for each TxLoop to ensure that the Umem region
+            // is allocated to the correct numa node
+            let cpu = CpuId::new(cpu_id)?;
+            set_cpu_affinity(None, [cpu])?;
+            let tx_loop_builder =
+                TxLoopBuilder::new(cpu_id, QueueId(i as u64), tx_loop_config.clone(), &dev);
+            // migrate main thread back off of the last xdp reserved cpu
+            set_cpu_affinity(None, unreserved_cores.iter().copied())?;
+            tx_loop_builders.push(tx_loop_builder);
+        }
 
         // switch to higher caps while we setup XDP. We assume that an error in
         // this function is irrecoverable so we don't try to drop on errors.

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -14,10 +14,10 @@ use {
             write_ip_header_for_udp, write_udp_header,
         },
         route::NextHop,
-        set_cpu_affinity,
         socket::{Socket, Tx, TxRing},
         umem::{Frame, OwnedUmem, PageAlignedMemory, Umem},
     },
+    agave_cpu_utils::set_cpu_affinity,
     crossbeam_channel::{Receiver, Sender, TryRecvError},
     libc::{_SC_PAGESIZE, sysconf},
     std::{
@@ -240,7 +240,7 @@ impl<U: Umem> TxLoop<U> {
         } = self;
 
         // each queue is bound to its own CPU core
-        set_cpu_affinity([cpu_id]).unwrap();
+        set_cpu_affinity(None, [agave_cpu_utils::CpuId::new(cpu_id).unwrap()]).unwrap();
 
         let umem = socket.umem();
         let umem_tx_capacity = umem.available();


### PR DESCRIPTION
#### Problem

problem #1968 

the current core_affinity crate has two critical issues for agave validators:
 1. incorrect CPU mapping: core_affinity::get_core_ids() filters out isolated cores, causing logical IDs to mismatch physical CPU IDs. setting --experimental-poh-pinned-cpu-core 2 with core 2 isolated pins to physical core 3
  instead.
  2. cannot access isolated cores: get_core_ids() only enumerates CPUs in the allowed affinity mask. isolated cores (via isolcpus) are not in this mask, making them invisible to core_affinity and preventing
  use of dedicated cores for PoH.

#### Summary of Changes
new crate: agave-cpu-utils
  - core affinity: set_cpu_affinity(), cpu_affinity(), max_cpu_id(), cpu_count(), isolated_cpus()
  - topology awareness: physical_core_count(), core_to_cpus_mapping(), set_affinity_physical_cores_only()
  - uses actual CPU IDs from sysfs (not filtered logical IDs)
  - detects and enables pinning to isolated cores
  - linux-only with proper platform guards

