### PR TITLE
use solana-cli without default features by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -426,7 +426,7 @@ solana-builtins = { path = "builtins", version = "=4.0.0-alpha.0", features = ["
 solana-builtins-default-costs = { path = "builtins-default-costs", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-clap-utils = { path = "clap-utils", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-clap-v3-utils = { path = "clap-v3-utils", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-solana-cli = { path = "cli", version = "=4.0.0-alpha.0" }
+solana-cli = { path = "cli", version = "=4.0.0-alpha.0", default-features = false }
 solana-cli-config = { path = "cli-config", version = "=4.0.0-alpha.0" }
 solana-cli-output = { path = "cli-output", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-client = { path = "client", version = "=4.0.0-alpha.0" }

--- a/cargo-registry/Cargo.toml
+++ b/cargo-registry/Cargo.toml
@@ -16,8 +16,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 default = ["remote-wallet-hidraw"]
 agave-unstable-api = []
 dev-context-only-utils = []
-remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
-remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
+remote-wallet-hidraw = [
+    "solana-remote-wallet/linux-static-hidraw",
+    "solana-cli/remote-wallet-hidraw",
+]
+remote-wallet-libusb = [
+    "solana-remote-wallet/linux-static-libusb",
+    "solana-cli/remote-wallet-libusb",
+]
 
 [dependencies]
 agave-logger = { workspace = true }

--- a/transaction-dos/Cargo.toml
+++ b/transaction-dos/Cargo.toml
@@ -23,7 +23,7 @@ log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 solana-clap-utils = { workspace = true }
-solana-cli = { workspace = true }
+solana-cli = { workspace = true, features = ["default"] }
 solana-client = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-faucet = { workspace = true }

--- a/transaction-dos/Cargo.toml
+++ b/transaction-dos/Cargo.toml
@@ -23,7 +23,7 @@ log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 solana-clap-utils = { workspace = true }
-solana-cli = { workspace = true, features = ["default"] }
+solana-cli = { workspace = true, features = ["remote-wallet-hidraw"] }
 solana-client = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-faucet = { workspace = true }


### PR DESCRIPTION
#### Problem

(split from https://github.com/anza-xyz/agave/pull/9456)

failed to compile:

```
cargo +nightly-2025-08-02 check --manifest-path cargo-registry/Cargo.toml \
  --no-default-features \
  --features remote-wallet-libusb
```

this is because the default solana-cli feature already includes `remote-wallet-hidraw`

https://github.com/anza-xyz/agave/blob/4e031c8025f0c14ecc2b8652f1a75cf5051e00f3/cli/Cargo.toml#L20


#### Summary of Changes

- don't enable solana-cli's default feature by default
- update cargo-registry accordingly
- enable solana-cli's default feature in transaction-dos to keep original behavior