### PR TITLE
Do not concatenate dedup maps

### DIFF
--- a/transaction-context/src/instruction.rs
+++ b/transaction-context/src/instruction.rs
@@ -6,12 +6,12 @@ use {
             GUEST_REGION_SIZE,
         },
         vm_slice::VmSlice,
-        IndexOfAccount, InstructionAccount, TransactionContext, MAX_ACCOUNTS_PER_TRANSACTION,
+        IndexOfAccount, InstructionAccount, TransactionContext,
     },
     solana_account::ReadableAccount,
     solana_instruction::error::InstructionError,
     solana_pubkey::Pubkey,
-    std::{collections::HashSet, ops::Range},
+    std::collections::HashSet,
 };
 
 /// Instruction shared between runtime and programs.
@@ -37,14 +37,6 @@ impl Default for InstructionFrame {
 }
 
 impl InstructionFrame {
-    /// This function retrieves the range to index transaction_context.deduplication_maps
-    pub fn deduplication_map_range(instruction_index: usize) -> Range<usize> {
-        instruction_index.saturating_mul(MAX_ACCOUNTS_PER_TRANSACTION)
-            ..instruction_index
-                .saturating_add(1)
-                .saturating_mul(MAX_ACCOUNTS_PER_TRANSACTION)
-    }
-
     pub fn configure_vm_slices(
         &mut self,
         instruction_index: u64,


### PR DESCRIPTION
#### Problem

Since we are not sharing the deduplication maps with programs, I think it is not necessary to concatenate all of them in the same array. Doing that increases code complexity.

#### Summary of Changes

1. Push all maps to a vector instead of concatenating everything.
2. Fix the preallocation values that were wrong.
3. Fix comments.
