### PR TITLE
deps: bump vote-interface to 5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-context",
 ]
@@ -490,7 +490,7 @@ dependencies = [
  "solana-signer",
  "solana-storage-bigtable",
  "solana-streamer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-test-validator",
  "solana-time-utils",
  "solana-tpu-client",
@@ -7241,7 +7241,7 @@ dependencies = [
  "solana-runtime",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-test-validator",
  "solana-transaction",
  "solana-transaction-status",
@@ -7318,7 +7318,7 @@ dependencies = [
  "solana-stake-interface",
  "solana-svm",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-time-utils",
  "solana-transaction",
@@ -7415,7 +7415,7 @@ dependencies = [
  "solana-runtime",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-transaction",
  "solana-transaction-context",
@@ -7650,7 +7650,7 @@ dependencies = [
  "solana-svm-log-collector",
  "solana-svm-measure",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction-context",
  "static_assertions",
  "test-case",
@@ -7671,7 +7671,7 @@ dependencies = [
  "solana-pubkey 4.0.0",
  "solana-sdk-ids",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
@@ -7793,7 +7793,7 @@ dependencies = [
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "tempfile",
  "thiserror 2.0.17",
  "tiny-bip39",
@@ -7825,7 +7825,7 @@ dependencies = [
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-zk-sdk",
  "tempfile",
  "thiserror 2.0.17",
@@ -7909,7 +7909,7 @@ dependencies = [
  "solana-signer",
  "solana-slot-history",
  "solana-stake-interface",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-test-validator",
  "solana-tps-client",
@@ -7976,7 +7976,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-stake-interface",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
@@ -8059,7 +8059,7 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-runtime",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-test-validator",
  "solana-transaction-status",
@@ -8085,7 +8085,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
@@ -8158,7 +8158,7 @@ dependencies = [
  "solana-signer",
  "solana-stake-interface",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
  "thiserror 2.0.17",
@@ -8211,7 +8211,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
  "solana-short-vec",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -8366,7 +8366,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-program",
  "solana-system-transaction",
  "solana-sysvar",
@@ -8435,7 +8435,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-program",
  "solana-system-transaction",
  "solana-transaction",
@@ -8664,7 +8664,7 @@ dependencies = [
  "solana-nonce",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "thiserror 2.0.17",
 ]
 
@@ -8691,7 +8691,7 @@ dependencies = [
  "solana-packet 4.0.0",
  "solana-pubkey 4.0.0",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-transaction",
  "solana-version",
@@ -8716,7 +8716,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-rent",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -9280,7 +9280,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
@@ -9330,7 +9330,7 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -9345,7 +9345,7 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -9425,7 +9425,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-stake-interface",
  "solana-streamer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-tpu-client",
@@ -9657,7 +9657,7 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
@@ -9912,7 +9912,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction",
@@ -9975,7 +9975,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-log-collector",
  "solana-svm-timings",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction",
@@ -10215,7 +10215,7 @@ dependencies = [
  "solana-storage-bigtable",
  "solana-svm",
  "solana-svm-log-collector",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-time-utils",
@@ -10331,7 +10331,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sha256-hasher",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "thiserror 2.0.17",
  "tokio",
@@ -10527,7 +10527,7 @@ dependencies = [
  "solana-svm-callback",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-program",
  "solana-system-transaction",
  "solana-sysvar",
@@ -10576,7 +10576,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-transaction",
  "solana-transaction-context",
@@ -10717,7 +10717,7 @@ dependencies = [
  "solana-runtime",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-tpu-client-next",
@@ -10911,7 +10911,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 3.0.0",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-sysvar-id",
 ]
@@ -11097,7 +11097,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-program",
  "solana-system-transaction",
  "solana-sysvar",
@@ -11216,7 +11216,7 @@ dependencies = [
  "solana-pubkey 4.0.0",
  "solana-sdk-ids",
  "solana-signature",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "static_assertions",
  "test-case",
@@ -11247,6 +11247,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-system-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14591d6508042ebefb110305d3ba761615927146a26917ade45dc332d8e1ecde"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-address 2.0.0",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+]
+
+[[package]]
 name = "solana-system-program"
 version = "4.0.0-alpha.0"
 dependencies = [
@@ -11274,7 +11289,7 @@ dependencies = [
  "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-program",
  "solana-sysvar",
  "solana-transaction-context",
@@ -11291,7 +11306,7 @@ dependencies = [
  "solana-message",
  "solana-pubkey 3.0.0",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
 ]
 
@@ -11445,7 +11460,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-stake-interface",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-test-validator",
  "solana-transaction",
  "solana-transaction-error",
@@ -11597,7 +11612,7 @@ dependencies = [
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-signature",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction-context",
  "static_assertions",
 ]
@@ -11632,7 +11647,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-runtime",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-status",
  "solana-version",
@@ -11700,7 +11715,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status",
@@ -11982,9 +11997,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "4.0.4"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6e123e16bfdd7a81d71b4c4699e0b29580b619f4cd2ef5b6aae1eb85e8979f"
+checksum = "f7b4fb47dbad5a777e08ac4b1259e1fc5839c2e250512902a6d3b814f5c6040f"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -11997,16 +12012,16 @@ dependencies = [
  "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 3.1.0",
+ "solana-hash 4.0.1",
  "solana-instruction",
  "solana-instruction-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.0.0",
  "solana-rent",
  "solana-sdk-ids",
  "solana-serde-varint",
  "solana-serialize-utils",
  "solana-short-vec",
- "solana-system-interface",
+ "solana-system-interface 3.0.0",
 ]
 
 [[package]]
@@ -12116,7 +12131,7 @@ dependencies = [
  "solana-program-test",
  "solana-pubkey 4.0.0",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
  "solana-zk-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -586,7 +586,7 @@ solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=4
 solana-validator-exit = "3.0.0"
 solana-version = { path = "version", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-vote = { path = "vote", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-solana-vote-interface = "4.0.4"
+solana-vote-interface = "5.0.0"
 solana-vote-program = { path = "programs/vote", version = "=4.0.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-wen-restart = { path = "wen-restart", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -1018,6 +1018,12 @@ pub async fn process_vote_authorize(
                 check_current_authority(&[vote_state.authorized_withdrawer], &authorized.pubkey())?
             }
         }
+        VoteAuthorize::VoterWithBLS(_) => {
+            return Err(CliError::BadParameter(
+                "VoterWithBLS authorization not yet supported".to_string(),
+            )
+            .into());
+        }
     }
 
     let vote_ix = if new_authorized_signer.is_some() {

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
  "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-status",
@@ -297,7 +297,7 @@ dependencies = [
  "solana-account",
  "solana-accounts-db",
  "solana-pubkey 4.0.0",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-version",
 ]
 
@@ -6192,7 +6192,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-stake-interface",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-time-utils",
  "solana-transaction",
@@ -6290,7 +6290,7 @@ dependencies = [
  "solana-runtime",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-tpu-client",
@@ -6427,7 +6427,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-streamer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-test-validator",
  "solana-time-utils",
  "solana-tps-client",
@@ -6558,7 +6558,7 @@ dependencies = [
  "solana-svm-log-collector",
  "solana-svm-measure",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction-context",
 ]
 
@@ -6685,7 +6685,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status",
@@ -6756,7 +6756,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
@@ -6854,7 +6854,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
  "solana-short-vec",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -6992,7 +6992,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-time-utils",
@@ -7044,7 +7044,7 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-sdk-ids",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction-error",
  "solana-vote-program",
 ]
@@ -7152,7 +7152,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-stake-interface",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-time-utils",
  "solana-tps-client",
  "solana-tpu-client",
@@ -7282,7 +7282,7 @@ dependencies = [
  "solana-packet 4.0.0",
  "solana-pubkey 4.0.0",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-transaction",
  "solana-version",
@@ -7307,7 +7307,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-rent",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -7757,7 +7757,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
@@ -7804,7 +7804,7 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -7819,7 +7819,7 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -7889,7 +7889,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-stake-interface",
  "solana-streamer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-tpu-client",
@@ -8090,7 +8090,7 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
@@ -8259,7 +8259,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction-context",
@@ -8317,7 +8317,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-log-collector",
  "solana-svm-timings",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction",
@@ -8523,7 +8523,7 @@ dependencies = [
  "solana-slot-history",
  "solana-storage-bigtable",
  "solana-svm",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-time-utils",
@@ -8754,7 +8754,7 @@ dependencies = [
  "solana-svm-callback",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-program",
  "solana-system-transaction",
  "solana-sysvar",
@@ -9073,7 +9073,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 3.0.0",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-sysvar-id",
 ]
@@ -9219,7 +9219,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar-id",
  "solana-transaction-context",
  "solana-transaction-error",
@@ -9296,6 +9296,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-system-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14591d6508042ebefb110305d3ba761615927146a26917ade45dc332d8e1ecde"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-address 2.0.0",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+]
+
+[[package]]
 name = "solana-system-program"
 version = "4.0.0-alpha.0"
 dependencies = [
@@ -9314,7 +9329,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm-log-collector",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-transaction-context",
 ]
@@ -9330,7 +9345,7 @@ dependencies = [
  "solana-message",
  "solana-pubkey 3.0.0",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
 ]
 
@@ -9624,7 +9639,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
@@ -9822,9 +9837,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "4.0.4"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6e123e16bfdd7a81d71b4c4699e0b29580b619f4cd2ef5b6aae1eb85e8979f"
+checksum = "f7b4fb47dbad5a777e08ac4b1259e1fc5839c2e250512902a6d3b814f5c6040f"
 dependencies = [
  "bincode",
  "cfg_eval",
@@ -9834,16 +9849,16 @@ dependencies = [
  "serde_derive",
  "serde_with",
  "solana-clock",
- "solana-hash 3.1.0",
+ "solana-hash 4.0.1",
  "solana-instruction",
  "solana-instruction-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.0.0",
  "solana-rent",
  "solana-sdk-ids",
  "solana-serde-varint",
  "solana-serialize-utils",
  "solana-short-vec",
- "solana-system-interface",
+ "solana-system-interface 3.0.0",
 ]
 
 [[package]]

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -101,7 +101,7 @@ pub(crate) mod tests {
         for i in 0..3 {
             stakes.push((
                 i,
-                VoteStateV4::new(
+                VoteStateV4::new_with_defaults(
                     &vote_pubkey1,
                     &VoteInit {
                         node_pubkey: node1,
@@ -118,7 +118,7 @@ pub(crate) mod tests {
 
         stakes.push((
             5,
-            VoteStateV4::new(
+            VoteStateV4::new_with_defaults(
                 &vote_pubkey2,
                 &VoteInit {
                     node_pubkey: node2,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
  "solana-signer",
  "solana-storage-bigtable",
  "solana-streamer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-test-validator",
  "solana-tpu-client",
  "solana-turbine",
@@ -6132,7 +6132,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-stake-interface",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-time-utils",
  "solana-transaction",
@@ -6394,7 +6394,7 @@ dependencies = [
  "solana-svm-log-collector",
  "solana-svm-measure",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction-context",
 ]
 
@@ -6521,7 +6521,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status",
@@ -6592,7 +6592,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-signature",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
@@ -6690,7 +6690,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
  "solana-short-vec",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -6828,7 +6828,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-time-utils",
@@ -6880,7 +6880,7 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-sdk-ids",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction-error",
  "solana-vote-program",
 ]
@@ -7081,7 +7081,7 @@ dependencies = [
  "solana-nonce",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "thiserror 2.0.17",
 ]
 
@@ -7107,7 +7107,7 @@ dependencies = [
  "solana-packet 4.0.0",
  "solana-pubkey 4.0.0",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-transaction",
  "solana-version",
@@ -7132,7 +7132,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-rent",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -7535,7 +7535,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
@@ -7582,7 +7582,7 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -7597,7 +7597,7 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -8016,7 +8016,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction-context",
@@ -8074,7 +8074,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-log-collector",
  "solana-svm-timings",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction",
@@ -8280,7 +8280,7 @@ dependencies = [
  "solana-slot-history",
  "solana-storage-bigtable",
  "solana-svm",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-time-utils",
@@ -8511,7 +8511,7 @@ dependencies = [
  "solana-svm-callback",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-system-program",
  "solana-system-transaction",
  "solana-sysvar",
@@ -8624,7 +8624,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-transaction",
  "solana-transaction-context",
@@ -8893,7 +8893,7 @@ dependencies = [
  "solana-sbf-rust-invoked-dep",
  "solana-sbf-rust-realloc-dep",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -8948,7 +8948,7 @@ dependencies = [
  "solana-pubkey 4.0.0",
  "solana-sbf-rust-invoked-dep",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
 ]
 
@@ -9098,7 +9098,7 @@ dependencies = [
  "solana-program-error",
  "solana-pubkey 4.0.0",
  "solana-sbf-rust-realloc-dep",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -9122,7 +9122,7 @@ dependencies = [
  "solana-pubkey 4.0.0",
  "solana-sbf-rust-realloc-dep",
  "solana-sbf-rust-realloc-invoke-dep",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -9164,7 +9164,7 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-pubkey 4.0.0",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -9257,7 +9257,7 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-pubkey 4.0.0",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -9590,7 +9590,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 3.0.0",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-sysvar-id",
 ]
@@ -9736,7 +9736,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar-id",
  "solana-transaction-context",
  "solana-transaction-error",
@@ -9858,6 +9858,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-system-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14591d6508042ebefb110305d3ba761615927146a26917ade45dc332d8e1ecde"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-address 2.0.0",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+]
+
+[[package]]
 name = "solana-system-program"
 version = "4.0.0-alpha.0"
 dependencies = [
@@ -9876,7 +9891,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm-log-collector",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-transaction-context",
 ]
@@ -9892,7 +9907,7 @@ dependencies = [
  "solana-message",
  "solana-pubkey 3.0.0",
  "solana-signer",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
 ]
 
@@ -10158,7 +10173,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
@@ -10356,9 +10371,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "4.0.4"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6e123e16bfdd7a81d71b4c4699e0b29580b619f4cd2ef5b6aae1eb85e8979f"
+checksum = "f7b4fb47dbad5a777e08ac4b1259e1fc5839c2e250512902a6d3b814f5c6040f"
 dependencies = [
  "bincode",
  "cfg_eval",
@@ -10368,16 +10383,16 @@ dependencies = [
  "serde_derive",
  "serde_with",
  "solana-clock",
- "solana-hash 3.1.0",
+ "solana-hash 4.0.1",
  "solana-instruction",
  "solana-instruction-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.0.0",
  "solana-rent",
  "solana-sdk-ids",
  "solana-serde-varint",
  "solana-serialize-utils",
  "solana-short-vec",
- "solana-system-interface",
+ "solana-system-interface 3.0.0",
 ]
 
 [[package]]

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -72,7 +72,7 @@ solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-svm-feature-set = { workspace = true }
-solana-vote-program = { path = ".", features = ["agave-unstable-api"] }
+solana-vote-program = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 test-case = { workspace = true }
 
 [[bench]]

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -18,8 +18,8 @@ use {
     solana_vote_program::{
         vote_instruction::VoteInstruction,
         vote_state::{
-            TowerSync, Vote, VoteInit, VoteStateUpdate, VoteStateV3, VoteStateVersions,
-            MAX_LOCKOUT_HISTORY,
+            handler::VoteStateHandle, TowerSync, Vote, VoteInit, VoteStateUpdate, VoteStateV3,
+            VoteStateVersions, MAX_LOCKOUT_HISTORY,
         },
     },
     test::Bencher,

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -19,9 +19,9 @@ use {
         vote_instruction::VoteInstruction,
         vote_processor::Entrypoint,
         vote_state::{
-            create_v4_account_with_authorized, TowerSync, Vote, VoteAuthorize,
-            VoteAuthorizeCheckedWithSeedArgs, VoteAuthorizeWithSeedArgs, VoteInit, VoteStateUpdate,
-            VoteStateV3, VoteStateVersions, MAX_LOCKOUT_HISTORY,
+            create_v4_account_with_authorized, handler::VoteStateHandle, TowerSync, Vote,
+            VoteAuthorize, VoteAuthorizeCheckedWithSeedArgs, VoteAuthorizeWithSeedArgs, VoteInit,
+            VoteStateUpdate, VoteStateV3, VoteStateVersions, MAX_LOCKOUT_HISTORY,
         },
     },
 };

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -2321,4 +2321,340 @@ mod tests {
             Ok(()),
         );
     }
+
+    // Explicitly covers uninitialized vote accounts for instructions.
+    // `test_vote_signature` above covered:
+    // * Vote
+    // * UpdateVoteState
+    // * CompactUpdateVoteState
+    // * TowerSync
+    #[test_case(false ; "VoteStateV3")]
+    #[test_case(true ; "VoteStateV4")]
+    fn test_uninitialized_vote_account(vote_state_v4_enabled: bool) {
+        // Set up uninitialized vote account.
+        let vote_pubkey = solana_pubkey::new_rand();
+        let vote_account =
+            AccountSharedData::new(100, vote_state_size_of(vote_state_v4_enabled), &id());
+
+        let expected_error = if vote_state_v4_enabled {
+            InstructionError::UninitializedAccount
+        } else {
+            InstructionError::InvalidAccountData
+        };
+
+        // VoteInstruction::Authorize
+        {
+            let new_authorized_pubkey = solana_pubkey::new_rand();
+
+            let instruction_data = serialize(&VoteInstruction::Authorize(
+                new_authorized_pubkey,
+                VoteAuthorize::Voter,
+            ))
+            .unwrap();
+
+            let transaction_accounts = vec![
+                (vote_pubkey, vote_account),
+                (sysvar::clock::id(), create_default_clock_account()),
+            ];
+
+            let instruction_accounts = vec![
+                AccountMeta {
+                    pubkey: vote_pubkey,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: sysvar::clock::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ];
+
+            process_instruction(
+                vote_state_v4_enabled,
+                &instruction_data,
+                transaction_accounts,
+                instruction_accounts,
+                Err(expected_error.clone()),
+            );
+        }
+
+        // VoteInstruction::AuthorizeWithSeed
+        {
+            let vote_account =
+                AccountSharedData::new(100, vote_state_size_of(vote_state_v4_enabled), &id());
+            let current_authority_base_key = Pubkey::new_unique();
+            let current_authority_owner = Pubkey::new_unique();
+            let new_authority_pubkey = Pubkey::new_unique();
+
+            let instruction_data = serialize(&VoteInstruction::AuthorizeWithSeed(
+                VoteAuthorizeWithSeedArgs {
+                    authorization_type: VoteAuthorize::Voter,
+                    current_authority_derived_key_owner: current_authority_owner,
+                    current_authority_derived_key_seed: String::from("SEED"),
+                    new_authority: new_authority_pubkey,
+                },
+            ))
+            .unwrap();
+
+            let transaction_accounts = vec![
+                (vote_pubkey, vote_account),
+                (sysvar::clock::id(), create_default_clock_account()),
+                (current_authority_base_key, AccountSharedData::default()),
+            ];
+
+            let instruction_accounts = vec![
+                AccountMeta {
+                    pubkey: vote_pubkey,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: sysvar::clock::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: current_authority_base_key,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ];
+
+            process_instruction(
+                vote_state_v4_enabled,
+                &instruction_data,
+                transaction_accounts,
+                instruction_accounts,
+                Err(expected_error.clone()),
+            );
+        }
+
+        // VoteInstruction::AuthorizeCheckedWithSeed
+        {
+            let vote_account =
+                AccountSharedData::new(100, vote_state_size_of(vote_state_v4_enabled), &id());
+            let current_authority_base_key = Pubkey::new_unique();
+            let current_authority_owner = Pubkey::new_unique();
+            let new_authority_pubkey = Pubkey::new_unique();
+
+            let instruction_data = serialize(&VoteInstruction::AuthorizeCheckedWithSeed(
+                VoteAuthorizeCheckedWithSeedArgs {
+                    authorization_type: VoteAuthorize::Voter,
+                    current_authority_derived_key_owner: current_authority_owner,
+                    current_authority_derived_key_seed: String::from("SEED"),
+                },
+            ))
+            .unwrap();
+
+            let transaction_accounts = vec![
+                (vote_pubkey, vote_account),
+                (sysvar::clock::id(), create_default_clock_account()),
+                (current_authority_base_key, AccountSharedData::default()),
+                (new_authority_pubkey, AccountSharedData::default()),
+            ];
+
+            let instruction_accounts = vec![
+                AccountMeta {
+                    pubkey: vote_pubkey,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: sysvar::clock::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: current_authority_base_key,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: new_authority_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ];
+
+            process_instruction(
+                vote_state_v4_enabled,
+                &instruction_data,
+                transaction_accounts,
+                instruction_accounts,
+                Err(expected_error.clone()),
+            );
+        }
+
+        // VoteInstruction::UpdateValidatorIdentity
+        {
+            let vote_account =
+                AccountSharedData::new(100, vote_state_size_of(vote_state_v4_enabled), &id());
+            let node_pubkey = Pubkey::new_unique();
+            let authorized_withdrawer = Pubkey::new_unique();
+
+            let instruction_data = serialize(&VoteInstruction::UpdateValidatorIdentity).unwrap();
+
+            let transaction_accounts = vec![
+                (vote_pubkey, vote_account),
+                (node_pubkey, AccountSharedData::default()),
+                (authorized_withdrawer, AccountSharedData::default()),
+            ];
+
+            let instruction_accounts = vec![
+                AccountMeta {
+                    pubkey: vote_pubkey,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: node_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: authorized_withdrawer,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ];
+
+            process_instruction(
+                vote_state_v4_enabled,
+                &instruction_data,
+                transaction_accounts,
+                instruction_accounts,
+                Err(expected_error.clone()),
+            );
+        }
+
+        // VoteInstruction::UpdateCommission
+        {
+            let vote_account =
+                AccountSharedData::new(100, vote_state_size_of(vote_state_v4_enabled), &id());
+            let authorized_withdrawer = Pubkey::new_unique();
+
+            let instruction_data = serialize(&VoteInstruction::UpdateCommission(42)).unwrap();
+
+            let transaction_accounts = vec![
+                (vote_pubkey, vote_account),
+                (authorized_withdrawer, AccountSharedData::default()),
+                (
+                    sysvar::clock::id(),
+                    account::create_account_shared_data_for_test(&Clock::default()),
+                ),
+                (
+                    sysvar::epoch_schedule::id(),
+                    account::create_account_shared_data_for_test(&EpochSchedule::without_warmup()),
+                ),
+            ];
+
+            let instruction_accounts = vec![
+                AccountMeta {
+                    pubkey: vote_pubkey,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: authorized_withdrawer,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ];
+
+            process_instruction(
+                vote_state_v4_enabled,
+                &instruction_data,
+                transaction_accounts,
+                instruction_accounts,
+                Err(expected_error.clone()),
+            );
+        }
+
+        // VoteInstruction::Withdraw
+        {
+            let vote_account =
+                AccountSharedData::new(100, vote_state_size_of(vote_state_v4_enabled), &id());
+            let recipient = Pubkey::new_unique();
+
+            let instruction_data = serialize(&VoteInstruction::Withdraw(10)).unwrap();
+
+            let transaction_accounts = vec![
+                (vote_pubkey, vote_account),
+                (recipient, AccountSharedData::default()),
+                (sysvar::clock::id(), create_default_clock_account()),
+                (sysvar::rent::id(), create_default_rent_account()),
+            ];
+
+            let instruction_accounts = vec![
+                AccountMeta {
+                    pubkey: vote_pubkey,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: recipient,
+                    is_signer: false,
+                    is_writable: true,
+                },
+            ];
+
+            process_instruction(
+                vote_state_v4_enabled,
+                &instruction_data,
+                transaction_accounts,
+                instruction_accounts,
+                Err(expected_error.clone()),
+            );
+        }
+
+        // VoteInstruction::AuthorizeChecked
+        {
+            let vote_account =
+                AccountSharedData::new(100, vote_state_size_of(vote_state_v4_enabled), &id());
+            let authorized_pubkey = Pubkey::new_unique();
+            let new_authorized_pubkey = Pubkey::new_unique();
+
+            let instruction_data =
+                serialize(&VoteInstruction::AuthorizeChecked(VoteAuthorize::Voter)).unwrap();
+
+            let transaction_accounts = vec![
+                (vote_pubkey, vote_account),
+                (sysvar::clock::id(), create_default_clock_account()),
+                (authorized_pubkey, AccountSharedData::default()),
+                (new_authorized_pubkey, AccountSharedData::default()),
+            ];
+
+            let instruction_accounts = vec![
+                AccountMeta {
+                    pubkey: vote_pubkey,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: sysvar::clock::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: authorized_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: new_authorized_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ];
+
+            process_instruction(
+                vote_state_v4_enabled,
+                &instruction_data,
+                transaction_accounts,
+                instruction_accounts,
+                Err(expected_error),
+            );
+        }
+    }
 }

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -255,6 +255,13 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 &clock,
             )
         }
+        // New instructions not yet implemented.
+        VoteInstruction::InitializeAccountV2(_)
+        | VoteInstruction::UpdateCommissionCollector(_)
+        | VoteInstruction::UpdateCommissionBps { .. }
+        | VoteInstruction::DepositDelegatorRewards { .. } => {
+            Err(InstructionError::InvalidInstructionData)
+        }
     }
 });
 
@@ -1027,7 +1034,11 @@ mod tests {
                 &instruction_data,
                 transaction_accounts.clone(),
                 instruction_accounts.clone(),
-                error(InstructionError::UninitializedAccount),
+                if vote_state_v4_enabled {
+                    error(InstructionError::UninitializedAccount)
+                } else {
+                    error(InstructionError::InvalidAccountData)
+                },
             );
         }
     }

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -968,10 +968,7 @@ pub(crate) fn try_convert_to_vote_state_v4(
     vote_pubkey: &Pubkey,
 ) -> Result<VoteStateV4, InstructionError> {
     match versioned {
-        VoteStateVersions::V0_23_5(_) => {
-            // V0_23_5 not supported.
-            Err(InstructionError::UninitializedAccount)
-        }
+        VoteStateVersions::Uninitialized => Err(InstructionError::UninitializedAccount),
         VoteStateVersions::V1_14_11(state) => Ok(VoteStateV4 {
             node_pubkey: state.node_pubkey,
             authorized_withdrawer: state.authorized_withdrawer,
@@ -1767,10 +1764,13 @@ mod tests {
         let account_data = vote_account.get_data();
         assert!(account_data.iter().all(|&b| b == 0),);
 
-        // Vote account was completely zeroed, so this should deserialize as a
-        // v1, but it should be uninitialized.
+        // Vote account was completely zeroed, so this should deserialize as
+        // uninitialized.
         let vote_state_versions = vote_account.get_state::<VoteStateVersions>().unwrap();
-        assert!(matches!(vote_state_versions, VoteStateVersions::V0_23_5(_)));
+        assert!(matches!(
+            vote_state_versions,
+            VoteStateVersions::Uninitialized
+        ));
         assert!(vote_state_versions.is_uninitialized());
     }
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -754,6 +754,10 @@ pub fn authorize<S: std::hash::BuildHasher>(
             verify_authorized_signer(vote_state.authorized_withdrawer(), signers)?;
             vote_state.set_authorized_withdrawer(*authorized);
         }
+        // VoterWithBLS not yet implemented.
+        VoteAuthorize::VoterWithBLS(_) => {
+            return Err(InstructionError::InvalidInstructionData);
+        }
     }
 
     vote_state.set_vote_account_state(vote_account)

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -7701,7 +7701,7 @@ pub mod tests {
 
         // Create a vote account with no stake.
         let alice_vote_keypair = Keypair::new();
-        let alice_vote_state = VoteStateV4::new(
+        let alice_vote_state = VoteStateV4::new_with_defaults(
             &alice_vote_keypair.pubkey(),
             &VoteInit {
                 node_pubkey: mint_keypair.pubkey(),

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1040,7 +1040,7 @@ mod tests {
         assert_eq!(bank.epoch(), op.epoch);
         for (vote_address, vote_op) in &op.vote_operations {
             if let Some(balance) = &vote_op.create_with_balance {
-                let vote_state = VoteStateVersions::V4(Box::new(VoteStateV4::new(
+                let vote_state = VoteStateVersions::V4(Box::new(VoteStateV4::new_with_defaults(
                     vote_address,
                     &VoteInit {
                         node_pubkey: Pubkey::new_unique(),

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -273,6 +273,60 @@ pub fn parse_vote(
                 }),
             })
         }
+        VoteInstruction::InitializeAccountV2(vote_init) => {
+            check_num_vote_accounts(&instruction.accounts, 2)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "initializeV2".to_string(),
+                info: json!({
+                    "voteAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "node": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "authorizedVoter": vote_init.authorized_voter.to_string(),
+                    "authorizedWithdrawer": vote_init.authorized_withdrawer.to_string(),
+                    "inflationRewardsCommissionBps": vote_init.inflation_rewards_commission_bps,
+                    "inflationRewardsCollector": vote_init.inflation_rewards_collector.to_string(),
+                    "blockRevenueCommissionBps": vote_init.block_revenue_commission_bps,
+                    "blockRevenueCollector": vote_init.block_revenue_collector.to_string(),
+                }),
+            })
+        }
+        VoteInstruction::UpdateCommissionCollector(kind) => {
+            check_num_vote_accounts(&instruction.accounts, 3)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "updateCommissionCollector".to_string(),
+                info: json!({
+                    "voteAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "newCollector": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "withdrawAuthority": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "commissionKind": kind,
+                }),
+            })
+        }
+        VoteInstruction::UpdateCommissionBps {
+            commission_bps,
+            kind,
+        } => {
+            check_num_vote_accounts(&instruction.accounts, 2)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "updateCommissionBps".to_string(),
+                info: json!({
+                    "voteAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "withdrawAuthority": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "commissionBps": commission_bps,
+                    "commissionKind": kind,
+                }),
+            })
+        }
+        VoteInstruction::DepositDelegatorRewards { deposit } => {
+            check_num_vote_accounts(&instruction.accounts, 2)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "depositDelegatorRewards".to_string(),
+                info: json!({
+                    "voteAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "source": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "deposit": deposit,
+                }),
+            })
+        }
     }
 }
 

--- a/vote/benches/vote_account.rs
+++ b/vote/benches/vote_account.rs
@@ -26,7 +26,7 @@ fn new_rand_vote_account<R: Rng>(
         leader_schedule_epoch: rng.random(),
         unix_timestamp: rng.random(),
     };
-    let vote_state = VoteStateV4::new(&vote_pubkey, &vote_init, &clock);
+    let vote_state = VoteStateV4::new_with_defaults(&vote_pubkey, &vote_init, &clock);
     let account = AccountSharedData::new_data(
         rng.random(), // lamports
         &VoteStateVersions::new_v4(vote_state.clone()),

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -115,7 +115,7 @@ impl VoteAccount {
             leader_schedule_epoch: rng.random(),
             unix_timestamp: rng.random(),
         };
-        let vote_state = VoteStateV4::new(&vote_pubkey, &vote_init, &clock);
+        let vote_state = VoteStateV4::new_with_defaults(&vote_pubkey, &vote_init, &clock);
         let account = AccountSharedData::new_data(
             rng.random(), // lamports
             &VoteStateVersions::new_v4(vote_state.clone()),
@@ -482,7 +482,7 @@ mod tests {
             leader_schedule_epoch: rng.random(),
             unix_timestamp: rng.random(),
         };
-        let vote_state = VoteStateV4::new(&vote_pubkey, &vote_init, &clock);
+        let vote_state = VoteStateV4::new_with_defaults(&vote_pubkey, &vote_init, &clock);
         AccountSharedData::new_data(
             rng.random(), // lamports
             &VoteStateVersions::new_v4(vote_state.clone()),

--- a/vote/src/vote_parser.rs
+++ b/vote/src/vote_parser.rs
@@ -70,9 +70,13 @@ fn parse_vote_instruction_data(
         | VoteInstruction::AuthorizeWithSeed(_)
         | VoteInstruction::AuthorizeCheckedWithSeed(_)
         | VoteInstruction::InitializeAccount(_)
+        | VoteInstruction::InitializeAccountV2(_)
         | VoteInstruction::UpdateCommission(_)
+        | VoteInstruction::UpdateCommissionCollector(_)
+        | VoteInstruction::UpdateCommissionBps { .. }
         | VoteInstruction::UpdateValidatorIdentity
-        | VoteInstruction::Withdraw(_) => None,
+        | VoteInstruction::Withdraw(_)
+        | VoteInstruction::DepositDelegatorRewards { .. } => None,
     }
 }
 


### PR DESCRIPTION
#### Problem
There was a new vote-interface major release, which included the removal of lots of program-specific code, which we already reimplemented here in the Vote program.

The new version also contains the necessary interfaces for BLS pubkey support and more block revenue distribution features.

#### Summary of Changes
Bump vote-interface to 5.0.0 and update any callsites.