### PR TITLE
Rearrange fields of InstructionFrame

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -423,11 +423,15 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             program_account_index_in_transaction.unwrap()
         };
 
+        // This ? operator should not error out because `fn get_current_instruction_index` is also called
+        // in `get_current_instruction_context`
+        let parent_index = self.transaction_context.get_current_instruction_index()?;
         self.transaction_context.configure_next_instruction(
             program_account_index,
             instruction_accounts,
             transaction_callee_map,
             Cow::Owned(instruction.data),
+            Some(parent_index as u32),
         )?;
         Ok(())
     }
@@ -470,6 +474,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             instruction_accounts,
             transaction_callee_map,
             Cow::Borrowed(data),
+            None,
         )?;
         Ok(())
     }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -431,7 +431,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             instruction_accounts,
             transaction_callee_map,
             Cow::Owned(instruction.data),
-            Some(parent_index as u32),
+            Some(parent_index as u16),
         )?;
         Ok(())
     }

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -794,6 +794,7 @@ mod tests {
                             instruction_accounts,
                             dedup_map,
                             Cow::Owned(instruction_data.clone()),
+                            None,
                         )
                         .unwrap();
                 } else {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1107,7 +1107,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 .zip(ix_data_trace.into_iter())
                 .zip(accounts)
             {
-                let stack_height = ix_in_trace.nesting_level.saturating_add(1);
+                let stack_height = ix_in_trace.nesting_level.saturating_add(1) as usize;
                 if stack_height == TRANSACTION_LEVEL_STACK_HEIGHT {
                     outer_instructions.push(Vec::new());
                 } else if let Some(inner_instructions) = outer_instructions.last_mut() {

--- a/transaction-context/src/instruction.rs
+++ b/transaction-context/src/instruction.rs
@@ -18,7 +18,9 @@ use {
 #[repr(C)]
 #[derive(Debug)]
 pub struct InstructionFrame {
-    pub program_account_index_in_tx: u32,
+    /// Reserved field for alignment and potential future usage.
+    pub reserved: u16,
+    pub program_account_index_in_tx: u16,
     pub nesting_level: u16,
     /// This is the index of the parent instruction if this is a CPI and u16::MAX if this is a
     /// top-level instruction
@@ -36,6 +38,7 @@ impl Default for InstructionFrame {
             // Using u64::MAX as the default pointer value, since it shall never be accessible.
             instruction_accounts: VmSlice::new(0, 0),
             instruction_data: VmSlice::new(0, 0),
+            reserved: 0,
         }
     }
 }

--- a/transaction-context/src/instruction.rs
+++ b/transaction-context/src/instruction.rs
@@ -18,11 +18,11 @@ use {
 #[repr(C)]
 #[derive(Debug)]
 pub struct InstructionFrame {
-    pub program_account_index_in_tx: u64,
-    pub nesting_level: u32,
-    /// This is the index of the parent instruction if this is a CPI and u32::MAX if this is a
+    pub program_account_index_in_tx: u32,
+    pub nesting_level: u16,
+    /// This is the index of the parent instruction if this is a CPI and u16::MAX if this is a
     /// top-level instruction
-    pub index_of_parent_instruction: u32,
+    pub index_of_parent_instruction: u16,
     pub instruction_accounts: VmSlice<InstructionAccount>,
     pub instruction_data: VmSlice<u8>,
 }
@@ -32,7 +32,7 @@ impl Default for InstructionFrame {
         InstructionFrame {
             nesting_level: 0,
             program_account_index_in_tx: 0,
-            index_of_parent_instruction: u32::MAX,
+            index_of_parent_instruction: u16::MAX,
             // Using u64::MAX as the default pointer value, since it shall never be accessible.
             instruction_accounts: VmSlice::new(0, 0),
             instruction_data: VmSlice::new(0, 0),

--- a/transaction-context/src/instruction.rs
+++ b/transaction-context/src/instruction.rs
@@ -18,8 +18,11 @@ use {
 #[repr(C)]
 #[derive(Debug)]
 pub struct InstructionFrame {
-    pub nesting_level: usize,
-    pub program_account_index_in_tx: IndexOfAccount,
+    pub program_account_index_in_tx: u64,
+    pub nesting_level: u32,
+    /// This is the index of the parent instruction if this is a CPI and u32::MAX if this is a
+    /// top-level instruction
+    pub index_of_parent_instruction: u32,
     pub instruction_accounts: VmSlice<InstructionAccount>,
     pub instruction_data: VmSlice<u8>,
 }
@@ -29,6 +32,7 @@ impl Default for InstructionFrame {
         InstructionFrame {
             nesting_level: 0,
             program_account_index_in_tx: 0,
+            index_of_parent_instruction: u32::MAX,
             // Using u64::MAX as the default pointer value, since it shall never be accessible.
             instruction_accounts: VmSlice::new(0, 0),
             instruction_data: VmSlice::new(0, 0),

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -299,7 +299,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
             .last_mut()
             .ok_or(InstructionError::CallDepth)?;
 
-        instruction.program_account_index_in_tx = program_index as u32;
+        instruction.program_account_index_in_tx = program_index;
         instruction.configure_vm_slices(
             instruction_index as u64,
             instruction_accounts.len(),

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -288,7 +288,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
         instruction_accounts: Vec<InstructionAccount>,
         deduplication_map: Vec<u16>,
         instruction_data: Cow<'ix_data, [u8]>,
-        parent_index: Option<u32>,
+        parent_index: Option<u16>,
     ) -> Result<(), InstructionError> {
         debug_assert_eq!(deduplication_map.len(), MAX_ACCOUNTS_PER_TRANSACTION);
         let trace_len = self.instruction_trace.len();
@@ -299,13 +299,13 @@ impl<'ix_data> TransactionContext<'ix_data> {
             .last_mut()
             .ok_or(InstructionError::CallDepth)?;
 
-        instruction.program_account_index_in_tx = program_index as u64;
+        instruction.program_account_index_in_tx = program_index as u32;
         instruction.configure_vm_slices(
             instruction_index as u64,
             instruction_accounts.len(),
             instruction_data.len() as u64,
         );
-        instruction.index_of_parent_instruction = parent_index.unwrap_or(u32::MAX);
+        instruction.index_of_parent_instruction = parent_index.unwrap_or(u16::MAX);
         self.deduplication_maps
             .push(deduplication_map.into_boxed_slice());
         self.instruction_accounts
@@ -352,7 +352,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
                 .instruction_trace
                 .last_mut()
                 .ok_or(InstructionError::CallDepth)?;
-            instruction.nesting_level = nesting_level as u32;
+            instruction.nesting_level = nesting_level as u16;
         }
         let index_in_trace = self.get_instruction_trace_length();
         if index_in_trace >= self.instruction_trace_capacity {

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -217,8 +217,8 @@ impl<'ix_data> TransactionContext<'ix_data> {
         Ok(InstructionContext {
             transaction_context: self,
             index_in_trace,
-            nesting_level: instruction.nesting_level,
-            program_account_index_in_tx: instruction.program_account_index_in_tx,
+            nesting_level: instruction.nesting_level as usize,
+            program_account_index_in_tx: instruction.program_account_index_in_tx as IndexOfAccount,
             instruction_accounts,
             dedup_map,
             instruction_data,
@@ -250,14 +250,18 @@ impl<'ix_data> TransactionContext<'ix_data> {
         self.instruction_stack.len()
     }
 
+    /// Returns the index in the instruction trace of the current executing instruction
+    pub fn get_current_instruction_index(&self) -> Result<usize, InstructionError> {
+        self.get_instruction_stack_height()
+            .checked_sub(1)
+            .ok_or(InstructionError::CallDepth)
+    }
+
     /// Returns a view on the current instruction
     pub fn get_current_instruction_context(
         &self,
     ) -> Result<InstructionContext<'_, '_>, InstructionError> {
-        let level = self
-            .get_instruction_stack_height()
-            .checked_sub(1)
-            .ok_or(InstructionError::CallDepth)?;
+        let level = self.get_current_instruction_index()?;
         self.get_instruction_context_at_nesting_level(level)
     }
 
@@ -284,6 +288,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
         instruction_accounts: Vec<InstructionAccount>,
         deduplication_map: Vec<u16>,
         instruction_data: Cow<'ix_data, [u8]>,
+        parent_index: Option<u32>,
     ) -> Result<(), InstructionError> {
         debug_assert_eq!(deduplication_map.len(), MAX_ACCOUNTS_PER_TRANSACTION);
         let trace_len = self.instruction_trace.len();
@@ -294,12 +299,13 @@ impl<'ix_data> TransactionContext<'ix_data> {
             .last_mut()
             .ok_or(InstructionError::CallDepth)?;
 
-        instruction.program_account_index_in_tx = program_index;
+        instruction.program_account_index_in_tx = program_index as u64;
         instruction.configure_vm_slices(
             instruction_index as u64,
             instruction_accounts.len(),
             instruction_data.len() as u64,
         );
+        instruction.index_of_parent_instruction = parent_index.unwrap_or(u32::MAX);
         self.deduplication_maps
             .push(deduplication_map.into_boxed_slice());
         self.instruction_accounts
@@ -330,6 +336,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
             instruction_accounts,
             dedup_map,
             Cow::Owned(instruction_data),
+            None,
         )
     }
 
@@ -345,7 +352,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
                 .instruction_trace
                 .last_mut()
                 .ok_or(InstructionError::CallDepth)?;
-            instruction.nesting_level = nesting_level;
+            instruction.nesting_level = nesting_level as u32;
         }
         let index_in_trace = self.get_instruction_trace_length();
         if index_in_trace >= self.instruction_trace_capacity {


### PR DESCRIPTION
#### Problem

The layout of `InstructionFrame` still differs from what we propose in [SIMD-0177](https://github.com/solana-foundation/solana-improvement-documents/pull/177). This PR changes field types and include new members to match with the proposal.

#### Summary of Changes

1. Make `program_account_index_in_tx` a `u64`.
2. Make `nesting_level` a `u32`.
3. Include `index_of_parent_instruction` in the structure.
4. Reorder fields to match the layout proposed in the SIMD.