### PR TITLE
fix(cli): include payer signature when extending lookup tables

### DIFF
--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -700,7 +700,10 @@ async fn process_extend_lookup_table(
         Some(&config.signers[0].pubkey()),
     ));
 
-    tx.try_sign(&[config.signers[0], authority_signer, payer_signer], blockhash)?;
+    tx.try_sign(
+        &[config.signers[0], authority_signer, payer_signer],
+        blockhash,
+    )?;
     let result = rpc_client
         .send_and_confirm_transaction_with_spinner_and_config(
             &tx,

--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -700,7 +700,7 @@ async fn process_extend_lookup_table(
         Some(&config.signers[0].pubkey()),
     ));
 
-    tx.try_sign(&[config.signers[0], authority_signer], blockhash)?;
+    tx.try_sign(&[config.signers[0], authority_signer, payer_signer], blockhash)?;
     let result = rpc_client
         .send_and_confirm_transaction_with_spinner_and_config(
             &tx,


### PR DESCRIPTION
The ExtendLookupTable instruction treats the payer as a required signer if provided. The CLI always supplies a payer, but previously signed only with the authority, which fails when payer ≠ authority. This change adds the payer signer to the transaction signing set in process_extend_lookup_table(), aligning with the program’s account metas and ensuring extensions succeed when a distinct payer funds reallocation.