### PR TITLE
Bump version to v3.1.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agave-cargo-registry"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "clap 2.33.3",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agave-fs"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
  "solana-clock",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "agave-install"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "atty",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "agave-io-uring"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "io-uring",
  "libc",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "agave-logger"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "env_logger",
  "libc",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "solana-frozen-abi",
@@ -251,11 +251,11 @@ dependencies = [
 
 [[package]]
 name = "agave-scheduler-bindings"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "agave-scheduling-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-scheduler-bindings",
  "agave-transaction-view",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "agave-snapshots"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-fs",
  "agave-logger",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-histogram"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "clap 2.33.3",
  "solana-version",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "agave-syscalls"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -323,7 +323,7 @@ dependencies = [
  "solana-bn254",
  "solana-clock",
  "solana-cpi",
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.1",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "agave-thread-manager"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "affinity",
  "agave-thread-manager",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-transaction-view",
  "bincode",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "agave-validator"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-geyser-plugin-interface",
  "agave-logger",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "agave-verified-packet-receiver"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "solana-perf",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "agave-votor"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "agave-votor-messages",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "agave-votor-messages"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "serde",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "agave-watchtower"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "clap 2.33.3",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-xdp-ebpf",
  "aya",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp-ebpf"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "aya",
  "aya-ebpf",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "gen-headers"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
  "regex",
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "gen-syscall-list"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "regex",
 ]
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "protobuf-src",
  "tonic-build",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "rbpf-cli"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "rdrand"
@@ -7079,7 +7079,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "Inflector",
  "assert_matches",
@@ -7122,7 +7122,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7148,7 +7148,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-cluster-bench"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "clap 2.33.3",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-fs",
  "agave-logger",
@@ -7330,7 +7330,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "borsh",
  "futures 0.3.31",
@@ -7360,7 +7360,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "serde",
  "solana-account",
@@ -7378,7 +7378,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7406,7 +7406,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-streamer"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "clap 3.2.23",
  "crossbeam-channel",
@@ -7418,7 +7418,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-vote"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -7476,7 +7476,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bencher",
  "bv",
@@ -7546,7 +7546,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-syscalls",
  "assert_matches",
@@ -7587,7 +7587,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program-tests"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -7607,7 +7607,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "bv",
@@ -7628,7 +7628,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -7646,7 +7646,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -7666,7 +7666,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-build-sbf"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "assert_cmd",
@@ -7688,7 +7688,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-test-sbf"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "cargo_metadata",
@@ -7700,7 +7700,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -7731,7 +7731,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -7764,7 +7764,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -7858,7 +7858,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -7871,7 +7871,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -7915,7 +7915,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7962,7 +7962,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client-test"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "futures-util",
@@ -8054,7 +8054,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "qualifier_attr",
  "solana-fee-structure",
@@ -8064,7 +8064,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8105,14 +8105,14 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-program-runtime",
 ]
 
 [[package]]
 name = "solana-compute-budget-program-bench"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "criterion",
@@ -8144,7 +8144,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "async-trait",
@@ -8169,7 +8169,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -8329,7 +8329,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8403,7 +8403,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -8438,7 +8438,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -8462,7 +8462,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-program-tests"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "ed25519-dalek 1.0.1",
@@ -8478,7 +8478,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "agave-reserved-account-keys",
@@ -8597,7 +8597,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -8648,7 +8648,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8806,7 +8806,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -8819,7 +8819,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -8849,7 +8849,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -9029,7 +9029,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keygen"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-votor-messages",
  "bs58",
