### PR TITLE
Update xtask version to 0.1.0 since we will never publish the xtask crate

### DIFF
--- a/ci/xtask/Cargo.lock
+++ b/ci/xtask/Cargo.lock
@@ -893,7 +893,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "xtask"
-version = "4.0.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "4.0.0-alpha.0"
+version = "0.1.0"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 description = "Blockchain, Rebuilt for Scale"
 repository = "https://github.com/anza-xyz/agave"

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -23,6 +23,7 @@ ignores=(
   .cargo
   target
   node_modules
+  ci/xtask
 )
 
 not_paths=()


### PR DESCRIPTION
### Problem
The version bump PRs increment the xtask crate version. we don't publish that crate so there's no need to increment the version number, and doing so clutters the version bumps.

## Solution
Revert xtask version to 0.1.0. 