### PR TITLE
removes duplicate function: `get_signed_data`

### DIFF
--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1748,7 +1748,7 @@ mod test {
                 shred::layout::get_chained_merkle_root(shred),
                 Some(chained_merkle_root)
             );
-            let data = shred::layout::get_signed_data(shred).unwrap();
+            let data = shred::layout::get_merkle_root(shred).unwrap();
             assert_eq!(data, merkle_root);
             assert!(signature.verify(pubkey.as_ref(), data.as_ref()));
         }

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -203,20 +203,6 @@ pub fn get_shred_id(shred: &[u8]) -> Option<ShredId> {
     ))
 }
 
-pub(crate) fn get_signed_data(shred: &[u8]) -> Option<Hash> {
-    let data = match get_shred_variant(shred).ok()? {
-        ShredVariant::MerkleCode {
-            proof_size,
-            resigned,
-        } => shred::merkle::ShredCode::get_merkle_root(shred, proof_size, resigned)?,
-        ShredVariant::MerkleData {
-            proof_size,
-            resigned,
-        } => shred::merkle::ShredData::get_merkle_root(shred, proof_size, resigned)?,
-    };
-    Some(data)
-}
-
 pub fn get_reference_tick(shred: &[u8]) -> Result<u8, Error> {
     if get_shred_type(shred)? != ShredType::Data {
         return Err(Error::InvalidShredType);
@@ -410,12 +396,12 @@ pub(crate) fn corrupt_packet<R: Rng>(
     let signature = get_signature(shred).unwrap();
     if coin_flip {
         let pubkey = keypairs[&slot].pubkey();
-        let data = get_signed_data(shred).unwrap();
+        let data = get_merkle_root(shred).unwrap();
         assert!(!signature.verify(pubkey.as_ref(), data.as_ref()));
     } else {
         // Slot may have been corrupted and no longer mapping to a keypair.
         let pubkey = keypairs.get(&slot).map(Keypair::pubkey).unwrap_or_default();
-        if let Some(data) = get_signed_data(shred) {
+        if let Some(data) = get_merkle_root(shred) {
             assert!(!signature.verify(pubkey.as_ref(), data.as_ref()));
         }
     }
@@ -566,7 +552,7 @@ mod tests {
                 )
             });
             assert_eq!(
-                get_signed_data(bytes).unwrap(),
+                get_merkle_root(bytes).unwrap(),
                 shred.merkle_root().unwrap()
             );
             assert_eq!(

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -40,7 +40,7 @@ pub fn verify_shred_cpu(
         return false;
     };
     trace!("signature {signature}");
-    let Some(data) = shred::layout::get_signed_data(shred) else {
+    let Some(data) = shred::layout::get_merkle_root(shred) else {
         return false;
     };
 
@@ -78,7 +78,7 @@ pub fn verify_shreds(
 fn sign_shred_cpu(keypair: &Keypair, packet: &mut PacketRefMut) {
     let sig = shred::layout::get_signature_range();
     let msg = shred::layout::get_shred(packet.as_ref())
-        .and_then(shred::layout::get_signed_data)
+        .and_then(shred::layout::get_merkle_root)
         .unwrap();
     assert!(
         packet.meta().size >= sig.end,
@@ -339,7 +339,7 @@ mod tests {
             let slot = shred::layout::get_slot(shred).unwrap();
             let signature = shred::layout::get_signature(shred).unwrap();
             let pubkey = keypairs[&slot].pubkey();
-            let data = shred::layout::get_signed_data(shred).unwrap();
+            let data = shred::layout::get_merkle_root(shred).unwrap();
             assert!(signature.verify(pubkey.as_ref(), data.as_ref()));
         }
         shreds


### PR DESCRIPTION
#### Problem

`get_signed_data` is the same function as `get_merkle_root`.


#### Summary of Changes

Removes `get_signed_data` and updates callers to call `get_merkle_root` instead.

Discovered this while work on introducing `FecSetRoot`.