### PR TITLE
Upgrades Rust to 1.91.1

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2025-08-02
+  nightly_version=2025-09-14
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.91.1"


### PR DESCRIPTION
https://blog.rust-lang.org/2025/10/30/Rust-1.91.0/
https://blog.rust-lang.org/2025/11/10/Rust-1.91.1/

Also upgraded nightly to 2025-09-14, which is the latest nightly still on 1.91.

Fixes #8117