### PR TITLE
Pass FileInfo to initialize AppendVec with snapshot utils

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1508,8 +1508,7 @@ fn snapshot_version_from_file(mut file_info: FileInfo) -> io::Result<String> {
                 "failed to read snapshot version from file '{}': {err}",
                 file_info.path.display()
             ))
-        })
-        .unwrap();
+        })?;
 
     Ok(snapshot_version.trim().to_string())
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -13,7 +13,7 @@ use {
             get_slot_and_append_vec_id, SnapshotStorageRebuilder,
         },
     },
-    agave_fs::buffered_writer::large_file_buf_writer,
+    agave_fs::{buffered_writer::large_file_buf_writer, FileInfo},
     agave_snapshots::{
         archive_snapshot,
         error::{
@@ -124,7 +124,9 @@ impl BankSnapshotInfo {
         // filled.  Check the version file as it is the last file written to avoid using a highest
         // found slot directory with missing content
         let version_path = bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_VERSION_FILENAME);
-        let version_str = snapshot_version_from_file(&version_path).map_err(|err| {
+        let version_file_info = FileInfo::new_from_path(&version_path)
+            .map_err(|err| SnapshotNewFromDirError::IncompleteDir(err, version_path))?;
+        let version_str = snapshot_version_from_file(version_file_info).map_err(|err| {
             SnapshotNewFromDirError::IncompleteDir(err, bank_snapshot_dir.clone())
         })?;
 
@@ -1146,34 +1148,34 @@ fn get_snapshot_file_kind(filename: &str) -> Option<SnapshotFileKind> {
 /// Due to parallel unpacking, we may receive some append_vec files before the snapshot file
 /// This function will push append_vec files into a buffer until we receive the snapshot file
 fn get_version_and_snapshot_files(
-    file_receiver: &Receiver<PathBuf>,
-) -> Result<(PathBuf, PathBuf, Vec<PathBuf>)> {
+    file_receiver: &Receiver<FileInfo>,
+) -> Result<(FileInfo, FileInfo, Vec<FileInfo>)> {
     let mut append_vec_files = Vec::with_capacity(1024);
-    let mut snapshot_version_path = None;
-    let mut snapshot_file_path = None;
+    let mut snapshot_version = None;
+    let mut snapshot_bank = None;
 
     loop {
-        if let Ok(path) = file_receiver.recv() {
-            let filename = path.file_name().unwrap().to_str().unwrap();
+        if let Ok(file_info) = file_receiver.recv() {
+            let filename = file_info.path.file_name().unwrap().to_str().unwrap();
             match get_snapshot_file_kind(filename) {
                 Some(SnapshotFileKind::Version) => {
-                    snapshot_version_path = Some(path);
+                    snapshot_version = Some(file_info);
 
                     // break if we have both the snapshot file and the version file
-                    if snapshot_file_path.is_some() {
+                    if snapshot_bank.is_some() {
                         break;
                     }
                 }
                 Some(SnapshotFileKind::BankFields) => {
-                    snapshot_file_path = Some(path);
+                    snapshot_bank = Some(file_info);
 
                     // break if we have both the snapshot file and the version file
-                    if snapshot_version_path.is_some() {
+                    if snapshot_version.is_some() {
                         break;
                     }
                 }
                 Some(SnapshotFileKind::Storage) => {
-                    append_vec_files.push(path);
+                    append_vec_files.push(file_info);
                 }
                 None => {} // do nothing for other kinds of files
             }
@@ -1183,10 +1185,10 @@ fn get_version_and_snapshot_files(
             ));
         }
     }
-    let snapshot_version_path = snapshot_version_path.unwrap();
-    let snapshot_file_path = snapshot_file_path.unwrap();
+    let snapshot_version = snapshot_version.unwrap();
+    let snapshot_bank = snapshot_bank.unwrap();
 
-    Ok((snapshot_version_path, snapshot_file_path, append_vec_files))
+    Ok((snapshot_version, snapshot_bank, append_vec_files))
 }
 
 /// Fields and information parsed from the snapshot.
@@ -1194,23 +1196,22 @@ struct SnapshotFieldsBundle {
     snapshot_version: SnapshotVersion,
     bank_fields: BankFieldsToDeserialize,
     accounts_db_fields: AccountsDbFields<SerializableAccountStorageEntry>,
-    append_vec_files: Vec<PathBuf>,
+    append_vec_files: Vec<FileInfo>,
 }
 
 /// Parses fields and information from the snapshot files provided by
 /// `file_receiver`.
-fn snapshot_fields_from_files(file_receiver: &Receiver<PathBuf>) -> Result<SnapshotFieldsBundle> {
-    let (snapshot_version_path, snapshot_file_path, append_vec_files) =
+fn snapshot_fields_from_files(file_receiver: &Receiver<FileInfo>) -> Result<SnapshotFieldsBundle> {
+    let (snapshot_version, snapshot_bank, append_vec_files) =
         get_version_and_snapshot_files(file_receiver)?;
-    let snapshot_version_str = snapshot_version_from_file(snapshot_version_path)?;
+    let snapshot_version_str = snapshot_version_from_file(snapshot_version)?;
     let snapshot_version = snapshot_version_str.parse().map_err(|err| {
         IoError::other(format!(
             "unsupported snapshot version '{snapshot_version_str}': {err}",
         ))
     })?;
 
-    let snapshot_file = fs::File::open(snapshot_file_path).unwrap();
-    let mut snapshot_stream = BufReader::new(snapshot_file);
+    let mut snapshot_stream = BufReader::new(snapshot_bank.file);
     let (bank_fields, accounts_db_fields) = match snapshot_version {
         SnapshotVersion::V1_2_0 => serde_snapshot::fields_from_stream(&mut snapshot_stream)?,
     };
@@ -1335,19 +1336,25 @@ fn spawn_streaming_snapshot_dir_files(
     snapshot_file_path: PathBuf,
     snapshot_version_path: PathBuf,
     account_paths: &[PathBuf],
-) -> (Receiver<PathBuf>, thread::JoinHandle<Result<()>>) {
+    writable: bool,
+) -> (Receiver<FileInfo>, thread::JoinHandle<Result<()>>) {
     let (file_sender, file_receiver) = crossbeam_channel::unbounded();
     let account_paths = account_paths.to_vec();
 
     let handle = thread::Builder::new()
         .name("solSnapDirFiles".to_string())
         .spawn(move || {
-            file_sender.send(snapshot_file_path)?;
-            file_sender.send(snapshot_version_path)?;
+            let snapshot_bank_file_info = FileInfo::new_from_path(snapshot_file_path)?;
+            file_sender.send(snapshot_bank_file_info)?;
+            let snapshot_version_file_info = FileInfo::new_from_path(snapshot_version_path)?;
+            file_sender.send(snapshot_version_file_info)?;
 
             for account_path in account_paths {
-                for file in fs::read_dir(account_path)? {
-                    file_sender.send(file?.path())?;
+                for dir_entry_result in fs::read_dir(account_path)? {
+                    let dir_entry = dir_entry_result?;
+                    let path = dir_entry.path();
+                    let file_info = FileInfo::new_from_path_writable(path, writable)?;
+                    file_sender.send(file_info)?;
                 }
             }
             Ok::<_, SnapshotError>(())
@@ -1444,10 +1451,12 @@ pub fn rebuild_storages_from_snapshot_dir(
 
     let snapshot_file_path = snapshot_info.snapshot_path();
     let snapshot_version_path = bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_VERSION_FILENAME);
+    #[allow(deprecated)]
     let (file_receiver, stream_files_handle) = spawn_streaming_snapshot_dir_files(
         snapshot_file_path,
         snapshot_version_path,
         account_paths,
+        storage_access == StorageAccess::Mmap,
     );
 
     let SnapshotFieldsBundle {
@@ -1477,19 +1486,12 @@ pub fn rebuild_storages_from_snapshot_dir(
 /// Reads the `snapshot_version` from a file. Before opening the file, its size
 /// is compared to `MAX_SNAPSHOT_VERSION_FILE_SIZE`. If the size exceeds this
 /// threshold, it is not opened and an error is returned.
-fn snapshot_version_from_file(path: impl AsRef<Path>) -> io::Result<String> {
-    // Check file size.
-    let file_metadata = fs::metadata(&path).map_err(|err| {
-        IoError::other(format!(
-            "failed to query snapshot version file metadata '{}': {err}",
-            path.as_ref().display(),
-        ))
-    })?;
-    let file_size = file_metadata.len();
+fn snapshot_version_from_file(mut file_info: FileInfo) -> io::Result<String> {
+    let file_size = file_info.size;
     if file_size > MAX_SNAPSHOT_VERSION_FILE_SIZE {
         let error_message = format!(
             "snapshot version file too large: '{}' has {} bytes (max size is {} bytes)",
-            path.as_ref().display(),
+            file_info.path.display(),
             file_size,
             MAX_SNAPSHOT_VERSION_FILE_SIZE,
         );
@@ -1498,18 +1500,16 @@ fn snapshot_version_from_file(path: impl AsRef<Path>) -> io::Result<String> {
 
     // Read snapshot_version from file.
     let mut snapshot_version = String::new();
-    let mut file = fs::File::open(&path).map_err(|err| {
-        IoError::other(format!(
-            "failed to open snapshot version file '{}': {err}",
-            path.as_ref().display()
-        ))
-    })?;
-    file.read_to_string(&mut snapshot_version).map_err(|err| {
-        IoError::other(format!(
-            "failed to read snapshot version from file '{}': {err}",
-            path.as_ref().display()
-        ))
-    })?;
+    file_info
+        .file
+        .read_to_string(&mut snapshot_version)
+        .map_err(|err| {
+            IoError::other(format!(
+                "failed to read snapshot version from file '{}': {err}",
+                file_info.path.display()
+            ))
+        })
+        .unwrap();
 
     Ok(snapshot_version.trim().to_string())
 }
@@ -1945,7 +1945,8 @@ mod tests {
         let file_content = SnapshotVersion::default().as_str();
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(file_content.as_bytes()).unwrap();
-        let version_from_file = snapshot_version_from_file(file.path()).unwrap();
+        let file_info = FileInfo::new_from_path(file.path()).unwrap();
+        let version_from_file = snapshot_version_from_file(file_info).unwrap();
         assert_eq!(version_from_file, file_content);
     }
 
@@ -1955,8 +1956,9 @@ mod tests {
         let file_content = vec![7u8; over_limit_size];
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&file_content).unwrap();
+        let file_info = FileInfo::new_from_path(file.path()).unwrap();
         assert_matches!(
-            snapshot_version_from_file(file.path()),
+            snapshot_version_from_file(file_info),
             Err(ref message) if message.to_string().starts_with("snapshot version file too large")
         );
     }

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -7,6 +7,7 @@ use {
         snapshot_storage_lengths_from_fields, AccountsDbFields, SerdeObsoleteAccountsMap,
         SerializableAccountStorageEntry, SerializedAccountsFileId,
     },
+    agave_fs::FileInfo,
     crossbeam_channel::{select, unbounded, Receiver, Sender},
     dashmap::DashMap,
     log::*,
@@ -36,13 +37,13 @@ use {
 #[derive(Debug)]
 pub(crate) struct SnapshotStorageRebuilder {
     /// Receiver for unpacked snapshot storage files
-    file_receiver: Receiver<PathBuf>,
+    file_receiver: Receiver<FileInfo>,
     /// Number of threads to rebuild with
     num_threads: usize,
     /// Snapshot storage lengths - from the snapshot file
     snapshot_storage_lengths: HashMap<Slot, HashMap<SerializedAccountsFileId, usize>>,
-    /// Container for storing snapshot file paths
-    storage_paths: DashMap<Slot, Mutex<Vec<PathBuf>>>,
+    /// Container for storing snapshot file infos
+    storage_file_infos: DashMap<Slot, Mutex<Vec<FileInfo>>>,
     /// Container for storing rebuilt snapshot storages
     storage: AccountStorageMap,
     /// Tracks next append_vec_id
@@ -63,8 +64,8 @@ impl SnapshotStorageRebuilder {
     /// Synchronously spawns threads to rebuild snapshot storages
     pub(crate) fn rebuild_storage(
         accounts_db_fields: &AccountsDbFields<SerializableAccountStorageEntry>,
-        append_vec_files: Vec<PathBuf>,
-        file_receiver: Receiver<PathBuf>,
+        append_vecs_files: Vec<FileInfo>,
+        file_receiver: Receiver<FileInfo>,
         num_threads: usize,
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_from: SnapshotFrom,
@@ -78,7 +79,7 @@ impl SnapshotStorageRebuilder {
             num_threads,
             next_append_vec_id,
             snapshot_storage_lengths,
-            append_vec_files,
+            append_vecs_files,
             snapshot_from,
             storage_access,
             obsolete_accounts,
@@ -88,9 +89,9 @@ impl SnapshotStorageRebuilder {
     }
 
     /// Create the SnapshotStorageRebuilder for storing state during rebuilding
-    ///     - pre-allocates data for storage paths
+    ///     - pre-allocates data for storage file infos
     fn new(
-        file_receiver: Receiver<PathBuf>,
+        file_receiver: Receiver<FileInfo>,
         num_threads: usize,
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_storage_lengths: HashMap<Slot, HashMap<usize, usize>>,
@@ -99,7 +100,7 @@ impl SnapshotStorageRebuilder {
         obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
     ) -> Self {
         let storage = AccountStorageMap::with_capacity(snapshot_storage_lengths.len());
-        let storage_paths: DashMap<_, _> = snapshot_storage_lengths
+        let storage_file_infos: DashMap<_, _> = snapshot_storage_lengths
             .iter()
             .map(|(slot, storage_lengths)| {
                 (*slot, Mutex::new(Vec::with_capacity(storage_lengths.len())))
@@ -109,7 +110,7 @@ impl SnapshotStorageRebuilder {
             file_receiver,
             num_threads,
             snapshot_storage_lengths,
-            storage_paths,
+            storage_file_infos,
             storage,
             next_append_vec_id,
             processed_slot_count: AtomicUsize::new(0),
@@ -122,11 +123,11 @@ impl SnapshotStorageRebuilder {
 
     /// Spawn threads for processing buffered append_vec_files, and then received files
     fn spawn_rebuilder_threads(
-        file_receiver: Receiver<PathBuf>,
+        file_receiver: Receiver<FileInfo>,
         num_threads: usize,
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_storage_lengths: HashMap<Slot, HashMap<usize, usize>>,
-        append_vec_files: Vec<PathBuf>,
+        append_vec_files: Vec<FileInfo>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
         obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
@@ -161,10 +162,10 @@ impl SnapshotStorageRebuilder {
     }
 
     /// Processes buffered append_vec_files
-    fn process_buffered_files(&self, append_vec_files: Vec<PathBuf>) -> Result<(), SnapshotError> {
+    fn process_buffered_files(&self, append_vec_files: Vec<FileInfo>) -> Result<(), SnapshotError> {
         append_vec_files
             .into_par_iter()
-            .map(|path| self.process_append_vec_file(path))
+            .map(|file_info| self.process_append_vec_file(file_info))
             .collect::<Result<(), SnapshotError>>()
     }
 
@@ -175,8 +176,8 @@ impl SnapshotStorageRebuilder {
         rebuilder: Arc<SnapshotStorageRebuilder>,
     ) {
         thread_pool.spawn(move || {
-            for path in rebuilder.file_receiver.iter() {
-                match rebuilder.process_append_vec_file(path) {
+            for file_info in rebuilder.file_receiver.iter() {
+                match rebuilder.process_append_vec_file(file_info) {
                     Ok(_) => {}
                     Err(err) => {
                         exit_sender
@@ -194,9 +195,9 @@ impl SnapshotStorageRebuilder {
     }
 
     /// Process an append_vec_file
-    fn process_append_vec_file(&self, path: PathBuf) -> Result<(), SnapshotError> {
-        let filename = path.file_name().unwrap().to_str().unwrap().to_owned();
-        if let Ok((slot, append_vec_id)) = get_slot_and_append_vec_id(&filename) {
+    fn process_append_vec_file(&self, file_info: FileInfo) -> Result<(), SnapshotError> {
+        let filename = file_info.path.file_name().unwrap().to_str().unwrap();
+        if let Ok((slot, append_vec_id)) = get_slot_and_append_vec_id(filename) {
             if self.snapshot_from == SnapshotFrom::Dir {
                 // Keep track of the highest append_vec_id in the system, so the future append_vecs
                 // can be assigned to unique IDs.  This is only needed when loading from a snapshot
@@ -205,7 +206,7 @@ impl SnapshotStorageRebuilder {
                 self.next_append_vec_id
                     .fetch_max((append_vec_id + 1) as AccountsFileId, Ordering::Relaxed);
             }
-            let slot_storage_count = self.insert_storage_file(&slot, path);
+            let slot_storage_count = self.insert_storage_file(&slot, file_info);
             if slot_storage_count == self.snapshot_storage_lengths.get(&slot).unwrap().len() {
                 // slot_complete
                 self.process_complete_slot(slot)?;
@@ -216,22 +217,22 @@ impl SnapshotStorageRebuilder {
     }
 
     /// Insert storage path into slot and return the number of storage files for the slot
-    fn insert_storage_file(&self, slot: &Slot, path: PathBuf) -> usize {
-        let slot_paths = self.storage_paths.get(slot).unwrap();
-        let mut lock = slot_paths.lock().unwrap();
-        lock.push(path);
+    fn insert_storage_file(&self, slot: &Slot, file_info: FileInfo) -> usize {
+        let slot_file_infos = self.storage_file_infos.get(slot).unwrap();
+        let mut lock = slot_file_infos.lock().unwrap();
+        lock.push(file_info);
         lock.len()
     }
 
     /// Process a slot that has received all storage entries
     fn process_complete_slot(&self, slot: Slot) -> Result<(), SnapshotError> {
-        let slot_storage_paths = self.storage_paths.get(&slot).unwrap();
-        let lock = slot_storage_paths.lock().unwrap();
+        let slot_storage_file_infos = self.storage_file_infos.get(&slot).unwrap();
+        let mut lock = slot_storage_file_infos.lock().unwrap();
 
         let slot_stores = lock
-            .iter()
-            .map(|path| {
-                let filename = path.file_name().unwrap().to_str().unwrap();
+            .drain(..)
+            .map(|file_info| {
+                let filename = file_info.path.file_name().unwrap().to_str().unwrap();
                 let (_, old_append_vec_id) = get_slot_and_append_vec_id(filename)?;
                 let current_len = *self
                     .snapshot_storage_lengths
@@ -245,14 +246,14 @@ impl SnapshotStorageRebuilder {
                         slot,
                         old_append_vec_id,
                         current_len,
-                        path.as_path(),
+                        file_info,
                         &self.next_append_vec_id,
                         &self.num_collisions,
                         self.storage_access,
                     )?,
                     SnapshotFrom::Dir => reconstruct_single_storage(
                         &slot,
-                        path.as_path(),
+                        file_info,
                         current_len,
                         old_append_vec_id as AccountsFileId,
                         self.storage_access,

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -64,7 +64,7 @@ impl SnapshotStorageRebuilder {
     /// Synchronously spawns threads to rebuild snapshot storages
     pub(crate) fn rebuild_storage(
         accounts_db_fields: &AccountsDbFields<SerializableAccountStorageEntry>,
-        append_vecs_files: Vec<FileInfo>,
+        append_vec_files: Vec<FileInfo>,
         file_receiver: Receiver<FileInfo>,
         num_threads: usize,
         next_append_vec_id: Arc<AtomicAccountsFileId>,
@@ -79,7 +79,7 @@ impl SnapshotStorageRebuilder {
             num_threads,
             next_append_vec_id,
             snapshot_storage_lengths,
-            append_vecs_files,
+            append_vec_files,
             snapshot_from,
             storage_access,
             obsolete_accounts,

--- a/snapshots/src/error.rs
+++ b/snapshots/src/error.rs
@@ -1,5 +1,7 @@
 use {
     crate::{hardened_unpack::UnpackError, snapshot_hash::SnapshotHash},
+    agave_fs::FileInfo,
+    crossbeam_channel::SendError,
     semver::Version,
     solana_accounts_db::{accounts_db::AccountsFileId, accounts_file::AccountsFileError},
     solana_clock::{Epoch, Slot},
@@ -93,6 +95,12 @@ pub enum SnapshotError {
 
     #[error("failed to rebuild snapshot storages: {0}")]
     RebuildStorages(String),
+}
+
+impl From<SendError<FileInfo>> for SnapshotError {
+    fn from(err: SendError<FileInfo>) -> Self {
+        Self::CrossbeamSend(SendError(err.into_inner().path))
+    }
 }
 
 #[derive(Error, Debug)]

--- a/snapshots/src/unarchive.rs
+++ b/snapshots/src/unarchive.rs
@@ -59,6 +59,7 @@ pub fn streaming_unarchive_snapshot(
                             err.0.path.display(),
                         );
                     }
+                    // Don't pass `File` back to file creator, so it's not closed (owned by channel now)
                     None
                 })?,
             )

--- a/snapshots/src/unarchive.rs
+++ b/snapshots/src/unarchive.rs
@@ -3,7 +3,7 @@ use {
         hardened_unpack::{self, UnpackError},
         ArchiveFormat, ArchiveFormatDecompressor,
     },
-    agave_fs::{buffered_reader, file_io::file_creator, io_setup::IoSetupState},
+    agave_fs::{buffered_reader, file_io::file_creator, io_setup::IoSetupState, FileInfo},
     bzip2::bufread::BzDecoder,
     crossbeam_channel::Sender,
     std::{
@@ -26,7 +26,7 @@ const MAX_UNPACK_WRITE_BUF_SIZE: usize = 512 * 1024 * 1024;
 
 /// Streams unpacked files across channel
 pub fn streaming_unarchive_snapshot(
-    file_sender: Sender<PathBuf>,
+    file_sender: Sender<FileInfo>,
     account_paths: Vec<PathBuf>,
     ledger_dir: PathBuf,
     snapshot_archive_path: PathBuf,
@@ -52,14 +52,14 @@ pub fn streaming_unarchive_snapshot(
             (
                 decompressor,
                 file_creator(write_buf_size, &io_setup, move |file_info| {
-                    let result = file_sender.send(file_info.path);
+                    let result = file_sender.send(file_info);
                     if let Err(err) = result {
                         panic!(
                             "failed to send path '{}' from unpacker to rebuilder: {err}",
-                            err.0.display(),
+                            err.0.path.display(),
                         );
                     }
-                    Some(file_info.file)
+                    None
                 })?,
             )
         };


### PR DESCRIPTION
#### Problem
During snapshot unpacking `FileInfo` objects are produced that contain path, size and `File` for all elements in a snapshot. This information can be used to populate accounts-db storage map instead opening and `stat`-ing the provided paths.

#### Summary of Changes
Use already provided `File` and size from `FileInfo` to create `AppendVec`