### PR TITLE
Removes test_store_account_stress()

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -8,9 +8,9 @@ mod meta;
 pub mod test_utils;
 
 #[cfg(feature = "dev-context-only-utils")]
-pub use meta::{AccountMeta, StoredAccountMeta, StoredMeta};
+pub use meta::StoredAccountMeta;
 #[cfg(not(feature = "dev-context-only-utils"))]
-use meta::{AccountMeta, StoredAccountMeta, StoredMeta};
+use meta::StoredAccountMeta;
 use {
     crate::{
         account_info::Offset,
@@ -30,7 +30,7 @@ use {
     },
     log::*,
     memmap2::MmapMut,
-    meta::StoredAccountNoData,
+    meta::{AccountMeta, StoredAccountNoData, StoredMeta},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_pubkey::Pubkey,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,


### PR DESCRIPTION
#### Problem

`test_store_account_stress()` is dead code.

This test was added back in 2019 (https://github.com/solana-labs/solana/pull/4523), and has been both (1) unchanged, and (2) marked 'ignore' since then. We've never run it as a test in CI ever.

The underlying issue was https://github.com/solana-labs/solana/pull/4511, which saw a race when appending/reusing accounts to storages. Since adding the accounts write cache, we no longer append to storage files; they are written in one shot. We also no longer reuse AccountStorageEntrys. So the underlying issue is no longer possible in today's system either.

And lastly, append_vec::{AccoutMeta, StoredMeta} are both leaked out of the append_vec module solely for this test. And again, it is never even run.


#### Summary of Changes

Remove the test.