### PR TITLE
reduce buffer size of "unused" side of socket

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2363,40 +2363,40 @@ impl ClusterInfo {
 
 #[derive(Debug)]
 pub struct Sockets {
-    pub gossip: Arc<[UdpSocket]>,
-    pub ip_echo: Option<TcpListener>,
-    pub tvu: Vec<UdpSocket>,
-    pub tpu_vote: Vec<UdpSocket>,
-    pub broadcast: Vec<UdpSocket>,
+    pub gossip: Arc<[UdpSocket]>,     // udp read/write
+    pub ip_echo: Option<TcpListener>, // read/write (tcp)
+    pub tvu: Vec<UdpSocket>,          // udp read only
+    pub tpu_vote: Vec<UdpSocket>,     // udp read only
+    pub broadcast: Vec<UdpSocket>,    // udp write only
     // Socket sending out local repair requests,
     // and receiving repair responses from the cluster.
-    pub repair: UdpSocket,
-    pub repair_quic: UdpSocket,
-    pub retransmit_sockets: Vec<UdpSocket>,
+    pub repair: UdpSocket,                  // udp read/write
+    pub repair_quic: UdpSocket,             // quic read/write
+    pub retransmit_sockets: Vec<UdpSocket>, // udp write only
     // Socket receiving remote repair requests from the cluster,
     // and sending back repair responses.
-    pub serve_repair: UdpSocket,
-    pub serve_repair_quic: UdpSocket,
+    pub serve_repair: UdpSocket,      // udp read/write
+    pub serve_repair_quic: UdpSocket, // quic read/write
     // Socket sending out local RepairProtocol::AncestorHashes,
     // and receiving AncestorHashesResponse from the cluster.
-    pub ancestor_hashes_requests: UdpSocket,
-    pub ancestor_hashes_requests_quic: UdpSocket,
-    pub tpu_quic: Vec<UdpSocket>,
-    pub tpu_forwards_quic: Vec<UdpSocket>,
-    pub tpu_vote_quic: Vec<UdpSocket>,
+    pub ancestor_hashes_requests: UdpSocket, // udp read/write
+    pub ancestor_hashes_requests_quic: UdpSocket, // quic read/write
+    pub tpu_quic: Vec<UdpSocket>,            // quic read only
+    pub tpu_forwards_quic: Vec<UdpSocket>,   // quic read only
+    pub tpu_vote_quic: Vec<UdpSocket>,       // quic read only
 
     /// Client-side socket for ForwardingStage vote transactions
-    pub tpu_vote_forwarding_client: UdpSocket,
+    pub tpu_vote_forwarding_client: UdpSocket, // udp write only
     /// Client-side socket for ForwardingStage non-vote transactions
-    pub tpu_transaction_forwarding_clients: Box<[UdpSocket]>,
+    pub tpu_transaction_forwarding_clients: Box<[UdpSocket]>, // quic write only
     /// Socket for alpenglow consensus logic
-    pub alpenglow: Option<UdpSocket>,
+    pub alpenglow: Option<UdpSocket>, // udp read/write
     /// Connection cache endpoint for QUIC-based Vote
-    pub quic_vote_client: UdpSocket,
+    pub quic_vote_client: UdpSocket, // quic write only
     /// Connection cache endpoint for QUIC-based Alpenglow messages
-    pub quic_alpenglow_client: UdpSocket,
+    pub quic_alpenglow_client: UdpSocket, // quic write only
     /// Client-side socket for RPC/SendTransactionService.
-    pub rpc_sts_client: UdpSocket,
+    pub rpc_sts_client: UdpSocket, // quic write only
 }
 
 pub struct NodeConfig {

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -57,13 +57,15 @@ pub struct Node {
 impl Node {
     /// Creates socket configurations for different socket usage patterns.
     ///
-    /// Many sockets are primarily read heavy or write heavy
-    /// QUIC sockets need a 4 MiB buffer on the unused side for control traffic
-    /// (handshakes, ACKs, connection management). UDP sockets use 0 buffer on
-    /// the unused side since they don't have bidirectional protocol requirements.
+    /// In Agave, many sockets are primarily read heavy or write heavy.
+    /// QUIC sockets get a 4 MiB buffer on the unused side for control traffic
+    /// (handshakes, ACKs, connection management). For UDP, "read/write" only
+    /// describes buffer tuning: Agave does not send from primarily_read_udp
+    /// sockets nor receive on primarily_write_udp sockets. Setting the unused
+    /// side to 0 avoids increasing it; Linux still enforces a minimum.
     ///
     /// NOTE: In Linux, the minimum send buffer size (SO_SNDBUF) is 2048 bytes
-    /// and the minimum receive buffer size (SO_RCVBUF) is 256 byts
+    /// and the minimum receive buffer size (SO_RCVBUF) is 256 bytes
     /// See: https://man7.org/linux/man-pages/man7/socket.7.html
     fn create_socket_configs() -> SocketConfigs {
         const QUIC_CONTROL_TRAFFIC_BUFFER_SIZE: usize = 4 * 1024 * 1024; // 4 MiB

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -27,6 +27,15 @@ use {
     },
 };
 
+/// Socket configurations for different usage patterns
+struct SocketConfigs {
+    read_write: SocketConfig,
+    primarily_read_quic: SocketConfig,
+    primarily_write_quic: SocketConfig,
+    primarily_read_udp: SocketConfig,
+    primarily_write_udp: SocketConfig,
+}
+
 // Socket addresses for each protocol across all interfaces
 #[derive(Debug, Clone)]
 pub struct MultihomingAddresses {
@@ -46,6 +55,30 @@ pub struct Node {
 }
 
 impl Node {
+    /// Creates socket configurations for different socket usage patterns.
+    ///
+    /// Many sockets are primarily read heavy or write heavy
+    /// QUIC sockets need a 4 MiB buffer on the unused side for control traffic
+    /// (handshakes, ACKs, connection management). UDP sockets use 0 buffer on
+    /// the unused side since they don't have bidirectional protocol requirements.
+    ///
+    /// NOTE: In Linux, the minimum send buffer size (SO_SNDBUF) is 2048 bytes
+    /// and the minimum receive buffer size (SO_RCVBUF) is 256 byts
+    /// See: https://man7.org/linux/man-pages/man7/socket.7.html
+    fn create_socket_configs() -> SocketConfigs {
+        const QUIC_CONTROL_TRAFFIC_BUFFER_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
+
+        SocketConfigs {
+            read_write: SocketConfig::default(),
+            primarily_read_quic: SocketConfig::default()
+                .send_buffer_size(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
+            primarily_write_quic: SocketConfig::default()
+                .recv_buffer_size(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
+            primarily_read_udp: SocketConfig::default().send_buffer_size(0),
+            primarily_write_udp: SocketConfig::default().recv_buffer_size(0),
+        }
+    }
+
     /// create localhost node for tests
     pub fn new_localhost() -> Self {
         let pubkey = solana_pubkey::new_rand();
@@ -105,12 +138,13 @@ impl Node {
             gossip_ports.push(port);
             ip_echo_sockets.push(ip_echo);
         }
-        let socket_config = SocketConfig::default();
+
+        let socket_configs = Self::create_socket_configs();
 
         let (tvu_port, mut tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
-            socket_config,
+            socket_configs.primarily_read_udp,
             num_tvu_receive_sockets.get(),
         )
         .expect("tvu multi_bind");
@@ -120,65 +154,89 @@ impl Node {
                 &bind_ip_addrs,
                 tvu_port,
                 num_tvu_receive_sockets.get(),
-                socket_config,
+                socket_configs.primarily_read_udp,
             )
             .expect("Secondary bind TVU"),
         );
         let tvu_addresses = Self::get_socket_addrs(&tvu_sockets);
 
         let (tpu_port_quic, tpu_quic) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_configs.primarily_read_quic)
                 .expect("tpu_quic primary bind");
-        let mut tpu_quic = bind_more_with_config(tpu_quic, num_quic_endpoints.get(), socket_config)
-            .expect("tpu_quic bind");
+        let mut tpu_quic = bind_more_with_config(
+            tpu_quic,
+            num_quic_endpoints.get(),
+            socket_configs.primarily_read_quic,
+        )
+        .expect("tpu_quic bind");
 
         // multihoming RX for TPU
         tpu_quic.append(
-            &mut Self::bind_to_extra_ip(&bind_ip_addrs, tpu_port_quic, 32, socket_config)
-                .expect("Secondary bind TPU QUIC"),
+            &mut Self::bind_to_extra_ip(
+                &bind_ip_addrs,
+                tpu_port_quic,
+                32,
+                socket_configs.primarily_read_quic,
+            )
+            .expect("Secondary bind TPU QUIC"),
         );
         let tpu_quic_addresses = Self::get_socket_addrs(&tpu_quic);
 
         let (tpu_forwards_quic_port, tpu_forwards_quic) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_configs.primarily_read_quic)
                 .expect("tpu_forwards_quic primary bind");
-        let mut tpu_forwards_quic =
-            bind_more_with_config(tpu_forwards_quic, num_quic_endpoints.get(), socket_config)
-                .expect("tpu_forwards_quic multi_bind");
+        let mut tpu_forwards_quic = bind_more_with_config(
+            tpu_forwards_quic,
+            num_quic_endpoints.get(),
+            socket_configs.primarily_read_quic,
+        )
+        .expect("tpu_forwards_quic multi_bind");
 
         tpu_forwards_quic.append(
             &mut Self::bind_to_extra_ip(
                 &bind_ip_addrs,
                 tpu_forwards_quic_port,
                 num_quic_endpoints.get(),
-                socket_config,
+                socket_configs.primarily_read_quic,
             )
             .expect("Secondary bind TPU forwards"),
         );
         let tpu_forwards_quic_addresses = Self::get_socket_addrs(&tpu_forwards_quic);
 
-        let (tpu_vote_port, mut tpu_vote_sockets) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 1)
-                .expect("tpu_vote multi_bind");
+        let (tpu_vote_port, mut tpu_vote_sockets) = multi_bind_in_range_with_config(
+            bind_ip_addr,
+            port_range,
+            socket_configs.primarily_read_udp,
+            1,
+        )
+        .expect("tpu_vote multi_bind");
 
         tpu_vote_sockets.extend(
-            Self::bind_to_extra_ip(&bind_ip_addrs, tpu_vote_port, 1, socket_config)
-                .expect("Secondary binds for tpu vote"),
+            Self::bind_to_extra_ip(
+                &bind_ip_addrs,
+                tpu_vote_port,
+                1,
+                socket_configs.primarily_read_udp,
+            )
+            .expect("Secondary binds for tpu vote"),
         );
         let tpu_vote_addresses = Self::get_socket_addrs(&tpu_vote_sockets);
 
         let (tpu_vote_quic_port, tpu_vote_quic) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_configs.primarily_read_quic)
                 .expect("tpu_vote_quic");
-        let mut tpu_vote_quic =
-            bind_more_with_config(tpu_vote_quic, num_quic_endpoints.get(), socket_config)
-                .expect("tpu_vote_quic multi_bind");
+        let mut tpu_vote_quic = bind_more_with_config(
+            tpu_vote_quic,
+            num_quic_endpoints.get(),
+            socket_configs.primarily_read_quic,
+        )
+        .expect("tpu_vote_quic multi_bind");
         tpu_vote_quic.append(
             &mut Self::bind_to_extra_ip(
                 &bind_ip_addrs,
                 tpu_vote_quic_port,
                 num_quic_endpoints.get(),
-                socket_config,
+                socket_configs.primarily_read_quic,
             )
             .expect("Secondary bind TPU vote"),
         );
@@ -187,7 +245,7 @@ impl Node {
         let (tvu_retransmit_port, mut retransmit_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
-            socket_config,
+            socket_configs.primarily_write_udp,
             num_tvu_retransmit_sockets.get(),
         )
         .expect("tvu retransmit multi_bind");
@@ -197,51 +255,68 @@ impl Node {
                 &bind_ip_addrs,
                 tvu_retransmit_port,
                 num_tvu_retransmit_sockets.get(),
-                socket_config,
+                socket_configs.primarily_write_udp,
             )
             .expect("Secondary bind TVU retransmit"),
         );
 
-        let (_, repair) = bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
-            .expect("repair bind");
-        let (_, repair_quic) = bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
-            .expect("repair_quic bind");
+        let (_, repair) =
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_configs.read_write)
+                .expect("repair bind");
+        let (_, repair_quic) =
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_configs.read_write)
+                .expect("repair_quic bind");
 
         let (serve_repair_port, serve_repair) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_configs.read_write)
                 .expect("serve_repair");
         let (serve_repair_quic_port, serve_repair_quic) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_configs.read_write)
                 .expect("serve_repair_quic");
 
