### PR TITLE
Splitting archive and serialize snapshot into two functions

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -105,11 +105,11 @@ impl SnapshotPackagerService {
                     );
 
                     let Ok(bank_snapshot_info) = bank_snapshot_info else {
+                        let err = bank_snapshot_info.unwrap_err();
                         error!(
-                            "Stopping {}! Fatal error while serializing snapshot for slot {}: \
-                             {bank_snapshot_info:?}",
+                            "Stopping {}! Fatal error while serializing snapshot for slot \
+                             {snapshot_slot}: {err}",
                             Self::NAME,
-                            snapshot_slot,
                         );
                         exit.store(true, Ordering::Relaxed);
                         break;

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -2,7 +2,7 @@ mod snapshot_gossip_manager;
 use {
     agave_snapshots::{
         paths as snapshot_paths, snapshot_config::SnapshotConfig,
-        snapshot_hash::StartingSnapshotHashes,
+        snapshot_hash::StartingSnapshotHashes, SnapshotKind,
     },
     snapshot_gossip_manager::SnapshotGossipManager,
     solana_accounts_db::accounts_db::AccountStorageEntry,
@@ -93,18 +93,40 @@ impl SnapshotPackagerService {
                         });
                     }
 
+                    let archive_time = Instant::now();
+                    // Serializing the snapshot package is not allowed to fail, as archiving is
+                    // not allowed to fail (see comment on archive_snapshot_package below
+                    let bank_snapshot_info = snapshot_utils::serialize_snapshot(
+                        &snapshot_config.bank_snapshots_dir,
+                        snapshot_config.snapshot_version,
+                        snapshot_package.bank_snapshot_package,
+                        snapshot_package.snapshot_storages.as_slice(),
+                        exit_backpressure.is_none(),
+                    );
+
+                    let Ok(bank_snapshot_info) = bank_snapshot_info else {
+                        error!(
+                            "Stopping {}! Fatal error while serializing snapshot for slot {}: \
+                             {bank_snapshot_info:?}",
+                            Self::NAME,
+                            snapshot_slot,
+                        );
+                        exit.store(true, Ordering::Relaxed);
+                        break;
+                    };
+
+                    let SnapshotKind::Archive(snapshot_archive_kind) = snapshot_kind;
                     // Archiving the snapshot package is not allowed to fail.
                     // AccountsBackgroundService calls `clean_accounts()` with a value for
                     // latest_full_snapshot_slot that requires this archive call to succeed.
