### PR TITLE
Gossip: Remove LegacyContactInfo

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2445,7 +2445,6 @@ pub fn push_messages_to_peer_for_tests(
 fn check_pull_request_shred_version(self_shred_version: u16, caller: &CrdsValue) -> bool {
     let shred_version = match caller.data() {
         CrdsData::ContactInfo(node) => node.shred_version(),
-        CrdsData::LegacyContactInfo(node) => node.shred_version(),
         _ => return false,
     };
     shred_version == self_shred_version
@@ -2507,7 +2506,6 @@ fn verify_gossip_addr<R: Rng + CryptoRng>(
 ) -> bool {
     let (pubkey, addr) = match value.data() {
         CrdsData::ContactInfo(node) => (node.pubkey(), node.gossip()),
-        CrdsData::LegacyContactInfo(node) => (node.pubkey(), node.gossip()),
         _ => return true, // If not a contact-info, nothing to verify.
     };
     // Invalid addresses are not verifiable.

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -3,7 +3,6 @@ use {
     crate::{
         crds_data::MAX_WALLCLOCK,
         define_tlv_enum,
-        legacy_contact_info::LegacyContactInfo,
         tlv::{self, TlvDecodeError, TlvRecord},
     },
     assert_matches::{assert_matches, debug_assert_matches},
@@ -411,8 +410,18 @@ impl ContactInfo {
         }
     }
 
+    /// port must not be 0
+    /// ip must be specified and not multicast
+    /// loopback ip is only allowed in tests
+    // TODO: Replace this entirely with streamer SocketAddrSpace.
     pub fn is_valid_address(addr: &SocketAddr, socket_addr_space: &SocketAddrSpace) -> bool {
-        LegacyContactInfo::is_valid_address(addr, socket_addr_space)
+        addr.port() != 0u16 && Self::is_valid_ip(addr.ip()) && socket_addr_space.check(addr)
+    }
+
+    fn is_valid_ip(addr: IpAddr) -> bool {
+        !(addr.is_unspecified() || addr.is_multicast())
+        // || (addr.is_loopback() && !cfg_test))
+        // TODO: boot loopback in production networks
     }
 
     /// New random ContactInfo for tests and simulations.
@@ -693,6 +702,23 @@ impl solana_frozen_abi::abi_example::AbiExample for ContactInfo {
             cache: EMPTY_SOCKET_ADDR_CACHE,
         }
     }
+}
+
+#[macro_export]
+macro_rules! socketaddr {
+    ($ip:expr, $port:expr) => {
+        std::net::SocketAddr::from((std::net::Ipv4Addr::from($ip), $port))
+    };
+    ($str:expr) => {{
+        $str.parse::<std::net::SocketAddr>().unwrap()
+    }};
+}
+
+#[macro_export]
+macro_rules! socketaddr_any {
+    () => {
+        socketaddr!(std::net::Ipv4Addr::UNSPECIFIED, 0)
+    };
 }
 
 #[cfg(test)]
@@ -976,72 +1002,6 @@ mod tests {
             let other: ContactInfo = bincode::deserialize(&bytes).unwrap();
             assert_eq!(node, other);
         }
-    }
-
-    fn cross_verify_with_legacy(node: &ContactInfo) {
-        let old = LegacyContactInfo::try_from(node).unwrap();
-        assert_eq!(old.gossip().unwrap(), node.gossip().unwrap());
-        assert_eq!(old.rpc().unwrap(), node.rpc().unwrap());
-        assert_eq!(old.rpc_pubsub().unwrap(), node.rpc_pubsub().unwrap());
-        assert_eq!(
-            old.serve_repair(Protocol::QUIC).unwrap(),
-            node.serve_repair(Protocol::QUIC).unwrap()
-        );
-        assert_eq!(
-            old.serve_repair(Protocol::UDP).unwrap(),
-            node.serve_repair(Protocol::UDP).unwrap()
-        );
-        assert_eq!(old.tpu().unwrap(), node.tpu(Protocol::UDP).unwrap());
-        assert_eq!(
-            node.tpu(Protocol::QUIC).unwrap(),
-            SocketAddr::new(
-                old.tpu().unwrap().ip(),
-                old.tpu().unwrap().port() + QUIC_PORT_OFFSET
-            )
-        );
-        assert_eq!(
-            old.tpu_forwards().unwrap(),
-            node.tpu_forwards(Protocol::UDP).unwrap()
-        );
-        assert_eq!(
-            node.tpu_forwards(Protocol::QUIC).unwrap(),
-            SocketAddr::new(
-                old.tpu_forwards().unwrap().ip(),
-                old.tpu_forwards().unwrap().port() + QUIC_PORT_OFFSET
-            )
-        );
-        assert_eq!(
-            old.tpu_vote().unwrap(),
-            node.tpu_vote(Protocol::UDP).unwrap()
-        );
-        assert_eq!(
-            old.tvu(Protocol::QUIC).unwrap(),
-            node.tvu(Protocol::QUIC).unwrap()
-        );
-        assert_eq!(
-            old.tvu(Protocol::UDP).unwrap(),
-            node.tvu(Protocol::UDP).unwrap()
-        );
-    }
-
-    #[test]
-    fn test_new_localhost() {
-        let node = ContactInfo::new_localhost(
-            &Keypair::new().pubkey(),
-            solana_time_utils::timestamp(), // wallclock
-        );
-        cross_verify_with_legacy(&node);
-    }
-
-    #[test]
-    fn test_new_with_socketaddr() {
-        let mut rng = rand::thread_rng();
-        let socket = repeat_with(|| new_rand_socket(&mut rng))
-            .filter(|socket| matches!(sanitize_socket(socket), Ok(())))
-            .find(|socket| socket.port().checked_add(11).is_some())
-            .unwrap();
-        let node = ContactInfo::new_with_socketaddr(&Keypair::new().pubkey(), &socket);
-        cross_verify_with_legacy(&node);
     }
 
     #[test]

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -412,16 +412,12 @@ impl ContactInfo {
 
     /// port must not be 0
     /// ip must be specified and not multicast
-    /// loopback ip is only allowed in tests
-    // TODO: Replace this entirely with streamer SocketAddrSpace.
     pub fn is_valid_address(addr: &SocketAddr, socket_addr_space: &SocketAddrSpace) -> bool {
         addr.port() != 0u16 && Self::is_valid_ip(addr.ip()) && socket_addr_space.check(addr)
     }
 
     fn is_valid_ip(addr: IpAddr) -> bool {
         !(addr.is_unspecified() || addr.is_multicast())
-        // || (addr.is_loopback() && !cfg_test))
-        // TODO: boot loopback in production networks
     }
 
     /// New random ContactInfo for tests and simulations.

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -665,7 +665,6 @@ pub(crate) mod tests {
         super::*,
         crate::{
             crds_data::{CrdsData, Vote},
-            legacy_contact_info::LegacyContactInfo,
             protocol::Protocol,
         },
         itertools::Itertools,
@@ -1560,14 +1559,8 @@ pub(crate) mod tests {
             node
         };
         {
-            let caller = CrdsValue::new(CrdsData::from(&node), &keypair);
+            let caller: CrdsValue = CrdsValue::new(CrdsData::from(&node), &keypair);
             assert_eq!(get_max_bloom_filter_bytes(&caller), 1175);
-            verify_get_max_bloom_filter_bytes(&mut rng, &caller, num_items);
-        }
-        let node = LegacyContactInfo::try_from(&node).unwrap();
-        {
-            let caller = CrdsValue::new(CrdsData::LegacyContactInfo(node), &keypair);
-            assert_eq!(get_max_bloom_filter_bytes(&caller), 1136);
             verify_get_max_bloom_filter_bytes(&mut rng, &caller, num_items);
         }
         let node = {
@@ -1580,12 +1573,6 @@ pub(crate) mod tests {
         {
             let caller = CrdsValue::new(CrdsData::from(&node), &keypair);
             assert_eq!(get_max_bloom_filter_bytes(&caller), 1155);
-            verify_get_max_bloom_filter_bytes(&mut rng, &caller, num_items);
-        }
-        let node = LegacyContactInfo::try_from(&node).unwrap();
-        {
-            let caller = CrdsValue::new(CrdsData::LegacyContactInfo(node), &keypair);
-            assert_eq!(get_max_bloom_filter_bytes(&caller), 992);
             verify_get_max_bloom_filter_bytes(&mut rng, &caller, num_items);
         }
     }

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -1,12 +1,11 @@
 #[cfg(test)]
-use crate::contact_info::{sanitize_socket, ContactInfo, Error, Protocol, SOCKET_ADDR_UNSPECIFIED};
+use crate::{socketaddr, socketaddr_any};
 use {
     crate::crds_data::{reject_deserialize, MAX_WALLCLOCK},
     serde::Serialize,
     solana_pubkey::Pubkey,
     solana_sanitize::{Sanitize, SanitizeError},
-    solana_streamer::socket::SocketAddrSpace,
-    std::net::{IpAddr, SocketAddr},
+    std::net::SocketAddr,
 };
 
 /// Structure representing a node on the network
@@ -50,45 +49,6 @@ impl Sanitize for LegacyContactInfo {
     }
 }
 
-macro_rules! get_socket {
-    ($name:ident) => {
-        #[cfg(test)]
-        pub(crate) fn $name(&self) -> Option<SocketAddr> {
-            let socket = self.$name;
-            sanitize_socket(&socket).ok()?;
-            Some(socket)
-        }
-    };
-    ($name:ident, $quic:ident) => {
-        #[cfg(test)]
-        pub(crate) fn $name(&self, protocol: Protocol) -> Option<SocketAddr> {
-            let socket = match protocol {
-                Protocol::QUIC => self.$quic,
-                Protocol::UDP => self.$name,
-            };
-            sanitize_socket(&socket).ok()?;
-            Some(socket)
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! socketaddr {
-    ($ip:expr, $port:expr) => {
-        std::net::SocketAddr::from((std::net::Ipv4Addr::from($ip), $port))
-    };
-    ($str:expr) => {{
-        $str.parse::<std::net::SocketAddr>().unwrap()
-    }};
-}
-
-#[macro_export]
-macro_rules! socketaddr_any {
-    () => {
-        socketaddr!(std::net::Ipv4Addr::UNSPECIFIED, 0)
-    };
-}
-
 #[cfg(test)]
 impl Default for LegacyContactInfo {
     fn default() -> Self {
@@ -120,113 +80,11 @@ impl LegacyContactInfo {
     pub(crate) fn wallclock(&self) -> u64 {
         self.wallclock
     }
-
-    #[inline]
-    pub(crate) fn shred_version(&self) -> u16 {
-        self.shred_version
-    }
-
-    pub(crate) fn gossip(&self) -> Option<SocketAddr> {
-        let socket = self.gossip;
-        crate::contact_info::sanitize_socket(&socket).ok()?;
-        Some(socket)
-    }
-
-    get_socket!(tvu, tvu_quic);
-    get_socket!(tpu);
-    get_socket!(tpu_forwards);
-    get_socket!(tpu_vote);
-    get_socket!(rpc);
-    get_socket!(rpc_pubsub);
-    get_socket!(serve_repair, serve_repair_quic);
-
-    fn is_valid_ip(addr: IpAddr) -> bool {
-        !(addr.is_unspecified() || addr.is_multicast())
-        // || (addr.is_loopback() && !cfg_test))
-        // TODO: boot loopback in production networks
-    }
-
-    /// port must not be 0
-    /// ip must be specified and not multicast
-    /// loopback ip is only allowed in tests
-    // TODO: Replace this entirely with streamer SocketAddrSpace.
-    pub(crate) fn is_valid_address(addr: &SocketAddr, socket_addr_space: &SocketAddrSpace) -> bool {
-        addr.port() != 0u16 && Self::is_valid_ip(addr.ip()) && socket_addr_space.check(addr)
-    }
-}
-
-#[cfg(test)]
-impl TryFrom<&ContactInfo> for LegacyContactInfo {
-    type Error = Error;
-
-    fn try_from(node: &ContactInfo) -> Result<Self, Self::Error> {
-        macro_rules! unwrap_socket {
-            ($name:ident) => {
-                node.$name().unwrap_or(SOCKET_ADDR_UNSPECIFIED)
-            };
-            ($name:ident, $protocol:expr) => {
-                node.$name($protocol).unwrap_or(SOCKET_ADDR_UNSPECIFIED)
-            };
-        }
-        Ok(Self {
-            id: *node.pubkey(),
-            gossip: unwrap_socket!(gossip),
-            tvu: unwrap_socket!(tvu, Protocol::UDP),
-            tvu_quic: unwrap_socket!(tvu, Protocol::QUIC),
-            serve_repair_quic: unwrap_socket!(serve_repair, Protocol::QUIC),
-            tpu: unwrap_socket!(tpu, Protocol::UDP),
-            tpu_forwards: unwrap_socket!(tpu_forwards, Protocol::UDP),
-            tpu_vote: unwrap_socket!(tpu_vote, Protocol::UDP),
-            rpc: unwrap_socket!(rpc),
-            rpc_pubsub: unwrap_socket!(rpc_pubsub),
-            serve_repair: unwrap_socket!(serve_repair, Protocol::UDP),
-            wallclock: node.wallclock(),
-            shred_version: node.shred_version(),
-        })
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use {super::*, std::net::Ipv4Addr};
-
-    #[test]
-    fn test_is_valid_address() {
-        let bad_address_port = socketaddr!(Ipv4Addr::LOCALHOST, 0);
-        assert!(!LegacyContactInfo::is_valid_address(
-            &bad_address_port,
-            &SocketAddrSpace::Unspecified
-        ));
-        let bad_address_unspecified = socketaddr!(Ipv4Addr::UNSPECIFIED, 1234);
-        assert!(!LegacyContactInfo::is_valid_address(
-            &bad_address_unspecified,
-            &SocketAddrSpace::Unspecified
-        ));
-        let bad_address_multicast = socketaddr!([224, 254, 0, 0], 1234);
-        assert!(!LegacyContactInfo::is_valid_address(
-            &bad_address_multicast,
-            &SocketAddrSpace::Unspecified
-        ));
-        let loopback = socketaddr!(Ipv4Addr::LOCALHOST, 1234);
-        assert!(LegacyContactInfo::is_valid_address(
-            &loopback,
-            &SocketAddrSpace::Unspecified
-        ));
-        //        assert!(!LegacyContactInfo::is_valid_ip_internal(loopback.ip(), false));
-    }
-
-    #[test]
-    fn test_default() {
-        let ci = LegacyContactInfo::default();
-        assert!(ci.gossip.ip().is_unspecified());
-        assert!(ci.tvu.ip().is_unspecified());
-        assert!(ci.tpu_forwards.ip().is_unspecified());
-        assert!(ci.rpc.ip().is_unspecified());
-        assert!(ci.rpc_pubsub.ip().is_unspecified());
-        assert!(ci.tpu.ip().is_unspecified());
-        assert!(ci.tpu_vote.ip().is_unspecified());
-        assert!(ci.serve_repair.ip().is_unspecified());
-    }
+    use super::*;
 
     #[test]
     fn test_sanitize() {

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 use crate::{socketaddr, socketaddr_any};
 use {
-    crate::crds_data::{reject_deserialize, MAX_WALLCLOCK},
+    crate::crds_data::reject_deserialize,
     serde::Serialize,
     solana_pubkey::Pubkey,
     solana_sanitize::{Sanitize, SanitizeError},
@@ -42,10 +42,7 @@ reject_deserialize!(LegacyContactInfo, "LegacyContactInfo is deprecated");
 
 impl Sanitize for LegacyContactInfo {
     fn sanitize(&self) -> std::result::Result<(), SanitizeError> {
-        if self.wallclock >= MAX_WALLCLOCK {
-            return Err(SanitizeError::ValueOutOfBounds);
-        }
-        Ok(())
+        Err(SanitizeError::ValueOutOfBounds)
     }
 }
 
@@ -79,18 +76,5 @@ impl LegacyContactInfo {
     #[inline]
     pub(crate) fn wallclock(&self) -> u64 {
         self.wallclock
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_sanitize() {
-        let mut ci = LegacyContactInfo::default();
-        assert_eq!(ci.sanitize(), Ok(()));
-        ci.wallclock = MAX_WALLCLOCK;
-        assert_eq!(ci.sanitize(), Err(SanitizeError::ValueOutOfBounds));
     }
 }

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -157,7 +157,7 @@ impl Sanitize for Protocol {
                 filter.sanitize()?;
                 // PullRequest is only allowed to have ContactInfo in its CrdsData
                 match val.data() {
-                    CrdsData::LegacyContactInfo(_) | CrdsData::ContactInfo(_) => val.sanitize(),
+                    CrdsData::ContactInfo(_) => val.sanitize(),
                     _ => Err(SanitizeError::InvalidValue),
                 }
             }


### PR DESCRIPTION
#### Problem
LegacyContactInfo is deprecated. let's remove it

#### Summary of Changes
Remove LegacyContactInfo outside of areas where it is still needed for backwards compatability: `CrdsData` 
Move helper functions from `LegacyContactInfo` to `ContactInfo`

