### PR TITLE
docs: align RentState transition spec with implementation

### DIFF
--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -281,10 +281,11 @@ Steps of `load_and_execute_sanitized_transactions`
       `TransactionError`, if any of instructions failed to execute
       correctly.
    7. Verify transaction accounts' `RentState` changes (`verify_changes` function)
-      - If the account `RentState` pre-transaction processing is rent exempt or unitiliazed, the verification will pass.
+      - If the account `RentState` post-transaction processing is rent exempt or uninitialized, the verification will pass, regardless of the pre-transaction `RentState`.
       - If the account `RentState` pre-transaction is rent paying:
-         - A transition to a state uninitialized or rent exempt post-transaction is not allowed.
-         - If its size has changed or its balance has increased, it cannot remain rent paying.
+         - It may remain rent paying only if its size has not changed and its balance has not increased.
+      - If the account `RentState` pre-transaction is rent exempt or uninitialized:
+         - It cannot become rent paying.
    8. Extract log messages.
    9. Extract inner instructions (`Vec<Vec<InnerInstruction>>`).
    10. Extract `ExecutionRecord` components from transaction context.


### PR DESCRIPTION
The RentState transition rules in svm/doc/spec.md were out of sync with the actual behavior implemented in transition_allowed and validated by existing tests. This change updates the documentation to reflect that transitions to Uninitialized or RentExempt are always allowed, RentExempt/Uninitialized accounts cannot become RentPaying, and RentPaying accounts may remain RentPaying only when size is unchanged and balance does not increase.