### PR TITLE
Implement drop guard for wincode VersionedMessage impl

### DIFF
--- a/entry/src/wincode.rs
+++ b/entry/src/wincode.rs
@@ -7,7 +7,7 @@ use {
     solana_message::{self, legacy, v0, MESSAGE_VERSION_PREFIX},
     solana_signature::Signature,
     solana_transaction::versioned,
-    std::mem::MaybeUninit,
+    std::mem::{self, MaybeUninit},
     wincode::{
         containers::{self, Pod},
         error::invalid_tag_encoding,
@@ -119,6 +119,81 @@ impl<'de> SchemaRead<'de> for VersionedMsg {
             };
         }
 
+        /// A guard that ensures the [`legacy::Message`] is properly dropped on error or panic.
+        ///
+        /// Fields will be dropped in reverse initialization order.
+        ///
+        /// This is necessary in particular for [`legacy::Message`] as it contains heap allocated fields.
+        /// Namely, `account_keys` and `instructions`, which are `Vec<Address>` and `Vec<CompiledInstruction>`,
+        /// respectively. These will leak if not dropped on error or panic.
+        struct LegacyMessageDropGuard<'a> {
+            inner: &'a mut MaybeUninit<legacy::Message>,
+            field_init_count: u8,
+        }
+
+        impl<'a> LegacyMessageDropGuard<'a> {
+            const fn new(inner: &'a mut MaybeUninit<legacy::Message>) -> Self {
+                Self {
+                    inner,
+                    field_init_count: 0,
+                }
+            }
+
+            const fn inc_init_count(&mut self) {
+                self.field_init_count += 1;
+            }
+        }
+
+        impl<'a> Drop for LegacyMessageDropGuard<'a> {
+            // Fields are initialized in order, matching the serialized format.
+            //
+            // 0 -> header
+            // 1 -> account_keys
+            // 2 -> recent_blockhash
+            // 3 -> instructions
+            //
+            // We drop in reverse order to match Rust's drop semantics.
+            fn drop(&mut self) {
+                use core::ptr;
+
+                // No fields have been initialized.
+                if self.field_init_count == 0 {
+                    return;
+                }
+
+                if self.field_init_count == 4 {
+                    // SAFETY: All fields have been initialized, safe to drop the entire message.
+                    unsafe { self.inner.assume_init_drop() };
+                    return;
+                }
+
+                let msg_ptr = self.inner.as_mut_ptr();
+
+                // We don't technically have to worry about recent_blockhash, since it's on the stack,
+                // but we do it for completeness.
+                if self.field_init_count == 3 {
+                    // SAFETY: Recent blockhash is initialized, safe to drop it.
+                    unsafe {
+                        ptr::drop_in_place(&raw mut (*msg_ptr).recent_blockhash);
+                    }
+                }
+                if self.field_init_count >= 2 {
+                    // SAFETY: Account keys are initialized, safe to drop.
+                    unsafe {
+                        ptr::drop_in_place(&raw mut (*msg_ptr).account_keys);
+                    }
+                }
+                // Similarly to recent_blockhash, we don't technically have to worry about header,
+                // but we do it for completeness.
+                if self.field_init_count >= 1 {
+                    // SAFETY: Header is initialized, safe to drop it.
+                    unsafe {
+                        ptr::drop_in_place(&raw mut (*msg_ptr).header);
+                    }
+                }
+            }
+        }
+
         let mut msg = MaybeUninit::<legacy::Message>::uninit();
         // We've already read the variant byte which, in the legacy case, represents
         // the `num_required_signatures` field.
@@ -126,14 +201,29 @@ impl<'de> SchemaRead<'de> for VersionedMsg {
         // as calling `LegacyMessage::read` will miss the first field.
         let header_uninit = LegacyMessage::uninit_header_mut(&mut msg);
 
+        // We don't need to worry about a drop guard for the header,
+        // as it's comprised entirely of `u8`s on the stack.
         MessageHeader::write_uninit_num_required_signatures(variant, header_uninit);
         MessageHeader::read_num_readonly_signed_accounts(reader, header_uninit)?;
         MessageHeader::read_num_readonly_unsigned_accounts(reader, header_uninit)?;
 
-        LegacyMessage::read_account_keys(reader, &mut msg)?;
-        LegacyMessage::read_recent_blockhash(reader, &mut msg)?;
-        LegacyMessage::read_instructions(reader, &mut msg)?;
+        let mut guard = LegacyMessageDropGuard::new(&mut msg);
+        // 1. Header is initialized.
+        guard.inc_init_count();
+        LegacyMessage::read_account_keys(reader, guard.inner)?;
+        // 2. Account keys are initialized.
+        guard.inc_init_count();
+        LegacyMessage::read_recent_blockhash(reader, guard.inner)?;
+        // 3. Recent blockhash is initialized.
+        guard.inc_init_count();
+        LegacyMessage::read_instructions(reader, guard.inner)?;
+        // 4. Instructions are initialized.
+        guard.inc_init_count();
 
+        // All fields are initialized, safe to drop the the guard.
+        mem::forget(guard);
+
+        // SAFETY: All fields are initialized, safe to assume initialized.
         let msg = unsafe { msg.assume_init() };
         dst.write(solana_message::VersionedMessage::Legacy(msg));
 


### PR DESCRIPTION
#### Problem
When deserializing a `VersionedMessage` (which is an enum comprised of either a versioned message or a `LegacyMessage`), the first byte of the payload may either denote a versioned message prefix _or_ the `num_required_signatures` field of `LegacyMessage`. This specific logic requires us to manually implement `SchemaRead` for `VersionedMessage`. In particular, we need to check the first byte of the payload against `MESSAGE_VERSION_PREFIX` to determine which branch to take (`V0Message` or `LegacyMessage`).

In the `LegacyMessage` case, we need to decode each field of the struct manually because we have already read its first byte. In particular, `LegacyMessage::read` will fail since the first byte in the `Reader` has already been consumed.

This is made fairly straight forward by `wincode`'s `struct_extensions`, which generates helper functions for this precise use-case.
https://github.com/anza-xyz/agave/blob/89c5cb3dbedc762ef7e5a3889403f63b6a86915b/entry/src/wincode.rs#L122-L135

There is a subtle issue here -- `account_keys` is heap allocated (it's a `Vec<Address>`), so it wont actually be dropped if the subsequent decoding of `recent_blockhash` or `instructions` were to error or panic.

#### Summary of Changes

This implements a drop guard for `LegacyMessage`, which keeps track of the initialization state of the struct, and has a `Drop` implementation that will drop the initialized fields.

This will be solved by [the upcoming improvements to `struct_extensions`](https://github.com/anza-xyz/wincode/pull/42), but since the existing code is included in `3.1` (which is pegged to wincode `v0.1.2`), I'm adding the manual implementation as a stop-gap.
