### PR TITLE
cli-output: Avoid extra String allocations

### DIFF
--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -40,8 +40,7 @@ impl Default for BuildBalanceMessageConfig {
 }
 
 fn is_memo_program(k: &Pubkey) -> bool {
-    let k_str = k.to_string();
-    (k_str == spl_memo_v1_id().to_string()) || (k_str == spl_memo_v3_id().to_string())
+    *k == spl_memo_v1_id() || *k == spl_memo_v3_id()
 }
 
 pub fn build_balance_message_with_config(


### PR DESCRIPTION
Switch is_memo_program to compare memo program Pubkeys directly instead of using to_string-based comparisons. This removes unnecessary String allocations in the transaction display hot path while keeping the behaviour identical and consistent with other memo-related code in the codebase.