### PR TITLE
perf(serde_snapshot): use Vec for deserialized slot to storages mapping

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -76,7 +76,7 @@ pub(crate) use {
 const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize)]
 pub(crate) struct AccountsDbFields<T>(
     Vec<(Slot, SmallVec<[T; 1]>)>,
     u64, // obsolete, formerly write_version

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -78,7 +78,7 @@ const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub(crate) struct AccountsDbFields<T>(
-    HashMap<Slot, SmallVec<[T; 1]>>,
+    Vec<(Slot, SmallVec<[T; 1]>)>,
     u64, // obsolete, formerly write_version
     Slot,
     BankHashInfo,


### PR DESCRIPTION
#### Problem
Bincode serializes maps and vectors with the same bytes (len + list of (K,V) pairs) and we don't rely on `AccountsDbFields.0` being map - after de-serialization it's converted to a transformed map, so only iteration is needed.
The struct is never used for serialization, so `Serialize` derive can be removed.

#### Summary of Changes
* Change deserialized field from `HashMap<Slot, SmallVec<[T; 1]>>` to `Vec<(Slot, SmallVec<[T; 1]>)>`
* Remove `Serialize`, `Clone`, `PartialEe` and `Eq` derives from `AccountsDbFields`