### PR TITLE
chore(bucket_map): switch to rand=0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7568,7 +7568,7 @@ dependencies = [
  "memmap2 0.9.8",
  "modular-bitfield",
  "num_enum",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rayon",
  "solana-bucket-map",
  "solana-clock",

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -25,7 +25,7 @@ bytemuck_derive = { workspace = true }
 memmap2 = { workspace = true }
 modular-bitfield = { workspace = true }
 num_enum = { workspace = true }
-rand = { workspace = true }
+rand = "0.9.2"
 solana-clock = { workspace = true }
 solana-measure = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -15,7 +15,7 @@ use {
         restart::RestartableBucket,
         MaxSearch, RefCount,
     },
-    rand::{thread_rng, Rng},
+    rand::{rng, Rng},
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
     std::{
@@ -156,7 +156,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
                     Arc::clone(&stats.index),
                     count,
                 );
-                let random = thread_rng().gen();
+                let random = rng().random();
                 restartable_bucket.set_file(file_name, random);
                 (index, random, false /* true = reused file */)
             });
@@ -593,7 +593,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
         let best_bucket = &mut self.data[best_fit_bucket as usize];
         let cap_power = best_bucket.contents.capacity_pow2();
         let cap = best_bucket.capacity();
-        let pos = thread_rng().gen_range(0..cap);
+        let pos = rng().random_range(0..cap);
         let mut success = false;
         // max search is increased here by a lot for this search. The idea is that we just have to find an empty bucket somewhere.
         // We don't mind waiting on a new write (by searching longer). Writing is done in the background only.

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -211,7 +211,7 @@ mod tests {
     use {
         super::*,
         crate::index_entry::MAX_LEGAL_REFCOUNT,
-        rand::{thread_rng, Rng},
+        rand::{rng, Rng},
         std::{collections::HashMap, sync::RwLock},
     };
 
@@ -403,11 +403,11 @@ mod tests {
             let all_keys = Mutex::new(vec![]);
 
             let gen_rand_value = || {
-                let count = thread_rng().gen_range(0..max_slot_list_len);
+                let count = rng().random_range(0..max_slot_list_len);
                 let v = (0..count)
-                    .map(|x| (x as usize, x as usize /*thread_rng().gen::<usize>()*/))
+                    .map(|x| (x as usize, x as usize /*rng().random::<usize>()*/))
                     .collect::<Vec<_>>();
-                let range = thread_rng().gen_range(0..100);
+                let range = rng().random_range(0..100);
                 // pick ref counts that are useful and common
                 let rc = if range < 50 {
                     1
@@ -416,7 +416,7 @@ mod tests {
                 } else if range < 70 {
                     2
                 } else {
-                    thread_rng().gen_range(0..MAX_LEGAL_REFCOUNT)
+                    rng().random_range(0..MAX_LEGAL_REFCOUNT)
                 };
 
                 (v, rc)
@@ -428,7 +428,7 @@ mod tests {
                     return None;
                 }
                 let len = keys.len();
-                Some(keys.remove(thread_rng().gen_range(0..len)))
+                Some(keys.remove(rng().random_range(0..len)))
             };
             let return_key = |key| {
                 let mut keys = all_keys.lock().unwrap();
@@ -478,11 +478,11 @@ mod tests {
             // verify consistency between hashmap and all bucket maps
             for i in 0..10000 {
                 initial = initial.saturating_sub(1);
-                if initial > 0 || thread_rng().gen_range(0..5) == 0 {
+                if initial > 0 || rng().random_range(0..5) == 0 {
                     // insert
                     let mut to_add = 1;
                     if initial > 1 && use_batch_insert {
-                        to_add = thread_rng().gen_range(1..(initial / 4).max(2));
+                        to_add = rng().random_range(1..(initial / 4).max(2));
                         initial -= to_add;
                     }
 
@@ -514,12 +514,12 @@ mod tests {
                         hash_map.write().unwrap().insert(k, v);
                         return_key(k);
                     });
-                    let insert = thread_rng().gen_range(0..2) == 0;
+                    let insert = rng().random_range(0..2) == 0;
                     maps.iter().for_each(|map| {
                         // batch insert can only work for the map with only 1 bucket so that we can batch add to a single bucket
                         let batch_insert_now = map.buckets.len() == 1
                             && use_batch_insert
-                            && thread_rng().gen_range(0..2) == 0;
+                            && rng().random_range(0..2) == 0;
                         if batch_insert_now {
                             // batch insert into the map with 1 bucket 50% of the time
                             let mut batch_additions = additions
@@ -528,12 +528,12 @@ mod tests {
                                 .map(|(k, mut v)| (k, v.0.pop().unwrap()))
                                 .collect::<Vec<_>>();
                             let mut duplicates = 0;
-                            if batch_additions.len() > 1 && thread_rng().gen_range(0..2) == 0 {
+                            if batch_additions.len() > 1 && rng().random_range(0..2) == 0 {
                                 // insert a duplicate sometimes
                                 let item_to_duplicate =
-                                    thread_rng().gen_range(0..batch_additions.len());
+                                    rng().random_range(0..batch_additions.len());
                                 let where_to_insert_duplicate =
-                                    thread_rng().gen_range(0..batch_additions.len());
+                                    rng().random_range(0..batch_additions.len());
                                 batch_additions.insert(
                                     where_to_insert_duplicate,
                                     batch_additions[item_to_duplicate],
@@ -570,13 +570,13 @@ mod tests {
                     // if we are using batch insert, it is illegal to update, delete, or addref/unref an account until all batch inserts are complete
                     continue;
                 }
-                if thread_rng().gen_range(0..10) == 0 {
+                if rng().random_range(0..10) == 0 {
                     // update
                     if let Some(k) = get_key() {
                         let hm = hash_map.read().unwrap();
                         let (v, rc) = gen_rand_value();
                         let v_old = hm.get(&k);
-                        let insert = thread_rng().gen_range(0..2) == 0;
+                        let insert = rng().random_range(0..2) == 0;
                         maps.iter().for_each(|map| {
                             if insert {
                                 map.insert(&k, (&v, rc))
@@ -592,7 +592,7 @@ mod tests {
                         return_key(k);
                     }
                 }
-                if thread_rng().gen_range(0..20) == 0 {
+                if rng().random_range(0..20) == 0 {
                     // delete
                     if let Some(k) = get_key() {
                         let mut hm = hash_map.write().unwrap();
@@ -602,10 +602,10 @@ mod tests {
                         });
                     }
                 }
-                if thread_rng().gen_range(0..10) == 0 {
+                if rng().random_range(0..10) == 0 {
                     // add/unref
                     if let Some(k) = get_key() {
-                        let mut inc = thread_rng().gen_range(0..2) == 0;
+                        let mut inc = rng().random_range(0..2) == 0;
                         let mut hm = hash_map.write().unwrap();
                         let (v, mut rc) = hm.get(&k).map(|(v, rc)| (v.to_vec(), *rc)).unwrap();
                         if !inc && rc == 0 {

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -1,7 +1,7 @@
 use {
     crate::{bucket_stats::BucketStats, MaxSearch},
     memmap2::MmapMut,
-    rand::{thread_rng, Rng},
+    rand::{rng, Rng},
     solana_measure::measure::Measure,
     std::{
         fs::{remove_file, OpenOptions},
@@ -454,9 +454,9 @@ impl<O: BucketOccupied> BucketStorage<O> {
 
     /// allocate a new memory mapped file of size `bytes` on one of `drives`
     fn new_map(drives: &[PathBuf], bytes: u64, stats: &BucketStats) -> (MmapMut, PathBuf, u128) {
-        let r = thread_rng().gen_range(0..drives.len());
+        let r = rng().random_range(0..drives.len());
         let drive = &drives[r];
-        let file_random = thread_rng().gen_range(0..u128::MAX);
+        let file_random = rng().random_range(0..u128::MAX);
         let pos = format!("{file_random}");
         let file = drive.join(pos);
         let res = Self::map_open_file(file.clone(), true, bytes, stats).unwrap();

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6490,7 +6490,7 @@ dependencies = [
  "memmap2 0.9.8",
  "modular-bitfield",
  "num_enum",
- "rand 0.8.5",
+ "rand 0.9.2",
  "solana-clock",
  "solana-measure",
  "solana-pubkey",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6319,7 +6319,7 @@ dependencies = [
  "memmap2 0.9.8",
  "modular-bitfield",
  "num_enum",
- "rand 0.8.5",
+ "rand 0.9.2",
  "solana-clock",
  "solana-measure",
  "solana-pubkey",


### PR DESCRIPTION
#### Problem
* `rand` crate with version >=0.9 fixes problem with `gen` function name colliding with keyword reserved in Rust 2024 edition
* there are performance improvements in newer versions of `rand`
* there are however many API breaking changes, but addressable as renames / import updates for production code 
* there are also reproducibility breaking changes affecting: `random_range` (`gen_range`), `sample*`, `choose_*`, `shuffle`)

This migration is tracked as https://github.com/anza-xyz/agave/issues/4738 and can't proceed in one go due to breaking behavior changes. In `bucket_map` however the affected behavior changes use thread random generator (not a stable seeded generator), so there should be no impact except improved performance.

#### Summary of Changes
Switch `bucket_map` to `rand` 0.9.2 
