### PR TITLE
refactor(scheduling-utils): improve safety of pointers

### DIFF
--- a/scheduling-utils/src/transaction_ptr.rs
+++ b/scheduling-utils/src/transaction_ptr.rs
@@ -131,12 +131,17 @@ impl<'a, M> TransactionPtrBatch<'a, M> {
         })
     }
 
-    /// Free all transactions in the batch, then free the batch itself.
-    pub fn free(self) {
-        for (transaction_ptr, _) in self.iter() {
-            unsafe { transaction_ptr.free(self.allocator) }
-        }
-
+    /// Free the transaction batch container.
+    ///
+    /// # Safety
+    ///
+    /// - [`SharableTransactionBatchRegion`] must be exclusively owned by this pointer.
+    ///
+    /// # Note
+    ///
+    /// This will not free the underlying transactions as their lifetimes may be differ from that of
+    /// the batch.
+    pub unsafe fn free(self) {
         unsafe { self.allocator.free(self.tx_ptr.cast()) }
     }
 }


### PR DESCRIPTION
#### Problem

- Pointers currently take awkward `allocator` references.
- Pointers expose dangerous `free` methods (only safe if pointer is unique which can be cumbersome to guarantee).

#### Summary of Changes

- Make all `free` functions `unsafe`.
- Don't take references on `allocator` if we can avoid it.