### PR TITLE
clippy(rpc): specify captured lifetime with use<> annotation

### DIFF
--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -415,7 +415,7 @@ fn filter_program_results(
     params: &ProgramSubscriptionParams,
     last_notified_slot: Slot,
     bank: Arc<Bank>,
-) -> (impl Iterator<Item = RpcKeyedAccount>, Slot) {
+) -> (impl Iterator<Item = RpcKeyedAccount> + use<>, Slot) {
     let accounts_is_empty = accounts.is_empty();
     let encoding = params.encoding;
     let filters = params.filters.clone();
@@ -445,7 +445,7 @@ fn filter_logs_results(
     _params: &LogsSubscriptionParams,
     last_notified_slot: Slot,
     _bank: Arc<Bank>,
-) -> (impl Iterator<Item = RpcLogsResponse>, Slot) {
+) -> (impl Iterator<Item = RpcLogsResponse> + use<>, Slot) {
     let responses = logs.into_iter().flatten().map(|log| RpcLogsResponse {
         signature: log.signature.to_string(),
         err: log.result.err().map(Into::into),


### PR DESCRIPTION
#### Problem
Compilation with Rust 2024 edition changes lifetime capture rules (all lifetimes are captured unless selective `use<..>` annotation is used), this causes following error:
```
error[E0308]: mismatched types
    --> rpc/src/rpc_subscriptions.rs:1061:40
     |
 448 |   ) -> (impl Iterator<Item = RpcLogsResponse>, Slot) {
     |         -------------------------------------
     |         |
     |         the expected opaque type
     |         the found opaque type
...
1061 |                           let notified = check_commitment_and_notify(
     |  ________________________________________^
1062 | |                             params,
1063 | |                             subscription,
1064 | |                             bank_forks,
...    |
1069 | |                             false,
1070 | |                         );
     | |_________________________^ one type is more general than the other
     |
     = note: expected tuple `(impl for<'a> std::iter::Iterator<Item = solana_rpc_client_api::response::RpcLogsResponse>, _)`
                found tuple `(impl std::iter::Iterator<Item = solana_rpc_client_api::response::RpcLogsResponse>, _)`
note: the lifetime requirement is introduced here
    --> rpc/src/rpc_subscriptions.rs:149:38
     |
 149 |     F: Fn(X, &P, Slot, Arc<Bank>) -> (I, Slot),
     |                                      ^^^^^^^^^
```

#### Summary of Changes
Since the functions return iterators without any borrowing, specify `use<>` annotation for their `impl`