### PR TITLE
Move startup disk index flushing to index generation

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6537,7 +6537,7 @@ impl AccountsDb {
                             let mut thread_accum = IndexGenerationAccumulator::new();
                             let mut reader = append_vec::new_scan_accounts_reader();
                             while let Some(next_item) = storages_orderer.next() {
-                                self.maybe_throttle_index_generation();
+                                //self.maybe_throttle_index_generation();
                                 let storage = next_item.storage;
                                 let store_id = storage.id();
                                 let slot = storage.slot();
@@ -6892,6 +6892,7 @@ impl AccountsDb {
 
     /// Startup processes can consume large amounts of memory while inserting accounts into the index as fast as possible.
     /// Calling this can slow down the insertion process to allow flushing to disk to keep pace.
+    #[allow(dead_code)]
     fn maybe_throttle_index_generation(&self) {
         // Only throttle if we are generating on-disk index. Throttling is not needed for in-mem index.
         if !self.accounts_index.is_disk_index_enabled() {

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1351,7 +1351,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
 
             let items = items.drain(start_index..);
             if use_disk {
-                r_account_maps.startup_insert_only(slot, items);
+                r_account_maps.write_startup_items_to_disk(slot, items);
             } else {
                 // not using disk buckets, so just write to in-mem
                 // this is no longer the default case

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -47,7 +47,7 @@ pub struct InMemAccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<
     flushing_active: AtomicBool,
 
     /// info to streamline initial index generation
-    startup_info: StartupInfo<T, U>,
+    startup_info: StartupInfo<T>,
 
     /// how many more ages to skip before this bucket is flushed (as opposed to being skipped).
     /// When this reaches 0, this bucket is flushed.
@@ -100,9 +100,7 @@ struct StartupInfoDuplicates<T: IndexValue> {
 }
 
 #[derive(Default, Debug)]
-struct StartupInfo<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
-    /// entries to add next time we are flushing to disk
-    insert: Mutex<Vec<(Pubkey, (Slot, U))>>,
+struct StartupInfo<T: IndexValue> {
     /// pubkeys with more than 1 entry
     duplicates: Mutex<StartupInfoDuplicates<T>>,
 }
@@ -674,22 +672,22 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         )
     }
 
-    /// Queue up these insertions for when the flush thread is dealing with this bin.
-    /// This is very fast and requires no lookups or disk access.
-    pub fn startup_insert_only(
+    /// Write drained startup items for this bin directly to disk.
+    pub fn write_startup_items_to_disk(
         &self,
         slot: Slot,
-        items: impl ExactSizeIterator<Item = (Pubkey, T)>,
+        items: impl Iterator<Item = (Pubkey, T)>,
     ) {
         assert!(self.storage.get_startup());
         assert!(self.bucket.is_some());
 
-        let mut insert = self.startup_info.insert.lock().unwrap();
         let m = Measure::start("copy");
-        insert.extend(items.map(|(k, v)| (k, (slot, v.into()))));
+        let insert: Vec<_> = items.map(|(k, v)| (k, (slot, v.into()))).collect();
         self.startup_stats
             .copy_data_us
             .fetch_add(m.end_as_us(), Ordering::Relaxed);
+
+        self.write_startup_info_to_disk(insert);
     }
 
     pub fn startup_update_duplicates_from_in_memory_only(&self, items: Vec<(Slot, Pubkey)>) {
@@ -962,8 +960,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         possible_evictions
     }
 
-    fn write_startup_info_to_disk(&self) {
-        let insert = std::mem::take(&mut *self.startup_info.insert.lock().unwrap());
+    fn write_startup_info_to_disk(&self, insert: Vec<(Pubkey, (Slot, U))>) {
         if insert.is_empty() {
             // nothing to insert for this bin
             return;
@@ -979,7 +976,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         );
         drop(map_internal);
 
-        // this fn should only be called from a single thread, so holding the lock is fine
+        // This fn is now called from multiple threads. lock is **required** to
+        // prevent race conditions. However, this can cause contention on the
+        // threads. Now I appreciate the previous design to call this fn in
+        // flushing threads, where only *one* thread is writing the disk index
+        // at a time.
         let mut duplicates = self.startup_info.duplicates.lock().unwrap();
 
         // merge all items into the disk index now
@@ -1005,9 +1006,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// These were collected for this bin when we did batch inserts in the bg flush threads.
     /// Insert these into the in-mem index, then return the duplicate (Slot, Pubkey)
     pub fn populate_and_retrieve_duplicate_keys_from_startup(&self) -> Vec<(Slot, Pubkey)> {
-        // in order to return accurate and complete duplicates, we must have nothing left remaining to insert
-        assert!(self.startup_info.insert.lock().unwrap().is_empty());
-
         let mut duplicate_items = self.startup_info.duplicates.lock().unwrap();
         let duplicates = std::mem::take(&mut duplicate_items.duplicates);
         let duplicates_put_on_disk = std::mem::take(&mut duplicate_items.duplicates_put_on_disk);
@@ -1084,7 +1082,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             // At startup we do not insert index entries into the normal in-mem index.
             // Instead, they are written to a startup-only struct.  Thus, at startup
             // we only need to flush that startup struct and then can return early.
-            self.write_startup_info_to_disk();
+            // self.write_startup_info_to_disk();
             if iterate_for_age {
                 // Note we still have to iterate ages too, since it is checked when
                 // transitioning from startup back to normal/steady state.


### PR DESCRIPTION
#### Problem

The current background index flushing code handles startup-only disk index insertion logic. 

This makes normal steady-state code had to branch on get_startup() check even
thouth they never execute. It also makes the code more complex than it should
be. 


#### Summary of Changes

This PR moves startup flushing to index generation:
insert_new_if_missing_into_primary_index() now calls flush_startup_inserts()
immediately after batching entries, and InMemAccountsIndex::flush_internal() no
longer checks the startup flag. The new helper simply drains the startup queue
when building the index, while steady-state flushes run the streamlined path.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
