### PR TITLE
Pass File objects for created files in FileCreator

### DIFF
--- a/fs/src/file_info.rs
+++ b/fs/src/file_info.rs
@@ -15,14 +15,14 @@ pub struct FileInfo {
 
 impl FileInfo {
     /// Create new instance by opening a file from a given `path` and reading its metadata
-    pub fn read_from_path(path: impl Into<PathBuf>) -> io::Result<Self> {
+    pub fn new_from_path(path: impl Into<PathBuf>) -> io::Result<Self> {
         let path = path.into();
         let file = File::open(&path)?;
-        Self::read_from_path_and_file(path, file)
+        Self::new_from_path_and_file(path, file)
     }
 
     /// Create new instance by using already open `file` and only reading its metadata
-    pub fn read_from_path_and_file(path: impl Into<PathBuf>, file: File) -> io::Result<Self> {
+    pub fn new_from_path_and_file(path: impl Into<PathBuf>, file: File) -> io::Result<Self> {
         let size = file.metadata()?.len();
         Ok(Self {
             path: path.into(),

--- a/fs/src/file_info.rs
+++ b/fs/src/file_info.rs
@@ -1,0 +1,33 @@
+use std::{fs::File, io, path::PathBuf};
+
+/// Open `File` coupled with its filesystem location and most useful information
+///
+/// The attached context for the `File` is kept minimal to make it easy to construct
+/// without unnecessary kernel queries, but allowing users to:
+/// * associate the file received in callbacks to the request (by its path)
+/// * get the file's most useful metadata information
+#[derive(Debug)]
+pub struct FileInfo {
+    pub file: File,
+    pub path: PathBuf,
+    pub size: u64,
+}
+
+impl FileInfo {
+    /// Create new instance by opening a file from a given `path` and reading its metadata
+    pub fn read_from_path(path: impl Into<PathBuf>) -> io::Result<Self> {
+        let path = path.into();
+        let file = File::open(&path)?;
+        Self::read_from_path_and_file(path, file)
+    }
+
+    /// Create new instance by using already open `file` and only reading its metadata
+    pub fn read_from_path_and_file(path: impl Into<PathBuf>, file: File) -> io::Result<Self> {
+        let size = file.metadata()?.len();
+        Ok(Self {
+            path: path.into(),
+            size,
+            file,
+        })
+    }
+}

--- a/fs/src/file_io.rs
+++ b/fs/src/file_io.rs
@@ -2,8 +2,7 @@
 
 //! File i/o helper functions.
 use {
-    crate::io_setup::IoSetupState,
-    crate::FileInfo,
+    crate::{io_setup::IoSetupState, FileInfo},
     std::{
         fs::{self, File, OpenOptions},
         io::{self, BufWriter, Write},
@@ -431,7 +430,7 @@ mod tests {
         // Shared state to capture callback invocations
         let mut callback_provided_file_info = None;
 
-        let mut creator = file_creator(2 << 20, |file_info| {
+        let mut creator = file_creator(2 << 20, &IoSetupState::default(), |file_info| {
             callback_provided_file_info = Some(file_info);
             None
         })?;

--- a/fs/src/file_io.rs
+++ b/fs/src/file_io.rs
@@ -3,6 +3,7 @@
 //! File i/o helper functions.
 use {
     crate::io_setup::IoSetupState,
+    crate::FileInfo,
     std::{
         fs::{self, File, OpenOptions},
         io::{self, BufWriter, Write},
@@ -138,7 +139,7 @@ pub trait FileCreator {
     ) -> io::Result<()>;
 
     /// Invoke implementation specific logic to handle file creation completion.
-    fn file_complete(&mut self, path: PathBuf);
+    fn file_complete(&mut self, created_file: File, path: PathBuf, file_size: u64);
 
     /// Waits for all operations to be completed
     fn drain(&mut self) -> io::Result<()>;
@@ -147,7 +148,7 @@ pub trait FileCreator {
 pub fn file_creator<'a>(
     buf_size: usize,
     io_setup: &IoSetupState,
-    file_complete: impl FnMut(PathBuf) + 'a,
+    file_complete: impl FnMut(FileInfo) -> Option<File> + 'a,
 ) -> io::Result<Box<dyn FileCreator + 'a>> {
     #[cfg(target_os = "linux")]
     if agave_io_uring::io_uring_supported() {
@@ -170,11 +171,11 @@ pub fn file_creator<'a>(
 }
 
 pub struct SyncIoFileCreator<'a> {
-    file_complete: Box<dyn FnMut(PathBuf) + 'a>,
+    file_complete: Box<dyn FnMut(FileInfo) -> Option<File> + 'a>,
 }
 
 impl<'a> SyncIoFileCreator<'a> {
-    fn new(_buf_size: usize, file_complete: impl FnMut(PathBuf) + 'a) -> Self {
+    fn new(_buf_size: usize, file_complete: impl FnMut(FileInfo) -> Option<File> + 'a) -> Self {
         Self {
             file_complete: Box::new(file_complete),
         }
@@ -223,12 +224,14 @@ impl FileCreator for SyncIoFileCreator<'_> {
         #[cfg(not(unix))]
         set_path_permissions(&path, mode)?;
 
-        self.file_complete(path);
+        let file = file_buf.into_inner()?;
+        let file_info = FileInfo::read_from_path_and_file(path, file)?;
+        (self.file_complete)(file_info);
         Ok(())
     }
 
-    fn file_complete(&mut self, path: PathBuf) {
-        (self.file_complete)(path)
+    fn file_complete(&mut self, file: File, path: PathBuf, size: u64) {
+        (self.file_complete)(FileInfo { file, path, size });
     }
 
     fn drain(&mut self) -> io::Result<()> {
@@ -242,7 +245,7 @@ mod tests {
         super::*,
         std::{
             fs,
-            io::{Cursor, Write},
+            io::{Cursor, Read, Write},
         },
         tempfile::tempfile,
     };
@@ -368,8 +371,9 @@ mod tests {
         let mut callback_invoked_path = None;
 
         // Instantiate FileCreator
-        let mut creator = file_creator(2 << 20, &IoSetupState::default(), |path| {
-            callback_invoked_path.replace(path);
+        let mut creator = file_creator(2 << 20, &IoSetupState::default(), |file_info| {
+            callback_invoked_path.replace(file_info.path);
+            Some(file_info.file)
         })?;
 
         let dir = Arc::new(File::open(temp_dir.path())?);
@@ -393,10 +397,11 @@ mod tests {
         let temp_dir = tempfile::tempdir()?;
         let mut callback_counter = 0;
 
-        let mut creator = file_creator(2 << 20, &IoSetupState::default(), |path: PathBuf| {
-            let contents = read_file_to_string(&path);
+        let mut creator = file_creator(2 << 20, &IoSetupState::default(), |file_info| {
+            let contents = read_file_to_string(&file_info.path);
             assert!(contents.starts_with("File "));
             callback_counter += 1;
+            Some(file_info.file)
         })?;
 
         let dir = Arc::new(File::open(temp_dir.path())?);
@@ -414,6 +419,43 @@ mod tests {
         drop(creator);
 
         assert_eq!(callback_counter, 5);
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_callback_claims_owned_file() -> io::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let file_path = temp_dir.path().join("test.txt");
+        let contents = "Hello, world!";
+
+        // Shared state to capture callback invocations
+        let mut callback_provided_file_info = None;
+
+        let mut creator = file_creator(2 << 20, |file_info| {
+            callback_provided_file_info = Some(file_info);
+            None
+        })?;
+
+        let dir = Arc::new(File::open(temp_dir.path())?);
+        creator.schedule_create_at_dir(
+            file_path.clone(),
+            0o644,
+            dir,
+            &mut Cursor::new(contents),
+        )?;
+        creator.drain()?;
+        drop(creator);
+
+        let mut read_buf = String::new();
+        let mut file_info = callback_provided_file_info.unwrap();
+        assert_eq!(
+            file_info.file.metadata().unwrap().len(),
+            contents.len() as u64
+        );
+        assert_eq!(file_info.size, contents.len() as u64);
+        file_info.file.read_to_string(&mut read_buf).unwrap();
+        assert_eq!(&read_buf, contents);
+
         Ok(())
     }
 }

--- a/fs/src/file_io.rs
+++ b/fs/src/file_io.rs
@@ -224,7 +224,7 @@ impl FileCreator for SyncIoFileCreator<'_> {
         set_path_permissions(&path, mode)?;
 
         let file = file_buf.into_inner()?;
-        let file_info = FileInfo::read_from_path_and_file(path, file)?;
+        let file_info = FileInfo::new_from_path_and_file(path, file)?;
         (self.file_complete)(file_info);
         Ok(())
     }

--- a/fs/src/io_setup.rs
+++ b/fs/src/io_setup.rs
@@ -70,14 +70,15 @@ mod tests {
         let mut file_creator = IoUringFileCreator::with_buffer_capacity(
             1 << 20,
             io_setup.shared_sqpoll_fd(),
-            move |path| {
+            move |file_info| {
                 let mut reader = SequentialFileReaderBuilder::new()
                     .shared_sqpoll(io_setup.shared_sqpoll_fd())
-                    .build(path, 1 << 20)
+                    .build(file_info.path, 1 << 20)
                     .unwrap();
                 reader
                     .read_to_end(read_bytes_ref.write().unwrap().as_mut())
                     .unwrap();
+                None
             },
         )
         .unwrap();

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -18,6 +18,9 @@
 pub mod buffered_reader;
 pub mod buffered_writer;
 pub mod dirs;
+mod file_info;
 pub mod file_io;
 pub mod io_setup;
 mod io_uring;
+
+pub use file_info::FileInfo;


### PR DESCRIPTION
#### Problem
* `FileCreator` performs file open, write and close and after files are written it passes file path to the user provided callback
* when snapshot unpacking receives the created file path, it will go on to open the file again and read its metadata to obtain file size - all those could be avoided if file creator delivered them, since it already operates on open file and knows its size

#### Summary of Changes
* introduce `FileInfo` struct containing open file, its path and size
* change `file_creator` to take callback receiving `FileInfo` (instead of `PathBuf`) and returning `Option<File>` (`Some` variant can be used to let `FileCreator` continue with old flow of closing the file if user doesn't need to claim its ownership)
* remove fixed file descriptors functionality in io-uring file creator and add `ASYNC` flag for writes
  * when using fixed file descriptors, the FD isn't surfaced in the completions, so we are unable to create valid `File` objects
  * performance impact of this change is neutral (independently checked)
  * previously when using fixed files `ASYNC` flag caused problems with kernel choosing unbounded worker pool / not hashing the file handle correctly - without fixed files we can make the code consistent with the way reads are issued to io-uring
* when `file_complete` callback returns `None` file creator implementation skips the operation of closing the file
* file creator now opens files for R+W (instead of Write-only), since files will be reused for other purpose than writing

This PR prepares API for use in future changes (next step implemented in https://github.com/kskalski/agave/pull/8)