### PR TITLE
Revamp debug information for SBF programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Release channels have their own copy of this changelog:
 ### CLI
 #### Changes
 * Support Trezor hardware wallets using `usb://trezor`
+### Platform tools
+#### Breaking
+* `cargo-build-sbf --debug` now generates a file `program.debug.so` instead of `program.debug`.
+* `cargo-build-sbf --debug` places all debug related objects inside `target/deploy/debug`.
+
 
 ## 3.1.0
 ### RPC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Release channels have their own copy of this changelog:
 * Support Trezor hardware wallets using `usb://trezor`
 ### Platform tools
 #### Breaking
-* `cargo-build-sbf --debug` now generates a file `program.debug.so` instead of `program.debug`.
+* `cargo-build-sbf --debug` now generates a file `program.so.debug` instead of `program.debug`.
 * `cargo-build-sbf --debug` places all debug related objects inside `target/deploy/debug`.
 
 

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -199,11 +199,7 @@ fn invoke_cargo(config: &Config, validated_toolchain_version: String) {
             &target_rustflags
         ));
     }
-    if config.debug {
-        // Passing 'opt-level=3' without '--release' allows us to have debug information
-        // in an optimized binary.
-        target_rustflags = Cow::Owned(format!("{} -C opt-level=3", &target_rustflags));
-    }
+
     if let Cow::Owned(flags) = target_rustflags {
         env::set_var(&cargo_target, flags);
     }

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -413,7 +413,7 @@ fn main() {
         )
         .arg(Arg::new("debug").long("debug").takes_value(false).help(
             "Create debug objects at \
-             `target/deploy/debug`.\n`target/deploy/debug/program.debug.so` contains all debug \
+             `target/deploy/debug`.\n`target/deploy/debug/program.so.debug` contains all debug \
              information available.\n`target/deploy/debug/program.so` is a stripped version for \
              execution in the VM.\nThese objects are not optimized for mainnet-beta deployment.",
         ))

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -412,7 +412,10 @@ fn main() {
                 .help("Disable remap of cwd prefix and preserve full path strings in binaries"),
         )
         .arg(Arg::new("debug").long("debug").takes_value(false).help(
-            "Enable debug symbols in a file available in target/deploy/<program-name>__debug__.so",
+            "Create debug objects at \
+             `target/deploy/debug`.\n`target/deploy/debug/program.debug.so` contains all debug \
+             information available.\n`target/deploy/debug/program.so` is a stripped version for \
+             execution in the VM.\nThese objects are not optimized for mainnet-beta deployment.",
         ))
         .arg(
             Arg::new("dump")

--- a/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
@@ -1,17 +1,147 @@
 use {
-    crate::{spawn, toolchain::rust_target_triple, Config},
+    crate::{
+        spawn,
+        toolchain::rust_target_triple,
+        utils::{copy_file, create_directory, generate_keypair},
+        Config,
+    },
     log::{debug, error, info, warn},
     regex::Regex,
-    solana_keypair::{write_keypair_file, Keypair},
     std::{
         collections::{HashMap, HashSet},
         fs::{self, File},
         io::{BufRead, BufReader, BufWriter, Write},
-        path::Path,
-        process::{exit, Command, Stdio},
+        path::{Path, PathBuf},
+        process::exit,
         str::FromStr,
     },
 };
+
+fn file_older_or_missing(prerequisite_file: &Path, target_file: &Path) -> bool {
+    let prerequisite_metadata = fs::metadata(prerequisite_file).unwrap_or_else(|err| {
+        error!(
+            "Unable to get file metadata for {}: {}",
+            prerequisite_file.display(),
+            err
+        );
+        exit(1);
+    });
+
+    if let Ok(target_metadata) = fs::metadata(target_file) {
+        use std::time::UNIX_EPOCH;
+        prerequisite_metadata.modified().unwrap_or(UNIX_EPOCH)
+            > target_metadata.modified().unwrap_or(UNIX_EPOCH)
+    } else {
+        true
+    }
+}
+
+fn create_folders(deploy_folder: &PathBuf, debug_folder: &PathBuf) {
+    if !deploy_folder.exists() {
+        create_directory(deploy_folder);
+    }
+
+    if !debug_folder.exists() {
+        create_directory(debug_folder);
+    }
+}
+
+fn generate_debug_objects(
+    config: &Config,
+    sbf_debug_dir: &Path,
+    finalized_program: &str,
+    program_unstripped_so: &Path,
+    deploy_keypair: &Path,
+    debug_keypair: &PathBuf,
+    program_name: &str,
+) -> PathBuf {
+    // debug objects
+    let program_debug = sbf_debug_dir.join(format!("{program_name}.debug.so"));
+    let program_debug_stripped = sbf_debug_dir.join(finalized_program);
+
+    if file_older_or_missing(program_unstripped_so, &program_debug_stripped) {
+        #[cfg(windows)]
+        let output = spawn(
+            &llvm_bin.join("llvm-objcopy"),
+            [
+                "--only-keep-debug".as_ref(),
+                program_unstripped_so.as_os_str(),
+                program_so.as_os_str(),
+            ],
+            config.generate_child_script_on_failure,
+        );
+        #[cfg(not(windows))]
+        let output = spawn(
+            &config.sbf_sdk.join("scripts").join("strip.sh"),
+            [
+                program_unstripped_so.as_os_str(),
+                program_debug_stripped.as_os_str(),
+                "--only-keep-debug".as_ref(),
+            ],
+            config.generate_child_script_on_failure,
+        );
+        if config.verbose {
+            debug!("{output}");
+        }
+    }
+
+    if file_older_or_missing(program_unstripped_so, &program_debug) {
+        copy_file(program_unstripped_so, &program_debug);
+    }
+
+    if deploy_keypair.exists() {
+        copy_file(deploy_keypair, debug_keypair);
+    } else {
+        generate_keypair(debug_keypair);
+    }
+
+    program_debug_stripped
+}
+
+fn generate_release_objects(
+    config: &Config,
+    sbf_out_dir: &Path,
+    program_unstripped_so: &Path,
+    deploy_keypair: &PathBuf,
+    debug_keypair: &Path,
+    program_name: &str,
+) -> PathBuf {
+    let program_so = sbf_out_dir.join(format!("{program_name}.so"));
+
+    if file_older_or_missing(program_unstripped_so, &program_so) {
+        #[cfg(windows)]
+        let output = spawn(
+            &llvm_bin.join("llvm-objcopy"),
+            [
+                "--strip-all".as_ref(),
+                program_unstripped_so.as_os_str(),
+                program_so.as_os_str(),
+            ],
+            config.generate_child_script_on_failure,
+        );
+        #[cfg(not(windows))]
+        let output = spawn(
+            &config.sbf_sdk.join("scripts").join("strip.sh"),
+            [
+                program_unstripped_so.as_os_str(),
+                program_so.as_os_str(),
+                "--strip-all".as_ref(),
+            ],
+            config.generate_child_script_on_failure,
+        );
+        if config.verbose {
+            debug!("{output}");
+        }
+    }
+
+    if deploy_keypair.exists() {
+        copy_file(debug_keypair, deploy_keypair);
+    } else {
+        generate_keypair(deploy_keypair);
+    }
+
+    program_so
+}
 
 pub(crate) fn post_process(config: &Config, target_directory: &Path, program_name: Option<String>) {
     let sbf_out_dir = config
@@ -20,6 +150,10 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
         .cloned()
         .unwrap_or_else(|| target_directory.join("deploy"));
     let target_triple = rust_target_triple(config);
+    let sbf_debug_dir = sbf_out_dir.join("debug");
+
+    create_folders(&sbf_out_dir, &sbf_debug_dir);
+
     let target_build_directory = if config.debug {
         target_directory.join(&target_triple).join("debug")
     } else {
@@ -27,41 +161,14 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
     };
 
     if let Some(program_name) = program_name {
-        let program_unstripped_so = target_build_directory.join(format!("{program_name}.so"));
+        let keypair_name = format!("{program_name}-keypair.json");
+        let deploy_keypair = sbf_out_dir.join(keypair_name.clone());
+        let debug_keypair = sbf_debug_dir.join(keypair_name);
+
+        let finalized_program_file = format!("{program_name}.so");
+
+        let program_unstripped_so = target_build_directory.join(finalized_program_file.clone());
         let program_dump = sbf_out_dir.join(format!("{program_name}-dump.txt"));
-        let program_so = sbf_out_dir.join(format!("{program_name}.so"));
-        let program_debug = sbf_out_dir.join(format!("{program_name}__debug__.so"));
-        let program_keypair = sbf_out_dir.join(format!("{program_name}-keypair.json"));
-
-        fn file_older_or_missing(prerequisite_file: &Path, target_file: &Path) -> bool {
-            let prerequisite_metadata = fs::metadata(prerequisite_file).unwrap_or_else(|err| {
-                error!(
-                    "Unable to get file metadata for {}: {}",
-                    prerequisite_file.display(),
-                    err
-                );
-                exit(1);
-            });
-
-            if let Ok(target_metadata) = fs::metadata(target_file) {
-                use std::time::UNIX_EPOCH;
-                prerequisite_metadata.modified().unwrap_or(UNIX_EPOCH)
-                    > target_metadata.modified().unwrap_or(UNIX_EPOCH)
-            } else {
-                true
-            }
-        }
-
-        if !program_keypair.exists() {
-            write_keypair_file(&Keypair::new(), &program_keypair).unwrap_or_else(|err| {
-                error!(
-                    "Unable to get create {}: {}",
-                    program_keypair.display(),
-                    err
-                );
-                exit(1);
-            });
-        }
 
         #[cfg(windows)]
         let llvm_bin = config
@@ -71,43 +178,26 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
             .join("llvm")
             .join("bin");
 
-        if config.debug && file_older_or_missing(&program_unstripped_so, &program_debug) {
-            #[cfg(windows)]
-            let command = "copy";
-            #[cfg(not(windows))]
-            let command = "cp";
-            let _ = Command::new(command)
-                .args([program_unstripped_so.as_os_str(), program_debug.as_os_str()])
-                .stdout(Stdio::piped())
-                .spawn()
-                .unwrap_or_else(|err| {
-                    error!("Failed to copy program to deploy folder: {err}");
-                    exit(1);
-                })
-                .wait();
-        }
-
-        if !config.debug && file_older_or_missing(&program_unstripped_so, &program_so) {
-            #[cfg(windows)]
-            let output = spawn(
-                &llvm_bin.join("llvm-objcopy"),
-                [
-                    "--strip-all".as_ref(),
-                    program_unstripped_so.as_os_str(),
-                    program_so.as_os_str(),
-                ],
-                config.generate_child_script_on_failure,
-            );
-            #[cfg(not(windows))]
-            let output = spawn(
-                &config.sbf_sdk.join("scripts").join("strip.sh"),
-                [&program_unstripped_so, &program_so],
-                config.generate_child_script_on_failure,
-            );
-            if config.verbose {
-                debug!("{output}");
-            }
-        }
+        let program_so = if config.debug {
+            generate_debug_objects(
+                config,
+                &sbf_debug_dir,
+                &finalized_program_file,
+                &program_unstripped_so,
+                &deploy_keypair,
+                &debug_keypair,
+                &program_name,
+            )
+        } else {
+            generate_release_objects(
+                config,
+                &sbf_out_dir,
+                &program_unstripped_so,
+                &deploy_keypair,
+                &debug_keypair,
+                &program_name,
+            )
+        };
 
         if config.dump && file_older_or_missing(&program_unstripped_so, &program_dump) {
             let dump_script = config.sbf_sdk.join("scripts").join("dump.sh");
@@ -141,21 +231,14 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
 
         if config.arch != "v3" {
             // SBPFv3 shall not have any undefined syscall.
-            check_undefined_symbols(
-                config,
-                if config.debug {
-                    &program_debug
-                } else {
-                    &program_so
-                },
-            );
+            check_undefined_symbols(config, &program_so);
         }
 
         if !config.debug {
             info!("To deploy this program:");
             info!("  $ solana program deploy {}", program_so.display());
             info!("The program address will default to this keypair (override with --program-id):");
-            info!("  {}", program_keypair.display());
+            info!("  {}", deploy_keypair.display());
         }
     } else if config.dump {
         warn!("Note: --dump is only available for crates with a cdylib target");

--- a/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
@@ -90,10 +90,12 @@ fn generate_debug_objects(
         copy_file(program_unstripped_so, &program_debug);
     }
 
-    if deploy_keypair.exists() {
-        copy_file(deploy_keypair, debug_keypair);
-    } else if !debug_keypair.exists() {
-        generate_keypair(debug_keypair);
+    if !debug_keypair.exists() {
+        if deploy_keypair.exists() {
+            copy_file(deploy_keypair, debug_keypair);
+        } else {
+            generate_keypair(debug_keypair);
+        }
     }
 
     program_debug_stripped
@@ -136,10 +138,12 @@ fn generate_release_objects(
         }
     }
 
-    if debug_keypair.exists() {
-        copy_file(debug_keypair, deploy_keypair);
-    } else if !deploy_keypair.exists() {
-        generate_keypair(deploy_keypair);
+    if !deploy_keypair.exists() {
+        if debug_keypair.exists() {
+            copy_file(debug_keypair, deploy_keypair);
+        } else {
+            generate_keypair(deploy_keypair);
+        }
     }
 
     program_so

--- a/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
@@ -36,12 +36,12 @@ fn file_older_or_missing(prerequisite_file: &Path, target_file: &Path) -> bool {
     }
 }
 
-fn create_folders(deploy_folder: &PathBuf, debug_folder: &PathBuf) {
+fn create_folders(config: &Config, deploy_folder: &PathBuf, debug_folder: &PathBuf) {
     if !deploy_folder.exists() {
         create_directory(deploy_folder);
     }
 
-    if !debug_folder.exists() {
+    if config.debug && !debug_folder.exists() {
         create_directory(debug_folder);
     }
 }
@@ -92,7 +92,7 @@ fn generate_debug_objects(
 
     if deploy_keypair.exists() {
         copy_file(deploy_keypair, debug_keypair);
-    } else {
+    } else if !debug_keypair.exists() {
         generate_keypair(debug_keypair);
     }
 
@@ -138,7 +138,7 @@ fn generate_release_objects(
 
     if debug_keypair.exists() {
         copy_file(debug_keypair, deploy_keypair);
-    } else {
+    } else if !deploy_keypair.exists() {
         generate_keypair(deploy_keypair);
     }
 
@@ -154,7 +154,7 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
     let target_triple = rust_target_triple(config);
     let sbf_debug_dir = sbf_out_dir.join("debug");
 
-    create_folders(&sbf_out_dir, &sbf_debug_dir);
+    create_folders(config, &sbf_out_dir, &sbf_debug_dir);
 
     let target_build_directory = if config.debug {
         target_directory.join(&target_triple).join("debug")

--- a/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
@@ -136,7 +136,7 @@ fn generate_release_objects(
         }
     }
 
-    if deploy_keypair.exists() {
+    if debug_keypair.exists() {
         copy_file(debug_keypair, deploy_keypair);
     } else {
         generate_keypair(deploy_keypair);

--- a/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
@@ -46,7 +46,12 @@ fn create_folders(config: &Config, deploy_folder: &PathBuf, debug_folder: &PathB
     }
 }
 
-fn strip_object(config: &Config, unstripped: &Path, stripped: &Path) {
+fn strip_object(
+    config: &Config,
+    unstripped: &Path,
+    stripped: &Path,
+    #[cfg(windows)] llvm_bin: &Path,
+) {
     #[cfg(windows)]
     let output = spawn(
         &llvm_bin.join("llvm-objcopy"),
@@ -87,7 +92,13 @@ fn generate_debug_objects(
     let program_debug_stripped = sbf_debug_dir.join(finalized_program);
 
     if file_older_or_missing(program_unstripped_so, &program_debug_stripped) {
-        strip_object(config, program_unstripped_so, &program_debug_stripped);
+        strip_object(
+            config,
+            program_unstripped_so,
+            &program_debug_stripped,
+            #[cfg(windows)]
+            llvm_bin,
+        );
     }
 
     if file_older_or_missing(program_unstripped_so, &program_debug) {
@@ -117,7 +128,13 @@ fn generate_release_objects(
     let program_so = sbf_out_dir.join(format!("{program_name}.so"));
 
     if file_older_or_missing(program_unstripped_so, &program_so) {
-        strip_object(config, program_unstripped_so, &program_so);
+        strip_object(
+            config,
+            program_unstripped_so,
+            &program_so,
+            #[cfg(windows)]
+            llvm_bin,
+        );
     }
 
     if !deploy_keypair.exists() {

--- a/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
@@ -54,6 +54,7 @@ fn generate_debug_objects(
     deploy_keypair: &Path,
     debug_keypair: &PathBuf,
     program_name: &str,
+    #[cfg(windows)] llvm_bin: &Path,
 ) -> PathBuf {
     // debug objects
     let program_debug = sbf_debug_dir.join(format!("{program_name}.debug.so"));
@@ -66,7 +67,7 @@ fn generate_debug_objects(
             [
                 "--only-keep-debug".as_ref(),
                 program_unstripped_so.as_os_str(),
-                program_so.as_os_str(),
+                program_debug_stripped.as_os_str(),
             ],
             config.generate_child_script_on_failure,
         );
@@ -105,6 +106,7 @@ fn generate_release_objects(
     deploy_keypair: &PathBuf,
     debug_keypair: &Path,
     program_name: &str,
+    #[cfg(windows)] llvm_bin: &Path,
 ) -> PathBuf {
     let program_so = sbf_out_dir.join(format!("{program_name}.so"));
 
@@ -187,6 +189,8 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
                 &deploy_keypair,
                 &debug_keypair,
                 &program_name,
+                #[cfg(windows)]
+                &llvm_bin,
             )
         } else {
             generate_release_objects(
@@ -196,6 +200,8 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
                 &deploy_keypair,
                 &debug_keypair,
                 &program_name,
+                #[cfg(windows)]
+                &llvm_bin,
             )
         };
 

--- a/platform-tools-sdk/cargo-build-sbf/src/utils.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/utils.rs
@@ -63,7 +63,7 @@ where
 }
 
 pub(crate) fn create_directory(path: &PathBuf) {
-    std::fs::create_dir(path).unwrap_or_else(|err| {
+    std::fs::create_dir_all(path).unwrap_or_else(|err| {
         error!("Failed create folder: {err}");
         exit(1);
     });
@@ -78,7 +78,7 @@ pub(crate) fn copy_file(from: &Path, to: &Path) {
 
 pub(crate) fn generate_keypair(path: &PathBuf) {
     write_keypair_file(&Keypair::new(), path).unwrap_or_else(|err| {
-        error!("Unable to get create {}: {}", path.display(), err);
+        error!("Unable to create {}: {err}", path.display());
         exit(1);
     });
 }

--- a/platform-tools-sdk/cargo-build-sbf/src/utils.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/utils.rs
@@ -63,31 +63,17 @@ where
 }
 
 pub(crate) fn create_directory(path: &PathBuf) {
-    let _ = Command::new("mkdir")
-        .arg(path)
-        .stdout(Stdio::piped())
-        .spawn()
-        .unwrap_or_else(|err| {
-            error!("Failed create folder: {err}");
-            exit(1);
-        })
-        .wait();
+    std::fs::create_dir(path).unwrap_or_else(|err| {
+        error!("Failed create folder: {err}");
+        exit(1);
+    });
 }
 
 pub(crate) fn copy_file(from: &Path, to: &Path) {
-    #[cfg(windows)]
-    let command = "copy";
-    #[cfg(not(windows))]
-    let command = "cp";
-    let _ = Command::new(command)
-        .args([from.as_os_str(), to.as_os_str()])
-        .stdout(Stdio::piped())
-        .spawn()
-        .unwrap_or_else(|err| {
-            error!("Failed to copy file: {err}");
-            exit(1);
-        })
-        .wait();
+    std::fs::copy(from, to).unwrap_or_else(|err| {
+        error!("Failed to copy file: {err}");
+        exit(1);
+    });
 }
 
 pub(crate) fn generate_keypair(path: &PathBuf) {

--- a/platform-tools-sdk/sbf/scripts/strip.sh
+++ b/platform-tools-sdk/sbf/scripts/strip.sh
@@ -10,6 +10,7 @@ if [[ -z $so_stripped ]]; then
   echo "Usage: $0 unstripped.so stripped.so"
   exit 1
 fi
+obj_copy_arg=$3
 
 sbf_sdk=$(cd "$(dirname "$0")/.." && pwd)
 # shellcheck source=platform-tools-sdk/sbf/env.sh
@@ -20,4 +21,4 @@ out_dir=$(dirname "$so_stripped")
 if [[ ! -d $out_dir ]]; then
   mkdir -p "$out_dir"
 fi
-"$sbf_sdk"/dependencies/platform-tools/llvm/bin/llvm-objcopy --strip-all "$so" "$so_stripped"
+"$sbf_sdk"/dependencies/platform-tools/llvm/bin/llvm-objcopy "$obj_copy_arg" "$so" "$so_stripped"


### PR DESCRIPTION
#### Problem

Our current setting for emitting debug information does not work, because the Rust compiler does not use the same command anymore, so I'm fixing it.

Furthermore, I found the existing scheme to be a little confusing, since `--debug` creates a `program.debug` file without telling anyone while also creating `program.so` without debug information.

#### Summary of Changes

1. Use the updated Rust command.
2. Update the CLI help description with the information of the files we are generating.
3. Create a `program.so.debug` file when we pass the flag `--debug`, together with a stripped version `program.so` and place both in `target/deploy/debug`.
