### PR TITLE
fix help text to clarify half open port range [start, end)

### DIFF
--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -399,7 +399,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .default_value(&default_args.dynamic_port_range)
             .validator(port_range_validator)
-            .help("Range to use for dynamically assigned ports"),
+            .help("Range to use for dynamically assigned ports. The range is half-open in which the end is exclusive, for example: 8000-8024 provides 24 usable ports."),
     )
     .arg(
         Arg::with_name("maximum_local_snapshot_age")


### PR DESCRIPTION
#### Problem

The cli args are a little misleading for the user for validator dynamic_port_range.

#### Summary of Changes

add args for for validators's --dynamic_port_range command so they can understand that the range of ports is half-open.

fixes https://github.com/anza-xyz/agave/issues/7759

