### PR TITLE
chore(deps): bump wincode from 0.2.1 to 0.2.3 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13727,9 +13727,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d814d39f8894e2f0b7c6dac8a4bf1f36bf40c9415c2ff02146d6f777a91e11d3"
+checksum = "f67e680788539097c13ae4311dc36e850624b62b2f481271621adef0fbac6062"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13740,9 +13740,9 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73ae1f9280de1c129b7baa5899ff75682ac67da1224d82d1b473a2ad1cbb49a"
+checksum = "bfe3057b011c49fd74405e08c867f8bb945a9c6bebfc81e086252483c95524d6"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -639,7 +639,7 @@ url = "2.5.7"
 vec_extract_if_polyfill = "0.1.0"
 wasm-bindgen = "0.2"
 winapi = "0.3.8"
-wincode = { version = "0.2.1", features = ["derive", "solana-short-vec"] }
+wincode = { version = "0.2.3", features = ["derive", "solana-short-vec"] }
 winreg = "0.55"
 x509-parser = "0.17.0"
 zeroize = { version = "1.8", default-features = false }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -11469,9 +11469,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d814d39f8894e2f0b7c6dac8a4bf1f36bf40c9415c2ff02146d6f777a91e11d3"
+checksum = "f67e680788539097c13ae4311dc36e850624b62b2f481271621adef0fbac6062"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11482,9 +11482,9 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73ae1f9280de1c129b7baa5899ff75682ac67da1224d82d1b473a2ad1cbb49a"
+checksum = "bfe3057b011c49fd74405e08c867f8bb945a9c6bebfc81e086252483c95524d6"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/entry/src/wincode.rs
+++ b/entry/src/wincode.rs
@@ -126,7 +126,7 @@ impl<'de> SchemaRead<'de> for VersionedMsg {
         // as calling `LegacyMessage::read` will miss the first field.
         // Builder is used to ensure any partially initialized data is dropped on errors.
         let mut msg_builder = LegacyMessageUninitBuilder::from_maybe_uninit_mut(&mut msg);
-        // SAFETY: initializer function uses header builder and initialie all fields
+        // SAFETY: initializer function uses header builder and initialize all fields
         unsafe {
             msg_builder.init_header_with(|uninit_header| {
                 let mut header_builder =

--- a/entry/src/wincode.rs
+++ b/entry/src/wincode.rs
@@ -7,7 +7,7 @@ use {
     solana_message::{self, legacy, v0, MESSAGE_VERSION_PREFIX},
     solana_signature::Signature,
     solana_transaction::versioned,
-    std::mem::{self, MaybeUninit},
+    std::mem::MaybeUninit,
     wincode::{
         containers::{self, Pod},
         error::invalid_tag_encoding,
@@ -119,111 +119,32 @@ impl<'de> SchemaRead<'de> for VersionedMsg {
             };
         }
 
-        /// A guard that ensures the [`legacy::Message`] is properly dropped on error or panic.
-        ///
-        /// Fields will be dropped in reverse initialization order.
-        ///
-        /// This is necessary in particular for [`legacy::Message`] as it contains heap allocated fields.
-        /// Namely, `account_keys` and `instructions`, which are `Vec<Address>` and `Vec<CompiledInstruction>`,
-        /// respectively. These will leak if not dropped on error or panic.
-        struct LegacyMessageDropGuard<'a> {
-            inner: &'a mut MaybeUninit<legacy::Message>,
-            field_init_count: u8,
-        }
-
-        impl<'a> LegacyMessageDropGuard<'a> {
-            const fn new(inner: &'a mut MaybeUninit<legacy::Message>) -> Self {
-                Self {
-                    inner,
-                    field_init_count: 0,
-                }
-            }
-
-            const fn inc_init_count(&mut self) {
-                self.field_init_count += 1;
-            }
-        }
-
-        impl<'a> Drop for LegacyMessageDropGuard<'a> {
-            // Fields are initialized in order, matching the serialized format.
-            //
-            // 0 -> header
-            // 1 -> account_keys
-            // 2 -> recent_blockhash
-            // 3 -> instructions
-            //
-            // We drop in reverse order to match Rust's drop semantics.
-            fn drop(&mut self) {
-                use core::ptr;
-
-                // No fields have been initialized.
-                if self.field_init_count == 0 {
-                    return;
-                }
-
-                if self.field_init_count == 4 {
-                    // SAFETY: All fields have been initialized, safe to drop the entire message.
-                    unsafe { self.inner.assume_init_drop() };
-                    return;
-                }
-
-                let msg_ptr = self.inner.as_mut_ptr();
-
-                // We don't technically have to worry about recent_blockhash, since it's on the stack,
-                // but we do it for completeness.
-                if self.field_init_count == 3 {
-                    // SAFETY: Recent blockhash is initialized, safe to drop it.
-                    unsafe {
-                        ptr::drop_in_place(&raw mut (*msg_ptr).recent_blockhash);
-                    }
-                }
-                if self.field_init_count >= 2 {
-                    // SAFETY: Account keys are initialized, safe to drop.
-                    unsafe {
-                        ptr::drop_in_place(&raw mut (*msg_ptr).account_keys);
-                    }
-                }
-                // Similarly to recent_blockhash, we don't technically have to worry about header,
-                // but we do it for completeness.
-                if self.field_init_count >= 1 {
-                    // SAFETY: Header is initialized, safe to drop it.
-                    unsafe {
-                        ptr::drop_in_place(&raw mut (*msg_ptr).header);
-                    }
-                }
-            }
-        }
-
         let mut msg = MaybeUninit::<legacy::Message>::uninit();
         // We've already read the variant byte which, in the legacy case, represents
         // the `num_required_signatures` field.
         // As such, we need to write the remaining fields into the message manually,
         // as calling `LegacyMessage::read` will miss the first field.
-        let header_uninit = LegacyMessage::uninit_header_mut(&mut msg);
-
-        // We don't need to worry about a drop guard for the header,
-        // as it's comprised entirely of `u8`s on the stack.
-        MessageHeader::write_uninit_num_required_signatures(variant, header_uninit);
-        MessageHeader::read_num_readonly_signed_accounts(reader, header_uninit)?;
-        MessageHeader::read_num_readonly_unsigned_accounts(reader, header_uninit)?;
-
-        let mut guard = LegacyMessageDropGuard::new(&mut msg);
-        // 1. Header is initialized.
-        guard.inc_init_count();
-        LegacyMessage::read_account_keys(reader, guard.inner)?;
-        // 2. Account keys are initialized.
-        guard.inc_init_count();
-        LegacyMessage::read_recent_blockhash(reader, guard.inner)?;
-        // 3. Recent blockhash is initialized.
-        guard.inc_init_count();
-        LegacyMessage::read_instructions(reader, guard.inner)?;
-        // 4. Instructions are initialized.
-        guard.inc_init_count();
-
-        // All fields are initialized, safe to drop the the guard.
-        mem::forget(guard);
-
-        // SAFETY: All fields are initialized, safe to assume initialized.
+        // Builder is used to ensure any partially initialized data is dropped on errors.
+        let mut msg_builder = LegacyMessageUninitBuilder::from_maybe_uninit_mut(&mut msg);
+        // SAFETY: initializer function uses header builder and initialie all fields
+        unsafe {
+            msg_builder.init_header_with(|uninit_header| {
+                let mut header_builder =
+                    MessageHeaderUninitBuilder::from_maybe_uninit_mut(uninit_header);
+                header_builder.write_num_required_signatures(variant);
+                header_builder.read_num_readonly_signed_accounts(reader)?;
+                header_builder.read_num_readonly_unsigned_accounts(reader)?;
+                debug_assert!(header_builder.is_init());
+                header_builder.finish();
+                Ok(())
+            })?;
+        }
+        msg_builder.read_account_keys(reader)?;
+        msg_builder.read_recent_blockhash(reader)?;
+        msg_builder.read_instructions(reader)?;
+        debug_assert!(msg_builder.is_init());
+        // SAFETY: All fields are initialized, safe to close the builder and assume initialized.
+        msg_builder.finish();
         let msg = unsafe { msg.assume_init() };
         dst.write(solana_message::VersionedMessage::Legacy(msg));
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -11980,9 +11980,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d814d39f8894e2f0b7c6dac8a4bf1f36bf40c9415c2ff02146d6f777a91e11d3"
+checksum = "f67e680788539097c13ae4311dc36e850624b62b2f481271621adef0fbac6062"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11993,9 +11993,9 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73ae1f9280de1c129b7baa5899ff75682ac67da1224d82d1b473a2ad1cbb49a"
+checksum = "bfe3057b011c49fd74405e08c867f8bb945a9c6bebfc81e086252483c95524d6"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
#### Problem
New version of wincode provides better API for performing partial initialization.

#### Summary of Changes
* bump wincode
* Switch LegacyMessage creation to uninit builder util and remove manual drop guard
