### PR TITLE
clippy: wrap env manipulation in proto build utils as unsafe

### DIFF
--- a/storage-bigtable/build-proto/src/main.rs
+++ b/storage-bigtable/build-proto/src/main.rs
@@ -1,8 +1,11 @@
 fn main() -> Result<(), std::io::Error> {
     const PROTOC_ENVAR: &str = "PROTOC";
+    // Safety: env is checked and updated before any threads might exist
     if std::env::var(PROTOC_ENVAR).is_err() {
         #[cfg(not(windows))]
-        std::env::set_var(PROTOC_ENVAR, protobuf_src::protoc());
+        unsafe {
+            std::env::set_var(PROTOC_ENVAR, protobuf_src::protoc())
+        }
     }
 
     let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/storage-proto/build.rs
+++ b/storage-proto/build.rs
@@ -1,8 +1,11 @@
 fn main() -> Result<(), std::io::Error> {
     const PROTOC_ENVAR: &str = "PROTOC";
+    // Safety: env is checked and updated before any threads might exist
     if std::env::var(PROTOC_ENVAR).is_err() {
         #[cfg(not(windows))]
-        std::env::set_var(PROTOC_ENVAR, protobuf_src::protoc());
+        unsafe {
+            std::env::set_var(PROTOC_ENVAR, protobuf_src::protoc())
+        }
     }
 
     let proto_base_path = std::path::PathBuf::from("proto");

--- a/wen-restart/build.rs
+++ b/wen-restart/build.rs
@@ -2,9 +2,12 @@ use std::io::Result;
 
 fn main() -> Result<()> {
     const PROTOC_ENVAR: &str = "PROTOC";
+    // Safety: env is checked and updated before any threads might exist
     if std::env::var(PROTOC_ENVAR).is_err() {
         #[cfg(not(windows))]
-        std::env::set_var(PROTOC_ENVAR, protobuf_src::protoc());
+        unsafe {
+            std::env::set_var(PROTOC_ENVAR, protobuf_src::protoc())
+        }
     }
 
     let proto_base_path = std::path::PathBuf::from("proto");


### PR DESCRIPTION
#### Problem
Rust edition 2024 marks `env` mutation functions as unsafe (https://github.com/rust-lang/rust/issues/90308), since updating env might invalidate memory that is borrowed in some threads.
In order to [migrate](https://github.com/anza-xyz/agave/issues/6203) to new edition we need to mark uses of `set_var`, etc. as unsafe, ideally auditing it's actually safe.

#### Summary of Changes
Trival uses as first call in a `main` function are obviously safe, which is a case for proto build utils. Mark with `unsafe` and add comment.