### PR TITLE
clippy: annotate env manipulaton with unsafe block

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -1,7 +1,6 @@
 //! The `logger` module configures `env_logger`
 #![cfg(feature = "agave-unstable-api")]
 use std::{
-    env,
     path::{Path, PathBuf},
     sync::{Arc, LazyLock, RwLock},
     thread::JoinHandle,
@@ -90,11 +89,6 @@ pub fn redirect_stderr(filename: &Path) {
 }
 
 pub fn initialize_logging(logfile: Option<PathBuf>) {
-    // Debugging panics is easier with a backtrace
-    if env::var_os("RUST_BACKTRACE").is_none() {
-        env::set_var("RUST_BACKTRACE", "1")
-    }
-
     let Some(logfile) = logfile else {
         setup_with_default_filter();
         return;
@@ -111,15 +105,10 @@ pub fn initialize_logging(logfile: Option<PathBuf>) {
     }
 }
 
-// Redirect stderr to a file with support for logrotate by sending a SIGUSR1 to the process.
-//
-// Upon success, future `log` macros and `eprintln!()` can be found in the specified log file.
+/// Redirect stderr to a file with support for logrotate by sending a SIGUSR1 to the process.
+///
+/// Upon success, future `log` macros and `eprintln!()` can be found in the specified log file.
 pub fn redirect_stderr_to_file(logfile: Option<PathBuf>) -> Option<JoinHandle<()>> {
-    // Default to RUST_BACKTRACE=1 for more informative validator logs
-    if env::var_os("RUST_BACKTRACE").is_none() {
-        env::set_var("RUST_BACKTRACE", "1")
-    }
-
     match logfile {
         None => {
             setup_with_default_filter();

--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -258,7 +258,7 @@ mod tests {
     fn test_metricsrate() {
         try_init_logger_at_level_info().ok();
         let _readlock = get_env_lock().read();
-        env::remove_var("SOLANA_DEFAULT_METRICS_RATE");
+        unsafe { env::remove_var("SOLANA_DEFAULT_METRICS_RATE") };
         let mut counter = create_counter!("test", 1000, 0);
         counter.init();
         assert_eq!(
@@ -272,7 +272,7 @@ mod tests {
     fn test_metricsrate_env() {
         try_init_logger_at_level_info().ok();
         let _writelock = get_env_lock().write();
-        env::set_var("SOLANA_DEFAULT_METRICS_RATE", "50");
+        unsafe { env::set_var("SOLANA_DEFAULT_METRICS_RATE", "50") };
         let mut counter = create_counter!("test", 1000, 0);
         counter.init();
         assert_eq!(counter.metricsrate.load(Ordering::Relaxed), 50);
@@ -314,12 +314,12 @@ mod tests {
         assert_ne!(DEFAULT_LOG_RATE, 0);
         let _writelock = get_env_lock().write();
         let mut counter = create_counter!("test_lograte_env", 0, 1);
-        env::set_var("SOLANA_DEFAULT_LOG_RATE", "50");
+        unsafe { env::set_var("SOLANA_DEFAULT_LOG_RATE", "50") };
         counter.init();
         assert_eq!(counter.lograte.load(Ordering::Relaxed), 50);
 
         let mut counter2 = create_counter!("test_lograte_env", 0, 1);
-        env::set_var("SOLANA_DEFAULT_LOG_RATE", "0");
+        unsafe { env::set_var("SOLANA_DEFAULT_LOG_RATE", "0") };
         counter2.init();
         assert_eq!(counter2.lograte.load(Ordering::Relaxed), DEFAULT_LOG_RATE);
     }

--- a/perf/src/perf_libs.rs
+++ b/perf/src/perf_libs.rs
@@ -20,5 +20,6 @@ pub fn append_to_ld_library_path(mut ld_library_path: String) {
         ld_library_path.push_str(&env_value);
     }
     info!("setting ld_library_path to: {ld_library_path:?}");
-    env::set_var("LD_LIBRARY_PATH", ld_library_path);
+    // Safety: caller (init_poh) is executed before any spawned threads might access the environment
+    unsafe { env::set_var("LD_LIBRARY_PATH", ld_library_path) }
 }

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -33,7 +33,7 @@ use {
     solana_test_validator::*,
     std::{
         collections::{HashMap, HashSet},
-        fs, io,
+        env, fs, io,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         path::{Path, PathBuf},
         process::exit,
@@ -51,6 +51,12 @@ enum Output {
 }
 
 fn main() {
+    // Debugging panics is easier with a backtrace
+    if env::var_os("RUST_BACKTRACE").is_none() {
+        // Safety: env update is made before any spawned threads might access the environment
+        unsafe { env::set_var("RUST_BACKTRACE", "1") }
+    }
+
     let default_args = cli::DefaultTestArgs::new();
     let version = solana_version::version!();
     let matches = cli::test_app(version, &default_args).get_matches();

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -71,6 +71,7 @@ use {
     solana_validator_exit::Exit,
     std::{
         collections::HashSet,
+        env,
         fs::{self, File},
         net::{IpAddr, Ipv4Addr, SocketAddr},
         num::{NonZeroU64, NonZeroUsize},
@@ -92,6 +93,12 @@ pub fn execute(
     solana_version: &str,
     operation: Operation,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Debugging panics is easier with a backtrace
+    if env::var_os("RUST_BACKTRACE").is_none() {
+        // Safety: env update is made before any spawned threads might access the environment
+        unsafe { env::set_var("RUST_BACKTRACE", "1") }
+    }
+
     let run_args = RunArgs::from_clap_arg_match(matches)?;
 
     let cli::thread_args::NumThreadConfig {

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -31,6 +31,11 @@ use {
 const DEFAULT_CHANNEL_SIZE: usize = 100_000;
 
 pub fn main() {
+    // Default to RUST_BACKTRACE=1 for more informative validator logs
+    if env::var_os("RUST_BACKTRACE").is_none() {
+        // Safety: env update is made before any spawned threads might access the environment
+        unsafe { env::set_var("RUST_BACKTRACE", "1") }
+    }
     agave_logger::setup();
 
     let args = Cli::parse();


### PR DESCRIPTION
#### Problem
Rust edition 2024 marks `env` mutation functions as unsafe (https://github.com/rust-lang/rust/issues/90308), since updating env might invalidate memory that is borrowed in some threads.
In order to [migrate](https://github.com/anza-xyz/agave/issues/6203) to new edition we need to mark uses of `set_var`, etc. as unsafe, ideally auditing it's actually safe.

#### Summary of Changes
Wrap with unsafe blocks and add comments as relevant.