### PR TITLE
Add check for existing program data account on migration

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1191,7 +1191,7 @@ pub mod fix_alt_bn128_pairing_length_check {
 pub mod replace_spl_token_with_p_token {
     use super::Pubkey;
 
-    solana_pubkey::declare_id!("ptokSWRqZz5u2xdqMdstkMKpFurauUpVen7TZXgDpkQ");
+    solana_pubkey::declare_id!("ptokEXBPT9HuYdAQRysaStZNTY9bHsAcQzNscEoA6HC");
 
     pub const SPL_TOKEN_PROGRAM_ID: Pubkey =
         Pubkey::from_str_const("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -511,7 +511,7 @@ pub(crate) mod tests {
         solana_native_token::LAMPORTS_PER_SOL,
         solana_program_runtime::loaded_programs::{ProgramCacheEntry, ProgramCacheEntryType},
         solana_pubkey::Pubkey,
-        solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, native_loader},
+        solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, native_loader, system_program},
         solana_signer::Signer,
         solana_transaction::Transaction,
         std::{fs::File, io::Read, sync::Arc},
@@ -2150,5 +2150,167 @@ pub(crate) mod tests {
         // Run the post-upgrade program checks on the restored bank.
         test_context.run_program_checks(&roundtrip_bank, upgrade_slot);
         assert_eq!(bank, roundtrip_bank);
+    }
+
+    #[test]
+    fn test_replace_spl_token_with_p_token_and_funded_program_data_account_e2e() {
+        let (mut genesis_config, mint_keypair) =
+            create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let slots_per_epoch = 32;
+        genesis_config.epoch_schedule =
+            EpochSchedule::custom(slots_per_epoch, slots_per_epoch, false);
+
+        let mut root_bank = Bank::new_for_tests(&genesis_config);
+
+        let feature_id = agave_feature_set::replace_spl_token_with_p_token::id();
+        let program_id = agave_feature_set::replace_spl_token_with_p_token::SPL_TOKEN_PROGRAM_ID;
+        let source_buffer_address =
+            agave_feature_set::replace_spl_token_with_p_token::PTOKEN_PROGRAM_BUFFER;
+
+        // Set up a mock BPF loader v2 program.
+        {
+            let program_account = mock_bpf_loader_v2_program(&root_bank);
+            root_bank.store_account_and_update_capitalization(&program_id, &program_account);
+            assert_eq!(
+                &root_bank.get_account(&program_id).unwrap(),
+                &program_account
+            );
+        };
+
+        // Set up the CPI mockup to test CPI'ing to the migrated program.
+        let cpi_program_id = Pubkey::new_unique();
+        let cpi_program_name = "mock_cpi_program";
+        root_bank.add_builtin(
+            cpi_program_id,
+            cpi_program_name,
+            ProgramCacheEntry::new_builtin(0, cpi_program_name.len(), cpi_mockup::Entrypoint::vm),
+        );
+
+        // Add the feature to the bank's inactive feature set.
+        // Note this will add the feature ID if it doesn't exist.
+        let mut feature_set = FeatureSet::all_enabled();
+        feature_set.deactivate(&feature_id);
+        root_bank.feature_set = Arc::new(feature_set);
+
+        // Initialize the source buffer account.
+        let test_context = TestContext::new(&root_bank, &program_id, &source_buffer_address, None);
+
+        // Fund the program data account so it will appear as an existing account.
+        let program_data_account = AccountSharedData::new(1_000_000_000, 0, &system_program::ID);
+        root_bank.store_account_and_update_capitalization(
+            &get_program_data_address(&program_id),
+            &program_data_account,
+        );
+
+        // Activate the feature and run the necessary checks.
+        activate_feature_and_run_checks(
+            root_bank,
+            &test_context,
+            &program_id,
+            &feature_id,
+            &source_buffer_address,
+            &mint_keypair,
+            slots_per_epoch,
+            &cpi_program_id,
+        );
+    }
+
+    #[test]
+    fn test_replace_spl_token_with_p_token_and_existing_program_data_account_failure() {
+        let (mut genesis_config, _mint_keypair) =
+            create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let slots_per_epoch = 32;
+        genesis_config.epoch_schedule =
+            EpochSchedule::custom(slots_per_epoch, slots_per_epoch, false);
+
+        let mut root_bank = Bank::new_for_tests(&genesis_config);
+
+        let feature_id = agave_feature_set::replace_spl_token_with_p_token::id();
+        let program_id = agave_feature_set::replace_spl_token_with_p_token::SPL_TOKEN_PROGRAM_ID;
+        let source_buffer_address =
+            agave_feature_set::replace_spl_token_with_p_token::PTOKEN_PROGRAM_BUFFER;
+
+        // Set up a mock BPF loader v2 program.
+        let program_account = mock_bpf_loader_v2_program(&root_bank);
+        root_bank.store_account_and_update_capitalization(&program_id, &program_account);
+        assert_eq!(
+            &root_bank.get_account(&program_id).unwrap(),
+            &program_account
+        );
+
+        // Set up the CPI mockup to test CPI'ing to the migrated program.
+        let cpi_program_id = Pubkey::new_unique();
+        let cpi_program_name = "mock_cpi_program";
+        root_bank.add_builtin(
+            cpi_program_id,
+            cpi_program_name,
+            ProgramCacheEntry::new_builtin(0, cpi_program_name.len(), cpi_mockup::Entrypoint::vm),
+        );
+
+        // Add the feature to the bank's inactive feature set.
+        // Note this will add the feature ID if it doesn't exist.
+        let mut feature_set = FeatureSet::all_enabled();
+        feature_set.deactivate(&feature_id);
+        root_bank.feature_set = Arc::new(feature_set);
+
+        // Initialize the source buffer account.
+        let _test_context = TestContext::new(&root_bank, &program_id, &source_buffer_address, None);
+
+        // Create the program data account to simulate existing account owned by
+        // the upgradeable loader.
+        let program_data_account =
+            AccountSharedData::new(1_000_000_000, 0, &bpf_loader_upgradeable::ID);
+        root_bank.store_account_and_update_capitalization(
+            &get_program_data_address(&program_id),
+            &program_data_account,
+        );
+
+        // Activate the feature and run the necessary checks.
+        let (bank, bank_forks) = root_bank.wrap_with_bank_forks_for_tests();
+
+        // Advance to the next epoch without activating the feature.
+        let mut first_slot_in_next_epoch = slots_per_epoch + 1;
+        let bank = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            &Pubkey::default(),
+            first_slot_in_next_epoch,
+        );
+
+        // Assert the feature was not activated and the program was not
+        // migrated.
+        assert!(!bank.feature_set.is_active(&feature_id));
+        assert!(bank.get_account(&source_buffer_address).is_some());
+
+        // Store the account to activate the feature.
+        bank.store_account_and_update_capitalization(
+            &feature_id,
+            &feature::create_account(&Feature::default(), 42),
+        );
+
+        // Advance the bank to cross the epoch boundary and activate the
+        // feature.
+        goto_end_of_slot(bank.clone());
+        first_slot_in_next_epoch += slots_per_epoch;
+        let _migration_slot = first_slot_in_next_epoch;
+        let bank = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            &Pubkey::default(),
+            first_slot_in_next_epoch,
+        );
+
+        // Check that the feature was activated.
+        assert!(bank.feature_set.is_active(&feature_id));
+        // The program should still be owned by the bpf loader v2.
+        let program_account = bank.get_account(&program_id).unwrap();
+        assert_eq!(program_account.owner(), &bpf_loader::id());
+        // The program data should have zero data and still have
+        // 1_000_000_000 lamports.
+        let program_data_account = bank
+            .get_account(&get_program_data_address(&program_id))
+            .unwrap();
+        assert_eq!(program_data_account.data().len(), 0);
+        assert_eq!(program_data_account.lamports(), 1_000_000_000);
     }
 }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -219,7 +219,7 @@ impl Bank {
     ) -> Result<(), CoreBpfMigrationError> {
         datapoint_info!(config.datapoint_name, ("slot", self.slot, i64));
 
-        let (target, target_program_data_account_lamports) =
+        let target =
             TargetBuiltin::new_checked(self, builtin_program_id, &config.migration_target)?;
         let source = if let Some(expected_hash) = config.verified_build_hash {
             SourceBuffer::new_checked_with_verified_build_hash(
@@ -269,7 +269,7 @@ impl Bank {
             target.program_account.lamports(),
             source.buffer_account.lamports(),
         )
-        .and_then(|v| checked_add(v, target_program_data_account_lamports.unwrap_or(0)))?;
+        .and_then(|v| checked_add(v, target.program_data_account_lamports))?;
         let lamports_to_fund = checked_add(
             new_target_program_account.lamports(),
             new_target_program_data_account.lamports(),
@@ -396,8 +396,7 @@ impl Bank {
     ) -> Result<(), CoreBpfMigrationError> {
         datapoint_info!(datapoint_name, ("slot", self.slot, i64));
 
-        let (target, target_program_data_account_lamports) =
-            TargetBpfV2::new_checked(self, loader_v2_bpf_program_address)?;
+        let target = TargetBpfV2::new_checked(self, loader_v2_bpf_program_address)?;
         let source = SourceBuffer::new_checked(self, source_buffer_address)?;
 
         // Attempt serialization first before modifying the bank.
@@ -440,7 +439,7 @@ impl Bank {
             target.program_account.lamports(),
             source.buffer_account.lamports(),
         )
-        .and_then(|v| checked_add(v, target_program_data_account_lamports.unwrap_or(0)))?;
+        .and_then(|v| checked_add(v, target.program_data_account_lamports))?;
         let lamports_to_fund = checked_add(
             new_target_program_account.lamports(),
             new_target_program_data_account.lamports(),

--- a/runtime/src/bank/builtins/core_bpf_migration/target_bpf_v2.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_bpf_v2.rs
@@ -5,7 +5,7 @@ use {
     solana_account::{AccountSharedData, ReadableAccount},
     solana_loader_v3_interface::get_program_data_address,
     solana_pubkey::Pubkey,
-    solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable},
+    solana_sdk_ids::{bpf_loader, system_program},
 };
 
 /// The account details of a Loader v2 BPF program slated to be upgraded.
@@ -50,7 +50,7 @@ impl TargetBpfV2 {
             if let Some(account) = bank.get_account_with_fixed_root(&program_data_address) {
                 // The program data account should not exist, but a system account with funded
                 // lamports is acceptable.
-                if account.owner() == &bpf_loader_upgradeable::id() {
+                if account.owner() != &system_program::id() {
                     return Err(CoreBpfMigrationError::ProgramHasDataAccount(
                         *program_address,
                     ));

--- a/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
@@ -5,7 +5,10 @@ use {
     solana_builtins::core_bpf_migration::CoreBpfMigrationTargetType,
     solana_loader_v3_interface::get_program_data_address,
     solana_pubkey::Pubkey,
-    solana_sdk_ids::native_loader::ID as NATIVE_LOADER_ID,
+    solana_sdk_ids::{
+        bpf_loader_upgradeable::ID as BPF_LOADER_UPGRADEABLE_ID,
+        native_loader::ID as NATIVE_LOADER_ID,
+    },
 };
 
 /// The account details of a built-in program to be migrated to Core BPF.
@@ -50,14 +53,20 @@ impl TargetBuiltin {
 
         let program_data_address = get_program_data_address(program_address);
 
-        // The program data account should not exist.
-        if bank
-            .get_account_with_fixed_root(&program_data_address)
-            .is_some()
-        {
-            return Err(CoreBpfMigrationError::ProgramHasDataAccount(
-                *program_address,
-            ));
+        // The program data account is expected not to exist.
+        if let Some(account) = bank.get_account_with_fixed_root(&program_data_address) {
+            // It is possible that the program data account had lamports sent to it,
+            // which would make the account to be found. If the owner is the loader v3,
+            // then it is a genuine program data account and the migration must already
+            // been performed. In this case, we fail; otherwise, we burn and purge the
+            // account before migration.
+            if account.owner() == &BPF_LOADER_UPGRADEABLE_ID {
+                return Err(CoreBpfMigrationError::ProgramHasDataAccount(
+                    *program_address,
+                ));
+            } else {
+                bank.burn_and_purge_account(&program_data_address, account);
+            }
         }
 
         Ok(Self {

--- a/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
@@ -26,7 +26,7 @@ impl TargetBuiltin {
         bank: &Bank,
         program_address: &Pubkey,
         migration_target: &CoreBpfMigrationTargetType,
-    ) -> Result<Self, CoreBpfMigrationError> {
+    ) -> Result<(Self, Option<u64>), CoreBpfMigrationError> {
         let program_account = match migration_target {
             CoreBpfMigrationTargetType::Builtin => {
                 // The program account should exist.
@@ -54,26 +54,28 @@ impl TargetBuiltin {
         let program_data_address = get_program_data_address(program_address);
 
         // The program data account is expected not to exist.
-        if let Some(account) = bank.get_account_with_fixed_root(&program_data_address) {
-            // It is possible that the program data account had lamports sent to it,
-            // which would make the account to be found. If the owner is the loader v3,
-            // then it is a genuine program data account and the migration must already
-            // been performed. In this case, we fail; otherwise, we burn and purge the
-            // account before migration.
-            if account.owner() == &BPF_LOADER_UPGRADEABLE_ID {
-                return Err(CoreBpfMigrationError::ProgramHasDataAccount(
-                    *program_address,
-                ));
+        let current_lamports =
+            if let Some(account) = bank.get_account_with_fixed_root(&program_data_address) {
+                // The program data account should not exist, but a system account with funded
+                // lamports is acceptable.
+                if account.owner() == &BPF_LOADER_UPGRADEABLE_ID {
+                    return Err(CoreBpfMigrationError::ProgramHasDataAccount(
+                        *program_address,
+                    ));
+                }
+                Some(account.lamports())
             } else {
-                bank.burn_and_purge_account(&program_data_address, account);
-            }
-        }
+                None
+            };
 
-        Ok(Self {
-            program_address: *program_address,
-            program_account,
-            program_data_address,
-        })
+        Ok((
+            Self {
+                program_address: *program_address,
+                program_account,
+                program_data_address,
+            },
+            current_lamports,
+        ))
     }
 }
 
@@ -83,9 +85,7 @@ mod tests {
         super::*, crate::bank::tests::create_simple_test_bank, agave_feature_set as feature_set,
         assert_matches::assert_matches, solana_account::Account,
         solana_feature_gate_interface as feature,
-        solana_loader_v3_interface::state::UpgradeableLoaderState,
-        solana_sdk_ids::bpf_loader_upgradeable::ID as BPF_LOADER_UPGRADEABLE_ID,
-        test_case::test_case,
+        solana_loader_v3_interface::state::UpgradeableLoaderState, test_case::test_case,
     };
 
     fn store_account<T: serde::Serialize>(
@@ -146,7 +146,7 @@ mod tests {
         let program_data_address = get_program_data_address(&program_address);
 
         // Success
-        let target_builtin =
+        let (target_builtin, _) =
             TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap();
         assert_eq!(target_builtin.program_address, program_address);
         assert_eq!(target_builtin.program_account, program_account);
@@ -209,7 +209,7 @@ mod tests {
         let program_data_address = get_program_data_address(&program_address);
 
         // Success
-        let target_builtin =
+        let (target_builtin, _) =
             TargetBuiltin::new_checked(&bank, &program_address, &migration_target).unwrap();
         assert_eq!(target_builtin.program_address, program_address);
         assert_eq!(target_builtin.program_account, program_account);

--- a/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
@@ -6,8 +6,7 @@ use {
     solana_loader_v3_interface::get_program_data_address,
     solana_pubkey::Pubkey,
     solana_sdk_ids::{
-        bpf_loader_upgradeable::ID as BPF_LOADER_UPGRADEABLE_ID,
-        native_loader::ID as NATIVE_LOADER_ID,
+        native_loader::ID as NATIVE_LOADER_ID, system_program::ID as SYSTEM_PROGRAM_ID,
     },
 };
 
@@ -59,7 +58,7 @@ impl TargetBuiltin {
             if let Some(account) = bank.get_account_with_fixed_root(&program_data_address) {
                 // The program data account should not exist, but a system account with funded
                 // lamports is acceptable.
-                if account.owner() == &BPF_LOADER_UPGRADEABLE_ID {
+                if account.owner() != &SYSTEM_PROGRAM_ID {
                     return Err(CoreBpfMigrationError::ProgramHasDataAccount(
                         *program_address,
                     ));
@@ -84,7 +83,9 @@ mod tests {
         super::*, crate::bank::tests::create_simple_test_bank, agave_feature_set as feature_set,
         assert_matches::assert_matches, solana_account::Account,
         solana_feature_gate_interface as feature,
-        solana_loader_v3_interface::state::UpgradeableLoaderState, test_case::test_case,
+        solana_loader_v3_interface::state::UpgradeableLoaderState,
+        solana_sdk_ids::bpf_loader_upgradeable::ID as BPF_LOADER_UPGRADEABLE_ID,
+        test_case::test_case,
     };
 
     fn store_account<T: serde::Serialize>(


### PR DESCRIPTION
#### Problem

When migrating builtin/loader-v2 programs to loader-v3, the migration can be blocked by pre-funding the program data account so it appears to already exist.

#### Summary of Changes

Add an additional check when the program data account is found to assert that it is a "real" program data account; otherwise, burn and purge the account so the migration succeeds.

Note: the PR also updates the p-token feature id.