### PR TITLE
clippy(snapshots): declare lifetime/types used by returned impl BufRead

### DIFF
--- a/snapshots/src/unarchive.rs
+++ b/snapshots/src/unarchive.rs
@@ -1,9 +1,9 @@
 use {
     crate::{
-        hardened_unpack::{self, UnpackError},
         ArchiveFormat, ArchiveFormatDecompressor,
+        hardened_unpack::{self, UnpackError},
     },
-    agave_fs::{buffered_reader, file_io::file_creator, io_setup::IoSetupState, FileInfo},
+    agave_fs::{FileInfo, buffered_reader, file_io::file_creator, io_setup::IoSetupState},
     bzip2::bufread::BzDecoder,
     crossbeam_channel::Sender,
     std::{
@@ -112,12 +112,12 @@ pub fn unpack_genesis_archive(
     Ok(())
 }
 
-fn decompressed_tar_reader(
+fn decompressed_tar_reader<T: AsRef<Path>>(
     archive_format: ArchiveFormat,
-    archive_path: impl AsRef<Path>,
+    archive_path: T,
     buf_size: u64,
     io_setup: &IoSetupState,
-) -> io::Result<ArchiveFormatDecompressor<impl BufRead>> {
+) -> io::Result<ArchiveFormatDecompressor<impl BufRead + use<T>>> {
     let buf_reader =
         buffered_reader::large_file_buf_reader(archive_path.as_ref(), buf_size as usize, io_setup)?;
     ArchiveFormatDecompressor::new(archive_format, buf_reader)

--- a/snapshots/src/unarchive.rs
+++ b/snapshots/src/unarchive.rs
@@ -1,9 +1,9 @@
 use {
     crate::{
-        ArchiveFormat, ArchiveFormatDecompressor,
         hardened_unpack::{self, UnpackError},
+        ArchiveFormat, ArchiveFormatDecompressor,
     },
-    agave_fs::{FileInfo, buffered_reader, file_io::file_creator, io_setup::IoSetupState},
+    agave_fs::{buffered_reader, file_io::file_creator, io_setup::IoSetupState, FileInfo},
     bzip2::bufread::BzDecoder,
     crossbeam_channel::Sender,
     std::{
@@ -112,13 +112,13 @@ pub fn unpack_genesis_archive(
     Ok(())
 }
 
-fn decompressed_tar_reader<T: AsRef<Path>>(
+fn decompressed_tar_reader(
     archive_format: ArchiveFormat,
-    archive_path: T,
+    archive_path: &Path,
     buf_size: u64,
     io_setup: &IoSetupState,
-) -> io::Result<ArchiveFormatDecompressor<impl BufRead + use<T>>> {
+) -> io::Result<ArchiveFormatDecompressor<impl BufRead + use<>>> {
     let buf_reader =
-        buffered_reader::large_file_buf_reader(archive_path.as_ref(), buf_size as usize, io_setup)?;
+        buffered_reader::large_file_buf_reader(archive_path, buf_size as usize, io_setup)?;
     ArchiveFormatDecompressor::new(archive_format, buf_reader)
 }


### PR DESCRIPTION
#### Problem
When compiling for Rust 2024 edition [migration](https://github.com/anza-xyz/agave/issues/6203) 
all types and lifetimes are captured by default by `impl Trait` types on return position. This causes some code that currently compiles to fail due to excess borrows.
Specifically `&ioSetupState` is captured by the returned reader type.

#### Summary of Changes
* apply `use<>` marker for returned `impl` such that reference to `IoSetupState` is not captured
* switch archive path to `&Path`, otherwise we need to use `T` and put it into `use<>`