### PR TITLE
chore: deny already satisfied edition 2024 warnings for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,17 @@ edition = "2021"
 [workspace.lints.rust]
 warnings = "deny"
 
+# List of rust-2024-compatibility lints that are already satisfied
+# See https://doc.rust-lang.org/rustc/lints/groups.html
+boxed_slice_into_iter = "deny"
+dependency_on_unit_never_type_fallback = "deny"
+deprecated_safe_2024 = "deny"
+missing_unsafe_on_extern = "deny"
+never_type_fallback_flowing_into_unsafe = "deny"
+rust_2024_guarded_string_incompatible_syntax = "deny"
+rust_2024_prelude_collisions = "deny"
+static_mut_refs = "deny"
+
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -21,6 +21,17 @@ edition = "2021"
 [workspace.lints.rust]
 warnings = "deny"
 
+# List of rust-2024-compatibility lints that are already satisfied
+# See https://doc.rust-lang.org/rustc/lints/groups.html
+boxed_slice_into_iter = "deny"
+dependency_on_unit_never_type_fallback = "deny"
+deprecated_safe_2024 = "deny"
+missing_unsafe_on_extern = "deny"
+never_type_fallback_flowing_into_unsafe = "deny"
+rust_2024_guarded_string_incompatible_syntax = "deny"
+rust_2024_prelude_collisions = "deny"
+static_mut_refs = "deny"
+
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -1,8 +1,6 @@
 // Activate some of the Rust 2024 lints to make the future migration easier.
 #![warn(if_let_rescope)]
 #![warn(keyword_idents_2024)]
-#![warn(missing_unsafe_on_extern)]
-#![warn(rust_2024_guarded_string_incompatible_syntax)]
 #![warn(rust_2024_incompatible_pat)]
 #![warn(tail_expr_drop_order)]
 #![warn(unsafe_attr_outside_unsafe)]

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -12,8 +12,6 @@
 // Activate some of the Rust 2024 lints to make the future migration easier.
 #![warn(if_let_rescope)]
 #![warn(keyword_idents_2024)]
-#![warn(missing_unsafe_on_extern)]
-#![warn(rust_2024_guarded_string_incompatible_syntax)]
 #![warn(rust_2024_incompatible_pat)]
 #![warn(tail_expr_drop_order)]
 #![warn(unsafe_attr_outside_unsafe)]

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -12,8 +12,6 @@
 // Activate some of the Rust 2024 lints to make the future migration easier.
 #![warn(if_let_rescope)]
 #![warn(keyword_idents_2024)]
-#![warn(missing_unsafe_on_extern)]
-#![warn(rust_2024_guarded_string_incompatible_syntax)]
 #![warn(rust_2024_incompatible_pat)]
 #![warn(tail_expr_drop_order)]
 #![warn(unsafe_attr_outside_unsafe)]

--- a/snapshots/src/lib.rs
+++ b/snapshots/src/lib.rs
@@ -10,8 +10,6 @@
 // Activate some of the Rust 2024 lints to make the future migration easier.
 #![warn(if_let_rescope)]
 #![warn(keyword_idents_2024)]
-#![warn(missing_unsafe_on_extern)]
-#![warn(rust_2024_guarded_string_incompatible_syntax)]
 #![warn(rust_2024_incompatible_pat)]
 #![warn(tail_expr_drop_order)]
 #![warn(unsafe_attr_outside_unsafe)]

--- a/votor-messages/src/lib.rs
+++ b/votor-messages/src/lib.rs
@@ -13,8 +13,6 @@
 // Activate some of the Rust 2024 lints to make the future migration easier.
 #![warn(if_let_rescope)]
 #![warn(keyword_idents_2024)]
-#![warn(missing_unsafe_on_extern)]
-#![warn(rust_2024_guarded_string_incompatible_syntax)]
 #![warn(rust_2024_incompatible_pat)]
 #![warn(tail_expr_drop_order)]
 #![warn(unsafe_attr_outside_unsafe)]

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -11,8 +11,6 @@
 // Activate some of the Rust 2024 lints to make the future migration easier.
 #![warn(if_let_rescope)]
 #![warn(keyword_idents_2024)]
-#![warn(missing_unsafe_on_extern)]
-#![warn(rust_2024_guarded_string_incompatible_syntax)]
 #![warn(rust_2024_incompatible_pat)]
 #![warn(tail_expr_drop_order)]
 #![warn(unsafe_attr_outside_unsafe)]

--- a/xdp-ebpf/src/lib.rs
+++ b/xdp-ebpf/src/lib.rs
@@ -10,8 +10,6 @@
 // Activate some of the Rust 2024 lints to make the future migration easier.
 #![warn(if_let_rescope)]
 #![warn(keyword_idents_2024)]
-#![warn(missing_unsafe_on_extern)]
-#![warn(rust_2024_guarded_string_incompatible_syntax)]
 #![warn(rust_2024_incompatible_pat)]
 #![warn(tail_expr_drop_order)]
 #![warn(unsafe_attr_outside_unsafe)]

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -10,8 +10,6 @@
 // Activate some of the Rust 2024 lints to make the future migration easier.
 #![warn(if_let_rescope)]
 #![warn(keyword_idents_2024)]
-#![warn(missing_unsafe_on_extern)]
-#![warn(rust_2024_guarded_string_incompatible_syntax)]
 #![warn(rust_2024_incompatible_pat)]
 #![warn(tail_expr_drop_order)]
 #![warn(unsafe_attr_outside_unsafe)]


### PR DESCRIPTION
#### Problem
There is set of warnings for [migration to edition 2024](https://github.com/anza-xyz/agave/issues/6203) t that can be enabled to catch code that would need to be changes in new edition.
Some of those warnings are already satisfied for the whole codebase, so they can be enabled globally.

#### Summary of Changes
* add subset of rust-2024-compatibility warnings to workspace
* Remove warnings elevated to workspace from individual crates