### PR TITLE
Removes slot from AccountStorageMap::insert()

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -171,13 +171,13 @@ impl AccountStorage {
         AccountStorageIter::new(self)
     }
 
-    pub(crate) fn insert(&self, slot: Slot, store: Arc<AccountStorageEntry>) {
+    pub(crate) fn insert(&self, store: Arc<AccountStorageEntry>) {
         assert!(
             self.no_shrink_in_progress(),
             "shrink is in progress! slots: {:?}",
             self.shrink_in_progress_map.read().unwrap().keys(),
         );
-        assert!(self.map.insert(slot, store).is_none());
+        assert!(self.map.insert(store.slot, store).is_none());
     }
 
     /// called when shrinking begins on a slot and append vec.
@@ -653,7 +653,7 @@ pub(crate) mod tests {
             .write()
             .unwrap()
             .insert(0, sample.clone());
-        storage.insert(0, sample);
+        storage.insert(sample);
     }
 
     #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4394,14 +4394,8 @@ impl AccountsDb {
         paths: &[PathBuf],
     ) -> Arc<AccountStorageEntry> {
         let store = self.create_store(slot, size, from, paths);
-        let store_for_index = store.clone();
-
-        self.insert_store(slot, store_for_index);
+        self.storage.insert(store.clone());
         store
-    }
-
-    fn insert_store(&self, slot: Slot, store: Arc<AccountStorageEntry>) {
-        self.storage.insert(slot, store)
     }
 
     pub fn enable_bank_drop_callback(&self) {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -2588,7 +2588,7 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
         AccountsFileProvider::AppendVec,
         storage_access,
     ));
-    db.storage.insert(store1_slot, Arc::clone(&store1));
+    db.storage.insert(Arc::clone(&store1));
     store1.alive_bytes.store(0, Ordering::Release);
     candidates.insert(store1_slot);
 
@@ -2601,7 +2601,7 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
         AccountsFileProvider::AppendVec,
         storage_access,
     ));
-    db.storage.insert(store2_slot, Arc::clone(&store2));
+    db.storage.insert(Arc::clone(&store2));
     store2
         .alive_bytes
         .store(store_file_size as usize / 2, Ordering::Release);
@@ -2616,7 +2616,7 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
         AccountsFileProvider::AppendVec,
         storage_access,
     ));
-    db.storage.insert(store3_slot, Arc::clone(&store3));
+    db.storage.insert(Arc::clone(&store3));
     store3
         .alive_bytes
         .store(store_file_size as usize, Ordering::Release);
@@ -2655,7 +2655,7 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
         AccountsFileProvider::AppendVec,
         storage_access,
     ));
-    db.storage.insert(store1_slot, Arc::clone(&store1));
+    db.storage.insert(Arc::clone(&store1));
     store1.alive_bytes.store(0, Ordering::Release);
     candidates.insert(store1_slot);
 
@@ -2668,7 +2668,7 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
         AccountsFileProvider::AppendVec,
         storage_access,
     ));
-    db.storage.insert(store2_slot, Arc::clone(&store2));
+    db.storage.insert(Arc::clone(&store2));
     store2
         .alive_bytes
         .store(store_file_size as usize / 2, Ordering::Release);
@@ -2683,7 +2683,7 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
         AccountsFileProvider::AppendVec,
         storage_access,
     ));
-    db.storage.insert(store3_slot, Arc::clone(&store3));
+    db.storage.insert(Arc::clone(&store3));
     store3
         .alive_bytes
         .store(store_file_size as usize, Ordering::Release);
@@ -2719,7 +2719,7 @@ fn test_select_candidates_by_total_usage_all_clean(storage_access: StorageAccess
         AccountsFileProvider::AppendVec,
         storage_access,
     ));
-    db.storage.insert(store1_slot, Arc::clone(&store1));
+    db.storage.insert(Arc::clone(&store1));
     store1
         .alive_bytes
         .store(store_file_size as usize / 4, Ordering::Release);
@@ -2734,7 +2734,7 @@ fn test_select_candidates_by_total_usage_all_clean(storage_access: StorageAccess
         AccountsFileProvider::AppendVec,
         storage_access,
     ));
-    db.storage.insert(store2_slot, Arc::clone(&store2));
+    db.storage.insert(Arc::clone(&store2));
     store2
         .alive_bytes
         .store(store_file_size as usize / 2, Ordering::Release);
@@ -6305,7 +6305,7 @@ fn test_handle_dropped_roots_for_ancient() {
 }
 
 fn insert_store(db: &AccountsDb, append_vec: Arc<AccountStorageEntry>) {
-    db.storage.insert(append_vec.slot(), append_vec);
+    db.storage.insert(append_vec);
 }
 
 #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -667,7 +667,7 @@ pub mod tests {
             db.storage_access(),
         );
         let storage = Arc::new(data);
-        db.storage.insert(slot, storage.clone());
+        db.storage.insert(storage.clone());
         storage
     }
 


### PR DESCRIPTION
#### Problem

AccountStorageMap::insert() takes two parameters: slot and storage. The slot is redundant, since the storage itself also contains the slot.

Historically the storage's slot field was an atomic, so we may've had the slot parameter here to avoid an atomic access. That's no longer the case, so the slot is redundant at best, and an opportunity for bugs at worst.


#### Summary of Changes

Remove the slot parameter.