### PR TITLE
build-sbf: Make it work in any directory

### DIFF
--- a/cargo-build-sbf
+++ b/cargo-build-sbf
@@ -2,15 +2,8 @@
 
 here=$(dirname "$0")
 
-maybe_sbf_sdk="--sbf-sdk $here/platform-tools-sdk/sbf"
-for a in "$@"; do
-  if [[ $a = --sbf-sdk ]]; then
-    maybe_sbf_sdk=
-  fi
-done
-
 set -ex
 if [[ ! -f "$here"/platform-tools-sdk/sbf/syscalls.txt ]]; then
   cargo build --manifest-path "$here"/syscalls/gen-syscall-list/Cargo.toml
 fi
-exec cargo run --manifest-path "$here"/platform-tools-sdk/cargo-build-sbf/Cargo.toml -- $maybe_sbf_sdk "$@"
+exec cargo run --manifest-path "$here"/platform-tools-sdk/cargo-build-sbf/Cargo.toml -- "$@"

--- a/cargo-test-sbf
+++ b/cargo-test-sbf
@@ -2,13 +2,6 @@
 
 here=$(dirname "$0")
 
-maybe_sbf_sdk="--sbf-sdk $here/platform-tools-sdk/sbf"
-for a in "$@"; do
-  if [[ $a = --sbf-sdk ]]; then
-    maybe_sbf_sdk=
-  fi
-done
-
 export CARGO_BUILD_SBF="$here"/cargo-build-sbf
 set -x
-exec cargo run --manifest-path "$here"/platform-tools-sdk/cargo-test-sbf/Cargo.toml -- $maybe_sbf_sdk "$@"
+exec cargo run --manifest-path "$here"/platform-tools-sdk/cargo-test-sbf/Cargo.toml -- "$@"

--- a/platform-tools-sdk/cargo-test-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-test-sbf/src/main.rs
@@ -14,7 +14,6 @@ use {
 };
 
 struct Config<'a> {
-    sbf_sdk: Option<String>,
     sbf_out_dir: Option<String>,
     platform_tools_version: Option<String>,
     cargo: PathBuf,
@@ -36,7 +35,6 @@ struct Config<'a> {
 impl Default for Config<'_> {
     fn default() -> Self {
         Self {
-            sbf_sdk: None,
             sbf_out_dir: None,
             platform_tools_version: None,
             cargo: PathBuf::from("cargo"),
@@ -141,10 +139,6 @@ fn test_solana_package(
     }
 
     let mut build_sbf_args = cargo_args.clone();
-    if let Some(sbf_sdk) = config.sbf_sdk.as_ref() {
-        build_sbf_args.push("--sbf-sdk");
-        build_sbf_args.push(sbf_sdk);
-    }
     build_sbf_args.push("--sbf-out-dir");
     build_sbf_args.push(&sbf_out_dir);
 
@@ -288,7 +282,7 @@ fn main() {
                 .long("sbf-sdk")
                 .value_name("PATH")
                 .takes_value(true)
-                .help("Path to the Solana SBF SDK"),
+                .help("UNUSED: Path to the Solana SBF SDK"),
         )
         .arg(
             Arg::new("features")
@@ -404,8 +398,13 @@ fn main() {
         )
         .get_matches_from(args);
 
+    if matches.is_present("sbf_sdk") {
+        println!(
+            "--sbf-sdk ignored, argument has been deprecated and will be removed in a future \
+             release."
+        );
+    }
     let mut config = Config {
-        sbf_sdk: matches.value_of_t("sbf_sdk").ok(),
         sbf_out_dir: matches.value_of_t("sbf_out_dir").ok(),
         extra_cargo_test_args: matches
             .values_of_t("extra_cargo_test_args")


### PR DESCRIPTION
#### Problem

Currently, users are forced to download the whole tarball just to get`cargo-build-sbf`, which adds a lot of unnecessary bloat, considering people are used to simply running `cargo install ...` to get binaries.

#### Summary of changes

Builds on top of https://github.com/anza-xyz/agave/pull/9345 and https://github.com/anza-xyz/agave/pull/9346 to remove the usage of `--sbf-sdk` everywhere, which makes cargo-build-sbf only depend on the platform tools install directory.

This means that the `cargo-build-sbf` binary can live anywhere and Just Work, so it will work in `cargo install` settings too!

Note: leaving this in draft until the other PRs land, but this gives a full look at the desired end state.