### PR TITLE
fix: remove redundant account_identity_ok in data_from_account

### DIFF
--- a/rpc-client-nonce-utils/src/nonblocking/mod.rs
+++ b/rpc-client-nonce-utils/src/nonblocking/mod.rs
@@ -220,7 +220,6 @@ pub fn state_from_account<T: ReadableAccount + StateMut<Versions>>(
 pub fn data_from_account<T: ReadableAccount + StateMut<Versions>>(
     account: &T,
 ) -> Result<Data, Error> {
-    account_identity_ok(account)?;
     state_from_account(account).and_then(|ref s| data_from_state(s).cloned())
 }
 


### PR DESCRIPTION
#### Problem

redundant account_identity_ok call from data_from_account, since state_from_account already validates the account owner and data presence

#### Summary of Changes

removed redundant account_identity_ok call from data_from_account
