### PR TITLE
clippy: fix forbidden gen keyword for rust 2024 edition

### DIFF
--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -2265,7 +2265,7 @@ mod tests {
                 1,
                 Arc::new(vec![0; rng.gen_range(0, 128)]),
                 Pubkey::new_unique(),
-                rng.gen(),
+                rng.r#gen(),
                 u64::MAX,
             );
             mock_bank.accounts_map.insert(Pubkey::new_unique(), account);
@@ -2279,7 +2279,7 @@ mod tests {
                 LAMPORTS_PER_SOL,
                 Arc::new(vec![0; rng.gen_range(0, 32)]),
                 system_program::id(),
-                rng.gen(),
+                rng.r#gen(),
                 u64::MAX,
             );
             mock_bank.accounts_map.insert(fee_payer, account);
@@ -2296,7 +2296,7 @@ mod tests {
                     1,
                     Arc::new(vec![0; rng.gen_range(0, 512)]),
                     *loader,
-                    rng.gen(),
+                    rng.r#gen(),
                     u64::MAX,
                 );
 
@@ -2307,7 +2307,7 @@ mod tests {
                 // this will always fail at execution but we are merely testing the data size accounting here
                 if *loader == bpf_loader_upgradeable::id() && account.data().len() >= 64 {
                     let programdata_address = Pubkey::new_unique();
-                    let has_programdata = rng.gen();
+                    let has_programdata = rng.r#gen();
 
                     if has_programdata {
                         let programdata_account =
@@ -2315,7 +2315,7 @@ mod tests {
                                 1,
                                 Arc::new(vec![0; rng.gen_range(0, 512)]),
                                 *loader,
-                                rng.gen(),
+                                rng.r#gen(),
                                 u64::MAX,
                             );
                         programdata_tracker.insert(
@@ -2328,7 +2328,7 @@ mod tests {
                         loader_owned_accounts.push(programdata_address);
                     }
 
-                    if has_programdata || rng.gen() {
+                    if has_programdata || rng.r#gen() {
                         account
                             .set_state(&UpgradeableLoaderState::Program {
                                 programdata_address,
@@ -2372,8 +2372,8 @@ mod tests {
 
                     accounts.push(AccountMeta {
                         pubkey,
-                        is_writable: rng.gen(),
-                        is_signer: rng.gen() && rng.gen(),
+                        is_writable: rng.r#gen(),
+                        is_signer: rng.r#gen() && rng.r#gen(),
                     });
                 }
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -3609,7 +3609,7 @@ mod balance_collector {
             for _ in 0..50 {
                 // failures result in no balance changes (note we use a separate fee-payer)
                 // we mix some in with the successes to test that we never record changes for failures
-                let expected_status = match rng.gen::<f64>() {
+                let expected_status = match rng.r#gen::<f64>() {
                     n if n < 0.85 => ExecutionStatus::Succeeded,
                     n if n < 0.90 => ExecutionStatus::ExecutedFailed,
                     n if n < 0.95 => ExecutionStatus::ProcessedFailed,

--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -48,7 +48,7 @@ impl AuthenticatedEncryption {
     /// This function is randomized. It internally samples a 128-bit key using `OsRng`.
     #[cfg(not(target_os = "solana"))]
     fn keygen() -> AeKey {
-        AeKey(OsRng.gen::<[u8; AE_KEY_LEN]>())
+        AeKey(OsRng.r#gen::<[u8; AE_KEY_LEN]>())
     }
 
     /// On input of an authenticated encryption key and an amount, the function returns a
@@ -56,7 +56,7 @@ impl AuthenticatedEncryption {
     #[cfg(not(target_os = "solana"))]
     fn encrypt(key: &AeKey, balance: u64) -> AeCiphertext {
         let mut plaintext = balance.to_le_bytes();
-        let nonce: Nonce = OsRng.gen::<[u8; NONCE_LEN]>();
+        let nonce: Nonce = OsRng.r#gen::<[u8; NONCE_LEN]>();
 
         // The balance and the nonce have fixed length and therefore, encryption should not fail.
         let ciphertext = Aes128GcmSiv::new(&key.0.into())


### PR DESCRIPTION
#### Problem
Rust 2024 edition forbids `gen` function names, but code using old `rand` library still uses it. Until `rand` can be updated (which is blocked on `ed25519_dalek` dependency upgrade) we can use `r#gen` for that function.

#### Summary of Changes
Replace `gen()` with `r#gen()`