### PR TITLE
Uses ahash in Bucket::bucket_index_ix()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7557,6 +7557,7 @@ name = "solana-bucket-map"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-logger",
+ "ahash 0.8.11",
  "bv",
  "bytemuck",
  "bytemuck_derive",

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -18,6 +18,7 @@ agave-unstable-api = []
 dev-context-only-utils = []
 
 [dependencies]
+ahash = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true }
 bytemuck_derive = { workspace = true }

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -19,9 +19,7 @@ use {
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
     std::{
-        collections::hash_map::DefaultHasher,
         fs,
-        hash::{Hash, Hasher},
         num::NonZeroU64,
         path::PathBuf,
         sync::{
@@ -822,14 +820,11 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
     }
 
     fn bucket_index_ix(key: &Pubkey, random: u64) -> u64 {
-        let mut s = DefaultHasher::new();
-        key.hash(&mut s);
-        //the locally generated random will make it hard for an attacker
-        //to deterministically cause all the pubkeys to land in the same
-        //location in any bucket on all validators
-        random.hash(&mut s);
-        s.finish()
-        //debug!(            "INDEX_IX: {:?} uid:{} loc: {} cap:{}",            key,            uid,            location,            index.capacity()        );
+        // the locally generated random will make it hard for an attacker
+        // to deterministically cause all the pubkeys to land in the same
+        // location in any bucket on all validators
+        let hasher_builder = ahash::RandomState::with_seeds(random, random, random, random);
+        hasher_builder.hash_one(key)
     }
 
     /// grow the appropriate piece. Note this takes an immutable ref.
@@ -899,8 +894,8 @@ mod tests {
         for reuse_type in 0..3 {
             let data_buckets = Vec::default();
             let v = 12u64;
-            let random = 1;
-            // with random=1, 6 entries is the most that don't collide on a single hash % cap value.
+            let random = 2;
+            // with random=2, 6 entries is the most that don't collide on a single hash % cap value.
             for len in 0..7 {
                 // cannot use pubkey [0,0,...] because that matches a zeroed out default file contents.
                 let raw = (0..len)
@@ -1586,5 +1581,19 @@ mod tests {
         bucket.delete_key(&key);
 
         bucket.batch_insert_non_duplicates(&[]);
+    }
+
+    /// Ensure bucket_index_ix() produces stable results
+    #[test]
+    fn test_bucket_index_ix_is_stable() {
+        const PUBKEY: Pubkey = Pubkey::new_from_array([0xC3; 32]);
+        const RANDOM1: u64 = 0x18E7_9D0B_94D8_E428;
+        const RANDOM2: u64 = 0x60AE_DA87_48E9_A887;
+
+        let ix1 = Bucket::<()>::bucket_index_ix(&PUBKEY, RANDOM1);
+        assert_eq!(ix1, 0x0CAD_75DB_E472_9589);
+
+        let ix2 = Bucket::<()>::bucket_index_ix(&PUBKEY, RANDOM2);
+        assert_ne!(ix2, ix1);
     }
 }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6483,6 +6483,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "ahash 0.8.12",
  "bv",
  "bytemuck",
  "bytemuck_derive",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6323,6 +6323,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "ahash 0.8.11",
  "bv",
  "bytemuck",
  "bytemuck_derive",


### PR DESCRIPTION
#### Problem

`Bucket::bucket_index_ix()` shows up in slowlana perf profiles as taking a non-negligible amount of time at startup. Most of the time is spent hashing.

Note that we call `Bucket::bucket_index_ix()` every time we access the disk index, not just at startup. So it is in our best interest to make this as fast as possible.

Currently, we use the rust default hasher, which is SipHash 1-3. But, we just a default instance of the hasher... so it kinda defeats the purpose of using a secure hasher like SipHash. This observation implies we actually want a stable hash, thus SipHash is not necessary, and a faster hasher can be used instead.

<details><summary>slowlana - master</summary>
<p>

Here's the call tree, showing that `bucket_index_ix()` currently uses ~5%:
<img width="3181" height="1891" alt="Screenshot 2025-11-07 at 1 45 30 PM" src="https://github.com/user-attachments/assets/d461a512-ca2b-4f1c-b09d-1b7879e3e0d8" />

And here's the flamegraph showing the same:
<img width="3181" height="1891" alt="Screenshot 2025-11-07 at 1 45 50 PM" src="https://github.com/user-attachments/assets/97ce4ae8-39b1-451d-8673-540eb57705ba" />

</p>
</details> 


#### Summary of Changes

Use ahash instead.

<details><summary>slowlana - pr</summary>
<p>

Here's the call tree showing that `bucket_index_ix()` now only takes ~0.6%:
<img width="3060" height="1704" alt="Screenshot 2025-11-07 at 1 20 35 PM" src="https://github.com/user-attachments/assets/a3a41c9f-9263-4d27-9af0-900536f85b4d" />

And here's the flamegraph showing the same:
<img width="3181" height="1891" alt="Screenshot 2025-11-07 at 1 24 03 PM" src="https://github.com/user-attachments/assets/b0fa8d23-7f12-4e1c-802f-3480e337e41c" />

</p>
</details> 

Another anecdotal comparison: I ran ledger-tool with a mnb snapshot on my dev box and saw that this PR finished building the accounts index slightly faster each time. When starting from no existing disk index files, master took ~48 seconds, and with this PR took ~46 seconds. There's probably some variation in there. More sharing to indicate we haven't caused some regression either.