### PR TITLE
SIMD-0290: Relax fee-payer constraint

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -355,6 +355,10 @@ impl Consumer {
             balance_collector,
         } = load_and_execute_transactions_output;
 
+        // HANA TODO i think we can safely transform ProcessedTransaction::NoOp into Err here
+        // this *should* let us avoid committing them when building blocks, but handle them gracefully in replay
+        // until we actually *do* async execution there is no reason to write garbage to chain
+
         let actual_execute_time = execute_and_commit_timings
             .execute_timings
             .execute_accessories

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -178,6 +178,7 @@ impl FeatureSet {
             create_account_allow_prefund: self.is_active(&create_account_allow_prefund::id()),
             bls_pubkey_management_in_vote_account: self
                 .is_active(&bls_pubkey_management_in_vote_account::id()),
+            relax_fee_payer_constraint: self.is_active(&relax_fee_payer_constraint::id()),
         }
     }
 }
@@ -1224,6 +1225,10 @@ pub mod relax_programdata_account_check_migration {
     solana_pubkey::declare_id!("rexav5eNTUSNT1K2N7cfRjnthwhcP5BC25v2tA4rW4h");
 }
 
+pub mod relax_fee_payer_constraint {
+    solana_pubkey::declare_id!("FEEXbxUuKobtrt1qNK5pjtzbPQhsppBTrNNG74xu4mai");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2194,6 +2199,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             relax_programdata_account_check_migration::id(),
             "SIMD-0444: Relax program data account check in migration",
+        ),
+        (
+            relax_fee_payer_constraint::id(),
+            "SIMD-0290: Relax block constraint requiring valid fee-payer",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -37,6 +37,7 @@ fn max_number_of_accounts_to_collect(
                 }
             }
             ProcessedTransaction::FeesOnly(fees_only_tx) => fees_only_tx.rollback_accounts.count(),
+            ProcessedTransaction::NoOp(_) => 0,
         })
         .sum()
 }
@@ -96,6 +97,7 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
                     &fees_only_tx.rollback_accounts,
                 );
             }
+            ProcessedTransaction::NoOp(_) => (),
         }
     }
     (accounts, transactions)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3258,9 +3258,9 @@ impl Bank {
                         executed_units,
                         loaded_accounts_data_size,
                     ),
-                    ProcessedTransaction::NoOp(err) => (
+                    ProcessedTransaction::NoOp(no_op_tx) => (
                         vec![],
-                        Err(err),
+                        Err(no_op_tx.validation_error),
                         None,
                         None,
                         None,
@@ -3849,20 +3849,19 @@ impl Bank {
                             .1
                             .lamports(),
                     }),
-                    // HANA idk if i like making fee_payer_post_balance 0... maybe could be an Option
-                    // but it affects all the way out to rpc/bigtable so its very annoying and breaking
-                    ProcessedTransaction::NoOp(err) => Ok(CommittedTransaction {
-                        status: Err(err),
+                    ProcessedTransaction::NoOp(no_op_tx) => Ok(CommittedTransaction {
+                        status: Err(no_op_tx.validation_error),
                         log_messages: None,
                         inner_instructions: None,
                         return_data: None,
                         executed_units,
+                        // HANA what is fee details doing here exactly? do we need to create it from Bank?
                         fee_details: FeeDetails::default(),
                         loaded_account_stats: TransactionLoadedAccountsStats {
                             loaded_accounts_count: 0,
                             loaded_accounts_data_size,
                         },
-                        fee_payer_post_balance: 0,
+                        fee_payer_post_balance: no_op_tx.fee_payer_balance.unwrap_or(0),
                     }),
                 }
             })

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3258,6 +3258,17 @@ impl Bank {
                         executed_units,
                         loaded_accounts_data_size,
                     ),
+                    ProcessedTransaction::NoOp(err) => (
+                        vec![],
+                        Err(err),
+                        // HANA unclear to me if Some(0) and None have any important semantic distinction
+                        Some(0),
+                        None,
+                        None,
+                        None,
+                        executed_units,
+                        loaded_accounts_data_size,
+                    ),
                 }
             }
             Err(error) => (vec![], Err(error), None, None, None, None, 0, 0),
