### PR TITLE
perf(ledger): deserialize shred headers using wincode

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -166,7 +166,7 @@ impl ShredFlags {
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(transparent)]
-    Bincode(#[from] bincode::Error),
+    WincodeRead(#[from] wincode::ReadError),
     #[error(transparent)]
     WincodeWrite(#[from] wincode::WriteError),
     #[error(transparent)]
@@ -255,7 +255,7 @@ enum ShredVariant {
 }
 
 /// A common header that is present in data and code shred headers
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaWrite)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaRead, SchemaWrite)]
 struct ShredCommonHeader {
     #[wincode(with = "Pod<_>")]
     signature: Signature,
@@ -267,7 +267,7 @@ struct ShredCommonHeader {
 }
 
 /// The data shred header has parent offset and flags
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaWrite)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaRead, SchemaWrite)]
 struct DataShredHeader {
     parent_offset: u16,
     #[wincode(with = "Pod<_>")]
@@ -276,7 +276,7 @@ struct DataShredHeader {
 }
 
 /// The coding shred header has FEC information
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaWrite)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaRead, SchemaWrite)]
 struct CodingShredHeader {
     num_data_shreds: u16,
     num_coding_shreds: u16,

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -26,7 +26,6 @@ use {
     solana_clock::Slot,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_perf::packet::deserialize_from_with_limit,
     solana_pubkey::Pubkey,
     solana_sha256_hasher::hashv,
     solana_signature::Signature,
@@ -510,7 +509,7 @@ impl<'a> ShredTrait<'a> for ShredData {
         }
         payload.truncate(Self::SIZE_OF_PAYLOAD);
         let (common_header, data_header): (ShredCommonHeader, _) =
-            deserialize_from_with_limit(&payload[..])?;
+            wincode::deserialize(&payload[..])?;
         if !matches!(common_header.shred_variant, ShredVariant::MerkleData { .. }) {
             return Err(Error::InvalidShredVariant);
         }
@@ -561,7 +560,7 @@ impl<'a> ShredTrait<'a> for ShredCode {
     {
         let mut payload = Payload::from(payload);
         let (common_header, coding_header): (ShredCommonHeader, _) =
-            deserialize_from_with_limit(&payload[..])?;
+            wincode::deserialize(&payload[..])?;
         if !matches!(common_header.shred_variant, ShredVariant::MerkleCode { .. }) {
             return Err(Error::InvalidShredVariant);
         }
@@ -803,8 +802,7 @@ pub(super) fn recover(
                     let Shred::ShredData(shred) = shred else {
                         return Err(Error::InvalidRecoveredShred);
                     };
-                    let (common_header, data_header) =
-                        deserialize_from_with_limit(&shred.payload[..])?;
+                    let (common_header, data_header) = wincode::deserialize(&shred.payload[..])?;
                     if shred.common_header != common_header {
                         return Err(Error::InvalidRecoveredShred);
                     }


### PR DESCRIPTION
#### Problem
Shred headers are deserialized using generic `perf::deserialize_from_with_limit` bincode deserialization. This can be replaced with simpler and faster wincode equivalent.

#### Summary of Changes
* annotate headers with `SchemaRead` derive
* switch `solana_perf::packet::deserialize_from_with_limit` calls in `shred/merkle.rs` to `wincode::deserialize`
* remove `bincode` error from `solana_ledger::shred::Error`

Note,  `deserialize_from_with_limit` sets-up some custom options for bincode deserialization, but it seems they do not make any difference for shred headers deserialization:
* `.with_limit(PACKET_DATA_SIZE as u64)` headers do not contain dynamic lists / collections, so the input and created structs are statically constrained by lower limit
*  `.with_fixint_encoding()` - headers do not contain collections, so len encoding isn't used 
*  `.allow_trailing_bytes()` - wincode will simply ignore the trailing bytes from provided slices by default

##### Benchmark performance
This change consistently trims ~3-5us across all `bench_recover_shreds` benches, e.g. 

master:
```
bench_recover_shreds_last_56_32
                        time:   [75.739 µs 76.169 µs 76.604 µs]
```

PR
```
bench_recover_shreds_last_56_32
                        time:   [71.568 µs 71.993 µs 72.434 µs]
```
