### PR TITLE
SIMD-0392: Relax post-execution balance check

### DIFF
--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -139,6 +139,57 @@ impl StakeReward {
         }
     }
 
+    pub fn new_with_pre_stake_account(
+        reward_lamports: i64,
+        stake_lamports: u64,
+        rent: &Rent,
+    ) -> (AccountSharedData, Self) {
+        let vote_pubkey = Pubkey::new_unique();
+        let vote_account = vote_state::create_v4_account_with_authorized(
+            &Pubkey::new_unique(),
+            &vote_pubkey,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
+            &vote_pubkey,
+            1000,
+            &vote_pubkey,
+            0,
+            &vote_pubkey,
+            stake_lamports,
+        );
+
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_pubkey = Pubkey::new_unique();
+        let pre_stake_account = create_stake_account(
+            &stake_pubkey,
+            &vote_pubkey,
+            &vote_account,
+            rent,
+            rent_exempt_reserve + stake_lamports,
+        );
+        let post_stake_account = create_stake_account(
+            &stake_pubkey,
+            &vote_pubkey,
+            &vote_account,
+            rent,
+            rent_exempt_reserve + stake_lamports + reward_lamports as u64,
+        );
+
+        (
+            pre_stake_account,
+            Self {
+                stake_pubkey,
+                stake_reward_info: StakeRewardInfo {
+                    reward_type: solana_reward_info::RewardType::Staking,
+                    lamports: reward_lamports,
+                    post_balance: 0,         /* unused atm */
+                    commission_bps: Some(0), /* unused but tests require some value */
+                },
+
+                stake_account: post_stake_account,
+            },
+        )
+    }
+
     pub fn credit(&mut self, amount: u64) {
         self.stake_reward_info.lamports = amount as i64;
         self.stake_reward_info.post_balance += amount;
@@ -160,6 +211,7 @@ fn create_stake_account(
     let vote_state =
         vote_state::VoteStateV4::deserialize(vote_account.data(), voter_pubkey).unwrap();
     let credits_observed = vote_state.credits();
+    let last_epoch = vote_state.epoch_credits.last().map(|c| c.0).unwrap_or(0);
 
     let rent_exempt_reserve = rent.minimum_balance(stake_account.data().len());
     let stake_amount = lamports
@@ -173,10 +225,14 @@ fn create_stake_account(
         ..Meta::default()
     };
 
-    let stake = Stake {
+    let mut stake = Stake {
         delegation: Delegation::new(voter_pubkey, stake_amount, Epoch::MAX),
         credits_observed,
     };
+
+    if stake_amount == 0 {
+        stake.delegation.deactivation_epoch = last_epoch;
+    }
 
     stake_account
         .set_state(&StakeStateV2::Stake(meta, stake, StakeFlags::empty()))

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -145,15 +145,16 @@ impl StakeReward {
         rent: &Rent,
     ) -> (AccountSharedData, Self) {
         let vote_pubkey = Pubkey::new_unique();
+        let node_pubkey = Pubkey::new_unique();
         let vote_account = vote_state::create_v4_account_with_authorized(
-            &Pubkey::new_unique(),
+            &node_pubkey,
             &vote_pubkey,
             [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &vote_pubkey,
             1000,
             &vote_pubkey,
             0,
-            &vote_pubkey,
+            &node_pubkey,
             stake_lamports,
         );
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -491,12 +491,14 @@ impl Consumer {
             .ok_or(TransactionError::AccountNotFound)?;
 
         validate_fee_payer(
-            fee_payer,
             &mut fee_payer_account,
             0,
             error_counters,
             &bank.rent_collector().rent,
             fee,
+            bank.feature_set
+                .snapshot()
+                .relax_post_exec_min_balance_check,
         )
     }
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -781,7 +781,9 @@ impl JsonRpcRequestProcessor {
                 &addresses,
                 &|reward_type| -> bool {
                     reward_type == RewardType::Voting
-                        || (!epoch_has_partitioned_rewards && reward_type == RewardType::Staking)
+                        || (!epoch_has_partitioned_rewards
+                            && (reward_type == RewardType::Staking
+                                || reward_type == RewardType::DeactivatedStake))
                 },
             )
             .collect()
@@ -861,7 +863,10 @@ impl JsonRpcRequestProcessor {
                     block.rewards,
                     slot,
                     addresses,
-                    &|reward_type| -> bool { reward_type == RewardType::Staking },
+                    &|reward_type| -> bool {
+                        reward_type == RewardType::Staking
+                            || reward_type == RewardType::DeactivatedStake
+                    },
                 );
                 reward_map.extend(index_reward_map);
             }

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -215,7 +215,7 @@ impl Bank {
                 account.lamports(),
                 account.data().len(),
                 &self.rent_collector().rent,
-                false,
+                feature_snapshot.relax_post_exec_min_balance_check,
             ) {
                 return Err(DepositFeeError::InvalidRentPayingAccount);
             }
@@ -259,7 +259,7 @@ pub mod tests {
     use {
         super::*,
         crate::genesis_utils::{create_genesis_config, create_genesis_config_with_leader},
-        agave_feature_set::FeatureSet,
+        agave_feature_set::{self as feature_set, FeatureSet},
         solana_account::state_traits::StateMut,
         solana_pubkey as pubkey,
         solana_rent::Rent,
@@ -554,6 +554,55 @@ pub mod tests {
             bank.get_account(&nonexistent_pubkey).is_none(),
             "Account should still not exist after failed deposit"
         );
+    }
+
+    #[test]
+    fn test_deposit_or_burn_fee_respects_relaxed_post_exec_min_balance_check() {
+        for relax_post_exec_min_balance_check in [false, true] {
+            let mut genesis = create_genesis_config(0);
+            let rent = Rent::default();
+            genesis.genesis_config.rent = rent.clone();
+            let mut bank = Bank::new_for_tests(&genesis.genesis_config);
+
+            let data_len = 64;
+            let rent_exempt_minimum = rent.minimum_balance(data_len);
+            assert!(rent_exempt_minimum > 1);
+
+            let pre_balance = rent_exempt_minimum - 2;
+            let deposit = 1;
+            let post_balance = pre_balance + deposit;
+            let leader_id = *bank.leader_id();
+
+            let account = AccountSharedData::new(pre_balance, data_len, &system_program::id());
+            bank.store_account(&leader_id, &account);
+
+            let mut feature_set = FeatureSet::all_enabled();
+            if !relax_post_exec_min_balance_check {
+                feature_set.deactivate(&feature_set::relax_post_exec_min_balance_check::id());
+            }
+            bank.feature_set = Arc::new(feature_set);
+
+            let burned = bank.deposit_or_burn_fee(deposit);
+            let rewards = bank.rewards.read().unwrap();
+
+            // post simd-392, deposits to existing accounts are always valid because
+            // they are rent-exempt before and after the deposit takes place.
+            // pre simd-392, if a deposit to a rent-paying account isn't sufficient to
+            // make it rent-exempt then it fails and the deposit is burned.
+            if relax_post_exec_min_balance_check {
+                assert_eq!(burned, 0);
+                assert_eq!(bank.get_balance(&leader_id), post_balance);
+                assert_eq!(rewards.len(), 1, "fee should be distributed to the leader");
+                assert_eq!(rewards[0].1.post_balance, post_balance);
+            } else {
+                assert_eq!(burned, deposit);
+                assert_eq!(bank.get_balance(&leader_id), pre_balance);
+                assert!(
+                    rewards.is_empty(),
+                    "fee should be burned when the rent transition is invalid"
+                );
+            }
+        }
     }
 
     #[test]

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -564,71 +564,95 @@ pub mod tests {
     fn test_deposit_or_burn_fee_respects_relaxed_post_exec_min_balance_check(
         custom_commission_collector: bool,
     ) {
-        for relax_post_exec_min_balance_check in [false, true] {
-            let mut genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), 1000);
-            let rent = Rent::default();
-            genesis.genesis_config.rent = rent.clone();
+        enum CollectorState {
+            InitializedToSubRentExemptMinimum,
+            UninitializedToSubRentExemptMinimum,
+            UninitializedToRentExempt,
+        }
 
-            let data_len = 64;
-            let rent_exempt_minimum = rent.minimum_balance(data_len);
-            assert!(rent_exempt_minimum > 1);
+        for collector_state in [
+            CollectorState::InitializedToSubRentExemptMinimum,
+            CollectorState::UninitializedToSubRentExemptMinimum,
+            CollectorState::UninitializedToRentExempt,
+        ] {
+            for relax_post_exec_min_balance_check in [false, true] {
+                let mut genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), 1000);
+                let rent = Rent::default();
+                genesis.genesis_config.rent = rent.clone();
 
-            let pre_balance = rent_exempt_minimum - 2;
-            let deposit = 1;
-            let post_balance = pre_balance + deposit;
-            let maybe_collector_id = if custom_commission_collector {
-                let mut maybe_collector_id = None;
-                for account in genesis.genesis_config.accounts.values_mut() {
-                    if account.owner == solana_sdk_ids::vote::id() {
-                        let mut vote_state =
-                            VoteStateV4::deserialize(account.data(), &Pubkey::default()).unwrap();
-                        let collector_id = Pubkey::new_unique();
-                        vote_state.block_revenue_collector = collector_id;
-                        maybe_collector_id = Some(collector_id);
-                        let versioned = VoteStateVersions::V4(Box::new(vote_state));
-                        account.set_state(&versioned).unwrap();
+                let initialized_data_len = 64;
+                let rent_exempt_minimum = rent.minimum_balance(initialized_data_len);
+                assert!(rent_exempt_minimum > 1);
+
+                let (pre_balance, deposit, should_succeed) = match collector_state {
+                    CollectorState::InitializedToSubRentExemptMinimum => (
+                        rent_exempt_minimum - 2,
+                        1,
+                        relax_post_exec_min_balance_check,
+                    ),
+                    CollectorState::UninitializedToSubRentExemptMinimum => (0, 1, false),
+                    CollectorState::UninitializedToRentExempt => (0, rent_exempt_minimum, true),
+                };
+                let post_balance = pre_balance + deposit;
+                let maybe_collector_id = if custom_commission_collector {
+                    let mut maybe_collector_id = None;
+                    for account in genesis.genesis_config.accounts.values_mut() {
+                        if account.owner == solana_sdk_ids::vote::id() {
+                            let mut vote_state =
+                                VoteStateV4::deserialize(account.data(), &Pubkey::default())
+                                    .unwrap();
+                            let collector_id = Pubkey::new_unique();
+                            vote_state.block_revenue_collector = collector_id;
+                            maybe_collector_id = Some(collector_id);
+                            let versioned = VoteStateVersions::V4(Box::new(vote_state));
+                            account.set_state(&versioned).unwrap();
+                        }
                     }
+                    maybe_collector_id
+                } else {
+                    None
+                };
+
+                let mut bank = Bank::new_for_tests(&genesis.genesis_config);
+
+                let mut feature_set = FeatureSet::all_enabled();
+                if !custom_commission_collector {
+                    feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
                 }
-                maybe_collector_id
-            } else {
-                None
-            };
+                if !relax_post_exec_min_balance_check {
+                    feature_set.deactivate(&feature_set::relax_post_exec_min_balance_check::id());
+                }
+                bank.feature_set = Arc::new(feature_set);
 
-            let mut bank = Bank::new_for_tests(&genesis.genesis_config);
-
-            let account = AccountSharedData::new(pre_balance, data_len, &system_program::id());
-
-            let mut feature_set = FeatureSet::all_enabled();
-            if !custom_commission_collector {
-                feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
-            }
-            if !relax_post_exec_min_balance_check {
-                feature_set.deactivate(&feature_set::relax_post_exec_min_balance_check::id());
-            }
-            bank.feature_set = Arc::new(feature_set);
-
-            let collector_id = maybe_collector_id.unwrap_or(*bank.leader_id());
-            bank.store_account(&collector_id, &account);
-
-            let burned = bank.deposit_or_burn_fee(deposit);
-            let rewards = bank.rewards.read().unwrap();
-
-            // post simd-392, deposits to existing accounts are always valid because
-            // they are rent-exempt before and after the deposit takes place.
-            // pre simd-392, if a deposit to a rent-paying account isn't sufficient to
-            // make it rent-exempt then it fails and the deposit is burned.
-            if relax_post_exec_min_balance_check {
-                assert_eq!(burned, 0);
-                assert_eq!(bank.get_balance(&collector_id), post_balance);
-                assert_eq!(rewards.len(), 1, "fee should be distributed to the leader");
-                assert_eq!(rewards[0].1.post_balance, post_balance);
-            } else {
-                assert_eq!(burned, deposit);
-                assert_eq!(bank.get_balance(&collector_id), pre_balance);
-                assert!(
-                    rewards.is_empty(),
-                    "fee should be burned when the rent transition is invalid"
+                let collector_id = maybe_collector_id.unwrap_or(*bank.leader_id());
+                let account = AccountSharedData::new(
+                    pre_balance,
+                    initialized_data_len,
+                    &system_program::id(),
                 );
+                bank.store_account(&collector_id, &account);
+
+                let burned = bank.deposit_or_burn_fee(deposit);
+                let rewards = bank.rewards.read().unwrap();
+
+                // post simd-392, deposits to existing accounts are always valid because
+                // they are rent-exempt before and after the deposit takes place.
+                // Deposits to uninitialized accounts still must make the account rent-exempt.
+                // pre simd-392, if a deposit to a rent-paying account isn't sufficient to
+                // make it rent-exempt then it fails and the deposit is burned.
+                if should_succeed {
+                    assert_eq!(burned, 0);
+                    assert_eq!(bank.get_balance(&collector_id), post_balance);
+                    assert_eq!(rewards.len(), 1, "fee should be distributed to the leader");
+                    assert_eq!(rewards[0].1.post_balance, post_balance);
+                } else {
+                    assert_eq!(burned, deposit);
+                    assert_eq!(bank.get_balance(&collector_id), pre_balance);
+                    assert!(
+                        rewards.is_empty(),
+                        "fee should be burned when the rent transition is invalid"
+                    );
+                }
             }
         }
     }

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -210,13 +210,16 @@ impl Bank {
 
             // rent state transition must be checked in case the account receiving the distribution
             // doesn't exist yet.
-            if !check_static_account_rent_state_transition(
+            if check_static_account_rent_state_transition(
                 pre_balance,
                 account.lamports(),
                 account.data().len(),
                 &self.rent_collector().rent,
+                0, // account index isn't relevant and only used for error message
                 feature_snapshot.relax_post_exec_min_balance_check,
-            ) {
+            )
+            .is_err()
+            {
                 return Err(DepositFeeError::InvalidRentPayingAccount);
             }
         }

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -559,13 +559,15 @@ pub mod tests {
         );
     }
 
-    #[test]
-    fn test_deposit_or_burn_fee_respects_relaxed_post_exec_min_balance_check() {
+    #[test_case(true; "custom_commission_collector")]
+    #[test_case(false; "no_custom_commission_collector")]
+    fn test_deposit_or_burn_fee_respects_relaxed_post_exec_min_balance_check(
+        custom_commission_collector: bool,
+    ) {
         for relax_post_exec_min_balance_check in [false, true] {
-            let mut genesis = create_genesis_config(0);
+            let mut genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), 1000);
             let rent = Rent::default();
             genesis.genesis_config.rent = rent.clone();
-            let mut bank = Bank::new_for_tests(&genesis.genesis_config);
 
             let data_len = 64;
             let rent_exempt_minimum = rent.minimum_balance(data_len);
@@ -574,16 +576,39 @@ pub mod tests {
             let pre_balance = rent_exempt_minimum - 2;
             let deposit = 1;
             let post_balance = pre_balance + deposit;
-            let leader_id = *bank.leader_id();
+            let maybe_collector_id = if custom_commission_collector {
+                let mut maybe_collector_id = None;
+                for account in genesis.genesis_config.accounts.values_mut() {
+                    if account.owner == solana_sdk_ids::vote::id() {
+                        let mut vote_state =
+                            VoteStateV4::deserialize(account.data(), &Pubkey::default()).unwrap();
+                        let collector_id = Pubkey::new_unique();
+                        vote_state.block_revenue_collector = collector_id;
+                        maybe_collector_id = Some(collector_id);
+                        let versioned = VoteStateVersions::V4(Box::new(vote_state));
+                        account.set_state(&versioned).unwrap();
+                    }
+                }
+                maybe_collector_id
+            } else {
+                None
+            };
+
+            let mut bank = Bank::new_for_tests(&genesis.genesis_config);
 
             let account = AccountSharedData::new(pre_balance, data_len, &system_program::id());
-            bank.store_account(&leader_id, &account);
 
             let mut feature_set = FeatureSet::all_enabled();
+            if !custom_commission_collector {
+                feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
+            }
             if !relax_post_exec_min_balance_check {
                 feature_set.deactivate(&feature_set::relax_post_exec_min_balance_check::id());
             }
             bank.feature_set = Arc::new(feature_set);
+
+            let collector_id = maybe_collector_id.unwrap_or(*bank.leader_id());
+            bank.store_account(&collector_id, &account);
 
             let burned = bank.deposit_or_burn_fee(deposit);
             let rewards = bank.rewards.read().unwrap();
@@ -594,12 +619,12 @@ pub mod tests {
             // make it rent-exempt then it fails and the deposit is burned.
             if relax_post_exec_min_balance_check {
                 assert_eq!(burned, 0);
-                assert_eq!(bank.get_balance(&leader_id), post_balance);
+                assert_eq!(bank.get_balance(&collector_id), post_balance);
                 assert_eq!(rewards.len(), 1, "fee should be distributed to the leader");
                 assert_eq!(rewards[0].1.post_balance, post_balance);
             } else {
                 assert_eq!(burned, deposit);
-                assert_eq!(bank.get_balance(&leader_id), pre_balance);
+                assert_eq!(bank.get_balance(&collector_id), pre_balance);
                 assert!(
                     rewards.is_empty(),
                     "fee should be burned when the rent transition is invalid"

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -12,7 +12,7 @@ use {
         transaction_meta::TransactionConfiguration, transaction_with_meta::TransactionWithMeta,
     },
     solana_sdk_ids::incinerator,
-    solana_svm::rent_calculator::{get_account_rent_state, transition_allowed},
+    solana_svm::rent_calculator::check_static_account_rent_state_transition,
     solana_system_interface::program as system_program,
     std::{result::Result, sync::atomic::Ordering::Relaxed},
     thiserror::Error,
@@ -202,24 +202,21 @@ impl Bank {
                 return Err(DepositFeeError::InvalidAccountOwner);
             }
 
-            let recipient_pre_rent_state = get_account_rent_state(
-                &self.rent_collector().rent,
-                account.lamports(),
-                account.data().len(),
-            );
+            let pre_balance = account.lamports();
             let distribution = account.checked_add_lamports(fees);
             if distribution.is_err() {
                 return Err(DepositFeeError::LamportOverflow);
             }
 
-            let recipient_post_rent_state = get_account_rent_state(
-                &self.rent_collector().rent,
+            // rent state transition must be checked in case the account receiving the distribution
+            // doesn't exist yet.
+            if !check_static_account_rent_state_transition(
+                pre_balance,
                 account.lamports(),
                 account.data().len(),
-            );
-            let rent_state_transition_allowed =
-                transition_allowed(&recipient_pre_rent_state, &recipient_post_rent_state);
-            if !rent_state_transition_allowed {
+                &self.rent_collector().rent,
+                false,
+            ) {
                 return Err(DepositFeeError::InvalidRentPayingAccount);
             }
         }
@@ -502,6 +499,61 @@ pub mod tests {
                 Err(DepositFeeError::ReservedCollector) | Err(DepositFeeError::InvalidAccountOwner),
             ));
         }
+    }
+
+    #[test]
+    fn test_deposit_fees_to_nonexistent_account_rent_exempt() {
+        let mut genesis = create_genesis_config(0);
+        let rent = Rent::default();
+        genesis.genesis_config.rent = rent.clone();
+        let bank = Bank::new_for_tests(&genesis.genesis_config);
+        let nonexistent_pubkey = Pubkey::new_unique();
+
+        // Fee is sufficient to make the new account rent-exempt
+        let deposit_amount = rent.minimum_balance(0);
+
+        assert!(
+            bank.get_account(&nonexistent_pubkey).is_none(),
+            "Account should not exist before deposit"
+        );
+
+        assert_eq!(
+            bank.deposit_fees(&nonexistent_pubkey, deposit_amount),
+            Ok(deposit_amount),
+            "Deposit should succeed when fee is sufficient for rent-exemption"
+        );
+
+        let account = bank.get_account(&nonexistent_pubkey).unwrap();
+        assert_eq!(account.lamports(), deposit_amount);
+        assert_eq!(account.owner(), &system_program::id());
+    }
+
+    #[test]
+    fn test_deposit_fees_to_nonexistent_account_not_rent_exempt() {
+        let mut genesis = create_genesis_config(0);
+        let rent = Rent::default();
+        genesis.genesis_config.rent = rent.clone();
+        let bank = Bank::new_for_tests(&genesis.genesis_config);
+        let nonexistent_pubkey = Pubkey::new_unique();
+
+        // Fee is insufficient to make the new account rent-exempt
+        let deposit_amount = rent.minimum_balance(0) - 1;
+
+        assert!(
+            bank.get_account(&nonexistent_pubkey).is_none(),
+            "Account should not exist before deposit"
+        );
+
+        assert_eq!(
+            bank.deposit_fees(&nonexistent_pubkey, deposit_amount),
+            Err(DepositFeeError::InvalidRentPayingAccount),
+            "Deposit should fail when fee is insufficient for rent-exemption"
+        );
+
+        assert!(
+            bank.get_account(&nonexistent_pubkey).is_none(),
+            "Account should still not exist after failed deposit"
+        );
     }
 
     #[test]

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -444,6 +444,7 @@ impl Bank {
         new_rate_activation_epoch: Option<Epoch>,
         delay_commission_updates: bool,
         commission_rate_in_basis_points: bool,
+        adjust_delegations_for_rent: bool,
     ) -> Option<DelegationRewards> {
         // curry closure to add the contextual stake_pubkey
         let reward_calc_tracer = reward_calc_tracer.as_ref().map(|outer| {
@@ -467,6 +468,12 @@ impl Bank {
         };
         let vote_state = vote_account.vote_state_view();
         let stake_state = stake_account.stake_state();
+
+        let current_lamports = stake_account.lamports();
+        let minimum_lamports = self
+            .rent_collector
+            .rent
+            .minimum_balance(stake_account.data_len());
 
         // Fetch the voter commission from past epochs to attempt to
         // delay the effect of commission updates by at least one
@@ -501,9 +508,11 @@ impl Bank {
                 stake_history,
                 new_rate_activation_epoch,
                 commission_rate_in_basis_points,
+                adjust_delegations_for_rent,
             },
             reward_calc_tracer,
-            stake_account.lamports(),
+            current_lamports,
+            minimum_lamports,
         ) {
             Ok((stake_reward, commission_lamports, stake)) => {
                 let stake_reward = PartitionedStakeReward {
@@ -548,6 +557,9 @@ impl Bank {
         let feature_snapshot = self.feature_set.snapshot();
         let delay_commission_updates = feature_snapshot.delay_commission_updates;
         let commission_rate_in_basis_points = feature_snapshot.commission_rate_in_basis_points;
+        // Name intentionally doesn't match -- "adjust delegations for rent" is
+        // part of relaxing post-exec min balance checks.
+        let adjust_delegations_for_rent = feature_snapshot.relax_post_exec_min_balance_check;
 
         let mut measure_redeem_rewards = Measure::start("redeem-rewards");
         // For N stake delegations, where N is >1,000,000, we produce:
@@ -579,6 +591,7 @@ impl Bank {
                                 new_warmup_cooldown_rate_epoch,
                                 delay_commission_updates,
                                 commission_rate_in_basis_points,
+                                adjust_delegations_for_rent,
                             )
                         });
                     let (stake_reward, maybe_reward_record) = match maybe_reward_record {

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -14,10 +14,15 @@ use {
     serde::{Deserialize, Serialize},
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut},
     solana_accounts_db::stake_rewards::{StakeReward, StakeRewardInfo},
+    solana_clock::Epoch,
     solana_measure::measure_us,
     solana_pubkey::Pubkey,
+    solana_rent::Rent,
     solana_reward_info::RewardType,
-    solana_stake_interface::state::{Delegation, StakeStateV2},
+    solana_stake_interface::{
+        stake_history::StakeHistory,
+        state::{Delegation, StakeStateV2},
+    },
     std::sync::{Arc, atomic::Ordering::Relaxed},
     thiserror::Error,
 };
@@ -190,8 +195,13 @@ impl Bank {
     }
 
     fn build_updated_stake_reward(
+        distribution_epoch: u64,
+        stake_history: &StakeHistory,
+        new_warmup_cooldown_rate_epoch: Option<Epoch>,
         stakes_cache_accounts: &imbl::HashMap<Pubkey, StakeAccount<Delegation>>,
         partitioned_stake_reward: &PartitionedStakeReward,
+        rent: &Rent,
+        adjust_delegations_for_rent: bool,
     ) -> Result<StakeReward, DistributionError> {
         let stake_account = stakes_cache_accounts
             .get(&partitioned_stake_reward.stake_pubkey)
@@ -209,13 +219,21 @@ impl Bank {
         account
             .checked_add_lamports(partitioned_stake_reward.stake_reward)
             .map_err(|_| DistributionError::ArithmeticOverflow)?;
-        assert_eq!(
-            stake
-                .delegation
-                .stake
-                .saturating_add(partitioned_stake_reward.stake_reward),
-            partitioned_stake_reward.stake.delegation.stake
-        );
+        if adjust_delegations_for_rent {
+            let minimum_balance = rent.minimum_balance(account.data().len());
+            assert!(
+                partitioned_stake_reward.stake.delegation.stake
+                    <= account.lamports().saturating_sub(minimum_balance),
+            );
+        } else {
+            assert_eq!(
+                stake
+                    .delegation
+                    .stake
+                    .saturating_add(partitioned_stake_reward.stake_reward),
+                partitioned_stake_reward.stake.delegation.stake
+            );
+        }
         account
             .set_state(&StakeStateV2::Stake(
                 meta,
@@ -223,10 +241,21 @@ impl Bank {
                 flags,
             ))
             .map_err(|_| DistributionError::UnableToSetState)?;
+
+        let reward_type = if partitioned_stake_reward.stake.delegation.stake(
+            distribution_epoch,
+            stake_history,
+            new_warmup_cooldown_rate_epoch,
+        ) == 0
+        {
+            RewardType::DeactivatedStake
+        } else {
+            RewardType::Staking
+        };
         Ok(StakeReward {
             stake_pubkey: partitioned_stake_reward.stake_pubkey,
             stake_reward_info: StakeRewardInfo {
-                reward_type: RewardType::Staking,
+                reward_type,
                 lamports: i64::try_from(partitioned_stake_reward.stake_reward).unwrap(),
                 post_balance: account.lamports(),
                 commission_bps: Some(partitioned_stake_reward.commission_bps),
@@ -249,6 +278,11 @@ impl Bank {
         partition_rewards: &StartBlockHeightAndPartitionedRewards,
         partition_index: u64,
     ) -> DistributionResults {
+        let feature_snapshot = self.feature_set.snapshot();
+        // Name intentionally doesn't match -- "adjust delegations for rent" is
+        // part of relaxing post-exec min balance checks.
+        let adjust_delegations_for_rent = feature_snapshot.relax_post_exec_min_balance_check;
+
         let mut lamports_distributed = 0;
         let mut lamports_burned = 0;
         let indices = partition_rewards
@@ -263,6 +297,9 @@ impl Bank {
         let mut updated_stake_rewards = Vec::with_capacity(indices.len());
         let stakes_cache = self.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
+        let stake_history = stakes_cache.history();
+        let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
+        let rent = &self.rent_collector.rent;
         for index in indices {
             let partitioned_stake_reward = partition_rewards
                 .all_stake_rewards
@@ -279,8 +316,15 @@ impl Bank {
                 });
             let stake_pubkey = partitioned_stake_reward.stake_pubkey;
             let reward_amount = partitioned_stake_reward.stake_reward;
-            match Self::build_updated_stake_reward(stakes_cache_accounts, partitioned_stake_reward)
-            {
+            match Self::build_updated_stake_reward(
+                self.epoch,
+                stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                partitioned_stake_reward,
+                rent,
+                adjust_delegations_for_rent,
+            ) {
                 Ok(stake_reward) => {
                     lamports_distributed += reward_amount;
                     updated_stake_rewards.push(stake_reward);
@@ -329,12 +373,14 @@ mod tests {
         solana_reward_info::RewardType,
         solana_stake_interface::{
             stake_flags::StakeFlags,
+            stake_history::StakeHistoryEntry,
             state::{Meta, Stake},
         },
         solana_sysvar as sysvar,
         solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
         solana_vote_program::vote_state,
         std::sync::Arc,
+        test_case::test_case,
     };
 
     #[test]
@@ -618,10 +664,31 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_build_updated_stake_reward() {
+    #[test_case(true; "adjust_delegations_for_rent")]
+    #[test_case(false; "no_adjust_delegations_for_rent")]
+    fn test_build_updated_stake_reward(adjust_delegations_for_rent: bool) {
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
         let bank = Bank::new_for_tests(&genesis_config);
+        // add an entry so we can get full deactivation one epoch later
+        let mut stake_history = StakeHistory::default();
+        stake_history.add(
+            0,
+            StakeHistoryEntry {
+                effective: 1_000_000 * LAMPORTS_PER_SOL,
+                activating: LAMPORTS_PER_SOL,
+                deactivating: LAMPORTS_PER_SOL,
+            },
+        );
+
+        let distribution_epoch = bank.epoch + 1;
+        let new_warmup_cooldown_rate_epoch = bank.new_warmup_cooldown_rate_epoch();
+        let mut rent = bank.rent_collector.rent.clone();
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+
+        // Adjust rent down, no impact at all
+        if adjust_delegations_for_rent {
+            rent.lamports_per_byte /= 2;
+        }
 
         let voter_pubkey = Pubkey::new_unique();
         let new_stake = Stake {
@@ -645,13 +712,19 @@ mod tests {
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
         assert_eq!(
-            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward,)
-                .unwrap_err(),
+            Bank::build_updated_stake_reward(
+                distribution_epoch,
+                &stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                &partitioned_stake_reward,
+                &rent,
+                adjust_delegations_for_rent,
+            )
+            .unwrap_err(),
             DistributionError::AccountNotFound
         );
         drop(stakes_cache);
-
-        let rent_exempt_reserve = 2_282_880;
 
         let overflowing_account = Pubkey::new_unique();
         let mut stake_account = AccountSharedData::new(
@@ -676,8 +749,16 @@ mod tests {
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
         assert_eq!(
-            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward,)
-                .unwrap_err(),
+            Bank::build_updated_stake_reward(
+                distribution_epoch,
+                &stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                &partitioned_stake_reward,
+                &rent,
+                adjust_delegations_for_rent,
+            )
+            .unwrap_err(),
             DistributionError::ArithmeticOverflow
         );
         drop(stakes_cache);
@@ -739,8 +820,97 @@ mod tests {
             },
         };
         assert_eq!(
-            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward,)
-                .unwrap(),
+            Bank::build_updated_stake_reward(
+                distribution_epoch,
+                &stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                &partitioned_stake_reward,
+                &rent,
+                adjust_delegations_for_rent,
+            )
+            .unwrap(),
+            expected_stake_reward
+        );
+        drop(stakes_cache);
+
+        let deactivating_account = Pubkey::new_unique();
+        let deactivating_stake = Stake {
+            delegation: Delegation {
+                voter_pubkey,
+                stake: 55_555,
+                deactivation_epoch: bank.epoch,
+                ..Delegation::default()
+            },
+            credits_observed: 42,
+        };
+        let starting_stake = deactivating_stake.delegation.stake - stake_reward;
+        let starting_lamports = rent_exempt_reserve + starting_stake;
+        let mut stake_account = AccountSharedData::new(
+            starting_lamports,
+            StakeStateV2::size_of(),
+            &solana_stake_interface::program::id(),
+        );
+        let other_stake = Stake {
+            delegation: Delegation {
+                voter_pubkey,
+                stake: starting_stake,
+                deactivation_epoch: bank.epoch,
+                ..Delegation::default()
+            },
+            credits_observed: 11,
+        };
+        stake_account
+            .set_state(&StakeStateV2::Stake(
+                Meta::default(),
+                other_stake,
+                StakeFlags::default(),
+            ))
+            .unwrap();
+        bank.store_account(&deactivating_account, &stake_account);
+        let partitioned_stake_reward = PartitionedStakeReward {
+            stake_pubkey: successful_account,
+            stake: deactivating_stake,
+            stake_reward,
+            commission_bps,
+        };
+        let stakes_cache = bank.stakes_cache.stakes();
+        let stakes_cache_accounts = stakes_cache.stake_delegations();
+        let expected_lamports = starting_lamports + stake_reward;
+        let mut expected_stake_account = AccountSharedData::new(
+            expected_lamports,
+            StakeStateV2::size_of(),
+            &solana_stake_interface::program::id(),
+        );
+        expected_stake_account
+            .set_state(&StakeStateV2::Stake(
+                Meta::default(),
+                deactivating_stake,
+                StakeFlags::default(),
+            ))
+            .unwrap();
+
+        let expected_stake_reward = StakeReward {
+            stake_pubkey: successful_account,
+            stake_account: expected_stake_account,
+            stake_reward_info: StakeRewardInfo {
+                reward_type: RewardType::DeactivatedStake,
+                lamports: stake_reward as i64,
+                post_balance: expected_lamports,
+                commission_bps: Some(commission_bps),
+            },
+        };
+        assert_eq!(
+            Bank::build_updated_stake_reward(
+                distribution_epoch,
+                &stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                &partitioned_stake_reward,
+                &rent,
+                adjust_delegations_for_rent,
+            )
+            .unwrap(),
             expected_stake_reward
         );
         drop(stakes_cache);
@@ -807,5 +977,100 @@ mod tests {
             ..
         } = bank.store_stake_accounts_in_partition(&partitioned_rewards, 0);
         assert_eq!(expected_total, lamports_distributed);
+    }
+
+    #[test]
+    fn test_distribute_with_increased_rent() {
+        let (mut genesis_config, _mint_keypair) =
+            create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        genesis_config.epoch_schedule = EpochSchedule::custom(432000, 432000, false);
+        let bank = Bank::new_for_tests(&genesis_config);
+
+        // Set up epoch_rewards sysvar with rewards with 10e9 lamports to distribute.
+        let total_rewards = 10 * LAMPORTS_PER_SOL;
+        let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
+        let total_points = (total_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
+        bank.create_epoch_rewards_sysvar(
+            0,
+            42,
+            num_partitions,
+            &PointValue {
+                rewards: total_rewards,
+                points: total_points,
+            },
+        );
+        let pre_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
+        let expected_balance =
+            bank.get_minimum_balance_for_rent_exemption(pre_epoch_rewards_account.data().len());
+        // Expected balance is the sysvar rent-exempt balance
+        assert_eq!(pre_epoch_rewards_account.lamports(), expected_balance);
+
+        // Use lower lamports per byte for creating, bank has higher amount
+        let mut lower_rent = bank.rent_collector.rent.clone();
+        lower_rent.lamports_per_byte /= 10;
+        let higher_rent = &bank.rent_collector.rent;
+
+        // Set up a partition of rewards to distribute
+        let stake_rewards = [
+            // Zero stake -> destaked
+            StakeReward::new_with_pre_stake_account(0, 0, &lower_rent),
+            // Below new minimum, small reward -> destaked
+            StakeReward::new_with_pre_stake_account(1, 1, &lower_rent),
+            // Below new minimum, no reward -> delegation modified
+            StakeReward::new_with_pre_stake_account(0, LAMPORTS_PER_SOL, &lower_rent),
+            // Below new minimum, small reward -> delegation modified
+            StakeReward::new_with_pre_stake_account(1, LAMPORTS_PER_SOL, &lower_rent),
+            // Below new minimum, big reward -> delegation modified
+            StakeReward::new_with_pre_stake_account(
+                LAMPORTS_PER_SOL as i64,
+                LAMPORTS_PER_SOL,
+                &lower_rent,
+            ),
+            // Above new minimum, small reward -> delegation capped
+            StakeReward::new_with_pre_stake_account(1, LAMPORTS_PER_SOL, higher_rent),
+            // Above new minimum, big reward -> delegation capped
+            StakeReward::new_with_pre_stake_account(
+                LAMPORTS_PER_SOL as i64,
+                LAMPORTS_PER_SOL,
+                higher_rent,
+            ),
+        ]
+        .into_iter()
+        .map(|r| {
+            bank.store_account(&r.1.stake_pubkey, &r.0);
+            r.1
+        })
+        .collect::<Vec<_>>();
+
+        let expected_num = stake_rewards.len();
+        let rewards_to_distribute = stake_rewards
+            .iter()
+            .map(|stake_reward| stake_reward.stake_reward_info.lamports)
+            .sum::<i64>() as u64;
+        let all_rewards = convert_rewards(stake_rewards);
+
+        let partitioned_rewards = StartBlockHeightAndPartitionedRewards {
+            distribution_starting_block_height: bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
+            all_stake_rewards: Arc::new(all_rewards),
+            partition_indices: vec![(0..expected_num).collect::<Vec<_>>()],
+        };
+
+        // Distribute rewards
+        let pre_cap = bank.capitalization();
+        bank.distribute_epoch_rewards_in_partition(&partitioned_rewards, 0);
+        let post_cap = bank.capitalization();
+        let post_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
+
+        // Assert that epoch rewards sysvar lamports balance does not change
+        assert_eq!(post_epoch_rewards_account.lamports(), expected_balance);
+
+        let epoch_rewards: sysvar::epoch_rewards::EpochRewards =
+            from_account(&post_epoch_rewards_account).unwrap();
+        assert_eq!(epoch_rewards.total_rewards, total_rewards);
+        assert_eq!(epoch_rewards.distributed_rewards, rewards_to_distribute,);
+
+        // Assert that the bank total capital changed by the amount of rewards
+        // distributed
+        assert_eq!(pre_cap + rewards_to_distribute, post_cap);
     }
 }

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -35,6 +35,9 @@ enum DistributionError {
     #[error("rewards arithmetic overflowed")]
     ArithmeticOverflow,
 
+    #[error("stake reward delegation is inconsistent with the updated account balance")]
+    InconsistentDelegation,
+
     #[error("stake account set_state failed")]
     UnableToSetState,
 }
@@ -221,18 +224,29 @@ impl Bank {
             .map_err(|_| DistributionError::ArithmeticOverflow)?;
         if adjust_delegations_for_rent {
             let minimum_balance = rent.minimum_balance(account.data().len());
-            assert!(
-                partitioned_stake_reward.stake.delegation.stake
-                    <= account.lamports().saturating_sub(minimum_balance),
+            let delegation_is_valid = partitioned_stake_reward.stake.delegation.stake
+                <= account.lamports().saturating_sub(minimum_balance);
+            debug_assert!(
+                delegation_is_valid,
+                "stake reward delegation must be consistent with the updated stake account \
+                 lamport balance"
             );
+            if !delegation_is_valid {
+                return Err(DistributionError::InconsistentDelegation);
+            }
         } else {
-            assert_eq!(
-                stake
-                    .delegation
-                    .stake
-                    .saturating_add(partitioned_stake_reward.stake_reward),
-                partitioned_stake_reward.stake.delegation.stake
+            let expected_delegation = stake
+                .delegation
+                .stake
+                .saturating_add(partitioned_stake_reward.stake_reward);
+            debug_assert_eq!(
+                expected_delegation, partitioned_stake_reward.stake.delegation.stake,
+                "stake reward delegation must be consistent with the updated stake account \
+                 lamport balance"
             );
+            if expected_delegation != partitioned_stake_reward.stake.delegation.stake {
+                return Err(DistributionError::InconsistentDelegation);
+            }
         }
         account
             .set_state(&StakeStateV2::Stake(

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -869,7 +869,7 @@ mod tests {
             .unwrap();
         bank.store_account(&deactivating_account, &stake_account);
         let partitioned_stake_reward = PartitionedStakeReward {
-            stake_pubkey: successful_account,
+            stake_pubkey: deactivating_account,
             stake: deactivating_stake,
             stake_reward,
             commission_bps,
@@ -891,7 +891,7 @@ mod tests {
             .unwrap();
 
         let expected_stake_reward = StakeReward {
-            stake_pubkey: successful_account,
+            stake_pubkey: deactivating_account,
             stake_account: expected_stake_account,
             stake_reward_info: StakeRewardInfo {
                 reward_type: RewardType::DeactivatedStake,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -963,7 +963,10 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
     let rewards = bank2.rewards.read().unwrap();
     rewards
         .iter()
-        .find(|(_address, reward)| reward.reward_type == RewardType::Staking)
+        .find(|(_address, reward)| {
+            reward.reward_type == RewardType::Staking
+                || reward.reward_type == RewardType::DeactivatedStake
+        })
         .unwrap();
 
     bank1.capitalization()

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -814,18 +814,18 @@ mod tests {
         post_stake: Stake,
         staker_rewards: Option<u64>,
     ) {
-        let mut vote_state = VoteStateV4::default();
+        let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::default());
         // put 1 credit to create rewards
         vote_state.increment_credits(rewarded_epoch, 1);
-        let stake_history = &StakeHistory::default();
+        let stake_history: &StakeHistory = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
         let adjust_delegations_for_rent = true;
 
         let maybe_rewards = redeem_stake_rewards(
             &mut pre_stake,
-            vote_state.inflation_rewards_commission_bps,
-            DelegatedVoteState::from(&vote_state),
+            vote_state.as_ref_v4().inflation_rewards_commission_bps,
+            DelegatedVoteState::from(vote_state.as_ref_v4()),
             CalculationEnvironment {
                 rewarded_epoch,
                 point_value: &PointValue {
@@ -999,7 +999,7 @@ mod tests {
         // -> decrease stake
         // This case is confusing because it pays out 2 lamports in rewards,
         // so we adjust minimum up so that even with 2 lamports in rewards, the
-        // delegation goegs down.
+        // delegation goes down.
         check_rent_adjusted_stake_delegation(
             rewarded_epoch,
             Stake {

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -33,7 +33,8 @@ pub(crate) fn redeem_rewards<'a>(
     vote_state: DelegatedVoteState,
     calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
-    stake_account_lamports_for_trace: u64,
+    current_lamports: u64,
+    minimum_lamports: u64,
 ) -> Result<(u64, u64, Stake), InstructionError> {
     if let StakeStateV2::Stake(_meta, stake, _stake_flags) = stake_state {
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
@@ -52,7 +53,7 @@ pub(crate) fn redeem_rewards<'a>(
                 )),
             );
             inflation_point_calc_tracer(&InflationPointCalculationEvent::PriorTotalLamports(
-                stake_account_lamports_for_trace,
+                current_lamports,
             ));
             // Choose which trace to emit based on the `commission_rate_in_basis_points` feature.
             if commission_rate_in_basis_points {
@@ -73,6 +74,8 @@ pub(crate) fn redeem_rewards<'a>(
             vote_state,
             calculation_environment,
             inflation_point_calc_tracer,
+            current_lamports,
+            minimum_lamports,
         ) {
             Ok((stakers_reward, voters_reward, stake))
         } else {
@@ -89,6 +92,8 @@ fn redeem_stake_rewards<'a>(
     vote_state: DelegatedVoteState,
     calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
+    current_lamports: u64,
+    minimum_lamports: u64,
 ) -> Option<(u64, u64)> {
     if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
         inflation_point_calc_tracer(&InflationPointCalculationEvent::CreditsObserved(
@@ -96,7 +101,10 @@ fn redeem_stake_rewards<'a>(
             None,
         ));
     }
-    calculate_stake_rewards(
+
+    let rewarded_epoch = calculation_environment.rewarded_epoch;
+    let adjust_delegations_for_rent = calculation_environment.adjust_delegations_for_rent;
+    let maybe_rewards = calculate_stake_rewards(
         stake,
         voter_commission_bps,
         vote_state,
@@ -111,12 +119,39 @@ fn redeem_stake_rewards<'a>(
             ));
         }
         stake.credits_observed = calculated_stake_rewards.new_credits_observed;
-        stake.delegation.stake += calculated_stake_rewards.staker_rewards;
         (
             calculated_stake_rewards.staker_rewards,
             calculated_stake_rewards.voter_rewards,
         )
-    })
+    });
+
+    let staker_rewards = maybe_rewards.map(|x| x.0).unwrap_or(0);
+    if adjust_delegations_for_rent {
+        let new_delegation = std::cmp::min(
+            stake.delegation.stake.saturating_add(staker_rewards),
+            current_lamports
+                .saturating_add(staker_rewards)
+                .saturating_sub(minimum_lamports),
+        );
+        // If `maybe_rewards.is_some()`, need to drive forward credits, even
+        // if rewards are zero
+        if new_delegation != stake.delegation.stake || maybe_rewards.is_some() {
+            stake.delegation.stake = new_delegation;
+            // Deactivate stake if needed. This deactivation is immediate,
+            // unlike a requested deactivation which happens at the next epoch
+            // boundary
+            if new_delegation == 0 {
+                stake.delegation.deactivation_epoch = rewarded_epoch;
+            }
+            let voter_rewards = maybe_rewards.map(|x| x.1).unwrap_or(0);
+            Some((staker_rewards, voter_rewards))
+        } else {
+            None
+        }
+    } else {
+        stake.delegation.stake += staker_rewards;
+        maybe_rewards
+    }
 }
 
 /// for a given stake and vote_state, calculate what distributions and what updates should be made
@@ -278,6 +313,7 @@ mod tests {
         solana_clock::Epoch,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_pubkey::Pubkey,
+        solana_rent::Rent,
         solana_stake_interface::{stake_history::StakeHistory, state::Delegation},
         solana_vote_program::vote_state::{VoteStateV4, handler::VoteStateHandler},
         test_case::test_case,
@@ -295,8 +331,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_stake_state_redeem_rewards() {
+    #[test_case(true; "adjust_delegations_for_rent")]
+    #[test_case(false; "no_adjust_delegations_for_rent")]
+    fn test_stake_state_redeem_rewards(adjust_delegations_for_rent: bool) {
         let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::default());
         // assume stake.stake() is right
         // bootstrap means fully-vested stake at epoch 0
@@ -310,6 +347,15 @@ mod tests {
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
+
+        let mut rent = Rent::default();
+        let minimum_balance = rent.minimum_balance(StakeStateV2::size_of());
+
+        // Adjust rent down, no impact
+        if adjust_delegations_for_rent {
+            rent.lamports_per_byte /= 2;
+        }
+        let new_minimum_balance = rent.minimum_balance(StakeStateV2::size_of());
 
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
@@ -327,8 +373,11 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
+                stake_lamports + minimum_balance,
+                new_minimum_balance,
             )
         );
 
@@ -352,8 +401,11 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
+                stake_lamports + minimum_balance,
+                new_minimum_balance,
             )
         );
 
@@ -374,6 +426,7 @@ mod tests {
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
+        let adjust_delegations_for_rent = true;
 
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
@@ -391,6 +444,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -420,6 +474,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -446,6 +501,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -475,6 +531,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -502,6 +559,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -531,6 +589,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -554,6 +613,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -574,6 +634,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -601,6 +662,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -628,6 +690,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -706,6 +769,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -734,9 +798,274 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
+        );
+    }
+
+    fn check_rent_adjusted_stake_delegation(
+        rewarded_epoch: u64,
+        mut pre_stake: Stake,
+        pre_lamports: u64,
+        new_minimum_balance: u64,
+        total_rewards: u64,
+        post_stake: Stake,
+        staker_rewards: Option<u64>,
+    ) {
+        let mut vote_state = VoteStateV4::default();
+        // put 1 credit to create rewards
+        vote_state.increment_credits(rewarded_epoch, 1);
+        let stake_history = &StakeHistory::default();
+        let new_rate_activation_epoch = None;
+        let commission_rate_in_basis_points = true;
+        let adjust_delegations_for_rent = true;
+
+        let maybe_rewards = redeem_stake_rewards(
+            &mut pre_stake,
+            vote_state.inflation_rewards_commission_bps,
+            DelegatedVoteState::from(&vote_state),
+            CalculationEnvironment {
+                rewarded_epoch,
+                point_value: &PointValue {
+                    rewards: total_rewards,
+                    points: 1,
+                },
+                stake_history,
+                new_rate_activation_epoch,
+                commission_rate_in_basis_points,
+                adjust_delegations_for_rent,
+            },
+            null_tracer(),
+            pre_lamports,
+            new_minimum_balance,
+        );
+        assert_eq!(pre_stake, post_stake);
+        assert_eq!(maybe_rewards.map(|x| x.0), staker_rewards)
+    }
+
+    #[test]
+    fn rent_adjusted_stake_delegation_calculations() {
+        let old_minimum_balance = 8;
+        let new_minimum_balance = 9;
+        let rewarded_epoch = 1;
+
+        // No rewards at all -> updated (all stakes get driven forward if
+        // inflation is disabled)
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            new_minimum_balance + 1,
+            new_minimum_balance,
+            0,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(0),
+        );
+
+        // Stake receives no rewards or delegation adjustment -> no update
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            new_minimum_balance + 1,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            None,
+        );
+
+        // Already destaked -> no update
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 0,
+                    deactivation_epoch: 0,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            old_minimum_balance - 1,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 0,
+                    deactivation_epoch: 0,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            None,
+        );
+
+        // Staked, already below minimum, go further below minimum
+        // -> destaked, still one lamport of rewards though
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            old_minimum_balance - 1,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 0,
+                    deactivation_epoch: rewarded_epoch,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(1),
+        );
+
+        // Delegation hits exactly 0 -> destaked, no rewards
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance,
+            new_minimum_balance,
+            0,
+            Stake {
+                delegation: Delegation {
+                    stake: 0,
+                    deactivation_epoch: rewarded_epoch,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(0),
+        );
+
+        // Delegation decreases to 1 -> still staked
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 2,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance + 1,
+            new_minimum_balance,
+            0,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(0),
+        );
+
+        // Rewards partially cover minimum balance change
+        // -> decrease stake
+        // This case is confusing because it pays out 2 lamports in rewards,
+        // so we adjust minimum up so that even with 2 lamports in rewards, the
+        // delegation goegs down.
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 2,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance,
+            new_minimum_balance + 1,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(2),
+        );
+
+        // Rewards cover minimum balance change -> no change in stake
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(1),
+        );
+
+        // Well above new minimum balance -> delegation change capped to rewards
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance + 2,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 2,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(1),
         );
     }
 
@@ -752,6 +1081,7 @@ mod tests {
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
+        let adjust_delegations_for_rent = true;
 
         calculate_stake_rewards(
             &stake,
@@ -763,6 +1093,7 @@ mod tests {
                 stake_history,
                 new_rate_activation_epoch,
                 commission_rate_in_basis_points,
+                adjust_delegations_for_rent,
             },
             null_tracer(),
         );
@@ -783,6 +1114,7 @@ mod tests {
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
+        let adjust_delegations_for_rent = true;
 
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
@@ -800,6 +1132,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -36,6 +36,7 @@ pub(crate) struct CalculationEnvironment<'a> {
     pub(crate) stake_history: &'a StakeHistory,
     pub(crate) new_rate_activation_epoch: Option<Epoch>,
     pub(crate) commission_rate_in_basis_points: bool,
+    pub(crate) adjust_delegations_for_rent: bool,
 }
 
 #[derive(Debug)]

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -45,6 +45,11 @@ impl<T> StakeAccount<T> {
     pub(crate) fn stake_state(&self) -> &StakeStateV2 {
         &self.stake_state
     }
+
+    #[inline]
+    pub(crate) fn data_len(&self) -> usize {
+        self.account.data().len()
+    }
 }
 
 impl StakeAccount<Delegation> {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -1356,6 +1356,10 @@ mod test {
         reward.reward_type = Some(RewardType::Staking);
         let gen_reward: generated::Reward = reward.clone().into();
         assert_eq!(reward, gen_reward.into());
+
+        reward.reward_type = Some(RewardType::DeactivatedStake);
+        let gen_reward: generated::Reward = reward.clone().into();
+        assert_eq!(reward, gen_reward.into());
     }
 
     #[test]

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -389,14 +389,20 @@ pub fn validate_fee_payer(
             TransactionError::InsufficientFundsForFee
         })?;
 
-    let payer_pre_rent_state =
-        get_account_rent_state(rent, payer_account.lamports(), payer_account.data().len());
+    let payer_pre_rent_state = get_account_rent_state(
+        payer_account.lamports(),
+        payer_account.data().len(),
+        rent.minimum_balance(payer_account.data().len()),
+    );
     payer_account
         .checked_sub_lamports(fee)
         .map_err(|_| TransactionError::InsufficientFundsForFee)?;
 
-    let payer_post_rent_state =
-        get_account_rent_state(rent, payer_account.lamports(), payer_account.data().len());
+    let payer_post_rent_state = get_account_rent_state(
+        payer_account.lamports(),
+        payer_account.data().len(),
+        rent.minimum_balance(payer_account.data().len()),
+    );
     check_rent_state_with_account(
         &payer_pre_rent_state,
         &payer_post_rent_state,
@@ -1915,9 +1921,23 @@ mod tests {
             1,
         );
 
+        let pre_account_state_info = TransactionAccountStateInfo::new_pre_exec(
+            &transaction_context,
+            sanitized_tx.message(),
+            &rent,
+            true,
+        );
+        assert_eq!(pre_account_state_info.len(), num_accounts);
+
         assert_eq!(
-            TransactionAccountStateInfo::new(&transaction_context, sanitized_tx.message(), &rent,)
-                .len(),
+            TransactionAccountStateInfo::new_post_exec(
+                &transaction_context,
+                sanitized_tx.message(),
+                &pre_account_state_info,
+                &rent,
+                true,
+            )
+            .len(),
             num_accounts,
         );
     }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1276,20 +1276,21 @@ mod tests {
             ..Rent::default()
         };
 
-        // nonce payer account has balance of u64::MAX, so does fee; due to nonce account
-        // requires additional min_balance, expect InsufficientFundsForFee error if feature gate is
-        // enabled
-        validate_fee_payer_account(
-            ValidateFeePayerTestParameter {
-                is_nonce: true,
-                payer_init_balance: u64::MAX,
-                fee: u64::MAX,
-                relax_post_exec_min_balance_check: true,
-                expected_result: Err(TransactionError::InsufficientFundsForFee),
-                payer_post_balance: u64::MAX,
-            },
-            &rent,
-        );
+        // nonce payer account has balance of u64::MAX, so does fee; the additional nonce
+        // min_balance requirement makes the checked arithmetic fail regardless of feature gate.
+        for relax_post_exec_min_balance_check in [false, true] {
+            validate_fee_payer_account(
+                ValidateFeePayerTestParameter {
+                    is_nonce: true,
+                    payer_init_balance: u64::MAX,
+                    fee: u64::MAX,
+                    relax_post_exec_min_balance_check,
+                    expected_result: Err(TransactionError::InsufficientFundsForFee),
+                    payer_post_balance: u64::MAX,
+                },
+                &rent,
+            );
+        }
     }
 
     #[test]

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -3,9 +3,7 @@ use qualifier_attr::{field_qualifiers, qualifiers};
 use {
     crate::{
         account_overrides::AccountOverrides,
-        rent_calculator::{
-            RENT_EXEMPT_RENT_EPOCH, check_rent_state_with_account, get_account_rent_state,
-        },
+        rent_calculator::{RENT_EXEMPT_RENT_EPOCH, check_static_account_rent_state_transition},
         rollback_accounts::RollbackAccounts,
         transaction_error_metrics::TransactionErrorMetrics,
     },
@@ -356,12 +354,12 @@ pub fn update_rent_exempt_status_for_account(rent: &Rent, account: &mut AccountS
 /// fee, the error_metrics is incremented, and a specific error is
 /// returned.
 pub fn validate_fee_payer(
-    payer_address: &Pubkey,
     payer_account: &mut AccountSharedData,
     payer_index: IndexOfAccount,
     error_metrics: &mut TransactionErrorMetrics,
     rent: &Rent,
     fee: u64,
+    relax_post_exec_min_balance_check: bool,
 ) -> Result<()> {
     if payer_account.lamports() == 0 {
         error_metrics.account_not_found += 1;
@@ -389,25 +387,19 @@ pub fn validate_fee_payer(
             TransactionError::InsufficientFundsForFee
         })?;
 
-    let payer_pre_rent_state = get_account_rent_state(
-        payer_account.lamports(),
-        payer_account.data().len(),
-        rent.minimum_balance(payer_account.data().len()),
-    );
+    let pre_balance = payer_account.lamports();
     payer_account
         .checked_sub_lamports(fee)
         .map_err(|_| TransactionError::InsufficientFundsForFee)?;
+    let post_balance = payer_account.lamports();
 
-    let payer_post_rent_state = get_account_rent_state(
-        payer_account.lamports(),
+    check_static_account_rent_state_transition(
+        pre_balance,
+        post_balance,
         payer_account.data().len(),
-        rent.minimum_balance(payer_account.data().len()),
-    );
-    check_rent_state_with_account(
-        &payer_pre_rent_state,
-        &payer_post_rent_state,
-        payer_address,
+        rent,
         payer_index,
+        relax_post_exec_min_balance_check,
     )
 }
 
@@ -1161,11 +1153,11 @@ mod tests {
         is_nonce: bool,
         payer_init_balance: u64,
         fee: u64,
+        relax_post_exec_min_balance_check: bool,
         expected_result: Result<()>,
         payer_post_balance: u64,
     }
     fn validate_fee_payer_account(test_parameter: ValidateFeePayerTestParameter, rent: &Rent) {
-        let payer_account_keys = Keypair::new();
         let mut account = if test_parameter.is_nonce {
             AccountSharedData::new_data(
                 test_parameter.payer_init_balance,
@@ -1177,12 +1169,12 @@ mod tests {
             AccountSharedData::new(test_parameter.payer_init_balance, 0, &system_program::id())
         };
         let result = validate_fee_payer(
-            &payer_account_keys.pubkey(),
             &mut account,
             0,
             &mut TransactionErrorMetrics::default(),
             rent,
             test_parameter.fee,
+            test_parameter.relax_post_exec_min_balance_check,
         );
 
         assert_eq!(result, test_parameter.expected_result);
@@ -1201,67 +1193,79 @@ mod tests {
         // If payer account has sufficient balance, expect successful fee deduction,
         // regardless feature gate status, or if payer is nonce account.
         {
-            for (is_nonce, min_balance) in [(true, min_balance), (false, 0)] {
-                validate_fee_payer_account(
-                    ValidateFeePayerTestParameter {
-                        is_nonce,
-                        payer_init_balance: min_balance + fee,
-                        fee,
-                        expected_result: Ok(()),
-                        payer_post_balance: min_balance,
-                    },
-                    &rent,
-                );
+            for relax_post_exec_min_balance_check in [false, true] {
+                for (is_nonce, min_balance) in [(true, min_balance), (false, 0)] {
+                    validate_fee_payer_account(
+                        ValidateFeePayerTestParameter {
+                            is_nonce,
+                            payer_init_balance: min_balance + fee,
+                            fee,
+                            relax_post_exec_min_balance_check,
+                            expected_result: Ok(()),
+                            payer_post_balance: min_balance,
+                        },
+                        &rent,
+                    );
+                }
             }
         }
 
-        // If payer account has no balance, expected AccountNotFound Error
+        // If payer account has no balance, expected AccountNotFound error
         // regardless feature gate status, or if payer is nonce account.
         {
-            for is_nonce in [true, false] {
-                validate_fee_payer_account(
-                    ValidateFeePayerTestParameter {
-                        is_nonce,
-                        payer_init_balance: 0,
-                        fee,
-                        expected_result: Err(TransactionError::AccountNotFound),
-                        payer_post_balance: 0,
-                    },
-                    &rent,
-                );
+            for relax_post_exec_min_balance_check in [false, true] {
+                for is_nonce in [true, false] {
+                    validate_fee_payer_account(
+                        ValidateFeePayerTestParameter {
+                            is_nonce,
+                            payer_init_balance: 0,
+                            fee,
+                            relax_post_exec_min_balance_check,
+                            expected_result: Err(TransactionError::AccountNotFound),
+                            payer_post_balance: 0,
+                        },
+                        &rent,
+                    );
+                }
             }
         }
 
         // If payer account has insufficient balance, expect InsufficientFundsForFee error
         // regardless feature gate status, or if payer is nonce account.
         {
-            for (is_nonce, min_balance) in [(true, min_balance), (false, 0)] {
+            for relax_post_exec_min_balance_check in [false, true] {
+                for (is_nonce, min_balance) in [(true, min_balance), (false, 0)] {
+                    validate_fee_payer_account(
+                        ValidateFeePayerTestParameter {
+                            is_nonce,
+                            payer_init_balance: min_balance + fee - 1,
+                            fee,
+                            relax_post_exec_min_balance_check,
+                            expected_result: Err(TransactionError::InsufficientFundsForFee),
+                            payer_post_balance: min_balance + fee - 1,
+                        },
+                        &rent,
+                    );
+                }
+            }
+        }
+
+        // normal payer account has balance of u64::MAX, so does fee; since it does not require
+        // min_balance, expect successful fee deduction, regardless of feature gate status
+        {
+            for relax_post_exec_min_balance_check in [false, true] {
                 validate_fee_payer_account(
                     ValidateFeePayerTestParameter {
-                        is_nonce,
-                        payer_init_balance: min_balance + fee - 1,
-                        fee,
-                        expected_result: Err(TransactionError::InsufficientFundsForFee),
-                        payer_post_balance: min_balance + fee - 1,
+                        is_nonce: false,
+                        payer_init_balance: u64::MAX,
+                        fee: u64::MAX,
+                        relax_post_exec_min_balance_check,
+                        expected_result: Ok(()),
+                        payer_post_balance: 0,
                     },
                     &rent,
                 );
             }
-        }
-
-        // normal payer account has balance of u64::MAX, so does fee; since it does not  require
-        // min_balance, expect successful fee deduction, regardless of feature gate status
-        {
-            validate_fee_payer_account(
-                ValidateFeePayerTestParameter {
-                    is_nonce: false,
-                    payer_init_balance: u64::MAX,
-                    fee: u64::MAX,
-                    expected_result: Ok(()),
-                    payer_post_balance: 0,
-                },
-                &rent,
-            );
         }
     }
 
@@ -1280,6 +1284,7 @@ mod tests {
                 is_nonce: true,
                 payer_init_balance: u64::MAX,
                 fee: u64::MAX,
+                relax_post_exec_min_balance_check: true,
                 expected_result: Err(TransactionError::InsufficientFundsForFee),
                 payer_post_balance: u64::MAX,
             },

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -102,8 +102,9 @@ pub fn check_static_account_rent_state_transition(
     post_exec_balance: u64,
     data_size: usize,
     rent: &Rent,
+    account_index: IndexOfAccount,
     relax_post_exec_min_balance_check: bool,
-) -> bool {
+) -> TransactionResult<()> {
     let rent_min_balance = rent.minimum_balance(data_size);
     let (pre_state, post_state) = if relax_post_exec_min_balance_check {
         let pre_state = if pre_exec_balance == 0 {
@@ -129,7 +130,13 @@ pub fn check_static_account_rent_state_transition(
             get_account_rent_state(post_exec_balance, data_size, rent_min_balance),
         )
     };
-    transition_allowed(&pre_state, &post_state)
+
+    if !transition_allowed(&pre_state, &post_state) {
+        let account_index = account_index as u8;
+        Err(TransactionError::InsufficientFundsForRent { account_index })
+    } else {
+        Ok(())
+    }
 }
 
 /// Check whether a transition from the pre_rent_state to the

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -78,13 +78,13 @@ pub fn check_rent_state_with_account(
 /// lamports as uninitialized and uses the implemented `get_rent` to
 /// determine whether an account is rent-exempt.
 pub fn get_account_rent_state(
-    rent: &Rent,
     account_lamports: u64,
     account_size: usize,
+    min_balance: u64,
 ) -> RentState {
     if account_lamports == 0 {
         RentState::Uninitialized
-    } else if rent.is_exempt(account_lamports, account_size) {
+    } else if account_lamports >= min_balance {
         RentState::RentExempt
     } else {
         RentState::RentPaying {
@@ -92,6 +92,44 @@ pub fn get_account_rent_state(
             lamports: account_lamports,
         }
     }
+}
+
+/// Check whether a transition from the pre_exec_balance to the
+/// post_exec_balance is valid for an account that hasn't changed owner
+/// or data size.
+pub fn check_static_account_rent_state_transition(
+    pre_exec_balance: u64,
+    post_exec_balance: u64,
+    data_size: usize,
+    rent: &Rent,
+    relax_post_exec_min_balance_check: bool,
+) -> bool {
+    let rent_min_balance = rent.minimum_balance(data_size);
+    let (pre_state, post_state) = if relax_post_exec_min_balance_check {
+        let pre_state = if pre_exec_balance == 0 {
+            RentState::Uninitialized
+        } else {
+            RentState::RentExempt
+        };
+        let post_state = match (post_exec_balance, &pre_state) {
+            (0, _) => RentState::Uninitialized,
+            (post_balance, _) if post_balance >= rent_min_balance => RentState::RentExempt,
+            (post_balance, RentState::RentExempt) if post_balance >= pre_exec_balance => {
+                RentState::RentExempt
+            }
+            (post_balance, _) => RentState::RentPaying {
+                data_size,
+                lamports: post_balance,
+            },
+        };
+        (pre_state, post_state)
+    } else {
+        (
+            get_account_rent_state(pre_exec_balance, data_size, rent_min_balance),
+            get_account_rent_state(post_exec_balance, data_size, rent_min_balance),
+        )
+    };
+    transition_allowed(&pre_state, &post_state)
 }
 
 /// Check whether a transition from the pre_rent_state to the

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -16,7 +16,7 @@ use {
 pub const RENT_EXEMPT_RENT_EPOCH: Epoch = Epoch::MAX;
 
 /// Rent state of a Solana account.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RentState {
     /// account.lamports == 0
     Uninitialized,
@@ -94,7 +94,7 @@ pub fn get_account_rent_state(
     }
 }
 
-/// Check whether a transition from the pre_exec_balance to the
+/// Returns whether a transition from the pre_exec_balance to the
 /// post_exec_balance is valid for an account that hasn't changed owner
 /// or data size.
 pub fn check_static_account_rent_state_transition(

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -25,7 +25,7 @@ impl TransactionAccountStateInfo {
         rent: &Rent,
         relax_post_exec_min_balance_check: bool,
     ) -> Vec<Self> {
-        write_iter_accounts(transaction_context, message)
+        iter_writable_accounts(transaction_context, message)
             .map(|acct_ref| {
                 let info = acct_ref.map(|account| {
                     let balance = account.lamports();
@@ -64,7 +64,7 @@ impl TransactionAccountStateInfo {
     ) -> Vec<Self> {
         debug_assert_eq!(pre_exec_state_infos.len(), message.account_keys().len());
 
-        write_iter_accounts(transaction_context, message)
+        iter_writable_accounts(transaction_context, message)
             .zip(pre_exec_state_infos)
             .map(|(acct_ref, pre_exec_state_info)| {
                 let info = acct_ref.map(|account| {
@@ -148,7 +148,7 @@ pub(crate) struct WritableTransactionAccountStateInfo {
     owner: Pubkey,
 }
 
-fn write_iter_accounts<'a>(
+fn iter_writable_accounts<'a>(
     transaction_context: &'a TransactionContext,
     message: &impl SVMMessage,
 ) -> impl Iterator<Item = Option<solana_transaction_context::transaction_accounts::AccountRef<'a>>>

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -1,10 +1,12 @@
 use {
     crate::rent_calculator::{RentState, check_rent_state, get_account_rent_state},
     solana_account::ReadableAccount,
+    solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction_context::{IndexOfAccount, transaction::TransactionContext},
     solana_transaction_error::TransactionResult as Result,
+    std::cmp::min,
 };
 
 #[derive(PartialEq, Debug)]
@@ -13,91 +15,172 @@ pub(crate) struct TransactionAccountStateInfo {
 }
 
 impl TransactionAccountStateInfo {
-    pub(crate) fn new(
+    pub(crate) fn as_ref(&self) -> Option<&WritableTransactionAccountStateInfo> {
+        self.info.as_ref()
+    }
+
+    pub(crate) fn new_pre_exec(
         transaction_context: &TransactionContext,
         message: &impl SVMMessage,
         rent: &Rent,
+        relax_post_exec_min_balance_check: bool,
     ) -> Vec<Self> {
-        (0..message.account_keys().len())
-            .map(|i| {
-                let info = if message.is_writable(i) {
-                    let state = if let Ok(account) = transaction_context
-                        .accounts()
-                        .try_borrow(i as IndexOfAccount)
-                    {
-                        let balance = account.lamports();
-                        let data_size = account.data().len();
-                        let rent_state = get_account_rent_state(rent, balance, data_size);
-                        Some(WritableTransactionAccountStateInfo {
-                            rent_state,
-                            data_size,
-                        })
+        iter_accounts(transaction_context, message)
+            .map(|acct_ref| {
+                let info = acct_ref.map(|account| {
+                    let balance = account.lamports();
+                    let data_size = account.data().len();
+                    let owner = *account.owner();
+
+                    let rent_state = if relax_post_exec_min_balance_check {
+                        // SIMD-0392 enabled. Assume `RentExempt` is impossible.
+                        if account.lamports() == 0 {
+                            RentState::Uninitialized
+                        } else {
+                            RentState::RentExempt
+                        }
                     } else {
-                        None
+                        get_account_rent_state(balance, data_size, rent.minimum_balance(data_size))
                     };
-                    debug_assert!(
-                        state.is_some(),
-                        "message and transaction context out of sync, fatal"
-                    );
-                    state
-                } else {
-                    None
-                };
+
+                    WritableTransactionAccountStateInfo {
+                        rent_state,
+                        balance,
+                        data_size,
+                        owner,
+                    }
+                });
                 Self { info }
             })
             .collect()
     }
 
-    pub(crate) fn verify_changes(
-        pre_state_infos: &[Self],
-        post_state_infos: &[Self],
+    pub(crate) fn new_post_exec(
         transaction_context: &TransactionContext,
-    ) -> Result<()> {
-        for (i, (pre_state_info, post_state_info)) in
-            pre_state_infos.iter().zip(post_state_infos).enumerate()
-        {
-            if let (Some(pre_state_info), Some(post_state_info)) =
-                (pre_state_info.info.as_ref(), post_state_info.info.as_ref())
-            {
-                check_rent_state(
-                    &pre_state_info.rent_state,
-                    &post_state_info.rent_state,
-                    transaction_context,
-                    i as IndexOfAccount,
-                )?;
-            }
-        }
-        Ok(())
+        message: &impl SVMMessage,
+        pre_exec_state_infos: &[TransactionAccountStateInfo],
+        rent: &Rent,
+        relax_post_exec_min_balance_check: bool,
+    ) -> Vec<Self> {
+        debug_assert_eq!(pre_exec_state_infos.len(), message.account_keys().len());
+
+        iter_accounts(transaction_context, message)
+            .zip(pre_exec_state_infos)
+            .map(|(acct_ref, pre_exec_state_info)| {
+                let info = acct_ref.map(|account| {
+                    // the same account MUST be present and marked writable in both pre and post exec
+                    debug_assert!(
+                        pre_exec_state_info.info.is_some(),
+                        "message and pre-exec state out of sync, fatal"
+                    );
+
+                    let balance = account.lamports();
+                    let data_size = account.data().len();
+                    let mut min_balance = rent.minimum_balance(data_size);
+
+                    if relax_post_exec_min_balance_check {
+                        // SIMD-0392 enabled.
+                        // Adjust min_balance according to SIMD-0392.
+                        if let Some(pre_exec_info) = pre_exec_state_info.as_ref() {
+                            // if the account size increased, account was created in this transaction,
+                            // or the owner of the account changed, do standard rent exempt check
+                            // otherwise, pre-exec balance can also be used as the minimum balance
+                            if pre_exec_info.rent_state != RentState::Uninitialized
+                                && data_size <= pre_exec_info.data_size
+                                && account.owner() == &pre_exec_info.owner
+                            {
+                                min_balance = min(pre_exec_info.balance, min_balance);
+                            }
+                        }
+                    }
+
+                    // Post-exec owner is currently not consumed by any caller.
+                    WritableTransactionAccountStateInfo {
+                        rent_state: get_account_rent_state(balance, data_size, min_balance),
+                        balance,
+                        data_size,
+                        owner: Pubkey::default(), // pubkey isn't needed for post-exec
+                    }
+                });
+                Self { info }
+            })
+            .collect()
     }
 }
 
-#[derive(PartialEq, Debug)]
-struct WritableTransactionAccountStateInfo {
-    rent_state: RentState,
-    data_size: usize,
+pub(crate) fn verify_changes(
+    pre_state_infos: &[TransactionAccountStateInfo],
+    post_state_infos: &[TransactionAccountStateInfo],
+    transaction_context: &TransactionContext,
+) -> Result<()> {
+    for (i, (pre_state_info, post_state_info)) in
+        pre_state_infos.iter().zip(post_state_infos).enumerate()
+    {
+        if let (Some(pre_state_info), Some(post_state_info)) =
+            (pre_state_info.as_ref(), post_state_info.as_ref())
+        {
+            check_rent_state(
+                &pre_state_info.rent_state,
+                &post_state_info.rent_state,
+                transaction_context,
+                i as IndexOfAccount,
+            )?;
+        }
+    }
+    Ok(())
 }
 
 // Returns the cumulative size of all post-exec uninitialized accounts
 pub(crate) fn get_uninitialized_accounts_size(post: &[TransactionAccountStateInfo]) -> u64 {
     post.iter()
-        .filter_map(|post_info| post_info.info.as_ref())
+        .filter_map(TransactionAccountStateInfo::as_ref)
         .filter_map(|post| {
             matches!(&post.rent_state, RentState::Uninitialized).then_some(post.data_size as u64)
         })
         .sum()
 }
 
+#[derive(PartialEq, Debug)]
+pub(crate) struct WritableTransactionAccountStateInfo {
+    rent_state: RentState,
+    balance: u64,
+    data_size: usize,
+    owner: Pubkey,
+}
+
+fn iter_accounts<'a>(
+    transaction_context: &'a TransactionContext,
+    message: &impl SVMMessage,
+) -> impl Iterator<Item = Option<solana_transaction_context::transaction_accounts::AccountRef<'a>>>
+{
+    (0..message.account_keys().len()).map(|i| {
+        if message.is_writable(i) {
+            let account = transaction_context
+                .accounts()
+                .try_borrow(i as IndexOfAccount);
+            debug_assert!(
+                account.is_ok(),
+                "message and transaction context out of sync, fatal"
+            );
+            account.ok()
+        } else {
+            None
+        }
+    })
+}
+
 #[cfg(test)]
 mod test {
     use {
         super::*,
-        solana_account::AccountSharedData,
+        solana_account::{AccountSharedData, WritableAccount},
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_message::{
             LegacyMessage, Message, MessageHeader, SanitizedMessage,
             compiled_instruction::CompiledInstruction,
         },
+        solana_pubkey::Pubkey,
         solana_rent::Rent,
         solana_signer::Signer,
         solana_transaction_context::transaction::TransactionContext,
@@ -105,16 +188,10 @@ mod test {
         std::collections::HashSet,
     };
 
-    #[test]
-    fn test_new() {
-        let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
-
+    // Helpers to reduce duplication in tests
+    fn sanitized_msg_for(key1: Pubkey, key2: Pubkey, key4: Pubkey) -> SanitizedMessage {
         let message = Message {
-            account_keys: vec![key2.pubkey(), key1.pubkey(), key4.pubkey()],
+            account_keys: vec![key2, key1, key4],
             header: MessageHeader::default(),
             instructions: vec![
                 CompiledInstruction {
@@ -130,35 +207,103 @@ mod test {
             ],
             recent_blockhash: Hash::default(),
         };
+        SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))
+    }
 
-        let sanitized_message =
-            SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()));
+    fn accounts_key2_first(
+        key1: Pubkey,
+        key2: Pubkey,
+        key3: Pubkey,
+        acc2: AccountSharedData,
+    ) -> Vec<(Pubkey, AccountSharedData)> {
+        vec![
+            (key2, acc2),
+            (key1, AccountSharedData::default()),
+            (key3, AccountSharedData::default()),
+        ]
+    }
+
+    fn ctx_from(accounts: Vec<(Pubkey, AccountSharedData)>, rent: &Rent) -> TransactionContext<'_> {
+        TransactionContext::new(accounts, rent.clone(), 20, 20, 1)
+    }
+
+    fn state_info(
+        rent_state: RentState,
+        balance: u64,
+        data_size: usize,
+        owner: Pubkey,
+    ) -> TransactionAccountStateInfo {
+        TransactionAccountStateInfo {
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state,
+                balance,
+                data_size,
+                owner,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_pre_exec_basics() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
 
         let transaction_accounts = vec![
             (key1.pubkey(), AccountSharedData::default()),
             (key2.pubkey(), AccountSharedData::default()),
             (key3.pubkey(), AccountSharedData::default()),
         ];
+        let default_owner = Pubkey::default();
 
         let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 1);
-        let result = TransactionAccountStateInfo::new(&context, &sanitized_message, &rent);
+        let result =
+            TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, true);
         assert_eq!(
             result,
             vec![
-                TransactionAccountStateInfo {
-                    info: Some(WritableTransactionAccountStateInfo {
-                        rent_state: RentState::Uninitialized,
-                        data_size: 0,
-                    })
-                },
+                state_info(RentState::Uninitialized, 0, 0, default_owner),
                 TransactionAccountStateInfo { info: None },
-                TransactionAccountStateInfo {
-                    info: Some(WritableTransactionAccountStateInfo {
-                        rent_state: RentState::Uninitialized,
-                        data_size: 0,
-                    })
-                }
+                state_info(RentState::Uninitialized, 0, 0, default_owner),
             ]
+        );
+
+        // no post-exec in this test
+    }
+
+    #[test]
+    fn test_pre_exec_legacy_rent_paying() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let data_len: usize = 64;
+        let min_full = rent.minimum_balance(data_len);
+        let pre_balance = min_full.saturating_sub(1);
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let tx_accounts = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+        );
+        let context = ctx_from(tx_accounts, &rent);
+        let pre =
+            TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, false);
+
+        assert_eq!(
+            pre[0].info.as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentPaying {
+                data_size: data_len,
+                lamports: pre_balance
+            })
         );
     }
 
@@ -199,33 +344,325 @@ mod test {
         ];
 
         let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 1);
-        let _result = TransactionAccountStateInfo::new(&context, &sanitized_message, &rent);
+        let _result =
+            TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, true);
+    }
+
+    #[test]
+    fn test_post_exec_unchanged_size_allows_pre_balance() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let data_len: usize = 64;
+        let min_full = rent.minimum_balance(data_len);
+        let pre_balance = min_full.saturating_sub(5); // less than full rent-exempt, but > 0
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let tx_accounts = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+        );
+        let context = ctx_from(tx_accounts, &rent);
+        let pre =
+            TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, true);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context,
+            &sanitized_message,
+            &pre,
+            &rent,
+            true,
+        );
+
+        // account index 0 in message is key2; expect RentExempt due to grace
+        assert_eq!(
+            post[0].as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentExempt)
+        );
+    }
+
+    #[test]
+    fn test_post_exec_legacy_ignores_pre_balance() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let data_len: usize = 64;
+        let min_full = rent.minimum_balance(data_len);
+        let pre_balance = min_full.saturating_sub(5);
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let tx_accounts = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+        );
+        let context = ctx_from(tx_accounts, &rent);
+        let pre =
+            TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, false);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context,
+            &sanitized_message,
+            &pre,
+            &rent,
+            false,
+        );
+
+        assert_eq!(
+            post[0].as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentPaying {
+                data_size: data_len,
+                lamports: pre_balance
+            })
+        );
+        assert!(post[1].as_ref().is_none());
+    }
+
+    #[test]
+    fn test_post_exec_unchanged_size_violation() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let data_len: usize = 64;
+        let min_full = rent.minimum_balance(data_len);
+        let pre_balance = min_full.saturating_sub(5);
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let mut tx_accounts = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+        );
+        let context_pre = TransactionContext::new(tx_accounts.clone(), rent.clone(), 20, 20, 1);
+        let pre = TransactionAccountStateInfo::new_pre_exec(
+            &context_pre,
+            &sanitized_message,
+            &rent,
+            true,
+        );
+
+        // post: drop balance by 1 (below minimum balance)
+        let post_balance = pre_balance.saturating_sub(1);
+        tx_accounts[0].1.set_lamports(post_balance);
+
+        let context_post = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 1);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context_post,
+            &sanitized_message,
+            &pre,
+            &rent,
+            true,
+        );
+
+        assert_eq!(
+            post[0].as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentPaying {
+                data_size: data_len,
+                lamports: post_balance
+            })
+        );
+
+        // verify_changes should flag InsufficientFundsForRent
+        let res = verify_changes(&pre, &post, &context_post);
+        assert_eq!(
+            res.err(),
+            Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
+        );
+    }
+
+    #[test]
+    fn test_post_exec_size_changed_requires_full_min() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let pre_len: usize = 32;
+        let post_len: usize = 256; // larger size => larger full min
+        let pre_min = rent.minimum_balance(pre_len);
+        let pre_balance = pre_min.saturating_sub(1);
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+
+        let tx_accounts_pre = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
+        );
+        let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 1);
+        let pre = TransactionAccountStateInfo::new_pre_exec(
+            &context_pre,
+            &sanitized_message,
+            &rent,
+            true,
+        );
+
+        // post: size increased; balance unchanged => should require full min for new size
+        let tx_accounts_post = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
+        );
+        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 1);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context_post,
+            &sanitized_message,
+            &pre,
+            &rent,
+            true,
+        );
+
+        assert_eq!(
+            post[0].as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentPaying {
+                data_size: post_len,
+                lamports: pre_balance
+            })
+        );
+        let res = verify_changes(&pre, &post, &context_post);
+        assert_eq!(
+            res.err(),
+            Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
+        );
+    }
+
+    #[test]
+    fn test_post_exec_size_shrunk_does_not_require_balance_adjustment() {
+        let pre_rent = Rent::default();
+        let post_rent = Rent {
+            lamports_per_byte: pre_rent.lamports_per_byte * 9,
+            ..Rent::default()
+        };
+
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let pre_len: usize = 256;
+        let post_len: usize = pre_len / 8; // smaller size, but rent increased after creation
+        let pre_balance = pre_rent.minimum_balance(pre_len);
+        let post_min = post_rent.minimum_balance(post_len);
+        assert!(post_min > pre_balance);
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+
+        let tx_accounts_pre = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
+        );
+        let context_pre = TransactionContext::new(tx_accounts_pre, pre_rent.clone(), 20, 20, 1);
+        let pre = TransactionAccountStateInfo::new_pre_exec(
+            &context_pre,
+            &sanitized_message,
+            &pre_rent,
+            true,
+        );
+
+        // post: size decreased; rent increased => should still not require top-up
+        let tx_accounts_post = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
+        );
+        let context_post = TransactionContext::new(tx_accounts_post, post_rent.clone(), 20, 20, 1);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context_post,
+            &sanitized_message,
+            &pre,
+            &post_rent,
+            true,
+        );
+
+        assert_eq!(post[0].as_ref().unwrap().rent_state, RentState::RentExempt);
+        let res = verify_changes(&pre, &post, &context_post);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_post_exec_owner_changed_requires_full_min() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+        let owner_pre = Keypair::new();
+        let owner_post = Keypair::new();
+
+        let data_len: usize = 64;
+        let min_full = rent.minimum_balance(data_len);
+        let pre_balance = min_full.saturating_sub(5);
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+
+        let tx_accounts_pre = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, data_len, &owner_pre.pubkey()),
+        );
+        let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 1);
+        let pre = TransactionAccountStateInfo::new_pre_exec(
+            &context_pre,
+            &sanitized_message,
+            &rent,
+            true,
+        );
+
+        // post: owner changed; balance/size unchanged => should require full min
+        let tx_accounts_post = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, data_len, &owner_post.pubkey()),
+        );
+        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 1);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context_post,
+            &sanitized_message,
+            &pre,
+            &rent,
+            true,
+        );
+
+        assert_eq!(
+            post[0].as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentPaying {
+                data_size: data_len,
+                lamports: pre_balance
+            })
+        );
+        let res = verify_changes(&pre, &post, &context_post);
+        assert_eq!(
+            res.err(),
+            Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
+        );
     }
 
     #[test]
     fn test_verify_changes() {
         let key1 = Keypair::new();
         let key2 = Keypair::new();
-        let pre_rent_state = vec![
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::Uninitialized,
-                    data_size: 0,
-                }),
-            },
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::Uninitialized,
-                    data_size: 0,
-                }),
-            },
-        ];
-        let post_rent_state = vec![TransactionAccountStateInfo {
-            info: Some(WritableTransactionAccountStateInfo {
-                rent_state: RentState::Uninitialized,
-                data_size: 0,
-            }),
-        }];
+        let owner = Pubkey::default();
+        let pre_state_infos = vec![state_info(RentState::Uninitialized, 0, 0, owner)];
+        let post_rent_states = vec![state_info(RentState::Uninitialized, 0, 0, owner)];
 
         let transaction_accounts = vec![
             (key1.pubkey(), AccountSharedData::default()),
@@ -234,28 +671,19 @@ mod test {
 
         let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 1);
 
-        let result = TransactionAccountStateInfo::verify_changes(
-            &pre_rent_state,
-            &post_rent_state,
-            &context,
-        );
+        let result = verify_changes(&pre_state_infos, &post_rent_states, &context);
         assert!(result.is_ok());
 
-        let pre_rent_state = vec![TransactionAccountStateInfo {
-            info: Some(WritableTransactionAccountStateInfo {
-                rent_state: RentState::Uninitialized,
-                data_size: 0,
-            }),
-        }];
-        let post_rent_state = vec![TransactionAccountStateInfo {
-            info: Some(WritableTransactionAccountStateInfo {
-                rent_state: RentState::RentPaying {
-                    data_size: 2,
-                    lamports: 5,
-                },
+        let pre_state_infos = vec![state_info(RentState::Uninitialized, 0, 0, owner)];
+        let post_rent_states = vec![state_info(
+            RentState::RentPaying {
                 data_size: 2,
-            }),
-        }];
+                lamports: 5,
+            },
+            0,
+            0,
+            owner,
+        )];
 
         let transaction_accounts = vec![
             (key1.pubkey(), AccountSharedData::default()),
@@ -263,11 +691,7 @@ mod test {
         ];
 
         let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 1);
-        let result = TransactionAccountStateInfo::verify_changes(
-            &pre_rent_state,
-            &post_rent_state,
-            &context,
-        );
+        let result = verify_changes(&pre_state_infos, &post_rent_states, &context);
         assert_eq!(
             result.err(),
             Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
@@ -276,31 +700,13 @@ mod test {
 
     #[test]
     fn test_get_uninitialized_accounts_size_with_deleted_accounts() {
+        let owner1 = Pubkey::new_unique();
+        let owner2 = Pubkey::new_unique();
+        let owner3 = Pubkey::new_unique();
         let post_state_infos = vec![
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::Uninitialized,
-                    data_size: 50,
-                }),
-            },
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::Uninitialized,
-                    data_size: 50,
-                }),
-            },
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::Uninitialized,
-                    data_size: 50,
-                }),
-            },
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::RentExempt,
-                    data_size: 50,
-                }),
-            },
+            state_info(RentState::Uninitialized, 0, 50, owner1),
+            state_info(RentState::Uninitialized, 0, 50, owner2),
+            state_info(RentState::Uninitialized, 0, 50, owner3),
         ];
 
         // 3 deleted accounts should contribute 3 * (50) = 150 to the count

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -9,7 +9,7 @@ use {
     std::cmp::min,
 };
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub(crate) struct TransactionAccountStateInfo {
     info: Option<WritableTransactionAccountStateInfo>, // None: readonly account
 }
