### PR TITLE
blockstore: Chain merkle root for slot 0 to genesis hash

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4820,14 +4820,16 @@ pub fn create_new_ledger(
     let entries = create_ticks(ticks_per_slot, hashes_per_tick, genesis_config.hash());
     let last_hash = entries.last().unwrap().hash;
     let version = solana_shred_version::version_from_hash(&last_hash);
+    // Slot 0 has no parent slot so there is nothing to chain to; instead,
+    // initialize the chained merkle root with the genesis hash
+    let chained_merkle_root = genesis_config.hash();
 
     let shredder = Shredder::new(0, 0, 0, version).unwrap();
     let (shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
         &Keypair::new(),
         &entries,
         true, // is_last_in_slot
-        // chained_merkle_root
-        Hash::new_from_array(rand::rng().random()),
+        chained_merkle_root,
         0, // next_shred_index
         0, // next_code_index
         &ReedSolomonCache::default(),


### PR DESCRIPTION
#### Problem
The function create_new_ledger() is used by solana-genesis to create a new blockstore with slot 0 full of ticks. The chained merkle root for the shredder is currently initialized to an array of random bytes. This means that calling this function two times with the same genesis config has no expectation of yielding shreds with the same chained merkle root

#### Summary of Changes
There is no reason for this to be the case and we can make this deterministic by seeding the chained merkle root for slot 0 with the genesis hash

This function is used by `solana-genesis`:
https://github.com/anza-xyz/agave/blob/f41e2ea524086ae045fe1b146cf1f2c2f78c9cc4/genesis/src/main.rs#L932-L938
Given that the previous behavior was "random", I don't believe there to be a concern about "breaking behavior" here. I'd definitely appreciate a second opinion though.

And for sake of papertrail, the randomness was originally added in https://github.com/solana-labs/solana/pull/34952