### PR TITLE
Adds rust-2024 lints to fs crate

### DIFF
--- a/fs/src/buffered_reader.rs
+++ b/fs/src/buffered_reader.rs
@@ -386,7 +386,7 @@ impl<R: BufRead> RequiredLenBufRead for BufReaderWithOverflow<R> {
 
 /// Open file at `path` with buffering reader using `buf_size` memory and doing
 /// read-ahead IO reads (if `io_uring` is supported by the platform)
-pub fn large_file_buf_reader(path: &Path, buf_size: usize) -> io::Result<impl BufRead> {
+pub fn large_file_buf_reader(path: &Path, buf_size: usize) -> io::Result<impl BufRead + use<>> {
     #[cfg(target_os = "linux")]
     {
         assert!(agave_io_uring::io_uring_supported());
@@ -415,7 +415,7 @@ mod tests {
     fn rand_bytes<const N: usize>() -> [u8; N] {
         use rand::Rng;
         let mut rng = rand::thread_rng();
-        std::array::from_fn(|_| rng.gen::<u8>())
+        std::array::from_fn(|_| rng.r#gen::<u8>())
     }
 
     #[test]

--- a/fs/src/buffered_reader.rs
+++ b/fs/src/buffered_reader.rs
@@ -47,12 +47,12 @@ impl<const N: usize> Stack<N> {
 
     #[inline(always)]
     unsafe fn as_slice(&self) -> &[u8] {
-        slice::from_raw_parts(self.0.as_ptr() as *const u8, N)
+        unsafe { slice::from_raw_parts(self.0.as_ptr() as *const u8, N) }
     }
 
     #[inline(always)]
     unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
-        slice::from_raw_parts_mut(self.0.as_mut_ptr() as *mut u8, N)
+        unsafe { slice::from_raw_parts_mut(self.0.as_mut_ptr() as *mut u8, N) }
     }
 }
 

--- a/fs/src/io_uring/dir_remover.rs
+++ b/fs/src/io_uring/dir_remover.rs
@@ -84,7 +84,8 @@ impl RingDirRemover {
             // dir.set_finished_scanning(), we must close the dir fd now. Otherwise it gets
             // closed by the last UnlinkOp::complete() call.
             if dir.scanned_and_unlinked() {
-                if let Some(fd) = dir.fd.take() {
+                let fd = dir.fd.take();
+                if let Some(fd) = fd {
                     self.ring
                         .push(Op::Close(CloseOp::new(dir_key, fd.into_raw_fd())))?;
                 }

--- a/fs/src/io_uring/file_creator.rs
+++ b/fs/src/io_uring/file_creator.rs
@@ -469,7 +469,7 @@ impl<'a> WriteOp {
         let WriteOp {
             file_key,
             offset,
-            ref mut buf,
+            buf,
             buf_offset,
             write_len,
         } = self;

--- a/fs/src/io_uring/memory.rs
+++ b/fs/src/io_uring/memory.rs
@@ -34,7 +34,7 @@ impl DerefMut for LargeBuffer {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             Self::Vec(buf) => buf.as_mut_slice(),
-            Self::HugeTable(ref mut mem) => mem.deref_mut(),
+            Self::HugeTable(mem) => mem.deref_mut(),
         }
     }
 }
@@ -43,7 +43,7 @@ impl AsMut<[u8]> for LargeBuffer {
     fn as_mut(&mut self) -> &mut [u8] {
         match self {
             Self::Vec(vec) => vec.as_mut_slice(),
-            LargeBuffer::HugeTable(ref mut mem) => mem,
+            LargeBuffer::HugeTable(mem) => mem,
         }
     }
 }

--- a/fs/src/io_uring/sequential_file_reader.rs
+++ b/fs/src/io_uring/sequential_file_reader.rs
@@ -209,7 +209,7 @@ impl<B: AsMut<[u8]>> BufRead for SequentialFileReader<B> {
             let num_buffers = state.buffers.len();
             let read_buf = &mut state.buffers[state.current_buf];
             match read_buf {
-                ReadBufState::Full(ref mut cursor) => {
+                ReadBufState::Full(cursor) => {
                     if !cursor.fill_buf()?.is_empty() {
                         // we have some data available
                         break true;

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -1,3 +1,13 @@
+// Activate some of the Rust 2024 lints to make the future migration easier.
+#![warn(if_let_rescope)]
+#![warn(keyword_idents_2024)]
+#![warn(missing_unsafe_on_extern)]
+#![warn(rust_2024_guarded_string_incompatible_syntax)]
+#![warn(rust_2024_incompatible_pat)]
+#![warn(tail_expr_drop_order)]
+#![warn(unsafe_attr_outside_unsafe)]
+#![warn(unsafe_op_in_unsafe_fn)]
+
 pub mod buffered_reader;
 pub mod dirs;
 pub mod file_io;


### PR DESCRIPTION
#### Problem

We want to update to rust 2024 edition (see #6203). But until then, we could still add 2024-incompatible code.


#### Summary of Changes
* Add lints to the new fs crate for rust 2024
* Fix temporary value scope
* Remove unnecessary `ref mut` bindings
* Quote `gen` symbol
* Add `use<>`

(This is based on Brooks' draft https://github.com/anza-xyz/agave/pull/8915)