### PR TITLE
Fix typos in comments

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -505,7 +505,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
     ) -> Result<(), BucketMapError> {
         let num_slots = data_len as u64;
         let best_fit_bucket = MultipleSlots::data_bucket_from_num_slots(data_len as u64);
-        // num_slots > 1 becuase we can store num_slots = 0 or num_slots = 1 in the index entry
+        // num_slots > 1 because we can store num_slots = 0 or num_slots = 1 in the index entry
         let requires_data_bucket = num_slots > 1 || ref_count != 1;
         if requires_data_bucket && self.data.get(best_fit_bucket as usize).is_none() {
             // fail early if the data bucket we need doesn't exist - we don't want the index entry partially allocated

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -326,13 +326,13 @@ clone_trait_object!(BankingPacketHandler);
 /// This block-production struct is expected to be shared across the scheduler thread and its
 /// handler threads because all of them needs to handle task creation unlike block verification.
 ///
-/// Particularly, usage_queue_loader is desired to be shared across hanlders so that task creation
+/// Particularly, usage_queue_loader is desired to be shared across handlers so that task creation
 /// can be processed in the multi-threaded way. For more details, see
 /// solana_core::banking_stage::unified_scheduler module doc.
 #[derive(Debug)]
 pub struct BankingStageHelper {
     usage_queue_loader: UsageQueueLoaderInner,
-    // Supplemental identification for tasks of identical priority, alloted according to FIFO of
+    // Supplemental identification for tasks of identical priority, allotted according to FIFO of
     // batch granularity, resulting in the total order over the set of available tasks,
     // collectively.
     next_task_id: AtomicUsize,
@@ -345,7 +345,7 @@ pub struct BankingStageHelper {
 // Note that this concern is of theoretical matter. As such, we introduce rather a naive limit with
 // great safety margin, considering relatively frequent check interval (a single session, usually a
 // slot). Regardless the aforementioned interval precondition, it's exceedingly hard to conceive
-// task id is alloted more than half of usize. That's because we'd still need to be running for
+// task id is allotted more than half of usize. That's because we'd still need to be running for
 // almost 300 years continuously to index BANKING_STAGE_MAX_TASK_ID txs at the rate of
 // 1_000_000_000/secs ingestion.
 // For the completeness of discussion, the existence of this check will alleviate the concern of
@@ -1104,7 +1104,7 @@ impl TaskHandler for DefaultTaskHandler {
         };
         let transaction_indexes = match scheduling_context.mode() {
             BlockVerification => {
-                // Blcok verification's task_id should always be within usize.
+                // Block verification's task_id should always be within usize.
                 vec![task_id.try_into().unwrap()]
             }
             BlockProduction => {
@@ -1525,7 +1525,7 @@ fn disconnected<T>() -> Receiver<T> {
 /// Timeouts are for rare conditions where there are abandoned-yet-unpruned banks in the
 /// [`BankForks`](solana_runtime::bank_forks::BankForks) under forky (unsteady rooting) cluster
 /// conditions. The pool's background cleaner thread (`solScCleaner`) triggers the timeout-based
-/// out-of-pool (i.e. _taken_) scheduler reclaimation with prior coordination of
+/// out-of-pool (i.e. _taken_) scheduler reclamation with prior coordination of
 /// [`BankForks::insert()`](solana_runtime::bank_forks::BankForks::insert) via
 /// [`InstalledSchedulerPool::register_timeout_listener`].
 ///
@@ -1551,7 +1551,7 @@ fn disconnected<T>() -> Receiver<T> {
 ///         Aborted --> if_usable: Dropped (BankForks-pruning by solReplayStage)
 ///         if_usable --> Pooled: IF !overgrown && !aborted
 ///         Active --> Aborted: Errored on TX execution
-///         Aborted --> Stale: !Droppped after TIMEOUT_DURATION since taken
+///         Aborted --> Stale: !Dropped after TIMEOUT_DURATION since taken
 ///         Active --> Stale: No new TX after TIMEOUT_DURATION since taken
 ///         Stale --> if_usable: Returned (Timeout-triggered by solScCleaner)
 ///         Pooled --> Active: Taken (New bank by solReplayStage)

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -862,7 +862,7 @@ type KnownSnapshotHashes = HashMap<(Slot, Hash), HashSet<(Slot, Hash)>>;
 /// queried for their individual snapshot hashes, their results will be checked against this
 /// map to verify correctness.
 ///
-/// NOTE: Only a single snashot hash is allowed per slot.  If somehow two known validators have
+/// NOTE: Only a single snapshot hash is allowed per slot.  If somehow two known validators have
 /// a snapshot hash with the same slot and _different_ hashes, the second will be skipped.
 /// This applies to both full and incremental snapshot hashes.
 fn get_snapshot_hashes_from_known_validators(

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -157,7 +157,7 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     //
     // Additionally, only check the pid() RPC call result if it will be used.
     // In an upgrade scenario, it is possible that a binary that calls pid()
-    // will be initating exit against a process that doesn't support pid().
+    // will be initiating exit against a process that doesn't support pid().
     const WAIT_FOR_EXIT_UNSUPPORTED_ERROR: &str = "remote process exit cannot be waited on. \
                                                    `--wait-for-exit` is not supported by the \
                                                    remote process";


### PR DESCRIPTION

Multiple spelling errors exist in code comments across the codebase, reducing code readability and professionalism.

Fixed 8 spelling errors in comments:

  - `bucket_map/src/bucket.rs`: "becuase" → "because"
  - `unified-scheduler-pool/src/lib.rs`: "hanlders" → "handlers", "alloted" → "allotted" (3 instances), "Blcok" → "Block",
   "reclaimation" → "reclamation", "Droppped" → "Dropped"
  - `validator/src/bootstrap.rs`: "snashot" → "snapshot"
  - `validator/src/commands/exit/mod.rs`: "initating" → "initiating"