### PR TITLE
chore(gossip): switch to compatibility random sampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8885,6 +8885,7 @@ version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
+ "agave-random",
  "anyhow",
  "arc-swap",
  "arrayvec",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -224,6 +224,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-random"
+version = "4.0.0-alpha.0"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "agave-reserved-account-keys"
 version = "4.0.0-alpha.0"
 dependencies = [
@@ -7455,6 +7462,7 @@ version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
+ "agave-random",
  "arc-swap",
  "arrayvec",
  "assert_matches",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -33,6 +33,7 @@ agave-unstable-api = []
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-logger = { workspace = true }
+agave-random = { workspace = true }
 arc-swap = { workspace = true }
 arrayvec = { workspace = true }
 assert_matches = { workspace = true }

--- a/gossip/src/weighted_shuffle.rs
+++ b/gossip/src/weighted_shuffle.rs
@@ -240,6 +240,7 @@ impl Clone for WeightedShuffle {
 mod tests {
     use {
         super::*,
+        agave_random::range::random_u64_range,
         itertools::Itertools,
         rand::SeedableRng,
         rand_chacha::{ChaCha8Rng, ChaChaRng},
@@ -290,7 +291,7 @@ mod tests {
             .map(|(i, _)| i)
             .collect();
         while high != 0 {
-            let sample = rng.gen_range(0..high);
+            let sample = random_u64_range(rng, 0..high);
             let index = weights
                 .iter()
                 .scan(0, |acc, &w| {
@@ -504,13 +505,13 @@ mod tests {
         )
         .map(ChaChaRng::from_seed)
         .unwrap();
-        let num_weights = rng.gen_range(1..=100_000);
+        let num_weights = random_u64_range(&mut rng, 1..=100_000) as usize;
         assert!((8143..=85348).contains(&num_weights), "{num_weights}");
         let weights: Vec<u64> = repeat_with(|| {
             if rng.gen_ratio(1, 100) {
                 0u64 // 1% zero weights.
             } else {
-                rng.gen_range(0..=(u64::MAX / num_weights as u64))
+                random_u64_range(&mut rng, 0..=(u64::MAX / num_weights as u64))
             }
         })
         .take(num_weights)
@@ -528,10 +529,10 @@ mod tests {
         assert_eq!(shuffle1.len(), num_weights);
         verify_shuffle(&shuffle1, &weights, vec![false; num_weights]);
         // Drop some of the weights and re-shuffle.
-        let num_drops = rng.gen_range(1..1_000);
+        let num_drops = random_u64_range(&mut rng, 1..1_000) as usize;
         assert!((253..=981).contains(&num_drops), "{num_drops}");
         let mut mask = vec![false; num_weights];
-        repeat_with(|| rng.gen_range(0..num_weights))
+        repeat_with(|| random_u64_range(&mut rng, 0..num_weights as u64) as usize)
             .filter(|&index| {
                 if mask[index] {
                     false
@@ -562,7 +563,9 @@ mod tests {
 
         fn test_weighted_shuffle_match_slow_impl<R: Rng + rand::SeedableRng<Seed = [u8; 32]>>() {
             let mut rng = rand::thread_rng();
-            let weights: Vec<u64> = repeat_with(|| rng.gen_range(0..1000)).take(997).collect();
+            let weights: Vec<u64> = repeat_with(|| random_u64_range(&mut rng, 0..1000))
+                .take(997)
+                .collect();
             for _ in 0..10 {
                 let mut seed = [0u8; 32];
                 rng.fill(&mut seed[..]);
@@ -590,7 +593,9 @@ mod tests {
 
         fn test_weighted_shuffle_paranoid_impl<R: Rng + Clone>(mut rng: R) {
             for size in 0..1351 {
-                let weights: Vec<_> = repeat_with(|| rng.gen_range(0..1000)).take(size).collect();
+                let weights: Vec<_> = repeat_with(|| random_u64_range(&mut rng, 0..1000))
+                    .take(size)
+                    .collect();
                 let shuffle_slow = weighted_shuffle_slow(&mut rng.clone(), weights.clone());
                 let mut shuffle = WeightedShuffle::new("", weights);
                 if size > 0 {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -141,6 +141,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-random"
+version = "4.0.0-alpha.0"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "agave-reserved-account-keys"
 version = "4.0.0-alpha.0"
 dependencies = [
@@ -7234,6 +7241,7 @@ version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
+ "agave-random",
  "arc-swap",
  "arrayvec",
  "assert_matches",


### PR DESCRIPTION
#### Problem
In order to [migrate](https://github.com/anza-xyz/agave/issues/4738) to `rand=0.9.2` we need to switch gossip (in particular `weighted_shuffle`) to implementation of random number sampling that is independent from used `rand` version.

#### Summary of Changes
* switch `weighted_shuffle` to use `agave_random::range::UniformU64Sampler` and `agave_random::range::random_u64_range` that are reproducible across rand version switches (see https://github.com/anza-xyz/agave/pull/9151).
* switch `push_active_set` tests to use `agave_random::range::random_u64_range` for generating test cases

##### Benchmark performance
master:
```
bench_weighted_shuffle_new
                        time:   [54.107 µs 54.373 µs 54.627 µs]

bench_weighted_shuffle_shuffle
                        time:   [157.56 µs 158.22 µs 158.88 µs]

bench_weighted_shuffle_collect
                        time:   [165.60 µs 166.34 µs 167.10 µs]
```

PR:
```
bench_weighted_shuffle_new
                        time:   [55.190 µs 55.450 µs 55.715 µs]
                        change: [-0.0848% +0.5796% +1.2525%] (p = 0.10 > 0.05

bench_weighted_shuffle_shuffle
                        time:   [156.02 µs 156.63 µs 157.30 µs]
                        change: [-0.0797% +0.4784% +1.0981%] (p = 0.12 > 0.05

bench_weighted_shuffle_collect
                        time:   [163.44 µs 164.16 µs 164.85 µs]
                        change: [-4.9006% -4.1275% -3.2927%] (p = 0.00 < 0.05)
```