### PR TITLE
Removes clippy-allow on AppendVec::scan_accounts_stored_meta()

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1011,7 +1011,6 @@ impl AppendVec {
     ///
     /// Prefer scan_accounts() when possible, as it does not contain file format
     /// implementation details, and thus potentially can read less and be faster.
-    #[allow(clippy::blocks_in_conditions)]
     fn scan_accounts_stored_meta<'a>(
         &'a self,
         reader: &mut impl RequiredLenBufFileRead<'a>,


### PR DESCRIPTION
#### Problem

`AppendVec::scan_accounts_stored_meta()` is annotated with `#[allow(clippy::blocks_in_conditions)]` unnecessarily.

Originally added in https://github.com/anza-xyz/agave/pull/902.


#### Summary of Changes

Remove it.