### PR TITLE
svm-test-harness: add txn fixture types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11077,14 +11077,24 @@ name = "solana-svm-test-harness-fixture"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-precompiles",
  "bincode",
  "prost",
  "prost-build",
  "protosol",
  "solana-account",
+ "solana-address-lookup-table-interface",
+ "solana-fee-structure",
+ "solana-hash 3.1.0",
  "solana-instruction",
  "solana-instruction-error",
+ "solana-message",
  "solana-pubkey 4.0.0",
+ "solana-signature",
+ "solana-stable-layout",
+ "solana-svm-transaction",
+ "solana-transaction",
+ "solana-transaction-error",
  "thiserror 2.0.17",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1171,7 +1171,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -4363,9 +4363,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if 1.0.4",
@@ -4404,9 +4404,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
 dependencies = [
  "cc",
  "libc",
@@ -9729,10 +9729,16 @@ name = "solana-svm-test-harness-fixture"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "bincode",
  "solana-account",
+ "solana-fee-structure",
+ "solana-hash 3.1.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.0.0",
+ "solana-stable-layout",
+ "solana-transaction",
+ "solana-transaction-error",
  "thiserror 2.0.17",
 ]
 
@@ -11978,9 +11984,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67e680788539097c13ae4311dc36e850624b62b2f481271621adef0fbac6062"
+checksum = "6a57af7f5cf2c575dd1ebd558b80e09545240b703faa2ac8cab94ebcd23a89a8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/svm-test-harness/fixture/Cargo.toml
+++ b/svm-test-harness/fixture/Cargo.toml
@@ -14,22 +14,36 @@ publish = false
 agave-unstable-api = []
 dummy-for-ci-check = ["fuzz"]
 fuzz = [
-    "dep:bincode",
+    "dep:agave-precompiles",
     "dep:prost",
     "dep:prost-build",
     "dep:protosol",
+    "dep:solana-address-lookup-table-interface",
+    "dep:solana-message",
+    "dep:solana-signature",
+    "dep:solana-svm-transaction",
     "solana-pubkey/default",
 ]
 
 [dependencies]
 agave-feature-set = { workspace = true }
-bincode = { workspace = true, optional = true }
+agave-precompiles = { workspace = true, optional = true }
+bincode = { workspace = true }
 prost = { workspace = true, optional = true }
 protosol = { workspace = true, optional = true }
 solana-account = { workspace = true }
+solana-address-lookup-table-interface = { workspace = true, optional = true, features = ["bincode", "bytemuck"] }
+solana-fee-structure = { workspace = true }
+solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true, features = ["serde"] }
+solana-message = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
+solana-signature = { workspace = true, optional = true }
+solana-stable-layout = { workspace = true }
+solana-svm-transaction = { workspace = true, optional = true }
+solana-transaction = { workspace = true, features = ["blake3"] }
+solana-transaction-error = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
 
 [build-dependencies]

--- a/svm-test-harness/fixture/src/error.rs
+++ b/svm-test-harness/fixture/src/error.rs
@@ -12,6 +12,12 @@ pub enum FixtureError {
     #[error("Invalid public key bytes")]
     InvalidPubkeyBytes(Vec<u8>),
 
+    #[error("Invalid hash bytes")]
+    InvalidHashBytes(Vec<u8>),
+
     #[error("An account is missing for instruction account index {0}")]
     AccountMissingForInstrAccount(usize),
+
+    #[error("Invalid address lookup table")]
+    InvalidAddressLookupTable,
 }

--- a/svm-test-harness/fixture/src/lib.rs
+++ b/svm-test-harness/fixture/src/lib.rs
@@ -9,6 +9,9 @@ pub mod error;
 pub mod feature_set;
 pub mod instr_context;
 pub mod instr_effects;
