### PR TITLE
build: add flake.nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 farf/
 target/
+/.direnv
 /solana-release/
 /solana-release.tar.bz2
 /solana-metrics/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1765897976,
+        "narHash": "sha256-VEKYsIEIq2/9peA8awjAE9JYUQiLikw8m74oo3vaWEY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f7ae028ab746ddcadd5b3b1a30e8154b92643095",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      ...
+    }:
+    {
+      # Dev.
+      devShells =
+        nixpkgs.lib.genAttrs
+          [
+            "aarch64-darwin"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "x86_64-linux"
+          ]
+          (
+            system:
+            let
+              pkgs = import nixpkgs {
+                inherit system;
+              };
+            in
+            {
+              default = pkgs.mkShell {
+                packages = with pkgs; [
+                  nixfmt-rfc-style
+                ];
+                buildInputs = with pkgs; [
+                  udev
+                  rust-jemalloc-sys-unprefixed
+                ];
+                nativeBuildInputs = with pkgs; [
+                  pkg-config
+                  rustPlatform.bindgenHook
+                ];
+              };
+            }
+          );
+    };
+}


### PR DESCRIPTION
#### Problem

- Checking out the `agave` repository and running `cargo check` will fail on nix systems as there are missing build dependencies.

#### Summary of Changes

- Introduce a `flake.nix` `devShell` that imports the required build dependencies to build agave.

#### Note

- Just floating this PR as a question, if there's little appetite to add yet more files to the repo root, I'm happy to work with git's local ignore system to prevent these from getting checked in.