### PR TITLE
Expose bp unified scheduler to agave-validator cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11829,6 +11829,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "solana-unified-scheduler-logic",
+ "solana-unified-scheduler-pool",
  "static_assertions",
  "test-case",
  "trait-set",

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -456,7 +456,7 @@ fn main() {
         tpu_vote_receiver,
         gossip_vote_sender,
         gossip_vote_receiver,
-    } = banking_tracer.create_channels(false);
+    } = banking_tracer.create_channels();
     let banking_stage = BankingStage::new_num_threads(
         block_production_method,
         poh_recorder.clone(),

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -163,7 +163,7 @@ fn bench_banking(
         tpu_vote_receiver,
         gossip_vote_sender,
         gossip_vote_receiver,
-    } = banking_tracer.create_channels(false);
+    } = banking_tracer.create_channels();
 
     let mut bank = Bank::new_for_benches(&genesis_config);
     // Allow arbitrary transaction processing time for the purposes of this bench

--- a/core/benches/banking_trace.rs
+++ b/core/benches/banking_trace.rs
@@ -40,7 +40,7 @@ fn bench_banking_tracer_main_thread_overhead_noop_baseline(bencher: &mut Bencher
         non_vote_sender,
         non_vote_receiver,
         ..
-    } = tracer.create_channels(false);
+    } = tracer.create_channels();
 
     let exit_for_dummy_thread = exit.clone();
     let dummy_main_thread = thread::spawn(move || {
@@ -73,7 +73,7 @@ fn bench_banking_tracer_main_thread_overhead_under_peak_write(bencher: &mut Benc
         non_vote_sender,
         non_vote_receiver,
         ..
-    } = tracer.create_channels(false);
+    } = tracer.create_channels();
 
     let exit_for_dummy_thread = exit.clone();
     let dummy_main_thread = thread::spawn(move || {
@@ -114,7 +114,7 @@ fn bench_banking_tracer_main_thread_overhead_under_sustained_write(bencher: &mut
         non_vote_sender,
         non_vote_receiver,
         ..
-    } = tracer.create_channels(false);
+    } = tracer.create_channels();
 
     let exit_for_dummy_thread = exit.clone();
     let dummy_main_thread = thread::spawn(move || {
@@ -159,7 +159,7 @@ fn bench_banking_tracer_background_thread_throughput(bencher: &mut Bencher) {
             non_vote_sender,
             non_vote_receiver,
             ..
-        } = tracer.create_channels(false);
+        } = tracer.create_channels();
 
         let dummy_main_thread = thread::spawn(move || {
             receiving_loop_with_minimized_sender_overhead::<_, TraceError, 0>(

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -791,7 +791,7 @@ impl BankingSimulator {
             tpu_vote_receiver,
             gossip_vote_sender,
             gossip_vote_receiver,
-        } = retracer.create_channels(false);
+        } = retracer.create_channels();
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -725,7 +725,7 @@ mod external {
             }: AgaveSession,
         ) -> Vec<JoinHandle<()>> {
             info!("Spawning external scheduler");
-            // Togging unified scheduler into the disabled state should always be a safe and
+            // Toggling unified scheduler into the disabled state should always be a safe and
             // idempotent operation.
             assert!(self.toggle_internal_unified(false));
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -725,6 +725,10 @@ mod external {
             }: AgaveSession,
         ) -> Vec<JoinHandle<()>> {
             info!("Spawning external scheduler");
+            // Togging unified scheduler into the disabled state should always be a safe and
+            // idempotent operation.
+            assert!(self.toggle_internal_unified(false));
+
             static_assertions::const_assert!(
                 agave_scheduling_utils::handshake::MAX_WORKERS
                     == BankingStage::max_num_workers().get()

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -543,7 +543,7 @@ impl BankingStage {
         scheduler_config: SchedulerConfig,
     ) -> Result<Vec<JoinHandle<()>>, ()> {
         info!("Spawning internal central scheduler");
-        // Togging unified scheduler into the disabled state should always be a safe and idempotent
+        // Toggling unified scheduler into the disabled state should always be a safe and idempotent
         // operation.
         assert!(self.toggle_internal_unified(false));
 

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -74,7 +74,7 @@ pub(crate) fn ensure_banking_stage_setup(
     }
 
     let sharable_banks = bank_forks.read().unwrap().sharable_banks();
-    let unified_receiver = channels.unified_receiver().clone();
+    let banking_packet_receiver = channels.receiver_for_unified_scheduler().clone();
 
     let (is_exited, decision_maker) = {
         let poh_recorder = poh_recorder.read().unwrap();
@@ -85,7 +85,7 @@ pub(crate) fn ensure_banking_stage_setup(
     };
 
     let banking_stage_monitor = Box::new(DecisionMakerWrapper::new(
-        channels.is_unified().clone(),
+        channels.clone_is_unified_for_unified_scheduler(),
         is_exited,
         decision_maker.clone(),
     ));
@@ -156,7 +156,7 @@ pub(crate) fn ensure_banking_stage_setup(
 
     pool.register_banking_stage(
         Some(num_threads.get()),
-        unified_receiver,
+        banking_packet_receiver,
         banking_packet_handler,
         transaction_recorder,
         banking_stage_monitor,

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -115,8 +115,6 @@ pub(crate) fn ensure_banking_stage_setup(
                     )
                     .ok()?;
 
-                    // WARN: Ignoring deactivation slot here can lead to the production of invalid
-                    // blocks. Currently, this code is not used in prod.
                     let (loaded_addresses, deactivation_slot) =
                         resolve_addresses_with_deactivation(&tx, &bank).ok()?;
                     let tx = RuntimeTransaction::<SanitizedTransaction>::try_from(

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -340,24 +340,6 @@ impl BankingTracer {
         let unified_sender = unified_sender.unwrap_or_else(|| sender.clone());
         let is_unified = is_unified.unwrap_or_default();
 
-        Self::channel_inner(
-            label,
-            active_tracer,
-            sender,
-            unified_sender,
-            is_unified,
-            receiver,
-        )
-    }
-
-    fn channel_inner(
-        label: ChannelLabel,
-        active_tracer: Option<ActiveTracer>,
-        sender: Sender<BankingPacketBatch>,
-        unified_sender: Sender<BankingPacketBatch>,
-        is_unified: Arc<AtomicBool>,
-        receiver: BankingPacketReceiver,
-    ) -> (TracedSender, Receiver<BankingPacketBatch>) {
         (
             TracedSender::new(label, sender, unified_sender, is_unified, active_tracer),
             receiver,

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -401,10 +401,11 @@ impl BankingTracer {
 }
 
 /// A small wrapper around the sender of crossbeam channels to message banking packet batches.
-/// These channels are used by the banking stage to receive packets from multiple sources. The
-/// sources are labelled as non-vote, tpu-vote, and gossip-vote respectively. And, traced senders
-/// are separately constructed for each of these sources are all grouped under the `Channels`
-/// struct transiently during setup.
+///
+/// The underlying channels are used by the banking stage to receive packets from multiple sources.
+/// The sources are labelled as non-vote, tpu-vote, and gossip-vote respectively. As such, traced
+/// senders are separately constructed for each of these sources, then all are grouped under the
+/// `Channels` struct transiently during setup.
 ///
 /// This wrapper exists to enable the banking trace functionality conditionally on creation.
 ///

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -466,7 +466,7 @@ impl TracedSender {
         // by privileged validator operators. Reasonably, they won't do this during their leader
         // slots, even if they're unaware of this implementation compromise.
         //
-        // As a extra comment, those possibly quite old txes in the unconsumed batches should
+        // As an extra comment, those possibly quite old txes in the unconsumed batches should
         // safely be discarded by the central scheduler, because it should be resilient against any
         // untrusted input by nature, should the block production method be switched back to the
         // central scheduler.

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -83,8 +83,9 @@ fn test_scheduler_waited_by_drop_bank_service() {
     // Setup bankforks with unified scheduler enabled
     let genesis_bank = Bank::new_for_tests(&genesis_config);
     let bank_forks = BankForks::new_rw_arc(genesis_bank);
-    let pool_raw =
-        SchedulerPool::<PooledScheduler<StallingHandler>, _>::new(None, None, None, None, None);
+    let pool_raw = SchedulerPool::<PooledScheduler<StallingHandler>, _>::new_for_verification(
+        None, None, None, None, None,
+    );
     let pool = pool_raw.clone();
     bank_forks.write().unwrap().install_scheduler_pool(pool);
     let genesis = 0;
@@ -228,10 +229,10 @@ fn test_scheduler_producing_blocks() {
         None,
         Some(leader_schedule_cache),
     );
-    let pool = DefaultSchedulerPool::new(None, None, None, None, None);
+    let pool = DefaultSchedulerPool::new_for_production(None, None, None, None, None);
     let channels = {
         let banking_tracer = BankingTracer::new_disabled();
-        banking_tracer.create_channels(true)
+        banking_tracer.create_channels()
     };
     ensure_banking_stage_setup(
         &pool,

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -274,7 +274,7 @@ fn test_scheduler_producing_blocks() {
 
     // Now, send transaction
     channels
-        .unified_sender()
+        .sender_for_unified_scheduler()
         .send(banking_packet_batch)
         .unwrap();
 

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -88,7 +88,7 @@ solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-context = { workspace = true }
 solana-transaction-status = { workspace = true }
-solana-unified-scheduler-pool = { workspace = true }
+solana-unified-scheduler-pool = { workspace = true, features = ["dev-context-only-utils"] }
 solana-version = { workspace = true }
 solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -40,7 +40,7 @@ use {
         snapshot_utils::{self, clean_orphaned_account_snapshot_dirs},
     },
     solana_transaction::versioned::VersionedTransaction,
-    solana_unified_scheduler_pool::DefaultSchedulerPool,
+    solana_unified_scheduler_pool::{DefaultSchedulerPool, SupportedSchedulingMode},
     std::{
         path::{Path, PathBuf},
         process::exit,
@@ -370,7 +370,8 @@ pub fn load_and_process_ledger(
             bank_forks
                 .write()
                 .unwrap()
-                .install_scheduler_pool(DefaultSchedulerPool::new_dyn(
+                .install_scheduler_pool(DefaultSchedulerPool::new(
+                    SupportedSchedulingMode::with_verification(),
                     unified_scheduler_handler_threads,
                     process_options.runtime_config.log_messages_bytes_limit,
                     transaction_status_sender.clone(),

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -315,7 +315,9 @@ impl BankForks {
         bank: Arc<Bank>,
     ) -> BankWithScheduler {
         let context = SchedulingContext::new_with_mode(mode, bank.clone());
-        let scheduler = scheduler_pool.take_scheduler(context);
+        let Some(scheduler) = scheduler_pool.take_scheduler(context) else {
+            return BankWithScheduler::new_without_scheduler(bank);
+        };
         let bank_with_scheduler = BankWithScheduler::new(bank, Some(scheduler));
         // Skip registering for block production. Both the tvu main loop in the replay stage
         // and PohRecorder don't support _concurrent block production_ at all. It's strongly
@@ -325,6 +327,22 @@ impl BankForks {
             scheduler_pool.register_timeout_listener(bank_with_scheduler.create_timeout_listener());
         }
         bank_with_scheduler
+    }
+
+    #[must_use]
+    pub fn toggle_unified_scheduler_block_production_mode(&self, enable: bool) -> bool {
+        if let Some(scheduler_pool) = &self.scheduler_pool {
+            scheduler_pool.toggle_block_production_mode(enable)
+        } else {
+            // unified scheduler pool isn't installed to begin with
+            if enable {
+                // Should fail when enabling
+                false
+            } else {
+                // Should succeed when disabling
+                true
+            }
+        }
     }
 
     pub fn insert_from_ledger(&mut self, bank: Bank) -> BankWithScheduler {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -334,14 +334,7 @@ impl BankForks {
         if let Some(scheduler_pool) = &self.scheduler_pool {
             scheduler_pool.toggle_block_production_mode(enable)
         } else {
-            // unified scheduler pool isn't installed to begin with
-            if enable {
-                // Should fail when enabling
-                false
-            } else {
-                // Should succeed when disabling
-                true
-            }
+            !enable
         }
     }
 

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -52,4 +52,6 @@ solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-system-transaction = { workspace = true }
+# See order-crates-for-publishing.py for using this unusual `path = "."`
+solana-unified-scheduler-pool = { path = ".", features = ["dev-context-only-utils"] }
 test-case = { workspace = true }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -21,8 +21,6 @@
 //! Refer to [`PooledScheduler`] doc comment for general overview of scheduler state transitions
 //! regarding to pooling and the actual use.
 
-#[cfg(feature = "dev-context-only-utils")]
-use qualifier_attr::qualifiers;
 use {
     agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
     assert_matches::assert_matches,
@@ -45,9 +43,9 @@ use {
     solana_runtime::{
         installed_scheduler_pool::{
             initialized_result_with_timings, InstalledScheduler, InstalledSchedulerBox,
-            InstalledSchedulerPool, InstalledSchedulerPoolArc, ResultWithTimings, ScheduleResult,
-            SchedulerAborted, SchedulerId, SchedulingContext, TimeoutListener,
-            UninstalledScheduler, UninstalledSchedulerBox,
+            InstalledSchedulerPool, ResultWithTimings, ScheduleResult, SchedulerAborted,
+            SchedulerId, SchedulingContext, TimeoutListener, UninstalledScheduler,
+            UninstalledSchedulerBox,
         },
         prioritization_fee_cache::PrioritizationFeeCache,
         vote_sender_types::ReplayVoteSender,
@@ -111,6 +109,32 @@ enum CheckPoint<'a> {
 type CountOrDefault = Option<usize>;
 type AtomicSchedulerId = AtomicU64;
 
+#[derive(Debug)]
+pub enum SupportedSchedulingMode {
+    Either(SchedulingMode),
+    Both,
+}
+
+impl SupportedSchedulingMode {
+    fn is_supported(&self, requested_mode: SchedulingMode) -> bool {
+        match (self, requested_mode) {
+            (Self::Both, _requested) => true,
+            (Self::Either(ref supported), ref requested) if supported == requested => true,
+            _ => false,
+        }
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn with_verification() -> Self {
+        Self::Either(BlockVerification)
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    fn with_production() -> Self {
+        Self::Either(BlockProduction)
+    }
+}
+
 /// A pool of idling schedulers (usually [`PooledScheduler`]), ready to be taken by bank.
 ///
 /// Also, the pool runs a _cleaner_ thread named as `solScCleaner`. its jobs include:
@@ -127,6 +151,7 @@ type AtomicSchedulerId = AtomicU64;
 /// explanation of this rather complex dyn trait/type hierarchy.
 #[derive(Debug)]
 pub struct SchedulerPool<S: SpawnableScheduler<TH>, TH: TaskHandler> {
+    supported_scheduling_mode: SupportedSchedulingMode,
     scheduler_inners: Mutex<Vec<(S::Inner, Instant)>>,
     block_production_scheduler_inner: Mutex<BlockProductionSchedulerInner<S, TH>>,
     trashed_scheduler_inners: Mutex<Vec<S::Inner>>,
@@ -204,6 +229,13 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> BlockProductionSchedulerInner<S
         match self {
             Self::NotSpawned | Self::Taken(_) => None,
             Self::Pooled(inner) => Some(inner),
+        }
+    }
+
+    fn is_not_spawned(&self) -> bool {
+        match self {
+            Self::NotSpawned => true,
+            Self::Pooled(_) | Self::Taken(_) => false,
         }
     }
 
@@ -461,10 +493,8 @@ where
     S: SpawnableScheduler<TH>,
     TH: TaskHandler,
 {
-    // Some internal impl and test code want an actual concrete type, NOT the
-    // `dyn InstalledSchedulerPool`. So don't merge this into `Self::new_dyn()`.
-    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-    fn new(
+    pub fn new(
+        supported_scheduling_mode: SupportedSchedulingMode,
         block_verification_handler_count: CountOrDefault,
         log_messages_bytes_limit: Option<usize>,
         transaction_status_sender: Option<TransactionStatusSender>,
@@ -472,6 +502,7 @@ where
         prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
     ) -> Arc<Self> {
         Self::do_new(
+            supported_scheduling_mode,
             block_verification_handler_count,
             log_messages_bytes_limit,
             transaction_status_sender,
@@ -484,7 +515,45 @@ where
         )
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn new_for_verification(
+        block_verification_handler_count: CountOrDefault,
+        log_messages_bytes_limit: Option<usize>,
+        transaction_status_sender: Option<TransactionStatusSender>,
+        replay_vote_sender: Option<ReplayVoteSender>,
+        prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
+    ) -> Arc<Self> {
+        Self::new(
+            SupportedSchedulingMode::with_verification(),
+            block_verification_handler_count,
+            log_messages_bytes_limit,
+            transaction_status_sender,
+            replay_vote_sender,
+            prioritization_fee_cache,
+        )
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn new_for_production(
+        block_verification_handler_count: CountOrDefault,
+        log_messages_bytes_limit: Option<usize>,
+        transaction_status_sender: Option<TransactionStatusSender>,
+        replay_vote_sender: Option<ReplayVoteSender>,
+        prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
+    ) -> Arc<Self> {
+        Self::new(
+            SupportedSchedulingMode::with_production(),
+            block_verification_handler_count,
+            log_messages_bytes_limit,
+            transaction_status_sender,
+            replay_vote_sender,
+            prioritization_fee_cache,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn do_new(
+        supported_scheduling_mode: SupportedSchedulingMode,
         block_verification_handler_count: CountOrDefault,
         log_messages_bytes_limit: Option<usize>,
         transaction_status_sender: Option<TransactionStatusSender>,
@@ -661,6 +730,7 @@ where
             .unwrap();
 
         let scheduler_pool = Arc::new_cyclic(|weak_self| Self {
+            supported_scheduling_mode,
             scheduler_inners: Mutex::default(),
             block_production_scheduler_inner: Mutex::default(),
             trashed_scheduler_inners: Mutex::default(),
@@ -688,24 +758,6 @@ where
         scheduler_pool
     }
 
-    // This apparently-meaningless wrapper is handy, because some callers explicitly want
-    // `dyn InstalledSchedulerPool` to be returned for type inference convenience.
-    pub fn new_dyn(
-        handler_count: Option<usize>,
-        log_messages_bytes_limit: Option<usize>,
-        transaction_status_sender: Option<TransactionStatusSender>,
-        replay_vote_sender: Option<ReplayVoteSender>,
-        prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
-    ) -> InstalledSchedulerPoolArc {
-        Self::new(
-            handler_count,
-            log_messages_bytes_limit,
-            transaction_status_sender,
-            replay_vote_sender,
-            prioritization_fee_cache,
-        )
-    }
-
     // See a comment at the weak_self field for justification of this method's existence.
     fn self_arc(&self) -> Arc<Self> {
         self.weak_self
@@ -722,9 +774,19 @@ where
     fn return_scheduler(&self, scheduler: S::Inner) {
         // Refer to the comment in is_aborted() as to the exact definition of the concept of
         // _trashed_ and the interaction among different parts of unified scheduler.
-        let should_trash = scheduler.is_trashed();
         let mut block_production_scheduler_inner =
             self.block_production_scheduler_inner.lock().unwrap();
+        let is_block_production_scheduler = block_production_scheduler_inner.can_put(&scheduler);
+        let is_block_production_disabled = matches!(
+            self.banking_stage_status(),
+            Some(BankingStageStatus::Disabled)
+        );
+        let should_trash = if is_block_production_scheduler && is_block_production_disabled {
+            info!("Forcibly trashing scheduler due to disabled block production mode");
+            true
+        } else {
+            scheduler.is_trashed()
+        };
 
         if should_trash {
             // Note that the following steps are tightly in sync with the bp
@@ -732,14 +794,16 @@ where
 
             // Maintain the runtime invariant established in register_banking_stage() about
             // the availability of pooled block production scheduler by re-spawning one.
-            if block_production_scheduler_inner.can_put(&scheduler) {
+            if is_block_production_scheduler {
                 block_production_scheduler_inner.trash_taken();
-                // To prevent block-production scheduler from being taken in
-                // do_take_resumed_scheduler() by different thread at this very moment, the
-                // preceding `.trash_taken()` and following `.put_spawned()` must be done
-                // atomically. That's why we pass around MutexGuard into
-                // spawn_block_production_scheduler().
-                self.spawn_block_production_scheduler(&mut block_production_scheduler_inner);
+                if !is_block_production_disabled {
+                    // To prevent block-production scheduler from being taken in
+                    // do_take_resumed_scheduler() by different thread at this very moment, the
+                    // preceding `.trash_taken()` and following `.put_spawned()` must be done
+                    // atomically. That's why we pass around MutexGuard into
+                    // spawn_block_production_scheduler().
+                    self.spawn_block_production_scheduler(&mut block_production_scheduler_inner);
+                }
             }
 
             // Delay drop()-ing this trashed returned scheduler inner by stashing it in
@@ -751,7 +815,7 @@ where
                 .expect("not poisoned")
                 .push(scheduler);
             sleepless_testing::at(CheckPoint::ReturningSchedulerTrashed);
-        } else if block_production_scheduler_inner.can_put(&scheduler) {
+        } else if is_block_production_scheduler {
             block_production_scheduler_inner.put_returned(scheduler);
         } else {
             self.scheduler_inners
@@ -765,13 +829,18 @@ where
     #[cfg(test)]
     fn do_take_scheduler(&self, context: SchedulingContext) -> S {
         self.do_take_resumed_scheduler(context, initialized_result_with_timings())
+            .unwrap()
     }
 
     fn do_take_resumed_scheduler(
         &self,
         context: SchedulingContext,
         result_with_timings: ResultWithTimings,
-    ) -> S {
+    ) -> Option<S> {
+        if !self.supported_scheduling_mode.is_supported(context.mode()) {
+            return None;
+        }
+
         assert_matches!(result_with_timings, (Ok(_), _));
 
         match context.mode() {
@@ -781,27 +850,28 @@ where
                 if let Some((inner, _pooled_at)) =
                     self.scheduler_inners.lock().expect("not poisoned").pop()
                 {
-                    S::from_inner(inner, context, result_with_timings)
+                    Some(S::from_inner(inner, context, result_with_timings))
                 } else {
-                    S::spawn(self.self_arc(), context, result_with_timings)
+                    Some(S::spawn(self.self_arc(), context, result_with_timings))
                 }
             }
             BlockProduction => {
+                if matches!(
+                    self.banking_stage_status()
+                        .expect("register_banking_stage() isn't called yet"),
+                    BankingStageStatus::Disabled
+                ) {
+                    return None;
+                }
+
                 // There must be a pooled block-production scheduler at this point because prior
                 // register_banking_stage() invocation should have spawned such one.
-                assert!(
-                    self.banking_stage_handler_context
-                        .lock()
-                        .expect("not poisoned")
-                        .is_some(),
-                    "register_banking_stage() isn't called yet",
-                );
                 let inner = self
                     .block_production_scheduler_inner
                     .lock()
                     .expect("not poisoned")
                     .take_pooled();
-                S::from_inner(inner, context, result_with_timings)
+                Some(S::from_inner(inner, context, result_with_timings))
             }
         }
     }
@@ -809,6 +879,10 @@ where
     #[cfg(feature = "dev-context-only-utils")]
     pub fn pooled_scheduler_count(&self) -> usize {
         self.scheduler_inners.lock().expect("not poisoned").len()
+    }
+
+    pub fn block_production_supported(&self) -> bool {
+        self.supported_scheduling_mode.is_supported(BlockProduction)
     }
 
     pub fn register_banking_stage(
@@ -828,9 +902,7 @@ where
         });
         // Immediately start a block production scheduler, so that the scheduler can start
         // buffering tasks, which are preprocessed as much as possible.
-        self.spawn_block_production_scheduler(
-            &mut self.block_production_scheduler_inner.lock().unwrap(),
-        );
+        assert!(self.toggle_block_production_mode(true));
     }
 
     fn unregister_banking_stage(&self) {
@@ -852,6 +924,14 @@ where
             .unwrap()
             .as_mut()
             .map(|context| context.banking_stage_monitor.status())
+    }
+
+    fn toggle_banking_packet_receiver(&self, enable: bool) {
+        let mut context = self.banking_stage_handler_context.lock().unwrap();
+        let context = context.as_mut().unwrap();
+        context
+            .banking_stage_monitor
+            .toggle_banking_packet_receiver(enable);
     }
 
     fn create_handler_context(
@@ -971,8 +1051,9 @@ where
         &self,
         context: SchedulingContext,
         result_with_timings: ResultWithTimings,
-    ) -> InstalledSchedulerBox {
-        Box::new(self.do_take_resumed_scheduler(context, result_with_timings))
+    ) -> Option<InstalledSchedulerBox> {
+        self.do_take_resumed_scheduler(context, result_with_timings)
+            .map(|s| Box::new(s) as InstalledSchedulerBox)
     }
 
     fn register_timeout_listener(&self, timeout_listener: TimeoutListener) {
@@ -1022,6 +1103,31 @@ where
         this.cleaner_thread.join().unwrap();
 
         info!("SchedulerPool::uninstalled_from_bank_forks(): ...finished");
+    }
+
+    fn toggle_block_production_mode(&self, enable: bool) -> bool {
+        if !self.block_production_supported() {
+            info!("toggle_block_production_mode: unsupported: enable: {enable}");
+            // block production isn't supported to begin with.
+            if enable {
+                // Fail always for enabling the unsupported mode.
+                return false;
+            } else {
+                // Succeed always for disabling the never enabled mode.
+                return true;
+            }
+        }
+
+        if enable {
+            let mut block_production_scheduler_inner =
+                self.block_production_scheduler_inner.lock().unwrap();
+            if block_production_scheduler_inner.is_not_spawned() {
+                self.spawn_block_production_scheduler(&mut block_production_scheduler_inner);
+            }
+        }
+        self.toggle_banking_packet_receiver(enable);
+        info!("toggle_block_production_mode: succeeded: enable: {enable}");
+        true
     }
 }
 
@@ -2671,11 +2777,13 @@ impl<TH: TaskHandler> SpawnableScheduler<TH> for PooledScheduler<TH> {
 pub enum BankingStageStatus {
     Active,
     Inactive,
+    Disabled,
     Exited,
 }
 
 pub trait BankingStageMonitor: Send + Debug {
     fn status(&mut self) -> BankingStageStatus;
+    fn toggle_banking_packet_receiver(&mut self, _enable: bool) {}
 }
 
 #[derive(Debug)]
@@ -2797,7 +2905,9 @@ mod tests {
             bank::Bank,
             bank_forks::BankForks,
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
-            installed_scheduler_pool::{BankWithScheduler, SchedulingContext},
+            installed_scheduler_pool::{
+                BankWithScheduler, InstalledSchedulerPoolArc, SchedulingContext,
+            },
         },
         solana_svm_timings::ExecuteTimingType,
         solana_system_transaction as system_transaction,
@@ -2813,6 +2923,56 @@ mod tests {
         },
         test_case::test_matrix,
     };
+
+    impl<S, TH> SchedulerPool<S, TH>
+    where
+        S: SpawnableScheduler<TH>,
+        TH: TaskHandler,
+    {
+        fn do_new_for_verification(
+            block_verification_handler_count: CountOrDefault,
+            log_messages_bytes_limit: Option<usize>,
+            transaction_status_sender: Option<TransactionStatusSender>,
+            replay_vote_sender: Option<ReplayVoteSender>,
+            prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
+            pool_cleaner_interval: Duration,
+            max_pooling_duration: Duration,
+            max_usage_queue_count: usize,
+            timeout_duration: Duration,
+        ) -> Arc<Self> {
+            Self::do_new(
+                SupportedSchedulingMode::with_verification(),
+                block_verification_handler_count,
+                log_messages_bytes_limit,
+                transaction_status_sender,
+                replay_vote_sender,
+                prioritization_fee_cache,
+                pool_cleaner_interval,
+                max_pooling_duration,
+                max_usage_queue_count,
+                timeout_duration,
+            )
+        }
+
+        // This apparently-meaningless wrapper is handy, because some callers explicitly want
+        // `dyn InstalledSchedulerPool` to be returned for type inference convenience.
+        fn new_dyn_for_verification(
+            block_verification_handler_count: CountOrDefault,
+            log_messages_bytes_limit: Option<usize>,
+            transaction_status_sender: Option<TransactionStatusSender>,
+            replay_vote_sender: Option<ReplayVoteSender>,
+            prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
+        ) -> InstalledSchedulerPoolArc {
+            Self::new(
+                SupportedSchedulingMode::with_verification(),
+                block_verification_handler_count,
+                log_messages_bytes_limit,
+                transaction_status_sender,
+                replay_vote_sender,
+                prioritization_fee_cache,
+            )
+        }
+    }
 
     #[derive(Debug)]
     enum TestCheckPoint {
@@ -2840,7 +3000,7 @@ mod tests {
     fn test_scheduler_pool_new() {
         agave_logger::setup();
 
-        let pool = DefaultSchedulerPool::new_dyn(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_dyn_for_verification(None, None, None, None, None);
 
         // this indirectly proves that there should be circular link because there's only one Arc
         // at this moment now
@@ -2854,10 +3014,10 @@ mod tests {
     fn test_scheduler_spawn() {
         agave_logger::setup();
 
-        let pool = DefaultSchedulerPool::new_dyn(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_dyn_for_verification(None, None, None, None, None);
         let bank = Arc::new(Bank::default_for_tests());
         let context = SchedulingContext::for_verification(bank);
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
 
         let debug = format!("{scheduler:#?}");
         assert!(!debug.is_empty());
@@ -2885,7 +3045,7 @@ mod tests {
             Duration::from_millis(TEST_MAX_POOLING_DURATION_MS);
         const TEST_WAIT_FOR_IDLE_MS: u64 = TEST_MAX_POOLING_DURATION_MS + 200;
         const TEST_WAIT_FOR_IDLE: Duration = Duration::from_millis(TEST_WAIT_FOR_IDLE_MS);
-        let pool_raw = DefaultSchedulerPool::do_new(
+        let pool_raw = DefaultSchedulerPool::do_new_for_verification(
             None,
             None,
             None,
@@ -2946,7 +3106,7 @@ mod tests {
         ]);
 
         const REDUCED_MAX_USAGE_QUEUE_COUNT: usize = 1;
-        let pool_raw = DefaultSchedulerPool::do_new(
+        let pool_raw = DefaultSchedulerPool::do_new_for_verification(
             None,
             None,
             None,
@@ -3021,7 +3181,7 @@ mod tests {
             &TestCheckPoint::AfterIdleSchedulerCleaned,
         ]);
 
-        let pool_raw = DefaultSchedulerPool::do_new(
+        let pool_raw = DefaultSchedulerPool::do_new_for_verification(
             None,
             None,
             None,
@@ -3035,7 +3195,7 @@ mod tests {
         let pool = pool_raw.clone();
         let bank = Arc::new(Bank::default_for_tests());
         let context = SchedulingContext::for_verification(bank.clone());
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         let bank = BankWithScheduler::new(bank, Some(scheduler));
         pool.register_timeout_listener(bank.create_timeout_listener());
         assert_eq!(pool_raw.scheduler_inners.lock().unwrap().len(), 0);
@@ -3068,17 +3228,18 @@ mod tests {
             &TestCheckPoint::AfterTimeoutListenerTriggered,
         ]);
 
-        let pool_raw = SchedulerPool::<PooledScheduler<ExecuteTimingCounter>, _>::do_new(
-            None,
-            None,
-            None,
-            None,
-            None,
-            SHORTENED_POOL_CLEANER_INTERVAL,
-            DEFAULT_MAX_POOLING_DURATION,
-            DEFAULT_MAX_USAGE_QUEUE_COUNT,
-            SHORTENED_TIMEOUT_DURATION,
-        );
+        let pool_raw =
+            SchedulerPool::<PooledScheduler<ExecuteTimingCounter>, _>::do_new_for_verification(
+                None,
+                None,
+                None,
+                None,
+                None,
+                SHORTENED_POOL_CLEANER_INTERVAL,
+                DEFAULT_MAX_POOLING_DURATION,
+                DEFAULT_MAX_USAGE_QUEUE_COUNT,
+                SHORTENED_TIMEOUT_DURATION,
+            );
 
         #[derive(Debug)]
         struct ExecuteTimingCounter;
@@ -3105,7 +3266,7 @@ mod tests {
 
         let context = SchedulingContext::for_verification(bank.clone());
 
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         let bank = BankWithScheduler::new(bank, Some(scheduler));
         pool.register_timeout_listener(bank.create_timeout_listener());
 
@@ -3153,7 +3314,7 @@ mod tests {
             &TestCheckPoint::AfterTimeoutListenerTriggered,
         ]);
 
-        let pool_raw = DefaultSchedulerPool::do_new(
+        let pool_raw = DefaultSchedulerPool::do_new_for_verification(
             None,
             None,
             None,
@@ -3172,7 +3333,7 @@ mod tests {
 
         let context = SchedulingContext::for_verification(bank.clone());
 
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         let bank = BankWithScheduler::new(bank, Some(scheduler));
         pool.register_timeout_listener(bank.create_timeout_listener());
 
@@ -3199,7 +3360,7 @@ mod tests {
             &TestCheckPoint::AfterTimeoutListenerTriggered,
         ]);
 
-        let pool_raw = SchedulerPool::<PooledScheduler<FaultyHandler>, _>::do_new(
+        let pool_raw = SchedulerPool::<PooledScheduler<FaultyHandler>, _>::do_new_for_verification(
             None,
             None,
             None,
@@ -3223,7 +3384,7 @@ mod tests {
 
         let context = SchedulingContext::for_verification(bank.clone());
 
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         let bank = BankWithScheduler::new(bank, Some(scheduler));
         pool.register_timeout_listener(bank.create_timeout_listener());
 
@@ -3300,8 +3461,9 @@ mod tests {
 
         let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
-        let pool =
-            SchedulerPool::<PooledScheduler<FaultyHandler>, _>::new(None, None, None, None, None);
+        let pool = SchedulerPool::<PooledScheduler<FaultyHandler>, _>::new_for_verification(
+            None, None, None, None, None,
+        );
         let context = SchedulingContext::for_verification(bank.clone());
         let scheduler = pool.do_take_scheduler(context);
         scheduler.schedule_execution(tx, 0).unwrap();
@@ -3386,8 +3548,9 @@ mod tests {
 
         let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
-        let pool =
-            SchedulerPool::<PooledScheduler<CountingHandler>, _>::new(None, None, None, None, None);
+        let pool = SchedulerPool::<PooledScheduler<CountingHandler>, _>::new_for_verification(
+            None, None, None, None, None,
+        );
         let context = SchedulingContext::for_verification(bank.clone());
         let scheduler = pool.do_take_scheduler(context);
 
@@ -3420,7 +3583,7 @@ mod tests {
     fn test_scheduler_pool_filo() {
         agave_logger::setup();
 
-        let pool = DefaultSchedulerPool::new(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_for_verification(None, None, None, None, None);
         let bank = Arc::new(Bank::default_for_tests());
         let context = &SchedulingContext::for_verification(bank);
 
@@ -3447,7 +3610,7 @@ mod tests {
     fn test_scheduler_pool_context_drop_unless_reinitialized() {
         agave_logger::setup();
 
-        let pool = DefaultSchedulerPool::new(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_for_verification(None, None, None, None, None);
         let bank = Arc::new(Bank::default_for_tests());
         let context = &SchedulingContext::for_verification(bank);
         let mut scheduler = pool.do_take_scheduler(context.clone());
@@ -3464,7 +3627,7 @@ mod tests {
     fn test_scheduler_pool_context_replace() {
         agave_logger::setup();
 
-        let pool = DefaultSchedulerPool::new(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_for_verification(None, None, None, None, None);
         let old_bank = &Arc::new(Bank::default_for_tests());
         let new_bank = &Arc::new(Bank::default_for_tests());
         assert!(!Arc::ptr_eq(old_bank, new_bank));
@@ -3476,7 +3639,7 @@ mod tests {
         let scheduler_id = scheduler.id();
         pool.return_scheduler(scheduler.into_inner().1);
 
-        let scheduler = pool.take_scheduler(new_context.clone());
+        let scheduler = pool.take_scheduler(new_context.clone()).unwrap();
         assert_eq!(scheduler_id, scheduler.id());
         assert!(Arc::ptr_eq(scheduler.context().bank().unwrap(), new_bank));
     }
@@ -3488,7 +3651,7 @@ mod tests {
         let bank = Bank::default_for_tests();
         let bank_forks = BankForks::new_rw_arc(bank);
         let mut bank_forks = bank_forks.write().unwrap();
-        let pool = DefaultSchedulerPool::new_dyn(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_dyn_for_verification(None, None, None, None, None);
         bank_forks.install_scheduler_pool(pool);
     }
 
@@ -3500,7 +3663,7 @@ mod tests {
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let child_bank = Bank::new_from_parent(bank, &Pubkey::default(), 1);
 
-        let pool = DefaultSchedulerPool::new_dyn(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_dyn_for_verification(None, None, None, None, None);
 
         let bank = Bank::default_for_tests();
         let bank_forks = BankForks::new_rw_arc(bank);
@@ -3548,11 +3711,11 @@ mod tests {
         ));
         let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
-        let pool = DefaultSchedulerPool::new_dyn(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_dyn_for_verification(None, None, None, None, None);
         let context = SchedulingContext::for_verification(bank.clone());
 
         assert_eq!(bank.transaction_count(), 0);
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         scheduler.schedule_execution(tx0, 0).unwrap();
         let bank = BankWithScheduler::new(bank, Some(scheduler));
         assert_matches!(bank.wait_for_completed_scheduler(), Some((Ok(()), _)));
@@ -3581,7 +3744,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
 
-        let pool_raw = DefaultSchedulerPool::do_new(
+        let pool_raw = DefaultSchedulerPool::do_new_for_verification(
             None,
             None,
             None,
@@ -3594,7 +3757,7 @@ mod tests {
         );
         let pool = pool_raw.clone();
         let context = SchedulingContext::for_verification(bank.clone());
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
 
         let unfunded_keypair = Keypair::new();
         let bad_tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
@@ -3713,7 +3876,7 @@ mod tests {
         // scheduler thread has been aborted already or not.
         const TX_COUNT: OrderedTaskId = 2;
 
-        let pool = SchedulerPool::<PooledScheduler<PanickingHandler>, _>::new_dyn(
+        let pool = SchedulerPool::<PooledScheduler<PanickingHandler>, _>::new_dyn_for_verification(
             Some(TX_COUNT.try_into().unwrap()), // fix to use exactly 2 handlers
             None,
             None,
@@ -3722,7 +3885,7 @@ mod tests {
         );
         let context = SchedulingContext::for_verification(bank.clone());
 
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
 
         for task_id in 0..TX_COUNT {
             // Use 2 non-conflicting txes to exercise the channel disconnected case as well.
@@ -3787,7 +3950,7 @@ mod tests {
 
         let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
-        let pool = SchedulerPool::<PooledScheduler<CountingFaultyHandler>, _>::new(
+        let pool = SchedulerPool::<PooledScheduler<CountingFaultyHandler>, _>::new_for_verification(
             None, None, None, None, None,
         );
         let context = SchedulingContext::for_verification(bank.clone());
@@ -3895,8 +4058,18 @@ mod tests {
 
         let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
-        let pool =
-            SchedulerPool::<PooledScheduler<StallingHandler>, _>::new(None, None, None, None, None);
+        let supported_scheduling_mode = match scheduling_mode {
+            BlockVerification => SupportedSchedulingMode::with_verification(),
+            BlockProduction => SupportedSchedulingMode::with_production(),
+        };
+        let pool = SchedulerPool::<PooledScheduler<StallingHandler>, _>::new(
+            supported_scheduling_mode,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         let (_banking_packet_sender, banking_packet_receiver) = crossbeam_channel::unbounded();
 
         let (record_sender, mut record_receiver) = record_channels(true);
@@ -3919,7 +4092,7 @@ mod tests {
         assert_eq!(bank.transaction_count(), expected_transaction_count.0);
 
         let context = SchedulingContext::new_with_mode(scheduling_mode, bank.clone());
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         let old_scheduler_id = scheduler.id();
         if matches!(scheduling_mode, BlockProduction) {
             scheduler.unpause_after_taken();
@@ -3960,7 +4133,7 @@ mod tests {
         record_receiver.restart(bank.bank_id());
 
         let context = SchedulingContext::new_with_mode(scheduling_mode, bank.clone());
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         // make sure the same scheduler is used to test its internal cross-session behavior
         // regardless scheduling_mode.
         assert_eq!(scheduler.id(), old_scheduler_id);
@@ -4014,7 +4187,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
 
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
-        let pool = DefaultSchedulerPool::new(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_for_production(None, None, None, None, None);
 
         let (_banking_packet_sender, banking_packet_receiver) = crossbeam_channel::unbounded();
         let (record_sender, mut record_receiver) = record_channels(true);
@@ -4037,7 +4210,7 @@ mod tests {
         bank.write_cost_tracker().unwrap().set_limits(0, 0, 0);
 
         let context = SchedulingContext::for_production(bank.clone());
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         let old_scheduler_id = scheduler.id();
         let bank = BankWithScheduler::new(bank, Some(scheduler));
         record_receiver.restart(bank.bank_id());
@@ -4066,7 +4239,7 @@ mod tests {
             .set_limits(u64::MAX, u64::MAX, u64::MAX);
 
         let context = SchedulingContext::for_production(bank.clone());
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         // Make sure the same scheduler is used to test its internal cross-session behavior
         assert_eq!(scheduler.id(), old_scheduler_id);
         let bank = BankWithScheduler::new(bank, Some(scheduler));
@@ -4116,7 +4289,7 @@ mod tests {
             bank0.slot().checked_add(1).unwrap(),
         ));
 
-        let pool = SchedulerPool::<PooledScheduler<TaskAndContextChecker>, _>::new(
+        let pool = SchedulerPool::<PooledScheduler<TaskAndContextChecker>, _>::new_for_verification(
             Some(4), // spawn 4 threads
             None,
             None,
@@ -4141,7 +4314,7 @@ mod tests {
             .cycle()
             .take(10000)
         {
-            let scheduler = pool.take_scheduler(context.clone());
+            let scheduler = pool.take_scheduler(context.clone()).unwrap();
             scheduler
                 .schedule_execution(dummy_tx.clone(), task_id)
                 .unwrap();
@@ -4344,10 +4517,14 @@ mod tests {
         let context = SchedulingContext::for_verification(bank.clone());
 
         let pool =
-            SchedulerPool::<AsyncScheduler<TRIGGER_RACE_CONDITION>, DefaultTaskHandler>::new_dyn(
-                None, None, None, None, None,
+            SchedulerPool::<AsyncScheduler<TRIGGER_RACE_CONDITION>, DefaultTaskHandler>::new_dyn_for_verification(
+                None,
+                None,
+                None,
+                None,
+                None,
             );
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
 
         let bank = BankWithScheduler::new(bank, Some(scheduler));
         assert_eq!(bank.transaction_count(), 0);
@@ -4592,7 +4769,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
 
-        let pool = DefaultSchedulerPool::new(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_for_production(None, None, None, None, None);
 
         let (_banking_packet_sender, banking_packet_receiver) = crossbeam_channel::unbounded();
         let (record_sender, mut record_receiver) = record_channels(true);
@@ -4610,7 +4787,7 @@ mod tests {
 
         assert_eq!(bank.transaction_count(), 0);
         let context = SchedulingContext::for_production(bank.clone());
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         scheduler.unpause_after_taken();
         let tx0 = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
             &mint_keypair,
@@ -4657,7 +4834,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
 
-        let pool = DefaultSchedulerPool::new(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_for_production(None, None, None, None, None);
 
         let (record_sender, mut record_receiver) = record_channels(true);
         let transaction_recorder = TransactionRecorder::new(record_sender);
@@ -4695,7 +4872,7 @@ mod tests {
 
         assert_eq!(bank.transaction_count(), 0);
         let context = SchedulingContext::for_production(bank.clone());
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         scheduler.unpause_after_taken();
         let bank = BankWithScheduler::new(bank, Some(scheduler));
         assert_matches!(bank.wait_for_completed_scheduler(), Some((Ok(()), _)));
@@ -4719,7 +4896,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
 
-        let pool = DefaultSchedulerPool::new(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_for_production(None, None, None, None, None);
 
         let (record_sender, mut record_receiver) = record_channels(true);
         let transaction_recorder = TransactionRecorder::new(record_sender);
@@ -4749,7 +4926,7 @@ mod tests {
         // Quickly take and return the scheduler so that this test can test the behavior while
         // waiting for new session...
         let context = SchedulingContext::for_production(bank.clone());
-        let scheduler = pool.take_scheduler(context.clone());
+        let scheduler = pool.take_scheduler(context.clone()).unwrap();
         scheduler.unpause_after_taken();
         let bank_tmp = BankWithScheduler::new(bank.clone(), Some(scheduler));
         assert_matches!(bank_tmp.wait_for_completed_scheduler(), Some((Ok(()), _)));
@@ -4765,7 +4942,7 @@ mod tests {
         assert_eq!(banking_packet_sender.len(), 0);
 
         assert_eq!(bank.transaction_count(), 0);
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         scheduler.unpause_after_taken();
         let bank = BankWithScheduler::new(bank, Some(scheduler));
         assert_matches!(bank.wait_for_completed_scheduler(), Some((Ok(()), _)));
@@ -4777,7 +4954,7 @@ mod tests {
     fn test_block_production_scheduler_take_without_registering() {
         agave_logger::setup();
 
-        let pool = DefaultSchedulerPool::new(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_for_production(None, None, None, None, None);
         let bank = Arc::new(Bank::default_for_tests());
         let context = &SchedulingContext::for_production(bank);
         let scheduler = pool.do_take_scheduler(context.clone());
@@ -4794,7 +4971,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
 
-        let pool = DefaultSchedulerPool::new(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new_for_production(None, None, None, None, None);
 
         let (record_sender, mut record_receiver) = record_channels(true);
         let transaction_recorder = TransactionRecorder::new(record_sender);
@@ -4835,6 +5012,7 @@ mod tests {
 
         const REDUCED_MAX_USAGE_QUEUE_COUNT: usize = 0;
         let pool = DefaultSchedulerPool::do_new(
+            SupportedSchedulingMode::with_production(),
             None,
             None,
             None,
@@ -4910,6 +5088,7 @@ mod tests {
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
 
         let pool = DefaultSchedulerPool::do_new(
+            SupportedSchedulingMode::with_production(),
             None,
             None,
             None,
@@ -4963,7 +5142,15 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
 
-        let pool = DefaultSchedulerPool::new(None, None, None, None, None);
+        let pool = DefaultSchedulerPool::new(
+            // Both block verification and production scheduler are needed for this test.
+            SupportedSchedulingMode::Both,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
 
         let (_banking_packet_sender, banking_packet_receiver) = crossbeam_channel::unbounded();
         let (record_sender, mut record_receiver) = record_channels(true);
@@ -4981,7 +5168,7 @@ mod tests {
         // Make sure the assertion in BlockProductionSchedulerInner::can_put() doesn't cause false
         // positives...
         let context = SchedulingContext::for_verification(bank.clone());
-        let scheduler = pool.take_scheduler(context);
+        let scheduler = pool.take_scheduler(context).unwrap();
         let bank_tmp = BankWithScheduler::new(bank, Some(scheduler));
         assert_matches!(bank_tmp.wait_for_completed_scheduler(), Some((Ok(()), _)));
     }
@@ -5022,6 +5209,7 @@ mod tests {
         let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
 
         let pool = DefaultSchedulerPool::do_new(
+            SupportedSchedulingMode::with_production(),
             None,
             None,
             None,

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -119,8 +119,7 @@ impl SupportedSchedulingMode {
     fn is_supported(&self, requested_mode: SchedulingMode) -> bool {
         match (self, requested_mode) {
             (Self::Both, _requested) => true,
-            (Self::Either(ref supported), ref requested) if supported == requested => true,
-            _ => false,
+            (Self::Either(ref supported), ref requested) => supported == requested,
         }
     }
 
@@ -1109,13 +1108,7 @@ where
         if !self.block_production_supported() {
             info!("toggle_block_production_mode: unsupported: enable: {enable}");
             // block production isn't supported to begin with.
-            if enable {
-                // Fail always for enabling the unsupported mode.
-                return false;
-            } else {
-                // Succeed always for disabling the never enabled mode.
-                return true;
-            }
+            return !enable;
         }
 
         if enable {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -664,6 +664,16 @@ pub fn execute(
         }
         BlockVerificationMethod::UnifiedScheduler => {}
     }
+    if matches!(
+        validator_config.block_production_method,
+        BlockProductionMethod::UnifiedScheduler
+    ) {
+        warn!(
+            "Currently, the unified-scheduler method is experimental for block-production. It has \
+             known security issues and should be used only for developing and benchmarking \
+             purposes"
+        );
+    }
 
     let public_rpc_addr = matches
         .value_of("public_rpc_addr")


### PR DESCRIPTION
#### Problem

Time has come to release me from the ordeal of rebases.

Having #7223 and #7444 and #8664 landed recently as the last blockers, it's time to make block production unified-scheduler available via cli finally.

#### Summary of Changes

Compared to https://github.com/anza-xyz/agave/pull/7271, this pr reduced its size by stripping non-essential changes (i.e. support for `agave-ledger-tool simulate-block-production` and `solana-banking-bench` and addition of local-cluster test).

Thus, this pr does minimal cli plumbing across the repo tree to conclude the 12 months efforts since opening #3946.

This pr also supports runtime block production method switching (i.e. `agave-validator manage-block-production --block-production-method XXX`) between `unified-scheduler` and `central-scheduler{,-greedy}`, which is introduced after #3946.

With all said, this pr does these changes:

- Make `BankForks`/`InstalledScheduler` aware of `SchedulingMode` with newly `Option`-ed scheduler taking (most code churn is due to this)
  - a tiny aux enum `SupportedSchedulingMode` is introduced for that.
- Make channels returned from `BankingTracer::create_channels()` support runtime switching of independent or unified channels.
- Make `PohController` track last bank for edge case of unified scheduler book-keeping.
- Introduce toggling of enabling/disabling unified scheduler bp mode for runtime switching.