### PR TITLE
fix(poh): don't process service messages if we have a record

### DIFF
--- a/poh/src/record_channels.rs
+++ b/poh/src/record_channels.rs
@@ -58,6 +58,7 @@ pub fn record_channels(track_transaction_indexes: bool) -> (RecordSender, Record
     )
 }
 
+#[derive(Debug)]
 pub enum RecordSenderError {
     /// The channel is full, the record was not sent.
     Full,
@@ -84,6 +85,11 @@ pub struct RecordSender {
 }
 
 impl RecordSender {
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.sender.is_empty()
+    }
+
     pub fn try_send(&self, record: Record) -> Result<Option<usize>, RecordSenderError> {
         let num_transactions: usize = record
             .transaction_batches


### PR DESCRIPTION
#### Problem

- #9002 : v3.1 nodes are panicking in rare circumstances where they are the leader but decide to abandon their slot and reset to the another leader's bank.
- This was triggered by a logic error where we would process service messages depsite having just cached a record message:

Store the message for later:
```rust
                    // check to see if a record request has been sent
                    if let Ok(record) = record_receiver.try_recv() {
                        // remember the record we just received as the next record to occur
                        *next_record = Some(record);
                        break;
                    }
```
Check service messages because channel is empty (ignoring the stored message):
```rust
                if Self::can_process_service_message(&service_message, &record_receiver)
                {
                    break;
                }
```

The fix is to ensure we don't have a stored message:
```rust
                if next_record.is_none()
                    && Self::can_process_service_message(&service_message, &record_receiver)
                {
                    break;
                }
```

#### Summary of Changes

- Add an `is_none` check to prevent processing service messages when the channel is empty.

Fixes #9002