@@ -9086,7 +9086,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -9100,7 +9100,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -9254,7 +9254,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "log",
@@ -9279,7 +9279,7 @@ dependencies = [
 
 [[package]]
 name = "solana-local-cluster"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "agave-snapshots",
@@ -9348,11 +9348,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "fast-math",
  "hex",
@@ -9382,7 +9382,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bencher",
  "crossbeam-channel",
@@ -9416,7 +9416,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-net-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "anyhow",
@@ -9474,7 +9474,7 @@ dependencies = [
 
 [[package]]
 name = "solana-notifier"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
  "reqwest 0.12.24",
@@ -9516,7 +9516,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "ahash 0.8.11",
@@ -9564,7 +9564,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "arc-swap",
@@ -9600,7 +9600,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh-bench"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "clap 3.2.23",
@@ -9626,7 +9626,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-bn254 0.5.0",
@@ -9704,7 +9704,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-binaries"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "serde",
@@ -9766,7 +9766,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "base64 0.22.1",
@@ -9818,7 +9818,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -9895,7 +9895,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -9921,7 +9921,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "async-lock",
@@ -9964,7 +9964,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
  "num_cpus",
@@ -9973,7 +9973,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "console 0.16.1",
@@ -10021,7 +10021,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -10128,7 +10128,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -10175,7 +10175,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -10195,7 +10195,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "clap 2.33.3",
@@ -10224,7 +10224,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -10251,7 +10251,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-test"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -10289,7 +10289,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-fs",
@@ -10439,7 +10439,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -10577,7 +10577,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "async-trait",
@@ -10749,7 +10749,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-accounts"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "clap 2.33.3",
  "solana-account",
@@ -10803,7 +10803,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -10824,7 +10824,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -10867,7 +10867,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "bs58",
@@ -10892,7 +10892,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "anyhow",
@@ -10943,7 +10943,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "agave-syscalls",
@@ -11019,7 +11019,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -11029,22 +11029,22 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-svm-test-harness"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -11080,7 +11080,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-timings"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -11089,7 +11089,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -11105,7 +11105,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "futures 0.3.31",
  "rand 0.8.5",
@@ -11129,7 +11129,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -11224,7 +11224,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -11280,7 +11280,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
 name = "solana-tls-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "rustls 0.23.34",
  "solana-keypair",
@@ -11291,7 +11291,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tokens"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "assert_matches",
@@ -11340,7 +11340,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tps-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
  "solana-account",
@@ -11372,7 +11372,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -11404,7 +11404,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -11460,7 +11460,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -11482,7 +11482,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-dos"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -11533,7 +11533,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -11551,7 +11551,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -11596,7 +11596,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -11619,7 +11619,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -11681,7 +11681,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -11696,7 +11696,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "solana-instruction",
@@ -11711,7 +11711,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-logger",
@@ -11757,7 +11757,7 @@ checksum = "c5d2face763df5afeaa9509b9019968860e69cc1531ec8b4a2e6c7b702204d5a"
 
 [[package]]
 name = "solana-version"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -11771,7 +11771,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vortexor"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-logger",
@@ -11825,7 +11825,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "arbitrary",
@@ -11889,7 +11889,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -11930,7 +11930,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "agave-snapshots",
@@ -11967,7 +11967,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -11984,7 +11984,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program-tests"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bytemuck",
  "solana-account",
@@ -12040,7 +12040,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -12057,7 +12057,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -12073,7 +12073,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.1",
  "solana-derivation-path",
  "solana-instruction",
  "solana-keypair",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "3.1.0-beta.0"
+version = "3.1.1"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 description = "Blockchain, Rebuilt for Scale"
 repository = "https://github.com/anza-xyz/agave"
@@ -182,26 +182,26 @@ used_underscore_binding = "deny"
 [workspace.dependencies]
 Inflector = "0.11.4"
 aes-gcm-siv = "0.11.1"
-agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-cargo-registry = { path = "cargo-registry", version = "=3.1.0-beta.0" }
-agave-feature-set = { path = "feature-set", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-fs = { path = "fs", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=3.1.0-beta.0" }
-agave-io-uring = { path = "io-uring", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-logger = { path = "logger", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-precompiles = { path = "precompiles", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "reserved-account-keys", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-scheduler-bindings = { path = "scheduler-bindings", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-scheduling-utils = { path = "scheduling-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-snapshots = { path = "snapshots", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-syscalls = { path = "syscalls", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-thread-manager = { path = "thread-manager", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-transaction-view = { path = "transaction-view", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-verified-packet-receiver = { path = "verified-packet-receiver", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-votor = { path = "votor", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-votor-messages = { path = "votor-messages", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-xdp = { path = "xdp", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-xdp-ebpf = { path = "xdp-ebpf", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-cargo-registry = { path = "cargo-registry", version = "=3.1.1" }
+agave-feature-set = { path = "feature-set", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-fs = { path = "fs", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=3.1.1" }
+agave-io-uring = { path = "io-uring", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-logger = { path = "logger", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-precompiles = { path = "precompiles", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "reserved-account-keys", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-scheduler-bindings = { path = "scheduler-bindings", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-scheduling-utils = { path = "scheduling-utils", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-snapshots = { path = "snapshots", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-syscalls = { path = "syscalls", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-thread-manager = { path = "thread-manager", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-transaction-view = { path = "transaction-view", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-verified-packet-receiver = { path = "verified-packet-receiver", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-votor = { path = "votor", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-votor-messages = { path = "votor-messages", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-xdp = { path = "xdp", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-xdp-ebpf = { path = "xdp-ebpf", version = "=3.1.1", features = ["agave-unstable-api"] }
 ahash = "0.8.11"
 anyhow = "1.0.100"
 aquamarine = "0.6.0"
@@ -386,70 +386,70 @@ smpl_jwt = "0.7.1"
 socket2 = "0.6.1"
 soketto = "0.7"
 solana-account = "3.2.0"
-solana-account-decoder = { path = "account-decoder", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-account-decoder = { path = "account-decoder", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-account-info = "3.0.0"
-solana-accounts-db = { path = "accounts-db", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-accounts-db = { path = "accounts-db", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-address = "1.0.0"
 solana-address-lookup-table-interface = "3.0.0"
 solana-atomic-u64 = "3.0.0"
-solana-banks-client = { path = "banks-client", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-banks-interface = { path = "banks-interface", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-banks-server = { path = "banks-server", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-banks-client = { path = "banks-client", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-banks-interface = { path = "banks-interface", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-banks-server = { path = "banks-server", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-big-mod-exp = "3.0.0"
 solana-bincode = "3.0.0"
 solana-blake3-hasher = "3.0.0"
-solana-bloom = { path = "bloom", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-bloom = { path = "bloom", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-bls-signatures = { version = "1.0.0", features = ["serde"] }
 solana-bn254 = "3.1.2"
 solana-borsh = "3.0.0"
-solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-bucket-map = { path = "bucket_map", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-builtins = { path = "builtins", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-builtins-default-costs = { path = "builtins-default-costs", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-clap-utils = { path = "clap-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-clap-v3-utils = { path = "clap-v3-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-cli = { path = "cli", version = "=3.1.0-beta.0" }
-solana-cli-config = { path = "cli-config", version = "=3.1.0-beta.0" }
-solana-cli-output = { path = "cli-output", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-client = { path = "client", version = "=3.1.0-beta.0" }
+solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-bucket-map = { path = "bucket_map", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-builtins = { path = "builtins", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-builtins-default-costs = { path = "builtins-default-costs", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-clap-utils = { path = "clap-utils", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-clap-v3-utils = { path = "clap-v3-utils", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-cli = { path = "cli", version = "=3.1.1" }
+solana-cli-config = { path = "cli-config", version = "=3.1.1" }
+solana-cli-output = { path = "cli-output", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-client = { path = "client", version = "=3.1.1" }
 solana-client-traits = "3.0.0"
 solana-clock = "3.0.0"
 solana-cluster-type = "3.0.0"
 solana-commitment-config = "3.0.0"
-solana-compute-budget = { path = "compute-budget", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-compute-budget = { path = "compute-budget", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-compute-budget-interface = "3.0.0"
-solana-compute-budget-program = { path = "programs/compute-budget", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-compute-budget-program = { path = "programs/compute-budget", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-config-interface = "2.0.0"
-solana-connection-cache = { path = "connection-cache", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
-solana-core = { path = "core", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-cost-model = { path = "cost-model", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-connection-cache = { path = "connection-cache", version = "=3.1.1", default-features = false, features = ["agave-unstable-api"] }
+solana-core = { path = "core", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-cost-model = { path = "cost-model", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-cpi = "3.0.0"
-solana-curve25519 = { path = "curves/curve25519", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-curve25519 = { path = "curves/curve25519", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-define-syscall = "3.0.0"
 solana-derivation-path = "3.0.0"
-solana-download-utils = { path = "download-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-download-utils = { path = "download-utils", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-ed25519-program = "3.0.0"
-solana-entry = { path = "entry", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-entry = { path = "entry", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-epoch-info = "3.0.0"
 solana-epoch-rewards = "3.0.0"
 solana-epoch-rewards-hasher = "3.0.0"
 solana-epoch-schedule = "3.0.0"
 solana-example-mocks = "3.0.0"
-solana-faucet = { path = "faucet", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-faucet = { path = "faucet", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-feature-gate-interface = "3.0.0"
-solana-fee = { path = "fee", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-fee = { path = "fee", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-fee-calculator = "3.0.0"
 solana-fee-structure = "3.0.0"
 solana-file-download = "3.1.0"
 solana-frozen-abi = "3.0.1"
 solana-frozen-abi-macro = "3.0.1"
-solana-genesis = { path = "genesis", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-genesis = { path = "genesis", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-genesis-config = "3.0.0"
-solana-genesis-utils = { path = "genesis-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-gossip = { path = "gossip", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-genesis-utils = { path = "genesis-utils", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-gossip = { path = "gossip", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-hard-forks = "3.0.0"
 solana-hash = "3.0.0"
 solana-inflation = "3.0.0"
@@ -459,56 +459,56 @@ solana-instructions-sysvar = "3.0.0"
 solana-keccak-hasher = "3.0.0"
 solana-keypair = "3.0.1"
 solana-last-restart-slot = "3.0.0"
-solana-lattice-hash = { path = "lattice-hash", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-ledger = { path = "ledger", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-lattice-hash = { path = "lattice-hash", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-ledger = { path = "ledger", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-loader-v2-interface = "3.0.0"
 solana-loader-v3-interface = "6.1.0"
 solana-loader-v4-interface = "3.1.0"
-solana-loader-v4-program = { path = "programs/loader-v4", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-local-cluster = { path = "local-cluster", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-measure = { path = "measure", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-merkle-tree = { path = "merkle-tree", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-loader-v4-program = { path = "programs/loader-v4", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-local-cluster = { path = "local-cluster", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-measure = { path = "measure", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-merkle-tree = { path = "merkle-tree", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-message = "3.0.1"
-solana-metrics = { path = "metrics", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-metrics = { path = "metrics", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-msg = "3.0.0"
 solana-native-token = "3.0.0"
-solana-net-utils = { path = "net-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-net-utils = { path = "net-utils", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-nohash-hasher = "0.2.1"
 solana-nonce = "3.0.0"
 solana-nonce-account = "3.0.0"
-solana-notifier = { path = "notifier", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-notifier = { path = "notifier", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-offchain-message = "3.0.0"
 solana-packet = "3.0.0"
-solana-perf = { path = "perf", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-poh = { path = "poh", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-perf = { path = "perf", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-poh = { path = "poh", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-poh-config = "3.0.0"
-solana-poseidon = { path = "poseidon", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-poseidon = { path = "poseidon", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-precompile-error = "3.0.0"
 solana-presigner = "3.0.0"
 solana-program = { version = "3.0.0", default-features = false }
-solana-program-binaries = { path = "program-binaries", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-program-binaries = { path = "program-binaries", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-program-entrypoint = "3.1.0"
 solana-program-error = "3.0.0"
 solana-program-memory = "3.0.0"
 solana-program-option = "3.0.0"
 solana-program-pack = "3.0.0"
-solana-program-runtime = { path = "program-runtime", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-program-test = { path = "program-test", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-program-runtime = { path = "program-runtime", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-program-test = { path = "program-test", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-pubkey = { version = "3.0.0", default-features = false }
-solana-pubsub-client = { path = "pubsub-client", version = "=3.1.0-beta.0" }
-solana-quic-client = { path = "quic-client", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-pubsub-client = { path = "pubsub-client", version = "=3.1.1" }
+solana-quic-client = { path = "quic-client", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-quic-definitions = "3.0.0"
-solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-remote-wallet = { path = "remote-wallet", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
+solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-remote-wallet = { path = "remote-wallet", version = "=3.1.1", default-features = false, features = ["agave-unstable-api"] }
 solana-rent = "3.0.0"
 solana-reward-info = "3.0.0"
-solana-rpc = { path = "rpc", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-rpc-client = { path = "rpc-client", version = "=3.1.0-beta.0", default-features = false }
-solana-rpc-client-api = { path = "rpc-client-api", version = "=3.1.0-beta.0" }
-solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=3.1.0-beta.0" }
-solana-rpc-client-types = { path = "rpc-client-types", version = "=3.1.0-beta.0" }
-solana-runtime = { path = "runtime", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-runtime-transaction = { path = "runtime-transaction", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-rpc = { path = "rpc", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-rpc-client = { path = "rpc-client", version = "=3.1.1", default-features = false }
+solana-rpc-client-api = { path = "rpc-client-api", version = "=3.1.1" }
+solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=3.1.1" }
+solana-rpc-client-types = { path = "rpc-client-types", version = "=3.1.1" }
+solana-runtime = { path = "runtime", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-runtime-transaction = { path = "runtime-transaction", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-sanitize = "3.0.1"
 solana-sbpf = { version = "=0.13.1", default-features = false }
 solana-sdk-ids = "3.0.0"
@@ -517,7 +517,7 @@ solana-secp256k1-recover = "3.0.0"
 solana-secp256r1-program = "3.0.0"
 solana-seed-derivable = "3.0.0"
 solana-seed-phrase = "3.0.0"
-solana-send-transaction-service = { path = "send-transaction-service", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-send-transaction-service = { path = "send-transaction-service", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-serde = "3.0.0"
 solana-serde-varint = "3.0.0"
 solana-serialize-utils = "3.1.0"
@@ -531,49 +531,49 @@ solana-slot-hashes = "3.0.0"
 solana-slot-history = "3.0.0"
 solana-stable-layout = "3.0.0"
 solana-stake-interface = { version = "2.0.1" }
-solana-storage-bigtable = { path = "storage-bigtable", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-storage-proto = { path = "storage-proto", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-streamer = { path = "streamer", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm = { path = "svm", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-callback = { path = "svm-callback", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-feature-set = { path = "svm-feature-set", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-log-collector = { path = "svm-log-collector", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-measure = { path = "svm-measure", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-test-harness = { path = "svm-test-harness", version = "=3.1.0-beta.0" }
-solana-svm-timings = { path = "svm-timings", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-transaction = { path = "svm-transaction", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-type-overrides = { path = "svm-type-overrides", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-storage-bigtable = { path = "storage-bigtable", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-storage-proto = { path = "storage-proto", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-streamer = { path = "streamer", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-svm = { path = "svm", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-svm-callback = { path = "svm-callback", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-svm-feature-set = { path = "svm-feature-set", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-svm-log-collector = { path = "svm-log-collector", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-svm-measure = { path = "svm-measure", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-svm-test-harness = { path = "svm-test-harness", version = "=3.1.1" }
+solana-svm-timings = { path = "svm-timings", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-svm-transaction = { path = "svm-transaction", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-svm-type-overrides = { path = "svm-type-overrides", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-system-interface = "2.0"
-solana-system-program = { path = "programs/system", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-system-program = { path = "programs/system", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-system-transaction = "3.0.0"
 solana-sysvar = "3.0.0"
 solana-sysvar-id = "3.0.0"
-solana-test-validator = { path = "test-validator", version = "=3.1.0-beta.0" }
+solana-test-validator = { path = "test-validator", version = "=3.1.1" }
 solana-time-utils = "3.0.0"
-solana-tls-utils = { path = "tls-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-tps-client = { path = "tps-client", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-tpu-client = { path = "tpu-client", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
-solana-tpu-client-next = { path = "tpu-client-next", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-tls-utils = { path = "tls-utils", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-tps-client = { path = "tps-client", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-tpu-client = { path = "tpu-client", version = "=3.1.1", default-features = false, features = ["agave-unstable-api"] }
+solana-tpu-client-next = { path = "tpu-client-next", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-transaction = "3.0.1"
-solana-transaction-context = { path = "transaction-context", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-context = { path = "transaction-context", version = "=3.1.1", features = ["agave-unstable-api", "bincode"] }
 solana-transaction-error = "3.0.0"
-solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-transaction-status = { path = "transaction-status", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-turbine = { path = "turbine", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-udp-client = { path = "udp-client", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-transaction-status = { path = "transaction-status", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-turbine = { path = "turbine", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-udp-client = { path = "udp-client", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-validator-exit = "3.0.0"
-solana-version = { path = "version", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-vote = { path = "vote", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-version = { path = "version", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-vote = { path = "vote", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-vote-interface = "4.0.4"
-solana-vote-program = { path = "programs/vote", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
-solana-wen-restart = { path = "wen-restart", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-vote-program = { path = "programs/vote", version = "=3.1.1", default-features = false, features = ["agave-unstable-api"] }
+solana-wen-restart = { path = "wen-restart", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-zk-sdk = "4.0.0"
-solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-zk-token-sdk = { path = "zk-token-sdk", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-zk-token-sdk = { path = "zk-token-sdk", version = "=3.1.1", features = ["agave-unstable-api"] }
 spl-associated-token-account-interface = "2.0.0"
 spl-generic-token = "2.0.0"
 spl-memo-interface = "2.0.0"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agave-fs"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
  "solana-clock",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "agave-io-uring"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "io-uring",
  "libc",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agave-ledger-tool"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "agave-logger"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "env_logger",
  "libc",
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey",
@@ -235,11 +235,11 @@ dependencies = [
 
 [[package]]
 name = "agave-scheduler-bindings"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "agave-scheduling-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-scheduler-bindings",
  "agave-transaction-view",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "agave-snapshots"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-fs",
  "bincode",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-tool"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "ahash 0.8.12",
  "clap 2.34.0",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "agave-syscalls"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "libsecp256k1",
@@ -309,7 +309,7 @@ dependencies = [
  "solana-bn254",
  "solana-clock",
  "solana-cpi",
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.1",
  "solana-hash",
  "solana-instruction",
  "solana-keccak-hasher",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "agave-verified-packet-receiver"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-perf",
  "solana-streamer",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "agave-votor"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "agave-votor-messages",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "agave-votor-messages"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "serde",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-xdp-ebpf",
  "aya",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp-ebpf"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "aya",
  "aya-ebpf",
@@ -6096,7 +6096,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -6136,7 +6136,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6160,7 +6160,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-fs",
  "ahash 0.8.12",
@@ -6272,7 +6272,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banking-bench"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-logger",
@@ -6308,7 +6308,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "borsh",
  "futures 0.3.31",
@@ -6334,7 +6334,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "serde",
  "solana-account",
@@ -6352,7 +6352,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -6380,7 +6380,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-tps"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bv",
  "fnv",
@@ -6540,7 +6540,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -6567,7 +6567,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bv",
  "bytemuck",
@@ -6584,7 +6584,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -6602,7 +6602,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -6618,7 +6618,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "dirs-next",
  "serde",
@@ -6658,7 +6658,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -6698,7 +6698,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -6807,7 +6807,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -6837,7 +6837,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -6861,7 +6861,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6882,7 +6882,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -7079,7 +7079,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -7114,7 +7114,7 @@ dependencies = [
 
 [[package]]
 name = "solana-dos"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -7157,7 +7157,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -7181,7 +7181,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -7258,7 +7258,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -7308,7 +7308,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -7350,7 +7350,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -7426,7 +7426,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -7439,7 +7439,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -7469,7 +7469,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -7666,7 +7666,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
  "solana-account",
@@ -7830,7 +7830,7 @@ dependencies = [
 
 [[package]]
 name = "solana-local-cluster"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "agave-snapshots",
@@ -7892,11 +7892,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -7925,7 +7925,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -7954,7 +7954,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-net-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8036,7 +8036,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -8075,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "arc-swap",
  "core_affinity",
@@ -8108,7 +8108,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-bn254 0.5.0",
@@ -8140,7 +8140,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-binaries"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "serde",
@@ -8200,7 +8200,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8243,7 +8243,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8316,7 +8316,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -8340,7 +8340,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -8377,7 +8377,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
  "num_cpus",
@@ -8385,7 +8385,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "console 0.16.1",
  "dialoguer",
@@ -8429,7 +8429,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -8513,7 +8513,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8551,7 +8551,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -8570,7 +8570,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -8585,7 +8585,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -8610,7 +8610,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-fs",
@@ -8746,7 +8746,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -8868,7 +8868,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -9047,7 +9047,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -9086,7 +9086,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "bs58",
@@ -9109,7 +9109,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -9155,7 +9155,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -9197,7 +9197,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -9207,22 +9207,22 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-svm-timings"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -9231,7 +9231,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -9243,7 +9243,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -9265,7 +9265,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "log",
@@ -9346,7 +9346,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -9402,7 +9402,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
 name = "solana-tls-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "rustls 0.23.34",
  "solana-keypair",
@@ -9413,7 +9413,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tps-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
  "solana-account",
@@ -9444,7 +9444,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -9476,7 +9476,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "log",
@@ -9523,7 +9523,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "serde",
@@ -9550,7 +9550,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9564,7 +9564,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -9605,7 +9605,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9627,7 +9627,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-votor",
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -9695,7 +9695,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -9707,7 +9707,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -9747,7 +9747,7 @@ checksum = "c5d2face763df5afeaa9509b9019968860e69cc1531ec8b4a2e6c7b702204d5a"
 
 [[package]]
 name = "solana-version"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -9759,7 +9759,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "itertools 0.12.1",
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -9842,7 +9842,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-snapshots",
  "anyhow",
@@ -9870,7 +9870,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -9922,7 +9922,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -9937,7 +9937,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -9953,7 +9953,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.1",
  "solana-derivation-path",
  "solana-instruction",
  "solana-pubkey",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.1.0-beta.0"
+version = "3.1.1"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 description = "Blockchain, Rebuilt for Scale"
 repository = "https://github.com/anza-xyz/agave"
@@ -36,12 +36,12 @@ manual_let_else = "deny"
 used_underscore_binding = "deny"
 
 [workspace.dependencies]
-agave-banking-stage-ingress-types = { path = "../banking-stage-ingress-types", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-feature-set = { path = "../feature-set", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-logger = { path = "../logger", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-snapshots = { path = "../snapshots", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-agave-syscalls = { path = "../syscalls", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+agave-banking-stage-ingress-types = { path = "../banking-stage-ingress-types", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-feature-set = { path = "../feature-set", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-logger = { path = "../logger", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-snapshots = { path = "../snapshots", version = "=3.1.1", features = ["agave-unstable-api"] }
+agave-syscalls = { path = "../syscalls", version = "=3.1.1", features = ["agave-unstable-api"] }
 ahash = "0.8.11"
 assert_cmd = "2.0"
 assert_matches = "1.5.0"
@@ -71,81 +71,81 @@ serde_yaml = "0.9.34"
 serial_test = "2.0.0"
 signal-hook = "0.3.18"
 solana-account = "3.2.0"
-solana-account-decoder = { path = "../account-decoder", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-accounts-db = { path = "../accounts-db", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-bench-tps = { path = "../bench-tps", version = "=3.1.0-beta.0" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-clap-utils = { path = "../clap-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-cli-config = { path = "../cli-config", version = "=3.1.0-beta.0" }
-solana-cli-output = { path = "../cli-output", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-client = { path = "../client", version = "=3.1.0-beta.0" }
+solana-account-decoder = { path = "../account-decoder", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-accounts-db = { path = "../accounts-db", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-bench-tps = { path = "../bench-tps", version = "=3.1.1" }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-clap-utils = { path = "../clap-utils", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-cli-config = { path = "../cli-config", version = "=3.1.1" }
+solana-cli-output = { path = "../cli-output", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-client = { path = "../client", version = "=3.1.1" }
 solana-clock = "3.0.0"
 solana-cluster-type = "3.0.0"
 solana-commitment-config = "3.0.0"
-solana-compute-budget = { path = "../compute-budget", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-compute-budget = { path = "../compute-budget", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-compute-budget-interface = "3.0.0"
-solana-connection-cache = { path = "../connection-cache", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
-solana-core = { path = "../core", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-cost-model = { path = "../cost-model", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-entry = { path = "../entry", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-faucet = { path = "../faucet", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-connection-cache = { path = "../connection-cache", version = "=3.1.1", default-features = false, features = ["agave-unstable-api"] }
+solana-core = { path = "../core", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-cost-model = { path = "../cost-model", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-entry = { path = "../entry", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-faucet = { path = "../faucet", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-feature-gate-interface = "3.0.0"
 solana-fee-calculator = "3.0.0"
-solana-genesis = { path = "../genesis", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-genesis = { path = "../genesis", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-genesis-config = "3.0.0"
-solana-genesis-utils = { path = "../genesis-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-gossip = { path = "../gossip", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-genesis-utils = { path = "../genesis-utils", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-gossip = { path = "../gossip", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-hash = "3.0.0"
 solana-inflation = "3.0.0"
 solana-instruction = "3.0.0"
 solana-keypair = "3.0.1"
-solana-ledger = { path = "../ledger", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-ledger = { path = "../ledger", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-loader-v3-interface = "6.1.0"
-solana-local-cluster = { path = "../local-cluster", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-measure = { path = "../measure", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-local-cluster = { path = "../local-cluster", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-measure = { path = "../measure", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-message = "3.0.1"
-solana-metrics = { path = "../metrics", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-metrics = { path = "../metrics", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-native-token = "3.0.0"
-solana-net-utils = { path = "../net-utils", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-net-utils = { path = "../net-utils", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-nonce = "3.0.0"
-solana-perf = { path = "../perf", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-poh = { path = "../poh", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-program-runtime = { path = "../program-runtime", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-perf = { path = "../perf", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-poh = { path = "../poh", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-program-runtime = { path = "../program-runtime", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-pubkey = { version = "3.0.0", default-features = false }
-solana-quic-client = { path = "../quic-client", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-quic-client = { path = "../quic-client", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-rent = "3.0.0"
-solana-rpc = { path = "../rpc", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-rpc-client = { path = "../rpc-client", version = "=3.1.0-beta.0", default-features = false }
-solana-rpc-client-api = { path = "../rpc-client-api", version = "=3.1.0-beta.0" }
-solana-rpc-client-nonce-utils = { path = "../rpc-client-nonce-utils", version = "=3.1.0-beta.0" }
-solana-runtime = { path = "../runtime", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-runtime-transaction = { path = "../runtime-transaction", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-rpc = { path = "../rpc", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-rpc-client = { path = "../rpc-client", version = "=3.1.1", default-features = false }
+solana-rpc-client-api = { path = "../rpc-client-api", version = "=3.1.1" }
+solana-rpc-client-nonce-utils = { path = "../rpc-client-nonce-utils", version = "=3.1.1" }
+solana-runtime = { path = "../runtime", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-runtime-transaction = { path = "../runtime-transaction", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-sbpf = { version = "=0.13.1", default-features = false }
 solana-sdk-ids = "3.0.0"
 solana-shred-version = "3.0.0"
 solana-signature = { version = "3.1.0", default-features = false }
 solana-signer = "3.0.0"
 solana-stake-interface = { version = "2.0.1" }
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-streamer = { path = "../streamer", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-callback = { path = "../svm-callback", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-feature-set = { path = "../svm-feature-set", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-log-collector = { path = "../svm-log-collector", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-svm-type-overrides = { path = "../svm-type-overrides", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-streamer = { path = "../streamer", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-svm-callback = { path = "../svm-callback", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-svm-feature-set = { path = "../svm-feature-set", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-svm-log-collector = { path = "../svm-log-collector", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-svm-type-overrides = { path = "../svm-type-overrides", version = "=3.1.1", features = ["agave-unstable-api"] }
 solana-system-interface = "2.0"
 solana-system-transaction = "3.0.0"
-solana-test-validator = { path = "../test-validator", version = "=3.1.0-beta.0" }
+solana-test-validator = { path = "../test-validator", version = "=3.1.1" }
 solana-time-utils = "3.0.0"
-solana-tps-client = { path = "../tps-client", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-tpu-client = { path = "../tpu-client", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
+solana-tps-client = { path = "../tps-client", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-tpu-client = { path = "../tpu-client", version = "=3.1.1", default-features = false, features = ["agave-unstable-api"] }
 solana-transaction = "3.0.1"
-solana-transaction-context = { path = "../transaction-context", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "bincode"] }
-solana-transaction-status = { path = "../transaction-status", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-version = { path = "../version", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-vote = { path = "../vote", version = "=3.1.0-beta.0", features = ["agave-unstable-api"] }
-solana-vote-program = { path = "../programs/vote", version = "=3.1.0-beta.0", default-features = false, features = ["agave-unstable-api"] }
+solana-transaction-context = { path = "../transaction-context", version = "=3.1.1", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-status = { path = "../transaction-status", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-version = { path = "../version", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-vote = { path = "../vote", version = "=3.1.1", features = ["agave-unstable-api"] }
+solana-vote-program = { path = "../programs/vote", version = "=3.1.1", default-features = false, features = ["agave-unstable-api"] }
 tempfile = "3.23.0"
 thiserror = "2.0.17"
 tokio = "1.48.0"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noop"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "package-metadata"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 description = "Solana SBF test program with tools version in package metadata"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-metadata"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 description = "Solana SBF test program with tools version in workspace metadata"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agave-fs"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
  "solana-clock",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "agave-io-uring"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "io-uring",
  "libc",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agave-logger"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "env_logger",
  "libc",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey",
@@ -151,11 +151,11 @@ dependencies = [
 
 [[package]]
 name = "agave-scheduler-bindings"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "agave-scheduling-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-scheduler-bindings",
  "agave-transaction-view",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "agave-snapshots"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-fs",
  "bincode",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "agave-syscalls"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "libsecp256k1 0.6.0",
@@ -211,7 +211,7 @@ dependencies = [
  "solana-bn254",
  "solana-clock",
  "solana-cpi",
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.1",
  "solana-hash",
  "solana-instruction",
  "solana-keccak-hasher",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "agave-validator"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-geyser-plugin-interface",
  "agave-logger",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "agave-verified-packet-receiver"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-perf",
  "solana-streamer",
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "agave-votor"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "agave-votor-messages",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "agave-votor-messages"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "serde",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-xdp-ebpf",
  "aya",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp-ebpf"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "aya",
  "aya-ebpf",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6100,7 +6100,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-fs",
  "ahash 0.8.11",
@@ -6212,7 +6212,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "borsh",
  "futures 0.3.31",
@@ -6238,7 +6238,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "serde",
  "solana-account",
@@ -6256,7 +6256,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -6317,7 +6317,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bv",
  "fnv",
@@ -6377,7 +6377,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -6404,7 +6404,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bv",
  "bytemuck",
@@ -6421,7 +6421,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -6439,7 +6439,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -6455,7 +6455,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "chrono",
  "clap",
@@ -6483,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "dirs-next",
  "serde",
@@ -6495,7 +6495,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -6535,7 +6535,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6636,7 +6636,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -6644,7 +6644,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -6674,7 +6674,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -6698,7 +6698,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -6862,7 +6862,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -6916,7 +6916,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -6951,7 +6951,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -6975,7 +6975,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -7083,7 +7083,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -7133,7 +7133,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -7217,7 +7217,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -7247,7 +7247,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -7435,7 +7435,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -7445,7 +7445,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -7587,7 +7587,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
  "solana-account",
@@ -7609,11 +7609,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -7642,7 +7642,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -7671,7 +7671,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-net-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7753,7 +7753,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -7784,7 +7784,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "arc-swap",
  "core_affinity",
@@ -7817,7 +7817,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-bn254 0.5.0",
@@ -7896,7 +7896,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-binaries"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "serde",
@@ -7958,7 +7958,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8001,7 +8001,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8074,7 +8074,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -8098,7 +8098,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -8135,7 +8135,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
  "num_cpus",
@@ -8143,7 +8143,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "console 0.16.1",
  "dialoguer",
@@ -8187,7 +8187,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -8271,7 +8271,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8309,7 +8309,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -8328,7 +8328,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -8343,7 +8343,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -8368,7 +8368,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-fs",
@@ -8504,7 +8504,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -8530,7 +8530,7 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbf-programs"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8603,7 +8603,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-program-entrypoint",
  "solana-sbf-rust-128bit-dep",
@@ -8611,11 +8611,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit-dep"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-sbf-rust-account-mem"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8626,7 +8626,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-account-mem-deprecated"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-program",
@@ -8637,7 +8637,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alloc"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-msg",
  "solana-program",
@@ -8647,7 +8647,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "array-bytes",
  "solana-bn254",
@@ -8657,7 +8657,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128-compression"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "array-bytes",
  "solana-bn254",
@@ -8667,7 +8667,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-big-mod-exp"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "array-bytes",
  "serde",
@@ -8679,7 +8679,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-args"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "borsh",
  "solana-account-info",
@@ -8691,7 +8691,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-depth"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-msg",
  "solana-program",
@@ -8701,7 +8701,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-caller-access"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8714,16 +8714,16 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-curve25519"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.1",
  "solana-msg",
  "solana-program-entrypoint",
 ]
 
 [[package]]
 name = "solana-sbf-rust-custom-heap"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8734,7 +8734,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-dep-crate"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "byteorder 1.5.0",
  "solana-program-entrypoint",
@@ -8742,7 +8742,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-deprecated-loader"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8758,7 +8758,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-divide-by-zero"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8768,7 +8768,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-dup-accounts"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8781,7 +8781,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-error-handling"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "num-derive",
  "num-traits",
@@ -8795,7 +8795,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-external-spend"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8805,7 +8805,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-get-minimum-delegation"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8817,7 +8817,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-inner_instruction_alignment_check"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8830,7 +8830,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-instruction-introspection"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8845,7 +8845,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-error"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8876,7 +8876,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-ok"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8888,7 +8888,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-return"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8900,11 +8900,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-dep"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-sbf-rust-invoked"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8920,7 +8920,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoked-dep"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
@@ -8928,7 +8928,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-iter"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-program",
  "solana-program-entrypoint",
@@ -8936,7 +8936,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-log-data"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-program",
@@ -8948,7 +8948,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-many-args"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-msg",
  "solana-program",
@@ -8958,7 +8958,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-many-args-dep"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-msg",
  "solana-program",
@@ -8966,7 +8966,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-mem"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8978,11 +8978,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-mem-dep"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-sbf-rust-membuiltins"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-program-entrypoint",
  "solana-sbf-rust-mem-dep",
@@ -8990,7 +8990,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-noop"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -9000,7 +9000,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-panic"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9011,7 +9011,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-param-passing"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-program",
  "solana-program-entrypoint",
@@ -9020,11 +9020,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-param-passing-dep"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-sbf-rust-poseidon"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "array-bytes",
  "solana-msg",
@@ -9034,7 +9034,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-r2-instruction-data-pointer"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-cpi",
  "solana-program-entrypoint",
@@ -9042,7 +9042,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-rand"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "getrandom 0.2.10",
  "rand 0.8.5",
@@ -9055,7 +9055,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9069,7 +9069,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-dep"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
@@ -9077,7 +9077,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -9093,11 +9093,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke-dep"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-sbf-rust-remaining-compute-units"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9109,7 +9109,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-ro-account_modify"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -9122,7 +9122,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-ro-modify"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9135,7 +9135,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sanity"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-secp256k1-recover"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "libsecp256k1 0.7.0",
  "sha3",
@@ -9161,7 +9161,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sha"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "blake3",
  "sha2 0.10.9",
@@ -9176,7 +9176,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sibling-inner-instructions"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -9188,7 +9188,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sibling-instructions"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -9201,7 +9201,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-simulation"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-clock",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-spoof1"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -9228,7 +9228,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-spoof1-system"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -9238,7 +9238,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sysvar"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "solana-account-info",
@@ -9256,7 +9256,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-upgradeable"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9268,7 +9268,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-upgraded"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9280,7 +9280,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-syscall-get-epoch-stake"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -9387,7 +9387,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -9564,7 +9564,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -9603,7 +9603,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "bs58",
@@ -9626,7 +9626,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -9672,7 +9672,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "ahash 0.8.11",
  "log",
@@ -9714,7 +9714,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -9724,22 +9724,22 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 
 [[package]]
 name = "solana-svm-timings"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -9748,7 +9748,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -9760,7 +9760,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -9782,7 +9782,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "log",
@@ -9865,7 +9865,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -9921,7 +9921,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
 name = "solana-tls-utils"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "rustls 0.23.34",
  "solana-keypair",
@@ -9932,7 +9932,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -9964,7 +9964,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "log",
@@ -10011,7 +10011,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -10039,7 +10039,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10053,7 +10053,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -10094,7 +10094,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10116,7 +10116,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "agave-votor",
@@ -10170,7 +10170,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -10184,7 +10184,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -10196,7 +10196,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -10236,7 +10236,7 @@ checksum = "c5d2face763df5afeaa9509b9019968860e69cc1531ec8b4a2e6c7b702204d5a"
 
 [[package]]
 name = "solana-version"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -10248,7 +10248,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "bincode",
  "itertools 0.12.1",
@@ -10301,7 +10301,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -10332,7 +10332,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-snapshots",
  "anyhow",
@@ -10360,7 +10360,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -10412,7 +10412,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -10427,7 +10427,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -10443,7 +10443,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "solana-curve25519 3.1.0-beta.0",
+ "solana-curve25519 3.1.1",
  "solana-derivation-path",
  "solana-instruction",
  "solana-pubkey",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -73,7 +73,7 @@ members = [
     "rust/upgraded",
 ]
 [workspace.package]
-version = "3.1.0-beta.0"
+version = "3.1.1"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
@@ -90,11 +90,11 @@ check-cfg = [
 ]
 
 [workspace.dependencies]
-agave-feature-set = { path = "../../feature-set", version = "=3.1.0-beta.0" }
-agave-logger = { path = "../../logger", version = "=3.1.0-beta.0" }
-agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=3.1.0-beta.0" }
-agave-syscalls = { path = "../../syscalls", version = "=3.1.0-beta.0" }
-agave-validator = { path = "../../validator", version = "=3.1.0-beta.0" }
+agave-feature-set = { path = "../../feature-set", version = "=3.1.1" }
+agave-logger = { path = "../../logger", version = "=3.1.1" }
+agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=3.1.1" }
+agave-syscalls = { path = "../../syscalls", version = "=3.1.1" }
+agave-validator = { path = "../../validator", version = "=3.1.1" }
 array-bytes = "=1.4.1"
 bincode = { version = "1.1.4", default-features = false }
 blake3 = "1.0.0"
@@ -114,64 +114,64 @@ serde = { version = "1.0.112", features = ["derive"] }
 serde_json = "1.0.56"
 sha2 = "0.10.8"
 sha3 = "0.10.8"
-solana-account-decoder = { path = "../../account-decoder", version = "=3.1.0-beta.0" }
+solana-account-decoder = { path = "../../account-decoder", version = "=3.1.1" }
 solana-account-info = "=3.0.0"
-solana-accounts-db = { path = "../../accounts-db", version = "=3.1.0-beta.0" }
+solana-accounts-db = { path = "../../accounts-db", version = "=3.1.1" }
 solana-big-mod-exp = "=3.0.0"
 solana-blake3-hasher = { version = "=3.0.0", features = ["blake3"] }
 solana-bn254 = "=3.1.2"
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=3.1.0-beta.0" }
-solana-cli-output = { path = "../../cli-output", version = "=3.1.0-beta.0" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=3.1.1" }
+solana-cli-output = { path = "../../cli-output", version = "=3.1.1" }
 solana-clock = { version = "=3.0.0", features = ["serde", "sysvar"] }
-solana-compute-budget = { path = "../../compute-budget", version = "=3.1.0-beta.0" }
-solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=3.1.0-beta.0" }
+solana-compute-budget = { path = "../../compute-budget", version = "=3.1.1" }
+solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=3.1.1" }
 solana-cpi = "=3.0.0"
-solana-curve25519 = { path = "../../curves/curve25519", version = "=3.1.0-beta.0" }
+solana-curve25519 = { path = "../../curves/curve25519", version = "=3.1.1" }
 solana-define-syscall = "=3.0.0"
-solana-fee = { path = "../../fee", version = "=3.1.0-beta.0" }
+solana-fee = { path = "../../fee", version = "=3.1.1" }
 solana-hash = { version = "=3.0.0", features = ["bytemuck", "serde", "std"] }
 solana-instruction = "=3.0.0"
 solana-instructions-sysvar = "=3.0.0"
 solana-keccak-hasher = { version = "=3.0.0", features = ["sha3"] }
-solana-ledger = { path = "../../ledger", version = "=3.1.0-beta.0" }
-solana-measure = { path = "../../measure", version = "=3.1.0-beta.0" }
+solana-ledger = { path = "../../ledger", version = "=3.1.1" }
+solana-measure = { path = "../../measure", version = "=3.1.1" }
 solana-msg = "=3.0.0"
-solana-poseidon = { path = "../../poseidon/", version = "=3.1.0-beta.0" }
+solana-poseidon = { path = "../../poseidon/", version = "=3.1.1" }
 solana-program = "=3.0.0"
 solana-program-entrypoint = "=3.1.0"
 solana-program-error = "=3.0.0"
 solana-program-memory = "=3.0.0"
-solana-program-runtime = { path = "../../program-runtime", version = "=3.1.0-beta.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=3.1.1" }
 solana-pubkey = { version = "=3.0.0", default-features = false }
-solana-runtime = { path = "../../runtime", version = "=3.1.0-beta.0" }
-solana-runtime-transaction = { path = "../../runtime-transaction", version = "=3.1.0-beta.0" }
-solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-invoke-dep = { path = "rust/invoke_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-invoked-dep = { path = "rust/invoked_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-r2-instruction-data-pointer = { path = "rust/r2_instruction_data_pointer", version = "=3.1.0-beta.0" }
-solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=3.1.0-beta.0" }
-solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=3.1.0-beta.0" }
+solana-runtime = { path = "../../runtime", version = "=3.1.1" }
+solana-runtime-transaction = { path = "../../runtime-transaction", version = "=3.1.1" }
+solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=3.1.1" }
+solana-sbf-rust-invoke-dep = { path = "rust/invoke_dep", version = "=3.1.1" }
+solana-sbf-rust-invoked-dep = { path = "rust/invoked_dep", version = "=3.1.1" }
+solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=3.1.1" }
+solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=3.1.1" }
+solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=3.1.1" }
+solana-sbf-rust-r2-instruction-data-pointer = { path = "rust/r2_instruction_data_pointer", version = "=3.1.1" }
+solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=3.1.1" }
+solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=3.1.1" }
 solana-sbpf = "=0.13.1"
 solana-sdk-ids = "=3.0.0"
 solana-secp256k1-recover = "=3.0.0"
 solana-sha256-hasher = { version = "=3.0.0", features = ["sha2"] }
 solana-stake-interface = { version = "=2.0.1", features = ["bincode"] }
-solana-svm = { path = "../../svm", version = "=3.1.0-beta.0" }
-solana-svm-callback = { path = "../../svm-callback", version = "=3.1.0-beta.0" }
-solana-svm-feature-set = { path = "../../svm-feature-set", version = "=3.1.0-beta.0" }
-solana-svm-log-collector = { path = "../../svm-log-collector", version = "=3.1.0-beta.0" }
-solana-svm-timings = { path = "../../svm-timings", version = "=3.1.0-beta.0" }
-solana-svm-transaction = { path = "../../svm-transaction", version = "=3.1.0-beta.0" }
-solana-svm-type-overrides = { path = "../../svm-type-overrides", version = "=3.1.0-beta.0" }
+solana-svm = { path = "../../svm", version = "=3.1.1" }
+solana-svm-callback = { path = "../../svm-callback", version = "=3.1.1" }
+solana-svm-feature-set = { path = "../../svm-feature-set", version = "=3.1.1" }
+solana-svm-log-collector = { path = "../../svm-log-collector", version = "=3.1.1" }
+solana-svm-timings = { path = "../../svm-timings", version = "=3.1.1" }
+solana-svm-transaction = { path = "../../svm-transaction", version = "=3.1.1" }
+solana-svm-type-overrides = { path = "../../svm-type-overrides", version = "=3.1.1" }
 solana-system-interface = { version = "=2.0", features = ["bincode"] }
 solana-sysvar = "=3.0.0"
-solana-transaction-context = { path = "../../transaction-context", version = "=3.1.0-beta.0" }
-solana-transaction-status = { path = "../../transaction-status", version = "=3.1.0-beta.0" }
-solana-vote = { path = "../../vote", version = "=3.1.0-beta.0" }
-solana-vote-program = { path = "../../programs/vote", version = "=3.1.0-beta.0" }
+solana-transaction-context = { path = "../../transaction-context", version = "=3.1.1" }
+solana-transaction-status = { path = "../../transaction-status", version = "=3.1.1" }
+solana-vote = { path = "../../vote", version = "=3.1.1" }
+solana-vote-program = { path = "../../programs/vote", version = "=3.1.1" }
 test-case = "3.3.1"
 thiserror = "1.0"
 

--- a/svm/tests/example-programs/clock-sysvar/Cargo.toml
+++ b/svm/tests/example-programs/clock-sysvar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock-sysvar-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/hello-solana/Cargo.toml
+++ b/svm/tests/example-programs/hello-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-solana-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/simple-transfer/Cargo.toml
+++ b/svm/tests/example-programs/simple-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-transfer-program"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/transfer-from-account/Cargo.toml
+++ b/svm/tests/example-programs/transfer-from-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-from-account"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/write-to-account/Cargo.toml
+++ b/svm/tests/example-programs/write-to-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-to-account"
-version = "3.1.0-beta.0"
+version = "3.1.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
We're abandoning the -beta prerelease suffix in v3.1 but will begin using it in v4.0. More context here: https://github.com/anza-xyz/agave/issues/8606


There's nothing in this change except the version bump
```
$ glol -2
372919c86c 2025-11-14 13:47:31 -0600  (HEAD -> v3.1.1_bump, willhickey/v3.1.1_bump)  will.hickey@anza.xyz Bump version to v3.1.1.
99945ca72d 2025-11-13 21:35:23 -0600  (agave/v3.1, v3.1)  81144685+2501babe@users.noreply.github.com deprecate `solana-stake-program` (#8860)
$ git diff v3.1..HEAD  | grep -vE "^ |^@@ |^--- |^\+\+\+ |^index |^diff |^-( \")?(solana|agave).*3.1.0|^\+( \")?(solana|agave).*3.1.1|^-version|^\+version"
$
```