### PR TITLE
Decople unstaked tps

### DIFF
--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -15,7 +15,11 @@ use {
     tokio::time::sleep,
 };
 
-const MAX_UNSTAKED_STREAMS_PERCENT: u64 = 20;
+/// Max TPS allowed for unstaked connection
+const MAX_UNSTAKED_TPS: u64 = 200;
+/// Expected % of max TPS to be consumed by unstaked connections
+const EXPECTED_UNSTAKED_STREAMS_PERCENT: u64 = 20;
+
 pub const STREAM_THROTTLING_INTERVAL_MS: u64 = 100;
 pub const STREAM_THROTTLING_INTERVAL: Duration =
     Duration::from_millis(STREAM_THROTTLING_INTERVAL_MS);
@@ -47,16 +51,14 @@ impl StakedStreamLoadEMA {
         let allow_unstaked_streams = max_unstaked_connections > 0;
         let max_staked_load_in_ema_window = if allow_unstaked_streams {
             (max_streams_per_ms
-                - Percentage::from(MAX_UNSTAKED_STREAMS_PERCENT).apply_to(max_streams_per_ms))
+                - Percentage::from(EXPECTED_UNSTAKED_STREAMS_PERCENT).apply_to(max_streams_per_ms))
                 * EMA_WINDOW_MS
         } else {
             max_streams_per_ms * EMA_WINDOW_MS
         };
 
         let max_unstaked_load_in_throttling_window = if allow_unstaked_streams {
-            Percentage::from(MAX_UNSTAKED_STREAMS_PERCENT)
-                .apply_to(max_streams_per_ms * STREAM_THROTTLING_INTERVAL_MS)
-                .saturating_div(max_unstaked_connections as u64)
+            MAX_UNSTAKED_TPS * STREAM_THROTTLING_INTERVAL_MS / 1000
         } else {
             0
         };


### PR DESCRIPTION
#### Problem

Unstaked TPS quota is cut away from staked under assumption that unstaked connections consume 100% of their allocated bandwidth at all times. This is generally not happening based on MNB data. Thus, the bandwidth allocation is overkill, preventing us from admitting more staked traffic.

#### Summary of Changes

  - Disconnects the unstaked from the TPS calculation of the staked connections.
  - Right now, the unstaked TPS allocation is computed as 20% of the total TPS allowed for all connections, and per-unstaked-connection TPS is capped based on the assumption that all unstaked slots are taken and used at 100% utilization. Decoupling unstaked connections from staked makes configuration simpler - user just needs to specify how many should be supported via `max_unstaked_connections` parameter.
  - This change fixes unstaked connection TPS at 200 irrespective of the connection table size to decouple their bandwidth from the staked TPS tunables. This matches current defaults but is more clear to the reader.

This is on top of https://github.com/anza-xyz/agave/pull/9277
