### PR TITLE
fix: correct program cache prune metric attribution

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2031,7 +2031,15 @@ fn load_frozen_forks(
                 root = new_root_bank.slot();
 
                 leader_schedule_cache.set_root(new_root_bank);
+                let mut program_cache_prune = Measure::start("program_cache_prune");
                 new_root_bank.prune_program_cache(root, new_root_bank.epoch());
+                program_cache_prune.stop();
+                datapoint_info!(
+                    "program_cache_prune",
+                    ("elapsed_ms", program_cache_prune.as_ms() as i64, i64),
+                    ("slot", root, i64),
+                    ("epoch", new_root_bank.epoch() as i64, i64),
+                );
                 let _ = bank_forks
                     .write()
                     .unwrap()

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -485,7 +485,6 @@ impl BankForks {
         snapshot_controller: Option<&SnapshotController>,
         highest_super_majority_root: Option<Slot>,
     ) -> Vec<BankWithScheduler> {
-        let program_cache_prune_start = Instant::now();
         let set_root_start = Instant::now();
         let (removed_banks, set_root_metrics) =
             self.do_set_root_return_metrics(root, snapshot_controller, highest_super_majority_root);
@@ -556,11 +555,6 @@ impl BankForks {
             (
                 "prune_remove_ms",
                 set_root_metrics.timings.prune_remove_ms,
-                i64
-            ),
-            (
-                "program_cache_prune_ms",
-                program_cache_prune_start.elapsed().as_millis() as i64,
                 i64
             ),
             ("dropped_banks_len", set_root_metrics.dropped_banks_len, i64),


### PR DESCRIPTION
This change removes the misleading program_cache_prune_ms field from bank_forks::set_root(), which suggested measuring program cache pruning although no pruning occurs inside set_root. Program cache pruning is performed by blockstore_processor before calling set_root, so the metric conflated elapsed set_root time with pruning. To restore accurate attribution, an explicit datapoint around new_root_bank.prune_program_cache(...) has been added in blockstore_processor.rs, reporting the actual prune duration along with slot and epoch. This avoids confusion in dashboards, eliminates redundancy with set_root elapsed_ms, and keeps telemetry semantically correct without changing runtime behavior.