### PR TITLE
Adding snapshot kind fastboot

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -115,24 +115,25 @@ impl SnapshotPackagerService {
                         break;
                     };
 
-                    let SnapshotKind::Archive(snapshot_archive_kind) = snapshot_kind;
-                    // Archiving the snapshot package is not allowed to fail.
-                    // AccountsBackgroundService calls `clean_accounts()` with a value for
-                    // latest_full_snapshot_slot that requires this archive call to succeed.
-                    if let Err(err) = snapshot_utils::archive_snapshot_package(
-                        snapshot_archive_kind,
-                        snapshot_slot,
-                        snapshot_hash,
-                        &bank_snapshot_info.snapshot_dir,
-                        snapshot_package.snapshot_storages,
-                        snapshot_config,
-                    ) {
-                        error!(
-                            "Stopping {}! Fatal error while archiving snapshot package: {err}",
-                            Self::NAME,
-                        );
-                        exit.store(true, Ordering::Relaxed);
-                        break;
+                    if let SnapshotKind::Archive(snapshot_archive_kind) = snapshot_kind {
+                        // Archiving the snapshot package is not allowed to fail.
+                        // AccountsBackgroundService calls `clean_accounts()` with a value for
+                        // latest_full_snapshot_slot that requires this archive call to succeed.
+                        if let Err(err) = snapshot_utils::archive_snapshot_package(
+                            snapshot_archive_kind,
+                            snapshot_slot,
+                            snapshot_hash,
+                            &bank_snapshot_info.snapshot_dir,
+                            snapshot_package.snapshot_storages,
+                            snapshot_config,
+                        ) {
+                            error!(
+                                "Stopping {}! Fatal error while archiving snapshot package: {err}",
+                                Self::NAME,
+                            );
+                            exit.store(true, Ordering::Relaxed);
+                            break;
+                        }
                     }
                     let archive_time_us = archive_time.elapsed().as_micros();
 

--- a/core/src/snapshot_packager_service/snapshot_gossip_manager.rs
+++ b/core/src/snapshot_packager_service/snapshot_gossip_manager.rs
@@ -63,6 +63,9 @@ impl SnapshotGossipManager {
                     base_slot,
                 );
             }
+            SnapshotKind::Fastboot => {
+                // Fastboot snapshots are not gossiped
+            }
         }
     }
 

