### PR TITLE
Save fastboot snapshot when exiting validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Release channels have their own copy of this changelog:
 * Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.
 #### Changes
 * `agave-validator exit` now saves bank state before exiting. This enables restarts from local state when snapshot generation is disabled.
+### CLI
 #### Changes
 * Support Trezor hardware wallets using `usb://trezor`
 ### Platform tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Release channels have their own copy of this changelog:
 #### Deprecations
 * Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.
 #### Changes
-* `agave-validator exit` now saves bank state before exiting. This enables restarts from local state when other snapshots are disabled.
+* `agave-validator exit` now saves bank state before exiting. This enables restarts from local state when snapshot generation disabled.
 #### Changes
 * Support Trezor hardware wallets using `usb://trezor`
 ### Platform tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,7 @@ Release channels have their own copy of this changelog:
 #### Deprecations
 * Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.
 #### Changes
-* When running the cli command agave-validator exit, the validator will now create a fastboot snapshot. This is a minimal snapshot which does not include archives. This snapshot allows for fastboot when all other snapshots are disabled.
-### CLI
+* `agave-validator exit` now saves bank state before exiting. This enables restarts from local state when other snapshots are disabled.
 #### Changes
 * Support Trezor hardware wallets using `usb://trezor`
 ### Platform tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Release channels have their own copy of this changelog:
   * `--wait-for-exit` (`exit` subcommand)
 #### Deprecations
 * Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.
+#### Changes
+* When running the cli command agave-validator exit, the validator will now create a fastboot snapshot. This is a minimal snapshot which does not include archives. This snapshot allows for fastboot when all other snapshots are disabled.
 ### CLI
 #### Changes
 * Support Trezor hardware wallets using `usb://trezor`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Release channels have their own copy of this changelog:
 #### Deprecations
 * Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.
 #### Changes
-* `agave-validator exit` now saves bank state before exiting. This enables restarts from local state when snapshot generation disabled.
+* `agave-validator exit` now saves bank state before exiting. This enables restarts from local state when snapshot generation is disabled.
 #### Changes
 * Support Trezor hardware wallets using `usb://trezor`
 ### Platform tools

