### PR TITLE
SIMD-0417: Assign Ed25519 precompile to native loader

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1204,6 +1204,10 @@ pub mod alt_bn128_little_endian {
     solana_pubkey::declare_id!("bnS3pWfLrxHRJvMyLm6EaYQkP7A2Fe9DxoKv4aGA8YM");
 }
 
+pub mod assign_ed25519_precompile_to_native_loader {
+    solana_pubkey::declare_id!("ownrov5XivPciuSz7cUNRUpJ4WC82H6N4KXvemHmHpU");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2158,6 +2162,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             alt_bn128_little_endian::id(),
             "SIMD-0284: Add little-endian compatibility for alt_bn128",
+        ),
+        (
+            assign_ed25519_precompile_to_native_loader::id(),
+            "Assign Ed25519 Precompile to native loader",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5375,6 +5375,7 @@ impl Bank {
                 let new_account = AccountSharedData::from(Account {
                     owner: native_loader::ID,
                     executable: true,
+                    data: b"ed25519_program".to_vec(),
                     ..Account::from(account)
                 });
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5359,6 +5359,29 @@ impl Bank {
             self.update_rent();
         }
 
+        if new_feature_activations
+            .contains(&feature_set::assign_ed25519_precompile_to_native_loader::id())
+        {
+            if let Some(account) = self
+                .get_account_with_fixed_root(&solana_sdk_ids::ed25519_program::id())
+                .and_then(|account| {
+                    if !native_loader::check_id(account.owner()) {
+                        Some(account)
+                    } else {
+                        None
+                    }
+                })
+            {
+                let new_account = AccountSharedData::from(Account {
+                    owner: native_loader::ID,
+                    executable: true,
+                    ..Account::from(account)
+                });
+
+                self.store_account(&solana_sdk_ids::ed25519_program::id(), &new_account);
+            }
+        }
+
         if new_feature_activations.contains(&feature_set::pico_inflation::id()) {
             *self.inflation.write().unwrap() = Inflation::pico();
             self.fee_rate_governor.burn_percent = solana_fee_calculator::DEFAULT_BURN_PERCENT; // 50% fee burn


### PR DESCRIPTION
#### Problem
A very old issue https://github.com/solana-labs/solana/pull/23219 of the Ed25519 program belonging to System Program rather than the Native Loader program has once again resurfaced. At the time, it was not resolved in a way that results in a consistent program owner across all clusters. As a result, the recent activation of SIMD-0186 has broken the Ed25519 precompile on the testnet cluster due to this branch of code now *correctly* enforcing the behavior we *should* have solved for: https://github.com/anza-xyz/agave/blob/89ead14a0fd576a13c37513419f8e2406769684f/svm/src/account_loader.rs#L607-L610

#### Summary of Changes
This PR implements https://github.com/solana-foundation/solana-improvement-documents/pull/417, introducing a feature gate that, when activated on testnet, updates the owner of the Ed25519 program to the Native Loader program and explicitly flags it as executable. All other account fields remain unchanged. No functionality changes occur on mainnet or devnet.

Fixes #23219