### PR TITLE
validator: Make PrioritizationFeeCache optional

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -29,9 +29,7 @@ use {
     solana_perf::packet::{to_packet_batches, PacketBatch},
     solana_poh::poh_recorder::{create_test_recorder, PohRecorder, WorkingBankEntry},
     solana_pubkey::{self as pubkey, Pubkey},
-    solana_runtime::{
-        bank::Bank, bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
-    },
+    solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_signature::Signature,
     solana_signer::Signer,
     solana_system_interface::instruction as system_instruction,
@@ -451,7 +449,6 @@ fn main() {
             BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT,
         )))
         .unwrap();
-    let prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
     let Channels {
         non_vote_sender,
         non_vote_receiver,
@@ -476,7 +473,7 @@ fn main() {
         replay_vote_sender,
         None,
         bank_forks.clone(),
-        prioritization_fee_cache,
+        None,
     );
 
     // This is so that the signal_receiver does not go out of scope after the closure.

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -35,9 +35,7 @@ use {
     solana_perf::packet::to_packet_batches,
     solana_poh::poh_recorder::{create_test_recorder, WorkingBankEntry},
     solana_pubkey as pubkey,
-    solana_runtime::{
-        bank::Bank, bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
-    },
+    solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_signature::Signature,
     solana_signer::Signer,
     solana_system_interface::instruction as system_instruction,
@@ -252,7 +250,7 @@ fn bench_banking(
         s,
         None,
         bank_forks,
-        Arc::new(PrioritizationFeeCache::new(0u64)),
+        None,
     );
 
     let chunk_len = verified.len() / CHUNKS;

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -42,7 +42,6 @@ use {
         bank::{Bank, HashOverrides},
         bank_forks::BankForks,
         installed_scheduler_pool::BankWithScheduler,
-        prioritization_fee_cache::PrioritizationFeeCache,
     },
     solana_shred_version::compute_shred_version,
     solana_signer::Signer,
@@ -833,7 +832,6 @@ impl BankingSimulator {
         );
 
         info!("Start banking stage!...");
-        let prioritization_fee_cache = &Arc::new(PrioritizationFeeCache::new(0u64));
         let banking_stage = BankingStage::new_num_threads(
             block_production_method.clone(),
             poh_recorder.clone(),
@@ -848,7 +846,7 @@ impl BankingSimulator {
             replay_vote_sender,
             None,
             bank_forks.clone(),
-            prioritization_fee_cache.clone(),
+            None,
         );
 
         let (&_slot, &raw_base_event_time) = freeze_time_by_slot

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -399,7 +399,7 @@ impl BankingStage {
         replay_vote_sender: ReplayVoteSender,
         log_messages_bytes_limit: Option<usize>,
         bank_forks: Arc<RwLock<BankForks>>,
-        prioritization_fee_cache: Arc<PrioritizationFeeCache>,
+        prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
     ) -> BankingStageHandle {
         let committer = Committer::new(
             transaction_status_sender,
@@ -956,7 +956,7 @@ mod tests {
             replay_vote_sender,
             None,
             bank_forks,
-            Arc::new(PrioritizationFeeCache::new(0u64)),
+            None,
         );
         drop(non_vote_sender);
         drop(tpu_vote_sender);
@@ -1020,7 +1020,7 @@ mod tests {
             replay_vote_sender,
             None,
             bank_forks,
-            Arc::new(PrioritizationFeeCache::new(0u64)),
+            None,
         );
         trace!("sending bank");
         drop(non_vote_sender);
@@ -1094,7 +1094,7 @@ mod tests {
             replay_vote_sender,
             None,
             bank_forks.clone(), // keep a local-copy of bank-forks so worker threads do not lose weak access to bank-forks
-            Arc::new(PrioritizationFeeCache::new(0u64)),
+            None,
         );
 
         // good tx, and no verify
@@ -1246,7 +1246,7 @@ mod tests {
                 replay_vote_sender,
                 None,
                 bank_forks,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
+                None,
             );
 
             // wait for banking_stage to eat the packets
@@ -1399,7 +1399,7 @@ mod tests {
             replay_vote_sender,
             None,
             bank_forks,
-            Arc::new(PrioritizationFeeCache::new(0u64)),
+            None,
         );
 
         let keypairs = (0..100).map(|_| Keypair::new()).collect_vec();

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -2122,8 +2122,7 @@ mod tests {
         },
         solana_pubkey::Pubkey,
         solana_runtime::{
-            bank::Bank, bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
-            vote_sender_types::ReplayVoteReceiver,
+            bank::Bank, bank_forks::BankForks, vote_sender_types::ReplayVoteReceiver,
         },
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_signer::Signer,
@@ -2184,11 +2183,7 @@ mod tests {
         let recorder = TransactionRecorder::new(record_sender);
 
         let (replay_vote_sender, replay_vote_receiver) = unbounded();
-        let committer = Committer::new(
-            None,
-            replay_vote_sender,
-            Arc::new(PrioritizationFeeCache::new(0u64)),
-        );
+        let committer = Committer::new(None, replay_vote_sender, None);
         let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
         let shared_leader_state = SharedLeaderState::new(0, None, None);
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -563,7 +563,7 @@ mod tests {
         solana_nonce_account::verify_nonce_account,
         solana_poh::record_channels::{record_channels, RecordReceiver},
         solana_pubkey::Pubkey,
-        solana_runtime::{bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache},
+        solana_runtime::bank_forks::BankForks,
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_signer::Signer,
         solana_system_interface::program as system_program,
@@ -612,11 +612,7 @@ mod tests {
         record_receiver.restart(bank.bank_id());
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-        let committer = Committer::new(
-            transaction_status_sender,
-            replay_vote_sender,
-            Arc::new(PrioritizationFeeCache::new(0u64)),
-        );
+        let committer = Committer::new(transaction_status_sender, replay_vote_sender, None);
         let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
         TestFrame {
@@ -639,11 +635,7 @@ mod tests {
         record_receiver.restart(bank.bank_id());
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-        let committer = Committer::new(
-            None,
-            replay_vote_sender,
-            Arc::new(PrioritizationFeeCache::new(0u64)),
-        );
+        let committer = Committer::new(None, replay_vote_sender, None);
         let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
         consumer.process_and_record_transactions(&bank, &transactions)
     }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -287,7 +287,7 @@ pub struct ReplayStageConfig {
     pub vote_tracker: Arc<VoteTracker>,
     pub cluster_slots: Arc<ClusterSlots>,
     pub log_messages_bytes_limit: Option<usize>,
-    pub prioritization_fee_cache: Arc<PrioritizationFeeCache>,
+    pub prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
     pub banking_tracer: Arc<BankingTracer>,
     pub snapshot_controller: Option<Arc<SnapshotController>>,
 }
@@ -801,7 +801,7 @@ impl ReplayStage {
                     log_messages_bytes_limit,
                     &replay_mode,
                     &replay_tx_thread_pool,
-                    &prioritization_fee_cache,
+                    prioritization_fee_cache.as_deref(),
                     &mut purge_repair_slot_counter,
                     &poh_recorder,
                     first_alpenglow_slot,
@@ -2299,7 +2299,7 @@ impl ReplayStage {
         entry_notification_sender: Option<&EntryNotifierSender>,
         replay_vote_sender: &ReplayVoteSender,
         log_messages_bytes_limit: Option<usize>,
-        prioritization_fee_cache: &PrioritizationFeeCache,
+        prioritization_fee_cache: Option<&PrioritizationFeeCache>,
     ) -> result::Result<usize, BlockstoreProcessorError> {
         let mut w_replay_stats = replay_stats.write().unwrap();
         let mut w_replay_progress = replay_progress.write().unwrap();
@@ -2950,7 +2950,7 @@ impl ReplayStage {
         replay_timing: &mut ReplayLoopTiming,
         log_messages_bytes_limit: Option<usize>,
         active_bank_slots: &[Slot],
-        prioritization_fee_cache: &PrioritizationFeeCache,
+        prioritization_fee_cache: Option<&PrioritizationFeeCache>,
     ) -> Vec<ReplaySlotFromBlockstore> {
         // Make mutable shared structures thread safe.
         let progress = RwLock::new(progress);
@@ -3063,7 +3063,7 @@ impl ReplayStage {
         replay_timing: &mut ReplayLoopTiming,
         log_messages_bytes_limit: Option<usize>,
         bank_slot: Slot,
-        prioritization_fee_cache: &PrioritizationFeeCache,
+        prioritization_fee_cache: Option<&PrioritizationFeeCache>,
     ) -> ReplaySlotFromBlockstore {
         let mut replay_result = ReplaySlotFromBlockstore {
             is_slot_dead: false,
@@ -3485,7 +3485,7 @@ impl ReplayStage {
         log_messages_bytes_limit: Option<usize>,
         replay_mode: &ForkReplayMode,
         replay_tx_thread_pool: &ThreadPool,
-        prioritization_fee_cache: &PrioritizationFeeCache,
+        prioritization_fee_cache: Option<&PrioritizationFeeCache>,
         purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
         poh_recorder: &RwLock<PohRecorder>,
         first_alpenglow_slot: Option<Slot>,
@@ -5184,7 +5184,7 @@ pub(crate) mod tests {
                 None,
                 &replay_vote_sender,
                 None,
-                &PrioritizationFeeCache::new(0u64),
+                None,
             );
             let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
             let rpc_subscriptions = Arc::new(RpcSubscriptions::new_for_tests(

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -157,7 +157,7 @@ impl Tpu {
         tpu_quic_server_config: SwQosQuicStreamerConfig,
         tpu_fwd_quic_server_config: SwQosQuicStreamerConfig,
         vote_quic_server_config: SimpleQosQuicStreamerConfig,
-        prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
+        prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
         block_production_method: BlockProductionMethod,
         block_production_num_workers: NonZeroUsize,
         block_production_scheduler_config: SchedulerConfig,
@@ -346,7 +346,7 @@ impl Tpu {
             replay_vote_sender,
             log_messages_bytes_limit,
             bank_forks.clone(),
-            prioritization_fee_cache.clone(),
+            prioritization_fee_cache,
         );
 
         #[cfg(unix)]

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -160,7 +160,7 @@ impl Tvu {
         wait_to_vote_slot: Option<Slot>,
         snapshot_controller: Option<Arc<SnapshotController>>,
         log_messages_bytes_limit: Option<usize>,
-        prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
+        prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
         banking_tracer: Arc<BankingTracer>,
         turbine_quic_endpoint_sender: AsyncSender<(SocketAddr, Bytes)>,
         turbine_quic_endpoint_receiver: Receiver<(Pubkey, SocketAddr, Bytes)>,
@@ -344,7 +344,7 @@ impl Tvu {
             vote_tracker,
             cluster_slots,
             log_messages_bytes_limit,
-            prioritization_fee_cache: prioritization_fee_cache.clone(),
+            prioritization_fee_cache,
             banking_tracer,
             snapshot_controller,
         };
@@ -535,7 +535,6 @@ pub mod tests {
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let (_, gossip_confirmed_slots_receiver) = unbounded();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
-        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
         let outstanding_repair_requests = Arc::<RwLock<OutstandingShredRepairs>>::default();
         let cluster_slots = Arc::new(ClusterSlots::default_for_tests());
         let wen_restart_repair_slots = if enable_wen_restart {
@@ -602,7 +601,7 @@ pub mod tests {
             None,
             None, // snapshot_controller
             None,
-            &ignored_prioritization_fee_cache,
+            None,
             BankingTracer::new_disabled(),
             turbine_quic_endpoint_sender,
             turbine_quic_endpoint_receiver,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -989,9 +989,11 @@ impl Validator {
 
         let (replay_vote_sender, replay_vote_receiver) = unbounded();
 
-        // block min prioritization fee cache should be readable by RPC, and writable by validator
-        // (by both replay stage and banking stage)
-        let prioritization_fee_cache = Arc::new(PrioritizationFeeCache::default());
+        let prioritization_fee_cache = if config.rpc_config.full_api {
+            Some(Arc::new(PrioritizationFeeCache::default()))
+        } else {
+            None
+        };
 
         let leader_schedule_cache = Arc::new(leader_schedule_cache);
         let (poh_recorder, entry_receiver) = {
@@ -1585,7 +1587,7 @@ impl Validator {
             config.wait_to_vote_slot,
             Some(snapshot_controller.clone()),
             config.runtime_config.log_messages_bytes_limit,
-            &prioritization_fee_cache,
+            prioritization_fee_cache.clone(),
             banking_tracer.clone(),
             turbine_quic_endpoint_sender.clone(),
             turbine_quic_endpoint_receiver,
@@ -1681,7 +1683,7 @@ impl Validator {
             tpu_quic_server_config,
             tpu_fwd_quic_server_config,
             vote_quic_server_config,
-            &prioritization_fee_cache,
+            prioritization_fee_cache,
             config.block_production_method.clone(),
             config.block_production_num_workers,
             config.block_production_scheduler_config.clone(),

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -30,7 +30,6 @@ use {
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, genesis_utils::GenesisConfigInfo,
         installed_scheduler_pool::SchedulingContext,
-        prioritization_fee_cache::PrioritizationFeeCache,
     },
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_svm_timings::ExecuteTimings,
@@ -84,14 +83,8 @@ fn test_scheduler_waited_by_drop_bank_service() {
     // Setup bankforks with unified scheduler enabled
     let genesis_bank = Bank::new_for_tests(&genesis_config);
     let bank_forks = BankForks::new_rw_arc(genesis_bank);
-    let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
-    let pool_raw = SchedulerPool::<PooledScheduler<StallingHandler>, _>::new(
-        None,
-        None,
-        None,
-        None,
-        ignored_prioritization_fee_cache,
-    );
+    let pool_raw =
+        SchedulerPool::<PooledScheduler<StallingHandler>, _>::new(None, None, None, None, None);
     let pool = pool_raw.clone();
     bank_forks.write().unwrap().install_scheduler_pool(pool);
     let genesis = 0;
@@ -219,7 +212,6 @@ fn test_scheduler_producing_blocks() {
     // Setup bank_forks with block-producing unified scheduler enabled
     let genesis_bank = Bank::new_for_tests(&genesis_config);
     let bank_forks = BankForks::new_rw_arc(genesis_bank);
-    let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
     let genesis_bank = bank_forks.read().unwrap().working_bank_with_scheduler();
     genesis_bank.set_fork_graph_in_program_cache(Arc::downgrade(&bank_forks));
     let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&genesis_bank));
@@ -236,7 +228,7 @@ fn test_scheduler_producing_blocks() {
         None,
         Some(leader_schedule_cache),
     );
-    let pool = DefaultSchedulerPool::new(None, None, None, None, ignored_prioritization_fee_cache);
+    let pool = DefaultSchedulerPool::new(None, None, None, None, None);
     let channels = {
         let banking_tracer = BankingTracer::new_disabled();
         banking_tracer.create_channels(true)

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -36,7 +36,6 @@ use {
             PrunedBanksRequestHandler, SnapshotRequestHandler,
         },
         bank_forks::BankForks,
-        prioritization_fee_cache::PrioritizationFeeCache,
         snapshot_controller::SnapshotController,
         snapshot_utils::{self, clean_orphaned_account_snapshot_dirs},
     },
@@ -368,7 +367,6 @@ pub fn load_and_process_ledger(
         }
         BlockVerificationMethod::UnifiedScheduler => {
             let no_replay_vote_sender = None;
-            let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
             bank_forks
                 .write()
                 .unwrap()
@@ -377,7 +375,7 @@ pub fn load_and_process_ledger(
                     process_options.runtime_config.log_messages_bytes_limit,
                     transaction_status_sender.clone(),
                     no_replay_vote_sender,
-                    ignored_prioritization_fee_cache,
+                    None,
                 ));
         }
     }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -487,7 +487,7 @@ pub struct JsonRpcServiceConfig<'a> {
     pub max_slots: Arc<MaxSlots>,
     pub leader_schedule_cache: Arc<LeaderScheduleCache>,
     pub max_complete_transaction_status_slot: Arc<AtomicU64>,
-    pub prioritization_fee_cache: Arc<PrioritizationFeeCache>,
+    pub prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
     pub rpc_tpu_client_args: RpcTpuClientArgs<'a>,
 }
 
@@ -583,7 +583,7 @@ impl JsonRpcService {
         leader_schedule_cache: Arc<LeaderScheduleCache>,
         client: Client,
         max_complete_transaction_status_slot: Arc<AtomicU64>,
-        prioritization_fee_cache: Arc<PrioritizationFeeCache>,
+        prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
         runtime: Arc<TokioRuntime>,
     ) -> Result<Self, String> {
         info!("rpc bound to {rpc_addr:?}");
@@ -903,7 +903,7 @@ mod tests {
             Arc::new(LeaderScheduleCache::default()),
             client,
             Arc::new(AtomicU64::default()),
-            Arc::new(PrioritizationFeeCache::default()),
+            Some(Arc::new(PrioritizationFeeCache::default())),
             runtime,
         )
         .expect("assume successful JsonRpcService start");

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1987,6 +1987,8 @@ pub(crate) mod tests {
         let mut highest_confirmed_slot: Slot = 0;
         let mut highest_root_slot: Slot = 0;
         let mut last_notified_confirmed_slot: Slot = 0;
+        let prioritization_fee_cache_inner: Option<Arc<PrioritizationFeeCache>> = None;
+        let prioritization_fee_cache = prioritization_fee_cache_inner.as_deref();
         // Optimistically notifying slot 3 without notifying slot 1 and 2, bank3 is unfrozen, we expect
         // to see transaction for alice and bob to be notified in order.
         OptimisticallyConfirmedBankTracker::process_notification(
@@ -2002,7 +2004,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &PrioritizationFeeCache::default(),
+            prioritization_fee_cache,
             &None, // no dependency tracker
         );
 
@@ -2059,7 +2061,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &PrioritizationFeeCache::default(),
+            prioritization_fee_cache,
             &None, // no dependency tracker
         );
 
@@ -2167,6 +2169,8 @@ pub(crate) mod tests {
         let mut highest_confirmed_slot: Slot = 0;
         let mut highest_root_slot: Slot = 0;
         let mut last_notified_confirmed_slot: Slot = 0;
+        let prioritization_fee_cache_inner: Option<Arc<PrioritizationFeeCache>> = None;
+        let prioritization_fee_cache = prioritization_fee_cache_inner.as_deref();
         // Optimistically notifying slot 3 without notifying slot 1 and 2, bank3 is not in the bankforks, we do not
         // expect to see any RPC notifications.
         OptimisticallyConfirmedBankTracker::process_notification(
@@ -2182,7 +2186,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &PrioritizationFeeCache::default(),
+            prioritization_fee_cache,
             &None, // no dependency tracker
         );
 
@@ -2246,6 +2250,7 @@ pub(crate) mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+
         let mut pending_optimistically_confirmed_banks = HashSet::new();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let subscriptions = Arc::new(RpcSubscriptions::new_for_tests(
@@ -2285,6 +2290,8 @@ pub(crate) mod tests {
         let mut highest_confirmed_slot: Slot = 0;
         let mut highest_root_slot: Slot = 0;
         let mut last_notified_confirmed_slot: Slot = 0;
+        let prioritization_fee_cache_inner: Option<Arc<PrioritizationFeeCache>> = None;
+        let prioritization_fee_cache = prioritization_fee_cache_inner.as_deref();
         // Optimistically notifying slot 3 without notifying slot 1 and 2, bank3 is not in the bankforks, we expect
         // to see transaction for alice and bob to be notified only when bank3 is added to the fork and
         // frozen. The notifications should be in the increasing order of the slot.
@@ -2301,7 +2308,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &PrioritizationFeeCache::default(),
+            prioritization_fee_cache,
             &None, // no dependency tracker
         );
 
@@ -2360,7 +2367,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &PrioritizationFeeCache::default(),
+            prioritization_fee_cache,
             &None, // no dependency tracker
         );
 
@@ -2781,6 +2788,9 @@ pub(crate) mod tests {
         let mut highest_confirmed_slot: Slot = 0;
         let mut highest_root_slot: Slot = 0;
         let mut last_notified_confirmed_slot: Slot = 0;
+        let prioritization_fee_cache_inner: Option<Arc<PrioritizationFeeCache>> = None;
+        let prioritization_fee_cache = prioritization_fee_cache_inner.as_deref();
+
         OptimisticallyConfirmedBankTracker::process_notification(
             (BankNotification::OptimisticallyConfirmed(2), None),
             &bank_forks,
@@ -2791,7 +2801,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &PrioritizationFeeCache::default(),
+            prioritization_fee_cache,
             &None, // no dependency tracker
         );
 
@@ -2810,7 +2820,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &PrioritizationFeeCache::default(),
+            prioritization_fee_cache,
             &None, // no dependency tracker
         );
 
@@ -2869,7 +2879,7 @@ pub(crate) mod tests {
             &mut highest_confirmed_slot,
             &mut highest_root_slot,
             &None,
-            &PrioritizationFeeCache::default(),
+            prioritization_fee_cache,
             &None, // no dependency tracker
         );
         let response = receiver1.recv();


### PR DESCRIPTION
#### Problem
The PrioritizationFeeCache tracks recent transaction priority fees and makes them available for read via the getRecentPrioritizationFees RPC call. The cache is updated in replay/leader code after transactions are committed and takes a non-trivial amount of time per slot

#### Summary of Changes
Since the RPC call is the only reader, there is no need to populate the cache at all if the node is not supporting the full RPC API. So, make the PrioritizationFeeCache an Option<> throughout the codebase

#### Metrics
Here are metrics from the Anza validator; this is showing `block_prioritization_fee_counters.total_update_elapsed_us` which is reported per slot. The purple trace (mean) shows that we typically spend < 1ms doing this work, but the blue trace (max) shows that we exceed 2ms at least once every 750 slots (my group by is 5 min) and a couple really bad spikes in excess of 10ms
<img width="1427" height="559" alt="image" src="https://github.com/user-attachments/assets/0615eb12-f609-46d6-9ca1-12f0a5d97d09" />

#### Future Work
The PrioritizationFeeCache could probably benefit from more refactoring. Ie, separating the cache (data) from the thread that is used to process updates such that `PrioritizationFeeCache::default()` doesn't create a thread