### PR TITLE
fix: apply `deprecate_rent_exemption_enabled` at genesis

### DIFF
--- a/program-test/tests/sysvar.rs
+++ b/program-test/tests/sysvar.rs
@@ -29,7 +29,7 @@ fn sysvar_getter_process_instruction(
     assert_eq!(epoch_schedule, EpochSchedule::default());
 
     let rent = Rent::get()?;
-    assert_eq!(rent, Rent::default());
+    assert_eq!(rent.exemption_threshold, 1.0);
 
     Ok(())
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5324,6 +5324,15 @@ impl Bank {
         let feature_set = self.compute_active_feature_set(false).0;
         self.feature_set = Arc::new(feature_set);
 
+        // Apply rent deprecation feature if it's active at genesis
+        // After feature cleanup, assert that rent exemption threshold is 1.0
+        if self
+            .feature_set
+            .is_active(&feature_set::deprecate_rent_exemption_threshold::id())
+        {
+            self.rent_collector.deprecate_rent_exemption_threshold();
+        }
+
         // Add built-in program accounts to the bank if they don't already exist
         self.add_builtin_program_accounts();
 
@@ -5369,10 +5378,7 @@ impl Bank {
 
         if new_feature_activations.contains(&feature_set::deprecate_rent_exemption_threshold::id())
         {
-            self.rent_collector.rent.lamports_per_byte_year =
-                (self.rent_collector.rent.lamports_per_byte_year as f64
-                    * self.rent_collector.rent.exemption_threshold) as u64;
-            self.rent_collector.rent.exemption_threshold = 1.0;
+            self.rent_collector.deprecate_rent_exemption_threshold();
             self.update_rent();
         }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -311,8 +311,8 @@ fn test_bank_new() {
     let rent = from_account::<sysvar::rent::Rent, _>(&rent_account).unwrap();
 
     assert_eq!(rent.burn_percent, 5);
-    assert_eq!(rent.exemption_threshold, 1.2);
-    assert_eq!(rent.lamports_per_byte_year, 5);
+    assert_eq!(rent.exemption_threshold, 1.0);
+    assert_eq!(rent.lamports_per_byte_year, 6);
 }
 
 pub(crate) fn create_simple_test_bank(lamports: u64) -> Bank {
@@ -5337,8 +5337,9 @@ fn test_fuzz_instructions() {
 // new feature that affects the bank hash, you should update this test to use a
 // test matrix that tests the bank hash calculation with and without your
 // added feature.
-#[test]
-fn test_bank_hash_consistency() {
+#[test_case(false ; "legacy")]
+#[test_case(true ; "deprecate rent exemption threshold")]
+fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
     let genesis_config = GenesisConfig {
         // Override the creation time to ensure bank hash consistency
         creation_time: 0,
@@ -5352,7 +5353,11 @@ fn test_bank_hash_consistency() {
 
     // Set the feature set to all enabled so that we detect any inconsistencies
     // in the hash computation that may arise from feature set changes
-    let feature_set = FeatureSet::all_enabled();
+    let mut feature_set = FeatureSet::all_enabled();
+
+    if !deprecate_rent_exemption_threshold {
+        feature_set.deactivate(&feature_set::deprecate_rent_exemption_threshold::id());
+    }
 
     let mut bank = Arc::new(Bank::new_from_genesis(
         &genesis_config,
@@ -5372,7 +5377,11 @@ fn test_bank_hash_consistency() {
             assert_eq!(bank.epoch(), 0);
             assert_eq!(
                 bank.hash().to_string(),
-                "EzyLJJki4ALhQAq5wbmiNctDhytQckGJRXnk9APKXv7r",
+                if deprecate_rent_exemption_threshold {
+                    "3KVpZkLPRXLUakJJkf9vqSapmy4a7rHVwgWa4y82mtjA"
+                } else {
+                    "EzyLJJki4ALhQAq5wbmiNctDhytQckGJRXnk9APKXv7r"
+                },
             );
         }
 
@@ -5380,14 +5389,22 @@ fn test_bank_hash_consistency() {
             assert_eq!(bank.epoch(), 1);
             assert_eq!(
                 bank.hash().to_string(),
-                "6h1KzSuTW6MwkgjtEbrv6AyUZ2NHtSxCQi8epjHDFYh8"
+                if deprecate_rent_exemption_threshold {
+                    "HvCfM9MQCvCDH4zW39G7UqKDB4PLR5GaqVSf9Jfe5XnS"
+                } else {
+                    "6h1KzSuTW6MwkgjtEbrv6AyUZ2NHtSxCQi8epjHDFYh8"
+                }
             );
         }
         if bank.slot == 128 {
             assert_eq!(bank.epoch(), 2);
             assert_eq!(
                 bank.hash().to_string(),
-                "4GX3883TVK7SQfbPUHem4HXcqdHU2DZVAB6yEXspn2qe"
+                if deprecate_rent_exemption_threshold {
+                    "GS2G4uVus4U97woniYLW1f2BWqoZFGFrpSQXto7PnjTT"
+                } else {
+                    "4GX3883TVK7SQfbPUHem4HXcqdHU2DZVAB6yEXspn2qe"
+                }
             );
             break;
         }
@@ -12349,6 +12366,48 @@ fn test_startup_from_snapshot_after_precompile_transition() {
 
     // Simulate starting up from snapshot finishing the initialization for a frozen bank
     bank.compute_and_apply_features_after_snapshot_restore();
+}
+
+#[test]
+fn test_genesis_deprecate_rent_exemption_enabled() {
+    let GenesisConfigInfo { genesis_config, .. } = genesis_utils::create_genesis_config(100_000);
+
+    let bank = Bank::new_for_tests(&genesis_config);
+    let rent_account = bank.get_account(&Rent::id()).unwrap();
+    let accounts_db_rent = bincode::deserialize::<Rent>(rent_account.data()).unwrap();
+    let rent_collector_rent = bank.rent_collector.rent.clone();
+    let tx_processor_rent = bank
+        .transaction_processor
+        .sysvar_cache()
+        .get_rent()
+        .unwrap()
+        .as_ref()
+        .clone();
+
+    assert_eq!(accounts_db_rent, tx_processor_rent);
+    assert_eq!(accounts_db_rent, rent_collector_rent);
+    assert!(accounts_db_rent.exemption_threshold == 1.0);
+}
+
+#[test]
+fn test_genesis_deprecate_rent_exemption_disabled() {
+    let (genesis_config, ..) = create_genesis_config(100_000);
+
+    let bank = Bank::new_for_tests(&genesis_config);
+    let rent_account = bank.get_account(&Rent::id()).unwrap();
+    let accounts_db_rent = bincode::deserialize::<Rent>(rent_account.data()).unwrap();
+    let rent_collector_rent = bank.rent_collector.rent.clone();
+    let tx_processor_rent = bank
+        .transaction_processor
+        .sysvar_cache()
+        .get_rent()
+        .unwrap()
+        .as_ref()
+        .clone();
+
+    assert_eq!(accounts_db_rent, tx_processor_rent);
+    assert_eq!(accounts_db_rent, rent_collector_rent);
+    assert!(accounts_db_rent.exemption_threshold == 2.0);
 }
 
 #[test]

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -45,4 +45,10 @@ impl RentCollector {
             ..self.clone()
         }
     }
+
+    pub(crate) fn deprecate_rent_exemption_threshold(&mut self) {
+        self.rent.lamports_per_byte_year =
+            (self.rent.lamports_per_byte_year as f64 * self.rent.exemption_threshold) as u64;
+        self.rent.exemption_threshold = 1.0;
+    }
 }


### PR DESCRIPTION
#### Problem
The `deprecate_rent_exemption_enabled` is not applied when enabled at genesis.

#### Summary of Changes
- Apply the feature at genesis and do some refactoring to reduce copied code

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
