### PR TITLE
clippy(ledger): fix temporary variable use in debug assert (conforming to rust 2024)

### DIFF
--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1283,9 +1283,12 @@ fn finish_erasure_batch(
         shred.set_signature(signature);
         debug_assert!(shred.verify(&keypair.pubkey()));
         debug_assert_matches!(shred.sanitize(), Ok(()));
-        // Assert that shred payload is fully populated.
-        let expected_shred = Shred::from_payload(shred.payload().clone()).unwrap();
-        debug_assert_eq!(shred, &expected_shred);
+        #[cfg(debug_assertions)]
+        {
+            // Assert that shred payload is fully populated.
+            let expected_shred = Shred::from_payload(shred.payload().clone()).unwrap();
+            debug_assert_eq!(shred, &expected_shred);
+        }
     }
     Ok(root)
 }

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1284,10 +1284,8 @@ fn finish_erasure_batch(
         debug_assert!(shred.verify(&keypair.pubkey()));
         debug_assert_matches!(shred.sanitize(), Ok(()));
         // Assert that shred payload is fully populated.
-        debug_assert_eq!(shred, {
-            let shred = shred.payload().clone();
-            &Shred::from_payload(shred).unwrap()
-        });
+        let expected_shred = Shred::from_payload(shred.payload().clone()).unwrap();
+        debug_assert_eq!(shred, &expected_shred);
     }
     Ok(root)
 }


### PR DESCRIPTION
#### Problem
When compiling for Rust 2024 edition [migration](https://github.com/anza-xyz/agave/issues/6203) temporary variables lifetime and drop rules change and some of the code needs update in temp variable scope.

#### Summary of Changes
Rearrange scope and temporary variable definition for checking it in debug assert