### PR TITLE
chore: remove dead ClosedStream variant from QuicError

### DIFF
--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -7,9 +7,8 @@ use {
     futures::future::TryFutureExt,
     log::*,
     quinn::{
-        crypto::rustls::QuicClientConfig, ClientConfig, ClosedStream, ConnectError, Connection,
-        ConnectionError, Endpoint, EndpointConfig, IdleTimeout, TokioRuntime, TransportConfig,
-        WriteError,
+        crypto::rustls::QuicClientConfig, ClientConfig, ConnectError, Connection, ConnectionError,
+        Endpoint, EndpointConfig, IdleTimeout, TokioRuntime, TransportConfig, WriteError,
     },
     solana_connection_cache::{
         client_connection::ClientStats, connection_cache_stats::ConnectionCacheStats,
@@ -52,8 +51,6 @@ pub enum QuicError {
     ConnectionError(#[from] ConnectionError),
     #[error(transparent)]
     ConnectError(#[from] ConnectError),
-    #[error(transparent)]
-    ClosedStream(#[from] ClosedStream),
 }
 
 impl From<QuicError> for ClientErrorKind {


### PR DESCRIPTION
#### Problem


The ClosedStream variant in `QuicError` was never constructed in practice. All stream write operations use `quinn::SendStream::write_all`, which returns `WriteError`, and `ClosedStream` is already represented as `WriteError::ClosedStream`. Keeping a separate ClosedStream branch in QuicError was redundant and could not be hit at runtime, while similar logic in tpu-client-next only matches on WriteError::ClosedStream. This change removes the unused import and enum variant to make the error type minimal and consistent with the rest of the codebase.


