### PR TITLE
ci: add missing coverage tests

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -256,7 +256,25 @@ EOF
              ^ci/test-coverage.sh \
              ^scripts/coverage.sh \
       ; then
-    command_step coverage "ci/docker-run-default-image.sh ci/test-coverage.sh" 80
+    cat >> "$output_file" <<"EOF"
+  - group: "coverage"
+    steps:
+      - command: "ci/docker-run-default-image.sh ci/coverage/part-1.sh"
+        name: "coverage-1"
+        timeout_in_minutes: 60
+        agents:
+          queue: "solana"
+      - command: "ci/docker-run-default-image.sh ci/coverage/part-2.sh"
+        name: "coverage-2"
+        timeout_in_minutes: 60
+        agents:
+          queue: "solana"
+      - command: "ci/docker-run-default-image.sh ci/coverage/part-3.sh"
+        name: "coverage-3"
+        timeout_in_minutes: 60
+        agents:
+          queue: "solana"
+EOF
   else
     annotate --style info --context test-coverage \
       "Coverage skipped as no .rs files were modified"

--- a/ci/coverage/common.sh
+++ b/ci/coverage/common.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export PART_1_PACKAGES=(
+  solana-ledger
+)
+
+export PART_2_PACKAGES=(
+  solana-accounts-db
+  solana-runtime
+  solana-perf
+  solana-core
+  solana-wen-restart
+  solana-gossip
+)

--- a/ci/coverage/part-1.sh
+++ b/ci/coverage/part-1.sh
@@ -3,9 +3,17 @@
 set -euo pipefail
 git_root=$(git rev-parse --show-toplevel)
 
+# shellcheck source=ci/coverage/common.sh
+source "$git_root"/ci/coverage/common.sh
+
+packages=()
+for package in "${PART_1_PACKAGES[@]}"; do
+  packages+=(--package "$package")
+done
+
 echo "--- coverage: root (part 1)"
 "$git_root"/ci/test-coverage.sh \
   --features frozen-abi \
   --features dev-context-only-utils \
   --lib \
-  --package solana-ledger
+  "${packages[@]}"

--- a/ci/coverage/part-1.sh
+++ b/ci/coverage/part-1.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 git_root=$(git rev-parse --show-toplevel)
 
 echo "--- coverage: root (part 1)"

--- a/ci/coverage/part-1.sh
+++ b/ci/coverage/part-1.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+git_root=$(git rev-parse --show-toplevel)
+
+echo "--- coverage: root (part 1)"
+"$git_root"/ci/test-coverage.sh \
+  --features frozen-abi \
+  --features dev-context-only-utils \
+  --lib \
+  --package solana-ledger

--- a/ci/coverage/part-2.sh
+++ b/ci/coverage/part-2.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+git_root=$(git rev-parse --show-toplevel)
+
+echo "--- coverage: root (part 2)"
+"$git_root"/ci/test-coverage.sh \
+  --features dev-context-only-utils \
+  --lib \
+  --package solana-accounts-db \
+  --package solana-runtime \
+  --package solana-perf \
+  --package solana-core \
+  --package solana-wen-restart \
+  --package solana-gossip

--- a/ci/coverage/part-2.sh
+++ b/ci/coverage/part-2.sh
@@ -3,13 +3,16 @@
 set -euo pipefail
 git_root=$(git rev-parse --show-toplevel)
 
+# shellcheck source=ci/coverage/common.sh
+source "$git_root"/ci/coverage/common.sh
+
+packages=()
+for package in "${PART_2_PACKAGES[@]}"; do
+  packages+=(--package "$package")
+done
+
 echo "--- coverage: root (part 2)"
 "$git_root"/ci/test-coverage.sh \
   --features dev-context-only-utils \
   --lib \
-  --package solana-accounts-db \
-  --package solana-runtime \
-  --package solana-perf \
-  --package solana-core \
-  --package solana-wen-restart \
-  --package solana-gossip
+  "${packages[@]}"

--- a/ci/coverage/part-2.sh
+++ b/ci/coverage/part-2.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 git_root=$(git rev-parse --show-toplevel)
 
 echo "--- coverage: root (part 2)"

