### PR TITLE
fix: enable solana-pubkey/default for solana-svm-test-harness/fuzz

### DIFF
--- a/svm-test-harness/Cargo.toml
+++ b/svm-test-harness/Cargo.toml
@@ -18,7 +18,13 @@ required-features = ["fuzz"]
 [features]
 agave-unstable-api = []
 dummy-for-ci-check = ["fuzz"]
-fuzz = ["dep:clap", "dep:prost", "dep:prost-build", "dep:protosol"]
+fuzz = [
+    "dep:clap",
+    "dep:prost",
+    "dep:prost-build",
+    "dep:protosol",
+    "solana-pubkey/default",
+]
 
 [dependencies]
 agave-feature-set = { workspace = true }


### PR DESCRIPTION
#### Problem

(split from #9456)

failed to compile:

```
cargo +nightly-2025-08-02 check --manifest-path svm-test-harness/Cargo.toml --no-default-features --features fuzz
```
#### Summary of Changes

enable solana-pubkey/default for solana-svm-test-harness/fuzz