### PR TITLE
Do not evict candidates to flush

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1162,71 +1162,64 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         // Process each candidate to flush
         // For each entry: lock map briefly, get entry, calculate disk value, release lock, then write to disk
         let flush_update_measure = Measure::start("flush_update");
-        let flushed_keys_to_evict: Vec<_> = candidates_to_flush
-            .0
-            .into_iter()
-            .filter_map(|key| {
-                // Entry was dirty at scan time, need to write to disk
-                let lock_measure = Measure::start("flush_read_lock");
-                let map_read_guard = self.map_internal.read().unwrap();
-                let entry = map_read_guard.get(&key)?;
+        for key in candidates_to_flush.0 {
+            // Entry was dirty at scan time, need to write to disk
+            let lock_measure = Measure::start("flush_read_lock");
+            let map_read_guard = self.map_internal.read().unwrap();
+            let Some(entry) = map_read_guard.get(&key) else {
+                continue;
+            };
 
-                let mse = Measure::start("flush_should_evict");
-                let maybe_entry_for_flush =
-                    self.try_make_entry_for_flush(entry, current_age, ages_flushing_now);
-                flush_stats.flush_should_evict_us += mse.end_as_us();
+            let mse = Measure::start("flush_should_evict");
+            let maybe_entry_for_flush =
+                self.try_make_entry_for_flush(entry, current_age, ages_flushing_now);
+            flush_stats.flush_should_evict_us += mse.end_as_us();
 
-                drop(map_read_guard);
-                flush_stats.flush_read_lock_us += lock_measure.end_as_us();
+            drop(map_read_guard);
+            flush_stats.flush_read_lock_us += lock_measure.end_as_us();
 
-                let (slot, account_info) = match maybe_entry_for_flush {
-                    ShouldFlush::Yes(entry_for_flush) => entry_for_flush,
-                    ShouldFlush::No(reason) => {
-                        match reason {
-                            ReasonToNotFlush::Clean => flush_stats.num_not_flushed_clean += 1,
-                            ReasonToNotFlush::Age => flush_stats.num_not_flushed_age += 1,
-                            ReasonToNotFlush::RefCount => {
-                                flush_stats.num_not_flushed_ref_count += 1
-                            }
-                            ReasonToNotFlush::SlotListLen => {
-                                flush_stats.num_not_flushed_slot_list_len += 1
-                            }
-                            ReasonToNotFlush::SlotListCached => {
-                                flush_stats.num_not_flushed_slot_list_cached += 1
-                            }
+            let (slot, account_info) = match maybe_entry_for_flush {
+                ShouldFlush::Yes(entry_for_flush) => entry_for_flush,
+                ShouldFlush::No(reason) => {
+                    match reason {
+                        ReasonToNotFlush::Clean => flush_stats.num_not_flushed_clean += 1,
+                        ReasonToNotFlush::Age => flush_stats.num_not_flushed_age += 1,
+                        ReasonToNotFlush::RefCount => flush_stats.num_not_flushed_ref_count += 1,
+                        ReasonToNotFlush::SlotListLen => {
+                            flush_stats.num_not_flushed_slot_list_len += 1
                         }
-                        return None;
+                        ReasonToNotFlush::SlotListCached => {
+                            flush_stats.num_not_flushed_slot_list_cached += 1
+                        }
                     }
-                };
-                let disk_entry = [(slot, account_info.into())];
+                    continue;
+                }
+            };
+            let disk_entry = [(slot, account_info.into())];
 
-                // Now write to disk WITHOUT holding any locks
-                // may have to loop if disk has to grow and we have to retry the write
-                loop {
-                    let disk_resize = disk.try_write(&key, (&disk_entry, /*ref count*/ 1));
-                    match disk_resize {
-                        Ok(_) => {
-                            // successfully written to disk
-                            flush_stats.flush_entries_updated_on_disk += 1;
-                            break;
-                        }
-                        Err(err) => {
-                            // disk needs to resize. This item did not get written. Resize and try again.
-                            let m = Measure::start("flush_grow");
-                            disk.grow(err);
-                            flush_stats.flush_grow_us += m.end_as_us();
-                        }
+            // Now write to disk WITHOUT holding any locks
+            // may have to loop if disk has to grow and we have to retry the write
+            loop {
+                let disk_resize = disk.try_write(&key, (&disk_entry, /*ref count*/ 1));
+                match disk_resize {
+                    Ok(_) => {
+                        // successfully written to disk
+                        flush_stats.flush_entries_updated_on_disk += 1;
+                        break;
+                    }
+                    Err(err) => {
+                        // disk needs to resize. This item did not get written. Resize and try again.
+                        let m = Measure::start("flush_grow");
+                        disk.grow(err);
+                        flush_stats.flush_grow_us += m.end_as_us();
                     }
                 }
-
-                Some(key)
-            })
-            .collect();
+            }
+        }
         flush_stats.flush_update_us = flush_update_measure.end_as_us();
         flush_stats.update_to_stats(self.stats());
 
         let m = Measure::start("flush_evict");
-        self.evict_from_cache(&flushed_keys_to_evict, current_age, ages_flushing_now);
         self.evict_from_cache(&candidates_to_evict.0, current_age, ages_flushing_now);
         Self::update_time_stat(&self.stats().flush_evict_us, m);
 
@@ -1588,37 +1581,63 @@ mod tests {
     }
 
     #[test]
-    fn test_flush_internal_flushes_dirty_entry_and_evicts_from_cache() {
+    fn test_flush_internal() {
         let accounts_index = new_disk_buckets_for_test::<u64>();
-        let pubkey_flush = solana_pubkey::new_rand();
-        let pubkey_no_flush = solana_pubkey::new_rand();
+        let pubkey_clean_new = solana_pubkey::new_rand();
+        let pubkey_clean_old = solana_pubkey::new_rand();
+        let pubkey_dirty_new = solana_pubkey::new_rand();
+        let pubkey_dirty_old = solana_pubkey::new_rand();
         let slot = 123;
         let info = 42;
 
-        assert!(accounts_index.load_from_disk(&pubkey_flush).is_none());
-        assert!(accounts_index.load_from_disk(&pubkey_no_flush).is_none());
+        assert!(accounts_index.load_from_disk(&pubkey_clean_new).is_none());
+        assert!(accounts_index.load_from_disk(&pubkey_clean_old).is_none());
+        assert!(accounts_index.load_from_disk(&pubkey_dirty_new).is_none());
+        assert!(accounts_index.load_from_disk(&pubkey_dirty_old).is_none());
 
-        let entry_flush = AccountMapEntry::new(
+        // A clean entry that is *not* in the flush/eviction window.
+        // This entry should *not* be eligible for eviction.
+        let entry_clean_new = AccountMapEntry::new(
             SlotList::from([(slot, info)]),
             1,
-            AccountMapEntryMeta::new_dirty(&accounts_index.storage, false),
+            AccountMapEntryMeta::new_clean(&accounts_index.storage),
         );
-        assert!(entry_flush.dirty());
-        entry_flush.set_age(accounts_index.storage.current_age());
+        assert!(!entry_clean_new.dirty());
 
-        // A dirty entry outside the eviction age window should not be flushed or evicted.
-        // A new entry's age is initialized to the future flush age, which won't be eligible
-        // for flushing/eviction at `current_age == 0`.
-        let entry_no_flush = AccountMapEntry::new(
+        // A clean entry that *is* in the flush/eviction window.
+        // This entry *should* be eligible for eviction.
+        let entry_clean_old = AccountMapEntry::new(
             SlotList::from([(slot + 1, info + 1)]),
+            1,
+            AccountMapEntryMeta::new_clean(&accounts_index.storage),
+        );
+        entry_clean_old.set_age(accounts_index.storage.current_age());
+        assert!(!entry_clean_old.dirty());
+
+        // A dirty entry that is *not* in the flush/eviction window.
+        // This entry should *not* be eligible for flush.
+        let entry_dirty_new = AccountMapEntry::new(
+            SlotList::from([(slot + 2, info + 2)]),
             1,
             AccountMapEntryMeta::new_dirty(&accounts_index.storage, false),
         );
-        assert!(entry_no_flush.dirty());
+        assert!(entry_dirty_new.dirty());
+
+        // A dirty entry that *is* in the flush/eviction window.
+        // This entry *should* be eligible for flush.
+        let entry_dirty_old = AccountMapEntry::new(
+            SlotList::from([(slot + 3, info + 3)]),
+            1,
+            AccountMapEntryMeta::new_dirty(&accounts_index.storage, false),
+        );
+        entry_dirty_old.set_age(accounts_index.storage.current_age());
+        assert!(entry_dirty_old.dirty());
 
         accounts_index.map_internal.write().unwrap().extend([
-            (pubkey_flush, Box::new(entry_flush)),
-            (pubkey_no_flush, Box::new(entry_no_flush)),
+            (pubkey_clean_new, Box::new(entry_clean_new)),
+            (pubkey_clean_old, Box::new(entry_clean_old)),
+            (pubkey_dirty_new, Box::new(entry_dirty_new)),
+            (pubkey_dirty_old, Box::new(entry_dirty_old)),
         ]);
 
         accounts_index
@@ -1627,26 +1646,54 @@ mod tests {
 
         accounts_index.flush(false);
 
-        // Dirty entry should be flushed to disk.
-        let (slot_list, ref_count) = accounts_index
-            .load_from_disk(&pubkey_flush)
-            .expect("entry should be written to disk");
-        assert_eq!(slot_list, SlotList::from([(slot, info)]));
-        assert_eq!(ref_count, 1);
-
-        // Flushed entry should be evicted from the in-mem cache.
-        let mut found_in_mem = false;
-        accounts_index.get_only_in_mem(&pubkey_flush, false, |entry| {
-            found_in_mem = entry.is_some();
+        // clean new entry should not be flushed/evicted
+        let mut found_in_mem = None;
+        accounts_index.get_only_in_mem(&pubkey_clean_new, false, |entry| {
+            found_in_mem = Some(entry.is_some());
+            let entry = entry.expect("entry should remain in memory");
+            assert!(!entry.dirty());
         });
-        assert!(!found_in_mem);
+        assert_eq!(found_in_mem, Some(true));
+        assert!(accounts_index.load_from_disk(&pubkey_clean_new).is_none());
 
-        // Dirty entry outside the age window should not be written to disk or evicted.
-        assert!(accounts_index.load_from_disk(&pubkey_no_flush).is_none());
-        accounts_index.get_only_in_mem(&pubkey_no_flush, false, |entry| {
+        // clean old entry should be evicted, and not flushed
+        let mut found_in_mem = None;
+        accounts_index.get_only_in_mem(&pubkey_clean_old, false, |entry| {
+            found_in_mem = Some(entry.is_some());
+        });
+        assert_eq!(found_in_mem, Some(false));
+        assert!(accounts_index.load_from_disk(&pubkey_clean_old).is_none());
+
+        // dirty new entry should not be flushed/evicted
+        let mut found_in_mem = None;
+        accounts_index.get_only_in_mem(&pubkey_dirty_new, false, |entry| {
+            found_in_mem = Some(entry.is_some());
             let entry = entry.expect("entry should remain in memory");
             assert!(entry.dirty());
         });
+        assert_eq!(found_in_mem, Some(true));
+        assert!(accounts_index.load_from_disk(&pubkey_dirty_new).is_none());
+
+        // old dirty entry should be flushed, and not evicted
+        let mut found_in_mem = None;
+        accounts_index.get_only_in_mem(&pubkey_dirty_old, false, |entry| {
+            found_in_mem = Some(entry.is_some());
+            let entry = entry.expect("entry should remain in memory");
+            assert!(!entry.dirty()); // flushing makes the entry clean
+
+            // also ensure that old dirty entry can be evicted next time
+            assert!(InMemAccountsIndex::<u64, u64>::should_evict_based_on_age(
+                accounts_index.storage.current_age(),
+                entry,
+                accounts_index.num_ages_to_distribute_flushes,
+            ));
+        });
+        assert_eq!(found_in_mem, Some(true));
+        let (slot_list, ref_count) = accounts_index
+            .load_from_disk(&pubkey_dirty_old)
+            .expect("entry should be written to disk");
+        assert_eq!(slot_list, SlotList::from([(slot + 3, info + 3)]));
+        assert_eq!(ref_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

When the accounts disk index is enabled, we periodically flush and evict entries from the in-mem bins in the background. Right now, flush and evict and integrated. We'd like a way to decouple them; e.g. to evict more often than the flush.

Additionally (and copying from https://github.com/anza-xyz/agave/pull/9586):

"Don’t evict items that were just flushed.

The intuition is that items we just flushed are dirty—they were recently written, so they are more likely to be written again soon. Evicting them immediately is counter-productive.

Instead, during eviction scans, we should evict only non-dirty items. Recently flushed (dirty) entries stay in memory for one more cycle. If they truly go cold and are not written again, they will naturally be picked up in the next eviction round.

This keeps hot items in memory longer and reduces unnecessary churn."


#### Summary of Changes

For this PR, do not also evict the candidates to flush.