### PR TITLE
Only sorts last element for get_next_snapshot_request()

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -188,13 +188,7 @@ impl SnapshotRequestHandler {
                 Some((snapshot_request, 1, 0))
             }
             _ => {
-                // Get the two highest priority requests, `y` and `z`.
-                // By asking for the second-to-last element to be in its final sorted position, we
-                // also ensure that the last element is also sorted.
-                // Note, we no longer need the second-to-last element; this code can be refactored.
-                let (_, _y, z) =
-                    requests.select_nth_unstable_by(requests_len - 2, cmp_requests_by_priority);
-                assert_eq!(z.len(), 1);
+                requests.select_nth_unstable_by(requests_len - 1, cmp_requests_by_priority);
 
                 // SAFETY: We know the len is > 1, so `pop` will return `Some`
                 let snapshot_request = requests.pop().unwrap();


### PR DESCRIPTION
#### Problem

`SnapshotRequestHandler::get_next_snapshot_request()`'s implementation is based on a time when the Epoch Accounts Hash feature was still enabled. Back then, we needed to look at the top two highest priority enqueued snapshot requests to pick the correct one. Now that EAH is gone, we don't need to do that, and instead can pick the single highest priority request.


#### Summary of Changes

Only sort one elem, for the single highest priority request.