### PR TITLE
gossip: fix EpochSlots Debug lowest_slot computation

### DIFF
--- a/gossip/src/epoch_slots.rs
+++ b/gossip/src/epoch_slots.rs
@@ -279,11 +279,7 @@ use std::fmt;
 impl fmt::Debug for EpochSlots {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let num_slots: usize = self.slots.iter().map(|s| s.num_slots()).sum();
-        let lowest_slot = self
-            .slots
-            .iter()
-            .map(|s| s.first_slot())
-            .fold(0, std::cmp::min);
+        let lowest_slot = self.first_slot().unwrap_or(0);
         write!(
             f,
             "EpochSlots {{ from: {} num_slots: {} lowest_slot: {} wallclock: {} }}",


### PR DESCRIPTION
This change corrects the `lowest_slot` value in `fmt::Debug` for `EpochSlots` by replacing `fold(0, std::cmp::min)` with `self.first_slot().unwrap_or(0)`. Using 0 as the initial accumulator biases the minimum toward 0 whenever all first_slot values are positive, producing incorrect logs. The new implementation aligns with the intended semantics and the existing EpochSlots::first_slot() method, preserves the empty-case fallback to 0, and ensures the debug output accurately reflects the actual lowest slot.