### PR TITLE
Reduce duplication of logic in pending snapshots push

### DIFF
--- a/runtime/src/accounts_background_service/pending_snapshot_packages.rs
+++ b/runtime/src/accounts_background_service/pending_snapshot_packages.rs
@@ -1,6 +1,6 @@
 use {
     crate::snapshot_package::{
-        are_snapshots_the_same_kind, cmp_snapshot_packages_by_priority, SnapshotPackage,
+        are_snapshot_packages_the_same_kind, cmp_snapshot_packages_by_priority, SnapshotPackage,
     },
     agave_snapshots::{SnapshotArchiveKind, SnapshotKind},
     log::*,
@@ -32,7 +32,7 @@ impl PendingSnapshotPackages {
         if let Some(pending_snapshot_package) = pending_package.as_ref() {
             // snapshots are monotonically increasing; only overwrite *old* packages
             assert!(
-                are_snapshots_the_same_kind(&snapshot_package, pending_snapshot_package),
+                are_snapshot_packages_the_same_kind(&snapshot_package, pending_snapshot_package),
                 "mismatched snapshot kinds: pending: {pending_snapshot_package:?}, new: \
                  {snapshot_package:?}",
             );

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -40,27 +40,28 @@ pub fn cmp_snapshot_archive_kinds_by_priority(
     }
 }
 
-/// Check if two snapshots are the same kind
+/// Check if two snapshots packages are the same kind
 #[must_use]
-pub fn are_snapshots_the_same_kind(a: &SnapshotPackage, b: &SnapshotPackage) -> bool {
-    are_snapshots_kinds_the_same_kind(&a.snapshot_kind, &b.snapshot_kind)
+pub fn are_snapshot_packages_the_same_kind(a: &SnapshotPackage, b: &SnapshotPackage) -> bool {
+    are_snapshot_kinds_the_same_kind(&a.snapshot_kind, &b.snapshot_kind)
 }
 
-/// Check if two snapshot kinds are the same kind.
+/// Check if two snapshot kinds are the same kind
 #[must_use]
-pub fn are_snapshots_kinds_the_same_kind(a: &SnapshotKind, b: &SnapshotKind) -> bool {
+pub fn are_snapshot_kinds_the_same_kind(a: &SnapshotKind, b: &SnapshotKind) -> bool {
     use SnapshotKind as Kind;
     match (a, b) {
         (Kind::Archive(archive_a), Kind::Archive(archive_b)) => {
-            are_snapshot_archives_kinds_the_same_kind(archive_a, archive_b)
+            are_snapshot_archive_kinds_the_same_kind(archive_a, archive_b)
         }
     }
 }
 
-// Check if two snapshot archives are the same kind. Incremental snapshot archives with different
-// base slots are considered the same kind.
+/// Check if two snapshot archives are the same kind
+///
+/// Incremental snapshot archives with different base slots are considered the same kind
 #[must_use]
-pub fn are_snapshot_archives_kinds_the_same_kind(
+pub fn are_snapshot_archive_kinds_the_same_kind(
     a: &SnapshotArchiveKind,
     b: &SnapshotArchiveKind,
 ) -> bool {
@@ -68,8 +69,8 @@ pub fn are_snapshot_archives_kinds_the_same_kind(
     match (a, b) {
         (Kind::Full, Kind::Full) => true,
         (Kind::Full, Kind::Incremental(_)) => false,
-        (Kind::Incremental(_), Kind::Incremental(_)) => true,
         (Kind::Incremental(_), Kind::Full) => false,
+        (Kind::Incremental(_), Kind::Incremental(_)) => true,
     }
 }
 
@@ -262,7 +263,7 @@ mod tests {
     }
 
     #[test]
-    fn test_are_snapshots_the_same_kind_function() {
+    fn test_are_snapshot_packages_the_same_kind() {
         for (snapshot_package_a, snapshot_package_b, expected_result) in [
             (
                 new(SnapshotKind::Archive(SnapshotArchiveKind::Full), 11),
@@ -309,12 +310,12 @@ mod tests {
             ),
         ] {
             let actual_result =
-                are_snapshots_the_same_kind(&snapshot_package_a, &snapshot_package_b);
+                are_snapshot_packages_the_same_kind(&snapshot_package_a, &snapshot_package_b);
             assert_eq!(expected_result, actual_result);
         }
     }
     #[test]
-    fn test_are_snapshots_the_same_kind() {
+    fn test_are_snapshot_kinds_the_same_kind() {
         for (snapshot_kind_a, snapshot_kind_b, expected_result) in [
             (
                 SnapshotKind::Archive(SnapshotArchiveKind::Full),
@@ -343,7 +344,7 @@ mod tests {
             ),
         ] {
             let actual_result =
-                are_snapshots_kinds_the_same_kind(&snapshot_kind_a, &snapshot_kind_b);
+                are_snapshot_kinds_the_same_kind(&snapshot_kind_a, &snapshot_kind_b);
             assert_eq!(expected_result, actual_result);
         }
     }

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -40,20 +40,53 @@ pub fn cmp_snapshot_archive_kinds_by_priority(
     }
 }
 
+/// Check if two snapshots are the same kind
+#[must_use]
+pub fn are_snapshots_the_same_kind(a: &SnapshotPackage, b: &SnapshotPackage) -> bool {
+    are_snapshots_kinds_the_same_kind(&a.snapshot_kind, &b.snapshot_kind)
+}
+
+/// Check if two snapshot kinds are the same kind.
+#[must_use]
+pub fn are_snapshots_kinds_the_same_kind(a: &SnapshotKind, b: &SnapshotKind) -> bool {
+    use SnapshotKind as Kind;
+    match (a, b) {
+        (Kind::Archive(archive_a), Kind::Archive(archive_b)) => {
+            are_snapshot_archives_kinds_the_same_kind(archive_a, archive_b)
+        }
+    }
+}
+
+// Check if two snapshot archives are the same kind. Incremental snapshot archives with different
+// base slots are considered the same kind.
+#[must_use]
+pub fn are_snapshot_archives_kinds_the_same_kind(
+    a: &SnapshotArchiveKind,
+    b: &SnapshotArchiveKind,
+) -> bool {
+    use SnapshotArchiveKind as Kind;
+    match (a, b) {
+        (Kind::Full, Kind::Full) => true,
+        (Kind::Full, Kind::Incremental(_)) => false,
+        (Kind::Incremental(_), Kind::Incremental(_)) => true,
+        (Kind::Incremental(_), Kind::Full) => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {super::*, solana_clock::Slot};
 
+    fn new(snapshot_kind: SnapshotKind, slot: Slot) -> SnapshotPackage {
+        SnapshotPackage {
+            snapshot_kind,
+            slot,
+            ..SnapshotPackage::default_for_tests()
+        }
+    }
+
     #[test]
     fn test_cmp_snapshot_packages_by_priority() {
-        fn new(snapshot_kind: SnapshotKind, slot: Slot) -> SnapshotPackage {
-            SnapshotPackage {
-                snapshot_kind,
-                slot,
-                ..SnapshotPackage::default_for_tests()
-            }
-        }
-
         for (snapshot_package_a, snapshot_package_b, expected_result) in [
             (
                 new(SnapshotKind::Archive(SnapshotArchiveKind::Full), 11),
@@ -224,6 +257,93 @@ mod tests {
                 &snapshot_archive_kind_a,
                 &snapshot_archive_kind_b,
             );
+            assert_eq!(expected_result, actual_result);
+        }
+    }
+
+    #[test]
+    fn test_are_snapshots_the_same_kind_function() {
+        for (snapshot_package_a, snapshot_package_b, expected_result) in [
+            (
+                new(SnapshotKind::Archive(SnapshotArchiveKind::Full), 11),
+                new(SnapshotKind::Archive(SnapshotArchiveKind::Full), 22),
+                true,
+            ),
+            (
+                new(SnapshotKind::Archive(SnapshotArchiveKind::Full), 11),
+                new(
+                    SnapshotKind::Archive(SnapshotArchiveKind::Incremental(5)),
+                    22,
+                ),
+                false,
+            ),
+            (
+                new(
+                    SnapshotKind::Archive(SnapshotArchiveKind::Incremental(5)),
+                    11,
+                ),
+                new(SnapshotKind::Archive(SnapshotArchiveKind::Full), 22),
+                false,
+            ),
+            (
+                new(
+                    SnapshotKind::Archive(SnapshotArchiveKind::Incremental(5)),
+                    11,
+                ),
+                new(
+                    SnapshotKind::Archive(SnapshotArchiveKind::Incremental(6)),
+                    22,
+                ),
+                true,
+            ),
+            (
+                new(
+                    SnapshotKind::Archive(SnapshotArchiveKind::Incremental(5)),
+                    11,
+                ),
+                new(
+                    SnapshotKind::Archive(SnapshotArchiveKind::Incremental(5)),
+                    22,
+                ),
+                true,
+            ),
+        ] {
+            let actual_result =
+                are_snapshots_the_same_kind(&snapshot_package_a, &snapshot_package_b);
+            assert_eq!(expected_result, actual_result);
+        }
+    }
+    #[test]
+    fn test_are_snapshots_the_same_kind() {
+        for (snapshot_kind_a, snapshot_kind_b, expected_result) in [
+            (
+                SnapshotKind::Archive(SnapshotArchiveKind::Full),
+                SnapshotKind::Archive(SnapshotArchiveKind::Full),
+                true,
+            ),
+            (
+                SnapshotKind::Archive(SnapshotArchiveKind::Full),
+                SnapshotKind::Archive(SnapshotArchiveKind::Incremental(5)),
+                false,
+            ),
+            (
+                SnapshotKind::Archive(SnapshotArchiveKind::Incremental(5)),
+                SnapshotKind::Archive(SnapshotArchiveKind::Full),
+                false,
+            ),
+            (
+                SnapshotKind::Archive(SnapshotArchiveKind::Incremental(5)),
+                SnapshotKind::Archive(SnapshotArchiveKind::Incremental(6)),
+                true,
+            ),
+            (
+                SnapshotKind::Archive(SnapshotArchiveKind::Incremental(5)),
+                SnapshotKind::Archive(SnapshotArchiveKind::Incremental(5)),
+                true,
+            ),
+        ] {
+            let actual_result =
+                are_snapshots_kinds_the_same_kind(&snapshot_kind_a, &snapshot_kind_b);
             assert_eq!(expected_result, actual_result);
         }
     }


### PR DESCRIPTION
#### Problem
Pending Snapshots push logic is duplicated. Adding more fastboot types will make duplication worse


#### Summary of Changes
De-duplicate the function

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
