### PR TITLE
Makes append vec tests module private

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1358,7 +1358,7 @@ impl ObsoleteAccountHash {
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use {
         super::{test_utils::*, *},
         assert_matches::assert_matches,


### PR DESCRIPTION
#### Problem

The `append_vec.rs` tests module is public unnecessarily.


#### Summary of Changes

Make it private.