### PR TITLE
ledger: Remove outdated shred method

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -17,8 +17,8 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
         next_slots_iterator::NextSlotsIterator,
         shred::{
-            self, resize_stored_shred, ErasureSetId, ProcessShredsStats, ReedSolomonCache, Shred,
-            ShredId, ShredType, Shredder, DATA_SHREDS_PER_FEC_BLOCK,
+            self, ErasureSetId, ProcessShredsStats, ReedSolomonCache, Shred, ShredId, ShredType,
+            Shredder, DATA_SHREDS_PER_FEC_BLOCK,
         },
         slot_stats::{ShredSource, SlotsStats},
         transaction_address_lookup_table_scanner::scan_transaction,
@@ -2261,13 +2261,7 @@ impl Blockstore {
     }
 
     pub fn get_data_shred(&self, slot: Slot, index: u64) -> Result<Option<Vec<u8>>> {
-        let shred = self.data_shred_cf.get_bytes((slot, index))?;
-        let shred = shred.map(resize_stored_shred).transpose();
-        shred.map_err(|err| {
-            let err = format!("Invalid stored shred: {err}");
-            let err = Box::new(bincode::ErrorKind::Custom(err));
-            BlockstoreError::InvalidShredData(err)
-        })
+        self.data_shred_cf.get_bytes((slot, index))
     }
 
     pub fn get_data_shreds_for_slot(&self, slot: Slot, start_index: u64) -> Result<Vec<Shred>> {

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -50,10 +50,7 @@
 //! So, given a) - c), we must restrict data shred's payload length such that the entire coding
 //! payload can fit into one coding shred / packet.
 
-pub(crate) use self::{
-    merkle_tree::PROOF_ENTRIES_FOR_32_32_BATCH, payload::serde_bytes_payload,
-    shred_data::resize_stored_shred,
-};
+pub(crate) use self::{merkle_tree::PROOF_ENTRIES_FOR_32_32_BATCH, payload::serde_bytes_payload};
 use {
     self::traits::{Shred as _, ShredData as _},
     crate::blockstore::{self},

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -1,21 +1,6 @@
 use crate::shred::{
-    traits::{Shred, ShredData as ShredDataTrait},
-    Error, ShredType, MAX_DATA_SHREDS_PER_SLOT,
+    traits::ShredData as ShredDataTrait, Error, ShredType, MAX_DATA_SHREDS_PER_SLOT,
 };
-
-// Possibly zero pads bytes stored in blockstore.
-pub(crate) fn resize_stored_shred(shred: Vec<u8>) -> Result<Vec<u8>, Error> {
-    use crate::shred::{merkle, ShredVariant};
-    match crate::shred::layout::get_shred_variant(&shred)? {
-        ShredVariant::MerkleCode { .. } => Err(Error::InvalidShredType),
-        ShredVariant::MerkleData { .. } => {
-            if shred.len() != <merkle::ShredData as Shred>::SIZE_OF_PAYLOAD {
-                return Err(Error::InvalidPayloadSize(shred.len()));
-            }
-            Ok(shred)
-        }
-    }
-}
 
 #[inline]
 pub(super) fn erasure_shard_index<T: ShredDataTrait>(shred: &T) -> Option<usize> {


### PR DESCRIPTION
#### Problem
We used to strip 0's from legacy shreds before storing in Blockstore. With legacy shreds gone, this doesn't happen anymore so this function no longer has value. There is a size check that we're removing, but this same check happens in `sanitize()` which is a more appropriate place for it.

I missed this function when doing https://github.com/anza-xyz/agave/pull/9403, but this removal is in the same spirit

#### Summary of Changes
Remove the function