### PR TITLE
Use rlim_t which is portable instead of u64 which breaks build on other OSs

### DIFF
--- a/core/src/resource_limits.rs
+++ b/core/src/resource_limits.rs
@@ -1,5 +1,10 @@
 use {std::io, thiserror::Error};
 
+#[cfg(not(unix))]
+#[derive(Error, Debug)]
+pub enum ResourceLimitError {}
+
+#[cfg(unix)]
 #[derive(Error, Debug)]
 pub enum ResourceLimitError {
     #[error(

--- a/core/src/resource_limits.rs
+++ b/core/src/resource_limits.rs
@@ -1,12 +1,8 @@
 use {std::io, thiserror::Error};
 
-#[cfg(not(unix))]
-#[derive(Error, Debug)]
-pub enum ResourceLimitError {}
-
-#[cfg(unix)]
 #[derive(Error, Debug)]
 pub enum ResourceLimitError {
+    #[cfg(unix)]
     #[error(
         "unable to increase the nofile limit to {desired} from {current}; setrlimit() error: \
          {error}"

--- a/core/src/resource_limits.rs
+++ b/core/src/resource_limits.rs
@@ -7,8 +7,8 @@ pub enum ResourceLimitError {
          {error}"
     )]
     Nofile {
-        desired: u64,
-        current: u64,
+        desired: libc::rlim_t,
+        current: libc::rlim_t,
         error: libc::c_int,
     },
 }


### PR DESCRIPTION
#### Problem
agave fails to build on OS's where rlim_t is a signed type (i.e. FreeBSD).
```
$ grep -rn rlim_t /usr/include/sys/*types.h|grep typed
/usr/include/sys/_types.h:135:typedef	__int64_t	__rlim_t;	/* resource limit - intentionally */
/usr/include/sys/types.h:191:typedef	__rlim_t	rlim_t;		/* resource limit */
```

Build fails with:
```
   Compiling solana-core v3.1.1 (/home/build/box/agave-v3.1.1/core)
error[E0308]: mismatched types
  --> core/src/resource_limits.rs:48:26
   |
43 |     if current < desired_nofile {
   |                  -------------- here the type of `desired_nofile` is inferred to be `i64`
...
48 |                 desired: desired_nofile,
   |                          ^^^^^^^^^^^^^^ expected `u64`, found `i64`

error[E0308]: mismatched types
  --> core/src/resource_limits.rs:49:17
   |
49 |                 current,
   |                 ^^^^^^^ expected `u64`, found `i64`
   |
help: you can convert an `i64` to a `u64` and panic if the converted value doesn't fit
   |
49 |                 current: current.try_into().unwrap(),
   |                 ++++++++        ++++++++++++++++++++

For more information about this error, try `rustc --explain E0308`.
error: could not compile `solana-core` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```

#### Summary of Changes
Declare members of ResourceLimitError::Nofile as type `libc::lim_t` instead of `u64`.