### PR TITLE
xtask: introduce buildkite-pipeline generator

### DIFF
--- a/ci/xtask/Cargo.lock
+++ b/ci/xtask/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +96,35 @@ dependencies = [
  "predicates-tree",
  "wait-timeout",
 ]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -98,6 +142,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -138,10 +188,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -190,6 +264,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +324,23 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
@@ -272,6 +388,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +445,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,11 +479,29 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -345,6 +542,244 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +803,16 @@ checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -407,6 +852,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +887,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -451,6 +927,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "octocrab"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0860f9250b6db66c5a4b46e00b381f063c58ad06a90f95f9ef701dd8679bb2c6"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "either",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonwebtoken",
+ "once_cell",
+ "percent-encoding",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "snafu",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "url",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +1012,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "parking_lot"
@@ -483,6 +1040,42 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -511,6 +1104,21 @@ checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
@@ -612,6 +1220,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +1245,65 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.23.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -643,6 +1324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +1343,38 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -708,12 +1430,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -743,12 +1488,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -764,6 +1527,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,10 +1558,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -791,13 +1587,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -808,6 +1621,39 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "test-case-core",
+]
 
 [[package]]
 name = "thiserror"
@@ -827,6 +1673,47 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -855,6 +1742,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -897,10 +1807,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -928,6 +1948,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +1972,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,10 +2037,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -963,7 +2110,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -977,20 +2124,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1000,9 +2169,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1012,9 +2193,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1024,15 +2217,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1056,6 +2267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "xtask"
 version = "0.1.0"
 dependencies = [
@@ -1064,15 +2281,19 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "env_logger",
+ "futures-util",
  "ignore",
  "log",
+ "octocrab",
  "pretty_assertions",
+ "regex",
  "scopeguard",
  "semver",
  "serde",
  "serde_json",
  "serial_test",
  "tempfile",
+ "test-case",
  "tokio",
  "toml_edit",
  "walkdir",
@@ -1083,6 +2304,89 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -16,18 +16,22 @@ publish = false
 agave-unstable-api = []
 dummy-for-ci-check = []
 frozen-abi = []
+integration-tests = []
 
 [dependencies]
 anyhow = "1.0.100"
 cargo_metadata = "0.23.1"
 clap = { version = "4.5.54", features = ["derive"] }
 env_logger = "0.11.8"
+futures-util = "0.3.31"
 ignore = "0.4.25"
 log = "0.4.28"
+octocrab = { version = "0.47.0", features = ["stream"] }
+regex = "1.12.2"
 scopeguard = "1.2.0"
 semver = "1.0.27"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 tokio = { version = "1.48.0", features = ["full"] }
 toml_edit = { version = "0.24.0", features = ["serde"] }
 walkdir = "2.5.0"
@@ -38,3 +42,4 @@ pretty_assertions = "1.4.1"
 scopeguard = "1.2.0"
 serial_test = "3.2.0"
 tempfile = "3.23.0"
+test-case = "3.3.1"

--- a/ci/xtask/src/commands.rs
+++ b/ci/xtask/src/commands.rs
@@ -1,4 +1,5 @@
 pub mod bump_version;
+pub mod generate_pipeline;
 pub mod hello;
 pub mod publish;
 pub mod update_crate;

--- a/ci/xtask/src/commands/generate_pipeline.rs
+++ b/ci/xtask/src/commands/generate_pipeline.rs
@@ -1,0 +1,465 @@
+use {
+    anyhow::Result,
+    clap::Args,
+    futures_util::TryStreamExt,
+    log::info,
+    regex::Regex,
+    std::{collections::HashMap, env, fs, path::PathBuf},
+    tokio::pin,
+};
+
+pub mod buildkite;
+
+#[derive(Args)]
+pub struct CommandArgs {
+    #[arg(short, long, default_value = "./pipeline.json")]
+    pub output_file: PathBuf,
+}
+
+pub async fn run(args: CommandArgs) -> Result<()> {
+    let branch = env::var("BUILDKITE_BRANCH")
+        .map_err(|e| anyhow::anyhow!("failed to get `BUILDKITE_BRANCH`: {e}"))?;
+    info!("Generating pipeline for branch: {branch}");
+
+    let pipeline = if branch.starts_with("gh-readonly-queue") {
+        info!("Branch is a GitHub Readonly Queue branch, exiting early.");
+        generate_merge_queue_pipeline()?
+    } else if let Some(captures) = Regex::new(r"pull/(\d+)/head")?.captures(&branch) {
+        if let Some(pr_match) = captures.get(1) {
+            let pr_number = pr_match
+                .as_str()
+                .parse::<u64>()
+                .map_err(|e| anyhow::anyhow!("failed to parse PR number: {e}"))?;
+
+            generate_pull_request_pipeline(pr_number).await?
+        } else {
+            info!("failed to get PR number from branch: {branch}, running full pipeline.");
+            generate_full_pipeline()?
+        }
+    } else {
+        info!("Branch matches no known pattern, running full pipeline.");
+        generate_full_pipeline()?
+    };
+
+    let output = args.output_file;
+    fs::write(&output, serde_json::to_string_pretty(&pipeline)?)?;
+    info!("Pipeline written to: {:?}", fs::canonicalize(&output)?);
+
+    Ok(())
+}
+
+fn generate_merge_queue_pipeline() -> Result<buildkite::Pipeline> {
+    let mut pipeline = buildkite::Pipeline::new();
+    pipeline.set_priority(10);
+    pipeline.add_step(default_sanity_step());
+    pipeline.add_step(default_checks_step());
+    Ok(pipeline)
+}
+
+async fn get_changed_files(pr_number: u64) -> Result<Vec<String>> {
+    let mut changed_files = vec![];
+    let github_client = octocrab::instance();
+    let stream = github_client
+        .pulls("anza-xyz", "agave")
+        .list_files(pr_number)
+        .await?
+        .into_stream(&github_client);
+    pin!(stream);
+    while let Some(file) = stream.try_next().await? {
+        changed_files.push(file.filename);
+    }
+    Ok(changed_files)
+}
+
+pub async fn generate_pull_request_pipeline(pr_number: u64) -> Result<buildkite::Pipeline> {
+    let changed_files = get_changed_files(pr_number).await?;
+
+    let mut pipeline = buildkite::Pipeline::new();
+
+    pipeline.add_step(default_sanity_step());
+    if changed_files.iter().any(|file| file.ends_with(".sh")) {
+        pipeline.add_step(default_shellcheck_step());
+    }
+
+    pipeline.add_step(wait_step());
+
+    if changed_files.iter().any(|file| {
+        file.ends_with("Cargo.toml") || file.ends_with("Cargo.lock") || file.ends_with(".rs")
+    }) {
+        pipeline.add_step(default_checks_step());
+        pipeline.add_step(default_dcou_step(3));
+        pipeline.add_step(default_miri_step());
+        pipeline.add_step(default_frozen_abi_step());
+
+        pipeline.add_step(wait_step());
+
+        pipeline.add_step(default_stable_step(3));
+        pipeline.add_step(default_local_cluster_step(10));
+        pipeline.add_step(default_docs_check_step());
+        pipeline.add_step(default_localnet_step());
+
+        pipeline.add_step(wait_step());
+
+        pipeline.add_step(default_stable_sbf_step());
+        pipeline.add_step(default_shuttle_step());
+        pipeline.add_step(default_coverage_step());
+    }
+
+    Ok(pipeline)
+}
+
+fn generate_full_pipeline() -> Result<buildkite::Pipeline> {
+    let mut pipeline = buildkite::Pipeline::new();
+
+    pipeline.add_step(default_sanity_step());
+    pipeline.add_step(default_shellcheck_step());
+
+    pipeline.add_step(wait_step());
+
+    pipeline.add_step(default_checks_step());
+    pipeline.add_step(default_dcou_step(3));
+    pipeline.add_step(default_miri_step());
+    pipeline.add_step(default_frozen_abi_step());
+
+    pipeline.add_step(wait_step());
+
+    pipeline.add_step(default_stable_step(3));
+    pipeline.add_step(default_local_cluster_step(10));
+    pipeline.add_step(default_docs_check_step());
+    pipeline.add_step(default_localnet_step());
+
+    pipeline.add_step(wait_step());
+
+    pipeline.add_step(default_stable_sbf_step());
+    pipeline.add_step(default_shuttle_step());
+    pipeline.add_step(default_coverage_step());
+
+    pipeline.add_step(wait_step());
+
+    pipeline.add_step(default_trigger_secondary_step());
+
+    Ok(pipeline)
+}
+
+fn default_sanity_step() -> buildkite::Step {
+    buildkite::Step::Command(buildkite::CommandStep {
+        name: String::from("sanity"),
+        command: String::from("ci/test-sanity.sh"),
+        agents: Some(HashMap::from([(
+            String::from("queue"),
+            String::from("check"),
+        )])),
+        timeout_in_minutes: Some(5),
+        ..Default::default()
+    })
+}
+
+fn default_shellcheck_step() -> buildkite::Step {
+    buildkite::Step::Command(buildkite::CommandStep {
+        name: String::from("shellcheck"),
+        command: String::from("ci/shellcheck.sh"),
+        agents: Some(HashMap::from([(
+            String::from("queue"),
+            String::from("check"),
+        )])),
+        timeout_in_minutes: Some(5),
+        ..Default::default()
+    })
+}
+
+fn default_checks_step() -> buildkite::Step {
+    buildkite::Step::Command(buildkite::CommandStep {
+        name: String::from("checks"),
+        command: String::from("ci/docker-run-default-image.sh ci/test-checks.sh"),
+        agents: Some(HashMap::from([(
+            String::from("queue"),
+            String::from("check"),
+        )])),
+        timeout_in_minutes: Some(20),
+        ..Default::default()
+    })
+}
+
+fn default_dcou_step(parallel: u64) -> buildkite::Step {
+    let mut dcou_group = buildkite::GroupStep {
+        name: String::from("dcou"),
+        steps: vec![],
+    };
+    for i in 1..=parallel {
+        dcou_group
+            .steps
+            .push(buildkite::Step::Command(buildkite::CommandStep {
+                name: format!("dcou {i}/{parallel}"),
+                command: format!(
+                    "ci/docker-run-default-image.sh ci/test-dev-context-only-utils.sh --partition \
+                     {i}/{parallel}"
+                ),
+                agents: Some(HashMap::from([(
+                    String::from("queue"),
+                    String::from("check"),
+                )])),
+                timeout_in_minutes: Some(20),
+                ..Default::default()
+            }));
+    }
+    buildkite::Step::Group(dcou_group)
+}
+
+fn default_miri_step() -> buildkite::Step {
+    buildkite::Step::Command(buildkite::CommandStep {
+        name: String::from("miri"),
+        command: String::from("ci/docker-run-default-image.sh ci/test-miri.sh"),
+        agents: Some(HashMap::from([(
+            String::from("queue"),
+            String::from("check"),
+        )])),
+        timeout_in_minutes: Some(5),
+        ..Default::default()
+    })
+}
+
+fn default_frozen_abi_step() -> buildkite::Step {
+    buildkite::Step::Command(buildkite::CommandStep {
+        name: String::from("frozen-abi"),
+        command: String::from("ci/docker-run-default-image.sh ci/test-abi.sh"),
+        agents: Some(HashMap::from([(
+            String::from("queue"),
+            String::from("check"),
+        )])),
+        timeout_in_minutes: Some(15),
+        ..Default::default()
+    })
+}
+
+fn wait_step() -> buildkite::Step {
+    buildkite::Step::Wait(buildkite::WaitStep {})
+}
+
+fn default_local_cluster_step(parallel: u64) -> buildkite::Step {
+    let mut local_cluster_group = buildkite::GroupStep {
+        name: String::from("local-cluster"),
+        steps: vec![],
+    };
+    for i in 1..=parallel {
+        local_cluster_group
+            .steps
+            .push(buildkite::Step::Command(buildkite::CommandStep {
+                name: format!("local-cluster {i}/{parallel}"),
+                command: format!(
+                    "ci/docker-run-default-image.sh ci/stable/run-local-cluster-partially.sh {i} \
+                     {parallel}"
+                ),
+                agents: Some(HashMap::from([(
+                    String::from("queue"),
+                    String::from("solana"),
+                )])),
+                timeout_in_minutes: Some(15),
+                retry: Some(HashMap::from([(
+                    String::from("automatic"),
+                    String::from("true"),
+                )])),
+                ..Default::default()
+            }));
+    }
+    buildkite::Step::Group(local_cluster_group)
+}
+
+fn default_docs_check_step() -> buildkite::Step {
+    buildkite::Step::Command(buildkite::CommandStep {
+        name: String::from("doctest"),
+        command: String::from("ci/docker-run-default-image.sh ci/test-docs.sh"),
+        agents: Some(HashMap::from([(
+            String::from("queue"),
+            String::from("solana"),
+        )])),
+        timeout_in_minutes: Some(15),
+        ..Default::default()
+    })
+}
+
+fn default_localnet_step() -> buildkite::Step {
+    buildkite::Step::Command(buildkite::CommandStep {
+        name: String::from("localnet"),
+        command: String::from("ci/docker-run-default-image.sh ci/stable/run-localnet.sh"),
+        agents: Some(HashMap::from([(
+            String::from("queue"),
+            String::from("solana"),
+        )])),
+        timeout_in_minutes: Some(30),
+        ..Default::default()
+    })
+}
+
+fn default_shuttle_step() -> buildkite::Step {
+    buildkite::Step::Command(buildkite::CommandStep {
+        name: String::from("shuttle"),
+        command: String::from("ci/docker-run-default-image.sh ci/test-shuttle.sh"),
+        agents: Some(HashMap::from([(
+            String::from("queue"),
+            String::from("solana"),
+        )])),
+        ..Default::default()
+    })
+}
+
+fn default_stable_sbf_step() -> buildkite::Step {
+    buildkite::Step::Command(buildkite::CommandStep {
+        name: String::from("stable-sbf"),
+        command: String::from("ci/docker-run-default-image.sh ci/test-stable-sbf.sh"),
+        agents: Some(HashMap::from([(
+            String::from("queue"),
+            String::from("solana"),
+        )])),
+        timeout_in_minutes: Some(35),
+        ..Default::default()
+    })
+}
+
+fn default_coverage_step() -> buildkite::Step {
+    buildkite::Step::Command(buildkite::CommandStep {
+        name: String::from("coverage"),
+        command: String::from("ci/docker-run-default-image.sh ci/test-coverage.sh"),
+        agents: Some(HashMap::from([(
+            String::from("queue"),
+            String::from("solana"),
+        )])),
+        timeout_in_minutes: Some(90),
+        ..Default::default()
+    })
+}
+
+fn default_trigger_secondary_step() -> buildkite::Step {
+    buildkite::Step::Trigger(buildkite::TriggerStep {
+        name: String::from("Trigger Build on agave-secondary"),
+        trigger: String::from("agave-secondary"),
+        branches: vec![String::from("!pull/*")],
+        is_async: Some(true),
+        soft_fail: Some(true),
+        build: Some(buildkite::Build {
+            message: Some(String::from("${BUILDKITE_MESSAGE}")),
+            commit: Some(String::from("${BUILDKITE_COMMIT}")),
+            branch: Some(String::from("${BUILDKITE_BRANCH}")),
+            env: Some(HashMap::from([(
+                String::from("TRIGGERED_BUILDKITE_TAG"),
+                String::from("${BUILDKITE_TAG}"),
+            )])),
+        }),
+    })
+}
+
+fn default_stable_step(parallel: u64) -> buildkite::Step {
+    let mut stable_group = buildkite::GroupStep {
+        name: String::from("stable"),
+        steps: vec![],
+    };
+    for i in 1..=parallel {
+        stable_group
+            .steps
+            .push(buildkite::Step::Command(buildkite::CommandStep {
+                name: format!("partitions {i}/{parallel}"),
+                command: format!(
+                    "ci/docker-run-default-image.sh ci/stable/run-partition.sh {i} {parallel}"
+                ),
+                agents: Some(HashMap::from([(
+                    String::from("queue"),
+                    String::from("solana"),
+                )])),
+                timeout_in_minutes: Some(25),
+                retry: Some(HashMap::from([(
+                    String::from("automatic"),
+                    String::from("true"),
+                )])),
+                ..Default::default()
+            }));
+    }
+    buildkite::Step::Group(stable_group)
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, pretty_assertions::assert_eq};
+
+    // PR 1850 is a good large PR for testing
+    #[cfg_attr(not(feature = "integration-tests"), ignore = "requires github api")]
+    #[tokio::test]
+    async fn test_get_changed_files_for_pr_1850() {
+        let changed_files = get_changed_files(1850).await.unwrap();
+        assert_eq!(changed_files.len(), 68);
+        assert!(changed_files.contains(&String::from("Cargo.lock")));
+        assert!(changed_files.contains(&String::from("Cargo.toml")));
+        assert!(changed_files.contains(&String::from("cli/Cargo.toml")));
+        assert!(changed_files.contains(&String::from("ledger-tool/Cargo.toml")));
+        assert!(changed_files.contains(&String::from("program-runtime/Cargo.toml")));
+        assert!(changed_files.contains(&String::from("program-test/Cargo.toml")));
+        assert!(changed_files.contains(&String::from("programs/bpf_loader/Cargo.toml")));
+        assert!(changed_files.contains(&String::from("programs/loader-v4/Cargo.toml")));
+        assert!(changed_files.contains(&String::from("programs/sbf/Cargo.lock")));
+        assert!(changed_files.contains(&String::from("programs/sbf/Cargo.toml")));
+        assert!(changed_files.contains(&String::from("rbpf/Cargo.toml")));
+        assert!(changed_files.contains(&String::from("rbpf/src/aarch64.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/aligned_memory.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/asm_parser.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/assembler.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/debugger.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/disassembler.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/ebpf.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/elf.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/elf_parser/consts.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/elf_parser/mod.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/elf_parser/types.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/elf_parser_glue.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/error.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/fuzz.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/insn_builder.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/interpreter.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/jit.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/lib.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/memory_management.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/memory_region.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/program.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/static_analysis.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/syscalls.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/utils.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/verifier.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/vm.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/src/x86.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/bss_section.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/bss_section.so")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/data_section.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/data_section.so")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/elf.ld")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/elfs.sh")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/long_section_name.so")));
+        assert!(
+            changed_files.contains(&String::from("rbpf/tests/elfs/program_headers_overflow.ld"))
+        );
+        assert!(
+            changed_files.contains(&String::from("rbpf/tests/elfs/program_headers_overflow.so"))
+        );
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/relative_call.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/relative_call.so")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/reloc_64_64.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/reloc_64_64.so")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/reloc_64_64_sbpfv1.so")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/reloc_64_relative.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/reloc_64_relative.so")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/reloc_64_relative_data.c")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/reloc_64_relative_data.so")));
+        assert!(changed_files.contains(&String::from(
+            "rbpf/tests/elfs/reloc_64_relative_data_sbpfv1.so"
+        )));
+        assert!(
+            changed_files.contains(&String::from("rbpf/tests/elfs/reloc_64_relative_sbpfv1.so"))
+        );
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/rodata_section.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/rodata_section.so")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/rodata_section_sbpfv1.so")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/struct_func_pointer.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/struct_func_pointer.so")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/syscall_reloc_64_32.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/syscall_reloc_64_32.so")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/syscall_static.rs")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/syscall_static.so")));
+        assert!(changed_files.contains(&String::from("rbpf/tests/elfs/syscalls.rs")));
+    }
+}

