### PR TITLE
fix: remove dead boolean contract from airdrop_lamports

### DIFF
--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -41,7 +41,7 @@ pub fn airdrop_lamports(
     faucet_addr: &SocketAddr,
     id: &Keypair,
     desired_balance: u64,
-) -> bool {
+) {
     let starting_balance = client.get_balance(&id.pubkey()).unwrap_or(0);
     info!("starting balance {starting_balance}");
 
@@ -96,7 +96,6 @@ pub fn airdrop_lamports(
             );
         }
     }
-    true
 }
 
 fn make_create_message(
@@ -300,15 +299,7 @@ async fn run_transactions_dos(
                 last_balance = Instant::now();
                 if *balance < lamports * 2 {
                     info!("Balance {balance} is less than needed: {lamports}, doing aidrop...");
-                    if !airdrop_lamports(
-                        &client,
-                        &faucet_addr,
-                        payer_keypairs[i],
-                        lamports * 100_000,
-                    ) {
-                        warn!("failed airdrop, exiting");
-                        return;
-                    }
+                    airdrop_lamports(&client, &faucet_addr, payer_keypairs[i], lamports * 100_000);
                 }
             }
         }


### PR DESCRIPTION
The airdrop_lamports helpers in transaction-dos and accounts-cluster-bench were declared as returning bool but unconditionally returned true and panicked on all real errors. Their callers checked for !airdrop_lamports(...) to log and exit, but that branch was unreachable in practice.
Made airdrop_lamports return unit and removes the dead boolean checks at the call sites. The effective behavior is unchanged: either the airdrop succeeds and execution continues, or the helper panics on failure.