### PR TITLE
tpu-client-next: set connection retry value to 1 for first retry

### DIFF
--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -251,7 +251,7 @@ impl ConnectionWorker {
             ConnectionError::VersionMismatch | ConnectionError::LocallyClosed => {
                 ConnectionState::Closing
             }
-            _ => ConnectionState::Retry(0),
+            _ => ConnectionState::Retry(1),
         };
     }
 
@@ -280,7 +280,7 @@ impl ConnectionWorker {
             // Check connection health before each send
             if connection.close_reason().is_some() {
                 debug!("Connection closed during transaction batch sending");
-                self.connection = ConnectionState::Retry(0);
+                self.connection = ConnectionState::Retry(1);
                 break;
             }
 
@@ -292,7 +292,7 @@ impl ConnectionWorker {
                     self.peer
                 );
                 record_error(error, &self.send_txs_stats);
-                self.connection = ConnectionState::Retry(0);
+                self.connection = ConnectionState::Retry(1);
                 // Exit early since connection is likely broken
                 break;
             } else {


### PR DESCRIPTION
#### Problem

Fix bug with incorrect retry counter used for re-establishing connections. 
This value is used like the follows:

```rust
                   ConnectionState::Retry(num_reconnects) => {
                        if *num_reconnects > self.max_reconnect_attempts {
                            error!(
                                "Failed to establish connection to {}: reached max reconnect \
                                 attempts",
                                self.peer
                            );
                            self.connection = ConnectionState::Closing;
                            continue;
                        }
                        sleep(RETRY_SLEEP_INTERVAL).await;
                        self.reconnect(*num_reconnects).await;
                    }
```

So if `max_reconnect_attempts == 0` we get `0 > 0` and try reconnecting, which is not what expected.

#### Summary of Changes

