### PR TITLE
blockstore: metrics: record duplicate shreds stats

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1322,8 +1322,13 @@ impl Blockstore {
             metrics,
         )?;
 
-        for shred in duplicate_shreds {
-            handle_duplicate(shred);
+        if !duplicate_shreds.is_empty() {
+            metrics.num_duplicate_shreds += duplicate_shreds.len() as u64;
+            let duplicate_handling_start = Measure::start("Handle duplicate shreds");
+            for shred in duplicate_shreds {
+                handle_duplicate(shred);
+            }
+            metrics.duplicate_shred_handing_us += duplicate_handling_start.end_as_us();
         }
 
         Ok(completed_data_set_infos)

--- a/ledger/src/blockstore_metrics.rs
+++ b/ledger/src/blockstore_metrics.rs
@@ -26,6 +26,8 @@ pub struct BlockstoreInsertionMetrics {
     pub index_meta_time_us: u64,
     pub num_shreds: usize,
     pub num_inserted: u64,
+    pub num_duplicate_shreds: u64,
+    pub duplicate_shred_handing_us: u64,
     pub num_repair: u64,
     pub num_recovered: usize,
     pub num_recovered_blockstore_error: usize,
@@ -75,6 +77,16 @@ impl BlockstoreInsertionMetrics {
                 i64
             ),
             ("num_inserted", self.num_inserted as i64, i64),
+            (
+                "num_duplicate_shreds",
+                self.num_duplicate_shreds as i64,
+                i64
+            ),
+            (
+                "duplicate_shred_handing_us",
+                self.duplicate_shred_handing_us as i64,
+                i64
+            ),
             ("num_repair", self.num_repair as i64, i64),
             ("num_recovered", self.num_recovered as i64, i64),
             (


### PR DESCRIPTION
#### Problem
We are not tracking the number of duplicate shreds observed during the blockstore shred insertion.

This number can be useful when analyzing the main blockstore insertion thread behavior.  Report of two extra counters should be cheap.  And the time measurement is skipped if there are no duplicate shreds to report.