### PR TITLE
Bring instruction accounts check earlier

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -34,7 +34,7 @@ use {
     solana_transaction_context::{
         instruction::InstructionContext, instruction_accounts::InstructionAccount,
         transaction_accounts::KeyedAccountSharedData, IndexOfAccount, TransactionContext,
-        MAX_ACCOUNTS_PER_TRANSACTION,
+        MAX_ACCOUNTS_PER_INSTRUCTION, MAX_ACCOUNTS_PER_TRANSACTION,
     },
     std::{
         alloc::Layout,
@@ -296,9 +296,6 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         instruction: Instruction,
         signers: &[Pubkey],
     ) -> Result<(), InstructionError> {
-        // We reference accounts by an u8 index, so we have a total of 256 accounts.
-        // This algorithm allocates the array on the stack for speed.
-        // On AArch64 in release mode, this function only consumes 640 bytes of stack.
         let mut transaction_callee_map: Vec<u8> = vec![u8::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
         let mut instruction_accounts: Vec<InstructionAccount> =
             Vec::with_capacity(instruction.accounts.len());
@@ -444,12 +441,13 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         program_account_index: IndexOfAccount,
         data: &'ix_data [u8],
     ) -> Result<(), InstructionError> {
-        // We reference accounts by an u8 index, so we have a total of 256 accounts.
-        // This algorithm allocates the array on the stack for speed.
-        // On AArch64 in release mode, this function only consumes 464 bytes of stack (when it is
-        // not inlined).
         let mut transaction_callee_map: Vec<u8> = vec![u8::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
-        debug_assert!(instruction.accounts.len() <= transaction_callee_map.len());
+        if instruction.accounts.len() > MAX_ACCOUNTS_PER_INSTRUCTION {
+            // We cannot serialize more than 255 accounts per instruction. We raise this error
+            // during serialization already, so this check only brings the error to an earlier
+            // stage.
+            return Err(InstructionError::MaxAccountsExceeded);
+        }
 
         let mut instruction_accounts: Vec<InstructionAccount> =
             Vec::with_capacity(instruction.accounts.len());


### PR DESCRIPTION
#### Problem

The debug assert in https://github.com/anza-xyz/agave/blob/c7b97bc77addacf03b229c51b47c18650d909576/program-runtime/src/invoke_context.rs#L452 can be hit if an instruction references more than 255 accounts. That case will error out later in the pipeline when we serialize accounts.

#### Summary of Changes

Added a check to `invoke_context.rs` to prevent the debug assert from being hit. That check is not in `message_processor.rs`, because the latter does not import instruction error.