### PR TITLE
fix(consensus): preserve slot on duplicate frozen votes in dirty set

### DIFF
--- a/core/src/consensus/latest_validator_votes_for_frozen_banks.rs
+++ b/core/src/consensus/latest_validator_votes_for_frozen_banks.rs
@@ -55,10 +55,14 @@ impl LatestValidatorVotesForFrozenBanks {
                             // Only record votes detected through replaying blocks,
                             // because votes in gossip are not consistently observable
                             // if the validator is replacing them.
-                            let (_, dirty_frozen_hashes) =
-                                self.fork_choice_dirty_set.entry(vote_pubkey).or_default();
-                            assert!(!dirty_frozen_hashes.contains(&frozen_hash));
-                            dirty_frozen_hashes.push(frozen_hash);
+                            self.fork_choice_dirty_set
+                                .entry(vote_pubkey)
+                                .and_modify(|(slot, hashes)| {
+                                    debug_assert_eq!(*slot, vote_slot);
+                                    assert!(!hashes.contains(&frozen_hash));
+                                    hashes.push(frozen_hash);
+                                })
+                                .or_insert((vote_slot, vec![frozen_hash]));
                         }
                         latest_frozen_vote_hashes.push(frozen_hash);
                         return (true, Some(vote_slot));


### PR DESCRIPTION
When adding a duplicate frozen vote for the same slot after take_votes_dirty_set cleared the dirty set, the code used or_default(), which initialized (slot, hashes) as (0, vec![]). This produced an incorrect slot in the dirty set, causing votes to be filtered out or misapplied by fork choice. The change replaces or_default() with entry(...).and_modify(...).or_insert((vote_slot, vec![frozen_hash])) and asserts slot equality, ensuring the correct slot is always propagated.