### PR TITLE
chore: add clone to encoded tx v2.3

### DIFF
--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -604,7 +604,7 @@ impl From<UiConfirmedBlock> for EncodedConfirmedBlock {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EncodedConfirmedTransactionWithStatusMeta {
     pub slot: u64,

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -576,7 +576,7 @@ impl Default for TransactionStatusMeta {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EncodedConfirmedBlock {
     pub previous_blockhash: String,


### PR DESCRIPTION
#### Problem
v2.3 also does not implement `Clone` for the `EncodedConfirmedTransactionWithStatusMeta` and
`EncodedConfirmedBlock` struct. I am using this version currently due to conflicts with other libraries on the newer versions. 
#### Summary of Changes
Added `Clone` to `EncodedConfirmedTransactionWithStatusMeta` and
`EncodedConfirmedBlock` structs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
