### PR TITLE
chore(accounts-db): switch to rand=0.9.2 and rand_chacha=0.9 (dev dependency)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy 0.7.31",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3015,7 +3015,7 @@ checksum = "18c1ddb9231d8554c2d6bdf4cfaabf0c59251658c68b6c95cd52dd0c513a912a"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.0",
+ "rand 0.9.2",
  "siphasher 1.0.1",
 ]
 
@@ -5621,7 +5621,7 @@ dependencies = [
  "bitflags 2.10.0",
  "lazy_static",
  "num-traits",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
  "regex-syntax",
@@ -5767,7 +5767,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.0",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.0.0",
  "rustls 0.23.34",
@@ -5853,13 +5853,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -7182,8 +7181,8 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "qualifier_attr",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rayon",
  "seqlock",
  "serde",
@@ -13180,7 +13179,7 @@ dependencies = [
  "http 1.1.0",
  "httparse",
  "log",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rustls 0.23.34",
  "rustls-pki-types",
  "sha1",
@@ -14119,16 +14118,7 @@ version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
- "zerocopy-derive 0.7.31",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
-dependencies = [
- "zerocopy-derive 0.8.23",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -14136,17 +14126,6 @@ name = "zerocopy-derive"
 version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -54,7 +54,7 @@ modular-bitfield = { workspace = true }
 num_cpus = { workspace = true }
 num_enum = { workspace = true }
 qualifier_attr = { workspace = true, optional = true }
-rand = { workspace = true }
+rand = "0.9.2"
 rayon = { workspace = true }
 seqlock = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
@@ -110,7 +110,7 @@ assert_matches = { workspace = true }
 criterion = { workspace = true }
 libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }
-rand_chacha = { workspace = true }
+rand_chacha = "0.9.0"
 serde_bytes = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-accounts-db = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -122,9 +122,9 @@ fn bench_concurrent_read_write(bencher: &mut Bencher) {
         "concurrent_read_write",
         bencher,
         |accounts, pubkeys| {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             loop {
-                let i = rng.gen_range(0..pubkeys.len());
+                let i = rng.random_range(0..pubkeys.len());
                 test::black_box(
                     accounts
                         .load_without_fixed_root(&Ancestors::default(), &pubkeys[i])
@@ -257,9 +257,9 @@ fn bench_dashmap_iter(bencher: &mut Bencher) {
 fn bench_load_largest_accounts(b: &mut Bencher) {
     let accounts_db = new_accounts_db(Vec::new());
     let accounts = Accounts::new(Arc::new(accounts_db));
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     for _ in 0..10_000 {
-        let lamports = rng.gen();
+        let lamports = rng.random();
         let pubkey = Pubkey::new_unique();
         let account = AccountSharedData::new(lamports, 0, &Pubkey::default());
         accounts
@@ -296,7 +296,7 @@ fn bench_sort_and_remove_dups(b: &mut Bencher) {
     use rand::prelude::*;
     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234);
     let accounts: Vec<_> =
-        std::iter::repeat_with(|| generate_sample_account_from_storage(rng.gen::<u8>()))
+        std::iter::repeat_with(|| generate_sample_account_from_storage(rng.random::<u8>()))
             .take(1000)
             .collect();
 
@@ -316,9 +316,10 @@ fn bench_sort_and_remove_dups_no_dups(b: &mut Bencher) {
     }
 
     use rand::prelude::*;
+
     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234);
     let mut accounts: Vec<_> =
-        std::iter::repeat_with(|| generate_sample_account_from_storage(rng.gen::<u8>()))
+        std::iter::repeat_with(|| generate_sample_account_from_storage(rng.random::<u8>()))
             .take(1000)
             .collect();
 

--- a/accounts-db/benches/accounts_index.rs
+++ b/accounts-db/benches/accounts_index.rs
@@ -3,7 +3,7 @@
 extern crate test;
 
 use {
-    rand::{thread_rng, Rng},
+    rand::{rng, Rng},
     solana_account::AccountSharedData,
     solana_accounts_db::{
         account_info::AccountInfo,
@@ -53,7 +53,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
     let mut root = 0;
     bencher.iter(|| {
         for _p in 0..NUM_PUBKEYS {
-            let pubkey = thread_rng().gen_range(0..NUM_PUBKEYS);
+            let pubkey = rng().random_range(0..NUM_PUBKEYS);
             index.upsert(
                 fork,
                 fork,

--- a/accounts-db/benches/read_only_accounts_cache.rs
+++ b/accounts-db/benches/read_only_accounts_cache.rs
@@ -1,6 +1,6 @@
 use {
     criterion::{criterion_group, criterion_main, BenchmarkId, Criterion},
-    rand::{rngs::SmallRng, seq::SliceRandom, SeedableRng},
+    rand::{rngs::SmallRng, seq::IndexedRandom as _, SeedableRng},
     solana_accounts_db::{
         accounts_db::AccountsDb, read_only_accounts_cache::ReadOnlyAccountsCache,
     },

--- a/accounts-db/benches/utils.rs
+++ b/accounts-db/benches/utils.rs
@@ -4,7 +4,7 @@
 
 use {
     rand::{
-        distributions::{Distribution, WeightedIndex},
+        distr::{weighted::WeightedIndex, Distribution},
         Rng, SeedableRng,
     },
     rand_chacha::ChaChaRng,
@@ -28,7 +28,7 @@ pub fn accounts<'a>(
     iter::repeat_with(move || {
         let index = distribution.sample(&mut rng);
         let data_size = data_sizes[index];
-        let owner: [u8; 32] = rng.gen();
+        let owner: [u8; 32] = rng.random();
         let owner = Pubkey::new_from_array(owner);
         (
             owner,

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -329,7 +329,7 @@ impl<'a> AccountStoragesOrderer<'a> {
     /// Create randomizing orderer.
     pub fn with_random_order(storages: &'a [Arc<AccountStorageEntry>]) -> Self {
         let mut indices: Vec<usize> = (0..storages.len()).collect();
-        indices.shuffle(&mut rand::thread_rng());
+        indices.shuffle(&mut rand::rng());
         Self {
             storages,
             indices: indices.into_boxed_slice(),

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -140,7 +140,11 @@ mod tests {
             ObsoleteAccounts,
         },
         log::*,
-        rand::{rngs::StdRng, seq::SliceRandom, SeedableRng},
+        rand::{
+            rngs::StdRng,
+            seq::{IndexedMutRandom as _, IndexedRandom},
+            SeedableRng,
+        },
         solana_account::AccountSharedData,
         solana_pubkey::Pubkey,
         std::iter,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -63,7 +63,7 @@ use {
     agave_fs::buffered_reader::RequiredLenBufFileRead,
     dashmap::{DashMap, DashSet},
     log::*,
-    rand::{thread_rng, Rng},
+    rand::{rng, Rng},
     rayon::{prelude::*, ThreadPool},
     seqlock::SeqLock,
     smallvec::SmallVec,
@@ -4361,7 +4361,7 @@ impl AccountsDb {
         self.stats
             .create_store_count
             .fetch_add(1, Ordering::Relaxed);
-        let path_index = thread_rng().gen_range(0..paths.len());
+        let path_index = rng().random_range(0..paths.len());
         let store = Arc::new(self.new_storage_entry(slot, Path::new(&paths[path_index]), size));
 
         debug!(
@@ -7281,7 +7281,7 @@ impl AccountsDb {
     pub fn check_accounts(&self, pubkeys: &[Pubkey], slot: Slot, num: usize, count: usize) {
         let ancestors = vec![(slot, 0)].into_iter().collect();
         for _ in 0..num {
-            let idx = thread_rng().gen_range(0..num);
+            let idx = rng().random_range(0..num);
             let account = self.load_without_fixed_root(&ancestors, &pubkeys[idx]);
             let account1 = Some((
                 AccountSharedData::new(

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -10,7 +10,7 @@ use {
         storable_accounts::AccountForStorage,
     },
     itertools::Itertools,
-    rand::{prelude::SliceRandom, thread_rng, Rng},
+    rand::{prelude::SliceRandom, rng, Rng},
     solana_account::{
         accounts_equal, Account, AccountSharedData, InheritableAccountFields, ReadableAccount,
         WritableAccount, DUMMY_INHERITABLE_ACCOUNT_FIELDS,
@@ -322,7 +322,7 @@ fn test_sort_and_remove_dups_random() {
     use rand::prelude::*;
     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1234);
     let accounts: Vec<_> =
-        std::iter::repeat_with(|| generate_sample_account_from_storage(rng.gen::<u8>()))
+        std::iter::repeat_with(|| generate_sample_account_from_storage(rng.random::<u8>()))
             .take(1000)
             .collect();
 
@@ -575,7 +575,7 @@ define_accounts_db_test!(test_accountsdb_add_root_many, |db| {
     let mut pubkeys: Vec<Pubkey> = vec![];
     db.create_account(&mut pubkeys, 0, 100, 0, 0);
     for _ in 1..100 {
-        let idx = thread_rng().gen_range(0..99);
+        let idx = rng().random_range(0..99);
         let ancestors = vec![(0, 0)].into_iter().collect();
         let account = db
             .load_without_fixed_root(&ancestors, &pubkeys[idx])
@@ -591,7 +591,7 @@ define_accounts_db_test!(test_accountsdb_add_root_many, |db| {
 
     // check that all the accounts appear with a new root
     for _ in 1..100 {
-        let idx = thread_rng().gen_range(0..99);
+        let idx = rng().random_range(0..99);
         let ancestors = vec![(0, 0)].into_iter().collect();
         let account0 = db
             .load_without_fixed_root(&ancestors, &pubkeys[idx])
@@ -802,7 +802,7 @@ define_accounts_db_test!(test_remove_unrooted_slot_storage, |db| {
 
 fn update_accounts(accounts: &AccountsDb, pubkeys: &[Pubkey], slot: Slot, range: usize) {
     for _ in 1..1000 {
-        let idx = thread_rng().gen_range(0..range);
+        let idx = rng().random_range(0..range);
         let ancestors = vec![(slot, 0)].into_iter().collect();
         if let Some((mut account, _)) = accounts.load_without_fixed_root(&ancestors, &pubkeys[idx])
         {
@@ -1929,7 +1929,7 @@ fn test_store_account_stress() {
                     let mut account = AccountSharedData::new(1, 0, &pubkey);
                     let mut i = 0;
                     loop {
-                        let account_bal = thread_rng().gen_range(1..99);
+                        let account_bal = rng().random_range(1..99);
                         account.set_lamports(account_bal);
                         db.store_for_tests((slot, [(&pubkey, &account)].as_slice()));
 
@@ -4388,7 +4388,7 @@ fn start_load_thread(
                 // Ordering::Relaxed is ok because of no data dependencies; the modified field is
                 // completely free-standing cfg(test) control-flow knob.
                 db.load_limit
-                    .store(thread_rng().gen_range(0..10) as u64, Ordering::Relaxed);
+                    .store(rng().random_range(0..10) as u64, Ordering::Relaxed);
 
                 // Load should never be unable to find this key
                 let loaded_account = db
@@ -4654,7 +4654,7 @@ fn test_cache_flush_remove_unrooted_race_multiple_slots() {
                 (slot, bank_id)
             })
             .collect();
-        all_slots.shuffle(&mut rand::thread_rng());
+        all_slots.shuffle(&mut rand::rng());
         let slots_to_dump = &all_slots[0..num_cached_slots as usize / 2];
         let slots_to_keep = &all_slots[num_cached_slots as usize / 2..];
 
@@ -5012,7 +5012,7 @@ fn test_calculate_storage_count_and_alive_bytes_obsolete_account(
     let mut offsets: Vec<_> = offsets.into_iter().zip(data_lens).collect();
 
     // Randomize the accounts that get marked obsolete
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     offsets.shuffle(&mut rng);
 
     let (accounts_to_mark_obsolete, accounts_to_keep) =

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -19,7 +19,7 @@ use {
     },
     iter::{AccountsIndexPubkeyIterOrder, AccountsIndexPubkeyIterator},
     log::*,
-    rand::{thread_rng, Rng},
+    rand::{rng, Rng},
     rayon::iter::{IntoParallelIterator, ParallelIterator},
     roots_tracker::RootsTracker,
     secondary::{RwLockSecondaryIndexEntry, SecondaryIndex, SecondaryIndexEntry},
@@ -1317,7 +1317,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         // This results in calls to insert_new_entry_if_missing_with_lock from different threads starting at different bins to avoid
         // lock contention.
         let bins = self.bins();
-        let random_bin_offset = thread_rng().gen_range(0..bins);
+        let random_bin_offset = rng().random_range(0..bins);
         let bin_calc = self.bin_calculator;
         items.sort_unstable_by(|(pubkey_a, _), (pubkey_b, _)| {
             ((bin_calc.bin_from_pubkey(pubkey_a) + random_bin_offset) % bins)

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -8,7 +8,7 @@ use {
         DiskIndexValue, IndexValue, ReclaimsSlotList, RefCount, SlotList, UpsertReclaim,
     },
     crate::pubkey_bins::PubkeyBinCalculator24,
-    rand::{thread_rng, Rng},
+    rand::{rng, Rng},
     solana_bucket_map::bucket_api::BucketApi,
     solana_clock::Slot,
     solana_measure::measure::Measure,
@@ -146,7 +146,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             // Spread out the scanning across all ages within the window.
             // This causes us to scan 1/N of the bins each 'Age'
             remaining_ages_to_skip_flushing: AtomicAge::new(
-                thread_rng().gen_range(0..num_ages_to_distribute_flushes),
+                rng().random_range(0..num_ages_to_distribute_flushes),
             ),
             num_ages_to_distribute_flushes,
             startup_stats: Arc::clone(&storage.startup_stats),

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -17,7 +17,7 @@ use {
         storable_accounts::{StorableAccounts, StorableAccountsBySlot},
         u64_align,
     },
-    rand::{thread_rng, Rng},
+    rand::{rng, Rng},
     rayon::prelude::{IntoParallelRefIterator, ParallelIterator},
     solana_clock::Slot,
     solana_measure::measure_us,
@@ -106,7 +106,7 @@ impl AncientSlotInfos {
             let should_shrink = if capacity > 0 {
                 if is_candidate_for_shrink {
                     true
-                } else if can_randomly_shrink && thread_rng().gen_range(0..10000) == 0 {
+                } else if can_randomly_shrink && rng().random_range(0..10000) == 0 {
                     was_randomly_shrunk = true;
                     true
                 } else {
@@ -1416,8 +1416,7 @@ pub mod tests {
                 // add some accounts to each storage so we can make partial progress
                 let mut data_size = 450;
                 // random # of extra accounts here
-                let total_accounts_per_storage =
-                    thread_rng().gen_range(0..total_accounts_per_storage);
+                let total_accounts_per_storage = rng().random_range(0..total_accounts_per_storage);
                 let _pubkeys_and_accounts = storages
                     .iter()
                     .map(|storage| {
@@ -2802,7 +2801,7 @@ pub mod tests {
             .collect();
 
         // shuffle the infos so they actually need to be sorted
-        infos.all_infos.shuffle(&mut thread_rng());
+        infos.all_infos.shuffle(&mut rng());
         infos.filter_by_smallest_capacity(&tuning, &ShrinkAncientStats::default());
 
         infos
@@ -2847,7 +2846,7 @@ pub mod tests {
             .collect();
 
         // shuffle the infos so they actually need to be sorted
-        infos.all_infos.shuffle(&mut thread_rng());
+        infos.all_infos.shuffle(&mut rng());
         infos.filter_by_smallest_capacity(&tuning, &ShrinkAncientStats::default());
 
         infos

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1364,7 +1364,7 @@ pub mod tests {
         super::{test_utils::*, *},
         assert_matches::assert_matches,
         memoffset::offset_of,
-        rand::prelude::*,
+        rand::{prelude::*, rng},
         rand_chacha::ChaChaRng,
         solana_account::{accounts_equal, Account, AccountSharedData},
         solana_clock::Slot,
@@ -1619,13 +1619,13 @@ pub mod tests {
         Vec<(Pubkey, AccountSharedData)>,
         TempFile,
     ) {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut create_account = |data_len: usize| -> (Pubkey, AccountSharedData) {
-            let pubkey = Pubkey::new_from_array(rng.gen());
-            let owner = Pubkey::new_from_array(rng.gen());
-            let mut account = AccountSharedData::new(rng.gen(), data_len, &owner);
+            let pubkey = Pubkey::new_from_array(rng.random());
+            let owner = Pubkey::new_from_array(rng.random());
+            let mut account = AccountSharedData::new(rng.random(), data_len, &owner);
             // Ensure we actually have some unique data to compare against when checking correctness
-            let data = std::iter::from_fn(|| Some(rng.gen::<u8>()))
+            let data = std::iter::from_fn(|| Some(rng.random::<u8>()))
                 .take(data_len)
                 .collect::<Vec<_>>();
             account.set_data(data);
@@ -1816,7 +1816,7 @@ pub mod tests {
 
         let now = Instant::now();
         for _ in 0..size {
-            let sample = thread_rng().gen_range(0..indexes.len());
+            let sample = rng().random_range(0..indexes.len());
             let account = create_test_account(sample + 1);
             assert_eq!(av.get_account_test(indexes[sample]).unwrap(), account);
         }
@@ -2154,12 +2154,12 @@ pub mod tests {
             .take(NUM_ACCOUNTS)
             .collect();
 
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut accounts = Vec::with_capacity(pubkeys.len());
         let mut stored_sizes = Vec::with_capacity(pubkeys.len());
         for _ in &pubkeys {
-            let lamports = rng.gen();
-            let data_len = rng.gen_range(0..MAX_PERMITTED_DATA_LENGTH) as usize;
+            let lamports = rng.random();
+            let data_len = rng.random_range(0..MAX_PERMITTED_DATA_LENGTH) as usize;
             let account = AccountSharedData::new(lamports, data_len, &Pubkey::default());
             accounts.push(account);
             stored_sizes.push(aligned_stored_size(data_len));
@@ -2214,8 +2214,8 @@ pub mod tests {
         let mut accounts = Vec::with_capacity(pubkeys.len());
         let mut total_stored_size = 0;
         for _ in &pubkeys {
-            let lamports = rng.gen();
-            let data_len = rng.gen_range(0..MAX_PERMITTED_DATA_LENGTH) as usize;
+            let lamports = rng.random();
+            let data_len = rng.random_range(0..MAX_PERMITTED_DATA_LENGTH) as usize;
             let account = AccountSharedData::new(lamports, data_len, &Pubkey::default());
             accounts.push(account);
             total_stored_size += aligned_stored_size(data_len);

--- a/accounts-db/src/append_vec/test_utils.rs
+++ b/accounts-db/src/append_vec/test_utils.rs
@@ -1,7 +1,7 @@
 //! Helpers for AppendVec tests and benches
 #![cfg(feature = "dev-context-only-utils")]
 use {
-    rand::{distributions::Alphanumeric, Rng},
+    rand::{distr::Alphanumeric, Rng},
     solana_account::AccountSharedData,
     solana_pubkey::Pubkey,
     std::path::PathBuf,
@@ -24,7 +24,7 @@ pub fn get_append_vec_dir() -> String {
 
 pub fn get_append_vec_path(path: &str) -> TempFile {
     let out_dir = get_append_vec_dir();
-    let rand_string: String = rand::thread_rng()
+    let rand_string: String = rand::rng()
         .sample_iter(&Alphanumeric)
         .map(char::from)
         .take(30)

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -83,7 +83,7 @@ use {
 #[cfg(feature = "dev-context-only-utils")]
 impl StakeReward {
     pub fn new_random() -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let rent = Rent::free();
 
@@ -101,7 +101,7 @@ impl StakeReward {
             validator_stake_lamports,
         );
 
-        let reward_lamports: i64 = rng.gen_range(1..200);
+        let reward_lamports: i64 = rng.random_range(1..200);
         let validator_stake_account = create_stake_account(
             &validator_staking_keypair.pubkey(),
             &validator_voting_keypair.pubkey(),

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -813,7 +813,7 @@ pub mod tests {
         // each slot has a random number of accounts, between 1 and 10
         for _slot in 0..num_slots {
             // generate random accounts per slot
-            let n = rand::thread_rng().gen_range(1..10);
+            let n = rand::rng().random_range(1..10);
             total += n;
             let accounts = (0..n).map(|_| &account_from_storage).collect::<Vec<_>>();
             all_accounts.push(accounts);

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -878,7 +878,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join("test");
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // create owners
         let owners: Vec<_> = std::iter::repeat_with(Pubkey::new_unique)
@@ -892,15 +892,15 @@ mod tests {
 
         // create account data
         let datas: Vec<_> = (0..num_accounts)
-            .map(|i| vec![i as u8; rng.gen_range(0..4096)])
+            .map(|i| vec![i as u8; rng.random_range(0..4096)])
             .collect();
 
         // create account metas that link to its data and owner
         let metas: Vec<_> = (0..num_accounts)
             .map(|i| {
                 HotAccountMeta::new()
-                    .with_lamports(rng.gen())
-                    .with_owner_offset(OwnerOffset(rng.gen_range(0..num_owners) as u32))
+                    .with_lamports(rng.random())
+                    .with_owner_offset(OwnerOffset(rng.random_range(0..num_owners) as u32))
                     .with_account_data_padding(padding_bytes(datas[i].len()))
             })
             .collect();
@@ -1156,13 +1156,13 @@ mod tests {
         let path = temp_dir.path().join("test_hot_storage_footer");
 
         const NUM_ACCOUNTS: u32 = 10;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let hot_account_metas: Vec<_> = (0..NUM_ACCOUNTS)
             .map(|_| {
                 HotAccountMeta::new()
-                    .with_lamports(rng.gen_range(0..u64::MAX))
-                    .with_owner_offset(OwnerOffset(rng.gen_range(0..NUM_ACCOUNTS)))
+                    .with_lamports(rng.random_range(0..u64::MAX))
+                    .with_owner_offset(OwnerOffset(rng.random_range(0..NUM_ACCOUNTS)))
             })
             .collect();
 
@@ -1237,7 +1237,7 @@ mod tests {
             .path()
             .join("test_hot_storage_get_account_offset_and_address");
         const NUM_ACCOUNTS: u32 = 10;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let addresses: Vec<_> = std::iter::repeat_with(Pubkey::new_unique)
             .take(NUM_ACCOUNTS as usize)
@@ -1248,7 +1248,7 @@ mod tests {
             .map(|address| AccountIndexWriterEntry {
                 address: *address,
                 offset: HotAccountOffset::new(
-                    rng.gen_range(0..u32::MAX) as usize * HOT_ACCOUNT_ALIGNMENT,
+                    rng.random_range(0..u32::MAX) as usize * HOT_ACCOUNT_ALIGNMENT,
                 )
                 .unwrap(),
             })

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -168,13 +168,13 @@ mod tests {
         let addresses: Vec<_> = std::iter::repeat_with(Pubkey::new_unique)
             .take(ENTRY_COUNT)
             .collect();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let index_entries: Vec<_> = addresses
             .iter()
             .map(|address| AccountIndexWriterEntry {
                 address: *address,
                 offset: HotAccountOffset::new(
-                    rng.gen_range(0..u32::MAX) as usize * HOT_ACCOUNT_ALIGNMENT,
+                    rng.random_range(0..u32::MAX) as usize * HOT_ACCOUNT_ALIGNMENT,
                 )
                 .unwrap(),
             })

--- a/accounts-db/tests/read_only_accounts_cache.rs
+++ b/accounts-db/tests/read_only_accounts_cache.rs
@@ -23,7 +23,7 @@ fn test_read_only_accounts_cache_eviction(num_accounts: (usize, usize), evict_sa
     let max_cache_size = num_accounts_lo.saturating_mul(CACHE_ENTRY_SIZE.saturating_add(DATA_SIZE));
     // Use SmallRng as it's faster than the default ChaCha and we don't
     // need a crypto rng here.
-    let mut rng = SmallRng::from_entropy();
+    let mut rng = SmallRng::from_os_rng();
     let cache = ReadOnlyAccountsCache::new(
         max_cache_size,
         usize::MAX, // <-- do not evict in the background

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6093,7 +6093,7 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "qualifier_attr",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rayon",
  "seqlock",
  "serde",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2382,7 +2382,7 @@ checksum = "18c1ddb9231d8554c2d6bdf4cfaabf0c59251658c68b6c95cd52dd0c513a912a"
 dependencies = [
  "getrandom 0.3.1",
  "libm",
- "rand 0.9.0",
+ "rand 0.9.2",
  "siphasher 1.0.1",
 ]
 
@@ -4908,7 +4908,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.1",
  "lru-slab",
- "rand 0.9.0",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.0.0",
  "rustls 0.23.34",
@@ -4975,13 +4975,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -6037,7 +6036,7 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "qualifier_attr",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rayon",
  "seqlock",
  "serde",
@@ -11450,7 +11449,7 @@ dependencies = [
  "http 1.2.0",
  "httparse",
  "log",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rustls 0.23.34",
  "rustls-pki-types",
  "sha1",


### PR DESCRIPTION
#### Problem
* `rand` crate with version >=0.9 fixes problem with `gen` function name colliding with keyword reserved in Rust 2024 edition (it doesn't strictly block https://github.com/anza-xyz/agave/issues/6203, but seems like a better way to hit two birds with one stone)
* there are performance improvements in newer versions of `rand`
* there are however many API breaking changes, but addressable as renames / import updates for production code 

Due to the last point we might be better off with updating rand incrementally (compare with previous attempt of upgrading in https://github.com/anza-xyz/agave/pull/4721). Now migration is tracked in https://github.com/anza-xyz/agave/issues/4738.

#### Summary of Changes
* switch accounts-db to `rand` 0.9.2
* switch dev dependency `rand_chacha` to 0.9.0 (closely coupled with `rand`, they both rely on same version of `rand_core`)
 
##### Performance
`rand` is mostly used in tests, comparison of their runtime:
* PR
```
test result: ok. 624 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 28.91s

 Running tests/read_only_accounts_cache.rs (target/debug/deps/read_only_accounts_cache-4c2601e53cf50ede)
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 11.12s

cargo +nightly-2025-06-23 bench --package solana-accounts-db --bench accounts
running 10 tests
test bench_concurrent_read_write                       ... bench:     773,307.62 ns/iter (+/- 315,471.86)
test bench_concurrent_scan_write                       ... bench:     768,964.80 ns/iter (+/- 344,317.74)
test bench_dashmap_iter                                ... bench:     197,803.35 ns/iter (+/- 1,568.51)
test bench_dashmap_par_iter                            ... bench:     163,446.24 ns/iter (+/- 9,036.01)
test bench_dashmap_single_reader_with_n_writers        ... ignored
test bench_delete_dependencies                         ... bench:   1,999,916.60 ns/iter (+/- 761,710.29)
test bench_load_largest_accounts                       ... bench:   5,656,484.20 ns/iter (+/- 43,204.14)
test bench_rwlock_hashmap_single_reader_with_n_writers ... ignored
test bench_sort_and_remove_dups                        ... bench:      29,782.58 ns/iter (+/- 145.07)
test bench_sort_and_remove_dups_no_dups                ... bench:      30,674.83 ns/iter (+/- 442.04)

test result: ok. 0 passed; 0 failed; 2 ignored; 8 measured; 0 filtered out; finished in 12.39s
```

* master
```
Test result: ok. 624 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 28.93s

Running tests/read_only_accounts_cache.rs (target/debug/deps/read_only_accounts_cache-8346ec7bbb2df948)
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 10.62s

running 10 tests
test bench_concurrent_read_write                       ... bench:     691,007.78 ns/iter (+/- 339,669.16)
test bench_concurrent_scan_write                       ... bench:     670,621.40 ns/iter (+/- 379,000.60)
test bench_dashmap_iter                                ... bench:     198,229.70 ns/iter (+/- 226.25)
test bench_dashmap_par_iter                            ... bench:     165,864.11 ns/iter (+/- 2,612.95)
test bench_dashmap_single_reader_with_n_writers        ... ignored
test bench_delete_dependencies                         ... bench:   1,326,333.00 ns/iter (+/- 19,858.66)
test bench_load_largest_accounts                       ... bench:   5,607,317.10 ns/iter (+/- 8,083.11)
test bench_rwlock_hashmap_single_reader_with_n_writers ... ignored
test bench_sort_and_remove_dups                        ... bench:      30,049.70 ns/iter (+/- 155.13)
test bench_sort_and_remove_dups_no_dups                ... bench:      31,657.24 ns/iter (+/- 126.11)

test result: ok. 0 passed; 0 failed; 2 ignored; 8 measured; 0 filtered out; finished in 13.72s
```

