### PR TITLE
fix(scheduling-utils): do not free inner txs in batch

### DIFF
--- a/scheduling-utils/src/transaction_ptr.rs
+++ b/scheduling-utils/src/transaction_ptr.rs
@@ -131,12 +131,12 @@ impl<'a, M> TransactionPtrBatch<'a, M> {
         })
     }
 
-    /// Free all transactions in the batch, then free the batch itself.
+    /// Free the transaction batch.
+    ///
+    /// # Note
+    ///
+    /// This will not free the underlying transactions which will remain valid after this call.
     pub fn free(self) {
-        for (transaction_ptr, _) in self.iter() {
-            unsafe { transaction_ptr.free(self.allocator) }
-        }
-
         unsafe { self.allocator.free(self.tx_ptr.cast()) }
     }
 }


### PR DESCRIPTION
#### Problem

- External schedulers will have their own lifetimes for individual transactions & they may store these in containers. If they send a batch for checking, they may only want to free the invalid transactions while keeping the valid. Currently the batch free will free everything which can easily lead to use after free.
- Memory leaks are easier to debug/notice then use after free/UB.

#### Summary of Changes

- Do not free the inner TXs this is left to the caller who owns these TXs.
