### PR TITLE
accounts-db: Remove remove_dead_slots_metadata counter

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5616,10 +5616,7 @@ impl AccountsDb {
     }
 
     fn remove_dead_slots_metadata<'a>(&'a self, dead_slots_iter: impl Iterator<Item = &'a Slot>) {
-        let mut measure = Measure::start("remove_dead_slots_metadata-ms");
         self.clean_dead_slots_from_accounts_index(dead_slots_iter);
-        measure.stop();
-        inc_new_counter_info!("remove_dead_slots_metadata-ms", measure.as_ms() as usize);
     }
 
     /// lookup each pubkey in 'pubkeys' and unref it in the accounts index


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/issues/9185

#### Summary of Changes
Rip out the duplicate metric. As Rory pointed out, we are covered already by `accounts_index_roots_len.clean_dead_slot_us` which is measured within `AccountsDb:: clean_dead_slots_from_accounts_index()`