--- a/runtime/src/accounts_background_service/pending_snapshot_packages.rs
+++ b/runtime/src/accounts_background_service/pending_snapshot_packages.rs
@@ -57,7 +57,7 @@ impl PendingSnapshotPackages {
     pub fn pop(&mut self) -> Option<SnapshotPackage> {
         let pending_full = self.full.take();
         let pending_incremental = self.incremental.take();
-        let pending_archive_snapshot = match (pending_full, pending_incremental) {
+        let pending_archive = match (pending_full, pending_incremental) {
             (Some(pending_full), pending_incremental) => {
                 // If there is a pending incremental snapshot package, check its slot.
                 // If its slot is greater than the full snapshot package's,
@@ -93,22 +93,22 @@ impl PendingSnapshotPackages {
 
         let pending_fastboot = self.fastboot.take();
 
-        match (pending_archive_snapshot, pending_fastboot) {
-            (Some(archive_snapshot), Some(pending_fastboot)) => {
+        match (pending_archive, pending_fastboot) {
+            (Some(pending_archive), Some(pending_fastboot)) => {
                 // Re-enqueue the fastboot snapshot package if its slot is greater
-                if pending_fastboot.slot > archive_snapshot.slot {
+                if pending_fastboot.slot > pending_archive.slot {
                     self.fastboot = Some(pending_fastboot);
                 }
-                Some(archive_snapshot)
+                Some(pending_archive)
             }
-            (Some(archive_snapshot), None) => Some(archive_snapshot),
-            (None, Some(fastboot_snapshot)) => {
+            (Some(pending_archive), None) => Some(pending_archive),
+            (None, Some(pending_fastboot)) => {
                 assert!(
-                    fastboot_snapshot.snapshot_kind == SnapshotKind::Fastboot,
+                    pending_fastboot.snapshot_kind == SnapshotKind::Fastboot,
                     "the pending fastboot snapshot package must be of kind Fastboot, but instead \
-                     was {fastboot_snapshot:?}",
+                     was {pending_fastboot:?}",
                 );
-                Some(fastboot_snapshot)
+                Some(pending_fastboot)
             }
             (None, None) => None,
         }
@@ -135,7 +135,6 @@ mod tests {
             slot,
         )
     }
-
     fn new_fastboot(slot: Slot) -> SnapshotPackage {
         new(SnapshotKind::Fastboot, slot)
     }
@@ -145,6 +144,7 @@ mod tests {
         let pending_snapshot_packages = PendingSnapshotPackages::default();
         assert!(pending_snapshot_packages.full.is_none());
         assert!(pending_snapshot_packages.incremental.is_none());
+        assert!(pending_snapshot_packages.fastboot.is_none());
     }
 
     #[test]
@@ -192,9 +192,43 @@ mod tests {
         );
         assert!(pending_snapshot_packages.fastboot.is_none());
 
-        // ensure pushing a full package doesn't affect the incremental package
-        // (we already tested above that pushing an incremental doesn't affect the full)
+        // ensure we can push fastboot packages
         let incremental_slot = slot;
+        let slot = slot + 50;
+        pending_snapshot_packages.push(new_fastboot(slot));
+        assert_eq!(
+            pending_snapshot_packages.full.as_ref().unwrap().slot,
+            full_slot,
+        );
+        assert_eq!(
+            pending_snapshot_packages.incremental.as_ref().unwrap().slot,
+            incremental_slot,
+        );
+        assert_eq!(
+            pending_snapshot_packages.fastboot.as_ref().unwrap().slot,
+            slot,
+        );
+
+        // ensure we can overwrite fastboot packages
+        let slot = slot + 10;
+        pending_snapshot_packages.push(new_fastboot(slot));
+        assert_eq!(
+            pending_snapshot_packages.full.as_ref().unwrap().slot,
+            full_slot,
+        );
+        assert_eq!(
+            pending_snapshot_packages.incremental.as_ref().unwrap().slot,
+            incremental_slot,
+        );
+        assert_eq!(
+            pending_snapshot_packages.fastboot.as_ref().unwrap().slot,
+            slot,
+        );
+
+        // ensure pushing a full package doesn't affect the incremental package or the fastboot
+        // package (we already tested above that pushing other packages don't affect the full
+        // above)
+        let fastboot_slot = slot;
         let slot = full_slot + 100;
         pending_snapshot_packages.push(new_full(slot));
         assert_eq!(pending_snapshot_packages.full.as_ref().unwrap().slot, slot);
@@ -202,10 +236,13 @@ mod tests {
             pending_snapshot_packages.incremental.as_ref().unwrap().slot,
             incremental_slot,
         );
-        assert!(pending_snapshot_packages.fastboot.is_none());
+        assert_eq!(
+            pending_snapshot_packages.fastboot.as_ref().unwrap().slot,
+            fastboot_slot,
+        );
 
         // ensure we can overwrite incremental packages with incremental packages
-        // with a new full slot
+        // with a new full slot and that the fastboot package is unaffected
         let full_slot = slot;
         let slot = slot + 10;
         pending_snapshot_packages.push(new_incr(slot, full_slot));
@@ -217,49 +254,9 @@ mod tests {
             pending_snapshot_packages.incremental.as_ref().unwrap().slot,
             slot,
         );
-        assert!(pending_snapshot_packages.fastboot.is_none());
-
-        // ensure we can push fastboot packages
-        let incremental_slot = slot;
-        let slot = slot + 50;
-        let fastboot_package = SnapshotPackage {
-            snapshot_kind: SnapshotKind::Fastboot,
-            slot,
-            ..SnapshotPackage::default_for_tests()
-        };
-        pending_snapshot_packages.push(fastboot_package);
         assert_eq!(
             pending_snapshot_packages.fastboot.as_ref().unwrap().slot,
-            slot,
-        );
-        assert_eq!(
-            pending_snapshot_packages.full.as_ref().unwrap().slot,
-            full_slot,
-        );
-        assert_eq!(
-            pending_snapshot_packages.incremental.as_ref().unwrap().slot,
-            incremental_slot,
-        );
-
-        // ensure we can overwrite fastboot packages
-        let slot = slot + 10;
-        let fastboot_package = SnapshotPackage {
-            snapshot_kind: SnapshotKind::Fastboot,
-            slot,
-            ..SnapshotPackage::default_for_tests()
-        };
-        pending_snapshot_packages.push(fastboot_package);
-        assert_eq!(
-            pending_snapshot_packages.fastboot.as_ref().unwrap().slot,
-            slot,
-        );
-        assert_eq!(
-            pending_snapshot_packages.full.as_ref().unwrap().slot,
-            full_slot,
-        );
-        assert_eq!(
-            pending_snapshot_packages.incremental.as_ref().unwrap().slot,
-            incremental_slot,
+            fastboot_slot,
         );
     }
 
@@ -323,66 +320,64 @@ mod tests {
         let mut scenarios = Vec::new();
 
         // Generate all combinations of full, incremental, and fastboot slots
-        for &full in &slots {
-            for &incr in &slots {
-                for &fastboot in &slots {
-                    scenarios.push((full, incr, fastboot));
+        for &full_slot in &slots {
+            for &incr_slot in &slots {
+                for &fastboot_slot in &slots {
+                    scenarios.push((full_slot, incr_slot, fastboot_slot));
                 }
             }
         }
 
-        for (full, incr, fastboot) in scenarios {
-            pending_snapshot_packages.full = full.map(new_full);
-            pending_snapshot_packages.incremental = incr.map(|slot| new_incr(slot, slot));
-            pending_snapshot_packages.fastboot = fastboot.map(new_fastboot);
+        // Test all variations of slot ages between full, incremental, and fastboot
+        for (queued_full_package_slot, queued_incr_package_slot, queued_fastboot_package_slot) in
+            scenarios
+        {
+            pending_snapshot_packages.full = queued_full_package_slot.map(new_full);
+            pending_snapshot_packages.incremental =
+                queued_incr_package_slot.map(|slot| new_incr(slot, slot));
+            pending_snapshot_packages.fastboot = queued_fastboot_package_slot.map(new_fastboot);
 
-            // Pop full snapshot if it exists
-            if let Some(full_slot) = full {
-                assert_eq!(pending_snapshot_packages.pop().unwrap().slot, full_slot);
+            // Pop full package if it exists
+            if let Some(full_slot) = queued_full_package_slot {
+                let full_package = pending_snapshot_packages.pop().unwrap();
+                assert_eq!(
+                    full_package.snapshot_kind,
+                    SnapshotKind::Archive(SnapshotArchiveKind::Full)
+                );
+                assert_eq!(full_package.slot, full_slot);
             }
 
-            // Pop incremental snapshot if it exists and is newer than the full snapshot
-            if let Some(incr_slot) = incr {
-                if full.is_none() || incr_slot > full.unwrap() {
-                    assert_eq!(pending_snapshot_packages.pop().unwrap().slot, incr_slot);
+            if let Some(incr_slot) = queued_incr_package_slot {
+                // If a full package existed, it was already popped above, leaving the incremental
+                // package as the next newest. However, if the incremental package had an older slot
+                // than the full package, it would have been discarded when the full package was popped.
+                if incr_slot > queued_full_package_slot.unwrap_or(0) {
+                    let incremental_package = pending_snapshot_packages.pop().unwrap();
+                    assert_eq!(
+                        incremental_package.snapshot_kind,
+                        SnapshotKind::Archive(SnapshotArchiveKind::Incremental(incr_slot))
+                    );
+                    assert_eq!(incremental_package.slot, incr_slot);
                 }
             }
 
-            // Pop fastboot snapshot if it exists and is newer than both full and incremental
-            if let Some(fastboot_slot) = fastboot {
-                if fastboot_slot > full.unwrap_or(0) && fastboot_slot > incr.unwrap_or(0) {
-                    assert_eq!(pending_snapshot_packages.pop().unwrap().slot, fastboot_slot);
+            if let Some(fastboot_slot) = queued_fastboot_package_slot {
+                // If a full or incremental package existed, they were already popped above, leaving
+                // the fastboot package as the next newest. However, if the fastboot package had an
+                // older slot than either the full or incremental package, it would have been discarded
+                // when those packages were popped.
+                if fastboot_slot > queued_full_package_slot.unwrap_or(0)
+                    && fastboot_slot > queued_incr_package_slot.unwrap_or(0)
+                {
+                    let fastboot_package = pending_snapshot_packages.pop().unwrap();
+                    assert_eq!(fastboot_package.snapshot_kind, SnapshotKind::Fastboot);
+                    assert_eq!(fastboot_package.slot, fastboot_slot);
                 }
             }
 
             // Ensure no more pending packages
             assert!(pending_snapshot_packages.pop().is_none());
         }
-    }
-
-    #[test]
-    fn test_pop_incremental() {
-        let mut pending_snapshot_packages = PendingSnapshotPackages::default();
-
-        // ensure pop returns incremental when there's only an incremental
-        let base = 100;
-        let slot = base + 10;
-        pending_snapshot_packages.incremental = Some(new_incr(slot, base));
-        let snapshot_package = pending_snapshot_packages.pop().unwrap();
-        assert!(snapshot_package.snapshot_kind.is_incremental_snapshot());
-        assert_eq!(snapshot_package.slot, slot);
-    }
-
-    #[test]
-    fn test_pop_fastboot() {
-        let mut pending_snapshot_packages = PendingSnapshotPackages::default();
-
-        // ensure pop returns fastboot when there's only a fastboot
-        let slot = 100;
-        pending_snapshot_packages.fastboot = Some(new_fastboot(slot));
-        let snapshot_package = pending_snapshot_packages.pop().unwrap();
-        assert!(snapshot_package.snapshot_kind == SnapshotKind::Fastboot);
-        assert_eq!(snapshot_package.slot, slot);
     }
 
     #[test]
@@ -413,7 +408,7 @@ mod tests {
         let mut pending_snapshot_packages = PendingSnapshotPackages {
             full: None,
             incremental: None,
-            fastboot: Some(new_full(100)), // <-- invalid! `incremental` is FullSnapshot
+            fastboot: Some(new_full(100)), // <-- invalid! `fastboot` is FullSnapshot
         };
         pending_snapshot_packages.pop();
     }

--- a/runtime/src/accounts_background_service/pending_snapshot_packages.rs
+++ b/runtime/src/accounts_background_service/pending_snapshot_packages.rs
@@ -12,6 +12,7 @@ use {
 pub struct PendingSnapshotPackages {
     full: Option<SnapshotPackage>,
     incremental: Option<SnapshotPackage>,
+    fastboot: Option<SnapshotPackage>,
 }
 
 impl PendingSnapshotPackages {
@@ -27,6 +28,7 @@ impl PendingSnapshotPackages {
             SnapshotKind::Archive(SnapshotArchiveKind::Incremental(_)) => {
                 (&mut self.incremental, "incremental")
             }
+            SnapshotKind::Fastboot => (&mut self.fastboot, "fastboot"),
         };
 
         if let Some(pending_snapshot_package) = pending_package.as_ref() {
@@ -55,7 +57,7 @@ impl PendingSnapshotPackages {
     pub fn pop(&mut self) -> Option<SnapshotPackage> {
         let pending_full = self.full.take();
         let pending_incremental = self.incremental.take();
-        match (pending_full, pending_incremental) {
+        let pending_archive_snapshot = match (pending_full, pending_incremental) {
             (Some(pending_full), pending_incremental) => {
                 // If there is a pending incremental snapshot package, check its slot.
                 // If its slot is greater than the full snapshot package's,
@@ -87,6 +89,28 @@ impl PendingSnapshotPackages {
                 Some(pending_incremental)
             }
             (None, None) => None,
+        };
+
+        let pending_fastboot = self.fastboot.take();
+
+        match (pending_archive_snapshot, pending_fastboot) {
+            (Some(archive_snapshot), Some(pending_fastboot)) => {
+                // Re-enqueue the fastboot snapshot package if its slot is greater
+                if pending_fastboot.slot > archive_snapshot.slot {
+                    self.fastboot = Some(pending_fastboot);
+                }
+                Some(archive_snapshot)
+            }
+            (Some(archive_snapshot), None) => Some(archive_snapshot),
+            (None, Some(fastboot_snapshot)) => {
+                assert!(
+                    fastboot_snapshot.snapshot_kind == SnapshotKind::Fastboot,
+                    "the pending fastboot snapshot package must be of kind Fastboot, but instead \
+                     was {fastboot_snapshot:?}",
+                );
+                Some(fastboot_snapshot)
+            }
+            (None, None) => None,
         }
     }
 }
@@ -112,6 +136,10 @@ mod tests {
         )
     }
 
+    fn new_fastboot(slot: Slot) -> SnapshotPackage {
+        new(SnapshotKind::Fastboot, slot)
+    }
+
     #[test]
     fn test_default() {
         let pending_snapshot_packages = PendingSnapshotPackages::default();
@@ -128,12 +156,14 @@ mod tests {
         pending_snapshot_packages.push(new_full(slot));
         assert_eq!(pending_snapshot_packages.full.as_ref().unwrap().slot, slot);
         assert!(pending_snapshot_packages.incremental.is_none());
+        assert!(pending_snapshot_packages.fastboot.is_none());
 
         // ensure we can overwrite full snapshot packages
         let slot = slot + 100;
         pending_snapshot_packages.push(new_full(slot));
         assert_eq!(pending_snapshot_packages.full.as_ref().unwrap().slot, slot);
         assert!(pending_snapshot_packages.incremental.is_none());
+        assert!(pending_snapshot_packages.fastboot.is_none());
 
         // ensure we can push incremental packages
         let full_slot = slot;
@@ -147,6 +177,7 @@ mod tests {
             pending_snapshot_packages.incremental.as_ref().unwrap().slot,
             slot,
         );
+        assert!(pending_snapshot_packages.fastboot.is_none());
 
         // ensure we can overwrite incremental packages
         let slot = slot + 10;
@@ -159,6 +190,7 @@ mod tests {
             pending_snapshot_packages.incremental.as_ref().unwrap().slot,
             slot,
         );
+        assert!(pending_snapshot_packages.fastboot.is_none());
 
         // ensure pushing a full package doesn't affect the incremental package
         // (we already tested above that pushing an incremental doesn't affect the full)
@@ -170,6 +202,7 @@ mod tests {
             pending_snapshot_packages.incremental.as_ref().unwrap().slot,
             incremental_slot,
         );
+        assert!(pending_snapshot_packages.fastboot.is_none());
 
         // ensure we can overwrite incremental packages with incremental packages
         // with a new full slot
@@ -184,6 +217,50 @@ mod tests {
             pending_snapshot_packages.incremental.as_ref().unwrap().slot,
             slot,
         );
+        assert!(pending_snapshot_packages.fastboot.is_none());
+
+        // ensure we can push fastboot packages
+        let incremental_slot = slot;
+        let slot = slot + 50;
+        let fastboot_package = SnapshotPackage {
+            snapshot_kind: SnapshotKind::Fastboot,
+            slot,
+            ..SnapshotPackage::default_for_tests()
+        };
+        pending_snapshot_packages.push(fastboot_package);
+        assert_eq!(
+            pending_snapshot_packages.fastboot.as_ref().unwrap().slot,
+            slot,
+        );
+        assert_eq!(
+            pending_snapshot_packages.full.as_ref().unwrap().slot,
+            full_slot,
+        );
+        assert_eq!(
+            pending_snapshot_packages.incremental.as_ref().unwrap().slot,
+            incremental_slot,
+        );
+
+        // ensure we can overwrite fastboot packages
+        let slot = slot + 10;
+        let fastboot_package = SnapshotPackage {
+            snapshot_kind: SnapshotKind::Fastboot,
+            slot,
+            ..SnapshotPackage::default_for_tests()
+        };
+        pending_snapshot_packages.push(fastboot_package);
+        assert_eq!(
+            pending_snapshot_packages.fastboot.as_ref().unwrap().slot,
+            slot,
+        );
+        assert_eq!(
+            pending_snapshot_packages.full.as_ref().unwrap().slot,
+            full_slot,
+        );
+        assert_eq!(
+            pending_snapshot_packages.incremental.as_ref().unwrap().slot,
+            incremental_slot,
+        );
     }
 
     #[test]
@@ -193,6 +270,7 @@ mod tests {
         let mut pending_snapshot_packages = PendingSnapshotPackages {
             full: Some(new_full(slot)),
             incremental: None,
+            fastboot: None,
         };
 
         // pushing an older full should panic
@@ -207,6 +285,7 @@ mod tests {
         let mut pending_snapshot_packages = PendingSnapshotPackages {
             full: None,
             incremental: Some(new_incr(slot, base)),
+            fastboot: None,
         };
 
         // pushing an older incremental should panic
@@ -214,53 +293,96 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "fastboot snapshot package must be newer than pending package")]
+    fn test_push_older_fastboot() {
+        let slot = 100;
+        let mut pending_snapshot_packages = PendingSnapshotPackages {
+            full: None,
+            incremental: None,
+            fastboot: Some(new_fastboot(slot)),
+        };
+
+        // pushing an older incremental should panic
+        pending_snapshot_packages.push(new_fastboot(slot - 1));
+    }
+
+    #[test]
     fn test_pop() {
         let mut pending_snapshot_packages = PendingSnapshotPackages::default();
 
-        // ensure we can call pop when there are no pending packages
-        assert!(pending_snapshot_packages.pop().is_none());
+        let oldest_slot = 100;
+        let middle_slot = 200;
+        let newest_slot = 300;
 
-        // ensure pop returns full when there's only a full
-        let slot = 100;
-        pending_snapshot_packages.full = Some(new_full(slot));
-        pending_snapshot_packages.incremental = None;
-        let snapshot_package = pending_snapshot_packages.pop().unwrap();
-        assert!(snapshot_package.snapshot_kind.is_full_snapshot());
-        assert_eq!(snapshot_package.slot, slot);
+        let slots = vec![
+            None,
+            Some(oldest_slot),
+            Some(middle_slot),
+            Some(newest_slot),
+        ];
+        let mut scenarios = Vec::new();
+
+        // Generate all combinations of full, incremental, and fastboot slots
+        for &full in &slots {
+            for &incr in &slots {
+                for &fastboot in &slots {
+                    scenarios.push((full, incr, fastboot));
+                }
+            }
+        }
+
+        for (full, incr, fastboot) in scenarios {
+            pending_snapshot_packages.full = full.map(new_full);
+            pending_snapshot_packages.incremental = incr.map(|slot| new_incr(slot, slot));
+            pending_snapshot_packages.fastboot = fastboot.map(new_fastboot);
+
+            // Pop full snapshot if it exists
+            if let Some(full_slot) = full {
+                assert_eq!(pending_snapshot_packages.pop().unwrap().slot, full_slot);
+            }
+
+            // Pop incremental snapshot if it exists and is newer than the full snapshot
+            if let Some(incr_slot) = incr {
+                if full.is_none() || incr_slot > full.unwrap() {
+                    assert_eq!(pending_snapshot_packages.pop().unwrap().slot, incr_slot);
+                }
+            }
+
+            // Pop fastboot snapshot if it exists and is newer than both full and incremental
+            if let Some(fastboot_slot) = fastboot {
+                if fastboot_slot > full.unwrap_or(0) && fastboot_slot > incr.unwrap_or(0) {
+                    assert_eq!(pending_snapshot_packages.pop().unwrap().slot, fastboot_slot);
+                }
+            }
+
+            // Ensure no more pending packages
+            assert!(pending_snapshot_packages.pop().is_none());
+        }
+    }
+
+    #[test]
+    fn test_pop_incremental() {
+        let mut pending_snapshot_packages = PendingSnapshotPackages::default();
 
         // ensure pop returns incremental when there's only an incremental
         let base = 100;
         let slot = base + 10;
-        pending_snapshot_packages.full = None;
         pending_snapshot_packages.incremental = Some(new_incr(slot, base));
         let snapshot_package = pending_snapshot_packages.pop().unwrap();
         assert!(snapshot_package.snapshot_kind.is_incremental_snapshot());
         assert_eq!(snapshot_package.slot, slot);
+    }
 
-        // ensure pop returns full when there's both a full and newer incremental
-        let full_slot = 100;
-        let incr_slot = full_slot + 10;
-        pending_snapshot_packages.full = Some(new_full(full_slot));
-        pending_snapshot_packages.incremental = Some(new_incr(incr_slot, full_slot));
-        let snapshot_package = pending_snapshot_packages.pop().unwrap();
-        assert!(snapshot_package.snapshot_kind.is_full_snapshot());
-        assert_eq!(snapshot_package.slot, full_slot);
+    #[test]
+    fn test_pop_fastboot() {
+        let mut pending_snapshot_packages = PendingSnapshotPackages::default();
 
-        // ..and then the second pop returns the incremental
+        // ensure pop returns fastboot when there's only a fastboot
+        let slot = 100;
+        pending_snapshot_packages.fastboot = Some(new_fastboot(slot));
         let snapshot_package = pending_snapshot_packages.pop().unwrap();
-        assert!(snapshot_package.snapshot_kind.is_incremental_snapshot());
-        assert_eq!(snapshot_package.slot, incr_slot);
-
-        // but, if there's a full and *older* incremental, pop should return
-        // the full and *not* re-enqueue the incremental
-        let full_slot = 200;
-        let incr_slot = full_slot - 10;
-        pending_snapshot_packages.full = Some(new_full(full_slot));
-        pending_snapshot_packages.incremental = Some(new_incr(incr_slot, full_slot));
-        let snapshot_package = pending_snapshot_packages.pop().unwrap();
-        assert!(snapshot_package.snapshot_kind.is_full_snapshot());
-        assert_eq!(snapshot_package.slot, full_slot);
-        assert!(pending_snapshot_packages.incremental.is_none());
+        assert!(snapshot_package.snapshot_kind == SnapshotKind::Fastboot);
+        assert_eq!(snapshot_package.slot, slot);
     }
 
     #[test]
@@ -269,6 +391,7 @@ mod tests {
         let mut pending_snapshot_packages = PendingSnapshotPackages {
             full: Some(new_incr(110, 100)), // <-- invalid! `full` is IncrementalSnapshot
             incremental: None,
+            fastboot: None,
         };
         pending_snapshot_packages.pop();
     }
@@ -279,6 +402,18 @@ mod tests {
         let mut pending_snapshot_packages = PendingSnapshotPackages {
             full: None,
             incremental: Some(new_full(100)), // <-- invalid! `incremental` is FullSnapshot
+            fastboot: None,
+        };
+        pending_snapshot_packages.pop();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_pop_invalid_pending_fastboot() {
+        let mut pending_snapshot_packages = PendingSnapshotPackages {
+            full: None,
+            incremental: None,
+            fastboot: Some(new_full(100)), // <-- invalid! `incremental` is FullSnapshot
         };
         pending_snapshot_packages.pop();
     }

--- a/snapshots/src/kind.rs
+++ b/snapshots/src/kind.rs
@@ -5,6 +5,7 @@ use solana_clock::Slot;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SnapshotKind {
     Archive(SnapshotArchiveKind),
+    Fastboot,
 }
 
 impl SnapshotKind {


### PR DESCRIPTION
#### Problem
Currently there is no way to make a snapshot without also creating an archive. For fastbooting purposes archives are not needed as the storages already present and are re-used

#### Summary of Changes
- And new SnapshotKind::Fastboot 
  - Lower priority than the other SnapshotKinds
  - Only creates a bank snapshot
  - Gets removed from the pending queue if any other newer archive is saved (as those include bank snapshots)
- Modify existing fastboot test flow to use the new snapshot kind
- Lots of lines of changes, but mostly testing

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
