### PR TITLE
chore(networking): fix impl_trait_overcaptures warning for edition 2024

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1179,12 +1179,12 @@ impl ClusterInfo {
     }
 
     // If the network entrypoint hasn't been discovered yet, add it to the crds table
-    fn append_entrypoint_to_pulls(
+    fn append_entrypoint_to_pulls<T: Iterator<Item = (SocketAddr, CrdsFilter)> + Clone>(
         &self,
         thread_pool: &ThreadPool,
         max_bloom_filter_bytes: usize,
-        pulls: impl Iterator<Item = (SocketAddr, CrdsFilter)> + Clone,
-    ) -> impl Iterator<Item = (SocketAddr, CrdsFilter)> {
+        pulls: T,
+    ) -> impl Iterator<Item = (SocketAddr, CrdsFilter)> + use<T> {
         const THROTTLE_DELAY: u64 = CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS / 2;
         let mut pulls = pulls.peekable();
         let entrypoint = {
@@ -1234,7 +1234,7 @@ impl ClusterInfo {
         thread_pool: &ThreadPool,
         gossip_validators: Option<&HashSet<Pubkey>>,
         stakes: &HashMap<Pubkey, u64>,
-    ) -> impl Iterator<Item = (SocketAddr, Protocol)> {
+    ) -> impl Iterator<Item = (SocketAddr, Protocol)> + use<> {
         let now = timestamp();
         let keypair = self.keypair();
         let mut contact_info = self.my_contact_info();
@@ -1285,7 +1285,7 @@ impl ClusterInfo {
     fn new_push_requests(
         &self,
         stakes: &HashMap<Pubkey, u64>,
-    ) -> impl Iterator<Item = (SocketAddr, Protocol)> {
+    ) -> impl Iterator<Item = (SocketAddr, Protocol)> + use<> {
         let self_id = self.id();
         let (entries, push_messages, num_pushes) = {
             let _st = ScopedTimer::from(&self.stats.new_push_requests);
@@ -1336,7 +1336,7 @@ impl ClusterInfo {
         gossip_validators: Option<&HashSet<Pubkey>>,
         stakes: &HashMap<Pubkey, u64>,
         generate_pull_requests: bool,
-    ) -> impl Iterator<Item = (SocketAddr, Protocol)> {
+    ) -> impl Iterator<Item = (SocketAddr, Protocol)> + use<> {
         self.trim_crds_table(CRDS_UNIQUE_PUBKEY_CAPACITY, stakes);
         // This will flush local pending push messages before generating
         // pull-request bloom filters, preventing pull responses to return the

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -400,7 +400,10 @@ impl Crds {
     }
 
     /// Returns all records associated with a pubkey.
-    pub(crate) fn get_records(&self, pubkey: &Pubkey) -> impl Iterator<Item = &VersionedCrdsValue> {
+    pub(crate) fn get_records(
+        &self,
+        pubkey: &Pubkey,
+    ) -> impl Iterator<Item = &VersionedCrdsValue> + use<'_> {
         self.records
             .get(pubkey)
             .into_iter()

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -213,7 +213,8 @@ impl CrdsGossip {
         ping_cache: &Mutex<PingCache>,
         pings: &mut Vec<(SocketAddr, Ping)>,
         socket_addr_space: &SocketAddrSpace,
-    ) -> Result<impl Iterator<Item = (SocketAddr, CrdsFilter)> + Clone, CrdsGossipError> {
+    ) -> Result<impl Iterator<Item = (SocketAddr, CrdsFilter)> + Clone + use<>, CrdsGossipError>
+    {
         self.pull.new_pull_request(
             thread_pool,
             &self.crds,

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -246,7 +246,8 @@ impl CrdsGossipPull {
         ping_cache: &Mutex<PingCache>,
         pings: &mut Vec<(SocketAddr, Ping)>,
         socket_addr_space: &SocketAddrSpace,
-    ) -> Result<impl Iterator<Item = (SocketAddr, CrdsFilter)> + Clone, CrdsGossipError> {
+    ) -> Result<impl Iterator<Item = (SocketAddr, CrdsFilter)> + Clone + use<>, CrdsGossipError>
+    {
         let mut rng = rand::thread_rng();
         // Active and valid gossip nodes with matching shred-version.
         let nodes = crds_gossip::get_gossip_nodes(

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -114,7 +114,7 @@ impl CrdsGossipPush {
             .into_group_map()
     }
 
-    fn wallclock_window(&self, now: u64) -> impl RangeBounds<u64> {
+    fn wallclock_window(&self, now: u64) -> impl RangeBounds<u64> + use<> {
         now.saturating_sub(self.msg_timeout)..=now.saturating_add(self.msg_timeout)
     }
 

--- a/gossip/src/push_active_set.rs
+++ b/gossip/src/push_active_set.rs
@@ -33,7 +33,7 @@ impl PushActiveSet {
         pubkey: &'a Pubkey, // This node.
         origin: &'a Pubkey, // CRDS value owner.
         stakes: &HashMap<Pubkey, u64>,
-    ) -> impl Iterator<Item = &'a Pubkey> + 'a {
+    ) -> impl Iterator<Item = &'a Pubkey> + 'a + use<'a> {
         let stake = stakes.get(pubkey).min(stakes.get(origin));
         self.get_entry(stake).get_nodes(pubkey, origin)
     }

--- a/gossip/src/received_cache.rs
+++ b/gossip/src/received_cache.rs
@@ -41,7 +41,7 @@ impl ReceivedCache {
         stake_threshold: f64,
         min_ingress_nodes: usize,
         stakes: &HashMap<Pubkey, u64>,
-    ) -> impl Iterator<Item = Pubkey> {
+    ) -> impl Iterator<Item = Pubkey> + use<> {
         match self.0.peek_mut(&origin) {
             None => None,
             Some(entry) if entry.num_upserts < Self::MIN_NUM_UPSERTS => None,
@@ -97,7 +97,7 @@ impl ReceivedCacheEntry {
         stake_threshold: f64,
         min_ingress_nodes: usize,
         stakes: &HashMap<Pubkey, u64>,
-    ) -> impl Iterator<Item = Pubkey> {
+    ) -> impl Iterator<Item = Pubkey> + use<> {
         debug_assert!((0.0..=1.0).contains(&stake_threshold));
         debug_assert!(self.num_upserts >= ReceivedCache::MIN_NUM_UPSERTS);
         // Enforce a minimum aggregate ingress stake; see:


### PR DESCRIPTION
#### Problem
Migration to Edition 2024 (https://github.com/anza-xyz/agave/issues/6203) changes semantics of capturing references.
Warnings reported by [impl_trait_overcaptures](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/impl_trait_overcaptures/static.IMPL_TRAIT_OVERCAPTURES.html) highlight the changed behavior, fixing them isn't strictly necessary for using edition 2024, however given small number and diff for them it's reasonable to fix and deny them.

#### Summary of Changes
Add use<..> annotations for returned impl types