### PR TITLE
Switch to Rust Edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,22 +146,6 @@ homepage = "https://anza.xyz/"
 license = "Apache-2.0"
 edition = "2024"
 
-[workspace.lints.rust]
-# List of rust-2024-compatibility lints that are already satisfied
-# See https://doc.rust-lang.org/rustc/lints/groups.html
-boxed_slice_into_iter = "deny"
-dependency_on_unit_never_type_fallback = "deny"
-deprecated_safe_2024 = "deny"
-impl_trait_overcaptures = "deny"
-missing_unsafe_on_extern = "deny"
-never_type_fallback_flowing_into_unsafe = "deny"
-rust_2024_guarded_string_incompatible_syntax = "deny"
-rust_2024_incompatible_pat = "deny"
-rust_2024_prelude_collisions = "deny"
-static_mut_refs = "deny"
-unsafe_attr_outside_unsafe = "deny"
-unsafe_op_in_unsafe_fn = "deny"
-
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ description = "Blockchain, Rebuilt for Scale"
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 
 [workspace.lints.rust]
 # List of rust-2024-compatibility lints that are already satisfied

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -6,7 +6,7 @@ description = "Blockchain, Rebuilt for Scale"
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 # Prevents auto-detection of parent workspace (ie. git worktrees).

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -19,22 +19,6 @@ homepage = "https://anza.xyz/"
 license = "Apache-2.0"
 edition = "2024"
 
-[workspace.lints.rust]
-# List of rust-2024-compatibility lints that are already satisfied
-# See https://doc.rust-lang.org/rustc/lints/groups.html
-boxed_slice_into_iter = "deny"
-dependency_on_unit_never_type_fallback = "deny"
-deprecated_safe_2024 = "deny"
-impl_trait_overcaptures = "deny"
-missing_unsafe_on_extern = "deny"
-never_type_fallback_flowing_into_unsafe = "deny"
-rust_2024_guarded_string_incompatible_syntax = "deny"
-rust_2024_incompatible_pat = "deny"
-rust_2024_prelude_collisions = "deny"
-static_mut_refs = "deny"
-unsafe_attr_outside_unsafe = "deny"
-unsafe_op_in_unsafe_fn = "deny"
-
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -17,7 +17,7 @@ description = "Blockchain, Rebuilt for Scale"
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 
 [workspace.lints.rust]
 # List of rust-2024-compatibility lints that are already satisfied

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -1,11 +1,4 @@
 #![cfg(feature = "agave-unstable-api")]
-// Activate some of the Rust 2024 lints to make the future migration easier.
-#![warn(if_let_rescope)]
-#![warn(keyword_idents_2024)]
-#![warn(rust_2024_incompatible_pat)]
-#![warn(tail_expr_drop_order)]
-#![warn(unsafe_attr_outside_unsafe)]
-#![warn(unsafe_op_in_unsafe_fn)]
 
 pub mod buffered_reader;
 pub mod buffered_writer;

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -1,13 +1,6 @@
 #![cfg(feature = "agave-unstable-api")]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
-// Activate some of the Rust 2024 lints to make the future migration easier.
-#![warn(if_let_rescope)]
-#![warn(keyword_idents_2024)]
-#![warn(rust_2024_incompatible_pat)]
-#![warn(tail_expr_drop_order)]
-#![warn(unsafe_attr_outside_unsafe)]
-#![warn(unsafe_op_in_unsafe_fn)]
 
 pub mod cluster_info;
 pub mod cluster_info_metrics;

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -168,12 +168,12 @@ fn slot_contains_nonvote_tx(blockstore: &Blockstore, slot: Slot) -> bool {
     let (entries, _, _) = blockstore
         .get_slot_entries_with_shred_info(slot, 0, false)
         .expect("Failed to get slot entries");
-    let contains_nonvote = entries
+
+    entries
         .iter()
         .flat_map(|entry| entry.transactions.iter())
         .flat_map(get_program_ids)
-        .any(|program_id| *program_id != solana_vote_program::id());
-    contains_nonvote
+        .any(|program_id| *program_id != solana_vote_program::id())
 }
 
 type OptimisticSlotInfo = (Slot, Option<(Hash, UnixTimestamp)>, bool);

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -95,8 +95,8 @@ fn load_blockstore(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -> Arc<Bank
         process_options,
         None,
     );