+pub mod message;
+pub mod txn_context;
+pub mod txn_result;
 
 #[cfg(feature = "fuzz")]
 pub mod proto {

--- a/svm-test-harness/fixture/src/message.rs
+++ b/svm-test-harness/fixture/src/message.rs
@@ -1,0 +1,167 @@
+//! Transaction message utilities.
+
+#![cfg(feature = "fuzz")]
+
+use {
+    super::{
+        error::FixtureError,
+        proto::{
+            CompiledInstruction as ProtoCompiledInstruction,
+            MessageAddressTableLookup as ProtoMessageAddressTableLookup,
+            MessageHeader as ProtoMessageHeader, TransactionMessage as ProtoTransactionMessage,
+        },
+    },
+    solana_account::Account,
+    solana_address_lookup_table_interface::state::AddressLookupTable,
+    solana_hash::Hash,
+    solana_message::{
+        compiled_instruction::CompiledInstruction,
+        legacy,
+        v0::{self, LoadedAddresses, LoadedMessage, MessageAddressTableLookup},
+        LegacyMessage, MessageHeader, SanitizedMessage,
+    },
+    solana_pubkey::Pubkey,
+    std::{cmp::max, collections::HashSet},
+};
+
+impl From<&ProtoMessageHeader> for MessageHeader {
+    fn from(value: &ProtoMessageHeader) -> Self {
+        MessageHeader {
+            num_required_signatures: max(1, value.num_required_signatures as u8),
+            num_readonly_signed_accounts: value.num_readonly_signed_accounts as u8,
+            num_readonly_unsigned_accounts: value.num_readonly_unsigned_accounts as u8,
+        }
+    }
+}
+
+impl From<&ProtoCompiledInstruction> for CompiledInstruction {
+    fn from(value: &ProtoCompiledInstruction) -> Self {
+        CompiledInstruction {
+            program_id_index: value.program_id_index as u8,
+            accounts: value.accounts.iter().map(|idx| *idx as u8).collect(),
+            data: value.data.clone(),
+        }
+    }
+}
+
+impl From<&ProtoMessageAddressTableLookup> for MessageAddressTableLookup {
+    fn from(value: &ProtoMessageAddressTableLookup) -> Self {
+        MessageAddressTableLookup {
+            account_key: Pubkey::new_from_array(value.account_key.clone().try_into().unwrap()),
+            writable_indexes: value
+                .writable_indexes
+                .iter()
+                .map(|idx| *idx as u8)
+                .collect(),
+            readonly_indexes: value
+                .readonly_indexes
+                .iter()
+                .map(|idx| *idx as u8)
+                .collect(),
+        }
+    }
+}
+
+fn resolve_address_table_lookups(
+    lookups: &[MessageAddressTableLookup],
+    accounts: &[(Pubkey, Account)],
+) -> Result<LoadedAddresses, FixtureError> {
+    let mut writable = Vec::new();
+    let mut readonly = Vec::new();
+
+    for lookup in lookups {
+        let alt_account = accounts
+            .iter()
+            .find(|(pubkey, _)| *pubkey == lookup.account_key)
+            .map(|(_, account)| account)
+            .ok_or(FixtureError::InvalidAddressLookupTable)?;
+
+        let alt = AddressLookupTable::deserialize(&alt_account.data)
+            .map_err(|_| FixtureError::InvalidAddressLookupTable)?;
+
+        for &idx in &lookup.writable_indexes {
+            writable.push(
+                *alt.addresses
+                    .get(idx as usize)
+                    .ok_or(FixtureError::InvalidAddressLookupTable)?,
+            );
+        }
+        for &idx in &lookup.readonly_indexes {
+            readonly.push(
+                *alt.addresses
+                    .get(idx as usize)
+                    .ok_or(FixtureError::InvalidAddressLookupTable)?,
+            );
+        }
+    }
+
+    Ok(LoadedAddresses { writable, readonly })
+}
+
+pub fn build_sanitized_message(
+    value: &ProtoTransactionMessage,
+    accounts: &[(Pubkey, Account)],
+) -> Result<SanitizedMessage, FixtureError> {
+    let header = if let Some(ref value_header) = value.header {
+        MessageHeader::from(value_header)
+    } else {
+        MessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 0,
+        }
+    };
+
+    let account_keys = value
+        .account_keys
+        .iter()
+        .map(|key| Pubkey::new_from_array(key.clone().try_into().unwrap()))
+        .collect::<Vec<Pubkey>>();
+
+    let recent_blockhash = if value.recent_blockhash.is_empty() {
+        Hash::new_from_array([0u8; 32])
+    } else {
+        Hash::new_from_array(value.recent_blockhash.clone().try_into().unwrap())
+    };
+
+    let instructions = value
+        .instructions
+        .iter()
+        .map(CompiledInstruction::from)
+        .collect::<Vec<CompiledInstruction>>();
+
+    if value.is_legacy {
+        let message = legacy::Message {
+            header,
+            account_keys,
+            recent_blockhash,
+            instructions,
+        };
+        Ok(SanitizedMessage::Legacy(LegacyMessage::new(
+            message,
+            &HashSet::new(),
+        )))
+    } else {
+        let address_table_lookups = value
+            .address_table_lookups
+            .iter()
+            .map(MessageAddressTableLookup::from)
+            .collect::<Vec<MessageAddressTableLookup>>();
+
+        let loaded_addresses = resolve_address_table_lookups(&address_table_lookups, accounts)?;
+
+        let message = v0::Message {
+            header,
+            account_keys,
+            recent_blockhash,
+            instructions,
+            address_table_lookups,
+        };
+
+        Ok(SanitizedMessage::V0(LoadedMessage::new(
+            message,
+            loaded_addresses,
+            &HashSet::new(),
+        )))
+    }
+}

