### PR TITLE
chore(perf): switch deduper test to use random_u64_range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9544,6 +9544,7 @@ name = "solana-perf"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-logger",
+ "agave-random",
  "ahash 0.8.12",
  "assert_matches",
  "bencher",

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -79,6 +79,7 @@ nix = { workspace = true, features = ["user"] }
 
 [dev-dependencies]
 agave-logger = { workspace = true }
+agave-random = { workspace = true }
 assert_matches = { workspace = true }
 bencher = { workspace = true }
 rand_chacha = "0.3.1"

--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -116,6 +116,7 @@ mod tests {
             sigverify,
             test_tx::test_tx,
         },
+        agave_random::range::random_u64_range,
         rand::SeedableRng,
         rand_chacha::ChaChaRng,
         solana_packet::{Meta, PACKET_DATA_SIZE},
@@ -248,7 +249,7 @@ mod tests {
         let mut packet = Packet::new([0u8; PACKET_DATA_SIZE], Meta::default());
         let mut dup_count = 0usize;
         for _ in 0..num_packets {
-            let size = rng.gen_range(0..PACKET_DATA_SIZE);
+            let size = random_u64_range(&mut rng, 0..PACKET_DATA_SIZE as u64) as usize;
             packet.meta_mut().size = size;
             rng.fill(&mut packet.buffer_mut()[0..size]);
             if deduper.dedup(packet.data(..).unwrap()) {


### PR DESCRIPTION
#### Problem
In order to [migrate](https://github.com/anza-xyz/agave/issues/4738) to `rand=0.9.2` we need to switch perf deduper tests to implementation of random number sampling that is independent from used `rand` version.

#### Summary of Changes
Switch `deduper` tests to use `agave_random::range::random_u64_range` for generating test cases (see https://github.com/anza-xyz/agave/pull/9286 for addition of its implementation)

This PR is extracted from https://github.com/anza-xyz/agave/pull/9276 such that it could be a rename-only change.
