### PR TITLE
Split archive and serialize

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -8,7 +8,6 @@ use {
             SerializableAccountStorageEntry, SnapshotAccountsDbFields, SnapshotBankFields,
             SnapshotStreams,
         },
-        snapshot_package::SnapshotPackage,
         snapshot_utils::snapshot_storage_rebuilder::{
             get_slot_and_append_vec_id, SnapshotStorageRebuilder,
         },
@@ -27,7 +26,7 @@ use {
         },
         snapshot_config::SnapshotConfig,
         streaming_unarchive_snapshot, ArchiveFormat, ArchivePackage, Result, SnapshotArchiveKind,
-        SnapshotKind, SnapshotVersion,
+        SnapshotVersion,
     },
     crossbeam_channel::{Receiver, Sender},
     log::*,
@@ -444,51 +443,12 @@ pub fn remove_tmp_snapshot_archives(snapshot_archives_dir: impl AsRef<Path>) {
     }
 }
 
-/// Serializes and archives a snapshot package
-pub fn serialize_and_archive_snapshot_package(
-    snapshot_package: SnapshotPackage,
+/// Archives an archive package
+pub fn archive_snapshot_package(
+    mut snapshot_package: ArchivePackage,
     snapshot_config: &SnapshotConfig,
-    should_flush_and_hard_link_storages: bool,
 ) -> Result<SnapshotArchiveInfo> {
-    let SnapshotPackage {
-        snapshot_kind,
-        slot,
-        block_height: _,
-        hash,
-        snapshot_storages,
-        status_cache_slot_deltas,
-        bank_fields_to_serialize,
-        bank_hash_stats,
-        write_version,
-        enqueued: _,
-    } = snapshot_package;
-
-    let bank_snapshot_package = BankSnapshotPackage {
-        bank_fields: bank_fields_to_serialize,
-        bank_hash_stats,
-        snapshot_storages: snapshot_storages.as_slice(),
-        slot_deltas: status_cache_slot_deltas,
-        write_version,
-    };
-
-    let bank_snapshot_info = serialize_snapshot(
-        &snapshot_config.bank_snapshots_dir,
-        snapshot_config.snapshot_version,
-        bank_snapshot_package,
-        should_flush_and_hard_link_storages,
-    )?;
-
-    let SnapshotKind::Archive(snapshot_archive_kind) = snapshot_kind;
-
-    let mut snapshot_package = ArchivePackage {
-        snapshot_archive_kind,
-        slot,
-        hash,
-        snapshot_storages,
-        bank_snapshot_dir: bank_snapshot_info.snapshot_dir,
-    };
-
-    let snapshot_archive_path = match snapshot_archive_kind {
+    let snapshot_archive_path = match snapshot_package.snapshot_archive_kind {
         SnapshotArchiveKind::Full => snapshot_paths::build_full_snapshot_archive_path(
             &snapshot_config.full_snapshot_archives_dir,
             snapshot_package.slot,
@@ -521,7 +481,7 @@ pub fn serialize_and_archive_snapshot_package(
 }
 
 /// Serializes a snapshot into `bank_snapshots_dir`
-fn serialize_snapshot(
+pub fn serialize_snapshot(
     bank_snapshots_dir: impl AsRef<Path>,
     snapshot_version: SnapshotVersion,
     bank_snapshot_package: BankSnapshotPackage,

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -11,7 +11,12 @@ use {
     solana_clock::Slot,
     solana_measure::measure::Measure,
     solana_metrics::datapoint_info,
-    std::{fs, io::Write, path::Path, sync::Arc},
+    std::{
+        fs,
+        io::Write,
+        path::{Path, PathBuf},
+        sync::Arc,
+    },
 };
 
 // Balance large and small files order in snapshot tar with bias towards small (4 small + 1 large),
@@ -19,18 +24,33 @@ use {
 // and towards the end of archive (sizes equalize) writes are >256KiB / file.
 const INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO: (usize, usize) = (4, 1);
 
-/// Archives a snapshot into `archive_path`
+// A package of snapshot information needed for archiving
+pub struct ArchivePackage {
+    pub snapshot_archive_kind: SnapshotArchiveKind,
+    pub slot: Slot,
+    pub hash: SnapshotHash,
+    pub snapshot_storages: Vec<Arc<AccountStorageEntry>>,
+    pub bank_snapshot_dir: PathBuf,
+}
+
+/// Archives an archive package into `archive_path`
 pub fn archive_snapshot(
-    snapshot_archive_kind: SnapshotArchiveKind,
-    snapshot_slot: Slot,
-    snapshot_hash: SnapshotHash,
-    snapshot_storages: &[Arc<AccountStorageEntry>],
-    bank_snapshot_dir: impl AsRef<Path>,
+    archive_package: ArchivePackage,
     archive_path: impl AsRef<Path>,
     archive_format: ArchiveFormat,
 ) -> Result<SnapshotArchiveInfo> {
     use ArchiveSnapshotPackageError as E;
     const ACCOUNTS_DIR: &str = "accounts";
+
+    let ArchivePackage {
+        slot: snapshot_slot,
+        snapshot_archive_kind,
+        hash: snapshot_hash,
+        bank_snapshot_dir,
+        snapshot_storages,
+    } = archive_package;
+    let snapshot_storages = snapshot_storages.as_slice();
+
     info!("Generating snapshot archive for slot {snapshot_slot}, kind: {snapshot_archive_kind:?}");
 
     let mut timer = Measure::start("snapshot_package-package_snapshots");
@@ -56,9 +76,9 @@ pub fn archive_snapshot(
         .map_err(|err| E::CreateSnapshotStagingDir(err, staging_snapshot_dir.clone()))?;
 
     // To be a source for symlinking and archiving, the path need to be an absolute path
-    let src_snapshot_dir = bank_snapshot_dir.as_ref().canonicalize().map_err(|err| {
-        E::CanonicalizeSnapshotSourceDir(err, bank_snapshot_dir.as_ref().to_path_buf())
-    })?;
+    let src_snapshot_dir = bank_snapshot_dir
+        .canonicalize()
+        .map_err(|err| E::CanonicalizeSnapshotSourceDir(err, bank_snapshot_dir.to_path_buf()))?;
     let staging_snapshot_file = staging_snapshot_dir.join(&slot_str);
     let src_snapshot_file = src_snapshot_dir.join(slot_str);
     symlink::symlink_file(&src_snapshot_file, &staging_snapshot_file)

--- a/snapshots/src/lib.rs
+++ b/snapshots/src/lib.rs
@@ -31,7 +31,7 @@ mod unarchive;
 pub type Result<T> = std::result::Result<T, error::SnapshotError>;
 
 pub use {
-    archive::archive_snapshot,
+    archive::{archive_snapshot, ArchivePackage},
     archive_format::*,
     kind::{SnapshotArchiveKind, SnapshotKind},
     snapshot_interval::SnapshotInterval,


### PR DESCRIPTION
#### Problem
With fastboots snapshots, Serialized Snapshots will be required without archives. Currently serialize_and_archive_snapshots is the main entry function and does both.

#### Summary of Changes
Best viewed as 3 changesets
- First Changeset: Adds BankSnapshotPackage
- Second Changset: Adds ArchivePackage
- Third Changeset: splits serialize_and_archive_snapshots into two functions
- Left the current parameter names alone as much as possible to make the changesets easier to follow

#### Other alternatives considered
Changing serialize_and_archive_snapshots to return early and skip archiving snapshots in the event of a fastboot snapshot. Returned Result<Option<SnapshotArchiveInfo>> instead of Result<SnapshotArchiveInfo>. 

Making serialize_snapshot public with minimal other changes.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
