### PR TITLE
Switch to compatibility random sampler for calculating leader schedule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9115,6 +9115,7 @@ version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
+ "agave-random",
  "agave-reserved-account-keys",
  "agave-snapshots",
  "anyhow",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -224,6 +224,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-random"
+version = "4.0.0-alpha.0"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "agave-reserved-account-keys"
 version = "4.0.0-alpha.0"
 dependencies = [
@@ -7613,6 +7620,7 @@ name = "solana-ledger"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-random",
  "agave-reserved-account-keys",
  "agave-snapshots",
  "anyhow",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -27,6 +27,7 @@ agave-unstable-api = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-random = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 agave-snapshots = { workspace = true }
 anyhow = { workspace = true }

--- a/ledger/src/leader_schedule.rs
+++ b/ledger/src/leader_schedule.rs
@@ -1,5 +1,5 @@
 use {
-    rand0_8_5::distributions::{Distribution, WeightedIndex},
+    agave_random::weighted::WeightedU64Index,
     rand_chacha0_3_1::{rand_core::SeedableRng, ChaChaRng},
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
@@ -80,7 +80,7 @@ fn stake_weighted_slot_leaders(
 ) -> Vec<Pubkey> {
     sort_stakes(&mut keyed_stakes);
     let (keys, stakes): (Vec<_>, Vec<_>) = keyed_stakes.into_iter().unzip();
-    let weighted_index = WeightedIndex::new(stakes).unwrap();
+    let weighted_index = WeightedU64Index::new(stakes).unwrap();
     let mut seed = [0u8; 32];
     seed[0..8].copy_from_slice(&epoch.to_le_bytes());
     let rng = &mut ChaChaRng::from_seed(seed);

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -141,6 +141,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-random"
+version = "4.0.0-alpha.0"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "agave-reserved-account-keys"
 version = "4.0.0-alpha.0"
 dependencies = [
@@ -7392,6 +7399,7 @@ name = "solana-ledger"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-random",
  "agave-reserved-account-keys",
  "agave-snapshots",
  "anyhow",


### PR DESCRIPTION
#### Problem
In order to [migrate](https://github.com/anza-xyz/agave/issues/4738) to `rand=0.9.2` we need to switch leader schedule to implementation of random number sampling that is independent from used `rand` version.

#### Summary of Changes
Switch weighted sampling to use `agave_random::weighted::WeightedU64Index` that is reproducible across rand version switches (see https://github.com/anza-xyz/agave/pull/9151).
