### PR TITLE
feat(scheduling-utils): impl `TransactionData` for `&TransactionPtr`

### DIFF
--- a/scheduling-utils/src/transaction_ptr.rs
+++ b/scheduling-utils/src/transaction_ptr.rs
@@ -19,6 +19,12 @@ impl TransactionData for TransactionPtr {
     }
 }
 
+impl TransactionData for &TransactionPtr {
+    fn data(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+}
+
 impl TransactionPtr {
     /// # Safety
     /// - `sharable_transaction_region` must reference a valid offset and length


### PR DESCRIPTION
#### Problem

- `TransactionPtr` represents ownership of the underlying allocation. It can be desirable to sanitize this allocation without taking ownership.

#### Summary of Changes

- Implement `TransactionData` for `&TransactionPtr`.
