### PR TITLE
chore: Remove unused rand dep from vortexor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11783,7 +11783,6 @@ dependencies = [
  "percentage",
  "quinn",
  "quinn-proto",
- "rand 0.8.5",
  "rustls 0.23.34",
  "signal-hook",
  "smallvec",

--- a/vortexor/Cargo.toml
+++ b/vortexor/Cargo.toml
@@ -42,7 +42,6 @@ pem = { workspace = true }
 percentage = { workspace = true }
 quinn = { workspace = true }
 quinn-proto = { workspace = true }
-rand = { workspace = true }
 rustls = { workspace = true }
 signal-hook = { workspace = true }
 smallvec = { workspace = true }


### PR DESCRIPTION
#### Problem
While reviewing https://github.com/anza-xyz/agave/pull/9118, I noticed that `vortexor` does not actually use `rand`

#### Summary of Changes
Remove the dep