### PR TITLE
bump workspace imports frozen-abi 3.1.1 / frozen-abi-macro 3.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8685,10 +8685,11 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "3.0.1"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497caf6b5b0ad5fbf3879d4417cd520e11f19c34f183d052e42370d9a585c79a"
+checksum = "c5d81d458718f726d05fc8d476225b907558875e461e7fbe3fcecfb142c061fb"
 dependencies = [
+ "bincode",
  "boxcar",
  "bs58",
  "bv",
@@ -8697,6 +8698,8 @@ dependencies = [
  "im",
  "log",
  "memmap2 0.5.10",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "serde",
  "serde_derive",
  "serde_with",
@@ -8707,9 +8710,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "3.0.1"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e4bb0f5232668866a7f6f5cbc3222bbd9eebbff6afe392e3394498e8c9b1fa"
+checksum = "5396c179ca7d76f866b102eb3819ca3922bdaa33c9ada8005f4e98fd59ab65f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -460,8 +460,8 @@ solana-fee = { path = "fee", version = "=4.0.0-alpha.0", features = ["agave-unst
 solana-fee-calculator = "3.0.0"
 solana-fee-structure = "3.0.0"
 solana-file-download = "3.1.0"
-solana-frozen-abi = "3.0.1"
-solana-frozen-abi-macro = "3.0.1"
+solana-frozen-abi = "3.1.1"
+solana-frozen-abi-macro = "3.2.1"
 solana-genesis = { path = "genesis", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-genesis-config = "3.0.0"
 solana-genesis-utils = { path = "genesis-utils", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }

--- a/ci/test-frozen-abi.sh
+++ b/ci/test-frozen-abi.sh
@@ -11,7 +11,9 @@ source "$here/rust-version.sh" nightly
 
 packages=$(cargo +"$rust_nightly" metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.features | has("frozen-abi")) | .name')
 for package in $packages; do
-  cmd="cargo +$rust_nightly test -p $package --features frozen-abi --lib -- test_abi_ --nocapture"
-  echo "--- $cmd"
-  $cmd
+  for test_name in test_api_digest test_abi_digest; do
+    cmd="cargo +$rust_nightly test -p $package --features frozen-abi --lib -- $test_name --nocapture"
+    echo "--- $cmd"
+    $cmd
+  done
 done

--- a/ci/test-frozen-abi.sh
+++ b/ci/test-frozen-abi.sh
@@ -11,9 +11,7 @@ source "$here/rust-version.sh" nightly
 
 packages=$(cargo +"$rust_nightly" metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.features | has("frozen-abi")) | .name')
 for package in $packages; do
-  for test_name in test_api_digest test_abi_digest; do
-    cmd="cargo +$rust_nightly test -p $package --features frozen-abi --lib -- $test_name --nocapture"
-    echo "--- $cmd"
-    $cmd
-  done
+  cmd="cargo +$rust_nightly test -p $package --features frozen-abi --lib -- test_abi_digest test_api_digest --nocapture"
+  echo "--- $cmd"
+  $cmd
 done


### PR DESCRIPTION
#### Description
There is new version of **frozen-abi** and **frozen-abi-macro** with the new feature `StableAbi` support.

https://github.com/anza-xyz/solana-sdk/pull/443
https://github.com/anza-xyz/agave/issues/8091
https://github.com/anza-xyz/solana-sdk/pull/466

#### Summary of Changes
This PR unlocks usage of the new feature `StableAbi`.

- Bumped frozen-abi to 3.1.1 
- Bumped frozen-abi-macro to 3.2.1
- Updated /ci/test-frozen-abi.sh