### PR TITLE
docs: document advanced stake CLI flags and behaviors

### DIFF
--- a/docs/src/cli/examples/delegate-stake.md
+++ b/docs/src/cli/examples/delegate-stake.md
@@ -50,6 +50,8 @@ solana create-stake-account --from <KEYPAIR> stake-account.json <AMOUNT> \
 `<AMOUNT>` tokens are transferred from the account at the "from" `<KEYPAIR>` to
 a new stake account at the public key of stake-account.json.
 
+Instead of a numeric amount, you can also use the keyword `ALL` to send all available SOL from the `--from` account, leaving only the minimum rent-exempt balance.
+
 The stake-account.json file can now be discarded. To authorize additional
 actions, you will use the `--stake-authority` or `--withdraw-authority` keypair,
 not stake-account.json.
@@ -171,6 +173,21 @@ solana deactivate-stake --stake-authority <KEYPAIR> <STAKE_ACCOUNT_ADDRESS> \
 The stake authority `<KEYPAIR>` authorizes the operation on the account with
 address `<STAKE_ACCOUNT_ADDRESS>`.
 
+If the stake account was created at a derived address, pass the same seed when
+deactivating:
+
+```bash
+solana deactivate-stake --stake-authority <KEYPAIR> --seed <STRING> <STAKE_ACCOUNT_ADDRESS> \
+    --fee-payer <KEYPAIR>
+```
+
+To deactivate stake delegated to a delinquent validator, use:
+
+```bash
+solana deactivate-stake --stake-authority <KEYPAIR> --delinquent <STAKE_ACCOUNT_ADDRESS> \
+    --fee-payer <KEYPAIR>
+```
+
 Note that stake takes several epochs to "cool down". Attempts to delegate stake
 in the cool down period will fail.
 
@@ -183,9 +200,17 @@ solana withdraw-stake --withdraw-authority <KEYPAIR> <STAKE_ACCOUNT_ADDRESS> <RE
     --fee-payer <KEYPAIR>
 ```
 
-`<STAKE_ACCOUNT_ADDRESS>` is the existing stake account, the stake authority
-`<KEYPAIR>` is the withdraw authority, and `<AMOUNT>` is the number of tokens to
-transfer to `<RECIPIENT_ADDRESS>`.
+`<STAKE_ACCOUNT_ADDRESS>` is the existing stake account, the `<KEYPAIR>` provided
+as `--withdraw-authority` is the withdraw authority, and `<AMOUNT>` is the number
+of tokens to transfer to `<RECIPIENT_ADDRESS>`.
+
+`<AMOUNT>` may be a numeric value in SOL or one of the keywords:
+
+- `ALL` – withdraw the maximum amount allowed from the stake account
+- `AVAILABLE` – withdraw only the portion that is currently withdrawable.
+
+The exact amount that can be withdrawn depends on whether the stake is active,
+cooling down, or fully inactive, and on any lockup that may apply.
 
 ## Split Stake
 
@@ -203,6 +228,21 @@ solana split-stake --stake-authority <KEYPAIR> <STAKE_ACCOUNT_ADDRESS> <NEW_STAK
 `<KEYPAIR>` is the stake authority, `<NEW_STAKE_ACCOUNT_KEYPAIR>` is the keypair
 for the new account, and `<AMOUNT>` is the number of tokens to transfer to the
 new account.
+
+When splitting stake, the amount moved into the new stake account must be at least
+the cluster's minimum delegation amount, otherwise the command will fail.
+
+The new stake account must also be rent-exempt. When signing the transaction
+offline, you must provide the rent-exempt reserve explicitly using the
+`--rent-exempt-reserve-sol` flag:
+
+```bash
+solana split-stake --stake-authority <KEYPAIR> <STAKE_ACCOUNT_ADDRESS> <NEW_STAKE_ACCOUNT_KEYPAIR> <AMOUNT> \
+    --rent-exempt-reserve-sol <RENT_EXEMPT_AMOUNT> --fee-payer <KEYPAIR>
+```
+
+`<RENT_EXEMPT_AMOUNT>` is the additional SOL sent to the new stake account to make
+it rent-exempt, in addition to `<AMOUNT>` of stake being split.
 
 To split a stake account into a derived account address, use the `--seed`
 option. See

--- a/docs/src/cli/examples/delegate-stake.md
+++ b/docs/src/cli/examples/delegate-stake.md
@@ -50,7 +50,7 @@ solana create-stake-account --from <KEYPAIR> stake-account.json <AMOUNT> \
 `<AMOUNT>` tokens are transferred from the account at the "from" `<KEYPAIR>` to
 a new stake account at the public key of stake-account.json.
 
-Instead of a numeric amount, you can also use the keyword `ALL` to send all available SOL from the `--from` account, leaving only the minimum rent-exempt balance.
+Instead of a numeric amount, you can also use the keyword `ALL` to send all available SOL from the `--from` account.
 
 The stake-account.json file can now be discarded. To authorize additional
 actions, you will use the `--stake-authority` or `--withdraw-authority` keypair,


### PR DESCRIPTION
Updated the staking CLI example documentation to reflect important behaviors that were previously undocumented but are supported by the current CLI implementation. It adds an explanation of using the ALL keyword with create-stake-account, documents the --seed and --delinquent flags for deactivate-stake, clarifies that withdraw-stake supports numeric amounts as well as the ALL and AVAILABLE keywords, and describes the minimum delegation requirement and the --rent-exempt-reserve-sol flag for split-stake. These updates align the docs with the actual command-line interface.