### PR TITLE
feat(transaction-view): add `fn inner_data(&self) -> &D`

### DIFF
--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -174,6 +174,11 @@ impl<const SANITIZED: bool, D: TransactionData> TransactionView<SANITIZED, D> {
     }
 
     #[inline]
+    pub fn inner_data(&self) -> &D {
+        &self.data
+    }
+
+    #[inline]
     pub fn into_inner_data(self) -> D {
         self.data
     }


### PR DESCRIPTION
#### Problem

- It can be useful to access the inner `D` that `TransactionView` wraps. However, the only way do this currently is `into_inner_data` which consumes `self` which is not easy to reverse (especially if the view is sanitized).

#### Summary of Changes

- Add a getter `fn inner_data(&self)` that does not consume `self`.