### PR TITLE
rpc-test: migrate test_rpc_subscriptions from UDP to QUIC using tpu-client-next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10349,6 +10349,7 @@ name = "solana-rpc-test"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-logger",
+ "async-trait",
  "bincode",
  "bs58",
  "crossbeam-channel",
@@ -10376,6 +10377,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-test-validator",
  "solana-tpu-client",
+ "solana-tpu-client-next",
  "solana-transaction",
  "solana-transaction-status",
  "tokio",

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -17,6 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 
 [dependencies]
+async-trait = { workspace = true }
 bincode = { workspace = true }
 bs58 = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -34,6 +35,7 @@ solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-test-validator = { workspace = true }
 solana-tpu-client = { workspace = true }
+solana-tpu-client-next = { workspace = true }
 solana-transaction-status = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -805,6 +805,7 @@ pub struct TestValidator {
     rpc_pubsub_url: String,
     rpc_url: String,
     tpu: SocketAddr,
+    tpu_quic: SocketAddr,
     gossip: SocketAddr,
     validator: Option<Validator>,
     vote_account_address: Pubkey,
@@ -1158,6 +1159,7 @@ impl TestValidator {
         let rpc_url = format!("http://{}", node.info.rpc().unwrap());
         let rpc_pubsub_url = format!("ws://{}/", node.info.rpc_pubsub().unwrap());
         let tpu = node.info.tpu(Protocol::UDP).unwrap();
+        let tpu_quic = node.info.tpu(Protocol::QUIC).unwrap_or(tpu);
         let gossip = node.info.gossip().unwrap();
 
         {
@@ -1260,6 +1262,7 @@ impl TestValidator {
             rpc_pubsub_url,
             rpc_url,
             tpu,
+            tpu_quic,
             gossip,
             validator,
             vote_account_address,
@@ -1393,6 +1396,11 @@ impl TestValidator {
     /// Return the validator's TPU address
     pub fn tpu(&self) -> &SocketAddr {
         &self.tpu
+    }
+
+    /// Return the validator's TPU QUIC address
+    pub fn tpu_quic(&self) -> &SocketAddr {
+        &self.tpu_quic
     }
 
     /// Return the validator's Gossip address


### PR DESCRIPTION
#### Problem

Two RPC tests in rpc-test/ rely on the deprecated UDP TPU path: `test_rpc_subscriptions` and `test_run_tpu_send_transaction`.

#### Summary of Changes

* Migrated `test_rpc_subscriptions` from UDP socket to QUIC using tpu-client-next
* Removed `test_tpu_send_transaction` test for UDP
* Updated `test_tpu_send_transaction` test to use tpu-client-next instead of ConnectionCache
* Updated `TestValidator` from `with_no_fees_udp()` to `with_no_fees()` (QUIC-based)

  Fixes #9091