### PR TITLE
fix(accounts-db): set Hot owner_entry_size and use stable footer hash

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -54,6 +54,7 @@ fn new_hot_footer() -> TieredStorageFooter {
         account_block_format: HOT_FORMAT.account_block_format,
         index_block_format: HOT_FORMAT.index_block_format,
         owners_block_format: HOT_FORMAT.owners_block_format,
+        owner_entry_size: std::mem::size_of::<Pubkey>() as u32,
         ..TieredStorageFooter::default()
     }
 }
@@ -814,6 +815,7 @@ impl HotStorageWriter {
         // writing footer
         footer.min_account_address = address_range.min;
         footer.max_account_address = address_range.max;
+        footer.hash = solana_hash::Hash::default();
         cursor += footer.write_footer_block(&mut self.storage)?;
 
         Ok(StoredAccountsInfo {


### PR DESCRIPTION
Set owner_entry_size for Hot footers to match the actual OwnersBlock layout (Pubkey) and write a stable default hash instead of a random value. This removes duplicated sources of truth in metadata and avoids persisting meaningless hash values. account_block_size remains 0 for Hot since readers derive sizes from offsets and the field is reserved for future formats.