### PR TITLE
nextest: limit sbf tests to 1 concurrent

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -36,6 +36,10 @@ threads-required = "num-cpus"
 filter = "package(solana-gossip) & test(/^cluster_info::tests::new_with_external_ip_test_random/)"
 threads-required = "num-cpus"
 
+[[profile.default.overrides]]
+filter = "package(solana-cargo-build-sbf)"
+test-group = "build-sbf"
+
 [[profile.ci.overrides]]
 filter = "package(solana-cargo-build-sbf)"
 test-group = "build-sbf"


### PR DESCRIPTION
#### Problem

The `build-sbf` tests all might download a tarball of the toolchain and when these tests are run concurrently each such download steps on each other toes, leading to pretty confusing failures.

CI profile already limits the execution to 1 parallel test of this category for what seems to be exactly the same reason.

#### Summary of Changes

Apply the same concurrency limit to default nextest profile.