### PR TITLE
fix: enable dep:qualifier_attr for svm/svm-internal

### DIFF
--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -33,7 +33,7 @@ shuttle-test = [
     "solana-program-runtime/shuttle-test",
     "solana-svm-type-overrides/shuttle-test",
 ]
-svm-internal = []
+svm-internal = ["dep:qualifier_attr"]
 
 [dependencies]
 ahash = { workspace = true }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -66,7 +66,7 @@ pub(crate) enum TransactionLoadResult {
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
-#[cfg_attr(feature = "svm-internal", field_qualifiers(nonce(pub)))]
+#[cfg_attr(feature = "svm-internal", qualifier_attr::field_qualifiers(nonce(pub)))]
 pub struct CheckedTransactionDetails {
     pub(crate) nonce: Option<NonceInfo>,
     pub(crate) compute_budget_and_limits: SVMTransactionExecutionAndFeeBudgetLimits,


### PR DESCRIPTION
#### Problem

(split from #9456)

failed to compile:

```
cargo +nightly-2025-08-02 check --manifest-path svm/Cargo.toml --no-default-features --features svm-internal
```

```
error: cannot find attribute `field_qualifiers` in this scope
  --> svm/src/account_loader.rs:69:38
   |
69 | #[cfg_attr(feature = "svm-internal", field_qualifiers(nonce(pub)))]
   |                                      ^^^^^^^^^^^^^^^^

error: could not compile `solana-svm` (lib) due to 1 previous error
```

#### Summary of Changes

enable dep:qualifier_attr for svm/svm-internal