### PR TITLE
Relax read_pod bound to AnyBitPattern

### DIFF
--- a/accounts-db/src/tiered_storage/file.rs
+++ b/accounts-db/src/tiered_storage/file.rs
@@ -68,7 +68,7 @@ impl TieredReadableFile {
     /// Reads a value of type `T` from the file.
     ///
     /// Type T must be plain ol' data.
-    pub fn read_pod<T: NoUninit + AnyBitPattern>(&self, value: &mut T) -> io::Result<()> {
+    pub fn read_pod<T: AnyBitPattern>(&self, value: &mut T) -> io::Result<()> {
         // SAFETY: Since T is AnyBitPattern, it is safe to cast bytes to T.
         unsafe { self.read_type(value) }
     }


### PR DESCRIPTION
Relax read_pod bound in accounts-db/src/tiered_storage/file.rs from NoUninit + AnyBitPattern to AnyBitPattern.
Reason: Reading raw bytes into T only requires that all bit patterns are valid (AnyBitPattern). NoUninit is required for writing T to bytes to avoid reading uninitialized memory. This aligns with bytemuck’s documented safety model and makes the API consistent with  accounts-db/src/tiered_storage/byte_block.rs (read_pod uses AnyBitPattern, write_pod uses NoUninit). No runtime behavior changes; only compile-time bound relaxation to broaden valid types.