### PR TITLE
Split serialize_and_archive_snapshots into two

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -112,7 +112,8 @@ impl SnapshotPackagerService {
 
                     if let Err(err) = bank_snapshot_info {
                         error!(
-                            "Stopping {}! Fatal error while serializing snapshot for slot {}: {err}",
+                            "Stopping {}! Fatal error while serializing snapshot for slot {}: \
+                             {err}",
                             Self::NAME,
                             snapshot_slot,
                         );
@@ -132,11 +133,9 @@ impl SnapshotPackagerService {
                     // Archiving the snapshot package is not allowed to fail.
                     // AccountsBackgroundService calls `clean_accounts()` with a value for
                     // latest_full_snapshot_slot that requires this archive call to succeed.
-                    let (archive_result, archive_time_us) =
-                        measure_us!(snapshot_utils::archive_snapshot_package(
-                            archive_package,
-                            snapshot_config
-                        ));
+                    let (archive_result, archive_time_us) = measure_us!(
+                        snapshot_utils::archive_snapshot_package(archive_package, snapshot_config)
+                    );
                     if let Err(err) = archive_result {
                         error!(
                             "Stopping {}! Fatal error while archiving snapshot package: {err}",

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -40,7 +40,7 @@ use {
         },
         snapshot_config::SnapshotConfig,
         snapshot_hash::SnapshotHash,
-        ArchiveFormat, SnapshotKind, SnapshotVersion, ArchivePackage,
+        ArchiveFormat, ArchivePackage, SnapshotKind, SnapshotVersion,
     },
     log::*,
     solana_accounts_db::{

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -13,7 +13,7 @@ use {
         },
     },
     agave_snapshots::{
-        archive_snapshot, ArchivePackage,
+        archive_snapshot,
         error::{
             AddBankSnapshotError, GetSnapshotAccountsHardLinkDirError,
             HardLinkStoragesToSnapshotError, SnapshotError, SnapshotFastbootError,
@@ -25,7 +25,8 @@ use {
             SnapshotArchiveInfoGetter,
         },
         snapshot_config::SnapshotConfig,
-        streaming_unarchive_snapshot, ArchiveFormat, Result, SnapshotKind, SnapshotVersion,
+        streaming_unarchive_snapshot, ArchiveFormat, ArchivePackage, Result, SnapshotKind,
+        SnapshotVersion,
     },
     crossbeam_channel::{Receiver, Sender},
     log::*,

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -11,12 +11,7 @@ use {
     solana_clock::Slot,
     solana_measure::measure::Measure,
     solana_metrics::datapoint_info,
-    std::{
-        fs,
-        io::Write,
-        path::{Path, PathBuf},
-        sync::Arc,
-    },
+    std::{fs, io::Write, path::{Path, PathBuf}, sync::Arc},
 };
 
 // Balance large and small files order in snapshot tar with bias towards small (4 small + 1 large),
@@ -75,9 +70,9 @@ pub fn archive_snapshot(
         .map_err(|err| E::CreateSnapshotStagingDir(err, staging_snapshot_dir.clone()))?;
 
     // To be a source for symlinking and archiving, the path need to be an absolute path
-    let src_snapshot_dir = bank_snapshot_dir
-        .canonicalize()
-        .map_err(|err| E::CanonicalizeSnapshotSourceDir(err, bank_snapshot_dir.to_path_buf()))?;
+    let src_snapshot_dir = bank_snapshot_dir.canonicalize().map_err(|err| {
+        E::CanonicalizeSnapshotSourceDir(err, bank_snapshot_dir.to_path_buf())
+    })?;
     let staging_snapshot_file = staging_snapshot_dir.join(&slot_str);
     let src_snapshot_file = src_snapshot_dir.join(slot_str);
     symlink::symlink_file(&src_snapshot_file, &staging_snapshot_file)

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -11,7 +11,12 @@ use {
     solana_clock::Slot,
     solana_measure::measure::Measure,
     solana_metrics::datapoint_info,
-    std::{fs, io::Write, path::{Path, PathBuf}, sync::Arc},
+    std::{
+        fs,
+        io::Write,
+        path::{Path, PathBuf},
+        sync::Arc,
+    },
 };
 
 // Balance large and small files order in snapshot tar with bias towards small (4 small + 1 large),
@@ -70,9 +75,9 @@ pub fn archive_snapshot(
         .map_err(|err| E::CreateSnapshotStagingDir(err, staging_snapshot_dir.clone()))?;
 
     // To be a source for symlinking and archiving, the path need to be an absolute path
-    let src_snapshot_dir = bank_snapshot_dir.canonicalize().map_err(|err| {
-        E::CanonicalizeSnapshotSourceDir(err, bank_snapshot_dir.to_path_buf())
-    })?;
+    let src_snapshot_dir = bank_snapshot_dir
+        .canonicalize()
+        .map_err(|err| E::CanonicalizeSnapshotSourceDir(err, bank_snapshot_dir.to_path_buf()))?;
     let staging_snapshot_file = staging_snapshot_dir.join(&slot_str);
     let src_snapshot_file = src_snapshot_dir.join(slot_str);
     symlink::symlink_file(&src_snapshot_file, &staging_snapshot_file)

--- a/snapshots/src/lib.rs
+++ b/snapshots/src/lib.rs
@@ -31,7 +31,7 @@ mod unarchive;
 pub type Result<T> = std::result::Result<T, error::SnapshotError>;
 
 pub use {
-    archive::archive_snapshot,
+    archive::{archive_snapshot, ArchivePackage},
     archive_format::*,
     kind::SnapshotKind,
     snapshot_interval::SnapshotInterval,


### PR DESCRIPTION
#### Problem
With fastboots snapshots, Serialized Snapshots will be required, without archives. Currently serialize_and_archive_snapshots does both.

#### Summary of Changes
- Best viewed as 3 changesets
- First Changeset: Adds BankSnapshotPackage
- Second Changset: Adds ArchivePackage
- Third Changeset: splits serialize_and_archive_snapshots into two functions
- Fourth Changeset and beyond: cleanup 

#### Other alternatives considered
- Changing serialize_and_archive_snapshots to return early and skip archiving snapshots in the event of a fastboot snapshot. Returned Result<Option<SnapshotArchiveInfo>> instead of Result<SnapshotArchiveInfo>. Easier change, but non intuitive



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
