### PR TITLE
Remove unused block_height field

### DIFF
--- a/runtime/src/accounts_background_service/pending_snapshot_packages.rs
+++ b/runtime/src/accounts_background_service/pending_snapshot_packages.rs
@@ -117,7 +117,6 @@ mod tests {
         SnapshotPackage {
             snapshot_kind,
             slot,
-            block_height: slot,
             ..SnapshotPackage::default_for_tests()
         }
     }

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -18,7 +18,6 @@ pub use compare::*;
 pub struct SnapshotPackage {
     pub snapshot_kind: SnapshotKind,
     pub slot: Slot,
-    pub block_height: Slot,
     pub hash: SnapshotHash,
     pub snapshot_storages: Vec<Arc<AccountStorageEntry>>,
     pub bank_snapshot_package: BankSnapshotPackage,
@@ -64,7 +63,6 @@ impl SnapshotPackage {
         Self {
             snapshot_kind,
             slot,
-            block_height: bank.block_height(),
             hash,
             bank_snapshot_package,
             snapshot_storages,
@@ -88,7 +86,6 @@ impl SnapshotPackage {
         Self {
             snapshot_kind: SnapshotKind::Archive(SnapshotArchiveKind::Full),
             slot: Slot::default(),
-            block_height: Slot::default(),
             hash: SnapshotHash(Hash::default()),
             snapshot_storages: Vec::default(),
             bank_snapshot_package,
@@ -102,7 +99,6 @@ impl std::fmt::Debug for SnapshotPackage {
         f.debug_struct("SnapshotPackage")
             .field("kind", &self.snapshot_kind)
             .field("slot", &self.slot)
-            .field("block_height", &self.block_height)
             .finish_non_exhaustive()
     }
 }

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -50,7 +50,6 @@ mod tests {
             SnapshotPackage {
                 snapshot_kind,
                 slot,
-                block_height: slot,
                 ..SnapshotPackage::default_for_tests()
             }
         }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -444,7 +444,6 @@ pub fn serialize_and_archive_snapshot_package(
     let SnapshotPackage {
         snapshot_kind,
         slot: snapshot_slot,
-        block_height: _,
         hash: snapshot_hash,
         mut snapshot_storages,
         bank_snapshot_package,


### PR DESCRIPTION
#### Problem
Block_height field in snapshot package is unused. 

#### Summary of Changes
Remove it

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