@@ -3838,6 +3849,21 @@ impl Bank {
                             .fee_payer()
                             .1
                             .lamports(),
+                    }),
+                    // HANA idk if i like making fee_payer_post_balance 0... maybe could be an Option
+                    // but it affects all the way out to rpc/bigtable so its very annoying and breaking
+                    ProcessedTransaction::NoOp(err) => Ok(CommittedTransaction {
+                        status: Err(err),
+                        log_messages: None,
+                        inner_instructions: None,
+                        return_data: None,
+                        executed_units,
+                        fee_details: FeeDetails::default(),
+                        loaded_account_stats: TransactionLoadedAccountsStats {
+                            loaded_accounts_count: 0,
+                            loaded_accounts_data_size,
+                        },
+                        fee_payer_post_balance: 0,
                     }),
                 }
             })

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3261,8 +3261,7 @@ impl Bank {
                     ProcessedTransaction::NoOp(err) => (
                         vec![],
                         Err(err),
-                        // HANA unclear to me if Some(0) and None have any important semantic distinction
-                        Some(0),
+                        None,
                         None,
                         None,
                         None,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3855,8 +3855,7 @@ impl Bank {
                         inner_instructions: None,
                         return_data: None,
                         executed_units,
-                        // HANA what is fee details doing here exactly? do we need to create it from Bank?
-                        fee_details: FeeDetails::default(),
+                        fee_details: no_op_tx.fee_details,
                         loaded_account_stats: TransactionLoadedAccountsStats {
                             loaded_accounts_count: 0,
                             loaded_accounts_data_size,

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -55,6 +55,7 @@ pub struct SVMFeatureSet {
     pub alt_bn128_little_endian: bool,
     pub create_account_allow_prefund: bool,
     pub bls_pubkey_management_in_vote_account: bool,
+    pub relax_fee_payer_constraint: bool,
 }
 
 impl SVMFeatureSet {
@@ -106,6 +107,7 @@ impl SVMFeatureSet {
             alt_bn128_little_endian: true,
             create_account_allow_prefund: true,
             bls_pubkey_management_in_vote_account: true,
+            relax_fee_payer_constraint: true,
         }
     }
 }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -982,9 +982,8 @@ mod tests {
                 assert_eq!(loaded_transaction.program_indices[0], 1);
             }
             TransactionLoadResult::FeesOnly(fees_only_tx) => panic!("{}", fees_only_tx.load_error),
-            TransactionLoadResult::NoOp(e) | TransactionLoadResult::Unprocessable(e) => {
-                panic!("{e}")
-            }
+            TransactionLoadResult::NoOp(no_op_tx) => panic!("{}", no_op_tx.validation_error),
+            TransactionLoadResult::Unprocessable(e) => panic!("{e}"),
         }
     }
 
@@ -1045,9 +1044,8 @@ mod tests {
                 assert_eq!(loaded_transaction.program_indices[1], 2);
             }
             TransactionLoadResult::FeesOnly(fees_only_tx) => panic!("{}", fees_only_tx.load_error),
-            TransactionLoadResult::NoOp(e) | TransactionLoadResult::Unprocessable(e) => {
-                panic!("{e}")
-            }
+            TransactionLoadResult::NoOp(no_op_tx) => panic!("{}", no_op_tx.validation_error),
+            TransactionLoadResult::Unprocessable(e) => panic!("{e}"),
         }
     }
 
@@ -1147,9 +1145,8 @@ mod tests {
                 assert_eq!(loaded_transaction.accounts[1].1.lamports(), 42);
             }
             TransactionLoadResult::FeesOnly(fees_only_tx) => panic!("{}", fees_only_tx.load_error),
-            TransactionLoadResult::NoOp(e) | TransactionLoadResult::Unprocessable(e) => {
-                panic!("{e}")
-            }
+            TransactionLoadResult::NoOp(no_op_tx) => panic!("{}", no_op_tx.validation_error),
+            TransactionLoadResult::Unprocessable(e) => panic!("{e}"),
         }
     }
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -47,21 +47,33 @@ pub(crate) const TRANSACTION_ACCOUNT_BASE_SIZE: usize = 64;
 // bytes: 8192 bytes for the maximum table size plus 56 bytes for metadata.
 const ADDRESS_LOOKUP_TABLE_BASE_SIZE: usize = 8248;
 
