### PR TITLE
clippy(platform-tools-sdk): wrap env manipulation with unsafe blocks

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -170,11 +170,12 @@ fn invoke_cargo(config: &Config, validated_toolchain_version: String) {
         .join("platform-tools")
         .join("llvm")
         .join("bin");
-    env::set_var("CC", llvm_bin.join("clang"));
-    env::set_var("AR", llvm_bin.join("llvm-ar"));
-    env::set_var("OBJDUMP", llvm_bin.join("llvm-objdump"));
-    env::set_var("OBJCOPY", llvm_bin.join("llvm-objcopy"));
-
+    unsafe {
+        env::set_var("CC", llvm_bin.join("clang"));
+        env::set_var("AR", llvm_bin.join("llvm-ar"));
+        env::set_var("OBJDUMP", llvm_bin.join("llvm-objdump"));
+        env::set_var("OBJCOPY", llvm_bin.join("llvm-objcopy"));
+    }
     let cargo_target = format!(
         "CARGO_TARGET_{}_RUSTFLAGS",
         target_triple.to_uppercase().replace("-", "_")
@@ -182,7 +183,7 @@ fn invoke_cargo(config: &Config, validated_toolchain_version: String) {
     let rustflags = env::var("RUSTFLAGS").ok().unwrap_or_default();
     if env::var("RUSTFLAGS").is_ok() {
         warn!("Removed RUSTFLAGS from cargo environment, because it overrides {cargo_target}.");
-        env::remove_var("RUSTFLAGS")
+        unsafe { env::remove_var("RUSTFLAGS") }
     }
     let target_rustflags = env::var(&cargo_target).ok();
     let mut target_rustflags = Cow::Borrowed(target_rustflags.as_deref().unwrap_or_default());
@@ -204,7 +205,7 @@ fn invoke_cargo(config: &Config, validated_toolchain_version: String) {
         target_rustflags = Cow::Owned(format!("{} -g", &target_rustflags));
     }
     if let Cow::Owned(flags) = target_rustflags {
-        env::set_var(&cargo_target, flags);
+        unsafe { env::set_var(&cargo_target, flags) }
     }
     if config.verbose {
         debug!(

--- a/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
@@ -531,6 +531,7 @@ pub(crate) fn install_and_link_tools(
                 "Removed RUSTC from cargo environment, because it overrides +solana cargo command \
                  line option."
             );
+            // Safety: cargo-build-sbf doesn't spawn any threads until final child process is spawned
             unsafe { env::remove_var("RUSTC") }
         }
     }

--- a/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
@@ -531,7 +531,7 @@ pub(crate) fn install_and_link_tools(
                 "Removed RUSTC from cargo environment, because it overrides +solana cargo command \
                  line option."
             );
-            env::remove_var("RUSTC")
+            unsafe { env::remove_var("RUSTC") }
         }
     }
 

--- a/platform-tools-sdk/cargo-test-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-test-sbf/src/main.rs
@@ -171,6 +171,7 @@ fn test_solana_package(
     );
 
     // Pass --sbf-out-dir along to the solana-program-test crate
+    // Safety: cargo-test-sbf doesn't spawn any threads, env is updated one-by-one between spawns
     unsafe {
         env::set_var("SBF_OUT_DIR", sbf_out_dir);
     }

--- a/platform-tools-sdk/cargo-test-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-test-sbf/src/main.rs
@@ -171,7 +171,9 @@ fn test_solana_package(
     );
 
     // Pass --sbf-out-dir along to the solana-program-test crate
-    env::set_var("SBF_OUT_DIR", sbf_out_dir);
+    unsafe {
+        env::set_var("SBF_OUT_DIR", sbf_out_dir);
+    }
 
     cargo_args.insert(0, "test");
 


### PR DESCRIPTION
#### Problem
Rust edition 2024 marks `env` mutation functions as unsafe (https://github.com/rust-lang/rust/issues/90308), since updating env might invalidate memory that is borrowed in some threads.
In order to [migrate](https://github.com/anza-xyz/agave/issues/6203) to new edition we need to mark uses of `set_var`, etc. as unsafe, ideally auditing it's actually safe.

#### Summary of Changes
Wrap with unsafe blocks.