### PR TITLE
chore: remove tpu_enable_udp configuration

### DIFF
--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -31,8 +31,6 @@ pub struct FetchStage {
 
 impl FetchStage {
     pub fn new(
-        sockets: Vec<UdpSocket>,
-        tpu_forwards_sockets: Vec<UdpSocket>,
         tpu_vote_sockets: Vec<UdpSocket>,
         exit: Arc<AtomicBool>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
@@ -40,55 +38,40 @@ impl FetchStage {
     ) -> (Self, PacketBatchReceiver, PacketBatchReceiver) {
         let (sender, receiver) = unbounded();
         let (vote_sender, vote_receiver) = unbounded();
-        let (forward_sender, forward_receiver) = unbounded();
+        let (_forward_sender, forward_receiver) = unbounded();
         (
             Self::new_with_sender(
-                sockets,
-                tpu_forwards_sockets,
                 tpu_vote_sockets,
                 exit,
                 &sender,
                 &vote_sender,
-                &forward_sender,
                 forward_receiver,
                 poh_recorder,
                 coalesce,
-                None,
             ),
             receiver,
             vote_receiver,
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn new_with_sender(
-        sockets: Vec<UdpSocket>,
-        tpu_forwards_sockets: Vec<UdpSocket>,
         tpu_vote_sockets: Vec<UdpSocket>,
         exit: Arc<AtomicBool>,
         sender: &PacketBatchSender,
         vote_sender: &PacketBatchSender,
-        forward_sender: &PacketBatchSender,
         forward_receiver: PacketBatchReceiver,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         coalesce: Option<Duration>,
-        in_vote_only_mode: Option<Arc<AtomicBool>>,
     ) -> Self {
-        let tx_sockets = sockets.into_iter().map(Arc::new).collect();
-        let tpu_forwards_sockets = tpu_forwards_sockets.into_iter().map(Arc::new).collect();
         let tpu_vote_sockets = tpu_vote_sockets.into_iter().map(Arc::new).collect();
         Self::new_multi_socket(
-            tx_sockets,
-            tpu_forwards_sockets,
             tpu_vote_sockets,
             exit,
             sender,
             vote_sender,
-            forward_sender,
             forward_receiver,
             poh_recorder,
             coalesce,
-            in_vote_only_mode,
         )
     }
 
@@ -134,62 +117,16 @@ impl FetchStage {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn new_multi_socket(
-        tpu_sockets: Vec<Arc<UdpSocket>>,
-        tpu_forwards_sockets: Vec<Arc<UdpSocket>>,
         tpu_vote_sockets: Vec<Arc<UdpSocket>>,
         exit: Arc<AtomicBool>,
         sender: &PacketBatchSender,
         vote_sender: &PacketBatchSender,
-        forward_sender: &PacketBatchSender,
         forward_receiver: PacketBatchReceiver,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         coalesce: Option<Duration>,
-        in_vote_only_mode: Option<Arc<AtomicBool>>,
     ) -> Self {
         let recycler: PacketBatchRecycler = Recycler::warmed(1000, 1024);
-
-        let tpu_stats = Arc::new(StreamerReceiveStats::new("tpu_receiver"));
-
-        let tpu_threads: Vec<_> = tpu_sockets
-            .into_iter()
-            .enumerate()
-            .map(|(i, socket)| {
-                streamer::receiver(
-                    format!("solRcvrTpu{i:02}"),
-                    socket,
-                    exit.clone(),
-                    sender.clone(),
-                    recycler.clone(),
-                    tpu_stats.clone(),
-                    coalesce,
-                    true,
-                    in_vote_only_mode.clone(),
-                    false, // unstaked connections
-                )
-            })
-            .collect();
-
-        let tpu_forward_stats = Arc::new(StreamerReceiveStats::new("tpu_forwards_receiver"));
-        let tpu_forwards_threads: Vec<_> = tpu_forwards_sockets
-            .into_iter()
-            .enumerate()
-            .map(|(i, socket)| {
-                streamer::receiver(
-                    format!("solRcvrTpuFwd{i:02}"),
-                    socket,
-                    exit.clone(),
-                    forward_sender.clone(),
-                    recycler.clone(),
-                    tpu_forward_stats.clone(),
-                    coalesce,
-                    true,
-                    in_vote_only_mode.clone(),
-                    false, // unstaked connections
-                )
-            })
-            .collect();
 
         let tpu_vote_stats = Arc::new(StreamerReceiveStats::new("tpu_vote_receiver"));
         let tpu_vote_threads: Vec<_> = tpu_vote_sockets
@@ -236,9 +173,7 @@ impl FetchStage {
             .spawn(move || loop {
                 sleep(Duration::from_secs(1));
 
-                tpu_stats.report();
                 tpu_vote_stats.report();
-                tpu_forward_stats.report();
 
                 if exit.load(Ordering::Relaxed) {
                     return;
@@ -247,15 +182,10 @@ impl FetchStage {
             .unwrap();
 
         Self {
-            thread_hdls: [
-                tpu_threads,
-                tpu_forwards_threads,
-                tpu_vote_threads,
-                vec![fwd_thread_hdl, metrics_thread_hdl],
-            ]
-            .into_iter()
-            .flatten()
-            .collect(),
+            thread_hdls: [tpu_vote_threads, vec![fwd_thread_hdl, metrics_thread_hdl]]
+                .into_iter()
+                .flatten()
+                .collect(),
         }
     }
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -153,7 +153,6 @@ impl Tpu {
         shared_staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
         banking_tracer_channels: Channels,
         tracer_thread_hdl: TracerThread,
-        tpu_enable_udp: bool,
         tpu_quic_server_config: SwQosQuicStreamerConfig,
         tpu_fwd_quic_server_config: SwQosQuicStreamerConfig,
         vote_quic_server_config: SimpleQosQuicStreamerConfig,
@@ -195,7 +194,6 @@ impl Tpu {
             poh_recorder,
             None, // coalesce
             Some(bank_forks.read().unwrap().get_vote_only_mode_signal()),
-            tpu_enable_udp,
         );
 
         let staked_nodes_updater_service = StakedNodesUpdaterService::new(

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -74,8 +74,6 @@ use {
 };
 
 pub struct TpuSockets {
-    pub transactions: Vec<UdpSocket>,
-    pub transaction_forwards: Vec<UdpSocket>,
     pub vote: Vec<UdpSocket>,
     pub broadcast: Vec<UdpSocket>,
     pub transactions_quic: Vec<UdpSocket>,
@@ -168,8 +166,6 @@ impl Tpu {
         cancel: CancellationToken,
     ) -> Self {
         let TpuSockets {
-            transactions: transactions_sockets,
-            transaction_forwards: tpu_forwards_sockets,
             vote: tpu_vote_sockets,
             broadcast: broadcast_sockets,
             transactions_quic: transactions_quic_sockets,
@@ -183,8 +179,8 @@ impl Tpu {
         let (vote_packet_sender, vote_packet_receiver) = unbounded();
         let (forwarded_packet_sender, forwarded_packet_receiver) = unbounded();
         let fetch_stage = FetchStage::new_with_sender(
-            transactions_sockets,
-            tpu_forwards_sockets,
+            vec![],
+            vec![],
             tpu_vote_sockets,
             exit.clone(),
             &packet_sender,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -179,17 +179,13 @@ impl Tpu {
         let (vote_packet_sender, vote_packet_receiver) = unbounded();
         let (forwarded_packet_sender, forwarded_packet_receiver) = unbounded();
         let fetch_stage = FetchStage::new_with_sender(
-            vec![],
-            vec![],
             tpu_vote_sockets,
             exit.clone(),
             &packet_sender,
             &vote_packet_sender,
-            &forwarded_packet_sender,
             forwarded_packet_receiver,
             poh_recorder,
             None, // coalesce
-            Some(bank_forks.read().unwrap().get_vote_only_mode_signal()),
         );
 
         let staked_nodes_updater_service = StakedNodesUpdaterService::new(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1722,8 +1722,6 @@ impl Validator {
             entry_receiver,
             retransmit_slots_receiver,
             TpuSockets {
-                transactions: node.sockets.tpu,
-                transaction_forwards: node.sockets.tpu_forwards,
                 vote: node.sockets.tpu_vote,
                 broadcast: node.sockets.broadcast,
                 transactions_quic: node.sockets.tpu_quic,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -597,8 +597,6 @@ pub struct ValidatorTpuConfig {
     pub vote_use_quic: bool,
     /// Controls the connection cache pool size
     pub tpu_connection_pool_size: usize,
-    /// Controls if to enable UDP for TPU transactions.
-    pub tpu_enable_udp: bool,
     /// QUIC server config for regular TPU
     pub tpu_quic_server_config: SwQosQuicStreamerConfig,
     /// QUIC server config for TPU forward
@@ -610,7 +608,7 @@ pub struct ValidatorTpuConfig {
 impl ValidatorTpuConfig {
     /// A convenient function to build a ValidatorTpuConfig for testing with good
     /// default.
-    pub fn new_for_tests(tpu_enable_udp: bool) -> Self {
+    pub fn new_for_tests() -> Self {
         let tpu_quic_server_config = SwQosQuicStreamerConfig {
             quic_streamer_config: QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: 32,
@@ -642,7 +640,6 @@ impl ValidatorTpuConfig {
         ValidatorTpuConfig {
             vote_use_quic: DEFAULT_VOTE_USE_QUIC,
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
-            tpu_enable_udp,
             tpu_quic_server_config,
             tpu_fwd_quic_server_config,
             vote_quic_server_config,
@@ -721,7 +718,6 @@ impl Validator {
         let ValidatorTpuConfig {
             vote_use_quic,
             tpu_connection_pool_size,
-            tpu_enable_udp,
             tpu_quic_server_config,
             tpu_fwd_quic_server_config,
             vote_quic_server_config,
@@ -1760,7 +1756,6 @@ impl Validator {
             config.staked_nodes_overrides.clone(),
             banking_tracer_channels,
             tracer_thread,
-            tpu_enable_udp,
             tpu_quic_server_config,
             tpu_fwd_quic_server_config,
             vote_quic_server_config,
@@ -2984,7 +2979,6 @@ mod tests {
         },
         solana_poh_config::PohConfig,
         solana_sha256_hasher::hash,
-        solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
         std::{fs::remove_dir_all, num::NonZeroU64, thread, time::Duration},
     };
 
@@ -3022,7 +3016,7 @@ mod tests {
             None, // rpc_to_plugin_manager_receiver
             start_progress.clone(),
             SocketAddrSpace::Unspecified,
-            ValidatorTpuConfig::new_for_tests(DEFAULT_TPU_ENABLE_UDP),
+            ValidatorTpuConfig::new_for_tests(),
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
@@ -3236,7 +3230,7 @@ mod tests {
                     None, // rpc_to_plugin_manager_receiver
                     Arc::new(RwLock::new(ValidatorStartProgress::default())),
                     SocketAddrSpace::Unspecified,
-                    ValidatorTpuConfig::new_for_tests(DEFAULT_TPU_ENABLE_UDP),
+                    ValidatorTpuConfig::new_for_tests(),
                     Arc::new(RwLock::new(None)),
                 )
                 .expect("assume successful validator start")

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -47,8 +47,7 @@ use {
     solana_streamer::streamer::StakedNodes,
     solana_system_transaction as system_transaction,
     solana_tpu_client::tpu_client::{
-        TpuClient, TpuClientConfig, DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_ENABLE_UDP,
-        DEFAULT_VOTE_USE_QUIC,
+        TpuClient, TpuClientConfig, DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC,
     },
     solana_transaction::Transaction,
     solana_transaction_error::TransportError,
@@ -419,9 +418,8 @@ impl LocalCluster {
                 None, // rpc_to_plugin_manager_receiver
                 Arc::new(RwLock::new(ValidatorStartProgress::default())),
                 socket_addr_space,
-                // We are turning tpu_enable_udp to true in order to prevent concurrent local cluster tests
                 // to use the same QUIC ports due to SO_REUSEPORT.
-                ValidatorTpuConfig::new_for_tests(true),
+                ValidatorTpuConfig::new_for_tests(),
                 Arc::new(RwLock::new(None)),
             )
             .expect("assume successful validator start");
@@ -632,7 +630,7 @@ impl LocalCluster {
             None, // rpc_to_plugin_manager_receiver
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            ValidatorTpuConfig::new_for_tests(DEFAULT_TPU_ENABLE_UDP),
+            ValidatorTpuConfig::new_for_tests(),
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");
@@ -698,7 +696,7 @@ impl LocalCluster {
                 None, // rpc_to_plugin_manager_receiver
                 Arc::new(RwLock::new(ValidatorStartProgress::default())),
                 socket_addr_space,
-                ValidatorTpuConfig::new_for_tests(true),
+                ValidatorTpuConfig::new_for_tests(),
                 Arc::new(RwLock::new(None)),
             )
             .unwrap_or_else(|e| panic!("Cluster leader failed to start: {e:?}"));
@@ -764,7 +762,7 @@ impl LocalCluster {
                     None, // rpc_to_plugin_manager_receiver
                     Arc::new(RwLock::new(ValidatorStartProgress::default())),
                     socket_addr_space,
-                    ValidatorTpuConfig::new_for_tests(DEFAULT_TPU_ENABLE_UDP),
+                    ValidatorTpuConfig::new_for_tests(),
                     Arc::new(RwLock::new(None)),
                 )
                 .unwrap_or_else(|e| panic!("Validator {i} failed to start: {e:?}"));
@@ -1317,7 +1315,7 @@ impl Cluster for LocalCluster {
             None, // rpc_to_plugin_manager_receiver
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
-            ValidatorTpuConfig::new_for_tests(DEFAULT_TPU_ENABLE_UDP),
+            ValidatorTpuConfig::new_for_tests(),
             Arc::new(RwLock::new(None)),
         )
         .expect("assume successful validator start");

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -867,18 +867,6 @@ impl TestValidator {
         Self::start_with_config(mint_address, faucet_addr, socket_addr_space, 0, false)
     }
 
-    /// Create a test validator using udp for TPU (deprecated - use with_no_fees instead).
-    ///
-    /// This function panics on initialization failure.
-    #[deprecated(since = "3.0.0", note = "UDP TPU is deprecated, use with_no_fees instead")]
-    pub fn with_no_fees_udp(
-        mint_address: Pubkey,
-        faucet_addr: Option<SocketAddr>,
-        socket_addr_space: SocketAddrSpace,
-    ) -> Self {
-        Self::with_no_fees(mint_address, faucet_addr, socket_addr_space)
-    }
-
     /// Create and start a `TestValidator` with custom transaction fees and minimal rent.
     /// Faucet optional.
     ///

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -867,6 +867,18 @@ impl TestValidator {
         Self::start_with_config(mint_address, faucet_addr, socket_addr_space, 0, false)
     }
 
+    /// Create a test validator using udp for TPU (deprecated - use with_no_fees instead).
+    ///
+    /// This function panics on initialization failure.
+    #[deprecated(since = "3.0.0", note = "UDP TPU is deprecated, use with_no_fees instead")]
+    pub fn with_no_fees_udp(
+        mint_address: Pubkey,
+        faucet_addr: Option<SocketAddr>,
+        socket_addr_space: SocketAddrSpace,
+    ) -> Self {
+        Self::with_no_fees(mint_address, faucet_addr, socket_addr_space)
+    }
+
     /// Create and start a `TestValidator` with custom transaction fees and minimal rent.
     /// Faucet optional.
     ///

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -25,7 +25,6 @@ use {
     solana_transaction_error::TransactionError, tokio::time::Duration,
 };
 
-pub const DEFAULT_TPU_ENABLE_UDP: bool = false;
 pub const DEFAULT_VOTE_USE_QUIC: bool = false;
 
 /// The default connection count is set to 1 -- it should

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1058,7 +1058,6 @@ mod tests {
             bank_forks::BankForks,
         },
         solana_system_interface::program as system_program,
-        solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
         spl_generic_token::token,
         spl_token_2022_interface::state::{
             Account as TokenAccount, AccountState as TokenAccountState, Mint,
@@ -1565,7 +1564,7 @@ mod tests {
                 None, // rpc_to_plugin_manager_receiver
                 start_progress.clone(),
                 SocketAddrSpace::Unspecified,
-                ValidatorTpuConfig::new_for_tests(DEFAULT_TPU_ENABLE_UDP),
+                ValidatorTpuConfig::new_for_tests(),
                 post_init.clone(),
             )
             .expect("assume successful validator start");

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -87,14 +87,6 @@ fn verify_reachable_ports(
     if verify_address(&node.info.serve_repair(Protocol::UDP)) {
         udp_sockets.push(&node.sockets.serve_repair);
     }
-    if verify_address(&node.info.tpu(Protocol::UDP)) {
-        udp_sockets.extend(node.sockets.tpu.iter());
-        udp_sockets.extend(&node.sockets.tpu_quic);
-    }
-    if verify_address(&node.info.tpu_forwards(Protocol::UDP)) {
-        udp_sockets.extend(node.sockets.tpu_forwards.iter());
-        udp_sockets.extend(&node.sockets.tpu_forwards_quic);
-    }
     if verify_address(&node.info.tpu_vote(Protocol::UDP)) {
         udp_sockets.extend(node.sockets.tpu_vote.iter());
     }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -63,7 +63,6 @@ use {
         nonblocking::{simple_qos::SimpleQosConfig, swqos::SwQosConfig},
         quic::{QuicStreamerConfig, SimpleQosQuicStreamerConfig, SwQosQuicStreamerConfig},
     },
-    solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
     solana_turbine::{
         broadcast_stage::BroadcastStageType,
         xdp::{set_cpu_affinity, XdpConfig},
@@ -261,13 +260,6 @@ pub fn execute(
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
     let vote_use_quic = value_t_or_exit!(matches, "vote_use_quic", bool);
-
-    let tpu_enable_udp = if matches.is_present("tpu_enable_udp") {
-        warn!("Submission of TPU transactions via UDP is deprecated.");
-        true
-    } else {
-        DEFAULT_TPU_ENABLE_UDP
-    };
 
     let tpu_connection_pool_size = value_t_or_exit!(matches, "tpu_connection_pool_size", usize);
 
@@ -1012,7 +1004,6 @@ pub fn execute(
         ValidatorTpuConfig {
             vote_use_quic,
             tpu_connection_pool_size,
-            tpu_enable_udp,
             tpu_quic_server_config,
             tpu_fwd_quic_server_config,
             vote_quic_server_config,


### PR DESCRIPTION
#### Problem

  The `tpu_enable_udp` configuration flag was deprecated to remove the UDP TPU transaction path in favor of QUIC-only transaction
  submission. This flag is now unused and can be safely removed from the codebase.

  #### Summary of Changes

  Removes the deprecated `tpu_enable_udp` configuration field and all related conditional logic that gated transaction receiver thread spawning.

  **Core Changes (solana-core):**
  - Remove `tpu_enable_udp` field from `ValidatorTpuConfig` struct
  - Remove `tpu_enable_udp` parameter from `Tpu::new_with_client()`
  - Remove `tpu_enable_udp` parameter from `FetchStage::new_with_sender()` and `new_multi_socket()`
  - Unconditionally spawn transaction and forwards receiver threads (removed `if tpu_enable_udp` conditionals)
  - Remove `DEFAULT_TPU_ENABLE_UDP` constant

  **Validator Changes:**
  - Remove `tpu_enable_udp` from `ValidatorTpuConfig` initialization in `execute.rs`
  - Remove UDP socket verification for deprecated `tpu` and `tpu_forwards` paths in `bootstrap.rs`
  - Keep verification for `tpu_vote` and `tvu` (still in use)

  **Test Infrastructure Changes:**
  - Remove `tpu_enable_udp` field from `TestValidatorGenesis`
  - Remove deprecated `with_no_fees_udp()` method (UDP-only variant)
  - Update test calls to use `with_no_fees()` instead
  - Update `test_rpc_subscriptions()` to use standard validator instead of UDP-only variant
  - Fix missing imports in `local-cluster` for `TpuClient`, `TpuClientConfig`, and `DEFAULT_TPU_CONNECTION_POOL_SIZE`

  Fixes #7525 (partially)