### PR TITLE
geyser: Uses original account for account update notifications

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5974,12 +5974,14 @@ impl AccountsDb {
         (0..accounts_and_meta_to_store.len())
             .map(|index| {
                 let txn = txs.map(|txs| *txs.get(index).expect("txs must be present if provided"));
-                accounts_and_meta_to_store.account_default_if_zero_lamport(index, |account| {
+                accounts_and_meta_to_store.account(index, |account| {
                     let account_shared_data = account.take_account();
                     let pubkey = account.pubkey();
                     let account_info =
                         AccountInfo::new(StorageLocation::Cached, account.is_zero_lamport());
 
+                    // if geyser is enabled, send the account update notification
+                    // with the original version of the account
                     self.notify_account_at_accounts_update(
                         slot,
                         &account_shared_data,
@@ -5989,7 +5991,14 @@ impl AccountsDb {
                     );
                     current_write_version = current_write_version.saturating_add(1);
 
-                    self.accounts_cache.store(slot, pubkey, account_shared_data);
+                    // ...but when actually storing the account, if its balance is zero,
+                    // use the default, which zeroes out all the account fields
+                    let account_to_store = if account.is_zero_lamport() {
+                        AccountSharedData::default()
+                    } else {
+                        account_shared_data
+                    };
+                    self.accounts_cache.store(slot, pubkey, account_to_store);
                     account_info
                 })
             })


### PR DESCRIPTION
#### Problem

With geyser account update notifications, any account that is stored (e.g. modified accounts from transaction processing) will send an account update notification to the loaded geyser plugins. The specific account that is used is the same as what we pass into the low-level storage of accounts-db. However, the low-level storage has an optimization for accounts that have been closed: all the bytes are zeroed out. This is a problem for geyser, as it means the original account's owner (and all other fields) is lost. This makes tracking accounts by owner much harder, as the plugin can no longer just filter by owner. To ensure notifications for closed accounts are not missed, the plugin must also inspect all notifications for accounts of the system program too (owner == all zeroes). Ouch.


Here's some other references describing the issue:

* https://github.com/anza-xyz/agave/pull/43
* https://github.com/anza-xyz/agave/pull/5114


#### Summary of Changes

Instead of using the account that we pass to the low-level accounts-db storage as the account for geyser notifications, use the original account instead. This preserves all the fields of the account. Most importantly, the owner is preserved.


#### Additional Testing

I made a geyser plugin that logs the account notifications and confirmed that notifications for closed accounts now contain the original account's information (i.e. owner).