### PR TITLE
local-cluster: avoid double Tower::restore() call in restore_tower()

### DIFF
--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -74,16 +74,14 @@ pub fn last_root_in_tower(tower_path: &Path, node_pubkey: &Pubkey) -> Option<Slo
 pub fn restore_tower(tower_path: &Path, node_pubkey: &Pubkey) -> Option<Tower> {
     let file_tower_storage = FileTowerStorage::new(tower_path.to_path_buf());
 
-    let tower = Tower::restore(&file_tower_storage, node_pubkey);
-    if let Err(tower_err) = tower {
-        if tower_err.is_file_missing() {
-            return None;
-        } else {
-            panic!("tower restore failed...: {tower_err:?}");
+    match Tower::restore(&file_tower_storage, node_pubkey) {
+        Ok(tower) => {
+            // actually saved tower must have at least one vote.
+            Some(tower)
         }
+        Err(tower_err) if tower_err.is_file_missing() => None,
+        Err(tower_err) => panic!("tower restore failed...: {tower_err:?}"),
     }
-    // actually saved tower must have at least one vote.
-    Tower::restore(&file_tower_storage, node_pubkey).ok()
 }
 
 pub fn remove_tower_if_exists(tower_path: &Path, node_pubkey: &Pubkey) {


### PR DESCRIPTION
Replaced the two-step restore flow in restore_tower() with a single match on Tower::restore(), preserving the existing handling of missing tower files and panicking on other errors. The previous implementation performed two independent loads of the same file which added redundant I/O and introduced a race window between calls without any functional benefit. Tower::restore() is a pure load through TowerStorage::load() and has no side effects that require retrying; all other sites in the codebase use a single restore call and pattern-match on is_file_missing(). Collapsing to a single call aligns with those conventions, reduces disk work, and removes the potential for inconsistent results if the file changes between reads.