### PR TITLE
svm-test-harness: compile accounts with Message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11160,7 +11160,6 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.0.0",
- "solana-stable-layout",
  "thiserror 2.0.17",
 ]
 
@@ -11182,17 +11181,18 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-last-restart-slot",
+ "solana-message",
  "solana-precompile-error",
  "solana-program-runtime",
  "solana-pubkey 4.0.0",
  "solana-rent",
  "solana-sdk-ids",
- "solana-stable-layout",
  "solana-svm",
  "solana-svm-callback",
  "solana-svm-log-collector",
  "solana-svm-test-harness-fixture",
  "solana-svm-timings",
+ "solana-svm-transaction",
  "solana-sysvar-id",
  "solana-transaction-context",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9778,7 +9778,6 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.0.0",
- "solana-stable-layout",
  "thiserror 2.0.17",
 ]
 
@@ -9799,17 +9798,18 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-last-restart-slot",
+ "solana-message",
  "solana-precompile-error",
  "solana-program-runtime",
  "solana-pubkey 4.0.0",
  "solana-rent",
  "solana-sdk-ids",
- "solana-stable-layout",
  "solana-svm",
  "solana-svm-callback",
  "solana-svm-log-collector",
  "solana-svm-test-harness-fixture",
  "solana-svm-timings",
+ "solana-svm-transaction",
  "solana-sysvar-id",
  "solana-transaction-context",
 ]

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -285,7 +285,7 @@ fn test_program_sbf_sanity() {
         let context = InstrContext {
             feature_set,
             accounts,
-            instruction: instruction.into(),
+            instruction,
         };
 
         let effects =
@@ -559,7 +559,7 @@ fn test_program_sbf_error_handling() {
             let context = InstrContext {
                 feature_set: feature_set.clone(),
                 accounts: accounts.clone(),
-                instruction: instruction.into(),
+                instruction,
             };
 
             harness::execute_instr(context, &compute_budget, program_cache, &sysvar_cache)

--- a/svm-test-harness/fixture/Cargo.toml
+++ b/svm-test-harness/fixture/Cargo.toml
@@ -30,7 +30,6 @@ solana-account = { workspace = true }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true, features = ["serde"] }
 solana-pubkey = { workspace = true }
-solana-stable-layout = { workspace = true }
 thiserror = { workspace = true }
 
 [build-dependencies]

--- a/svm-test-harness/fixture/src/instr_context.rs
+++ b/svm-test-harness/fixture/src/instr_context.rs
@@ -1,15 +1,15 @@
 //! Instruction context (input).
 
 use {
-    agave_feature_set::FeatureSet, solana_account::Account, solana_pubkey::Pubkey,
-    solana_stable_layout::stable_instruction::StableInstruction,
+    agave_feature_set::FeatureSet, solana_account::Account, solana_instruction::Instruction,
+    solana_pubkey::Pubkey,
 };
 
 /// Instruction context fixture.
 pub struct InstrContext {
     pub feature_set: FeatureSet,
     pub accounts: Vec<(Pubkey, Account)>,
-    pub instruction: StableInstruction,
+    pub instruction: Instruction,
 }
 
 #[cfg(feature = "fuzz")]
@@ -64,9 +64,9 @@ impl TryFrom<ProtoInstrContext> for InstrContext {
             return Err(FixtureError::InvalidFixtureInput);
         }
 
-        let instruction = StableInstruction {
-            accounts: instruction_accounts.into(),
-            data: value.data.into(),
+        let instruction = Instruction {
+            accounts: instruction_accounts,
+            data: value.data,
             program_id,
         };
 

--- a/svm-test-harness/instr/Cargo.toml
+++ b/svm-test-harness/instr/Cargo.toml
@@ -34,17 +34,18 @@ solana-epoch-schedule = { workspace = true, features = ["sysvar"] }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true, features = ["serde"] }
 solana-last-restart-slot = { workspace = true, features = ["sysvar"] }
+solana-message = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true, features = ["sysvar"] }
 solana-sdk-ids = { workspace = true }
-solana-stable-layout = { workspace = true }
 solana-svm = { workspace = true }
 solana-svm-callback = { workspace = true }
 solana-svm-log-collector = { workspace = true }
 solana-svm-test-harness-fixture = { workspace = true }
 solana-svm-timings = { workspace = true }
+solana-svm-transaction = { workspace = true }
 solana-sysvar-id = { workspace = true }
 solana-transaction-context = { workspace = true }
 


### PR DESCRIPTION
#### Problem
Currently the account compilation for the `InvokeContext` is being done locally within the `harness` module in a free function. However, we can just use a `Message`.

#### Summary of Changes
Create a single-instruction `Message` and use `InvokeContext::prepare_next_top_level_instruction` like the runtime does.