### PR TITLE
fix(cli): use authority_signer instead of hardcoded config.signers[1] in migrate_program

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2564,7 +2564,7 @@ fn process_migrate_program(
     simulate_and_update_compute_unit_limit(&ComputeUnitLimit::Simulated, rpc_client, &mut message)?;
 
     let mut tx = Transaction::new_unsigned(message);
-    tx.try_sign(&[config.signers[0], config.signers[1]], blockhash)?;
+    tx.try_sign(&[config.signers[0], authority_signer], blockhash)?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
         &tx,
         config.commitment,


### PR DESCRIPTION
  ## Problem

  Running `solana program migrate PROGRAM_ID` without the `--authority` flag causes an index out of bounds panic. The code was hardcoding `config.signers[1]` even when only a single signer (the payer) was available.

  ## Summary of Changes

  Changed line 2567 in `cli/src/program.rs` from:
  ```rust
  tx.try_sign(&[config.signers[0], config.signers[1]], blockhash)?;
```

  To:
```rust
  tx.try_sign(&[config.signers[0], authority_signer], blockhash)?;
```

  This uses the pre-computed authority_signer_index to correctly access the authority signer, which handles both cases:
  - When --authority flag is provided: authority_signer_index = 1
  - When --authority flag is not provided: authority_signer_index = 0 (defaults to payer)

  Fixes #8457