### PR TITLE
remove connection-cache for TPU txs from validator

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -10,7 +10,7 @@ use {
     solana_keypair::{read_keypair_file, Keypair},
     solana_pubkey::Pubkey,
     solana_streamer::quic::DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-    solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC},
+    solana_tpu_client::tpu_client::DEFAULT_TPU_CONNECTION_POOL_SIZE,
     std::{
         net::{IpAddr, Ipv4Addr},
         time::Duration,
@@ -65,7 +65,6 @@ pub struct Config {
     pub num_lamports_per_account: u64,
     pub target_slots_per_epoch: u64,
     pub external_client_type: ExternalClientType,
-    pub use_quic: bool,
     pub tpu_connection_pool_size: usize,
     pub tpu_max_connections_per_ipaddr_per_minute: u64,
     pub compute_unit_price: Option<ComputeUnitPrice>,
@@ -101,7 +100,6 @@ impl Default for Config {
             num_lamports_per_account: NUM_LAMPORTS_PER_ACCOUNT_DEFAULT,
             target_slots_per_epoch: 0,
             external_client_type: ExternalClientType::default(),
-            use_quic: DEFAULT_TPU_USE_QUIC,
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
             tpu_max_connections_per_ipaddr_per_minute:
                 DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
@@ -283,15 +281,6 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .help("Submit transactions with a TpuClient"),
         )
         .arg(
-            Arg::with_name("tpu_disable_quic")
-                .long("tpu-disable-quic")
-                .takes_value(false)
-                .help(
-                    "DEPRECATED: Do not submit transactions via QUIC; only affects TpuClient \
-                     (default) sends",
-                ),
-        )
-        .arg(
             Arg::with_name("tpu_connection_pool_size")
                 .long("tpu-connection-pool-size")
                 .takes_value(true)
@@ -446,11 +435,6 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
 
     if matches.is_present("rpc_client") {
         args.external_client_type = ExternalClientType::RpcClient;
-    }
-
-    if matches.is_present("tpu_disable_quic") {
-        eprintln!("Warning: TPU over UDP is deprecated");
-        args.use_quic = false;
     }
 
     if let Some(v) = matches.value_of("tpu_connection_pool_size") {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -76,17 +76,10 @@ fn find_node_activated_stake(
 fn create_connection_cache(
     json_rpc_url: &str,
     tpu_connection_pool_size: usize,
-    use_quic: bool,
     bind_address: IpAddr,
     client_node_id: Option<&Keypair>,
     commitment_config: CommitmentConfig,
 ) -> ConnectionCache {
-    if !use_quic {
-        return ConnectionCache::with_udp(
-            "bench-tps-connection_cache_udp",
-            tpu_connection_pool_size,
-        );
-    }
     if client_node_id.is_none() {
         return ConnectionCache::new_quic(
             "bench-tps-connection_cache_quic",
@@ -193,7 +186,6 @@ fn main() {
         target_lamports_per_signature,
         num_lamports_per_account,
         external_client_type,
-        use_quic,
         tpu_connection_pool_size,
         skip_tx_account_data_size,
         compute_unit_price,
@@ -240,7 +232,6 @@ fn main() {
     let connection_cache = create_connection_cache(
         json_rpc_url,
         *tpu_connection_pool_size,
-        *use_quic,
         *bind_address,
         client_node_id.as_ref(),
         *commitment_config,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -160,7 +160,6 @@ impl Tvu {
         wait_to_vote_slot: Option<Slot>,
         snapshot_controller: Option<Arc<SnapshotController>>,
         log_messages_bytes_limit: Option<usize>,
-        connection_cache: Option<&Arc<ConnectionCache>>,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         banking_tracer: Arc<BankingTracer>,
         turbine_quic_endpoint_sender: AsyncSender<(SocketAddr, Bytes)>,
@@ -361,7 +360,7 @@ impl Tvu {
         );
 
         let warm_quic_cache_service = create_cache_warmer_if_needed(
-            connection_cache,
+            None,
             vote_connection_cache,
             cluster_info,
             poh_recorder,
@@ -603,7 +602,6 @@ pub mod tests {
             None,
             None, // snapshot_controller
             None,
-            Some(&Arc::new(ConnectionCache::new("connection_cache_test"))),
             &ignored_prioritization_fee_cache,
             BankingTracer::new_disabled(),
             turbine_quic_endpoint_sender,

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -80,7 +80,6 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         replay_transactions_threads: config.replay_transactions_threads,
         tvu_shred_sigverify_threads: config.tvu_shred_sigverify_threads,
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
-        use_tpu_client_next: config.use_tpu_client_next,
         retransmit_xdp: config.retransmit_xdp.clone(),
         repair_handler_type: config.repair_handler_type.clone(),
     }

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -26,7 +26,6 @@ use {
 };
 
 pub const DEFAULT_TPU_ENABLE_UDP: bool = false;
-pub const DEFAULT_TPU_USE_QUIC: bool = true;
 pub const DEFAULT_VOTE_USE_QUIC: bool = false;
 
 /// The default connection count is set to 1 -- it should

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1299,15 +1299,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .requires("retransmit_xdp_cpu_cores")
             .help("EXPERIMENTAL: Enable XDP zero copy. Requires hardware support"),
     )
-    .arg(
-        Arg::with_name("use_connection_cache")
-            .long("use-connection-cache")
-            .takes_value(false)
-            .help(
-                "Use connection-cache crate to send transactions over TPU ports. If not \
-                 set,tpu-client-next is used by default.",
-            ),
-    )
     .args(&pub_sub_config::args(/*test_validator:*/ false))
     .args(&json_rpc_config::args())
     .args(&rpc_bigtable_config::args())

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -213,10 +213,6 @@ pub fn execute(
     if bind_addresses.len() > 1 {
         for (flag, msg) in [
             (
-                "use_connection_cache",
-                "Connection cache can not be used in a multihoming context",
-            ),
-            (
                 "advertised_ip",
                 "--advertised-ip cannot be used in a multihoming context. In multihoming, the \
                  validator will advertise the first --bind-address as this node's public IP \
@@ -587,7 +583,6 @@ pub fn execute(
         turbine_disabled: Arc::<AtomicBool>::default(),
         retransmit_xdp,
         broadcast_stage_type: BroadcastStageType::Standard,
-        use_tpu_client_next: !matches.is_present("use_connection_cache"),
         block_verification_method: value_t_or_exit!(
             matches,
             "block_verification_method",
@@ -998,7 +993,6 @@ pub fn execute(
         start_progress,
         run_args.socket_addr_space,
         ValidatorTpuConfig {
-            use_quic: true,
             vote_use_quic,
             tpu_connection_pool_size,
             tpu_enable_udp,


### PR DESCRIPTION
#### Problem

Since UDP is no longer needed for TPU, we are free to remove also `ConnectionCache` support for TPU from validator.
Note that I need to also remove wrapper code from `SendTransactionService` and `ForwardingStage` which will be done [in a separate PR ](https://github.com/anza-xyz/agave/pull/9102) because otherwise might be hard to review.

#### Summary of Changes

Removes legacy code.