### PR TITLE
svm-test-harness: add features for programs/sbf

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -286,7 +286,6 @@ fn test_program_sbf_sanity() {
             feature_set,
             accounts,
             instruction: instruction.into(),
-            cu_avail: compute_budget.compute_unit_limit,
         };
 
         let effects =
@@ -561,7 +560,6 @@ fn test_program_sbf_error_handling() {
                 feature_set: feature_set.clone(),
                 accounts: accounts.clone(),
                 instruction: instruction.into(),
-                cu_avail: compute_budget.compute_unit_limit,
             };
 
             harness::execute_instr(context, &compute_budget, program_cache, &sysvar_cache)

--- a/svm-test-harness/fixture/src/instr_context.rs
+++ b/svm-test-harness/fixture/src/instr_context.rs
@@ -10,7 +10,6 @@ pub struct InstrContext {
     pub feature_set: FeatureSet,
     pub accounts: Vec<(Pubkey, Account)>,
     pub instruction: StableInstruction,
-    pub cu_avail: u64,
 }
 
 #[cfg(feature = "fuzz")]
@@ -75,7 +74,6 @@ impl TryFrom<ProtoInstrContext> for InstrContext {
             feature_set,
             accounts,
             instruction,
-            cu_avail: value.cu_avail,
         })
     }
 }

--- a/svm-test-harness/fixture/src/instr_effects.rs
+++ b/svm-test-harness/fixture/src/instr_effects.rs
@@ -11,6 +11,16 @@ pub struct InstrEffects {
     pub return_data: Vec<u8>,
 }
 
+impl InstrEffects {
+    /// Returns the modified account for the given pubkey, if it exists.
+    pub fn get_account(&self, pubkey: &Pubkey) -> Option<&Account> {
+        self.modified_accounts
+            .iter()
+            .find(|(pk, _)| pk == pubkey)
+            .map(|(_, acc)| acc)
+    }
+}
+
 #[cfg(feature = "fuzz")]
 use {crate::proto::InstrEffects as ProtoInstrEffects, bincode};
 

--- a/svm-test-harness/fixture/src/instr_effects.rs
+++ b/svm-test-harness/fixture/src/instr_effects.rs
@@ -9,6 +9,7 @@ pub struct InstrEffects {
     pub modified_accounts: Vec<(Pubkey, Account)>,
     pub cu_avail: u64,
     pub return_data: Vec<u8>,
+    pub logs: Vec<String>,
 }
 
 impl InstrEffects {

--- a/svm-test-harness/instr/src/fuzz.rs
+++ b/svm-test-harness/instr/src/fuzz.rs
@@ -32,6 +32,8 @@ pub unsafe extern "C" fn sol_compat_init(_log_level: i32) {
 pub unsafe extern "C" fn sol_compat_fini() {}
 
 pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects> {
+    let cu_avail = input.cu_avail;
+
     let Ok(instr_context) = InstrContext::try_from(input) else {
         return None;
     };
@@ -42,7 +44,7 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects
 
     let compute_budget = {
         let mut budget = ComputeBudget::new_with_defaults(simd_0268_active, simd_0339_active);
-        budget.compute_unit_limit = instr_context.cu_avail;
+        budget.compute_unit_limit = cu_avail;
         budget
     };
 

--- a/svm-test-harness/instr/src/harness.rs
+++ b/svm-test-harness/instr/src/harness.rs
@@ -56,6 +56,7 @@ fn compile_accounts<'a>(
     input: &'a InstrContext,
     compute_budget: &ComputeBudget,
     rent: Rent,
+    loader_key: &Pubkey,
 ) -> (Vec<InstructionAccount>, TransactionContext<'a>) {
     let mut transaction_accounts: Vec<KeyedAccountSharedData> = input
         .accounts
@@ -68,7 +69,10 @@ fn compile_accounts<'a>(
         .iter()
         .any(|(pubkey, _)| pubkey == &input.instruction.program_id)
     {
-        transaction_accounts.push((input.instruction.program_id, AccountSharedData::default()));
+        transaction_accounts.push((
+            input.instruction.program_id,
+            AccountSharedData::new(0, 0, loader_key),
+        ));
     }
 
     let transaction_context = TransactionContext::new(
@@ -110,8 +114,12 @@ pub fn execute_instr(
     let runtime_features = input.feature_set.runtime_features();
 
     let rent = sysvar_cache.get_rent().unwrap();
+    let loader_key = program_cache
+        .find(&input.instruction.program_id)?
+        .account_owner();
+
     let (instruction_accounts, mut transaction_context) =
-        compile_accounts(&input, compute_budget, (*rent).clone());
+        compile_accounts(&input, compute_budget, (*rent).clone(), &loader_key);
 
     let environments = ProgramRuntimeEnvironments {
         program_runtime_v1: Arc::new(

--- a/svm-test-harness/instr/src/harness.rs
+++ b/svm-test-harness/instr/src/harness.rs
@@ -186,7 +186,9 @@ pub fn execute_instr(
         }
     };
 
-    let cu_avail = input.cu_avail.saturating_sub(compute_units_consumed);
+    let cu_avail = compute_budget
+        .compute_unit_limit
+        .saturating_sub(compute_units_consumed);
     let return_data = transaction_context.get_return_data().1.to_vec();
 
     let account_keys: Vec<Pubkey> = (0..transaction_context.get_number_of_accounts())
@@ -330,7 +332,6 @@ mod tests {
                 ]
                 .into(),
             },
-            cu_avail,
         };
 
         // Set up the Compute Budget.

--- a/svm-test-harness/instr/src/keyed_account.rs
+++ b/svm-test-harness/instr/src/keyed_account.rs
@@ -1,0 +1,22 @@
+//! Keyed account helpers.
+
+use {
+    solana_account::Account, solana_builtins::BUILTINS, solana_pubkey::Pubkey, solana_rent::Rent,
+};
+
+fn create_keyed_account_for_builtin_program(program_id: &Pubkey, name: &str) -> (Pubkey, Account) {
+    let data = name.as_bytes().to_vec();
+    let lamports = Rent::default().minimum_balance(data.len());
+    let account = Account {
+        lamports,
+        data,
+        owner: solana_sdk_ids::native_loader::id(),
+        executable: true,
+        ..Default::default()
+    };
+    (*program_id, account)
+}
+
+pub fn keyed_account_for_system_program() -> (Pubkey, Account) {
+    create_keyed_account_for_builtin_program(&BUILTINS[0].program_id, BUILTINS[0].name)
+}

--- a/svm-test-harness/instr/src/lib.rs
+++ b/svm-test-harness/instr/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod file;
 mod harness;
+pub mod keyed_account;
 pub mod program_cache;
 pub mod sysvar_cache;
 


### PR DESCRIPTION
#### Problem
The test harness was missing a few features required for refactoring the tests in programs/sbf to use this new library.

#### Summary of Changes
Fixes:
* Dynamic loader key selection for default program account
* Unifies CU limit inputs to the ComputeBudget

Adds:
* Keyed account helpers for builtins (System for now)
* get_account helper on the effects
* Log support