### PR TITLE
feat: add vote account flags to cli leader-schedule command

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -87,6 +87,8 @@ pub enum CliCommand {
     },
     LeaderSchedule {
         epoch: Option<Epoch>,
+        vote_addresses: Option<Vec<Pubkey>>,
+        only_vote_addresses: bool,
     },
     LiveSlots,
     Logs {
@@ -931,8 +933,19 @@ pub async fn process_command(config: &CliConfig<'_>) -> ProcessResult {
         CliCommand::Inflation(inflation_subcommand) => {
             process_inflation_subcommand(&rpc_client, config, inflation_subcommand).await
         }
-        CliCommand::LeaderSchedule { epoch } => {
-            process_leader_schedule(&rpc_client, config, *epoch).await
+        CliCommand::LeaderSchedule {
+            epoch,
+            vote_addresses,
+            only_vote_addresses,
+        } => {
+            process_leader_schedule(
+                &rpc_client,
+                config,
+                *epoch,
+                vote_addresses.clone(),
+                *only_vote_addresses,
+            )
+            .await
         }
         CliCommand::LiveSlots => process_live_slots(config),
         CliCommand::Logs { filter } => process_logs(config, filter),

--- a/rpc-client-types/src/config.rs
+++ b/rpc-client-types/src/config.rs
@@ -61,6 +61,7 @@ pub struct RpcRequestAirdropConfig {
 #[serde(rename_all = "camelCase")]
 pub struct RpcLeaderScheduleConfig {
     pub identity: Option<String>, // validator identity, as a base-58 encoded string
+    pub vote_accounts: Option<Vec<String>>, // base-58 vote account pubkeys
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
 }


### PR DESCRIPTION
#### Problem

  CLI cannot filter leader schedules by vote accounts.

  #### Summary of Changes

  Add `--vote-addresses` and `--only-vote-addresses` flags to `leader-schedule` command for vote account
  filtering and output transformation.

  Fixes #9676 