### PR TITLE
scale max_concurrent_uni_streams with BDP

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -61,10 +61,6 @@ const CONNECTION_CLOSE_REASON_DROPPED_ENTRY: &[u8] = b"dropped";
 pub(crate) const CONNECTION_CLOSE_CODE_DISALLOWED: u32 = 2;
 pub(crate) const CONNECTION_CLOSE_REASON_DISALLOWED: &[u8] = b"disallowed";
 
-pub(crate) const CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT: u32 = 3;
-pub(crate) const CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT: &[u8] =
-    b"exceed_max_stream_count";
-
 const CONNECTION_CLOSE_CODE_TOO_MANY: u32 = 4;
 const CONNECTION_CLOSE_REASON_TOO_MANY: &[u8] = b"too_many";
 
@@ -412,7 +408,6 @@ pub fn get_connection_stake(
 #[derive(Debug)]
 pub(crate) enum ConnectionHandlerError {
     ConnectionAddError,
-    MaxStreamError,
 }
 
 pub(crate) fn update_open_connections_stat<S: OpaqueStreamerCounter>(

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -6,8 +6,7 @@ use {
                 get_connection_stake, update_open_connections_stat, ClientConnectionTracker,
                 ConnectionHandlerError, ConnectionPeerType, ConnectionTable, ConnectionTableKey,
                 ConnectionTableType, CONNECTION_CLOSE_CODE_DISALLOWED,
-                CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT, CONNECTION_CLOSE_REASON_DISALLOWED,
-                CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT,
+                CONNECTION_CLOSE_REASON_DISALLOWED,
             },
             stream_throttle::{
                 throttle_stream, ConnectionStreamCounter, StakedStreamLoadEMA,
@@ -48,6 +47,13 @@ pub const QUIC_MIN_STAKED_CONCURRENT_STREAMS: usize = 128;
 pub const QUIC_MAX_STAKED_CONCURRENT_STREAMS: usize = 512;
 
 pub const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: usize = 100_000;
+/// Below this RTT, we apply the legacy logic (no BDP scaling)
+/// Above this RTT, we increase the RX window and number of streams
+/// as RTT increases to preserve reasonable bandwidth.
+const REFERENCE_RTT_MS: u64 = 50;
+
+/// Above this RTT we stop scaling for BDP
+const MAX_RTT_MS: u64 = 350;
 
 #[derive(Clone)]
 pub struct SwQosConfig {
@@ -140,8 +146,12 @@ impl SwQos {
     }
 }
 
-fn compute_max_allowed_uni_streams(peer_type: ConnectionPeerType, total_stake: u64) -> usize {
-    match peer_type {
+fn compute_max_allowed_uni_streams(
+    rtt_millis: u64,
+    peer_type: ConnectionPeerType,
+    total_stake: u64,
+) -> u32 {
+    let streams = match peer_type {
         ConnectionPeerType::Staked(peer_stake) => {
             // No checked math for f64 type. So let's explicitly check for 0 here
             if total_stake == 0 || peer_stake > total_stake {
@@ -164,7 +174,10 @@ fn compute_max_allowed_uni_streams(peer_type: ConnectionPeerType, total_stake: u
             }
         }
         ConnectionPeerType::Unstaked => QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,
-    }
+    };
+    let streams =
+        streams as u64 * rtt_millis.clamp(REFERENCE_RTT_MS, MAX_RTT_MS) / REFERENCE_RTT_MS;
+    streams.min(u32::MAX as u64) as u32
 }
 
 impl SwQos {
@@ -182,58 +195,51 @@ impl SwQos {
         ),
         ConnectionHandlerError,
     > {
-        if let Ok(max_uni_streams) = VarInt::from_u64(compute_max_allowed_uni_streams(
+        // get current RTT and limit it to MAX_RTT_MS
+        let rtt_millis = connection.rtt().as_millis() as u64;
+        let max_uni_streams = VarInt::from_u32(compute_max_allowed_uni_streams(
+            rtt_millis,
             conn_context.peer_type(),
             conn_context.total_stake,
-        ) as u64)
-        {
-            let remote_addr = connection.remote_address();
+        ));
 
-            debug!(
-                "Peer type {:?}, total stake {}, max streams {} from peer {}",
+        let remote_addr = connection.remote_address();
+
+        debug!(
+            "Peer type {:?}, total stake {}, max streams {} from peer {}",
+            conn_context.peer_type(),
+            conn_context.total_stake,
+            max_uni_streams.into_inner(),
+            remote_addr,
+        );
+
+        let max_connections_per_peer = match conn_context.peer_type() {
+            ConnectionPeerType::Unstaked => self.config.max_connections_per_unstaked_peer,
+            ConnectionPeerType::Staked(_) => self.config.max_connections_per_staked_peer,
+        };
+        if let Some((last_update, cancel_connection, stream_counter)) = connection_table_l
+            .try_add_connection(
+                ConnectionTableKey::new(remote_addr.ip(), conn_context.remote_pubkey),
+                remote_addr.port(),
+                client_connection_tracker,
+                Some(connection.clone()),
                 conn_context.peer_type(),
-                conn_context.total_stake,
-                max_uni_streams.into_inner(),
-                remote_addr,
-            );
+                conn_context.last_update.clone(),
+                max_connections_per_peer,
+                || Arc::new(ConnectionStreamCounter::new()),
+            )
+        {
+            update_open_connections_stat(&self.stats, &connection_table_l);
+            drop(connection_table_l);
 
-            let max_connections_per_peer = match conn_context.peer_type() {
-                ConnectionPeerType::Unstaked => self.config.max_connections_per_unstaked_peer,
-                ConnectionPeerType::Staked(_) => self.config.max_connections_per_staked_peer,
-            };
-            if let Some((last_update, cancel_connection, stream_counter)) = connection_table_l
-                .try_add_connection(
-                    ConnectionTableKey::new(remote_addr.ip(), conn_context.remote_pubkey),
-                    remote_addr.port(),
-                    client_connection_tracker,
-                    Some(connection.clone()),
-                    conn_context.peer_type(),
-                    conn_context.last_update.clone(),
-                    max_connections_per_peer,
-                    || Arc::new(ConnectionStreamCounter::new()),
-                )
-            {
-                update_open_connections_stat(&self.stats, &connection_table_l);
-                drop(connection_table_l);
+            connection.set_max_concurrent_uni_streams(max_uni_streams);
 
-                connection.set_max_concurrent_uni_streams(max_uni_streams);
-
-                Ok((last_update, cancel_connection, stream_counter))
-            } else {
-                self.stats
-                    .connection_add_failed
-                    .fetch_add(1, Ordering::Relaxed);
-                Err(ConnectionHandlerError::ConnectionAddError)
-            }
+            Ok((last_update, cancel_connection, stream_counter))
         } else {
-            connection.close(
-                CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT.into(),
-                CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT,
-            );
             self.stats
-                .connection_add_failed_invalid_stream_count
+                .connection_add_failed
                 .fetch_add(1, Ordering::Relaxed);
-            Err(ConnectionHandlerError::MaxStreamError)
+            Err(ConnectionHandlerError::ConnectionAddError)
         }
     }
 
@@ -528,27 +534,35 @@ pub mod test {
     #[test]
     fn test_max_allowed_uni_streams() {
         assert_eq!(
-            compute_max_allowed_uni_streams(ConnectionPeerType::Unstaked, 0),
-            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS
+            compute_max_allowed_uni_streams(REFERENCE_RTT_MS, ConnectionPeerType::Unstaked, 0),
+            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS as u32
         );
         assert_eq!(
-            compute_max_allowed_uni_streams(ConnectionPeerType::Staked(10), 0),
-            QUIC_MIN_STAKED_CONCURRENT_STREAMS
+            compute_max_allowed_uni_streams(REFERENCE_RTT_MS, ConnectionPeerType::Staked(10), 0),
+            QUIC_MIN_STAKED_CONCURRENT_STREAMS as u32
         );
         let delta =
             (QUIC_TOTAL_STAKED_CONCURRENT_STREAMS - QUIC_MIN_STAKED_CONCURRENT_STREAMS) as f64;
         assert_eq!(
-            compute_max_allowed_uni_streams(ConnectionPeerType::Staked(1000), 10000),
-            QUIC_MAX_STAKED_CONCURRENT_STREAMS,
+            compute_max_allowed_uni_streams(
+                REFERENCE_RTT_MS,
+                ConnectionPeerType::Staked(1000),
+                10000
+            ),
+            QUIC_MAX_STAKED_CONCURRENT_STREAMS as u32,
         );
         assert_eq!(
-            compute_max_allowed_uni_streams(ConnectionPeerType::Staked(100), 10000),
+            compute_max_allowed_uni_streams(
+                REFERENCE_RTT_MS,
+                ConnectionPeerType::Staked(100),
+                10000
+            ),
             ((delta / (100_f64)) as usize + QUIC_MIN_STAKED_CONCURRENT_STREAMS)
-                .min(QUIC_MAX_STAKED_CONCURRENT_STREAMS)
+                .min(QUIC_MAX_STAKED_CONCURRENT_STREAMS) as u32
         );
         assert_eq!(
-            compute_max_allowed_uni_streams(ConnectionPeerType::Unstaked, 10000),
-            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS
+            compute_max_allowed_uni_streams(REFERENCE_RTT_MS, ConnectionPeerType::Unstaked, 10000),
+            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS as u32
         );
     }
 }


### PR DESCRIPTION
#### Problem
Streamer ignores RTT in all its calculations. This means that connections with high latency are heavily rate limited, **much more than the stake amount would suggest**. This happens before the actual stake-based stream throttling even has a change to kick in, and is thus very counterintuitive to the client. 

A more principled version of https://github.com/anza-xyz/agave/pull/7954

#### Some preliminary concepts:
- Sender can not have more than max_concurrent_streams worth of open streams at any time
- These together limit how many TXs can be “in flight” between client and server and not yet ACKd. Currently, these limits are computed based on stake. We need to compute them based on stake and RTT to the client (as longer RTT means you need to have more things on the wire before you see an ACK).
- Beyond all the limits mentioned above, there is an overall stream limit imposed by the code in stream_throttle.rs. That is out of scope of this PR.

**This mechanism is not intended as the actual rate limiter for complaint clients, just as a limit on network buffers and such like. This is designed to allocate more bandwidth than what you'd get today.**


#### Summary of Changes

- Assume that in the original code the RTT was expected to be ~50ms
- Scale RX window and max_streams with RTT if it is above 50ms

Whether 50ms is the right latency to pick is a good question. 50 ms was chosen as a compromise between allowing more TPS and keeping changes small.

### Impact 
Before:
<img width="640" height="480" alt="plot_old_512_bytes" src="https://github.com/user-attachments/assets/80adc209-6465-4b79-8417-ca9fc231529b" />

After:
<img width="640" height="480" alt="plot_new_512_bytes" src="https://github.com/user-attachments/assets/f638c707-6f01-4892-a354-c2e4e93cd399" />
