### PR TITLE
feat(scheduling-utils): add `from_raw_parts` for pointers

### DIFF
--- a/scheduling-utils/Cargo.toml
+++ b/scheduling-utils/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [features]
 agave-unstable-api = []
+dev-context-only-utils = []
 
 [dependencies]
 agave-scheduler-bindings = { workspace = true }

--- a/scheduling-utils/src/pubkeys_ptr.rs
+++ b/scheduling-utils/src/pubkeys_ptr.rs
@@ -9,6 +9,22 @@ pub struct PubkeysPtr {
 }
 
 impl PubkeysPtr {
+    /// Constructions a [`PubkeysPtr`] from raw parts.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must be valid for reads.
+    /// - `count` must be accurate (in number of pubkeys) and not overrun the end of `ptr`.
+    ///
+    /// # Note
+    ///
+    /// If you are trying to construct a pointer for use by Agave, you almost certainly want to use
+    /// [`Self::from_sharable_pubkeys`].
+    #[cfg(feature = "dev-context-only-utils")]
+    pub unsafe fn from_raw_parts(ptr: NonNull<Pubkey>, count: usize) -> Self {
+        Self { ptr, count }
+    }
+
     /// Constructs the pointer from a [`SharablePubkeys`].
     ///
     /// # Safety

--- a/scheduling-utils/src/responses_region.rs
+++ b/scheduling-utils/src/responses_region.rs
@@ -101,6 +101,22 @@ pub struct CheckResponsesPtr {
 }
 
 impl CheckResponsesPtr {
+    /// Constructions a [`CheckResponsesPtr`] from raw parts.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must be valid for reads.
+    /// - `count` must be accurate (in number of responses) and not overrun the end of `ptr`.
+    ///
+    /// # Note
+    ///
+    /// If you are trying to construct a pointer for use by Agave, you almost certainly want to use
+    /// [`Self::from_transaction_response_region`].
+    #[cfg(feature = "dev-context-only-utils")]
+    pub unsafe fn from_raw_parts(ptr: NonNull<CheckResponse>, count: usize) -> Self {
+        Self { ptr, count }
+    }
+
     /// Constructs the pointer from a [`TransactionResponseRegion`].
     ///
     /// # Safety
@@ -153,6 +169,22 @@ pub struct ExecutionResponsesPtr {
 }
 
 impl ExecutionResponsesPtr {
+    /// Constructions a [`ExecutionResponsesPtr`] from raw parts.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must be valid for reads.
+    /// - `count` must be accurate (in number of responses) and not overrun the end of `ptr`.
+    ///
+    /// # Note
+    ///
+    /// If you are trying to construct a pointer for use by Agave, you almost certainly want to use
+    /// [`Self::from_transaction_response_region`].
+    #[cfg(feature = "dev-context-only-utils")]
+    pub unsafe fn from_raw_parts(ptr: NonNull<ExecutionResponse>, count: usize) -> Self {
+        Self { ptr, count }
+    }
+
     /// Constructs the pointer from a [`TransactionResponseRegion`].
     ///
     /// # Safety

--- a/scheduling-utils/src/transaction_ptr.rs
+++ b/scheduling-utils/src/transaction_ptr.rs
@@ -10,22 +10,38 @@ use {
 
 pub struct TransactionPtr {
     ptr: NonNull<u8>,
-    len: usize,
+    count: usize,
 }
 
 impl TransactionData for TransactionPtr {
     fn data(&self) -> &[u8] {
-        unsafe { core::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+        unsafe { core::slice::from_raw_parts(self.ptr.as_ptr(), self.count) }
     }
 }
 
 impl TransactionData for &TransactionPtr {
     fn data(&self) -> &[u8] {
-        unsafe { core::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+        unsafe { core::slice::from_raw_parts(self.ptr.as_ptr(), self.count) }
     }
 }
 
 impl TransactionPtr {
+    /// Constructions a [`TransactionPtr`] from raw parts.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must be valid for reads.
+    /// - `count` must be accurate and not overrun the end of `ptr`.
+    ///
+    /// # Note
+    ///
+    /// If you are trying to construct a pointer for use by Agave, you almost certainly want to use
+    /// [`Self::from_sharable_transaction_region`].
+    #[cfg(feature = "dev-context-only-utils")]
+    pub unsafe fn from_raw_parts(ptr: NonNull<u8>, count: usize) -> Self {
+        Self { ptr, count }
+    }
+
     /// # Safety
     /// - `sharable_transaction_region` must reference a valid offset and length
     ///   within the `allocator`.
@@ -36,7 +52,7 @@ impl TransactionPtr {
         let ptr = allocator.ptr_from_offset(sharable_transaction_region.offset);
         Self {
             ptr,
-            len: sharable_transaction_region.length as usize,
+            count: sharable_transaction_region.length as usize,
         }
     }
 
@@ -55,7 +71,7 @@ impl TransactionPtr {
         let offset = unsafe { allocator.offset(self.ptr) };
         SharableTransactionRegion {
             offset,
-            length: self.len as u32,
+            length: self.count as u32,
         }
     }
 


### PR DESCRIPTION
#### Problem

- Scheduling pointers are currently tied to `rts_alloc` as the only way to construct them requires an instance of `Allocator`. This can be painful for downstream consumers wanting to allocate pointers for testing purposes.

#### Summary of Changes

- Add a `from_raw_parts` that lets a user construct the pointer in a more traditional fashion.