### PR TITLE
add `agave-unstable-api` deprecation warning to new `agave-fs` crate

### DIFF
--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -1,3 +1,12 @@
+#![cfg_attr(
+    not(feature = "agave-unstable-api"),
+    deprecated(
+        since = "3.1.0",
+        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
+                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
+                acknowledge use of an interface that may break without warning."
+    )
+)]
 // Activate some of the Rust 2024 lints to make the future migration easier.
 #![warn(if_let_rescope)]
 #![warn(keyword_idents_2024)]


### PR DESCRIPTION
#### Problem
the `agave-fs` crate introduction snuck in around #8424, leaving it in v3.1 branch without a deprecation warning

#### Summary of Changes
add the deprecation warning for consistency