### PR TITLE
clippy: One more manual_is_multiple_of

### DIFF
--- a/programs/sbf/rust/remaining_compute_units/src/lib.rs
+++ b/programs/sbf/rust/remaining_compute_units/src/lib.rs
@@ -13,7 +13,7 @@ pub fn process_instruction(
 ) -> ProgramResult {
     let mut i = 0u32;
     for _ in 0..100_000 {
-        if i % 500 == 0 {
+        if i.is_multiple_of(500) {
             let remaining = sol_remaining_compute_units();
             msg!("remaining compute units: {:?}", remaining);
             if remaining < 25_000 {


### PR DESCRIPTION
#### Problem
Missed one more 🤦 , always forget to check in `programs/sbf`
```
error: manual implementation of `.is_multiple_of()`
  --> rust/remaining_compute_units/src/lib.rs:16:12
   |
16 |         if i % 500 == 0 {
   |            ^^^^^^^^^^^^ help: replace with: `i.is_multiple_of(500)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of
   = note: `-D clippy::manual-is-multiple-of` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::manual_is_multiple_of)]`
```