### PR TITLE
feat(rpc): allow filtering leader schedule by vote accounts

### DIFF
--- a/ledger/src/leader_schedule_utils.rs
+++ b/ledger/src/leader_schedule_utils.rs
@@ -39,6 +39,21 @@ pub fn leader_schedule_by_identity<'a>(
         .collect()
 }
 
+pub fn vote_account_to_identity_map(leader_schedule: &LeaderSchedule) -> HashMap<Pubkey, Pubkey> {
+    let mut vote_to_identity = HashMap::new();
+    let num_slots = leader_schedule.num_slots();
+    let slot_leaders = leader_schedule.get_slot_leaders();
+
+    for slot_index in 0..num_slots {
+        if let Some(vote_account_pubkey) = leader_schedule.get_vote_key_at_slot_index(slot_index) {
+            let identity_pubkey = slot_leaders[slot_index % slot_leaders.len()];
+            vote_to_identity.insert(*vote_account_pubkey, identity_pubkey);
+        }
+    }
+
+    vote_to_identity
+}
+
 /// Return the leader for the given slot.
 pub fn slot_leader_at(slot: Slot, bank: &Bank) -> Option<Pubkey> {
     let (epoch, slot_index) = bank.get_epoch_and_slot_index(slot);

--- a/rpc-client-api/src/custom_error.rs
+++ b/rpc-client-api/src/custom_error.rs
@@ -80,8 +80,6 @@ pub enum RpcCustomError {
     SlotNotEpochBoundary { slot: Slot },
     #[error("LongTermStorageUnreachable")]
     LongTermStorageUnreachable,
-    #[error("InvalidParam")]
-    InvalidParam,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -259,11 +257,6 @@ impl From<RpcCustomError> for Error {
             RpcCustomError::LongTermStorageUnreachable => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE),
                 message: "Failed to query long-term storage; please try again".to_string(),
-                data: None,
-            },
-            RpcCustomError::InvalidParam => Self {
-                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE),
-                message: "Invalid parameter provided".to_string(),
                 data: None,
             },
         }

--- a/rpc-client-api/src/custom_error.rs
+++ b/rpc-client-api/src/custom_error.rs
@@ -80,6 +80,8 @@ pub enum RpcCustomError {
     SlotNotEpochBoundary { slot: Slot },
     #[error("LongTermStorageUnreachable")]
     LongTermStorageUnreachable,
+    #[error("InvalidParam")]
+    InvalidParam,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -257,6 +259,11 @@ impl From<RpcCustomError> for Error {
             RpcCustomError::LongTermStorageUnreachable => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE),
                 message: "Failed to query long-term storage; please try again".to_string(),
+                data: None,
+            },
+            RpcCustomError::InvalidParam => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE),
+                message: "Invalid parameter provided".to_string(),
                 data: None,
             },
         }

--- a/rpc-client-types/src/config.rs
+++ b/rpc-client-types/src/config.rs
@@ -61,6 +61,7 @@ pub struct RpcRequestAirdropConfig {
 #[serde(rename_all = "camelCase")]
 pub struct RpcLeaderScheduleConfig {
     pub identity: Option<String>, // validator identity, as a base-58 encoded string
+    pub vote_accounts: Option<Vec<String>>, // base-58 vote account pubkeys
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5582,8 +5582,7 @@ pub mod tests {
         assert!(result.is_some());
         let schedule = result.unwrap();
         // Should only contain the node pubkey associated with vote_keypair1
-        assert!(schedule.contains_key(&node_keypair1.pubkey().to_string())
-            || schedule.is_empty()); // empty if node_keypair1 is not a leader in this epoch
+        assert!(schedule.contains_key(&node_keypair1.pubkey().to_string()) || schedule.is_empty());
 
         // Test filtering by multiple vote accounts
         let request = create_test_request(


### PR DESCRIPTION
#### Problem

getLeaderSchedule does not support filtering results using vote account addresses.

#### Summary of Changes

Adds support for filtering the leader schedule by vote accounts by resolving them to validator identities.

Fixes #9676