### PR TITLE
zk-token-sdk: Do not require passing owned vectors to `RangeProof`

### DIFF
--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u128.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u128.rs
@@ -88,7 +88,7 @@ impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU128Data {
         let proof: RangeProof = self.proof.try_into()?;
 
         proof
-            .verify(commitments.iter().collect(), bit_lengths, &mut transcript)
+            .verify(commitments, bit_lengths, &mut transcript)
             .map_err(|e| e.into())
     }
 }

--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u256.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u256.rs
@@ -100,7 +100,7 @@ impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU256Data {
         let proof: RangeProof = self.proof.try_into()?;
 
         proof
-            .verify(commitments.iter().collect(), bit_lengths, &mut transcript)
+            .verify(commitments, bit_lengths, &mut transcript)
             .map_err(|e| e.into())
     }
 }

--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u64.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u64.rs
@@ -87,7 +87,7 @@ impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU64Data {
         let proof: RangeProof = self.proof.try_into()?;
 
         proof
-            .verify(commitments.iter().collect(), bit_lengths, &mut transcript)
+            .verify(commitments, bit_lengths, &mut transcript)
             .map_err(|e| e.into())
     }
 }

--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -583,7 +583,7 @@ impl TransferWithFeeProof {
             .ok_or(ProofGenerationError::FeeCalculation)?;
 
         let range_proof = RangeProof::new(
-            vec![
+            &[
                 source_new_balance,
                 transfer_amount_lo,
                 transfer_amount_hi,
@@ -593,7 +593,7 @@ impl TransferWithFeeProof {
                 fee_amount_hi,
                 amount_sub_fee,
             ],
-            vec![
+            &[
                 TRANSFER_SOURCE_AMOUNT_BITS, // 64
                 TRANSFER_AMOUNT_LO_BITS,     // 16
                 TRANSFER_AMOUNT_HI_BITS,     // 32
@@ -603,7 +603,7 @@ impl TransferWithFeeProof {
                 FEE_AMOUNT_HI_BITS,          // 32
                 TRANSFER_SOURCE_AMOUNT_BITS, // 64
             ],
-            vec![
+            &[
                 &opening_source,
                 opening_lo,
                 opening_hi,
@@ -742,7 +742,7 @@ impl TransferWithFeeProof {
         let amount_sub_fee_commitment = combined_commitment - combined_fee_commitment;
 
         range_proof.verify(
-            vec![
+            &[
                 &new_source_commitment,
                 ciphertext_lo.get_commitment(),
                 ciphertext_hi.get_commitment(),
@@ -752,7 +752,7 @@ impl TransferWithFeeProof {
                 fee_ciphertext_hi.get_commitment(),
                 &amount_sub_fee_commitment,
             ],
-            vec![
+            &[
                 TRANSFER_SOURCE_AMOUNT_BITS, // 64
                 TRANSFER_AMOUNT_LO_BITS,     // 16
                 TRANSFER_AMOUNT_HI_BITS,     // 32

--- a/zk-token-sdk/src/instruction/transfer/without_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/without_fee.rs
@@ -340,13 +340,13 @@ impl TransferProof {
         // generate the range proof
         let range_proof = if TRANSFER_AMOUNT_LO_BITS == 32 {
             RangeProof::new(
-                vec![source_new_balance, transfer_amount_lo, transfer_amount_hi],
-                vec![
+                &[source_new_balance, transfer_amount_lo, transfer_amount_hi],
+                &[
                     TRANSFER_SOURCE_AMOUNT_BITS,
                     TRANSFER_AMOUNT_LO_BITS,
                     TRANSFER_AMOUNT_HI_BITS,
                 ],
-                vec![&source_opening, opening_lo, opening_hi],
+                &[&source_opening, opening_lo, opening_hi],
                 transcript,
             )
         } else {
@@ -355,19 +355,19 @@ impl TransferProof {
             let opening_lo_negated = &PedersenOpening::default() - opening_lo;
 
             RangeProof::new(
-                vec![
+                &[
                     source_new_balance,
                     transfer_amount_lo,
                     transfer_amount_lo_negated,
                     transfer_amount_hi,
                 ],
-                vec![
+                &[
                     TRANSFER_SOURCE_AMOUNT_BITS,
                     TRANSFER_AMOUNT_LO_BITS,
                     TRANSFER_AMOUNT_LO_NEGATED_BITS,
                     TRANSFER_AMOUNT_HI_BITS,
                 ],
-                vec![&source_opening, opening_lo, &opening_lo_negated, opening_hi],
+                &[&source_opening, opening_lo, &opening_lo_negated, opening_hi],
                 transcript,
             )
         }?;
@@ -430,12 +430,12 @@ impl TransferProof {
         let new_source_commitment = self.new_source_commitment.try_into()?;
         if TRANSFER_AMOUNT_LO_BITS == 32 {
             range_proof.verify(
-                vec![
+                &[
                     &new_source_commitment,
                     ciphertext_lo.get_commitment(),
                     ciphertext_hi.get_commitment(),
                 ],
-                vec![
+                &[
                     TRANSFER_SOURCE_AMOUNT_BITS,
                     TRANSFER_AMOUNT_LO_BITS,
                     TRANSFER_AMOUNT_HI_BITS,
@@ -446,13 +446,13 @@ impl TransferProof {
             let commitment_lo_negated = &(*COMMITMENT_MAX) - ciphertext_lo.get_commitment();
 
             range_proof.verify(
-                vec![
+                &[
                     &new_source_commitment,
                     ciphertext_lo.get_commitment(),
                     &commitment_lo_negated,
                     ciphertext_hi.get_commitment(),
                 ],
-                vec![
+                &[
                     TRANSFER_SOURCE_AMOUNT_BITS,
                     TRANSFER_AMOUNT_LO_BITS,
                     TRANSFER_AMOUNT_LO_NEGATED_BITS,

--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -11,7 +11,7 @@ use {
         transcript::TranscriptProtocol,
     },
     merlin::Transcript,
-    std::convert::TryInto,
+    std::{convert::TryInto, slice},
 };
 use {
     crate::{
@@ -156,8 +156,12 @@ impl WithdrawProof {
             transcript,
         );
 
-        let range_proof =
-            RangeProof::new(vec![final_balance], vec![64], vec![&opening], transcript)?;
+        let range_proof = RangeProof::new(
+            slice::from_ref(&final_balance),
+            slice::from_ref(&64),
+            slice::from_ref(&opening),
+            transcript,
+        )?;
 
         Ok(Self {
             commitment: pod_commitment,
@@ -185,8 +189,8 @@ impl WithdrawProof {
 
         // verify range proof
         range_proof.verify(
-            vec![&commitment],
-            vec![WITHDRAW_AMOUNT_BIT_LENGTH],
+            slice::from_ref(&commitment),
+            slice::from_ref(&WITHDRAW_AMOUNT_BIT_LENGTH),
             transcript,
         )?;
 

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -72,7 +72,7 @@ mod tests {
         super::*,
         crate::{encryption::pedersen::Pedersen, range_proof::RangeProof},
         merlin::Transcript,
-        std::convert::TryInto,
+        std::{convert::TryInto, slice},
     };
 
     #[test]
@@ -82,19 +82,33 @@ mod tests {
         let mut transcript_create = Transcript::new(b"Test");
         let mut transcript_verify = Transcript::new(b"Test");
 
-        let proof =
-            RangeProof::new(vec![55], vec![64], vec![&open], &mut transcript_create).unwrap();
+        let proof = RangeProof::new(
+            slice::from_ref(&55),
+            slice::from_ref(&64),
+            slice::from_ref(&open),
+            &mut transcript_create,
+        )
+        .unwrap();
 
         let proof_serialized: pod::RangeProofU64 = proof.try_into().unwrap();
         let proof_deserialized: RangeProof = proof_serialized.try_into().unwrap();
 
         assert!(proof_deserialized
-            .verify(vec![&comm], vec![64], &mut transcript_verify)
+            .verify(
+                slice::from_ref(&comm),
+                slice::from_ref(&64),
+                &mut transcript_verify
+            )
             .is_ok());
 
         // should fail to serialize to pod::RangeProof128
-        let proof =
-            RangeProof::new(vec![55], vec![64], vec![&open], &mut transcript_create).unwrap();
+        let proof = RangeProof::new(
+            slice::from_ref(&55),
+            slice::from_ref(&64),
+            slice::from_ref(&open),
+            &mut transcript_create,
+        )
+        .unwrap();
 
         assert!(TryInto::<pod::RangeProofU128>::try_into(proof).is_err());
     }
@@ -109,9 +123,9 @@ mod tests {
         let mut transcript_verify = Transcript::new(b"Test");
 
         let proof = RangeProof::new(
-            vec![55, 77, 99],
-            vec![64, 32, 32],
-            vec![&open_1, &open_2, &open_3],
+            &[55, 77, 99],
+            &[64, 32, 32],
+            &[&open_1, &open_2, &open_3],
             &mut transcript_create,
         )
         .unwrap();
@@ -121,17 +135,17 @@ mod tests {
 
         assert!(proof_deserialized
             .verify(
-                vec![&comm_1, &comm_2, &comm_3],
-                vec![64, 32, 32],
+                &[&comm_1, &comm_2, &comm_3],
+                &[64, 32, 32],
                 &mut transcript_verify,
             )
             .is_ok());
 
         // should fail to serialize to pod::RangeProof64
         let proof = RangeProof::new(
-            vec![55, 77, 99],
-            vec![64, 32, 32],
-            vec![&open_1, &open_2, &open_3],
+            &[55, 77, 99],
+            &[64, 32, 32],
+            &[&open_1, &open_2, &open_3],
             &mut transcript_create,
         )
         .unwrap();


### PR DESCRIPTION
#### Problem

The current implementation of `RangeProof::new` and `RangeProof::verify` requires the caller to pass inputs as owned vectors. That requires heap allocations even if the number of inputs is small (even as small as 1).

#### Summary of Changes

Remove that requirement by accepting `AsRef<[T]>` trait as inputs, which still makes it possible to pass `Vec<T>`, so we don't break the old users relying on the old API. But for callers who want performance, it accepts also the following types that can be allocated on the stack:

- `[T]`
- `[T; N]`
- `&[T]`

Furthermore, single elements can be passed using `slice::from_ref`[0], e.g.

```rust
let proof = RangeProof::new(
    slice::from_ref(&55),
    slice::from_ref(&64),
    slice::from_ref(&open),
    &mut transcript_create,
)
```

which does not perform any allocation at all. Instead, it performs raw pointer casting to coerce a reference to a single-element slice[1][2].

Additionally, `AsRef<T>` makes it possible to pass the following iterable types:

- `std::slice::Iter<'_, T>`
- `IterMut<'_, T>`
- `IntoIter<T, A>`

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
