### PR TITLE
chore: Remove counter from vote-program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11909,7 +11909,6 @@ dependencies = [
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-keypair",
- "solana-metrics",
  "solana-packet 4.0.0",
  "solana-program-runtime",
  "solana-pubkey 3.0.0",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10317,7 +10317,6 @@ dependencies = [
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-keypair",
- "solana-metrics",
  "solana-packet 4.0.0",
  "solana-program-runtime",
  "solana-pubkey 3.0.0",

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -17,7 +17,6 @@ crate-type = ["lib"]
 name = "solana_vote_program"
 
 [features]
-default = ["metrics"]
 agave-unstable-api = []
 dev-context-only-utils = []
 frozen-abi = [
@@ -26,7 +25,6 @@ frozen-abi = [
     "solana-program-runtime/frozen-abi",
     "solana-vote-interface/frozen-abi",
 ]
-metrics = ["dep:solana-metrics"]
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -48,7 +46,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-metrics = { workspace = true, optional = true }
 solana-packet = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true, features = ["curve25519"] }

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -12,10 +12,6 @@
 pub mod vote_processor;
 pub mod vote_state;
 
-#[cfg_attr(feature = "metrics", macro_use)]
-#[cfg(feature = "metrics")]
-extern crate solana_metrics;
-
 #[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -297,8 +297,6 @@ fn check_and_filter_proposed_vote_state(
             proposed_hash,
             slot_hashes[slot_hashes_index].1
         );
-        #[cfg(feature = "metrics")]
-        inc_new_counter_info!("dropped-vote-hash", 1);
         return Err(VoteError::SlotHashMismatch);
     }
 


### PR DESCRIPTION
#### Problem
Part of https://github.com/anza-xyz/agave/issues/9185

This counter would trigger when a vote was processed that differed from what the local node calculated.
- If the other node was incorrect, there is no action for the local node as the local node is still in consensus with the cluster
- If the local node was incorrect, the node will log the same information and eventually panic if the issue is non-recoverable (repair / replay / dump loop)

#### Summary of Changes
In either scenario, this counter doesn't provide much extra information over other signals so rip it out
