### PR TITLE
chore(vote): switch to rand=0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11784,7 +11784,7 @@ dependencies = [
  "bincode",
  "itertools 0.13.0",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
  "serde",
  "solana-account",
  "solana-bincode",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9686,7 +9686,7 @@ dependencies = [
  "bincode",
  "itertools 0.13.0",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
  "serde",
  "solana-account",
  "solana-bincode",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10200,7 +10200,7 @@ dependencies = [
  "bincode",
  "itertools 0.13.0",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
  "serde",
  "solana-account",
  "solana-bincode",

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -25,7 +25,7 @@ frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 bincode = { workspace = true, optional = true }
 itertools = { workspace = true }
 log = { workspace = true }
-rand = { workspace = true, optional = true }
+rand = { version = "0.9.2", optional = true }
 serde = { workspace = true, features = ["rc"] }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-bincode = { workspace = true }
@@ -55,7 +55,7 @@ agave-logger = { workspace = true }
 arbitrary = { workspace = true }
 bencher = { workspace = true }
 bincode = { workspace = true }
-rand = { workspace = true }
+rand = "0.9.2"
 solana-keypair = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true }

--- a/vote/benches/vote_account.rs
+++ b/vote/benches/vote_account.rs
@@ -17,18 +17,18 @@ fn new_rand_vote_account<R: Rng>(
         node_pubkey: node_pubkey.unwrap_or_else(Pubkey::new_unique),
         authorized_voter: Pubkey::new_unique(),
         authorized_withdrawer: Pubkey::new_unique(),
-        commission: rng.gen(),
+        commission: rng.random(),
     };
     let clock = solana_clock::Clock {
-        slot: rng.gen(),
-        epoch_start_timestamp: rng.gen(),
-        epoch: rng.gen(),
-        leader_schedule_epoch: rng.gen(),
-        unix_timestamp: rng.gen(),
+        slot: rng.random(),
+        epoch_start_timestamp: rng.random(),
+        epoch: rng.random(),
+        leader_schedule_epoch: rng.random(),
+        unix_timestamp: rng.random(),
     };
     let vote_state = VoteStateV4::new(&vote_pubkey, &vote_init, &clock);
     let account = AccountSharedData::new_data(
-        rng.gen(), // lamports
+        rng.random(), // lamports
         &VoteStateVersions::new_v4(vote_state.clone()),
         &solana_sdk_ids::vote::id(), // owner
     )
@@ -37,7 +37,7 @@ fn new_rand_vote_account<R: Rng>(
 }
 
 fn bench_vote_account_try_from(b: &mut Bencher) {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let (account, vote_state) = new_rand_vote_account(&mut rng, None);
 
     b.iter(|| {
@@ -58,7 +58,7 @@ fn bench_vote_account_try_from(b: &mut Bencher) {
 }
 
 fn bench_staked_nodes_compute(b: &mut Bencher) {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut vote_accounts_map = HashMap::new();
 
     // Create a scenario with ~400 vote accounts
@@ -70,7 +70,7 @@ fn bench_staked_nodes_compute(b: &mut Bencher) {
         let (account, _) = new_rand_vote_account(&mut rng, None);
         let vote_account = VoteAccount::try_from(account).unwrap();
         // Stake amount represents total delegated stake (from multiple stake accounts)
-        let stake: u64 = rng.gen_range(1_000_000..100_000_000);
+        let stake: u64 = rng.random_range(1_000_000..100_000_000);
         vote_accounts_map.insert(Pubkey::new_unique(), (stake, vote_account));
     }
 

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -99,25 +99,25 @@ impl VoteAccount {
             solana_vote_interface::state::{VoteInit, VoteStateV4, VoteStateVersions},
         };
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let vote_pubkey = Pubkey::new_unique();
 
         let vote_init = VoteInit {
             node_pubkey: Pubkey::new_unique(),
             authorized_voter: Pubkey::new_unique(),
             authorized_withdrawer: Pubkey::new_unique(),
-            commission: rng.gen(),
+            commission: rng.random(),
         };
         let clock = Clock {
-            slot: rng.gen(),
-            epoch_start_timestamp: rng.gen(),
-            epoch: rng.gen(),
-            leader_schedule_epoch: rng.gen(),
-            unix_timestamp: rng.gen(),
+            slot: rng.random(),
+            epoch_start_timestamp: rng.random(),
+            epoch: rng.random(),
+            leader_schedule_epoch: rng.random(),
+            unix_timestamp: rng.random(),
         };
         let vote_state = VoteStateV4::new(&vote_pubkey, &vote_init, &clock);
         let account = AccountSharedData::new_data(
-            rng.gen(), // lamports
+            rng.random(), // lamports
             &VoteStateVersions::new_v4(vote_state.clone()),
             &solana_sdk_ids::vote::id(), // owner
         )
@@ -473,18 +473,18 @@ mod tests {
             node_pubkey: node_pubkey.unwrap_or_else(Pubkey::new_unique),
             authorized_voter: Pubkey::new_unique(),
             authorized_withdrawer: Pubkey::new_unique(),
-            commission: rng.gen(),
+            commission: rng.random(),
         };
         let clock = Clock {
-            slot: rng.gen(),
-            epoch_start_timestamp: rng.gen(),
-            epoch: rng.gen(),
-            leader_schedule_epoch: rng.gen(),
-            unix_timestamp: rng.gen(),
+            slot: rng.random(),
+            epoch_start_timestamp: rng.random(),
+            epoch: rng.random(),
+            leader_schedule_epoch: rng.random(),
+            unix_timestamp: rng.random(),
         };
         let vote_state = VoteStateV4::new(&vote_pubkey, &vote_init, &clock);
         AccountSharedData::new_data(
-            rng.gen(), // lamports
+            rng.random(), // lamports
             &VoteStateVersions::new_v4(vote_state.clone()),
             &solana_sdk_ids::vote::id(), // owner
         )
@@ -497,9 +497,9 @@ mod tests {
     ) -> impl Iterator<Item = (Pubkey, (/*stake:*/ u64, VoteAccount))> + '_ {
         let nodes: Vec<_> = repeat_with(Pubkey::new_unique).take(num_nodes).collect();
         repeat_with(move || {
-            let node = nodes[rng.gen_range(0..nodes.len())];
+            let node = nodes[rng.random_range(0..nodes.len())];
             let account = new_rand_vote_account(rng, Some(node));
-            let stake = rng.gen_range(0..997);
+            let stake = rng.random_range(0..997);
             let vote_account = VoteAccount::try_from(account).unwrap();
             (Pubkey::new_unique(), (stake, vote_account))
         })
@@ -524,7 +524,7 @@ mod tests {
 
     #[test]
     fn test_vote_account_try_from() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let account = new_rand_vote_account(&mut rng, None);
         let lamports = account.lamports();
         let vote_account = VoteAccount::try_from(account.clone()).unwrap();
@@ -535,7 +535,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "InvalidOwner")]
     fn test_vote_account_try_from_invalid_owner() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut account = new_rand_vote_account(&mut rng, None);
         account.set_owner(Pubkey::new_unique());
         VoteAccount::try_from(account).unwrap();
@@ -551,7 +551,7 @@ mod tests {
 
     #[test]
     fn test_vote_account_serialize() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let account = new_rand_vote_account(&mut rng, None);
         let vote_account = VoteAccount::try_from(account.clone()).unwrap();
         // Assert that VoteAccount has the same wire format as Account.
@@ -563,7 +563,7 @@ mod tests {
 
     #[test]
     fn test_vote_accounts_serialize() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let vote_accounts_hash_map: VoteAccountsHashMap =
             new_rand_vote_accounts(&mut rng, 64).take(1024).collect();
         let vote_accounts = VoteAccounts::from(Arc::new(vote_accounts_hash_map.clone()));
@@ -582,7 +582,7 @@ mod tests {
 
     #[test]
     fn test_vote_accounts_deserialize() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let vote_accounts_hash_map: VoteAccountsHashMap =
             new_rand_vote_accounts(&mut rng, 64).take(1024).collect();
         let data = bincode::serialize(&vote_accounts_hash_map).unwrap();
@@ -598,7 +598,7 @@ mod tests {
 
     #[test]
     fn test_vote_accounts_deserialize_invalid_account() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         // we'll populate the map with 1 valid and 2 invalid accounts, then ensure that we only get
         // the valid one after deserialiation
         let mut vote_accounts_hash_map = HashMap::<Pubkey, (u64, AccountSharedData)>::new();
@@ -631,7 +631,7 @@ mod tests {
 
     #[test]
     fn test_staked_nodes() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut accounts: Vec<_> = new_rand_vote_accounts(&mut rng, 64).take(1024).collect();
         let mut vote_accounts = VoteAccounts::default();
         // Add vote accounts.
@@ -646,7 +646,7 @@ mod tests {
         }
         // Remove some of the vote accounts.
         for k in 0..256 {
-            let index = rng.gen_range(0..accounts.len());
+            let index = rng.random_range(0..accounts.len());
             let (pubkey, (_, _)) = accounts.swap_remove(index);
             vote_accounts.remove(&pubkey);
             if (k + 1) % 32 == 0 {
@@ -655,9 +655,9 @@ mod tests {
         }
         // Modify the stakes for some of the accounts.
         for k in 0..2048 {
-            let index = rng.gen_range(0..accounts.len());
+            let index = rng.random_range(0..accounts.len());
             let (pubkey, (stake, _)) = &mut accounts[index];
-            let new_stake = rng.gen_range(0..997);
+            let new_stake = rng.random_range(0..997);
             if new_stake < *stake {
                 vote_accounts.sub_stake(pubkey, *stake - new_stake);
             } else {
@@ -670,7 +670,7 @@ mod tests {
         }
         // Remove everything.
         while !accounts.is_empty() {
-            let index = rng.gen_range(0..accounts.len());
+            let index = rng.random_range(0..accounts.len());
             let (pubkey, (_, _)) = accounts.swap_remove(index);
             vote_accounts.remove(&pubkey);
             if accounts.len() % 32 == 0 {
@@ -684,7 +684,7 @@ mod tests {
     fn test_staked_nodes_update() {
         let mut vote_accounts = VoteAccounts::default();
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let pubkey = Pubkey::new_unique();
         let node_pubkey = Pubkey::new_unique();
         let account1 = new_rand_vote_account(&mut rng, Some(node_pubkey));
@@ -737,7 +737,7 @@ mod tests {
     fn test_staked_nodes_zero_stake() {
         let mut vote_accounts = VoteAccounts::default();
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let pubkey = Pubkey::new_unique();
         let node_pubkey = Pubkey::new_unique();
         let account1 = new_rand_vote_account(&mut rng, Some(node_pubkey));
@@ -767,7 +767,7 @@ mod tests {
     // Asserts that returned staked-nodes are copy-on-write references.
     #[test]
     fn test_staked_nodes_cow() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut accounts = new_rand_vote_accounts(&mut rng, 64);
         // Add vote accounts.
         let mut vote_accounts = VoteAccounts::default();
@@ -799,7 +799,7 @@ mod tests {
     // Asserts that returned vote-accounts are copy-on-write references.
     #[test]
     fn test_vote_accounts_cow() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut accounts = new_rand_vote_accounts(&mut rng, 64);
         // Add vote accounts.
         let mut vote_accounts = VoteAccounts::default();


### PR DESCRIPTION
#### Problem
* `rand` crate with version >=0.9 fixes problem with `gen` function name colliding with keyword reserved in Rust 2024 edition
* there are performance improvements in newer versions of `rand`
* there are however many API breaking changes, but addressable as renames / import updates for production code
* there are also reproducibility breaking changes affecting: `random_range` (`gen_range`), `sample*`, `choose_*`, `shuffle`)

This migration is tracked as https://github.com/anza-xyz/agave/issues/4738 and can't proceed in one go as there are some breaking behavior changes (e.g. `sample` and `random_range`, which uses sampling). In `vote` however no production code uses range or sampling functions.

#### Summary of Changes
Switch `vote` to `rand` 0.9.2 
