### PR TITLE
ledger: remove redundant scheduler wait

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2174,11 +2174,6 @@ pub fn process_single_slot(
         }
         err
     })?;
-
-    if let Some((result, _timings)) = bank.wait_for_completed_scheduler() {
-        result?
-    }
-
     let block_id = blockstore
         .check_last_fec_set_and_get_block_id(slot, bank.hash(), &bank.feature_set)
         .inspect_err(|err| {


### PR DESCRIPTION
#### Problem

Redundant second call to wait_for_completed_scheduler in process_single_slot
In process_single_slot:
```rust
confirm_full_slot(...)? 
    .and_then(|()| {
        if let Some((result, completed_timings)) = bank.wait_for_completed_scheduler() {
            timing.accumulate(&completed_timings);
            result?
        }
        Ok(())
    })?;...

if let Some((result, _timings)) = bank.wait_for_completed_scheduler() {
    result?
}
```
wait_for_completed_scheduler transitions the scheduler from Active/Stale to Unavailable.
After the first successful call, the second call will always return None (via the SchedulerStatus::Unavailable branch) and only performs unnecessary RwLock acquisition.

#### Summary of Changes

Removed the second call and leave the semantics fully defined by the first one, which still waits for the unified scheduler to finish and accumulates its timings. The behavior is unchanged from a correctness point of view, but avoids a pointless extra RwLock acquisition and makes the control flow around scheduler termination clearer.
