### PR TITLE
chore: fix and deny unsafe-op-in-unsafe-fn for rust 2024 migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,7 @@ rust_2024_incompatible_pat = "deny"
 rust_2024_prelude_collisions = "deny"
 static_mut_refs = "deny"
 unsafe_attr_outside_unsafe = "deny"
+unsafe_op_in_unsafe_fn = "deny"
 
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -995,16 +995,18 @@ pub(crate) mod external {
         /// - destination is appropriately sized
         /// - destination does not overlap with loaded_addresses allocation
         unsafe fn copy_loaded_addresses(loaded_addresses: &LoadedAddresses, dest: NonNull<Pubkey>) {
-            core::ptr::copy_nonoverlapping(
-                loaded_addresses.writable.as_ptr(),
-                dest.as_ptr(),
-                loaded_addresses.writable.len(),
-            );
-            core::ptr::copy_nonoverlapping(
-                loaded_addresses.readonly.as_ptr(),
-                dest.add(loaded_addresses.writable.len()).as_ptr(),
-                loaded_addresses.readonly.len(),
-            );
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    loaded_addresses.writable.as_ptr(),
+                    dest.as_ptr(),
+                    loaded_addresses.writable.len(),
+                );
+                core::ptr::copy_nonoverlapping(
+                    loaded_addresses.readonly.as_ptr(),
+                    dest.add(loaded_addresses.writable.len()).as_ptr(),
+                    loaded_addresses.readonly.len(),
+                );
+            }
         }
 
         /// Returns `true` if a message is valid and can be processed.

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -34,6 +34,7 @@ rust_2024_incompatible_pat = "deny"
 rust_2024_prelude_collisions = "deny"
 static_mut_refs = "deny"
 unsafe_attr_outside_unsafe = "deny"
+unsafe_op_in_unsafe_fn = "deny"
 
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -86,7 +86,9 @@ impl PartitionedStakeRewards {
     }
 
     unsafe fn assume_init(&mut self, num_stake_rewards: usize) {
-        self.rewards.set_len(self.rewards.capacity());
+        unsafe {
+            self.rewards.set_len(self.rewards.capacity());
+        }
         self.num_rewards = num_stake_rewards;
     }
 }

--- a/scheduling-utils/src/responses_region.rs
+++ b/scheduling-utils/src/responses_region.rs
@@ -86,7 +86,7 @@ unsafe fn from_iterator<T: Sized>(
 ) -> Option<TransactionResponseRegion> {
     let num_transaction_responses = iter.len();
     let (response_ptr, region) =
-        allocate_response_region(allocator, tag, num_transaction_responses)?;
+        unsafe { allocate_response_region(allocator, tag, num_transaction_responses)? };
     for (index, response) in iter.enumerate() {
         // SAFETY: `response_ptr` is sufficiently sized to fit the response vector.
         unsafe { response_ptr.add(index).write(response) };

--- a/syscalls/src/mem_ops.rs
+++ b/syscalls/src/mem_ops.rs
@@ -162,13 +162,14 @@ fn memmove(
 // Marked unsafe since it assumes that the slices are at least `n` bytes long.
 unsafe fn memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
     for i in 0..n {
-        let a = *s1.get_unchecked(i);
-        let b = *s2.get_unchecked(i);
-        if a != b {
-            return (a as i32).saturating_sub(b as i32);
-        };
+        unsafe {
+            let a = *s1.get_unchecked(i);
+            let b = *s2.get_unchecked(i);
+            if a != b {
+                return (a as i32).saturating_sub(b as i32);
+            };
+        }
     }
-
     0
 }
 

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -27,7 +27,7 @@ pub(super) trait ListFrame {
     /// - The passed `item_data` slice is large enough for the type `Self::Item`
     /// - `Self::Item` is valid for any sequence of bytes
     unsafe fn read_item<'a>(&self, item_data: &'a [u8]) -> &'a Self::Item {
-        &*(item_data.as_ptr() as *const Self::Item)
+        unsafe { &*(item_data.as_ptr() as *const Self::Item) }
     }
 
     fn total_size(&self) -> usize {
@@ -67,9 +67,11 @@ impl ListFrame for VotesFrame {
     }
 
     unsafe fn read_item<'a>(&self, item_data: &'a [u8]) -> &'a Self::Item {
-        match self {
-            Self::Lockout(frame) => frame.read_item(item_data),
-            Self::Landed(frame) => frame.read_item(item_data),
+        unsafe {
+            match self {
+                Self::Lockout(frame) => frame.read_item(item_data),
+                Self::Landed(frame) => frame.read_item(item_data),
+            }
         }
     }
 }
@@ -221,7 +223,7 @@ impl ListFrame for LandedVotesListFrame {
     }
 
     unsafe fn read_item<'a>(&self, item_data: &'a [u8]) -> &'a Self::Item {
-        &*(item_data[1..].as_ptr() as *const LockoutItem)
+        unsafe { &*(item_data[1..].as_ptr() as *const LockoutItem) }
     }
 }
 


### PR DESCRIPTION
#### Problem
Rust 2024 edition (https://github.com/anza-xyz/agave/issues/6203) requires all unsafe calls to be surrounded by unsafe {..} block even if it is in function marked as unsafe itself.

#### Summary of Changes
Wrap blocks of code with `unsafe { .. }` as necessary
