### PR TITLE
fix: write rollback-accs in Transaction-sim-result

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3185,16 +3185,24 @@ impl Bank {
                             loaded_accounts_data_size,
                         )
                     }
-                    ProcessedTransaction::FeesOnly(fees_only_tx) => (
-                        vec![],
-                        Err(fees_only_tx.load_error),
-                        Some(fees_only_tx.fee_details.total_fee()),
-                        None,
-                        None,
-                        None,
-                        executed_units,
-                        loaded_accounts_data_size,
-                    ),
+                    ProcessedTransaction::FeesOnly(fees_only_tx) => {
+                        let post_simulation_accounts = fees_only_tx
+                            .rollback_accounts
+                            .iter()
+                            .cloned()
+                            .collect::<Vec<_>>();
+
+                        (
+                            post_simulation_accounts,
+                            Err(fees_only_tx.load_error),
+                            Some(fees_only_tx.fee_details.total_fee()),
+                            None,
+                            None,
+                            None,
+                            executed_units,
+                            loaded_accounts_data_size,
+                        )
+                    }
                 }
             }
             Err(error) => (vec![], Err(error), None, None, None, None, 0, 0),


### PR DESCRIPTION
#### Problem
When simulating a transaction and fees are only collected, the rollback accounts are not written to the result.


#### Summary of Changes
* Bank::simulate_transaction_unchecked: Updated handling of ProcessedTransaction::FeesOnly.
* Previously: post_simulation_accounts was always vec![].
* Now: post_simulation_accounts is populated from fees_only_tx.rollback_accounts (cloned).
* No other fields (result, fee, units_consumed, etc.) were modified.

Fixes #9231 
