### PR TITLE
chore(gossip): switch push_active_set tests to random_u64_range

### DIFF
--- a/gossip/src/push_active_set.rs
+++ b/gossip/src/push_active_set.rs
@@ -177,8 +177,8 @@ fn get_stake_bucket(stake: Option<&u64>) -> usize {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, itertools::iproduct, rand::SeedableRng, rand_chacha::ChaChaRng,
-        std::iter::repeat_with,
+        super::*, agave_random::range::random_u64_range, itertools::iproduct, rand::SeedableRng,
+        rand_chacha::ChaChaRng, std::iter::repeat_with,
     };
 
     #[test]
@@ -211,9 +211,9 @@ mod tests {
         let mut rng = ChaChaRng::from_seed([189u8; 32]);
         let pubkey = Pubkey::new_unique();
         let nodes: Vec<_> = repeat_with(Pubkey::new_unique).take(20).collect();
-        let stakes = repeat_with(|| rng.gen_range(1..MAX_STAKE));
+        let stakes = repeat_with(|| random_u64_range(&mut rng, 1..MAX_STAKE));
         let mut stakes: HashMap<_, _> = nodes.iter().copied().zip(stakes).collect();
-        stakes.insert(pubkey, rng.gen_range(1..MAX_STAKE));
+        stakes.insert(pubkey, random_u64_range(&mut rng, 1..MAX_STAKE));
         let mut active_set = PushActiveSet::default();
         assert!(active_set.0.iter().all(|entry| entry.0.is_empty()));
         active_set.rotate(&mut rng, 5, CLUSTER_SIZE, &nodes, &stakes);
@@ -266,7 +266,9 @@ mod tests {
         const NUM_BLOOM_FILTER_ITEMS: usize = 100;
         let mut rng = ChaChaRng::from_seed([147u8; 32]);
         let nodes: Vec<_> = repeat_with(Pubkey::new_unique).take(20).collect();
-        let weights: Vec<_> = repeat_with(|| rng.gen_range(1..1000)).take(20).collect();
+        let weights: Vec<_> = repeat_with(|| random_u64_range(&mut rng, 1..1000))
+            .take(20)
+            .collect();
         let mut entry = PushActiveSetEntry::default();
         entry.rotate(
             &mut rng,


### PR DESCRIPTION
#### Problem
In order to [migrate](https://github.com/anza-xyz/agave/issues/4738) to `rand=0.9.2` we need to switch `push_active_set` tests to implementation of random number sampling that is independent from used `rand` version.

#### Summary of Changes
Switch `push_active_set` tests to use `agave_random::range::random_u64_range` for stakes / weights created in test cases (see https://github.com/anza-xyz/agave/pull/9286 for addition of its implementation).

This PR is extracted from https://github.com/anza-xyz/agave/pull/9276 such that it could be a rename-only change.
