### PR TITLE
validator: Deprecate --dev-halt-at-slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ deprecated, signaling their inclusion in the Agave Unstable API. Enable the
 `agave-unstable-api` crate feature to acknowledge use of an interface that may break
 without warning. From v4.0.0 onward, symbols in these crates will be unavailable without
 `agave-unstable-api` enabled.
+* The `--dev-halt-at-slot` flag is now deprecated.
 
 #### Changes
 * The accounts index is now kept entirely in memory by default.

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -137,6 +137,16 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         usage_warning: "CUDA support will be dropped"
     );
     add_arg!(
+        // deprecated in v3.1.3
+        Arg::with_name("dev_halt_at_slot")
+            .long("dev-halt-at-slot")
+            .value_name("SLOT")
+            .validator(is_slot)
+            .takes_value(true)
+            .help("Halt the validator when it reaches the given slot"),
+        usage_warning: "--dev-halt-at-slot will be removed in the future"
+    );
+    add_arg!(
         // deprecated in v3.1.0
         Arg::with_name("tpu_coalesce_ms")
             .long("tpu-coalesce-ms")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -241,14 +241,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("dev_halt_at_slot")
-            .long("dev-halt-at-slot")
-            .value_name("SLOT")
-            .validator(is_slot)
-            .takes_value(true)
-            .help("Halt the validator when it reaches the given slot"),
-    )
-    .arg(
         Arg::with_name("rpc_port")
             .long("rpc-port")
             .value_name("PORT")


### PR DESCRIPTION
#### Problem
This was a debug flag to stop the validator midway through startup. The argument no longer has value so start the removal process by marking it deprecated. The flag was first added prior to https://github.com/anza-xyz/agave/commit/8b2327ed349b90ac19d0dab5539a223212c15974 (2019); I didn't care to go digging further but its time has come

#### Summary of Changes
Move the argument to deprecated list + add a CHANGELOG entry

Verified the flag can still be set:
```
$ cargo run -- --dev-halt-at-slot 20 --identity test-ledger/validator-keypair.json --log - 
...
--dev-halt-at-slot is deprecated.  --dev-halt-at-slot will be removed in the future.
[2025-11-22T21:10:12.559089000Z INFO  agave_validator::commands::run::execute] agave-validator 4.0.0 (src:144249c9; feat:3706929056, client:Agave)
[2025-11-22T21:10:12.559229000Z INFO  agave_validator::commands::run::execute] Starting validator with: ArgsOs {
        inner: [
            "/.../src/solana/target/debug/agave-validator",
            "--dev-halt-at-slot",
            "20",
            "--identity",
            "test-ledger/validator-keypair.json",
            "--log",
            "-",
        ],
    }
```