### PR TITLE
bug: filter by block id when collecting genesis votes

### DIFF
--- a/votor/src/consensus_pool/vote_pool.rs
+++ b/votor/src/consensus_pool/vote_pool.rs
@@ -188,7 +188,15 @@ impl InternalVotePool {
                 .collect(),
             Vote::Skip(_) => self.skip.values().cloned().collect(),
             Vote::SkipFallback(_) => self.skip_fallback.values().cloned().collect(),
-            Vote::Genesis(_) => self.genesis.values().cloned().collect(),
+            Vote::Genesis(genesis) => self
+                .genesis
+                .values()
+                .filter(|vote| {
+                    // unwrap should be safe as we should only store genesis votes here
+                    vote.vote.block_id().unwrap() == &genesis.block_id
+                })
+                .cloned()
+                .collect(),
         }
     }
 }


### PR DESCRIPTION
#### Problem

The vote pool stores genesis votes indexed by block id.  When aggregating votes to build a certificate, we should filter by the block id.


#### Summary of Changes


Adds the filtering.