### PR TITLE
feat(scheduling-utils): expose client/server session setup fns

### DIFF
--- a/scheduling-utils/src/handshake/client.rs
+++ b/scheduling-utils/src/handshake/client.rs
@@ -132,7 +132,7 @@ fn recv_response(stream: &mut UnixStream) -> Result<Vec<i32>, ClientHandshakeErr
     Ok(fds)
 }
 
-fn setup_session(
+pub fn setup_session(
     logon: &ClientLogon,
     fds: Vec<i32>,
 ) -> Result<ClientSession, ClientHandshakeError> {

--- a/scheduling-utils/src/handshake/server.rs
+++ b/scheduling-utils/src/handshake/server.rs
@@ -145,7 +145,9 @@ impl Server {
         Ok(logon)
     }
 
-    fn setup_session(logon: ClientLogon) -> Result<(AgaveSession, Vec<File>), AgaveHandshakeError> {
+    pub fn setup_session(
+        logon: ClientLogon,
+    ) -> Result<(AgaveSession, Vec<File>), AgaveHandshakeError> {
         // Setup the allocator in shared memory (`worker_count` & `allocator_handles` have been
         // validated so this won't panic).
         let (allocator_file, tpu_to_pack_allocator) = Self::create_allocator(&logon)?;


### PR DESCRIPTION
#### Problem

- For external scheduler implementations it can be desirable to construct client/server sessions locally.

#### Summary of Changes

- Expose this capability in the crates API.
