### PR TITLE
Adds rust-2024 lints to votor-messages crate

### DIFF
--- a/votor-messages/src/lib.rs
+++ b/votor-messages/src/lib.rs
@@ -10,6 +10,15 @@
 //! Alpenglow vote message types
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![deny(missing_docs)]
+// Activate some of the Rust 2024 lints to make the future migration easier.
+#![warn(if_let_rescope)]
+#![warn(keyword_idents_2024)]
+#![warn(missing_unsafe_on_extern)]
+#![warn(rust_2024_guarded_string_incompatible_syntax)]
+#![warn(rust_2024_incompatible_pat)]
+#![warn(tail_expr_drop_order)]
+#![warn(unsafe_attr_outside_unsafe)]
+#![warn(unsafe_op_in_unsafe_fn)]
 
 pub mod consensus_message;
 pub mod vote;


### PR DESCRIPTION
#### Problem

We want to update to rust 2024 edition (see #6203). But until then, we could still add 2024-incompatible code.

#### Summary of Changes

Add lints to the votor-messages crate for rust 2024.

Also see https://github.com/anza-xyz/agave/pull/8953.