### PR TITLE
Splitting snapshot type into snapshot type and snapshot archive type

### DIFF
--- a/core/src/snapshot_packager_service/snapshot_gossip_manager.rs
+++ b/core/src/snapshot_packager_service/snapshot_gossip_manager.rs
@@ -3,7 +3,7 @@ use {
         snapshot_hash::{
             FullSnapshotHash, IncrementalSnapshotHash, SnapshotHash, StartingSnapshotHashes,
         },
-        SnapshotKind,
+        SnapshotArchiveKind, SnapshotKind,
     },
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
@@ -54,10 +54,10 @@ impl SnapshotGossipManager {
         snapshot_hash: (Slot, SnapshotHash),
     ) {
         match snapshot_kind {
-            SnapshotKind::FullSnapshot => {
+            SnapshotKind::Archive(SnapshotArchiveKind::Full) => {
                 self.push_full_snapshot_hash(FullSnapshotHash(snapshot_hash));
             }
-            SnapshotKind::IncrementalSnapshot(base_slot) => {
+            SnapshotKind::Archive(SnapshotArchiveKind::Incremental(base_slot)) => {
                 self.push_incremental_snapshot_hash(
                     IncrementalSnapshotHash(snapshot_hash),
                     base_slot,

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -10,7 +10,7 @@
 pub use solana_file_download::DownloadProgressRecord;
 use {
     agave_snapshots::{
-        paths as snapshot_paths, snapshot_hash::SnapshotHash, ArchiveFormat, ArchiveKind,
+        paths as snapshot_paths, snapshot_hash::SnapshotHash, ArchiveFormat, SnapshotArchiveKind,
         ZstdConfig,
     },
     log::*,
@@ -56,7 +56,7 @@ pub fn download_snapshot_archive(
     full_snapshot_archives_dir: &Path,
     incremental_snapshot_archives_dir: &Path,
     desired_snapshot_hash: (Slot, SnapshotHash),
-    archive_kind: ArchiveKind,
+    snapshot_kind: SnapshotArchiveKind,
     maximum_full_snapshot_archives_to_retain: NonZeroUsize,
     maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
     use_progress_bar: bool,
@@ -70,9 +70,9 @@ pub fn download_snapshot_archive(
     );
 
     let snapshot_archives_remote_dir =
-        snapshot_paths::build_snapshot_archives_remote_dir(match archive_kind {
-            ArchiveKind::FullArchive => full_snapshot_archives_dir,
-            ArchiveKind::IncrementalArchive(_) => incremental_snapshot_archives_dir,
+        snapshot_paths::build_snapshot_archives_remote_dir(match snapshot_kind {
+            SnapshotArchiveKind::Full => full_snapshot_archives_dir,
+            SnapshotArchiveKind::Incremental(_) => incremental_snapshot_archives_dir,
         });
     fs::create_dir_all(&snapshot_archives_remote_dir).unwrap();
 
@@ -82,14 +82,14 @@ pub fn download_snapshot_archive(
         },
         ArchiveFormat::TarLz4,
     ] {
-        let destination_path = match archive_kind {
-            ArchiveKind::FullArchive => snapshot_paths::build_full_snapshot_archive_path(
+        let destination_path = match snapshot_kind {
+            SnapshotArchiveKind::Full => snapshot_paths::build_full_snapshot_archive_path(
                 &snapshot_archives_remote_dir,
                 desired_snapshot_hash.0,
                 &desired_snapshot_hash.1,
                 archive_format,
             ),
-            ArchiveKind::IncrementalArchive(base_slot) => {
+            SnapshotArchiveKind::Incremental(base_slot) => {
                 snapshot_paths::build_incremental_snapshot_archive_path(
                     &snapshot_archives_remote_dir,
                     base_slot,

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -10,7 +10,7 @@
 pub use solana_file_download::DownloadProgressRecord;
 use {
     agave_snapshots::{
-        paths as snapshot_paths, snapshot_hash::SnapshotHash, ArchiveFormat, SnapshotKind,
+        paths as snapshot_paths, snapshot_hash::SnapshotHash, ArchiveFormat, ArchiveKind,
         ZstdConfig,
     },
     log::*,
@@ -56,7 +56,7 @@ pub fn download_snapshot_archive(
     full_snapshot_archives_dir: &Path,
     incremental_snapshot_archives_dir: &Path,
     desired_snapshot_hash: (Slot, SnapshotHash),
-    snapshot_kind: SnapshotKind,
+    archive_kind: ArchiveKind,
     maximum_full_snapshot_archives_to_retain: NonZeroUsize,
     maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
     use_progress_bar: bool,
@@ -70,9 +70,9 @@ pub fn download_snapshot_archive(
     );
 
     let snapshot_archives_remote_dir =
-        snapshot_paths::build_snapshot_archives_remote_dir(match snapshot_kind {
-            SnapshotKind::FullSnapshot => full_snapshot_archives_dir,
-            SnapshotKind::IncrementalSnapshot(_) => incremental_snapshot_archives_dir,
+        snapshot_paths::build_snapshot_archives_remote_dir(match archive_kind {
+            ArchiveKind::FullArchive => full_snapshot_archives_dir,
+            ArchiveKind::IncrementalArchive(_) => incremental_snapshot_archives_dir,
         });
     fs::create_dir_all(&snapshot_archives_remote_dir).unwrap();
 
@@ -82,14 +82,14 @@ pub fn download_snapshot_archive(
         },
         ArchiveFormat::TarLz4,
     ] {
-        let destination_path = match snapshot_kind {
-            SnapshotKind::FullSnapshot => snapshot_paths::build_full_snapshot_archive_path(
+        let destination_path = match archive_kind {
+            ArchiveKind::FullArchive => snapshot_paths::build_full_snapshot_archive_path(
                 &snapshot_archives_remote_dir,
                 desired_snapshot_hash.0,
                 &desired_snapshot_hash.1,
                 archive_format,
             ),
-            SnapshotKind::IncrementalSnapshot(base_slot) => {
+            ArchiveKind::IncrementalArchive(base_slot) => {
                 snapshot_paths::build_incremental_snapshot_archive_path(
                     &snapshot_archives_remote_dir,
                     base_slot,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2,7 +2,7 @@
 use {
     agave_snapshots::{
         paths as snapshot_paths, snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::SnapshotConfig, ArchiveKind, SnapshotInterval,
+        snapshot_config::SnapshotConfig, SnapshotArchiveKind, SnapshotInterval,
     },
     assert_matches::assert_matches,
     crossbeam_channel::{unbounded, Receiver},
@@ -526,7 +526,7 @@ fn test_snapshot_download() {
             full_snapshot_archive_info.slot(),
             *full_snapshot_archive_info.hash(),
         ),
-        ArchiveKind::FullArchive,
+        SnapshotArchiveKind::Full,
         validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -655,7 +655,7 @@ fn test_incremental_snapshot_download() {
             full_snapshot_archive_info.slot(),
             *full_snapshot_archive_info.hash(),
         ),
-        ArchiveKind::FullArchive,
+        SnapshotArchiveKind::Full,
         validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -683,7 +683,7 @@ fn test_incremental_snapshot_download() {
             incremental_snapshot_archive_info.slot(),
             *incremental_snapshot_archive_info.hash(),
         ),
-        ArchiveKind::IncrementalArchive(incremental_snapshot_archive_info.base_slot()),
+        SnapshotArchiveKind::Incremental(incremental_snapshot_archive_info.base_slot()),
         validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -828,7 +828,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
             .incremental_snapshot_archives_dir
             .path(),
         (full_snapshot_archive.slot(), *full_snapshot_archive.hash()),
-        ArchiveKind::FullArchive,
+        SnapshotArchiveKind::Full,
         validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -865,7 +865,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
             incremental_snapshot_archive.slot(),
             *incremental_snapshot_archive.hash(),
         ),
-        ArchiveKind::IncrementalArchive(incremental_snapshot_archive.base_slot()),
+        SnapshotArchiveKind::Incremental(incremental_snapshot_archive.base_slot()),
         validator_snapshot_test_config
             .validator_config
             .snapshot_config

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2,7 +2,7 @@
 use {
     agave_snapshots::{
         paths as snapshot_paths, snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::SnapshotConfig, SnapshotInterval, SnapshotKind,
+        snapshot_config::SnapshotConfig, ArchiveKind, SnapshotInterval,
     },
     assert_matches::assert_matches,
     crossbeam_channel::{unbounded, Receiver},
@@ -526,7 +526,7 @@ fn test_snapshot_download() {
             full_snapshot_archive_info.slot(),
             *full_snapshot_archive_info.hash(),
         ),
-        SnapshotKind::FullSnapshot,
+        ArchiveKind::FullArchive,
         validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -655,7 +655,7 @@ fn test_incremental_snapshot_download() {
             full_snapshot_archive_info.slot(),
             *full_snapshot_archive_info.hash(),
         ),
-        SnapshotKind::FullSnapshot,
+        ArchiveKind::FullArchive,
         validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -683,7 +683,7 @@ fn test_incremental_snapshot_download() {
             incremental_snapshot_archive_info.slot(),
             *incremental_snapshot_archive_info.hash(),
         ),
-        SnapshotKind::IncrementalSnapshot(incremental_snapshot_archive_info.base_slot()),
+        ArchiveKind::IncrementalArchive(incremental_snapshot_archive_info.base_slot()),
         validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -828,7 +828,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
             .incremental_snapshot_archives_dir
             .path(),
         (full_snapshot_archive.slot(), *full_snapshot_archive.hash()),
-        SnapshotKind::FullSnapshot,
+        ArchiveKind::FullArchive,
         validator_snapshot_test_config
             .validator_config
             .snapshot_config
@@ -865,7 +865,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
             incremental_snapshot_archive.slot(),
             *incremental_snapshot_archive.hash(),
         ),
-        SnapshotKind::IncrementalSnapshot(incremental_snapshot_archive.base_slot()),
+        ArchiveKind::IncrementalArchive(incremental_snapshot_archive.base_slot()),
         validator_snapshot_test_config
             .validator_config
             .snapshot_config

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -14,7 +14,7 @@ use {
         snapshot_controller::SnapshotController,
         snapshot_package::SnapshotPackage,
     },
-    agave_snapshots::{error::SnapshotError, SnapshotKind},
+    agave_snapshots::{error::SnapshotError, SnapshotArchiveKind, SnapshotKind},
     crossbeam_channel::{Receiver, SendError, Sender},
     log::*,
     rayon::iter::{IntoParallelIterator, ParallelIterator},
@@ -651,7 +651,7 @@ impl AbsStatus {
 #[must_use]
 fn new_snapshot_kind(snapshot_request: &SnapshotRequest) -> Option<SnapshotKind> {
     match snapshot_request.request_kind {
-        SnapshotRequestKind::FullSnapshot => Some(SnapshotKind::FullSnapshot),
+        SnapshotRequestKind::FullSnapshot => Some(SnapshotKind::Archive(SnapshotArchiveKind::Full)),
         SnapshotRequestKind::IncrementalSnapshot => {
             if let Some(latest_full_snapshot_slot) = snapshot_request
                 .snapshot_root_bank
@@ -660,7 +660,9 @@ fn new_snapshot_kind(snapshot_request: &SnapshotRequest) -> Option<SnapshotKind>
                 .accounts_db
                 .latest_full_snapshot_slot()
             {
-                Some(SnapshotKind::IncrementalSnapshot(latest_full_snapshot_slot))
+                Some(SnapshotKind::Archive(SnapshotArchiveKind::Incremental(
+                    latest_full_snapshot_slot,
+                )))
             } else {
                 warn!(
                     "Ignoring IncrementalSnapshot request for slot {} because there is no latest \

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -39,7 +39,7 @@ use {
         },
         snapshot_config::SnapshotConfig,
         snapshot_hash::SnapshotHash,
-        ArchiveFormat, SnapshotKind, SnapshotVersion,
+        ArchiveFormat, SnapshotArchiveKind, SnapshotKind, SnapshotVersion,
     },
     log::*,
     solana_accounts_db::{
@@ -692,7 +692,7 @@ fn bank_to_full_snapshot_archive_with(
     bank.clean_accounts();
 
     let snapshot_package = SnapshotPackage::new(
-        SnapshotKind::FullSnapshot,
+        SnapshotKind::Archive(SnapshotArchiveKind::Full),
         bank,
         bank.get_snapshot_storages(None),
         bank.status_cache.read().unwrap().root_slot_deltas(),
@@ -747,7 +747,7 @@ pub fn bank_to_incremental_snapshot_archive(
     bank.clean_accounts();
 
     let snapshot_package = SnapshotPackage::new(
-        SnapshotKind::IncrementalSnapshot(full_snapshot_slot),
+        SnapshotKind::Archive(SnapshotArchiveKind::Incremental(full_snapshot_slot)),
         bank,
         bank.get_snapshot_storages(Some(full_snapshot_slot)),
         bank.status_cache.read().unwrap().root_slot_deltas(),

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -2,7 +2,7 @@
 use solana_hash::Hash;
 use {
     crate::bank::{Bank, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
-    agave_snapshots::{snapshot_hash::SnapshotHash, SnapshotKind},
+    agave_snapshots::{snapshot_hash::SnapshotHash, SnapshotArchiveKind, SnapshotKind},
     solana_accounts_db::accounts_db::AccountStorageEntry,
     solana_clock::Slot,
     std::{
@@ -39,7 +39,10 @@ impl SnapshotPackage {
         status_cache_slot_deltas: Vec<BankSlotDelta>,
     ) -> Self {
         let slot = bank.slot();
-        if let SnapshotKind::IncrementalSnapshot(incremental_snapshot_base_slot) = snapshot_kind {
+        if let SnapshotKind::Archive(SnapshotArchiveKind::Incremental(
+            incremental_snapshot_base_slot,
+        )) = snapshot_kind
+        {
             assert!(
                 slot > incremental_snapshot_base_slot,
                 "Incremental snapshot base slot must be less than the bank being snapshotted!"
@@ -73,7 +76,7 @@ impl SnapshotPackage {
     /// Only use for tests; many of the fields are invalid!
     pub fn default_for_tests() -> Self {
         Self {
-            snapshot_kind: SnapshotKind::FullSnapshot,
+            snapshot_kind: SnapshotKind::Archive(SnapshotArchiveKind::Full),
             slot: Slot::default(),
             block_height: Slot::default(),
             hash: SnapshotHash(Hash::default()),

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -3,35 +3,40 @@ use {
     std::cmp::Ordering::{self, Equal, Greater, Less},
 };
 
-/// Compare snapshot packages by priority; first by type, then by slot
+/// Compare snapshot packages by priority; first by kind, then by slot
 #[must_use]
 pub fn cmp_snapshot_packages_by_priority(a: &SnapshotPackage, b: &SnapshotPackage) -> Ordering {
     cmp_snapshot_kinds_by_priority(&a.snapshot_kind, &b.snapshot_kind).then(a.slot.cmp(&b.slot))
 }
 
 /// Compare snapshot kinds by priority
-///
-/// Full snapshots are higher in priority than incremental snapshots.
-/// If two `IncrementalSnapshot`s are compared, their base slots are the tiebreaker.
 #[must_use]
 pub fn cmp_snapshot_kinds_by_priority(a: &SnapshotKind, b: &SnapshotKind) -> Ordering {
     use SnapshotKind as Kind;
     match (a, b) {
-        (Kind::Archive(SnapshotArchiveKind::Full), Kind::Archive(SnapshotArchiveKind::Full)) => {
-            Equal
+        (Kind::Archive(snapshot_archive_kind_a), Kind::Archive(snapshot_archive_kind_b)) => {
+            cmp_snapshot_archive_kinds_by_priority(snapshot_archive_kind_a, snapshot_archive_kind_b)
         }
-        (
-            Kind::Archive(SnapshotArchiveKind::Full),
-            Kind::Archive(SnapshotArchiveKind::Incremental(_)),
-        ) => Greater,
-        (
-            Kind::Archive(SnapshotArchiveKind::Incremental(_)),
-            Kind::Archive(SnapshotArchiveKind::Full),
-        ) => Less,
-        (
-            Kind::Archive(SnapshotArchiveKind::Incremental(base_slot_a)),
-            Kind::Archive(SnapshotArchiveKind::Incremental(base_slot_b)),
-        ) => base_slot_a.cmp(base_slot_b),
+    }
+}
+
+/// Compare snapshot archive kinds by priority
+///
+/// Full snapshot archives are higher in priority than incremental snapshot archives.
+/// If two `Incremental`s are compared, their base slots are the tiebreaker.
+#[must_use]
+pub fn cmp_snapshot_archive_kinds_by_priority(
+    a: &SnapshotArchiveKind,
+    b: &SnapshotArchiveKind,
+) -> Ordering {
+    use SnapshotArchiveKind as Kind;
+    match (a, b) {
+        (Kind::Full, Kind::Full) => Equal,
+        (Kind::Full, Kind::Incremental(_)) => Greater,
+        (Kind::Incremental(_), Kind::Full) => Less,
+        (Kind::Incremental(base_slot_a), Kind::Incremental(base_slot_b)) => {
+            base_slot_a.cmp(base_slot_b)
+        }
     }
 }
 
@@ -182,6 +187,44 @@ mod tests {
             ),
         ] {
             let actual_result = cmp_snapshot_kinds_by_priority(&snapshot_kind_a, &snapshot_kind_b);
+            assert_eq!(expected_result, actual_result);
+        }
+    }
+
+    #[test]
+    fn test_cmp_snapshot_archive_kinds_by_priority() {
+        for (snapshot_archive_kind_a, snapshot_archive_kind_b, expected_result) in [
+            (SnapshotArchiveKind::Full, SnapshotArchiveKind::Full, Equal),
+            (
+                SnapshotArchiveKind::Full,
+                SnapshotArchiveKind::Incremental(5),
+                Greater,
+            ),
+            (
+                SnapshotArchiveKind::Incremental(5),
+                SnapshotArchiveKind::Full,
+                Less,
+            ),
+            (
+                SnapshotArchiveKind::Incremental(5),
+                SnapshotArchiveKind::Incremental(6),
+                Less,
+            ),
+            (
+                SnapshotArchiveKind::Incremental(5),
+                SnapshotArchiveKind::Incremental(5),
+                Equal,
+            ),
+            (
+                SnapshotArchiveKind::Incremental(5),
+                SnapshotArchiveKind::Incremental(4),
+                Greater,
+            ),
+        ] {
+            let actual_result = cmp_snapshot_archive_kinds_by_priority(
+                &snapshot_archive_kind_a,
+                &snapshot_archive_kind_b,
+            );
             assert_eq!(expected_result, actual_result);
         }
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -466,7 +466,7 @@ pub fn serialize_and_archive_snapshot_package(
 
     let archive_kind = snapshot_kind
         .try_into()
-        .expect("Snapshot kind includes archive");
+        .expect("Snapshot kind includes archive when attempting to archive snapshhot");
 
     let snapshot_archive_path = match archive_kind {
         ArchiveKind::FullArchive => snapshot_paths::build_full_snapshot_archive_path(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -26,7 +26,8 @@ use {
             SnapshotArchiveInfoGetter,
         },
         snapshot_config::SnapshotConfig,
-        streaming_unarchive_snapshot, ArchiveFormat, Result, SnapshotArchiveKind, SnapshotVersion,
+        streaming_unarchive_snapshot, ArchiveFormat, Result, SnapshotArchiveKind, SnapshotKind,
+        SnapshotVersion,
     },
     crossbeam_channel::{Receiver, Sender},
     log::*,
@@ -464,9 +465,7 @@ pub fn serialize_and_archive_snapshot_package(
         should_flush_and_hard_link_storages,
     )?;
 
-    let snapshot_archive_kind = snapshot_kind
-        .try_into()
-        .expect("Snapshot kind includes archive when attempting to archive snapshhot");
+    let SnapshotKind::Archive(snapshot_archive_kind) = snapshot_kind;
 
     let snapshot_archive_path = match snapshot_archive_kind {
         SnapshotArchiveKind::Full => snapshot_paths::build_full_snapshot_archive_path(

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         error::ArchiveSnapshotPackageError, paths, snapshot_archive_info::SnapshotArchiveInfo,
-        snapshot_hash::SnapshotHash, ArchiveFormat, ArchiveKind, Result,
+        snapshot_hash::SnapshotHash, ArchiveFormat, Result, SnapshotArchiveKind,
     },
     log::info,
     solana_accounts_db::{
@@ -21,7 +21,7 @@ const INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO: (usize, usize) = (4, 1);
 
 /// Archives a snapshot into `archive_path`
 pub fn archive_snapshot(
-    archive_kind: ArchiveKind,
+    snapshot_archive_kind: SnapshotArchiveKind,
     snapshot_slot: Slot,
     snapshot_hash: SnapshotHash,
     snapshot_storages: &[Arc<AccountStorageEntry>],
@@ -31,7 +31,7 @@ pub fn archive_snapshot(
 ) -> Result<SnapshotArchiveInfo> {
     use ArchiveSnapshotPackageError as E;
     const ACCOUNTS_DIR: &str = "accounts";
-    info!("Generating snapshot archive for slot {snapshot_slot}, kind: {archive_kind:?}");
+    info!("Generating snapshot archive for slot {snapshot_slot}, kind: {snapshot_archive_kind:?}");
 
     let mut timer = Measure::start("snapshot_package-package_snapshots");
     let tar_dir = archive_path
@@ -179,7 +179,7 @@ pub fn archive_snapshot(
         ("archive_format", archive_format.to_string(), String),
         ("duration_ms", timer.as_ms(), i64),
         (
-            if archive_kind.is_full_archive() {
+            if snapshot_archive_kind == SnapshotArchiveKind::Full {
                 "full-snapshot-archive-size"
             } else {
                 "incremental-snapshot-archive-size"

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         error::ArchiveSnapshotPackageError, paths, snapshot_archive_info::SnapshotArchiveInfo,
-        snapshot_hash::SnapshotHash, ArchiveFormat, Result, SnapshotKind,
+        snapshot_hash::SnapshotHash, ArchiveFormat, ArchiveKind, Result,
     },
     log::info,
     solana_accounts_db::{
@@ -21,7 +21,7 @@ const INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO: (usize, usize) = (4, 1);
 
 /// Archives a snapshot into `archive_path`
 pub fn archive_snapshot(
-    snapshot_kind: SnapshotKind,
+    archive_kind: ArchiveKind,
     snapshot_slot: Slot,
     snapshot_hash: SnapshotHash,
     snapshot_storages: &[Arc<AccountStorageEntry>],
@@ -31,7 +31,7 @@ pub fn archive_snapshot(
 ) -> Result<SnapshotArchiveInfo> {
     use ArchiveSnapshotPackageError as E;
     const ACCOUNTS_DIR: &str = "accounts";
-    info!("Generating snapshot archive for slot {snapshot_slot}, kind: {snapshot_kind:?}");
+    info!("Generating snapshot archive for slot {snapshot_slot}, kind: {archive_kind:?}");
 
     let mut timer = Measure::start("snapshot_package-package_snapshots");
     let tar_dir = archive_path
@@ -179,7 +179,7 @@ pub fn archive_snapshot(
         ("archive_format", archive_format.to_string(), String),
         ("duration_ms", timer.as_ms(), i64),
         (
-            if snapshot_kind.is_full_snapshot() {
+            if archive_kind.is_full_archive() {
                 "full-snapshot-archive-size"
             } else {
                 "incremental-snapshot-archive-size"

--- a/snapshots/src/kind.rs
+++ b/snapshots/src/kind.rs
@@ -19,8 +19,8 @@ impl SnapshotKind {
     }
 }
 
-/// Archives come in two kinds, Full and Incremental. The incremental archive has a Slot field,
-/// which is the incremental archive base slot.
+/// Snapshot archives come in two kinds, Full and Incremental. The incremental snapshot archive has a Slot field,
+/// which is the incremental snapshot base slot.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SnapshotArchiveKind {
     Full,

--- a/snapshots/src/kind.rs
+++ b/snapshots/src/kind.rs
@@ -15,34 +15,23 @@ impl SnapshotKind {
     pub fn is_incremental_snapshot(&self) -> bool {
         matches!(self, SnapshotKind::IncrementalSnapshot(_))
     }
-    pub fn includes_archive(&self) -> bool {
-        match self {
-            SnapshotKind::FullSnapshot => true,
-            SnapshotKind::IncrementalSnapshot(_) => true,
-        }
-    }
 }
 
-/// Archives come in two kinds, Full and Incremental.  The IncrementalArchive has a Slot field,
+/// Archives come in two kinds, Full and Incremental. The incremental archive has a Slot field,
 /// which is the incremental archive base slot.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ArchiveKind {
-    FullArchive,
-    IncrementalArchive(Slot),
+pub enum SnapshotArchiveKind {
+    Full,
+    Incremental(Slot),
 }
 
-impl ArchiveKind {
-    pub fn is_full_archive(&self) -> bool {
-        matches!(self, ArchiveKind::FullArchive)
-    }
-}
-impl TryFrom<SnapshotKind> for ArchiveKind {
+impl TryFrom<SnapshotKind> for SnapshotArchiveKind {
     type Error = ();
 
     fn try_from(snapshot_kind: SnapshotKind) -> Result<Self, Self::Error> {
         match snapshot_kind {
-            SnapshotKind::FullSnapshot => Ok(ArchiveKind::FullArchive),
-            SnapshotKind::IncrementalSnapshot(slot) => Ok(ArchiveKind::IncrementalArchive(slot)),
+            SnapshotKind::FullSnapshot => Ok(SnapshotArchiveKind::Full),
+            SnapshotKind::IncrementalSnapshot(slot) => Ok(SnapshotArchiveKind::Incremental(slot)),
         }
     }
 }

--- a/snapshots/src/kind.rs
+++ b/snapshots/src/kind.rs
@@ -1,19 +1,21 @@
 use solana_clock::Slot;
 
-/// Snapshots come in two kinds, Full and Incremental.  The IncrementalSnapshot has a Slot field,
-/// which is the incremental snapshot base slot.
+/// All snapshots also write archives at this time, but it is possible that
+/// in the future there could be other kinds of snapshots that do not write archives.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SnapshotKind {
-    FullSnapshot,
-    IncrementalSnapshot(Slot),
+    Archive(SnapshotArchiveKind),
 }
 
 impl SnapshotKind {
     pub fn is_full_snapshot(&self) -> bool {
-        matches!(self, SnapshotKind::FullSnapshot)
+        matches!(self, SnapshotKind::Archive(SnapshotArchiveKind::Full))
     }
     pub fn is_incremental_snapshot(&self) -> bool {
-        matches!(self, SnapshotKind::IncrementalSnapshot(_))
+        matches!(
+            self,
+            SnapshotKind::Archive(SnapshotArchiveKind::Incremental(_))
+        )
     }
 }
 
@@ -23,15 +25,4 @@ impl SnapshotKind {
 pub enum SnapshotArchiveKind {
     Full,
     Incremental(Slot),
-}
-
-impl TryFrom<SnapshotKind> for SnapshotArchiveKind {
-    type Error = ();
-
-    fn try_from(snapshot_kind: SnapshotKind) -> Result<Self, Self::Error> {
-        match snapshot_kind {
-            SnapshotKind::FullSnapshot => Ok(SnapshotArchiveKind::Full),
-            SnapshotKind::IncrementalSnapshot(slot) => Ok(SnapshotArchiveKind::Incremental(slot)),
-        }
-    }
 }

--- a/snapshots/src/kind.rs
+++ b/snapshots/src/kind.rs
@@ -15,4 +15,34 @@ impl SnapshotKind {
     pub fn is_incremental_snapshot(&self) -> bool {
         matches!(self, SnapshotKind::IncrementalSnapshot(_))
     }
+    pub fn includes_archive(&self) -> bool {
+        match self {
+            SnapshotKind::FullSnapshot => true,
+            SnapshotKind::IncrementalSnapshot(_) => true,
+        }
+    }
+}
+
+/// Archives come in two kinds, Full and Incremental.  The IncrementalArchive has a Slot field,
+/// which is the incremental archive base slot.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ArchiveKind {
+    FullArchive,
+    IncrementalArchive(Slot),
+}
+
+impl ArchiveKind {
+    pub fn is_full_archive(&self) -> bool {
+        matches!(self, ArchiveKind::FullArchive)
+    }
+}
+impl TryFrom<SnapshotKind> for ArchiveKind {
+    type Error = ();
+
+    fn try_from(snapshot_kind: SnapshotKind) -> Result<Self, Self::Error> {
+        match snapshot_kind {
+            SnapshotKind::FullSnapshot => Ok(ArchiveKind::FullArchive),
+            SnapshotKind::IncrementalSnapshot(slot) => Ok(ArchiveKind::IncrementalArchive(slot)),
+        }
+    }
 }

--- a/snapshots/src/kind.rs
+++ b/snapshots/src/kind.rs
@@ -1,7 +1,7 @@
 use solana_clock::Slot;
 
-/// All snapshots also write archives at this time, but it is possible that
-/// in the future there could be other kinds of snapshots that do not write archives.
+/// All snapshots are archived at this time, but it is possible that
+/// in the future there could be other kinds of snapshots that are not archived.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SnapshotKind {
     Archive(SnapshotArchiveKind),

--- a/snapshots/src/kind.rs
+++ b/snapshots/src/kind.rs
@@ -19,8 +19,8 @@ impl SnapshotKind {
     }
 }
 
-/// Snapshot archives come in two kinds, Full and Incremental. The incremental snapshot archive has a Slot field,
-/// which is the incremental snapshot base slot.
+/// Snapshot archives come in two kinds, Full and Incremental. The incremental snapshot archive has
+/// a Slot field, which is the incremental snapshot base slot.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SnapshotArchiveKind {
     Full,

--- a/snapshots/src/lib.rs
+++ b/snapshots/src/lib.rs
@@ -33,7 +33,7 @@ pub type Result<T> = std::result::Result<T, error::SnapshotError>;
 pub use {
     archive::archive_snapshot,
     archive_format::*,
-    kind::SnapshotKind,
+    kind::{ArchiveKind, SnapshotKind},
     snapshot_interval::SnapshotInterval,
     snapshot_version::SnapshotVersion,
     unarchive::{streaming_unarchive_snapshot, unpack_genesis_archive},

--- a/snapshots/src/lib.rs
+++ b/snapshots/src/lib.rs
@@ -33,7 +33,7 @@ pub type Result<T> = std::result::Result<T, error::SnapshotError>;
 pub use {
     archive::archive_snapshot,
     archive_format::*,
-    kind::{ArchiveKind, SnapshotKind},
+    kind::{SnapshotArchiveKind, SnapshotKind},
     snapshot_interval::SnapshotInterval,
     snapshot_version::SnapshotVersion,
     unarchive::{streaming_unarchive_snapshot, unpack_genesis_archive},

--- a/snapshots/src/paths.rs
+++ b/snapshots/src/paths.rs
@@ -113,7 +113,8 @@ pub fn parse_full_snapshot_archive_filename(
     })
 }
 
-/// Parse an incremental snapshot archive filename into its base Slot, actual Slot, Hash, and Archive Format
+/// Parse an incremental snapshot archive filename into its base Slot, actual Slot, Hash, and
+/// Archive Format
 pub fn parse_incremental_snapshot_archive_filename(
     archive_filename: &str,
 ) -> Result<(Slot, Slot, SnapshotHash, ArchiveFormat)> {

--- a/snapshots/src/paths.rs
+++ b/snapshots/src/paths.rs
@@ -113,8 +113,7 @@ pub fn parse_full_snapshot_archive_filename(
     })
 }
 
-/// Parse an incremental snapshot archive filename into its base Slot, actual Slot, Hash, and
-/// Archive Format
+/// Parse an incremental snapshot archive filename into its base Slot, actual Slot, Hash, and Archive Format
 pub fn parse_incremental_snapshot_archive_filename(
     archive_filename: &str,
 ) -> Result<(Slot, Slot, SnapshotHash, ArchiveFormat)> {

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1,6 +1,7 @@
 use {
     agave_snapshots::{
-        paths as snapshot_paths, snapshot_archive_info::SnapshotArchiveInfoGetter as _, ArchiveKind,
+        paths as snapshot_paths, snapshot_archive_info::SnapshotArchiveInfoGetter as _,
+        SnapshotArchiveKind,
     },
     itertools::Itertools,
     log::*,
@@ -1152,7 +1153,7 @@ fn download_snapshots(
             download_abort_count,
             rpc_contact_info,
             full_snapshot_hash,
-            ArchiveKind::FullArchive,
+            SnapshotArchiveKind::Full,
         )?;
     }
 
@@ -1183,7 +1184,7 @@ fn download_snapshots(
                     download_abort_count,
                     rpc_contact_info,
                     incremental_snapshot_hash,
-                    ArchiveKind::IncrementalArchive(full_snapshot_hash.0),
+                    SnapshotArchiveKind::Incremental(full_snapshot_hash.0),
                 )?;
             }
         }
@@ -1204,7 +1205,7 @@ fn download_snapshot(
     download_abort_count: &mut u64,
     rpc_contact_info: &ContactInfo,
     desired_snapshot_hash: (Slot, Hash),
-    archive_kind: ArchiveKind,
+    snapshot_kind: SnapshotArchiveKind,
 ) -> Result<(), String> {
     let maximum_full_snapshot_archives_to_retain = validator_config
         .snapshot_config
@@ -1234,7 +1235,7 @@ fn download_snapshot(
         full_snapshot_archives_dir,
         incremental_snapshot_archives_dir,
         desired_snapshot_hash,
-        archive_kind,
+        snapshot_kind,
         maximum_full_snapshot_archives_to_retain,
         maximum_incremental_snapshot_archives_to_retain,
         use_progress_bar,

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1,7 +1,6 @@
 use {
     agave_snapshots::{
-        paths as snapshot_paths, snapshot_archive_info::SnapshotArchiveInfoGetter as _,
-        SnapshotKind,
+        paths as snapshot_paths, snapshot_archive_info::SnapshotArchiveInfoGetter as _, ArchiveKind,
     },
     itertools::Itertools,
     log::*,
@@ -1153,7 +1152,7 @@ fn download_snapshots(
             download_abort_count,
             rpc_contact_info,
             full_snapshot_hash,
-            SnapshotKind::FullSnapshot,
+            ArchiveKind::FullArchive,
         )?;
     }
 
@@ -1184,7 +1183,7 @@ fn download_snapshots(
                     download_abort_count,
                     rpc_contact_info,
                     incremental_snapshot_hash,
-                    SnapshotKind::IncrementalSnapshot(full_snapshot_hash.0),
+                    ArchiveKind::IncrementalArchive(full_snapshot_hash.0),
                 )?;
             }
         }
@@ -1205,7 +1204,7 @@ fn download_snapshot(
     download_abort_count: &mut u64,
     rpc_contact_info: &ContactInfo,
     desired_snapshot_hash: (Slot, Hash),
-    snapshot_kind: SnapshotKind,
+    archive_kind: ArchiveKind,
 ) -> Result<(), String> {
     let maximum_full_snapshot_archives_to_retain = validator_config
         .snapshot_config
@@ -1235,7 +1234,7 @@ fn download_snapshot(
         full_snapshot_archives_dir,
         incremental_snapshot_archives_dir,
         desired_snapshot_hash,
-        snapshot_kind,
+        archive_kind,
         maximum_full_snapshot_archives_to_retain,
         maximum_incremental_snapshot_archives_to_retain,
         use_progress_bar,


### PR DESCRIPTION
#### Problem
With fastboot snapshots, there will be a new snapshot type that does not have an archive. A snapshot without an archive is not supported and would require panics or errors on match statements which could be handled earlier with a type conversion. 

#### Summary of Changes
- Created new type SnapshotArchiveType. Used this type on paths where a snapshot without an archive is not useful. 
-- Modified download_snapshot_archive to use new type
-- Modified archive_snapshot to use new type
- Left the gossip snapshot broadcast path as is. When fastboot snapshots are implemented, they will skip broadcasting on gossip. 

#### Other Notes

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
