### PR TITLE
ReceiveAndBuffer: use SharableBanks

### DIFF
--- a/core/benches/receive_and_buffer_utils.rs
+++ b/core/benches/receive_and_buffer_utils.rs
@@ -140,7 +140,7 @@ impl ReceiveAndBufferCreator for TransactionViewReceiveAndBuffer {
     ) -> Self {
         TransactionViewReceiveAndBuffer {
             receiver,
-            bank_forks,
+            sharable_banks: bank_forks.read().unwrap().sharable_banks(),
         }
     }
 }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -539,7 +539,7 @@ impl BankingStage {
         // Setup receive & buffer.
         let receive_and_buffer = TransactionViewReceiveAndBuffer {
             receiver: self.non_vote_receiver.clone(),
-            bank_forks: self.bank_forks.clone(),
+            sharable_banks: self.bank_forks.read().unwrap().sharable_banks(),
         };
 
         // Spawn vote worker.

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -26,7 +26,10 @@ use {
     solana_cost_model::cost_model::CostModel,
     solana_fee_structure::FeeBudgetLimits,
     solana_message::v0::LoadedAddresses,
-    solana_runtime::{bank::Bank, bank_forks::BankForks},
+    solana_runtime::{
+        bank::Bank,
+        bank_forks::{BankPair, SharableBanks},
+    },
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_meta::StaticMeta,
         transaction_with_meta::TransactionWithMeta,
@@ -35,10 +38,7 @@ use {
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction::sanitized::MessageHash,
     solana_transaction_error::TransactionError,
-    std::{
-        sync::{Arc, RwLock},
-        time::Instant,
-    },
+    std::time::Instant,
 };
 
 #[derive(Debug)]
@@ -104,7 +104,7 @@ pub(crate) trait ReceiveAndBuffer {
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) struct TransactionViewReceiveAndBuffer {
     pub receiver: BankingPacketReceiver,
-    pub bank_forks: Arc<RwLock<BankForks>>,
+    pub sharable_banks: SharableBanks,
 }
 
 impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
@@ -116,12 +116,10 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
         container: &mut Self::Container,
         decision: &BufferedPacketsDecision,
     ) -> Result<ReceivingStats, DisconnectedError> {
-        let (root_bank, working_bank) = {
-            let bank_forks = self.bank_forks.read().unwrap();
-            let root_bank = bank_forks.root_bank();
-            let working_bank = bank_forks.working_bank();
-            (root_bank, working_bank)
-        };
+        let BankPair {
+            root_bank,
+            working_bank,
+        } = self.sharable_banks.load();
 
         // Receive packet batches.
         const TIMEOUT: Duration = Duration::from_millis(10);
@@ -587,10 +585,12 @@ mod tests {
         solana_packet::{Meta, PACKET_DATA_SIZE},
         solana_perf::packet::{to_packet_batches, Packet, PacketBatch, RecycledPacketBatch},
         solana_pubkey::Pubkey,
+        solana_runtime::bank_forks::BankForks,
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
         solana_system_transaction::transfer,
         solana_transaction::versioned::VersionedTransaction,
+        std::sync::{Arc, RwLock},
     };
 
     fn test_bank_forks() -> (Arc<RwLock<BankForks>>, Keypair) {
@@ -615,7 +615,7 @@ mod tests {
     ) {
         let receive_and_buffer = TransactionViewReceiveAndBuffer {
             receiver,
-            bank_forks,
+            sharable_banks: bank_forks.read().unwrap().sharable_banks(),
         };
         let container = TransactionViewStateContainer::with_capacity(TEST_CONTAINER_CAPACITY);
         (receive_and_buffer, container)

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -502,7 +502,7 @@ mod tests {
     ) -> TransactionViewReceiveAndBuffer {
         TransactionViewReceiveAndBuffer {
             receiver,
-            bank_forks,
+            sharable_banks: bank_forks.read().unwrap().sharable_banks(),
         }
     }
 


### PR DESCRIPTION
#### Problem
- profile showing we get stuck at bank fork's read lock acquisition for long periods
- we have a solution to this...which thought I already did

#### Summary of Changes
- use `SharableBanks` to load root/working bank without taking lock on BankForks

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
