### PR TITLE
Adds rust-2024 lints to votor crate

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -1624,11 +1624,14 @@ mod tests {
             .unwrap();
         }
         assert_eq!(new_events.len(), 1);
-        if let VotorEvent::SafeToNotar((event_slot, event_block_id)) = new_events[0] {
-            assert_eq!(block_id, event_block_id);
-            assert_eq!(slot, event_slot);
-        } else {
-            panic!("Expected SafeToNotar event");
+        match new_events[0] {
+            VotorEvent::SafeToNotar((event_slot, event_block_id)) => {
+                assert_eq!(block_id, event_block_id);
+                assert_eq!(slot, event_slot);
+            }
+            _ => {
+                panic!("Expected SafeToNotar event");
+            }
         }
         new_events.clear();
 
@@ -1679,16 +1682,20 @@ mod tests {
             .unwrap();
         }
         assert_eq!(new_events.len(), 2);
-        if let VotorEvent::SafeToSkip(event_slot) = new_events[0] {
-            assert_eq!(slot, event_slot);
-        } else {
-            panic!("Expected SafeToSkip event");
+        match new_events[0] {
+            VotorEvent::SafeToSkip(event_slot) => {
+                assert_eq!(slot, event_slot);
+            }
+            _ => {
+                panic!("Expected SafeToSkip event");
+            }
         }
-        if let VotorEvent::SafeToNotar((event_slot, event_block_id)) = new_events[1] {
-            assert_eq!(block_id, event_block_id);
-            assert_eq!(slot, event_slot);
-        } else {
-            panic!("Expected SafeToNotar event");
+        match new_events[1] {
+            VotorEvent::SafeToNotar((event_slot, event_block_id)) => {
+                assert_eq!(block_id, event_block_id);
+                assert_eq!(slot, event_slot);
+            }
+            _ => panic!("Expected SafeToNotar event"),
         }
         new_events.clear();
 
@@ -1709,11 +1716,12 @@ mod tests {
         }
 
         assert_eq!(new_events.len(), 1);
-        if let VotorEvent::SafeToNotar((event_slot, event_block_id)) = new_events[0] {
-            assert_eq!(duplicate_block_id, event_block_id);
-            assert_eq!(slot, event_slot);
-        } else {
-            panic!("Expected SafeToNotar event");
+        match new_events[0] {
+            VotorEvent::SafeToNotar((event_slot, event_block_id)) => {
+                assert_eq!(duplicate_block_id, event_block_id);
+                assert_eq!(slot, event_slot);
+            }
+            _ => panic!("Expected SafeToNotar event"),
         }
     }
 
@@ -1754,10 +1762,9 @@ mod tests {
             .unwrap();
         }
         assert_eq!(new_events.len(), 1);
-        if let VotorEvent::SafeToSkip(event_slot) = new_events[0] {
-            assert_eq!(slot, event_slot);
-        } else {
-            panic!("Expected SafeToSkip event");
+        match new_events[0] {
+            VotorEvent::SafeToSkip(event_slot) => assert_eq!(slot, event_slot),
+            _ => panic!("Expected SafeToSkip event"),
         }
         new_events.clear();
         // Add 10% more notarize, will not send new SafeToSkip because the event was already sent

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -524,7 +524,8 @@ mod tests {
         let start = Instant::now();
         let mut event_received = false;
         while start.elapsed() < Duration::from_secs(5) {
-            if let Ok(event) = receiver.recv_timeout(Duration::from_millis(500)) {
+            let res = receiver.recv_timeout(Duration::from_millis(500));
+            if let Ok(event) = res {
                 if condition(&event) {
                     event_received = true;
                     break;

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -239,11 +239,11 @@ impl EventHandler {
     ) -> Result<Vec<BLSOp>, EventLoopError> {
         let mut votes = vec![];
         let LocalContext {
-            ref mut my_pubkey,
-            ref mut pending_blocks,
-            ref mut finalized_blocks,
-            ref mut received_shred,
-            ref mut stats,
+            my_pubkey,
+            pending_blocks,
+            finalized_blocks,
+            received_shred,
+            stats,
         } = local_context;
         match event {
             // Block has completed replay

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -8,6 +8,15 @@
     )
 )]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+// Activate some of the Rust 2024 lints to make the future migration easier.
+#![warn(if_let_rescope)]
+#![warn(keyword_idents_2024)]
+#![warn(missing_unsafe_on_extern)]
+#![warn(rust_2024_guarded_string_incompatible_syntax)]
+#![warn(rust_2024_incompatible_pat)]
+#![warn(tail_expr_drop_order)]
+#![warn(unsafe_attr_outside_unsafe)]
+#![warn(unsafe_op_in_unsafe_fn)]
 
 #[macro_use]
 extern crate log;

--- a/votor/src/timer_manager.rs
+++ b/votor/src/timer_manager.rs
@@ -82,7 +82,8 @@ mod tests {
         let mut timeouts_received = 0;
         while timeouts_received < 2 && Instant::now().duration_since(start) < Duration::from_secs(2)
         {
-            if let Ok(event) = event_receiver.recv_timeout(Duration::from_millis(200)) {
+            let res = event_receiver.recv_timeout(Duration::from_millis(200));
+            if let Ok(event) = res {
                 match event {
                     VotorEvent::Timeout(s) => {
                         assert_eq!(s, slot);

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -128,7 +128,7 @@ impl VoteHistory {
     pub fn votes_cast_since(&self, slot: Slot) -> Vec<Vote> {
         self.votes_cast
             .iter()
-            .filter(|(&s, _)| s > slot)
+            .filter(|(s, _)| s > &&slot)
             .flat_map(|(_, votes)| votes.iter())
             .cloned()
             .collect()

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -360,6 +360,9 @@ mod tests {
 
         let my_keys = &validator_keypairs[my_index];
         let sharable_banks = bank_forks.read().unwrap().sharable_banks();
+        let (bls_sender, _bls_receiver) = unbounded();
+        let (commitment_sender, _commitment_receiver) = unbounded();
+        let (consensus_metrics_sender, _consensus_metrics_receiver) = unbounded();
         VotingContext {
             vote_history: VoteHistory::new(my_keys.node_keypair.pubkey(), 0),
             vote_account_pubkey: my_keys.vote_keypair.pubkey(),
@@ -370,11 +373,11 @@ mod tests {
             derived_bls_keypairs: HashMap::new(),
             has_new_vote_been_rooted: false,
             own_vote_sender,
-            bls_sender: unbounded().0,
-            commitment_sender: unbounded().0,
+            bls_sender,
+            commitment_sender,
             wait_to_vote_slot: None,
             sharable_banks,
-            consensus_metrics_sender: unbounded().0,
+            consensus_metrics_sender,
         }
     }
 


### PR DESCRIPTION
#### Problem

We want to update to rust 2024 edition (see #6203). But until then, we could still add 2024-incompatible code.

#### Summary of Changes

Add lints to the votor crate for rust 2024.

Also see https://github.com/anza-xyz/agave/pull/8898.