### PR TITLE
tpu-client-next: add no log mode for better feature isolation

### DIFF
--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -16,7 +16,7 @@ agave-unstable-api = []
 default = ["log"]
 dev-context-only-utils = []
 log = ["dep:log"]
-metrics = ["dep:solana-metrics"]
+metrics = ["dep:solana-metrics", "dep:log"]
 tracing = ["dep:tracing"]
 websocket-node-address-service = ["dep:solana-pubsub-client", "dep:tokio-stream"]
 

--- a/tpu-client-next/src/logging.rs
+++ b/tpu-client-next/src/logging.rs
@@ -9,11 +9,30 @@ pub use log::{debug, error, info, trace, warn};
 #[cfg(feature = "tracing")]
 pub use tracing::{debug, error, info, trace, warn};
 
-#[cfg(not(any(feature = "log", feature = "tracing")))]
-compile_error!("Either 'log' or 'tracing' feature must be enabled");
-
 #[cfg(all(feature = "log", feature = "tracing"))]
 compile_error!("'log' and 'tracing' features are mutually exclusive");
+
+#[cfg(not(any(feature = "log", feature = "tracing")))]
+#[macro_export]
+macro_rules! do_nothing {
+    ($($tt:tt)*) => {
+        // trick compiler to think the tt has been consumed or it complains about unused arguments
+        if false {
+            unreachable!($($tt)*);
+        }
+    };
+}
+
+#[cfg(not(any(feature = "log", feature = "tracing")))]
+pub use do_nothing as debug;
+#[cfg(not(any(feature = "log", feature = "tracing")))]
+pub use do_nothing as error;
+#[cfg(not(any(feature = "log", feature = "tracing")))]
+pub use do_nothing as info;
+#[cfg(not(any(feature = "log", feature = "tracing")))]
+pub use do_nothing as trace;
+#[cfg(not(any(feature = "log", feature = "tracing")))]
+pub use do_nothing as warn;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
#### Problem

(split from https://github.com/anza-xyz/agave/pull/9456)

failed to compile:

```
cargo +nightly-2025-08-02 check \
  --manifest-path tpu-client-next/Cargo.toml \
  --no-default-features \
  --features websocket-node-address-service
```

we introduced a log selecting feature in https://github.com/anza-xyz/agave/pull/7053, but we couldn't disable all. it forces other features to depend on one logging feature.

I am not sure whether this behavior is expected. this PR adds the ability to disable all logging, allowing features to be used more independently

#### Summary of Changes

- introduced a no log mode (relaxing the requirement to enable either log or tracing)
- afaik metrics is tied to log. included it so that we can enable metrics feature individually

