### PR TITLE
Removing full snapshot slot file

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2534,15 +2534,5 @@ mod tests {
         .unwrap();
         let bank_snapshot = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
         assert_eq!(bank_snapshot.slot, highest_bank_snapshot.slot - 1);
-
-        // 6. delete the full snapshot slot file, get_highest_loadable() should return return Some() again, with slot-1
-        fs::remove_file(
-            bank_snapshot
-                .snapshot_dir
-                .join(snapshot_paths::SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME),
-        )
-        .unwrap();
-        let bank_snapshot2 = get_highest_loadable_bank_snapshot(&snapshot_config).unwrap();
-        assert_eq!(bank_snapshot2, bank_snapshot);
     }
 }

--- a/snapshots/src/paths.rs
+++ b/snapshots/src/paths.rs
@@ -21,14 +21,10 @@ use {
 pub const SNAPSHOT_STATUS_CACHE_FILENAME: &str = "status_cache";
 pub const SNAPSHOT_VERSION_FILENAME: &str = "version";
 pub const SNAPSHOT_FASTBOOT_VERSION_FILENAME: &str = "fastboot_version";
-/// No longer checked in version v3.1. Can be removed in v3.2
-pub const SNAPSHOT_STATE_COMPLETE_FILENAME: &str = "state_complete";
 pub const SNAPSHOT_STORAGES_FLUSHED_FILENAME: &str = "storages_flushed";
 pub const SNAPSHOT_ACCOUNTS_HARDLINKS: &str = "accounts_hardlinks";
 pub const SNAPSHOT_ARCHIVE_DOWNLOAD_DIR: &str = "remote";
 pub const SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME: &str = "obsolete_accounts";
-/// No longer checked in version v3.1. Can be removed in v3.2
-pub const SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME: &str = "full_snapshot_slot";
 /// When a snapshot is taken of a bank, the state is serialized under this directory.
 /// Specifically in `BANK_SNAPSHOTS_DIR/SLOT/`.
 /// This is also where the bank state is located in the snapshot archive.


### PR DESCRIPTION
#### Problem
Full snapshot slot file is no longer per comment /// No longer checked in version v3.1. Can be removed in v3.2

#### Summary of Changes
- Remove full snapshot slot file entirely

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
