### PR TITLE
Add snapshot controller to admin rpc

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -7,7 +7,7 @@ use {
     solana_gossip::{cluster_info::ClusterInfo, node::NodeMultihoming},
     solana_pubkey::Pubkey,
     solana_quic_definitions::NotifyKeyUpdate,
-    solana_runtime::bank_forks::BankForks,
+    solana_runtime::{bank_forks::BankForks, snapshot_controller::SnapshotController},
     std::{
         collections::{HashMap, HashSet},
         net::UdpSocket,
@@ -82,4 +82,5 @@ pub struct AdminRpcRequestMetadataPostInit {
     pub cluster_slots: Arc<ClusterSlots>,
     pub node: Option<Arc<NodeMultihoming>>,
     pub banking_control_sender: mpsc::Sender<BankingControlMsg>,
+    pub snapshot_controller: Arc<SnapshotController>,
 }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -85,6 +85,8 @@ impl SnapshotPackagerService {
                     let snapshot_slot = snapshot_package.slot;
                     let snapshot_hash = snapshot_package.hash;
 
+                    snapshot_controller.set_latest_bank_snapshot_slot(snapshot_slot);
+
                     if exit_backpressure.is_some() {
                         // With exit backpressure, we will delay flushing snapshot storages
                         // until we receive a graceful exit request.

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -668,7 +668,7 @@ pub struct Validator {
     gossip_service: GossipService,
     serve_repair_service: ServeRepairService,
     completed_data_sets_service: Option<CompletedDataSetsService>,
-    snapshot_packager_service: Option<SnapshotPackagerService>,
+    snapshot_packager_service: SnapshotPackagerService,
     poh_recorder: Arc<RwLock<PohRecorder>>,
     poh_service: PohService,
     tpu: Tpu,
@@ -986,29 +986,20 @@ impl Validator {
         ));
 
         let pending_snapshot_packages = Arc::new(Mutex::new(PendingSnapshotPackages::default()));
-        let snapshot_packager_service = if snapshot_controller
-            .snapshot_config()
-            .should_generate_snapshots()
-        {
-            let exit_backpressure = config
-                .validator_exit_backpressure
-                .get(SnapshotPackagerService::NAME)
-                .cloned();
-            let enable_gossip_push = true;
-            let snapshot_packager_service = SnapshotPackagerService::new(
-                pending_snapshot_packages.clone(),
-                starting_snapshot_hashes,
-                exit.clone(),
-                exit_backpressure,
-                cluster_info.clone(),
-                snapshot_controller.clone(),
-                enable_gossip_push,
-            );
-            Some(snapshot_packager_service)
-        } else {
-            None
-        };
-
+        let exit_backpressure = config
+            .validator_exit_backpressure
+            .get(SnapshotPackagerService::NAME)
+            .cloned();
+        let enable_gossip_push = true;
+        let snapshot_packager_service = SnapshotPackagerService::new(
+            pending_snapshot_packages.clone(),
+            starting_snapshot_hashes,
+            exit.clone(),
+            exit_backpressure,
+            cluster_info.clone(),
+            snapshot_controller.clone(),
+            enable_gossip_push,
+        );
         let snapshot_request_handler = SnapshotRequestHandler {
             snapshot_controller: snapshot_controller.clone(),
             snapshot_request_receiver,
@@ -1786,6 +1777,7 @@ impl Validator {
             cluster_slots,
             node: Some(node_multihoming),
             banking_control_sender,
+            snapshot_controller,
         });
 
         Ok(Self {
@@ -1965,9 +1957,9 @@ impl Validator {
                 .expect("entry_notifier_service");
         }
 
-        if let Some(s) = self.snapshot_packager_service {
-            s.join().expect("snapshot_packager_service");
-        }
+        self.snapshot_packager_service
+            .join()
+            .expect("snapshot_packager_service");
 
         self.gossip_service.join().expect("gossip_service");
         self.repair_quic_endpoints

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1030,6 +1030,8 @@ pub fn load_staked_nodes_overrides(
 mod tests {
     use {
         super::*,
+        agave_snapshots::snapshot_config::SnapshotConfig,
+        crossbeam_channel::unbounded,
         serde_json::Value,
         solana_account::{Account, AccountSharedData},
         solana_accounts_db::{
@@ -1056,6 +1058,7 @@ mod tests {
         solana_runtime::{
             bank::{Bank, BankTestConfig},
             bank_forks::BankForks,
+            snapshot_controller::SnapshotController,
         },
         solana_system_interface::program as system_program,
         solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
@@ -1102,6 +1105,14 @@ mod tests {
                     ..ACCOUNTS_DB_CONFIG_FOR_TESTING
                 },
             });
+
+            let (snapshot_request_sender, _) = unbounded();
+            let snapshot_controller = Arc::new(SnapshotController::new(
+                snapshot_request_sender.clone(),
+                SnapshotConfig::default(),
+                bank_forks.read().unwrap().root(),
+            ));
+
             let vote_account = vote_keypair.pubkey();
             let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
             let repair_whitelist = Arc::new(RwLock::new(HashSet::new()));
@@ -1128,6 +1139,7 @@ mod tests {
                     ),
                     node: None,
                     banking_control_sender: mpsc::channel(1).0,
+                    snapshot_controller,
                 }))),
                 staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
                 rpc_to_plugin_manager_sender: None,


### PR DESCRIPTION
#### Problem
Incremental snapshots or Full snapshots need to be generated and written for fastboot to work. This leads to increased I/O that doesn't serve a purpose for anyone not serving snapshots. 

#### Summary of Changes
- Add snapshot controller to the RPC Admin
- Always start the snapshot packager service, even if snapshots are disabled
- Add a new field: last snapshot slot to the snapshot controller
- On agave-validator exit RPC command , generate a fastboot snapshot and wait for the next snapshot to be completed

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
