### PR TITLE
Make epoch_slots deflate always fail when compressed output larger than input.

### DIFF
--- a/gossip/src/epoch_slots.rs
+++ b/gossip/src/epoch_slots.rs
@@ -446,7 +446,7 @@ mod tests {
         let mut slots = Uncompressed::new(4);
         let data = [6940, 6971];
         slots.add(&data);
-        assert!(Flate2::deflate(slots).is_err());
+        assert_eq!(Flate2::deflate(slots), Err(Error::CompressError));
     }
 
     #[test]

--- a/gossip/src/epoch_slots.rs
+++ b/gossip/src/epoch_slots.rs
@@ -115,13 +115,20 @@ impl Flate2 {
         let num = unc.num;
         let block_len = unc.slots.block_len();
         let bits = Arc::unwrap_or_clone(unc.slots).into_boxed_slice();
-        compressor.compress_vec(&bits[0..block_len], &mut compressed, FlushCompress::Finish)?;
+        let status =
+            compressor.compress_vec(&bits[0..block_len], &mut compressed, FlushCompress::Finish)?;
+        if status != flate2::Status::StreamEnd {
+            return Err(Error::CompressError);
+        }
         let rv = Self {
             first_slot,
             num,
             compressed: Arc::new(compressed),
         };
-        let _ = rv.inflate()?;
+        let new_uncompressed = rv.inflate()?;
+        if new_uncompressed.slots.block_len() != block_len {
+            return Err(Error::CompressError);
+        }
         Ok(rv)
     }
 
@@ -432,6 +439,14 @@ mod tests {
         assert_eq!(slots.first_slot, 1);
         assert_eq!(slots.num, 701);
         assert_eq!(slots.to_slots(1), vec![1, 2, 701]);
+    }
+
+    #[test]
+    fn test_epoch_slots_compressed_fails_when_input_smaller_than_output() {
+        let mut slots = Uncompressed::new(4);
+        let data = [6940, 6971];
+        slots.add(&data);
+        assert!(Flate2::deflate(slots).is_err());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
In epoch_slots `deflate`, we rely on undocumented flate2 behavior that when the compressed output is larger than input, `decompress_vec` will emit an error.
This was true in flate2 1.0.31, no longer true in 1.1.5.

#### Summary of Changes
Instead make it more robust, let's check:
- `compress_vec` returns `StreamEnd`, meaning it wrote all output already (instead of waiting for some new output vec to magically appear)
- when doing `rv.inflate`, not only verify that no error was returned (because uncompress may be naively waiting for more output vec to magically appear), but also verify the inflated slots len is the same as the old one
