### PR TITLE
perf(ledger): use wincode for shreds serialization

### DIFF
--- a/ledger/benches/make_shreds_from_entries.rs
+++ b/ledger/benches/make_shreds_from_entries.rs
@@ -41,7 +41,7 @@ fn make_dummy_entries<R: Rng>(rng: &mut R, data_size: usize) -> Vec<Entry> {
     let mut serialized_size = 8; // length prefix.
     repeat_with(|| make_dummy_entry(rng))
         .take_while(|entry| {
-            serialized_size += bincode::serialized_size(entry).unwrap();
+            serialized_size += wincode::serialized_size(entry).unwrap();
             serialized_size < data_size as u64
         })
         .collect()

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -74,8 +74,13 @@ use {
     solana_sha256_hasher::hashv,
     solana_signature::{Signature, SIGNATURE_BYTES},
     static_assertions::const_assert_eq,
-    std::fmt::Debug,
+    std::{fmt::Debug, mem::MaybeUninit},
     thiserror::Error,
+    wincode::{
+        containers::Pod,
+        io::{Reader, Writer},
+        SchemaRead, SchemaWrite,
+    },
 };
 #[cfg(any(test, feature = "dev-context-only-utils"))]
 use {solana_keypair::Keypair, solana_perf::packet::Packet, solana_signer::Signer};
@@ -162,6 +167,8 @@ pub enum Error {
     #[error(transparent)]
     Bincode(#[from] bincode::Error),
     #[error(transparent)]
+    WincodeWrite(#[from] wincode::WriteError),
+    #[error(transparent)]
     Erasure(#[from] reed_solomon_erasure::Error),
     #[error("Invalid data size: {size}, payload: {payload}")]
     InvalidDataSize { size: u16, payload: usize },
@@ -210,11 +217,25 @@ pub enum Error {
 #[repr(u8)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
 #[derive(
-    Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, IntoPrimitive, Serialize, TryFromPrimitive,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    PartialEq,
+    Deserialize,
+    IntoPrimitive,
+    Serialize,
+    TryFromPrimitive,
+    SchemaWrite,
+    SchemaRead,
 )]
 #[serde(into = "u8", try_from = "u8")]
+#[wincode(tag_encoding = "u8")]
 pub enum ShredType {
+    #[wincode(tag = 0b1010_0101)]
     Data = 0b1010_0101,
+    #[wincode(tag = 0b0101_1010)]
     Code = 0b0101_1010,
 }
 
@@ -233,8 +254,9 @@ enum ShredVariant {
 }
 
 /// A common header that is present in data and code shred headers
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaWrite)]
 struct ShredCommonHeader {
+    #[wincode(with = "Pod<_>")]
     signature: Signature,
     shred_variant: ShredVariant,
     slot: Slot,
@@ -244,15 +266,16 @@ struct ShredCommonHeader {
 }
 
 /// The data shred header has parent offset and flags
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaWrite)]
 struct DataShredHeader {
     parent_offset: u16,
+    #[wincode(with = "Pod<_>")]
     flags: ShredFlags,
     size: u16, // common shred header + data shred header + data
 }
 
 /// The coding shred header has FEC information
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaWrite)]
 struct CodingShredHeader {
     num_data_shreds: u16,
     num_coding_shreds: u16,
@@ -660,6 +683,41 @@ impl TryFrom<u8> for ShredVariant {
     }
 }
 
