### PR TITLE
Refactors AppendVec's stored_size fns

### DIFF
--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -136,7 +136,7 @@ fn bench_scan_pubkeys(c: &mut Criterion) {
         _ = std::fs::remove_file(&append_vec_path);
         let file_size = storable_accounts
             .iter()
-            .map(|(_, account)| append_vec::aligned_stored_size(account.data().len()))
+            .map(|(_, account)| AppendVec::calculate_stored_size(account.data().len()))
             .sum();
         let append_vec = AppendVec::new(append_vec_path, true, file_size, StorageAccess::File);
         let stored_accounts_info = append_vec
@@ -226,7 +226,7 @@ fn bench_get_account_shared_data(c: &mut Criterion) {
         _ = std::fs::remove_file(&append_vec_path);
         let file_size = storable_accounts
             .iter()
-            .map(|(_, account)| append_vec::aligned_stored_size(account.data().len()))
+            .map(|(_, account)| AppendVec::calculate_stored_size(account.data().len()))
             .sum();
         let append_vec = AppendVec::new(append_vec_path, true, file_size, StorageAccess::File);
         let stored_accounts_info = append_vec

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -50,7 +50,7 @@ use {
         accounts_update_notifier_interface::{AccountForGeyser, AccountsUpdateNotifier},
         active_stats::{ActiveStatItem, ActiveStats},
         ancestors::Ancestors,
-        append_vec::{self, aligned_stored_size, STORE_META_OVERHEAD},
+        append_vec::{self, AppendVec, STORE_META_OVERHEAD},
         contains::Contains,
         is_zero_lamport::IsZeroLamport,
         obsolete_accounts::ObsoleteAccounts,
@@ -317,7 +317,7 @@ impl AccountFromStorage {
         &self.pubkey
     }
     pub fn stored_size(&self) -> usize {
-        aligned_stored_size(self.data_len as usize)
+        AppendVec::calculate_stored_size(self.data_len as usize)
     }
     pub fn data_len(&self) -> usize {
         self.data_len as usize
@@ -5024,7 +5024,7 @@ impl AccountsDb {
                     .unwrap_or(true);
                 if should_flush {
                     flush_stats.num_bytes_flushed +=
-                        aligned_stored_size(account.data().len()) as u64;
+                        AppendVec::calculate_stored_size(account.data().len()) as u64;
                     flush_stats.num_accounts_flushed += 1;
                     Some((key, account))
                 } else {
@@ -5032,7 +5032,7 @@ impl AccountsDb {
                     // index, since it's equivalent to purging
                     pubkeys.push(*key);
                     flush_stats.num_bytes_purged +=
-                        aligned_stored_size(account.data().len()) as u64;
+                        AppendVec::calculate_stored_size(account.data().len()) as u64;
                     flush_stats.num_accounts_purged += 1;
                     None
                 }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1125,7 +1125,7 @@ pub mod tests {
             accounts_index::{
                 AccountsIndexScanResult, ReclaimsSlotList, RefCount, ScanFilter, UpsertReclaim,
             },
-            append_vec::{self, aligned_stored_size},
+            append_vec::{self, AppendVec},
             storable_accounts::StorableAccountsBySlot,
             utils::create_account_shared_data,
         },
@@ -1265,7 +1265,7 @@ pub mod tests {
                         bytes: accounts
                             .stored_accounts
                             .iter()
-                            .map(|account| aligned_stored_size(account.data_len()))
+                            .map(|account| AppendVec::calculate_stored_size(account.data_len()))
                             .sum(),
                         slot,
                     })
@@ -1344,7 +1344,7 @@ pub mod tests {
                         bytes: accounts
                             .stored_accounts
                             .iter()
-                            .map(|account| aligned_stored_size(account.data_len()))
+                            .map(|account| AppendVec::calculate_stored_size(account.data_len()))
                             .sum(),
                         slot,
                     })
@@ -1454,7 +1454,7 @@ pub mod tests {
                         bytes: accounts
                             .stored_accounts
                             .iter()
-                            .map(|account| aligned_stored_size(account.data_len()))
+                            .map(|account| AppendVec::calculate_stored_size(account.data_len()))
                             .sum(),
                         slot,
                     })
@@ -1465,7 +1465,7 @@ pub mod tests {
                     NonZeroU64::new(ideal_size).unwrap(),
                 );
 
-                let largest_account_size = aligned_stored_size(data_size) as u64;
+                let largest_account_size = AppendVec::calculate_stored_size(data_size) as u64;
                 // all packed storages should be close to ideal size
                 result.iter().enumerate().for_each(|(i, packed)| {
                     if i + 1 < result.len() && ideal_size > largest_account_size {
@@ -1505,7 +1505,10 @@ pub mod tests {
                             .iter()
                             .map(|(_slot, accounts)| accounts
                                 .iter()
-                                .map(|account| aligned_stored_size(account.data_len()) as u64)
+                                .map(
+                                    |account| AppendVec::calculate_stored_size(account.data_len())
+                                        as u64
+                                )
                                 .sum::<u64>())
                             .sum::<u64>()
                     );
@@ -1636,7 +1639,7 @@ pub mod tests {
         agave_logger::setup();
 
         let data_size = 48;
-        let alive_bytes_per_slot = aligned_stored_size(data_size as usize) as u64;
+        let alive_bytes_per_slot = AppendVec::calculate_stored_size(data_size as usize) as u64;
 
         // pack 2.5 ancient slots into 1 packed slot ideally
         let tuning = PackedAncientStorageTuning {
@@ -1740,7 +1743,7 @@ pub mod tests {
         // 1 account each
         // all accounts have 1 ref or all accounts have 2 refs
         let data_size = 48;
-        let alive_bytes_per_account = aligned_stored_size(data_size as usize) as u64;
+        let alive_bytes_per_account = AppendVec::calculate_stored_size(data_size as usize) as u64;
 
         // pack 1 account into a slot ideally
         let tuning = PackedAncientStorageTuning {
@@ -3177,7 +3180,9 @@ pub mod tests {
                             bytes,
                             initial_accounts
                                 .iter()
-                                .map(|(_, account)| aligned_stored_size(account.data().len()) as u64)
+                                .map(|(_, account)| AppendVec::calculate_stored_size(
+                                    account.data().len()
+                                ) as u64)
                                 .sum::<u64>()
                         );
 


### PR DESCRIPTION
#### Problem

The AppendVec meta fields for stored size, `StoredAccountMeta::stored_size` and `StoredAccountNoData::stored_size`, always include the alignment padding. The stored size *is* the aligned stored size. However, in the append vec code, we sometimes have both unaligned and aligned stored size variables/calculations/etc next to each other, in the same functions, with the same names. I end up needing to trace the field/fn definitions to double check each one to know if it is unaligned or aligned.

Zooming out, I think since "stored size" always includes alignment, then anytime we want/use stored size that is *unaligned*, we should say so explicitly.

Lastly, we have duplication for fns that calculate the stored size. That's easy to clean up.


#### Summary of Changes

* Uses of *unaligned* stored size now are explicit
* Refactor and unify the fns that calculate stored size