### PR TITLE
feat(ledger): validate data-shreds using shred.parent() instead of SlotMeta

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2185,12 +2185,10 @@ impl Blockstore {
             return false;
         }
 
-        // TODO Shouldn't this use shred.parent() instead and update
-        // slot_meta.parent_slot accordingly?
-        slot_meta
-            .parent_slot
-            .map(|parent_slot| verify_shred_slots(slot, parent_slot, max_root))
-            .unwrap_or_default()
+        match shred.parent() {
+            Ok(parent_slot) => verify_shred_slots(slot, parent_slot, max_root),
+            Err(_) => false,
+        }
     }
 
     fn insert_data_shred<'a>(


### PR DESCRIPTION
Replace dependency on SlotMeta.parent_slot in should_insert_data_shred with shred.parent() to avoid stale/absent parent metadata affecting validation; SlotMeta.parent_slot is already set earlier via get_slot_meta_entry(shred.parent()), so no additional updates are needed here; this aligns validation with the shred’s declared lineage and reduces fragility without changing surrounding behavior