--- a/ci/xtask/src/commands/generate_pipeline/buildkite.rs
+++ b/ci/xtask/src/commands/generate_pipeline/buildkite.rs
@@ -1,0 +1,400 @@
+use {
+    serde::{Serialize, Serializer},
+    std::collections::HashMap,
+};
+
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum Step {
+    Command(CommandStep),
+    Wait(WaitStep),
+    Group(GroupStep),
+    Trigger(TriggerStep),
+}
+
+#[derive(Debug, Serialize, Default, PartialEq)]
+pub struct CommandStep {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub name: String,
+
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub command: String,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub commands: Vec<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancel_on_build_failing: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub soft_fail: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agents: Option<HashMap<String, String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_in_minutes: Option<i64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct WaitStep {}
+
+impl Serialize for WaitStep {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry("wait", "~")?;
+        map.end()
+    }
+}
+
+#[derive(Debug, Default, Serialize, PartialEq)]
+pub struct GroupStep {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(rename = "group")]
+    pub name: String,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub steps: Vec<Step>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct TriggerStep {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub name: String,
+
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub trigger: String,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub branches: Vec<String>,
+
+    #[serde(rename = "async")]
+    pub is_async: Option<bool>,
+
+    pub soft_fail: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build: Option<Build>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct Build {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct Pipeline {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i64>,
+
+    pub steps: Vec<Step>,
+}
+
+impl Pipeline {
+    pub fn new() -> Self {
+        Pipeline {
+            priority: None,
+            steps: Vec::new(),
+        }
+    }
+
+    pub fn set_priority(&mut self, priority: i64) {
+        self.priority = Some(priority);
+    }
+
+    pub fn add_step(&mut self, step: Step) {
+        self.steps.push(step);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, pretty_assertions::assert_eq, test_case::test_case};
+
+    macro_rules! assert_json_eq {
+        ($actual:expr, $expected:expr) => {
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>($actual).unwrap(),
+                serde_json::from_str::<serde_json::Value>($expected).unwrap()
+            );
+        };
+    }
+
+    #[test_case(
+        Step::Command(CommandStep {
+            name: String::from("basic test"),
+            ..Default::default()
+        }),
+        r#"{
+            "name": "basic test"
+        }"#;
+        "command_step_basic_name_only"
+    )]
+    #[test_case(
+        Step::Command(CommandStep {
+            name: String::from("test with command"),
+            command: String::from("echo hello"),
+            ..Default::default()
+        }),
+        r#"{
+            "name": "test with command",
+            "command": "echo hello"
+        }"#;
+        "command_step_with_single_command"
+    )]
+    #[test_case(
+        Step::Command(CommandStep {
+            name: String::from("test with commands"),
+            commands: vec![String::from("echo hello"), String::from("echo world")],
+            ..Default::default()
+        }),
+        r#"{
+            "name": "test with commands",
+            "commands": ["echo hello", "echo world"]
+        }"#;
+        "command_step_with_multiple_commands"
+    )]
+    #[test_case(
+        Step::Command(CommandStep {
+            name: String::from("test with cancel"),
+            cancel_on_build_failing: Some(true),
+            ..Default::default()
+        }),
+        r#"{
+            "name": "test with cancel",
+            "cancel_on_build_failing": true
+        }"#;
+        "command_step_with_cancel_on_build_failing_true"
+    )]
+    #[test_case(
+        Step::Command(CommandStep {
+            name: String::from("test no cancel"),
+            cancel_on_build_failing: Some(false),
+            ..Default::default()
+        }),
+        r#"{
+            "name": "test no cancel",
+            "cancel_on_build_failing": false
+        }"#;
+        "command_step_with_cancel_on_build_failing_false"
+    )]
+    #[test_case(
+        Step::Command(CommandStep {
+            name: String::from("test soft fail"),
+            soft_fail: Some(true),
+            ..Default::default()
+        }),
+        r#"{
+            "name": "test soft fail",
+            "soft_fail": true
+        }"#;
+        "command_step_with_soft_fail_true"
+    )]
+    #[test_case(
+        Step::Command(CommandStep {
+            name: String::from("test no soft fail"),
+            soft_fail: Some(false),
+            ..Default::default()
+        }),
+        r#"{
+            "name": "test no soft fail",
+            "soft_fail": false
+        }"#;
+        "command_step_with_soft_fail_false"
+    )]
+    #[test_case(
+        Step::Command(CommandStep {
+            name: String::from("test with agents"),
+            agents: Some(HashMap::from([
+                (String::from("queue"), String::from("default")),
+                (String::from("os"), String::from("linux"))
+            ])),
+            ..Default::default()
+        }),
+        r#"{
+            "name": "test with agents",
+            "agents": {"queue": "default", "os": "linux"}
+        }"#;
+        "command_step_with_agents"
+    )]
+    #[test_case(
+        Step::Command(CommandStep {
+            name: String::from("test with timeout"),
+            timeout_in_minutes: Some(30),
+            ..Default::default()
+        }),
+        r#"{
+            "name": "test with timeout",
+            "timeout_in_minutes": 30
+        }"#;
+        "command_step_with_timeout"
+    )]
+    #[test_case(
+        Step::Command(CommandStep {
+            name: String::from("test with retry"),
+            retry: Some(HashMap::from([
+                (String::from("automatic"), String::from("true")),
+                (String::from("manual"), String::from("false"))
+            ])),
+            ..Default::default()
+        }),
+        r#"{
+            "name": "test with retry",
+            "retry": {"automatic": "true", "manual": "false"}
+        }"#;
+        "command_step_with_retry"
+    )]
+    #[test_case(
+        Step::Command(CommandStep {
+            name: String::from("full command step"),
+            command: String::from("npm test"),
+            cancel_on_build_failing: Some(true),
+            soft_fail: Some(false),
+            agents: Some(HashMap::from([(String::from("queue"), String::from("test"))])),
+            timeout_in_minutes: Some(15),
+            retry: Some(HashMap::from([(String::from("automatic"), String::from("true"))])),
+            ..Default::default()
+        }),
+        r#"{
+            "name": "full command step",
+            "command": "npm test",
+            "cancel_on_build_failing": true,
+            "soft_fail": false,
+            "agents": {"queue": "test"},
+            "timeout_in_minutes": 15,
+            "retry": {"automatic": "true"}
+        }"#;
+        "command_step_with_all_fields"
+    )]
+    #[test_case(
+        Step::Wait(WaitStep {}),
+        r#"{
+            "wait": "~"
+        }"#;
+        "wait_step"
+    )]
+    #[test_case(
+        Step::Group(GroupStep {
+            name: String::from("empty group"),
+            steps: vec![
+                Step::Command(CommandStep {
+                    name: String::from("step 1"),
+                    command: String::from("echo 1"),
+                    ..Default::default()
+                }),
+                Step::Wait(WaitStep {}),
+                Step::Command(CommandStep {
+                    name: String::from("step 2"),
+                    command: String::from("echo 2"),
+                    ..Default::default()
+                })
+            ],
+        }),
+        r#"{
+            "group": "empty group",
+            "steps": [
+                {"name": "step 1", "command": "echo 1"},
+                {"wait": "~"},
+                {"name": "step 2", "command": "echo 2"}
+            ]
+        }"#;
+        "group_step"
+    )]
+    #[test_case(
+        Step::Trigger(TriggerStep {
+            name: String::from("Trigger Build on agave-secondary"),
+            trigger: String::from("agave-secondary"),
+            branches: vec![String::from("!pull/*")],
+            is_async: Some(true),
+            soft_fail: Some(true),
+            build: Some(Build {
+                message: Some(String::from("${BUILDKITE_MESSAGE}")),
+                commit: Some(String::from("${BUILDKITE_COMMIT}")),
+                branch: Some(String::from("${BUILDKITE_BRANCH}")),
+                env: Some(HashMap::from([(
+                    String::from("TRIGGERED_BUILDKITE_TAG"),
+                    String::from("${BUILDKITE_TAG}"),
+                )])),
+            }),
+        }),
+        r#"{
+            "name": "Trigger Build on agave-secondary",
+            "trigger": "agave-secondary",
+            "branches": ["!pull/*"],
+            "async": true,
+            "soft_fail": true,
+            "build": {
+                "branch": "${BUILDKITE_BRANCH}",
+                "commit": "${BUILDKITE_COMMIT}",
+                "message": "${BUILDKITE_MESSAGE}",
+                "env": {"TRIGGERED_BUILDKITE_TAG": "${BUILDKITE_TAG}"}
+            }
+        }"#;
+        "trigger_step"
+    )]
+    fn test_step_serialize_json(step: Step, expected: &str) {
+        let serialized = serde_json::to_string(&step).unwrap();
+        assert_json_eq!(&serialized, expected);
+    }
+
+    #[test]
+    fn test_pipeline_creation() {
+        let mut pipeline = Pipeline::new();
+        assert!(pipeline.steps.is_empty());
+
+        pipeline.add_step(Step::Command(CommandStep {
+            name: String::from("test"),
+            ..Default::default()
+        }));
+
+        assert_eq!(pipeline.steps.len(), 1);
+    }
+
+    #[test]
+    fn test_priority_pipeline() {
+        let mut pipeline = Pipeline::new();
+        pipeline.set_priority(10);
+        assert_eq!(pipeline.priority, Some(10));
+
+        pipeline.add_step(Step::Command(CommandStep {
+            name: String::from("step 1"),
+            command: String::from("echo 1"),
+            ..Default::default()
+        }));
+
+        pipeline.add_step(Step::Command(CommandStep {
+            name: String::from("step 2"),
+            command: String::from("echo 2"),
+            ..Default::default()
+        }));
+
+        let serialized = serde_json::to_string(&pipeline).unwrap();
+        assert_json_eq!(
+            &serialized,
+            r#"{
+            "priority": 10,
+            "steps": [
+                {"name": "step 1", "command": "echo 1"},
+                {"name": "step 2", "command": "echo 2"}
+            ]
+        }"#
+        );
+    }
+}

--- a/ci/xtask/src/main.rs
+++ b/ci/xtask/src/main.rs
@@ -27,6 +27,8 @@ enum Commands {
     UpdateCrate(commands::update_crate::CommandArgs),
     #[command(about = "Publish crates")]
     Publish(commands::publish::CommandArgs),
+    #[command(about = "Generate pipeline")]
+    GeneratePipeline(commands::generate_pipeline::CommandArgs),
 }
 
 #[derive(Args, Debug)]
@@ -70,6 +72,9 @@ async fn try_main() -> Result<()> {
         }
         Commands::Publish(args) => {
             commands::publish::run(args)?;
+        }
+        Commands::GeneratePipeline(args) => {
+            commands::generate_pipeline::run(args).await?;
         }
     }
 


### PR DESCRIPTION

(split from https://github.com/anza-xyz/agave/pull/6765 and some refactoring)

#### Summary of Changes

introduce xtask pipeline generator to replace `ci/buildkite-pipeline.sh`. this PR only adds the tool. will have a follow-up PR to handle the actual switch