### PR TITLE
Move metrics init and init_poh earlier in validator execute

### DIFF
--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -123,6 +123,10 @@ pub fn execute(
     info!("{} {}", crate_name!(), solana_version);
     info!("Starting validator with: {:#?}", std::env::args_os());
 
+    solana_metrics::set_host_id(identity_keypair.pubkey().to_string());
+    solana_metrics::set_panic_hook("validator", Some(String::from(solana_version)));
+    solana_entry::entry::init_poh();
+
     solana_core::validator::report_target_features();
 
     let authorized_voter_keypairs = keypairs_of(matches, "authorized_voter_keypairs")
@@ -892,9 +896,6 @@ pub fn execute(
         }
     }
 
-    solana_metrics::set_host_id(identity_keypair.pubkey().to_string());
-    solana_metrics::set_panic_hook("validator", Some(String::from(solana_version)));
-    solana_entry::entry::init_poh();
     snapshot_utils::remove_tmp_snapshot_archives(
         &validator_config.snapshot_config.full_snapshot_archives_dir,
     );


### PR DESCRIPTION
#### Problem
`solana_entry::entry::init_poh` updates env variable (`LD_LIBRARY_PATH`), which is an unsafe operation when other threads (especially non-rust code using libc functions) are present.
We should ensure the code executes as early as possible in validator startup for easier reasoning that above can't happen.

Additionally, we set `solana_metrics` host id and panic hook just before `init_poh`, but those can be moved earlier, such that we preserve behavior in case of panics in poh.

#### Summary of Changes
* Move `solana_metrics` set host id and panic hook just after logging init.
* Move `init_poh` after metrics init
