### PR TITLE
Remove usages of `WritableAccount::create`

### DIFF
--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -248,9 +248,9 @@ mod test {
             UiAccountData::Binary(_, UiAccountEncoding::Base64Zstd)
         );
 
-        let decoded_account = encoded_account.decode::<Account>().unwrap();
+        let decoded_account = encoded_account.to_account_shared_data().unwrap();
         assert_eq!(decoded_account.data(), &vec![0; 1024]);
-        let decoded_account = encoded_account.decode::<AccountSharedData>().unwrap();
+        let decoded_account = encoded_account.to_account().unwrap();
         assert_eq!(decoded_account.data(), &vec![0; 1024]);
     }
 }

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -733,9 +733,9 @@ mod tests {
                 meta: LookupTableMeta::default(),
                 addresses: Cow::Owned(table_addresses.clone()),
             };
-            AccountSharedData::create(
+            AccountSharedData::create_from_existing_shared_data(
                 1,
-                table_state.serialize_for_tests().unwrap(),
+                Arc::new(table_state.serialize_for_tests().unwrap()),
                 address_lookup_table::program::id(),
                 false,
                 0,

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1748,7 +1748,7 @@ pub mod tests {
     use {
         super::{bucket_map_holder::BucketMapHolder, *},
         crate::accounts_index::account_map_entry::AccountMapEntryMeta,
-        solana_account::{AccountSharedData, WritableAccount},
+        solana_account::AccountSharedData,
         solana_pubkey::PUBKEY_BYTES,
         spl_generic_token::{spl_token_ids, token::SPL_TOKEN_ACCOUNT_OWNER_OFFSET},
         std::ops::{
@@ -3124,9 +3124,9 @@ pub mod tests {
                 *slot,
                 &account_key,
                 // Make sure these accounts are added to secondary index
-                &AccountSharedData::create(
+                &AccountSharedData::create_from_existing_shared_data(
                     0,
-                    account_data.to_vec(),
+                    Arc::new(account_data.to_vec()),
                     spl_generic_token::token::id(),
                     false,
                     0,
@@ -3513,7 +3513,13 @@ pub mod tests {
             0,
             0,
             &account_key,
-            &AccountSharedData::create(0, account_data.to_vec(), Pubkey::default(), false, 0),
+            &AccountSharedData::create_from_existing_shared_data(
+                0,
+                Arc::new(account_data.to_vec()),
+                Pubkey::default(),
+                false,
+                0,
+            ),
             &secondary_indexes,
             true,
             &mut ReclaimsSlotList::new(),
@@ -3527,7 +3533,13 @@ pub mod tests {
             0,
             0,
             &account_key,
-            &AccountSharedData::create(0, account_data[1..].to_vec(), *token_id, false, 0),
+            &AccountSharedData::create_from_existing_shared_data(
+                0,
+                Arc::new(account_data[1..].to_vec()),
+                *token_id,
+                false,
+                0,
+            ),
             &secondary_indexes,
             true,
             &mut ReclaimsSlotList::new(),
@@ -3542,7 +3554,13 @@ pub mod tests {
         for _ in 0..2 {
             index.update_secondary_indexes(
                 &account_key,
-                &AccountSharedData::create(0, account_data.to_vec(), *token_id, false, 0),
+                &AccountSharedData::create_from_existing_shared_data(
+                    0,
+                    Arc::new(account_data.to_vec()),
+                    *token_id,
+                    false,
+                    0,
+                ),
                 &secondary_indexes,
             );
             check_secondary_index_mapping_correct(secondary_index, &[index_key], &account_key);
@@ -3560,7 +3578,13 @@ pub mod tests {
         secondary_index.reverse_index.clear();
         index.update_secondary_indexes(
             &account_key,
-            &AccountSharedData::create(0, account_data.to_vec(), *token_id, false, 0),
+            &AccountSharedData::create_from_existing_shared_data(
+                0,
+                Arc::new(account_data.to_vec()),
+                *token_id,
+                false,
+                0,
+            ),
             &secondary_indexes,
         );
         assert!(!secondary_index.index.is_empty());
@@ -3576,7 +3600,13 @@ pub mod tests {
         secondary_index.reverse_index.clear();
         index.update_secondary_indexes(
             &account_key,
-            &AccountSharedData::create(0, account_data.to_vec(), *token_id, false, 0),
+            &AccountSharedData::create_from_existing_shared_data(
+                0,
+                Arc::new(account_data.to_vec()),
+                *token_id,
+                false,
+                0,
+            ),
             &secondary_indexes,
         );
         assert!(!secondary_index.index.is_empty());
@@ -3652,7 +3682,13 @@ pub mod tests {
             slot,
             slot,
             &account_key,
-            &AccountSharedData::create(0, account_data1.to_vec(), *token_id, false, 0),
+            &AccountSharedData::create_from_existing_shared_data(
+                0,
+                Arc::new(account_data1.to_vec()),
+                *token_id,
+                false,
+                0,
+            ),
             secondary_indexes,
             true,
             &mut ReclaimsSlotList::new(),
@@ -3664,7 +3700,13 @@ pub mod tests {
             slot,
             slot,
             &account_key,
-            &AccountSharedData::create(0, account_data2.to_vec(), *token_id, false, 0),
+            &AccountSharedData::create_from_existing_shared_data(
+                0,
+                Arc::new(account_data2.to_vec()),
+                *token_id,
+                false,
+                0,
+            ),
             secondary_indexes,
             true,
             &mut ReclaimsSlotList::new(),
@@ -3684,7 +3726,13 @@ pub mod tests {
             later_slot,
             later_slot,
             &account_key,
-            &AccountSharedData::create(0, account_data1.to_vec(), *token_id, false, 0),
+            &AccountSharedData::create_from_existing_shared_data(
+                0,
+                Arc::new(account_data1.to_vec()),
+                *token_id,
+                false,
+                0,
+            ),
             secondary_indexes,
             true,
             &mut ReclaimsSlotList::new(),

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -31,7 +31,7 @@ use {
     log::*,
     memmap2::MmapMut,
     meta::StoredAccountNoData,
-    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
+    solana_account::{AccountSharedData, ReadableAccount},
     solana_pubkey::Pubkey,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     std::{
@@ -44,7 +44,7 @@ use {
         ptr, slice,
         sync::{
             atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
-            Mutex, MutexGuard,
+            Arc, Mutex, MutexGuard,
         },
     },
     thiserror::Error,
@@ -891,9 +891,9 @@ impl AppendVec {
                     }
                     // SAFETY: we've just checked that `bytes_read` is at least `data_len`.
                     unsafe { data.set_len(data_len as usize) };
-                    AccountSharedData::create(
+                    AccountSharedData::create_from_existing_shared_data(
                         account_meta.lamports,
-                        data,
+                        Arc::new(data),
                         account_meta.owner,
                         account_meta.executable,
                         account_meta.rent_epoch,
@@ -1366,7 +1366,7 @@ pub mod tests {
         memoffset::offset_of,
         rand::{prelude::*, rng},
         rand_chacha::ChaChaRng,
-        solana_account::{accounts_equal, Account, AccountSharedData},
+        solana_account::{accounts_equal, Account, AccountSharedData, WritableAccount},
         solana_clock::Slot,
         std::{mem::ManuallyDrop, time::Instant},
         test_case::{test_case, test_matrix},

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -367,7 +367,7 @@ pub mod tests {
             accounts_file::AccountsFileProvider,
         },
         rand::Rng,
-        solana_account::{accounts_equal, AccountSharedData, WritableAccount},
+        solana_account::{accounts_equal, AccountSharedData},
         std::sync::Arc,
     };
 
@@ -547,9 +547,9 @@ pub mod tests {
                     let mut raw4 = Vec::new();
                     for entry in 0..entries {
                         let pk = Pubkey::from([entry; 32]);
-                        let account = AccountSharedData::create(
+                        let account = AccountSharedData::create_from_existing_shared_data(
                             (entry as u64) * starting_slot,
-                            Vec::default(),
+                            Arc::new(Vec::default()),
                             Pubkey::default(),
                             false,
                             0,
@@ -678,9 +678,9 @@ pub mod tests {
             let mut raw2 = Vec::new();
             for entry in 0..entries {
                 let pk = Pubkey::from([entry; 32]);
-                let account = AccountSharedData::create(
+                let account = AccountSharedData::create_from_existing_shared_data(
                     entry as u64,
-                    Vec::default(),
+                    Arc::new(Vec::default()),
                     Pubkey::default(),
                     false,
                     0,

--- a/accounts-db/src/utils.rs
+++ b/accounts-db/src/utils.rs
@@ -1,13 +1,13 @@
 use {
     agave_fs::dirs,
     log::*,
-    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
+    solana_account::{AccountSharedData, ReadableAccount},
     solana_measure::measure_time,
     std::{
         collections::HashSet,
         fs, io,
         path::{Path, PathBuf},
-        sync::Mutex,
+        sync::{Arc, Mutex},
         thread,
     },
 };
@@ -154,9 +154,9 @@ pub fn create_and_canonicalize_directory(directory: impl AsRef<Path>) -> io::Res
 /// Creates a new AccountSharedData structure for anything that implements ReadableAccount.
 /// This function implies data copies.
 pub fn create_account_shared_data(account: &impl ReadableAccount) -> AccountSharedData {
-    AccountSharedData::create(
+    AccountSharedData::create_from_existing_shared_data(
         account.lamports(),
-        account.data().to_vec(),
+        Arc::new(account.data().to_vec()),
         *account.owner(),
         account.executable(),
         account.rent_epoch(),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -11,7 +11,7 @@ use {
     console::style,
     crossbeam_channel::unbounded,
     serde::{Deserialize, Serialize},
-    solana_account::{from_account, state_traits::StateMut, Account},
+    solana_account::{from_account, state_traits::StateMut},
     solana_clap_utils::{
         compute_budget::{compute_unit_price_arg, ComputeUnitLimit, COMPUTE_UNIT_PRICE_ARG},
         input_parsers::*,
@@ -2001,7 +2001,7 @@ pub async fn process_show_stakes(
 
     let mut stake_accounts: Vec<CliKeyedStakeState> = vec![];
     for (stake_pubkey, stake_ui_account) in all_stake_accounts {
-        let stake_account: Account = stake_ui_account.decode().expect(
+        let stake_account = stake_ui_account.to_account().expect(
             "It should be impossible at this point for the account data not to be decodable. \
              Ensure that the account was fetched using a binary encoding.",
         );

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -16,7 +16,7 @@ use {
     bip39::{Language, Mnemonic, MnemonicType, Seed},
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand},
     log::*,
-    solana_account::{state_traits::StateMut, Account},
+    solana_account::state_traits::StateMut,
     solana_account_decoder::{UiAccount, UiAccountEncoding, UiDataSliceConfig},
     solana_clap_utils::{
         self,
@@ -1987,7 +1987,7 @@ async fn get_buffers(
 
     let mut buffers = vec![];
     for (address, ui_account) in results.iter() {
-        let account: Account = ui_account.decode().expect(
+        let account = ui_account.to_account().expect(
             "It should be impossible at this point for the account data not to be decodable. \
              Ensure that the account was fetched using a binary encoding.",
         );
@@ -2040,7 +2040,7 @@ async fn get_programs(
 
     let mut programs = vec![];
     for (programdata_address, programdata_ui_account) in results.iter() {
-        let programdata_account: Account = programdata_ui_account.decode().expect(
+        let programdata_account = programdata_ui_account.to_account().expect(
             "It should be impossible at this point for the account data not to be decodable. \
              Ensure that the account was fetched using a binary encoding.",
         );

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -2,7 +2,7 @@
 pub(crate) mod tests {
     use {
         rand::Rng,
-        solana_account::{AccountSharedData, WritableAccount},
+        solana_account::AccountSharedData,
         solana_clock::Clock,
         solana_instruction::Instruction,
         solana_keypair::Keypair,
@@ -20,6 +20,7 @@ pub(crate) mod tests {
             vote_instruction,
             vote_state::{VoteInit, VoteStateV4, VoteStateVersions},
         },
+        std::sync::Arc,
     };
 
     pub(crate) fn setup_vote_and_stake_accounts(
@@ -79,9 +80,9 @@ pub(crate) mod tests {
             StakeFlags::default(),
         );
 
-        let account = AccountSharedData::create(
+        let account = AccountSharedData::create_from_existing_shared_data(
             1,
-            bincode::serialize(&stake_account).unwrap(),
+            Arc::new(bincode::serialize(&stake_account).unwrap()),
             stake_program::id(),
             false,
             u64::MAX,

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -3529,7 +3529,7 @@ impl RpcClient {
             .map(|response| Response {
                 context: response.context,
                 value: response.value.map(|ui_account| {
-                    ui_account.decode().expect(
+                    ui_account.to_account().expect(
                         "It should be impossible at this point for the account data not to be \
                          decodable. Ensure that the account was fetched using a binary encoding.",
                     )
@@ -3566,7 +3566,7 @@ impl RpcClient {
                     value: rpc_account,
                 } = serde_json::from_value::<Response<Option<UiAccount>>>(result_json)?;
                 trace!("Response account {pubkey:?} {rpc_account:?}");
-                let account = rpc_account.and_then(|rpc_account| rpc_account.decode());
+                let account = rpc_account.and_then(|rpc_account| rpc_account.to_account());
 
                 Ok(Response {
                     context,
@@ -3804,7 +3804,7 @@ impl RpcClient {
                 .into_iter()
                 .map(|ui_account| {
                     ui_account.map(|ui_account| {
-                        ui_account.decode().expect(
+                        ui_account.to_account().expect(
                             "It should be impossible at this point for the account data not to be \
                              decodable. Ensure that the account was fetched using a binary \
                              encoding.",
@@ -3840,7 +3840,7 @@ impl RpcClient {
             } = serde_json::from_value::<Response<Vec<Option<UiAccount>>>>(response)?;
             let accounts: Vec<Option<Account>> = accounts
                 .into_iter()
-                .map(|rpc_account| rpc_account.and_then(|a| a.decode()))
+                .map(|rpc_account| rpc_account.and_then(|a| a.to_account()))
                 .collect();
             Ok(Response {
                 context,
@@ -4108,7 +4108,7 @@ impl RpcClient {
                 .map(|(pubkey, ui_account)| {
                     (
                         pubkey,
-                        ui_account.decode().expect(
+                        ui_account.to_account().expect(
                             "It should be impossible at this point for the account data not to be \
                              decodable. Ensure that the account was fetched using a binary \
                              encoding.",
@@ -4916,7 +4916,7 @@ pub(crate) fn parse_keyed_accounts(
         })?;
         pubkey_accounts.push((
             pubkey,
-            account.decode().ok_or_else(|| {
+            account.to_account().ok_or_else(|| {
                 ClientError::new_with_request(
                     RpcError::ParseError("Account from rpc".to_string()).into(),
                     request,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4524,7 +4524,7 @@ pub mod tests {
         jsonrpc_core::{futures, ErrorCode, MetaIoHandler, Output, Response, Value},
         jsonrpc_core_client::transports::local,
         serde::de::DeserializeOwned,
-        solana_account::{state_traits::StateMut, Account, WritableAccount},
+        solana_account::{state_traits::StateMut, Account},
         solana_accounts_db::accounts_db::{AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_TESTING},
         solana_address_lookup_table_interface::{
             self as address_lookup_table,
@@ -4954,10 +4954,11 @@ pub mod tests {
                     },
                     addresses: Cow::Owned(vec![Pubkey::new_unique()]),
                 };
-                let address_table_data = address_table_state.serialize_for_tests().unwrap();
+                let address_table_data =
+                    Arc::new(address_table_state.serialize_for_tests().unwrap());
                 let min_balance_lamports =
                     bank.get_minimum_balance_for_rent_exemption(address_table_data.len());
-                AccountSharedData::create(
+                AccountSharedData::create_from_existing_shared_data(
                     min_balance_lamports,
                     address_table_data,
                     address_lookup_table::program::id(),
@@ -5559,7 +5560,13 @@ pub mod tests {
         let pubkey = Pubkey::new_unique();
         let address = pubkey.to_string();
         let data = vec![1, 2, 3, 4, 5];
-        let account = AccountSharedData::create(42, data.clone(), Pubkey::default(), false, 0);
+        let account = AccountSharedData::create_from_existing_shared_data(
+            42,
+            Arc::new(data.clone()),
+            Pubkey::default(),
+            false,
+            0,
+        );
         bank.store_account(&pubkey, &account);
 
         let request = create_test_request(
@@ -5607,7 +5614,13 @@ pub mod tests {
     fn test_encode_account_does_not_throw_when_slice_larger_than_account() {
         let data = vec![42; 5];
         let pubkey = Pubkey::new_unique();
-        let account = AccountSharedData::create(42, data, pubkey, false, 0);
+        let account = AccountSharedData::create_from_existing_shared_data(
+            42,
+            Arc::new(data),
+            pubkey,
+            false,
+            0,
+        );
         let result = encode_account(
             &account,
             &pubkey,
@@ -5624,7 +5637,13 @@ pub mod tests {
     fn test_encode_account_throws_when_data_too_large_to_base58_encode() {
         let data = vec![42; MAX_BASE58_BYTES + 1];
         let pubkey = Pubkey::new_unique();
-        let account = AccountSharedData::create(42, data, pubkey, false, 0);
+        let account = AccountSharedData::create_from_existing_shared_data(
+            42,
+            Arc::new(data),
+            pubkey,
+            false,
+            0,
+        );
         let _ = encode_account(&account, &pubkey, UiAccountEncoding::Base58, None).unwrap();
     }
 
@@ -5633,7 +5652,13 @@ pub mod tests {
     ) {
         let data = vec![42; MAX_BASE58_BYTES + 1];
         let pubkey = Pubkey::new_unique();
-        let account = AccountSharedData::create(42, data, pubkey, false, 0);
+        let account = AccountSharedData::create_from_existing_shared_data(
+            42,
+            Arc::new(data),
+            pubkey,
+            false,
+            0,
+        );
         let result = encode_account(
             &account,
             &pubkey,
@@ -5651,7 +5676,13 @@ pub mod tests {
     ) {
         let data = vec![42; MAX_BASE58_BYTES];
         let pubkey = Pubkey::new_unique();
-        let account = AccountSharedData::create(42, data, pubkey, false, 0);
+        let account = AccountSharedData::create_from_existing_shared_data(
+            42,
+            Arc::new(data),
+            pubkey,
+            false,
+            0,
+        );
         let result = encode_account(
             &account,
             &pubkey,
@@ -5669,7 +5700,13 @@ pub mod tests {
     ) {
         let data = vec![42; MAX_BASE58_BYTES + 1];
         let pubkey = Pubkey::new_unique();
-        let account = AccountSharedData::create(42, data, pubkey, false, 0);
+        let account = AccountSharedData::create_from_existing_shared_data(
+            42,
+            Arc::new(data),
+            pubkey,
+            false,
+            0,
+        );
         let result = encode_account(
             &account,
             &pubkey,
@@ -5691,7 +5728,13 @@ pub mod tests {
         let pubkey = Pubkey::new_unique();
         let address = pubkey.to_string();
         let data = vec![1, 2, 3, 4, 5];
-        let account = AccountSharedData::create(42, data.clone(), Pubkey::default(), false, 0);
+        let account = AccountSharedData::create_from_existing_shared_data(
+            42,
+            Arc::new(data.clone()),
+            Pubkey::default(),
+            false,
+            0,
+        );
         bank.store_account(&pubkey, &account);
 
         // Test 3 accounts, one empty, one non-existent, and one with data
@@ -6315,9 +6358,9 @@ pub mod tests {
             },
             &mut mint_data,
         );
-        let account = AccountSharedData::create(
+        let account = AccountSharedData::create_from_existing_shared_data(
             mint_rent_exempt_amount,
-            mint_data.into(),
+            Arc::new(mint_data.into()),
             spl_token_interface::id(),
             false,
             0,
@@ -6343,9 +6386,9 @@ pub mod tests {
             },
             &mut token_account_data,
         );
-        let account = AccountSharedData::create(
+        let account = AccountSharedData::create_from_existing_shared_data(
             token_account_rent_exempt_amount,
-            token_account_data.into(),
+            Arc::new(token_account_data.into()),
             spl_token_interface::id(),
             false,
             0,

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -6,9 +6,7 @@ use {
     agave_votor_messages::consensus_message::BLS_KEYPAIR_DERIVE_SEED,
     bincode::serialize,
     log::*,
-    solana_account::{
-        state_traits::StateMut, Account, AccountSharedData, ReadableAccount, WritableAccount,
-    },
+    solana_account::{state_traits::StateMut, Account, AccountSharedData, ReadableAccount},
     solana_bls_signatures::{
         keypair::Keypair as BLSKeypair, pubkey::PubkeyCompressed as BLSPubkeyCompressed,
         Pubkey as BLSPubkey,
@@ -33,7 +31,7 @@ use {
     },
     solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
     solana_vote_program::vote_state,
-    std::borrow::Borrow,
+    std::{borrow::Borrow, sync::Arc},
 };
 
 // Default amount received by the validator
@@ -466,7 +464,13 @@ pub fn add_genesis_epoch_rewards_account(genesis_config: &mut GenesisConfig) -> 
     let data = vec![0; EpochRewards::size_of()];
     let lamports = std::cmp::max(genesis_config.rent.minimum_balance(data.len()), 1);
 
-    let account = AccountSharedData::create(lamports, data, sysvar::id(), false, u64::MAX);
+    let account = AccountSharedData::create_from_existing_shared_data(
+        lamports,
+        Arc::new(data),
+        sysvar::id(),
+        false,
+        u64::MAX,
+    );
 
     genesis_config.add_account(epoch_rewards::id(), account);
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -2467,9 +2467,9 @@ mod tests {
         let mut next_size = 1;
         let mut make_account = |pubkey, owner, executable| {
             let size = next_size;
-            let account = AccountSharedData::create(
+            let account = AccountSharedData::create_from_existing_shared_data(
                 LAMPORTS_PER_SOL,
-                vec![0; size],
+                Arc::new(vec![0; size]),
                 owner,
                 executable,
                 u64::MAX,
@@ -2789,9 +2789,9 @@ mod tests {
 
         // arbitrary accounts
         for _ in 0..128 {
-            let account = AccountSharedData::create(
+            let account = AccountSharedData::create_from_existing_shared_data(
                 1,
-                vec![0; rng.gen_range(0, 128)],
+                Arc::new(vec![0; rng.gen_range(0, 128)]),
                 Pubkey::new_unique(),
                 rng.gen(),
                 u64::MAX,
@@ -2803,9 +2803,9 @@ mod tests {
         let mut fee_payers = vec![];
         for _ in 0..8 {
             let fee_payer = Pubkey::new_unique();
-            let account = AccountSharedData::create(
+            let account = AccountSharedData::create_from_existing_shared_data(
                 LAMPORTS_PER_SOL,
-                vec![0; rng.gen_range(0, 32)],
+                Arc::new(vec![0; rng.gen_range(0, 32)]),
                 system_program::id(),
                 rng.gen(),
                 u64::MAX,
@@ -2820,9 +2820,9 @@ mod tests {
         for loader in PROGRAM_OWNERS {
             for _ in 0..16 {
                 let program_id = Pubkey::new_unique();
-                let mut account = AccountSharedData::create(
+                let mut account = AccountSharedData::create_from_existing_shared_data(
                     1,
-                    vec![0; rng.gen_range(0, 512)],
+                    Arc::new(vec![0; rng.gen_range(0, 512)]),
                     *loader,
                     rng.gen(),
                     u64::MAX,
@@ -2838,13 +2838,14 @@ mod tests {
                     let has_programdata = rng.gen();
 
                     if has_programdata {
-                        let programdata_account = AccountSharedData::create(
-                            1,
-                            vec![0; rng.gen_range(0, 512)],
-                            *loader,
-                            rng.gen(),
-                            u64::MAX,
-                        );
+                        let programdata_account =
+                            AccountSharedData::create_from_existing_shared_data(
+                                1,
+                                Arc::new(vec![0; rng.gen_range(0, 512)]),
+                                *loader,
+                                rng.gen(),
+                                u64::MAX,
+                            );
                         programdata_tracker.insert(
                             program_id,
                             (programdata_address, programdata_account.data().len()),

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -1825,9 +1825,9 @@ fn simd83_nonce_reuse(fee_paying_nonce: bool) -> Vec<SvmTestEntry> {
 
         test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE * 2);
 
-        let new_nonce_state = AccountSharedData::create(
+        let new_nonce_state = AccountSharedData::create_from_existing_shared_data(
             LAMPORTS_PER_SOL,
-            vec![0; nonce_size],
+            Arc::new(vec![0; nonce_size]),
             system_program::id(),
             false,
             u64::MAX,
@@ -2082,9 +2082,9 @@ fn simd83_account_deallocate() -> Vec<SvmTestEntry> {
 
         let target = Pubkey::new_unique();
 
-        let mut target_data = AccountSharedData::create(
+        let mut target_data = AccountSharedData::create_from_existing_shared_data(
             Rent::default().minimum_balance(1),
-            vec![0],
+            Arc::new(vec![0]),
             program_id,
             false,
             u64::MAX,
@@ -2306,9 +2306,9 @@ fn simd83_account_reallocate(formalize_loaded_transaction_data_size: bool) -> Ve
     common_test_entry.add_initial_account(fee_payer, &fee_payer_data);
 
     let mk_target = |size| {
-        AccountSharedData::create(
+        AccountSharedData::create_from_existing_shared_data(
             LAMPORTS_PER_SOL * 10,
-            vec![0; size],
+            Arc::new(vec![0; size]),
             program_id,
             false,
             u64::MAX,
@@ -2680,9 +2680,9 @@ fn program_cache_loaderv3_update_tombstone(upgrade_program: bool, invoke_changed
         let mut program_bytecode = load_program(program_name.to_string());
         data.append(&mut program_bytecode);
 
-        let buffer_account = AccountSharedData::create(
+        let buffer_account = AccountSharedData::create_from_existing_shared_data(
             LAMPORTS_PER_SOL,
-            data,
+            Arc::new(data),
             bpf_loader_upgradeable::id(),
             true,
             u64::MAX,
@@ -2788,9 +2788,9 @@ fn program_cache_loaderv3_buffer_swap(invoke_changed_program: bool) {
     let mut program_bytecode = load_program(program_name.to_string());
     buffer_data.append(&mut program_bytecode);
 
-    let buffer_account = AccountSharedData::create(
+    let buffer_account = AccountSharedData::create_from_existing_shared_data(
         LAMPORTS_PER_SOL,
-        buffer_data.clone(),
+        Arc::new(buffer_data.clone()),
         bpf_loader_upgradeable::id(),
         true,
         u64::MAX,
@@ -2803,9 +2803,9 @@ fn program_cache_loaderv3_buffer_swap(invoke_changed_program: bool) {
         programdata_address,
     })
     .unwrap();
-    let program_account = AccountSharedData::create(
+    let program_account = AccountSharedData::create_from_existing_shared_data(
         LAMPORTS_PER_SOL,
-        program_data,
+        Arc::new(program_data),
         bpf_loader_upgradeable::id(),
         true,
         u64::MAX,
@@ -2918,9 +2918,9 @@ fn program_cache_stats() {
         let mut program_bytecode = load_program(program_name.to_string());
         data.append(&mut program_bytecode);
 
-        let buffer_account = AccountSharedData::create(
+        let buffer_account = AccountSharedData::create_from_existing_shared_data(
             LAMPORTS_PER_SOL,
-            data,
+            Arc::new(data),
             bpf_loader_upgradeable::id(),
             true,
             u64::MAX,
@@ -3239,8 +3239,13 @@ fn svm_inspect_nonce_load_failure(
     separate_fee_payer_account.set_lamports(LAMPORTS_PER_SOL);
     let separate_fee_payer_account = separate_fee_payer_account;
 
-    let dummy_account =
-        AccountSharedData::create(1, vec![0; 2], system_program::id(), false, u64::MAX);
+    let dummy_account = AccountSharedData::create_from_existing_shared_data(
+        1,
+        Arc::new(vec![0; 2]),
+        system_program::id(),
+        false,
+        u64::MAX,
+    );
     test_entry.add_initial_account(dummy, &dummy_account);
 
     // we always inspect the nonce at least once
@@ -3350,9 +3355,9 @@ fn svm_inspect_account() {
     expected_inspected_accounts.inspect(recipient, Inspect::DeadWrite);
 
     // system program
-    let system_account = AccountSharedData::create(
+    let system_account = AccountSharedData::create_from_existing_shared_data(
         5000,
-        "system_program".as_bytes().to_vec(),
+        Arc::new("system_program".as_bytes().to_vec()),
         native_loader::id(),
         true,
         0,
@@ -3603,9 +3608,9 @@ mod balance_collector {
         let bob = bob_keypair.pubkey();
         let charlie = charlie_keypair.pubkey();
 
-        let native_state = AccountSharedData::create(
+        let native_state = AccountSharedData::create_from_existing_shared_data(
             STARTING_BALANCE,
-            vec![],
+            Arc::new(vec![]),
             system_program::id(),
             false,
             u64::MAX,
@@ -3619,9 +3624,9 @@ mod balance_collector {
         }
         .pack_into_slice(&mut mint_buf);
 
-        let mint_state = AccountSharedData::create(
+        let mint_state = AccountSharedData::create_from_existing_shared_data(
             LAMPORTS_PER_SOL,
-            mint_buf,
+            Arc::new(mint_buf),
             spl_token_interface::id(),
             false,
             u64::MAX,
@@ -3638,9 +3643,9 @@ mod balance_collector {
         let mut token_buf = vec![0; TokenAccount::get_packed_len()];
         token_account_for_tests().pack_into_slice(&mut token_buf);
 
-        let token_state = AccountSharedData::create(
+        let token_state = AccountSharedData::create_from_existing_shared_data(
             LAMPORTS_PER_SOL,
-            token_buf,
+            Arc::new(token_buf),
             spl_token_interface::id(),
             false,
             u64::MAX,
@@ -3770,9 +3775,9 @@ mod balance_collector {
 
                 token_account.amount = *user_balances.get(&alice).unwrap();
                 token_account.pack_into_slice(&mut token_buf);
-                let final_token_state = AccountSharedData::create(
+                let final_token_state = AccountSharedData::create_from_existing_shared_data(
                     LAMPORTS_PER_SOL,
-                    token_buf.clone(),
+                    Arc::new(token_buf.clone()),
                     spl_token_interface::id(),
                     false,
                     u64::MAX,
@@ -3781,9 +3786,9 @@ mod balance_collector {
 
                 token_account.amount = *user_balances.get(&bob).unwrap();
                 token_account.pack_into_slice(&mut token_buf);
-                let final_token_state = AccountSharedData::create(
+                let final_token_state = AccountSharedData::create_from_existing_shared_data(
                     LAMPORTS_PER_SOL,
-                    token_buf.clone(),
+                    Arc::new(token_buf.clone()),
                     spl_token_interface::id(),
                     false,
                     u64::MAX,
@@ -3792,9 +3797,9 @@ mod balance_collector {
 
                 token_account.amount = *user_balances.get(&charlie).unwrap();
                 token_account.pack_into_slice(&mut token_buf);
-                let final_token_state = AccountSharedData::create(
+                let final_token_state = AccountSharedData::create_from_existing_shared_data(
                     LAMPORTS_PER_SOL,
-                    token_buf.clone(),
+                    Arc::new(token_buf.clone()),
                     spl_token_interface::id(),
                     false,
                     u64::MAX,

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -554,7 +554,7 @@ impl TestValidatorGenesis {
             let account = account_info
                 .keyed_account
                 .account
-                .decode::<AccountSharedData>()
+                .to_account_shared_data()
                 .unwrap();
 
             self.add_account(address, account);


### PR DESCRIPTION
#### Problem

We want to remove `fn create` from `trait WritableAccount`, since program-runtime has adopted an account interface that contains references and cannot be created with owned types like those of `fn create`'s signature.

Following the discussion in https://github.com/anza-xyz/solana-sdk/pull/456#pullrequestreview-3502482103, we will replace `WritableAccount::create` by `AccountSharedData::create_from_existing_shared_data` for `AccountSharedData`, and `Account` instances will be initialized directly since all its members are public.

#### Summary of Changes

1. Replace `WritableAccount::create` by `AccountSharedData::create_from_existing_shared_data` for `AccountSharedData`.
2. Initialize `Account` directly.
