### PR TITLE
add bench-tps back into builds for net.sh

### DIFF
--- a/scripts/agave-build-lists.sh
+++ b/scripts/agave-build-lists.sh
@@ -33,6 +33,7 @@ AGAVE_BINS_VAL_OP=(
 
 AGAVE_BINS_DCOU=(
   agave-ledger-tool
+  solana-bench-tps
 )
 
 # These bins are deprecated and will be removed in a future release


### PR DESCRIPTION
#### Problem

- net.sh start fails to find solana-bench-tps
- Relevant build command removed in https://github.com/anza-xyz/agave/pull/8059

#### Summary of Changes

- bring it back to unblock net.sh  (I hope I'm adding it into the correct list)
