### PR TITLE
wip

### DIFF
--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -32,31 +32,29 @@ impl VoteType {
     }
 }
 
-/// For a given [`CertificateType`], returns the fractional stake and the [`Vote`]s required to construct it.
+/// For a given [`CertificateType`], returns the fractional stake and the [`Vote`] and fallback [`Vote`] required to construct it.
 ///
 /// Must be in sync with [`vote_to_certificate_ids`].
-pub(crate) fn certificate_limits_and_votes(cert_type: &CertificateType) -> (f64, Vec<Vote>) {
+pub(crate) fn certificate_limits_and_votes(
+    cert_type: &CertificateType,
+) -> (f64, Vote, Option<Vote>) {
     match cert_type {
         CertificateType::Notarize(slot, block_id) => {
-            (0.6, vec![Vote::new_notarization_vote(*slot, *block_id)])
+            (0.6, Vote::new_notarization_vote(*slot, *block_id), None)
         }
         CertificateType::NotarizeFallback(slot, block_id) => (
             0.6,
-            vec![
-                Vote::new_notarization_vote(*slot, *block_id),
-                Vote::new_notarization_fallback_vote(*slot, *block_id),
-            ],
+            Vote::new_notarization_vote(*slot, *block_id),
+            Some(Vote::new_notarization_fallback_vote(*slot, *block_id)),
         ),
         CertificateType::FinalizeFast(slot, block_id) => {
-            (0.8, vec![Vote::new_notarization_vote(*slot, *block_id)])
+            (0.8, Vote::new_notarization_vote(*slot, *block_id), None)
         }
-        CertificateType::Finalize(slot) => (0.6, vec![Vote::new_finalization_vote(*slot)]),
+        CertificateType::Finalize(slot) => (0.6, Vote::new_finalization_vote(*slot), None),
         CertificateType::Skip(slot) => (
             0.6,
-            vec![
-                Vote::new_skip_vote(*slot),
-                Vote::new_skip_fallback_vote(*slot),
-            ],
+            Vote::new_skip_vote(*slot),
+            Some(Vote::new_skip_fallback_vote(*slot)),
         ),
     }
 }

--- a/votor/src/consensus_pool/certificate_builder.rs
+++ b/votor/src/consensus_pool/certificate_builder.rs
@@ -1,5 +1,5 @@
 use {
-    crate::common::{certificate_limits_and_vote_types, VoteType},
+    crate::common::certificate_limits_and_votes,
     agave_votor_messages::consensus_message::{Certificate, CertificateType, VoteMessage},
     bitvec::prelude::*,
     solana_bls_signatures::{BlsError, SignatureProjective},
@@ -146,24 +146,23 @@ impl BuilderType {
         cert_type: &CertificateType,
         msgs: &[VoteMessage],
     ) -> Result<(), AggregateError> {
-        let vote_types = certificate_limits_and_vote_types(cert_type).1;
+        let votes = certificate_limits_and_votes(cert_type).1;
         match self {
             Self::DoubleVote {
                 signature,
                 bitmap0,
                 bitmap1,
             } => {
-                debug_assert_eq!(vote_types.len(), 2);
-                if vote_types.len() != 2 {
+                debug_assert_eq!(votes.len(), 2);
+                if votes.len() != 2 {
                     return Err(AggregateError::InvalidVoteTypes);
                 }
                 for msg in msgs {
-                    let vote_type = VoteType::get_type(&msg.vote);
-                    if vote_type == vote_types[0] {
+                    if msg.vote == votes[0] {
                         try_set_bitmap(bitmap0, msg.rank)?;
                     } else {
-                        debug_assert_eq!(vote_type, vote_types[1]);
-                        if vote_type != vote_types[1] {
+                        debug_assert_eq!(msg.vote, votes[1]);
+                        if msg.vote != votes[1] {
                             return Err(AggregateError::InvalidVoteTypes);
                         }
                         match bitmap1 {
@@ -180,14 +179,13 @@ impl BuilderType {
             }
 
             Self::SingleVote { signature, bitmap } => {
-                debug_assert_eq!(vote_types.len(), 1);
-                if vote_types.len() != 1 {
+                debug_assert_eq!(votes.len(), 1);
+                if votes.len() != 1 {
                     return Err(AggregateError::InvalidVoteTypes);
                 }
                 for msg in msgs {
-                    let vote_type = VoteType::get_type(&msg.vote);
-                    debug_assert_eq!(vote_type, vote_types[0]);
-                    if vote_type != vote_types[0] {
+                    debug_assert_eq!(msg.vote, votes[0]);
+                    if msg.vote != votes[0] {
                         return Err(AggregateError::InvalidVoteTypes);
                     }
                     try_set_bitmap(bitmap, msg.rank)?;


### PR DESCRIPTION
# The current certificate builder is stateful

In particular, in order to use the builder, the user has to first instantiate it (telling it which `CertificateType` it will build); then aggregate votes into it; and then finally build a `Certificate` from it.

## The problem with the stateful builder

### Multiple callers of `certificate_limits_and_vote_types`
Currently, the [consensus_pool](https://github.com/anza-xyz/agave/blob/944d47a112a3d1e426a18e133aaa777d452a973a/votor/src/consensus_pool.rs#L158) and the [certificate builder](https://github.com/anza-xyz/agave/blob/944d47a112a3d1e426a18e133aaa777d452a973a/votor/src/consensus_pool/certificate_builder.rs#L149) are both calling `certificate_limits_and_vote_types()`.  

[Here](https://github.com/anza-xyz/agave/pull/8781#discussion_r2482695232), we got feedback that this means that changes to `certificate_limits_and_vote_types` will require changes in multiple places which is not good.

This also requires the builder to repeat some of the checks that the consensus pool has already performed.  In particular, the consensus pool has already used `certificate_limits_and_vote_types` to deduce how many types of `Vote`s there will be for a given `CertType` and that logic is duplicated in the builder.

## Observation

The observation made is that the lifetime of the builder is within a single function: `update_certificates`.  So it seems like there is not obvious reason for the builder for store state as it is not a long living object.

## Proposed solution

This PR implements a stateless certificate builder.  Simpler than that, it implements a stateless signature aggregator and combines all the logic of what types of votes are needed to build what type of certificate in one place.

The certificate builder is replaced with a single function: 
```
fn build_sig_and_bitmap(votes: &[VoteMessage], fallback: Option<&[VoteMessage]>) -> Result<(BLSSignature, Vec<u8>), BuildError>;
```

The consensus pool is finally the only caller of `certificate_limits_and_vote_types` and the only place that contains the logic of how to build different types of certificates in the consensus pool.

Note that `certificate_limits_and_vote_types` is also updated to the following:
```
fn certificate_limits_and_votes(cert_type: &CertificateType) -> (f64, Vote, Option<Vote>);
```

i.e. for a given `CertType`, it now returns which main `Vote` and which optional fallback `Vote` will be needed to build the `Certificate`.

### Benefits
- We are using a single function to replace a stateful builder which seems a bit more straightforward to understand.  And based on the lines of change in the PR, also takes less code to implement.
- We are resolving the feedback we got previously about duplicated checks in consensus pool and certificate builder.  