-        let (broadcast_port, mut broadcast) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 4)
-                .expect("broadcast multi_bind");
+        let (broadcast_port, mut broadcast) = multi_bind_in_range_with_config(
+            bind_ip_addr,
+            port_range,
+            socket_configs.primarily_write_udp,
+            4,
+        )
+        .expect("broadcast multi_bind");
         // Multihoming TX for broadcast
         broadcast.append(
-            &mut Self::bind_to_extra_ip(&bind_ip_addrs, broadcast_port, 4, socket_config)
-                .expect("Secondary bind broadcast"),
+            &mut Self::bind_to_extra_ip(
+                &bind_ip_addrs,
+                broadcast_port,
+                4,
+                socket_configs.primarily_write_udp,
+            )
+            .expect("Secondary bind broadcast"),
         );
 
         let (_, ancestor_hashes_requests) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_configs.read_write)
                 .expect("ancestor_hashes_requests bind");
         let (_, ancestor_hashes_requests_quic) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_configs.read_write)
                 .expect("ancestor_hashes_requests QUIC bind should succeed");
 
         let (alpenglow_port, alpenglow) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_configs.read_write)
                 .expect("Alpenglow port bind should succeed");
         // These are "client" sockets, so they could use ephemeral ports, but we
         // force them into the provided port_range to simplify the operations.
 
         // vote forwarding is only bound to primary interface for now
         let (_, tpu_vote_forwarding_client) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config).unwrap();
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_configs.primarily_write_udp)
+                .unwrap();
 
         let (tpu_transaction_forwarding_client_port, tpu_transaction_forwarding_clients) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config).expect(
+            bind_in_range_with_config(
+                bind_ip_addr,
+                port_range,
+                socket_configs.primarily_write_quic,
+            )
+            .expect(
                 "TPU transaction forwarding client bind on interface {bind_ip_addr} should succeed",
             );
         let tpu_transaction_forwarding_clients = once(tpu_transaction_forwarding_clients)
@@ -250,20 +325,28 @@ impl Node {
                     &bind_ip_addrs,
                     tpu_transaction_forwarding_client_port,
                     1,
-                    socket_config,
+                    socket_configs.primarily_write_quic,
                 )
                 .expect("Secondary interface binds for tpu forward clients should succeed"),
             )
             .collect();
 
