### PR TITLE
clippy: fix and deny unsafe_attr_outside_unsafe warning for edition 2024 migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,7 @@ never_type_fallback_flowing_into_unsafe = "deny"
 rust_2024_guarded_string_incompatible_syntax = "deny"
 rust_2024_prelude_collisions = "deny"
 static_mut_refs = "deny"
+unsafe_attr_outside_unsafe = "deny"
 
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -32,6 +32,7 @@ never_type_fallback_flowing_into_unsafe = "deny"
 rust_2024_guarded_string_incompatible_syntax = "deny"
 rust_2024_prelude_collisions = "deny"
 static_mut_refs = "deny"
+unsafe_attr_outside_unsafe = "deny"
 
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"

--- a/svm-test-harness/src/fuzz.rs
+++ b/svm-test-harness/src/fuzz.rs
@@ -16,7 +16,7 @@ use {
     std::{env, ffi::c_int, sync::Arc},
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn sol_compat_init(_log_level: i32) {
     env::set_var("SOLANA_RAYON_THREADS", "1");
     env::set_var("RAYON_NUM_THREADS", "1");
@@ -26,7 +26,7 @@ pub unsafe extern "C" fn sol_compat_init(_log_level: i32) {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn sol_compat_fini() {}
 
 pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects> {
@@ -88,7 +88,7 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects
     instr_effects.map(Into::into)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn sol_compat_instr_execute_v1(
     out_ptr: *mut u8,
     out_psz: *mut u64,


### PR DESCRIPTION
#### Problem
Rust edition 2024 [migration](https://github.com/anza-xyz/agave/issues/6203) requires unsafe annotation for `no_mangle` attribute.
This is detected by `unsafe_attr_outside_unsafe` warning and since that is the only violation in the codebase, we can add it to deny list once fixed

#### Summary of Changes
* update attribute with `unsafe`
* deny `unsafe_attr_outside_unsafe` in workspace