### PR TITLE
Ensures AccountMapEntry size doesn't change unexpectedly

### DIFF
--- a/accounts-db/src/account_info.rs
+++ b/accounts-db/src/account_info.rs
@@ -89,6 +89,9 @@ pub struct AccountInfo {
     account_offset_and_flags: PackedOffsetAndFlags,
 }
 
+// Ensure the size of AccountInfo never changes unexpectedly
+const _: () = assert!(size_of::<AccountInfo>() == 8);
+
 impl IsZeroLamport for AccountInfo {
     fn is_zero_lamport(&self) -> bool {
         self.account_offset_and_flags.is_zero_lamport()

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -3,7 +3,7 @@ use {
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
         AtomicRefCount, DiskIndexValue, IndexValue, RefCount, SlotList,
     },
-    crate::is_zero_lamport::IsZeroLamport,
+    crate::{account_info::AccountInfo, is_zero_lamport::IsZeroLamport},
     solana_clock::Slot,
     std::{
         fmt::Debug,
@@ -29,6 +29,9 @@ pub struct AccountMapEntry<T> {
     /// synchronization metadata for in-memory state since last flush to disk accounts index
     meta: AccountMapEntryMeta,
 }
+
+// Ensure the size of AccountMapEntry never changes unexpectedly
+const _: () = assert!(size_of::<AccountMapEntry<AccountInfo>>() == 48);
 
 impl<T: IndexValue> AccountMapEntry<T> {
     pub fn new(slot_list: SlotList<T>, ref_count: RefCount, meta: AccountMapEntryMeta) -> Self {


### PR DESCRIPTION
#### Problem

The system is very sensitive to the size of each element in the in-memory accounts index. Yet, we don't test, nor ensure, that its size never changes.


#### Summary of Changes

Add compile time asserts to ensure the size never changes unexpectedly.