### PR TITLE
clippy(storage-bigtable): limit captured lifetimes by get_protobuf_or_bincode_cells

### DIFF
--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -802,14 +802,15 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         deserialize_protobuf_or_bincode_cell_data(&row_data, table, key)
     }
 
-    pub async fn get_protobuf_or_bincode_cells<'a, B, P>(
+    pub async fn get_protobuf_or_bincode_cells<'a, B, P, R>(
         &mut self,
         table: &'a str,
-        row_keys: impl IntoIterator<Item = RowKey>,
-    ) -> Result<impl Iterator<Item = (RowKey, CellData<B, P>)> + 'a>
+        row_keys: R,
+    ) -> Result<impl Iterator<Item = (RowKey, CellData<B, P>)> + 'a + use<'a, F, B, P, R>>
     where
         B: serde::de::DeserializeOwned,
         P: prost::Message + Default,
+        R: IntoIterator<Item = RowKey>,
     {
         Ok(self
             .get_multi_row_data(


### PR DESCRIPTION
#### Problem
Rust 2024 captures lifetimes more widely and it can cause some callers to fail due to over-borrowed references:
```
error[E0515]: cannot return value referencing local variable `bigtable`
   --> storage-bigtable/src/lib.rs:577:9
    |
562 |         let data = bigtable
    |                    -------- `bigtable` is borrowed here
...
577 |         Ok(data)
    |         ^^^^^^^^ returns a value referencing data owned by the current function
    |
note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
   --> storage-bigtable/src/lib.rs:562:20
    |
562 |           let data = bigtable
    |  ____________________^
563 | |             .get_protobuf_or_bincode_cells("blocks", row_keys)
    | |______________________________________________________________^
note: you could use a `use<...>` bound to explicitly specify captures, but argument-position `impl Trait`s are not nameable
   --> storage-bigtable/src/bigtable.rs:808:19
    |
808 |         row_keys: impl IntoIterator<Item = RowKey>,
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: use the precise capturing `use<...>` syntax to make the captures explicit
   --> storage-bigtable/src/bigtable.rs:805:56
    |
805 ~     pub async fn get_protobuf_or_bincode_cells<'a, B, P, T: IntoIterator<Item = RowKey>>(
806 |         &mut self,
807 |         table: &'a str,
808 ~         row_keys: T,
809 ~     ) -> Result<impl Iterator<Item = (RowKey, CellData<B, P>)> + 'a + use<'a, B, P, F, T>>

```

This blocks moving to [edition 2024](https://github.com/anza-xyz/agave/issues/6203) 

#### Summary of Changes
Annotate explicitly types and lifetimes used by the returned `impl` type omitting `&self`'s lifetime in `get_protobuf_or_bincode_cells`