### PR TITLE
build-sbf: patch the binaries in downloaded toolchain for NixOS users

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -560,12 +560,12 @@ fn main() {
              may get mixed results with it.",
         ))
         .arg(
-            Arg::new("patch_nix")
+            Arg::new("patch_binaries_for_nix")
                 .long("patch-binaries-for-nix")
                 .takes_value(true)
-                .required(false)
-                .validator(|val| val.parse::<bool>().map_err(|e| e.to_string()))
-                .help("Should patch the downloaded toolchain binaries to work on nix systems?"),
+                .default_missing_value("true")
+                .possible_values(["true", "false"])
+                .help("Patch the downloaded toolchain binaries to work on nix systems"),
         )
         .get_matches_from(args);
 
@@ -641,8 +641,8 @@ fn main() {
         lto: matches.is_present("lto"),
         install_only: matches.is_present("install_only"),
         patch_binaries_for_nix: matches
-            .is_present("patch_nix")
-            .then(|| matches.value_of_t("patch_nix").unwrap()),
+            .is_present("patch_binaries_for_nix")
+            .then(|| matches.value_of_t("patch_binaries_for_nix").unwrap()),
     };
     let manifest_path: Option<PathBuf> = matches.value_of_t("manifest_path").ok();
     if config.verbose {

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -50,6 +50,7 @@ pub struct Config<'a> {
     optimize_size: bool,
     lto: bool,
     install_only: bool,
+    patch_binaries_for_nix: Option<bool>,
 }
 
 impl Default for Config<'_> {
@@ -84,6 +85,7 @@ impl Default for Config<'_> {
             optimize_size: false,
             lto: false,
             install_only: false,
+            patch_binaries_for_nix: None,
         }
     }
 }
@@ -557,6 +559,14 @@ fn main() {
              decrease program size and CU consumption. The default option is LTO disabled, as one \
              may get mixed results with it.",
         ))
+        .arg(
+            Arg::new("patch_nix")
+                .long("patch-binaries-for-nix")
+                .takes_value(true)
+                .required(false)
+                .validator(|val| val.parse::<bool>().map_err(|e| e.to_string()))
+                .help("Should patch the downloaded toolchain binaries to work on nix systems?"),
+        )
         .get_matches_from(args);
 
     let sbf_sdk: PathBuf = matches.value_of_t_or_exit("sbf_sdk");
