### PR TITLE
test-validator: Remove logrotate support

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -1,5 +1,4 @@
 use {
-    agave_logger::redirect_stderr_to_file,
     agave_validator::{
         admin_rpc_service, cli, commands::FromClapArgMatches, dashboard::Dashboard,
         ledger_lockfile, lock_ledger, println_name_value,
@@ -122,7 +121,7 @@ fn main() {
     } else {
         None
     };
-    let _logger_thread = redirect_stderr_to_file(logfile);
+    agave_logger::initialize_logging(logfile);
 
     info!("{} {}", crate_name!(), solana_version::version!());
     info!("Starting validator with: {:#?}", std::env::args_os());


### PR DESCRIPTION
#### Problem
The test-validator currently uses a kitchen sink function that sets up logging and spins up a new thread to support logrotate. Supporting logrotate is useful for real validators, but really doesn't belong for a dev tool like test-validator

#### Summary of Changes
Use the new function which does not handle `SIGUSR1`. This was never documented / claimed to be supported for test-validator, and if anyone is actually using logrotate with test-validator, I have more questions