### PR TITLE
perf(snapshots): use BufWriter with larger buf size for archiving

### DIFF
--- a/fs/src/buffered_writer.rs
+++ b/fs/src/buffered_writer.rs
@@ -13,7 +13,6 @@ const DEFAULT_BUFFER_SIZE: usize = 2 * 1024 * 1024;
 ///
 /// The returned writer is using a buffer size tuned for writing large files to disks.
 pub fn large_file_buf_writer(path: impl AsRef<Path>) -> io::Result<impl io::Write + io::Seek> {
-    let path = path.as_ref();
     let file = fs::File::create(path)?;
 
     Ok(BufWriter::with_capacity(DEFAULT_BUFFER_SIZE, file))

--- a/fs/src/buffered_writer.rs
+++ b/fs/src/buffered_writer.rs
@@ -1,0 +1,20 @@
+use std::{
+    fs,
+    io::{self, BufWriter},
+    path::Path,
+};
+
+/// Default buffer size for writing large files to disks. Since current implementation does not do
+/// background writing, this size is set above minimum reasonable SSD write sizes to also reduce
+/// number of syscalls.
+const DEFAULT_BUFFER_SIZE: usize = 2 * 1024 * 1024;
+
+/// Return a buffered writer for creating a new file at `path`
+///
+/// The returned writer is using a buffer size tuned for writing large files to disks.
+pub fn large_file_buf_writer(path: impl AsRef<Path>) -> io::Result<impl io::Write + io::Seek> {
+    let path = path.as_ref();
+    let file = fs::File::create(path)?;
+
+    Ok(BufWriter::with_capacity(DEFAULT_BUFFER_SIZE, file))
+}

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -16,6 +16,7 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 
 pub mod buffered_reader;
+pub mod buffered_writer;
 pub mod dirs;
 pub mod file_io;
 mod io_uring;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -42,7 +42,7 @@ use {
     std::{
         cell::RefCell,
         collections::{HashMap, HashSet},
-        io::{self, BufReader, BufWriter, Read, Write},
+        io::{self, BufReader, Read, Write},
         path::{Path, PathBuf},
         result::Result,
         sync::{
@@ -598,7 +598,7 @@ where
 
 #[cfg(test)]
 pub(crate) fn bank_to_stream<W>(
-    stream: &mut BufWriter<W>,
+    stream: &mut io::BufWriter<W>,
     bank: &Bank,
     snapshot_storages: &[Vec<Arc<AccountStorageEntry>>],
 ) -> Result<(), Error>
@@ -615,17 +615,14 @@ where
 }
 
 /// Serializes bank snapshot into `stream` with bincode
-pub fn serialize_bank_snapshot_into<W>(
-    stream: &mut BufWriter<W>,
+pub fn serialize_bank_snapshot_into(
+    stream: &mut dyn Write,
     bank_fields: BankFieldsToSerialize,
     bank_hash_stats: BankHashStats,
     account_storage_entries: &[Vec<Arc<AccountStorageEntry>>],
     extra_fields: ExtraFieldsToSerialize,
     write_version: u64,
-) -> Result<(), Error>
-where
-    W: Write,
-{
+) -> Result<(), Error> {
     let mut serializer = bincode::Serializer::new(
         stream,
         bincode::DefaultOptions::new().with_fixint_encoding(),


### PR DESCRIPTION
#### Problem
Default buffer size when using `BufWriter::new` or what `std::io::copy` uses for non-buffered write (https://stdrs.dev/nightly/x86_64-unknown-linux-gnu/src/std/io/copy.rs.html#298-306) destination is 8KiB.
This is a bit lower than optimal write size for typical SSDs (generally >= 64KB, best closer to 256KiB) and incurs extra syscalls, since it doesn't do io-uring / background processing.

#### Summary of Changes
* add `agave-fs` module for buffered writers and function for creating files using buffer writer with better default
* switch snapshot file, obsolete accounts file creator to new function
* wrap tar.zst archive creation file with buffered writer using above function (previously it wasn't buffering and ended up using `std::io::copy` invoked in `tar`, which uses small sized stack buffer

The performance impact of this change isn't big, since IO writes are quite a small fraction of time taken for writing snapshots (for incremental snapshot archive it's around 5%).
On profiles this change reduces time for calling file `write` in half.