### PR TITLE
Removes extra startup accounts index flush threads

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6474,8 +6474,7 @@ impl AccountsDb {
         }
         let num_storages = storages.len();
 
-        self.accounts_index
-            .set_startup(Startup::StartupWithExtraThreads);
+        self.accounts_index.set_startup(Startup::Startup);
         let storage_info = StorageSizeAndCountMap::default();
 
         /// Accumulator for the values produced while generating the index

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1740,13 +1740,7 @@ pub(crate) enum Startup {
     Normal,
     /// startup (not steady state execution)
     /// requesting 'startup'-like behavior where in-mem acct idx items are flushed asap
-    #[cfg(test)]
     Startup,
-    /// startup (not steady state execution)
-    /// but also requesting additional threads to be running to flush the acct idx to disk asap
-    /// The idea is that the best perf to ssds will be with multiple threads,
-    ///  but during steady state, we can't allocate as many threads because we'd starve the rest of the system.
-    StartupWithExtraThreads,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem

At startup, when the accounts disk index is enabled, we spin up another set of background threads to flush index entries to disk.

These extra threads no longer are beneficial. Note also that we also have num_cores-worth of threads for generating the index (scanning the storages, computing the lt hash), so all additional threads may be stealing resources.

<img width="1821" height="1665" alt="Screenshot 2025-11-06 at 1 47 16 PM" src="https://github.com/user-attachments/assets/ff7bca36-b075-48b1-a5f2-92cbe33a5298" />
In the image (of master) above we can see a few things:
1. The num_cores-worth of threads for generating the index. I.e. `solGenIndex63`
2. The `solIdxFlusher` threads, and the duplicates/extra
3. The large time gaps where the flusher threads are not busy
4. Dips in the `solGenIndex` threads while the flusher threads are busy -- I believe this indicates cpu resource contention, and the flushing stealing from generating the index.
5. The highlighted line, on `wait_timeout`, which is 8.1%


#### Summary of Changes

Remove the extra startup flush threads.

On my dev box I compared this PR to master for startup time, on mnb, and noticed that master finished building the index in 30-32 seconds, whereas this PR took 28-30 seconds. So this PR was a bit faster, anecdotally. May be attributed by lower resource contention, or just per run variation.

Here's the slowlana profile of this PR. Note:
1. Extra threads are no longer present
2. Non-busy gaps in the flusher threads are reduced
3. The highlighted line, on `wait_timeout`, has reduced to 1.2%
<img width="2400" height="1713" alt="Screenshot 2025-11-06 at 1 47 48 PM" src="https://github.com/user-attachments/assets/5caef431-e798-4513-a38e-428eb9c0018f" />