### PR TITLE
Update docs that reference Solana Labs in roles that have been taken over by Anza

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ maintainer to review.
 
 Add only code to the codebase that is ready to be deployed. If you are building
 a large library, consider developing it in a separate git repository. When it
-is ready to be integrated, the Solana Labs Maintainers will work with you to decide
+is ready to be integrated, the repository maintainers will work with you to decide
 on a path forward. Smaller libraries may be copied in whereas very large ones
 may be pulled in with a package manager.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,10 @@ This validator's documentation is built using [Docusaurus v2](https://v2.docusau
 Static content delivery is handled using `vercel`.
 
 > Note: The documentation within this repo is specifically focused on the
-> Solana validator client maintained by Solana Labs. The more "common"
-> documentation, which is generalized to the Solana protocol as a whole and applies
+> Agave validator client maintained by Anza. Solana protocol documentation, which applies
 > to all Solana validator implementations, is maintained within the
 > [`developer-content`](https://github.com/solana-foundation/developer-content/)
-> repo. Those "common docs" are managed by the Solana Foundation within their
+> repo. Those protocol docs are managed by the Solana Foundation within their
 > GitHub organization and are publicly accessible via
 > [solana.com/docs](https://solana.com/docs)
 

--- a/docs/src/clusters/available.md
+++ b/docs/src/clusters/available.md
@@ -66,7 +66,7 @@ $ agave-validator \
 ```
 
 The [`--known-validator`s](../operations/guides/validator-start.md#known-validators)
-are operated by Solana Labs
+are operated by Anza
 
 ## Testnet
 
@@ -119,7 +119,7 @@ $ agave-validator \
 The identities of the
 [`--known-validator`s](../operations/guides/validator-start.md#known-validators) are:
 
-- `5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on` - Solana Labs
+- `5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on` - Anza
 - `dDzy5SR3AXdYWVqbDEkVFdvSPCtS9ihF5kJkHCtXoFs` - MonkeDAO
 - `Ft5fbkqNa76vnsjYNwjDZUXoTWpP7VYm3mtsaQckQADN` - Certus One
 - `eoKpUABi59aT4rR9HGS3LcMecfut9x7zJyodWWP43YQ` - SerGo
@@ -172,5 +172,5 @@ $ agave-validator \
 
 :::info
 The above four [`--known-validator`s](../operations/guides/validator-start.md#known-validators)
-are operated by Solana Labs.
+are operated by Anza.
 :::

--- a/docs/src/operations/setup-an-rpc-node.md
+++ b/docs/src/operations/setup-an-rpc-node.md
@@ -61,7 +61,7 @@ If you are interested in setting up your own bigtable instance, see these docs i
 
 The identities of the [known validators](./guides/validator-start.md#known-validators) supplied in these example snippets (via the `--known-validator` flag) are:
 
-- `5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on` - Solana Labs
+- `5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on` - Anza
 - `dDzy5SR3AXdYWVqbDEkVFdvSPCtS9ihF5kJkHCtXoFs` - MonkeDAO
 - `Ft5fbkqNa76vnsjYNwjDZUXoTWpP7VYm3mtsaQckQADN` - Certus One
 - `eoKpUABi59aT4rR9HGS3LcMecfut9x7zJyodWWP43YQ` - SerGo


### PR DESCRIPTION
Found an old, unmerged branch with some Labs cleanup 😅 

Other than these changes there are 3 remaining instances of `Solana Labs` in this repo, but they all reference Labs in a historical context.