### PR TITLE
Made account storage entry Module

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -1,7 +1,7 @@
 //! Manage the map of slot -> append vec
 
 use {
-    crate::accounts_db::{AccountStorageEntry, AccountsFileId},
+    crate::{account_storage_entry::AccountStorageEntry, accounts_db::AccountsFileId},
     dashmap::DashMap,
     rand::seq::SliceRandom,
     rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},

--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -1,0 +1,257 @@
+use {
+    crate::{
+        account_info::Offset,
+        accounts_db::AccountsFileId,
+        accounts_file::{AccountsFile, AccountsFileError, AccountsFileProvider, StorageAccess},
+        obsolete_accounts::ObsoleteAccounts,
+    },
+    solana_clock::Slot,
+    solana_nohash_hasher::IntSet,
+    std::{
+        path::Path,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            RwLock, RwLockReadGuard,
+        },
+    },
+};
+
+/// Persistent storage structure holding the accounts
+#[derive(Debug)]
+pub struct AccountStorageEntry {
+    pub(crate) id: AccountsFileId,
+
+    pub(crate) slot: Slot,
+
+    /// storage holding the accounts
+    pub accounts: AccountsFile,
+
+    /// The number of alive accounts in this storage
+    pub(crate) count: AtomicUsize,
+
+    pub(crate) alive_bytes: AtomicUsize,
+
+    /// offsets to accounts that are zero lamport single ref stored in this
+    /// storage. These are still alive. But, shrink will be able to remove them.
+    ///
+    /// NOTE: It's possible that one of these zero lamport single ref accounts
+    /// could be written in a new transaction (and later rooted & flushed) and a
+    /// later clean runs and marks this account dead before this storage gets a
+    /// chance to be shrunk, thus making the account dead in both "alive_bytes"
+    /// and as a zero lamport single ref. If this happens, we will count this
+    /// account as "dead" twice. However, this should be fine. It just makes
+    /// shrink more likely to visit this storage.
+    zero_lamport_single_ref_offsets: RwLock<IntSet<Offset>>,
+
+    /// Obsolete Accounts. These are accounts that are still present in the storage
+    /// but should be ignored during rebuild. They have been removed
+    /// from the accounts index, so they will not be picked up by scan.
+    /// Slot is the slot at which the account is no longer needed.
+    /// Two scenarios cause an account entry to be marked obsolete
+    /// 1. The account was rewritten to a newer slot
+    /// 2. The account was set to zero lamports and is older than the last
+    ///    full snapshot. In this case, slot is set to the snapshot slot
+    pub(crate) obsolete_accounts: RwLock<ObsoleteAccounts>,
+}
+
+impl AccountStorageEntry {
+    pub fn new(
+        path: &Path,
+        slot: Slot,
+        id: AccountsFileId,
+        file_size: u64,
+        provider: AccountsFileProvider,
+        storage_access: StorageAccess,
+    ) -> Self {
+        let tail = AccountsFile::file_name(slot, id);
+        let path = Path::new(path).join(tail);
+        let accounts = provider.new_writable(path, file_size, storage_access);
+
+        Self {
+            id,
+            slot,
+            accounts,
+            count: AtomicUsize::new(0),
+            alive_bytes: AtomicUsize::new(0),
+            zero_lamport_single_ref_offsets: RwLock::default(),
+            obsolete_accounts: RwLock::default(),
+        }
+    }
+
+    /// open a new instance of the storage that is readonly
+    pub(crate) fn reopen_as_readonly(&self, storage_access: StorageAccess) -> Option<Self> {
+        if storage_access != StorageAccess::File {
+            // if we are only using mmap, then no reason to re-open
+            return None;
+        }
+
+        self.accounts.reopen_as_readonly().map(|accounts| Self {
+            id: self.id,
+            slot: self.slot,
+            count: AtomicUsize::new(self.count()),
+            alive_bytes: AtomicUsize::new(self.alive_bytes()),
+            accounts,
+            zero_lamport_single_ref_offsets: RwLock::new(
+                self.zero_lamport_single_ref_offsets.read().unwrap().clone(),
+            ),
+            obsolete_accounts: RwLock::new(self.obsolete_accounts.read().unwrap().clone()),
+        })
+    }
+
+    pub fn new_existing(
+        slot: Slot,
+        id: AccountsFileId,
+        accounts: AccountsFile,
+        obsolete_accounts: ObsoleteAccounts,
+    ) -> Self {
+        Self {
+            id,
+            slot,
+            accounts,
+            count: AtomicUsize::new(0),
+            alive_bytes: AtomicUsize::new(0),
+            zero_lamport_single_ref_offsets: RwLock::default(),
+            obsolete_accounts: RwLock::new(obsolete_accounts),
+        }
+    }
+
+    /// Returns the number of alive accounts in this storage
+    pub fn count(&self) -> usize {
+        self.count.load(Ordering::Acquire)
+    }
+
+    pub fn alive_bytes(&self) -> usize {
+        self.alive_bytes.load(Ordering::Acquire)
+    }
+
+    /// Returns the accounts that were marked obsolete as of the passed in slot
+    /// or earlier. Returned data includes the slots that the accounts were marked
+    /// obsolete at
+    pub fn obsolete_accounts_for_snapshots(&self, slot: Slot) -> ObsoleteAccounts {
+        self.obsolete_accounts_read_lock()
+            .obsolete_accounts_for_snapshots(slot)
+    }
+
+    /// Locks obsolete accounts with a read lock and returns the the accounts with the guard
+    pub(crate) fn obsolete_accounts_read_lock(&self) -> RwLockReadGuard<'_, ObsoleteAccounts> {
+        self.obsolete_accounts.read().unwrap()
+    }
+
+    /// Returns the number of bytes that were marked obsolete as of the passed
+    /// in slot or earlier. If slot is None, then slot will be assumed to be the
+    /// max root, and all obsolete bytes will be returned.
+    pub fn get_obsolete_bytes(&self, slot: Option<Slot>) -> usize {
+        let obsolete_bytes: usize = self
+            .obsolete_accounts_read_lock()
+            .filter_obsolete_accounts(slot)
+            .map(|(offset, data_len)| {
+                self.accounts
+                    .calculate_stored_size(data_len)
+                    .min(self.accounts.len() - offset)
+            })
+            .sum();
+        obsolete_bytes
+    }
+
+    /// Return true if offset is "new" and inserted successfully. Otherwise,
+    /// return false if the offset exists already.
+    pub(crate) fn insert_zero_lamport_single_ref_account_offset(&self, offset: usize) -> bool {
+        let mut zero_lamport_single_ref_offsets =
+            self.zero_lamport_single_ref_offsets.write().unwrap();
+        zero_lamport_single_ref_offsets.insert(offset)
+    }
+
+    /// Insert offsets into the zero lamport single ref account offset set.
+    /// Return the number of new offsets that were inserted.
+    pub(crate) fn batch_insert_zero_lamport_single_ref_account_offsets(
+        &self,
+        offsets: &[Offset],
+    ) -> u64 {
+        let mut zero_lamport_single_ref_offsets =
+            self.zero_lamport_single_ref_offsets.write().unwrap();
+        let mut count = 0;
+        for offset in offsets {
+            if zero_lamport_single_ref_offsets.insert(*offset) {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Return the number of zero_lamport_single_ref accounts in the storage.
+    pub(crate) fn num_zero_lamport_single_ref_accounts(&self) -> usize {
+        self.zero_lamport_single_ref_offsets.read().unwrap().len()
+    }
+
+    /// Return the "alive_bytes" minus "zero_lamport_single_ref_accounts bytes".
+    pub(crate) fn alive_bytes_exclude_zero_lamport_single_ref_accounts(&self) -> usize {
+        let zero_lamport_dead_bytes = self
+            .accounts
+            .dead_bytes_due_to_zero_lamport_single_ref(self.num_zero_lamport_single_ref_accounts());
+        self.alive_bytes().saturating_sub(zero_lamport_dead_bytes)
+    }
+
+    /// Returns the number of bytes used in this storage
+    pub fn written_bytes(&self) -> u64 {
+        self.accounts.len() as u64
+    }
+
+    /// Returns the number of bytes, not accounts, this storage can hold
+    pub fn capacity(&self) -> u64 {
+        self.accounts.capacity()
+    }
+
+    pub fn has_accounts(&self) -> bool {
+        self.count() > 0
+    }
+
+    pub fn slot(&self) -> Slot {
+        self.slot
+    }
+
+    pub fn id(&self) -> AccountsFileId {
+        self.id
+    }
+
+    pub fn flush(&self) -> Result<(), AccountsFileError> {
+        self.accounts.flush()
+    }
+
+    pub(crate) fn add_accounts(&self, num_accounts: usize, num_bytes: usize) {
+        self.count.fetch_add(num_accounts, Ordering::Release);
+        self.alive_bytes.fetch_add(num_bytes, Ordering::Release);
+    }
+
+    /// Removes `num_bytes` and `num_accounts` from the storage,
+    /// and returns the remaining number of accounts.
+    pub(crate) fn remove_accounts(&self, num_bytes: usize, num_accounts: usize) -> usize {
+        let prev_alive_bytes = self.alive_bytes.fetch_sub(num_bytes, Ordering::Release);
+        let prev_count = self.count.fetch_sub(num_accounts, Ordering::Release);
+
+        // enforce invariant that we're not removing too many bytes or accounts
+        assert!(
+            num_bytes <= prev_alive_bytes && num_accounts <= prev_count,
+            "Too many bytes or accounts removed from storage! slot: {}, id: {}, initial alive \
+             bytes: {prev_alive_bytes}, initial num accounts: {prev_count}, num bytes removed: \
+             {num_bytes}, num accounts removed: {num_accounts}",
+            self.slot,
+            self.id,
+        );
+
+        // SAFETY: subtraction is safe since we just asserted num_accounts <= prev_num_accounts
+        prev_count - num_accounts
+    }
+
+    /// Returns the path to the underlying accounts storage file
+    pub fn path(&self) -> &Path {
+        self.accounts.path()
+    }
+}
+
+#[cfg(test)]
+impl AccountStorageEntry {
+    // Function to modify the list in the account storage entry directly. Only intended for use in testing
+    pub(crate) fn obsolete_accounts(&self) -> &RwLock<ObsoleteAccounts> {
+        &self.obsolete_accounts
+    }
+}

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         account_info::Offset,
-        accounts_db::AccountStorageEntry,
+        account_storage_entry::AccountStorageEntry,
         accounts_file::{AccountsFile, InternalsForArchive},
     },
     solana_clock::Slot,
@@ -135,7 +135,8 @@ mod tests {
     use {
         super::*,
         crate::{
-            accounts_db::{get_temp_accounts_paths, AccountStorageEntry},
+            account_storage_entry::AccountStorageEntry,
+            accounts_db::get_temp_accounts_paths,
             accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
             ObsoleteAccounts,
         },

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -35,12 +35,13 @@ use {
             stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
             AccountStorage, AccountStoragesOrderer, ShrinkInProgress,
         },
+        account_storage_entry::AccountStorageEntry,
         accounts_cache::{AccountsCache, CachedAccount, SlotCache},
         accounts_db::stats::{
             AccountsStats, CleanAccountsStats, FlushStats, ObsoleteAccountsStats, PurgeStats,
             ShrinkAncientStats, ShrinkStats, ShrinkStatsSub, StoreAccountsTiming,
         },
-        accounts_file::{AccountsFile, AccountsFileError, AccountsFileProvider, StorageAccess},
+        accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
         accounts_hash::{AccountLtHash, AccountsLtHash, ZERO_LAMPORT_ACCOUNT_LT_HASH},
         accounts_index::{
             in_mem_accounts_index::StartupStats, AccountSecondaryIndexes, AccountsIndex,
@@ -53,7 +54,6 @@ use {
         append_vec::{self, AppendVec, STORE_META_OVERHEAD},
         contains::Contains,
         is_zero_lamport::IsZeroLamport,
-        obsolete_accounts::ObsoleteAccounts,
         partitioned_rewards::PartitionedEpochRewardsConfig,
         read_only_accounts_cache::ReadOnlyAccountsCache,
         storable_accounts::{StorableAccounts, StorableAccountsBySlot},
@@ -86,7 +86,7 @@ use {
         path::{Path, PathBuf},
         sync::{
             atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering},
-            Arc, Condvar, Mutex, RwLock, RwLockReadGuard,
+            Arc, Condvar, Mutex, RwLock,
         },
         thread::{self, sleep},
         time::{Duration, Instant},
@@ -796,236 +796,6 @@ struct CleanKeyTimings {
     oldest_dirty_slot: Slot,
     /// number of ancient append vecs that were scanned because they were dirty when clean started
     dirty_ancient_stores: usize,
-}
-
-/// Persistent storage structure holding the accounts
-#[derive(Debug)]
-pub struct AccountStorageEntry {
-    pub(crate) id: AccountsFileId,
-
-    pub(crate) slot: Slot,
-
-    /// storage holding the accounts
-    pub accounts: AccountsFile,
-
-    /// The number of alive accounts in this storage
-    count: AtomicUsize,
-
-    alive_bytes: AtomicUsize,
-
-    /// offsets to accounts that are zero lamport single ref stored in this
-    /// storage. These are still alive. But, shrink will be able to remove them.
-    ///
-    /// NOTE: It's possible that one of these zero lamport single ref accounts
-    /// could be written in a new transaction (and later rooted & flushed) and a
-    /// later clean runs and marks this account dead before this storage gets a
-    /// chance to be shrunk, thus making the account dead in both "alive_bytes"
-    /// and as a zero lamport single ref. If this happens, we will count this
-    /// account as "dead" twice. However, this should be fine. It just makes
-    /// shrink more likely to visit this storage.
-    zero_lamport_single_ref_offsets: RwLock<IntSet<Offset>>,
-
-    /// Obsolete Accounts. These are accounts that are still present in the storage
-    /// but should be ignored during rebuild. They have been removed
-    /// from the accounts index, so they will not be picked up by scan.
-    /// Slot is the slot at which the account is no longer needed.
-    /// Two scenarios cause an account entry to be marked obsolete
-    /// 1. The account was rewritten to a newer slot
-    /// 2. The account was set to zero lamports and is older than the last
-    ///    full snapshot. In this case, slot is set to the snapshot slot
-    obsolete_accounts: RwLock<ObsoleteAccounts>,
-}
-
-impl AccountStorageEntry {
-    pub fn new(
-        path: &Path,
-        slot: Slot,
-        id: AccountsFileId,
-        file_size: u64,
-        provider: AccountsFileProvider,
-        storage_access: StorageAccess,
-    ) -> Self {
-        let tail = AccountsFile::file_name(slot, id);
-        let path = Path::new(path).join(tail);
-        let accounts = provider.new_writable(path, file_size, storage_access);
-
-        Self {
-            id,
-            slot,
-            accounts,
-            count: AtomicUsize::new(0),
-            alive_bytes: AtomicUsize::new(0),
-            zero_lamport_single_ref_offsets: RwLock::default(),
-            obsolete_accounts: RwLock::default(),
-        }
-    }
-
-    /// open a new instance of the storage that is readonly
-    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-    fn reopen_as_readonly(&self, storage_access: StorageAccess) -> Option<Self> {
-        if storage_access != StorageAccess::File {
-            // if we are only using mmap, then no reason to re-open
-            return None;
-        }
-
-        self.accounts.reopen_as_readonly().map(|accounts| Self {
-            id: self.id,
-            slot: self.slot,
-            count: AtomicUsize::new(self.count()),
-            alive_bytes: AtomicUsize::new(self.alive_bytes()),
-            accounts,
-            zero_lamport_single_ref_offsets: RwLock::new(
-                self.zero_lamport_single_ref_offsets.read().unwrap().clone(),
-            ),
-            obsolete_accounts: RwLock::new(self.obsolete_accounts.read().unwrap().clone()),
-        })
-    }
-
-    pub fn new_existing(
-        slot: Slot,
-        id: AccountsFileId,
-        accounts: AccountsFile,
-        obsolete_accounts: ObsoleteAccounts,
-    ) -> Self {
-        Self {
-            id,
-            slot,
-            accounts,
-            count: AtomicUsize::new(0),
-            alive_bytes: AtomicUsize::new(0),
-            zero_lamport_single_ref_offsets: RwLock::default(),
-            obsolete_accounts: RwLock::new(obsolete_accounts),
-        }
-    }
-
-    /// Returns the number of alive accounts in this storage
-    pub fn count(&self) -> usize {
-        self.count.load(Ordering::Acquire)
-    }
-
-    pub fn alive_bytes(&self) -> usize {
-        self.alive_bytes.load(Ordering::Acquire)
-    }
-
-    /// Returns the accounts that were marked obsolete as of the passed in slot
-    /// or earlier. Returned data includes the slots that the accounts were marked
-    /// obsolete at
-    pub fn obsolete_accounts_for_snapshots(&self, slot: Slot) -> ObsoleteAccounts {
-        self.obsolete_accounts_read_lock()
-            .obsolete_accounts_for_snapshots(slot)
-    }
-
-    /// Locks obsolete accounts with a read lock and returns the the accounts with the guard
-    pub(crate) fn obsolete_accounts_read_lock(&self) -> RwLockReadGuard<'_, ObsoleteAccounts> {
-        self.obsolete_accounts.read().unwrap()
-    }
-
-    /// Returns the number of bytes that were marked obsolete as of the passed
-    /// in slot or earlier. If slot is None, then slot will be assumed to be the
-    /// max root, and all obsolete bytes will be returned.
-    pub fn get_obsolete_bytes(&self, slot: Option<Slot>) -> usize {
-        let obsolete_bytes: usize = self
-            .obsolete_accounts_read_lock()
-            .filter_obsolete_accounts(slot)
-            .map(|(offset, data_len)| {
-                self.accounts
-                    .calculate_stored_size(data_len)
-                    .min(self.accounts.len() - offset)
-            })
-            .sum();
-        obsolete_bytes
-    }
-
-    /// Return true if offset is "new" and inserted successfully. Otherwise,
-    /// return false if the offset exists already.
-    fn insert_zero_lamport_single_ref_account_offset(&self, offset: usize) -> bool {
-        let mut zero_lamport_single_ref_offsets =
-            self.zero_lamport_single_ref_offsets.write().unwrap();
-        zero_lamport_single_ref_offsets.insert(offset)
-    }
-
-    /// Insert offsets into the zero lamport single ref account offset set.
-    /// Return the number of new offsets that were inserted.
-    fn batch_insert_zero_lamport_single_ref_account_offsets(&self, offsets: &[Offset]) -> u64 {
-        let mut zero_lamport_single_ref_offsets =
-            self.zero_lamport_single_ref_offsets.write().unwrap();
-        let mut count = 0;
-        for offset in offsets {
-            if zero_lamport_single_ref_offsets.insert(*offset) {
-                count += 1;
-            }
-        }
-        count
-    }
-
-    /// Return the number of zero_lamport_single_ref accounts in the storage.
-    fn num_zero_lamport_single_ref_accounts(&self) -> usize {
-        self.zero_lamport_single_ref_offsets.read().unwrap().len()
-    }
-
-    /// Return the "alive_bytes" minus "zero_lamport_single_ref_accounts bytes".
-    fn alive_bytes_exclude_zero_lamport_single_ref_accounts(&self) -> usize {
-        let zero_lamport_dead_bytes = self
-            .accounts
-            .dead_bytes_due_to_zero_lamport_single_ref(self.num_zero_lamport_single_ref_accounts());
-        self.alive_bytes().saturating_sub(zero_lamport_dead_bytes)
-    }
-
-    /// Returns the number of bytes used in this storage
-    pub fn written_bytes(&self) -> u64 {
-        self.accounts.len() as u64
-    }
-
-    /// Returns the number of bytes, not accounts, this storage can hold
-    pub fn capacity(&self) -> u64 {
-        self.accounts.capacity()
-    }
-
-    pub fn has_accounts(&self) -> bool {
-        self.count() > 0
-    }
-
-    pub fn slot(&self) -> Slot {
-        self.slot
-    }
-
-    pub fn id(&self) -> AccountsFileId {
-        self.id
-    }
-
-    pub fn flush(&self) -> Result<(), AccountsFileError> {
-        self.accounts.flush()
-    }
-
-    fn add_accounts(&self, num_accounts: usize, num_bytes: usize) {
-        self.count.fetch_add(num_accounts, Ordering::Release);
-        self.alive_bytes.fetch_add(num_bytes, Ordering::Release);
-    }
-
-    /// Removes `num_bytes` and `num_accounts` from the storage,
-    /// and returns the remaining number of accounts.
-    fn remove_accounts(&self, num_bytes: usize, num_accounts: usize) -> usize {
-        let prev_alive_bytes = self.alive_bytes.fetch_sub(num_bytes, Ordering::Release);
-        let prev_count = self.count.fetch_sub(num_accounts, Ordering::Release);
-
-        // enforce invariant that we're not removing too many bytes or accounts
-        assert!(
-            num_bytes <= prev_alive_bytes && num_accounts <= prev_count,
-            "Too many bytes or accounts removed from storage! slot: {}, id: {}, initial alive \
-             bytes: {prev_alive_bytes}, initial num accounts: {prev_count}, num bytes removed: \
-             {num_bytes}, num accounts removed: {num_accounts}",
-            self.slot,
-            self.id,
-        );
-
-        // SAFETY: subtraction is safe since we just asserted num_accounts <= prev_num_accounts
-        prev_count - num_accounts
-    }
-
-    /// Returns the path to the underlying accounts storage file
-    pub fn path(&self) -> &Path {
-        self.accounts.path()
-    }
 }
 
 pub fn get_temp_accounts_paths(count: u32) -> io::Result<(Vec<TempDir>, Vec<PathBuf>)> {
@@ -7171,14 +6941,6 @@ impl AccountStorageEntry {
             })
             .expect("must scan accounts storage");
         count
-    }
-}
-
-#[cfg(test)]
-impl AccountStorageEntry {
-    // Function to modify the list in the account storage entry directly. Only intended for use in testing
-    pub(crate) fn obsolete_accounts(&self) -> &RwLock<ObsoleteAccounts> {
-        &self.obsolete_accounts
     }
 }
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -7,11 +7,11 @@
 use {
     crate::{
         account_storage::ShrinkInProgress,
+        account_storage_entry::AccountStorageEntry,
         accounts_db::{
             stats::{ShrinkAncientStats, ShrinkStatsSub},
-            AccountFromStorage, AccountStorageEntry, AccountsDb, AliveAccounts,
-            GetUniqueAccountsResult, ShrinkCollect, ShrinkCollectAliveSeparatedByRefs,
-            UpdateIndexThreadSelection,
+            AccountFromStorage, AccountsDb, AliveAccounts, GetUniqueAccountsResult, ShrinkCollect,
+            ShrinkCollectAliveSeparatedByRefs, UpdateIndexThreadSelection,
         },
         active_stats::ActiveStatItem,
         storable_accounts::{StorableAccounts, StorableAccountsBySlot},

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod account_info;
 pub mod account_locks;
 pub mod account_storage;
+pub mod account_storage_entry;
 pub mod account_storage_reader;
 pub mod accounts;
 mod accounts_cache;

--- a/accounts-db/src/sorted_storages.rs
+++ b/accounts-db/src/sorted_storages.rs
@@ -1,5 +1,5 @@
 use {
-    crate::accounts_db::AccountStorageEntry,
+    crate::account_storage_entry::AccountStorageEntry,
     log::*,
     solana_clock::Slot,
     solana_measure::measure::Measure,
@@ -195,7 +195,8 @@ mod tests {
     use {
         super::*,
         crate::{
-            accounts_db::{AccountStorageEntry, AccountsFileId},
+            account_storage_entry::AccountStorageEntry,
+            accounts_db::AccountsFileId,
             accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
             append_vec::AppendVec,
         },

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -2,7 +2,8 @@
 use {
     crate::{
         account_storage::stored_account_info::StoredAccountInfo,
-        accounts_db::{AccountFromStorage, AccountStorageEntry, AccountsDb},
+        account_storage_entry::AccountStorageEntry,
+        accounts_db::{AccountFromStorage, AccountsDb},
         is_zero_lamport::IsZeroLamport,
         utils::create_account_shared_data,
     },
@@ -363,7 +364,8 @@ pub mod tests {
         super::*,
         crate::{
             account_info::{AccountInfo, StorageLocation},
-            accounts_db::{get_temp_accounts_paths, AccountStorageEntry},
+            account_storage_entry::AccountStorageEntry,
+            accounts_db::get_temp_accounts_paths,
             accounts_file::AccountsFileProvider,
         },
         rand::Rng,

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -5,7 +5,7 @@ use {
         snapshot_hash::StartingSnapshotHashes, SnapshotKind,
     },
     snapshot_gossip_manager::SnapshotGossipManager,
-    solana_accounts_db::accounts_db::AccountStorageEntry,
+    solana_accounts_db::account_storage_entry::AccountStorageEntry,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::{meas_dur, measure::Measure, measure_us},

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -84,8 +84,9 @@ use {
     },
     solana_accounts_db::{
         account_locks::validate_account_locks,
+        account_storage_entry::AccountStorageEntry,
         accounts::{AccountAddressFilter, Accounts, PubkeyAccountSlot},
-        accounts_db::{AccountStorageEntry, AccountsDb, AccountsDbConfig},
+        accounts_db::{AccountsDb, AccountsDbConfig},
         accounts_hash::AccountsLtHash,
         accounts_index::{IndexKey, ScanConfig, ScanResult},
         accounts_update_notifier_interface::AccountsUpdateNotifier,

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -345,7 +345,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "6TVD4xhoKHV6mMFHotMJ2UMdraAffjmfVRHRZEJguzoC")
+            frozen_abi(digest = "368HqLKrMhTVTbue6c2SvgKmuzRGdvZUjNLFYL8BXBwj")
         )]
         #[derive(serde::Serialize)]
         pub struct BankAbiTestWrapper {

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -14,8 +14,9 @@ mod tests {
         agave_snapshots::snapshot_config::SnapshotConfig,
         solana_accounts_db::{
             account_storage::AccountStorageMap,
+            account_storage_entry::AccountStorageEntry,
             accounts_db::{
-                get_temp_accounts_paths, AccountStorageEntry, AccountsDb, AtomicAccountsFileId,
+                get_temp_accounts_paths, AccountsDb, AtomicAccountsFileId,
                 ACCOUNTS_DB_CONFIG_FOR_TESTING,
             },
             accounts_file::{AccountsFile, AccountsFileError, StorageAccess},

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -20,10 +20,10 @@ use {
     serde::{de::DeserializeOwned, Deserialize, Serialize},
     smallvec::SmallVec,
     solana_accounts_db::{
+        account_storage_entry::AccountStorageEntry,
         accounts::Accounts,
         accounts_db::{
-            AccountStorageEntry, AccountsDb, AccountsDbConfig, AccountsFileId,
-            AtomicAccountsFileId, IndexGenerationInfo,
+            AccountsDb, AccountsDbConfig, AccountsFileId, AtomicAccountsFileId, IndexGenerationInfo,
         },
         accounts_file::{AccountsFile, StorageAccess},
         accounts_hash::AccountsLtHash,

--- a/runtime/src/serde_snapshot/obsolete_accounts.rs
+++ b/runtime/src/serde_snapshot/obsolete_accounts.rs
@@ -4,9 +4,8 @@ use {
     rayon::iter::{IntoParallelRefIterator, ParallelIterator},
     serde::{Deserialize, Serialize},
     solana_accounts_db::{
-        account_info::Offset,
-        accounts_db::{AccountStorageEntry, AccountsFileId},
-        ObsoleteAccountItem, ObsoleteAccounts,
+        account_info::Offset, account_storage_entry::AccountStorageEntry,
+        accounts_db::AccountsFileId, ObsoleteAccountItem, ObsoleteAccounts,
     },
     solana_clock::Slot,
     std::sync::Arc,

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -1,6 +1,6 @@
 use {
     serde::{Deserialize, Serialize},
-    solana_accounts_db::accounts_db::AccountStorageEntry,
+    solana_accounts_db::account_storage_entry::AccountStorageEntry,
     solana_clock::Slot,
 };
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -16,11 +16,12 @@ mod serde_snapshot_tests {
         solana_account::{AccountSharedData, ReadableAccount},
         solana_accounts_db::{
             account_storage::AccountStorageMap,
+            account_storage_entry::AccountStorageEntry,
             account_storage_reader::AccountStorageReader,
             accounts::Accounts,
             accounts_db::{
-                get_temp_accounts_paths, AccountStorageEntry, AccountsDb, AccountsDbConfig,
-                AtomicAccountsFileId, MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING,
+                get_temp_accounts_paths, AccountsDb, AccountsDbConfig, AtomicAccountsFileId,
+                MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING,
             },
             accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
             ancestors::Ancestors,

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -12,9 +12,9 @@ use {
     },
     solana_account::{state_traits::StateMut, ReadableAccount},
     solana_accounts_db::{
+        account_storage_entry::AccountStorageEntry,
         accounts_db::{
-            stats::PurgeStats, AccountStorageEntry, AccountsDb, GetUniqueAccountsResult,
-            UpdateIndexThreadSelection,
+            stats::PurgeStats, AccountsDb, GetUniqueAccountsResult, UpdateIndexThreadSelection,
         },
         storable_accounts::StorableAccountsBySlot,
     },

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -3,7 +3,7 @@ use solana_hash::Hash;
 use {
     crate::bank::{Bank, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
     agave_snapshots::{snapshot_hash::SnapshotHash, SnapshotArchiveKind, SnapshotKind},
-    solana_accounts_db::accounts_db::AccountStorageEntry,
+    solana_accounts_db::account_storage_entry::AccountStorageEntry,
     solana_clock::Slot,
     std::{sync::Arc, time::Instant},
 };

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -36,7 +36,8 @@ use {
     semver::Version,
     solana_accounts_db::{
         account_storage::AccountStorageMap,
-        accounts_db::{AccountStorageEntry, AccountsDbConfig, AtomicAccountsFileId},
+        account_storage_entry::AccountStorageEntry,
+        accounts_db::{AccountsDbConfig, AtomicAccountsFileId},
         accounts_file::{AccountsFile, StorageAccess},
         utils::{move_and_async_delete_path, ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR},
     },

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -6,8 +6,8 @@ use {
     agave_fs::buffered_writer::large_file_buf_writer,
     log::info,
     solana_accounts_db::{
-        account_storage::AccountStoragesOrderer, account_storage_reader::AccountStorageReader,
-        accounts_db::AccountStorageEntry, accounts_file::AccountsFile,
+        account_storage::AccountStoragesOrderer, account_storage_entry::AccountStorageEntry,
+        account_storage_reader::AccountStorageReader, accounts_file::AccountsFile,
     },
     solana_clock::Slot,
     solana_measure::measure::Measure,


### PR DESCRIPTION
#### Problem
Account Storage Entry type should have its own file separate from accounts db

#### Summary of Changes
- Moved account storage entry to own file
- Made various functions/types pub (crate) to avoid any other changes (can clean up later!)
- Updated dependencies across the board

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
