### PR TITLE
perf(serde_snapshot): serialize account storages mapping without Vec allocs

### DIFF
--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -345,7 +345,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "AA17oKJsK6QTAntr31iPoonMYtVfks2syxMfj15AkXfa")
+            frozen_abi(digest = "6TVD4xhoKHV6mMFHotMJ2UMdraAffjmfVRHRZEJguzoC")
         )]
         #[derive(serde::Serialize)]
         pub struct BankAbiTestWrapper {

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -8,10 +8,7 @@ mod tests {
             runtime_config::RuntimeConfig,
             serde_snapshot::{self, ExtraFieldsToSerialize, SnapshotStreams},
             snapshot_bank_utils,
-            snapshot_utils::{
-                create_tmp_accounts_dir_for_tests, get_storages_to_serialize,
-                StorageAndNextAccountsFileId,
-            },
+            snapshot_utils::{create_tmp_accounts_dir_for_tests, StorageAndNextAccountsFileId},
             stakes::{SerdeStakesToStakeFormat, Stakes},
         },
         agave_snapshots::snapshot_config::SnapshotConfig,
@@ -121,7 +118,7 @@ mod tests {
                 &mut writer,
                 bank_fields,
                 bank2.get_bank_hash_stats(),
-                &get_storages_to_serialize(&bank2.get_snapshot_storages(None)),
+                &bank2.get_snapshot_storages(None),
                 ExtraFieldsToSerialize {
                     lamports_per_signature: bank2.fee_rate_governor.lamports_per_signature,
                     obsolete_incremental_snapshot_persistence: None,
@@ -217,7 +214,7 @@ mod tests {
         crate::serde_snapshot::bank_to_stream(
             &mut std::io::BufWriter::new(&mut writer),
             &bank,
-            &get_storages_to_serialize(&snapshot_storages),
+            &snapshot_storages,
         )
         .unwrap();
 
@@ -379,7 +376,7 @@ mod tests {
                 serializer,
                 bank_fields,
                 BankHashStats::default(),
-                &get_storages_to_serialize(&snapshot_storages),
+                &snapshot_storages,
                 ExtraFieldsToSerialize {
                     lamports_per_signature: bank.fee_rate_governor.lamports_per_signature,
                     obsolete_incremental_snapshot_persistence: Some(

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -7,7 +7,7 @@ mod serde_snapshot_tests {
                 deserialize_accounts_db_fields, reconstruct_accountsdb_from_fields,
                 remap_append_vec_file, SerializableAccountsDb, SnapshotAccountsDbFields,
             },
-            snapshot_utils::{get_storages_to_serialize, StorageAndNextAccountsFileId},
+            snapshot_utils::StorageAndNextAccountsFileId,
         },
         agave_fs::FileInfo,
         bincode::{serialize_into, Error},
@@ -100,7 +100,7 @@ mod serde_snapshot_tests {
         stream: &mut W,
         accounts_db: &AccountsDb,
         slot: Slot,
-        account_storage_entries: &[Vec<Arc<AccountStorageEntry>>],
+        account_storage_entries: &[Arc<AccountStorageEntry>],
     ) -> Result<(), Error>
     where
         W: Write,
@@ -162,13 +162,7 @@ mod serde_snapshot_tests {
     ) -> AccountsDb {
         let mut writer = Cursor::new(vec![]);
         let snapshot_storages = accounts.get_storages(..=slot).0;
-        accountsdb_to_stream(
-            &mut writer,
-            accounts,
-            slot,
-            &get_storages_to_serialize(&snapshot_storages),
-        )
-        .unwrap();
+        accountsdb_to_stream(&mut writer, accounts, slot, &snapshot_storages).unwrap();
 
         let buf = writer.into_inner();
         let mut reader = BufReader::new(&buf[..]);
@@ -235,7 +229,7 @@ mod serde_snapshot_tests {
             &mut writer,
             &accounts.accounts_db,
             slot,
-            &get_storages_to_serialize(&accounts.accounts_db.get_storages(..=slot).0),
+            &accounts.accounts_db.get_storages(..=slot).0,
         )
         .unwrap();
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -534,7 +534,7 @@ pub fn serialize_snapshot(
                 stream,
                 bank_fields,
                 bank_hash_stats,
-                &get_storages_to_serialize(snapshot_storages),
+                snapshot_storages,
                 extra_fields,
                 write_version,
             )?;
@@ -1012,17 +1012,6 @@ pub fn hard_link_storages_to_snapshot(
         })?;
     }
     Ok(())
-}
-
-/// serializing needs Vec<Vec<Arc<AccountStorageEntry>>>, but data structure at runtime is Vec<Arc<AccountStorageEntry>>
-/// translates to what we need
-pub(crate) fn get_storages_to_serialize(
-    snapshot_storages: &[Arc<AccountStorageEntry>],
-) -> Vec<Vec<Arc<AccountStorageEntry>>> {
-    snapshot_storages
-        .iter()
-        .map(|storage| vec![Arc::clone(storage)])
-        .collect::<Vec<_>>()
 }
 
 /// Unarchives the given full and incremental snapshot archives, as long as they are compatible.


### PR DESCRIPTION
#### Problem
Account storages mapping in snapshot is a key-value sequence where values are single element sequences. When serializing, a small struct is used to hold intermediate representation created from borrowed slice `&[Arc<AccountStorageEntry>]`, where items represent separate slot->storage entries, allocating new vector of vectors.

Those allocations are not necessary, since struct is serialized using custom `Serialize` implementation and it can easily do it for original slice and creating single-element slices per value.

#### Summary of Changes
Remove allocation of `Vec<Vec<..>>` when creating `SerializableAccountsDb`, use original slice and serialize sequence of sequences using iterators and `utils::serialize_iter_as_seq`