### PR TITLE
chore(ledger): Remove unused std::fmt::Debug import

### DIFF
--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -11,7 +11,6 @@ use {
     solana_keypair::Keypair,
     solana_rayon_threadlimit::get_thread_count,
     std::{
-        fmt::Debug,
         sync::{Arc, OnceLock, RwLock},
         time::Instant,
     },


### PR DESCRIPTION
This change removes the unused std::fmt::Debug import from ledger/src/shredder.rs to clean up dead code and prevent potential lint failures (e.g., unused imports) in CI. The Debug trait does not need to be imported explicitly for #[derive(Debug)], so keeping it adds no value and may slightly increase compile noise.