### PR TITLE
pubsub-client: avoid cloning JSON Value in blocking pubsub client

### DIFF
--- a/pubsub-client/src/pubsub_client.rs
+++ b/pubsub-client/src/pubsub_client.rs
@@ -230,7 +230,7 @@ where
         if let Ok(json_msg) = serde_json::from_str::<Map<String, Value>>(message_text) {
             if let Some(Object(params)) = json_msg.get("params") {
                 if let Some(result) = params.get("result") {
-                    if let Ok(x) = serde_json::from_value::<T>(result.clone()) {
+                    if let Ok(x) = T::deserialize(result) {
                         return Ok(Some(x));
                     }
                 }


### PR DESCRIPTION
Switched PubsubClientSubscription::read_message to deserialize directly from &Value via T::deserialize(result) instead of calling serde_json::from_value(result.clone()). This removes a deep clone of the JSON subtree for each pubsub message while preserving the existing error handling and message parsing behavior.