### PR TITLE
refactor(fs): use builder for initialization of SequentialFileReader

### DIFF
--- a/fs/src/buffered_reader.rs
+++ b/fs/src/buffered_reader.rs
@@ -390,10 +390,9 @@ pub fn large_file_buf_reader(path: &Path, buf_size: usize) -> io::Result<impl Bu
     #[cfg(target_os = "linux")]
     {
         assert!(agave_io_uring::io_uring_supported());
-        use crate::io_uring::sequential_file_reader::{SequentialFileReader, DEFAULT_READ_SIZE};
+        use crate::io_uring::sequential_file_reader::SequentialFileReaderBuilder;
 
-        let buf_size = buf_size.max(DEFAULT_READ_SIZE);
-        SequentialFileReader::with_capacity(buf_size, path)
+        SequentialFileReaderBuilder::new().build(path, buf_size)
     }
     #[cfg(not(target_os = "linux"))]
     {


### PR DESCRIPTION
#### Problem
We need a more advanced way to create io_uring sequential file reader with several tuning options.
The nearest uses for this will be:
* ability to enable/disable `DIRECT_IO` (we want to reserve ability to turn it off in case of bugs)
* ability to enable/disable registering buffer with kernel as `FIXED` (it requires memlock ulimit that is not always available)
* providing shared sqpoll FD
* adjusting IO kernel workers, sqsize, etc. -> those can be tuned depending on whether sqpoll is used or if we use many readers across threads or pushing lots of ops into single threaded one, etc.

All those low level options would clutter the API when required to be passed as parameters to constructor functions.

#### Summary of Changes
* add `SequentialFileReaderBuilder`, which uses defaults when created by `new()` and allows adjusting parameters and finally building the reader
* extract some blocks of code used for initialization into separate functions
* extract starting of reading into separate function (in the future we will allow building reader without providing the path, so start of reading will in fact be a separate flow)