### PR TITLE
ledger: Remove outdated shred method

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2234,11 +2234,8 @@ impl Blockstore {
 
         // Commit step: commit all changes to the mutable structures at once, or none at all.
         // We don't want only a subset of these changes going through.
-        self.data_shred_cf.put_bytes_in_batch(
-            write_batch,
-            (slot, index),
-            shred.bytes_to_store(),
-        )?;
+        self.data_shred_cf
+            .put_bytes_in_batch(write_batch, (slot, index), shred.payload())?;
         data_index.insert(index);
         let newly_completed_data_sets = update_slot_meta(
             last_in_slot,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -453,15 +453,6 @@ impl Shred {
         self.common_header().index
     }
 
-    // Possibly trimmed payload;
-    // Should only be used when storing shreds to blockstore.
-    pub(crate) fn bytes_to_store(&self) -> &[u8] {
-        match self {
-            Self::ShredCode(shred) => shred.payload(),
-            Self::ShredData(shred) => shred.bytes_to_store(),
-        }
-    }
-
     pub fn fec_set_index(&self) -> u32 {
         self.common_header().fec_set_index
     }
@@ -1800,7 +1791,6 @@ mod tests {
         let mut packet = Packet::default();
         packet.buffer_mut()[..payload.len()].copy_from_slice(&payload);
         packet.meta_mut().size = payload.len();
-        assert_eq!(shred.bytes_to_store(), payload);
         assert_eq!(
             shred,
             Shred::new_from_serialized_shred(payload.to_vec()).unwrap()
@@ -1850,7 +1840,6 @@ mod tests {
         let mut packet = Packet::default();
         packet.buffer_mut()[..payload.len()].copy_from_slice(&payload);
         packet.meta_mut().size = payload.len();
-        assert_eq!(shred.bytes_to_store(), payload);
         assert_eq!(
             shred,
             Shred::new_from_serialized_shred(payload.to_vec()).unwrap()

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -230,10 +230,6 @@ impl ShredData {
     pub(super) fn reference_tick(&self) -> u8 {
         (self.data_header.flags & ShredFlags::SHRED_TICK_REFERENCE_MASK).bits()
     }
-
-    pub(super) fn bytes_to_store(&self) -> &[u8] {
-        &self.payload
-    }
 }
 
 impl ShredCode {


### PR DESCRIPTION
#### Summary of Changes
Legacy shreds had some zero-padding that could be omitted when the shred is stored in the Blockstore. This is not the case with Merkle shreds and the callstack already reflects this, so remove the intermediate function