### PR TITLE
fix: enable solana-client/dev-context-only-utils for solana-cli/dev-context-only-utils

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,10 @@ path = "src/main.rs"
 [features]
 default = ["remote-wallet-hidraw"]
 agave-unstable-api = []
-dev-context-only-utils = ["solana-faucet/dev-context-only-utils"]
+dev-context-only-utils = [
+    "solana-faucet/dev-context-only-utils",
+    "solana-client/dev-context-only-utils",
+]
 remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
 remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 


### PR DESCRIPTION
#### Problem

(split from #9456)

failed to compile:

```
cargo +nightly-2025-08-02 check --manifest-path cli/Cargo.toml --no-default-features --features dev-context-only-utils
```

#### Summary of Changes

enable solana-client/dev-context-only-utils for solana-cli/dev-context-only-utils