### PR TITLE
chore: annotate code with unsafe blocks to fix unsafe_op_in_unsafe_fn

### DIFF
--- a/io-uring/src/ring.rs
+++ b/io-uring/src/ring.rs
@@ -50,7 +50,7 @@ impl<T, E: RingOp<T>> Ring<T, E> {
     /// See
     /// [Submitter::register_buffers](https://docs.rs/io-uring/0.6.3/io_uring/struct.Submitter.html#method.register_buffers).
     pub unsafe fn register_buffers(&self, iovecs: &[libc::iovec]) -> io::Result<()> {
-        self.ring.submitter().register_buffers(iovecs)
+        unsafe { self.ring.submitter().register_buffers(iovecs) }
     }
 
     /// Registers file descriptors as fixed for I/O with the kernel.

--- a/transaction-view/src/bytes.rs
+++ b/transaction-view/src/bytes.rs
@@ -42,7 +42,7 @@ pub fn read_byte(bytes: &[u8], offset: &mut usize) -> Result<u8> {
 /// 2. `offset` must be a valid offset into `bytes`.
 #[inline(always)]
 pub unsafe fn unchecked_read_byte(bytes: &[u8], offset: &mut usize) -> u8 {
-    let value = *bytes.get_unchecked(*offset);
+    let value = unsafe { *bytes.get_unchecked(*offset) };
     *offset = offset.wrapping_add(1);
     value
 }
@@ -185,7 +185,7 @@ pub unsafe fn read_slice_data<'a, T: Sized>(
     offset: &mut usize,
     num_elements: u16,
 ) -> Result<&'a [T]> {
-    let current_ptr = bytes.as_ptr().add(*offset);
+    let current_ptr = unsafe { bytes.as_ptr().add(*offset) };
     advance_offset_for_array::<T>(bytes, offset, num_elements)?;
     Ok(unsafe { core::slice::from_raw_parts(current_ptr as *const T, usize::from(num_elements)) })
 }
@@ -210,7 +210,7 @@ pub unsafe fn unchecked_read_slice_data<'a, T: Sized>(
     offset: &mut usize,
     num_elements: u16,
 ) -> &'a [T] {
-    let current_ptr = bytes.as_ptr().add(*offset);
+    let current_ptr = unsafe { bytes.as_ptr().add(*offset) };
     let array_len_bytes = usize::from(num_elements).wrapping_mul(core::mem::size_of::<T>());
     *offset = offset.wrapping_add(array_len_bytes);
     unsafe { core::slice::from_raw_parts(current_ptr as *const T, usize::from(num_elements)) }
@@ -230,7 +230,7 @@ pub unsafe fn unchecked_read_slice_data<'a, T: Sized>(
 /// 4. `T` must be validly initialized.
 #[inline(always)]
 pub unsafe fn read_type<'a, T: Sized>(bytes: &'a [u8], offset: &mut usize) -> Result<&'a T> {
-    let current_ptr = bytes.as_ptr().add(*offset);
+    let current_ptr = unsafe { bytes.as_ptr().add(*offset) };
     advance_offset_for_type::<T>(bytes, offset)?;
     Ok(unsafe { &*(current_ptr as *const T) })
 }

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -166,10 +166,12 @@ impl TransactionFrame {
         //   `bytes`. This means it will not be mutated or deallocated while
         //   holding the slice.
         // - The length does not overflow `isize`.
-        core::slice::from_raw_parts(
-            bytes.as_ptr().add(usize::from(self.signature.offset)) as *const Signature,
-            usize::from(self.signature.num_signatures),
-        )
+        unsafe {
+            core::slice::from_raw_parts(
+                bytes.as_ptr().add(usize::from(self.signature.offset)) as *const Signature,
+                usize::from(self.signature.num_signatures),
+            )
+        }
     }
 
     /// Return the slice of static account keys in the transaction.
@@ -196,12 +198,15 @@ impl TransactionFrame {
         //   `bytes`. This means it will not be mutated or deallocated while
         //   holding the slice.
         // - The length does not overflow `isize`.
-        core::slice::from_raw_parts(
-            bytes
-                .as_ptr()
-                .add(usize::from(self.static_account_keys.offset)) as *const Pubkey,
-            usize::from(self.static_account_keys.num_static_accounts),
-        )
+        unsafe {
+            core::slice::from_raw_parts(
+                bytes
+                    .as_ptr()
+                    .add(usize::from(self.static_account_keys.offset))
+                    as *const Pubkey,
+                usize::from(self.static_account_keys.num_static_accounts),
+            )
+        }
     }
 
     /// Return the recent blockhash in the transaction.
@@ -219,9 +224,11 @@ impl TransactionFrame {
         //   is not initialized properly.
         // - Aliasing rules are respected because the lifetime of the returned
         //   reference is the same as the input/source `bytes`.
-        &*(bytes
-            .as_ptr()
-            .add(usize::from(self.recent_blockhash_offset)) as *const Hash)
+        unsafe {
+            &*(bytes
+                .as_ptr()
+                .add(usize::from(self.recent_blockhash_offset)) as *const Hash)
+        }
     }
 
     /// Return an iterator over the instructions in the transaction.

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -1460,7 +1460,7 @@ impl SchedulingStateMachine {
 
     #[cfg(test)]
     unsafe fn exclusively_initialize_current_thread_for_scheduling_for_test() -> Self {
-        Self::exclusively_initialize_current_thread_for_scheduling(None)
+        unsafe { Self::exclusively_initialize_current_thread_for_scheduling(None) }
     }
 }
 


### PR DESCRIPTION
#### Problem
A few more places which somehow do not trigger warning with lint enabled in `Cargo.toml` for `unsafe_op_in_unsafe_fn`
Fixing those will allow migrating to Rust 2024 (https://github.com/anza-xyz/agave/issues/6203)

#### Summary of Changes
Annotate relevant code with `unsafe { .. }` blocks.