### PR TITLE
Remove generic type from WeightedShuffle forcing it to u64

### DIFF
--- a/gossip/benches/weighted_shuffle.rs
+++ b/gossip/benches/weighted_shuffle.rs
@@ -17,7 +17,7 @@ fn bench_weighted_shuffle_new(c: &mut Criterion) {
     c.bench_function("bench_weighted_shuffle_new", |b| {
         b.iter(|| {
             let weights = make_weights(&mut rng);
-            black_box(WeightedShuffle::<u64>::new("", &weights));
+            black_box(WeightedShuffle::new("", &weights));
         })
     });
 }

--- a/gossip/src/push_active_set.rs
+++ b/gossip/src/push_active_set.rs
@@ -143,7 +143,7 @@ impl PushActiveSetEntry {
     ) {
         debug_assert_eq!(nodes.len(), weights.len());
         debug_assert!(weights.iter().all(|&weight| weight != 0u64));
-        let mut weighted_shuffle = WeightedShuffle::<u64>::new("rotate-active-set", weights);
+        let mut weighted_shuffle = WeightedShuffle::new("rotate-active-set", weights);
         for node in weighted_shuffle.shuffle(rng).map(|k| &nodes[k]) {
             // We intend to discard the oldest/first entry in the index-map.
             if self.0.len() > size {

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -39,7 +39,7 @@ use {
 };
 
 thread_local! {
-    static THREAD_LOCAL_WEIGHTED_SHUFFLE: RefCell<WeightedShuffle<u64>> = RefCell::new(
+    static THREAD_LOCAL_WEIGHTED_SHUFFLE: RefCell<WeightedShuffle> = RefCell::new(
         WeightedShuffle::new::<[u64; 0]>("get_retransmit_addrs", []),
     );
 }
@@ -84,7 +84,8 @@ pub struct ClusterNodes<T> {
     nodes: Vec<Node>,
     // Reverse index from nodes pubkey to their index in self.nodes.
     index: HashMap<Pubkey, /*index:*/ usize>,
-    weighted_shuffle: WeightedShuffle</*stake:*/ u64>,
+    // Shuffles by weights = stakes
+    weighted_shuffle: WeightedShuffle,
     use_cha_cha_8: bool,
     _phantom: PhantomData<T>,
 }


### PR DESCRIPTION
#### Problem
* all production code uses `WeightedShuffle<u64>` making the generic type parameter redundant and increasing complexity
* this can also add confusion when testing, since `rand`'s sampling algorithm depends on domain of type used for sampling, i.e. `<u64 ...>::single_sample(0, 1000, rng)` will yield different values than `<u32 ...>::single_sample(0, 1000, rng)` (see https://github.com/rust-random/rand/blob/937320cbfeebd4352a23086d9c6e68f067f74644/src/distributions/uniform.rs#L544)
* narrowing the used types and cleaning up generic code will make it easier to replace sampling strategy or implementation (to allow migrating `rand` to newer version: https://github.com/anza-xyz/agave/issues/4738) - hardcoding the sampling impl used by `rand=0.8.5` is most likely the easiest solution

#### Summary of Changes
Make `WeightedShuffle` always operate on `u64`

##### Benchmark performance
master:
```
bench_weighted_shuffle_new
                        time:   [54.900 µs 55.207 µs 55.616 µs]
                        change: [-2.5134% -1.9464% -1.3591%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

bench_weighted_shuffle_shuffle
                        time:   [173.31 µs 174.09 µs 175.03 µs]
                        change: [+4.8127% +5.3451% +5.9186%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

bench_weighted_shuffle_collect
                        time:   [183.40 µs 184.39 µs 185.60 µs]
                        change: [+1.1841% +2.5204% +3.7953%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  9 (9.00%) high mild
```

PR:
```
bench_weighted_shuffle_new
                        time:   [56.794 µs 57.035 µs 57.279 µs]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

bench_weighted_shuffle_shuffle
                        time:   [167.39 µs 167.98 µs 168.61 µs]
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

bench_weighted_shuffle_collect
                        time:   [184.39 µs 186.68 µs 189.07 µs]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```
