### PR TITLE
bpf_loader: Apply debug port offset with regards to the CPI level to prevent port collisions

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1531,7 +1531,7 @@ fn execute<'a, 'b: 'a>(
 
         #[cfg(feature = "sbpf-debugger")]
         if let Some(debug_port) = &mut vm.debug_port {
-            // Apply an offset to the debug port with regards to the CPI level to prevent port collisions.
+            // Offset the debug port with regards to the CPI level to prevent port collisions.
             let debug_port_cpi_offset = vm
                 .context_object_pointer
                 .transaction_context

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1478,6 +1478,12 @@ fn execute<'a, 'b: 'a>(
             let use_jit = executable.get_compiled_program().is_some();
         }
     }
+    cfg_if! {
+        if #[cfg(feature = "sbpf-debugger")] {
+            // Calculate an offset to the VM's debug port by the CPI level.
+            let debug_port_cpi_offset = instruction_context.get_stack_height().saturating_sub(1) as u16;
+        }
+    }
     let stricter_abi_and_runtime_constraints = invoke_context
         .get_feature_set()
         .stricter_abi_and_runtime_constraints;
@@ -1528,6 +1534,12 @@ fn execute<'a, 'b: 'a>(
             }
         };
         create_vm_time.stop();
+
+        #[cfg(feature = "sbpf-debugger")]
+        if let Some(debug_port) = &mut vm.debug_port {
+            // Apply the debug port offset with regards to the CPI level to prevent port collisions.
+            *debug_port = debug_port.saturating_add(debug_port_cpi_offset);
+        }
 
         vm.context_object_pointer.execute_time = Some(Measure::start("execute"));
         vm.registers[1] = ebpf::MM_INPUT_START;


### PR DESCRIPTION
#### Problem

Currently on each program execution the SBPF debugger starts listening on $VM_DEBUG_PORT.
This is particularly a problem when there are CPIs as on each CPI another VM is instantiated attempting to reuse $VM_DEBUG_PORT.

#### Summary of Changes

The VM's debug port is added an offset with regards to the CPI level to avoid port collisions.

This PR wraps up everything explained here https://github.com/anza-xyz/sbpf/pull/79 but I believe with a simpler and cleaner implementation.