@@ -25,7 +25,7 @@ impl TransactionAccountStateInfo {
         rent: &Rent,
         relax_post_exec_min_balance_check: bool,
     ) -> Vec<Self> {
-        iter_accounts(transaction_context, message)
+        write_iter_accounts(transaction_context, message)
             .map(|acct_ref| {
                 let info = acct_ref.map(|account| {
                     let balance = account.lamports();
@@ -33,7 +33,7 @@ impl TransactionAccountStateInfo {
                     let owner = *account.owner();
 
                     let rent_state = if relax_post_exec_min_balance_check {
-                        // SIMD-0392 enabled. Assume `RentExempt` is impossible.
+                        // SIMD-0392 enabled. Assume `RentPaying` is impossible.
                         if account.lamports() == 0 {
                             RentState::Uninitialized
                         } else {
@@ -64,7 +64,7 @@ impl TransactionAccountStateInfo {
     ) -> Vec<Self> {
         debug_assert_eq!(pre_exec_state_infos.len(), message.account_keys().len());
 
-        iter_accounts(transaction_context, message)
+        write_iter_accounts(transaction_context, message)
             .zip(pre_exec_state_infos)
             .map(|(acct_ref, pre_exec_state_info)| {
                 let info = acct_ref.map(|account| {
@@ -99,7 +99,7 @@ impl TransactionAccountStateInfo {
                         rent_state: get_account_rent_state(balance, data_size, min_balance),
                         balance,
                         data_size,
-                        owner: Pubkey::default(), // pubkey isn't needed for post-exec
+                        owner: *account.owner(),
                     }
                 });
                 Self { info }
@@ -140,7 +140,7 @@ pub(crate) fn get_uninitialized_accounts_size(post: &[TransactionAccountStateInf
         .sum()
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub(crate) struct WritableTransactionAccountStateInfo {
     rent_state: RentState,
     balance: u64,
@@ -148,7 +148,7 @@ pub(crate) struct WritableTransactionAccountStateInfo {
     owner: Pubkey,
 }
 
-fn iter_accounts<'a>(
+fn write_iter_accounts<'a>(
     transaction_context: &'a TransactionContext,
     message: &impl SVMMessage,
 ) -> impl Iterator<Item = Option<solana_transaction_context::transaction_accounts::AccountRef<'a>>>
@@ -189,9 +189,13 @@ mod test {
     };
 
     // Helpers to reduce duplication in tests
-    fn sanitized_msg_for(key1: Pubkey, key2: Pubkey, key4: Pubkey) -> SanitizedMessage {
+    fn sanitized_msg_for(
+        program_key: Pubkey,
+        writable_key: Pubkey,
+        other_writable_key: Pubkey,
+    ) -> SanitizedMessage {
         let message = Message {
-            account_keys: vec![key2, key1, key4],
+            account_keys: vec![writable_key, program_key, other_writable_key],
             header: MessageHeader::default(),
             instructions: vec![
                 CompiledInstruction {
@@ -210,65 +214,46 @@ mod test {
         SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))
     }
 
-    fn accounts_key2_first(
-        key1: Pubkey,
-        key2: Pubkey,
-        key3: Pubkey,
-        acc2: AccountSharedData,
-    ) -> Vec<(Pubkey, AccountSharedData)> {
-        vec![
-            (key2, acc2),
-            (key1, AccountSharedData::default()),
-            (key3, AccountSharedData::default()),
-        ]
-    }
-
-    fn ctx_from(accounts: Vec<(Pubkey, AccountSharedData)>, rent: &Rent) -> TransactionContext<'_> {
-        TransactionContext::new(accounts, rent.clone(), 20, 20, 1)
-    }
-
-    fn state_info(
-        rent_state: RentState,
-        balance: u64,
-        data_size: usize,
-        owner: Pubkey,
-    ) -> TransactionAccountStateInfo {
-        TransactionAccountStateInfo {
-            info: Some(WritableTransactionAccountStateInfo {
-                rent_state,
-                balance,
-                data_size,
-                owner,
-            }),
-        }
-    }
-
     #[test]
     fn test_pre_exec_basics() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
 
         let transaction_accounts = vec![
-            (key1.pubkey(), AccountSharedData::default()),
-            (key2.pubkey(), AccountSharedData::default()),
-            (key3.pubkey(), AccountSharedData::default()),
+            (account.pubkey(), AccountSharedData::default()),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
         ];
         let default_owner = Pubkey::default();
 
-        let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 1);
+        let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 2);
         let result =
             TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, true);
         assert_eq!(
             result,
             vec![
-                state_info(RentState::Uninitialized, 0, 0, default_owner),
+                TransactionAccountStateInfo {
+                    info: Some(WritableTransactionAccountStateInfo {
+                        rent_state: RentState::Uninitialized,
+                        balance: 0,
+                        data_size: 0,
+                        owner: default_owner,
+                    }),
+                },
                 TransactionAccountStateInfo { info: None },
-                state_info(RentState::Uninitialized, 0, 0, default_owner),
+                TransactionAccountStateInfo {
+                    info: Some(WritableTransactionAccountStateInfo {
+                        rent_state: RentState::Uninitialized,
+                        balance: 0,
+                        data_size: 0,
+                        owner: default_owner,
+                    }),
+                },
             ]
         );
 
@@ -278,23 +263,25 @@ mod test {
     #[test]
     fn test_pre_exec_legacy_rent_paying() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(1);
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
-        let tx_accounts = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
-        );
-        let context = ctx_from(tx_accounts, &rent);
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let tx_accounts = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 2);
         let pre =
             TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, false);
 
@@ -311,13 +298,18 @@ mod test {
     #[should_panic(expected = "message and transaction context out of sync, fatal")]
     fn test_new_panic() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
+        let extra_account = Keypair::new();
 
         let message = Message {
-            account_keys: vec![key2.pubkey(), key1.pubkey(), key4.pubkey(), key3.pubkey()],
+            account_keys: vec![
+                account.pubkey(),
+                program.pubkey(),
+                other_account.pubkey(),
+                extra_account.pubkey(),
+            ],
             header: MessageHeader::default(),
             instructions: vec![
                 CompiledInstruction {
@@ -338,12 +330,12 @@ mod test {
             SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()));
 
         let transaction_accounts = vec![
-            (key1.pubkey(), AccountSharedData::default()),
-            (key2.pubkey(), AccountSharedData::default()),
-            (key3.pubkey(), AccountSharedData::default()),
+            (account.pubkey(), AccountSharedData::default()),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
         ];
 
-        let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 1);
+        let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 2);
         let _result =
             TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, true);
     }
@@ -351,23 +343,25 @@ mod test {
     #[test]
     fn test_post_exec_unchanged_size_allows_pre_balance() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5); // less than full rent-exempt, but > 0
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
-        let tx_accounts = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
-        );
-        let context = ctx_from(tx_accounts, &rent);
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let tx_accounts = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 2);
         let pre =
             TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, true);
         let post = TransactionAccountStateInfo::new_post_exec(
@@ -378,7 +372,6 @@ mod test {
             true,
         );
 
-        // account index 0 in message is key2; expect RentExempt due to grace
         assert_eq!(
             post[0].as_ref().map(|info| &info.rent_state),
             Some(&RentState::RentExempt)
@@ -388,23 +381,25 @@ mod test {
     #[test]
     fn test_post_exec_legacy_ignores_pre_balance() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5);
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
-        let tx_accounts = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
-        );
-        let context = ctx_from(tx_accounts, &rent);
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let tx_accounts = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 2);
         let pre =
             TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, false);
         let post = TransactionAccountStateInfo::new_post_exec(
@@ -428,23 +423,25 @@ mod test {
     #[test]
     fn test_post_exec_unchanged_size_violation() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5);
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
-        let mut tx_accounts = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
-        );
-        let context_pre = TransactionContext::new(tx_accounts.clone(), rent.clone(), 20, 20, 1);
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let mut tx_accounts = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_pre = TransactionContext::new(tx_accounts.clone(), rent.clone(), 20, 20, 2);
         let pre = TransactionAccountStateInfo::new_pre_exec(
             &context_pre,
             &sanitized_message,
@@ -456,7 +453,7 @@ mod test {
         let post_balance = pre_balance.saturating_sub(1);
         tx_accounts[0].1.set_lamports(post_balance);
 
-        let context_post = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 1);
+        let context_post = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 2);
         let post = TransactionAccountStateInfo::new_post_exec(
             &context_post,
             &sanitized_message,
@@ -484,25 +481,27 @@ mod test {
     #[test]
     fn test_post_exec_size_changed_requires_full_min() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
         let pre_len: usize = 32;
         let post_len: usize = 256; // larger size => larger full min
         let pre_min = rent.minimum_balance(pre_len);
         let pre_balance = pre_min.saturating_sub(1);
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
 
-        let tx_accounts_pre = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
-        );
-        let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 1);
+        let tx_accounts_pre = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 2);
         let pre = TransactionAccountStateInfo::new_pre_exec(
             &context_pre,
             &sanitized_message,
@@ -511,13 +510,15 @@ mod test {
         );
 
         // post: size increased; balance unchanged => should require full min for new size
-        let tx_accounts_post = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
-        );
-        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 1);
+        let tx_accounts_post = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 2);
         let post = TransactionAccountStateInfo::new_post_exec(
             &context_post,
             &sanitized_message,
@@ -548,10 +549,9 @@ mod test {
             ..Rent::default()
         };
 
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
         let pre_len: usize = 256;
         let post_len: usize = pre_len / 8; // smaller size, but rent increased after creation
@@ -559,15 +559,18 @@ mod test {
         let post_min = post_rent.minimum_balance(post_len);
         assert!(post_min > pre_balance);
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
 
-        let tx_accounts_pre = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
-        );
-        let context_pre = TransactionContext::new(tx_accounts_pre, pre_rent.clone(), 20, 20, 1);
+        let tx_accounts_pre = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_pre = TransactionContext::new(tx_accounts_pre, pre_rent.clone(), 20, 20, 2);
         let pre = TransactionAccountStateInfo::new_pre_exec(
             &context_pre,
             &sanitized_message,
@@ -576,13 +579,15 @@ mod test {
         );
 
         // post: size decreased; rent increased => should still not require top-up
-        let tx_accounts_post = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
-        );
-        let context_post = TransactionContext::new(tx_accounts_post, post_rent.clone(), 20, 20, 1);
+        let tx_accounts_post = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_post = TransactionContext::new(tx_accounts_post, post_rent.clone(), 20, 20, 2);
         let post = TransactionAccountStateInfo::new_post_exec(
             &context_post,
             &sanitized_message,
@@ -599,10 +604,9 @@ mod test {
     #[test]
     fn test_post_exec_owner_changed_requires_full_min() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
         let owner_pre = Keypair::new();
         let owner_post = Keypair::new();
 
@@ -610,15 +614,18 @@ mod test {
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5);
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
 
-        let tx_accounts_pre = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, data_len, &owner_pre.pubkey()),
-        );
-        let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 1);
+        let tx_accounts_pre = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, data_len, &owner_pre.pubkey()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 2);
         let pre = TransactionAccountStateInfo::new_pre_exec(
             &context_pre,
             &sanitized_message,
@@ -627,13 +634,15 @@ mod test {
         );
 
         // post: owner changed; balance/size unchanged => should require full min
-        let tx_accounts_post = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, data_len, &owner_post.pubkey()),
-        );
-        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 1);
+        let tx_accounts_post = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, data_len, &owner_post.pubkey()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 2);
         let post = TransactionAccountStateInfo::new_post_exec(
             &context_post,
             &sanitized_message,
@@ -658,39 +667,64 @@ mod test {
 
     #[test]
     fn test_verify_changes() {
+        // mostly a sanity check for the plumbing since transitions_allowed enforces
+        // the specific transition rules.
         let key1 = Keypair::new();
         let key2 = Keypair::new();
         let owner = Pubkey::default();
-        let pre_state_infos = vec![state_info(RentState::Uninitialized, 0, 0, owner)];
-        let post_rent_states = vec![state_info(RentState::Uninitialized, 0, 0, owner)];
+        let pre_state_infos = vec![TransactionAccountStateInfo {
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state: RentState::Uninitialized,
+                balance: 0,
+                data_size: 0,
+                owner,
+            }),
+        }];
+        let post_rent_states = vec![TransactionAccountStateInfo {
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state: RentState::Uninitialized,
+                balance: 0,
+                data_size: 0,
+                owner,
+            }),
+        }];
 
         let transaction_accounts = vec![
             (key1.pubkey(), AccountSharedData::default()),
             (key2.pubkey(), AccountSharedData::default()),
         ];
 
