### PR TITLE
perf(ledger): use boxed slice instead of Vec for BitVec

### DIFF
--- a/ledger/src/bit_vec.rs
+++ b/ledger/src/bit_vec.rs
@@ -28,13 +28,13 @@ const BITS_PER_WORD: usize = std::mem::size_of::<Word>() * 8;
 #[serde(transparent)]
 pub struct BitVec<const NUM_BITS: usize> {
     #[serde(with = "serde_bytes")]
-    words: Vec<Word>,
+    words: Box<[Word]>,
 }
 
 impl<const NUM_BITS: usize> Default for BitVec<NUM_BITS> {
     fn default() -> Self {
         Self {
-            words: vec![0; Self::NUM_WORDS],
+            words: vec![0; Self::NUM_WORDS].into_boxed_slice(),
         }
     }
 }
@@ -58,7 +58,9 @@ impl<'de, const NUM_BITS: usize> Deserialize<'de> for BitVec<NUM_BITS> {
         words.extend_from_slice(bytes);
         words.resize(Self::NUM_WORDS, 0);
 
-        Ok(Self { words })
+        Ok(Self {
+            words: words.into_boxed_slice(),
+        })
     }
 }
 


### PR DESCRIPTION
#### Problem
Since `BitVec` is not resizable, we don't need it to be backed by `Vec` and save on any extra data or checks in `Vec` while we could operate on slices.

#### Summary of Changes
Use `Box<[Word]>` for `BitVec`.
