### PR TITLE
refactor(snapshot_utils): filter storages for base_slot before rebuild

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1473,10 +1473,10 @@ pub(crate) fn rebuild_storages_from_snapshot_dir(
 
     let num_rebuilder_threads = num_cpus::get_physical().saturating_sub(1).max(1);
 
-    let snapshot_storage_lenghts =
+    let snapshot_storage_lengths =
         accounts_db_fields.get_storage_lengths_for_snapshot_slots(None)?;
     let storage = SnapshotStorageRebuilder::spawn_rebuilder_threads(
-        snapshot_storage_lenghts,
+        snapshot_storage_lengths,
         append_vec_files,
         file_receiver,
         num_rebuilder_threads,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -203,7 +203,7 @@ pub struct UnarchivedSnapshot {
     unpack_dir: TempDir,
     pub storage: AccountStorageMap,
     pub bank_fields: BankFieldsToDeserialize,
-    pub accounts_db_fields: AccountsDbFields<SerializableAccountStorageEntry>,
+    pub(crate) accounts_db_fields: AccountsDbFields<SerializableAccountStorageEntry>,
     pub unpacked_snapshots_dir_and_version: UnpackedSnapshotsDirAndVersion,
     pub measure_untar: Measure,
 }
@@ -1054,6 +1054,7 @@ pub fn verify_and_unarchive_snapshots(
         account_paths,
         full_snapshot_archive_info.archive_format(),
         next_append_vec_id.clone(),
+        None,
         accounts_db_config,
     )?;
 
@@ -1080,6 +1081,7 @@ pub fn verify_and_unarchive_snapshots(
             account_paths,
             incremental_snapshot_archive_info.archive_format(),
             next_append_vec_id.clone(),
+            Some(incremental_snapshot_archive_info.base_slot()),
             accounts_db_config,
         )?;
         (
@@ -1270,6 +1272,7 @@ fn unarchive_snapshot(
     account_paths: &[PathBuf],
     archive_format: ArchiveFormat,
     next_append_vec_id: Arc<AtomicAccountsFileId>,
+    base_slot: Option<Slot>,
     accounts_db_config: &AccountsDbConfig,
 ) -> Result<UnarchivedSnapshot> {
     let unpack_dir = tempfile::Builder::new()
@@ -1296,9 +1299,11 @@ fn unarchive_snapshot(
              append_vec_files,
              ..
          }| {
+            let snapshot_storage_lengths =
+                accounts_db_fields.get_storage_lengths_for_snapshot_slots(base_slot)?;
             let (storage, measure_untar) = measure_time!(
-                SnapshotStorageRebuilder::rebuild_storage(
-                    &accounts_db_fields,
+                SnapshotStorageRebuilder::spawn_rebuilder_threads(
+                    snapshot_storage_lengths,
                     append_vec_files,
                     file_receiver,
                     num_rebuilder_threads,
@@ -1368,7 +1373,7 @@ fn spawn_streaming_snapshot_dir_files(
 ///
 /// Handles reading the snapshot file and version file,
 /// then returning those fields plus the rebuilt storages.
-pub fn rebuild_storages_from_snapshot_dir(
+pub(crate) fn rebuild_storages_from_snapshot_dir(
     snapshot_info: &BankSnapshotInfo,
     account_paths: &[PathBuf],
     next_append_vec_id: Arc<AtomicAccountsFileId>,
@@ -1467,8 +1472,11 @@ pub fn rebuild_storages_from_snapshot_dir(
     } = snapshot_fields_from_files(&file_receiver)?;
 
     let num_rebuilder_threads = num_cpus::get_physical().saturating_sub(1).max(1);
-    let storage = SnapshotStorageRebuilder::rebuild_storage(
-        &accounts_db_fields,
+
+    let snapshot_storage_lenghts =
+        accounts_db_fields.get_storage_lengths_for_snapshot_slots(None)?;
+    let storage = SnapshotStorageRebuilder::spawn_rebuilder_threads(
+        snapshot_storage_lenghts,
         append_vec_files,
         file_receiver,
         num_rebuilder_threads,

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -181,7 +181,7 @@ impl SnapshotStorageRebuilder {
         let (_, old_append_vec_id) = get_slot_and_append_vec_id(filename)?;
         let Some(&current_len) = self.snapshot_storage_lengths.get(&slot) else {
             return Err(SnapshotError::RebuildStorages(format!(
-                "append vec file {filename} for slot outside of expected range in snapshot"
+                "account storage file '{filename}' for slot outside of expected range in snapshot"
             )));
         };
 

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -3,9 +3,7 @@
 use {
     super::{SnapshotError, SnapshotFrom},
     crate::serde_snapshot::{
-        reconstruct_single_storage, remap_and_reconstruct_single_storage,
-        snapshot_storage_lengths_from_fields, AccountsDbFields, SerdeObsoleteAccountsMap,
-        SerializableAccountStorageEntry,
+        reconstruct_single_storage, remap_and_reconstruct_single_storage, SerdeObsoleteAccountsMap,
     },
     agave_fs::FileInfo,
     crossbeam_channel::{select, unbounded, Receiver, Sender},
@@ -58,33 +56,6 @@ pub(crate) struct SnapshotStorageRebuilder {
 }
 
 impl SnapshotStorageRebuilder {
-    /// Synchronously spawns threads to rebuild snapshot storages
-    pub(crate) fn rebuild_storage(
-        accounts_db_fields: &AccountsDbFields<SerializableAccountStorageEntry>,
-        append_vec_files: Vec<FileInfo>,
-        file_receiver: Receiver<FileInfo>,
-        num_threads: usize,
-        next_append_vec_id: Arc<AtomicAccountsFileId>,
-        snapshot_from: SnapshotFrom,
-        storage_access: StorageAccess,
-        obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
-    ) -> Result<AccountStorageMap, SnapshotError> {
-        let snapshot_storage_lengths = snapshot_storage_lengths_from_fields(accounts_db_fields);
-
-        let account_storage_map = Self::spawn_rebuilder_threads(
-            file_receiver,
-            num_threads,
-            next_append_vec_id,
-            snapshot_storage_lengths,
-            append_vec_files,
-            snapshot_from,
-            storage_access,
-            obsolete_accounts,
-        )?;
-
-        Ok(account_storage_map)
-    }
-
     /// Create the SnapshotStorageRebuilder for storing state during rebuilding
     ///     - pre-allocates data for storage file infos
     fn new(
@@ -111,13 +82,15 @@ impl SnapshotStorageRebuilder {
         }
     }
 
+    /// Synchronously spawns threads to rebuild snapshot storages returning when they complete
+    ///
     /// Spawn threads for processing buffered append_vec_files, and then received files
-    fn spawn_rebuilder_threads(
+    pub(crate) fn spawn_rebuilder_threads(
+        snapshot_storage_lengths: HashMap<Slot, usize>,
+        append_vec_files: Vec<FileInfo>,
         file_receiver: Receiver<FileInfo>,
         num_threads: usize,
         next_append_vec_id: Arc<AtomicAccountsFileId>,
-        snapshot_storage_lengths: HashMap<Slot, usize>,
-        append_vec_files: Vec<FileInfo>,
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
         obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
@@ -206,7 +179,11 @@ impl SnapshotStorageRebuilder {
     fn process_complete_slot(&self, slot: Slot, file_info: FileInfo) -> Result<(), SnapshotError> {
         let filename = file_info.path.file_name().unwrap().to_str().unwrap();
         let (_, old_append_vec_id) = get_slot_and_append_vec_id(filename)?;
-        let current_len = *self.snapshot_storage_lengths.get(&slot).unwrap();
+        let Some(&current_len) = self.snapshot_storage_lengths.get(&slot) else {
+            return Err(SnapshotError::RebuildStorages(format!(
+                "append vec file {filename} for slot outside of expected range in snapshot"
+            )));
+        };
 
         let storage_entry = match &self.snapshot_from {
             SnapshotFrom::Archive => remap_and_reconstruct_single_storage(

--- a/snapshots/src/error.rs
+++ b/snapshots/src/error.rs
@@ -69,6 +69,9 @@ pub enum SnapshotError {
     #[error("snapshot epoch stakes are invalid: {0}")]
     VerifyEpochStakes(#[from] VerifyEpochStakesError),
 
+    #[error("slot in storages map {0} exceeds snapshot slot: {1}")]
+    MismatchedSnapshotStorageSlot(Slot, Slot),
+
     #[error("bank_snapshot_info new_from_dir failed: {0}")]
     NewFromDir(#[from] SnapshotNewFromDirError),
 


### PR DESCRIPTION
#### Problem
Rebuild storages gets `AccountsDbFields` and extracts lengths of storages from it creating a full map for all slots, which is then used to map encountered files.
This:
* unnecessarily populates the map for incremental archive with slots that are not expected
* doesn't actually prevent unexpected files to be populated in resulting storage map - currently we do not verify that files from incremental do not overlap with files / slots from full snapshot

There is code that attempts to do some validation later on when both full and incremental snapshot slot mapping is available, but currently its logic is mostly no-op and it doesn't verify the slots for actual rebuilt storages.

#### Summary of Changes
* filter slots in obtained storage lengths map before we start rebuilding storages
* validate that all files being rebuilt as storages match the expected list of slots (filtered to >base slot for incremental)
* also validate the all slots in the deserialized mapping are <= deserialized snapshot slot
* remove redundant and limited validation from later stage (since it operates only on the mapping, which contains all the slots, so it is unable to correctly verify non-overlap condition for full vs incremental)
