### PR TITLE
clippy(xdp-ebpf): escape gen symbol in import

### DIFF
--- a/xdp-ebpf/src/bin/agave-xdp-prog.rs
+++ b/xdp-ebpf/src/bin/agave-xdp-prog.rs
@@ -4,7 +4,7 @@
 use {
     aya_ebpf::{
         bindings::xdp_action::{XDP_DROP, XDP_PASS},
-        helpers::gen::bpf_xdp_get_buff_len,
+        helpers::r#gen::bpf_xdp_get_buff_len,
         macros::xdp,
         programs::XdpContext,
     },


### PR DESCRIPTION
#### Problem
Rust 2024 [migration](https://github.com/anza-xyz/agave/issues/6203) requires that `gen` symbols are quoted as this is now reserved keyword.

#### Summary of Changes
Use `r#gen` instead
