### PR TITLE
Clarify generate_index metric name

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -500,8 +500,8 @@ impl GenerateIndexTimings {
         datapoint_info!(
             "generate_index",
             ("overall_us", self.total_time_us, i64),
+            ("index_time_us", self.index_time, i64),
             // we cannot accurately measure index insertion time because of many threads and lock contention
-            ("total_us", self.index_time, i64),
             ("insertion_time_us", self.insertion_time_us, i64),
             (
                 "storage_size_storages_us",


### PR DESCRIPTION
#### Problem

Rename the generate_index datapoint from total_us to index_time_us so the metric matches what it measures. This avoids confusion with overall_us and keeps the label aligned with GenerateIndexTimings.index_time. 


#### Summary of Changes

rename index_time_us


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