-// for the load instructions
+// Result of pre-SVM (runtime) transaction checks.
 pub type TransactionCheckResult = Result<CheckedTransactionDetails>;
-type TransactionValidationResult = Result<ValidatedTransactionDetails>;
+
+// Combined result of runtime, fee-payer, and nonce checks.
+// HANA idk if i want to box or not. probably not
+#[allow(clippy::large_enum_variant)]
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub(crate) enum TransactionValidationResult {
+    Loadable(ValidatedTransactionDetails),
+    NoOp(TransactionError),
+    Unprocessable(TransactionError),
+}
 
 #[derive(PartialEq, Eq, Debug)]
 pub(crate) enum TransactionLoadResult {
-    /// All transaction accounts were loaded successfully
+    /// All transaction accounts were loaded successfully.
     Loaded(LoadedTransaction),
     /// Some transaction accounts needed for execution were unable to be loaded
     /// but the fee payer and any nonce account needed for fee collection were
-    /// loaded successfully
+    /// loaded successfully.
     FeesOnly(FeesOnlyTransaction),
-    /// Some transaction accounts needed for fee collection were unable to be
-    /// loaded
-    NotLoaded(TransactionError),
+    /// This transaction will be processed but entail no account state changes.
+    /// If SIMD-0290 is enabled, invalid fee-payers are processable.
+    /// If SIMD-0297 is enabled, invalid nonce accounts are processable.
+    NoOp(TransactionError),
+    /// Mandatory checks failed; this transaction will be discarded as unprocessable.
+    Unprocessable(TransactionError),
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -163,7 +175,6 @@ pub struct FeesOnlyTransaction {
 pub(crate) struct AccountLoader<'a, CB: TransactionProcessingCallback> {
     loaded_accounts: AHashMap<Pubkey, (AccountSharedData, Slot)>,
     callbacks: &'a CB,
-    #[allow(unused)]
     pub(crate) feature_set: &'a SVMFeatureSet,
 }
 
@@ -408,8 +419,9 @@ pub(crate) fn load_transaction<CB: TransactionProcessingCallback>(
     rent: &Rent,
 ) -> TransactionLoadResult {
     match validation_result {
-        Err(e) => TransactionLoadResult::NotLoaded(e),
-        Ok(tx_details) => {
+        TransactionValidationResult::Unprocessable(e) => TransactionLoadResult::Unprocessable(e),
+        TransactionValidationResult::NoOp(e) => TransactionLoadResult::NoOp(e),
+        TransactionValidationResult::Loadable(tx_details) => {
             let load_result = load_transaction_accounts(
                 account_loader,
                 message,
@@ -770,7 +782,7 @@ mod tests {
         load_transaction(
             &mut account_loader,
             &sanitized_tx,
-            Ok(ValidatedTransactionDetails {
+            TransactionValidationResult::Loadable(ValidatedTransactionDetails {
                 loaded_fee_payer_account: LoadedTransactionAccount {
                     account: fee_payer_account,
                     ..LoadedTransactionAccount::default()
@@ -963,7 +975,9 @@ mod tests {
                 assert_eq!(loaded_transaction.program_indices[0], 1);
             }
             TransactionLoadResult::FeesOnly(fees_only_tx) => panic!("{}", fees_only_tx.load_error),
-            TransactionLoadResult::NotLoaded(e) => panic!("{e}"),
+            TransactionLoadResult::NoOp(e) | TransactionLoadResult::Unprocessable(e) => {
+                panic!("{e}")
+            }
         }
     }
 
@@ -1024,7 +1038,9 @@ mod tests {
                 assert_eq!(loaded_transaction.program_indices[1], 2);
             }
             TransactionLoadResult::FeesOnly(fees_only_tx) => panic!("{}", fees_only_tx.load_error),
-            TransactionLoadResult::NotLoaded(e) => panic!("{e}"),
+            TransactionLoadResult::NoOp(e) | TransactionLoadResult::Unprocessable(e) => {
+                panic!("{e}")
+            }
         }
     }
 
@@ -1054,7 +1070,7 @@ mod tests {
         load_transaction(
             &mut account_loader,
             &tx,
-            Ok(ValidatedTransactionDetails::default()),
+            TransactionValidationResult::Loadable(ValidatedTransactionDetails::default()),
             &mut error_metrics,
             &Rent::default(),
         )
@@ -1124,7 +1140,9 @@ mod tests {
                 assert_eq!(loaded_transaction.accounts[1].1.lamports(), 42);
             }
             TransactionLoadResult::FeesOnly(fees_only_tx) => panic!("{}", fees_only_tx.load_error),
-            TransactionLoadResult::NotLoaded(e) => panic!("{e}"),
+            TransactionLoadResult::NoOp(e) | TransactionLoadResult::Unprocessable(e) => {
+                panic!("{e}")
+            }
         }
     }
 
@@ -1880,7 +1898,7 @@ mod tests {
         let load_result = load_transaction(
             &mut account_loader,
             &sanitized_tx.clone(),
-            Ok(ValidatedTransactionDetails::default()),
+            TransactionValidationResult::Loadable(ValidatedTransactionDetails::default()),
             &mut error_metrics,
             &Rent::default(),
         );
@@ -1966,13 +1984,14 @@ mod tests {
             false,
         );
 
-        let validation_result = Ok(ValidatedTransactionDetails {
-            loaded_fee_payer_account: LoadedTransactionAccount {
-                account: fee_payer_account,
-                loaded_size: TRANSACTION_ACCOUNT_BASE_SIZE,
-            },
-            ..ValidatedTransactionDetails::default()
-        });
+        let validation_result =
+            TransactionValidationResult::Loadable(ValidatedTransactionDetails {
+                loaded_fee_payer_account: LoadedTransactionAccount {
+                    account: fee_payer_account,
+                    loaded_size: TRANSACTION_ACCOUNT_BASE_SIZE,
+                },
+                ..ValidatedTransactionDetails::default()
+            });
 
         let load_result = load_transaction(
             &mut account_loader,
@@ -2037,7 +2056,9 @@ mod tests {
             false,
         );
 
-        let validation_result = Ok(ValidatedTransactionDetails::default());
+        let validation_result =
+            TransactionValidationResult::Loadable(ValidatedTransactionDetails::default());
+
         let load_result = load_transaction(
             &mut account_loader,
             &sanitized_transaction,
@@ -2054,7 +2075,8 @@ mod tests {
             }),
         ));
 
-        let validation_result = Err(TransactionError::InvalidWritableAccount);
+        let validation_result =
+            TransactionValidationResult::Unprocessable(TransactionError::InvalidWritableAccount);
 
         let load_result = load_transaction(
             &mut account_loader,
@@ -2066,7 +2088,7 @@ mod tests {
 
         assert!(matches!(
             load_result,
-            TransactionLoadResult::NotLoaded(TransactionError::InvalidWritableAccount),
+            TransactionLoadResult::Unprocessable(TransactionError::InvalidWritableAccount),
         ));
     }
 
@@ -2160,13 +2182,14 @@ mod tests {
             vec![Signature::new_unique()],
             false,
         );
-        let validation_result = Ok(ValidatedTransactionDetails {
-            loaded_fee_payer_account: LoadedTransactionAccount {
-                account: account0.clone(),
-                ..LoadedTransactionAccount::default()
-            },
-            ..ValidatedTransactionDetails::default()
-        });
+        let validation_result =
+            TransactionValidationResult::Loadable(ValidatedTransactionDetails {
+                loaded_fee_payer_account: LoadedTransactionAccount {
+                    account: account0.clone(),
+                    ..LoadedTransactionAccount::default()
+                },
+                ..ValidatedTransactionDetails::default()
+            });
         let _load_results = load_transaction(
             &mut account_loader,
             &sanitized_transaction,

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -169,6 +169,7 @@ pub struct FeesOnlyTransaction {
 pub struct NoOpTransaction {
     pub validation_error: TransactionError,
     pub fee_payer_balance: Option<u64>,
+    pub fee_details: FeeDetails,
 }
 
 // This is an internal SVM type that tracks account changes throughout a

--- a/svm/src/transaction_processing_result.rs
+++ b/svm/src/transaction_processing_result.rs
@@ -71,7 +71,7 @@ impl ProcessedTransaction {
         match self {
             Self::Executed(executed_tx) => executed_tx.loaded_transaction.fee_details,
             Self::FeesOnly(details) => details.fee_details,
-            Self::NoOp(_) => FeeDetails::default(),
+            Self::NoOp(details) => details.fee_details,
         }
     }
 

--- a/svm/src/transaction_processing_result.rs
+++ b/svm/src/transaction_processing_result.rs
@@ -24,6 +24,8 @@ pub enum ProcessedTransaction {
     /// Transaction was not able to be executed but fees are able to be
     /// collected and any nonces are advanceable
     FeesOnly(Box<FeesOnlyTransaction>),
+    /// Transactions that cannot modify state but can still be processed
+    NoOp(TransactionError),
 }
 
 impl TransactionProcessingResultExtensions for TransactionProcessingResult {
@@ -53,7 +55,7 @@ impl ProcessedTransaction {
     fn was_processed_with_successful_result(&self) -> bool {
         match self {
             Self::Executed(executed_tx) => executed_tx.execution_details.status.is_ok(),
-            Self::FeesOnly(_) => false,
+            Self::FeesOnly(_) | Self::NoOp(_) => false,
         }
     }
 
@@ -61,6 +63,7 @@ impl ProcessedTransaction {
         match self {
             Self::Executed(executed_tx) => executed_tx.execution_details.status.clone(),
             Self::FeesOnly(details) => Err(TransactionError::clone(&details.load_error)),
+            Self::NoOp(err) => Err(err.clone()),
         }
     }
 
@@ -68,20 +71,21 @@ impl ProcessedTransaction {
         match self {
             Self::Executed(executed_tx) => executed_tx.loaded_transaction.fee_details,
             Self::FeesOnly(details) => details.fee_details,
+            Self::NoOp(_) => FeeDetails::default(),
         }
     }
 
     pub fn executed_transaction(&self) -> Option<&ExecutedTransaction> {
         match self {
             Self::Executed(context) => Some(context),
-            Self::FeesOnly { .. } => None,
+            Self::FeesOnly(_) | Self::NoOp(_) => None,
         }
     }
 
     pub fn execution_details(&self) -> Option<&TransactionExecutionDetails> {
         match self {
             Self::Executed(context) => Some(&context.execution_details),
-            Self::FeesOnly { .. } => None,
+            Self::FeesOnly(_) | Self::NoOp(_) => None,
         }
     }
 
@@ -95,6 +99,7 @@ impl ProcessedTransaction {
         match self {
             Self::Executed(context) => context.loaded_transaction.loaded_accounts_data_size,
             Self::FeesOnly(details) => details.rollback_accounts.data_size() as u32,
+            Self::NoOp(_) => 0,
         }
     }
 }

--- a/svm/src/transaction_processing_result.rs
+++ b/svm/src/transaction_processing_result.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        account_loader::FeesOnlyTransaction,
+        account_loader::{FeesOnlyTransaction, NoOpTransaction},
         transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
     },
     solana_fee_structure::FeeDetails,
@@ -25,7 +25,7 @@ pub enum ProcessedTransaction {
     /// collected and any nonces are advanceable
     FeesOnly(Box<FeesOnlyTransaction>),
     /// Transactions that cannot modify state but can still be processed
-    NoOp(TransactionError),
+    NoOp(Box<NoOpTransaction>),
 }
 
 impl TransactionProcessingResultExtensions for TransactionProcessingResult {
@@ -63,7 +63,7 @@ impl ProcessedTransaction {
         match self {
             Self::Executed(executed_tx) => executed_tx.execution_details.status.clone(),
             Self::FeesOnly(details) => Err(TransactionError::clone(&details.load_error)),
-            Self::NoOp(err) => Err(err.clone()),
+            Self::NoOp(details) => Err(TransactionError::clone(&details.validation_error)),
         }
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -728,6 +728,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 TransactionValidationResult::NoOp(NoOpTransaction {
                     validation_error: e,
                     fee_payer_balance,
+                    fee_details: compute_budget_and_limits.fee_details,
                 })
             }
             Err(e) => TransactionValidationResult::Unprocessable(e),


### PR DESCRIPTION
wip but i might want to break this pr up after i get it working. maybe like:
* new svm noop variants of check/validate, but return err and no new variant in processedtransaction
* new processedtransaction noop variant and handle it in runtime/blockstore/banking, but nothing ever creates it
* feature gate switch to create it

NOTE the svm/runtime parts of this look good. next step is triage test failures in core, ledger, and unified scheduler

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
