### PR TITLE
Include rollback accounts in simulate_transaction result

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3185,16 +3185,23 @@ impl Bank {
                             loaded_accounts_data_size,
                         )
                     }
-                    ProcessedTransaction::FeesOnly(fees_only_tx) => (
-                        vec![],
-                        Err(fees_only_tx.load_error),
-                        Some(fees_only_tx.fee_details.total_fee()),
-                        None,
-                        None,
-                        None,
-                        executed_units,
-                        loaded_accounts_data_size,
-                    ),
+                    ProcessedTransaction::FeesOnly(fees_only_tx) => {
+                        let post_simulation_accounts = fees_only_tx
+                            .rollback_accounts
+                            .iter()
+                            .cloned()
+                            .collect::<Vec<_>>();
+                        (
+                            post_simulation_accounts,
+                            Err(fees_only_tx.load_error),
+                            Some(fees_only_tx.fee_details.total_fee()),
+                            None,
+                            None,
+                            None,
+                            executed_units,
+                            loaded_accounts_data_size,
+                        )
+                    }
                 }
             }
             Err(error) => (vec![], Err(error), None, None, None, None, 0, 0),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11611,7 +11611,8 @@ fn test_failed_simulation_load_error() {
     let transaction = Transaction::new(&[&mint_keypair], message, bank.last_blockhash());
 
     bank.freeze();
-    let mint_balance = bank.get_account(&mint_keypair.pubkey()).unwrap().lamports();
+    let mint_account = bank.get_account(&mint_keypair.pubkey()).unwrap();
+    let mint_balance = mint_account.lamports();
     let sanitized = RuntimeTransaction::from_transaction_for_tests(transaction);
     let simulation = bank.simulate_transaction(&sanitized, false);
     assert_eq!(
@@ -11619,7 +11620,7 @@ fn test_failed_simulation_load_error() {
         TransactionSimulationResult {
             result: Err(TransactionError::ProgramAccountNotFound),
             logs: vec![],
-            post_simulation_accounts: vec![],
+            post_simulation_accounts: vec![(mint_keypair.pubkey(), mint_account)],
             units_consumed: 0,
             loaded_accounts_data_size: 0,
             return_data: None,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11620,7 +11620,7 @@ fn test_failed_simulation_load_error() {
         TransactionSimulationResult {
             result: Err(TransactionError::ProgramAccountNotFound),
             logs: vec![],
-            post_simulation_accounts: vec![(mint_keypair.pubkey(), mint_account)],
+            post_simulation_accounts: vec![],
             units_consumed: 0,
             loaded_accounts_data_size: 0,
             return_data: None,


### PR DESCRIPTION
#### Problem

  When simulating a transaction that results in FeesOnly (fees collected but transaction failed during loading), the rollback
  accounts were not being written to the TransactionSimulationResult. The `post_simulation_accounts` field was returning an
  empty vector instead of the fee payer (and potentially nonce) account states after fee collection.

  This prevented clients from seeing the updated account states when fees were deducted during failed transaction simulations.

  #### Summary of Changes

  - Modified `Bank::simulate_transaction` in `runtime/src/bank.rs` to extract rollback accounts from
  `fees_only_tx.rollback_accounts` instead of returning an empty vector
  - Updated test `test_failed_simulation_load_error` in `runtime/src/bank/tests.rs` to expect the fee payer account in
  `post_simulation_accounts`

  Fixes #9231