### PR TITLE
fix: genesis: feature-gated vote state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9306,6 +9306,7 @@ dependencies = [
 name = "solana-local-cluster"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "agave-feature-set",
  "agave-logger",
  "agave-snapshots",
  "assert_matches",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7825,6 +7825,7 @@ dependencies = [
 name = "solana-local-cluster"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "agave-feature-set",
  "agave-logger",
  "agave-snapshots",
  "crossbeam-channel",

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
-    agave_feature_set::FEATURE_NAMES,
+    agave_feature_set::{vote_state_v4, FEATURE_NAMES},
     base64::{prelude::BASE64_STANDARD, Engine},
     clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg, ArgMatches},
     itertools::Itertools,
@@ -48,7 +48,7 @@ use {
     solana_sdk_ids::system_program,
     solana_signer::Signer,
     solana_stake_interface::state::StakeStateV2,
-    solana_vote_program::vote_state::{self, VoteStateV4},
+    solana_vote_program::vote_state::{self, VoteStateV3, VoteStateV4},
     std::{
         collections::HashMap,
         error,
@@ -131,6 +131,7 @@ pub fn load_validator_accounts(
     commission: u8,
     rent: &Rent,
     genesis_config: &mut GenesisConfig,
+    vote_state_v4_enabled: bool,
 ) -> io::Result<()> {
     let accounts_file = File::open(file)?;
     let validator_genesis_accounts: Vec<StakedValidatorAccountInfo> =
@@ -179,6 +180,7 @@ pub fn load_validator_accounts(
             commission,
             rent,
             None,
+            vote_state_v4_enabled,
         )?;
     }
 
@@ -258,6 +260,7 @@ fn add_validator_accounts(
     commission: u8,
     rent: &Rent,
     authorized_pubkey: Option<&Pubkey>,
+    vote_state_v4_enabled: bool,
 ) -> io::Result<()> {
     rent_exempt_check(
         stake_lamports,
@@ -277,14 +280,24 @@ fn add_validator_accounts(
         );
 
         let bls_pubkey_compressed_bytes = bls_pubkeys_iter.next().map(|bls_pubkey| bls_pubkey.0);
-        let vote_account = vote_state::create_v4_account_with_authorized(
-            identity_pubkey,
-            identity_pubkey,
-            identity_pubkey,
-            bls_pubkey_compressed_bytes,
-            u16::from(commission) * 100,
-            rent.minimum_balance(VoteStateV4::size_of()).max(1),
-        );
+        let vote_account = if vote_state_v4_enabled {
+            vote_state::create_v4_account_with_authorized(
+                identity_pubkey,
+                identity_pubkey,
+                identity_pubkey,
+                bls_pubkey_compressed_bytes,
+                u16::from(commission) * 100,
+                rent.minimum_balance(VoteStateV4::size_of()).max(1),
+            )
+        } else {
+            vote_state::create_v3_account_with_authorized(
+                identity_pubkey,
+                identity_pubkey,
+                identity_pubkey,
+                commission,
+                rent.minimum_balance(VoteStateV3::size_of()).max(1),
+            )
+        };
 
         genesis_config.add_account(
             *stake_pubkey,
@@ -727,6 +740,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             std::process::exit(1);
         });
 
+    // Determine if vote_state_v4 will be active at genesis
+    let vote_state_v4_enabled = !features_to_deactivate.contains(&vote_state_v4::id());
+
     match matches.value_of("hashes_per_tick").unwrap() {
         "auto" => match cluster_type {
             ClusterType::Development => {
@@ -796,6 +812,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         commission,
         &rent,
         bootstrap_stake_authorized_pubkey.as_ref(),
+        vote_state_v4_enabled,
     )?;
 
     if let Some(creation_time) = unix_timestamp_from_rfc3339_datetime(&matches, "creation_time") {
@@ -833,7 +850,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     if let Some(files) = matches.values_of("validator_accounts_file") {
         for file in files {
-            load_validator_accounts(file, commission, &rent, &mut genesis_config)?;
+            load_validator_accounts(
+                file,
+                commission,
+                &rent,
+                &mut genesis_config,
+                vote_state_v4_enabled,
+            )?;
         }
     }
 
@@ -1325,6 +1348,7 @@ mod tests {
             100,
             &Rent::default(),
             &mut GenesisConfig::default(),
+            true, // vote_state_v4_enabled
         )
         .is_err());
 
@@ -1387,8 +1411,14 @@ mod tests {
         file.write_all(b"validator_accounts:\n").unwrap();
         file.write_all(serialized.as_bytes()).unwrap();
 
-        load_validator_accounts(&filename, 100, &Rent::default(), &mut genesis_config)
-            .expect("Failed to load validator accounts");
+        load_validator_accounts(
+            &filename,
+            100,
+            &Rent::default(),
+            &mut genesis_config,
+            true, // vote_state_v4_enabled
+        )
+        .expect("Failed to load validator accounts");
 
         remove_file(path).unwrap();
 

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -17,6 +17,7 @@ agave-unstable-api = []
 dev-context-only-utils = ["solana-core/dev-context-only-utils"]
 
 [dependencies]
+agave-feature-set = { workspace = true }
 agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -297,7 +297,7 @@ impl LocalCluster {
         let leader_pubkey = leader_keypair.pubkey();
         let leader_node = Node::new_localhost_with_pubkey(&leader_pubkey);
 
-        let _feature_set = FeatureSet::all_enabled();
+        let feature_set = FeatureSet::all_enabled();
 
         let GenesisConfigInfo {
             mut genesis_config,
@@ -308,6 +308,7 @@ impl LocalCluster {
             &keys_in_genesis,
             stakes_in_genesis,
             config.cluster_type,
+            &feature_set,
             false,
         );
         genesis_config.accounts.extend(

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -5,6 +5,7 @@ use {
         integration_tests::DEFAULT_NODE_STAKE,
         validator_configs::*,
     },
+    agave_feature_set::FeatureSet,
     agave_snapshots::{paths::BANK_SNAPSHOTS_DIR, snapshot_config::SnapshotConfig},
     itertools::izip,
     log::*,
@@ -295,6 +296,8 @@ impl LocalCluster {
         let leader_vote_keypair = &keys_in_genesis[0].vote_keypair;
         let leader_pubkey = leader_keypair.pubkey();
         let leader_node = Node::new_localhost_with_pubkey(&leader_pubkey);
+
+        let _feature_set = FeatureSet::all_enabled();
 
         let GenesisConfigInfo {
             mut genesis_config,

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -839,6 +839,7 @@ impl ProgramTest {
             fee_rate_governor,
             rent.clone(),
             ClusterType::Development,
+            &feature_set,
             std::mem::take(&mut self.genesis_accounts),
         );
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -843,24 +843,6 @@ impl ProgramTest {
             std::mem::take(&mut self.genesis_accounts),
         );
 
-        // Remove features tagged to deactivate
-        for deactivate_feature_pk in &self.deactivate_feature_set {
-            if FEATURE_NAMES.contains_key(deactivate_feature_pk) {
-                match genesis_config.accounts.remove(deactivate_feature_pk) {
-                    Some(_) => debug!("Feature for {deactivate_feature_pk:?} deactivated"),
-                    None => warn!(
-                        "Feature {deactivate_feature_pk:?} set for deactivation not found in \
-                         genesis_config account list, ignored."
-                    ),
-                }
-            } else {
-                warn!(
-                    "Feature {deactivate_feature_pk:?} set for deactivation is not a known \
-                     Feature public key"
-                );
-            }
-        }
-
         let target_tick_duration = Duration::from_micros(100);
         genesis_config.poh_config = PohConfig::new_sleep(target_tick_duration);
         debug!("Payer address: {}", mint_keypair.pubkey());

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -14,7 +14,7 @@
 pub use tokio;
 use {
     agave_feature_set::{
-        increase_cpi_account_info_limit, raise_cpi_nesting_limit_to_8, FEATURE_NAMES,
+        increase_cpi_account_info_limit, raise_cpi_nesting_limit_to_8, FeatureSet, FEATURE_NAMES,
     },
     async_trait::async_trait,
     base64::{prelude::BASE64_STANDARD, Engine},
@@ -813,6 +813,19 @@ impl ProgramTest {
 
         let mint_keypair = Keypair::new();
         let voting_keypair = Keypair::new();
+
+        // Remove features tagged to deactivate
+        let mut feature_set = FeatureSet::all_enabled();
+        for deactivate_feature_pk in &self.deactivate_feature_set {
+            if FEATURE_NAMES.contains_key(deactivate_feature_pk) {
+                feature_set.deactivate(deactivate_feature_pk);
+            } else {
+                warn!(
+                    "Feature {deactivate_feature_pk:?} set for deactivation is not a known \
+                     Feature public key"
+                );
+            }
+        }
 
         let mut genesis_config = create_genesis_config_with_leader_ex(
             1_000_000 * LAMPORTS_PER_SOL,

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1951,6 +1951,7 @@ fn get_stable_genesis_config() -> GenesisConfigInfo {
         FeeRateGovernor::new(0, 0), // most tests can't handle transaction fees
         Rent::free(),               // most tests don't expect rent
         ClusterType::Development,
+        &FeatureSet::all_enabled(),
         vec![],
     );
     genesis_config.creation_time = Duration::ZERO.as_secs() as UnixTimestamp;

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -497,7 +497,7 @@ mod tests {
             )
         } else {
             let balance = rent.minimum_balance(vote_state_size_of(vote_state_v4_enabled));
-            vote_state::create_account_with_authorized(
+            vote_state::create_v3_account_with_authorized(
                 &node_pubkey,
                 &vote_pubkey,
                 &vote_pubkey,
@@ -546,7 +546,7 @@ mod tests {
                 100,
             )
         } else {
-            vote_state::create_account_with_authorized(
+            vote_state::create_v3_account_with_authorized(
                 &node_pubkey,
                 authorized_voter,
                 authorized_withdrawer,
@@ -586,7 +586,7 @@ mod tests {
                 100,
             )
         } else {
-            vote_state::create_account_with_authorized(
+            vote_state::create_v3_account_with_authorized(
                 &node_pubkey,
                 &authorized_voter,
                 &authorized_withdrawer,

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1189,8 +1189,7 @@ fn do_process_tower_sync(
     )
 }
 
-#[cfg(test)]
-pub fn create_account_with_authorized(
+pub fn create_v3_account_with_authorized(
     node_pubkey: &Pubkey,
     authorized_voter: &Pubkey,
     authorized_withdrawer: &Pubkey,

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -114,6 +114,7 @@ pub fn create_genesis_config_with_vote_accounts(
         voting_keypairs,
         stakes,
         ClusterType::Development,
+        &FeatureSet::all_enabled(),
         false,
     )
 }
@@ -128,6 +129,7 @@ pub fn create_genesis_config_with_alpenglow_vote_accounts(
         voting_keypairs,
         stakes,
         ClusterType::Development,
+        &FeatureSet::all_enabled(),
         true,
     )
 }
@@ -137,6 +139,7 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
     voting_keypairs: &[impl Borrow<ValidatorVoteKeypairs>],
     stakes: Vec<u64>,
     cluster_type: ClusterType,
+    feature_set: &FeatureSet,
     is_alpenglow: bool,
 ) -> GenesisConfigInfo {
     assert!(!voting_keypairs.is_empty());
@@ -168,6 +171,7 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
         FeeRateGovernor::new(0, 0), // most tests can't handle transaction fees
         Rent::free(),               // most tests don't expect rent
         cluster_type,
+        feature_set,
         vec![],
     );
 
@@ -269,6 +273,7 @@ pub fn create_genesis_config_with_leader_with_mint_keypair(
         FeeRateGovernor::new(0, 0), // most tests can't handle transaction fees
         Rent::free(),               // most tests don't expect rent
         ClusterType::Development,
+        &FeatureSet::all_enabled(),
         vec![],
     );
 
@@ -350,6 +355,7 @@ pub fn create_genesis_config_with_leader_ex_no_features(
     fee_rate_governor: FeeRateGovernor,
     rent: Rent,
     cluster_type: ClusterType,
+    _feature_set: &FeatureSet,
     mut initial_accounts: Vec<(Pubkey, AccountSharedData)>,
 ) -> GenesisConfig {
     let validator_vote_account = vote_state::create_v4_account_with_authorized(
@@ -423,6 +429,7 @@ pub fn create_genesis_config_with_leader_ex(
     fee_rate_governor: FeeRateGovernor,
     rent: Rent,
     cluster_type: ClusterType,
+    feature_set: &FeatureSet,
     initial_accounts: Vec<(Pubkey, AccountSharedData)>,
 ) -> GenesisConfig {
     let mut genesis_config = create_genesis_config_with_leader_ex_no_features(
@@ -437,6 +444,7 @@ pub fn create_genesis_config_with_leader_ex(
         fee_rate_governor,
         rent,
         cluster_type,
+        feature_set,
         initial_accounts,
     );
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -57,7 +57,7 @@ use {
     },
     solana_runtime::{
         bank_forks::BankForks,
-        genesis_utils::{self, create_genesis_config_with_leader_ex_no_features},
+        genesis_utils::{self, create_genesis_config_with_leader_ex},
         runtime_config::RuntimeConfig,
     },
     solana_sdk_ids::address_lookup_table,
@@ -997,7 +997,7 @@ impl TestValidator {
             );
         }
 
-        let mut genesis_config = create_genesis_config_with_leader_ex_no_features(
+        let mut genesis_config = create_genesis_config_with_leader_ex(
             mint_lamports,
             &mint_address,
             &validator_identity.pubkey(),
@@ -1009,6 +1009,7 @@ impl TestValidator {
             config.fee_rate_governor.clone(),
             config.rent.clone(),
             solana_cluster_type::ClusterType::Development,
+            &feature_set,
             accounts.into_iter().collect(),
         );
         genesis_config.epoch_schedule = config

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -56,8 +56,7 @@ use {
         client_error::Error as RpcClientError, request::MAX_MULTIPLE_ACCOUNTS,
     },
     solana_runtime::{
-        bank_forks::BankForks,
-        genesis_utils::{self, create_genesis_config_with_leader_ex},
+        bank_forks::BankForks, genesis_utils::create_genesis_config_with_leader_ex,
         runtime_config::RuntimeConfig,
     },
     solana_sdk_ids::address_lookup_table,
@@ -1024,10 +1023,6 @@ impl TestValidator {
 
         if let Some(inflation) = config.inflation {
             genesis_config.inflation = inflation;
-        }
-
-        for feature in feature_set.active().keys() {
-            genesis_utils::activate_feature(&mut genesis_config, *feature);
         }
 
         let ledger_path = match &config.ledger_path {

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -935,10 +935,13 @@ impl TestValidator {
         let mint_lamports = 500_000_000 * LAMPORTS_PER_SOL;
 
         // Only activate features which are not explicitly deactivated.
-        let mut feature_set = FeatureSet::default().inactive().clone();
+        let mut feature_set = FeatureSet::all_enabled();
+        // TODO: remove after cli change for bls_pubkey_management_in_vote_account is checked in
+        feature_set.deactivate(&agave_feature_set::bls_pubkey_management_in_vote_account::id());
         for feature in &config.deactivate_feature_set {
-            if feature_set.remove(feature) {
-                info!("Feature for {feature:?} deactivated")
+            if FEATURE_NAMES.contains_key(feature) {
+                feature_set.deactivate(feature);
+                info!("Feature for {feature:?} deactivated");
             } else {
                 warn!("Feature {feature:?} set for deactivation is not a known Feature public key",)
             }
@@ -950,7 +953,7 @@ impl TestValidator {
         }
         for (address, account) in
             solana_program_binaries::core_bpf_programs(&config.rent, |feature_id| {
-                feature_set.contains(feature_id)
+                feature_set.is_active(feature_id)
             })
         {
             accounts.entry(address).or_insert(account);
@@ -1022,11 +1025,8 @@ impl TestValidator {
             genesis_config.inflation = inflation;
         }
 
-        for feature in feature_set {
-            // TODO: remove after cli change for bls_pubkey_management_in_vote_account is checked in
-            if feature != agave_feature_set::bls_pubkey_management_in_vote_account::id() {
-                genesis_utils::activate_feature(&mut genesis_config, feature);
-            }
+        for feature in feature_set.active().keys() {
+            genesis_utils::activate_feature(&mut genesis_config, *feature);
         }
 
         let ledger_path = match &config.ledger_path {


### PR DESCRIPTION
#### Problem
As described in #9377, development clusters who deactivate the vote state v4 feature are stalling since the genesis config will create vote state v4 accounts anyway.

#### Summary of Changes
Changes the no-features variant (`create_genesis_config_with_leader_ex_no_features`) to first check the provided `initial_accounts` for the vote account, and default to vote state V3 if not provided. For the variant with all features enabled (`create_genesis_config_with_leader_ex`), use vote state V4.

Also removes the BLS pubkey arg from the no-features variant since it's unused.

Fixes #9377
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
