### PR TITLE
Remove `LargeBuffer` and use only `PageAlignedMemory`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "test-case",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "log",
  "slab",
  "smallvec",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -24,6 +24,7 @@ libc = { workspace = true }
 log = { workspace = true }
 slab = { workspace = true }
 smallvec = { workspace = true }
+thiserror = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 agave-io-uring = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "log",
  "slab",
  "smallvec",
+ "thiserror 2.0.17",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Summary of Changes
Removed `LargeBuffer` from `memory.rs` and use just `PageAlignedMemory` for reading/writing to files. Buffers will now always be page aligned regardless of size.

Instead of using `Vec::new` to allocate small buffers, we use `std::alloc::alloc` to allocate page aligned memory even for small buffers.

Needed by https://github.com/anza-xyz/agave/pull/9395
