### PR TITLE
Adds type alias for a slot list item

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -5,7 +5,8 @@ use {
         },
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
         stats::Stats,
-        DiskIndexValue, IndexValue, ReclaimsSlotList, RefCount, SlotList, UpsertReclaim,
+        DiskIndexValue, IndexValue, ReclaimsSlotList, RefCount, SlotList, SlotListItem,
+        UpsertReclaim,
     },
     crate::pubkey_bins::PubkeyBinCalculator24,
     rand::{rng, Rng},
@@ -412,7 +413,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
     /// Insert a cached entry into the accounts index
     /// If the entry is already present, just mark dirty and set the age to the future
-    fn cache_entry_at_slot(current: &AccountMapEntry<T>, new_value: (Slot, T)) {
+    fn cache_entry_at_slot(current: &AccountMapEntry<T>, new_value: SlotListItem<T>) {
         let mut slot_list = current.slot_list_write_lock();
         let (slot, new_entry) = new_value;
         if !slot_list
@@ -540,7 +541,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// Note:: This function only supports uncached types `T`.
     fn lock_and_update_slot_list(
         current: &AccountMapEntry<T>,
-        new_value: (Slot, T),
+        new_value: SlotListItem<T>,
         other_slot: Option<Slot>,
         reclaims: &mut ReclaimsSlotList<T>,
         reclaim: UpsertReclaim,
@@ -841,7 +842,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         entry: &AccountMapEntry<T>,
         current_age: Age,
         ages_flushing_now: Age,
-    ) -> ShouldFlush<(Slot, T)> {
+    ) -> ShouldFlush<SlotListItem<T>> {
         // Step 1: Perform the cheap checks on the entry
         // Step 2: Clear the dirty flag
         // Step 3: Perform all the checks on the entry.

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -2,9 +2,8 @@ use {
     super::{
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
         in_mem_accounts_index::InMemAccountsIndex,
-        DiskIndexValue, IndexValue,
+        DiskIndexValue, IndexValue, SlotListItem,
     },
-    solana_clock::Slot,
     solana_time_utils::AtomicInterval,
     std::{
         fmt::Debug,
@@ -287,7 +286,7 @@ impl Stats {
                 // and for entries held in mem due to ref count or slot list length, assume
                 // conservatively a slot list with two entries
                 + (held_in_mem_ref_count + held_in_mem_slot_list_len) as usize
-                    * size_of::<(Slot, T)>() // <-- size of one slot list entry
+                    * size_of::<SlotListItem<T>>() // <-- size of one slot list entry
                     * 2; // <-- and assume there are two entries
             datapoint_info!(
                 datapoint_name,


### PR DESCRIPTION
#### Problem

Modifying the SlotList definition is more cumbersome than necessary because we don't already have a type alias for what the SlotList actually contains.

(Motivation here is that I'm working on removing `Slot` from the SlotList, and it would be more straight forward to edit a single type alias than all the places that use `(Slot, T)` somewhere.)


#### Summary of Changes

Add type alias.