### PR TITLE
refactor: rename the `VerifiedVote` channel types

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -58,10 +58,10 @@ pub type ThresholdConfirmedSlots = Vec<(Slot, Hash)>;
 pub type VerifiedVoteTransactionsSender = Sender<Vec<Transaction>>;
 pub type VerifiedVoteTransactionsReceiver = Receiver<Vec<Transaction>>;
 // Send side of verified voter channel.
-// Each message contains the Pubkey of the voter and the list of slots for which its votes were verified.
-pub type VerifiedVoterSender = Sender<(Pubkey, Vec<Slot>)>;
+// Each message contains the Pubkey of the voter and the slots in last verified vote.
+pub type VerifiedVoterSlotsSender = Sender<(Pubkey, Vec<Slot>)>;
 // Receive side of verified voter channel.
-pub type VerifiedVoterReceiver = Receiver<(Pubkey, Vec<Slot>)>;
+pub type VerifiedVoterSlotsReceiver = Receiver<(Pubkey, Vec<Slot>)>;
 pub type GossipVerifiedVoteHashSender = Sender<(Pubkey, Slot, Hash)>;
 pub type GossipVerifiedVoteHashReceiver = Receiver<(Pubkey, Slot, Hash)>;
 pub type DuplicateConfirmedSlotsSender = Sender<ThresholdConfirmedSlots>;
@@ -196,7 +196,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
         subscriptions: Option<Arc<RpcSubscriptions>>,
-        verified_voter_sender: VerifiedVoterSender,
+        verified_voter_slots_sender: VerifiedVoterSlotsSender,
         gossip_verified_vote_hash_sender: GossipVerifiedVoteHashSender,
         replay_votes_receiver: ReplayVoteReceiver,
         blockstore: Arc<Blockstore>,
