### PR TITLE
clippy: derivable_impls

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -19,19 +19,14 @@ use {
 
 const NUM_LAMPORTS_PER_ACCOUNT_DEFAULT: u64 = solana_native_token::LAMPORTS_PER_SOL;
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Default)]
 pub enum ExternalClientType {
     // Submits transactions to an Rpc node using an RpcClient
     RpcClient,
     // Submits transactions directly to leaders using a TpuClient, broadcasting to upcoming leaders
     // via TpuClient default configuration
+    #[default]
     TpuClient,
-}
-
-impl Default for ExternalClientType {
-    fn default() -> Self {
-        Self::TpuClient
-    }
 }
 
 #[derive(Eq, PartialEq, Debug)]

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -134,8 +134,9 @@ fn render_dot(dot: String, output_file: &str, output_format: &str) -> io::Result
     Ok(())
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 enum GraphVoteAccountMode {
+    #[default]
     Disabled,
     LastOnly,
     WithHistory,
@@ -160,12 +161,6 @@ impl AsRef<str> for GraphVoteAccountMode {
             Self::LastOnly => Self::LAST_ONLY,
             Self::WithHistory => Self::WITH_HISTORY,
         }
-    }
-}
-
-impl Default for GraphVoteAccountMode {
-    fn default() -> Self {
-        Self::Disabled
     }
 }
 


### PR DESCRIPTION
#### Problem

Fix new clippy lints that are blocking #9259.

For this PR, it's this one:

```
error: this `impl` can be derived
  --> /solana/bench-tps/src/cli.rs:31:1
   |
31 | / impl Default for ExternalClientType {
32 | |     fn default() -> Self {
33 | |         Self::TpuClient
34 | |     }
35 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derivable_impls
   = note: `-D clippy::derivable-impls` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::derivable_impls)]`
help: replace the manual implementation with a derive attribute and mark the default variant
```


#### Summary of Changes

Fix it!