### PR TITLE
nit: improves some outdated documentation in `ConsensusPool`

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -134,17 +134,10 @@ impl ConsensusPool {
         }
     }
 
-    /// For a new vote `slot` , `vote_type` checks if any
-    /// of the related certificates are newly complete.
-    /// For each newly constructed certificate
-    /// - Insert it into `self.certificates`
-    /// - Potentially update `self.highest_finalized_slot`,
-    /// - If we have a new highest finalized slot, return it
-    /// - update any newly created events
-    fn update_certificates(
+    /// Builds new [`Certificate`]s that depend on votes of type [`Vote`] if enough stake has voted for them.
+    fn build_certs(
         &mut self,
         vote: &Vote,
-        events: &mut Vec<VotorEvent>,
         total_stake: Stake,
     ) -> Result<Vec<Arc<Certificate>>, AddVoteError> {
         let Some(vote_pool) = self.vote_pools.get(&vote.slot()) else {
@@ -174,18 +167,14 @@ impl ConsensusPool {
             self.stats.incr_cert_type(&new_cert.cert_type, true);
             new_certificates_to_send.push(new_cert);
         }
-        for cert in &new_certificates_to_send {
-            self.insert_certificate(cert.cert_type, cert.clone(), events);
-        }
         Ok(new_certificates_to_send)
     }
 
-    fn insert_certificate(
-        &mut self,
-        cert_type: CertificateType,
-        cert: Arc<Certificate>,
-        events: &mut Vec<VotorEvent>,
-    ) {
+    /// Inserts a new [`Certificate`].
+    ///
+    /// Based on the type of certificate being inserted, updates [`self.parent_ready_tracker`] and other metadata on self.
+    fn insert_certificate(&mut self, cert: Arc<Certificate>, events: &mut Vec<VotorEvent>) {
+        let cert_type = cert.cert_type;
         trace!(
             "{}: Inserting certificate {:?}",
             self.cluster_info.id(),
@@ -345,7 +334,11 @@ impl ConsensusPool {
             },
         }
         self.stats.incr_ingested_vote(&vote);
-        self.update_certificates(&vote, events, total_stake)
+        self.build_certs(&vote, total_stake).inspect(|certs| {
+            for cert in certs {
+                self.insert_certificate(cert.clone(), events)
+            }
+        })
     }
 
     fn add_certificate(
@@ -365,7 +358,7 @@ impl ConsensusPool {
             return Ok(vec![]);
         }
         let cert = Arc::new(cert);
-        self.insert_certificate(cert_type, cert.clone(), events);
+        self.insert_certificate(cert.clone(), events);
 
         self.stats.incr_cert_type(&cert_type, false);
 

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -347,21 +347,19 @@ impl ConsensusPool {
         cert: Certificate,
         events: &mut Vec<VotorEvent>,
     ) -> Result<Vec<Arc<Certificate>>, AddCertError> {
-        let cert_type = cert.cert_type;
+        let cert_type = &cert.cert_type;
         self.stats.incoming_certs = self.stats.incoming_certs.saturating_add(1);
         if cert_type.slot() < root_slot {
             self.stats.out_of_range_certs = self.stats.out_of_range_certs.saturating_add(1);
             return Err(AddCertError::UnrootedSlot);
         }
-        if self.completed_certificates.contains_key(&cert_type) {
+        if self.completed_certificates.contains_key(cert_type) {
             self.stats.exist_certs = self.stats.exist_certs.saturating_add(1);
             return Ok(vec![]);
         }
+        self.stats.incr_cert_type(cert_type, false);
         let cert = Arc::new(cert);
         self.insert_certificate(cert.clone(), events);
-
-        self.stats.incr_cert_type(&cert_type, false);
-
         Ok(vec![cert])
     }
 


### PR DESCRIPTION
#### Problem

- Some functions names did not really reflect what they were doing.
- Some function documentations were outdated
- There an unnecessary `Copy` happening in `add_certificate()`


#### Summary of Changes

- Improves the names of the functions and documentation
- Removes the `Copy` in `add_certificate()`