--- a/ci/coverage/part-3.sh
+++ b/ci/coverage/part-3.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+git_root=$(git rev-parse --show-toplevel)
+
+echo "--- coverage: coverage (part 3)"
+"$git_root"/ci/test-coverage.sh \
+  --features frozen-abi \
+  --features dev-context-only-utils \
+  --workspace \
+  --lib \
+  --exclude solana-ledger \
+  --exclude solana-accounts-db \
+  --exclude solana-runtime \
+  --exclude solana-perf \
+  --exclude solana-core \
+  --exclude solana-wen-restart \
+  --exclude solana-local-cluster \
+  --exclude solana-gossip
+
+# Clean up
+cargo clean
+
+echo "--- coverage: dev-bins"
+"$git_root"/ci/test-coverage.sh \
+  --features dev-context-only-utils \
+  --manifest-path "$git_root"/dev-bins/Cargo.toml \
+  --workspace \
+  --lib
+
+# Clean up
+cargo clean
+
+echo "--- coverage: xtask"
+"$git_root"/ci/test-coverage.sh --manifest-path "$git_root"/ci/xtask/Cargo.toml

--- a/ci/coverage/part-3.sh
+++ b/ci/coverage/part-3.sh
@@ -3,20 +3,25 @@
 set -euo pipefail
 git_root=$(git rev-parse --show-toplevel)
 
+# shellcheck source=ci/coverage/common.sh
+source "$git_root"/ci/coverage/common.sh
+
+exclude_packages=()
+for package in "${PART_1_PACKAGES[@]}"; do
+  exclude_packages+=(--exclude "$package")
+done
+for package in "${PART_2_PACKAGES[@]}"; do
+  exclude_packages+=(--exclude "$package")
+done
+exclude_packages+=(--exclude solana-local-cluster)
+
 echo "--- coverage: coverage (part 3)"
 "$git_root"/ci/test-coverage.sh \
   --features frozen-abi \
   --features dev-context-only-utils \
   --workspace \
   --lib \
-  --exclude solana-ledger \
-  --exclude solana-accounts-db \
-  --exclude solana-runtime \
-  --exclude solana-perf \
-  --exclude solana-core \
-  --exclude solana-wen-restart \
-  --exclude solana-local-cluster \
-  --exclude solana-gossip
+  "${exclude_packages[@]}"
 
 # Clean up
 cargo clean

--- a/ci/coverage/part-3.sh
+++ b/ci/coverage/part-3.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 git_root=$(git rev-parse --show-toplevel)
 
 echo "--- coverage: coverage (part 3)"

--- a/ci/test-coverage.sh
+++ b/ci/test-coverage.sh
@@ -3,9 +3,6 @@
 set -e
 here=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
-# shellcheck source=ci/upload-ci-artifact.sh
-source "$here/upload-ci-artifact.sh"
-
 if [[ -z $CI ]]; then
   echo "This script is used by CI environment. \
 Use \`scripts/coverage.sh\` directly if you only want to obtain the coverage report"
