### PR TITLE
validator: Remove deprecated exit subcommand args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Release channels have their own copy of this changelog:
   * `--accounts-hash-cache-path`
   * `--disable-accounts-disk-index`
   * `--dev-halt-at-slot`
+  * `--monitor` (`exit` subcommand)
+  * `--wait-for-exit` (`exit` subcommand)
 #### Deprecations
 * Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.
 ### CLI

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -3,13 +3,10 @@ use std::{io, thread, time::Duration};
 use {
     crate::{
         admin_rpc_service,
-        commands::{monitor, wait_for_restart_window, Error, FromClapArgMatches, Result},
+        commands::{wait_for_restart_window, Error, FromClapArgMatches, Result},
     },
     clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand},
-    solana_clap_utils::{
-        hidden_unless_forced,
-        input_validators::{is_parsable, is_valid_percentage},
-    },
+    solana_clap_utils::input_validators::{is_parsable, is_valid_percentage},
     std::path::Path,
 };
 
@@ -18,18 +15,10 @@ const COMMAND: &str = "exit";
 const DEFAULT_MIN_IDLE_TIME: &str = "10";
 const DEFAULT_MAX_DELINQUENT_STAKE: &str = "5";
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum PostExitAction {
-    // Run the agave-validator monitor command indefinitely
-    Monitor,
-    // Block until the exiting validator process has terminated
-    Wait,
-}
-
 #[derive(Debug, PartialEq)]
 pub struct ExitArgs {
     pub force: bool,
-    pub post_exit_action: Option<PostExitAction>,
+    pub wait_for_exit: bool,
     pub min_idle_time: usize,
     pub max_delinquent_stake: u8,
     pub skip_new_snapshot_check: bool,
@@ -38,32 +27,9 @@ pub struct ExitArgs {
 
 impl FromClapArgMatches for ExitArgs {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
-        let post_exit_action = if matches.is_present("monitor") {
-            Some(PostExitAction::Monitor)
-        } else if matches.is_present("no_wait_for_exit") {
-            None
-        } else {
-            Some(PostExitAction::Wait)
-        };
-
-        // Deprecated in v3.0.0
-        if matches.is_present("wait_for_exit") {
-            eprintln!(
-                "WARN: The --wait-for-exit flag has been deprecated, waiting for exit is now the \
-                 default behavior"
-            );
-        }
-        // Deprecated in v3.1.0
-        if matches.is_present("monitor") {
-            eprintln!(
-                "WARN: The --monitor flag has been deprecated, use \"agave-validator monitor\" \
-                 instead"
-            );
-        }
-
         Ok(ExitArgs {
             force: matches.is_present("force"),
-            post_exit_action,
+            wait_for_exit: !matches.is_present("no_wait_for_exit"),
             min_idle_time: value_t_or_exit!(matches, "min_idle_time", usize),
             max_delinquent_stake: value_t_or_exit!(matches, "max_delinquent_stake", u8),
             skip_new_snapshot_check: matches.is_present("skip_new_snapshot_check"),
@@ -84,22 +50,6 @@ pub fn command<'a>() -> App<'a, 'a> {
                     "Request the validator exit immediately instead of waiting for a restart \
                      window",
                 ),
-        )
-        .arg(
-            Arg::with_name("monitor")
-                .short("m")
-                .long("monitor")
-                .takes_value(false)
-                .requires("no_wait_for_exit")
-                .hidden(hidden_unless_forced())
-                .help("Monitor the validator after sending the exit request"),
-        )
-        .arg(
-            Arg::with_name("wait_for_exit")
-                .long("wait-for-exit")
-                .conflicts_with("monitor")
-                .hidden(hidden_unless_forced())
-                .help("Wait for the validator to terminate after sending the exit request"),
         )
         .arg(
             Arg::with_name("no_wait_for_exit")
@@ -161,15 +111,15 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     const WAIT_FOR_EXIT_UNSUPPORTED_ERROR: &str = "remote process exit cannot be waited on. \
                                                    `--wait-for-exit` is not supported by the \
                                                    remote process";
-    let post_exit_action = exit_args.post_exit_action.clone();
     let validator_pid = admin_rpc_service::runtime().block_on(async move {
         let admin_client = admin_rpc_service::connect(ledger_path).await?;
-        let validator_pid = match post_exit_action {
-            Some(PostExitAction::Wait) => admin_client
+        let validator_pid = if exit_args.wait_for_exit {
+            admin_client
                 .pid()
                 .await
-                .map_err(|_err| Error::Dynamic(WAIT_FOR_EXIT_UNSUPPORTED_ERROR.into()))?,
-            _ => 0,
+                .map_err(|_err| Error::Dynamic(WAIT_FOR_EXIT_UNSUPPORTED_ERROR.into()))?
+        } else {
+            0
         };
         admin_client.exit().await?;
 
@@ -177,12 +127,9 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     })?;
 
     println!("Exit request sent");
-
-    match exit_args.post_exit_action {
-        None => Ok(()),
-        Some(PostExitAction::Monitor) => monitor::execute(matches, ledger_path),
-        Some(PostExitAction::Wait) => poll_until_pid_terminates(validator_pid),
-    }?;
+    if exit_args.wait_for_exit {
+        poll_until_pid_terminates(validator_pid)?;
+    }
 
     Ok(())
 }
@@ -257,7 +204,7 @@ mod tests {
                     .parse()
                     .expect("invalid DEFAULT_MAX_DELINQUENT_STAKE"),
                 force: false,
-                post_exit_action: Some(PostExitAction::Wait),
+                wait_for_exit: true,
                 skip_new_snapshot_check: false,
                 skip_health_check: false,
             }
@@ -282,30 +229,12 @@ mod tests {
     }
 
     #[test]
-    fn verify_args_struct_by_command_exit_with_post_exit_action() {
-        verify_args_struct_by_command(
-            command(),
-            vec![COMMAND, "--monitor", "--no-wait-for-exit"],
-            ExitArgs {
-                post_exit_action: Some(PostExitAction::Monitor),
-                ..ExitArgs::default()
-            },
-        );
-
+    fn verify_args_struct_by_command_exit_wait_for_exit() {
         verify_args_struct_by_command(
             command(),
             vec![COMMAND, "--no-wait-for-exit"],
             ExitArgs {
-                post_exit_action: None,
-                ..ExitArgs::default()
-            },
-        );
-
-        verify_args_struct_by_command(
-            command(),
-            vec![COMMAND, "--wait-for-exit"],
-            ExitArgs {
-                post_exit_action: Some(PostExitAction::Wait),
+                wait_for_exit: false,
                 ..ExitArgs::default()
             },
         );


### PR DESCRIPTION
#### Problem
CLI args were previously deprecated in v3.x release

#### Summary of Changes
Remove them now that upcoming release will be v4.x