### PR TITLE
Add threshold-based flushing/evicting for accounts index

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -227,13 +227,15 @@ enum ScanTypes<R: RangeBounds<Pubkey>> {
     Indexed(IndexKey),
 }
 
-/// specification of how much memory the in-mem portion of account index can use
+/// specification of how much memory the in-mem portion of account index can hold
 #[derive(Debug, Copy, Clone)]
 pub enum IndexLimit {
     /// use disk index while keeping a minimal amount in-mem
     Minimal,
     /// in-mem-only was specified, no disk index
     InMemOnly,
+    /// flush to disk when memory usage exceeds threshold in bytes
+    Threshold(u64),
 }
 
 #[derive(Debug, Clone)]

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -234,7 +234,7 @@ pub enum IndexLimit {
     Minimal,
     /// in-mem-only was specified, no disk index
     InMemOnly,
-    /// flush to disk when memory usage exceeds threshold in bytes
+    /// evict from in-mem when usage exceeds threshold in bytes
     Threshold(u64),
 }
 

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -267,9 +267,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
                     Self::calculate_threshold_entries(target_entries_per_bin);
 
                 info!(
-                    "AccountsIndex threshold configured: limit_bytes={limit_bytes}, target_bytes={}, \
-                     bytes_per_bin={bytes_per_bin}, entries_per_bin={entries_per_bin}, \
-                     target_entries_per_bin={}, high_water_mark={}, low_water_mark={}",
+                    "AccountsIndex threshold configured: limit_bytes={limit_bytes}, \
+                     target_bytes={}, bytes_per_bin={bytes_per_bin}, \
+                     entries_per_bin={entries_per_bin}, target_entries_per_bin={}, \
+                     high_water_mark={}, low_water_mark={}",
                     target_entries_per_bin * bins * bytes_per_entry,
                     threshold_entries_per_bin.target_entries,
                     threshold_entries_per_bin.high_water_mark,

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -595,7 +595,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_threshold_flush_below_limit() {
+    fn test_should_flush_below_limit() {
         let bins = 1;
         let threshold_entries = 1000;
         let bytes_per_entry = InMemAccountsIndex::<u64, u64>::size_of_uninitialized()
@@ -618,7 +618,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_threshold_flush_above_limit() {
+    fn test_should_flush_above_limit() {
         let bins = 1;
         let threshold_entries = 1000;
         let bytes_per_entry = InMemAccountsIndex::<u64, u64>::size_of_uninitialized()
@@ -637,7 +637,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_threshold_flush_at_boundary() {
+    fn test_should_flush_at_boundary() {
         let bins = 1;
         let threshold_entries = 1000;
         let bytes_per_entry = InMemAccountsIndex::<u64, u64>::size_of_uninitialized()
@@ -656,7 +656,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_minimal_always_flushes() {
+    fn test_should_flush_minimal_always_flushes() {
         let bins = 1;
         let config = AccountsIndexConfig {
             index_limit: IndexLimit::Minimal,
@@ -670,7 +670,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_in_mem_only_never_flushes() {
+    fn test_should_flush_in_mem_only_never_flushes() {
         let bins = 1;
         let config = AccountsIndexConfig {
             index_limit: IndexLimit::InMemOnly,

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -35,13 +35,6 @@ const HIGH_WATER_MARK_PERCENTAGE: usize = 85;
 // Evict down to this percent of the target entries when flushing
 const LOW_WATER_MARK_PERCENTAGE: usize = 70;
 
-#[derive(Clone, Copy, Debug)]
-struct ThresholdEntriesPerBin {
-    target_entries: usize,
-    high_water_mark: usize,
-    low_water_mark: usize,
-}
-
 pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     pub disk: Option<BucketMap<(Slot, U)>>,
 
@@ -467,6 +460,18 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             self.stats.active_threads.fetch_sub(1, Ordering::Relaxed);
         }
     }
+}
+
+/// Precomputed thresholds derived from the configured per-bin target.
+#[derive(Clone, Copy, Debug)]
+struct ThresholdEntriesPerBin {
+    /// Rounded target entries per bin used as the baseline for thresholds.
+    target_entries: usize,
+    /// Entry count above which a bin triggers flushing to disk and eviction
+    /// from in-memory index.
+    high_water_mark: usize,
+    /// Entry count to reach after flushing/evicting from a bin.
+    low_water_mark: usize,
 }
 
 #[cfg(test)]

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -686,34 +686,10 @@ pub mod tests {
         let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
         let low_water_mark = test.threshold_entries_per_bin.unwrap().low_water_mark;
         assert_eq!(low_water_mark, 313);
-        let expected_evictions = |current_entries: usize| {
-            NonZeroUsize::new(current_entries.saturating_sub(low_water_mark).max(1)).unwrap()
-        };
-
-        assert_eq!(
-            test.max_evictions_for_threshold(2000),
-            expected_evictions(2000)
+        let expected = Some(
+            NonZeroUsize::new(2000usize.saturating_sub(low_water_mark).max(1)).unwrap(),
         );
-
-        assert_eq!(
-            test.max_evictions_for_threshold(1500),
-            expected_evictions(1500)
-        );
-
-        assert_eq!(
-            test.max_evictions_for_threshold(896),
-            expected_evictions(896)
-        );
-
-        assert_eq!(
-            test.max_evictions_for_threshold(500),
-            expected_evictions(500)
-        );
-        assert_eq!(
-            test.max_evictions_for_threshold(100),
-            expected_evictions(100)
-        );
-        assert_eq!(test.max_evictions_for_threshold(0), expected_evictions(0));
+        assert_eq!(test.max_evictions_for_threshold(2000), expected);
     }
 
     #[test]
@@ -731,30 +707,10 @@ pub mod tests {
 
         let low_water_mark = test.threshold_entries_per_bin.unwrap().low_water_mark;
         assert_eq!(low_water_mark, 78);
-        let expected_evictions = |current_entries: usize| {
-            NonZeroUsize::new(current_entries.saturating_sub(low_water_mark).max(1)).unwrap()
-        };
-
-        assert_eq!(
-            test.max_evictions_for_threshold(500),
-            expected_evictions(500)
+        let expected = Some(
+            NonZeroUsize::new(500usize.saturating_sub(low_water_mark).max(1)).unwrap(),
         );
-
-        assert_eq!(
-            test.max_evictions_for_threshold(300),
-            expected_evictions(300)
-        );
-
-        assert_eq!(
-            test.max_evictions_for_threshold(224),
-            expected_evictions(224)
-        );
-
-        assert_eq!(
-            test.max_evictions_for_threshold(100),
-            expected_evictions(100)
-        );
-        assert_eq!(test.max_evictions_for_threshold(50), expected_evictions(50));
+        assert_eq!(test.max_evictions_for_threshold(500), expected);
     }
 
     #[test]

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -614,9 +614,7 @@ pub mod tests {
         assert_eq!(thresholds.low_water_mark, 313);
 
         // Below high water mark
-        assert!(!test.should_flush(
-            thresholds.high_water_mark.saturating_sub(200),
-        ));
+        assert!(!test.should_flush(thresholds.high_water_mark.saturating_sub(200),));
         assert!(!test.should_flush(thresholds.high_water_mark));
 
         // At boundary and above
@@ -686,9 +684,7 @@ pub mod tests {
         let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
         let low_water_mark = test.threshold_entries_per_bin.unwrap().low_water_mark;
         assert_eq!(low_water_mark, 313);
-        let expected = Some(
-            NonZeroUsize::new(2000usize.saturating_sub(low_water_mark).max(1)).unwrap(),
-        );
+        let expected = NonZeroUsize::new(2000usize.saturating_sub(low_water_mark).max(1)).unwrap();
         assert_eq!(test.max_evictions_for_threshold(2000), expected);
     }
 
@@ -707,9 +703,7 @@ pub mod tests {
 
         let low_water_mark = test.threshold_entries_per_bin.unwrap().low_water_mark;
         assert_eq!(low_water_mark, 78);
-        let expected = Some(
-            NonZeroUsize::new(500usize.saturating_sub(low_water_mark).max(1)).unwrap(),
-        );
+        let expected = NonZeroUsize::new(500usize.saturating_sub(low_water_mark).max(1)).unwrap();
         assert_eq!(test.max_evictions_for_threshold(500), expected);
     }
 

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -791,10 +791,6 @@ pub mod tests {
     fn test_size_of_entry() {
         let size_of_uninitialized = InMemAccountsIndex::<u64, u64>::size_of_uninitialized();
         let size_of_single_entry = InMemAccountsIndex::<u64, u64>::size_of_single_entry();
-
-        assert_eq!(size_of_uninitialized, 40, "size_of_uninitialized");
-        assert_eq!(size_of_single_entry, 48, "size_of_single_entry");
-
         let bytes_per_entry = size_of_uninitialized + size_of_single_entry;
         assert_eq!(bytes_per_entry, 88, "total bytes_per_entry");
     }

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -330,7 +330,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
     }
 
     fn scale_by_percentage(value: usize, percentage: usize) -> usize {
-        value.saturating_mul(percentage) / 100
+        // SAFETY: `value * percentage` is not allowed to overflow
+        value.checked_mul(percentage).unwrap() / 100
     }
 
     // get the next bucket to flush, with the idea that the previous bucket

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -30,7 +30,7 @@ const _: () = assert!(std::mem::size_of::<Age>() == std::mem::size_of::<AtomicAg
 //   index is entirely disabled!  But there were concerns about the in-mem index growth behavior.
 // - 2 seconds is much faster, and does also reduce disk iops quite a lot.
 const AGE_MS: u64 = 2_000;
-// Trigger flushing when a bin exceeds this percent of the target entries.
+// Trigger eviction when a bin exceeds this percent of the target entries.
 // 85% strikes a balance: high enough to avoid frequent oscillations yet low enough
 // to catch growth before bins overshoot far past the target.
 const HIGH_WATER_MARK_PERCENTAGE: usize = 85;

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -708,14 +708,6 @@ pub mod tests {
     }
 
     #[test]
-    fn test_size_of_entry() {
-        let size_of_uninitialized = InMemAccountsIndex::<u64, u64>::size_of_uninitialized();
-        let size_of_single_entry = InMemAccountsIndex::<u64, u64>::size_of_single_entry();
-        let bytes_per_entry = size_of_uninitialized + size_of_single_entry;
-        assert_eq!(bytes_per_entry, 88, "total bytes_per_entry");
-    }
-
-    #[test]
     fn test_age_time() {
         agave_logger::setup();
         let bins = 1;

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -267,9 +267,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
                     Self::calculate_threshold_entries(target_entries_per_bin);
 
                 info!(
-                    "AccountsIndex threshold configured: limit_bytes={limit_bytes}, \
+                    "AccountsIndex threshold configured: limit_bytes={limit_bytes}, target_bytes={}, \
                      bytes_per_bin={bytes_per_bin}, entries_per_bin={entries_per_bin}, \
                      target_entries_per_bin={}, high_water_mark={}, low_water_mark={}",
+                    target_entries_per_bin * bins * bytes_per_entry,
                     threshold_entries_per_bin.target_entries,
                     threshold_entries_per_bin.high_water_mark,
                     threshold_entries_per_bin.low_water_mark,

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -109,15 +109,15 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         low_water_mark_ratio: f64,
     ) -> NonZeroUsize {
         let evictions = match self.target_entries_per_bin {
-            None => current_entries.max(1),
+            None => current_entries,
             Some(target_per_bin) => {
                 // Low water mark: flush down to specified ratio of the per-bin threshold
                 let threshold_entries = (target_per_bin as f64 * low_water_mark_ratio) as usize;
-                current_entries.saturating_sub(threshold_entries).max(1)
+                current_entries.saturating_sub(threshold_entries)
             }
         };
         // SAFETY: evictions is ensured to be non-zero above.
-        NonZeroUsize::new(evictions).unwrap()
+        NonZeroUsize::new(evictions.max(1)).unwrap()
     }
 
     pub fn increment_age(&self) {

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -5,6 +5,7 @@ use {
         AccountsIndexConfig, DiskIndexValue, IndexLimit, IndexValue,
     },
     crate::waitable_condvar::WaitableCondvar,
+    log::*,
     solana_bucket_map::bucket_map::{BucketMap, BucketMapConfig},
     solana_clock::Slot,
     solana_measure::measure::Measure,
@@ -12,6 +13,7 @@ use {
     std::{
         fmt::Debug,
         marker::PhantomData,
+        num::NonZeroUsize,
         sync::{
             atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering},
             Arc,
@@ -67,6 +69,10 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     _phantom: PhantomData<T>,
 
     pub(crate) startup_stats: Arc<StartupStats>,
+
+    /// Target entry count per bin for flushing
+    /// None for Minimal/InMemOnly, Some(entries_per_bin) for Threshold
+    target_entries_per_bin: Option<usize>,
 }
 
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Debug for BucketMapHolder<T, U> {
@@ -80,6 +86,38 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
     /// is the accounts index using disk as a backing store
     pub fn is_disk_index_enabled(&self) -> bool {
         self.disk.is_some()
+    }
+
+    /// Check if flushing to disk should occur based on entry count threshold per bin
+    pub fn should_flush_to_disk(&self, entries_in_bin: usize, high_water_mark_ratio: f64) -> bool {
+        match self.target_entries_per_bin {
+            None => self.is_disk_index_enabled(),
+            Some(target_entries_per_bin) => {
+                let high_water_mark =
+                    (target_entries_per_bin as f64 * high_water_mark_ratio) as usize;
+                entries_in_bin > high_water_mark
+            }
+        }
+    }
+
+    /// Calculate maximum evictions to perform for threshold-based flushing
+    /// Returns current_entries for Minimal disk index
+    /// Returns the max_evictions for Threshold mode to bring count to low_water_mark_ratio * target_per_bin
+    pub fn max_evictions_for_threshold(
+        &self,
+        current_entries: usize,
+        low_water_mark_ratio: f64,
+    ) -> NonZeroUsize {
+        let evictions = match self.target_entries_per_bin {
+            None => current_entries.max(1),
+            Some(target_per_bin) => {
+                // Low water mark: flush down to specified ratio of the per-bin threshold
+                let threshold_entries = (target_per_bin as f64 * low_water_mark_ratio) as usize;
+                current_entries.saturating_sub(threshold_entries).max(1)
+            }
+        };
+        // SAFETY: evictions is ensured to be non-zero above.
+        NonZeroUsize::new(evictions).unwrap()
     }
 
     pub fn increment_age(&self) {
@@ -209,7 +247,31 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
 
         let disk = match config.index_limit {
             IndexLimit::InMemOnly => None,
-            IndexLimit::Minimal => Some(BucketMap::new(bucket_config)),
+            IndexLimit::Minimal | IndexLimit::Threshold(_) => Some(BucketMap::new(bucket_config)),
+        };
+
+        // Compute threshold_entries once here
+        let target_entries_per_bin = match config.index_limit {
+            IndexLimit::InMemOnly | IndexLimit::Minimal => None,
+            IndexLimit::Threshold(limit_bytes) => {
+                let bytes_per_bin = (limit_bytes as usize) / bins;
+                let entries_per_bin = bytes_per_bin
+                    / (InMemAccountsIndex::<T, U>::size_of_uninitialized()
+                        + InMemAccountsIndex::<T, U>::size_of_single_entry());
+                let target_entries_per_bin = if entries_per_bin == 0 {
+                    0
+                } else {
+                    let entries_per_bin_log2 = entries_per_bin.ilog2();
+                    (1usize << entries_per_bin_log2) * 7 / 8
+                };
+
+                info!(
+                    "AccountsIndex threshold configured: limit_bytes={limit_bytes}, \
+                     bytes_per_bin={bytes_per_bin}, entries_per_bin={entries_per_bin}, \
+                     target_entries_per_bin={target_entries_per_bin}"
+                );
+                Some(target_entries_per_bin)
+            }
         };
 
         Self {
@@ -232,6 +294,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             threads,
             _phantom: PhantomData,
             startup_stats: Arc::default(),
+            target_entries_per_bin,
         }
     }
 
@@ -481,6 +544,206 @@ pub mod tests {
         };
         let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
         assert!(test.is_disk_index_enabled());
+    }
+
+    #[test]
+    fn test_threshold_flush_below_limit() {
+        let bins = 1;
+        let threshold_entries = 1000;
+        let bytes_per_entry = InMemAccountsIndex::<u64, u64>::size_of_uninitialized()
+            + InMemAccountsIndex::<u64, u64>::size_of_single_entry();
+        let limit_bytes = (threshold_entries * bytes_per_entry) as u64;
+        let config = AccountsIndexConfig {
+            index_limit: IndexLimit::Threshold(limit_bytes),
+            ..Default::default()
+        };
+        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
+        assert!(test.is_disk_index_enabled());
+
+        let current_entries = 200;
+        assert!(!test.should_flush_to_disk(current_entries, 0.75));
+
+        let current_entries = 336;
+        assert!(!test.should_flush_to_disk(current_entries, 0.75));
+    }
+
+    #[test]
+    fn test_threshold_flush_above_limit() {
+        let bins = 1;
+        let threshold_entries = 1000;
+        let bytes_per_entry = InMemAccountsIndex::<u64, u64>::size_of_uninitialized()
+            + InMemAccountsIndex::<u64, u64>::size_of_single_entry();
+        let limit_bytes = (threshold_entries * bytes_per_entry) as u64;
+        let config = AccountsIndexConfig {
+            index_limit: IndexLimit::Threshold(limit_bytes),
+            ..Default::default()
+        };
+        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
+
+        let current_entries = 337;
+        assert!(test.should_flush_to_disk(current_entries, 0.75));
+
+        let current_entries = 500;
+        assert!(test.should_flush_to_disk(current_entries, 0.75));
+    }
+
+    #[test]
+    fn test_threshold_flush_at_boundary() {
+        let bins = 1;
+        let threshold_entries = 1000;
+        let bytes_per_entry = InMemAccountsIndex::<u64, u64>::size_of_uninitialized()
+            + InMemAccountsIndex::<u64, u64>::size_of_single_entry();
+        let limit_bytes = (threshold_entries * bytes_per_entry) as u64;
+        let config = AccountsIndexConfig {
+            index_limit: IndexLimit::Threshold(limit_bytes),
+            ..Default::default()
+        };
+        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
+
+        let current_entries = 336;
+        assert!(!test.should_flush_to_disk(current_entries, 0.75));
+
+        let current_entries = 337;
+        assert!(test.should_flush_to_disk(current_entries, 0.75));
+    }
+
+    #[test]
+    fn test_minimal_always_flushes() {
+        let bins = 1;
+        let config = AccountsIndexConfig {
+            index_limit: IndexLimit::Minimal,
+            ..Default::default()
+        };
+        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
+
+        assert!(test.should_flush_to_disk(0, 0.75));
+        assert!(test.should_flush_to_disk(1000, 0.75));
+        assert!(test.should_flush_to_disk(usize::MAX, 0.75));
+    }
+
+    #[test]
+    fn test_in_mem_only_never_flushes() {
+        let bins = 1;
+        let config = AccountsIndexConfig {
+            index_limit: IndexLimit::InMemOnly,
+            ..Default::default()
+        };
+        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
+
+        assert!(!test.should_flush_to_disk(0, 0.75));
+        assert!(!test.should_flush_to_disk(1000, 0.75));
+        assert!(!test.should_flush_to_disk(usize::MAX, 0.75));
+    }
+
+    #[test]
+    fn test_max_evictions_minimal() {
+        let bins = 1;
+        let config = AccountsIndexConfig {
+            index_limit: IndexLimit::Minimal,
+            ..Default::default()
+        };
+        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
+
+        assert_eq!(
+            test.max_evictions_for_threshold(0, 0.50),
+            NonZeroUsize::new(1).unwrap()
+        );
+        assert_eq!(
+            test.max_evictions_for_threshold(1000, 0.50),
+            NonZeroUsize::new(1000).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_max_evictions_threshold() {
+        let bins = 1;
+        let threshold_entries = 1000;
+        let bytes_per_entry = InMemAccountsIndex::<u64, u64>::size_of_uninitialized()
+            + InMemAccountsIndex::<u64, u64>::size_of_single_entry();
+        let limit_bytes = (threshold_entries * bytes_per_entry) as u64;
+        let config = AccountsIndexConfig {
+            index_limit: IndexLimit::Threshold(limit_bytes),
+            ..Default::default()
+        };
+        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
+
+        assert_eq!(
+            test.max_evictions_for_threshold(2000, 0.50),
+            NonZeroUsize::new(1776).unwrap()
+        );
+
+        assert_eq!(
+            test.max_evictions_for_threshold(1500, 0.50),
+            NonZeroUsize::new(1276).unwrap()
+        );
+
+        assert_eq!(
+            test.max_evictions_for_threshold(896, 0.50),
+            NonZeroUsize::new(672).unwrap()
+        );
+
+        assert_eq!(
+            test.max_evictions_for_threshold(500, 0.50),
+            NonZeroUsize::new(276).unwrap()
+        );
+        assert_eq!(
+            test.max_evictions_for_threshold(100, 0.50),
+            NonZeroUsize::new(1).unwrap()
+        );
+        assert_eq!(
+            test.max_evictions_for_threshold(0, 0.50),
+            NonZeroUsize::new(1).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_max_evictions_threshold_multiple_bins() {
+        let bins = 4;
+        let threshold_entries = 1000;
+        let bytes_per_entry = InMemAccountsIndex::<u64, u64>::size_of_uninitialized()
+            + InMemAccountsIndex::<u64, u64>::size_of_single_entry();
+        let limit_bytes = (threshold_entries * bytes_per_entry) as u64;
+        let config = AccountsIndexConfig {
+            index_limit: IndexLimit::Threshold(limit_bytes),
+            ..Default::default()
+        };
+        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
+
+        assert_eq!(
+            test.max_evictions_for_threshold(500, 0.50),
+            NonZeroUsize::new(444).unwrap()
+        );
+
+        assert_eq!(
+            test.max_evictions_for_threshold(300, 0.50),
+            NonZeroUsize::new(244).unwrap()
+        );
+
+        assert_eq!(
+            test.max_evictions_for_threshold(224, 0.50),
+            NonZeroUsize::new(168).unwrap()
+        );
+
+        assert_eq!(
+            test.max_evictions_for_threshold(100, 0.50),
+            NonZeroUsize::new(44).unwrap()
+        );
+        assert_eq!(
+            test.max_evictions_for_threshold(50, 0.50),
+            NonZeroUsize::new(1).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_size_of_entry() {
+        let size_of_uninitialized = InMemAccountsIndex::<u64, u64>::size_of_uninitialized();
+        let size_of_single_entry = InMemAccountsIndex::<u64, u64>::size_of_single_entry();
+
+        assert_eq!(size_of_uninitialized, 40, "size_of_uninitialized");
+        assert_eq!(size_of_single_entry, 48, "size_of_single_entry");
+
+        let bytes_per_entry = size_of_uninitialized + size_of_single_entry;
+        assert_eq!(bytes_per_entry, 88, "total bytes_per_entry");
     }
 
     #[test]

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -30,9 +30,14 @@ const _: () = assert!(std::mem::size_of::<Age>() == std::mem::size_of::<AtomicAg
 //   index is entirely disabled!  But there were concerns about the in-mem index growth behavior.
 // - 2 seconds is much faster, and does also reduce disk iops quite a lot.
 const AGE_MS: u64 = 2_000;
-// Trigger flushing when a bin exceeds this percent of the target entries
+// Trigger flushing when a bin exceeds this percent of the target entries.
+// 85% strikes a balance: high enough to avoid frequent oscillations yet low enough
+// to catch growth before bins overshoot far past the target.
 const HIGH_WATER_MARK_PERCENTAGE: usize = 85;
-// Evict down to this percent of the target entries when flushing
+// Evict down to this percent of the target entries when flushing.
+// 70% is intentionally not too low; it reduces unnecessary evictions while
+// still providing headroom so bins don't immediately re-trigger flushing scan
+// after eviction.
 const LOW_WATER_MARK_PERCENTAGE: usize = 70;
 
 pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -306,6 +306,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         if entries_per_bin == 0 {
             0
         } else {
+            // HashMap capacities grow in powers of 2 and typically trigger a reallocation
+            // when ~7/8 full. Derive the target as the highest power-of-two capacity that
+            // fits within entries_per_bin, then apply the 7/8 factor to stay below the
+            // reallocation threshold.
             let entries_per_bin_log2 = entries_per_bin.ilog2();
             (1usize << entries_per_bin_log2) * 7 / 8
         }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -965,7 +965,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let (possible_evictions, m) = {
             let map = self.map_internal.read().unwrap();
             let m = Measure::start("flush_scan"); // we don't care about lock time in this metric - bg threads can wait
-            let max_evictions = self.storage.max_evictions_for_threshold(map.len(), 0.7);
+            let max_evictions = self.storage.max_evictions_for_threshold(map.len());
             let possible_evictions = Self::gather_possible_evictions(
                 map.iter(),
                 current_age,
@@ -1124,7 +1124,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         // For threshold-based flushing, check if current entry count warrants flushing
         let entries_in_bin = self.map_internal.read().unwrap().len();
-        if !self.storage.should_flush_to_disk(entries_in_bin, 0.85) {
+        if !self.storage.should_flush_to_disk(entries_in_bin) {
             // Entry count is below threshold, no need to flush
             // Still mark as aged to avoid infinite scanning
             assert_eq!(current_age, self.storage.current_age());

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1124,7 +1124,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         // For threshold-based flushing, check if current entry count warrants flushing
         let entries_in_bin = self.map_internal.read().unwrap().len();
-        if !self.storage.should_flush_to_disk(entries_in_bin) {
+        if !self.storage.should_flush(entries_in_bin) {
             // Entry count is below threshold, no need to flush
             // Still mark as aged to avoid infinite scanning
             assert_eq!(current_age, self.storage.current_age());

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -965,7 +965,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let (possible_evictions, m) = {
             let map = self.map_internal.read().unwrap();
             let m = Measure::start("flush_scan"); // we don't care about lock time in this metric - bg threads can wait
-            let max_evictions = NonZeroUsize::new(map.len().max(1)).unwrap();
+            let max_evictions = self.storage.max_evictions_for_threshold(map.len(), 0.7);
             let possible_evictions = Self::gather_possible_evictions(
                 map.iter(),
                 current_age,
@@ -1121,6 +1121,16 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         // from this point forward, we know iterate_for_age == true
         debug_assert!(iterate_for_age);
+
+        // For threshold-based flushing, check if current entry count warrants flushing
+        let entries_in_bin = self.map_internal.read().unwrap().len();
+        if !self.storage.should_flush_to_disk(entries_in_bin, 0.85) {
+            // Entry count is below threshold, no need to flush
+            // Still mark as aged to avoid infinite scanning
+            assert_eq!(current_age, self.storage.current_age());
+            self.set_has_aged(current_age, can_advance_age);
+            return;
+        }
 
         let ages_flushing_now = {
             let old_value = self


### PR DESCRIPTION
#### Problem

split from https://github.com/anza-xyz/agave/pull/8767

Add threshold-based flushing/evicting for accounts index


#### Summary of Changes

- Introduce IndexLimit::Threshold(u64) to cap in-memory accounts index by bytes and log the derived per-bin target 
- Compute per-bin thresholds for flushing on a high-water mark and sizing evictions to a low-water mark 
- Update in-memory index flushing to use threshold checks and bounded eviction counts
- Add unit coverage for threshold calculations, flush boundaries, eviction sizing, and entry sizing.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
