### PR TITLE
Fix: Replace .into_par_iter() with .iter() in sigverify_shreds::verify_shreds (Issue #9238)

### DIFF
--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -63,7 +63,7 @@ pub fn verify_shreds(
 ) -> Vec<Vec<u8>> {
     thread_pool.install(|| {
         batches
-            .into_par_iter()
+            .iter()
             .map(|batch| {
                 batch
                     .par_iter()


### PR DESCRIPTION

**Описание:**

Этот Pull Request устраняет потенциальную избыточную многопоточность, описанную в Issue #9238, путем замены внешней параллельной итерации `.into_par_iter()` на последовательный итератор `.iter()` в функции `verify_shreds`.

**Изменение:**
```rust
-            .into_par_iter()
+            .iter()
Это позволяет избежать вложенного параллелизма, когда Rayon пытается параллельно итерировать как по PacketBatch, так и по Packet внутри, что может приводить к накладным расходам (overhead). Сохраняется внутренняя параллельность (.par_iter()) по пакетам, что является более эффективным подходом для этой операции.

Проверено:

Тесты в sigverify_shreds успешно пройдены локально.
