### PR TITLE
chore(scheduling-utils): derive `Debug` on public structs

### DIFF
--- a/scheduling-utils/src/pubkeys_ptr.rs
+++ b/scheduling-utils/src/pubkeys_ptr.rs
@@ -3,6 +3,7 @@ use {
     std::ptr::NonNull,
 };
 
+#[derive(Debug)]
 pub struct PubkeysPtr {
     ptr: NonNull<Pubkey>,
     count: usize,

--- a/scheduling-utils/src/responses_region.rs
+++ b/scheduling-utils/src/responses_region.rs
@@ -95,6 +95,7 @@ unsafe fn from_iterator<T: Sized>(
     Some(region)
 }
 
+#[derive(Debug)]
 pub struct CheckResponsesPtr {
     ptr: NonNull<CheckResponse>,
     count: usize,
@@ -147,6 +148,7 @@ impl CheckResponsesPtr {
     }
 }
 
+#[derive(Debug)]
 pub struct ExecutionResponsesPtr {
     ptr: NonNull<ExecutionResponse>,
     count: usize,

--- a/scheduling-utils/src/thread_aware_account_locks.rs
+++ b/scheduling-utils/src/thread_aware_account_locks.rs
@@ -19,11 +19,13 @@ type LockCount = u32;
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct ThreadSet(u64);
 
+#[derive(Debug)]
 struct AccountWriteLocks {
     thread_id: ThreadId,
     lock_count: LockCount,
 }
 
+#[derive(Debug)]
 struct AccountReadLocks {
     thread_set: ThreadSet,
     lock_counts: [LockCount; MAX_THREADS],
@@ -34,7 +36,7 @@ struct AccountReadLocks {
 ///     Contains how many write locks are held by the thread.
 /// Read Locks - multiple threads can hold a read lock at a time.
 ///     Contains thread-set for easily checking which threads are scheduled.
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct AccountLocks {
     pub write_locks: Option<AccountWriteLocks>,
     pub read_locks: Option<AccountReadLocks>,
@@ -53,6 +55,7 @@ pub enum TryLockError {
 /// that already hold locks on the account. This is useful for allowing
 /// queued transactions to be scheduled on a thread while the transaction
 /// is still being executed on the thread.
+#[derive(Debug)]
 pub struct ThreadAwareAccountLocks {
     /// Number of threads.
     num_threads: usize, // 0..MAX_THREADS

--- a/scheduling-utils/src/transaction_ptr.rs
+++ b/scheduling-utils/src/transaction_ptr.rs
@@ -8,6 +8,7 @@ use {
     std::marker::PhantomData,
 };
 
+#[derive(Debug)]
 pub struct TransactionPtr {
     ptr: NonNull<u8>,
     len: usize,


### PR DESCRIPTION
#### Problem

- Downstream consumers may store these pointers within their structs, having them be non Debug makes this annoying.

#### Summary of Changes

- Derive Debug on majority of public structs.
