### PR TITLE
Map PubkeyError to InstructionError explicitly across built-ins

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -599,13 +599,16 @@ fn process_loader_upgradeable_instruction(
             let transaction_context = &invoke_context.transaction_context;
             let instruction_context = transaction_context.get_current_instruction_context()?;
             let caller_program_id = instruction_context.get_program_key()?;
-            // The conversion from `PubkeyError` to `InstructionError` through
-            // num-traits is incorrect, but it's the existing behavior.
             let signers = [[new_program_id.as_ref(), &[bump_seed]]]
                 .iter()
                 .map(|seeds| Pubkey::create_program_address(seeds, caller_program_id))
                 .collect::<Result<Vec<Pubkey>, solana_pubkey::PubkeyError>>()
-                .map_err(|e| e as u64)?;
+                .map_err(|e| match e {
+                    solana_pubkey::PubkeyError::MaxSeedLengthExceeded => {
+                        InstructionError::MaxSeedLengthExceeded
+                    }
+                    _ => InstructionError::InvalidSeeds,
+                })?;
             invoke_context.native_invoke(instruction, signers.as_slice())?;
 
             // Load and verify the program bits

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -31,15 +31,18 @@ fn process_authorize_with_seed_instruction(
     let mut expected_authority_keys: HashSet<Pubkey> = HashSet::default();
     if instruction_context.is_instruction_account_signer(2)? {
         let base_pubkey = instruction_context.get_key_of_instruction_account(2)?;
-        // The conversion from `PubkeyError` to `InstructionError` through
-        // num-traits is incorrect, but it's the existing behavior.
         expected_authority_keys.insert(
             Pubkey::create_with_seed(
                 base_pubkey,
                 current_authority_derived_key_seed,
                 current_authority_derived_key_owner,
             )
-            .map_err(|e| e as u64)?,
+            .map_err(|e| match e {
+                solana_pubkey::PubkeyError::MaxSeedLengthExceeded => {
+                    InstructionError::MaxSeedLengthExceeded
+                }
+                _ => InstructionError::InvalidSeeds,
+            })?,
         );
     };
     vote_state::authorize(


### PR DESCRIPTION
Replaced legacy PubkeyError → u64 casts with explicit InstructionError mapping to avoid lossy and potentially incorrect conversions.