### PR TITLE
xdp: move init steps that require caps early in validator process start up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,6 @@ dependencies = [
  "agave-xdp-ebpf",
  "arc-swap",
  "aya",
- "caps",
  "crossbeam-channel",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11750,6 +11750,7 @@ dependencies = [
  "bincode",
  "bs58",
  "caps",
+ "core_affinity",
  "crossbeam-channel",
  "itertools 0.14.0",
  "lazy-lru",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11746,6 +11746,7 @@ dependencies = [
  "agave-xdp",
  "arc-swap",
  "assert_matches",
+ "aya",
  "bencher",
  "bincode",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
  "agave-logger",
  "agave-snapshots",
  "assert_cmd",
+ "caps",
  "chrono",
  "clap 2.33.3",
  "console 0.16.2",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -141,7 +141,7 @@ use {
     solana_turbine::{
         self,
         broadcast_stage::BroadcastStageType,
-        xdp::{master_ip_if_bonded, XdpConfig, XdpRetransmitter},
+        xdp::{master_ip_if_bonded, XdpConfig, XdpRetransmitBuilder, XdpRetransmitter},
     },
     solana_unified_scheduler_logic::SchedulingMode,
     solana_unified_scheduler_pool::{DefaultSchedulerPool, SupportedSchedulingMode},
@@ -1543,27 +1543,28 @@ impl Validator {
             )
         });
 
-        let (xdp_retransmitter, xdp_sender) = if let Some(xdp_config) =
-            config.retransmit_xdp.clone()
-        {
-            let src_port = node.sockets.retransmit_sockets[0]
-                .local_addr()
-                .expect("failed to get local address")
-                .port();
-            let src_ip = match node.bind_ip_addrs.active() {
-                IpAddr::V4(ip) if !ip.is_unspecified() => Some(ip),
-                IpAddr::V4(_unspecified) => xdp_config
-                    .interface
-                    .as_ref()
-                    .and_then(|iface| master_ip_if_bonded(iface)),
-                _ => panic!("IPv6 not supported"),
+        let (xdp_retransmitter, xdp_sender) =
+            if let Some(xdp_config) = config.retransmit_xdp.clone() {
+                let src_port = node.sockets.retransmit_sockets[0]
+                    .local_addr()
+                    .expect("failed to get local address")
+                    .port();
+                let src_ip = match node.bind_ip_addrs.active() {
+                    IpAddr::V4(ip) if !ip.is_unspecified() => Some(ip),
+                    IpAddr::V4(_unspecified) => xdp_config
+                        .interface
+                        .as_ref()
+                        .and_then(|iface| master_ip_if_bonded(iface)),
+                    _ => panic!("IPv6 not supported"),
+                };
+                let xdp_retransmit_builder =
+                    XdpRetransmitBuilder::new(xdp_config, src_port, src_ip, exit.clone())
+                        .expect("failed to create xdp retransmitter");
+                let (rtx, sender) = xdp_retransmit_builder.build();
+                (Some(rtx), Some(sender))
+            } else {
+                (None, None)
             };
-            let (rtx, sender) = XdpRetransmitter::new(xdp_config, src_port, src_ip, exit.clone())
-                .expect("failed to create xdp retransmitter");
-            (Some(rtx), Some(sender))
-        } else {
-            (None, None)
-        };
 
         // disable all2all tests if not allowed for a given cluster type
         let alpenglow_socket = if genesis_config.cluster_type == ClusterType::Testnet

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -141,7 +141,7 @@ use {
     solana_turbine::{
         self,
         broadcast_stage::BroadcastStageType,
-        xdp::{master_ip_if_bonded, XdpConfig, XdpRetransmitBuilder, XdpRetransmitter},
+        xdp::{XdpRetransmitBuilder, XdpRetransmitter},
     },
     solana_unified_scheduler_logic::SchedulingMode,
     solana_unified_scheduler_pool::{DefaultSchedulerPool, SupportedSchedulingMode},
@@ -151,7 +151,7 @@ use {
     std::{
         borrow::Cow,
         collections::{HashMap, HashSet},
-        net::{IpAddr, SocketAddr},
+        net::SocketAddr,
         num::{NonZeroU64, NonZeroUsize},
         path::{Path, PathBuf},
         str::FromStr,
@@ -412,7 +412,6 @@ pub struct ValidatorConfig {
     pub replay_transactions_threads: NonZeroUsize,
     pub tvu_shred_sigverify_threads: NonZeroUsize,
     pub delay_leader_block_for_pending_fork: bool,
-    pub retransmit_xdp: Option<XdpConfig>,
     pub repair_handler_type: RepairHandlerType,
 }
 
@@ -494,7 +493,6 @@ impl ValidatorConfig {
             tvu_shred_sigverify_threads: NonZeroUsize::new(get_thread_count())
                 .expect("thread count is non-zero"),
             delay_leader_block_for_pending_fork: false,
-            retransmit_xdp: None,
             repair_handler_type: RepairHandlerType::default(),
         }
     }
@@ -688,6 +686,43 @@ pub struct Validator {
 impl Validator {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        node: Node,
+        identity_keypair: Arc<Keypair>,
+        ledger_path: &Path,
+        vote_account: &Pubkey,
+        authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
+        cluster_entrypoints: Vec<ContactInfo>,
+        config: &ValidatorConfig,
+        should_check_duplicate_instance: bool,
+        rpc_to_plugin_manager_receiver: Option<Receiver<GeyserPluginManagerRequest>>,
+        start_progress: Arc<RwLock<ValidatorStartProgress>>,
+        socket_addr_space: SocketAddrSpace,
+        tpu_config: ValidatorTpuConfig,
+        admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
+        maybe_xdp_retransmit_builder: Option<XdpRetransmitBuilder>,
+    ) -> Result<Self> {
+        let exit = Arc::new(AtomicBool::new(false));
+        Self::new_with_exit(
+            node,
+            identity_keypair,
+            ledger_path,
+            vote_account,
+            authorized_voter_keypairs,
+            cluster_entrypoints,
+            config,
+            should_check_duplicate_instance,
+            rpc_to_plugin_manager_receiver,
+            start_progress,
+            socket_addr_space,
+            tpu_config,
+            admin_rpc_service_post_init,
+            maybe_xdp_retransmit_builder,
+            exit,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_exit(
         mut node: Node,
         identity_keypair: Arc<Keypair>,
         ledger_path: &Path,
@@ -701,6 +736,8 @@ impl Validator {
         socket_addr_space: SocketAddrSpace,
         tpu_config: ValidatorTpuConfig,
         admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
+        maybe_xdp_retransmit_builder: Option<XdpRetransmitBuilder>,
+        exit: Arc<AtomicBool>,
     ) -> Result<Self> {
         #[cfg(debug_assertions)]
         const DEBUG_ASSERTION_STATUS: &str = "enabled";
@@ -745,8 +782,6 @@ impl Validator {
         }
 
         let mut bank_notification_senders = Vec::new();
-
-        let exit = Arc::new(AtomicBool::new(false));
 
         let geyser_plugin_config_files = config
             .on_start_geyser_plugin_config_files
@@ -1544,22 +1579,7 @@ impl Validator {
         });
 
         let (xdp_retransmitter, xdp_sender) =
-            if let Some(xdp_config) = config.retransmit_xdp.clone() {
-                let src_port = node.sockets.retransmit_sockets[0]
-                    .local_addr()
-                    .expect("failed to get local address")
-                    .port();
-                let src_ip = match node.bind_ip_addrs.active() {
-                    IpAddr::V4(ip) if !ip.is_unspecified() => Some(ip),
-                    IpAddr::V4(_unspecified) => xdp_config
-                        .interface
-                        .as_ref()
-                        .and_then(|iface| master_ip_if_bonded(iface)),
-                    _ => panic!("IPv6 not supported"),
-                };
-                let xdp_retransmit_builder =
-                    XdpRetransmitBuilder::new(xdp_config, src_port, src_ip, exit.clone())
-                        .expect("failed to create xdp retransmitter");
+            if let Some(xdp_retransmit_builder) = maybe_xdp_retransmit_builder {
                 let (rtx, sender) = xdp_retransmit_builder.build();
                 (Some(rtx), Some(sender))
             } else {
@@ -2944,6 +2964,7 @@ mod tests {
             SocketAddrSpace::Unspecified,
             ValidatorTpuConfig::new_for_tests(),
             Arc::new(RwLock::new(None)),
+            None,
         )
         .expect("assume successful validator start");
         assert_eq!(
@@ -3158,6 +3179,7 @@ mod tests {
                     SocketAddrSpace::Unspecified,
                     ValidatorTpuConfig::new_for_tests(),
                     Arc::new(RwLock::new(None)),
+                    None,
                 )
                 .expect("assume successful validator start")
             })

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9681,6 +9681,7 @@ dependencies = [
  "agave-votor",
  "agave-xdp",
  "arc-swap",
+ "aya",
  "bincode",
  "caps",
  "core_affinity",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9683,6 +9683,7 @@ dependencies = [
  "arc-swap",
  "bincode",
  "caps",
+ "core_affinity",
  "crossbeam-channel",
  "itertools 0.14.0",
  "lazy-lru",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -457,7 +457,6 @@ dependencies = [
  "agave-xdp-ebpf",
  "arc-swap",
  "aya",
- "caps",
  "crossbeam-channel",
  "libc",
  "log",

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -408,6 +408,7 @@ impl LocalCluster {
                 // to use the same QUIC ports due to SO_REUSEPORT.
                 ValidatorTpuConfig::new_for_tests(),
                 Arc::new(RwLock::new(None)),
+                None,
             )
             .expect("assume successful validator start");
 
@@ -617,6 +618,7 @@ impl LocalCluster {
             socket_addr_space,
             ValidatorTpuConfig::new_for_tests(),
             Arc::new(RwLock::new(None)),
+            None,
         )
         .expect("assume successful validator start");
 
@@ -682,6 +684,7 @@ impl LocalCluster {
                 socket_addr_space,
                 ValidatorTpuConfig::new_for_tests(),
                 Arc::new(RwLock::new(None)),
+                None,
             )
             .unwrap_or_else(|e| panic!("Cluster leader failed to start: {e:?}"));
 
@@ -745,6 +748,7 @@ impl LocalCluster {
                     socket_addr_space,
                     ValidatorTpuConfig::new_for_tests(),
                     Arc::new(RwLock::new(None)),
+                    None,
                 )
                 .unwrap_or_else(|e| panic!("Validator {i} failed to start: {e:?}"));
 
@@ -1298,6 +1302,7 @@ impl Cluster for LocalCluster {
             socket_addr_space,
             ValidatorTpuConfig::new_for_tests(),
             Arc::new(RwLock::new(None)),
+            None,
         )
         .expect("assume successful validator start");
         cluster_validator_info.validator = Some(restarted_node);

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -79,7 +79,6 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         replay_transactions_threads: config.replay_transactions_threads,
         tvu_shred_sigverify_threads: config.tvu_shred_sigverify_threads,
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
-        retransmit_xdp: config.retransmit_xdp.clone(),
         repair_handler_type: config.repair_handler_type.clone(),
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
  "agave-geyser-plugin-interface",
  "agave-logger",
  "agave-snapshots",
+ "caps",
  "chrono",
  "clap",
  "console 0.16.2",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10197,6 +10197,7 @@ dependencies = [
  "arc-swap",
  "bincode",
  "caps",
+ "core_affinity",
  "crossbeam-channel",
  "itertools 0.14.0",
  "lazy-lru",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10195,6 +10195,7 @@ dependencies = [
  "agave-votor",
  "agave-xdp",
  "arc-swap",
+ "aya",
  "bincode",
  "caps",
  "core_affinity",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -440,7 +440,6 @@ dependencies = [
  "agave-xdp-ebpf",
  "arc-swap",
  "aya",
- "caps",
  "crossbeam-channel",
  "libc",
  "log",

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1227,6 +1227,7 @@ impl TestValidator {
             socket_addr_space,
             ValidatorTpuConfig::new_for_tests(),
             config.admin_rpc_service_post_init.clone(),
+            None,
         )?);
 
         let test_validator = TestValidator {

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -57,6 +57,7 @@ wincode = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = { workspace = true }
+core_affinity = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { workspace = true }

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -56,6 +56,7 @@ thiserror = { workspace = true }
 wincode = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+aya = { workspace = true }
 caps = { workspace = true }
 core_affinity = { workspace = true }
 

--- a/turbine/src/xdp.rs
+++ b/turbine/src/xdp.rs
@@ -7,9 +7,11 @@ use {
         load_xdp_program,
         route::Router,
         route_monitor::RouteMonitor,
-        tx_loop::{TxLoopBuilder, TxLoopConfigBuilder},
+        tx_loop::{TxLoop, TxLoopBuilder, TxLoopConfigBuilder},
+        umem::{OwnedUmem, PageAlignedMemory},
     },
     arc_swap::ArcSwap,
+    aya::Ebpf,
     crossbeam_channel::TryRecvError,
     std::{thread::Builder, time::Duration},
 };
@@ -114,14 +116,26 @@ pub struct XdpRetransmitter {
     threads: Vec<thread::JoinHandle<()>>,
 }
 
-impl XdpRetransmitter {
+#[cfg(not(target_os = "linux"))]
+pub struct XdpRetransmitBuilder {}
+
+#[cfg(target_os = "linux")]
+pub struct XdpRetransmitBuilder {
+    tx_loops: Vec<TxLoop<OwnedUmem<PageAlignedMemory>>>,
+    rtx_channel_cap: usize,
+    maybe_ebpf: Option<Ebpf>,
+    atomic_router: Arc<ArcSwap<Router>>,
+    route_monitor_handle: thread::JoinHandle<()>,
+}
+
+impl XdpRetransmitBuilder {
     #[cfg(not(target_os = "linux"))]
     pub fn new(
         _config: XdpConfig,
         _src_port: u16,
         _src_ip: Option<Ipv4Addr>,
         _exit: Arc<AtomicBool>,
-    ) -> Result<(Self, XdpSender), Box<dyn Error>> {
+    ) -> Result<Self, Box<dyn Error>> {
         Err("XDP is only supported on Linux".into())
     }
 
@@ -131,7 +145,7 @@ impl XdpRetransmitter {
         src_port: u16,
         src_ip: Option<Ipv4Addr>,
         exit: Arc<AtomicBool>,
-    ) -> Result<(Self, XdpSender), Box<dyn Error>> {
+    ) -> Result<Self, Box<dyn Error>> {
         use {
             caps::{
                 CapSet,
@@ -139,7 +153,52 @@ impl XdpRetransmitter {
             },
             std::collections::HashSet,
         };
-        const DROP_CHANNEL_CAP: usize = 1_000_000;
+        let XdpConfig {
+            interface: maybe_interface,
+            cpus,
+            zero_copy,
+            rtx_channel_cap,
+        } = config;
+
+        let dev = Arc::new(if let Some(interface) = maybe_interface {
+            NetworkDevice::new(interface).unwrap()
+        } else {
+            NetworkDevice::new_from_default_route().unwrap()
+        });
+
+        let mut tx_loop_config_builder = TxLoopConfigBuilder::new(src_port);
+        tx_loop_config_builder.zero_copy(zero_copy);
+        if let Some(src_ip) = src_ip {
+            tx_loop_config_builder.override_src_ip(src_ip);
+        }
+        let tx_loop_config = tx_loop_config_builder.build_with_src_device(&dev);
+
+        let reserved_cores = cpus.iter().cloned().collect::<HashSet<_>>();
+        let available_cores = core_affinity::get_core_ids()
+            .expect("linux provide affine cores")
+            .into_iter()
+            .map(|core_affinity::CoreId { id }| id)
+            .collect::<HashSet<_>>();
+        let unreserved_cores = available_cores
+            .difference(&reserved_cores)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let tx_loop_builders = cpus
+            .into_iter()
+            .zip(std::iter::repeat_with(|| tx_loop_config.clone()))
+            .enumerate()
+            .map(|(i, (cpu_id, config))| {
+                // since we aren't necessarily allocating from the thread that we intend to run on,
+                // temporarily switch to the target cpu for each TxLoop to ensure that the Umem region
+                // is allocated to the correct numa node
+                set_cpu_affinity([cpu_id]).unwrap();
+                let tx_loop_builder = TxLoopBuilder::new(cpu_id, QueueId(i as u64), config, &dev);
+                // migrate main thread back off of the last xdp reserved cpu
+                set_cpu_affinity(unreserved_cores.clone()).unwrap();
+                tx_loop_builder
+            })
+            .collect::<Vec<_>>();
 
         // switch to higher caps while we setup XDP. We assume that an error in
         // this function is irrecoverable so we don't try to drop on errors.
@@ -148,38 +207,66 @@ impl XdpRetransmitter {
                 .map_err(|e| format!("failed to raise {cap:?} capability: {e}"))?;
         }
 
-        let dev = Arc::new(if let Some(interface) = config.interface {
-            NetworkDevice::new(interface).unwrap()
-        } else {
-            NetworkDevice::new_from_default_route().unwrap()
-        });
-
-        let ebpf = if config.zero_copy {
-            Some(load_xdp_program(&dev).map_err(|e| format!("failed to attach xdp program: {e}"))?)
+        let maybe_ebpf_result = if zero_copy {
+            Some(load_xdp_program(&dev).map_err(|e| format!("failed to attach xdp program: {e}")))
         } else {
             None
         };
+
+        let tx_loops = tx_loop_builders
+            .into_iter()
+            .map(|tx_loop_builder| tx_loop_builder.build())
+            .collect::<Vec<_>>();
+
+        let router_result = Router::new();
 
         for cap in [CAP_NET_ADMIN, CAP_NET_RAW, CAP_BPF, CAP_PERFMON] {
             caps::drop(None, CapSet::Effective, cap).unwrap();
         }
 
-        let (senders, receivers) = (0..config.cpus.len())
-            .map(|_| crossbeam_channel::bounded(config.rtx_channel_cap))
-            .unzip::<_, _, Vec<_>, Vec<_>>();
-
+        let router = router_result?;
         // Use ArcSwap for lock-free updates of the routing table
-        let atomic_router = Arc::new(ArcSwap::from_pointee(Router::new()?));
-        let monitor_handle = RouteMonitor::start(
+        let atomic_router = Arc::new(ArcSwap::from_pointee(router));
+        let route_monitor_handle = RouteMonitor::start(
             Arc::clone(&atomic_router),
             exit.clone(),
             ROUTE_MONITOR_UPDATE_INTERVAL,
         );
 
-        let mut threads = vec![];
-        threads.push(monitor_handle);
+        let maybe_ebpf = maybe_ebpf_result.transpose()?;
+
+        Ok(Self {
+            tx_loops,
+            rtx_channel_cap,
+            maybe_ebpf,
+            atomic_router,
+            route_monitor_handle,
+        })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn build(self) -> (XdpRetransmitter, XdpSender) {
+        (
+            XdpRetransmitter { threads: vec![] },
+            XdpSender { senders: vec![] },
+        )
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn build(self) -> (XdpRetransmitter, XdpSender) {
+        const DROP_CHANNEL_CAP: usize = 1_000_000;
+
+        let Self {
+            tx_loops,
+            rtx_channel_cap,
+            maybe_ebpf,
+            atomic_router,
+            route_monitor_handle,
+        } = self;
 
         let (drop_sender, drop_receiver) = crossbeam_channel::bounded(DROP_CHANNEL_CAP);
+        let mut threads = vec![route_monitor_handle];
+
         threads.push(
             Builder::new()
                 .name("solRetransmDrop".to_owned())
@@ -198,46 +285,16 @@ impl XdpRetransmitter {
                         }
                     }
                     // move the ebpf program here so it stays attached until we exit
-                    drop(ebpf);
+                    drop(maybe_ebpf);
                 })
                 .unwrap(),
         );
 
-        let mut tx_loop_config_builder = TxLoopConfigBuilder::new(src_port);
-        tx_loop_config_builder.zero_copy(config.zero_copy);
-        if let Some(src_ip) = src_ip {
-            tx_loop_config_builder.override_src_ip(src_ip);
-        }
-        let tx_loop_config = tx_loop_config_builder.build_with_src_device(&dev);
-
-        let reserved_cores = config.cpus.iter().cloned().collect::<HashSet<_>>();
-        let available_cores = core_affinity::get_core_ids()
-            .expect("linux provide affine cores")
-            .into_iter()
-            .map(|core_affinity::CoreId { id }| id)
-            .collect::<HashSet<_>>();
-        let unreserved_cores = available_cores
-            .difference(&reserved_cores)
-            .cloned()
-            .collect::<Vec<_>>();
-
-        for (i, (receiver, cpu_id)) in receivers
-            .into_iter()
-            .zip(config.cpus.into_iter())
-            .enumerate()
-        {
-            let dev = Arc::clone(&dev);
+        let mut senders = vec![];
+        for (i, tx_loop) in tx_loops.into_iter().enumerate() {
+            let (sender, receiver) = crossbeam_channel::bounded(rtx_channel_cap);
             let drop_sender = drop_sender.clone();
             let atomic_router = Arc::clone(&atomic_router);
-            let config = tx_loop_config.clone();
-            // since we aren't necessarily allocating from the thread that we intend to run on,
-            // temporarily switch to the target cpu for each TxLoop to ensure that the Umem region
-            // is allocated to the correct numa node
-            set_cpu_affinity([cpu_id]).unwrap();
-            let tx_loop_builder = TxLoopBuilder::new(cpu_id, QueueId(i as u64), config, &dev);
-            // migrate main thread back off of the last xdp reserved cpu
-            set_cpu_affinity(unreserved_cores.clone()).unwrap();
-            let tx_loop = tx_loop_builder.build();
             threads.push(
                 Builder::new()
                     .name(format!("solRetransmIO{i:02}"))
@@ -249,11 +306,14 @@ impl XdpRetransmitter {
                     })
                     .unwrap(),
             );
+            senders.push(sender);
         }
 
-        Ok((Self { threads }, XdpSender { senders }))
+        (XdpRetransmitter { threads }, XdpSender { senders })
     }
+}
 
+impl XdpRetransmitter {
     pub fn join(self) -> thread::Result<()> {
         for handle in self.threads {
             handle.join()?;

--- a/turbine/src/xdp.rs
+++ b/turbine/src/xdp.rs
@@ -239,6 +239,13 @@ impl XdpRetransmitBuilder {
             Arc::clone(&atomic_router),
             exit.clone(),
             ROUTE_MONITOR_UPDATE_INTERVAL,
+            || {
+                // we need to retain CAP_NET_ADMIN in case the netlink socket needs reinitialized
+                let retained_caps = caps::CapsHashSet::from_iter([caps::Capability::CAP_NET_ADMIN]);
+                caps::set(None, caps::CapSet::Permitted, &retained_caps)
+                    .expect("linux allows permitted capset to be set");
+                info!("route monitor thread started");
+            },
         );
 
         let maybe_ebpf = maybe_ebpf_result.transpose()?;

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -95,6 +95,9 @@ tokio = { workspace = true }
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 jemallocator = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+caps = { workspace = true }
+
 [target."cfg(unix)".dependencies]
 libc = { workspace = true }
 

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1618,6 +1618,7 @@ mod tests {
                 SocketAddrSpace::Unspecified,
                 ValidatorTpuConfig::new_for_tests(),
                 post_init.clone(),
+                None,
             )
             .expect("assume successful validator start");
             assert_eq!(

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -21,4 +21,3 @@ thiserror = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 agave-xdp-ebpf = { workspace = true }
 aya = { workspace = true }
-caps = { workspace = true }

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -262,6 +262,9 @@ pub(crate) struct RingConsumer {
     cached_consumer: u32,
 }
 
+///Safety: Instances of `RingConsumer` MUST only be resident on one thread at a time
+unsafe impl Send for RingConsumer {}
+
 impl RingConsumer {
     pub fn new(producer: *mut AtomicU32, consumer: *mut AtomicU32) -> Self {
         Self {
@@ -305,6 +308,9 @@ pub(crate) struct RingProducer {
     cached_consumer: u32,
     size: u32,
 }
+
+///Safety: Instances of `RingProducer` MUST only be resident on one thread at a time
+unsafe impl Send for RingProducer {}
 
 impl RingProducer {
     pub fn new(producer: *mut AtomicU32, consumer: *mut AtomicU32, size: u32) -> Self {
@@ -434,6 +440,9 @@ pub struct RingMmap<T> {
     pub desc: *mut T,
     pub flags: *mut AtomicU32,
 }
+
+///Safety: Instances of `RingMmap<T>` MUST only be resident on one thread at a time
+unsafe impl<T> Send for RingMmap<T> {}
 
 impl<T> Drop for RingMmap<T> {
     fn drop(&mut self) {

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -64,3 +64,21 @@ pub fn set_cpu_affinity(cpus: impl IntoIterator<Item = usize>) -> Result<(), io:
 pub fn set_cpu_affinity(_cpus: impl IntoIterator<Item = usize>) -> Result<(), io::Error> {
     unimplemented!()
 }
+
+#[cfg(target_os = "linux")]
+pub fn get_cpu() -> Result<usize, io::Error> {
+    unsafe {
+        let result = libc::sched_getcpu();
+        if result < 0 {
+            assert_eq!(result, -1);
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(result as usize)
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn get_cpu() -> Result<usize, io::Error> {
+    unimplemented!()
+}

--- a/xdp/src/route_monitor.rs
+++ b/xdp/src/route_monitor.rs
@@ -26,14 +26,18 @@ impl RouteMonitor {
     /// Subscribes to RTMGRP_IPV4_ROUTE | RTMGRP_NEIGH multicast groups
     /// Waits for updates to arrive on the netlink socket
     /// Publishes the updated routing table every `update_interval` if needed
-    pub fn start(
+    pub fn start<F: FnOnce() + Send + Sync + 'static>(
         atomic_router: Arc<ArcSwap<Router>>,
         exit: Arc<AtomicBool>,
         update_interval: Duration,
+        on_thread_start: F,
     ) -> thread::JoinHandle<()> {
         thread::Builder::new()
             .name("solRouteMon".to_string())
             .spawn(move || {
+                // MUST remain first to run here
+                on_thread_start();
+
                 let mut state =
                     RouteMonitorState::new(Router::new().expect("error creating Router"));
 

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        device::{NetworkDevice, QueueId, RingSizes},
+        device::{DeviceQueue, NetworkDevice, QueueId, RingSizes, TxCompletionRing},
         netlink::MacAddress,
         packet::{
             write_eth_header, write_ip_header, write_udp_header, ETH_HEADER_SIZE, IP_HEADER_SIZE,
@@ -11,7 +11,7 @@ use {
         route::NextHop,
         set_cpu_affinity,
         socket::{Socket, Tx, TxRing},
-        umem::{Frame, OwnedUmem, PageAlignedMemory, Umem as _},
+        umem::{Frame, OwnedUmem, PageAlignedMemory, Umem},
     },
     caps::{
         CapSet,
@@ -97,262 +97,339 @@ pub struct TxLoopConfig {
     src_port: u16,
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>, R: Fn(&IpAddr) -> Option<NextHop>>(
+pub struct TxLoopBuilder<U: Umem> {
     cpu_id: usize,
-    dev: &NetworkDevice,
     queue_id: QueueId,
-    config: TxLoopConfig,
-    receiver: Receiver<(A, T)>,
-    drop_sender: Sender<(A, T)>,
-    route_fn: R,
-) {
-    let TxLoopConfig {
-        zero_copy,
-        src_mac,
-        src_ip,
-        src_port,
-    } = config;
+    zero_copy: bool,
+    src_mac: MacAddress,
+    src_ip: Ipv4Addr,
+    src_port: u16,
+    queue: DeviceQueue,
+    tx_size: usize,
+    umem: U,
+}
 
-    log::info!(
-        "starting xdp loop on {} queue {queue_id:?} cpu {cpu_id}",
-        dev.name()
-    );
+impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
+    pub fn new(
+        cpu_id: usize,
+        queue_id: QueueId,
+        config: TxLoopConfig,
+        dev: &NetworkDevice,
+    ) -> TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
+        let TxLoopConfig {
+            zero_copy,
+            src_mac,
+            src_ip,
+            src_port,
+        } = config;
 
-    // each queue is bound to its own CPU core
-    set_cpu_affinity([cpu_id]).unwrap();
-
-    // some drivers require frame_size=page_size
-    let frame_size = unsafe { sysconf(_SC_PAGESIZE) } as usize;
-
-    let queue = dev
-        .open_queue(queue_id)
-        .expect("failed to open queue for AF_XDP socket");
-    let RingSizes {
-        rx: rx_size,
-        tx: tx_size,
-    } = queue.ring_sizes().unwrap_or_else(|| {
         log::info!(
-            "using default ring sizes for {} queue {queue_id:?}",
+            "starting xdp loop on {} queue {queue_id:?} cpu {cpu_id}",
             dev.name()
         );
-        RingSizes::default()
-    });
 
-    let frame_count = (rx_size + tx_size) * 2;
+        // some drivers require frame_size=page_size
+        let frame_size = unsafe { sysconf(_SC_PAGESIZE) } as usize;
 
-    // try to allocate huge pages first, then fall back to regular pages
-    const HUGE_2MB: usize = 2 * 1024 * 1024;
-    let memory = PageAlignedMemory::alloc_with_page_size(frame_size, frame_count, HUGE_2MB, true)
-        .or_else(|_| {
-            log::warn!("huge page alloc failed, falling back to regular page size");
-            PageAlignedMemory::alloc(frame_size, frame_count)
-        })
-        .unwrap();
-    let umem = OwnedUmem::new(memory, frame_size as u32).unwrap();
+        let queue = dev
+            .open_queue(queue_id)
+            .expect("failed to open queue for AF_XDP socket");
+        let RingSizes {
+            rx: rx_size,
+            tx: tx_size,
+        } = queue.ring_sizes().unwrap_or_else(|| {
+            log::info!(
+                "using default ring sizes for {} queue {queue_id:?}",
+                dev.name()
+            );
+            RingSizes::default()
+        });
 
-    // we need NET_ADMIN and NET_RAW for the socket
-    for cap in [CAP_NET_ADMIN, CAP_NET_RAW] {
-        caps::raise(None, CapSet::Effective, cap).unwrap();
+        let frame_count = (rx_size + tx_size) * 2;
+
+        // try to allocate huge pages first, then fall back to regular pages
+        const HUGE_2MB: usize = 2 * 1024 * 1024;
+        let memory =
+            PageAlignedMemory::alloc_with_page_size(frame_size, frame_count, HUGE_2MB, true)
+                .or_else(|_| {
+                    log::warn!("huge page alloc failed, falling back to regular page size");
+                    PageAlignedMemory::alloc(frame_size, frame_count)
+                })
+                .unwrap();
+        let umem = OwnedUmem::new(memory, frame_size as u32).unwrap();
+
+        TxLoopBuilder {
+            cpu_id,
+            queue_id,
+            zero_copy,
+            src_mac,
+            src_ip,
+            src_port,
+            queue,
+            tx_size,
+            umem,
+        }
     }
 
-    let Ok((mut socket, tx)) = Socket::tx(queue, umem, zero_copy, tx_size * 2, tx_size) else {
-        panic!("failed to create AF_XDP socket on queue {queue_id:?}");
-    };
+    pub fn build(self) -> TxLoop<OwnedUmem<PageAlignedMemory>> {
+        let TxLoopBuilder {
+            cpu_id,
+            queue_id,
+            zero_copy,
+            src_mac,
+            src_ip,
+            src_port,
+            queue,
+            tx_size,
+            umem,
+        } = self;
 
-    let umem = socket.umem();
-    let umem_tx_capacity = umem.available();
-    let Tx {
-        // this is where we'll queue frames
-        ring,
-        // this is where we'll get completion events once frames have been picked up by the NIC
-        mut completion,
-    } = tx;
-    let mut ring = ring.unwrap();
+        // we need NET_ADMIN and NET_RAW for the socket
+        for cap in [CAP_NET_ADMIN, CAP_NET_RAW] {
+            caps::raise(None, CapSet::Effective, cap).unwrap();
+        }
 
-    // we don't need higher caps anymore
-    for cap in [CAP_NET_ADMIN, CAP_NET_RAW] {
-        caps::drop(None, CapSet::Effective, cap).unwrap();
-    }
-
-    // How long we sleep waiting to receive shreds from the channel.
-    const RECV_TIMEOUT: Duration = Duration::from_nanos(1000);
-
-    const MAX_TIMEOUTS: usize = 1;
-
-    // We try to collect _at least_ BATCH_SIZE packets before queueing into the NIC. This is to
-    // avoid introducing too much per-packet overhead and giving the NIC time to complete work
-    // before we queue the next chunk of packets.
-    const BATCH_SIZE: usize = 64;
-
-    // Local buffer where we store packets before sending themi.
-    let mut batched_items = Vec::with_capacity(BATCH_SIZE);
-
-    // How many packets we've batched. This is _not_ batched_items.len(), but item * peers. For
-    // example if we have 3 packets to transmit to 2 destination addresses each, we have 6 batched
-    // packets.
-    let mut batched_packets = 0;
-
-    let mut timeouts = 0;
-    loop {
-        match receiver.try_recv() {
-            Ok((addrs, payload)) => {
-                batched_packets += addrs.as_ref().len();
-                batched_items.push((addrs, payload));
-                timeouts = 0;
-                if batched_packets < BATCH_SIZE {
-                    continue;
-                }
-            }
-            Err(TryRecvError::Empty) => {
-                if timeouts < MAX_TIMEOUTS {
-                    timeouts += 1;
-                    thread::sleep(RECV_TIMEOUT);
-                } else {
-                    timeouts = 0;
-                    // we haven't received anything in a while, kick the driver
-                    ring.commit();
-                    kick(&ring);
-                }
-            }
-            Err(TryRecvError::Disconnected) => {
-                // keep looping until we've flushed all the packets
-                if batched_packets == 0 {
-                    break;
-                }
-            }
+        let Ok((socket, tx)) = Socket::tx(queue, umem, zero_copy, tx_size * 2, tx_size) else {
+            panic!("failed to create AF_XDP socket on queue {queue_id:?}");
         };
 
-        // this is the number of packets after which we commit the ring and kick the driver if
-        // necessary
-        let mut chunk_remaining = BATCH_SIZE.min(batched_packets);
+        let Tx {
+            // this is where we'll queue frames
+            ring,
+            // this is where we'll get completion events once frames have been picked up by the NIC
+            completion,
+        } = tx;
+        let ring = ring.unwrap();
 
-        for (addrs, payload) in batched_items.drain(..) {
-            for addr in addrs.as_ref() {
-                if ring.available() == 0 || umem.available() == 0 {
-                    // loop until we have space for the next packet
-                    loop {
-                        completion.sync(true);
-                        // we haven't written any frames so we only need to sync the consumer position
-                        ring.sync(false);
+        // we don't need higher caps anymore
+        for cap in [CAP_NET_ADMIN, CAP_NET_RAW] {
+            caps::drop(None, CapSet::Effective, cap).unwrap();
+        }
 
-                        // check if any frames were completed
-                        while let Some(frame_offset) = completion.read() {
-                            umem.release(frame_offset);
-                        }
+        TxLoop {
+            cpu_id,
+            src_mac,
+            src_ip,
+            src_port,
+            socket,
+            ring,
+            completion,
+        }
+    }
+}
 
-                        if ring.available() > 0 && umem.available() > 0 {
-                            // we have space for the next packet, break out of the loop
-                            break;
-                        }
+pub struct TxLoop<U: Umem> {
+    cpu_id: usize,
+    src_mac: MacAddress,
+    src_ip: Ipv4Addr,
+    src_port: u16,
+    socket: Socket<U>,
+    ring: TxRing<U::Frame>,
+    completion: TxCompletionRing,
+}
 
-                        // queues are full, if NEEDS_WAKEUP is set kick the driver so hopefully it'll
-                        // complete some work
+impl<U: Umem> TxLoop<U> {
+    pub fn run<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>, R: Fn(&IpAddr) -> Option<NextHop>>(
+        self,
+        receiver: Receiver<(A, T)>,
+        drop_sender: Sender<(A, T)>,
+        route_fn: R,
+    ) {
+        // How long we sleep waiting to receive shreds from the channel.
+        const RECV_TIMEOUT: Duration = Duration::from_nanos(1000);
+
+        const MAX_TIMEOUTS: usize = 1;
+
+        // We try to collect _at least_ BATCH_SIZE packets before queueing into the NIC. This is to
+        // avoid introducing too much per-packet overhead and giving the NIC time to complete work
+        // before we queue the next chunk of packets.
+        const BATCH_SIZE: usize = 64;
+
+        let TxLoop {
+            cpu_id,
+            src_mac,
+            src_ip,
+            src_port,
+            mut socket,
+            mut ring,
+            mut completion,
+        } = self;
+
+        // each queue is bound to its own CPU core
+        set_cpu_affinity([cpu_id]).unwrap();
+
+        let umem = socket.umem();
+        let umem_tx_capacity = umem.available();
+
+        // Local buffer where we store packets before sending themi.
+        let mut batched_items = Vec::with_capacity(BATCH_SIZE);
+
+        // How many packets we've batched. This is _not_ batched_items.len(), but item * peers. For
+        // example if we have 3 packets to transmit to 2 destination addresses each, we have 6 batched
+        // packets.
+        let mut batched_packets = 0;
+
+        let mut timeouts = 0;
+        loop {
+            match receiver.try_recv() {
+                Ok((addrs, payload)) => {
+                    batched_packets += addrs.as_ref().len();
+                    batched_items.push((addrs, payload));
+                    timeouts = 0;
+                    if batched_packets < BATCH_SIZE {
+                        continue;
+                    }
+                }
+                Err(TryRecvError::Empty) => {
+                    if timeouts < MAX_TIMEOUTS {
+                        timeouts += 1;
+                        thread::sleep(RECV_TIMEOUT);
+                    } else {
+                        timeouts = 0;
+                        // we haven't received anything in a while, kick the driver
+                        ring.commit();
                         kick(&ring);
                     }
                 }
-
-                // at this point we're guaranteed to have a frame to write the next packet into and
-                // a slot in the ring to submit it
-                let mut frame = umem.reserve().unwrap();
-                let IpAddr::V4(dst_ip) = addr.ip() else {
-                    panic!("IPv6 not supported");
-                };
-
-                let dest_mac = {
-                    let ip = addr.ip();
-                    let Some(next_hop) = route_fn(&ip) else {
-                        log::warn!("dropping packet: no route for peer {addr}");
-                        batched_packets -= 1;
-                        umem.release(frame.offset());
-                        continue;
-                    };
-
-                    // we need the MAC address to send the packet
-                    let Some(dest_mac) = next_hop.mac_addr else {
-                        log::warn!(
-                            "dropping packet: peer {addr} must be routed through {} which has no \
-                             known MAC address",
-                            next_hop.ip_addr
-                        );
-                        batched_packets -= 1;
-                        umem.release(frame.offset());
-                        continue;
-                    };
-
-                    dest_mac
-                };
-
-                const PACKET_HEADER_SIZE: usize =
-                    ETH_HEADER_SIZE + IP_HEADER_SIZE + UDP_HEADER_SIZE;
-                let len = payload.as_ref().len();
-                frame.set_len(PACKET_HEADER_SIZE + len);
-                let packet = umem.map_frame_mut(&frame);
-
-                // write the payload first as it's needed for checksum calculation (if enabled)
-                packet[PACKET_HEADER_SIZE..][..len].copy_from_slice(payload.as_ref());
-
-                write_eth_header(packet, &src_mac.0, &dest_mac.0);
-
-                write_ip_header(
-                    &mut packet[ETH_HEADER_SIZE..],
-                    &src_ip,
-                    &dst_ip,
-                    (UDP_HEADER_SIZE + len) as u16,
-                );
-
-                write_udp_header(
-                    &mut packet[ETH_HEADER_SIZE + IP_HEADER_SIZE..],
-                    &src_ip,
-                    src_port,
-                    &dst_ip,
-                    addr.port(),
-                    len as u16,
-                    // don't do checksums
-                    false,
-                );
-
-                // write the packet into the ring
-                ring.write(frame, 0)
-                    .map_err(|_| "ring full")
-                    // this should never happen as we check for available slots above
-                    .expect("failed to write to ring");
-
-                batched_packets -= 1;
-                chunk_remaining -= 1;
-
-                // check if it's time to commit the ring and kick the driver
-                if chunk_remaining == 0 {
-                    chunk_remaining = BATCH_SIZE.min(batched_packets);
-
-                    // commit new frames
-                    ring.commit();
-                    kick(&ring);
+                Err(TryRecvError::Disconnected) => {
+                    // keep looping until we've flushed all the packets
+                    if batched_packets == 0 {
+                        break;
+                    }
                 }
+            };
+
+            // this is the number of packets after which we commit the ring and kick the driver if
+            // necessary
+            let mut chunk_remaining = BATCH_SIZE.min(batched_packets);
+
+            for (addrs, payload) in batched_items.drain(..) {
+                for addr in addrs.as_ref() {
+                    if ring.available() == 0 || umem.available() == 0 {
+                        // loop until we have space for the next packet
+                        loop {
+                            completion.sync(true);
+                            // we haven't written any frames so we only need to sync the consumer position
+                            ring.sync(false);
+
+                            // check if any frames were completed
+                            while let Some(frame_offset) = completion.read() {
+                                umem.release(frame_offset);
+                            }
+
+                            if ring.available() > 0 && umem.available() > 0 {
+                                // we have space for the next packet, break out of the loop
+                                break;
+                            }
+
+                            // queues are full, if NEEDS_WAKEUP is set kick the driver so hopefully it'll
+                            // complete some work
+                            kick(&ring);
+                        }
+                    }
+
+                    // at this point we're guaranteed to have a frame to write the next packet into and
+                    // a slot in the ring to submit it
+                    let mut frame = umem.reserve().unwrap();
+                    let IpAddr::V4(dst_ip) = addr.ip() else {
+                        panic!("IPv6 not supported");
+                    };
+
+                    let dest_mac = {
+                        let ip = addr.ip();
+                        let Some(next_hop) = route_fn(&ip) else {
+                            log::warn!("dropping packet: no route for peer {addr}");
+                            batched_packets -= 1;
+                            umem.release(frame.offset());
+                            continue;
+                        };
+
+                        // we need the MAC address to send the packet
+                        let Some(dest_mac) = next_hop.mac_addr else {
+                            log::warn!(
+                                "dropping packet: peer {addr} must be routed through {} which has \
+                                 no known MAC address",
+                                next_hop.ip_addr
+                            );
+                            batched_packets -= 1;
+                            umem.release(frame.offset());
+                            continue;
+                        };
+
+                        dest_mac
+                    };
+
+                    const PACKET_HEADER_SIZE: usize =
+                        ETH_HEADER_SIZE + IP_HEADER_SIZE + UDP_HEADER_SIZE;
+                    let len = payload.as_ref().len();
+                    frame.set_len(PACKET_HEADER_SIZE + len);
+                    let packet = umem.map_frame_mut(&frame);
+
+                    // write the payload first as it's needed for checksum calculation (if enabled)
+                    packet[PACKET_HEADER_SIZE..][..len].copy_from_slice(payload.as_ref());
+
+                    write_eth_header(packet, &src_mac.0, &dest_mac.0);
+
+                    write_ip_header(
+                        &mut packet[ETH_HEADER_SIZE..],
+                        &src_ip,
+                        &dst_ip,
+                        (UDP_HEADER_SIZE + len) as u16,
+                    );
+
+                    write_udp_header(
+                        &mut packet[ETH_HEADER_SIZE + IP_HEADER_SIZE..],
+                        &src_ip,
+                        src_port,
+                        &dst_ip,
+                        addr.port(),
+                        len as u16,
+                        // don't do checksums
+                        false,
+                    );
+
+                    // write the packet into the ring
+                    ring.write(frame, 0)
+                        .map_err(|_| "ring full")
+                        // this should never happen as we check for available slots above
+                        .expect("failed to write to ring");
+
+                    batched_packets -= 1;
+                    chunk_remaining -= 1;
+
+                    // check if it's time to commit the ring and kick the driver
+                    if chunk_remaining == 0 {
+                        chunk_remaining = BATCH_SIZE.min(batched_packets);
+
+                        // commit new frames
+                        ring.commit();
+                        kick(&ring);
+                    }
+                }
+                let _ = drop_sender.try_send((addrs, payload));
             }
-            let _ = drop_sender.try_send((addrs, payload));
+            debug_assert_eq!(batched_packets, 0);
         }
-        debug_assert_eq!(batched_packets, 0);
-    }
-    assert_eq!(batched_packets, 0);
+        assert_eq!(batched_packets, 0);
 
-    // drain the ring
-    while umem.available() < umem_tx_capacity || ring.available() < ring.capacity() {
-        log::debug!(
-            "draining xdp ring umem {}/{} ring {}/{}",
-            umem.available(),
-            umem_tx_capacity,
-            ring.available(),
-            ring.capacity()
-        );
+        // drain the ring
+        while umem.available() < umem_tx_capacity || ring.available() < ring.capacity() {
+            log::debug!(
+                "draining xdp ring umem {}/{} ring {}/{}",
+                umem.available(),
+                umem_tx_capacity,
+                ring.available(),
+                ring.capacity()
+            );
 
-        completion.sync(true);
-        while let Some(frame_offset) = completion.read() {
-            umem.release(frame_offset);
+            completion.sync(true);
+            while let Some(frame_offset) = completion.read() {
+                umem.release(frame_offset);
+            }
+
+            ring.sync(false);
+            kick(&ring);
         }
-
-        ring.sync(false);
-        kick(&ring);
     }
 }
 

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -11,7 +11,7 @@ use {
         route::NextHop,
         set_cpu_affinity,
         socket::{Socket, Tx, TxRing},
-        umem::{Frame as _, PageAlignedMemory, SliceUmem, SliceUmemFrame, Umem as _},
+        umem::{Frame, PageAlignedMemory, SliceUmem, Umem as _},
     },
     caps::{
         CapSet,
@@ -360,7 +360,7 @@ pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>, R: Fn(&IpAddr) -> Option<
 // With some drivers, or always when we work in SKB mode, we need to explicitly kick the driver once
 // we want the NIC to do something.
 #[inline(always)]
-fn kick(ring: &TxRing<SliceUmemFrame<'_>>) {
+fn kick<F: Frame>(ring: &TxRing<F>) {
     if !ring.needs_wakeup() {
         return;
     }

--- a/xdp/src/umem.rs
+++ b/xdp/src/umem.rs
@@ -216,6 +216,9 @@ pub struct PageAlignedMemory {
     len: usize,
 }
 
+/// Safety: a `PageAlignedMemory` instance MUST only be resident in one thread at a time
+unsafe impl Send for PageAlignedMemory {}
+
 impl PageAlignedMemory {
     pub fn alloc(frame_size: usize, frame_count: usize) -> Result<Self, AllocError> {
         Self::alloc_with_page_size(


### PR DESCRIPTION
#### Problem
we do the xdp init steps that requires capabilities quite late in validator process start up. we've already spawned many threads, which will have inherited caps that they do not need, posing security risk

#### Summary of Changes
* do a bit of refactoring to get the steps that require caps isolated
* move xdp init as early as possible in validator start up
* revoke caps from the process when we're done with them

Fixes: https://github.com/anza-xyz/agave/issues/6087
---

i know the new type names suck. suggestions welcome