### PR TITLE
fix: enable solana-pubkey/serde for solana-transaction-context/serde

### DIFF
--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg=docsrs"]
 agave-unstable-api = []
 bincode = ["dep:bincode", "serde", "solana-account/bincode"]
 dev-context-only-utils = ["bincode", "solana-account/dev-context-only-utils", "dep:qualifier_attr"]
-serde = ["serde/derive"]
+serde = ["serde/derive", "solana-pubkey/serde"]
 
 [dependencies]
 qualifier_attr = { workspace = true, optional = true }


### PR DESCRIPTION
#### Problem

(split from #9456)

failed to compile:
```
cargo +nightly-2025-08-02 check --manifest-path transaction-context/Cargo.toml --no-default-features --features serde
```

#### Summary of Changes

enable `solana-pubkey/serde` for `solana-transaction-context/serde`