### PR TITLE
Implement max_eviction cutoff in gathering candidates to evict

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -937,12 +937,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     },
                     &mut rng,
                 );
+            } else if v.dirty() {
+                candidates_to_flush.push(*k);
             } else {
-                if v.dirty() {
-                    candidates_to_flush.push(*k);
-                } else {
-                    candidates_to_evict.push(*k);
-                }
+                candidates_to_evict.push(*k);
             }
         }
 


### PR DESCRIPTION
#### Problem

split from https://github.com/anza-xyz/agave/pull/8767

Implement max_eviction cutoff in gathering candidate to evict.


#### Summary of Changes

- Gather eviction candidates now accepts total_entries and optional max_evictions, using probabilistic sampling with early exit to cap selections while respecting flush-age filtering 
- Flush scan passes the current bin size into the sampler (still uncapped) to keep selection math consistent with the new API 
- Added a statistical test to confirm sampled eviction counts stay near the expected proportion when max_evictions is set


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