@@ -630,6 +640,9 @@ fn main() {
         optimize_size: matches.is_present("optimize_size"),
         lto: matches.is_present("lto"),
         install_only: matches.is_present("install_only"),
+        patch_binaries_for_nix: matches
+            .is_present("patch_nix")
+            .then(|| matches.value_of_t("patch_nix").unwrap()),
     };
     let manifest_path: Option<PathBuf> = matches.value_of_t("manifest_path").ok();
     if config.verbose {

--- a/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
@@ -1,16 +1,18 @@
 use {
     crate::{home_dir, utils::spawn, Config},
     bzip2::bufread::BzDecoder,
-    log::{debug, error, warn},
+    log::{debug, error, info, warn},
     regex::Regex,
     serde::{Deserialize, Serialize},
     solana_file_download::{download_file, download_file_with_headers},
     std::{
         env,
+        ffi::OsString,
         fs::{self, File},
-        io::BufReader,
+        io::{BufRead, BufReader, ErrorKind},
         path::{Path, PathBuf},
-        process::exit,
+        process::{exit, Command},
+        sync::OnceLock,
     },
     tar::Archive,
 };
@@ -315,9 +317,16 @@ pub(crate) fn install_if_missing(
         let zip = File::open(&download_file_path).map_err(|err| err.to_string())?;
         let tar = BzDecoder::new(BufReader::new(zip));
         let mut archive = Archive::new(tar);
-        archive.unpack(target_path).map_err(|err| err.to_string())?;
-        fs::remove_file(download_file_path).map_err(|err| err.to_string())?;
+        archive
+            .unpack(target_path)
+            .map_err(|err| format!("could not unpack downloaded archive: {err}"))?;
+        fs::remove_file(download_file_path)
+            .map_err(|err| format!("could not remove downloaded archive: {err}"))?;
+        if should_fix_bins_and_dylibs(config) {
+            let _ = fix_all_bins_and_dylibs(target_path);
+        }
     }
+
     // Make a symbolic link source_path -> target_path in the
     // platform-tools-sdk/sbf/dependencies directory if no valid link found.
     let source_base = config.sbf_sdk.join("dependencies");
@@ -568,4 +577,148 @@ pub(crate) fn rust_target_triple(config: &Config) -> String {
     } else {
         format!("sbpf{}-solana-solana", config.arch)
     }
+}
+
+fn fix_all_bins_and_dylibs(path: &Path) -> Result<(), std::io::Error> {
+    for libdir in [path.join("llvm/lib"), path.join("rust/lib")] {
+        for candidate in std::fs::read_dir(libdir)? {
+            let Ok(candidate) = candidate else { continue };
+            if path_is_dylib(&candidate.path()) {
+                fix_bin_or_dylib(path, &candidate.path());
+            }
+        }
+    }
+    for bindir in [path.join("llvm/bin"), path.join("rust/bin")] {
+        for candidate in std::fs::read_dir(bindir)? {
+            let Ok(candidate) = candidate else { continue };
+            fix_bin_or_dylib(path, &candidate.path());
+        }
+    }
+    for targetdir in std::fs::read_dir(path.join("rust/lib/rustlib"))? {
+        let targetdir = targetdir?;
+        for bindir in ["bin", "bin/gcc-ld"] {
+            let Ok(bindir_candidates) = std::fs::read_dir(targetdir.path().join(bindir)) else {
+                continue;
+            };
+            for candidate in bindir_candidates {
+                let Ok(candidate) = candidate else { continue };
+                fix_bin_or_dylib(path, &candidate.path());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn fix_bin_or_dylib(out: &Path, fname: &Path) {
+    debug!("attempting to patch {}", fname.display());
+    // Only build `.nix-deps` once.
+    static NIX_DEPS_DIR: OnceLock<PathBuf> = OnceLock::new();
+    let mut nix_build_succeeded = true;
+    let nix_deps_dir = NIX_DEPS_DIR.get_or_init(|| {
+        // Run `nix-build` to "build" each dependency (which will likely reuse the existing
+        // `/nix/store` copy, or at most download a pre-built copy).
+        //
+        // Importantly, we create a gc-root called `.nix-deps` in the target directory, but still
+        // reference the actual `/nix/store` path in the rpath as it makes it significantly more
+        // robust against changes to the location of the `.nix-deps` location.
+        //
+        // bintools: Needed for the path of `ld-linux.so` (via `nix-support/dynamic-linker`).
+        // zlib: Needed as a system dependency of various LLVM tools.
+        // patchelf: Needed for patching ELF binaries.
+        // libgcc.lib: libstdc++
+        let nix_deps_dir = out.join(".nix-deps");
+        const NIX_EXPR: &str = "
+        with (import <nixpkgs> {});
+        symlinkJoin {
+            name = \"solana-sbf-dependencies\";
+            paths = [
+                zlib
+                patchelf
+                stdenv.cc.bintools
+                libgcc.lib
+            ];
+        }
+        ";
+        nix_build_succeeded = Command::new("nix-build")
+            .args([
+                Path::new("-E"),
+                Path::new(NIX_EXPR),
+                Path::new("-o"),
+                &nix_deps_dir,
+            ])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        nix_deps_dir
+    });
+    if !nix_build_succeeded {
+        return;
+    }
+
+    let mut patchelf = Command::new(nix_deps_dir.join("bin/patchelf"));
+    patchelf.args(&[
+        OsString::from("--add-rpath"),
+        OsString::from(fs::canonicalize(nix_deps_dir).unwrap().join("lib")),
+    ]);
+    if !path_is_dylib(fname) {
+        // Finally, set the correct .interp for binaries
+        let dynamic_linker_path = nix_deps_dir.join("nix-support/dynamic-linker");
+        let dynamic_linker = fs::read_to_string(dynamic_linker_path).unwrap();
+        patchelf.args(["--set-interpreter", dynamic_linker.trim_end()]);
+    }
+    patchelf.arg(fname);
+    let _ = patchelf.output();
+}
+
+fn path_is_dylib(path: &Path) -> bool {
+    // The .so is not necessarily the extension, it might be libLLVM.so.18.1
+    path.to_str().is_some_and(|path| path.contains(".so"))
+}
+
+fn should_fix_bins_and_dylibs(config: &Config) -> bool {
+    static SHOULD_FIX_BINS_AND_DYLIBS: OnceLock<bool> = OnceLock::new();
+    let val = *SHOULD_FIX_BINS_AND_DYLIBS.get_or_init(|| {
+        let uname = Command::new("uname").arg("-s").output();
+        let Ok(output) = uname else {
+            return false;
+        };
+        let output = output.stdout;
+        if !output.starts_with(b"Linux") {
+            return false;
+        }
+        // If the user has asked binaries to be patched for Nix, then
+        // don't check for NixOS or `/lib`.
+        // NOTE: this intentionally comes after the Linux check:
+        // - patchelf only works with ELF files, so no need to run it on Mac or Windows
+        // - On other Unix systems, there is no stable syscall interface, so Nix doesn't manage the
+        // global libc.
+        if let Some(explicit_value) = config.patch_binaries_for_nix {
+            return explicit_value;
+        }
+
+        // Use `/etc/os-release` instead of `/etc/NIXOS`.
+        // The latter one does not exist on NixOS when using tmpfs as root.
+        let is_nixos = match File::open("/etc/os-release") {
+            Err(e) if e.kind() == ErrorKind::NotFound => false,
+            Err(e) => panic!("failed to access /etc/os-release: {e}"),
+            Ok(os_release) => BufReader::new(os_release).lines().any(|l| {
+                let l = l.expect("reading /etc/os-release");
+                matches!(l.trim(), "ID=nixos" | "ID='nixos'" | "ID=\"nixos\"")
+            }),
+        };
+        if !is_nixos {
+            let in_nix_shell = env::var("IN_NIX_SHELL");
+            if let Ok(in_nix_shell) = in_nix_shell {
+                info!(
+                    "The IN_NIX_SHELL environment variable is `{in_nix_shell}`; you may need to \
+                     set the --patch-binaries-for-nix argument"
+                );
+            }
+        }
+        is_nixos
+    });
+    if val {
+        info!("You seem to be using Nix.");
+    }
+    val
 }

--- a/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
@@ -250,14 +250,16 @@ pub(crate) fn install_if_missing(
     if config.force_tools_install {
         if target_path.is_dir() {
             debug!("Remove directory {target_path:?}");
-            fs::remove_dir_all(target_path).map_err(|err| err.to_string())?;
+            fs::remove_dir_all(target_path)
+                .map_err(|err| format!("could not remove {target_path:?}: {err}"))?;
         }
         let source_base = config.sbf_sdk.join("dependencies");
         if source_base.exists() {
             let source_path = source_base.join(package);
             if source_path.exists() {
                 debug!("Remove file {source_path:?}");
-                fs::remove_file(source_path).map_err(|err| err.to_string())?;
+                fs::remove_file(&source_path)
+                    .map_err(|err| format!("could not remove {source_path:?}: {err}"))?;
             }
         }
     }
@@ -273,7 +275,8 @@ pub(crate) fn install_if_missing(
             .is_none()
     {
         debug!("Remove directory {target_path:?}");
-        fs::remove_dir(target_path).map_err(|err| err.to_string())?;
+        fs::remove_dir(target_path)
+            .map_err(|err| format!("could not remove {target_path:?}: {err}"))?;
     }
 
     // Check whether the package is already in ~/.cache/solana.
@@ -286,10 +289,12 @@ pub(crate) fn install_if_missing(
     {
         if target_path.exists() {
             debug!("Remove file {target_path:?}");
-            fs::remove_file(target_path).map_err(|err| err.to_string())?;
+            fs::remove_file(target_path)
+                .map_err(|err| format!("could not remove {target_path:?}: {err}"))?;
         }
 
-        fs::create_dir_all(target_path).map_err(|err| err.to_string())?;
+        fs::create_dir_all(target_path)
+            .map_err(|err| format!("could not create {target_path:?}: {err}"))?;
         let arch = if cfg!(target_arch = "aarch64") {
             "aarch64"
         } else {
@@ -305,7 +310,8 @@ pub(crate) fn install_if_missing(
 
         let download_file_path = target_path.join(&platform_tools_download_file_name);
         if download_file_path.exists() {
-            fs::remove_file(&download_file_path).map_err(|err| err.to_string())?;
+            fs::remove_file(&download_file_path)
+                .map_err(|err| format!("could not remove {download_file_path:?}: {err}"))?;
         }
 
         download_platform_tools(
@@ -322,8 +328,8 @@ pub(crate) fn install_if_missing(
             .map_err(|err| format!("could not unpack downloaded archive: {err}"))?;
         fs::remove_file(download_file_path)
             .map_err(|err| format!("could not remove downloaded archive: {err}"))?;
-        if should_fix_bins_and_dylibs(config) {
-            let _ = fix_all_bins_and_dylibs(target_path);
+        if should_nix_patch_bins_and_dylibs(config) {
+            let _ = nix_patch_all_bins_and_dylibs(target_path);
         }
     }
 
@@ -331,13 +337,15 @@ pub(crate) fn install_if_missing(
     // platform-tools-sdk/sbf/dependencies directory if no valid link found.
     let source_base = config.sbf_sdk.join("dependencies");
     if !source_base.exists() {
-        fs::create_dir_all(&source_base).map_err(|err| err.to_string())?;
+        fs::create_dir_all(&source_base)
+            .map_err(|err| format!("could not create {source_base:?}: {err}"))?;
     }
     let source_path = source_base.join(package);
     // Check whether the correct symbolic link exists.
     let invalid_link = if let Ok(link_target) = source_path.read_link() {
         if link_target.ne(target_path) {
-            fs::remove_file(&source_path).map_err(|err| err.to_string())?;
+            fs::remove_file(&source_path)
+                .map_err(|err| format!("could not remove {source_path:?}: {err}"))?;
             true
         } else {
             false
@@ -347,10 +355,13 @@ pub(crate) fn install_if_missing(
     };
     if invalid_link {
         #[cfg(unix)]
-        std::os::unix::fs::symlink(target_path, source_path).map_err(|err| err.to_string())?;
+        std::os::unix::fs::symlink(&target_path, &source_path).map_err(|err| {
+            format!("could not symlink {source_path:?} -> {target_path:?}: {err}")
+        })?;
         #[cfg(windows)]
-        std::os::windows::fs::symlink_dir(target_path, source_path)
-            .map_err(|err| err.to_string())?;
+        std::os::windows::fs::symlink_dir(&target_path, &source_path).map_err(|err| {
+            format!("could not symlink {source_path:?} -> {target_path:?}: {err}")
+        })?;
     }
     Ok(())
 }
@@ -579,19 +590,19 @@ pub(crate) fn rust_target_triple(config: &Config) -> String {
     }
 }
 
-fn fix_all_bins_and_dylibs(path: &Path) -> Result<(), std::io::Error> {
+fn nix_patch_all_bins_and_dylibs(path: &Path) -> Result<(), std::io::Error> {
     for libdir in [path.join("llvm/lib"), path.join("rust/lib")] {
         for candidate in std::fs::read_dir(libdir)? {
             let Ok(candidate) = candidate else { continue };
             if path_is_dylib(&candidate.path()) {
-                fix_bin_or_dylib(path, &candidate.path());
+                nix_patch_bin_or_dylib(path, &candidate.path());
             }
         }
     }
     for bindir in [path.join("llvm/bin"), path.join("rust/bin")] {
         for candidate in std::fs::read_dir(bindir)? {
             let Ok(candidate) = candidate else { continue };
-            fix_bin_or_dylib(path, &candidate.path());
+            nix_patch_bin_or_dylib(path, &candidate.path());
         }
     }
     for targetdir in std::fs::read_dir(path.join("rust/lib/rustlib"))? {
@@ -602,14 +613,14 @@ fn fix_all_bins_and_dylibs(path: &Path) -> Result<(), std::io::Error> {
             };
             for candidate in bindir_candidates {
                 let Ok(candidate) = candidate else { continue };
-                fix_bin_or_dylib(path, &candidate.path());
+                nix_patch_bin_or_dylib(path, &candidate.path());
             }
         }
     }
     Ok(())
 }
 
-fn fix_bin_or_dylib(out: &Path, fname: &Path) {
+fn nix_patch_bin_or_dylib(out: &Path, fname: &Path) {
     debug!("attempting to patch {}", fname.display());
     // Only build `.nix-deps` once.
     static NIX_DEPS_DIR: OnceLock<PathBuf> = OnceLock::new();
@@ -632,7 +643,12 @@ fn fix_bin_or_dylib(out: &Path, fname: &Path) {
         symlinkJoin {
             name = \"solana-sbf-dependencies\";
             paths = [
+                libedit
+                python310
+                ncurses
                 zlib
+                xz.out
+                libxml2.out
                 patchelf
                 stdenv.cc.bintools
                 libgcc.lib
@@ -666,6 +682,9 @@ fn fix_bin_or_dylib(out: &Path, fname: &Path) {
         let dynamic_linker = fs::read_to_string(dynamic_linker_path).unwrap();
         patchelf.args(["--set-interpreter", dynamic_linker.trim_end()]);
     }
+    // Adjustments for lldb (which references debian/ubuntu specific sonames.)
+    patchelf.args(["--replace-needed", "libedit.so.2", "libedit.so"]);
+    patchelf.args(["--replace-needed", "libxml2.so.2", "libxml2.so"]);
     patchelf.arg(fname);
     let _ = patchelf.output();
 }
@@ -675,7 +694,7 @@ fn path_is_dylib(path: &Path) -> bool {
     path.to_str().is_some_and(|path| path.contains(".so"))
 }
 
-fn should_fix_bins_and_dylibs(config: &Config) -> bool {
+fn should_nix_patch_bins_and_dylibs(config: &Config) -> bool {
     static SHOULD_FIX_BINS_AND_DYLIBS: OnceLock<bool> = OnceLock::new();
     let val = *SHOULD_FIX_BINS_AND_DYLIBS.get_or_init(|| {
         let uname = Command::new("uname").arg("-s").output();
@@ -709,7 +728,7 @@ fn should_fix_bins_and_dylibs(config: &Config) -> bool {
         if !is_nixos {
             let in_nix_shell = env::var("IN_NIX_SHELL");
             if let Ok(in_nix_shell) = in_nix_shell {
-                info!(
+                warn!(
                     "The IN_NIX_SHELL environment variable is `{in_nix_shell}`; you may need to \
                      set the --patch-binaries-for-nix argument"
                 );

--- a/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
@@ -329,7 +329,12 @@ pub(crate) fn install_if_missing(
         fs::remove_file(download_file_path)
             .map_err(|err| format!("could not remove downloaded archive: {err}"))?;
         if should_nix_patch_bins_and_dylibs(config) {
-            let _ = nix_patch_all_bins_and_dylibs(target_path);
+            if let Err(e) = nix_patch_all_bins_and_dylibs(target_path) {
+                error!(
+                    "patching for nix failed ({e};) will continue, but tools might not work \
+                     out-of-box"
+                )
+            }
         }
     }
 

--- a/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
@@ -360,11 +360,11 @@ pub(crate) fn install_if_missing(
     };
     if invalid_link {
         #[cfg(unix)]
-        std::os::unix::fs::symlink(&target_path, &source_path).map_err(|err| {
+        std::os::unix::fs::symlink(target_path, &source_path).map_err(|err| {
             format!("could not symlink {source_path:?} -> {target_path:?}: {err}")
         })?;
         #[cfg(windows)]
-        std::os::windows::fs::symlink_dir(&target_path, &source_path).map_err(|err| {
+        std::os::windows::fs::symlink_dir(target_path, &source_path).map_err(|err| {
             format!("could not symlink {source_path:?} -> {target_path:?}: {err}")
         })?;
     }

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
@@ -328,8 +328,6 @@ fn test_corrupted_toolchain() {
 
     assert_failed_command();
 
-    fs::rename(bin_folder.join("rustc_2"), bin_folder.join("rustc"))
-        .expect("Failed to rename file");
     fs::rename(&bin_folder, bin_folder.parent().unwrap().join("bin2"))
         .expect("Failed to rename file");
 
@@ -366,4 +364,39 @@ fn test_alternate_download() {
     assert.success();
 
     build_noop_and_readelf("v0");
+}
+
+#[test]
+#[serial]
+fn test_binaries_work() {
+    let args = [
+        "-v",
+        "--sbf-sdk",
+        "../sbf",
+        "--install-only",
+        "--force-tools-install",
+    ];
+    let assert = assert_cmd::Command::cargo_bin("cargo-build-sbf")
+        .unwrap()
+        .env("RUST_LOG", "debug")
+        .args(args)
+        .assert();
+    assert.success();
+    let cwd = env::current_dir().expect("Unable to get current working directory");
+    let sdk_path = cwd.parent().unwrap().join("sbf");
+    let platform_folder = sdk_path.join("dependencies").join("platform-tools");
+    let rust_bin_folder = platform_folder.join("rust").join("bin");
+    let llvm_bin_folder = platform_folder.join("llvm").join("bin");
+    for binary in ["lldb", "lld", "clang", "solana-lldb"] {
+        assert_cmd::Command::new(llvm_bin_folder.join(binary))
+            .arg("--version")
+            .assert()
+            .success();
+    }
+    for binary in ["rustc", "cargo", "rustdoc"] {
+        assert_cmd::Command::new(rust_bin_folder.join(binary))
+            .arg("--version")
+            .assert()
+            .success();
+    }
 }

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
@@ -387,7 +387,7 @@ fn test_binaries_work() {
     let platform_folder = sdk_path.join("dependencies").join("platform-tools");
     let rust_bin_folder = platform_folder.join("rust").join("bin");
     let llvm_bin_folder = platform_folder.join("llvm").join("bin");
-    for binary in ["lld", "clang"] {
+    for binary in ["llc", "clang"] {
         assert_cmd::Command::new(llvm_bin_folder.join(binary))
             .arg("--version")
             .assert()

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
@@ -387,7 +387,7 @@ fn test_binaries_work() {
     let platform_folder = sdk_path.join("dependencies").join("platform-tools");
     let rust_bin_folder = platform_folder.join("rust").join("bin");
     let llvm_bin_folder = platform_folder.join("llvm").join("bin");
-    for binary in ["lldb", "lld", "clang", "solana-lldb"] {
+    for binary in ["lld", "clang"] {
         assert_cmd::Command::new(llvm_bin_folder.join(binary))
             .arg("--version")
             .assert()


### PR DESCRIPTION
#### Problem

On NixOS the `build-sbf` tests fail out of the box as they are trying to use binaries with an interpreter at `/lib/ld-linux.so`, which on NixOS does not exist.

#### Summary of Changes

This effectively duplicates similar logic from rustc's build process that gets applied to the downloaded bootstrap compiler.

This is a relatively selfish PR, I'll admit, as I'm using NixOS and want to be able to run the test suite without having to jump through the hoops of setting up the environment tailored for the tests.

As far as I understand `build-sbf`, it appears to be end-user facing and therefore should now allow anybody using NixOS to use `build-sbf` with a similar level of experience as people who use a more traditional distribution get.

The intent is that the patching logic here is self-contained, requires little maintenance effort and would be largely transparent to users who have nothing to do with Nix. Even if the patching logic somehow ended up being executed, any failures are silent (though for NixOS users themselves they'd "simply" get an error some time down the line) and would not otherwise interrupt the installation process.