### PR TITLE
Update Rust to 1.90.0

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2025-06-23
+  nightly_version=2025-08-02
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"


### PR DESCRIPTION
#### Summary of Changes
~~CI will assuredly fail for this since we don't have the docker containers for the new Rust version yet, but creating the PR so we can test the new GH action that will automatically create the container.~~

Update stable to 1.90.0 and nightly to final 1.90.0 nightly (2025-08-02)

To find the latest `Rust 1.90.0` nightly build, I went to [this](https://releases.rs/docs/) page and checked [the 1.90 entry](https://releases.rs/docs/1.90.0/). Within there, there is a note:
> Branched from master on: 1 August, 2025

So, I started on `2025-08-01` and ran the following commands to find when nightly switched over from 1.90 to 1.91.
```
$ cargo +nightly-2025-08-02 --version
cargo 1.90.0-nightly (840b83a10 2025-07-30)

$ cargo +nightly-2025-08-03 --version
cargo 1.91.0-nightly (840b83a10 2025-07-30)
```
Wherever the payloads for these are hosted, I'm guessing there are some artifacts that might be able to be queried to both lighter and programmatic. However, granted that I only had to check several versions, my dumb method seemed sufficient