### PR TITLE
Alternative to #8767: Decouple In-Mem Index Eviction From Flush and Integrate Into Update Path

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -58,7 +58,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndex
     bins: Some(BINS_FOR_TESTING),
     num_flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: IndexLimitMb::InMemOnly,
+    index_limit: IndexLimit::InMemOnly,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
     num_initial_accounts: None,
@@ -67,7 +67,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
     bins: Some(BINS_FOR_BENCHMARKS),
     num_flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: IndexLimitMb::InMemOnly,
+    index_limit: IndexLimit::InMemOnly,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
     num_initial_accounts: None,
@@ -227,13 +227,15 @@ enum ScanTypes<R: RangeBounds<Pubkey>> {
     Indexed(IndexKey),
 }
 
-/// specification of how much memory in-mem portion of account index can use
+/// specification of how many entries the in-mem portion of account index can hold
 #[derive(Debug, Copy, Clone)]
-pub enum IndexLimitMb {
+pub enum IndexLimit {
     /// use disk index while keeping a minimal amount in-mem
     Minimal,
     /// in-mem-only was specified, no disk index
     InMemOnly,
+    /// flush to disk when memory usage exceeds threshold in bytes
+    Threshold(u64),
 }
 
 #[derive(Debug, Clone)]
@@ -241,7 +243,7 @@ pub struct AccountsIndexConfig {
     pub bins: Option<usize>,
     pub num_flush_threads: Option<NonZeroUsize>,
     pub drives: Option<Vec<PathBuf>>,
-    pub index_limit_mb: IndexLimitMb,
+    pub index_limit: IndexLimit,
     pub ages_to_stay_in_cache: Option<Age>,
     pub scan_results_limit_bytes: Option<usize>,
     /// Initial number of accounts, used to pre-allocate HashMap capacity at startup.
@@ -254,7 +256,7 @@ impl Default for AccountsIndexConfig {
             bins: None,
             num_flush_threads: None,
             drives: None,
-            index_limit_mb: IndexLimitMb::InMemOnly,
+            index_limit: IndexLimit::InMemOnly,
             ages_to_stay_in_cache: None,
             scan_results_limit_bytes: None,
             num_initial_accounts: None,
@@ -2241,10 +2243,10 @@ pub mod tests {
         let key = solana_pubkey::new_rand();
 
         let mut config = ACCOUNTS_INDEX_CONFIG_FOR_TESTING;
-        config.index_limit_mb = if use_disk {
-            IndexLimitMb::Minimal
+        config.index_limit = if use_disk {
+            IndexLimit::Minimal
         } else {
-            IndexLimitMb::InMemOnly // in-mem only
+            IndexLimit::InMemOnly // in-mem only
         };
         let index = AccountsIndex::<T, T>::new(&config, Arc::default());
         let mut gc = ReclaimsSlotList::new();

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -115,6 +115,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         })
     }
 
+    /// Get the target entries per bin for threshold-based flushing
+    pub fn target_entries_per_bin(&self) -> Option<usize> {
+        self.target_entries_per_bin
+    }
+
     pub fn increment_age(&self) {
         // since we are about to change age, there are now 0 buckets that have been flushed at this age
         // this should happen before the age.fetch_add
@@ -251,8 +256,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             IndexLimit::Threshold(limit_bytes) => {
                 let bytes_per_bin = (limit_bytes as usize) / bins;
                 let entries_per_bin = bytes_per_bin
-                    / InMemAccountsIndex::<T, U>::size_of_uninitialized()
-                    + InMemAccountsIndex::<T, U>::size_of_single_entry();
+                    / (InMemAccountsIndex::<T, U>::size_of_uninitialized()
+                        + InMemAccountsIndex::<T, U>::size_of_single_entry());
                 let target_entries_per_bin = if entries_per_bin == 0 {
                     0
                 } else {

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -62,6 +62,15 @@ pub struct Stats {
     bins: u64,
     pub flush_should_evict_us: AtomicU64,
     pub flush_read_lock_us: AtomicU64,
+    // Max flush stats for 10s reporting interval
+    pub flush_max_total_entries_before: AtomicU64,
+    pub flush_max_num_flushed: AtomicU64,
+    pub flush_max_map_len_before: AtomicU64,
+    pub flush_max_map_capacity_before: AtomicU64,
+    pub flush_max_map_len_after: AtomicU64,
+    pub flush_max_map_capacity_after: AtomicU64,
+    pub flush_max_evicted: AtomicU64,
+    pub flush_max_total_entries_after: AtomicU64,
 }
 
 impl Stats {
@@ -149,6 +158,36 @@ impl Stats {
     pub fn remaining_until_next_interval(&self) -> u64 {
         self.last_time
             .remaining_until_next_interval(STATS_INTERVAL_MS)
+    }
+
+    /// Update flush stats with max values
+    pub fn update_flush_stats_max(
+        &self,
+        total_entries_before: usize,
+        num_flushed: usize,
+        map_len_before: usize,
+        map_capacity_before: usize,
+        map_len_after: usize,
+        map_capacity_after: usize,
+        evicted: usize,
+        total_entries_after: usize,
+    ) {
+        self.flush_max_total_entries_before
+            .fetch_max(total_entries_before as u64, Ordering::Relaxed);
+        self.flush_max_num_flushed
+            .fetch_max(num_flushed as u64, Ordering::Relaxed);
+        self.flush_max_map_len_before
+            .fetch_max(map_len_before as u64, Ordering::Relaxed);
+        self.flush_max_map_capacity_before
+            .fetch_max(map_capacity_before as u64, Ordering::Relaxed);
+        self.flush_max_map_len_after
+            .fetch_max(map_len_after as u64, Ordering::Relaxed);
+        self.flush_max_map_capacity_after
+            .fetch_max(map_capacity_after as u64, Ordering::Relaxed);
+        self.flush_max_evicted
+            .fetch_max(evicted as u64, Ordering::Relaxed);
+        self.flush_max_total_entries_after
+            .fetch_max(total_entries_after as u64, Ordering::Relaxed);
     }
 
     /// return min, max, sum, median of data
@@ -555,6 +594,49 @@ impl Stats {
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),
+                (
+                    "flush_max_total_entries_before",
+                    self.flush_max_total_entries_before
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_num_flushed",
+                    self.flush_max_num_flushed.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_len_before",
+                    self.flush_max_map_len_before.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_capacity_before",
+                    self.flush_max_map_capacity_before
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_len_after",
+                    self.flush_max_map_len_after.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_capacity_after",
+                    self.flush_max_map_capacity_after.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_evicted",
+                    self.flush_max_evicted.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_total_entries_after",
+                    self.flush_max_total_entries_after
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
             );
         } else {
             datapoint_info!(
@@ -621,6 +703,49 @@ impl Stats {
                 ("inserts", self.inserts.swap(0, Ordering::Relaxed), i64),
                 ("deletes", self.deletes.swap(0, Ordering::Relaxed), i64),
                 ("keys", self.keys.swap(0, Ordering::Relaxed), i64),
+                (
+                    "flush_max_total_entries_before",
+                    self.flush_max_total_entries_before
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_num_flushed",
+                    self.flush_max_num_flushed.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_len_before",
+                    self.flush_max_map_len_before.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_capacity_before",
+                    self.flush_max_map_capacity_before
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_len_after",
+                    self.flush_max_map_len_after.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_map_capacity_after",
+                    self.flush_max_map_capacity_after.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_evicted",
+                    self.flush_max_evicted.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_max_total_entries_after",
+                    self.flush_max_total_entries_after
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
             );
         }
     }

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -6,7 +6,7 @@ use {
     solana_accounts_db::{
         accounts_db::{AccountsDbConfig, DEFAULT_MEMLOCK_BUDGET_SIZE},
         accounts_file::StorageAccess,
-        accounts_index::{AccountsIndexConfig, IndexLimitMb, ScanFilter},
+        accounts_index::{AccountsIndexConfig, IndexLimit, ScanFilter},
     },
     solana_clap_utils::{
         hidden_unless_forced,
@@ -67,6 +67,18 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .long_help(
                 "Enables the disk-based accounts index. Reduce the memory footprint of the \
                  accounts index at the cost of index performance.",
+            ),
+        Arg::with_name("accounts_index_limit_bytes")
+            .long("accounts-index-limit-bytes")
+            .value_name("BYTES")
+            .takes_value(true)
+            .requires("enable_accounts_disk_index")
+            .help("Flush accounts index to disk when memory usage exceeds this limit in bytes")
+            .long_help(
+                "Sets a memory size threshold for the in-memory accounts index. When the memory \
+                 usage of the index exceeds this limit (in bytes), it will flush to disk. This \
+                 provides a middle ground between pure in-memory (default) and always-on-disk \
+                 (--enable-accounts-disk-index) modes. Requires --enable-accounts-disk-index.",
             ),
         Arg::with_name("accounts_db_skip_shrink")
             .long("accounts-db-skip-shrink")
@@ -252,10 +264,14 @@ pub fn get_accounts_db_config(
     let accounts_index_bins = value_t!(arg_matches, "accounts_index_bins", usize).ok();
     let num_initial_accounts =
         value_t!(arg_matches, "accounts_index_initial_accounts_count", usize).ok();
-    let accounts_index_index_limit_mb = if !arg_matches.is_present("enable_accounts_disk_index") {
-        IndexLimitMb::InMemOnly
+    let accounts_index_index_limit = if arg_matches.is_present("enable_accounts_disk_index") {
+        if let Ok(limit_bytes) = value_t!(arg_matches, "accounts_index_limit_bytes", u64) {
+            IndexLimit::Threshold(limit_bytes)
+        } else {
+            IndexLimit::Minimal
+        }
     } else {
-        IndexLimitMb::Minimal
+        IndexLimit::InMemOnly
     };
     let accounts_index_drives = values_t!(arg_matches, "accounts_index_path", String)
         .ok()
@@ -264,7 +280,7 @@ pub fn get_accounts_db_config(
     let accounts_index_config = AccountsIndexConfig {
         bins: accounts_index_bins,
         num_initial_accounts,
-        index_limit_mb: accounts_index_index_limit_mb,
+        index_limit: accounts_index_index_limit,
         drives: Some(accounts_index_drives),
         ..AccountsIndexConfig::default()
     };

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -394,9 +394,7 @@ mod tests {
         solana_account::{ReadableAccount as _, WritableAccount as _},
         solana_accounts_db::{
             accounts_db::{AccountsDbConfig, MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING},
-            accounts_index::{
-                AccountsIndexConfig, IndexLimitMb, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
-            },
+            accounts_index::{AccountsIndexConfig, IndexLimit, ACCOUNTS_INDEX_CONFIG_FOR_TESTING},
         },
         solana_fee_calculator::FeeRateGovernor,
         solana_genesis_config::{self, GenesisConfig},
@@ -778,12 +776,12 @@ mod tests {
 
     #[test_matrix(
         [Features::None, Features::All],
-        [IndexLimitMb::Minimal, IndexLimitMb::InMemOnly],
+        [IndexLimit::Minimal, IndexLimit::InMemOnly],
         [MarkObsoleteAccounts::Disabled, MarkObsoleteAccounts::Enabled]
     )]
     fn test_verify_accounts_lt_hash_at_startup(
         features: Features,
-        accounts_index_limit: IndexLimitMb,
+        accounts_index_limit: IndexLimit,
         mark_obsolete_accounts: MarkObsoleteAccounts,
     ) {
         let (mut genesis_config, mint_keypair) = genesis_config_with(features);
@@ -870,7 +868,7 @@ mod tests {
         .unwrap();
         let (_accounts_tempdir, accounts_dir) = snapshot_utils::create_tmp_accounts_dir_for_tests();
         let accounts_index_config = AccountsIndexConfig {
-            index_limit_mb: accounts_index_limit,
+            index_limit: accounts_index_limit,
             ..ACCOUNTS_INDEX_CONFIG_FOR_TESTING
         };
         let accounts_db_config = AccountsDbConfig {

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1191,6 +1191,20 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
+        Arg::with_name("accounts_index_limit_bytes")
+            .long("accounts-index-limit-bytes")
+            .value_name("BYTES")
+            .takes_value(true)
+            .requires("enable_accounts_disk_index")
+            .help("Flush accounts index to disk when memory usage exceeds this limit in bytes")
+            .long_help(
+                "Sets a memory size threshold for the in-memory accounts index. When the memory \
+                 usage of the index exceeds this limit (in bytes), it will flush to disk. This \
+                 provides a middle ground between pure in-memory (default) and always-on-disk \
+                 (--enable-accounts-disk-index) modes. Requires --enable-accounts-disk-index.",
+            ),
+    )
+    .arg(
         Arg::with_name("accounts_shrink_optimize_total_space")
             .long("accounts-shrink-optimize-total-space")
             .takes_value(true)

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -19,7 +19,7 @@ use {
     solana_accounts_db::{
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig, MarkObsoleteAccounts},
         accounts_file::StorageAccess,
-        accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig, IndexLimitMb, ScanFilter},
+        accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig, IndexLimit, ScanFilter},
         utils::{
             create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories,
             create_and_canonicalize_directory,
@@ -325,10 +325,14 @@ pub fn execute(
         accounts_index_config.num_initial_accounts = Some(num_initial_accounts);
     }
 
-    accounts_index_config.index_limit_mb = if !matches.is_present("enable_accounts_disk_index") {
-        IndexLimitMb::InMemOnly
+    accounts_index_config.index_limit = if matches.is_present("enable_accounts_disk_index") {
+        if let Ok(limit_bytes) = value_t!(matches, "accounts_index_limit_bytes", u64) {
+            IndexLimit::Threshold(limit_bytes)
+        } else {
+            IndexLimit::Minimal
+        }
     } else {
-        IndexLimitMb::Minimal
+        IndexLimit::InMemOnly
     };
 
     {


### PR DESCRIPTION
#### Problem
This PR explores an alternative approach to https://github.com/anza-xyz/agave/pull/8767. It separates in-memory index eviction from the index-flush path and moves the eviction logic directly into the index-update flow.


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
