### PR TITLE
frozen-abi: fix derives for agave-votor-messages and agave-votor

### DIFF
--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -11,7 +11,12 @@ edition = { workspace = true }
 
 [features]
 agave-unstable-api = []
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-hash/frozen-abi",
+    "solana-bls-signatures/frozen-abi",
+]
 
 [dependencies]
 agave-logger = { workspace = true }

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -19,6 +19,8 @@ frozen-abi = [
     "solana-bloom/frozen-abi",
     "solana-ledger/frozen-abi",
     "solana-runtime/frozen-abi",
+    "solana-signature/frozen-abi",
+    "agave-votor-messages/frozen-abi",
 ]
 
 [dependencies]


### PR DESCRIPTION
#### Problem

(split from #9025)

These two commands don't work on the tip of master. They should be caught by the `frozen-abi` test. However they don't. I'll dig deeper to understand why. 

```
cargo +nightly-2025-06-23 test --features frozen-abi -p agave-votor-messages
```

```
cargo +nightly-2025-06-23 test --features frozen-abi -p agave-votor
```

#### Summary of Changes

add missing enabling