--- a/svm-test-harness/fixture/src/txn_context.rs
+++ b/svm-test-harness/fixture/src/txn_context.rs
@@ -1,0 +1,132 @@
+//! Transaction context (input).
+
+use {
+    agave_feature_set::FeatureSet,
+    solana_account::Account,
+    solana_hash::Hash,
+    solana_pubkey::Pubkey,
+    solana_transaction::{sanitized::SanitizedTransaction, Transaction},
+};
+
+/// Transaction context fixture.
+pub struct TxnContext {
+    pub feature_set: FeatureSet,
+    pub blockhash_queue: Vec<Hash>,
+    pub slot: u64,
+    pub accounts: Vec<(Pubkey, Account)>,
+    pub transaction: SanitizedTransaction,
+}
+
+impl TxnContext {
+    pub fn new(
+        feature_set: FeatureSet,
+        blockhash_queue: Vec<Hash>,
+        slot: u64,
+        accounts: Vec<(Pubkey, Account)>,
+        transaction: Transaction,
+    ) -> Self {
+        let transaction = SanitizedTransaction::from_transaction_for_tests(transaction);
+        Self {
+            feature_set,
+            blockhash_queue,
+            slot,
+            accounts,
+            transaction,
+        }
+    }
+}
+
+#[cfg(feature = "fuzz")]
+use {
+    super::{
+        error::FixtureError, message::build_sanitized_message, proto::TxnContext as ProtoTxnContext,
+    },
+    solana_signature::Signature,
+};
+
+#[cfg(feature = "fuzz")]
+impl TryFrom<ProtoTxnContext> for TxnContext {
+    type Error = FixtureError;
+
+    fn try_from(value: ProtoTxnContext) -> Result<Self, Self::Error> {
+        let feature_set: FeatureSet = value
+            .epoch_ctx
+            .as_ref()
+            .and_then(|epoch_ctx| epoch_ctx.features.as_ref())
+            .map(|fs| fs.into())
+            .unwrap_or_default();
+
+        let blockhash_queue: Vec<Hash> = if value.blockhash_queue.is_empty() {
+            vec![Hash::default()]
+        } else {
+            value
+                .blockhash_queue
+                .into_iter()
+                .map(|hash_bytes| {
+                    let hash_array: [u8; 32] = hash_bytes
+                        .try_into()
+                        .map_err(FixtureError::InvalidHashBytes)?;
+                    Ok(Hash::new_from_array(hash_array))
+                })
+                .collect::<Result<Vec<_>, FixtureError>>()?
+        };
+
+        let slot = value
+            .slot_ctx
+            .as_ref()
+            .map(|slot_ctx| slot_ctx.slot)
+            .unwrap_or_default();
+
+        let accounts: Vec<(Pubkey, Account)> = value
+            .account_shared_data
+            .into_iter()
+            .map(|acct_state| acct_state.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let proto_tx = value.tx.ok_or(FixtureError::InvalidFixtureInput)?;
+        let proto_message = proto_tx.message.ok_or(FixtureError::InvalidFixtureInput)?;
+
+        let message = build_sanitized_message(&proto_message, &accounts)?;
+        let message_hash: Hash = if proto_tx.message_hash.is_empty() {
+            Hash::default()
+        } else {
+            let hash_array: [u8; 32] = proto_tx
+                .message_hash
+                .try_into()
+                .map_err(FixtureError::InvalidHashBytes)?;
+            Hash::new_from_array(hash_array)
+        };
+
+        let mut signatures: Vec<Signature> = proto_tx
+            .signatures
+            .iter()
+            .map(|sig_bytes| {
+                let sig_array: [u8; 64] = sig_bytes
+                    .clone()
+                    .try_into()
+                    .map_err(|_| FixtureError::InvalidFixtureInput)?;
+                Ok(Signature::from(sig_array))
+            })
+            .collect::<Result<Vec<_>, FixtureError>>()?;
+
+        if signatures.is_empty() {
+            signatures.push(Signature::default());
+        }
+
+        let transaction = SanitizedTransaction::try_new_from_fields(
+            message,
+            message_hash,
+            /* is_simple_vote_tx */ false,
+            signatures,
+        )
+        .map_err(|_| FixtureError::InvalidFixtureInput)?;
+
+        Ok(Self {
+            feature_set,
+            blockhash_queue,
+            slot,
+            accounts,
+            transaction,
+        })
+    }
+}

--- a/svm-test-harness/fixture/src/txn_result.rs
+++ b/svm-test-harness/fixture/src/txn_result.rs
@@ -1,0 +1,136 @@
+//! Transaction result (output).
+
+use {
+    solana_account::Account, solana_fee_structure::FeeDetails, solana_pubkey::Pubkey,
+    solana_transaction_error::TransactionResult,
+};
+
+/// Transaction execution result.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TxnResult {
+    pub status: TransactionResult<()>,
+    pub resulting_accounts: Vec<(Pubkey, Account)>,
+    pub return_data: Vec<u8>,
+    pub executed_units: u64,
+    pub fee_details: FeeDetails,
+    pub loaded_accounts_data_size: u64,
+}
+
+#[cfg(feature = "fuzz")]
+use {
+    super::proto::{
+        FeeDetails as ProtoFeeDetails, ResultingState as ProtoResultingState,
+        TxnResult as ProtoTxnResult,
+    },
+    agave_precompiles::get_precompile,
+    solana_instruction_error::InstructionError,
+    solana_svm_transaction::svm_message::SVMMessage,
+    solana_transaction_error::TransactionError,
+};
+
+#[cfg(feature = "fuzz")]
+fn transaction_error_to_err_nums(error: &TransactionError) -> (u32, u32, u32, u32) {
+    let (instr_err_no, custom_err_no, instr_err_idx) = match error.clone() {
+        TransactionError::InstructionError(idx, instr_err) => {
+            let instr_err_no = {
+                let serialized = bincode::serialize(&instr_err).unwrap_or(vec![0, 0, 0, 0]);
+                u32::from_le_bytes(serialized[0..4].try_into().unwrap()).saturating_add(1)
+            };
+            let custom_err_no = match instr_err {
+                InstructionError::Custom(code) => code,
+                _ => 0,
+            };
+            (instr_err_no, custom_err_no, idx)
+        }
+        _ => (0, 0, 0),
+    };
+
+    let txn_err_no = {
+        let serialized = bincode::serialize(error).unwrap_or(vec![0, 0, 0, 0]);
+        u32::from_le_bytes(serialized[0..4].try_into().unwrap()).saturating_add(1)
+    };
+
+    (
+        txn_err_no,
+        instr_err_no,
+        custom_err_no,
+        instr_err_idx.into(),
+    )
+}
+
+/// Convert a `TxnResult` to a protobuf `TxnResult`, filtering accounts to only
+/// those marked writable in the message.
+#[cfg(feature = "fuzz")]
+pub fn txn_result_to_proto(result: TxnResult, message: &impl SVMMessage) -> ProtoTxnResult {
+    let acct_states: Vec<_> = result
+        .resulting_accounts
+        .into_iter()
+        .enumerate()
+        .filter(|&(i, _)| message.is_writable(i))
+        .map(|(_, acct)| acct.into())
+        .collect();
+
+    let (
+        executed,
+        sanitization_error,
+        is_ok,
+        status,
+        instruction_error,
+        instruction_error_index,
+        custom_error,
+    ) = match &result.status {
+        Ok(()) => (true, false, true, 0, 0, 0, 0),
+        Err(err) => {
+            let (status, instr_err, custom_err, instr_err_idx) = transaction_error_to_err_nums(err);
+            // Set custom err to 0 if the failing instruction is a precompile.
+            let custom_err = message
+                .instructions_iter()
+                .nth(instr_err_idx as usize)
+                .and_then(|instr| {
+                    message
+                        .account_keys()
+                        .get(usize::from(instr.program_id_index))
+                        .map(|program_id| {
+                            if get_precompile(program_id, |_| true).is_some() {
+                                0
+                            } else {
+                                custom_err
+                            }
+                        })
+                })
+                .unwrap_or(custom_err);
+            (
+                true,
+                false,
+                false,
+                status,
+                instr_err,
+                instr_err_idx,
+                custom_err,
+            )
+        }
+    };
+
+    ProtoTxnResult {
+        executed,
+        sanitization_error,
+        resulting_state: Some(ProtoResultingState {
+            acct_states,
+            rent_debits: vec![],
+            transaction_rent: 0,
+        }),
+        rent: 0,
+        is_ok,
+        status,
+        instruction_error,
+        instruction_error_index,
+        custom_error,
+        return_data: result.return_data,
+        executed_units: result.executed_units,
+        fee_details: Some(ProtoFeeDetails {
+            transaction_fee: result.fee_details.transaction_fee(),
+            prioritization_fee: result.fee_details.prioritization_fee(),
+        }),
+        loaded_accounts_data_size: result.loaded_accounts_data_size,
+    }
+}


### PR DESCRIPTION
#### Problem
Soon we're going to need transaction-level testing in `programs/sbf` as we continue to refactor the tests to avoid using Bank and `solana-runtime`. However, the svm-test-harness doesn't have any transaction material yet.

#### Summary of Changes
Add the fixture types for transaction inputs and outputs to the svm-test-harness. In follow-up work, we'll attach the harness for these.