@@ -21,16 +18,6 @@ annotate() {
 # run coverage for all
 SHORT_CI_COMMIT=${CI_COMMIT:0:9}
 COMMIT_HASH=$SHORT_CI_COMMIT "$here/../scripts/coverage.sh" "$@"
-
-# compress coverage reports
-HTML_REPORT_TAR_NAME="coverage.tar.gz"
-HTML_REPORT_TAR_PATH="$here/../target/cov/${SHORT_CI_COMMIT}/$HTML_REPORT_TAR_NAME"
-tar zcf "$HTML_REPORT_TAR_PATH" "$here/../target/cov/${SHORT_CI_COMMIT}/coverage"
-
-# upload reports to buildkite
-upload-ci-artifact "$HTML_REPORT_TAR_PATH"
-annotate --style success --context lcov-report \
-  "lcov report: <a href=\"artifact://$HTML_REPORT_TAR_NAME\">$HTML_REPORT_TAR_NAME</a>"
 
 echo "--- codecov.io report"
 if [[ -z "$CODECOV_TOKEN" ]]; then

--- a/ci/test-coverage.sh
+++ b/ci/test-coverage.sh
@@ -9,12 +9,6 @@ Use \`scripts/coverage.sh\` directly if you only want to obtain the coverage rep
   exit 1
 fi
 
-annotate() {
-  ${BUILDKITE:-false} && {
-    buildkite-agent annotate "$@"
-  }
-}
-
 # run coverage for all
 SHORT_CI_COMMIT=${CI_COMMIT:0:9}
 COMMIT_HASH=$SHORT_CI_COMMIT "$here/../scripts/coverage.sh" "$@"
@@ -26,6 +20,8 @@ if [[ -z "$CODECOV_TOKEN" ]]; then
 else
   codecov -t "${CODECOV_TOKEN}" --dir "$here/../target/cov/${SHORT_CI_COMMIT}"
 
-  annotate --style success --context codecov.io \
-    "CodeCov report: https://codecov.io/github/anza-xyz/agave/commit/$CI_COMMIT"
+  if [[ -n "$BUILDKITE" ]]; then
+    buildkite-agent annotate --style success --context codecov.io \
+      "CodeCov report: https://codecov.io/github/anza-xyz/agave/commit/$CI_COMMIT"
+  fi
 fi

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -50,23 +50,26 @@ export RUSTFLAGS="--cfg curve25519_dalek_backend=\"serial\" $RUSTFLAGS"
 export LLVM_PROFILE_FILE="$here/../target/cov/${COMMIT_HASH}/profraw/default-%p-%m.profraw"
 
 if [[ -z $1 ]]; then
-  PACKAGES=(--lib --all --exclude solana-local-cluster)
+  EXTRA_ARGS=(
+    --features frozen-abi
+    --lib
+    --all
+    --exclude solana-local-cluster
+    --
+    --skip shred::merkle::test::test_make_shreds_from_data::
+    --skip shred::merkle::test::test_make_shreds_from_data_rand::
+    --skip shred::merkle::test::test_recover_merkle_shreds::
+  )
 else
-  PACKAGES=("$@")
+  EXTRA_ARGS=("$@")
 fi
-
-TEST_ARGS=(
-  --skip shred::merkle::test::test_make_shreds_from_data::
-  --skip shred::merkle::test::test_make_shreds_from_data_rand::
-  --skip shred::merkle::test::test_recover_merkle_shreds::
-)
 
 # Most verbose log level (trace) is enabled for all solana code to make log!
 # macro code green always. Also, forcibly discard the vast amount of log by
 # redirecting the stderr altogether on CI, where all tests are run unlike
 # developing.
 RUST_LOG="solana=trace,agave=trace,$RUST_LOG" INTERCEPT_OUTPUT=/dev/null "$here/../ci/intercept.sh" \
-  cargo +"$rust_nightly" test --features frozen-abi --target-dir "$here/../target/cov" "${PACKAGES[@]}" -- "${TEST_ARGS[@]}"
+  cargo +"$rust_nightly" test --target-dir "$here/../target/cov" "${EXTRA_ARGS[@]}"
 
 # Generate test reports
 echo "--- grcov"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -79,11 +79,7 @@ grcov_common_args=(
   --binary-path "$here/../target/cov/debug"
   --llvm
   --llvm-path "$llvm_path"
-  --ignore \*.cargo\*
-  --ignore \*build.rs
-  --ignore bench-tps\*
-  --ignore bench-streamer\*
-  --ignore local-cluster\*
+  --ignore /\*
 )
 
 grcov "${grcov_common_args[@]}" -t html -o "$here/../target/cov/${COMMIT_HASH}/coverage/html"


### PR DESCRIPTION
#### Problem

Since we added 2 new workspaces: `dev-bins` and `xtask`. We need to update the coverage test scripts to include their results. Also, a full coverage test takes ~30 minutes, which is quite long. I took this opportunity to split it up as well.

#### Summary of Changes

Split the coverage tests into 3 parts. The first and second are part of root workspace (run with some packages). The third includes the remaining root workspace packages + dev-bins + xtask

You can check this link for the latest coverage result: https://app.codecov.io/gh/anza-xyz/agave/tree/yihau%2Fsolana%3Aimprove-coverage-tests

dev-bins:
<img width="1308" height="68" alt="Screenshot 2025-11-12 at 18 53 23" src="https://github.com/user-attachments/assets/568db654-3bac-4922-8482-f0da490ee3d9" />


xtask:
<img width="1298" height="65" alt="Screenshot 2025-11-12 at 18 51 45" src="https://github.com/user-attachments/assets/5e0569d7-7a7d-4749-a9ee-ad3e0f2dae8d" />
