### PR TITLE
Removes Bank::replace_program_account()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5696,43 +5696,6 @@ impl Bank {
         }
     }
 
-    /// Use to replace programs by feature activation
-    #[allow(dead_code)]
-    fn replace_program_account(
-        &mut self,
-        old_address: &Pubkey,
-        new_address: &Pubkey,
-        datapoint_name: &'static str,
-    ) {
-        if let Some(old_account) = self.get_account_with_fixed_root(old_address) {
-            if let Some(new_account) = self.get_account_with_fixed_root(new_address) {
-                datapoint_info!(datapoint_name, ("slot", self.slot, i64));
-
-                // Burn lamports in the old account
-                self.capitalization
-                    .fetch_sub(old_account.lamports(), Relaxed);
-
-                // Transfer new account to old account
-                self.store_account(old_address, &new_account);
-
-                // Clear new account
-                self.store_account(new_address, &AccountSharedData::default());
-
-                // Unload a program from the bank's cache
-                self.transaction_processor
-                    .global_program_cache
-                    .write()
-                    .unwrap()
-                    .remove_programs([*old_address].into_iter());
-
-                self.calculate_and_update_accounts_data_size_delta_off_chain(
-                    old_account.data().len(),
-                    new_account.data().len(),
-                );
-            }
-        }
-    }
-
     /// Calculates the accounts data size of all accounts
     ///
     /// Panics if total overflows a u64.

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7031,44 +7031,6 @@ fn test_block_limits() {
     );
 }
 
-#[test]
-fn test_program_replacement() {
-    let mut bank = create_simple_test_bank(0);
-
-    // Setup original program account
-    let old_address = Pubkey::new_unique();
-    let new_address = Pubkey::new_unique();
-    bank.store_account_and_update_capitalization(
-        &old_address,
-        &AccountSharedData::from(Account {
-            lamports: 100,
-            ..Account::default()
-        }),
-    );
-    assert_eq!(bank.get_balance(&old_address), 100);
-
-    // Setup new program account
-    let new_program_account = AccountSharedData::from(Account {
-        lamports: 123,
-        ..Account::default()
-    });
-    bank.store_account_and_update_capitalization(&new_address, &new_program_account);
-    assert_eq!(bank.get_balance(&new_address), 123);
-
-    let original_capitalization = bank.capitalization();
-
-    bank.replace_program_account(&old_address, &new_address, "bank-apply_program_replacement");
-
-    // New program account is now empty
-    assert_eq!(bank.get_balance(&new_address), 0);
-
-    // Old program account holds the new program account
-    assert_eq!(bank.get_account(&old_address), Some(new_program_account));
-
-    // Lamports in the old token account were burnt
-    assert_eq!(bank.capitalization(), original_capitalization - 100);
-}
-
 fn min_rent_exempt_balance_for_sysvars(bank: &Bank, sysvar_ids: &[Pubkey]) -> u64 {
     sysvar_ids
         .iter()


### PR DESCRIPTION
#### Problem

Bank::replace_program_account() is dead code.


OLD:

When replacing a program via `Bank::replace_program_account()`, it incorrectly updates the accounts data size.

The fn basically overwrites the old account with the new account. Initially both accounts exist, and afterwards only the new account exists (just now at the old address). So the change in accounts data size is the _removal_ of the old account.


#### Summary of Changes

Remove it.