### PR TITLE
Update Dependabot config so it checks dependencies for dev-bins, ci/xtask, and programs/sbf

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
   - package-ecosystem: cargo
     directories:
       - "/"
+      - "/dev-bins"
+      - "/ci/xtask"
       - "/programs/sbf"
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,9 @@
 version: 2
 updates:
   - package-ecosystem: cargo
-    directory: "/"
+    directories:
+      - "/"
+      - "/programs/sbf"
     schedule:
       interval: daily
       time: "01:00"


### PR DESCRIPTION
#### Problem
Example: https://github.com/anza-xyz/agave/pull/8975

CI is failing with:
```
... which satisfies dependency `solana-instruction = "=3.0.0"` of package `solana-sbf-rust-caller-access v4.0.0-alpha.0 (/var/lib/buildkite-agent/builds/ci52/anza/agave/programs/sbf/rust/caller_access)`
```
Because not all instances of `solana-instruction` dependency were bumped.

#### Summary of Changes
Switch from `directory` to `directories` and include programs/sbf

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
