### PR TITLE
blockstore: Remove slow test_purge_huge

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -89,10 +89,6 @@ filter = 'package(solana-cargo-build-sbf)'
 slow-timeout = { period = "60s", terminate-after = 5 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-ledger) & test(/^test_purge_huge$/)'
-slow-timeout = { period = "60s", terminate-after = 4 }
-
-[[profile.ci.overrides]]
 filter = 'package(solana-ledger) & test(/^shred::merkle::test::test_merkle_tree_round_trip/)'
 slow-timeout = { period = "60s", terminate-after = 3 }
 

--- a/ledger/tests/blockstore.rs
+++ b/ledger/tests/blockstore.rs
@@ -2,7 +2,7 @@ use {
     solana_entry::entry,
     solana_hash::Hash,
     solana_ledger::{
-        blockstore::{self, make_many_slot_entries, test_all_empty_or_min, Blockstore},
+        blockstore::{self, Blockstore},
         get_tmp_ledger_path_auto_delete,
     },
     std::{sync::Arc, thread::Builder},
@@ -45,16 +45,4 @@ fn test_multiple_threads_insert_shred() {
         // Delete slots for next iteration
         blockstore.purge_and_compact_slots(0, num_threads + 1);
     }
-}
-
-#[test]
-fn test_purge_huge() {
-    let ledger_path = get_tmp_ledger_path_auto_delete!();
-    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-
-    let (shreds, _) = make_many_slot_entries(0, 5000, 10);
-    blockstore.insert_shreds(shreds, None, false).unwrap();
-
-    blockstore.purge_and_compact_slots(0, 4999);
-    test_all_empty_or_min(&blockstore, 5000);
 }


### PR DESCRIPTION
#### Problem
<img width="1305" height="406" alt="image" src="https://github.com/user-attachments/assets/406ca98c-7003-4a2a-af33-8599dc0f797f" />

`test_purge_huge` is a slow test. We have the same correctness coverage with below test:
https://github.com/anza-xyz/agave/blob/bf93218979e244e13c5ac69c42100a6fb761ba07/ledger/src/blockstore/blockstore_purge.rs#L527-L551

So, the only "value" remaining for this test is as a "bench". CI isn't the right place for that as the results will be noisy from all the tests running in parallel. Additionally, we significantly optimized purge a while back (https://github.com/solana-labs/solana/pull/26651); it'd hypothetically be nice to have a guard to ensure we don't make it worse again but this CI test isn't that so this isn't a reason to hang onto the test either

#### Solution
Rip the test and give everyone their 2-3 minutes / CI run back