### PR TITLE
remove deprecated UDP TPU socket bindings

### DIFF
--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -968,7 +968,7 @@ pub mod test {
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
-                tpu_use_quic: false,
+                tpu_use_quic: true,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -1017,7 +1017,7 @@ pub mod test {
                     transaction_type: None,
                     num_instructions: None,
                 },
-                tpu_use_quic: false,
+                tpu_use_quic: true,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -1045,7 +1045,7 @@ pub mod test {
                     transaction_type: None,
                     num_instructions: None,
                 },
-                tpu_use_quic: false,
+                tpu_use_quic: true,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -1073,13 +1073,14 @@ pub mod test {
                     transaction_type: None,
                     num_instructions: None,
                 },
-                tpu_use_quic: false,
+                tpu_use_quic: true,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
     }
 
-    fn run_dos_with_blockhash_and_payer(tpu_use_quic: bool) {
+    #[test]
+    fn run_dos_with_blockhash_and_payer() {
         agave_logger::setup();
 
         // 1. Create faucet thread
@@ -1153,7 +1154,7 @@ pub mod test {
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(1),
                 },
-                tpu_use_quic,
+                tpu_use_quic: true,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -1183,7 +1184,7 @@ pub mod test {
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(1),
                 },
-                tpu_use_quic,
+                tpu_use_quic: true,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -1212,7 +1213,7 @@ pub mod test {
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(8),
                 },
-                tpu_use_quic,
+                tpu_use_quic: true,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
@@ -1241,19 +1242,9 @@ pub mod test {
                     transaction_type: Some(TransactionType::AccountCreation),
                     num_instructions: None,
                 },
-                tpu_use_quic,
+                tpu_use_quic: true,
                 send_batch_size: TEST_SEND_BATCH_SIZE,
             },
         );
-    }
-
-    #[test]
-    fn test_dos_with_blockhash_and_payer() {
-        run_dos_with_blockhash_and_payer(/*tpu_use_quic*/ false)
-    }
-
-    #[test]
-    fn test_dos_with_blockhash_and_payer_and_quic() {
-        run_dos_with_blockhash_and_payer(/*tpu_use_quic*/ true)
     }
 }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -595,10 +595,10 @@ impl ClusterInfo {
                         },
                         self.addr_to_string(&ip_addr, &node.gossip()),
                         self.addr_to_string(&ip_addr, &node.tpu_vote(contact_info::Protocol::UDP)),