@@ -234,7 +234,7 @@ impl ClusterInfoVoteListener {
                     dumped_slot_subscription,
                     subscriptions.as_deref(),
                     gossip_verified_vote_hash_sender,
-                    verified_voter_sender,
+                    verified_voter_slots_sender,
                     replay_votes_receiver,
                     blockstore,
                     bank_notification_sender,
@@ -322,7 +322,7 @@ impl ClusterInfoVoteListener {
         dumped_slot_subscription: DumpedSlotSubscription,
         subscriptions: Option<&RpcSubscriptions>,
         gossip_verified_vote_hash_sender: GossipVerifiedVoteHashSender,
-        verified_voter_sender: VerifiedVoterSender,
+        verified_voter_slots_sender: VerifiedVoterSlotsSender,
         replay_votes_receiver: ReplayVoteReceiver,
         blockstore: Arc<Blockstore>,
         bank_notification_sender: Option<BankNotificationSenderConfig>,
@@ -359,7 +359,7 @@ impl ClusterInfoVoteListener {
                 &root_bank,
                 subscriptions,
                 &gossip_verified_vote_hash_sender,
-                &verified_voter_sender,
+                &verified_voter_slots_sender,
                 &replay_votes_receiver,
                 &bank_notification_sender,
                 &duplicate_confirmed_slot_sender,
@@ -393,7 +393,7 @@ impl ClusterInfoVoteListener {
         root_bank: &Bank,
         subscriptions: Option<&RpcSubscriptions>,
         gossip_verified_vote_hash_sender: &GossipVerifiedVoteHashSender,
-        verified_voter_sender: &VerifiedVoterSender,
+        verified_voter_slots_sender: &VerifiedVoterSlotsSender,
         replay_votes_receiver: &ReplayVoteReceiver,
         bank_notification_sender: &Option<BankNotificationSenderConfig>,
         duplicate_confirmed_slot_sender: &Option<DuplicateConfirmedSlotsSender>,
@@ -426,7 +426,7 @@ impl ClusterInfoVoteListener {
                     root_bank,
                     subscriptions,
                     gossip_verified_vote_hash_sender,
-                    verified_voter_sender,
+                    verified_voter_slots_sender,
                     bank_notification_sender,
                     duplicate_confirmed_slot_sender,
                     vote_processing_time,
@@ -448,7 +448,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: &VoteTracker,
         root_bank: &Bank,
         rpc_subscriptions: Option<&RpcSubscriptions>,
-        verified_voter_sender: &VerifiedVoterSender,
+        verified_voter_slots_sender: &VerifiedVoterSlotsSender,
         gossip_verified_vote_hash_sender: &GossipVerifiedVoteHashSender,
         diff: &mut HashMap<Slot, HashMap<Pubkey, bool>>,
         new_optimistic_confirmed_slots: &mut ThresholdConfirmedSlots,
@@ -599,7 +599,7 @@ impl ClusterInfoVoteListener {
             if let Some(rpc_subscriptions) = rpc_subscriptions {
                 rpc_subscriptions.notify_vote(*vote_pubkey, vote, vote_transaction_signature);
             }
-            let _ = verified_voter_sender.send((*vote_pubkey, vote_slots));
+            let _ = verified_voter_slots_sender.send((*vote_pubkey, vote_slots));
         }
     }
 
@@ -611,7 +611,7 @@ impl ClusterInfoVoteListener {
         root_bank: &Bank,
         subscriptions: Option<&RpcSubscriptions>,
         gossip_verified_vote_hash_sender: &GossipVerifiedVoteHashSender,
-        verified_voter_sender: &VerifiedVoterSender,
+        verified_voter_slots_sender: &VerifiedVoterSlotsSender,
         bank_notification_sender: &Option<BankNotificationSenderConfig>,
         duplicate_confirmed_slot_sender: &Option<DuplicateConfirmedSlotsSender>,
         vote_processing_time: &mut Option<VoteProcessingTiming>,
@@ -637,7 +637,7 @@ impl ClusterInfoVoteListener {
                 vote_tracker,
                 root_bank,
                 subscriptions,
-                verified_voter_sender,
+                verified_voter_slots_sender,
                 gossip_verified_vote_hash_sender,
                 &mut diff,
                 &mut new_optimistic_confirmed_slots,
@@ -860,7 +860,7 @@ mod tests {
             ..
         } = setup();
         let (votes_sender, votes_receiver) = unbounded();
-        let (verified_voter_sender, _verified_voter_receiver) = unbounded();
+        let (verified_voter_slots_sender, _verified_voter_slots_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
         let (replay_votes_sender, replay_votes_receiver) = unbounded();
         let mut latest_vote_slot_per_validator = HashMap::new();
@@ -895,7 +895,7 @@ mod tests {
             &bank3,
             Some(&subscriptions),
             &gossip_verified_vote_hash_sender,
-            &verified_voter_sender,
+            &verified_voter_slots_sender,
             &replay_votes_receiver,
             &None,
             &None,
@@ -930,7 +930,7 @@ mod tests {
             &bank3,
             Some(&subscriptions),
             &gossip_verified_vote_hash_sender,
-            &verified_voter_sender,
+            &verified_voter_slots_sender,
             &replay_votes_receiver,
             &None,
             &None,
@@ -994,7 +994,7 @@ mod tests {
         let (votes_txs_sender, votes_txs_receiver) = unbounded();
         let (replay_votes_sender, replay_votes_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = unbounded();
-        let (verified_voter_sender, verified_voter_receiver) = unbounded();
+        let (verified_voter_slots_sender, verified_voter_slots_receiver) = unbounded();
         let mut latest_vote_slot_per_validator = HashMap::new();
         let mut bank_hash_cache = BankHashCache::new(bank_forks);
 
@@ -1024,7 +1024,7 @@ mod tests {
             &bank0,
             Some(&subscriptions),
             &gossip_verified_vote_hash_sender,
-            &verified_voter_sender,
+            &verified_voter_slots_sender,
             &replay_votes_receiver,
             &None,
             &None,
@@ -1068,14 +1068,14 @@ mod tests {
         }
 
         // Check that the received votes were pushed to other components
-        // subscribing via `verified_voter_receiver`
+        // subscribing via `verified_voter_slots_receiver`
         let all_expected_slots: BTreeSet<_> = gossip_vote_slots
             .clone()
             .into_iter()
             .chain(replay_vote_slots.clone())
             .collect();
         let mut pubkey_to_slots: HashMap<Pubkey, BTreeSet<Slot>> = HashMap::new();
-        for (received_pubkey, new_slots) in verified_voter_receiver.try_iter() {
+        for (received_pubkey, new_slots) in verified_voter_slots_receiver.try_iter() {
             let already_received_slots = pubkey_to_slots.entry(received_pubkey).or_default();
             for new_slot in new_slots {
                 // `new_slot` should only be received once
@@ -1154,12 +1154,12 @@ mod tests {
         // Send some votes to process
         let (votes_txs_sender, votes_txs_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
-        let (verified_voter_sender, verified_voter_receiver) = unbounded();
+        let (verified_voter_slots_sender, verified_voter_slots_receiver) = unbounded();
         let (_replay_votes_sender, replay_votes_receiver) = unbounded();
         let mut latest_vote_slot_per_validator = HashMap::new();
         let mut bank_hash_cache = BankHashCache::new(bank_forks);
 
-        let mut expected_votes = vec![];
+        let mut expected_voter_slots = vec![];
         let num_voters_per_slot = 2;
         let bank_hash = Hash::default();
         for (i, keyset) in validator_voting_keypairs
@@ -1171,7 +1171,7 @@ mod tests {
                 .map(|keypairs| {
                     let node_keypair = &keypairs.node_keypair;
                     let vote_keypair = &keypairs.vote_keypair;
-                    expected_votes.push((vote_keypair.pubkey(), vec![i as Slot + 1]));
+                    expected_voter_slots.push((vote_keypair.pubkey(), vec![i as Slot + 1]));
                     let tower_sync =
                         TowerSync::new_from_slots(vec![(i as u64 + 1)], bank_hash, None);
                     vote_transaction::new_tower_sync_transaction(
@@ -1194,7 +1194,7 @@ mod tests {
             &bank0,
             Some(&subscriptions),
             &gossip_verified_vote_hash_sender,
-            &verified_voter_sender,
+            &verified_voter_slots_sender,
             &replay_votes_receiver,
             &None,
             &None,
@@ -1207,10 +1207,10 @@ mod tests {
 
         // Check that the received votes were pushed to other components
         // subscribing via a channel
-        let received_voters = verified_voter_receiver.try_iter().collect::<Vec<_>>();
-        assert_eq!(received_voters.len(), validator_voting_keypairs.len());
-        for (expected_voter, received_voter) in expected_votes.iter().zip(received_voters.iter()) {
-            assert_eq!(expected_voter, received_voter);
+        let received_voter_slots = verified_voter_slots_receiver.try_iter().collect::<Vec<_>>();
+        assert_eq!(received_voter_slots.len(), validator_voting_keypairs.len());
+        for (e, r) in expected_voter_slots.iter().zip(received_voter_slots.iter()) {
+            assert_eq!(e, r);
         }
 
         // Check that all the votes were registered for each validator correctly
@@ -1241,7 +1241,7 @@ mod tests {
 
     fn run_test_process_votes3(switch_proof_hash: Option<Hash>) {
         let (votes_sender, votes_receiver) = unbounded();
-        let (verified_voter_sender, _verified_voter_receiver) = unbounded();
+        let (verified_voter_slots_sender, _verified_voter_slots_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
         let (replay_votes_sender, replay_votes_receiver): (ReplayVoteSender, ReplayVoteReceiver) =
             unbounded();
@@ -1305,7 +1305,7 @@ mod tests {
                     &bank,
                     Some(&subscriptions),
                     &gossip_verified_vote_hash_sender,
-                    &verified_voter_sender,
+                    &verified_voter_slots_sender,
                     &replay_votes_receiver,
                     &None,
                     &None,
@@ -1386,7 +1386,7 @@ mod tests {
             None,
         )];
 
-        let (verified_voter_sender, _verified_voter_receiver) = unbounded();
+        let (verified_voter_slots_sender, _verified_voter_slots_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
         ClusterInfoVoteListener::filter_and_confirm_with_new_votes(
             &vote_tracker,
@@ -1401,7 +1401,7 @@ mod tests {
             &bank,
             Some(&subscriptions),
             &gossip_verified_vote_hash_sender,
-            &verified_voter_sender,
+            &verified_voter_slots_sender,
             &None,
             &None,
             &mut None,
@@ -1450,7 +1450,7 @@ mod tests {
             &new_root_bank,
             Some(&subscriptions),
             &gossip_verified_vote_hash_sender,
-            &verified_voter_sender,
+            &verified_voter_slots_sender,
             &None,
             &None,
             &mut None,
@@ -1640,7 +1640,7 @@ mod tests {
         let mut latest_vote_slot_per_validator = HashMap::new();
         let mut bank_hash_cache = BankHashCache::new(bank_forks);
 
-        let (verified_voter_sender, _verified_voter_receiver) = unbounded();
+        let (verified_voter_slots_sender, _verified_voter_slots_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
         let mut diff = HashMap::default();
         let mut new_optimistic_confirmed_slots = vec![];
@@ -1664,7 +1664,7 @@ mod tests {
             &vote_tracker,
             &bank,
             Some(&subscriptions),
-            &verified_voter_sender,
+            &verified_voter_slots_sender,
             &gossip_verified_vote_hash_sender,
             &mut diff,
             &mut new_optimistic_confirmed_slots,
@@ -1697,7 +1697,7 @@ mod tests {
             &vote_tracker,
             &bank,
             Some(&subscriptions),
-            &verified_voter_sender,
+            &verified_voter_slots_sender,
             &gossip_verified_vote_hash_sender,
             &mut diff,
             &mut new_optimistic_confirmed_slots,

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -57,8 +57,11 @@ use {
 pub type ThresholdConfirmedSlots = Vec<(Slot, Hash)>;
 pub type VerifiedVoteTransactionsSender = Sender<Vec<Transaction>>;
 pub type VerifiedVoteTransactionsReceiver = Receiver<Vec<Transaction>>;
-pub type VerifiedVoteSender = Sender<(Pubkey, Vec<Slot>)>;
-pub type VerifiedVoteReceiver = Receiver<(Pubkey, Vec<Slot>)>;
+// Send side of verified voter channel.
+// Each message contains the Pubkey of the voter and the list of slots for which its votes were verified.
+pub type VerifiedVoterSender = Sender<(Pubkey, Vec<Slot>)>;
+// Receive side of verified voter channel.
+pub type VerifiedVoterReceiver = Receiver<(Pubkey, Vec<Slot>)>;
 pub type GossipVerifiedVoteHashSender = Sender<(Pubkey, Slot, Hash)>;
 pub type GossipVerifiedVoteHashReceiver = Receiver<(Pubkey, Slot, Hash)>;
 pub type DuplicateConfirmedSlotsSender = Sender<ThresholdConfirmedSlots>;
@@ -193,7 +196,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
         subscriptions: Option<Arc<RpcSubscriptions>>,
-        verified_vote_sender: VerifiedVoteSender,
+        verified_voter_sender: VerifiedVoterSender,
         gossip_verified_vote_hash_sender: GossipVerifiedVoteHashSender,
         replay_votes_receiver: ReplayVoteReceiver,
         blockstore: Arc<Blockstore>,
@@ -231,7 +234,7 @@ impl ClusterInfoVoteListener {
                     dumped_slot_subscription,
                     subscriptions.as_deref(),
                     gossip_verified_vote_hash_sender,
-                    verified_vote_sender,
+                    verified_voter_sender,
                     replay_votes_receiver,
                     blockstore,
                     bank_notification_sender,
@@ -319,7 +322,7 @@ impl ClusterInfoVoteListener {
         dumped_slot_subscription: DumpedSlotSubscription,
         subscriptions: Option<&RpcSubscriptions>,
         gossip_verified_vote_hash_sender: GossipVerifiedVoteHashSender,
-        verified_vote_sender: VerifiedVoteSender,
+        verified_voter_sender: VerifiedVoterSender,
         replay_votes_receiver: ReplayVoteReceiver,
         blockstore: Arc<Blockstore>,
         bank_notification_sender: Option<BankNotificationSenderConfig>,
@@ -356,7 +359,7 @@ impl ClusterInfoVoteListener {
                 &root_bank,
                 subscriptions,
                 &gossip_verified_vote_hash_sender,
-                &verified_vote_sender,
+                &verified_voter_sender,
                 &replay_votes_receiver,
                 &bank_notification_sender,
                 &duplicate_confirmed_slot_sender,
@@ -390,7 +393,7 @@ impl ClusterInfoVoteListener {
         root_bank: &Bank,
         subscriptions: Option<&RpcSubscriptions>,
         gossip_verified_vote_hash_sender: &GossipVerifiedVoteHashSender,
-        verified_vote_sender: &VerifiedVoteSender,
+        verified_voter_sender: &VerifiedVoterSender,
         replay_votes_receiver: &ReplayVoteReceiver,
         bank_notification_sender: &Option<BankNotificationSenderConfig>,
         duplicate_confirmed_slot_sender: &Option<DuplicateConfirmedSlotsSender>,
@@ -423,7 +426,7 @@ impl ClusterInfoVoteListener {
                     root_bank,
                     subscriptions,
                     gossip_verified_vote_hash_sender,
-                    verified_vote_sender,
+                    verified_voter_sender,
                     bank_notification_sender,
                     duplicate_confirmed_slot_sender,
                     vote_processing_time,
@@ -445,7 +448,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: &VoteTracker,
         root_bank: &Bank,
         rpc_subscriptions: Option<&RpcSubscriptions>,
-        verified_vote_sender: &VerifiedVoteSender,
+        verified_voter_sender: &VerifiedVoterSender,
         gossip_verified_vote_hash_sender: &GossipVerifiedVoteHashSender,
         diff: &mut HashMap<Slot, HashMap<Pubkey, bool>>,
         new_optimistic_confirmed_slots: &mut ThresholdConfirmedSlots,
@@ -596,7 +599,7 @@ impl ClusterInfoVoteListener {
             if let Some(rpc_subscriptions) = rpc_subscriptions {
                 rpc_subscriptions.notify_vote(*vote_pubkey, vote, vote_transaction_signature);
             }
-            let _ = verified_vote_sender.send((*vote_pubkey, vote_slots));
+            let _ = verified_voter_sender.send((*vote_pubkey, vote_slots));
         }
     }
 
@@ -608,7 +611,7 @@ impl ClusterInfoVoteListener {
         root_bank: &Bank,
         subscriptions: Option<&RpcSubscriptions>,
         gossip_verified_vote_hash_sender: &GossipVerifiedVoteHashSender,
-        verified_vote_sender: &VerifiedVoteSender,
+        verified_voter_sender: &VerifiedVoterSender,
         bank_notification_sender: &Option<BankNotificationSenderConfig>,
         duplicate_confirmed_slot_sender: &Option<DuplicateConfirmedSlotsSender>,
         vote_processing_time: &mut Option<VoteProcessingTiming>,
@@ -634,7 +637,7 @@ impl ClusterInfoVoteListener {
                 vote_tracker,
                 root_bank,
                 subscriptions,
-                verified_vote_sender,
+                verified_voter_sender,
                 gossip_verified_vote_hash_sender,
                 &mut diff,
                 &mut new_optimistic_confirmed_slots,
@@ -857,7 +860,7 @@ mod tests {
             ..
         } = setup();
         let (votes_sender, votes_receiver) = unbounded();
-        let (verified_vote_sender, _verified_vote_receiver) = unbounded();
+        let (verified_voter_sender, _verified_voter_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
         let (replay_votes_sender, replay_votes_receiver) = unbounded();
         let mut latest_vote_slot_per_validator = HashMap::new();
@@ -892,7 +895,7 @@ mod tests {
             &bank3,
             Some(&subscriptions),
             &gossip_verified_vote_hash_sender,
-            &verified_vote_sender,
+            &verified_voter_sender,
             &replay_votes_receiver,
             &None,
             &None,
@@ -927,7 +930,7 @@ mod tests {
             &bank3,
             Some(&subscriptions),
             &gossip_verified_vote_hash_sender,
-            &verified_vote_sender,
+            &verified_voter_sender,
             &replay_votes_receiver,
             &None,
             &None,
@@ -991,7 +994,7 @@ mod tests {
         let (votes_txs_sender, votes_txs_receiver) = unbounded();
         let (replay_votes_sender, replay_votes_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = unbounded();
-        let (verified_vote_sender, verified_vote_receiver) = unbounded();
+        let (verified_voter_sender, verified_voter_receiver) = unbounded();
         let mut latest_vote_slot_per_validator = HashMap::new();
         let mut bank_hash_cache = BankHashCache::new(bank_forks);
 
@@ -1021,7 +1024,7 @@ mod tests {
             &bank0,
             Some(&subscriptions),
             &gossip_verified_vote_hash_sender,
-            &verified_vote_sender,
+            &verified_voter_sender,
             &replay_votes_receiver,
             &None,
             &None,
@@ -1065,24 +1068,24 @@ mod tests {
         }
 
         // Check that the received votes were pushed to other components
-        // subscribing via `verified_vote_receiver`
+        // subscribing via `verified_voter_receiver`
         let all_expected_slots: BTreeSet<_> = gossip_vote_slots
             .clone()
             .into_iter()
             .chain(replay_vote_slots.clone())
             .collect();
-        let mut pubkey_to_votes: HashMap<Pubkey, BTreeSet<Slot>> = HashMap::new();
-        for (received_pubkey, new_votes) in verified_vote_receiver.try_iter() {
-            let already_received_votes = pubkey_to_votes.entry(received_pubkey).or_default();
-            for new_vote in new_votes {
-                // `new_vote` should only be received once
-                assert!(already_received_votes.insert(new_vote));
+        let mut pubkey_to_slots: HashMap<Pubkey, BTreeSet<Slot>> = HashMap::new();
+        for (received_pubkey, new_slots) in verified_voter_receiver.try_iter() {
+            let already_received_slots = pubkey_to_slots.entry(received_pubkey).or_default();
+            for new_slot in new_slots {
+                // `new_slot` should only be received once
+                assert!(already_received_slots.insert(new_slot));
             }
         }
-        assert_eq!(pubkey_to_votes.len(), validator_voting_keypairs.len());
+        assert_eq!(pubkey_to_slots.len(), validator_voting_keypairs.len());
         for keypairs in &validator_voting_keypairs {
             assert_eq!(
-                *pubkey_to_votes
+                *pubkey_to_slots
                     .get(&keypairs.vote_keypair.pubkey())
                     .unwrap(),
                 all_expected_slots
@@ -1151,7 +1154,7 @@ mod tests {
         // Send some votes to process
         let (votes_txs_sender, votes_txs_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
-        let (verified_vote_sender, verified_vote_receiver) = unbounded();
+        let (verified_voter_sender, verified_voter_receiver) = unbounded();
         let (_replay_votes_sender, replay_votes_receiver) = unbounded();
         let mut latest_vote_slot_per_validator = HashMap::new();
         let mut bank_hash_cache = BankHashCache::new(bank_forks);
@@ -1191,7 +1194,7 @@ mod tests {
             &bank0,
             Some(&subscriptions),
             &gossip_verified_vote_hash_sender,
-            &verified_vote_sender,
+            &verified_voter_sender,
             &replay_votes_receiver,
             &None,
             &None,
@@ -1204,12 +1207,10 @@ mod tests {
 
         // Check that the received votes were pushed to other components
         // subscribing via a channel
-        let received_votes: Vec<_> = verified_vote_receiver.try_iter().collect();
-        assert_eq!(received_votes.len(), validator_voting_keypairs.len());
-        for (expected_pubkey_vote, received_pubkey_vote) in
-            expected_votes.iter().zip(received_votes.iter())
-        {
-            assert_eq!(expected_pubkey_vote, received_pubkey_vote);
+        let received_voters = verified_voter_receiver.try_iter().collect::<Vec<_>>();
+        assert_eq!(received_voters.len(), validator_voting_keypairs.len());
+        for (expected_voter, received_voter) in expected_votes.iter().zip(received_voters.iter()) {
+            assert_eq!(expected_voter, received_voter);
         }
 
         // Check that all the votes were registered for each validator correctly
@@ -1240,7 +1241,7 @@ mod tests {
 
     fn run_test_process_votes3(switch_proof_hash: Option<Hash>) {
         let (votes_sender, votes_receiver) = unbounded();
-        let (verified_vote_sender, _verified_vote_receiver) = unbounded();
+        let (verified_voter_sender, _verified_voter_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
         let (replay_votes_sender, replay_votes_receiver): (ReplayVoteSender, ReplayVoteReceiver) =
             unbounded();
@@ -1304,7 +1305,7 @@ mod tests {
                     &bank,
                     Some(&subscriptions),
                     &gossip_verified_vote_hash_sender,
-                    &verified_vote_sender,
+                    &verified_voter_sender,
                     &replay_votes_receiver,
                     &None,
                     &None,
@@ -1385,7 +1386,7 @@ mod tests {
             None,
         )];
 
-        let (verified_vote_sender, _verified_vote_receiver) = unbounded();
+        let (verified_voter_sender, _verified_voter_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
         ClusterInfoVoteListener::filter_and_confirm_with_new_votes(
             &vote_tracker,
@@ -1400,7 +1401,7 @@ mod tests {
             &bank,
             Some(&subscriptions),
             &gossip_verified_vote_hash_sender,
-            &verified_vote_sender,
+            &verified_voter_sender,
             &None,
             &None,
             &mut None,
@@ -1449,7 +1450,7 @@ mod tests {
             &new_root_bank,
             Some(&subscriptions),
             &gossip_verified_vote_hash_sender,
-            &verified_vote_sender,
+            &verified_voter_sender,
             &None,
             &None,
             &mut None,
@@ -1639,7 +1640,7 @@ mod tests {
         let mut latest_vote_slot_per_validator = HashMap::new();
         let mut bank_hash_cache = BankHashCache::new(bank_forks);
 
-        let (verified_vote_sender, _verified_vote_receiver) = unbounded();
+        let (verified_voter_sender, _verified_voter_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
         let mut diff = HashMap::default();
         let mut new_optimistic_confirmed_slots = vec![];
@@ -1663,7 +1664,7 @@ mod tests {
             &vote_tracker,
             &bank,
             Some(&subscriptions),
-            &verified_vote_sender,
+            &verified_voter_sender,
             &gossip_verified_vote_hash_sender,
             &mut diff,
             &mut new_optimistic_confirmed_slots,
@@ -1696,7 +1697,7 @@ mod tests {
             &vote_tracker,
             &bank,
             Some(&subscriptions),
-            &verified_vote_sender,
+            &verified_voter_sender,
             &gossip_verified_vote_hash_sender,
             &mut diff,
             &mut new_optimistic_confirmed_slots,

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -3,7 +3,7 @@
 use {
     super::standard_repair_handler::StandardRepairHandler,
     crate::{
-        cluster_info_vote_listener::VerifiedVoteReceiver,
+        cluster_info_vote_listener::VerifiedVoterReceiver,
         cluster_slots_service::cluster_slots::ClusterSlots,
         repair::{
             ancestor_hashes_service::{
@@ -203,7 +203,7 @@ pub struct RepairTiming {
     pub set_root_elapsed: u64,
     pub dump_slots_elapsed: u64,
     pub get_votes_elapsed: u64,
-    pub add_votes_elapsed: u64,
+    pub add_voters_elapsed: u64,
     pub purge_outstanding_repairs: u64,
     pub handle_popular_pruned_forks: u64,
     pub get_best_orphans_elapsed: u64,
@@ -222,7 +222,7 @@ impl RepairTiming {
             ("set-root-elapsed", self.set_root_elapsed, i64),
             ("dump-slots-elapsed", self.dump_slots_elapsed, i64),
             ("get-votes-elapsed", self.get_votes_elapsed, i64),
-            ("add-votes-elapsed", self.add_votes_elapsed, i64),
+            ("add-voters-elapsed", self.add_voters_elapsed, i64),
             (
                 "purge-outstanding-repairs",
                 self.purge_outstanding_repairs,
@@ -384,7 +384,7 @@ impl Default for RepairSlotRange {
 
 struct RepairChannels {
     repair_request_quic_sender: AsyncSender<(SocketAddr, Bytes)>,
-    verified_vote_receiver: VerifiedVoteReceiver,
+    verified_voter_receiver: VerifiedVoterReceiver,
     dumped_slots_receiver: DumpedSlotsReceiver,
     popular_pruned_forks_sender: PopularPrunedForksSender,
 }
@@ -397,7 +397,7 @@ pub struct RepairServiceChannels {
 impl RepairServiceChannels {
     pub fn new(
         repair_request_quic_sender: AsyncSender<(SocketAddr, Bytes)>,
-        verified_vote_receiver: VerifiedVoteReceiver,
+        verified_voter_receiver: VerifiedVoterReceiver,
         dumped_slots_receiver: DumpedSlotsReceiver,
         popular_pruned_forks_sender: PopularPrunedForksSender,
         ancestor_hashes_request_quic_sender: AsyncSender<(SocketAddr, Bytes)>,
@@ -407,7 +407,7 @@ impl RepairServiceChannels {
         Self {
             repair_channels: RepairChannels {
                 repair_request_quic_sender,
-                verified_vote_receiver,
+                verified_voter_receiver,
                 dumped_slots_receiver,
                 popular_pruned_forks_sender,
             },
@@ -485,7 +485,7 @@ impl RepairService {
         repair_weight: &mut RepairWeight,
         popular_pruned_forks_requests: &mut HashSet<Slot>,
         dumped_slots_receiver: &DumpedSlotsReceiver,
-        verified_vote_receiver: &VerifiedVoteReceiver,
+        verified_voter_receiver: &VerifiedVoterReceiver,
         repair_metrics: &mut RepairMetrics,
     ) {
         // Purge outdated slots from the weighting heuristic
@@ -526,7 +526,7 @@ impl RepairService {
         // Add new votes to the weighting heuristic
         let mut get_votes_elapsed = Measure::start("get_votes_elapsed");
         let mut slot_to_vote_pubkeys: HashMap<Slot, Vec<Pubkey>> = HashMap::new();
-        verified_vote_receiver
+        verified_voter_receiver
             .try_iter()
             .for_each(|(vote_pubkey, vote_slots)| {
                 for slot in vote_slots {
@@ -538,19 +538,19 @@ impl RepairService {
             });
         get_votes_elapsed.stop();
 
-        let mut add_votes_elapsed = Measure::start("add_votes");
-        repair_weight.add_votes(
+        let mut add_voters_elapsed = Measure::start("add_voters");
+        repair_weight.add_voters(
             blockstore,
             slot_to_vote_pubkeys.into_iter(),
             root_bank.epoch_stakes_map(),
             root_bank.epoch_schedule(),
         );
-        add_votes_elapsed.stop();
+        add_voters_elapsed.stop();
 
         repair_metrics.timing.set_root_elapsed += set_root_elapsed.as_us();
         repair_metrics.timing.dump_slots_elapsed += dump_slots_elapsed.as_us();
         repair_metrics.timing.get_votes_elapsed += get_votes_elapsed.as_us();
-        repair_metrics.timing.add_votes_elapsed += add_votes_elapsed.as_us();
+        repair_metrics.timing.add_voters_elapsed += add_voters_elapsed.as_us();
     }
 
     fn identify_repairs(
@@ -690,7 +690,7 @@ impl RepairService {
     ) {
         let RepairChannels {
             repair_request_quic_sender,
-            verified_vote_receiver,
+            verified_voter_receiver,
             dumped_slots_receiver,
             popular_pruned_forks_sender,
         } = repair_channels;
@@ -711,7 +711,7 @@ impl RepairService {
             repair_weight,
             popular_pruned_forks_requests,
             dumped_slots_receiver,
-            verified_vote_receiver,
+            verified_voter_receiver,
             repair_metrics,
         );
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -12,7 +12,7 @@ use {
         banking_trace::{Channels, TracerThread},
         cluster_info_vote_listener::{
             ClusterInfoVoteListener, DuplicateConfirmedSlotsSender, GossipVerifiedVoteHashSender,
-            VerifiedVoterSender, VoteTracker,
+            VerifiedVoterSlotsSender, VoteTracker,
         },
         fetch_stage::FetchStage,
         forwarding_stage::{
@@ -139,7 +139,7 @@ impl Tpu {
         shred_version: u16,
         vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
-        verified_voter_sender: VerifiedVoterSender,
+        verified_voter_slots_sender: VerifiedVoterSlotsSender,
         gossip_verified_vote_hash_sender: GossipVerifiedVoteHashSender,
         replay_vote_receiver: ReplayVoteReceiver,
         replay_vote_sender: ReplayVoteSender,
@@ -324,7 +324,7 @@ impl Tpu {
             vote_tracker,
             bank_forks.clone(),
             subscriptions,
-            verified_voter_sender,
+            verified_voter_slots_sender,
             gossip_verified_vote_hash_sender,
             replay_vote_receiver,
             blockstore.clone(),

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -12,7 +12,7 @@ use {
         banking_trace::{Channels, TracerThread},
         cluster_info_vote_listener::{
             ClusterInfoVoteListener, DuplicateConfirmedSlotsSender, GossipVerifiedVoteHashSender,
-            VerifiedVoteSender, VoteTracker,
+            VerifiedVoterSender, VoteTracker,
         },
         fetch_stage::FetchStage,
         forwarding_stage::{
@@ -139,7 +139,7 @@ impl Tpu {
         shred_version: u16,
         vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
-        verified_vote_sender: VerifiedVoteSender,
+        verified_voter_sender: VerifiedVoterSender,
         gossip_verified_vote_hash_sender: GossipVerifiedVoteHashSender,
         replay_vote_receiver: ReplayVoteReceiver,
         replay_vote_sender: ReplayVoteSender,
@@ -324,7 +324,7 @@ impl Tpu {
             vote_tracker,
             bank_forks.clone(),
             subscriptions,
-            verified_vote_sender,
+            verified_voter_sender,
             gossip_verified_vote_hash_sender,
             replay_vote_receiver,
             blockstore.clone(),

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -5,8 +5,8 @@ use {
     crate::{
         banking_trace::BankingTracer,
         cluster_info_vote_listener::{
-            DuplicateConfirmedSlotsReceiver, GossipVerifiedVoteHashReceiver, VerifiedVoterReceiver,
-            VoteTracker,
+            DuplicateConfirmedSlotsReceiver, GossipVerifiedVoteHashReceiver,
+            VerifiedVoterSlotsReceiver, VoteTracker,
         },
         cluster_slots_service::{cluster_slots::ClusterSlots, ClusterSlotsService},
         completed_data_sets_service::CompletedDataSetsSender,
@@ -149,7 +149,7 @@ impl Tvu {
         vote_tracker: Arc<VoteTracker>,
         retransmit_slots_sender: Sender<Slot>,
         gossip_verified_vote_hash_receiver: GossipVerifiedVoteHashReceiver,
-        verified_voter_receiver: VerifiedVoterReceiver,
+        verified_voter_slots_receiver: VerifiedVoterSlotsReceiver,
         replay_vote_sender: ReplayVoteSender,
         completed_data_sets_sender: Option<CompletedDataSetsSender>,
         bank_notification_sender: Option<BankNotificationSenderConfig>,
@@ -259,7 +259,7 @@ impl Tvu {
             };
             let repair_service_channels = RepairServiceChannels::new(
                 repair_request_quic_sender,
-                verified_voter_receiver,
+                verified_voter_slots_receiver,
                 dumped_slots_receiver,
                 popular_pruned_forks_sender,
                 ancestor_hashes_request_quic_sender,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -5,7 +5,7 @@ use {
     crate::{
         banking_trace::BankingTracer,
         cluster_info_vote_listener::{
-            DuplicateConfirmedSlotsReceiver, GossipVerifiedVoteHashReceiver, VerifiedVoteReceiver,
+            DuplicateConfirmedSlotsReceiver, GossipVerifiedVoteHashReceiver, VerifiedVoterReceiver,
             VoteTracker,
         },
         cluster_slots_service::{cluster_slots::ClusterSlots, ClusterSlotsService},
@@ -149,7 +149,7 @@ impl Tvu {
         vote_tracker: Arc<VoteTracker>,
         retransmit_slots_sender: Sender<Slot>,
         gossip_verified_vote_hash_receiver: GossipVerifiedVoteHashReceiver,
-        verified_vote_receiver: VerifiedVoteReceiver,
+        verified_voter_receiver: VerifiedVoterReceiver,
         replay_vote_sender: ReplayVoteSender,
         completed_data_sets_sender: Option<CompletedDataSetsSender>,
         bank_notification_sender: Option<BankNotificationSenderConfig>,
@@ -259,7 +259,7 @@ impl Tvu {
             };
             let repair_service_channels = RepairServiceChannels::new(
                 repair_request_quic_sender,
-                verified_vote_receiver,
+                verified_voter_receiver,
                 dumped_slots_receiver,
                 popular_pruned_forks_sender,
                 ancestor_hashes_request_quic_sender,


### PR DESCRIPTION
#### Problem
`VerifiedVoteSender` and `VerifiedVoteReceiver` are poorly named.  The channels are not sending verified votes but actually sending information the slots in which a voter voted and that was verified.  This type and the associated variable names in the code cause quite a bit of confusion.

#### Summary of Changes

- renames `VerifiedVoteSender` to `VerifiedVoterSender`
- renames `VerifiedVoteReceiver` to `VerifiedVoterReceiver`
- renames the associated variables

I know generally speaking renaming stuff is bad practice as it can makes it harder to parse git history.  I hope this change will still be accepted as it has caused me confusion more than once.  And a bunch of the code in this space is in flux due to the ongoing work on Alpenglow and repair.