### PR TITLE
fix(random): return Overflow error when sum of weights exceed u64::MAX

### DIFF
--- a/random/src/weighted.rs
+++ b/random/src/weighted.rs
@@ -27,7 +27,7 @@ impl WeightedU64Index {
         // chosen weight.
         let mut total_weight = 0u64;
         for weight in weights.iter_mut() {
-            total_weight = total_weight.saturating_add(*weight);
+            total_weight = total_weight.checked_add(*weight).ok_or(Error::Overflow)?;
             *weight = total_weight;
         }
         if weights.pop().is_none() {
@@ -104,6 +104,10 @@ mod tests {
         assert_matches!(
             WeightedU64Index::new(vec![0, 0, 0, 0, 0]),
             Err(Error::InsufficientNonZero)
+        );
+        assert_matches!(
+            WeightedU64Index::new(vec![u64::MAX / 3, u64::MAX / 2, 0, u64::MAX / 3]),
+            Err(Error::Overflow)
         );
     }
 }


### PR DESCRIPTION
#### Problem
`agave-random` uses saturating add when summing weights for `WeightedU64Index`. We don't expect the sum of weights to ever exceed `u64`, so we should treat it as error as suggested in https://github.com/anza-xyz/agave/pull/9151#pullrequestreview-3514490894

#### Summary of Changes
Return `rand::dist::weighted::Error::Overflow` when sum of weights exceed `u64::MAX`. This also follows behavior of `rand::distr::weighted::WeightedIndex::new`.