-                    let (archive_result, archive_time_us) =
-                        measure_us!(snapshot_utils::serialize_and_archive_snapshot_package(
-                            snapshot_package,
-                            snapshot_config,
-                            // Without exit backpressure, always flush the snapshot storages,
-                            // which is required for fastboot.
-                            exit_backpressure.is_none(),
-                        ));
-                    if let Err(err) = archive_result {
+                    if let Err(err) = snapshot_utils::archive_snapshot_package(
+                        snapshot_archive_kind,
+                        snapshot_slot,
+                        snapshot_hash,
+                        &bank_snapshot_info.snapshot_dir,
+                        snapshot_package.snapshot_storages,
+                        snapshot_config,
+                    ) {
                         error!(
                             "Stopping {}! Fatal error while archiving snapshot package: {err}",
                             Self::NAME,
@@ -112,6 +134,7 @@ impl SnapshotPackagerService {
                         exit.store(true, Ordering::Relaxed);
                         break;
                     }
+                    let archive_time_us = archive_time.elapsed().as_micros();
 
                     if let Some(snapshot_gossip_manager) = snapshot_gossip_manager.as_mut() {
                         snapshot_gossip_manager

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -691,8 +691,10 @@ fn bank_to_full_snapshot_archive_with(
     bank.force_flush_accounts_cache();
     bank.clean_accounts();
 
+    let snapshot_archive_kind = SnapshotArchiveKind::Full;
+
     let snapshot_package = SnapshotPackage::new(
-        SnapshotKind::Archive(SnapshotArchiveKind::Full),
+        SnapshotKind::Archive(snapshot_archive_kind),
         bank,
         bank.get_snapshot_storages(None),
         bank.status_cache.read().unwrap().root_slot_deltas(),
@@ -706,10 +708,24 @@ fn bank_to_full_snapshot_archive_with(
         snapshot_version,
         ..Default::default()
     };
-    let snapshot_archive_info = snapshot_utils::serialize_and_archive_snapshot_package(
-        snapshot_package,
-        &snapshot_config,
+
+    let snapshot_storages = snapshot_package.snapshot_storages;
+
+    let bank_snapshot_info = snapshot_utils::serialize_snapshot(
+        &snapshot_config.bank_snapshots_dir,
+        snapshot_config.snapshot_version,
+        snapshot_package.bank_snapshot_package,
+        snapshot_storages.as_slice(),
         should_flush_and_hard_link_storages,
+    )?;
+
+    let snapshot_archive_info = snapshot_utils::archive_snapshot_package(
+        snapshot_archive_kind,
+        snapshot_package.slot,
+        snapshot_package.hash,
+        bank_snapshot_info.snapshot_dir,
+        snapshot_storages,
+        &snapshot_config,
     )?;
 
     Ok(FullSnapshotArchiveInfo::new(snapshot_archive_info))
@@ -746,8 +762,10 @@ pub fn bank_to_incremental_snapshot_archive(
     bank.force_flush_accounts_cache();
     bank.clean_accounts();
 
+    let snapshot_archive_kind = SnapshotArchiveKind::Incremental(full_snapshot_slot);
+
     let snapshot_package = SnapshotPackage::new(
-        SnapshotKind::Archive(SnapshotArchiveKind::Incremental(full_snapshot_slot)),
+        SnapshotKind::Archive(snapshot_archive_kind),
         bank,
         bank.get_snapshot_storages(Some(full_snapshot_slot)),
         bank.status_cache.read().unwrap().root_slot_deltas(),
@@ -765,10 +783,23 @@ pub fn bank_to_incremental_snapshot_archive(
         snapshot_version,
         ..Default::default()
     };
-    let snapshot_archive_info = snapshot_utils::serialize_and_archive_snapshot_package(
-        snapshot_package,
-        &snapshot_config,
+
+    let snapshot_storages = snapshot_package.snapshot_storages;
+    let bank_snapshot_info = snapshot_utils::serialize_snapshot(
+        &snapshot_config.bank_snapshots_dir,
+        snapshot_config.snapshot_version,
+        snapshot_package.bank_snapshot_package,
+        snapshot_storages.as_slice(),
         false, // we do not intend to fastboot, so skip flushing and hard linking the storages
+    )?;
+
+    let snapshot_archive_info = snapshot_utils::archive_snapshot_package(
+        snapshot_archive_kind,
+        snapshot_package.slot,
+        snapshot_package.hash,
+        bank_snapshot_info.snapshot_dir,
+        snapshot_storages,
+        &snapshot_config,
     )?;
 
     Ok(IncrementalSnapshotArchiveInfo::new(

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -785,6 +785,7 @@ pub fn bank_to_incremental_snapshot_archive(
     };
 
     let snapshot_storages = snapshot_package.snapshot_storages;
+
     let bank_snapshot_info = snapshot_utils::serialize_snapshot(
         &snapshot_config.bank_snapshots_dir,
         snapshot_config.snapshot_version,


### PR DESCRIPTION
#### Problem
Fastboot snapshots will need to be serialized but not archived, but the public API only supports archivation only. 

#### Summary of Changes
- Change serialize_and_archive_snapshot into archive_snapshot and remove archiving functionality
- Make serialize_snapshot public
- Modify callers to support new behaviour 

#### Alternatives Considered
- Renaming serialize_and_archive_snapshot to save_snapshot and handling the different types within
- In that method would need to determine what should be returned from the function, as a bank only snapshot will not have an archive. Could combine the return parameters into a nested structure, but that didn't end up being the most clear approach. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
