### PR TITLE
feat(svm): split out static elements of `SVMMessage`

### DIFF
--- a/compute-budget-instruction/benches/process_compute_budget_instructions.rs
+++ b/compute-budget-instruction/benches/process_compute_budget_instructions.rs
@@ -8,7 +8,7 @@ use {
     solana_message::Message,
     solana_pubkey::Pubkey,
     solana_signer::Signer,
-    solana_svm_transaction::svm_message::SVMMessage,
+    solana_svm_transaction::svm_message::SVMStaticMessage,
     solana_system_interface::instruction::transfer,
     solana_transaction::{sanitized::SanitizedTransaction, Transaction},
 };
@@ -35,7 +35,7 @@ fn bench_process_compute_budget_instructions_empty(c: &mut Criterion) {
                 bencher.iter(|| {
                     (0..NUM_TRANSACTIONS_PER_ITER).for_each(|_| {
                         assert!(process_compute_budget_instructions(
-                            black_box(SVMMessage::program_instructions_iter(&tx)),
+                            black_box(SVMStaticMessage::program_instructions_iter(&tx)),
                             black_box(&feature_set),
                         )
                         .is_ok())
@@ -66,7 +66,7 @@ fn bench_process_compute_budget_instructions_no_builtins(c: &mut Criterion) {
                     bencher.iter(|| {
                         (0..NUM_TRANSACTIONS_PER_ITER).for_each(|_| {
                             assert!(process_compute_budget_instructions(
-                                black_box(SVMMessage::program_instructions_iter(&tx)),
+                                black_box(SVMStaticMessage::program_instructions_iter(&tx)),
                                 black_box(&feature_set),
                             )
                             .is_ok())
@@ -92,7 +92,7 @@ fn bench_process_compute_budget_instructions_compute_budgets(c: &mut Criterion) 
                 bencher.iter(|| {
                     (0..NUM_TRANSACTIONS_PER_ITER).for_each(|_| {
                         assert!(process_compute_budget_instructions(
-                            black_box(SVMMessage::program_instructions_iter(&tx)),
+                            black_box(SVMStaticMessage::program_instructions_iter(&tx)),
                             black_box(&feature_set),
                         )
                         .is_ok())
@@ -125,7 +125,7 @@ fn bench_process_compute_budget_instructions_builtins(c: &mut Criterion) {
                 bencher.iter(|| {
                     (0..NUM_TRANSACTIONS_PER_ITER).for_each(|_| {
                         assert!(process_compute_budget_instructions(
-                            black_box(SVMMessage::program_instructions_iter(&tx)),
+                            black_box(SVMStaticMessage::program_instructions_iter(&tx)),
                             black_box(&feature_set),
                         )
                         .is_ok())
@@ -165,7 +165,7 @@ fn bench_process_compute_budget_instructions_mixed(c: &mut Criterion) {
                     bencher.iter(|| {
                         (0..NUM_TRANSACTIONS_PER_ITER).for_each(|_| {
                             assert!(process_compute_budget_instructions(
-                                black_box(SVMMessage::program_instructions_iter(&tx)),
+                                black_box(SVMStaticMessage::program_instructions_iter(&tx)),
                                 black_box(&feature_set),
                             )
                             .is_ok())

--- a/compute-budget-instruction/src/compute_budget_instruction_details.rs
+++ b/compute-budget-instruction/src/compute_budget_instruction_details.rs
@@ -231,7 +231,7 @@ mod test {
         solana_message::Message,
         solana_pubkey::Pubkey,
         solana_signer::Signer,
-        solana_svm_transaction::svm_message::SVMMessage,
+        solana_svm_transaction::svm_message::SVMStaticMessage,
         solana_transaction::{sanitized::SanitizedTransaction, Transaction},
     };
 
@@ -258,7 +258,9 @@ mod test {
             ..ComputeBudgetInstructionDetails::default()
         });
         assert_eq!(
-            ComputeBudgetInstructionDetails::try_from(SVMMessage::program_instructions_iter(&tx),),
+            ComputeBudgetInstructionDetails::try_from(SVMStaticMessage::program_instructions_iter(
+                &tx
+            ),),
             expected_details
         );
 
@@ -268,7 +270,9 @@ mod test {
             ComputeBudgetInstruction::request_heap_frame(41 * 1024),
         ]);
         assert_eq!(
-            ComputeBudgetInstructionDetails::try_from(SVMMessage::program_instructions_iter(&tx),),
+            ComputeBudgetInstructionDetails::try_from(SVMStaticMessage::program_instructions_iter(
+                &tx
+            ),),
             Err(TransactionError::DuplicateInstruction(2))
         );
     }
@@ -286,7 +290,9 @@ mod test {
             ..ComputeBudgetInstructionDetails::default()
         });
         assert_eq!(
-            ComputeBudgetInstructionDetails::try_from(SVMMessage::program_instructions_iter(&tx),),
+            ComputeBudgetInstructionDetails::try_from(SVMStaticMessage::program_instructions_iter(
+                &tx
+            ),),
             expected_details
         );
 
@@ -296,7 +302,9 @@ mod test {
             ComputeBudgetInstruction::set_compute_unit_limit(u32::MAX),
         ]);
         assert_eq!(
-            ComputeBudgetInstructionDetails::try_from(SVMMessage::program_instructions_iter(&tx),),
+            ComputeBudgetInstructionDetails::try_from(SVMStaticMessage::program_instructions_iter(
+                &tx
+            ),),
             Err(TransactionError::DuplicateInstruction(2))
         );
     }
@@ -316,7 +324,9 @@ mod test {
             ..ComputeBudgetInstructionDetails::default()
         });
         assert_eq!(
-            ComputeBudgetInstructionDetails::try_from(SVMMessage::program_instructions_iter(&tx),),
+            ComputeBudgetInstructionDetails::try_from(SVMStaticMessage::program_instructions_iter(
+                &tx
+            ),),
             expected_details
         );
 
@@ -326,7 +336,9 @@ mod test {
             ComputeBudgetInstruction::set_compute_unit_price(u64::MAX),
         ]);
         assert_eq!(
-            ComputeBudgetInstructionDetails::try_from(SVMMessage::program_instructions_iter(&tx),),
+            ComputeBudgetInstructionDetails::try_from(SVMStaticMessage::program_instructions_iter(
+                &tx
+            ),),
             Err(TransactionError::DuplicateInstruction(2))
         );
     }
@@ -346,7 +358,9 @@ mod test {
             ..ComputeBudgetInstructionDetails::default()
         });
         assert_eq!(
-            ComputeBudgetInstructionDetails::try_from(SVMMessage::program_instructions_iter(&tx),),
+            ComputeBudgetInstructionDetails::try_from(SVMStaticMessage::program_instructions_iter(
+                &tx
+            ),),
             expected_details
         );
 
@@ -356,7 +370,9 @@ mod test {
             ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(u32::MAX),
         ]);
         assert_eq!(
-            ComputeBudgetInstructionDetails::try_from(SVMMessage::program_instructions_iter(&tx),),
+            ComputeBudgetInstructionDetails::try_from(SVMStaticMessage::program_instructions_iter(
+                &tx
+            ),),
             Err(TransactionError::DuplicateInstruction(2))
         );
     }
@@ -543,7 +559,7 @@ mod test {
                 .migrating_builtin[*position] = Saturating(1);
             let expected_details = Ok(expected_details);
             let details = ComputeBudgetInstructionDetails::try_from(
-                SVMMessage::program_instructions_iter(&tx),
+                SVMStaticMessage::program_instructions_iter(&tx),
             );
             assert_eq!(details, expected_details);
             let details = details.unwrap();

--- a/compute-budget-instruction/src/instructions_processor.rs
+++ b/compute-budget-instruction/src/instructions_processor.rs
@@ -29,7 +29,7 @@ mod tests {
         solana_message::Message,
         solana_pubkey::Pubkey,
         solana_signer::Signer,
-        solana_svm_transaction::svm_message::SVMMessage,
+        solana_svm_transaction::svm_message::SVMStaticMessage,
         solana_system_interface::instruction::transfer,
         solana_transaction::{sanitized::SanitizedTransaction, Transaction},
         solana_transaction_error::TransactionError,
@@ -51,7 +51,7 @@ mod tests {
             ));
 
             let result = process_compute_budget_instructions(
-                SVMMessage::program_instructions_iter(&tx),
+                SVMStaticMessage::program_instructions_iter(&tx),
                 $feature_set,
             );
             assert_eq!($expected_result, result);
@@ -437,7 +437,7 @@ mod tests {
             ),
         ] {
             let result = process_compute_budget_instructions(
-                SVMMessage::program_instructions_iter(&transaction),
+                SVMStaticMessage::program_instructions_iter(&transaction),
                 &feature_set,
             );
 

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -310,7 +310,7 @@ mod tests {
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk_ids::{compute_budget, system_program},
         solana_signer::Signer,
-        solana_svm_transaction::svm_message::SVMMessage,
+        solana_svm_transaction::svm_message::SVMStaticMessage,
         solana_system_interface::instruction::{self as system_instruction},
         solana_system_transaction as system_transaction,
         solana_transaction::Transaction,

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -179,7 +179,7 @@ impl<Tx> UsageCostDetails<'_, Tx> {
 pub struct WritableKeysTransaction(pub Vec<Pubkey>);
 
 #[cfg(feature = "dev-context-only-utils")]
-impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction {
+impl solana_svm_transaction::svm_message::SVMStaticMessage for WritableKeysTransaction {
     fn num_transaction_signatures(&self) -> u64 {
         unimplemented!("WritableKeysTransaction::num_transaction_signatures")
     }
@@ -217,24 +217,8 @@ impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction
         &self.0
     }
 
-    fn account_keys(&self) -> solana_message::AccountKeys<'_> {
-        solana_message::AccountKeys::new(&self.0, None)
-    }
-
     fn fee_payer(&self) -> &Pubkey {
         unimplemented!("WritableKeysTransaction::fee_payer")
-    }
-
-    fn is_writable(&self, _index: usize) -> bool {
-        true
-    }
-
-    fn is_signer(&self, _index: usize) -> bool {
-        unimplemented!("WritableKeysTransaction::is_signer")
-    }
-
-    fn is_invoked(&self, _key_index: usize) -> bool {
-        unimplemented!("WritableKeysTransaction::is_invoked")
     }
 
     fn num_lookup_tables(&self) -> usize {
@@ -249,6 +233,25 @@ impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction
         >,
     > {
         core::iter::empty()
+    }
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction {
+    fn account_keys(&self) -> solana_message::AccountKeys<'_> {
+        solana_message::AccountKeys::new(&self.0, None)
+    }
+
+    fn is_writable(&self, _index: usize) -> bool {
+        true
+    }
+
+    fn is_signer(&self, _index: usize) -> bool {
+        unimplemented!("WritableKeysTransaction::is_signer")
+    }
+
+    fn is_invoked(&self, _key_index: usize) -> bool {
+        unimplemented!("WritableKeysTransaction::is_invoked")
     }
 }
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -57,7 +57,7 @@ use {
         transaction_processor::ExecutionRecordingConfig,
     },
     solana_svm_timings::ExecuteTimings,
-    solana_svm_transaction::svm_message::SVMMessage,
+    solana_svm_transaction::svm_message::SVMStaticMessage,
     solana_svm_type_overrides::rand,
     solana_system_interface::{program as system_program, MAX_PERMITTED_DATA_LENGTH},
     solana_transaction::Transaction,
@@ -3884,7 +3884,7 @@ fn test_program_fees() {
     .unwrap();
     let fee_budget_limits = FeeBudgetLimits::from(
         process_compute_budget_instructions(
-            SVMMessage::program_instructions_iter(&sanitized_message),
+            SVMStaticMessage::program_instructions_iter(&sanitized_message),
             &feature_set,
         )
         .unwrap_or_default(),
@@ -3917,7 +3917,7 @@ fn test_program_fees() {
     .unwrap();
     let fee_budget_limits = FeeBudgetLimits::from(
         process_compute_budget_instructions(
-            SVMMessage::program_instructions_iter(&sanitized_message),
+            SVMStaticMessage::program_instructions_iter(&sanitized_message),
             &feature_set,
         )
         .unwrap_or_default(),

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -18,8 +18,10 @@ use {
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_svm_transaction::{
-        instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
-        svm_message::SVMMessage, svm_transaction::SVMTransaction,
+        instruction::SVMInstruction,
+        message_address_table_lookup::SVMMessageAddressTableLookup,
+        svm_message::{SVMMessage, SVMStaticMessage},
+        svm_transaction::SVMTransaction,
     },
 };
 
@@ -68,8 +70,7 @@ impl<T> Deref for RuntimeTransaction<T> {
         &self.transaction
     }
 }
-
-impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
+impl<T: SVMStaticMessage> SVMStaticMessage for RuntimeTransaction<T> {
     fn num_transaction_signatures(&self) -> u64 {
         self.transaction.num_transaction_signatures()
     }
@@ -118,12 +119,24 @@ impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
         self.transaction.static_account_keys()
     }
 
-    fn account_keys(&self) -> AccountKeys<'_> {
-        self.transaction.account_keys()
-    }
-
     fn fee_payer(&self) -> &Pubkey {
         self.transaction.fee_payer()
+    }
+
+    fn num_lookup_tables(&self) -> usize {
+        self.transaction.num_lookup_tables()
+    }
+
+    fn message_address_table_lookups(
+        &self,
+    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
+        self.transaction.message_address_table_lookups()
+    }
+}
+
+impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
+    fn account_keys(&self) -> AccountKeys<'_> {
+        self.transaction.account_keys()
     }
 
     fn is_writable(&self, index: usize) -> bool {
@@ -136,16 +149,6 @@ impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
 
     fn is_invoked(&self, key_index: usize) -> bool {
         self.transaction.is_invoked(key_index)
-    }
-
-    fn num_lookup_tables(&self) -> usize {
-        self.transaction.num_lookup_tables()
-    }
-
-    fn message_address_table_lookups(
-        &self,
-    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
-        self.transaction.message_address_table_lookups()
     }
 }
 

--- a/svm-transaction/src/svm_message.rs
+++ b/svm-transaction/src/svm_message.rs
@@ -19,8 +19,7 @@ static_assertions::const_assert_eq!(
 );
 const NONCED_TX_MARKER_IX_INDEX: u8 = 0;
 
-// - Debug to support legacy logging
-pub trait SVMMessage: Debug {
+pub trait SVMStaticMessage {
     /// Return the number of transaction-level signatures in the message.
     fn num_transaction_signatures(&self) -> u64;
     /// Return the number of ed25519 precompile signatures in the message.
@@ -58,11 +57,22 @@ pub trait SVMMessage: Debug {
     /// Return the list of static account keys.
     fn static_account_keys(&self) -> &[Pubkey];
 
-    /// Return the account keys.
-    fn account_keys(&self) -> AccountKeys<'_>;
-
     /// Return the fee-payer
     fn fee_payer(&self) -> &Pubkey;
+
+    /// Get the number of lookup tables.
+    fn num_lookup_tables(&self) -> usize;
+
+    /// Get message address table lookups used in the message
+    fn message_address_table_lookups(
+        &self,
+    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>>;
+}
+
+// - Debug to support legacy logging
+pub trait SVMMessage: Debug + SVMStaticMessage {
+    /// Return the account keys.
+    fn account_keys(&self) -> AccountKeys<'_>;
 
     /// Returns `true` if the account at `index` is writable.
     fn is_writable(&self, index: usize) -> bool;
@@ -135,14 +145,6 @@ pub trait SVMMessage: Debug {
                     .filter_map(|signer_index| self.account_keys().get(signer_index))
             })
     }
-
-    /// Get the number of lookup tables.
-    fn num_lookup_tables(&self) -> usize;
-
-    /// Get message address table lookups used in the message
-    fn message_address_table_lookups(
-        &self,
-    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>>;
 }
 
 fn default_precompile_signature_count<'a>(

--- a/svm-transaction/src/svm_message/sanitized_message.rs
+++ b/svm-transaction/src/svm_message/sanitized_message.rs
@@ -1,15 +1,15 @@
 use {
     crate::{
-        instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
-        svm_message::SVMMessage,
+        instruction::SVMInstruction,
+        message_address_table_lookup::SVMMessageAddressTableLookup,
+        svm_message::{SVMMessage, SVMStaticMessage},
     },
     solana_hash::Hash,
     solana_message::{AccountKeys, SanitizedMessage},
     solana_pubkey::Pubkey,
 };
 
-// Implement for the "reference" `SanitizedMessage` type.
-impl SVMMessage for SanitizedMessage {
+impl SVMStaticMessage for SanitizedMessage {
     fn num_transaction_signatures(&self) -> u64 {
         u64::from(self.header().num_required_signatures)
     }
@@ -43,24 +43,8 @@ impl SVMMessage for SanitizedMessage {
         SanitizedMessage::static_account_keys(self)
     }
 
-    fn account_keys(&self) -> AccountKeys<'_> {
-        SanitizedMessage::account_keys(self)
-    }
-
     fn fee_payer(&self) -> &Pubkey {
         SanitizedMessage::fee_payer(self)
-    }
-
-    fn is_writable(&self, index: usize) -> bool {
-        SanitizedMessage::is_writable(self, index)
-    }
-
-    fn is_signer(&self, index: usize) -> bool {
-        SanitizedMessage::is_signer(self, index)
-    }
-
-    fn is_invoked(&self, key_index: usize) -> bool {
-        SanitizedMessage::is_invoked(self, key_index)
     }
 
     fn num_lookup_tables(&self) -> usize {
@@ -73,5 +57,24 @@ impl SVMMessage for SanitizedMessage {
         SanitizedMessage::message_address_table_lookups(self)
             .iter()
             .map(SVMMessageAddressTableLookup::from)
+    }
+}
+
+// Implement for the "reference" `SanitizedMessage` type.
+impl SVMMessage for SanitizedMessage {
+    fn account_keys(&self) -> AccountKeys<'_> {
+        SanitizedMessage::account_keys(self)
+    }
+
+    fn is_writable(&self, index: usize) -> bool {
+        SanitizedMessage::is_writable(self, index)
+    }
+
+    fn is_signer(&self, index: usize) -> bool {
+        SanitizedMessage::is_signer(self, index)
+    }
+
+    fn is_invoked(&self, key_index: usize) -> bool {
+        SanitizedMessage::is_invoked(self, key_index)
     }
 }

--- a/svm-transaction/src/svm_message/sanitized_transaction.rs
+++ b/svm-transaction/src/svm_message/sanitized_transaction.rs
@@ -1,7 +1,8 @@
 use {
     crate::{
-        instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
-        svm_message::SVMMessage,
+        instruction::SVMInstruction,
+        message_address_table_lookup::SVMMessageAddressTableLookup,
+        svm_message::{SVMMessage, SVMStaticMessage},
     },
     solana_hash::Hash,
     solana_message::AccountKeys,
@@ -9,43 +10,55 @@ use {
     solana_transaction::sanitized::SanitizedTransaction,
 };
 
-impl SVMMessage for SanitizedTransaction {
+impl SVMStaticMessage for SanitizedTransaction {
     fn num_transaction_signatures(&self) -> u64 {
-        SVMMessage::num_transaction_signatures(SanitizedTransaction::message(self))
+        SVMStaticMessage::num_transaction_signatures(SanitizedTransaction::message(self))
     }
 
     fn num_write_locks(&self) -> u64 {
-        SVMMessage::num_write_locks(SanitizedTransaction::message(self))
+        SVMStaticMessage::num_write_locks(SanitizedTransaction::message(self))
     }
 
     fn recent_blockhash(&self) -> &Hash {
-        SVMMessage::recent_blockhash(SanitizedTransaction::message(self))
+        SVMStaticMessage::recent_blockhash(SanitizedTransaction::message(self))
     }
 
     fn num_instructions(&self) -> usize {
-        SVMMessage::num_instructions(SanitizedTransaction::message(self))
+        SVMStaticMessage::num_instructions(SanitizedTransaction::message(self))
     }
 
     fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
-        SVMMessage::instructions_iter(SanitizedTransaction::message(self))
+        SVMStaticMessage::instructions_iter(SanitizedTransaction::message(self))
     }
 
     fn program_instructions_iter(
         &self,
     ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
-        SVMMessage::program_instructions_iter(SanitizedTransaction::message(self))
+        SVMStaticMessage::program_instructions_iter(SanitizedTransaction::message(self))
     }
 
     fn static_account_keys(&self) -> &[Pubkey] {
-        SVMMessage::static_account_keys(SanitizedTransaction::message(self))
-    }
-
-    fn account_keys(&self) -> AccountKeys<'_> {
-        SVMMessage::account_keys(SanitizedTransaction::message(self))
+        SVMStaticMessage::static_account_keys(SanitizedTransaction::message(self))
     }
 
     fn fee_payer(&self) -> &Pubkey {
-        SVMMessage::fee_payer(SanitizedTransaction::message(self))
+        SVMStaticMessage::fee_payer(SanitizedTransaction::message(self))
+    }
+
+    fn num_lookup_tables(&self) -> usize {
+        SVMStaticMessage::num_lookup_tables(SanitizedTransaction::message(self))
+    }
+
+    fn message_address_table_lookups(
+        &self,
+    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
+        SVMStaticMessage::message_address_table_lookups(SanitizedTransaction::message(self))
+    }
+}
+
+impl SVMMessage for SanitizedTransaction {
+    fn account_keys(&self) -> AccountKeys<'_> {
+        SVMMessage::account_keys(SanitizedTransaction::message(self))
     }
 
     fn is_writable(&self, index: usize) -> bool {
@@ -58,15 +71,5 @@ impl SVMMessage for SanitizedTransaction {
 
     fn is_invoked(&self, key_index: usize) -> bool {
         SVMMessage::is_invoked(SanitizedTransaction::message(self), key_index)
-    }
-
-    fn num_lookup_tables(&self) -> usize {
-        SVMMessage::num_lookup_tables(SanitizedTransaction::message(self))
-    }
-
-    fn message_address_table_lookups(
-        &self,
-    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
-        SVMMessage::message_address_table_lookups(SanitizedTransaction::message(self))
     }
 }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -43,7 +43,10 @@ use {
         },
     },
     solana_svm_feature_set::SVMFeatureSet,
-    solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMMessage},
+    solana_svm_transaction::{
+        instruction::SVMInstruction,
+        svm_message::{SVMMessage, SVMStaticMessage},
+    },
     solana_svm_type_overrides::sync::{Arc, RwLock},
     solana_system_interface::{instruction as system_instruction, program as system_program},
     solana_system_transaction as system_transaction,
@@ -515,7 +518,7 @@ impl SvmTestEntry {
                 let message = SanitizedTransaction::from_transaction_for_tests(item.transaction);
                 let check_result = item.check_result.map(|tx_details| {
                     let compute_budget_limits = process_test_compute_budget_instructions(
-                        SVMMessage::program_instructions_iter(&message),
+                        SVMStaticMessage::program_instructions_iter(&message),
                     );
                     let signature_count = message
                         .num_transaction_signatures()


### PR DESCRIPTION
#### Problem

- Not all methods on `SVMMessage` require ALT resolution - this can make it cumbersome to work with unresolved transactions (where we lose the SVMMessage functions).

#### Summary of Changes

- Split out the parts of `SVMMessage` that do not rely on ALT resolution. `SVMMessage` will then depend on this subset so downstream consumers can continue using `SVMMessage` uninterrupted.