### PR TITLE
ledger: Make Shredder single-threaded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9170,7 +9170,6 @@ dependencies = [
  "solana-program-pack",
  "solana-program-runtime",
  "solana-pubkey 3.0.0",
- "solana-rayon-threadlimit",
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-seed-derivable",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9170,7 +9170,6 @@ dependencies = [
  "solana-program-pack",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rayon-threadlimit",
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-sha256-hasher",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7672,7 +7672,6 @@ dependencies = [
  "solana-perf",
  "solana-program-runtime",
  "solana-pubkey 3.0.0",
- "solana-rayon-threadlimit",
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-seed-derivable",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7216,7 +7216,6 @@ dependencies = [
  "solana-perf",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rayon-threadlimit",
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-sha256-hasher",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -91,7 +91,6 @@ solana-packet = { workspace = true }
 solana-perf = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-pubkey = { workspace = true }
-solana-rayon-threadlimit = { workspace = true }
 solana-runtime = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-seed-derivable = { workspace = true }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -89,7 +89,6 @@ solana-packet = { workspace = true }
 solana-perf = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-pubkey = { workspace = true, features = ["wincode"] }
-solana-rayon-threadlimit = { workspace = true }
 solana-runtime = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-sha256-hasher = { workspace = true }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -939,7 +939,6 @@ mod tests {
         itertools::Itertools,
         rand::Rng,
         rand_chacha::{rand_core::SeedableRng, ChaChaRng},
-        rayon::ThreadPoolBuilder,
         solana_keypair::keypair_from_seed,
         std::io::{Cursor, Seek, SeekFrom, Write},
         test_case::test_case,
@@ -968,7 +967,6 @@ mod tests {
         data_size: usize,
         is_last_in_slot: bool,
     ) -> Result<Vec<merkle::Shred>, Error> {
-        let thread_pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
         let chained_merkle_root = Hash::new_from_array(rng.random());
         let parent_offset = rng.random_range(1..=u16::try_from(slot).unwrap_or(u16::MAX));
         let parent_slot = slot.checked_sub(u64::from(parent_offset)).unwrap();
@@ -976,7 +974,6 @@ mod tests {
         let fec_set_index = rng.random_range(0..21) * DATA_SHREDS_PER_FEC_BLOCK as u32;
         rng.fill(&mut data[..]);
         merkle::make_shreds_from_data(
-            &thread_pool,
             &Keypair::new(),
             chained_merkle_root,
             &data[..],

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -50,6 +50,8 @@
 //! payload can fit into one coding shred / packet.
 
 pub(crate) use self::merkle_tree::PROOF_ENTRIES_FOR_32_32_BATCH;
+#[cfg(test)]
+use rand::Rng;
 use {
     self::traits::{Shred as _, ShredData as _},
     bitflags::bitflags,
@@ -81,8 +83,6 @@ pub use {
     },
     crate::shredder::{ReedSolomonCache, Shredder},
 };
-#[cfg(test)]
-use {rand::Rng, rayon::ThreadPoolBuilder};
 #[cfg(any(test, feature = "dev-context-only-utils"))]
 use {solana_keypair::Keypair, solana_perf::packet::Packet, solana_signer::Signer};
 
@@ -806,7 +806,6 @@ pub(crate) fn make_merkle_shreds_for_tests<R: Rng>(
     data_size: usize,
     is_last_in_slot: bool,
 ) -> Result<Vec<merkle::Shred>, Error> {
-    let thread_pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
     let chained_merkle_root = Hash::new_from_array(rng.random());
     let parent_offset = rng.random_range(1..=u16::try_from(slot).unwrap_or(u16::MAX));
     let parent_slot = slot.checked_sub(u64::from(parent_offset)).unwrap();
@@ -814,7 +813,6 @@ pub(crate) fn make_merkle_shreds_for_tests<R: Rng>(
     let fec_set_index = rng.random_range(0..21) * DATA_SHREDS_PER_FEC_BLOCK as u32;
     rng.fill(&mut data[..]);
     merkle::make_shreds_from_data(
-        &thread_pool,
         &Keypair::new(),
         chained_merkle_root,
         &data[..],

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -20,7 +20,6 @@ use {
     },
     assert_matches::debug_assert_matches,
     itertools::{Either, Itertools},
-    rayon::{ThreadPool, prelude::*},
     reed_solomon_erasure::Error::{InvalidIndex, TooFewParityShards},
     solana_clock::Slot,
     solana_hash::Hash,
@@ -1016,7 +1015,6 @@ fn make_shreds_code_header_only(
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn make_shreds_from_data(
-    thread_pool: &ThreadPool,
     keypair: &Keypair,
     chained_merkle_root: Hash,
     data: &[u8], // Serialized &[Entry]
@@ -1190,13 +1188,7 @@ pub(crate) fn make_shreds_from_data(
     // (and so the signature) cannot be computed without the Merkle root of
     // the previous erasure batch.
     batches.try_fold(chained_merkle_root, |chained_merkle_root, batch| {
-        finish_erasure_batch(
-            Some(thread_pool),
-            keypair,
-            batch,
-            chained_merkle_root,
-            reed_solomon_cache,
-        )
+        finish_erasure_batch(keypair, batch, chained_merkle_root, reed_solomon_cache)
     })?;
     stats.gen_coding_elapsed += now.elapsed().as_micros() as u64;
     Ok(shreds)
@@ -1243,7 +1235,6 @@ fn shred_leftover_data(
 // - Populates Merkle proof for each shred and attaches the signature.
 // Returns the root of the Merkle tree.
 fn finish_erasure_batch(
-    thread_pool: Option<&ThreadPool>,
     keypair: &Keypair,
     shreds: &mut [Shred],
     // The Merkle root of the previous erasure batch if chained.
@@ -1264,12 +1255,7 @@ fn finish_erasure_batch(
             }
         }
     }
-    match thread_pool {
-        None => shreds.iter_mut().try_for_each(write_headers),
-        Some(thread_pool) => {
-            thread_pool.install(|| shreds.par_iter_mut().try_for_each(write_headers))
-        }
-    }?;
+    shreds.iter_mut().try_for_each(write_headers)?;
     // Fill in erasure code buffers in the coding shreds.
     let CodingShredHeader {
         num_data_shreds,
@@ -1299,19 +1285,7 @@ fn finish_erasure_batch(
     }
 
     // Compute the Merkle tree for the erasure batch.
-    let tree = match thread_pool {
-        None => {
-            let nodes = shreds.iter().map(Shred::merkle_node);
-            MerkleTree::try_new(nodes)
-        }
-        Some(thread_pool) => MerkleTree::try_new(thread_pool.install(|| {
-            shreds
-                .par_iter()
-                .map(Shred::merkle_node)
-                .collect::<Vec<_>>()
-                .into_iter()
-        })),
-    }?;
+    let tree = MerkleTree::try_new(shreds.iter().map(Shred::merkle_node))?;
     // Sign the root of the Merkle tree.
     let signature = keypair.sign_message(tree.root().as_ref());
     // Populate merkle proof for all shreds and attach signature.
@@ -1343,13 +1317,8 @@ pub(crate) fn finish_erasure_batch_for_tests(
         .cloned()
         .map(crate::shred::Shred::try_into)
         .collect::<Result<_, _>>()?;
-    let chained_merkle_root = finish_erasure_batch(
-        None,
-        keypair,
-        &mut batch,
-        chained_merkle_root,
-        reed_solomon_cache,
-    )?;
+    let chained_merkle_root =
+        finish_erasure_batch(keypair, &mut batch, chained_merkle_root, reed_solomon_cache)?;
     for (dst, src) in shreds.iter_mut().zip(batch) {
         *dst = crate::shred::Shred::from(src);
     }
@@ -1364,7 +1333,6 @@ mod test {
         assert_matches::assert_matches,
         itertools::Itertools,
         rand::{CryptoRng, Rng, seq::SliceRandom},
-        rayon::ThreadPoolBuilder,
         reed_solomon_erasure::Error::TooFewShardsPresent,
         solana_keypair::Keypair,
         solana_packet::PACKET_DATA_SIZE,
@@ -1689,7 +1657,6 @@ mod test {
         is_last_in_slot: bool,
         reed_solomon_cache: &ReedSolomonCache,
     ) {
-        let thread_pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
         let keypair = Keypair::new();
         let chained_merkle_root = Hash::new_from_array(rng.random());
         let slot = 149_745_689;
@@ -1701,7 +1668,6 @@ mod test {
         let mut data = vec![0u8; data_size];
         rng.fill(&mut data[..]);
         let shreds = make_shreds_from_data(
-            &thread_pool,
             &keypair,
             chained_merkle_root,
             &data[..],

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -3,27 +3,17 @@ use {
         self, DATA_SHREDS_PER_FEC_BLOCK, Error, ProcessShredsStats, Shred, ShredData, ShredFlags,
     },
     lazy_lru::LruCache,
-    rayon::ThreadPool,
     reed_solomon_erasure::{Error::TooFewDataShards, galois_8::ReedSolomon},
     solana_clock::Slot,
     solana_entry::{block_component::BlockComponent, entry::Entry},
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_rayon_threadlimit::get_thread_count,
     std::{
         fmt::Debug,
         sync::{Arc, OnceLock, RwLock},
         time::Instant,
     },
 };
-
-static PAR_THREAD_POOL: std::sync::LazyLock<ThreadPool> = std::sync::LazyLock::new(|| {
-    rayon::ThreadPoolBuilder::new()
-        .num_threads(get_thread_count())
-        .thread_name(|i| format!("solShredder{i:02}"))
-        .build()
-        .unwrap()
-});
 
 // Arc<...> wrapper so that cache entries can be initialized without locking
 // the entire cache.
@@ -134,9 +124,7 @@ impl Shredder {
         reed_solomon_cache: &ReedSolomonCache,
         stats: &mut ProcessShredsStats,
     ) -> Result<impl Iterator<Item = Shred> + use<>, Error> {
-        let thread_pool: &ThreadPool = &PAR_THREAD_POOL;
         let shreds = shred::merkle::make_shreds_from_data(
-            thread_pool,
             keypair,
             chained_merkle_root,
             data,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7451,7 +7451,6 @@ dependencies = [
  "solana-perf",
  "solana-program-runtime",
  "solana-pubkey 3.0.0",
- "solana-rayon-threadlimit",
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-seed-derivable",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7407,7 +7407,6 @@ dependencies = [
  "solana-perf",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rayon-threadlimit",
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-sha256-hasher",


### PR DESCRIPTION
#### Problem
Shredder has used a rayon threadpool since the days of legacy shreds. Merkle shreds have long been adopted which has reduced the amount of work fanned out to the threadpool. As such, the ratio of overhead to actual work done by the threadpool has greatly increased.

#### Summary of Changes
Remove the threadpool to make Shredder completely single-threaded

#### Testing Done

Local benches, CI.

Closes https://github.com/anza-xyz/agave/issues/9238