### PR TITLE
fix(rpc): return JsonParsed for native mint in get_parsed_token_account

### DIFF
--- a/rpc/src/parsed_token_accounts.rs
+++ b/rpc/src/parsed_token_accounts.rs
@@ -28,18 +28,25 @@ pub fn get_parsed_token_account(
     // only used for simulation results
     overwrite_accounts: Option<&HashMap<Pubkey, AccountSharedData>>,
 ) -> UiAccount {
-    let additional_data = get_token_account_mint(account.data())
-        .and_then(|mint_pubkey| {
+    let additional_data = get_token_account_mint(account.data()).and_then(|mint_pubkey| {
+        if mint_pubkey == spl_token_interface::native_mint::id() {
+            Some(AccountAdditionalDataV3 {
+                spl_token_additional_data: Some(SplTokenAdditionalDataV2::with_decimals(
+                    spl_token_interface::native_mint::DECIMALS,
+                )),
+            })
+        } else {
             account_resolver::get_account_from_overwrites_or_bank(
                 &mint_pubkey,
                 bank,
                 overwrite_accounts,
             )
-        })
-        .and_then(|mint_account| get_additional_mint_data(bank, mint_account.data()).ok())
-        .map(|data| AccountAdditionalDataV3 {
-            spl_token_additional_data: Some(data),
-        });
+            .and_then(|mint_account| get_additional_mint_data(bank, mint_account.data()).ok())
+            .map(|data| AccountAdditionalDataV3 {
+                spl_token_additional_data: Some(data),
+            })
+        }
+    });
 
     encode_ui_account(
         pubkey,
@@ -128,4 +135,51 @@ fn get_additional_mint_data(bank: &Bank, data: &[u8]) -> Result<SplTokenAddition
                 scaled_ui_amount_config,
             }
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_account::Account as OnchainAccount,
+        solana_account_decoder::UiAccountData,
+        solana_program_option::COption,
+        solana_program_pack::Pack,
+        solana_runtime::{bank::Bank, genesis_utils::create_genesis_config},
+        spl_token_2022_interface::state::{Account as TokenAccount, AccountState},
+    };
+
+    #[test]
+    fn test_get_parsed_token_account_native_mint_returns_json() {
+        let genesis = create_genesis_config(100);
+        let bank = Bank::new_for_tests(&genesis.genesis_config);
+
+        let owner_pubkey = solana_pubkey::new_rand();
+        let mut data = vec![0; TokenAccount::get_packed_len()];
+        let mut token_account = TokenAccount::unpack_unchecked(&data).unwrap();
+        token_account.mint = spl_token_interface::native_mint::id();
+        token_account.owner = owner_pubkey;
+        token_account.amount = 1;
+        token_account.state = AccountState::Initialized;
+        token_account.is_native = COption::None;
+        token_account.close_authority = COption::None;
+        TokenAccount::pack(token_account, &mut data).unwrap();
+
+        let onchain_account = OnchainAccount {
+            lamports: 0,
+            data,
+            owner: spl_token_interface::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+        let account = AccountSharedData::from(onchain_account);
+
+        let ui = get_parsed_token_account(&bank, &solana_pubkey::new_rand(), account, None);
+        match ui.data {
+            UiAccountData::Json(parsed) => {
+                assert_eq!(parsed.program, "spl-token".to_string());
+            }
+            _ => panic!("expected Json parsed data for native mint"),
+        }
+    }
 }


### PR DESCRIPTION
The single-account path didn’t parse SPL token accounts with the native mint because it relied on reading the mint account from bank/overwrites. Since the native mint has no account, additional_data was None and encode_ui_account() fell back to Binary. The batch path already special-cased native mint, returning parsed JSON. This change special-cases native mint in get_parsed_token_account() by providing SplTokenAdditionalDataV2::with_decimals(native_mint::DECIMALS), making single-account behavior consistent with the batch path and preserving overwrite handling for non-native mints.