### PR TITLE
perf(serde_snapshot): use smallvec for storage entry list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6983,6 +6983,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smpl_jwt"
@@ -10378,6 +10381,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "shuttle",
+ "smallvec",
  "solana-account",
  "solana-account-info",
  "solana-accounts-db",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -5962,6 +5962,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smpl_jwt"
@@ -8643,6 +8646,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "smallvec",
  "solana-account",
  "solana-account-info",
  "solana-accounts-db",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5898,6 +5898,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smpl_jwt"
@@ -8398,6 +8401,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "smallvec",
  "solana-account",
  "solana-account-info",
  "solana-accounts-db",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -94,6 +94,7 @@ serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 shuttle = { workspace = true, optional = true }
+smallvec = { workspace = true, features = ["serde"] }
 solana-account = { workspace = true }
 solana-account-info = { workspace = true }
 solana-accounts-db = { workspace = true }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -15,6 +15,7 @@ use {
     bincode::{self, config::Options, Error},
     log::*,
     serde::{de::DeserializeOwned, Deserialize, Serialize},
+    smallvec::SmallVec,
     solana_accounts_db::{
         accounts::Accounts,
         accounts_db::{
@@ -74,7 +75,7 @@ const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct AccountsDbFields<T>(
-    HashMap<Slot, Vec<T>>,
+    HashMap<Slot, SmallVec<[T; 1]>>,
     u64, // obsolete, formerly write_version
     Slot,
     BankHashInfo,


### PR DESCRIPTION
#### Problem
`AccountsDbFields` has a `slot -> Vec<(id, len)>` map that in currently expected snapshot format always has exactly 1 element in the values. We can save allocations by using small vec there.

#### Summary of Changes
Switch `AccountsDbFields<T>` to `HashMap<Slot, SmallVec<[T; 1]>>`