### PR TITLE
clippy: manual_is_multiple_of

### DIFF
--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -1667,9 +1667,9 @@ mod tests {
             |_, p| p < (PACKETS_PER_BATCH / 2),
             // uniform sparse
             // discard even packets
-            |b, p| ((b * PACKETS_PER_BATCH) + p) % 2 == 0,
+            |b, p| (((b * PACKETS_PER_BATCH) + p) as usize).is_multiple_of(2),
             // discard odd packets
-            |b, p| ((b * PACKETS_PER_BATCH) + p) % 2 == 1,
+            |b, p| !(((b * PACKETS_PER_BATCH) + p) as usize).is_multiple_of(2),
             // discard even batches
             |b, _| b % 2 == 0,
             // discard odd batches


### PR DESCRIPTION
#### Problem
Another one of these snuck in after https://github.com/anza-xyz/agave/pull/8959 previously cleaned these all up in advance of updating to Rust 1.90
```
warning: manual implementation of `.is_multiple_of()`
    --> perf/src/sigverify.rs:1670:20
     |
1670 |             |b, p| ((b * PACKETS_PER_BATCH) + p) % 2 == 0,
     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `((b * PACKETS_PER_BATCH) + p).is_multiple_of(2)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of
     = note: `#[warn(clippy::manual_is_multiple_of)]` on by default
``` 
Note that I had to add the `as usize` to avoid this:
```
error[E0282]: type annotations needed
    --> perf/src/sigverify.rs:1670:20
     |
1670 |             |b, p| ((b * PACKETS_PER_BATCH) + p).is_multiple_of(2),
     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
```

#### Summary of Changes
Fix it