### PR TITLE
Rust fmt accounts db

### DIFF
--- a/accounts-db/benches/bench_lock_accounts.rs
+++ b/accounts-db/benches/bench_lock_accounts.rs
@@ -37,8 +37,9 @@ fn create_test_transactions(lock_count: usize, read_conflicts: bool) -> Vec<Sani
 
         #[allow(clippy::needless_range_loop)]
         for i in 0..lock_count {
-            // `lock_accounts()` distinguishes writable from readonly, so give transactions an even split
-            // signer doesn't matter for locking but `sanitize()` expects to see at least one
+            // `lock_accounts()` distinguishes writable from readonly, so give transactions an even
+            // split signer doesn't matter for locking but `sanitize()` expects to see
+            // at least one
             let account_meta = if i == 0 {
                 AccountMeta::new(Pubkey::new_unique(), true)
             } else if i % 2 == 0 {

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -25,8 +25,9 @@ pub struct AccountStorage {
     /// map from Slot -> the single append vec for the slot
     map: AccountStorageMap,
     /// while shrink is operating on a slot, there can be 2 append vecs active for that slot
-    /// Once the index has been updated to only refer to the new append vec, the single entry for the slot in 'map' can be updated.
-    /// Entries in 'shrink_in_progress_map' can be found by 'get_account_storage_entry'
+    /// Once the index has been updated to only refer to the new append vec, the single entry for
+    /// the slot in 'map' can be updated. Entries in 'shrink_in_progress_map' can be found by
+    /// 'get_account_storage_entry'
     shrink_in_progress_map: RwLock<IntMap<Slot, Arc<AccountStorageEntry>>>,
 }
 
@@ -41,14 +42,18 @@ impl AccountStorage {
     /// then the new append vec is dropped from 'shrink_in_progress_map'.
     /// So, it is possible for a race with this fn and dropping 'shrink_in_progress'.
     /// Callers to this function have 2 choices:
-    /// 1. hold the account index read lock for the pubkey so that the account index entry cannot be changed prior to or during this call. (scans do this)
+    /// 1. hold the account index read lock for the pubkey so that the account index entry cannot be
+    ///    changed prior to or during this call. (scans do this)
     /// 2. expect to be ready to start over and read the index again if this function returns None
     ///
-    /// Operations like shrinking or write cache flushing may have updated the index between when the caller read the index and called this function to
-    /// load from the append vec specified in the index.
+    /// Operations like shrinking or write cache flushing may have updated the index between when
+    /// the caller read the index and called this function to load from the append vec specified
+    /// in the index.
     ///
-    /// In practice, this fn will return the entry from the map in the very first lookup unless a shrink is in progress.
-    /// The third lookup will only be called if a requesting thread exactly interposes itself between the 2 map manipulations in the drop of 'shrink_in_progress'.
+    /// In practice, this fn will return the entry from the map in the very first lookup unless a
+    /// shrink is in progress. The third lookup will only be called if a requesting thread
+    /// exactly interposes itself between the 2 map manipulations in the drop of
+    /// 'shrink_in_progress'.
     pub(crate) fn get_account_storage_entry(
         &self,
         slot: Slot,
@@ -77,7 +82,8 @@ impl AccountStorage {
     }
 
     /// return the append vec for 'slot' if it exists
-    /// This is only ever called when shrink is not possibly running and there is a max of 1 append vec per slot.
+    /// This is only ever called when shrink is not possibly running and there is a max of 1 append
+    /// vec per slot.
     pub fn get_slot_storage_entry(&self, slot: Slot) -> Option<Arc<AccountStorageEntry>> {
         assert!(
             self.no_shrink_in_progress(),
@@ -162,11 +168,12 @@ impl AccountStorage {
     }
 
     /// called when shrinking begins on a slot and append vec.
-    /// When 'ShrinkInProgress' is dropped by caller, the old store will be replaced with 'new_store' in the storage map.
-    /// Fails if there are no existing stores at the slot.
+    /// When 'ShrinkInProgress' is dropped by caller, the old store will be replaced with
+    /// 'new_store' in the storage map. Fails if there are no existing stores at the slot.
     /// 'new_store' will be replacing the current store at 'slot' in 'map'
     /// So, insert 'new_store' into 'shrink_in_progress_map'.
-    /// This allows tx processing loads to find the items in 'shrink_in_progress_map' after the index is updated and item is now located in 'new_store'.
+    /// This allows tx processing loads to find the items in 'shrink_in_progress_map' after the
+    /// index is updated and item is now located in 'new_store'.
     pub(crate) fn shrinking_in_progress(
         &self,
         slot: Slot,
@@ -264,7 +271,8 @@ pub struct ShrinkInProgress<'a> {
     slot: Slot,
 }
 
-/// called when the shrink is no longer in progress. This means we can release the old append vec and update the map of slot -> append vec
+/// called when the shrink is no longer in progress. This means we can release the old append vec
+/// and update the map of slot -> append vec
 impl Drop for ShrinkInProgress<'_> {
     fn drop(&mut self) {
         assert_eq!(
@@ -426,9 +434,9 @@ pub struct NextItem<'a> {
 /// Select the `nth` (`0 <= nth < range.len()`) value from a `range`, choosing values alternately
 /// from its start or end according to a `start_rate : end_rate` ratio.
 ///
-/// For every `start_rate` values selected from the start, `end_rate` values are selected from the end.
-/// The resulting sequence alternates in a balanced and interleaved fashion between the range's start and end.
-/// ```
+/// For every `start_rate` values selected from the start, `end_rate` values are selected from the
+/// end. The resulting sequence alternates in a balanced and interleaved fashion between the range's
+/// start and end. ```
 fn select_from_range_with_start_end_rates(
     range: Range<usize>,
     nth: usize,

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -321,8 +321,8 @@ mod tests {
         // Close the file
         drop(output_file);
 
-        // If the number of accounts left is not zero, create a new AccountsFile from the output file
-        // and verify that the number of accounts in the new file is correct
+        // If the number of accounts left is not zero, create a new AccountsFile from the output
+        // file and verify that the number of accounts in the new file is correct
         if (total_accounts - number_of_accounts_to_remove) != 0 {
             let (accounts_file, num_accounts) =
                 AccountsFile::new_from_file(temp_file_path, current_len, StorageAccess::File)
@@ -426,8 +426,8 @@ mod tests {
                 storage.accounts.len() - storage.get_obsolete_bytes(Some(snapshot_slot));
             assert_eq!(reader.len(), current_len);
 
-            // Create a file to write the reader's output. It will get deleted by AccountsFile::drop() every
-            // iteration so it does not need a unique name
+            // Create a file to write the reader's output. It will get deleted by
+            // AccountsFile::drop() every iteration so it does not need a unique name
             let temp_file_path = temp_dir.path().join("output_file");
             let mut output_file = File::create(&temp_file_path).unwrap();
 

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -180,7 +180,8 @@ impl Accounts {
     }
 
     /// same as `load_with_fixed_root` except:
-    /// if the account is not already in the read cache, it is NOT put in the read cache on successful load
+    /// if the account is not already in the read cache, it is NOT put in the read cache on
+    /// successful load
     pub fn load_with_fixed_root_do_not_populate_read_cache(
         &self,
         ancestors: &Ancestors,
@@ -954,7 +955,8 @@ mod tests {
             results1,
             vec![
                 Ok(()), // Read-only account (keypair1) can be referenced multiple times
-                Err(TransactionError::AccountInUse), // Read-only account (keypair1) cannot also be locked as writable
+                Err(TransactionError::AccountInUse), /* Read-only account (keypair1) cannot also
+                                                      * be locked as writable */
             ],
         );
         assert!(accounts
@@ -1219,8 +1221,11 @@ mod tests {
             results,
             vec![
                 Ok(()), // Read-only account (keypair0) can be referenced multiple times
-                Err(TransactionError::WouldExceedMaxBlockCostLimit), // is not locked due to !qos_results[1].is_ok()
-                Ok(()), // Read-only account (keypair0) can be referenced multiple times
+                Err(TransactionError::WouldExceedMaxBlockCostLimit), /* is not locked due to !qos_results[1].is_ok() */
+                Ok(()),                                              /* Read-only account
+                                                                      * (keypair0) can be
+                                                                      * referenced multiple
+                                                                      * times */
             ],
         );
 

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -107,8 +107,8 @@ impl SlotCache {
         self.cache
             .get(pubkey)
             // 1) Maybe can eventually use a Cow to avoid a clone on every read
-            // 2) Popping is only safe if it's guaranteed that only
-            //    replay/banking threads are reading from the AccountsDb
+            // 2) Popping is only safe if it's guaranteed that only replay/banking threads are
+            //    reading from the AccountsDb
             .map(|account_ref| account_ref.value().clone())
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -111,8 +111,8 @@ pub const DEFAULT_MEMLOCK_BUDGET_SIZE: usize = 2_000_000_000;
 // Linux distributions often have some small memory lock limit (e.g. 8MB) that we can tap into.
 const MEMLOCK_BUDGET_SIZE_FOR_TESTS: usize = 4_000_000;
 
-// When getting accounts for shrinking from the index, this is the # of accounts to lookup per thread.
-// This allows us to split up accounts index accesses across multiple threads.
+// When getting accounts for shrinking from the index, this is the # of accounts to lookup per
+// thread. This allows us to split up accounts index accesses across multiple threads.
 const SHRINK_COLLECT_CHUNK_SIZE: usize = 50;
 
 /// The number of shrink candidate slots that is small enough so that
@@ -148,7 +148,8 @@ pub(crate) struct ShrinkCollectAliveSeparatedByRefs<'a> {
     pub(crate) one_ref: AliveAccounts<'a>,
     /// account where ref_count > 1, but this slot contains the alive entry with the highest slot
     pub(crate) many_refs_this_is_newest_alive: AliveAccounts<'a>,
-    /// account where ref_count > 1, and this slot is NOT the highest alive entry in the index for the pubkey
+    /// account where ref_count > 1, and this slot is NOT the highest alive entry in the index for
+    /// the pubkey
     pub(crate) many_refs_old_alive: AliveAccounts<'a>,
 }
 
@@ -229,7 +230,8 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
             &mut self.many_refs_this_is_newest_alive
         } else {
             // This entry is alive but is older than at least one other slot in the index.
-            // We would expect clean to get rid of the entry for THIS slot at some point, but clean hasn't done that yet.
+            // We would expect clean to get rid of the entry for THIS slot at some point, but clean
+            // hasn't done that yet.
             &mut self.many_refs_old_alive
         };
         other.add(ref_count, account, slot_list);
@@ -324,9 +326,10 @@ impl AccountFromStorage {
     }
     #[cfg(test)]
     pub(crate) fn new(offset: Offset, account: &StoredAccountInfoWithoutData) -> Self {
-        // the id is irrelevant in this account info. This structure is only used DURING shrink operations.
-        // In those cases, there is only 1 append vec id per slot when we read the accounts.
-        // Any value of storage id in account info works fine when we want the 'normal' storage.
+        // the id is irrelevant in this account info. This structure is only used DURING shrink
+        // operations. In those cases, there is only 1 append vec id per slot when we read
+        // the accounts. Any value of storage id in account info works fine when we want the
+        // 'normal' storage.
         let storage_id = 0;
         AccountFromStorage {
             index_info: AccountInfo::new(
@@ -500,7 +503,8 @@ impl GenerateIndexTimings {
         datapoint_info!(
             "generate_index",
             ("overall_us", self.total_time_us, i64),
-            // we cannot accurately measure index insertion time because of many threads and lock contention
+            // we cannot accurately measure index insertion time because of many threads and lock
+            // contention
             ("total_us", self.index_time, i64),
             ("insertion_time_us", self.insertion_time_us, i64),
             (
@@ -832,8 +836,8 @@ pub struct AccountStorageEntry {
     /// Slot is the slot at which the account is no longer needed.
     /// Two scenarios cause an account entry to be marked obsolete
     /// 1. The account was rewritten to a newer slot
-    /// 2. The account was set to zero lamports and is older than the last
-    ///    full snapshot. In this case, slot is set to the snapshot slot
+    /// 2. The account was set to zero lamports and is older than the last full snapshot. In this
+    ///    case, slot is set to the snapshot slot
     obsolete_accounts: RwLock<ObsoleteAccounts>,
 }
 
@@ -1090,7 +1094,8 @@ pub struct AccountsDb {
     pub accounts_index: AccountInfoAccountsIndex,
 
     /// Some(offset) iff we want to squash old append vecs together into 'ancient append vecs'
-    /// Some(offset) means for slots up to (max_slot - (slots_per_epoch - 'offset')), put them in ancient append vecs
+    /// Some(offset) means for slots up to (max_slot - (slots_per_epoch - 'offset')), put them in
+    /// ancient append vecs
     pub ancient_append_vec_offset: Option<i64>,
     pub ancient_storage_ideal_size: u64,
     pub max_ancient_storages: usize,
@@ -1466,9 +1471,10 @@ impl AccountsDb {
         reclaims
     }
 
-    /// Reclaim older states of accounts older than max_clean_root_inclusive for AccountsDb bloat mitigation.
-    /// Any accounts which are removed from the accounts index are returned in PubkeysRemovedFromAccountsIndex.
-    /// These should NOT be unref'd later from the accounts index.
+    /// Reclaim older states of accounts older than max_clean_root_inclusive for AccountsDb bloat
+    /// mitigation. Any accounts which are removed from the accounts index are returned in
+    /// PubkeysRemovedFromAccountsIndex. These should NOT be unref'd later from the accounts
+    /// index.
     fn clean_accounts_older_than_root(
         &self,
         reclaims: &SlotList<AccountInfo>,
@@ -1492,7 +1498,8 @@ impl AccountsDb {
 
     /// increment store_counts to non-zero for all stores that can not be deleted.
     /// a store cannot be deleted if:
-    /// 1. one of the pubkeys in the store has account info to a store whose store count is not going to zero
+    /// 1. one of the pubkeys in the store has account info to a store whose store count is not
+    ///    going to zero
     /// 2. a pubkey we were planning to remove is not removing all stores that contain the account
     fn calc_delete_dependencies(
         &self,
@@ -1520,8 +1527,9 @@ impl AccountsDb {
                                 continue;
                             }
                         }
-                        // One of the pubkeys in the store has account info to a store whose store count is not going to zero.
-                        // If the store cannot be found, that also means store isn't being deleted.
+                        // One of the pubkeys in the store has account info to a store whose store
+                        // count is not going to zero. If the store cannot
+                        // be found, that also means store isn't being deleted.
                         failed_slot = Some(*slot);
                         delete = false;
                         break;
@@ -1531,7 +1539,8 @@ impl AccountsDb {
                         continue;
                     }
                 } else {
-                    // a pubkey we were planning to remove is not removing all stores that contain the account
+                    // a pubkey we were planning to remove is not removing all stores that contain
+                    // the account
                     debug!(
                         "calc_delete_dependencies(), pubkey: {pubkey}, slot list len: {}, ref \
                          count: {ref_count}, slot list: {slot_list:?}",
@@ -1567,9 +1576,11 @@ impl AccountsDb {
                     if !already_counted.insert(slot) {
                         continue;
                     }
-                    // the point of all this code: remove the store count for all stores we cannot remove
+                    // the point of all this code: remove the store count for all stores we cannot
+                    // remove
                     if let Some(store_count) = store_counts.remove(&slot) {
-                        // all pubkeys in this store also cannot be removed from all stores they are in
+                        // all pubkeys in this store also cannot be removed from all stores they are
+                        // in
                         let affected_pubkeys = &store_count.1;
                         for key in affected_pubkeys {
                             let candidates_bin_index =
@@ -2066,7 +2077,8 @@ impl AccountsDb {
                                         let (slot, account_info) = &slot_list[index_in_slot_list];
                                         if account_info.is_zero_lamport() {
                                             useless = false;
-                                            // The latest one is zero lamports. We may be able to purge it.
+                                            // The latest one is zero lamports. We may be able to
+                                            // purge it.
                                             // Add all the rooted entries that contain this pubkey.
                                             // We know the highest rooted entry is zero lamports.
                                             candidate_info.slot_list =
@@ -2091,12 +2103,15 @@ impl AccountsDb {
                                         }
                                     }
                                     None => {
-                                        // This pubkey is in the index but not in a root slot, so clean
+                                        // This pubkey is in the index but not in a root slot, so
+                                        // clean
                                         // it up by adding it to the to-be-purged list.
                                         //
-                                        // Also, this pubkey must have been touched by some slot since
-                                        // it was in the dirty list, so we assume that the slot it was
-                                        // touched in must be unrooted.
+                                        // Also, this pubkey must have been touched by some slot
+                                        // since
+                                        // it was in the dirty list, so we assume that the slot it
+                                        // was touched in
+                                        // must be unrooted.
                                         not_found_on_fork += 1;
                                         should_collect_reclaims = true;
                                         purges_old_accounts_local += 1;
@@ -2194,8 +2209,8 @@ impl AccountsDb {
                         // slot was purged
                         return false;
                     }
-                    // Check if this update in `slot` to the account with `key` was reclaimed earlier by
-                    // `clean_accounts_older_than_root()`
+                    // Check if this update in `slot` to the account with `key` was reclaimed
+                    // earlier by `clean_accounts_older_than_root()`
                     let was_reclaimed = removed_accounts
                         .get(slot)
                         .map(|store_removed| store_removed.contains(&account_info.offset()))
@@ -2446,29 +2461,27 @@ impl AccountsDb {
     /// remove all the storage entries for `S`.
     ///
     /// # Arguments
-    /// * `reclaims` - The accounts to remove from storage entries' "count". Note here
-    ///   that we should not remove cache entries, only entries for accounts actually
-    ///   stored in a storage entry.
-    /// * `expected_single_dead_slot` - A correctness assertion. If this is equal to `Some(S)`,
-    ///   then the function will check that the only slot being cleaned up in `reclaims`
-    ///   is the slot == `S`. This is true for instance when `handle_reclaims` is called
-    ///   from store or slot shrinking, as those should only touch the slot they are
-    ///   currently storing to or shrinking.
+    /// * `reclaims` - The accounts to remove from storage entries' "count". Note here that we
+    ///   should not remove cache entries, only entries for accounts actually stored in a storage
+    ///   entry.
+    /// * `expected_single_dead_slot` - A correctness assertion. If this is equal to `Some(S)`, then
+    ///   the function will check that the only slot being cleaned up in `reclaims` is the slot ==
+    ///   `S`. This is true for instance when `handle_reclaims` is called from store or slot
+    ///   shrinking, as those should only touch the slot they are currently storing to or shrinking.
     /// * `pubkeys_removed_from_accounts_index` - These keys have already been removed from the
-    ///   accounts index and should not be unref'd. If they exist in the accounts index,
-    ///   they are NEW.
-    /// * `handle_reclaims`. `purge_stats` are stats used to track performance of purging
-    ///   dead slots if value is `ProcessDeadSlots`.
-    ///   Otherwise, there can be no dead slots
-    ///   that happen as a result of this call, and the function will check that no slots are
-    ///   cleaned up/removed via `process_dead_slots`. For instance, on store, no slots should
-    ///   be cleaned up, but during the background clean accounts purges accounts from old rooted
-    ///   slots, so outdated slots may be removed.
+    ///   accounts index and should not be unref'd. If they exist in the accounts index, they are
+    ///   NEW.
+    /// * `handle_reclaims`. `purge_stats` are stats used to track performance of purging dead slots
+    ///   if value is `ProcessDeadSlots`. Otherwise, there can be no dead slots that happen as a
+    ///   result of this call, and the function will check that no slots are cleaned up/removed via
+    ///   `process_dead_slots`. For instance, on store, no slots should be cleaned up, but during
+    ///   the background clean accounts purges accounts from old rooted slots, so outdated slots may
+    ///   be removed.
     /// * 'mark_accounts_obsolete' - Whether to mark accounts as obsolete or not. If `Yes`, then
     ///   obsolete account entry will be marked in the storage so snapshots/accounts hash can
     ///   determine the state of the account at a specified slot. This should only be done if the
-    ///   account is already unrefed and removed from the accounts index
-    ///   It must be unrefed and removed to avoid double counting or missed counting in shrink
+    ///   account is already unrefed and removed from the accounts index It must be unrefed and
+    ///   removed to avoid double counting or missed counting in shrink
     fn handle_reclaims<'a, I>(
         &'a self,
         reclaims: I,
@@ -2514,16 +2527,17 @@ impl AccountsDb {
     /// than the latest full snapshot slot.  This is to protect against the following scenario:
     ///
     ///   ```text
-    ///   A full snapshot is taken, including account 'alpha' with a non-zero balance.  In a later slot,
-    ///   alpha's lamports go to zero.  Eventually, cleaning runs.  Without this change,
-    ///   alpha would be cleaned up and removed completely. Finally, an incremental snapshot is taken.
+    ///   A full snapshot is taken, including account 'alpha' with a non-zero balance.  In a later
+    /// slot,   alpha's lamports go to zero.  Eventually, cleaning runs.  Without this change,
+    ///   alpha would be cleaned up and removed completely. Finally, an incremental snapshot is
+    /// taken.
     ///
     ///   Later, the incremental and full snapshots are used to rebuild the bank and accounts
     ///   database (e.x. if the node restarts).  The full snapshot _does_ contain alpha
     ///   and its balance is non-zero.  However, since alpha was cleaned up in a slot after the full
-    ///   snapshot slot (due to having zero lamports), the incremental snapshot would not contain alpha.
-    ///   Thus, the accounts database will contain the old, incorrect info for alpha with a non-zero
-    ///   balance.  Very bad!
+    ///   snapshot slot (due to having zero lamports), the incremental snapshot would not contain
+    /// alpha.   Thus, the accounts database will contain the old, incorrect info for alpha with
+    /// a non-zero   balance.  Very bad!
     ///   ```
     ///
     /// This filtering step can be skipped if there is no `latest_full_snapshot_slot`, or if the
@@ -2551,7 +2565,8 @@ impl AccountsDb {
                 for (slot, _account_info) in slot_list.iter() {
                     if let Some(store_count) = store_counts.get(slot) {
                         if store_count.0 != 0 {
-                            // one store this pubkey is in is not being removed, so this pubkey cannot be removed at all
+                            // one store this pubkey is in is not being removed, so this pubkey
+                            // cannot be removed at all
                             return false;
                         }
                     } else {
@@ -2590,10 +2605,10 @@ impl AccountsDb {
 
     // Must be kept private!, does sensitive cleanup that should only be called from
     // supported pipelines in AccountsDb
-    /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts index
-    ///    and should not be unref'd. If they exist in the accounts index, they are NEW.
-    /// clean_stored_dead_slots - clean_stored_dead_slots iterates through all the pubkeys in the dead
-    ///    slots and unrefs them in the acocunts index if they are not present in
+    /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts
+    /// index    and should not be unref'd. If they exist in the accounts index, they are NEW.
+    /// clean_stored_dead_slots - clean_stored_dead_slots iterates through all the pubkeys in the
+    /// dead    slots and unrefs them in the acocunts index if they are not present in
     ///    pubkeys_removed_from_accounts_index. Skipping clean is the equivilent to
     ///    pubkeys_removed_from_accounts_index containing all the pubkeys in the dead slots
     fn process_dead_slots(
@@ -2680,7 +2695,8 @@ impl AccountsDb {
                             .unwrap_or(true)
                     {
                         // only do this if our slot is prior to the latest full snapshot
-                        // we found a zero lamport account that is the only instance of this account. We can delete it completely.
+                        // we found a zero lamport account that is the only instance of this
+                        // account. We can delete it completely.
                         zero_lamport_single_ref_pubkeys.push(pubkey);
                         self.add_uncleaned_pubkeys_after_shrink(
                             slot_to_shrink,
@@ -2695,15 +2711,17 @@ impl AccountsDb {
                 if let Some((slot_list, ref_count)) = slots_refs {
                     index_scan_returned_some_count += 1;
                     let is_alive = slot_list.iter().any(|(slot, _acct_info)| {
-                        // if the accounts index contains an entry at this slot, then the append vec we're asking about contains this item and thus, it is alive at this slot
+                        // if the accounts index contains an entry at this slot, then the append vec
+                        // we're asking about contains this item and thus, it is alive at this slot
                         *slot == slot_to_shrink
                     });
 
                     if !is_alive {
                         // This pubkey was found in the storage, but no longer exists in the index.
-                        // It would have had a ref to the storage from the initial store, but it will
-                        // not exist in the re-written slot. Unref it to keep the index consistent with
-                        // rewriting the storage entries.
+                        // It would have had a ref to the storage from the initial store, but it
+                        // will not exist in the re-written slot. Unref it
+                        // to keep the index consistent with rewriting the
+                        // storage entries.
                         pubkeys_to_unref.push(pubkey);
                         dead += 1;
                     } else {
@@ -2711,11 +2729,13 @@ impl AccountsDb {
                     }
                 } else {
                     index_scan_returned_none_count += 1;
-                    // getting None here means the account is 'normal' and was written to disk. This means it must have ref_count=1 and
-                    // slot_list.len() = 1. This means it must be alive in this slot. This is by far the most common case.
-                    // Note that we could get Some(...) here if the account is in the in mem index because it is hot.
-                    // Note this could also mean the account isn't on disk either. That would indicate a bug in accounts db.
-                    // Account is alive.
+                    // getting None here means the account is 'normal' and was written to disk. This
+                    // means it must have ref_count=1 and slot_list.len() = 1.
+                    // This means it must be alive in this slot. This is by far the most common
+                    // case. Note that we could get Some(...) here if the
+                    // account is in the in mem index because it is hot.
+                    // Note this could also mean the account isn't on disk either. That would
+                    // indicate a bug in accounts db. Account is alive.
                     let ref_count = 1;
                     let slot_list = [(slot_to_shrink, AccountInfo::default())];
                     do_populate_accounts_for_shrink(ref_count, &slot_list);
@@ -2755,7 +2775,8 @@ impl AccountsDb {
         store
             .accounts
             .scan_accounts_without_data(|offset, account| {
-                // file_id is unused and can be anything. We will always be loading whatever storage is in the slot.
+                // file_id is unused and can be anything. We will always be loading whatever storage
+                // is in the slot.
                 let file_id = 0;
                 stored_accounts.push(AccountFromStorage {
                     index_info: AccountInfo::new(
@@ -2825,7 +2846,8 @@ impl AccountsDb {
     }
 
     /// shared code for shrinking normal slots and combining into ancient append vecs
-    /// note 'unique_accounts' is passed by ref so we can return references to data within it, avoiding self-references
+    /// note 'unique_accounts' is passed by ref so we can return references to data within it,
+    /// avoiding self-references
     pub(crate) fn shrink_collect<'a: 'b, 'b, T: ShrinkCollectRefs<'b>>(
         &self,
         store: &'a AccountStorageEntry,
@@ -2927,16 +2949,16 @@ impl AccountsDb {
         shrink_collect
     }
 
-    /// These accounts were found during shrink of `slot` to be slot_list=[slot] and ref_count == 1 and lamports = 0.
-    /// This means this slot contained the only account data for this pubkey and it is zero lamport.
-    /// Thus, we did NOT treat this as an alive account, so we did NOT copy the zero lamport account to the new
-    /// storage. So, the account will no longer be alive or exist at `slot`.
-    /// So, first, remove the ref count since this newly shrunk storage will no longer access it.
-    /// Second, remove `slot` from the index entry's slot list. If the slot list is now empty, then the
-    /// pubkey can be removed completely from the index.
-    /// In parallel with this code (which is running in the bg), the same pubkey could be revived and written to
-    /// as part of tx processing. In that case, the slot list will contain a slot in the write cache and the
-    /// index entry will NOT be deleted.
+    /// These accounts were found during shrink of `slot` to be slot_list=[slot] and ref_count == 1
+    /// and lamports = 0. This means this slot contained the only account data for this pubkey
+    /// and it is zero lamport. Thus, we did NOT treat this as an alive account, so we did NOT
+    /// copy the zero lamport account to the new storage. So, the account will no longer be
+    /// alive or exist at `slot`. So, first, remove the ref count since this newly shrunk
+    /// storage will no longer access it. Second, remove `slot` from the index entry's slot
+    /// list. If the slot list is now empty, then the pubkey can be removed completely from the
+    /// index. In parallel with this code (which is running in the bg), the same pubkey could be
+    /// revived and written to as part of tx processing. In that case, the slot list will
+    /// contain a slot in the write cache and the index entry will NOT be deleted.
     fn remove_zero_lamport_single_ref_accounts_after_shrink(
         &self,
         zero_lamport_single_ref_pubkeys: &[&Pubkey],
@@ -2949,8 +2971,9 @@ impl AccountsDb {
             Ordering::Relaxed,
         );
 
-        // we have to unref before we `purge_keys_exact`. Otherwise, we could race with the foreground with tx processing
-        // reviving this index entry and then we'd unref the revived version, which is a refcount bug.
+        // we have to unref before we `purge_keys_exact`. Otherwise, we could race with the
+        // foreground with tx processing reviving this index entry and then we'd unref the
+        // revived version, which is a refcount bug.
 
         self.accounts_index.scan(
             zero_lamport_single_ref_pubkeys.iter().cloned(),
@@ -2980,8 +3003,8 @@ impl AccountsDb {
         let mut time = Measure::start("remove_old_stores_shrink");
 
         // handle the zero lamport alive accounts before calling clean
-        // We have to update the index entries for these zero lamport pubkeys before we remove the storage in `mark_dirty_dead_stores`
-        // that contained the accounts.
+        // We have to update the index entries for these zero lamport pubkeys before we remove the
+        // storage in `mark_dirty_dead_stores` that contained the accounts.
         self.remove_zero_lamport_single_ref_accounts_after_shrink(
             &shrink_collect.zero_lamport_single_ref_pubkeys,
             shrink_collect.slot,
@@ -2990,12 +3013,13 @@ impl AccountsDb {
         );
 
         // Purge old, overwritten storage entries
-        // This has the side effect of dropping `shrink_in_progress`, which removes the old storage completely. The
-        // index has to be correct before we drop the old storage.
+        // This has the side effect of dropping `shrink_in_progress`, which removes the old storage
+        // completely. The index has to be correct before we drop the old storage.
         let dead_storages = self.mark_dirty_dead_stores(
             shrink_collect.slot,
-            // If all accounts are zero lamports, then we want to mark the entire OLD append vec as dirty.
-            // otherwise, we'll call 'add_uncleaned_pubkeys_after_shrink' just on the unref'd keys below.
+            // If all accounts are zero lamports, then we want to mark the entire OLD append vec as
+            // dirty. otherwise, we'll call 'add_uncleaned_pubkeys_after_shrink' just
+            // on the unref'd keys below.
             shrink_collect.all_are_zero_lamports,
             shrink_in_progress,
             shrink_can_be_active,
@@ -3033,7 +3057,8 @@ impl AccountsDb {
             |pubkey, slot_refs| {
                 match slot_refs {
                     Some((slot_list, ref_count)) => {
-                        // Let's handle the special case - after unref, the result is a single ref zero lamport account.
+                        // Let's handle the special case - after unref, the result is a single ref
+                        // zero lamport account.
                         if slot_list.len() == 1 && ref_count == 2 {
                             if let Some((slot_alive, acct_info)) = slot_list.first() {
                                 if acct_info.is_zero_lamport() && !acct_info.is_cached() {
@@ -3067,7 +3092,8 @@ impl AccountsDb {
         );
     }
 
-    /// This function handles the case when zero lamport single ref accounts are found during shrink.
+    /// This function handles the case when zero lamport single ref accounts are found during
+    /// shrink.
     pub(crate) fn zero_lamport_single_ref_found(&self, slot: Slot, offset: Offset) {
         // This function can be called when a zero lamport single ref account is
         // found during shrink. Therefore, we can't use the safe version of
@@ -3120,17 +3146,23 @@ impl AccountsDb {
     fn shrink_storage(&self, store: Arc<AccountStorageEntry>) {
         let slot = store.slot();
         if self.accounts_cache.contains(slot) {
-            // It is not correct to shrink a slot while it is in the write cache until flush is complete and the slot is removed from the write cache.
-            // There can exist a window after a slot is made a root and before the write cache flushing for that slot begins and then completes.
-            // There can also exist a window after a slot is being flushed from the write cache until the index is updated and the slot is removed from the write cache.
-            // During the second window, once an append vec has been created for the slot, it could be possible to try to shrink that slot.
-            // Shrink no-ops before this function if there is no store for the slot (notice this function requires 'store' to be passed).
-            // So, if we enter this function but the slot is still in the write cache, reasonable behavior is to skip shrinking this slot.
-            // Flush will ONLY write alive accounts to the append vec, which is what shrink does anyway.
-            // Flush then adds the slot to 'uncleaned_roots', which causes clean to take a look at the slot.
-            // Clean causes us to mark accounts as dead, which causes shrink to later take a look at the slot.
-            // This could be an assert, but it could lead to intermittency in tests.
-            // It is 'correct' to ignore calls to shrink when a slot is still in the write cache.
+            // It is not correct to shrink a slot while it is in the write cache until flush is
+            // complete and the slot is removed from the write cache. There can exist a
+            // window after a slot is made a root and before the write cache flushing for that slot
+            // begins and then completes. There can also exist a window after a slot is
+            // being flushed from the write cache until the index is updated and the slot is removed
+            // from the write cache. During the second window, once an append vec has
+            // been created for the slot, it could be possible to try to shrink that slot.
+            // Shrink no-ops before this function if there is no store for the slot (notice this
+            // function requires 'store' to be passed). So, if we enter this function
+            // but the slot is still in the write cache, reasonable behavior is to skip shrinking
+            // this slot. Flush will ONLY write alive accounts to the append vec, which
+            // is what shrink does anyway. Flush then adds the slot to
+            // 'uncleaned_roots', which causes clean to take a look at the slot.
+            // Clean causes us to mark accounts as dead, which causes shrink to later take a look at
+            // the slot. This could be an assert, but it could lead to intermittency in
+            // tests. It is 'correct' to ignore calls to shrink when a slot is still in
+            // the write cache.
             return;
         }
         let mut unique_accounts =
@@ -3143,7 +3175,8 @@ impl AccountsDb {
         );
 
         // This shouldn't happen if alive_bytes is accurate.
-        // However, it is possible that the remaining alive bytes could be 0. In that case, the whole slot should be marked dead by clean.
+        // However, it is possible that the remaining alive bytes could be 0. In that case, the
+        // whole slot should be marked dead by clean.
         if Self::should_not_shrink(
             shrink_collect.alive_total_bytes as u64,
             shrink_collect.capacity,
@@ -3155,7 +3188,8 @@ impl AccountsDb {
             }
 
             if !shrink_collect.all_are_zero_lamports {
-                // if all are zero lamports, then we expect that we would like to mark the whole slot dead, but we cannot. That's clean's job.
+                // if all are zero lamports, then we expect that we would like to mark the whole
+                // slot dead, but we cannot. That's clean's job.
                 info!(
                     "Unexpected shrink for slot {} alive {} capacity {}, likely caused by a bug \
                      for calculating alive bytes.",
@@ -3260,9 +3294,10 @@ impl AccountsDb {
     }
 
     /// get stores for 'slot'
-    /// Drop 'shrink_in_progress', which will cause the old store to be removed from the storage map.
-    /// For 'shrink_in_progress'.'old_storage' which is not retained, insert in 'dead_storages' and optionally 'dirty_stores'
-    /// This is the end of the life cycle of `shrink_in_progress`.
+    /// Drop 'shrink_in_progress', which will cause the old store to be removed from the storage
+    /// map. For 'shrink_in_progress'.'old_storage' which is not retained, insert in
+    /// 'dead_storages' and optionally 'dirty_stores' This is the end of the life cycle of
+    /// `shrink_in_progress`.
     pub fn mark_dirty_dead_stores(
         &self,
         slot: Slot,
@@ -3282,7 +3317,8 @@ impl AccountsDb {
         if let Some(shrink_in_progress) = shrink_in_progress {
             // shrink is in progress, so 1 new append vec to keep, 1 old one to throw away
             not_retaining_store(shrink_in_progress.old_storage());
-            // dropping 'shrink_in_progress' removes the old append vec that was being shrunk from db's storage
+            // dropping 'shrink_in_progress' removes the old append vec that was being shrunk from
+            // db's storage
         } else if let Some(store) = self.storage.remove(&slot, shrink_can_be_active) {
             // no shrink in progress, so all append vecs in this slot are dead
             not_retaining_store(&store);
@@ -3291,18 +3327,19 @@ impl AccountsDb {
         dead_storages
     }
 
-    /// we are done writing to the storage at `slot`. It can be re-opened as read-only if that would help
-    /// system performance.
+    /// we are done writing to the storage at `slot`. It can be re-opened as read-only if that would
+    /// help system performance.
     pub(crate) fn reopen_storage_as_readonly_shrinking_in_progress_ok(&self, slot: Slot) {
         if let Some(storage) = self
             .storage
             .get_slot_storage_entry_shrinking_in_progress_ok(slot)
         {
             if let Some(new_storage) = storage.reopen_as_readonly(self.storage_access) {
-                // consider here the race condition of tx processing having looked up something in the index,
-                // which could return (slot, append vec id). We want the lookup for the storage to get a storage
-                // that works whether the lookup occurs before or after the replace call here.
-                // So, the two storages have to be exactly equivalent wrt offsets, counts, len, id, etc.
+                // consider here the race condition of tx processing having looked up something in
+                // the index, which could return (slot, append vec id). We want the
+                // lookup for the storage to get a storage that works whether the
+                // lookup occurs before or after the replace call here. So, the two
+                // storages have to be exactly equivalent wrt offsets, counts, len, id, etc.
                 assert_eq!(storage.id(), new_storage.id());
                 assert_eq!(storage.accounts.len(), new_storage.accounts.len());
                 self.storage
@@ -3376,8 +3413,8 @@ impl AccountsDb {
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
 
-        // Working from the beginning of store_usage which are the most sparse and see when we can stop
-        // shrinking while still achieving the overall goals.
+        // Working from the beginning of store_usage which are the most sparse and see when we can
+        // stop shrinking while still achieving the overall goals.
         let mut shrink_slots = IntMap::default();
         let mut shrink_slots_next_batch = ShrinkCandidates::default();
         for usage in &store_usage {
@@ -3425,9 +3462,10 @@ impl AccountsDb {
             .get_all_less_than(slot)
     }
 
-    /// return all slots that are more than one epoch old and thus could already be an ancient append vec
-    /// or which could need to be combined into a new or existing ancient append vec
-    /// offset is used to combine newer slots than we normally would. This is designed to be used for testing.
+    /// return all slots that are more than one epoch old and thus could already be an ancient
+    /// append vec or which could need to be combined into a new or existing ancient append vec
+    /// offset is used to combine newer slots than we normally would. This is designed to be used
+    /// for testing.
     fn get_sorted_potential_ancient_slots(&self, oldest_non_ancient_slot: Slot) -> Vec<Slot> {
         let mut ancient_slots = self.get_roots_less_than(oldest_non_ancient_slot);
         ancient_slots.sort_unstable();
@@ -3605,10 +3643,11 @@ impl AccountsDb {
         num_selected
     }
 
-    /// This is only called at startup from bank when we are being extra careful such as when we downloaded a snapshot.
-    /// Also called from tests.
-    /// `newest_slot_skip_shrink_inclusive` is used to avoid shrinking the slot we are loading a snapshot from. If we shrink that slot, we affect
-    /// the bank hash calculation verification at startup.
+    /// This is only called at startup from bank when we are being extra careful such as when we
+    /// downloaded a snapshot. Also called from tests.
+    /// `newest_slot_skip_shrink_inclusive` is used to avoid shrinking the slot we are loading a
+    /// snapshot from. If we shrink that slot, we affect the bank hash calculation verification
+    /// at startup.
     pub fn shrink_all_slots(
         &self,
         is_startup: bool,
@@ -3620,19 +3659,22 @@ impl AccountsDb {
         const OUTER_CHUNK_SIZE: usize = 2000;
         let mut slots = self.all_slots_in_storage();
         if let Some(newest_slot_skip_shrink_inclusive) = newest_slot_skip_shrink_inclusive {
-            // at startup, we cannot shrink the slot that we're about to replay and recalculate bank hash for.
-            // That storage's contents are used to verify the bank hash (and accounts delta hash) of the startup slot.
+            // at startup, we cannot shrink the slot that we're about to replay and recalculate bank
+            // hash for. That storage's contents are used to verify the bank hash (and
+            // accounts delta hash) of the startup slot.
             slots.retain(|slot| slot < &newest_slot_skip_shrink_inclusive);
         }
 
-        // if we are restoring from incremental + full snapshot, then we cannot clean past latest_full_snapshot_slot.
-        // If we were to clean past that, then we could mark accounts prior to latest_full_snapshot_slot as dead.
-        // If we mark accounts prior to latest_full_snapshot_slot as dead, then we could shrink those accounts away.
-        // If we shrink accounts away, then when we run the full hash of all accounts calculation up to latest_full_snapshot_slot,
-        // then we will get the wrong answer, because some accounts may be GONE from the slot range up to latest_full_snapshot_slot.
+        // if we are restoring from incremental + full snapshot, then we cannot clean past
+        // latest_full_snapshot_slot. If we were to clean past that, then we could mark
+        // accounts prior to latest_full_snapshot_slot as dead. If we mark accounts prior to
+        // latest_full_snapshot_slot as dead, then we could shrink those accounts away.
+        // If we shrink accounts away, then when we run the full hash of all accounts calculation up
+        // to latest_full_snapshot_slot, then we will get the wrong answer, because some
+        // accounts may be GONE from the slot range up to latest_full_snapshot_slot.
         // So, we can only clean UP TO and including latest_full_snapshot_slot.
-        // As long as we don't mark anything as dead at slots > latest_full_snapshot_slot, then shrink will have nothing to do for
-        // slots > latest_full_snapshot_slot.
+        // As long as we don't mark anything as dead at slots > latest_full_snapshot_slot, then
+        // shrink will have nothing to do for slots > latest_full_snapshot_slot.
         let maybe_clean = || {
             if self.dirty_stores.len() > DIRTY_STORES_CLEANING_THRESHOLD {
                 let latest_full_snapshot_slot = self.latest_full_snapshot_slot();
@@ -3810,13 +3852,15 @@ impl AccountsDb {
             // been flushed. This is guaranteed because we only remove the rooted slot from
             // the cache *after* we've finished flushing in `flush_slot_cache`.
             // Regarding `shrinking_in_progress_ok`:
-            // This fn could be running in the foreground, so shrinking could be running in the background, independently.
-            // Even if shrinking is running, there will be 0-1 active storages to scan here at any point.
-            // When a concurrent shrink completes, the active storage at this slot will
-            // be replaced with an equivalent storage with only alive accounts in it.
-            // A shrink on this slot could have completed anytime before the call here, a shrink could currently be in progress,
-            // or the shrink could complete immediately or anytime after this call. This has always been true.
-            // So, whether we get a never-shrunk, an about-to-be shrunk, or a will-be-shrunk-in-future storage here to scan,
+            // This fn could be running in the foreground, so shrinking could be running in the
+            // background, independently. Even if shrinking is running, there will be
+            // 0-1 active storages to scan here at any point. When a concurrent shrink
+            // completes, the active storage at this slot will be replaced with an
+            // equivalent storage with only alive accounts in it. A shrink on this slot
+            // could have completed anytime before the call here, a shrink could currently be in
+            // progress, or the shrink could complete immediately or anytime after this
+            // call. This has always been true. So, whether we get a never-shrunk, an
+            // about-to-be shrunk, or a will-be-shrunk-in-future storage here to scan,
             // all are correct and possible in a normally running system.
             if let Some(storage) = self
                 .storage
@@ -3839,7 +3883,8 @@ impl AccountsDb {
     }
 
     /// load the account with `pubkey` into the read only accounts cache.
-    /// The goal is to make subsequent loads (which caller expects to occur) to find the account quickly.
+    /// The goal is to make subsequent loads (which caller expects to occur) to find the account
+    /// quickly.
     pub fn load_account_into_read_cache(&self, ancestors: &Ancestors, pubkey: &Pubkey) {
         self.do_load_with_populate_read_cache(
             ancestors,
@@ -3909,8 +3954,8 @@ impl AccountsDb {
         //          |                           |
         //        <LoadedAccount>               |
         //          V                           |
-        // R4 take_account()                    | cached/stored: entry of cache/storage for (slot, pubkey)
-        //          |                           |
+        // R4 take_account()                    | cached/stored: entry of cache/storage for (slot,
+        // pubkey)          |                           |
         //        <AccountSharedData>           |
         //          V                           |
         //    Account!!                         V
@@ -3931,9 +3976,9 @@ impl AccountsDb {
         // F4 accounts_cache.remove_slot()      | map of caches (removes old entry)
         //                                      V
         //
-        // Remarks for flusher: So, for any reading operations, it's a race condition where F4 happens
-        // between R1 and R2. In that case, retrying from R1 is safu because F3 should have
-        // been occurred.
+        // Remarks for flusher: So, for any reading operations, it's a race condition where F4
+        // happens between R1 and R2. In that case, retrying from R1 is safu because F3
+        // should have been occurred.
         //
         // Shrinker                             | Accessed data source for stored
         // -------------------------------------+----------------------------------
@@ -3952,8 +3997,8 @@ impl AccountsDb {
         //        dead_storages
         //
         // Remarks for shrinker: So, for any reading operations, it's a race condition
-        // where S4 happens between R1 and R2. In that case, retrying from R1 is safu because S3 should have
-        // been occurred, and S3 atomically replaced the index accordingly.
+        // where S4 happens between R1 and R2. In that case, retrying from R1 is safu because S3
+        // should have been occurred, and S3 atomically replaced the index accordingly.
         //
         // Cleaner                              | Accessed data source for stored
         // -------------------------------------+----------------------------------
@@ -4011,18 +4056,20 @@ impl AccountsDb {
                 }
                 LoadedAccountAccessor::Cached(None) => {
                     num_acceptable_failed_iterations += 1;
-                    // Cache was flushed in between checking the index and retrieving from the cache,
-                    // so retry. This works because in accounts cache flush, an account is written to
-                    // storage *before* it is removed from the cache
+                    // Cache was flushed in between checking the index and retrieving from the
+                    // cache, so retry. This works because in accounts cache
+                    // flush, an account is written to storage *before* it is
+                    // removed from the cache
                     match load_hint {
                         LoadHint::FixedMaxRootDoNotPopulateReadCache | LoadHint::FixedMaxRoot => {
                             // it's impossible for this to fail for transaction loads from
                             // replaying/banking more than once.
                             // This is because:
                             // 1) For a slot `X` that's being replayed, there is only one
-                            // latest ancestor containing the latest update for the account, and this
-                            // ancestor can only be flushed once.
-                            // 2) The root cannot move while replaying, so the index cannot continually
+                            // latest ancestor containing the latest update for the account, and
+                            // this ancestor can only be flushed once.
+                            // 2) The root cannot move while replaying, so the index cannot
+                            //    continually
                             // find more up to date entries than the current `slot`
                             assert!(num_acceptable_failed_iterations <= 1);
                         }
@@ -4045,31 +4092,38 @@ impl AccountsDb {
                             // 1) Shrink has removed the old storage entry and rewritten to
                             // a newer storage entry
                             // 2) The `pubkey` asked for in this function is a zero-lamport account,
-                            // and the storage entry holding this account qualified for zero-lamport clean.
+                            // and the storage entry holding this account qualified for zero-lamport
+                            // clean.
                             //
-                            // In both these cases, it should be safe to retry and recheck the accounts
-                            // index indefinitely, without incrementing num_acceptable_failed_iterations.
+                            // In both these cases, it should be safe to retry and recheck the
+                            // accounts index indefinitely, without
+                            // incrementing num_acceptable_failed_iterations.
                             // That's because if the root is fixed, there should be a bounded number
-                            // of pending cleans/shrinks (depends how far behind the AccountsBackgroundService
+                            // of pending cleans/shrinks (depends how far behind the
+                            // AccountsBackgroundService
                             // is), termination to the desired condition is guaranteed.
                             //
                             // Also note that in both cases, if we do find the storage entry,
                             // we can guarantee that the storage entry is safe to read from because
                             // we grabbed a reference to the storage entry while it was still in the
-                            // storage map. This means even if the storage entry is removed from the storage
-                            // map after we grabbed the storage entry, the recycler should not reset the
+                            // storage map. This means even if the storage entry is removed from the
+                            // storage map after we grabbed the storage
+                            // entry, the recycler should not reset the
                             // storage entry until we drop the reference to the storage entry.
                             //
                             // eh, no code in this arm? yes!
                         }
                         LoadHint::Unspecified => {
-                            // RPC get_account() may have fetched an old root from the index that was
-                            // either:
-                            // 1) Cleaned up by clean_accounts(), so the accounts index has been updated
+                            // RPC get_account() may have fetched an old root from the index that
+                            // was either:
+                            // 1) Cleaned up by clean_accounts(), so the accounts index has been
+                            //    updated
                             // and the storage entries have been removed.
-                            // 2) Dropped by purge_slots() because the slot was on a minor fork, which
-                            // removes the slots' storage entries but doesn't purge from the accounts index
-                            // (account index cleanup is left to clean for stored slots). Note that
+                            // 2) Dropped by purge_slots() because the slot was on a minor fork,
+                            //    which
+                            // removes the slots' storage entries but doesn't purge from the
+                            // accounts index (account index cleanup is
+                            // left to clean for stored slots). Note that
                             // this generally is impossible to occur in the wild because the RPC
                             // should hold the slot's bank, preventing it from being purged() to
                             // begin with.
@@ -4117,31 +4171,33 @@ impl AccountsDb {
                              {load_hint:?}, {new_storage_location:?}, {entry:?})"
                         );
                         // Considering that we've failed to get accessor above and further that
-                        // the index still returned the same (slot, store_id) tuple, offset must be same
-                        // too.
+                        // the index still returned the same (slot, store_id) tuple, offset must be
+                        // same too.
                         assert!(
                             new_storage_location.is_offset_equal(&storage_location),
                             "{message}"
                         );
 
-                        // If the entry was missing from the cache, that means it must have been flushed,
-                        // and the accounts index is always updated before cache flush, so store_id must
-                        // not indicate being cached at this point.
+                        // If the entry was missing from the cache, that means it must have been
+                        // flushed, and the accounts index is always updated
+                        // before cache flush, so store_id must not indicate
+                        // being cached at this point.
                         assert!(!new_storage_location.is_cached(), "{message}");
 
                         // If this is not a cache entry, then this was a minor fork slot
                         // that had its storage entries cleaned up by purge_slots() but hasn't been
-                        // cleaned yet. That means this must be rpc access and not replay/banking at the
-                        // very least. Note that purge shouldn't occur even for RPC as caller must hold all
-                        // of ancestor slots..
+                        // cleaned yet. That means this must be rpc access and not replay/banking at
+                        // the very least. Note that purge shouldn't occur
+                        // even for RPC as caller must hold all of ancestor
+                        // slots..
                         assert_eq!(load_hint, LoadHint::Unspecified, "{message}");
 
-                        // Everything being assert!()-ed, let's panic!() here as it's an error condition
-                        // after all....
+                        // Everything being assert!()-ed, let's panic!() here as it's an error
+                        // condition after all....
                         // That reasoning is based on the fact all of code-path reaching this fn
                         // retry_to_get_account_accessor() must outlive the Arc<Bank> (and its all
-                        // ancestors) over this fn invocation, guaranteeing the prevention of being purged,
-                        // first of all.
+                        // ancestors) over this fn invocation, guaranteeing the prevention of being
+                        // purged, first of all.
                         // For details, see the comment in AccountIndex::do_checked_scan_accounts(),
                         // which is referring back here.
                         panic!("{message}");
@@ -4411,9 +4467,9 @@ impl AccountsDb {
 
     /// This should only be called after the `Bank::drop()` runs in bank.rs, See BANK_DROP_SAFETY
     /// comment below for more explanation.
-    /// * `is_serialized_with_abs` - indicates whether this call runs sequentially
-    ///   with all other accounts_db relevant calls, such as shrinking, purging etc.,
-    ///   in accounts background service.
+    /// * `is_serialized_with_abs` - indicates whether this call runs sequentially with all other
+    ///   accounts_db relevant calls, such as shrinking, purging etc., in accounts background
+    ///   service.
     pub fn purge_slot(&self, slot: Slot, bank_id: BankId, is_serialized_with_abs: bool) {
         if self.is_bank_drop_callback_enabled.load(Ordering::Acquire) && !is_serialized_with_abs {
             panic!(
@@ -4967,7 +5023,8 @@ impl AccountsDb {
             })
             .flatten();
 
-        // Always flush up to `requested_flush_root`, which is necessary for things like snapshotting.
+        // Always flush up to `requested_flush_root`, which is necessary for things like
+        // snapshotting.
         let flushed_roots: BTreeSet<Slot> = self.accounts_cache.clear_roots(requested_flush_root);
 
         // Iterate from highest to lowest so that we don't need to flush earlier
@@ -5054,7 +5111,8 @@ impl AccountsDb {
         // Cleaning is enabled if `should_flush_f` is Some.
         // should_flush_f is set to None when
         // 1) There's an ongoing scan to avoid reclaiming accounts being scanned.
-        // 2) The slot is > max_clean_root to prevent unrooted slots from reclaiming rooted versions.
+        // 2) The slot is > max_clean_root to prevent unrooted slots from reclaiming rooted
+        //    versions.
         let reclaim_method = if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled
             && should_flush_f.is_some()
         {
@@ -5089,8 +5147,8 @@ impl AccountsDb {
             self.reopen_storage_as_readonly_shrinking_in_progress_ok(slot);
         }
 
-        // Remove this slot from the cache, which will to AccountsDb's new readers should look like an
-        // atomic switch from the cache to storage.
+        // Remove this slot from the cache, which will to AccountsDb's new readers should look like
+        // an atomic switch from the cache to storage.
         // There is some racy condition for existing readers who just has read exactly while
         // flushing. That case is handled by retry_to_get_account_accessor()
         assert!(self.accounts_cache.remove_slot(slot).is_some());
@@ -5376,8 +5434,8 @@ impl AccountsDb {
     }
 
     /// Updates the accounts index with the given `infos` and `accounts`.
-    /// Returns a vector of `SlotList<AccountInfo>` containing the reclaims for each batch processed.
-    /// The element of the returned vector is guaranteed to be non-empty.
+    /// Returns a vector of `SlotList<AccountInfo>` containing the reclaims for each batch
+    /// processed. The element of the returned vector is guaranteed to be non-empty.
     fn update_index<'a>(
         &self,
         infos: Vec<AccountInfo>,
@@ -5477,7 +5535,8 @@ impl AccountsDb {
     /// candidate for shrinking.
     pub(crate) fn is_candidate_for_shrink(&self, store: &AccountStorageEntry) -> bool {
         // appended ancient append vecs should not be shrunk by the normal shrink codepath.
-        // It is not possible to identify ancient append vecs when we pack, so no check for ancient when we are not appending.
+        // It is not possible to identify ancient append vecs when we pack, so no check for ancient
+        // when we are not appending.
         let total_bytes = store.capacity();
 
         let alive_bytes = store.alive_bytes_exclude_zero_lamport_single_ref_accounts() as u64;
@@ -5535,13 +5594,16 @@ impl AccountsDb {
                 );
 
                 let remaining_accounts = if offsets.len() == store.count() {
-                    // all remaining alive accounts in the storage are being removed, so the entire storage/slot is dead
+                    // all remaining alive accounts in the storage are being removed, so the entire
+                    // storage/slot is dead
                     store.remove_accounts(store.alive_bytes(), offsets.len())
                 } else {
-                    // not all accounts are being removed, so figure out sizes of accounts we are removing and update the alive bytes and alive account count
+                    // not all accounts are being removed, so figure out sizes of accounts we are
+                    // removing and update the alive bytes and alive account count
                     let (remaining_accounts, us) = measure_us!({
                         let mut offsets = offsets.iter().cloned().collect::<Vec<_>>();
-                        // sort so offsets are in order. This improves efficiency of loading the accounts.
+                        // sort so offsets are in order. This improves efficiency of loading the
+                        // accounts.
                         offsets.sort_unstable();
                         let data_lens = store.accounts.get_account_data_lens(&offsets);
                         let dead_bytes = data_lens
@@ -5640,14 +5702,16 @@ impl AccountsDb {
                         .skip(skip)
                         .take(UNREF_ACCOUNTS_BATCH_SIZE)
                         .filter(|pubkey| {
-                            // filter out pubkeys that have already been removed from the accounts index in a previous step
+                            // filter out pubkeys that have already been removed from the accounts
+                            // index in a previous step
                             let already_removed =
                                 pubkeys_removed_from_accounts_index.contains(pubkey);
                             !already_removed
                         }),
                     |_pubkey, slots_refs| {
                         if let Some((slot_list, ref_count)) = slots_refs {
-                            // Let's handle the special case - after unref, the result is a single ref zero lamport account.
+                            // Let's handle the special case - after unref, the result is a single
+                            // ref zero lamport account.
                             if slot_list.len() == 1 && ref_count == 2 {
                                 if let Some((slot_alive, acct_info)) = slot_list.first() {
                                     if acct_info.is_zero_lamport() && !acct_info.is_cached() {
@@ -5670,8 +5734,8 @@ impl AccountsDb {
 
     /// lookup each pubkey in 'purged_slot_pubkeys' and unref it in the accounts index
     /// populate 'purged_stored_account_slots' by grouping 'purged_slot_pubkeys' by pubkey
-    /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts index
-    ///    and should not be unref'd. If they exist in the accounts index, they are NEW.
+    /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts
+    /// index    and should not be unref'd. If they exist in the accounts index, they are NEW.
     fn unref_accounts(
         &self,
         purged_slot_pubkeys: HashSet<(Slot, Pubkey)>,
@@ -5728,8 +5792,8 @@ impl AccountsDb {
             .update(&accounts_index_root_stats);
     }
 
-    /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts index
-    ///    and should not be unref'd. If they exist in the accounts index, they are NEW.
+    /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts
+    /// index    and should not be unref'd. If they exist in the accounts index, they are NEW.
     fn clean_stored_dead_slots(
         &self,
         dead_slots: &IntSet<Slot>,
@@ -5851,9 +5915,10 @@ impl AccountsDb {
 
     /// Stores accounts in the storage and updates the index.
     /// This function is intended for accounts that are rooted (frozen).
-    /// - `UpsertReclaims` is set to `IgnoreReclaims`. If the slot in `accounts` differs from the new slot,
-    ///   accounts may be removed from the account index. In such cases, the caller must ensure that alive
-    ///   accounts are decremented for the older storage or that the old storage is removed entirely
+    /// - `UpsertReclaims` is set to `IgnoreReclaims`. If the slot in `accounts` differs from the
+    ///   new slot, accounts may be removed from the account index. In such cases, the caller must
+    ///   ensure that alive accounts are decremented for the older storage or that the old storage
+    ///   is removed entirely
     pub fn store_accounts_frozen<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
@@ -5884,8 +5949,9 @@ impl AccountsDb {
         // Flush the read cache if necessary. This will occur during shrink or clean
         if self.read_only_accounts_cache.can_slot_be_in_cache(slot) {
             (0..accounts.len()).for_each(|index| {
-                // based on the patterns of how a validator writes accounts, it is almost always the case that there is no read only cache entry
-                // for this pubkey and slot. So, we can give that hint to the `remove` for performance.
+                // based on the patterns of how a validator writes accounts, it is almost always the
+                // case that there is no read only cache entry for this pubkey and
+                // slot. So, we can give that hint to the `remove` for performance.
                 self.read_only_accounts_cache
                     .remove_assume_not_present(accounts.pubkey(index));
             });
@@ -6412,13 +6478,15 @@ impl AccountsDb {
             .insert_new_if_missing_into_primary_index(slot, keyed_account_infos);
 
         {
-            // second, collect into the shared DashMap once we've figured out all the info per store_id
+            // second, collect into the shared DashMap once we've figured out all the info per
+            // store_id
             let mut info = storage_info.entry(store_id).or_default();
             info.stored_size += stored_size_alive;
             info.count += insert_info.count;
 
-            // sanity check that stored_size is not larger than the u64 aligned size of the accounts files.
-            // Note that the stored_size is aligned, so it can be larger than the size of the accounts file.
+            // sanity check that stored_size is not larger than the u64 aligned size of the accounts
+            // files. Note that the stored_size is aligned, so it can be larger than the
+            // size of the accounts file.
             assert!(
                 info.stored_size <= u64_align!(storage.accounts.len()),
                 "Stored size ({}) is larger than the size of the accounts file ({}) for store_id: \
@@ -6799,7 +6867,8 @@ impl AccountsDb {
         total_accum.accounts_data_len -= accounts_data_len_from_duplicates;
         info!("accounts data len: {}", total_accum.accounts_data_len);
 
-        // insert all zero lamport account storage into the dirty stores and add them into the uncleaned roots for clean to pick up
+        // insert all zero lamport account storage into the dirty stores and add them into the
+        // uncleaned roots for clean to pick up
         info!(
             "insert all zero slots to clean at startup {}",
             total_accum.all_zeros_slots.len()
@@ -6817,11 +6886,12 @@ impl AccountsDb {
 
         if self.mark_obsolete_accounts == MarkObsoleteAccounts::Enabled {
             let mut mark_obsolete_accounts_time = Measure::start("mark_obsolete_accounts_time");
-            // Mark all reclaims at max_slot. This is safe because only the snapshot paths care about
-            // this information. Since this account was just restored from the previous snapshot and
-            // it is known that it was already obsolete at that time, it must hold true that it will
-            // still be obsolete if a newer snapshot is created, since a newer snapshot will always
-            // be performed on a slot greater than the current slot
+            // Mark all reclaims at max_slot. This is safe because only the snapshot paths care
+            // about this information. Since this account was just restored from the
+            // previous snapshot and it is known that it was already obsolete at that
+            // time, it must hold true that it will still be obsolete if a newer
+            // snapshot is created, since a newer snapshot will always be performed on a
+            // slot greater than the current slot
             let slot_marked_obsolete = storages.last().unwrap().slot();
             let obsolete_account_stats =
                 self.mark_obsolete_accounts_at_startup(slot_marked_obsolete, unique_pubkeys_by_bin);
@@ -6893,20 +6963,24 @@ impl AccountsDb {
         stats
     }
 
-    /// Startup processes can consume large amounts of memory while inserting accounts into the index as fast as possible.
-    /// Calling this can slow down the insertion process to allow flushing to disk to keep pace.
+    /// Startup processes can consume large amounts of memory while inserting accounts into the
+    /// index as fast as possible. Calling this can slow down the insertion process to allow
+    /// flushing to disk to keep pace.
     fn maybe_throttle_index_generation(&self) {
-        // Only throttle if we are generating on-disk index. Throttling is not needed for in-mem index.
+        // Only throttle if we are generating on-disk index. Throttling is not needed for in-mem
+        // index.
         if !self.accounts_index.is_disk_index_enabled() {
             return;
         }
         // This number is chosen to keep the initial ram usage sufficiently small
-        // The process of generating the index is governed entirely by how fast the disk index can be populated.
-        // 10M accounts is sufficiently small that it will never have memory usage. It seems sufficiently large that it will provide sufficient performance.
+        // The process of generating the index is governed entirely by how fast the disk index can
+        // be populated. 10M accounts is sufficiently small that it will never have memory
+        // usage. It seems sufficiently large that it will provide sufficient performance.
         // Performance is measured by total time to generate the index.
-        // Just estimating - 150M accounts can easily be held in memory in the accounts index on a 256G machine. 2-300M are also likely 'fine' during startup.
-        // 550M was straining a 384G machine at startup.
-        // This is a tunable parameter that just needs to be small enough to keep the generation threads from overwhelming RAM and oom at startup.
+        // Just estimating - 150M accounts can easily be held in memory in the accounts index on a
+        // 256G machine. 2-300M are also likely 'fine' during startup. 550M was straining a
+        // 384G machine at startup. This is a tunable parameter that just needs to be small
+        // enough to keep the generation threads from overwhelming RAM and oom at startup.
         const LIMIT: usize = 10_000_000;
         while self
             .accounts_index
@@ -6914,7 +6988,8 @@ impl AccountsDb {
             > LIMIT
         {
             // 10 ms is long enough to allow some flushing to occur before insertion is resumed.
-            // callers of this are typically run in parallel, so many threads will be sleeping at different starting intervals, waiting to resume insertion.
+            // callers of this are typically run in parallel, so many threads will be sleeping at
+            // different starting intervals, waiting to resume insertion.
             sleep(Duration::from_millis(10));
         }
     }
@@ -7021,15 +7096,18 @@ impl AccountsDb {
             |pubkey, slots_refs| {
                 if let Some((slot_list, _ref_count)) = slots_refs {
                     if slot_list.len() > 1 {
-                        // Only the account data len in the highest slot should be used, and the rest are
-                        // duplicates.  So find the max slot to keep.
-                        // Then sum up the remaining data len, which are the duplicates.
-                        // All of the slots need to go in the 'uncleaned_slots' list. For clean to work properly,
-                        // the slot where duplicate accounts are found in the index need to be in 'uncleaned_slots' list, too.
+                        // Only the account data len in the highest slot should be used, and the
+                        // rest are duplicates.  So find the max slot to
+                        // keep. Then sum up the remaining data len, which
+                        // are the duplicates. All of the slots need to go
+                        // in the 'uncleaned_slots' list. For clean to work properly,
+                        // the slot where duplicate accounts are found in the index need to be in
+                        // 'uncleaned_slots' list, too.
                         let max = slot_list.iter().map(|(slot, _)| slot).max().unwrap();
                         slot_list.iter().for_each(|(slot, account_info)| {
                             if slot == max {
-                                // the info in 'max' is the most recent, current info for this pubkey
+                                // the info in 'max' is the most recent, current info for this
+                                // pubkey
                                 return;
                             }
                             let maybe_storage_entry = self
@@ -7178,7 +7256,8 @@ impl AccountStorageEntry {
 
 #[cfg(test)]
 impl AccountStorageEntry {
-    // Function to modify the list in the account storage entry directly. Only intended for use in testing
+    // Function to modify the list in the account storage entry directly. Only intended for use in
+    // testing
     pub(crate) fn obsolete_accounts(&self) -> &RwLock<ObsoleteAccounts> {
         &self.obsolete_accounts
     }
@@ -7261,7 +7340,8 @@ impl AccountsDb {
             pubkey,
             None,
             LoadHint::Unspecified,
-            // callers of this expect zero lamport accounts that exist in the index to be returned as Some(empty)
+            // callers of this expect zero lamport accounts that exist in the index to be returned
+            // as Some(empty)
             LoadZeroLamports::SomeWithZeroLamportAccountForTests,
         )
     }

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -117,23 +117,23 @@ pub mod tests {
         // to correct slots. Cache flush can skip writes if accounts have already been written to
         // a newer slot
         let slot0 = 0;
-        let storage0 = accounts_db.create_and_insert_store(slot0, /*size*/ 4_096, "");
+        let storage0 = accounts_db.create_and_insert_store(slot0, /* size */ 4_096, "");
         storage0
             .accounts
-            .write_accounts(&(slot0, [(&key1, &account)].as_slice()), /*skip*/ 0);
+            .write_accounts(&(slot0, [(&key1, &account)].as_slice()), /* skip */ 0);
 
         let slot1 = 1;
-        let storage1 = accounts_db.create_and_insert_store(slot1, /*size*/ 4_096, "");
+        let storage1 = accounts_db.create_and_insert_store(slot1, /* size */ 4_096, "");
         storage1
             .accounts
-            .write_accounts(&(slot1, [(&key1, &account)].as_slice()), /*skip*/ 0);
+            .write_accounts(&(slot1, [(&key1, &account)].as_slice()), /* skip */ 0);
 
         // Account with key2 is updated in a single slot, should get notified once
         let slot2 = 2;
-        let storage2 = accounts_db.create_and_insert_store(slot2, /*size*/ 4_096, "");
+        let storage2 = accounts_db.create_and_insert_store(slot2, /* size */ 4_096, "");
         storage2
             .accounts
-            .write_accounts(&(slot2, [(&key2, &account)].as_slice()), /*skip*/ 0);
+            .write_accounts(&(slot2, [(&key2, &account)].as_slice()), /* skip */ 0);
 
         // Do the notification
         let notifier = GeyserTestPlugin::default();
@@ -182,8 +182,8 @@ pub mod tests {
         let notifier = Arc::new(notifier);
         accounts.set_geyser_plugin_notifier(Some(notifier.clone()));
 
-        // Account with key1 is updated twice in two different slots -- should only get notified twice.
-        // Account with key2 is updated slot0, should get notified once
+        // Account with key1 is updated twice in two different slots -- should only get notified
+        // twice. Account with key2 is updated slot0, should get notified once
         // Account with key3 is updated in slot1, should get notified once
         let key1 = solana_pubkey::new_rand();
         let account1_lamports1: u64 = 1;

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -287,7 +287,8 @@ fn test_sort_and_remove_dups() {
         ];
         let mut expected = test1.clone();
         expected.truncate(1); // get rid of 1st duplicate
-        test1.first_mut().unwrap().data_len = 2342342; // this one should be ignored, so modify the data_len so it will fail the compare below if it is used
+        test1.first_mut().unwrap().data_len = 2342342; // this one should be ignored, so modify the data_len so it will fail the compare below if
+                                                       // it is used
         if insert_other_good < 2 {
             // insert another good one before or after the 2 bad ones
             test1.insert(insert_other_good, generate_sample_account_from_storage(1));
@@ -304,7 +305,8 @@ fn test_sort_and_remove_dups() {
         .map(generate_sample_account_from_storage)
         .collect::<Vec<_>>();
     test1.iter_mut().take(3).for_each(|entry| {
-        entry.data_len = 2342342; // this one should be ignored, so modify the data_len so it will fail the compare below if it is used
+        entry.data_len = 2342342; // this one should be ignored, so modify the data_len so it will fail the compare below if
+                                  // it is used
         entry.index_info = AccountInfo::new(StorageLocation::Cached, false);
     });
 
@@ -726,7 +728,8 @@ fn test_flush_slots_with_reclaim_old_slots() {
 
     accounts.accounts_index.add_root(new_slot);
 
-    // Flushing this storage directly using _store_accounts_frozen. This is done to pass in UpsertReclaim::ReclaimOldSlots
+    // Flushing this storage directly using _store_accounts_frozen. This is done to pass in
+    // UpsertReclaim::ReclaimOldSlots
     accounts._store_accounts_frozen(
         (new_slot, &accounts_list[..]),
         &storage,
@@ -1310,10 +1313,12 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
 #[test]
 fn test_shrink_zero_lamport_single_ref_account() {
     agave_logger::setup();
-    // note that 'None' checks the case based on the default value of `latest_full_snapshot_slot` in `AccountsDb`
+    // note that 'None' checks the case based on the default value of `latest_full_snapshot_slot` in
+    // `AccountsDb`
     for latest_full_snapshot_slot in [None, Some(0), Some(1), Some(2)] {
         // store a zero and non-zero lamport account
-        // make sure clean marks the ref_count=1, zero lamport account dead and removes pubkey from index completely
+        // make sure clean marks the ref_count=1, zero lamport account dead and removes pubkey from
+        // index completely
         let accounts = AccountsDb::new_single_for_tests();
         let pubkey_zero = Pubkey::from([1; 32]);
         let pubkey2 = Pubkey::from([2; 32]);
@@ -1344,7 +1349,8 @@ fn test_shrink_zero_lamport_single_ref_account() {
             accounts.set_latest_full_snapshot_slot(latest_full_snapshot_slot);
         }
 
-        // Shrink the slot. The behavior on the zero lamport account will depend on `latest_full_snapshot_slot`.
+        // Shrink the slot. The behavior on the zero lamport account will depend on
+        // `latest_full_snapshot_slot`.
         accounts.shrink_slot_forced(slot);
 
         assert!(
@@ -1742,7 +1748,8 @@ fn test_clean_max_slot_zero_lamport_account(mark_obsolete_accounts: MarkObsolete
     accounts.add_root_and_flush_write_cache(0);
     accounts.add_root_and_flush_write_cache(1);
 
-    // Clean is performed as part of flush with obsolete accounts marked, so explicit clean isn't needed
+    // Clean is performed as part of flush with obsolete accounts marked, so explicit clean isn't
+    // needed
     if mark_obsolete_accounts == MarkObsoleteAccounts::Disabled {
         // Only clean up to account 0, should not purge slot 0 based on
         // updates in later slots in slot 1
@@ -2454,7 +2461,8 @@ fn test_shrink_candidate_slots() {
 
     // Only, try to shrink stale slots, nothing happens because shrink ratio
     // is not small enough to do a shrink
-    // Note this shrink ratio had to change because we are WAY over-allocating append vecs when we flush the write cache at the moment.
+    // Note this shrink ratio had to change because we are WAY over-allocating append vecs when we
+    // flush the write cache at the moment.
     accounts.shrink_ratio = AccountShrinkThreshold::TotalSpace { shrink_ratio: 0.4 };
     accounts.shrink_candidate_slots(&EpochSchedule::default());
     assert_eq!(
@@ -2571,7 +2579,8 @@ fn test_select_candidates_by_total_usage_no_candidates() {
 #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
 #[test_case(StorageAccess::File)]
 fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: StorageAccess) {
-    // three candidates, one selected for shrink, one is put back to the candidate list and one is ignored
+    // three candidates, one selected for shrink, one is put back to the candidate list and one is
+    // ignored
     agave_logger::setup();
     let mut candidates = ShrinkCandidates::default();
     let db = AccountsDb::new_single_for_tests();
@@ -2622,10 +2631,10 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
         .store(store_file_size as usize, Ordering::Release);
     candidates.insert(store3_slot);
 
-    // Set the target alive ratio to 0.6 so that we can just get rid of store1, the remaining two stores
-    // alive ratio can be > the target ratio: the actual ratio is 0.75 because of 150 alive bytes / 200 total bytes.
-    // The target ratio is also set to larger than store2's alive ratio: 0.5 so that it would be added
-    // to the candidates list for next round.
+    // Set the target alive ratio to 0.6 so that we can just get rid of store1, the remaining two
+    // stores alive ratio can be > the target ratio: the actual ratio is 0.75 because of 150
+    // alive bytes / 200 total bytes. The target ratio is also set to larger than store2's alive
+    // ratio: 0.5 so that it would be added to the candidates list for next round.
     let target_alive_ratio = 0.6;
     let (selected_candidates, next_candidates) =
         db.select_candidates_by_total_usage(&candidates, target_alive_ratio);
@@ -2689,7 +2698,8 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
         .store(store_file_size as usize, Ordering::Release);
     candidates.insert(store3_slot);
 
-    // Set the target ratio to default (0.8), both store1 and store2 must be selected and store3 is ignored.
+    // Set the target ratio to default (0.8), both store1 and store2 must be selected and store3 is
+    // ignored.
     let target_alive_ratio = DEFAULT_ACCOUNTS_SHRINK_RATIO;
     let (selected_candidates, next_candidates) =
         db.select_candidates_by_total_usage(&candidates, target_alive_ratio);
@@ -2740,7 +2750,8 @@ fn test_select_candidates_by_total_usage_all_clean(storage_access: StorageAccess
         .store(store_file_size as usize / 2, Ordering::Release);
     candidates.insert(store2_slot);
 
-    // Set the target ratio to default (0.8), both stores from the two different slots must be selected.
+    // Set the target ratio to default (0.8), both stores from the two different slots must be
+    // selected.
     let target_alive_ratio = DEFAULT_ACCOUNTS_SHRINK_RATIO;
     let (selected_candidates, next_candidates) =
         db.select_candidates_by_total_usage(&candidates, target_alive_ratio);
@@ -3990,12 +4001,14 @@ fn run_test_accounts_db_cache_clean_max_root(
             if *slot >= requested_flush_root || *slot >= scan_root.unwrap_or(Slot::MAX) {
                 // 1) If slot > `requested_flush_root`, then  either:
                 //   a) If `is_cache_at_limit == false`, still in the cache
-                //   b) if `is_cache_at_limit == true`, were not cleaned before being flushed to storage.
+                //   b) if `is_cache_at_limit == true`, were not cleaned before being flushed to
+                // storage.
                 //
                 // In both cases all the *original* updates at index `slot` were uncleaned and thus
                 // should be discoverable by this scan.
                 //
-                // 2) If slot == `requested_flush_root`, the slot was not cleaned before being flushed to storage,
+                // 2) If slot == `requested_flush_root`, the slot was not cleaned before being
+                //    flushed to storage,
                 // so it also contains all the original updates.
                 //
                 // 3) If *slot >= scan_root, then we should not clean it either
@@ -4004,8 +4017,8 @@ fn run_test_accounts_db_cache_clean_max_root(
                     .cloned()
                     .collect::<HashSet<Pubkey>>()
             } else {
-                // Slots less than `requested_flush_root` and `scan_root` were cleaned in the cache before being flushed
-                // to storage, should only contain one account
+                // Slots less than `requested_flush_root` and `scan_root` were cleaned in the cache
+                // before being flushed to storage, should only contain one account
                 std::iter::once(keys[*slot as usize]).collect::<HashSet<Pubkey>>()
             };
 
@@ -4708,8 +4721,9 @@ fn test_cache_flush_remove_unrooted_race_multiple_slots() {
                     LoadHint::FixedMaxRoot
                 )
                 .is_some());
-            // Clear for next iteration so that `assert!(self.storage.get_slot_storage_entry(purged_slot).is_none());`
-            // in `purge_slot_pubkeys()` doesn't trigger
+            // Clear for next iteration so that
+            // `assert!(self.storage.get_slot_storage_entry(purged_slot).is_none());` in
+            // `purge_slot_pubkeys()` doesn't trigger
             db.remove_unrooted_slots(&[(*slot, *bank_id)]);
         }
     }
@@ -5126,7 +5140,8 @@ define_accounts_db_test!(test_purge_alive_unrooted_slots_after_clean, |accounts|
     assert_no_storages_at_slot(&accounts, slot0);
 });
 
-/// asserts that not only are there 0 append vecs, but there is not even an entry in the storage map for 'slot'
+/// asserts that not only are there 0 append vecs, but there is not even an entry in the storage map
+/// for 'slot'
 fn assert_no_storages_at_slot(db: &AccountsDb, slot: Slot) {
     assert!(db.storage.get_slot_storage_entry(slot).is_none());
 }
@@ -5499,8 +5514,8 @@ define_accounts_db_test!(test_mark_dirty_dead_stores_empty, |db| {
 fn test_mark_dirty_dead_stores_no_shrink_in_progress() {
     // None for shrink_in_progress, 1 existing store at the slot
     // There should be no more append vecs at that slot after the call to mark_dirty_dead_stores.
-    // This tests the case where this slot was combined into an ancient append vec from an older slot and
-    // there is no longer an append vec at this slot.
+    // This tests the case where this slot was combined into an ancient append vec from an older
+    // slot and there is no longer an append vec at this slot.
     for add_dirty_stores in [false, true] {
         let slot = 0;
         let db = AccountsDb::new_single_for_tests();
@@ -5583,7 +5598,8 @@ fn test_sweep_get_oldest_non_ancient_slot_max() {
             epoch_schedule.slots_per_epoch * 10,
         ] {
             db.add_root(max_root_inclusive);
-            // oldest non-ancient will never exceed max_root_inclusive, even if the offset is so large it would mathematically move ancient PAST the newest root
+            // oldest non-ancient will never exceed max_root_inclusive, even if the offset is so
+            // large it would mathematically move ancient PAST the newest root
             assert_eq!(
                 max_root_inclusive,
                 db.get_oldest_non_ancient_slot(&epoch_schedule)
@@ -5607,7 +5623,8 @@ fn test_sweep_get_oldest_non_ancient_slot() {
     );
     // before any roots are added, we expect the oldest non-ancient slot to be 0
     assert_eq!(0, db.get_oldest_non_ancient_slot(&epoch_schedule));
-    // adding roots until slots_per_epoch +/- ancient_append_vec_offset should still saturate to 0 as oldest non ancient slot
+    // adding roots until slots_per_epoch +/- ancient_append_vec_offset should still saturate to 0
+    // as oldest non ancient slot
     let max_root_inclusive = AccountsDb::apply_offset_to_slot(0, ancient_append_vec_offset - 1);
     db.add_root(max_root_inclusive);
     // oldest non-ancient will never exceed max_root_inclusive
@@ -5637,11 +5654,12 @@ fn test_sweep_get_oldest_non_ancient_slot() {
 
 #[test]
 fn test_sweep_get_oldest_non_ancient_slot2() {
-    // note that this test has to worry about saturation at 0 as we subtract `slots_per_epoch` and `ancient_append_vec_offset`
+    // note that this test has to worry about saturation at 0 as we subtract `slots_per_epoch` and
+    // `ancient_append_vec_offset`
     let epoch_schedule = EpochSchedule::default();
     for ancient_append_vec_offset in [-10_000i64, 50_000] {
-        // at `starting_slot_offset`=0, with a negative `ancient_append_vec_offset`, we expect saturation to 0
-        // big enough to avoid all saturation issues.
+        // at `starting_slot_offset`=0, with a negative `ancient_append_vec_offset`, we expect
+        // saturation to 0 big enough to avoid all saturation issues.
         let avoid_saturation = 1_000_000;
         assert!(
             avoid_saturation
@@ -5915,7 +5933,8 @@ fn test_shrink_collect_simple() {
                             } else {
                                 assert_eq!(shrink_collect.alive_total_bytes, 0);
                             }
-                            // expected_capacity is determined by what size append vec gets created when the write cache is flushed to an append vec.
+                            // expected_capacity is determined by what size append vec gets created
+                            // when the write cache is flushed to an append vec.
                             let mut expected_capacity =
                                 (account_count * aligned_stored_size(space)) as u64;
                             if append_opposite_zero_lamport_account && space != 0 {
@@ -5986,7 +6005,8 @@ fn test_shrink_collect_with_obsolete_accounts() {
     let storage = db.get_and_assert_single_storage(slot);
 
     for (i, pubkey) in pubkeys.iter().enumerate() {
-        // Mark Some accounts obsolete. These will include zero lamport and non zero lamport accounts
+        // Mark Some accounts obsolete. These will include zero lamport and non zero lamport
+        // accounts
         if i % 5 == 0 {
             // Lookup the pubkey in the database and find the AccountInfo
             db.accounts_index
@@ -6021,7 +6041,8 @@ fn test_shrink_collect_with_obsolete_accounts() {
 
     assert_eq!(shrink_collect.slot, slot);
 
-    // Ensure that the keys to unref does not include the obsolete accounts and only includes the unreferenced accounts
+    // Ensure that the keys to unref does not include the obsolete accounts and only includes the
+    // unreferenced accounts
     assert_eq!(
         shrink_collect
             .pubkeys_to_unref
@@ -6074,7 +6095,8 @@ fn get_all_accounts_from_storages<'a>(
                 })
                 .expect("must scan accounts storage");
             // make sure scan_pubkeys results match
-            // Note that we assume traversals are both in the same order, but this doesn't have to be true.
+            // Note that we assume traversals are both in the same order, but this doesn't have to
+            // be true.
             let mut compare = Vec::default();
             storage
                 .accounts

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -52,7 +52,8 @@ pub enum StorageAccess {
     #[deprecated(since = "4.0.0")]
     Mmap,
     /// storages should be accessed by File I/O
-    /// ancient storages are created by 1-shot write to pack multiple accounts together more efficiently with new formats
+    /// ancient storages are created by 1-shot write to pack multiple accounts together more
+    /// efficiently with new formats
     #[default]
     File,
 }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -125,7 +125,8 @@ pub enum ScanFilter {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// how accounts index 'upsert' should handle reclaims
 pub enum UpsertReclaim {
-    /// previous entry for this slot in the index is expected to be cached, so irrelevant to reclaims
+    /// previous entry for this slot in the index is expected to be cached, so irrelevant to
+    /// reclaims
     PreviousSlotEntryWasCached,
     /// previous entry for this slot in the index may need to be reclaimed, so return it.
     /// reclaims is the only output of upsert, requiring a synchronous execution
@@ -307,11 +308,13 @@ pub struct AccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     // `S` as the id because there can be more than one version of a slot `S`). If a fork
     // is abandoned, all of the slots on that fork up to `S` will be removed via
     // `AccountsDb::remove_unrooted_slots()`. When the scan finishes, it'll realize that the
-    // results of the scan may have been corrupted by `remove_unrooted_slots` and abort its results.
+    // results of the scan may have been corrupted by `remove_unrooted_slots` and abort its
+    // results.
     //
-    // `removed_bank_ids` tracks all the slot ids that were removed via `remove_unrooted_slots()` so any attempted scans
-    // on any of these slots fails. This is safe to purge once the associated Bank is dropped and
-    // scanning the fork with that Bank at the tip is no longer possible.
+    // `removed_bank_ids` tracks all the slot ids that were removed via `remove_unrooted_slots()`
+    // so any attempted scans on any of these slots fails. This is safe to purge once the
+    // associated Bank is dropped and scanning the fork with that Bank at the tip is no longer
+    // possible.
     pub removed_bank_ids: Mutex<HashSet<BankId>>,
 
     storage: AccountsIndexStorage<T, U>,
@@ -541,9 +544,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         // `R_new` is an ancestor of `B`, and `R < R_new < B`, then `B.ancestors.contains(R_new)`.
         //
         // Now until the next `set_root`, any new banks constructed from `new_from_parent` will
-        // also have `max_root == R_new` in their ancestor set, so the claim holds for those descendants
-        // as well. Once the next `set_root` happens, we once again update `max_root` and the same
-        // inductive argument can be applied again to show the claim holds.
+        // also have `max_root == R_new` in their ancestor set, so the claim holds for those
+        // descendants as well. Once the next `set_root` happens, we once again update
+        // `max_root` and the same inductive argument can be applied again to show the claim
+        // holds.
 
         // Check that the `max_root` is present in `ancestors`. From the proof above, if
         // `max_root` is not present in `ancestors`, this means the bank `B` with the
@@ -857,7 +861,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     }
 
     /// Remove keys from the account index if the key's slot list is empty.
-    /// Returns the keys that were removed from the index. These keys should not be accessed again in the current code path.
+    /// Returns the keys that were removed from the index. These keys should not be accessed again
+    /// in the current code path.
     #[must_use]
     pub fn handle_dead_keys(
         &self,
@@ -1029,19 +1034,18 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     /// This fn takes 4 arguments.
     ///  - an iterator of pubkeys to scan
     ///  - callback fn to run for each pubkey in the accounts index
-    ///  - avoid_callback_result. If it is Some(default), then callback is ignored and
-    ///    default is returned instead.
-    ///  - provide_entry_in_callback. If true, populate the ref of the Arc of the
-    ///    index entry to `callback` fn. Otherwise, provide None.
+    ///  - avoid_callback_result. If it is Some(default), then callback is ignored and default is
+    ///    returned instead.
+    ///  - provide_entry_in_callback. If true, populate the ref of the Arc of the index entry to
+    ///    `callback` fn. Otherwise, provide None.
     ///
     /// The `callback` fn must return `AccountsIndexScanResult`, which is
     /// used to indicates whether the AccountIndex Entry should be added to
     /// in-memory cache. The `callback` fn takes in 3 arguments:
     ///   - the first an immutable ref of the pubkey,
     ///   - the second an option of the SlotList and RefCount
-    ///   - the third an option of the AccountMapEntry, which is only populated
-    ///     when `provide_entry_in_callback` is true. Otherwise, it will be
-    ///     None.
+    ///   - the third an option of the AccountMapEntry, which is only populated when
+    ///     `provide_entry_in_callback` is true. Otherwise, it will be None.
     pub(crate) fn scan<'a, F, I>(
         &self,
         pubkeys: I,
@@ -1116,9 +1120,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
 
             match filter {
                 ScanFilter::All => {
-                    // SAFETY: The caller must ensure that if `provide_entry_in_callback` is true, and
-                    // if it's possible for `callback` to clone the entry Arc, then it must also add
-                    // the entry to the in-mem cache if the entry is made dirty.
+                    // SAFETY: The caller must ensure that if `provide_entry_in_callback` is true,
+                    // and if it's possible for `callback` to clone the entry
+                    // Arc, then it must also add the entry to the in-mem cache
+                    // if the entry is made dirty.
                     lock.as_ref()
                         .unwrap()
                         .get_internal_inner(pubkey, internal_callback);
@@ -1136,8 +1141,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                                     if local_entry.ref_count() == 1
                                         && local_entry.slot_list_lock_read_len() == 1
                                     {
-                                        // Account was found in memory, but is a single ref single slot account
-                                        // For testing purposes, return None as this can be treated like
+                                        // Account was found in memory, but is a single ref single
+                                        // slot account
+                                        // For testing purposes, return None as this can be treated
+                                        // like
                                         // a normal account that was flushed to storage.
                                         entry = None;
                                     }
@@ -1314,8 +1321,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         let mut num_existed_on_disk = 0;
 
         // offset bin processing in the 'binned' array by a random amount.
-        // This results in calls to insert_new_entry_if_missing_with_lock from different threads starting at different bins to avoid
-        // lock contention.
+        // This results in calls to insert_new_entry_if_missing_with_lock from different threads
+        // starting at different bins to avoid lock contention.
         let bins = self.bins();
         let random_bin_offset = rng().random_range(0..bins);
         let bin_calc = self.bin_calculator;
@@ -1420,7 +1427,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     }
 
     /// Updates the given pubkey at the given slot with the new account information.
-    /// on return, the index's previous account info may be returned in 'reclaims' depending on 'previous_slot_entry_was_cached'
+    /// on return, the index's previous account info may be returned in 'reclaims' depending on
+    /// 'previous_slot_entry_was_cached'
     pub fn upsert(
         &self,
         new_slot: Slot,
@@ -1432,20 +1440,23 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         reclaims: &mut ReclaimsSlotList<T>,
         reclaim: UpsertReclaim,
     ) {
-        // vast majority of updates are to item already in accounts index, so store as raw to avoid unnecessary allocations
+        // vast majority of updates are to item already in accounts index, so store as raw to avoid
+        // unnecessary allocations
         let store_raw = true;
 
         // We don't atomically update both primary index and secondary index together.
-        // This certainly creates a small time window with inconsistent state across the two indexes.
-        // However, this is acceptable because:
+        // This certainly creates a small time window with inconsistent state across the two
+        // indexes. However, this is acceptable because:
         //
-        //  - A strict consistent view at any given moment of time is not necessary, because the only
-        //  use case for the secondary index is `scan`, and `scans` are only supported/require consistency
-        //  on frozen banks, and this inconsistency is only possible on working banks.
+        //  - A strict consistent view at any given moment of time is not necessary, because the
+        //    only
+        //  use case for the secondary index is `scan`, and `scans` are only supported/require
+        // consistency  on frozen banks, and this inconsistency is only possible on working
+        // banks.
         //
         //  - The secondary index is never consulted as primary source of truth for gets/stores.
-        //  So, what the accounts_index sees alone is sufficient as a source of truth for other non-scan
-        //  account operations.
+        //  So, what the accounts_index sees alone is sufficient as a source of truth for other
+        // non-scan  account operations.
         let new_item = PreAllocatedAccountMapEntry::new(
             new_slot,
             account_info,
@@ -1636,10 +1647,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     /// a) If slot < newest_root_in_slot_list, then we know the update is outdated by a later rooted
     /// update, namely the one in newest_root_in_slot_list
     ///
-    /// b) If slot > newest_root_in_slot_list, then because slot < max_clean_root_exclusive and we know there are
-    /// no roots in the slot list between newest_root_in_slot_list and max_clean_root_exclusive, (otherwise there
-    /// would be a bigger newest_root_in_slot_list, which is a contradiction), then we know slot must be
-    /// an unrooted slot less than max_clean_root_exclusive and thus safe to clean as well.
+    /// b) If slot > newest_root_in_slot_list, then because slot < max_clean_root_exclusive and we
+    /// know there are no roots in the slot list between newest_root_in_slot_list and
+    /// max_clean_root_exclusive, (otherwise there would be a bigger newest_root_in_slot_list,
+    /// which is a contradiction), then we know slot must be an unrooted slot less than
+    /// max_clean_root_exclusive and thus safe to clean as well.
     fn can_purge_older_entries(
         max_clean_root_exclusive: Slot,
         newest_root_in_slot_list: Slot,
@@ -2251,7 +2263,8 @@ pub mod tests {
 
         match upsert_method {
             Some(upsert_method) => {
-                // insert first entry for pubkey. This will use new_entry_after_update and not call update.
+                // insert first entry for pubkey. This will use new_entry_after_update and not call
+                // update.
                 index.upsert(
                     slot0,
                     slot0,
@@ -2293,7 +2306,8 @@ pub mod tests {
 
         match upsert_method {
             Some(upsert_method) => {
-                // insert second entry for pubkey. This will use update and NOT use new_entry_after_update.
+                // insert second entry for pubkey. This will use update and NOT use
+                // new_entry_after_update.
                 index.upsert(
                     slot1,
                     slot1,
@@ -3692,9 +3706,9 @@ pub mod tests {
         );
         assert_eq!(secondary_index.get(&secondary_key1), vec![account_key]);
 
-        // If we set a root at `later_slot`, and clean, then even though the account with secondary_key1
-        // was outdated by the update in the later slot, the primary account key is still alive,
-        // so both secondary keys will still be kept alive.
+        // If we set a root at `later_slot`, and clean, then even though the account with
+        // secondary_key1 was outdated by the update in the later slot, the primary account
+        // key is still alive, so both secondary keys will still be kept alive.
         index.add_root(later_slot);
         index.slot_list_mut(&account_key, |mut slot_list| {
             index.purge_older_root_entries(&mut slot_list, &mut ReclaimsSlotList::new(), None)
@@ -3957,7 +3971,8 @@ pub mod tests {
         // this is because of inclusive vs exclusive in the call to can_purge_older_entries
         assert!(!index.clean_rooted_entries(&key, &mut gc, Some(slot1)));
         // this will delete the entry because it is <= max_root_inclusive and NOT a root
-        // note this has to be slot2 because of inclusive vs exclusive in the call to can_purge_older_entries
+        // note this has to be slot2 because of inclusive vs exclusive in the call to
+        // can_purge_older_entries
         {
             let mut gc = ReclaimsSlotList::new();
             assert!(index.clean_rooted_entries(&key, &mut gc, Some(slot2)));

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -20,7 +20,8 @@ use {
 #[derive(Debug)]
 pub struct AccountMapEntry<T> {
     /// number of alive slots that contain >= 1 instances of account data for this pubkey
-    /// where alive represents a slot that has not yet been removed by clean via AccountsDB::clean_stored_dead_slots() for containing no up to date account information
+    /// where alive represents a slot that has not yet been removed by clean via
+    /// AccountsDB::clean_stored_dead_slots() for containing no up to date account information
     ref_count: AtomicRefCount,
     /// list of slots in which this pubkey was updated
     /// Note that 'clean' removes outdated entries (ie. older roots) from this slot_list
@@ -121,16 +122,16 @@ impl<T: IndexValue> AccountMapEntry<T> {
 
     /// Acquire a read lock on the slot list and return accessor for interpreting its representation
     ///
-    /// Do not call any locking function (`slot_list_*lock*`) on the same `AccountMapEntry` until accessor
-    /// they return is dropped.
+    /// Do not call any locking function (`slot_list_*lock*`) on the same `AccountMapEntry` until
+    /// accessor they return is dropped.
     pub fn slot_list_read_lock(&self) -> SlotListReadGuard<'_, T> {
         SlotListReadGuard(self.slot_list.read().unwrap())
     }
 
     /// Acquire a write lock on the slot list and return accessor for modifying it
     ///
-    /// Do not call any locking function (`slot_list_*lock*`) on the same `AccountMapEntry` until accessor
-    /// they return is dropped.
+    /// Do not call any locking function (`slot_list_*lock*`) on the same `AccountMapEntry` until
+    /// accessor they return is dropped.
     pub fn slot_list_write_lock(&self) -> SlotListWriteGuard<'_, T> {
         SlotListWriteGuard(self.slot_list.write().unwrap())
     }
@@ -268,7 +269,8 @@ impl<T: IndexValue> PreAllocatedAccountMapEntry<T> {
     /// 1. new empty (refcount=0, slot_list={})
     /// 2. update(slot, account_info)
     ///
-    /// This code is called when the first entry [ie. (slot,account_info)] for a pubkey is inserted into the index.
+    /// This code is called when the first entry [ie. (slot,account_info)] for a pubkey is inserted
+    /// into the index.
     pub fn new<U: DiskIndexValue + From<T> + Into<T>>(
         slot: Slot,
         account_info: T,

--- a/accounts-db/src/accounts_index/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index/accounts_index_storage.rs
@@ -76,7 +76,8 @@ impl BgThreads {
                     let system_exit = exit.clone();
                     let in_mem_ = in_mem.to_vec();
 
-                    // note that using rayon here causes us to exhaust # rayon threads and many tests running in parallel deadlock
+                    // note that using rayon here causes us to exhaust # rayon threads and many
+                    // tests running in parallel deadlock
                     Builder::new()
                         .name(format!("solIdxFlusher{idx:02}"))
                         .spawn(move || {

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -180,7 +180,8 @@ impl Stats {
 
     /// This is an estimate of the # of items in mem that are awaiting flushing to disk.
     /// returns (# items in mem) - (# items we intend to hold in mem for performance heuristics)
-    /// The result is also an estimate because 'held_in_mem' is based on a stat that is swapped out when stats are reported.
+    /// The result is also an estimate because 'held_in_mem' is based on a stat that is swapped out
+    /// when stats are reported.
     pub fn get_remaining_items_to_flush_estimate(&self) -> usize {
         let in_mem = self.count_in_mem.load(Ordering::Relaxed) as u64;
         let held_in_mem = self.held_in_mem.slot_list_cached.load(Ordering::Relaxed)

--- a/accounts-db/src/ancestors.rs
+++ b/accounts-db/src/ancestors.rs
@@ -33,7 +33,8 @@ impl Default for Ancestors {
 
 impl From<Vec<Slot>> for Ancestors {
     fn from(mut source: Vec<Slot>) -> Ancestors {
-        // bitfield performs optimally when we insert the minimum value first so that it knows the correct start/end values
+        // bitfield performs optimally when we insert the minimum value first so that it knows the
+        // correct start/end values
         source.sort_unstable();
         let mut result = Ancestors::default();
         source.into_iter().for_each(|slot| {

--- a/accounts-db/src/append_vec/meta.rs
+++ b/accounts-db/src/append_vec/meta.rs
@@ -15,8 +15,9 @@ use {
 pub struct StoredMeta {
     /// global write version
     /// This will be made completely obsolete such that we stop storing it.
-    /// We will not support multiple append vecs per slot anymore, so this concept is no longer necessary.
-    /// Order of stores of an account to an append vec will determine 'latest' account data per pubkey.
+    /// We will not support multiple append vecs per slot anymore, so this concept is no longer
+    /// necessary. Order of stores of an account to an append vec will determine 'latest'
+    /// account data per pubkey.
     pub write_version_obsolete: u64,
     pub data_len: u64,
     /// key for the account
@@ -180,8 +181,9 @@ impl<'append_vec> StoredAccountNoData<'append_vec> {
 
     /// Check if the account data matches that of a default account.
     ///
-    /// Note that we are not comparing against AccountSharedData::default() because we do not have access to the account data,
-    /// so we compare data _length_ in lieu of actual data. This check otherwise identical to AccountSharedData::default().
+    /// Note that we are not comparing against AccountSharedData::default() because we do not have
+    /// access to the account data, so we compare data _length_ in lieu of actual data. This
+    /// check otherwise identical to AccountSharedData::default().
     pub fn is_default_account(&self) -> bool {
         self.account_meta.lamports == 0
             && self.meta.data_len == 0
@@ -200,7 +202,8 @@ impl<'append_vec> StoredAccountNoData<'append_vec> {
         // Yes, this really happens; see test_new_from_file_crafted_executable
         let executable_bool: &bool = &self.account_meta.executable;
         let executable_bool_ptr = ptr::from_ref(executable_bool);
-        // UNSAFE: Force to interpret mmap-backed bool as u8 to really read the actual memory content
+        // UNSAFE: Force to interpret mmap-backed bool as u8 to really read the actual memory
+        // content
         let executable_byte: &u8 = unsafe { &*(executable_bool_ptr.cast()) };
         executable_byte
     }

--- a/accounts-db/src/rolling_bit_field.rs
+++ b/accounts-db/src/rolling_bit_field.rs
@@ -157,7 +157,8 @@ impl RollingBitField {
                     break;
                 }
 
-                // move the min item from bits to excess and then purge from min to make room for this new max
+                // move the min item from bits to excess and then purge from min to make room for
+                // this new max
                 let inserted = self.excess.insert(self.min);
                 assert!(inserted);
 
@@ -167,7 +168,8 @@ impl RollingBitField {
                 self.purge(&key);
 
                 if self.all_items_in_excess() {
-                    // if we moved the last existing item to excess, then we are ready to insert the new item in the bits
+                    // if we moved the last existing item to excess, then we are ready to insert the
+                    // new item in the bits
                     bits_empty = true;
                     break;
                 }
@@ -244,16 +246,18 @@ impl RollingBitField {
             }
         } else {
             // The idea is that there are no items in the bitfield anymore.
-            // But, there MAY be items in excess. The model works such that items < min go into excess.
-            // So, after purging all items from bitfield, we hold max to be what it previously was, but set min to max.
-            // Thus, if we lookup >= max, answer is always false without having to look in excess.
-            // If we changed max here to 0, we would lose the ability to know the range of items in excess (if any).
+            // But, there MAY be items in excess. The model works such that items < min go into
+            // excess. So, after purging all items from bitfield, we hold max to be what
+            // it previously was, but set min to max. Thus, if we lookup >= max, answer
+            // is always false without having to look in excess. If we changed max here
+            // to 0, we would lose the ability to know the range of items in excess (if any).
             // So, now, with min updated = max:
             // If we lookup < max, then we first check min.
             // If >= min, then we look in bitfield.
             // Otherwise, we look in excess since the request is < min.
-            // So, resetting min like this after a remove results in the correct behavior for the model.
-            // Later, if we insert and there are 0 items total (excess + bitfield), then we reset min/max to reflect the new item only.
+            // So, resetting min like this after a remove results in the correct behavior for the
+            // model. Later, if we insert and there are 0 items total (excess +
+            // bitfield), then we reset min/max to reflect the new item only.
             self.min = self.max_exclusive;
         }
     }
@@ -632,7 +636,8 @@ pub mod tests {
         let start = 100;
         let mut bitfield = setup_wide(width, start).bitfield;
 
-        let slot = start + 2 - width; // this item would make our width exactly equal to what is allowed, but it is also inserting prior to min
+        let slot = start + 2 - width; // this item would make our width exactly equal to what is allowed, but it is also inserting
+                                      // prior to min
         bitfield.insert(slot);
         assert_eq!(1, bitfield.excess.len());
         assert!(bitfield.contains(&slot));
@@ -686,7 +691,8 @@ pub mod tests {
         tester.insert(slot);
         assert!(tester.bitfield.excess.is_empty());
 
-        // insert a slot before the previous one. this is 'excess' since we don't use this pattern in normal operation
+        // insert a slot before the previous one. this is 'excess' since we don't use this pattern
+        // in normal operation
         let slot2 = slot - 1;
         tester.insert(slot2);
         assert_eq!(tester.bitfield.excess.len(), 1);
@@ -725,7 +731,8 @@ pub mod tests {
                     for slot in start..max {
                         // subsequent roots to add
                         for slot2 in (slot + 1)..max {
-                            // reverse_slots = 1 means add slots in reverse order (max to min). This causes us to add second and later slots to excess.
+                            // reverse_slots = 1 means add slots in reverse order (max to min). This
+                            // causes us to add second and later slots to excess.
                             for reverse_slots in [false, true].iter().cloned() {
                                 let maybe_reverse = |slot| {
                                     if reverse_slots {

--- a/accounts-db/src/rolling_bit_field/iterators.rs
+++ b/accounts-db/src/rolling_bit_field/iterators.rs
@@ -32,7 +32,8 @@ impl Iterator for RollingBitFieldOnesIter<'_> {
 
         // Then iterate over the bit vec
         loop {
-            // If there are no more bits in the range, then we've iterated over everything and are done
+            // If there are no more bits in the range, then we've iterated over everything and are
+            // done
             let bit = self.bit_range.next()?;
 
             if self.rolling_bit_field.contains_assume_in_range(&bit) {

--- a/accounts-db/src/sorted_storages.rs
+++ b/accounts-db/src/sorted_storages.rs
@@ -75,12 +75,14 @@ impl<'a> SortedStorages<'a> {
     /// `source` does not have to be sorted in any way, but is assumed to not have duplicate slot #s
     pub fn new_with_slots(
         source: impl Iterator<Item = (&'a Arc<AccountStorageEntry>, Slot)> + Clone,
-        // A slot used as a lower bound, but potentially smaller than the smallest slot in the given 'source' iterator
+        // A slot used as a lower bound, but potentially smaller than the smallest slot in the
+        // given 'source' iterator
         min_slot: Option<Slot>,
-        // highest valid slot. Only matters if source array does not contain a slot >= max_slot_inclusive.
-        // An example is a slot that has accounts in the write cache at slots <= 'max_slot_inclusive' but no storages at those slots.
-        // None => self.range.end = source.1.max() + 1
-        // Some(slot) => self.range.end = std::cmp::max(slot, source.1.max())
+        // highest valid slot. Only matters if source array does not contain a slot >=
+        // max_slot_inclusive. An example is a slot that has accounts in the write cache at
+        // slots <= 'max_slot_inclusive' but no storages at those slots. None => self.
+        // range.end = source.1.max() + 1 Some(slot) => self.range.end =
+        // std::cmp::max(slot, source.1.max())
         max_slot_inclusive: Option<Slot>,
     ) -> Self {
         let mut min = Slot::MAX;
@@ -148,7 +150,8 @@ impl<'a> Iterator for SortedStoragesIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let slot = self.next_slot;
         if slot < self.range.end {
-            // iterator is still in range. Storage may or may not exist at this slot, but the iterator still needs to return the slot
+            // iterator is still in range. Storage may or may not exist at this slot, but the
+            // iterator still needs to return the slot
             self.next_slot += 1;
             Some((slot, self.storages.get(slot)))
         } else {
@@ -166,7 +169,8 @@ impl<'a> SortedStoragesIter<'a> {
         let storage_range = storages.range();
         let next_slot = match range.start_bound() {
             Bound::Unbounded => {
-                storage_range.start // unbounded beginning starts with the min known slot (which is inclusive)
+                storage_range.start // unbounded beginning starts with the min known slot (which is
+                                    // inclusive)
             }
             Bound::Included(x) => *x,
             Bound::Excluded(x) => *x + 1, // make inclusive

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -52,7 +52,8 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
         &self.1[index].stake_pubkey
     }
     fn slot(&self, _index: usize) -> Slot {
-        // per-index slot is not unique per slot when per-account slot is not included in the source data
+        // per-index slot is not unique per slot when per-account slot is not included in the source
+        // data
         self.target_slot()
     }
     fn target_slot(&self) -> Slot {

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -15,7 +15,8 @@ use {
     },
 };
 
-/// hold a ref to an account to store. The account could be represented in memory a few different ways
+/// hold a ref to an account to store. The account could be represented in memory a few different
+/// ways
 #[derive(Debug, Copy, Clone)]
 pub enum AccountForStorage<'a> {
     AddressAndAccount((&'a Pubkey, &'a AccountSharedData)),
@@ -172,7 +173,8 @@ impl<'a: 'b, 'b> StorableAccounts<'a> for (Slot, &'b [(&'a Pubkey, &'a AccountSh
         self.1[index].0
     }
     fn slot(&self, _index: usize) -> Slot {
-        // per-index slot is not unique per slot when per-account slot is not included in the source data
+        // per-index slot is not unique per slot when per-account slot is not included in the source
+        // data
         self.target_slot()
     }
     fn target_slot(&self) -> Slot {
@@ -201,7 +203,8 @@ impl<'a: 'b, 'b> StorableAccounts<'a> for (Slot, &'b [(Pubkey, AccountSharedData
         &self.1[index].0
     }
     fn slot(&self, _index: usize) -> Slot {
-        // per-index slot is not unique per slot when per-account slot is not included in the source data
+        // per-index slot is not unique per slot when per-account slot is not included in the source
+        // data
         self.target_slot()
     }
     fn target_slot(&self) -> Slot {
@@ -268,8 +271,9 @@ impl<'a> StorableAccountsBySlot<'a> {
     /// on the starting_offsets based on the assumption that the
     /// starting_offsets are always sorted.
     fn find_internal_index(&self, index: usize) -> (usize, usize) {
-        // special case for when there is only one slot - just return the first index without searching.
-        // This happens when we are just shrinking a single slot storage, which happens very often.
+        // special case for when there is only one slot - just return the first index without
+        // searching. This happens when we are just shrinking a single slot storage, which
+        // happens very often.
         if !self.contains_multiple_slots {
             return (0, index);
         }
@@ -375,7 +379,8 @@ pub mod tests {
         /// given an overall index for all accounts in self:
         /// return (slots_and_accounts index, index within those accounts)
         /// This is the baseline unoptimized implementation. It is not used in the validator. It
-        /// is used for testing an optimized version - `find_internal_index`, in the actual implementation.
+        /// is used for testing an optimized version - `find_internal_index`, in the actual
+        /// implementation.
         fn find_internal_index_loop(&self, index: usize) -> (usize, usize) {
             // search offsets for the accounts slice that contains 'index'.
             // This could be a binary search.
@@ -401,7 +406,8 @@ pub mod tests {
 
     /// this is used in the test for generation of storages
     /// this is no longer used in the validator.
-    /// It is very tricky to get these right. There are already tests for this. It is likely worth it to leave this here for a while until everything has settled.
+    /// It is very tricky to get these right. There are already tests for this. It is likely worth
+    /// it to leave this here for a while until everything has settled.
     impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountInfo<'a>]) {
         fn account<Ret>(
             &self,
@@ -422,7 +428,8 @@ pub mod tests {
             self.1[index].pubkey()
         }
         fn slot(&self, _index: usize) -> Slot {
-            // per-index slot is not unique per slot when per-account slot is not included in the source data
+            // per-index slot is not unique per slot when per-account slot is not included in the
+            // source data
             self.0
         }
         fn target_slot(&self) -> Slot {
@@ -433,7 +440,8 @@ pub mod tests {
         }
     }
 
-    /// this is no longer used. It is very tricky to get these right. There are already tests for this. It is likely worth it to leave this here for a while until everything has settled.
+    /// this is no longer used. It is very tricky to get these right. There are already tests for
+    /// this. It is likely worth it to leave this here for a while until everything has settled.
     impl<'a, T: ReadableAccount + Sync> StorableAccounts<'a> for (Slot, &'a [&'a (Pubkey, T)])
     where
         AccountForStorage<'a>: From<(&'a Pubkey, &'a T)>,
@@ -455,7 +463,8 @@ pub mod tests {
             &self.1[index].0
         }
         fn slot(&self, _index: usize) -> Slot {
-            // per-index slot is not unique per slot when per-account slot is not included in the source data
+            // per-index slot is not unique per slot when per-account slot is not included in the
+            // source data
             self.target_slot()
         }
         fn target_slot(&self) -> Slot {
@@ -466,7 +475,8 @@ pub mod tests {
         }
     }
 
-    /// this is no longer used. It is very tricky to get these right. There are already tests for this. It is likely worth it to leave this here for a while until everything has settled.
+    /// this is no longer used. It is very tricky to get these right. There are already tests for
+    /// this. It is likely worth it to leave this here for a while until everything has settled.
     /// this tuple contains a single different source slot that applies to all accounts
     /// accounts are StoredAccountInfo
     impl<'a> StorableAccounts<'a> for (Slot, &'a [&'a StoredAccountInfo<'a>], Slot) {
@@ -717,7 +727,8 @@ pub mod tests {
                 .collect();
             let raw2_refs = raw2.iter().collect::<Vec<_>>();
 
-            // enumerate through permutations of # entries (ie. accounts) in each slot. Each one is 0..=entries.
+            // enumerate through permutations of # entries (ie. accounts) in each slot. Each one is
+            // 0..=entries.
             for entries0 in 0..=entries {
                 let remaining1 = entries.saturating_sub(entries0);
                 for entries1 in 0..=remaining1 {

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -28,8 +28,8 @@ use {
 };
 
 /// When rent is collected from an exempt account, rent_epoch is set to this
-/// value. The idea is to have a fixed, consistent value for rent_epoch for all accounts that do not collect rent.
-/// This enables us to get rid of the field completely.
+/// value. The idea is to have a fixed, consistent value for rent_epoch for all accounts that do not
+/// collect rent. This enables us to get rid of the field completely.
 pub const RENT_EXEMPT_RENT_EPOCH: Epoch = Epoch::MAX;
 #[cfg(test)]
 static_assertions::const_assert_eq!(

--- a/accounts-db/src/waitable_condvar.rs
+++ b/accounts-db/src/waitable_condvar.rs
@@ -3,8 +3,8 @@ use std::{
     time::Duration,
 };
 
-// encapsulate complications of unneeded mutex and Condvar to give us event behavior of wait and notify
-// this will likely be wrapped in an arc somehow
+// encapsulate complications of unneeded mutex and Condvar to give us event behavior of wait and
+// notify this will likely be wrapped in an arc somehow
 #[derive(Default, Debug)]
 pub struct WaitableCondvar {
     pub mutex: Mutex<()>,
@@ -71,7 +71,11 @@ pub mod tests {
         // just wait, but 1 less pass - verifies that notify_all works with multiple and with 1
         let handle2 = Builder::new().spawn(move || {
             for _pass in 0..(passes - 1) {
-                assert!(!cv2__.wait_timeout(Duration::from_millis(10000))); // long enough to not be intermittent, short enough to fail if we really don't get notified
+                assert!(!cv2__.wait_timeout(Duration::from_millis(10000))); // long enough to not be
+                                                                            // intermittent, short
+                                                                            // enough to fail if we
+                                                                            // really don't get
+                                                                            // notified
             }
         });
         for _pass in 0..passes {


### PR DESCRIPTION
#### Problem
Rust Format supports limiting comment length to 100, but there are many outstanding offending comments

#### Summary of Changes
- Ran Rusfmt with 
```
comment_width = 100
wrap_comments = true
```

On the accounts database directory

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
