### PR TITLE
refactor: remove unused core_allocations map in ThreadManager::new

### DIFF
--- a/thread-manager/src/lib.rs
+++ b/thread-manager/src/lib.rs
@@ -178,7 +178,6 @@ impl ThreadManager {
     }
 
     pub fn new(config: ThreadManagerConfig) -> anyhow::Result<Self> {
-        let mut core_allocations = HashMap::<String, Vec<usize>>::new();
         Self::set_process_affinity(&config)?;
         let mut manager = ThreadManagerInner::default();
         manager.populate_mappings(&config);
@@ -193,8 +192,6 @@ impl ThreadManager {
 
         for (name, cfg) in config.tokio_configs.iter() {
             let tokiort = TokioRuntime::new(name.clone(), cfg.clone())?;
-
-            core_allocations.insert(name.clone(), cfg.core_allocation.as_core_mask_vector());
             manager.tokio_runtimes.insert(name.clone(), tokiort);
         }
         Ok(Self {


### PR DESCRIPTION
The local core_allocations HashMap in ThreadManager::new was never read anywhere in the codebase. Tokio core masks are computed and applied inside TokioRuntime::new, so this map did not participate in affinity logic and only caused extra allocations and noise. Removing it simplifies the constructor and avoids unnecessary work without changing runtime behavior.