### PR TITLE
tests: programs/sbf: refactor low-hanging fruit to use svm-test-harness

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -2481,14 +2481,7 @@ fn test_program_reads_from_program_account() {
         &compute_budget,
     );
 
-    let mut sysvar_cache = SysvarCache::default();
-    sysvar_cache.fill_missing_entries(|pubkey, callback| {
-        if pubkey == &rent::id() {
-            let rent = Rent::default();
-            let rent_data = bincode::serialize(&rent).unwrap();
-            callback(&rent_data);
-        }
-    });
+    let sysvar_cache = default_sysvar_cache();
 
     // Build the program account data: LoaderV4State header + ELF bytes
     let loader_state = LoaderV4State {
@@ -2547,13 +2540,7 @@ fn test_program_sbf_c_dup() {
         &compute_budget,
     );
 
-    let mut sysvar_cache = SysvarCache::default();
-    sysvar_cache.fill_missing_entries(|pubkey, callback| {
-        if pubkey == &rent::id() {
-            let rent_data = bincode::serialize(&Rent::default()).unwrap();
-            callback(&rent_data);
-        }
-    });
+    let sysvar_cache = default_sysvar_cache();
 
     let account_address = Pubkey::new_unique();
     let account =


### PR DESCRIPTION
#### Problem
Following the model of #8753, refactors all of the lowest-hanging fruit in programs/sbf to use the new svm-test-harness lib. The more involved cases can either be refactored or moved elsewhere in the monorepo in follow-up work.

#### Summary of Changes

The pattern is the same as #8753 for each test. A few commits to svm-test-harness kick things off by fixing a few small issues and adding support for other test utils, then each test is refactored in its own dedicated commit.