### PR TITLE
Add snapshot kind fastboot

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -115,24 +115,25 @@ impl SnapshotPackagerService {
                         break;
                     };
 
-                    let SnapshotKind::Archive(snapshot_archive_kind) = snapshot_kind;
-                    // Archiving the snapshot package is not allowed to fail.
-                    // AccountsBackgroundService calls `clean_accounts()` with a value for
-                    // latest_full_snapshot_slot that requires this archive call to succeed.
-                    if let Err(err) = snapshot_utils::archive_snapshot_package(
-                        snapshot_archive_kind,
-                        snapshot_slot,
-                        snapshot_hash,
-                        &bank_snapshot_info.snapshot_dir,
-                        snapshot_package.snapshot_storages,
-                        snapshot_config,
-                    ) {
-                        error!(
-                            "Stopping {}! Fatal error while archiving snapshot package: {err}",
-                            Self::NAME,
-                        );
-                        exit.store(true, Ordering::Relaxed);
-                        break;
+                    if let SnapshotKind::Archive(snapshot_archive_kind) = snapshot_kind {
+                        // Archiving the snapshot package is not allowed to fail.
+                        // AccountsBackgroundService calls `clean_accounts()` with a value for
+                        // latest_full_snapshot_slot that requires this archive call to succeed.
+                        if let Err(err) = snapshot_utils::archive_snapshot_package(
+                            snapshot_archive_kind,
+                            snapshot_slot,
+                            snapshot_hash,
+                            &bank_snapshot_info.snapshot_dir,
+                            snapshot_package.snapshot_storages,
+                            snapshot_config,
+                        ) {
+                            error!(
+                                "Stopping {}! Fatal error while archiving snapshot package: {err}",
+                                Self::NAME,
+                            );
+                            exit.store(true, Ordering::Relaxed);
+                            break;
+                        }
                     }
                     let archive_time_us = archive_time.elapsed().as_micros();
 

--- a/core/src/snapshot_packager_service/snapshot_gossip_manager.rs
+++ b/core/src/snapshot_packager_service/snapshot_gossip_manager.rs
@@ -63,6 +63,9 @@ impl SnapshotGossipManager {
                     base_slot,
                 );
             }
+            SnapshotKind::Fastboot => {
+                // Fastboot snapshots are not gossiped
+            }
         }
     }
 

--- a/snapshots/src/kind.rs
+++ b/snapshots/src/kind.rs
@@ -5,6 +5,7 @@ use solana_clock::Slot;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SnapshotKind {
     Archive(SnapshotArchiveKind),
+    Fastboot,
 }
 
 impl SnapshotKind {


### PR DESCRIPTION
#### Problem
Currently there is no way to make a snapshot without also creating an archive. For fastbooting purposes archives are not needed as the storages already present can be used. 

#### Summary of Changes
- And new SnapshotKind::Fastboot 
  - Lower priority than the other SnapshotKinds
  - Only creates a bank snapshot
  - Gets removed from the pending queue if any other newer archive is saved (as those include bank snapshots)
- Modify existing fastboot test flow to use the new snapshot kind
- Lots of lines of changes, but mostly testing

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
