### PR TITLE
ci: move docs deploy logic out of build script

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -89,6 +89,12 @@ jobs:
         run: |
           npm install
           ./build.sh
+
+      - name: Deploy
+        if: ${{ github.event_name == 'push' }}
+        working-directory: docs
+        run: |
+          ./deploy.sh
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_SCOPE: ${{ secrets.VERCEL_SCOPE }}

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -15,15 +15,3 @@ source ../ci/rust-version.sh
 # Build from /src into /build
 npm run build
 echo $?
-
-# Publish only from merge commits and beta release tags
-if [[ -n $CI ]]; then
-  if [[ -z $CI_PULL_REQUEST ]]; then
-    eval "$(../ci/channel-info.sh)"
-    if [[ -n $CI_TAG ]] && [[ $CI_TAG != $BETA_CHANNEL* ]]; then
-      echo "not a beta tag"
-      exit 0
-    fi
-    ./publish-docs.sh
-  fi
-fi

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Publish only from merge commits and beta release tags
+if [[ -n $CI ]]; then
+  if [[ -z $CI_PULL_REQUEST ]]; then
+    eval "$(../ci/channel-info.sh)"
+    if [[ -n $CI_TAG ]] && [[ $CI_TAG != $BETA_CHANNEL* ]]; then
+      echo "not a beta tag"
+      exit 0
+    fi
+    ./publish-docs.sh
+  fi
+fi


### PR DESCRIPTION
#### Problem

The old docs ci script combined both build and deploy logic in a single script, which prevented us from introducing environment-based secrets. (#8877)

#### Summary of Changes

move deploy logic to another script