### PR TITLE
streamer: refactor config structs

### DIFF
--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -267,12 +267,14 @@ fn main() -> Result<()> {
                 max_connections_per_ipaddr_per_min: max_connections_per_ipaddr_per_min
                     .try_into()
                     .unwrap(),
+                ..Default::default()
+            };
+            let qos_config = SwQosConfig {
                 max_connections_per_unstaked_peer: max_connections_per_peer,
                 max_staked_connections: max_connections,
                 max_unstaked_connections: 0,
                 ..Default::default()
             };
-            let qos_config = SwQosConfig::default();
             let (s_reader, r_reader) = unbounded();
             read_channels.push(r_reader);
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -589,17 +589,18 @@ impl ValidatorTpuConfig {
         let tpu_fwd_quic_server_config = SwQosQuicStreamerConfig {
             quic_streamer_config: QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: 32,
+                ..Default::default()
+            },
+            qos_config: SwQosConfig {
                 max_unstaked_connections: 0,
                 ..Default::default()
             },
-            qos_config: SwQosConfig::default(),
         };
 
         // vote and tpu_fwd share the same characteristics -- disallow non-staked connections:
         let vote_quic_server_config = SimpleQosQuicStreamerConfig {
             quic_streamer_config: QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: 32,
-                max_unstaked_connections: 0,
                 ..Default::default()
             },
             qos_config: SimpleQosConfig::default(),

--- a/streamer/examples/swqos.rs
+++ b/streamer/examples/swqos.rs
@@ -68,8 +68,10 @@ pub fn load_staked_nodes_overrides(path: &String) -> anyhow::Result<HashMap<Pubk
 
 #[derive(Debug, Parser)]
 struct Cli {
-    #[arg(short, long, default_value_t = 1)]
-    max_connections_per_peer: usize,
+    #[arg(short, long, default_value_t = 10)]
+    max_connections_per_staked_peer: usize,
+    #[arg(short, long, default_value_t = 10)]
+    max_connections_per_unstaked_peer: usize,
 
     #[arg(short, long, default_value = "0.0.0.0:8008")]
     bind_to: SocketAddr,
@@ -120,10 +122,13 @@ async fn main() -> anyhow::Result<()> {
         sender,
         staked_nodes,
         QuicStreamerConfig {
-            max_connections_per_unstaked_peer: cli.max_connections_per_peer,
             ..QuicStreamerConfig::default()
         },
-        SwQosConfig::default(),
+        SwQosConfig {
+            max_connections_per_staked_peer: cli.max_connections_per_staked_peer,
+            max_connections_per_unstaked_peer: cli.max_connections_per_unstaked_peer,
+            ..Default::default()
+        },
         cancel.clone(),
     )?;
     info!("Server listening on {}", socket.local_addr()?);

--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -51,4 +51,9 @@ pub(crate) trait QosController<C: ConnectionContext> {
         context: &C,
         connection: Connection,
     ) -> impl Future<Output = usize> + Send;
+
+    /// How many concurrent
+    fn max_concurrent_connections(&self) -> usize;
 }
