### PR TITLE
chore: Refactor to avoid extra Arc<Bank>::clone()

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -195,10 +195,13 @@ impl StandardBroadcastRun {
         receive_results: ReceiveResults,
         process_stats: &mut ProcessShredsStats,
     ) -> Result<()> {
-        let num_entries = receive_results.entries.len();
-        let bank = receive_results.bank.clone();
-        let last_tick_height = receive_results.last_tick_height;
-        inc_new_counter_info!("broadcast_service-entries_received", num_entries);
+        let ReceiveResults {
+            entries,
+            bank,
+            last_tick_height,
+        } = receive_results;
+
+        inc_new_counter_info!("broadcast_service-entries_received", entries.len());
 
         let mut to_shreds_time = Measure::start("broadcast_to_shreds");
 
@@ -270,7 +273,7 @@ impl StandardBroadcastRun {
         let shreds = self
             .entries_to_shreds(
                 keypair,
-                &receive_results.entries,
+                &entries,
                 reference_tick as u8,
                 is_last_in_slot,
                 process_stats,


### PR DESCRIPTION
#### Summary of Changes
Use destructuring to take ownership of the items and avoid the extra `Arc` clone. Since it is cloning an `Arc`, the clone is cheap but still no reason not to clean this up.

The `inc_new_counter_info` will be adjusted in a followup PR, but decided to split the PR and do one-thing-per-PR