### PR TITLE
Use FileInfo to initialize AppendVec on startup

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -9,7 +9,7 @@ use {
             error::TieredStorageError, hot::HOT_FORMAT, index::IndexOffset, TieredStorage,
         },
     },
-    agave_fs::buffered_reader::RequiredLenBufFileRead,
+    agave_fs::{buffered_reader::RequiredLenBufFileRead, FileInfo},
     solana_account::AccountSharedData,
     solana_clock::Slot,
     solana_pubkey::Pubkey,
@@ -80,17 +80,17 @@ impl AccountsFile {
         Ok((Self::AppendVec(av), num_accounts))
     }
 
-    /// Creates a new AccountsFile for the underlying storage at `path`
+    /// Creates a new AccountsFile for the underlying storage at `file_info`
     ///
     /// This version of `new()` may only be called when reconstructing storages as part of startup.
     /// It trusts the snapshot's value for `current_len`, and relies on later index generation or
     /// accounts verification to ensure it is valid.
     pub fn new_for_startup(
-        path: impl Into<PathBuf>,
+        file_info: FileInfo,
         current_len: usize,
         storage_access: StorageAccess,
     ) -> Result<Self> {
-        let av = AppendVec::new_for_startup(path, current_len, storage_access)?;
+        let av = AppendVec::new_for_startup(file_info, current_len, storage_access)?;
         Ok(Self::AppendVec(av))
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -418,6 +418,7 @@ impl AppendVec {
         current_len: usize,
         storage_access: StorageAccess,
     ) -> Result<(Self, usize)> {
+        // AppendVec is in read-only mode, but mmap access requires file to be writable
         #[allow(deprecated)]
         let is_writable = storage_access == StorageAccess::Mmap;
         let file_info = FileInfo::new_from_path_writable(path, is_writable)?;
@@ -2071,7 +2072,9 @@ mod tests {
 
         // Truncate the AppendVec to PAGESIZE. This will cause get_account* to fail to load the account.
         let truncated_accounts_len: usize = PAGE_SIZE;
-        let file_info = FileInfo::new_from_path(path).unwrap();
+        #[allow(deprecated)]
+        let is_writable = storage_access == StorageAccess::Mmap;
+        let file_info = FileInfo::new_from_path_writable(path, is_writable).unwrap();
         let av = AppendVec::new_from_file_info_unchecked(
             file_info,
             truncated_accounts_len,

--- a/fs/src/file_info.rs
+++ b/fs/src/file_info.rs
@@ -1,4 +1,8 @@
-use std::{fs::File, io, path::PathBuf};
+use std::{
+    fs::{File, OpenOptions},
+    io,
+    path::PathBuf,
+};
 
 /// Open `File` coupled with its filesystem location and most useful information
 ///
@@ -18,6 +22,20 @@ impl FileInfo {
     pub fn new_from_path(path: impl Into<PathBuf>) -> io::Result<Self> {
         let path = path.into();
         let file = File::open(&path)?;
+        Self::new_from_path_and_file(path, file)
+    }
+
+    /// Create new instance by opening file with R/RW mode from a given `path` and reading its metadata
+    ///
+    /// `is_writable` indicates whether the file should be opened in write mode. Note that file needs
+    /// to exist, so even if `is_writable` is true, the file will not be created when missing.
+    pub fn new_from_path_writable(path: impl Into<PathBuf>, is_writable: bool) -> io::Result<Self> {
+        let path = path.into();
+        let file = OpenOptions::new()
+            .read(true)
+            .create(false)
+            .write(is_writable)
+            .open(&path)?;
         Self::new_from_path_and_file(path, file)
     }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -10,6 +10,7 @@ use {
         stake_account::StakeAccount,
         stakes::{serialize_stake_accounts_to_delegation_format, Stakes},
     },
+    agave_fs::FileInfo,
     agave_snapshots::error::SnapshotError,
     bincode::{self, config::Options, Error},
     log::*,
@@ -885,8 +886,11 @@ pub(crate) fn reconstruct_single_storage(
         (current_len, ObsoleteAccounts::default())
     };
 
+    #[allow(deprecated)]
+    let append_vec_file_info =
+        FileInfo::new_from_path_writable(append_vec_path, storage_access == StorageAccess::Mmap)?;
     let accounts_file =
-        AccountsFile::new_for_startup(append_vec_path, current_len, storage_access)?;
+        AccountsFile::new_for_startup(append_vec_file_info, current_len, storage_access)?;
     Ok(Arc::new(AccountStorageEntry::new_existing(
         *slot,
         id,


### PR DESCRIPTION
#### Problem
We would like to initialize append vecs using pre-constructed `FileInfo` objects instead of performing file open / metadata fetches in append file constructor.

#### Summary of Changes
Update `new_*` APIs in `AppendVec` and `AppendFile`. This is extracted from a larger change updating startup initialization using already available file infos (https://github.com/anza-xyz/agave/pull/9517).