### PR TITLE
Add compatibilty implementation of random sampling based on algorihtms from rand=0.8.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-random"
+version = "4.0.0-alpha.0"
+dependencies = [
+ "assert_matches",
+ "bs58",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "sha2 0.10.9",
+ "test-case",
+]
+
+[[package]]
 name = "agave-reserved-account-keys"
 version = "4.0.0-alpha.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
     "programs/zk-token-proof",
     "pubsub-client",
     "quic-client",
+    "random",
     "rayon-threadlimit",
     "rbpf-cli",
     "remote-wallet",
@@ -205,6 +206,7 @@ agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=
 agave-io-uring = { path = "io-uring", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 agave-logger = { path = "logger", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 agave-precompiles = { path = "precompiles", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
+agave-random = { path = "random", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 agave-scheduler-bindings = { path = "scheduler-bindings", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 agave-scheduling-utils = { path = "scheduling-utils", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }

--- a/random/Cargo.toml
+++ b/random/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "agave-random"
+description = "Agave randomization utils"
+documentation = "https://docs.rs/agave-random"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "agave_random"
+
+[features]
+agave-unstable-api = []
+
+[dependencies]
+rand0_8_5 = { package = "rand", version = "0.8.5" }
+
+[dev-dependencies]
+assert_matches = { workspace = true }
+bs58 = { workspace = true, features = ["alloc"] }
+rand_chacha0_3_1 = { package = "rand_chacha", version = "0.3.1" }
+sha2 = { workspace = true }
+test-case = { workspace = true }

--- a/random/src/lib.rs
+++ b/random/src/lib.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(
+    not(feature = "agave-unstable-api"),
+    deprecated(
+        since = "3.1.0",
+        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
+                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
+                acknowledge use of an interface that may break without warning."
+    )
+)]
+
+pub mod range;
+pub mod weighted;

--- a/random/src/range.rs
+++ b/random/src/range.rs
@@ -1,0 +1,146 @@
+use {rand0_8_5::Rng, std::num::NonZero};
+
+/// Compatibility uniform range `[0, limit)` sampler for `u64` numbers
+///
+/// Sampler uses provided `rand::Rng` reference to generate random `u64` numbers and
+/// map them to desired range maintaining uniform distribution of generated numbers.
+///
+/// This utility exists only to provide compatibility of sampling algorithm with `rand`
+/// library at versions <=0.8.5, since parts of the system rely on reproducible sequence
+/// of numbers given stable seeded random number generator.
+///
+/// Two sampling algorithms are supported (they initialize internal `zone` value in different ways)
+/// to provide compatibility with two ways `rand` sampling can be performed:
+/// - `new_like_instance_sample`: reproduces values obtained from sampler instance created with
+///   `rand::distributions::uniform::UniformSampler::new` and then used by calling `sample`
+/// - `new_like_trait_sample`: reproduces values obtained from trait function calls
+///   `rand::distributions::uniform::UniformSampler::sample_single`
+#[derive(Debug)]
+pub struct UniformU64Sampler {
+    range_end: NonZero<u64>,
+    zone: u64,
+}
+
+impl UniformU64Sampler {
+    /// Create sampler reproducing `sample` calls on `UniformInt` instance
+    ///
+    /// The `zone` internal threshold is obtained by calculating modulo of `u64::MAX`'s difference
+    /// with provided range's end to itself. See:
+    /// https://github.com/rust-random/rand/blob/937320cbfeebd4352a23086d9c6e68f067f74644/src/distributions/uniform.rs#L458-L504
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn new_like_instance_sample(range_end: NonZero<u64>) -> Self {
+        let ints_to_reject = (u64::MAX - range_end.get() + 1) % range_end.get();
+        let zone = u64::MAX - ints_to_reject;
+        Self { range_end, zone }
+    }
+
+    /// Create sampler reproducing direct `sample_single` calls on `UniformInt` trait
+    ///
+    /// The `zone` internal threshold is obtained by calculating 2^{number of leading zeros in provided range}. See
+    /// https://github.com/rust-random/rand/blob/937320cbfeebd4352a23086d9c6e68f067f74644/src/distributions/uniform.rs#L534-L553
+    pub fn new_like_trait_sample(range_end: NonZero<u64>) -> Self {
+        let zone = (range_end.get() << range_end.leading_zeros()).wrapping_sub(1);
+        Self { range_end, zone }
+    }
+
+    /// Obtain random number from `rng` and map it to the initialized range of this sampler
+    pub fn sample(&self, rng: &mut impl Rng) -> u64 {
+        loop {
+            let (hi, lo) = Self::wmul(rng.r#gen(), self.range_end);
+            if lo <= self.zone {
+                return hi;
+            }
+        }
+    }
+
+    #[allow(clippy::arithmetic_side_effects)]
+    fn wmul(x: u64, y: NonZero<u64>) -> (u64, u64) {
+        let tmp = (x as u128) * (y.get() as u128);
+        ((tmp >> 64) as u64, tmp as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        rand0_8_5::{
+            distributions::uniform::{SampleUniform, UniformSampler as _},
+            SeedableRng as _,
+        },
+        rand_chacha0_3_1::ChaChaRng,
+        sha2::{Digest, Sha256},
+        std::array,
+        test_case::test_case,
+    };
+
+    const CHACHA_SEED: [u8; 32] = [16; 32];
+
+    #[test]
+    fn test_uniform_sample_like_instance_sample_example() {
+        let mut rng_compat = ChaChaRng::from_seed(CHACHA_SEED);
+        let sampler_compat =
+            UniformU64Sampler::new_like_instance_sample(NonZero::new(294_533).unwrap());
+        let values: [u64; 10] = array::from_fn(|_| sampler_compat.sample(&mut rng_compat));
+        assert_eq!(
+            values,
+            [280405, 7507, 84194, 272634, 52124, 190984, 8676, 230277, 223574, 126007]
+        );
+    }
+
+    #[test_case(10, "5p3DrG89DLrJotbMuZJUDHMrqcfoQiDQpa3FbNDbnND6")]
+    #[test_case(2_729, "J65XfpzkppuxWEyvgVdDmGBsJSex6BuevYuDSRtaDNAK")]
+    #[test_case(4_098, "EaRABrcPBw5LLNBmjn5ay5YN5yTPgv3GnQJLbpUarRkJ")]
+    #[test_case(504_302_479, "HniJPVe7zir8XxHmtUuxzhPVvWjMcJxVhhj8QSs1PZTC")]
+    #[test_case(1_000_346_000_000, "BghMy7yLe6BVzMbc4zNvAB4sz3ZSPYKJS5oLGvXYVzw2")]
+    fn test_uniform_sampler_like_instance_sample_compat(range_end: u64, expected_hash: &str) {
+        let mut rng_rand = ChaChaRng::from_seed(CHACHA_SEED);
+        let sampler_rand = <u64 as SampleUniform>::Sampler::new(0, range_end);
+
+        let mut rng_compat = ChaChaRng::from_seed(CHACHA_SEED);
+        let sampler_compat =
+            UniformU64Sampler::new_like_instance_sample(NonZero::new(range_end).unwrap());
+
+        let mut hash = Sha256::new();
+        (0..600_000).for_each(|i| {
+            let rand = sampler_rand.sample(&mut rng_rand);
+            let compat = sampler_compat.sample(&mut rng_compat);
+            assert_eq!(rand, compat, "should be equal at {i}");
+            hash.update(compat.to_le_bytes());
+        });
+        assert_eq!(bs58::encode(hash.finalize()).into_string(), expected_hash);
+    }
+
+    #[test]
+    fn test_uniform_sample_like_trait_sample_example() {
+        let mut rng_compat = ChaChaRng::from_seed(CHACHA_SEED);
+        let sampler_compat =
+            UniformU64Sampler::new_like_trait_sample(NonZero::new(294_533).unwrap());
+        let values: [u64; 10] = array::from_fn(|_| sampler_compat.sample(&mut rng_compat));
+        assert_eq!(
+            values,
+            [272634, 52124, 8676, 230277, 223574, 137788, 212533, 213080, 187008, 209168]
+        );
+    }
+
+    #[test_case(10, "2tsA6RuXekKvMMvAqjkMMipjYySpw8mrrwwoBeoKohD1")]
+    #[test_case(1_000, "58SG5gnD5wR6ngrjxuTv7m1SEXiXejZvuJPUCsyrmqWx")]
+    #[test_case(4098, "7w4TY1oaeEeqHmPw3iobD8WVq1BsL5eo7ZuNdvDkoSQo")]
+    #[test_case(10_000_000_000, "ENe5A82Wq2nYsH17q9WkKAudXdLE9FVGRbySuuCpaR5k")]
+    fn test_uniform_sampler_like_trait_sample_single(range_end: u64, expected_hash: &str) {
+        let mut rng_rand = ChaChaRng::from_seed(CHACHA_SEED);
+
+        let mut rng_compat = ChaChaRng::from_seed(CHACHA_SEED);
+        let sampler_compat =
+            UniformU64Sampler::new_like_trait_sample(NonZero::new(range_end).unwrap());
+
+        let mut hash = Sha256::new();
+        (0..1_000).for_each(|i| {
+            let rand = <u64 as SampleUniform>::Sampler::sample_single(0, range_end, &mut rng_rand);
+            let compat = sampler_compat.sample(&mut rng_compat);
+            assert_eq!(rand, compat, "should be equal at {i}");
+            hash.update(compat.to_le_bytes());
+        });
+        assert_eq!(bs58::encode(hash.finalize()).into_string(), expected_hash);
+    }
+}

--- a/random/src/weighted.rs
+++ b/random/src/weighted.rs
@@ -1,0 +1,114 @@
+use {
+    crate::range::UniformU64Sampler,
+    rand0_8_5::{distributions::weighted::WeightedError, Rng},
+    std::num::NonZero,
+};
+
+/// Compatibility weighted sampler for `u64` numbers
+///
+/// Sampler uses provided `rand::Rng` reference to generate random `u64` numbers and
+/// map them to the index of the weight from weights vector provided on initialization.
+///
+/// This utility exists only to provide compatibility of sampling algorithm with `rand`
+/// library at versions <=0.8.5, since parts of the system rely on reproducible sequence
+/// of numbers given stable seeded random number generator.
+///
+/// The algorithm reproduces indices returned by `rand::distributions::WeightedIndex`
+/// for the same weights vector and seeded random number generator.
+#[derive(Debug)]
+pub struct WeightedU64Index {
+    weights: Vec<u64>,
+    total_weight_sampler: UniformU64Sampler,
+}
+
+impl WeightedU64Index {
+    pub fn new(mut weights: Vec<u64>) -> Result<Self, WeightedError> {
+        // Calculate prefix sum of weights such that binary search can find the index of the
+        // chosen weight.
+        let mut total_weight = 0u64;
+        for weight in weights.iter_mut() {
+            total_weight = total_weight.saturating_add(*weight);
+            *weight = total_weight;
+        }
+        if weights.pop().is_none() {
+            return Err(WeightedError::NoItem);
+        }
+        let Some(total_weight) = NonZero::new(total_weight) else {
+            return Err(WeightedError::AllWeightsZero);
+        };
+
+        Ok(Self {
+            weights,
+            total_weight_sampler: UniformU64Sampler::new_like_instance_sample(total_weight),
+        })
+    }
+
+    pub fn sample(&self, rng: &mut impl Rng) -> usize {
+        let chosen_weight = self.total_weight_sampler.sample(rng);
+        // Find the first item which has a weight *higher* than the chosen weight.
+        self.weights.partition_point(|w| *w <= chosen_weight)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        assert_matches::assert_matches,
+        rand0_8_5::{distributions::WeightedIndex, prelude::Distribution, SeedableRng as _},
+        rand_chacha0_3_1::ChaChaRng,
+        sha2::{Digest, Sha256},
+        std::array,
+        test_case::test_case,
+    };
+
+    const CHACHA_SEED: [u8; 32] = [16; 32];
+
+    #[test_case(100, 0, [95, 2, 28, 92, 17, 64, 2, 78, 75, 42])]
+    #[test_case(1_000, 0, [952, 25, 285, 925, 176, 648, 29, 781, 759, 427])]
+    #[test_case(1_000, 1, [975, 160, 534, 962, 420, 805, 172, 884, 871, 654])]
+    #[test_case(1_000, 2, [983, 294, 658, 974, 561, 865, 309, 921, 912, 753])]
+    #[test_case(10_000, 1, [9757, 1596, 5346, 9621, 4207, 8052, 1716, 8842, 8712, 6540])]
+    fn test_weighted_u64_index_example(num_weights: u64, pow: u32, expected_indices: [usize; 10]) {
+        let weights: Vec<_> = (0..num_weights).map(|i| i.pow(pow)).collect();
+
+        let mut rng_compat = ChaChaRng::from_seed(CHACHA_SEED);
+        let index_compat =
+            WeightedU64Index::new(weights.clone()).expect("non empty and non zero is ok");
+
+        let indices = array::from_fn(|_| index_compat.sample(&mut rng_compat));
+        assert_eq!(indices, expected_indices);
+    }
+
+    #[test_case(30_000, 0, 50_000, "23K23NXJpui3d9nrKLNfvwpHHRs4dxFfZ8saxH6ZPJyw")]
+    #[test_case(20_000, 1, 45_000, "9yvuyu8JDQtUo7cvWJKkc3cUmzWw5RzBJoEtoVR2N2r2")]
+    #[test_case(10_000, 2, 35_000, "842FcJe1kmnmrZXAA3rETtBakk1jFdz1dnzMbkf875gh")]
+    #[test_case(10_000, 3, 30_000, "5LNbaEBQrb5CzsoHdK79XNDENAJ9WJqW9LpWktqkRchf")]
+    fn test_weighted_u64_index_compat(num_weights: u64, pow: u32, len: usize, expected_hash: &str) {
+        let weights: Vec<_> = (0..num_weights).map(|i| i.pow(pow)).collect();
+
+        let mut rng_rand = ChaChaRng::from_seed(CHACHA_SEED);
+        let index_rand = WeightedIndex::new(weights.clone()).expect("non empty and non zero is ok");
+
+        let mut rng_compat = ChaChaRng::from_seed(CHACHA_SEED);
+        let index_compat = WeightedU64Index::new(weights).expect("non empty and non zero is ok");
+
+        let mut hash = Sha256::new();
+        (0..len).for_each(|i| {
+            let rand = index_rand.sample(&mut rng_rand);
+            let compat = index_compat.sample(&mut rng_compat);
+            assert_eq!(rand, compat, "should be equal at {i}");
+            hash.update(compat.to_le_bytes());
+        });
+        assert_eq!(&bs58::encode(hash.finalize()).into_string(), expected_hash);
+    }
+
+    #[test]
+    fn test_weighted_u64_index_error_on_new() {
+        assert_matches!(WeightedU64Index::new(vec![]), Err(WeightedError::NoItem));
+        assert_matches!(
+            WeightedU64Index::new(vec![0, 0, 0, 0, 0]),
+            Err(WeightedError::AllWeightsZero)
+        );
+    }
+}


### PR DESCRIPTION
#### Problem
We rely on fragile selection of sampling algorithms from specific `rand` crate version in important part of networked coordination schemes (leader schedule, turbine tree through weighted shuffle). At the moment this is a roadblock for [bumping](https://github.com/anza-xyz/agave/issues/4738) `rand` dependency.

#### Summary of Changes
Add module that provides compatibility samplers for uniform and weighted distributions with implementation and APIs trimmed to provide minimum requires scope use in agave.
Those implement algorithms provided by `rand=0.8.5`.

The usage of this module is left for subsequent PRs that will switch uses one by one (namely `leader_schedule` and `weighted_shuffle`)
