### PR TITLE
ci: use docker.io/rust:1-alpine3.22

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -37,7 +37,7 @@ jobs:
           - os: macos-latest
           # musl with dynamic linking
           - os: ubuntu-latest
-            container: docker.io/rust:1-alpine
+            container: docker.io/rust:1-alpine3.22
             rustflags: -C target-feature=-crt-static
           - os: windows-latest
     runs-on: ${{ matrix.os.os }}


### PR DESCRIPTION
#### Problem

context: https://discord.com/channels/428295358100013066/560503042458517505/1450542735122632767

the latest tag breaks us unexpectedly

#### Summary of Changes

pin the alpine version