### PR TITLE
Makes AppendVec::get_stored_account_meta_callback() private

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -710,7 +710,7 @@ impl AppendVec {
     ///
     /// Prefer get_stored_account_callback() when possible, as it does not contain file format
     /// implementation details, and thus potentially can read less and be faster.
-    pub fn get_stored_account_meta_callback<Ret>(
+    fn get_stored_account_meta_callback<Ret>(
         &self,
         offset: usize,
         mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>) -> Ret,
@@ -919,7 +919,7 @@ impl AppendVec {
                 r2.as_ref().unwrap()
             ));
             assert_eq!(sizes, r_callback.stored_size());
-            let pubkey = r_callback.meta().pubkey;
+            let pubkey = r_callback.meta.pubkey;
             Some((pubkey, create_account_shared_data(&r_callback)))
         });
         if result.is_none() {

--- a/accounts-db/src/append_vec/meta.rs
+++ b/accounts-db/src/append_vec/meta.rs
@@ -86,14 +86,6 @@ impl<'append_vec> StoredAccountMeta<'append_vec> {
     pub fn data(&self) -> &'append_vec [u8] {
         self.data
     }
-
-    pub fn data_len(&self) -> usize {
-        self.meta.data_len as usize
-    }
-
-    pub fn meta(&self) -> &StoredMeta {
-        self.meta
-    }
 }
 
 impl IsZeroLamport for StoredAccountMeta<'_> {

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -136,7 +136,7 @@ fn do_inspect(file: impl AsRef<Path>, verbose: bool) -> Result<(), String> {
                     account.offset(),
                     account.pubkey().to_string(),
                     account.owner().to_string(),
-                    account.data_len(),
+                    account.data().len(),
                     account.lamports(),
                 );
             }
@@ -212,7 +212,7 @@ fn do_search(
                             account.offset(),
                             account.pubkey(),
                             account.owner(),
-                            account.data_len(),
+                            account.data().len(),
                             account.lamports(),
                         );
                     }


### PR DESCRIPTION
#### Problem

`AppendVec::get_stored_account_meta_callback()` isn't used outside of `append_vec.rs`, but is marked as public. We don't want other callers of this fn, as it exposes `StoredAccountMeta`, which is an internal/implementation detail of append vecs.


#### Summary of Changes

Make the fn private.