### PR TITLE
cli: avoid unnecessary rent-exempt RPC for non-stake Available

### DIFF
--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -122,14 +122,15 @@ where
             .value
             .unwrap_or_default();
         let mut from_balance = account.lamports;
-        let from_rent_exempt_minimum =
-            if amount == SpendAmount::RentExempt || amount == SpendAmount::Available {
-                rpc_client
-                    .get_minimum_balance_for_rent_exemption(account.data.len())
-                    .await?
-            } else {
-                0
-            };
+        let from_rent_exempt_minimum = if amount == SpendAmount::RentExempt
+            || (amount == SpendAmount::Available && account.owner == solana_sdk_ids::stake::id())
+        {
+            rpc_client
+                .get_minimum_balance_for_rent_exemption(account.data.len())
+                .await?
+        } else {
+            0
+        };
         if amount == SpendAmount::Available && account.owner == solana_sdk_ids::stake::id() {
             let state = stake::get_account_stake_state(
                 rpc_client,


### PR DESCRIPTION
This change narrows when we call get_minimum_balance_for_rent_exemption while resolving spend amounts. Previously we fetched the rent-exempt minimum for both RentExempt and Available regardless of the account owner, even though the value is only used for RentExempt and for Available on stake accounts. Now the RPC is only invoked for SpendAmount::RentExempt and for SpendAmount::Available when the source account is a stake account, which preserves behavior for stake and rent-exempt flows while avoiding an unnecessary network call for other accounts.