### PR TITLE
ledger-tool: Add --log arg to support logfile

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -859,8 +859,6 @@ fn main() {
         unsafe { signal_hook::low_level::register(signal_hook::consts::SIGUSR1, || {}) }.unwrap();
     }
 
-    agave_logger::setup_with_default_filter();
-
     let load_genesis_config_arg = load_genesis_arg();
     let accounts_db_config_args = accounts_db_args();
     let snapshot_config_args = snapshot_args();
@@ -971,6 +969,14 @@ fn main() {
                 .global(true)
                 .default_value("ledger")
                 .help("Use DIR as ledger location"),
+        )
+        .arg(
+            Arg::with_name("logfile")
+                .long("log")
+                .value_name("FILE")
+                .takes_value(true)
+                .global(true)
+                .help("Redirect logging to the specified file, stderr is used if unset"),
         )
         .arg(
             Arg::with_name("wal_recovery_mode")
@@ -1688,6 +1694,9 @@ fn main() {
         )
         .program_subcommand()
         .get_matches();
+
+    let logfile = value_t!(matches, "logfile", PathBuf).ok();
+    agave_logger::initialize_logging(logfile);
 
     info!("{} {}", crate_name!(), solana_version::version!());
 


### PR DESCRIPTION
#### Problem
`ledger-tool` has use cases where examining logs is useful. But, `ledger-tool` also has some commands where one may only care about the "final result" that is output to `stdout`. Currently, one gets `ledger-tool` to output to logs by redirecting (`agave-ledger-tool ... 2> lt.log`).

#### Summary of Changes
Add a `--log` argument to allow writing logs (and all stderr technically) to a logfile. As mentioned, someone can just redirect but adding the arg creates consistency with `agave-validator` and also ease things for when we provide instructions (ie cluster restarts)

#### Output
No logfile (current behavior):
```
$ ~/.../agave-ledger-tool bounds --ledger ~/ledger
[2025-11-13T20:23:11.465581947Z INFO  agave_ledger_tool] agave-ledger-tool 4.0.0 (src:a8bc48d9; feat:2823985021, client:Agave)
[2025-11-13T20:23:11.465613307Z INFO  solana_core::resource_limits] Maximum open file descriptors: 1000000
[2025-11-13T20:23:11.469958031Z INFO  solana_ledger::blockstore] Opening blockstore at "/home/sol/ledger/rocksdb"
[2025-11-13T20:23:11.470447090Z INFO  solana_ledger::blockstore_db] Opening Rocks with secondary (read only) access at: "/home/sol/ledger/rocksdb/solana-secondary". This secondary access could temporarily degrade other accesses, such as by agave-validator
[2025-11-13T20:23:33.586397539Z INFO  solana_ledger::blockstore_db] Rocks's automatic compactions are disabled due to Secondary access
[2025-11-13T20:23:33.586524559Z INFO  solana_ledger::blockstore] Opening blockstore done; blockstore open took 22.1s
Ledger has data for 616216 slots 379261594 to 379878767
  with 615820 rooted slots from 379261594 to 379878735
  and 32 slots past the last root

[2025-11-13T20:23:36.656143121Z INFO  agave_ledger_tool] ledger tool took 25.2s
```
With logfile:
```
$ ~/.../agave-ledger-tool bounds --ledger ~/ledger --log ~/test.log
Ledger has data for 616753 slots 379260974 to 379878684
  with 616357 rooted slots from 379260974 to 379878652
  and 32 slots past the last root

$ cat ~/test.log
[2025-11-13T20:22:39.422612152Z INFO  agave_ledger_tool] agave-ledger-tool 4.0.0 (src:a8bc48d9; feat:2823985021, client:Agave)
[2025-11-13T20:22:39.422651602Z INFO  solana_core::resource_limits] Maximum open file descriptors: 1000000
[2025-11-13T20:22:39.426766207Z INFO  solana_ledger::blockstore] Opening blockstore at "/home/sol/ledger/rocksdb"
[2025-11-13T20:22:39.427281295Z INFO  solana_ledger::blockstore_db] Opening Rocks with secondary (read only) access at: "/home/sol/ledger/rocksdb/solana-secondary". This secondary access could temporarily degrade other accesses, such as by agave-validator
[2025-11-13T20:23:00.363579067Z INFO  solana_ledger::blockstore_db] Rocks's automatic compactions are disabled due to Secondary access
[2025-11-13T20:23:00.363701977Z INFO  solana_ledger::blockstore] Opening blockstore done; blockstore open took 20.9s
[2025-11-13T20:23:03.569527217Z INFO  agave_ledger_tool] ledger tool took 24.1s
```