### PR TITLE
refactor(shred): remove ShredData wrapper enum

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -17,8 +17,8 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
         next_slots_iterator::NextSlotsIterator,
         shred::{
-            self, ErasureSetId, ProcessShredsStats, ReedSolomonCache, Shred, ShredData, ShredId,
-            ShredType, Shredder, DATA_SHREDS_PER_FEC_BLOCK,
+            self, resize_stored_shred, ErasureSetId, ProcessShredsStats, ReedSolomonCache, Shred,
+            ShredId, ShredType, Shredder, DATA_SHREDS_PER_FEC_BLOCK,
         },
         slot_stats::{ShredSource, SlotsStats},
         transaction_address_lookup_table_scanner::scan_transaction,
@@ -2265,7 +2265,7 @@ impl Blockstore {
 
     pub fn get_data_shred(&self, slot: Slot, index: u64) -> Result<Option<Vec<u8>>> {
         let shred = self.data_shred_cf.get_bytes((slot, index))?;
-        let shred = shred.map(ShredData::resize_stored_shred).transpose();
+        let shred = shred.map(resize_stored_shred).transpose();
         shred.map_err(|err| {
             let err = format!("Invalid stored shred: {err}");
             let err = Box::new(bincode::ErrorKind::Custom(err));

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -50,9 +50,12 @@
 //! So, given a) - c), we must restrict data shred's payload length such that the entire coding
 //! payload can fit into one coding shred / packet.
 
-pub(crate) use self::{merkle_tree::PROOF_ENTRIES_FOR_32_32_BATCH, payload::serde_bytes_payload};
+pub(crate) use self::{
+    merkle_tree::PROOF_ENTRIES_FOR_32_32_BATCH, payload::serde_bytes_payload,
+    shred_data::resize_stored_shred,
+};
 use {
-    self::traits::Shred as _,
+    self::traits::{Shred as _, ShredData as _},
     crate::blockstore::{self},
     assert_matches::debug_assert_matches,
     bitflags::bitflags,
@@ -76,9 +79,8 @@ use {
 };
 pub use {
     self::{
-        merkle::ShredCode,
+        merkle::{ShredCode, ShredData},
         payload::Payload,
-        shred_data::ShredData,
         stats::{ProcessShredsStats, ShredFetchStats},
     },
     crate::shredder::{ReedSolomonCache, Shredder},
@@ -87,7 +89,7 @@ pub use {
 use {solana_keypair::Keypair, solana_perf::packet::Packet, solana_signer::Signer};
 
 mod common;
-pub(crate) mod merkle;
+pub mod merkle;
 mod merkle_tree;
 mod payload;
 mod shred_code;
@@ -286,7 +288,7 @@ struct CodingShredHeader {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Shred {
     ShredCode(ShredCode),
-    ShredData(ShredData),
+    ShredData(merkle::ShredData),
 }
 
 /// Tuple which uniquely identifies a shred should it exists.
@@ -425,7 +427,7 @@ impl Shred {
             }
             ShredVariant::MerkleData { .. } => {
                 let shred = merkle::ShredData::from_payload(shred)?;
-                Self::from(ShredData::from(shred))
+                Self::ShredData(shred)
             }
         })
     }
@@ -581,7 +583,7 @@ impl Shred {
     fn retransmitter_signature_offset(&self) -> Result<usize, Error> {
         match self {
             Self::ShredCode(shred) => shred.retransmitter_signature_offset(),
-            Self::ShredData(ShredData::Merkle(shred)) => shred.retransmitter_signature_offset(),
+            Self::ShredData(shred) => shred.retransmitter_signature_offset(),
         }
     }
 }
@@ -592,17 +594,11 @@ impl From<ShredCode> for Shred {
     }
 }
 
-impl From<ShredData> for Shred {
-    fn from(shred: ShredData) -> Self {
-        Self::ShredData(shred)
-    }
-}
-
 impl From<merkle::Shred> for Shred {
     fn from(shred: merkle::Shred) -> Self {
         match shred {
             merkle::Shred::ShredCode(shred) => Self::ShredCode(shred),
-            merkle::Shred::ShredData(shred) => Self::ShredData(ShredData::Merkle(shred)),
+            merkle::Shred::ShredData(shred) => Self::ShredData(shred),
         }
     }
 }
@@ -613,7 +609,7 @@ impl TryFrom<Shred> for merkle::Shred {
     fn try_from(shred: Shred) -> Result<Self, Self::Error> {
         match shred {
             Shred::ShredCode(shred) => Ok(Self::ShredCode(shred)),
-            Shred::ShredData(ShredData::Merkle(shred)) => Ok(Self::ShredData(shred)),
+            Shred::ShredData(shred) => Ok(Self::ShredData(shred)),
         }
     }
 }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -401,6 +401,7 @@ impl Shred {
 
     dispatch!(pub fn chained_merkle_root(&self) -> Result<Hash, Error>);
     dispatch!(pub(crate) fn retransmitter_signature(&self) -> Result<Signature, Error>);
+    dispatch!(pub fn retransmitter_signature_offset(&self) -> Result<usize, Error>);
 
     dispatch!(pub fn into_payload(self) -> Payload);
     dispatch!(pub fn merkle_root(&self) -> Result<Hash, Error>);
@@ -423,7 +424,7 @@ impl Shred {
         Ok(match layout::get_shred_variant(shred.as_ref())? {
             ShredVariant::MerkleCode { .. } => {
                 let shred = merkle::ShredCode::from_payload(shred)?;
-                Self::from(shred)
+                Self::ShredCode(shred)
             }
             ShredVariant::MerkleData { .. } => {
                 let shred = merkle::ShredData::from_payload(shred)?;
@@ -578,19 +579,6 @@ impl Shred {
                 .unwrap_or_else(|| shred.payload())
         }
         get_payload(self) != get_payload(other)
-    }
-
-    fn retransmitter_signature_offset(&self) -> Result<usize, Error> {
-        match self {
-            Self::ShredCode(shred) => shred.retransmitter_signature_offset(),
-            Self::ShredData(shred) => shred.retransmitter_signature_offset(),
-        }
-    }
-}
-
-impl From<ShredCode> for Shred {
-    fn from(shred: ShredCode) -> Self {
-        Self::ShredCode(shred)
     }
 }
 

--- a/ledger/src/shred/common.rs
+++ b/ledger/src/shred/common.rs
@@ -1,30 +1,3 @@
-macro_rules! dispatch {
-    ($vis:vis fn $name:ident(&self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
-        #[inline]
-        $vis fn $name(&self $(, $arg:$ty)?) $(-> $out)? {
-            match self {
-                Self::Merkle(shred) => shred.$name($($arg, )?),
-            }
-        }
-    };
-    ($vis:vis fn $name:ident(self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
-        #[inline]
-        $vis fn $name(self $(, $arg:$ty)?) $(-> $out)? {
-            match self {
-                Self::Merkle(shred) => shred.$name($($arg, )?),
-            }
-        }
-    };
-    ($vis:vis fn $name:ident(&mut self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
-        #[inline]
-        $vis fn $name(&mut self $(, $arg:$ty)?) $(-> $out)? {
-            match self {
-                Self::Merkle(shred) => shred.$name($($arg, )?),
-            }
-        }
-    }
-}
-
 macro_rules! impl_shred_common {
     () => {
         #[inline]
@@ -50,4 +23,4 @@ macro_rules! impl_shred_common {
     };
 }
 
-pub(super) use {dispatch, impl_shred_common};
+pub(super) use impl_shred_common;

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -214,6 +214,26 @@ impl ShredData {
             None => Err(proof_size),
         }
     }
+
+    pub(super) fn last_in_slot(&self) -> bool {
+        self.data_header
+            .flags
+            .contains(ShredFlags::LAST_SHRED_IN_SLOT)
+    }
+
+    pub(super) fn data_complete(&self) -> bool {
+        self.data_header
+            .flags
+            .contains(ShredFlags::DATA_COMPLETE_SHRED)
+    }
+
+    pub(super) fn reference_tick(&self) -> u8 {
+        (self.data_header.flags & ShredFlags::SHRED_TICK_REFERENCE_MASK).bits()
+    }
+
+    pub(super) fn bytes_to_store(&self) -> &[u8] {
+        &self.payload
+    }
 }
 
 impl ShredCode {

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -645,7 +645,6 @@ mod tests {
                 assert_eq!(get_data_size(bytes).unwrap(), shred_data_header.size);
                 assert_eq!(get_data(bytes).unwrap(), shred.data().unwrap());
                 assert_eq!(get_reference_tick(bytes).unwrap(), {
-                    let shred = shred::shred_data::ShredData::Merkle(shred.clone());
                     shred.reference_tick()
                 });
             }


### PR DESCRIPTION
#### Problem

  Since legacy shred variants were removed, the ShredData wrapper enum
  only contains a single Merkle variant. This unnecessary single-variant
  enum adds complexity to the API with redundant pattern matching throughout
  the codebase.

  #### Summary of Changes

  This PR removes the ShredData wrapper enum and uses merkle::ShredData
  directly in the Shred enum, simplifying the API and eliminating a layer
  of indirection.

  Fixes #9230