### PR TITLE
Uses AHasher in Bucket::bucket_index_ix()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7557,6 +7557,7 @@ name = "solana-bucket-map"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-logger",
+ "ahash 0.8.11",
  "bv",
  "bytemuck",
  "bytemuck_derive",

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -18,6 +18,7 @@ agave-unstable-api = []
 dev-context-only-utils = []
 
 [dependencies]
+ahash = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true }
 bytemuck_derive = { workspace = true }

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -15,11 +15,11 @@ use {
         restart::RestartableBucket,
         MaxSearch, RefCount,
     },
+    ahash::AHasher,
     rand::{thread_rng, Rng},
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
     std::{
-        collections::hash_map::DefaultHasher,
         fs,
         hash::{Hash, Hasher},
         num::NonZeroU64,
@@ -822,7 +822,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
     }
 
     fn bucket_index_ix(key: &Pubkey, random: u64) -> u64 {
-        let mut s = DefaultHasher::new();
+        let mut s = AHasher::default();
         key.hash(&mut s);
         //the locally generated random will make it hard for an attacker
         //to deterministically cause all the pubkeys to land in the same

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6483,6 +6483,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "ahash 0.8.12",
  "bv",
  "bytemuck",
  "bytemuck_derive",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6323,6 +6323,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "ahash 0.8.11",
  "bv",
  "bytemuck",
  "bytemuck_derive",


### PR DESCRIPTION
#### Problem

`Bucket::bucket_index_ix()` shows up in slowlana perf profiles as taking a large amount of time at startup. Most of the time is spent hashing. 

Currently, we use the rust default hasher, which is SipHash 1-3. But, we just a default instance of the hasher... so it kinda defeats the purpose of using a secure hasher like SipHash. This observation implies we actually want a stable hash, thus SipHash is not necessary, and a faster hasher can be used instead.


#### Summary of Changes

Use AHasher instead.
