### PR TITLE
clippy(unified-scheduler-pool): remove redundant ref binding

### DIFF
--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -119,7 +119,7 @@ impl SupportedSchedulingMode {
     fn is_supported(&self, requested_mode: SchedulingMode) -> bool {
         match (self, requested_mode) {
             (Self::Both, _requested) => true,
-            (Self::Either(ref supported), ref requested) => supported == requested,
+            (Self::Either(supported), ref requested) => supported == requested,
         }
     }
 


### PR DESCRIPTION
#### Problem
When compiling for Rust 2024 edition [migration](https://github.com/anza-xyz/agave/issues/6203) compiler detects redundant `ref` bindings in patterns.

#### Summary of Changes
Remove unnecessary `ref`, since the variable is already a reference.