### PR TITLE
Prepare next top level instruction in place

### DIFF
--- a/transaction-context/src/instruction.rs
+++ b/transaction-context/src/instruction.rs
@@ -51,6 +51,7 @@ impl InstructionFrame {
 
     /// This function retrieves the range to index transaction_context.deduplication_maps
     pub fn deduplication_map_range(instruction_index: usize) -> Range<usize> {
+        // We reference transaction accounts by an u8 index, so we have a total of 256 accounts.
         instruction_index.saturating_mul(MAX_ACCOUNTS_PER_TRANSACTION)
             ..instruction_index
                 .saturating_add(1)


### PR DESCRIPTION
#### Problem

I mentioned in https://github.com/anza-xyz/agave/pull/8919#discussion_r2495755830 that we could avoid copying data when preparing the next instruction. This PR fixes that for top level instructions. Non top instructions require more work and will be in a separate PR.

#### Summary of Changes

1. The deduplication map is now initialized with u16::MAX for its full capacity.
2. Create `configure_next_instruction_in_place` to perform the configuration in place.
3. Refactor `prepare_next_top_level_instruction` to deal with the change.
4. Added a couple of safeguards to avoid panics and out of bounds reads.
