### PR TITLE
Removes shrink_to_fit() in accounts index

### DIFF
--- a/accounts-db/src/accounts_index/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index/accounts_index_storage.rs
@@ -106,11 +106,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexStorage<
     pub(crate) fn set_startup(&self, startup: Startup) {
         let is_startup = startup != Startup::Normal;
         self.storage.set_startup(is_startup);
-        if !is_startup {
-            // transitioning from startup to !startup (ie. steady state)
-            // maybe shrink hashmaps
-            self.shrink_to_fit();
-        }
     }
 
     /// estimate how many items are still needing to be flushed to the disk cache.
@@ -120,10 +115,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexStorage<
             .as_ref()
             .map(|_| self.storage.stats.get_remaining_items_to_flush_estimate())
             .unwrap_or_default()
-    }
-
-    fn shrink_to_fit(&self) {
-        self.in_mem.iter().for_each(|mem| mem.shrink_to_fit())
     }
 
     /// allocate BucketMapHolder and InMemAccountsIndex[]

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -170,16 +170,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         self.last_age_flushed.load(Ordering::Acquire)
     }
 
-    /// Release entire in-mem hashmap to free all memory associated with it.
-    /// Idea is that during startup we needed a larger map than we need during runtime.
-    /// When using disk-buckets, in-mem index grows over time with dynamic use and then shrinks, in theory back to 0.
-    pub fn shrink_to_fit(&self) {
-        // shrink_to_fit could be quite expensive on large map sizes, which 'no disk buckets' could produce, so avoid shrinking in case we end up here
-        if self.storage.is_disk_index_enabled() {
-            self.map_internal.write().unwrap().shrink_to_fit();
-        }
-    }
-
     /// return all keys in this bin
     pub fn keys(&self) -> Vec<Pubkey> {
         Self::update_stat(&self.stats().keys, 1);


### PR DESCRIPTION
#### Problem

`shrink_to_fit()` in the accounts index is never used/called.

While generating the accounts index, we indicate we're in "startup" mode. And then upon completion, we go back to "normal" mode. When transitioning back to "normal" mode, we shrink the index:
https://github.com/anza-xyz/agave/blob/3e44377c2338a4cf212997d9dab42fa09fd37111/accounts-db/src/accounts_index/accounts_index_storage.rs#L103-L114

As we trace the call stack, we see we visit each in-mem bucket to shrink:
https://github.com/anza-xyz/agave/blob/3e44377c2338a4cf212997d9dab42fa09fd37111/accounts-db/src/accounts_index/accounts_index_storage.rs#L125-L127

And lastly that we only shrink the in-mem hashmaps if the disk index is enabled:
https://github.com/anza-xyz/agave/blob/3e44377c2338a4cf212997d9dab42fa09fd37111/accounts-db/src/accounts_index/in_mem_accounts_index.rs#L173-L181

So we only shrink when the disk index is enabled. But, when the disk index is enabled, we don't insert into the in-mem index. Instead, we insert directly to the disk buckets:
https://github.com/anza-xyz/agave/blob/3e44377c2338a4cf212997d9dab42fa09fd37111/accounts-db/src/accounts_index.rs#L1353-L1354
where `startup_insert_only()` copies index entry info to the bin's `StartupInfo` field, which is then flushed to disk during normal index flushing.

The main thing to note is that when the disk index is enabled, that startup doesn't insert into the in-mem hashmaps at all. So, since we only called `shrink_to_fit()` when the disk index was enabled AND when the disk index is enabled we never insert into the in-mem hashmaps, then we do not have a need to call `shrink_to_fit()` ever.



#### Summary of Changes

Remove it.