### PR TITLE
Allow warnings during compilation at workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,8 +163,6 @@ license = "Apache-2.0"
 edition = "2021"
 
 [workspace.lints.rust]
-warnings = "deny"
-
 # List of rust-2024-compatibility lints that are already satisfied
 # See https://doc.rust-lang.org/rustc/lints/groups.html
 boxed_slice_into_iter = "deny"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -19,8 +19,6 @@ license = "Apache-2.0"
 edition = "2021"
 
 [workspace.lints.rust]
-warnings = "deny"
-
 # List of rust-2024-compatibility lints that are already satisfied
 # See https://doc.rust-lang.org/rustc/lints/groups.html
 boxed_slice_into_iter = "deny"


### PR DESCRIPTION
#### Problem
During development warnings marked as errors are wasting a lot of time to ensure code is sanitized before every test run, debug build or experiment run.

Most warnings are not critical errors that make the code obviously wrong or dangerous, especially lints about code-style, unused code (that is pretty common when writing new code or testing alternative implementations) and could be permitted until the code is submitted for review and merged.

Note that warnings are still printed out on every build, so they are usually noticed by the developer, but they may choose to treat them as only informational as appropriate during development.

#### Summary of Changes
Remove deny of warnings in `Cargo.toml` and `dev-bins/Cargo.toml` to streamline development. The warnings as still treated as errors by `ci/test-checks.sh` and consequently by CI.