-        let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 1);
+        let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 2);
 
         let result = verify_changes(&pre_state_infos, &post_rent_states, &context);
         assert!(result.is_ok());
 
-        let pre_state_infos = vec![state_info(RentState::Uninitialized, 0, 0, owner)];
-        let post_rent_states = vec![state_info(
-            RentState::RentPaying {
-                data_size: 2,
-                lamports: 5,
-            },
-            0,
-            0,
-            owner,
-        )];
+        let pre_state_infos = vec![TransactionAccountStateInfo {
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state: RentState::Uninitialized,
+                balance: 0,
+                data_size: 0,
+                owner,
+            }),
+        }];
+        let post_rent_states = vec![TransactionAccountStateInfo {
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state: RentState::RentPaying {
+                    data_size: 2,
+                    lamports: 5,
+                },
+                balance: 0,
+                data_size: 0,
+                owner,
+            }),
+        }];
 
         let transaction_accounts = vec![
             (key1.pubkey(), AccountSharedData::default()),
             (key2.pubkey(), AccountSharedData::default()),
         ];
 
-        let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 1);
+        let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 2);
         let result = verify_changes(&pre_state_infos, &post_rent_states, &context);
         assert_eq!(
             result.err(),
@@ -700,13 +734,17 @@ mod test {
 
     #[test]
     fn test_get_uninitialized_accounts_size_with_deleted_accounts() {
-        let owner1 = Pubkey::new_unique();
-        let owner2 = Pubkey::new_unique();
-        let owner3 = Pubkey::new_unique();
         let post_state_infos = vec![
-            state_info(RentState::Uninitialized, 0, 50, owner1),
-            state_info(RentState::Uninitialized, 0, 50, owner2),
-            state_info(RentState::Uninitialized, 0, 50, owner3),
+            TransactionAccountStateInfo {
+                info: Some(WritableTransactionAccountStateInfo {
+                    rent_state: RentState::Uninitialized,
+                    balance: 0,
+                    data_size: 50,
+                    owner: Pubkey::new_unique(),
+                }),
+            }
+            .clone();
+            3
         ];
 
         // 3 deleted accounts should contribute 3 * (50) = 150 to the count

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -11,7 +11,7 @@ use {
         program_loader::{get_program_deployment_slot, load_program_with_pubkey},
         rollback_accounts::RollbackAccounts,
         transaction_account_state_info::{
-            TransactionAccountStateInfo, get_uninitialized_accounts_size,
+            TransactionAccountStateInfo, get_uninitialized_accounts_size, verify_changes,
         },
         transaction_balances::{BalanceCollectionRoutines, BalanceCollector},
         transaction_error_metrics::TransactionErrorMetrics,
@@ -963,8 +963,14 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             tx.num_instructions(),
         );
 
-        let pre_account_state_info =
-            TransactionAccountStateInfo::new(&transaction_context, tx, &environment.rent);
+        let relax_post_exec_min_balance_check =
+            environment.feature_set.relax_post_exec_min_balance_check;
+        let pre_account_state_info = TransactionAccountStateInfo::new_pre_exec(
+            &transaction_context,
+            tx,
+            &environment.rent,
+            relax_post_exec_min_balance_check,
+        );
 
         let log_collector = if config.recording_config.enable_log_recording {
             match config.log_messages_bytes_limit {
@@ -1011,10 +1017,15 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         execute_timings.execute_accessories.process_message_us += process_message_time.as_us();
 
         let mut post_account_state_info_result = process_result
-            .and_then(|_| {
-                let post_account_state_info =
-                    TransactionAccountStateInfo::new(&transaction_context, tx, &environment.rent);
-                TransactionAccountStateInfo::verify_changes(
+            .and_then(|_info| {
+                let post_account_state_info = TransactionAccountStateInfo::new_post_exec(
+                    &transaction_context,
+                    tx,
+                    &pre_account_state_info,
+                    &environment.rent,
+                    relax_post_exec_min_balance_check,
+                );
+                verify_changes(
                     &pre_account_state_info,
                     &post_account_state_info,
                     &transaction_context,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -461,6 +461,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         &environment.blockhash,
                         environment.blockhash_lamports_per_signature,
                         &environment.rent,
+                        environment.feature_set.relax_post_exec_min_balance_check,
                         &mut error_metrics,
                     )
                 }));
@@ -664,6 +665,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         environment_blockhash: &Hash,
         next_lamports_per_signature: u64,
         rent: &Rent,
+        relax_post_exec_min_balance_check: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> TransactionResult<ValidatedTransactionDetails> {
         let CheckedTransactionDetails {
@@ -695,6 +697,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             nonce_info,
             compute_budget_and_limits,
             rent,
+            relax_post_exec_min_balance_check,
             error_counters,
         )
     }
@@ -708,6 +711,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         nonce_info: Option<NonceInfo>,
         compute_budget_and_limits: SVMTransactionExecutionAndFeeBudgetLimits,
         rent: &Rent,
+        relax_post_exec_min_balance_check: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> TransactionResult<ValidatedTransactionDetails> {
         let fee_payer_address = message.fee_payer();
@@ -727,12 +731,12 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         let fee_payer_index = 0;
         validate_fee_payer(
-            fee_payer_address,
             &mut loaded_fee_payer.account,
             fee_payer_index,
             error_counters,
             rent,
             compute_budget_and_limits.fee_details.total_fee(),
+            relax_post_exec_min_balance_check,
         )?;
 
         // Capture fee-subtracted fee payer account and next nonce account state
@@ -2219,6 +2223,7 @@ mod tests {
                 &Hash::default(),
                 lamports_per_signature,
                 &rent,
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2270,6 +2275,7 @@ mod tests {
                 &Hash::default(),
                 lamports_per_signature,
                 &Rent::default(),
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2310,6 +2316,7 @@ mod tests {
                 &Hash::default(),
                 lamports_per_signature,
                 &Rent::default(),
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2354,6 +2361,7 @@ mod tests {
                 &Hash::default(),
                 lamports_per_signature,
                 &rent,
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2396,6 +2404,7 @@ mod tests {
                 &Hash::default(),
                 lamports_per_signature,
                 &Rent::default(),
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2582,6 +2591,7 @@ mod tests {
                 &environment_blockhash,
                 lamports_per_signature,
                 &rent,
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2642,6 +2652,7 @@ mod tests {
                 &environment_blockhash,
                 lamports_per_signature,
                 &rent,
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2690,6 +2701,7 @@ mod tests {
             &Hash::default(),
             lamports_per_signature,
             &Rent::default(),
+            mock_bank.feature_set.relax_post_exec_min_balance_check,
             &mut TransactionErrorMetrics::default(),
         )
         .unwrap();

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -2368,6 +2368,196 @@ fn simd83_account_reallocate() -> Vec<SvmTestEntry> {
     test_entries
 }
 
+fn simd0392_balance_checks() -> Vec<SvmTestEntry> {
+    let mut test_entries = vec![];
+
+    let program_name = "write-to-account";
+    let program_id = program_address(program_name);
+
+    let base_rent = Rent::default();
+    let bumped_rent = Rent {
+        lamports_per_byte: base_rent.lamports_per_byte.saturating_mul(4),
+        ..base_rent
+    };
+
+    let target_size = 8usize;
+    let old_min_balance = base_rent.minimum_balance(target_size);
+    let new_min_balance = bumped_rent.minimum_balance(target_size);
+    assert!(new_min_balance > old_min_balance + LAMPORTS_PER_SIGNATURE);
+
+    let mk_program_account = |lamports, size| {
+        AccountSharedData::create_from_existing_shared_data(
+            lamports,
+            Arc::new(vec![0; size]),
+            program_id,
+            false,
+            u64::MAX,
+        )
+    };
+
+    let mk_system_account = |lamports, size| {
+        AccountSharedData::create_from_existing_shared_data(
+            lamports,
+            Arc::new(vec![0; size]),
+            system_program::id(),
+            false,
+            u64::MAX,
+        )
+    };
+
+    // write-only should succeed below updated rent minimum
+    {
+        let mut test_entry = SvmTestEntry::default();
+        test_entry.set_rent_params(bumped_rent.clone());
+        test_entry.add_initial_program(program_name);
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        fee_payer_data.set_rent_epoch(u64::MAX);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let target = Pubkey::new_unique();
+        let target_data = mk_program_account(old_min_balance, target_size);
+        test_entry.add_initial_account(target, &target_data);
+
+        let set_data_transaction = WriteProgramInstruction::Set.create_transaction(
+            program_id,
+            &fee_payer_keypair,
+            target,
+            None,
+        );
+        test_entry.push_transaction(set_data_transaction);
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        let mut expected_target = target_data;
+        expected_target.data_as_mut_slice()[0] = 100;
+        test_entry.update_expected_account_data(target, &expected_target);
+
+        test_entries.push(test_entry);
+    }
+
+    // realloc to a smaller size should succeed below updated rent minimum
+    {
+        let mut test_entry = SvmTestEntry::default();
+        test_entry.set_rent_params(bumped_rent.clone());
+        test_entry.add_initial_program(program_name);
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        fee_payer_data.set_rent_epoch(u64::MAX);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let target = Pubkey::new_unique();
+        let target_data = mk_program_account(old_min_balance, target_size);
+        test_entry.add_initial_account(target, &target_data);
+
+        let new_target_size = target_size - 1;
+        let realloc_transaction = WriteProgramInstruction::Realloc(new_target_size)
+            .create_transaction(program_id, &fee_payer_keypair, target, None);
+        test_entry.push_transaction(realloc_transaction);
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        let expected_target = mk_program_account(old_min_balance, new_target_size);
+        test_entry.update_expected_account_data(target, &expected_target);
+
+        test_entries.push(test_entry);
+    }
+
+    // realloc to a larger size should fail below updated rent minimum
+    {
+        let mut test_entry = SvmTestEntry::default();
+        test_entry.set_rent_params(bumped_rent.clone());
+        test_entry.add_initial_program(program_name);
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        fee_payer_data.set_rent_epoch(u64::MAX);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let target = Pubkey::new_unique();
+        let target_data = mk_program_account(old_min_balance, target_size);
+        test_entry.add_initial_account(target, &target_data);
+
+        let new_target_size = target_size + 1;
+        let realloc_transaction = WriteProgramInstruction::Realloc(new_target_size)
+            .create_transaction(program_id, &fee_payer_keypair, target, None);
+        test_entry
+            .push_transaction_with_status(realloc_transaction, ExecutionStatus::ExecutedFailed);
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        test_entries.push(test_entry);
+    }
+
+    // owner change should fail below updated rent minimum
+    {
+        let mut test_entry = SvmTestEntry::default();
+        test_entry.set_rent_params(bumped_rent.clone());
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        fee_payer_data.set_rent_epoch(u64::MAX);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let target_keypair = Keypair::new();
+        let target = target_keypair.pubkey();
+        let target_data = mk_system_account(old_min_balance, target_size);
+        test_entry.add_initial_account(target, &target_data);
+
+        let new_owner = Pubkey::new_unique();
+        let transaction = Transaction::new_signed_with_payer(
+            &[system_instruction::assign(&target, &new_owner)],
+            Some(&fee_payer),
+            &[&fee_payer_keypair, &target_keypair],
+            Hash::default(),
+        );
+        test_entry.push_transaction_with_status(transaction, ExecutionStatus::ExecutedFailed);
+
+        test_entry.decrease_expected_lamports(&fee_payer, 2 * LAMPORTS_PER_SIGNATURE);
+
+        test_entries.push(test_entry);
+    }
+
+    // fee payer drops below updated rent minimum, should fail
+    {
+        let mut test_entry = SvmTestEntry::default();
+        test_entry.set_rent_params(bumped_rent.clone());
+        test_entry.add_initial_program(program_name);
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+        let fee_payer_data =
+            mk_system_account(old_min_balance + LAMPORTS_PER_SIGNATURE, target_size);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let target = Pubkey::new_unique();
+        let target_data = mk_program_account(old_min_balance, target_size);
+        test_entry.add_initial_account(target, &target_data);
+
+        let set_data_transaction = WriteProgramInstruction::Set.create_transaction(
+            program_id,
+            &fee_payer_keypair,
+            target,
+            None,
+        );
+        test_entry.push_transaction_with_status(set_data_transaction, ExecutionStatus::Discarded);
+
+        test_entries.push(test_entry);
+    }
+
+    test_entries
+}
+
 enum AbortReason {
     None,
     Unprocessable,
@@ -2549,6 +2739,7 @@ fn drop_on_failure_batch(statuses: &[bool]) -> Vec<SvmTestEntry> {
 #[test_case(simd83_account_deallocate())]
 #[test_case(simd83_fee_payer_deallocate())]
 #[test_case(simd83_account_reallocate())]
+#[test_case(simd0392_balance_checks())]
 #[test_case(all_or_nothing(AbortReason::None))]
 #[test_case(all_or_nothing(AbortReason::Unprocessable))]
 #[test_case(all_or_nothing(AbortReason::DropOnFailure))]


### PR DESCRIPTION
Implementation of the proposal described in [SIMD-0392](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0392-rent-increase-adaptations.md). 

#### Summary of Changes

- ~~SIMD-0392 assumes all existing accounts are rent-exempt pre-execution, so the `RentState::RentPaying` state is ignored in several places (most notably in `new_pre_exec` and `validate_fee_payer`). IOW the expectation is that no rent paying accounts exist currently and none can be created, which I believe is already true on mainnet.~~
  - ~~many tests using rent paying accounts and expecting those semantics needed to be modified. A few that specifically tested the processing of rent paying accounts were removed as they should no longer be necessary.~~
  - Moved these changes into a separate [PR](https://github.com/anza-xyz/agave/pull/9438) and rebased this branch onto it.
- Feature gating in `execute_loaded_transaction` to introduce new post-exec balance checking logic. When the feature is activated, any state transitions containing a `RentPaying` rent state (either pre or post exec) will be explicitly disallowed (rather than implicitly, which is the case now).
- The post-exec minimum balance requirement is `min(rent_exempt_minimum(acc), acc.pre_exec_balance)` if the account wasn't allocated or reallocated during execution. Otherwise, the account is subject to the current rent exempt minimum as before (see SIMD for more details). This allows for rent increases without making existing accounts `RentPaying`.
- merged the rent adjusted delegation changes from https://github.com/igor56D/agave/pull/1 into this branch.

#### TODO
- ~~feature gate keypair generation~~