### PR TITLE
chore: clarify port range error message when binding fails

### DIFF
--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -306,9 +306,9 @@ pub fn bind_two_in_range_with_offset_and_config(
             }
         }
     }
-    Err(io::Error::other(
-        "couldn't find two ports with the correct offset in range".to_string(),
-    ))
+    Err(io::Error::other(format!(
+        "couldn't find two unused ports with the correct offset in range {range:?}"
+    )))
 }
 
 pub fn bind_more_with_config(

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -307,7 +307,7 @@ pub fn bind_two_in_range_with_offset_and_config(
         }
     }
     Err(io::Error::other(format!(
-        "couldn't find two unused ports with the correct offset in range {range:?}"
+        "couldn't find two unused ports with offset {offset} in range {range:?}"
     )))
 }
 


### PR DESCRIPTION
## Problem
  When the Agave validator fails to bind to ports in the dynamic port range because they're already in use, it displays an unhelpful error message: `"couldn't find two ports with the correct offset in range"`. This lacks clarity about what went wrong and which ports were affected, making it difficult for users to diagnose port conflicts.

  ## Summary of Changes
  Improved the error message in `bind_two_in_range_with_offset_and_config()` to:
  - Clarify that ports are "already in use" (not just unavailable)
  - Display the specific port range that was attempted
  - Provide better context for troubleshooting

  This helps users quickly diagnose port conflicts when setting up validators without extensive troubleshooting.

  Fixes #9032