--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -7,7 +7,7 @@ use {
     solana_gossip::{cluster_info::ClusterInfo, node::NodeMultihoming},
     solana_pubkey::Pubkey,
     solana_quic_definitions::NotifyKeyUpdate,
-    solana_runtime::bank_forks::BankForks,
+    solana_runtime::{bank_forks::BankForks, snapshot_controller::SnapshotController},
     std::{
         collections::{HashMap, HashSet},
         net::UdpSocket,
@@ -82,4 +82,5 @@ pub struct AdminRpcRequestMetadataPostInit {
     pub cluster_slots: Arc<ClusterSlots>,
     pub node: Option<Arc<NodeMultihoming>>,
     pub banking_control_sender: mpsc::Sender<BankingControlMsg>,
+    pub snapshot_controller: Arc<SnapshotController>,
 }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -85,6 +85,8 @@ impl SnapshotPackagerService {
                     let snapshot_slot = snapshot_package.slot;
                     let snapshot_hash = snapshot_package.hash;
 
+                    snapshot_controller.set_latest_bank_snapshot_slot(snapshot_slot);
+
                     if exit_backpressure.is_some() {
                         // With exit backpressure, we will delay flushing snapshot storages
                         // until we receive a graceful exit request.

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1810,6 +1810,7 @@ impl Validator {
             cluster_slots,
             node: Some(node_multihoming),
             banking_control_sender,
+            snapshot_controller,
         });
 
         Ok(Self {

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -867,7 +867,7 @@ fn test_fastboot_snapshots_teardown(exit_backpressure: bool) {
     exit.store(true, Ordering::Relaxed);
     let packager_exit_result = snapshot_packager_service.join();
     assert!(packager_exit_result.is_ok());
-    assert!(snapshot_controller.latest_bank_snapshot_slot() == LAST_SLOT);
+    assert_eq!(snapshot_controller.latest_bank_snapshot_slot(), LAST_SLOT);
 
     // verify that the fastboot snapshot was written and can be restored from
     let bank_snapshot = snapshot_utils::get_highest_bank_snapshot(

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -867,6 +867,7 @@ fn test_fastboot_snapshots_teardown(exit_backpressure: bool) {
     exit.store(true, Ordering::Relaxed);
     let packager_exit_result = snapshot_packager_service.join();
     assert!(packager_exit_result.is_ok());
+    assert!(snapshot_controller.latest_bank_snapshot_slot() == LAST_SLOT);
 
     // verify that the fastboot snapshot was written and can be restored from
     let bank_snapshot = snapshot_utils::get_highest_bank_snapshot(

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -28,6 +28,7 @@ pub struct SnapshotController {
     snapshot_config: SnapshotConfig,
     latest_abs_request_slot: AtomicU64,
     request_fastboot_snapshot: AtomicBool,
+    latest_bank_snapshot_slot: AtomicU64,
 }
 
 impl SnapshotController {
@@ -41,6 +42,7 @@ impl SnapshotController {
             snapshot_config,
             latest_abs_request_slot: AtomicU64::new(root_slot),
             request_fastboot_snapshot: AtomicBool::new(false),
+            latest_bank_snapshot_slot: AtomicU64::new(root_slot),
         }
     }
 
@@ -65,6 +67,15 @@ impl SnapshotController {
     pub fn request_fastboot_snapshot(&self) {
         self.request_fastboot_snapshot
             .store(true, Ordering::Relaxed);
+    }
+
+    pub fn latest_bank_snapshot_slot(&self) -> Slot {
+        self.latest_bank_snapshot_slot.load(Ordering::Relaxed)
+    }
+
+    pub fn set_latest_bank_snapshot_slot(&self, slot: Slot) {
+        self.latest_bank_snapshot_slot
+            .store(slot, Ordering::Relaxed);
     }
 
     pub fn handle_new_roots(&self, root: Slot, banks: &[&Arc<Bank>]) -> (bool, SquashTiming, u64) {

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -41,7 +41,7 @@ use {
             Arc, RwLock,
         },
         thread::{self, Builder},
-        time::{Duration, SystemTime},
+        time::{Duration, Instant, SystemTime},
     },
     tokio::runtime::Runtime,
 };
@@ -295,9 +295,32 @@ impl AdminRpc for AdminRpcImpl {
         thread::Builder::new()
             .name("solProcessExit".into())
             .spawn(move || {
-                // Delay exit signal until this RPC request completes, otherwise the caller of `exit` might
-                // receive a confusing error as the validator shuts down before a response is sent back.
-                thread::sleep(Duration::from_millis(100));
+                // Extract the snapshot controller if it exists
+                let binding = meta.post_init.read().unwrap();
+                let snapshot_controller = binding
+                    .as_ref()
+                    .map(|post_init| post_init.snapshot_controller.as_ref());
+
+                if let Some(snapshot_controller) = snapshot_controller {
+                    let latest_snapshot_slot = snapshot_controller.latest_bank_snapshot_slot();
+
+                    info!("Requesting fastboot snapshot before exit");
+                    snapshot_controller.request_fastboot_snapshot();
+
+                    // Wait up to 5s for a snapshot to finish. This should allow time for the
+                    // fastboot snapshot to complete without stalling exit indefinitely.
+                    // The timeout will be hit in the event new roots are not being created.
+                    let timeout = Duration::from_secs(5);
+                    let start_time = Instant::now();
+                    while snapshot_controller.latest_bank_snapshot_slot() == latest_snapshot_slot {
+                        if start_time.elapsed() > timeout {
+                            warn!("Timeout waiting for snapshot to complete");
+                            break;
+                        }
+                        thread::sleep(Duration::from_millis(100));
+                    }
+                    info!("Completed waiting for new snapshot in {:?}", start_time.elapsed());
+                }
 
                 info!("validator exit requested");
                 meta.validator_exit.write().unwrap().exit();
@@ -1030,6 +1053,8 @@ pub fn load_staked_nodes_overrides(
 mod tests {
     use {
         super::*,
+        agave_snapshots::snapshot_config::SnapshotConfig,
+        crossbeam_channel::unbounded,
         serde_json::Value,
         solana_account::{Account, AccountSharedData},
         solana_accounts_db::{
@@ -1056,6 +1081,7 @@ mod tests {
         solana_runtime::{
             bank::{Bank, BankTestConfig},
             bank_forks::BankForks,
+            snapshot_controller::SnapshotController,
         },
         solana_system_interface::program as system_program,
         solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
@@ -1102,6 +1128,14 @@ mod tests {
                     ..ACCOUNTS_DB_CONFIG_FOR_TESTING
                 },
             });
+
+            let (snapshot_request_sender, _) = unbounded();
+            let snapshot_controller = Arc::new(SnapshotController::new(
+                snapshot_request_sender.clone(),
+                SnapshotConfig::default(),
+                bank_forks.read().unwrap().root(),
+            ));
+
             let vote_account = vote_keypair.pubkey();
             let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
             let repair_whitelist = Arc::new(RwLock::new(HashSet::new()));
@@ -1128,6 +1162,7 @@ mod tests {
                     ),
                     node: None,
                     banking_control_sender: mpsc::channel(1).0,
+                    snapshot_controller,
                 }))),
                 staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
                 rpc_to_plugin_manager_sender: None,

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -318,7 +318,7 @@ impl AdminRpc for AdminRpcImpl {
                             warn!("Timeout waiting for snapshot to complete");
                             datapoint_warn!(
                                 "admin-rpc-snapshot-timeout",
-                                ("timeout_msecs", start_time.elapsed().as_millis(), i64)
+                                ("timeout_us", start_time.elapsed().as_micros(), i64)
                             );
                             break;
                         }


### PR DESCRIPTION
#### Problem
Previously fastbooting required writing archives periodically. Only fastboot snapshots are required now, but fastboot snapshots are not generated by the controller. 

#### Summary of Changes
- Upon receiving agave-validator exit, request a fastboot snapshot. After a 5s timeout, or a change in latest snapshot slot, proceed with shutting down the validator.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
