### PR TITLE
Feat: add BAM client version to gossip

### DIFF
--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -29,6 +29,7 @@ pub enum ClientId {
     JitoLabs,
     Firedancer,
     Agave,
+    Bam,
     // If new variants are added, update From<u16> and TryFrom<ClientId>.
     Unknown(u16),
 }
@@ -110,6 +111,7 @@ impl From<u16> for ClientId {
             1u16 => Self::JitoLabs,
             2u16 => Self::Firedancer,
             3u16 => Self::Agave,
+            6u16 => Self::Bam,
             _ => Self::Unknown(client),
         }
     }
@@ -124,6 +126,7 @@ impl TryFrom<ClientId> for u16 {
             ClientId::JitoLabs => Ok(1u16),
             ClientId::Firedancer => Ok(2u16),
             ClientId::Agave => Ok(3u16),
+            ClientId::Bam => Ok(6u16),
             ClientId::Unknown(client @ 0u16..=3u16) => Err(format!("Invalid client: {client}")),
             ClientId::Unknown(client) => Ok(client),
         }
@@ -162,7 +165,8 @@ mod test {
         assert_eq!(ClientId::from(1u16), ClientId::JitoLabs);
         assert_eq!(ClientId::from(2u16), ClientId::Firedancer);
         assert_eq!(ClientId::from(3u16), ClientId::Agave);
-        for client in 4u16..=u16::MAX {
+        assert_eq!(ClientId::from(6u16), ClientId::Bam);
+        for client in 7u16..=u16::MAX {
             assert_eq!(ClientId::from(client), ClientId::Unknown(client));
         }
         assert_eq!(u16::try_from(ClientId::SolanaLabs), Ok(0u16));
@@ -175,7 +179,7 @@ mod test {
                 Err(format!("Invalid client: {client}"))
             );
         }
-        for client in 4u16..=u16::MAX {
+        for client in 7u16..=u16::MAX {
             assert_eq!(u16::try_from(ClientId::Unknown(client)), Ok(client));
         }
     }


### PR DESCRIPTION
#### Problem
* Add's bam client id to versions, according to [this](https://github.com/solana-foundation/solana-validator-client-ids/pull/2)
* Matches what we have in bam-client [here](https://github.com/jito-labs/bam-client/blob/master/version/src/lib.rs)


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
