### PR TITLE
Renames index skipped flush metrics

### DIFF
--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -316,11 +316,19 @@ impl Stats {
                     ),
                     f64
                 ),
-                ("slot_list_len", held_in_mem_slot_list_len, i64),
-                ("ref_count", held_in_mem_ref_count, i64),
-                ("slot_list_cached", held_in_mem_slot_list_cached, i64),
                 ("num_not_flushed_clean", held_in_mem_clean, i64),
                 ("num_not_flushed_age", held_in_mem_age, i64),
+                ("num_not_flushed_ref_count", held_in_mem_ref_count, i64),
+                (
+                    "num_not_flushed_slot_list_len",
+                    held_in_mem_slot_list_len,
+                    i64
+                ),
+                (
+                    "num_not_flushed_slot_list_cached",
+                    held_in_mem_slot_list_cached,
+                    i64
+                ),
                 ("min_in_bin_disk", disk_stats.0, i64),
                 ("max_in_bin_disk", disk_stats.1, i64),
                 ("count_from_bins_disk", disk_stats.2, i64),


### PR DESCRIPTION
#### Problem

Originally from https://github.com/anza-xyz/agave/pull/9225#discussion_r2556902380, the naming is inconsistent (and IMO the previous ones were not clear) of the metrics for the reason index entries were not flushed.


#### Summary of Changes

Rename the metrics.