-                        self.addr_to_string(&ip_addr, &node.tpu(contact_info::Protocol::UDP)),
+                        self.addr_to_string(&ip_addr, &node.tpu(contact_info::Protocol::QUIC)),
                         self.addr_to_string(
                             &ip_addr,
-                            &node.tpu_forwards(contact_info::Protocol::UDP)
+                            &node.tpu_forwards(contact_info::Protocol::QUIC)
                         ),
                         self.addr_to_string(&ip_addr, &node.tvu(contact_info::Protocol::UDP)),
                         self.addr_to_string(
@@ -1143,7 +1143,7 @@ impl ClusterInfo {
 
     fn is_spy_node(node: &ContactInfo, socket_addr_space: &SocketAddrSpace) -> bool {
         ![
-            node.tpu(contact_info::Protocol::UDP),
+            node.tpu(contact_info::Protocol::QUIC),
             node.gossip(),
             node.tvu(contact_info::Protocol::UDP),
         ]
@@ -2362,8 +2362,6 @@ pub struct Sockets {
     pub gossip: Arc<[UdpSocket]>,
     pub ip_echo: Option<TcpListener>,
     pub tvu: Vec<UdpSocket>,
-    pub tpu: Vec<UdpSocket>,
-    pub tpu_forwards: Vec<UdpSocket>,
     pub tpu_vote: Vec<UdpSocket>,
     pub broadcast: Vec<UdpSocket>,
     // Socket sending out local repair requests,
@@ -2867,7 +2865,7 @@ mod tests {
         }
         check_sockets(&node.sockets.gossip, ip, range);
         check_sockets(&node.sockets.tvu, ip, range);
-        check_sockets(&node.sockets.tpu, ip, range);
+        check_sockets(&node.sockets.tpu_quic, ip, range);
     }
 
     #[test]

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -34,8 +34,8 @@ const SOCKET_TAG_RPC: u8 = 2;
 const SOCKET_TAG_RPC_PUBSUB: u8 = 3;
 const SOCKET_TAG_SERVE_REPAIR: u8 = 4;
 const SOCKET_TAG_SERVE_REPAIR_QUIC: u8 = 1;
-const SOCKET_TAG_TPU: u8 = 5;
-const SOCKET_TAG_TPU_FORWARDS: u8 = 6;
+const SOCKET_TAG_TPU: u8 = 5; // not in use
+const SOCKET_TAG_TPU_FORWARDS: u8 = 6; // not in use
 const SOCKET_TAG_TPU_FORWARDS_QUIC: u8 = 7;
 const SOCKET_TAG_TPU_QUIC: u8 = 8;
 const SOCKET_TAG_TPU_VOTE: u8 = 9;
@@ -442,10 +442,7 @@ impl ContactInfo {
         let mut node = Self::new(*pubkey, wallclock, /*shred_version:*/ 0u16);
         node.set_gossip((Ipv4Addr::LOCALHOST, 8000)).unwrap();
         node.set_tvu(UDP, (Ipv4Addr::LOCALHOST, 8001)).unwrap();
-        node.set_tpu(UDP, (Ipv4Addr::LOCALHOST, 8003)).unwrap();
         node.set_tpu(QUIC, (Ipv4Addr::LOCALHOST, 8009)).unwrap();
-        node.set_tpu_forwards(UDP, (Ipv4Addr::LOCALHOST, 8004))
-            .unwrap();
         node.set_tpu_forwards(QUIC, (Ipv4Addr::LOCALHOST, 8010))
             .unwrap();
         node.set_tpu_vote(UDP, (Ipv4Addr::LOCALHOST, 8005)).unwrap();
@@ -475,9 +472,7 @@ impl ContactInfo {
         node.set_gossip((addr, port + 1)).unwrap();
         node.set_tvu(UDP, (addr, port + 2)).unwrap();
         node.set_tvu(QUIC, (addr, port + 3)).unwrap();
-        node.set_tpu(UDP, (addr, port)).unwrap();
         node.set_tpu(QUIC, (addr, port + 6)).unwrap();
-        node.set_tpu_forwards(UDP, (addr, port + 5)).unwrap();
         node.set_tpu_forwards(QUIC, (addr, port + 11)).unwrap();
         node.set_tpu_vote(UDP, (addr, port + 7)).unwrap();
         node.set_tpu_vote(QUIC, (addr, port + 9)).unwrap();
@@ -902,16 +897,8 @@ mod tests {
                 sockets.get(&SOCKET_TAG_SERVE_REPAIR_QUIC)
             );
             assert_eq!(
-                node.tpu(Protocol::UDP).as_ref(),
-                sockets.get(&SOCKET_TAG_TPU)
-            );
-            assert_eq!(
                 node.tpu(Protocol::QUIC).as_ref(),
                 sockets.get(&SOCKET_TAG_TPU_QUIC)
-            );
-            assert_eq!(
-                node.tpu_forwards(Protocol::UDP).as_ref(),
-                sockets.get(&SOCKET_TAG_TPU_FORWARDS)
             );
             assert_eq!(
                 node.tpu_forwards(Protocol::QUIC).as_ref(),

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -1567,7 +1567,7 @@ pub(crate) mod tests {
         };
         {
             let caller: CrdsValue = CrdsValue::new(CrdsData::from(&node), &keypair);
-            assert_eq!(get_max_bloom_filter_bytes(&caller), 1175);
+            assert_eq!(get_max_bloom_filter_bytes(&caller), 1184);
             verify_get_max_bloom_filter_bytes(&mut rng, &caller, num_items);
         }
         let node = {
@@ -1579,7 +1579,7 @@ pub(crate) mod tests {
         };
         {
             let caller = CrdsValue::new(CrdsData::from(&node), &keypair);
-            assert_eq!(get_max_bloom_filter_bytes(&caller), 1155);
+            assert_eq!(get_max_bloom_filter_bytes(&caller), 1165);
             verify_get_max_bloom_filter_bytes(&mut rng, &caller, num_items);
         }
     }

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -128,12 +128,6 @@ impl Node {
         );
         let tvu_addresses = Self::get_socket_addrs(&tvu_sockets);
 
-        let (tpu_port, tpu_socket) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
-                .expect("tpu_socket primary bind");
-        let tpu_sockets =
-            bind_more_with_config(tpu_socket, 32, socket_config).expect("tpu_sockets multi_bind");
-
         let (tpu_port_quic, tpu_quic) =
             bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
                 .expect("tpu_quic primary bind");
@@ -147,11 +141,6 @@ impl Node {
         );
         let tpu_quic_addresses = Self::get_socket_addrs(&tpu_quic);
 
-        let (tpu_forwards_port, tpu_forwards_socket) =
-            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
-                .expect("tpu_forwards primary bind");
-        let tpu_forwards_sockets = bind_more_with_config(tpu_forwards_socket, 8, socket_config)
-            .expect("tpu_forwards multi_bind");
         let (tpu_forwards_quic_port, tpu_forwards_quic) =
             bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
                 .expect("tpu_forwards_quic primary bind");
@@ -290,14 +279,25 @@ impl Node {
             public_tvu_addr.unwrap_or_else(|| SocketAddr::new(advertised_ip, tvu_port)),
         )
         .unwrap();
-        info.set_tpu(UDP, (advertised_ip, tpu_port)).unwrap();
+        // placeholder to prevent legacy nodes from assuming we do not have open TPU ports
+        // see https://github.com/anza-xyz/agave/pull/10174
+        info.set_tpu(
+            UDP,
+            public_tpu_addr.unwrap_or_else(|| SocketAddr::new(advertised_ip, 1)),
+        )
+        .unwrap();
         info.set_tpu(
             QUIC,
             public_tpu_addr.unwrap_or_else(|| SocketAddr::new(advertised_ip, tpu_port_quic)),
         )
         .unwrap();
-        info.set_tpu_forwards(UDP, (advertised_ip, tpu_forwards_port))
-            .unwrap();
+        // placeholder to prevent legacy nodes from assuming we do not have open TPU ports
+        // see https://github.com/anza-xyz/agave/pull/10174
+        info.set_tpu_forwards(
+            UDP,
+            public_tpu_forwards_addr.unwrap_or_else(|| SocketAddr::new(advertised_ip, 1)),
+        )
+        .unwrap();
         info.set_tpu_forwards(
             QUIC,
             public_tpu_forwards_addr
@@ -336,8 +336,6 @@ impl Node {
             alpenglow: Some(alpenglow),
             gossip: gossip_sockets.into_iter().collect(),
             tvu: tvu_sockets,
-            tpu: tpu_sockets,
-            tpu_forwards: tpu_forwards_sockets,
             tpu_vote: tpu_vote_sockets,
             broadcast,
             repair,
@@ -525,10 +523,7 @@ pub use multihoming::*;
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        crate::contact_info::Protocol::{QUIC, UDP},
-    };
+    use {super::*, crate::contact_info::Protocol::QUIC};
 
     /// Regression test for fix where tpu_forwards_quic was incorrectly
     /// using tpu_forwards_port (UDP) instead of tpu_forwards_quic_port (QUIC)
@@ -538,7 +533,6 @@ mod tests {
         let node = Node::new_localhost_with_pubkey(&pubkey);
 
         let tpu_forwards_quic = node.info.tpu_forwards(QUIC).unwrap();
-        let tpu_forwards_udp = node.info.tpu_forwards(UDP).unwrap();
 
         let actual_quic_port = node.sockets.tpu_forwards_quic[0]
             .local_addr()
@@ -549,12 +543,6 @@ mod tests {
             tpu_forwards_quic.port(),
             actual_quic_port,
             "TPU forwards QUIC advertised port should match actual bound QUIC socket"
-        );
-
-        assert_ne!(
-            tpu_forwards_quic.port(),
-            tpu_forwards_udp.port(),
-            "TPU forwards QUIC and UDP should use different ports"
         );
     }
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3667,15 +3667,11 @@ pub mod rpc_full {
                             tvu: contact_info
                                 .tvu(Protocol::UDP)
                                 .filter(|addr| socket_addr_space.check(addr)),
-                            tpu: contact_info
-                                .tpu(Protocol::UDP)
-                                .filter(|addr| socket_addr_space.check(addr)),
+                            tpu: None,
                             tpu_quic: contact_info
                                 .tpu(Protocol::QUIC)
                                 .filter(|addr| socket_addr_space.check(addr)),
-                            tpu_forwards: contact_info
-                                .tpu_forwards(Protocol::UDP)
-                                .filter(|addr| socket_addr_space.check(addr)),
+                            tpu_forwards: None,
                             tpu_forwards_quic: contact_info
                                 .tpu_forwards(Protocol::QUIC)
                                 .filter(|addr| socket_addr_space.check(addr)),
@@ -5185,9 +5181,9 @@ pub mod tests {
             "gossip": "127.0.0.1:8000",
             "shredVersion": 0u16,
             "tvu": "127.0.0.1:8001",
-            "tpu": "127.0.0.1:8003",
+            "tpu": null,
             "tpuQuic": "127.0.0.1:8009",
-            "tpuForwards": "127.0.0.1:8004",
+            "tpuForwards": null,
             "tpuForwardsQuic": "127.0.0.1:8010",
             "tpuVote": "127.0.0.1:8005",
             "serveRepair": "127.0.0.1:8008",
@@ -5200,9 +5196,9 @@ pub mod tests {
             "gossip": "127.0.0.1:1235",
             "shredVersion": 0u16,
             "tvu": "127.0.0.1:1236",
-            "tpu": "127.0.0.1:1234",
+            "tpu": null,
             "tpuQuic": "127.0.0.1:1240",
-            "tpuForwards": "127.0.0.1:1239",
+            "tpuForwards": null,
             "tpuForwardsQuic": "127.0.0.1:1245",
             "tpuVote": "127.0.0.1:1241",
             "serveRepair": "127.0.0.1:1242",

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -795,7 +795,6 @@ pub struct TestValidator {
     preserve_ledger: bool,
     rpc_pubsub_url: String,
     rpc_url: String,
-    tpu: SocketAddr,
     tpu_quic: SocketAddr,
     gossip: SocketAddr,
     validator: Option<Validator>,
@@ -1130,8 +1129,7 @@ impl TestValidator {
         let vote_account_address = validator_vote_account.pubkey();
         let rpc_url = format!("http://{}", node.info.rpc().unwrap());
         let rpc_pubsub_url = format!("ws://{}/", node.info.rpc_pubsub().unwrap());
-        let tpu = node.info.tpu(Protocol::UDP).unwrap();
-        let tpu_quic = node.info.tpu(Protocol::QUIC).unwrap_or(tpu);
+        let tpu_quic = node.info.tpu(Protocol::QUIC).unwrap();
         let gossip = node.info.gossip().unwrap();
 
         {
@@ -1234,7 +1232,6 @@ impl TestValidator {
             preserve_ledger,
             rpc_pubsub_url,
             rpc_url,
-            tpu,
             tpu_quic,
             gossip,
             validator,
@@ -1364,11 +1361,6 @@ impl TestValidator {
             sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT)).await;
         }
         panic!("Timeout waiting for program to become usable");
-    }
-
-    /// Return the validator's TPU address
-    pub fn tpu(&self) -> &SocketAddr {
-        &self.tpu
     }
 
     /// Return the validator's TPU QUIC address

--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -105,8 +105,8 @@ impl Dashboard {
                 if let Some(gossip) = contact_info.gossip {
                     println_name_value("Gossip Address:", &gossip.to_string());
                 }
-                if let Some(tpu) = contact_info.tpu {
-                    println_name_value("TPU Address:", &tpu.to_string());
+                if let Some(tpu) = contact_info.tpu_quic {
+                    println_name_value("TPU QUIC Address:", &tpu.to_string());
                 }
                 if let Some(rpc) = contact_info.rpc {
                     println_name_value("JSON RPC URL:", &format!("http://{rpc}"));


### PR DESCRIPTION
## Problem

  The validator binds an excessive number of network ports. UDP TPU path (transaction ingress via UDP) is deprecated since
  version 3.0 and no longer used - the system now exclusively uses QUIC for TPU transaction ingress. Removing these unused socket bindings reduces resource consumption and simplifies network configuration.

  ## Summary of Changes

  Removes deprecated UDP socket bindings for TPU and TPU forwards paths that are no longer in use:

  - Removed `tpu_port` and `tpu_sockets` UDP socket binding code from `Node::new_with_client()`
  - Removed `tpu_forwards_port` and `tpu_forwards_sockets` UDP socket binding code
  - Removed `tpu: Vec<UdpSocket>` and `tpu_forwards: Vec<UdpSocket>` fields from `Sockets` struct
  - Updated `test_tpu_forwards_quic_uses_correct_port` test to only verify QUIC paths (UDP variant no longer exists)
  - Updated `CLUSTER_INFO_TRACE_LENGTH` constant to reflect the changes in ContactInfo trace output
  - Removed test helper reference to non-existent `sockets.tpu` field

  Fixes #7525 (partially)