### PR TITLE
RFC | Don’t apply throttling unless a specific load threshold is reached.

### DIFF
--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -27,6 +27,12 @@ const STREAM_LOAD_EMA_INTERVAL_MS: u64 = 5;
 const STREAM_LOAD_EMA_INTERVAL_COUNT: u64 = 10;
 const EMA_WINDOW_MS: u64 = STREAM_LOAD_EMA_INTERVAL_MS * STREAM_LOAD_EMA_INTERVAL_COUNT;
 
+const STAKED_STREAM_THROTTLING_LOAD_THRESHOLD_PERCENT: u64 = 50;
+
+// Unstaked nodes must contribute to the EMA load for this threshold to be meaningful.
+// See increment_load().
+const UNSTAKED_STREAM_THROTTLING_LOAD_THRESHOLD_PERCENT: u64 = 0;
+
 pub(crate) struct StakedStreamLoadEMA {
     current_load_ema: AtomicU64,
     load_in_recent_interval: AtomicU64,
@@ -40,6 +46,11 @@ pub(crate) struct StakedStreamLoadEMA {
     // Maximum number of streams for an unstaked connection in stream throttling window
     max_unstaked_load_in_throttling_window: u64,
     max_streams_per_ms: u64,
+
+    // No throttling for staked connections below this load.
+    staked_stream_throttling_load_threshold: u64,
+    // No throttling for unstaked connections below this load.
+    unstaked_stream_throttling_load_threshold: u64,
 }
 
 impl StakedStreamLoadEMA {
@@ -63,6 +74,14 @@ impl StakedStreamLoadEMA {
             0
         };
 
+        let staked_stream_throttling_load_threshold =
+            Percentage::from(STAKED_STREAM_THROTTLING_LOAD_THRESHOLD_PERCENT)
+                .apply_to(max_staked_load_in_ema_window);
+
+        let unstaked_stream_throttling_load_threshold =
+            Percentage::from(UNSTAKED_STREAM_THROTTLING_LOAD_THRESHOLD_PERCENT)
+                .apply_to(max_staked_load_in_ema_window);
+
         Self {
             current_load_ema: AtomicU64::default(),
             load_in_recent_interval: AtomicU64::default(),
@@ -71,6 +90,8 @@ impl StakedStreamLoadEMA {
             max_staked_load_in_ema_window,
             max_unstaked_load_in_throttling_window,
             max_streams_per_ms,
+            staked_stream_throttling_load_threshold,
+            unstaked_stream_throttling_load_threshold,
         }
     }
 
@@ -149,12 +170,37 @@ impl StakedStreamLoadEMA {
         peer_type: ConnectionPeerType,
         total_stake: u64,
     ) -> u64 {
+        let current_load = self.current_load_ema.load(Ordering::Relaxed);
+        match peer_type {
+            ConnectionPeerType::Unstaked => {
+                if current_load < self.unstaked_stream_throttling_load_threshold {
+                    MAX_UNSTAKED_TPS
+                } else {
+                    self.available_throttled_load_capacity(peer_type, total_stake, current_load)
+                }
+            }
+            ConnectionPeerType::Staked(_) => {
+                if current_load < self.staked_stream_throttling_load_threshold {
+                    self.max_streams_per_ms * STREAM_THROTTLING_INTERVAL_MS
+                } else {
+                    self.available_throttled_load_capacity(peer_type, total_stake, current_load)
+                }
+            }
+        }
+    }
+
+    pub fn available_throttled_load_capacity(
+        &self,
+        peer_type: ConnectionPeerType,
+        total_stake: u64,
+        current_load: u64,
+    ) -> u64 {
         match peer_type {
             ConnectionPeerType::Unstaked => self.max_unstaked_load_in_throttling_window,
             ConnectionPeerType::Staked(stake) => {
                 // If the current load is low, cap it to 25% of max_load.
                 let current_load = u128::from(cmp::max(
-                    self.current_load_ema.load(Ordering::Relaxed),
+                    current_load,
                     self.max_staked_load_in_ema_window / 4,
                 ));
 

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -185,7 +185,7 @@ impl StakedStreamLoadEMA {
             }
             ConnectionPeerType::Staked(_) => {
                 if current_load < self.staked_stream_throttling_load_threshold {
-                    self.max_streams_per_ms * STREAM_THROTTLING_INTERVAL_MS
+                    self.max_staked_load_in_ema_window
                 } else {
                     self.available_throttled_load_capacity(peer_type, total_stake, current_load)
                 }

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -27,7 +27,7 @@ const STREAM_LOAD_EMA_INTERVAL_MS: u64 = 5;
 const STREAM_LOAD_EMA_INTERVAL_COUNT: u64 = 10;
 const EMA_WINDOW_MS: u64 = STREAM_LOAD_EMA_INTERVAL_MS * STREAM_LOAD_EMA_INTERVAL_COUNT;
 
-const STAKED_STREAM_THROTTLING_LOAD_THRESHOLD_PERCENT: u64 = 50;
+const STAKED_STREAM_THROTTLING_LOAD_THRESHOLD_PERCENT: u64 = 90;
 
 // Unstaked nodes must contribute to the EMA load for this threshold to be meaningful.
 // See increment_load().
@@ -170,7 +170,11 @@ impl StakedStreamLoadEMA {
         peer_type: ConnectionPeerType,
         total_stake: u64,
     ) -> u64 {
-        let current_load = self.current_load_ema.load(Ordering::Relaxed);
+        let current_load = self
+            .current_load_ema
+            .load(Ordering::Relaxed)
+            // translating from streams/STREAM_LOAD_EMA_INTERVAL_MS to streams/EMA_WINDOW_MS
+            .saturating_mul(STREAM_LOAD_EMA_INTERVAL_COUNT);
         match peer_type {
             ConnectionPeerType::Unstaked => {
                 if current_load < self.unstaked_stream_throttling_load_threshold {


### PR DESCRIPTION
#### Problem
Staked connections are being throttled on unloaded systems.

#### Summary of Changes
For the v3.1.x fix, it's probably safer to use a minimal change that does not remove (yet) the current throttling entirely. For v4.0.0, we'll replace it with a better mechanism.
The approach taken here is simply not to apply any throttling until a configurable load threshold has been reached.

#### Open Questions
- Throttling threshold (50% was chosen arbitrarily).
- Throttling limit (5K now).

#### Details
Simulations with the current EMA load mechanism (stream_throttle.rs) show that staked connections with very low stake (e.g., ~0.01% of total stake) receive streams-per-100ms quotas that are similar to unstaked connections even in no-load scenarios.
```
Example:
        step  load_in_5ms          ema  quota_0.01%   quota_0.1%     quota_1%
           0            0            0           21          160         1600
           1         3000          544           21          160         1600
           2         1000          626           21          160         1600
```
Data collected on mds1 (over a few leader slots) also showed these low-stake connections being throttled:
```
[2025-12-04T22:56:59.929547468Z ERROR solana_streamer::nonblocking::stream_throttle] Throttling tpu stream from 3.66.188.50:8016, peer type: Staked(30314578869242), current_load: 11, total_stake: 415746706271632896, max_streams_per_interval: 28, read_interval_streams: 28 throttle_duration: 99.948899ms
```

In all observed cases, the effective load was basically 0 (3–25 streams per 5ms) while affected connections had quotas of 28–64 streams per 100ms, and stakes of ~0.007–0.016% of total stake.

With the change in this PR, mds1 has been running for multiple days without any staked connections being throttled (since Dec 6)

<img width="870" height="272" alt="Screenshot 2025-12-10 at 17 17 58" src="https://github.com/user-attachments/assets/16b28068-f154-4449-b809-7dfe7bb0e46c" />

Simulation of the new approach:
```
# max_streams_per_ms=500 max_unstaked_connections=2000 max_staked_load_in_ema_window=20000 max_unstaked_load_in_throttling_window=20
        step  load_in_5ms          ema     quota_0% quota_0.0010377902708922533% quota_0.0013466210076322612% quota_0.011060899378932171% quota_0.11449796281145662% quota_0.9999999999999997%
           0            0            0          200        50000        50000        50000        50000        50000
           1           10            1          200        50000        50000        50000        50000        50000
           2           50            9          200        50000        50000        50000        50000        50000
          [...]
          12        20000         8706          200        50000        50000        50000        50000        50000
          13        20000        10757           20           21           21           21           84          742
          14        20000        12435           20           21           21           21           72          642
```
Note that throttling is applied after the load is above 10K (50% of 20K-per-5ms => 500K TPS target configuration in this case).
