### PR TITLE
runtime: Gate genesis vote account creation behind feature

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -145,7 +145,7 @@ check_dcou() {
   # output after turning rustc into the nightly mode with RUSTC_BOOTSTRAP=1.
   # In this way, additional requirement of nightly rustc toolchian is avoided.
   # Note that `cargo tree` can't be used, because it doesn't support `--bin`.
-  if check_dcou "${binArgs[@]}" --workspace; then
+  if check_dcou "$buildProfileArg" "${binArgs[@]}" --workspace; then
      echo 'dcou feature activation is incorrectly activated!'
      exit 1
   fi


### PR DESCRIPTION

Fixes #9377

Проблема: 
В настоящее время Bank::new_from_genesis всегда создает аккаунты голосования (vote accounts) из GenesisConfig, даже если соответствующий feature gate отключен. Это может привести к непредвиденным последствиям, если планируется отложить активацию аккаунтов голосования до более позднего этапа.

Решение:
Добавляет явную проверку в fn process_genesis_config в runtime/src/bank.rs.

Если owner аккаунта совпадает с ID программы голосования (solana_vote_program::vote_program::id()) 
и при этом feature gate `vote_account_creation_feature_gate_id` НЕ активен, 
то аккаунт пропускается и не добавляется в Bank. 

Это гарантирует, что аккаунты голосования будут созданы в генезисе только при явной активации соответствующей фичи.