### PR TITLE
deprecate the --cuda cli argument

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -130,6 +130,14 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
     }
 
     add_arg!(
+        // deprecated in v3.1.1
+        Arg::with_name("cuda")
+            .long("cuda")
+            .takes_value(false)
+            .help("Use CUDA"),
+        usage_warning: "CUDA support will be dropped"
+    );
+    add_arg!(
         // deprecated in v3.0.0
         Arg::with_name("gossip_host")
             .long("gossip-host")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -628,12 +628,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Skip ledger verification at validator bootup."),
     )
     .arg(
-        Arg::with_name("cuda")
-            .long("cuda")
-            .takes_value(false)
-            .help("Use CUDA"),
-    )
-    .arg(
         clap::Arg::with_name("require_tower")
             .long("require-tower")
             .takes_value(false)


### PR DESCRIPTION
#### Problem

- CUDA support is getting removed in https://github.com/anza-xyz/agave/pull/8967/
- We should deprecate the CLI arg before 4.0 is released to signal the change to the one user that does use CUDA.

#### Summary of Changes

- Deprecate the CLI argument

This PR should be backported to 3.1