### PR TITLE
streamer: don't use Connection::remote_address to avoid lock

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -503,6 +503,7 @@ async fn setup_connection<Q, C>(
                 {
                     tasks.spawn(handle_connection(
                         packet_sender.clone(),
+                        from,
                         new_connection,
                         stats,
                         server_params.wait_for_chunk_timeout,
@@ -592,6 +593,7 @@ fn track_streamer_fetch_packet_performance(
 
 async fn handle_connection<Q, C>(
     packet_sender: Sender<PacketBatch>,
+    remote_address: SocketAddr,
     connection: Connection,
     stats: Arc<StreamerStats>,
     wait_for_chunk_timeout: Duration,
@@ -603,10 +605,9 @@ async fn handle_connection<Q, C>(
     C: ConnectionContext + Send + Sync + 'static,
 {
     let peer_type = context.peer_type();
-    let remote_addr = connection.remote_address();
     debug!(
         "quic new connection {} streams: {} connections: {}",
-        remote_addr,
+        remote_address,
         stats.active_streams.load(Ordering::Relaxed),
         stats.total_connections.load(Ordering::Relaxed),
     );
@@ -632,7 +633,7 @@ async fn handle_connection<Q, C>(
         stats.total_new_streams.fetch_add(1, Ordering::Relaxed);
 
         let mut meta = Meta::default();
-        meta.set_socket_addr(&remote_addr);
+        meta.set_socket_addr(&remote_address);
         meta.set_from_staked_node(matches!(peer_type, ConnectionPeerType::Staked(_)));
         if let Some(pubkey) = context.remote_pubkey() {
             meta.set_remote_pubkey(pubkey);


### PR DESCRIPTION
#### Problem

We call `Connection::remote_address` inside `handle_connection` which implemented with lock inside. 
This lock is visible in profiler and it is unnecessary to use it since we can pass `from` to the function. 

#### Summary of Changes

