### PR TITLE
Save Fastboot snapshot during teardown

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -12,7 +12,9 @@ use {
     solana_perf::thread::renice_this_thread,
     solana_runtime::{
         accounts_background_service::PendingSnapshotPackages,
-        snapshot_controller::SnapshotController, snapshot_package::SnapshotPackage, snapshot_utils,
+        snapshot_controller::SnapshotController,
+        snapshot_package::{BankSnapshotPackage, SnapshotPackage},
+        snapshot_utils,
     },
     std::{
         sync::{
@@ -58,7 +60,7 @@ impl SnapshotPackagerService {
                 let mut teardown_state = None;
                 loop {
                     if exit.load(Ordering::Relaxed) {
-                        if let Some(teardown_state) = &teardown_state {
+                        if let Some(teardown_state) = teardown_state {
                             info!("Received exit request, tearing down...");
                             let (_, dur) = meas_dur!(Self::teardown(
                                 teardown_state,
@@ -87,10 +89,30 @@ impl SnapshotPackagerService {
                         // With exit backpressure, we will delay flushing snapshot storages
                         // until we receive a graceful exit request.
                         // Save the snapshot storages here, so we can flush later (as needed).
-                        teardown_state = Some(TeardownState {
-                            snapshot_slot: snapshot_package.slot,
-                            snapshot_storages: snapshot_package.snapshot_storages.clone(),
-                        });
+                        // For fastboot snapshots, the bank snapshot is saved and
+                        // the rest of the snapshotting process is skipped
+                        if snapshot_kind == SnapshotKind::Fastboot {
+                            teardown_state = Some(TeardownState {
+                                snapshot_slot: snapshot_package.slot,
+                                snapshot_storages: snapshot_package.snapshot_storages.clone(),
+                                bank_snapshot_package: Some(snapshot_package.bank_snapshot_package),
+                            });
+
+                            let handling_time = measure_handling.end_as_us();
+                            datapoint_info!(
+                                "snapshot_packager_service_fastboot",
+                                ("enqueued_time_us", enqueued_time.as_micros(), i64),
+                                ("handling_time_us", handling_time, i64),
+                            );
+
+                            continue;
+                        } else {
+                            teardown_state = Some(TeardownState {
+                                snapshot_slot: snapshot_package.slot,
+                                snapshot_storages: snapshot_package.snapshot_storages.clone(),
+                                bank_snapshot_package: None,
+                            });
+                        }
                     }
 
                     let archive_time = Instant::now();
@@ -198,10 +220,35 @@ impl SnapshotPackagerService {
     }
 
     /// Performs final operations before gracefully shutting down
-    fn teardown(state: &TeardownState, snapshot_config: &SnapshotConfig) {
-        info!("Flushing account storages...");
+    fn teardown(state: TeardownState, snapshot_config: &SnapshotConfig) {
         let start = Instant::now();
-        for storage in &state.snapshot_storages {
+
+        let TeardownState {
+            snapshot_slot,
+            snapshot_storages,
+            bank_snapshot_package,
+        } = state;
+
+        if let Some(bank_snapshot_package) = bank_snapshot_package {
+            let result = snapshot_utils::serialize_snapshot(
+                &snapshot_config.bank_snapshots_dir,
+                snapshot_config.snapshot_version,
+                bank_snapshot_package,
+                snapshot_storages.as_slice(),
+                false,
+            );
+
+            if let Err(err) = result {
+                warn!(
+                    "Failed to serialize bank '{}': {err}",
+                    snapshot_config.bank_snapshots_dir.as_path().display(),
+                );
+                // If serializing the bank fails, we do *NOT* want to write
+                // the mark_bank_snapshot_as_loadable file, so return early.
+                return;
+            }
+        }
+        for storage in &snapshot_storages {
             let result = storage.flush();
             if let Err(err) = result {
                 warn!(
@@ -217,15 +264,15 @@ impl SnapshotPackagerService {
 
         let bank_snapshot_dir = snapshot_paths::get_bank_snapshot_dir(
             &snapshot_config.bank_snapshots_dir,
-            state.snapshot_slot,
+            snapshot_slot,
         );
 
         info!("Hard linking account storages...");
         let start = Instant::now();
         let result = snapshot_utils::hard_link_storages_to_snapshot(
             &bank_snapshot_dir,
-            state.snapshot_slot,
-            &state.snapshot_storages,
+            snapshot_slot,
+            &snapshot_storages,
         );
         if let Err(err) = result {
             warn!("Failed to hard link account storages: {err}");
@@ -242,8 +289,8 @@ impl SnapshotPackagerService {
         let start = Instant::now();
         let result = snapshot_utils::write_obsolete_accounts_to_snapshot(
             &bank_snapshot_dir,
-            &state.snapshot_storages,
-            state.snapshot_slot,
+            &snapshot_storages,
+            snapshot_slot,
         );
         if let Err(err) = result {
             warn!("Failed to serialize obsolete accounts: {err}");
@@ -267,4 +314,7 @@ struct TeardownState {
     snapshot_slot: Slot,
     /// The storages of the latest snapshot
     snapshot_storages: Vec<Arc<AccountStorageEntry>>,
+    /// The bank snapshot package of the latest snapshot. Stored if the last snapshot
+    /// handled a fastboot snapshot.
+    bank_snapshot_package: Option<BankSnapshotPackage>,
 }

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -4,7 +4,7 @@ use {
     crate::snapshot_utils::create_tmp_accounts_dir_for_tests,
     agave_snapshots::{
         paths as snapshot_paths, snapshot_archive_info::FullSnapshotArchiveInfo,
-        snapshot_config::SnapshotConfig, SnapshotInterval,
+        snapshot_config::SnapshotConfig, SnapshotInterval, SnapshotKind,
     },
     crossbeam_channel::unbounded,
     itertools::Itertools,
@@ -28,6 +28,7 @@ use {
         runtime_config::RuntimeConfig,
         snapshot_bank_utils,
         snapshot_controller::SnapshotController,
+        snapshot_package::SnapshotPackage,
         snapshot_utils,
         status_cache::MAX_CACHE_ENTRIES,
     },
@@ -45,6 +46,7 @@ use {
         time::{Duration, Instant},
     },
     tempfile::TempDir,
+    test_case::test_case,
 };
 
 struct SnapshotTestConfig {
@@ -759,4 +761,152 @@ fn test_snapshots_with_background_services() {
     exit.store(true, Ordering::Relaxed);
     _ = accounts_background_service.join();
     _ = snapshot_packager_service.join();
+}
+
+#[test_case(true)]
+#[test_case(false)]
+fn test_fastboot_snapshots_teardown(exit_backpressure: bool) {
+    agave_logger::setup();
+    const FASTBOOT_SNAPSHOT_INTERVAL_SLOTS: Slot = 4;
+    // Queue a few fastboot snapshots to make sure the newest one is processed during teardown
+    const LAST_SLOT: Slot = FASTBOOT_SNAPSHOT_INTERVAL_SLOTS * 4 + 1;
+
+    // Test injects snapshots at specific slots, so disable automatic snapshots
+    let snapshot_test_config =
+        SnapshotTestConfig::new(SnapshotInterval::Disabled, SnapshotInterval::Disabled);
+
+    let node_keypair = Arc::new(Keypair::new());
+    let cluster_info = Arc::new(ClusterInfo::new(
+        ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
+        node_keypair,
+        SocketAddrSpace::Unspecified,
+    ));
+
+    let (snapshot_request_sender, _snapshot_request_receiver) = unbounded();
+    let pending_snapshot_packages = Arc::new(Mutex::new(PendingSnapshotPackages::default()));
+
+    let bank_forks = snapshot_test_config.bank_forks.clone();
+
+    let snapshot_controller = Arc::new(SnapshotController::new(
+        snapshot_request_sender.clone(),
+        snapshot_test_config.snapshot_config.clone(),
+        bank_forks.read().unwrap().root(),
+    ));
+
+    // Enable or disable backpressure based on the test case parameter
+    let exit_backpressure = exit_backpressure.then(|| Arc::new(AtomicBool::new(false)));
+
+    let exit = Arc::new(AtomicBool::new(false));
+    let snapshot_packager_service = SnapshotPackagerService::new(
+        pending_snapshot_packages.clone(),
+        None,
+        exit.clone(),
+        exit_backpressure.clone(),
+        cluster_info.clone(),
+        snapshot_controller.clone(),
+        false,
+    );
+
+    let mint_keypair = &snapshot_test_config.genesis_config_info.mint_keypair;
+    for slot in 1..=LAST_SLOT {
+        // Make a new bank and process some transactions
+        {
+            let parent_bank = bank_forks.read().unwrap().get(slot - 1).unwrap();
+            let bank = bank_forks
+                .write()
+                .unwrap()
+                .insert(Bank::new_from_parent(parent_bank, &Pubkey::default(), slot))
+                .clone_without_scheduler();
+
+            let key = solana_pubkey::new_rand();
+            let tx = system_transaction::transfer(mint_keypair, &key, 1, bank.last_blockhash());
+            assert_eq!(bank.process_transaction(&tx), Ok(()));
+
+            let key = solana_pubkey::new_rand();
+            let tx = system_transaction::transfer(mint_keypair, &key, 0, bank.last_blockhash());
+            assert_eq!(bank.process_transaction(&tx), Ok(()));
+
+            bank.fill_bank_with_ticks_for_tests();
+        }
+
+        // Inject a fastboot snapshot at a specific slot
+        if slot % FASTBOOT_SNAPSHOT_INTERVAL_SLOTS == 0 {
+            bank_forks
+                .write()
+                .unwrap()
+                .set_root(slot, Some(&snapshot_controller), None);
+
+            let bank = bank_forks.read().unwrap().get(slot).unwrap();
+            bank.force_flush_accounts_cache();
+            bank.squash();
+            let snapshot_package = SnapshotPackage::new(
+                SnapshotKind::Fastboot,
+                &bank,
+                bank.get_snapshot_storages(None),
+                bank.status_cache.read().unwrap().root_slot_deltas(),
+            );
+            pending_snapshot_packages
+                .lock()
+                .unwrap()
+                .push(snapshot_package);
+
+            // Wait while the fastboot snapshot is processed
+            while !pending_snapshot_packages.lock().unwrap().is_empty() {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        }
+    }
+
+    let bank_snapshots = snapshot_utils::get_bank_snapshots(
+        &snapshot_test_config.snapshot_config.bank_snapshots_dir,
+    );
+
+    if exit_backpressure.is_none() {
+        // Without backpressure, the fastboot snapshot should be present
+        assert!(!bank_snapshots.is_empty());
+    } else {
+        // With backpressure, the fastboot snapshot will not be written until teardown
+        // is triggered by writing true to exit below
+        assert!(bank_snapshots.is_empty());
+    }
+
+    // Stop the background services, ignore any errors
+    exit.store(true, Ordering::Relaxed);
+    let packager_exit_result = snapshot_packager_service.join();
+    assert!(packager_exit_result.is_ok());
+
+    // verify that the fastboot snapshot was written and can be restored from
+    let bank_snapshot = snapshot_utils::get_highest_bank_snapshot(
+        &snapshot_test_config.snapshot_config.bank_snapshots_dir,
+    )
+    .unwrap();
+
+    let bank_constructed = snapshot_bank_utils::bank_from_snapshot_dir(
+        &[snapshot_test_config.accounts_dir.clone()],
+        &bank_snapshot,
+        &snapshot_test_config.genesis_config_info.genesis_config,
+        &RuntimeConfig::default(),
+        None,
+        None,
+        false,
+        ACCOUNTS_DB_CONFIG_FOR_TESTING,
+        None,
+        Arc::default(),
+    )
+    .unwrap();
+
+    // Get the slot of the last fastboot snapshot taken
+    let last_fastboot_snapshot_slot =
+        (LAST_SLOT / FASTBOOT_SNAPSHOT_INTERVAL_SLOTS) * FASTBOOT_SNAPSHOT_INTERVAL_SLOTS;
+
+    assert!(bank_constructed.slot() == last_fastboot_snapshot_slot);
+    assert_eq!(
+        &bank_constructed,
+        bank_forks
+            .read()
+            .unwrap()
+            .get(bank_constructed.slot())
+            .unwrap()
+            .as_ref()
+    );
 }

--- a/runtime/src/accounts_background_service/pending_snapshot_packages.rs
+++ b/runtime/src/accounts_background_service/pending_snapshot_packages.rs
@@ -113,6 +113,11 @@ impl PendingSnapshotPackages {
             (None, None) => None,
         }
     }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn is_empty(&self) -> bool {
+        self.incremental.is_none() && self.full.is_none() && self.fastboot.is_none()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
Saving bank snapshots isn't required for fastboot unless shutdown is occurring. 

#### Summary of Changes
- Add the bank snapshot to the teardown structure for fastboot snapshots
- If back pressure is enabled, then store the bank snapshot in the teardown structure, otherwise handle normally
- Serialize the bank snapshot during teardown

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