+
+pub trait QosConfig {}

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -157,7 +157,7 @@ where
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    let max_concurrent_connections = quic_server_params.max_concurrent_connections();
+    let max_concurrent_connections = qos.max_concurrent_connections();
     let handle = tokio::spawn({
         let endpoints = endpoints.clone();
         let stats = stats.clone();
@@ -334,10 +334,9 @@ where
                 continue;
             }
 
-            let Ok(client_connection_tracker) = ClientConnectionTracker::new(
-                stats.clone(),
-                quic_server_params.max_concurrent_connections(),
-            ) else {
+            let Ok(client_connection_tracker) =
+                ClientConnectionTracker::new(stats.clone(), qos.max_concurrent_connections())
+            else {
                 stats
                     .refused_connections_too_many_open_connections
                     .fetch_add(1, Ordering::Relaxed);
@@ -1351,7 +1350,7 @@ pub mod test {
         } = setup_quic_server(
             None,
             QuicStreamerConfig::default_for_tests(),
-            SwQosConfig::default(),
+            SwQosConfig::default_for_tests(),
         );
         check_block_multiple_connections(server_address).await;
         cancel.cancel();
@@ -1372,10 +1371,12 @@ pub mod test {
         } = setup_quic_server(
             None,
             QuicStreamerConfig {
-                max_connections_per_unstaked_peer: 2,
                 ..QuicStreamerConfig::default_for_tests()
             },
-            SwQosConfig::default(),
+            SwQosConfig {
+                max_connections_per_unstaked_peer: 2,
+                ..SwQosConfig::default_for_tests()
+            },
         );
 
         let client_socket = bind_to_localhost_unique().expect("should bind - client");
@@ -1582,10 +1583,12 @@ pub mod test {
             sender,
             staked_nodes,
             QuicStreamerConfig {
-                max_unstaked_connections: 0, // Do not allow any connection from unstaked clients/nodes
                 ..QuicStreamerConfig::default_for_tests()
             },
-            SwQosConfig::default(),
+            SwQosConfig {
+                max_unstaked_connections: 0, // Do not allow any connection from unstaked clients/nodes
+                ..Default::default()
+            },
             cancel.clone(),
         )
         .unwrap();
@@ -1616,10 +1619,12 @@ pub mod test {
             sender,
             staked_nodes,
             QuicStreamerConfig {
-                max_connections_per_unstaked_peer: 2,
                 ..QuicStreamerConfig::default_for_tests()
             },
-            SwQosConfig::default(),
+            SwQosConfig {
+                max_connections_per_unstaked_peer: 2,
+                ..Default::default()
+            },
             cancel.clone(),
         )
         .unwrap();

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -48,10 +48,6 @@ where
 
     let swqos = Arc::new(SwQos::new(
         qos_config,
-        quic_server_params.max_staked_connections,
-        quic_server_params.max_unstaked_connections,
-        quic_server_params.max_connections_per_staked_peer,
-        quic_server_params.max_connections_per_unstaked_peer,
         stats.clone(),
         staked_nodes,
         cancel.clone(),

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -310,13 +310,13 @@ async fn test_connection_denied_until_allowed() {
         cancel,
     } = setup_quic_server(
         None,
-        QuicStreamerConfig {
+        QuicStreamerConfig::default_for_tests(),
+        SwQosConfig {
             // To prevent server from accepting a new connection, we
             // set max_connections_per_peer == 1
             max_connections_per_unstaked_peer: 1,
-            ..QuicStreamerConfig::default_for_tests()
+            ..Default::default()
         },
-        SwQosConfig::default(),
     );
 
     // If we create a blocking connection and try to create connections to send TXs,
@@ -386,11 +386,13 @@ async fn test_connection_pruned_and_reopened() {
     } = setup_quic_server(
         None,
         QuicStreamerConfig {
-            max_connections_per_unstaked_peer: 100,
-            max_unstaked_connections: 1,
             ..QuicStreamerConfig::default_for_tests()
         },
-        SwQosConfig::default(),
+        SwQosConfig {
+            max_connections_per_unstaked_peer: 100,
+            max_unstaked_connections: 1,
+            ..Default::default()
+        },
     );
 
     // Setup sending txs
@@ -443,14 +445,16 @@ async fn test_staked_connection() {
     } = setup_quic_server(
         Some(staked_nodes),
         QuicStreamerConfig {
+            ..QuicStreamerConfig::default()
+        },
+        SwQosConfig {
             // Must use at least the number of endpoints (10) because
             // `max_staked_connections` and `max_unstaked_connections` are
             // cumulative for all the endpoints.
             max_staked_connections: 10,
             max_unstaked_connections: 0,
-            ..QuicStreamerConfig::default_for_tests()
+            ..Default::default()
         },
-        SwQosConfig::default(),
     );
 
     // Setup sending txs
@@ -594,11 +598,13 @@ async fn test_rate_limiting() {
     } = setup_quic_server(
         None,
         QuicStreamerConfig {
-            max_connections_per_unstaked_peer: 100,
             max_connections_per_ipaddr_per_min: 1,
             ..QuicStreamerConfig::default_for_tests()
         },
-        SwQosConfig::default(),
+        SwQosConfig {
+            max_connections_per_unstaked_peer: 100,
+            ..Default::default()
+        },
     );
 
     // open a connection to consume the limit
@@ -656,11 +662,13 @@ async fn test_rate_limiting_establish_connection() {
     } = setup_quic_server(
         None,
         QuicStreamerConfig {
-            max_connections_per_unstaked_peer: 100,
             max_connections_per_ipaddr_per_min: 1,
             ..QuicStreamerConfig::default_for_tests()
         },
-        SwQosConfig::default(),
+        SwQosConfig {
+            max_connections_per_unstaked_peer: 100,
+            ..Default::default()
+        },
     );
 
     let connection_to_reach_limit = make_client_endpoint(&server_address, None).await;
@@ -738,15 +746,17 @@ async fn test_update_identity() {
     } = setup_quic_server(
         Some(staked_nodes),
         QuicStreamerConfig {
+            ..QuicStreamerConfig::default_for_tests()
+        },
+        SwQosConfig {
             // Must use at least the number of endpoints (10) because
             // `max_staked_connections` and `max_unstaked_connections` are
             // cumulative for all the endpoints.
             max_staked_connections: 10,
             // Deny all unstaked connections.
             max_unstaked_connections: 0,
-            ..QuicStreamerConfig::default_for_tests()
+            ..Default::default()
         },
-        SwQosConfig::default(),
     );
 
     // Setup sending txs
@@ -802,11 +812,13 @@ async fn test_proactive_connection_close_detection() {
     } = setup_quic_server(
         None,
         QuicStreamerConfig {
-            max_connections_per_unstaked_peer: 1,
-            max_unstaked_connections: 1,
             ..QuicStreamerConfig::default_for_tests()
         },
-        SwQosConfig::default(),
+        SwQosConfig {
+            max_connections_per_unstaked_peer: 1,
+            max_unstaked_connections: 1,
+            ..Default::default()
+        },
     );
 
     // Setup controlled transaction sending

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -958,6 +958,11 @@ pub fn execute(
 
     let tpu_quic_server_config = SwQosQuicStreamerConfig {
         quic_streamer_config: QuicStreamerConfig {
+            max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
+            num_threads: tpu_transaction_receive_threads,
+            ..Default::default()
+        },
+        qos_config: SwQosConfig {
             max_connections_per_unstaked_peer: tpu_max_connections_per_unstaked_peer
                 .try_into()
                 .unwrap(),
@@ -966,15 +971,17 @@ pub fn execute(
                 .unwrap(),
             max_staked_connections: tpu_max_staked_connections.try_into().unwrap(),
             max_unstaked_connections: tpu_max_unstaked_connections.try_into().unwrap(),
-            max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
-            num_threads: tpu_transaction_receive_threads,
-            ..Default::default()
+            max_streams_per_ms,
         },
-        qos_config: SwQosConfig { max_streams_per_ms },
     };
 
     let tpu_fwd_quic_server_config = SwQosQuicStreamerConfig {
         quic_streamer_config: QuicStreamerConfig {
+            max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
+            num_threads: tpu_transaction_forward_receive_threads,
+            ..Default::default()
+        },
+        qos_config: SwQosConfig {
             max_connections_per_staked_peer: tpu_max_connections_per_staked_peer
                 .try_into()
                 .unwrap(),
@@ -983,23 +990,19 @@ pub fn execute(
                 .unwrap(),
             max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
             max_unstaked_connections: tpu_max_fwd_unstaked_connections.try_into().unwrap(),
-            max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
-            num_threads: tpu_transaction_forward_receive_threads,
-            ..Default::default()
+            max_streams_per_ms,
         },
-        qos_config: SwQosConfig { max_streams_per_ms },
     };
 
     let vote_quic_server_config = SimpleQosQuicStreamerConfig {
         quic_streamer_config: QuicStreamerConfig {
-            max_connections_per_unstaked_peer: 1,
-            max_staked_connections: tpu_max_fwd_staked_connections.try_into().unwrap(),
             max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
             num_threads: tpu_vote_transaction_receive_threads,
             ..Default::default()
         },
         qos_config: SimpleQosConfig {
             max_streams_per_second: MAX_VOTES_PER_SECOND,
+            ..Default::default()
         },
     };
 


### PR DESCRIPTION
#### Problem

- Streamer config structs are a bit messy.
- Parameters that are only useful for SWQOS ended up in the struct that was used for both QOS modes
- Config parameters were splatted in the QoS modules complicating further modifications
- Current organization blocks https://github.com/anza-xyz/agave/pull/8880

#### Summary of Changes

- Organize the config structs for TPU QoS
- This PR does not introduce any functional changes
