### PR TITLE
feat(cost): compute cost without needing ALTs

### DIFF
--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -12,11 +12,9 @@ use {
     solana_compute_budget::compute_budget_limits::DEFAULT_HEAP_COST,
     solana_fee_structure::FeeStructure,
     solana_pubkey::Pubkey,
-    solana_runtime_transaction::{
-        transaction_meta::StaticMeta, transaction_with_meta::TransactionWithMeta,
-    },
+    solana_runtime_transaction::transaction_meta::StaticMeta,
     solana_sdk_ids::system_program,
-    solana_svm_transaction::instruction::SVMInstruction,
+    solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMStaticMessage},
     solana_system_interface::{
         instruction::SystemInstruction, MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION,
         MAX_PERMITTED_DATA_LENGTH,
@@ -34,7 +32,7 @@ enum SystemProgramAccountAllocation {
 }
 
 impl CostModel {
-    pub fn calculate_cost<'a, Tx: TransactionWithMeta>(
+    pub fn calculate_cost<'a, Tx: StaticMeta + SVMStaticMessage>(
         transaction: &'a Tx,
         feature_set: &FeatureSet,
     ) -> TransactionCost<'a, Tx> {
@@ -58,7 +56,7 @@ impl CostModel {
 
     // Calculate executed transaction CU cost, with actual execution and loaded accounts size
     // costs.
-    pub fn calculate_cost_for_executed_transaction<'a, Tx: TransactionWithMeta>(
+    pub fn calculate_cost_for_executed_transaction<'a, Tx: StaticMeta + SVMStaticMessage>(
         transaction: &'a Tx,
         actual_programs_execution_cost: u64,
         actual_loaded_accounts_data_size_bytes: u32,

--- a/fee/src/lib.rs
+++ b/fee/src/lib.rs
@@ -10,7 +10,7 @@
 use {
     agave_feature_set::{enable_secp256r1_precompile, FeatureSet},
     solana_fee_structure::FeeDetails,
-    solana_svm_transaction::svm_message::SVMMessage,
+    solana_svm_transaction::svm_message::SVMStaticMessage,
 };
 
 /// Bools indicating the activation of features relevant
@@ -34,7 +34,7 @@ impl From<&FeatureSet> for FeeFeatures {
 
 /// Calculate fee for `SanitizedMessage`
 pub fn calculate_fee(
-    message: &impl SVMMessage,
+    message: &impl SVMStaticMessage,
     zero_fees_for_test: bool,
     lamports_per_signature: u64,
     prioritization_fee: u64,
@@ -51,7 +51,7 @@ pub fn calculate_fee(
 }
 
 pub fn calculate_fee_details(
-    message: &impl SVMMessage,
+    message: &impl SVMStaticMessage,
     zero_fees_for_test: bool,
     lamports_per_signature: u64,
     prioritization_fee: u64,
@@ -98,7 +98,7 @@ pub struct SignatureCounts {
     pub num_secp256r1_signatures: u64,
 }
 
-impl<Tx: SVMMessage> From<&Tx> for SignatureCounts {
+impl<Tx: SVMStaticMessage> From<&Tx> for SignatureCounts {
     fn from(message: &Tx) -> Self {
         Self {
             num_transaction_signatures: message.num_transaction_signatures(),


### PR DESCRIPTION
#### Problem

- It can be desirable to compute the cost of a transaction without resolving the lookup tables, this is useful for schedulers.

#### Summary of Changes

- Relax the cost trait constraint from `SVMMessage` -> `SVMStaticMessage`.


