### PR TITLE
chore(svm): fix unsafe-op-in-unsafe-fn for rust 2024 migration

### DIFF
--- a/svm-test-harness/src/fuzz.rs
+++ b/svm-test-harness/src/fuzz.rs
@@ -18,8 +18,10 @@ use {
 
 #[no_mangle]
 pub unsafe extern "C" fn sol_compat_init(_log_level: i32) {
-    env::set_var("SOLANA_RAYON_THREADS", "1");
-    env::set_var("RAYON_NUM_THREADS", "1");
+    unsafe {
+        env::set_var("SOLANA_RAYON_THREADS", "1");
+        env::set_var("RAYON_NUM_THREADS", "1");
+    }
     if env::var("ENABLE_SOLANA_LOGGER").is_ok() {
         /* Pairs with RUST_LOG={trace,debug,info,etc} */
         agave_logger::setup();
@@ -95,20 +97,21 @@ pub unsafe extern "C" fn sol_compat_instr_execute_v1(
     in_ptr: *mut u8,
     in_sz: u64,
 ) -> c_int {
-    let in_slice = std::slice::from_raw_parts(in_ptr, in_sz as usize);
+    let in_slice = unsafe { std::slice::from_raw_parts(in_ptr, in_sz as usize) };
     let Ok(instr_context) = ProtoInstrContext::decode(in_slice) else {
         return 0;
     };
     let Some(instr_effects) = execute_instr_proto(instr_context) else {
         return 0;
     };
-    let out_slice = std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize);
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize) };
     let out_vec = instr_effects.encode_to_vec();
     if out_vec.len() > out_slice.len() {
         return 0;
     }
     out_slice[..out_vec.len()].copy_from_slice(&out_vec);
-    *out_psz = out_vec.len() as u64;
-
+    unsafe {
+        *out_psz = out_vec.len() as u64;
+    }
     1
 }


### PR DESCRIPTION
#### Problem
Rust 2024 edition (https://github.com/anza-xyz/agave/issues/6203) requires all unsafe calls to be surrounded by `unsafe {..}` block even if it is in function marked as `unsafe` itself.

#### Summary of Changes
Fix cases reported by `unsafe-op-in-unsafe-fn` in svm-test-harness
