### PR TITLE
genesis: feature gate v4 vote account creation

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1062,7 +1062,6 @@ fn do_process_tower_sync(
     )
 }
 
-#[cfg(test)]
 pub fn create_account_with_authorized(
     node_pubkey: &Pubkey,
     authorized_voter: &Pubkey,


### PR DESCRIPTION
#### Problem
We are unable to spin up clusters where the `vote_state_v4` feature flag is not active (e.g. `cluster_type == MainnetBeta`)

To repro: `solana-test-validator --deactivate-feature Gx4XFcrVMt4HUvPzTpTSVkdDVgcDSjKhDN1RqRS6KDuZ` - no slots will be finalized.

#### Summary of Changes
When setting up genesis vote accounts, check the feature flag to determine whether they should be V3 or V4 vote accounts

