### PR TITLE
fix: enable dcou for solana-accounts-db/frozen-abi

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -29,6 +29,7 @@ dev-context-only-utils = [
     "solana-transaction/dev-context-only-utils",
 ]
 frozen-abi = [
+    "dev-context-only-utils",
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-fee-calculator/frozen-abi",


### PR DESCRIPTION
#### Problem

(split from #9456)

failed to compile:
```
cargo +nightly-2025-08-02 check --manifest-path accounts-db/Cargo.toml --no-default-features --features frozen-abi
```

```
error[E0599]: no function or associated item named `new_single_for_tests` found for struct `AccountsDb` in the current scope
    --> accounts-db/src/accounts_db.rs:1235:39
     |
1088 | pub struct AccountsDb {
     | --------------------- function or associated item `new_single_for_tests` not found for this struct
...
1235 |         let accounts_db = AccountsDb::new_single_for_tests();
     |                                       ^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `AccountsDb`
     |
note: if you're trying to build a new `AccountsDb`, consider using `AccountsDb::new_with_config` which returns `AccountsDb`
    --> accounts-db/src/accounts_db.rs:1262:5
     |
1262 | /     pub fn new_with_config(
1263 | |         paths: Vec<PathBuf>,
1264 | |         accounts_db_config: AccountsDbConfig,
1265 | |         accounts_update_notifier: Option<AccountsUpdateNotifier>,
1266 | |         exit: Arc<AtomicBool>,
1267 | |     ) -> Self {
     | |_____________^
```

#### Summary of Changes

enable `dev-context-only-utils` for `solana-accounts-db/frozen-abi`