-    let bank = bank_forks.read().unwrap().working_bank();
-    bank
+
+    bank_forks.read().unwrap().working_bank()
 }
 
 pub trait ProgramSubCommand {

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -1,14 +1,6 @@
 #![cfg(feature = "agave-unstable-api")]
 //! The `net_utils` module assists with networking
 
-// Activate some of the Rust 2024 lints to make the future migration easier.
-#![warn(if_let_rescope)]
-#![warn(keyword_idents_2024)]
-#![warn(rust_2024_incompatible_pat)]
-#![warn(tail_expr_drop_order)]
-#![warn(unsafe_attr_outside_unsafe)]
-#![warn(unsafe_op_in_unsafe_fn)]
-
 pub mod banlist;
 mod ip_echo_client;
 mod ip_echo_server;

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -79,7 +79,7 @@ authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 
 [workspace.lints.rust]
 # List of rust-2024-compatibility lints that are already satisfied

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -81,22 +81,6 @@ homepage = "https://anza.xyz"
 license = "Apache-2.0"
 edition = "2024"
 
-[workspace.lints.rust]
-# List of rust-2024-compatibility lints that are already satisfied
-# See https://doc.rust-lang.org/rustc/lints/groups.html
-boxed_slice_into_iter = "deny"
-dependency_on_unit_never_type_fallback = "deny"
-deprecated_safe_2024 = "deny"
-impl_trait_overcaptures = "deny"
-missing_unsafe_on_extern = "deny"
-never_type_fallback_flowing_into_unsafe = "deny"
-rust_2024_guarded_string_incompatible_syntax = "deny"
-rust_2024_incompatible_pat = "deny"
-rust_2024_prelude_collisions = "deny"
-static_mut_refs = "deny"
-unsafe_attr_outside_unsafe = "deny"
-unsafe_op_in_unsafe_fn = "deny"
-
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,3 @@
 imports_granularity = "One"
 format_strings = true
 group_imports = "One"
-style_edition = "2024"

--- a/scripts/cargo-clippy-nightly.sh
+++ b/scripts/cargo-clippy-nightly.sh
@@ -22,6 +22,8 @@ source "$here/../ci/rust-version.sh" nightly
 # Similarly, nightly is desired to run clippy over all of bench files because
 # the bench itself isn't stabilized yet...
 #   ref: https://github.com/rust-lang/rust/issues/66287
+#
+# allow arguments are temporary, violations should be fixed after migration to Rust 2024
 "$here/cargo-for-all-lock-files.sh" -- \
   "+${rust_nightly}" clippy \
   --workspace --all-targets --features dummy-for-ci-check,frozen-abi -- \
@@ -30,4 +32,5 @@ source "$here/../ci/rust-version.sh" nightly
   --deny=clippy::arithmetic_side_effects \
   --deny=clippy::manual_let_else \
   --deny=clippy::uninlined-format-args \
-  --deny=clippy::used_underscore_binding
+  --deny=clippy::used_underscore_binding \
+  --allow=clippy::collapsible_if

--- a/snapshots/src/lib.rs
+++ b/snapshots/src/lib.rs
@@ -1,11 +1,4 @@
 #![cfg(feature = "agave-unstable-api")]
-// Activate some of the Rust 2024 lints to make the future migration easier.
-#![warn(if_let_rescope)]
-#![warn(keyword_idents_2024)]
-#![warn(rust_2024_incompatible_pat)]
-#![warn(tail_expr_drop_order)]
-#![warn(unsafe_attr_outside_unsafe)]
-#![warn(unsafe_op_in_unsafe_fn)]
 
 mod archive;
 mod archive_format;

--- a/votor-messages/src/lib.rs
+++ b/votor-messages/src/lib.rs
@@ -2,13 +2,6 @@
 //! Alpenglow vote message types
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![deny(missing_docs)]
-// Activate some of the Rust 2024 lints to make the future migration easier.
-#![warn(if_let_rescope)]
-#![warn(keyword_idents_2024)]
-#![warn(rust_2024_incompatible_pat)]
-#![warn(tail_expr_drop_order)]
-#![warn(unsafe_attr_outside_unsafe)]
-#![warn(unsafe_op_in_unsafe_fn)]
 
 pub mod consensus_message;
 pub mod fraction;

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -1,12 +1,5 @@
 #![cfg(feature = "agave-unstable-api")]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-// Activate some of the Rust 2024 lints to make the future migration easier.
-#![warn(if_let_rescope)]
-#![warn(keyword_idents_2024)]
-#![warn(rust_2024_incompatible_pat)]
-#![warn(tail_expr_drop_order)]
-#![warn(unsafe_attr_outside_unsafe)]
-#![warn(unsafe_op_in_unsafe_fn)]
 
 #[macro_use]
 extern crate log;

--- a/xdp-ebpf/src/lib.rs
+++ b/xdp-ebpf/src/lib.rs
@@ -1,11 +1,4 @@
 #![cfg(feature = "agave-unstable-api")]
-// Activate some of the Rust 2024 lints to make the future migration easier.
-#![warn(if_let_rescope)]
-#![warn(keyword_idents_2024)]
-#![warn(rust_2024_incompatible_pat)]
-#![warn(tail_expr_drop_order)]
-#![warn(unsafe_attr_outside_unsafe)]
-#![warn(unsafe_op_in_unsafe_fn)]
 #![no_std]
 
 #[repr(C, align(8))]

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -1,11 +1,4 @@
 #![cfg(feature = "agave-unstable-api")]
-// Activate some of the Rust 2024 lints to make the future migration easier.
-#![warn(if_let_rescope)]
-#![warn(keyword_idents_2024)]
-#![warn(rust_2024_incompatible_pat)]
-#![warn(tail_expr_drop_order)]
-#![warn(unsafe_attr_outside_unsafe)]
-#![warn(unsafe_op_in_unsafe_fn)]
 
 #[cfg(target_os = "linux")]
 pub mod device;


### PR DESCRIPTION
#### Problem
New Rust edition is available

#### Summary of Changes
Note: this switch apart from enabling new syntax also changes drop semantics for some local variables / bindings. This affects a lot of the code, but the new semantics is usually better, since it shortens the lifetimes of some values such that they are dropped earlier:
* [if-let-rescope](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#if-let-rescope), 
* [tail-expr-drop-order](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#tail-expr-drop-order), 
* [edition-2024-expr-fragment-specifier](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#edition-2024-expr-fragment-specifier) (might affect some macros)

##### Changes:
* switch all workspaces to Rust 2024
* remove temporary per-crate warning denies that were put in to help migration to new edition
* remove workspace level rust lint denies that were protecting from accumulating Rust 2024 incompatible code
* fix some let and return cases that were forced in code by above warnings (some of the warnings were designed to prevent semantic changes in Rust 2021 - 2024 change, we are actually fine with new semantics and keeping that code now triggers a let_and_return lint)
* add temporary allow for `clippy::collapsible_if` lint:
  * this lint is impossible to fix before switching edition, since edition enables new syntax
  * fixing it lint can be done automatically and the diff is pretty straight-forward, but it's pretty large
  * the fix has no semantic changes as opposed to this PR
  * when done independently (after this PR), the diff can be split per crate / ownership
  * thus I would prefer to fix those in independent PR, such that we can keep this one small and conflict free in case it needs revert (due to semantic changes)

Fixes #6203

##### Further cleanup
* fix `clippy::collapsible_if` and remove allow from clippy script
* switch individual crates that are already using 2024 to use default workspace edition (excluded from here due to explosion of code-owners requirement - it's safe and even desired to delay such cleanup)