+impl SchemaWrite for ShredVariant {
+    type Src = Self;
+
+    fn size_of(_src: &Self::Src) -> wincode::WriteResult<usize> {
+        Ok(1)
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> wincode::WriteResult<()> {
+        let repr: u8 = (*src).into();
+        // Safety: u8 is a plain data type
+        unsafe { writer.write_t(&repr) }?;
+        Ok(())
+    }
+}
+
+impl<'a> SchemaRead<'a> for ShredVariant {
+    type Dst = Self;
+
+    fn read(
+        reader: &mut impl Reader<'a>,
+        dst: &mut MaybeUninit<Self::Dst>,
+    ) -> wincode::ReadResult<()> {
+        let mut repr_uninit = MaybeUninit::<u8>::uninit();
+        // Safety: u8 will always be properly initialized by a 1-byte read
+        let repr = unsafe {
+            reader.copy_into_t(&mut repr_uninit)?;
+            repr_uninit.assume_init()
+        };
+        let value = Self::try_from(repr)
+            .map_err(|_| wincode::ReadError::InvalidTagEncoding(repr as usize))?;
+        dst.write(value);
+        Ok(())
+    }
+}
+
 pub fn recover<T: IntoIterator<Item = Shred>>(
     shreds: T,
     reed_solomon_cache: &ReedSolomonCache,
@@ -935,7 +993,6 @@ mod tests {
     use {
         super::*,
         assert_matches::assert_matches,
-        bincode::serialized_size,
         itertools::Itertools,
         rand::Rng,
         rand_chacha::{rand_core::SeedableRng, ChaChaRng},
@@ -994,6 +1051,8 @@ mod tests {
 
     #[test]
     fn test_shred_constants() {
+        use wincode::Serialize as _;
+
         let common_header = ShredCommonHeader {
             signature: Signature::default(),
             shred_variant: ShredVariant::MerkleCode {
@@ -1017,15 +1076,15 @@ mod tests {
         };
         assert_eq!(
             SIZE_OF_COMMON_SHRED_HEADER,
-            serialized_size(&common_header).unwrap() as usize
+            wincode::serialized_size(&common_header).unwrap() as usize
         );
         assert_eq!(
             SIZE_OF_CODING_SHRED_HEADERS - SIZE_OF_COMMON_SHRED_HEADER,
-            serialized_size(&coding_shred_header).unwrap() as usize
+            wincode::serialized_size(&coding_shred_header).unwrap() as usize
         );
         assert_eq!(
             SIZE_OF_DATA_SHRED_HEADERS - SIZE_OF_COMMON_SHRED_HEADER,
-            serialized_size(&data_shred_header).unwrap() as usize
+            wincode::serialized_size(&data_shred_header).unwrap() as usize
         );
         let data_shred_header_with_size = DataShredHeader {
             size: 1000,
@@ -1033,15 +1092,15 @@ mod tests {
         };
         assert_eq!(
             SIZE_OF_DATA_SHRED_HEADERS - SIZE_OF_COMMON_SHRED_HEADER,
-            serialized_size(&data_shred_header_with_size).unwrap() as usize
+            wincode::serialized_size(&data_shred_header_with_size).unwrap() as usize
         );
         assert_eq!(
             SIZE_OF_SIGNATURE,
-            bincode::serialized_size(&Signature::default()).unwrap() as usize
+            Pod::<Signature>::serialized_size(&Signature::default()).unwrap() as usize
         );
         assert_eq!(
             SIZE_OF_SHRED_VARIANT,
-            bincode::serialized_size(&ShredVariant::MerkleCode {
+            wincode::serialized_size(&ShredVariant::MerkleCode {
                 proof_size: 15,
                 resigned: true
             })
@@ -1049,11 +1108,11 @@ mod tests {
         );
         assert_eq!(
             SIZE_OF_SHRED_SLOT,
-            bincode::serialized_size(&Slot::default()).unwrap() as usize
+            wincode::serialized_size(&Slot::default()).unwrap() as usize
         );
         assert_eq!(
             SIZE_OF_SHRED_INDEX,
-            bincode::serialized_size(&common_header.index).unwrap() as usize
+            wincode::serialized_size(&common_header.index).unwrap() as usize
         );
     }
 
@@ -1518,26 +1577,26 @@ mod tests {
         assert_eq!(std::mem::size_of::<ShredType>(), std::mem::size_of::<u8>());
         assert_matches!(ShredType::try_from(0u8), Err(_));
         assert_matches!(ShredType::try_from(1u8), Err(_));
-        assert_matches!(bincode::deserialize::<ShredType>(&[0u8]), Err(_));
-        assert_matches!(bincode::deserialize::<ShredType>(&[1u8]), Err(_));
+        assert_matches!(wincode::deserialize::<ShredType>(&[0u8]), Err(_));
+        assert_matches!(wincode::deserialize::<ShredType>(&[1u8]), Err(_));
         // data shred
         assert_eq!(ShredType::Data as u8, 0b1010_0101);
         assert_eq!(u8::from(ShredType::Data), 0b1010_0101);
         assert_eq!(ShredType::try_from(0b1010_0101), Ok(ShredType::Data));
-        let buf = bincode::serialize(&ShredType::Data).unwrap();
+        let buf = wincode::serialize(&ShredType::Data).unwrap();
         assert_eq!(buf, vec![0b1010_0101]);
         assert_matches!(
-            bincode::deserialize::<ShredType>(&[0b1010_0101]),
+            wincode::deserialize::<ShredType>(&[0b1010_0101]),
             Ok(ShredType::Data)
         );
         // coding shred
         assert_eq!(ShredType::Code as u8, 0b0101_1010);
         assert_eq!(u8::from(ShredType::Code), 0b0101_1010);
         assert_eq!(ShredType::try_from(0b0101_1010), Ok(ShredType::Code));
-        let buf = bincode::serialize(&ShredType::Code).unwrap();
+        let buf = wincode::serialize(&ShredType::Code).unwrap();
         assert_eq!(buf, vec![0b0101_1010]);
         assert_matches!(
-            bincode::deserialize::<ShredType>(&[0b0101_1010]),
+            wincode::deserialize::<ShredType>(&[0b0101_1010]),
             Ok(ShredType::Code)
         );
     }
@@ -1548,12 +1607,12 @@ mod tests {
         assert_matches!(ShredVariant::try_from(1u8), Err(_));
         assert_matches!(ShredVariant::try_from(0b0101_0000), Err(_));
         assert_matches!(ShredVariant::try_from(0b1010_0000), Err(_));
-        assert_matches!(bincode::deserialize::<ShredVariant>(&[0b0101_0000]), Err(_));
-        assert_matches!(bincode::deserialize::<ShredVariant>(&[0b1010_0000]), Err(_));
+        assert_matches!(wincode::deserialize::<ShredVariant>(&[0b0101_0000]), Err(_));
+        assert_matches!(wincode::deserialize::<ShredVariant>(&[0b1010_0000]), Err(_));
         assert_matches!(ShredVariant::try_from(0b0101_1010), Err(_));
-        assert_matches!(bincode::deserialize::<ShredVariant>(&[0b0101_1010]), Err(_));
+        assert_matches!(wincode::deserialize::<ShredVariant>(&[0b0101_1010]), Err(_));
         assert_matches!(ShredVariant::try_from(0b1010_0101), Err(_));
-        assert_matches!(bincode::deserialize::<ShredVariant>(&[0b1010_0101]), Err(_));
+        assert_matches!(wincode::deserialize::<ShredVariant>(&[0b1010_0101]), Err(_));
     }
 
     #[test_case(false, 0b0110_0000)]
@@ -1582,14 +1641,14 @@ mod tests {
                     resigned,
                 },
             );
-            let buf = bincode::serialize(&ShredVariant::MerkleCode {
+            let wincode_buf = wincode::serialize(&ShredVariant::MerkleCode {
                 proof_size,
                 resigned,
             })
             .unwrap();
-            assert_eq!(buf, vec![byte]);
+            assert_eq!(wincode_buf, vec![byte]);
             assert_eq!(
-                bincode::deserialize::<ShredVariant>(&[byte]).unwrap(),
+                wincode::deserialize::<ShredVariant>(&[byte]).unwrap(),
                 ShredVariant::MerkleCode {
                     proof_size,
                     resigned,
@@ -1624,14 +1683,14 @@ mod tests {
                     resigned
                 }
             );
-            let buf = bincode::serialize(&ShredVariant::MerkleData {
+            let wincode_buf = wincode::serialize(&ShredVariant::MerkleData {
                 proof_size,
                 resigned,
             })
             .unwrap();
-            assert_eq!(buf, vec![byte]);
+            assert_eq!(wincode_buf, vec![byte]);
             assert_eq!(
-                bincode::deserialize::<ShredVariant>(&[byte]).unwrap(),
+                wincode::deserialize::<ShredVariant>(&[byte]).unwrap(),
                 ShredVariant::MerkleData {
                     proof_size,
                     resigned
@@ -1815,38 +1874,42 @@ mod tests {
 
     #[test]
     fn test_shred_flags_serde() {
-        let flags: ShredFlags = bincode::deserialize(&[0b0001_0101]).unwrap();
+        use wincode::{Deserialize as _, Serialize as _};
+
+        let flags = Pod::<ShredFlags>::deserialize(&[0b0001_0101]).unwrap();
         assert_eq!(flags, ShredFlags::from_bits(0b0001_0101).unwrap());
         assert!(!flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(!flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
         assert_eq!((flags & ShredFlags::SHRED_TICK_REFERENCE_MASK).bits(), 21u8);
-        assert_eq!(bincode::serialize(&flags).unwrap(), [0b0001_0101]);
+        assert_eq!(Pod::<ShredFlags>::serialize(&flags).unwrap(), [0b0001_0101]);
 
-        let flags: ShredFlags = bincode::deserialize(&[0b0111_0001]).unwrap();
+        let flags = Pod::<ShredFlags>::deserialize(&[0b0111_0001]).unwrap();
         assert_eq!(flags, ShredFlags::from_bits(0b0111_0001).unwrap());
         assert!(flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(!flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
         assert_eq!((flags & ShredFlags::SHRED_TICK_REFERENCE_MASK).bits(), 49u8);
-        assert_eq!(bincode::serialize(&flags).unwrap(), [0b0111_0001]);
+        assert_eq!(Pod::<ShredFlags>::serialize(&flags).unwrap(), [0b0111_0001]);
 
-        let flags: ShredFlags = bincode::deserialize(&[0b1110_0101]).unwrap();
+        let flags = Pod::<ShredFlags>::deserialize(&[0b1110_0101]).unwrap();
         assert_eq!(flags, ShredFlags::from_bits(0b1110_0101).unwrap());
         assert!(flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
         assert_eq!((flags & ShredFlags::SHRED_TICK_REFERENCE_MASK).bits(), 37u8);
-        assert_eq!(bincode::serialize(&flags).unwrap(), [0b1110_0101]);
+        assert_eq!(Pod::<ShredFlags>::serialize(&flags).unwrap(), [0b1110_0101]);
 
-        let flags: ShredFlags = bincode::deserialize(&[0b1011_1101]).unwrap();
+        let flags = Pod::<ShredFlags>::deserialize(&[0b1011_1101]).unwrap();
         assert_eq!(flags, ShredFlags::from_bits(0b1011_1101).unwrap());
         assert!(!flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(!flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
         assert_eq!((flags & ShredFlags::SHRED_TICK_REFERENCE_MASK).bits(), 61u8);
-        assert_eq!(bincode::serialize(&flags).unwrap(), [0b1011_1101]);
+        assert_eq!(Pod::<ShredFlags>::serialize(&flags).unwrap(), [0b1011_1101]);
     }
 
     // Verifies that LAST_SHRED_IN_SLOT also implies DATA_COMPLETE_SHRED.
     #[test]
     fn test_shred_flags_data_complete() {
+        use wincode::Deserialize as _;
+
         let mut flags = ShredFlags::empty();
         assert!(!flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(!flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
@@ -1861,7 +1924,7 @@ mod tests {
         assert!(flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
 
-        let mut flags: ShredFlags = bincode::deserialize(&[0b1011_1111]).unwrap();
+        let mut flags = Pod::<ShredFlags>::deserialize(&[0b1011_1111]).unwrap();
         assert!(!flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(!flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
         flags.insert(ShredFlags::LAST_SHRED_IN_SLOT);

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -871,7 +871,10 @@ fn make_stub_shred(
         // For coding shreds {common,coding} headers are not part of the
         // erasure coded slice and need to be written to the payload here.
         let mut payload = vec![0u8; ShredCode::SIZE_OF_PAYLOAD];
-        bincode::serialize_into(&mut payload[..], &(&common_header, &coding_header))?;
+        wincode::serialize_into(
+            &mut payload.as_mut_slice(),
+            &(&common_header, &coding_header),
+        )?;
         Shred::ShredCode(ShredCode {
             common_header,
             coding_header,
@@ -1210,16 +1213,16 @@ fn finish_erasure_batch(
 ) -> Result<Hash, Error> {
     debug_assert_eq!(shreds.iter().map(Shred::fec_set_index).dedup().count(), 1);
     // Write common and {data,coding} headers into shreds' payload.
-    fn write_headers(shred: &mut Shred) -> Result<(), bincode::Error> {
+    fn write_headers(shred: &mut Shred) -> Result<(), wincode::WriteError> {
         match shred {
-            Shred::ShredCode(shred) => bincode::serialize_into(
-                &mut shred.payload.as_mut()[..],
-                &(&shred.common_header, &shred.coding_header),
-            ),
-            Shred::ShredData(shred) => bincode::serialize_into(
-                &mut shred.payload.as_mut()[..],
-                &(&shred.common_header, &shred.data_header),
-            ),
+            Shred::ShredCode(shred) => {
+                let mut dst = &mut shred.payload.as_mut()[..];
+                wincode::serialize_into(&mut dst, &(&shred.common_header, &shred.coding_header))
+            }
+            Shred::ShredData(shred) => {
+                let mut dst = &mut shred.payload.as_mut()[..];
+                wincode::serialize_into(&mut dst, &(&shred.common_header, &shred.data_header))
+            }
         }
     }
     match thread_pool {
@@ -1466,7 +1469,8 @@ mod test {
                 ..data_header
             };
             let mut payload = vec![0u8; ShredData::SIZE_OF_PAYLOAD];
-            bincode::serialize_into(&mut payload[..], &(&common_header, &data_header)).unwrap();
+            wincode::serialize_into(&mut payload.as_mut_slice(), &(&common_header, &data_header))
+                .unwrap();
             rng.fill(&mut payload[ShredData::SIZE_OF_HEADERS..size]);
             let shred = ShredData {
                 common_header,
@@ -1500,7 +1504,12 @@ mod test {
                 ..coding_header
             };
             let mut payload = vec![0u8; ShredCode::SIZE_OF_PAYLOAD];
-            bincode::serialize_into(&mut payload[..], &(&common_header, &coding_header)).unwrap();
+            wincode::serialize_into(
+                &mut payload.as_mut_slice(),
+                &(&common_header, &coding_header),
+            )
+            .unwrap();
+
             payload[ShredCode::SIZE_OF_HEADERS..ShredCode::SIZE_OF_HEADERS + code.len()]
                 .copy_from_slice(&code);
             let shred = ShredCode {

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -543,7 +543,7 @@ mod tests {
             let shred_common_header = shred.common_header();
             assert_eq!(
                 get_common_header_bytes(bytes).unwrap(),
-                bincode::serialize(shred_common_header).unwrap(),
+                wincode::serialize(shred_common_header).unwrap(),
             );
             assert_eq!(get_signature(bytes).unwrap(), shred_common_header.signature,);
             assert_eq!(

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -47,7 +47,7 @@ fn test_multi_fec_block_coding(is_last_in_slot: bool) {
         .collect();
 
     let reed_solomon_cache = ReedSolomonCache::default();
-    let serialized_entries = bincode::serialize(&entries).unwrap();
+    let serialized_entries = wincode::serialize(&entries).unwrap();
 
     let (data_shreds, coding_shreds) = shredder.entries_to_merkle_shreds_for_tests(
         &keypair,


### PR DESCRIPTION
#### Problem
Serializing shreds can be sped up using `wincode`

#### Summary of Changes
* annotate a few structs with derive `SchemaWrite`
* implement `Schema*` for `ShredVariant`, since it uses custom conversion to/from `u8` that is then used for serialization
* use `Pod` for `ShredFlags`, since it uses `bitflags!` macro that doesn't work with wincode derives
* use `Pod` for `Signature` as it's foreign struct not annotated with `Schema*` (can be simplified after https://github.com/anza-xyz/solana-sdk/pull/461)

##### Benchmark performance
* master:
```
bench_make_shreds_from_entries_256
                        time:   [3.1432 ms 3.1912 ms 3.2381 ms]
```
* master, thread pool disabled:
```
bench_make_shreds_from_entries_256
                        time:   [1.0407 ms 1.0474 ms 1.0548 ms]
```

* PR:
```
bench_make_shreds_from_entries_256
                        time:   [3.0346 ms 3.0794 ms 3.1257 ms]
```

* PR, thread pool disabled:
```
bench_make_shreds_from_entries_256
                        time:   [935.45 µs 940.73 µs 946.09 µs]
```