### PR TITLE
feat(scheduling-utils): add scheduler pointer helpers

### DIFF
--- a/scheduling-utils/src/lib.rs
+++ b/scheduling-utils/src/lib.rs
@@ -7,11 +7,13 @@
                 acknowledge use of an interface that may break without warning."
     )
 )]
+pub mod error;
 pub mod thread_aware_account_locks;
 
-pub mod error;
 #[cfg(unix)]
 pub mod handshake;
+#[cfg(unix)]
+pub mod pubkeys_ptr;
 #[cfg(unix)]
 pub mod responses_region;
 #[cfg(unix)]

--- a/scheduling-utils/src/pubkeys_ptr.rs
+++ b/scheduling-utils/src/pubkeys_ptr.rs
@@ -1,0 +1,47 @@
+use {
+    agave_scheduler_bindings::SharablePubkeys, rts_alloc::Allocator, solana_pubkey::Pubkey,
+    std::ptr::NonNull,
+};
+
+pub struct PubkeysPtr<'a> {
+    ptr: NonNull<Pubkey>,
+    count: usize,
+    allocator: &'a Allocator,
+}
+
+impl<'a> PubkeysPtr<'a> {
+    /// Constructs the pointer from a [`SharablePubkeys`].
+    ///
+    /// # Safety
+    ///
+    /// - The allocation pointed to by this region must not have previously been freed.
+    /// - Pointer must be exclusive so that calling [`Self::free`] is safe.
+    /// - `sharable_pubkeys.num_pubkeys` must be accurate and not overrun the allocation.
+    pub unsafe fn from_sharable_pubkeys(
+        sharable_pubkeys: &SharablePubkeys,
+        allocator: &'a Allocator,
+    ) -> Self {
+        assert_ne!(sharable_pubkeys.num_pubkeys, 0);
+        let ptr = allocator.ptr_from_offset(sharable_pubkeys.offset).cast();
+
+        Self {
+            ptr,
+            count: sharable_pubkeys.num_pubkeys as usize,
+            allocator,
+        }
+    }
+
+    /// Returns the allocation as a slice.
+    pub fn as_slice(&self) -> &[Pubkey] {
+        // SAFETY
+        // - Constructor invariants guarantee that we don't overrun the end of the allocation.
+        unsafe { core::slice::from_raw_parts(self.ptr.as_ptr(), self.count) }
+    }
+
+    /// Frees the underlying allocation.
+    pub fn free(self) {
+        // SAFETY
+        // - Constructor invariants guarantee that we exclusively own this pointer.
+        unsafe { self.allocator.free(self.ptr.cast()) };
+    }
+}

--- a/scheduling-utils/src/transaction_ptr.rs
+++ b/scheduling-utils/src/transaction_ptr.rs
@@ -90,6 +90,16 @@ impl<'a> TransactionPtrBatch<'a> {
         }
     }
 
+    /// The number of transactions in this batch.
+    pub const fn len(&self) -> usize {
+        self.num_transactions
+    }
+
+    /// Whether the batch is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Iterator returning [`TransactionPtr`] for each transaction in the batch.
     pub fn iter(&'a self) -> impl Iterator<Item = TransactionPtr> + 'a {
         (0..self.num_transactions)


### PR DESCRIPTION
#### Problem

- Iterating through variable length message types can be quite cumbersome & unsafe.

#### Summary of Changes

- Steal @apfitzge very useful helpers and ship it to agave.