### PR TITLE
chore(svm): fix rust_2024_incompatible_pat warnings

### DIFF
--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -132,7 +132,7 @@ impl SysvarCache {
         &self,
         sysvar_id: &Pubkey,
     ) -> Result<Arc<T>, InstructionError> {
-        if let Some(ref sysvar_buf) = self.sysvar_id_to_buffer(sysvar_id) {
+        if let Some(sysvar_buf) = self.sysvar_id_to_buffer(sysvar_id) {
             bincode::deserialize(sysvar_buf)
                 .map(Arc::new)
                 .map_err(|_| InstructionError::UnsupportedSysvar)

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -44,7 +44,7 @@ impl NonceInfo {
     ) -> Result<(), AdvanceNonceError> {
         let nonce_versions = StateMut::<NonceVersions>::state(&self.account)
             .map_err(|_| AdvanceNonceError::Invalid)?;
-        if let NonceState::Initialized(ref data) = nonce_versions.state() {
+        if let NonceState::Initialized(data) = nonce_versions.state() {
             let nonce_state =
                 NonceState::new_initialized(&data.authority, durable_nonce, lamports_per_signature);
             let nonce_versions = NonceVersions::new(nonce_state);

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -757,7 +757,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             })
             .and_then(
                 |current_nonce_versions| match current_nonce_versions.state() {
-                    NonceState::Initialized(ref current_nonce_data) => {
+                    NonceState::Initialized(current_nonce_data) => {
                         let nonce_can_be_advanced =
                             &current_nonce_data.durable_nonce != next_durable_nonce;
 


### PR DESCRIPTION
#### Problem
Migration to Edition 2024 (https://github.com/anza-xyz/agave/issues/6203) changes semantics of pattern matching bindings.
Warnings reported by [rust_2024_incompatible_pat ](https://doc.rust-lang.org/beta/nightly-rustc/rustc_lint/builtin/static.RUST_2024_INCOMPATIBLE_PAT.html) hightlight changed behavior. Given small number of the warnings it's reasonable to update code such that edition switch will keep semantics unchanged.

#### Summary of Changes
Update pattern bindings.