-        let (_, quic_vote_client) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config).unwrap();
+        let (_, quic_vote_client) = bind_in_range_with_config(
+            bind_ip_addr,
+            port_range,
+            socket_configs.primarily_write_quic,
+        )
+        .unwrap();
 
         let (_, quic_alpenglow_client) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config).unwrap();
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_configs.read_write).unwrap();
 
-        let (_, rpc_sts_client) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config).unwrap();
+        let (_, rpc_sts_client) = bind_in_range_with_config(
+            bind_ip_addr,
+            port_range,
+            socket_configs.primarily_write_quic,
+        )
+        .unwrap();
 
         let mut info = ContactInfo::new(
             *pubkey,


### PR DESCRIPTION
Follow Up to PR: https://github.com/anza-xyz/agave/pull/3929 and redo of: https://github.com/anza-xyz/agave/pull/4313

#### Problem
According to the agave validator docs, the max buffer sizes should be set to 128 MB. See: https://github.com/anza-xyz/agave/blob/6133008a0b9f1d599bf53c8c8127072801ed5614/docs/src/operations/setup-a-validator.md?plain=1#L317-L321. But we do not make a recommendation for default size. Default size is host dependent. The default size is the limit the buffer can be until the operator calls `setsockopt` on the socket and increases (limited by `net.core.rmem_max` and `net.core.wmem_max`). 

While the kernel doesn't pre allocate memory for these buffers, we want to prevent the kernel from allocating twice the memory for protocols that don't read AND write from their socket(s). For example, `retransmit_sockets` are strictly write-only sockets. A peer can send to the `retransmit_sockets` and get the node to allocate memory that will never be used (except to hold the garbage data sent by the peer). 

The "unused" side of a socket is either the read or write side of the socket that is not used. So for `retransmit_sockets` the "unused" side is the read side. For `tvu`, the unused side is the write side.

#### Summary of Changes
1) QUIC: Reduce "unused" side of socket to 4 MB (need enough for control traffic)
2) UDP: Reduce "unused" side of socket to 0 MB (the kernel will actually set these to 2048 bytes and 256 bytes for send and receiver buffers respectively): https://man7.org/linux/man-pages/man7/socket.7.html
3) I purposely did not touch Alpenglow related sockets here

Services/Sockets as defined in `Sockets`: https://github.com/anza-xyz/agave/blob/e9052f0e63bca0839b9b0eef8ca945c2d07eee0f/gossip/src/cluster_info.rs#L2369-L2408

**_Read/Write_**
```
gossip
ip_echo
repair
repair_quic
serve_repair
serve_repair_quic
ancestor_hashes_requests_quic
ancestor_hashes_requests
alpenglow
```

**_Read Only_ : \<send buffer size\>**
```
tvu: 0 MB 
tpu: 0 MB
tpu_forwards: 0 MB
tpu_vote: 0 MB
vortexor_receivers: 0 MB
tvu_quic: 4 MB
tpu_quic: 4 MB 
tpu_forwards_quic:4 MB
tpu_vote_quic: 4 MB
```


**_Write Only_ : \<read buffer size\>**
```
retransmitter: 0 MB
broadcast: 0 MB
tpu_vote_forwarding_client: 0 MB
quic_vote_client: 4 MB
tpu_transaction_forwarding_clients: 4MB
rpc_sts_client (quic): 4 MB
quic_alpenglow_client: <unchanged>
```

