### PR TITLE
Removes deprecated accounts-db arg from validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Release channels have their own copy of this changelog:
 * Added `--enable-scheduler-bindings` which binds an IPC server at `<ledger-path>/scheduler_bindings.ipc` for external schedulers to connect to.
 ### Validator
 #### Breaking
+* Removed deprecated arguments
+  * `--accounts-db-clean-threads`
+  * `--accounts-db-hash-threads`
+  * `--accounts-db-read-cache-limit-mb`
+  * `--accounts-hash-cache-path`
+  * `--disable-accounts-disk-index`
 #### Deprecations
 * Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.
 

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -131,64 +131,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
 
     add_arg!(
         // deprecated in v3.0.0
-        Arg::with_name("accounts_db_clean_threads")
-            .long("accounts-db-clean-threads")
-            .takes_value(true)
-            .value_name("NUMBER")
-            .conflicts_with("accounts_db_background_threads"),
-        replaced_by: "accounts-db-background-threads",
-    );
-    add_arg!(
-        // deprecated in v3.1.0
-        Arg::with_name("accounts_db_hash_threads")
-            .long("accounts-db-hash-threads")
-            .takes_value(true)
-            .value_name("NUMBER"),
-        usage_warning: "There is no more startup background accounts hash calculation",
-    );
-    add_arg!(
-        // deprecated in v3.0.0
-        Arg::with_name("accounts_db_read_cache_limit_mb")
-            .long("accounts-db-read-cache-limit-mb")
-            .value_name("MAX | LOW,HIGH")
-            .takes_value(true)
-            .min_values(1)
-            .max_values(2)
-            .multiple(false)
-            .require_delimiter(true)
-            .help("How large the read cache for account data can become, in mebibytes")
-            .long_help(
-                "How large the read cache for account data can become, in mebibytes. \
-                 If given a single value, it will be the maximum size for the cache. \
-                 If given a pair of values, they will be the low and high watermarks \
-                 for the cache. When the cache exceeds the high watermark, entries will \
-                 be evicted until the size reaches the low watermark."
-            )
-            .hidden(hidden_unless_forced())
-            .conflicts_with("accounts_db_read_cache_limit"),
-            replaced_by: "accounts-db-read-cache-limit",
-    );
-    add_arg!(
-        // deprecated in v3.0.0
-        Arg::with_name("accounts_hash_cache_path")
-            .long("accounts-hash-cache-path")
-            .value_name("PATH")
-            .takes_value(true)
-            .help(
-                "Use PATH as accounts hash cache location \
-                 [default: <LEDGER>/accounts_hash_cache]",
-            ),
-            usage_warning: "The accounts hash cache is obsolete",
-    );
-    add_arg!(Arg::with_name("disable_accounts_disk_index")
-        // (actually) deprecated in v3.1.0
-        .long("disable-accounts-disk-index")
-        .help("Disable the disk-based accounts index if it is enabled by default.")
-        .conflicts_with("enable_accounts_disk_index"),
-        usage_warning: "The disk-based accounts index is disabled by default",
-    );
-    add_arg!(
-        // deprecated in v3.0.0
         Arg::with_name("gossip_host")
             .long("gossip-host")
             .value_name("HOST")

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -113,15 +113,12 @@ pub struct NumThreadConfig {
 }
 
 pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
-    let accounts_db_background_threads = {
-        if matches.is_present("accounts_db_clean_threads") {
-            value_t_or_exit!(matches, "accounts_db_clean_threads", NonZeroUsize)
-        } else {
-            value_t_or_exit!(matches, AccountsDbBackgroundThreadsArg::NAME, NonZeroUsize)
-        }
-    };
     NumThreadConfig {
-        accounts_db_background_threads,
+        accounts_db_background_threads: value_t_or_exit!(
+            matches,
+            AccountsDbBackgroundThreadsArg::NAME,
+            NonZeroUsize
+        ),
         accounts_db_foreground_threads: value_t_or_exit!(
             matches,
             AccountsDbForegroundThreadsArg::NAME,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -382,24 +382,6 @@ pub fn execute(
                 }
             }
         });
-    // accounts-db-read-cache-limit-mb was deprecated in v3.0.0
-    let read_cache_limit_mb =
-        values_of::<usize>(matches, "accounts_db_read_cache_limit_mb").map(|limits| {
-            match limits.len() {
-                // we were given explicit low and high watermark values, so use them
-                2 => (limits[0] * MB, limits[1] * MB),
-                // we were given a single value, so use it for both low and high watermarks
-                1 => (limits[0] * MB, limits[0] * MB),
-                _ => {
-                    // clap will enforce either one or two values is given
-                    unreachable!(
-                        "invalid number of values given to accounts-db-read-cache-limit-mb"
-                    )
-                }
-            }
-        });
-    // clap will enforce only one cli arg is provided, so pick whichever is Some
-    let read_cache_limit_bytes = read_cache_limit_bytes.or(read_cache_limit_mb);
 
     let storage_access = matches
         .value_of("accounts_db_access_storages_method")


### PR DESCRIPTION
#### Problem

There are accounts-db args that were deprecated in v3. They are now candidates for removal.


#### Summary of Changes

Remove 'em.