### PR TITLE
validator: Remove --dev-halt-at-slot argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Release channels have their own copy of this changelog:
   * `--accounts-db-read-cache-limit-mb`
   * `--accounts-hash-cache-path`
   * `--disable-accounts-disk-index`
+  * `--dev-halt-at-slot`
 #### Deprecations
 * Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -307,7 +307,6 @@ pub struct GeneratorConfig {
 pub struct ValidatorConfig {
     /// The destination file for validator logs; `stderr` is used if `None`
     pub logfile: Option<PathBuf>,
-    pub halt_at_slot: Option<Slot>,
     pub expected_genesis_hash: Option<Hash>,
     pub expected_bank_hash: Option<Hash>,
     pub expected_shred_version: Option<u16>,
@@ -390,7 +389,6 @@ impl ValidatorConfig {
 
         Self {
             logfile: None,
-            halt_at_slot: None,
             expected_genesis_hash: None,
             expected_bank_hash: None,
             expected_shred_version: None,
@@ -502,7 +500,11 @@ pub enum ValidatorStartProgress {
         max_slot: Slot,
     },
     StartingServices,
-    Halted, // Validator halted due to `--dev-halt-at-slot` argument
+    // This case corresponds to a state that is entered by using the now
+    // deprecated `--dev-halt-at-slot` flag. A different version of the
+    // validator may be used to monitor a running validator so leave the case
+    // here to avoid any compatibility concerns
+    Halted,
     WaitingForSupermajority {
         slot: Slot,
         gossip_stake_percent: u64,
@@ -1318,19 +1320,6 @@ impl Validator {
             (None, None, None, None, None, None, None, None)
         };
 
-        if config.halt_at_slot.is_some() {
-            // Simulate a confirmed root to avoid RPC errors with CommitmentConfig::finalized() and
-            // to ensure RPC endpoints like getConfirmedBlock, which require a confirmed root, work
-            block_commitment_cache
-                .write()
-                .unwrap()
-                .set_highest_super_majority_root(bank_forks.read().unwrap().root());
-
-            // Park with the RPC service running, ready for inspection!
-            warn!("Validator halted");
-            *start_progress.write().unwrap() = ValidatorStartProgress::Halted;
-            std::thread::park();
-        }
         let ip_echo_server = match node.sockets.ip_echo {
             None => None,
             Some(tcp_listener) => Some(solana_net_utils::ip_echo_server(
@@ -2179,9 +2168,7 @@ fn load_blockstore(
 
     let blockstore = Arc::new(blockstore);
     let blockstore_root_scan = BlockstoreRootScan::new(config, blockstore.clone(), exit.clone());
-    let halt_at_slot = config
-        .halt_at_slot
-        .or_else(|| blockstore.highest_slot().unwrap_or(None));
+    let halt_at_slot = blockstore.highest_slot().unwrap_or(None);
 
     let process_options = blockstore_processor::ProcessOptions {
         run_verification: config.run_verification,

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -7,7 +7,6 @@ use {
 pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
     ValidatorConfig {
         logfile: config.logfile.clone(),
-        halt_at_slot: config.halt_at_slot,
         expected_genesis_hash: config.expected_genesis_hash,
         expected_bank_hash: config.expected_bank_hash,
         expected_shred_version: config.expected_shred_version,

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -25,9 +25,6 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --gossip-port ]]; then
       args+=("$1" "$2")
       shift 2
-    elif [[ $1 = --dev-halt-at-slot ]]; then
-      args+=("$1" "$2")
-      shift 2
     elif [[ $1 = --dynamic-port-range ]]; then
       args+=("$1" "$2")
       shift 2

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -104,9 +104,6 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --dev-no-sigverify ]]; then
       args+=("$1")
       shift
-    elif [[ $1 = --dev-halt-at-slot ]]; then
-      args+=("$1" "$2")
-      shift 2
     elif [[ $1 = --rpc-port ]]; then
       args+=("$1" "$2")
       shift 2

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -137,16 +137,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         usage_warning: "CUDA support will be dropped"
     );
     add_arg!(
-        // deprecated in v3.1.3
-        Arg::with_name("dev_halt_at_slot")
-            .long("dev-halt-at-slot")
-            .value_name("SLOT")
-            .validator(is_slot)
-            .takes_value(true)
-            .help("Halt the validator when it reaches the given slot"),
-        usage_warning: "--dev-halt-at-slot will be removed in the future"
-    );
-    add_arg!(
         // deprecated in v3.1.0
         Arg::with_name("tpu_coalesce_ms")
             .long("tpu-coalesce-ms")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -504,7 +504,6 @@ pub fn execute(
         logfile,
         require_tower: matches.is_present("require_tower"),
         tower_storage,
-        halt_at_slot: value_t!(matches, "dev_halt_at_slot", Slot).ok(),
         max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         expected_genesis_hash: matches
             .value_of("expected_genesis_hash")


### PR DESCRIPTION
#### Summary of Changes
This was a debug flag to stop the validator midway through startup; it has no value now so remove the underlying logic and mark the flag as deprecated

The flag was added prior to 8b2327ed349 (2019); I didn't care to go digging further but I think its time has come