### PR TITLE
blockstore: Use rocksdb ReadOnly mode over Secondary

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -1375,7 +1375,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             let blockstore = crate::open_blockstore(
                 &canonicalize_ledger_path(ledger_path),
                 arg_matches,
-                AccessType::Secondary,
+                AccessType::ReadOnly,
             );
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -39,6 +39,14 @@ use {
     },
 };
 
+/// Blockstore supports two types of access that do not modify the data
+/// (https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances),
+/// among which Secondary offers extra capabilities that are not used by the ledger tool.
+/// Since there were also cases where secondary access had degraded performance
+/// (https://github.com/anza-xyz/agave/issues/7216), the best is to use ReadOnly when writing
+/// is not needed.
+pub(super) const NON_WRITABLE_BLOCKSTORE_ACCESS: AccessType = AccessType::ReadOnly;
+
 fn analyze_column(blockstore: &Blockstore, column_name: &str) -> Result<()> {
     let mut key_len: u64 = 0;
     let mut key_tot: u64 = 0;
@@ -599,14 +607,14 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
         ("analyze-storage", Some(arg_matches)) => analyze_storage(&crate::open_blockstore(
             &ledger_path,
             arg_matches,
-            AccessType::Secondary,
+            NON_WRITABLE_BLOCKSTORE_ACCESS,
         ))?,
         ("bounds", Some(arg_matches)) => {
             let output_format = OutputFormat::from_matches(arg_matches, "output_format", false);
             let all = arg_matches.is_present("all");
 
             let blockstore =
-                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+                crate::open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
             let slot_meta_iterator = blockstore.slot_meta_iterator(0)?;
             let slots: Vec<_> = slot_meta_iterator.map(|(slot, _)| slot).collect();
 
@@ -665,7 +673,8 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             let target_ledger =
                 PathBuf::from(value_t_or_exit!(arg_matches, "target_ledger", String));
 
-            let source = crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+            let source =
+                crate::open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
             let target = crate::open_blockstore(
                 &target_ledger,
                 arg_matches,
@@ -685,7 +694,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
         }
         ("dead-slots", Some(arg_matches)) => {
             let blockstore =
-                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+                crate::open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
             let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
             for slot in blockstore.dead_slots_iterator(starting_slot)? {
                 println!("{slot}");
@@ -693,7 +702,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
         }
         ("duplicate-slots", Some(arg_matches)) => {
             let blockstore =
-                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+                crate::open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
             let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
             let output_format =
                 OutputFormat::from_matches(arg_matches, "output_format", verbose_level > 1);
@@ -708,7 +717,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
         }
         ("latest-optimistic-slots", Some(arg_matches)) => {
             let blockstore =
-                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+                crate::open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
             let num_slots = value_t_or_exit!(arg_matches, "num_slots", usize);
             let exclude_vote_only_slots = arg_matches.is_present("exclude_vote_only_slots");
             let slots =
@@ -738,7 +747,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
         }
         ("list-roots", Some(arg_matches)) => {
             let blockstore =
-                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+                crate::open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
 
             let max_height = value_t!(arg_matches, "max_height", usize).unwrap_or(usize::MAX);
             let start_root = value_t!(arg_matches, "start_root", Slot).unwrap_or(0);
@@ -770,7 +779,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
             let ending_slot = value_t_or_exit!(arg_matches, "ending_slot", Slot);
             let blockstore =
-                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+                crate::open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
             let mut ancestors = BTreeSet::new();
             assert!(
                 blockstore.meta(ending_slot)?.is_some(),
@@ -835,7 +844,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             let output_format = OutputFormat::from_matches(arg_matches, "output_format", false);
 
             output_ledger(
-                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary),
+                crate::open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS),
                 starting_slot,
                 ending_slot,
                 allow_dead_slots,
@@ -847,7 +856,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
         }
         ("print-file-metadata", Some(arg_matches)) => {
             let blockstore =
-                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+                crate::open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
             let sst_file_name = arg_matches.value_of("file_name");
             print_blockstore_file_metadata(&blockstore, &sst_file_name)?;
         }
@@ -998,7 +1007,8 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             }
             let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
             let ending_slot = value_t!(arg_matches, "ending_slot", Slot).unwrap_or(Slot::MAX);
-            let ledger = crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+            let ledger =
+                crate::open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
             for (slot, _meta) in ledger
                 .slot_meta_iterator(starting_slot)?
                 .take_while(|(slot, _)| *slot <= ending_slot)
@@ -1029,7 +1039,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             let output_format = OutputFormat::from_matches(arg_matches, "output_format", false);
 
             let blockstore =
-                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+                crate::open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
             for slot in slots {
                 output_slot(
                     &blockstore,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{blockstore::NON_WRITABLE_BLOCKSTORE_ACCESS, LEDGER_TOOL_DIRECTORY},
+    crate::LEDGER_TOOL_DIRECTORY,
     agave_snapshots::{
         paths::{self as snapshot_paths, BANK_SNAPSHOTS_DIR},
         snapshot_config::{SnapshotConfig, SnapshotUsage},
@@ -80,7 +80,7 @@ pub(crate) enum LoadAndProcessLedgerError {
     #[error("failed to create all run and snapshot directories: {0}")]
     CreateAllAccountsRunAndSnapshotDirectories(#[source] std::io::Error),
 
-    #[error("custom accounts path is not supported with non-writable blockstore access")]
+    #[error("custom accounts path is not supported with read-only blockstore access")]
     CustomAccountsPathUnsupported(#[source] BlockstoreError),
 
     #[error(
@@ -238,7 +238,7 @@ pub fn load_and_process_ledger(
             .join(LEDGER_TOOL_DIRECTORY)
             .join("accounts");
         info!(
-            "Default accounts path is switched aligning with Blockstore's non-writable access: \
+            "Default accounts path is switched aligning with Blockstore's read-only access: \
              {non_primary_accounts_path:?}"
         );
         vec![non_primary_accounts_path]
@@ -460,13 +460,15 @@ pub fn open_blockstore(
                 .starts_with("Invalid argument: Column family not found:");
             // The blockstore settings with Primary access can resolve the
             // above issues automatically, so only emit the help messages
-            // if access type is Secondary / ReadOnly
-            if missing_blockstore && access_type.is_non_writable() {
+            // if access type is ReadOnly
+            let is_read_only = access_type == AccessType::ReadOnly;
+
+            if missing_blockstore && is_read_only {
                 eprintln!(
                     "Failed to open blockstore at {ledger_path:?}, it is missing at least one \
                      critical file: {err:?}"
                 );
-            } else if missing_column && access_type.is_non_writable() {
+            } else if missing_column && is_read_only {
                 eprintln!(
                     "Failed to open blockstore at {ledger_path:?}, it does not have all necessary \
                      columns: {err:?}"
@@ -557,7 +559,7 @@ pub fn get_program_ids(tx: &VersionedTransaction) -> impl Iterator<Item = &Pubke
 /// Get the AccessType required, based on `process_options`
 pub(crate) fn get_access_type(process_options: &ProcessOptions) -> AccessType {
     match process_options.use_snapshot_archives_at_startup {
-        UseSnapshotArchivesAtStartup::Always => NON_WRITABLE_BLOCKSTORE_ACCESS,
+        UseSnapshotArchivesAtStartup::Always => AccessType::ReadOnly,
         UseSnapshotArchivesAtStartup::Never => AccessType::PrimaryForMaintenance,
         UseSnapshotArchivesAtStartup::WhenNewest => AccessType::PrimaryForMaintenance,
     }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2571,8 +2571,8 @@ fn main() {
                     };
                     process_options.halt_at_slot = Some(parent_slot);
 
-                    // PrimaryForMaintenance needed over ReadOnly to purge any
-                    // existing simulated shreds from previous runs
+                    // PrimaryForMaintenance needed to purge(write) any existing simulated shreds
+                    // from previous runs
                     let blockstore = Arc::new(open_blockstore(
                         &ledger_path,
                         arg_matches,
@@ -3165,7 +3165,7 @@ fn main() {
                 }
                 ("compute-slot-cost", Some(arg_matches)) => {
                     let blockstore =
-                        open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
+                        open_blockstore(&ledger_path, arg_matches, AccessType::ReadOnly);
 
                     let mut slots: Vec<u64> = vec![];
                     if !arg_matches.is_present("slots") {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2571,7 +2571,7 @@ fn main() {
                     };
                     process_options.halt_at_slot = Some(parent_slot);
 
-                    // PrimaryForMaintenance needed over Secondary to purge any
+                    // PrimaryForMaintenance needed over Secondary / ReadOnly to purge any
                     // existing simulated shreds from previous runs
                     let blockstore = Arc::new(open_blockstore(
                         &ledger_path,
@@ -3165,7 +3165,7 @@ fn main() {
                 }
                 ("compute-slot-cost", Some(arg_matches)) => {
                     let blockstore =
-                        open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+                        open_blockstore(&ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
 
                     let mut slots: Vec<u64> = vec![];
                     if !arg_matches.is_present("slots") {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2571,7 +2571,7 @@ fn main() {
                     };
                     process_options.halt_at_slot = Some(parent_slot);
 
-                    // PrimaryForMaintenance needed over Secondary / ReadOnly to purge any
+                    // PrimaryForMaintenance needed over ReadOnly to purge any
                     // existing simulated shreds from previous runs
                     let blockstore = Arc::new(open_blockstore(
                         &ledger_path,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2571,7 +2571,7 @@ fn main() {
                     };
                     process_options.halt_at_slot = Some(parent_slot);
 
-                    // PrimaryForMaintenance needed to purge(write) any existing simulated shreds
+                    // PrimaryForMaintenance needed to purge (write) any existing simulated shreds
                     // from previous runs
                     let blockstore = Arc::new(open_blockstore(
                         &ledger_path,

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        args::*, blockstore::NON_WRITABLE_BLOCKSTORE_ACCESS, canonicalize_ledger_path,
-        ledger_utils::*,
-    },
+    crate::{args::*, canonicalize_ledger_path, ledger_utils::*},
     agave_syscalls::create_program_runtime_environment_v1,
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand},
     log::*,
@@ -14,6 +11,7 @@ use {
     solana_bpf_loader_program::{create_vm, load_program_from_bytes},
     solana_cli_output::{OutputFormat, QuietDisplay, VerboseDisplay},
     solana_clock::Slot,
+    solana_ledger::blockstore_options::AccessType,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_program_runtime::{
         invoke_context::InvokeContext,
@@ -81,7 +79,7 @@ fn load_blockstore(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -> Arc<Bank
 
     let genesis_config = open_genesis_config_by(ledger_path, arg_matches);
     info!("genesis hash: {}", genesis_config.hash());
-    let blockstore = open_blockstore(ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
+    let blockstore = open_blockstore(ledger_path, arg_matches, AccessType::ReadOnly);
     let LoadAndProcessLedgerOutput { bank_forks, .. } = load_and_process_ledger_or_exit(
         arg_matches,
         &genesis_config,

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{args::*, canonicalize_ledger_path, ledger_utils::*},
+    crate::{
+        args::*, blockstore::NON_WRITABLE_BLOCKSTORE_ACCESS, canonicalize_ledger_path,
+        ledger_utils::*,
+    },
     agave_syscalls::create_program_runtime_environment_v1,
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand},
     log::*,
@@ -11,7 +14,6 @@ use {
     solana_bpf_loader_program::{create_vm, load_program_from_bytes},
     solana_cli_output::{OutputFormat, QuietDisplay, VerboseDisplay},
     solana_clock::Slot,
-    solana_ledger::blockstore_options::AccessType,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_program_runtime::{
         invoke_context::InvokeContext,
@@ -79,7 +81,7 @@ fn load_blockstore(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -> Arc<Bank
 
     let genesis_config = open_genesis_config_by(ledger_path, arg_matches);
     info!("genesis hash: {}", genesis_config.hash());
-    let blockstore = open_blockstore(ledger_path, arg_matches, AccessType::Secondary);
+    let blockstore = open_blockstore(ledger_path, arg_matches, NON_WRITABLE_BLOCKSTORE_ACCESS);
     let LoadAndProcessLedgerOutput { bank_forks, .. } = load_and_process_ledger_or_exit(
         arg_matches,
         &genesis_config,

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -45,10 +45,19 @@ pub enum AccessType {
     Primary,
     /// Primary (read/write) access with RocksDB automatic compaction disabled.
     PrimaryForMaintenance,
-    /// Secondary (read) access; multiple processes can have Secondary access.
-    /// Additionally, Secondary access can be obtained while another process
-    /// already has Primary access.
+    /// Secondary (read) access; multiple processes can have Secondary access,
+    /// which supports ability to dynamically catch-up with the Primary instance
+    /// that might be updating store from another process.
     Secondary,
+    /// Read-only access. When the Read-only instance is created, it gets a static
+    /// read-only view of the Primary Instance’s database contents.
+    ReadOnly,
+}
+
+impl AccessType {
+    pub fn is_non_writable(&self) -> bool {
+        matches!(self, AccessType::ReadOnly | AccessType::Secondary)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -46,14 +46,9 @@ pub enum AccessType {
     /// Primary (read/write) access with RocksDB automatic compaction disabled.
     PrimaryForMaintenance,
     /// Read-only access. When the Read-only instance is created, it gets a static
-    /// read-only view of the Primary Instance’s database contents.
+    /// read-only view of the Primary Instance’s database contents
+    /// (https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances).
     ReadOnly,
-}
-
-impl AccessType {
-    pub fn is_non_writable(&self) -> bool {
-        matches!(self, AccessType::ReadOnly)
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -45,10 +45,6 @@ pub enum AccessType {
     Primary,
     /// Primary (read/write) access with RocksDB automatic compaction disabled.
     PrimaryForMaintenance,
-    /// Secondary (read) access; multiple processes can have Secondary access,
-    /// which supports ability to dynamically catch-up with the Primary instance
-    /// that might be updating store from another process.
-    Secondary,
     /// Read-only access. When the Read-only instance is created, it gets a static
     /// read-only view of the Primary Instance’s database contents.
     ReadOnly,
@@ -56,7 +52,7 @@ pub enum AccessType {
 
 impl AccessType {
     pub fn is_non_writable(&self) -> bool {
-        matches!(self, AccessType::ReadOnly | AccessType::Secondary)
+        matches!(self, AccessType::ReadOnly)
     }
 }
 

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -39,15 +39,16 @@ impl BlockstoreOptions {
     }
 }
 
+/// The mode to open a Blockstore with. For more details, see:
+/// https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AccessType {
     /// Primary (read/write) access; only one process can have Primary access.
     Primary,
     /// Primary (read/write) access with RocksDB automatic compaction disabled.
     PrimaryForMaintenance,
-    /// Read-only access. When the Read-only instance is created, it gets a static
-    /// read-only view of the Primary Instance’s database contents
-    /// (https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances).
+    /// Read only access; multiple processes can obtain ReadOnly access.
+    /// ReadOnly instance gets a static view of the database at creation time.
     ReadOnly,
 }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2402,7 +2402,7 @@ pub mod tests {
     // Convenience wrapper to optionally process blockstore with ReadOnly access.
     //
     // Setting up the ledger for a test requires Primary access as items will need to be inserted.
-    // However, once a ReaDOnly access has been opened, it won't automatically see updates made by
+    // However, once a ReadOnly access has been opened, it won't automatically see updates made by
     // the Primary access. So, open (and close) the ReadOnly access within this function to ensure
     // that "stale" ReadOnly accesses don't propagate.
     fn test_process_blockstore_with_custom_options(

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -980,7 +980,7 @@ pub fn process_blockstore_from_root(
             .expect("Couldn't mark start_slot as connected during startup")
     } else {
         info!(
-            "Start slot {start_slot} isn't a root, and won't be updated due to secondary \
+            "Start slot {start_slot} isn't a root, and won't be updated due to read-only \
              blockstore access"
         );
     }
@@ -2208,7 +2208,7 @@ pub fn process_single_slot(
                 .expect("Failed to mark slot as dead in blockstore");
         } else {
             info!(
-                "Failed slot {slot} won't be marked dead due to being secondary blockstore access"
+                "Failed slot {slot} won't be marked dead due to being read-only blockstore access"
             );
         }
         err
@@ -2229,7 +2229,7 @@ pub fn process_single_slot(
             } else {
                 info!(
                     "Failed last fec set checks slot {slot} won't be marked dead due to being \
-                     secondary blockstore access"
+                     read-only blockstore access"
                 );
             }
         })?;
@@ -2399,12 +2399,12 @@ pub mod tests {
         trees::tr,
     };
 
-    // Convenience wrapper to optionally process blockstore with Secondary access.
+    // Convenience wrapper to optionally process blockstore with ReadOnly access.
     //
     // Setting up the ledger for a test requires Primary access as items will need to be inserted.
-    // However, once a Secondary access has been opened, it won't automatically see updates made by
-    // the Primary access. So, open (and close) the Secondary access within this function to ensure
-    // that "stale" Secondary accesses don't propagate.
+    // However, once a ReaDOnly access has been opened, it won't automatically see updates made by
+    // the Primary access. So, open (and close) the ReadOnly access within this function to ensure
+    // that "stale" ReadOnly accesses don't propagate.
     fn test_process_blockstore_with_custom_options(
         genesis_config: &GenesisConfig,
         blockstore: &Blockstore,
@@ -2417,7 +2417,7 @@ pub mod tests {
                 // just pass the original session if it is a Primary variant
                 test_process_blockstore(genesis_config, blockstore, opts, Arc::default())
             }
-            AccessType::Secondary | AccessType::ReadOnly => {
+            AccessType::ReadOnly => {
                 let read_only_blockstore = Blockstore::open_with_options(
                     blockstore.ledger_path(),
                     BlockstoreOptions {
@@ -2446,11 +2446,6 @@ pub mod tests {
     #[test]
     fn test_process_blockstore_with_missing_hashes() {
         do_test_process_blockstore_with_missing_hashes(AccessType::Primary);
-    }
-
-    #[test]
-    fn test_process_blockstore_with_missing_hashes_secondary_access() {
-        do_test_process_blockstore_with_missing_hashes(AccessType::Secondary);
     }
 
     #[test]
@@ -2503,9 +2498,9 @@ pub mod tests {
 
         let dead_slots: Vec<Slot> = blockstore.dead_slots_iterator(0).unwrap().collect();
         match blockstore_access_type {
-            // Secondary access is non-writable so even though a dead slot
+            // In ReadOnly access even though a dead slot
             // will be identified, it won't actually be marked dead.
-            AccessType::Secondary | AccessType::ReadOnly => {
+            AccessType::ReadOnly => {
                 assert_eq!(dead_slots.len(), 0);
             }
             AccessType::Primary | AccessType::PrimaryForMaintenance => {
@@ -4825,11 +4820,6 @@ pub mod tests {
     #[test]
     fn test_process_blockstore_with_supermajority_root_without_blockstore_root() {
         run_test_process_blockstore_with_supermajority_root(None, AccessType::Primary);
-    }
-
-    #[test]
-    fn test_process_blockstore_with_supermajority_root_without_blockstore_root_secondary_access() {
-        run_test_process_blockstore_with_supermajority_root(None, AccessType::Secondary);
     }
 
     #[test]

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -108,13 +108,13 @@ pub fn open_blockstore(ledger_path: &Path) -> Blockstore {
             ..BlockstoreOptions::default()
         },
     )
-    // Fall back on Secondary if Primary fails; Primary will fail if
+    // Fall back on ReadOnly if Primary fails; Primary will fail if
     // a handle to Blockstore is being held somewhere else
     .unwrap_or_else(|_| {
         Blockstore::open_with_options(
             ledger_path,
             BlockstoreOptions {
-                access_type: AccessType::Secondary,
+                access_type: AccessType::ReadOnly,
                 recovery_mode: None,
                 ..BlockstoreOptions::default()
             },


### PR DESCRIPTION
#### Problem
Blockstore supports two types of access that do not modify the data
(https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances),
among which Secondary offers extra capabilities that are not used by the ledger tool.
Since there were also cases where secondary access had degraded performance, the best is to use ReadOnly when writing is not needed.

#### Summary of Changes
* introduce `AccessType::ReadOnly` for opening blockstore
* switch ledger-tool to use it

Fixes #7216
