### PR TITLE
Replace select_nth_unstable_by with max_by for O(n) snapshot selection

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -188,7 +188,6 @@ impl SnapshotRequestHandler {
                 Some((snapshot_request, 1, 0))
             }
             _ => {
-                // Find the highest priority request in O(n) time
                 let max_idx = requests
                     .iter()
                     .enumerate()

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -196,7 +196,6 @@ impl SnapshotRequestHandler {
                     .unwrap(); // SAFETY: We know len > 1
                 let snapshot_request = requests.swap_remove(max_idx);
                 let handled_request_slot = snapshot_request.snapshot_root_bank.slot();
-
                 // Re-enqueue any remaining requests for slots GREATER-THAN the one that will be handled
                 let num_re_enqueued_requests = requests
                     .into_iter()

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -188,13 +188,18 @@ impl SnapshotRequestHandler {
                 Some((snapshot_request, 1, 0))
             }
             _ => {
-                requests.select_nth_unstable_by(requests_len - 1, cmp_requests_by_priority);
+                // Find the highest priority request in O(n) time
+                let max_idx = requests
+                    .iter()
+                    .enumerate()
+                    .max_by(|(_, a), (_, b)| cmp_requests_by_priority(a, b))
+                    .map(|(idx, _)| idx)
+                    .unwrap(); // SAFETY: We know len > 1
 
-                // SAFETY: We know the len is > 1, so `pop` will return `Some`
-                let snapshot_request = requests.pop().unwrap();
-
+                let snapshot_request = requests.swap_remove(max_idx);
                 let handled_request_slot = snapshot_request.snapshot_root_bank.slot();
-                // re-enqueue any remaining requests for slots GREATER-THAN the one that will be handled
+
+                // Re-enqueue any remaining requests for slots GREATER-THAN the one that will be handled
                 let num_re_enqueued_requests = requests
                     .into_iter()
                     .filter(|snapshot_request| {

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -194,7 +194,6 @@ impl SnapshotRequestHandler {
                     .max_by(|(_, a), (_, b)| cmp_requests_by_priority(a, b))
                     .map(|(idx, _)| idx)
                     .unwrap(); // SAFETY: We know len > 1
-
                 let snapshot_request = requests.swap_remove(max_idx);
                 let handled_request_slot = snapshot_request.snapshot_root_bank.slot();
 

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -196,7 +196,7 @@ impl SnapshotRequestHandler {
                     .unwrap(); // SAFETY: We know len > 1
                 let snapshot_request = requests.swap_remove(max_idx);
                 let handled_request_slot = snapshot_request.snapshot_root_bank.slot();
-                // Re-enqueue any remaining requests for slots GREATER-THAN the one that will be handled
+                // re-enqueue any remaining requests for slots GREATER-THAN the one that will be handled
                 let num_re_enqueued_requests = requests
                     .into_iter()
                     .filter(|snapshot_request| {


### PR DESCRIPTION
#### Problem

We don't need to select sort snapshot requests any more. All we need is to get the max priority snapshot request. So we can avoid the complexity of select sort.


#### Summary of Changes

replace select sort with max_by.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
