### PR TITLE
ledger-tool: allow overriding heap frame size on `program run`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -190,7 +190,7 @@ pub struct InvokeContext<'a, 'ix_data> {
     /// Runtime configurations used to provision the invocation environment.
     pub environment_config: EnvironmentConfig<'a>,
     /// The compute budget for the current invocation.
-    compute_budget: SVMTransactionExecutionBudget,
+    pub compute_budget: SVMTransactionExecutionBudget,
     /// The compute cost for the current invocation.
     execution_cost: SVMTransactionExecutionCost,
     /// Instruction compute meter, for tracking compute units consumed against


### PR DESCRIPTION
#### Problem

The accepted `--memory` option on `agave-ledger-tool program run` subcommand is not respected.

#### Summary of Changes

This commit makes `InvokeContext.compute_budget` field public. As the `ComputeBudget` struct is `Clone + Copy`, I believe this change does not break any current usage. For backwards compatibility, `InvokeContext::get_compute_budget` is preserved.

Then, right after creating mock invoke_context on `program.rs`, compute_budget.heap_size arg is updated when specified.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
