### PR TITLE
streamer/sigverify: use bounded channels between streamers and sigver

### DIFF
--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -104,6 +104,10 @@ impl SigVerifier {
 // Conservatively allow 20 TPS per validator.
 pub const MAX_VOTES_PER_SECOND: u64 = 20;
 
+/// Size of the channel between streamer and TPU sigverify stage. The values have been selected to
+/// be conservative max of obsersed on mnb during high-load events.
+const TPU_CHANNEL_SIZE: usize = 50_000;
+
 pub struct Tpu {
     fetch_stage: FetchStage,
     sig_verifier: SigVerifier,
@@ -180,7 +184,7 @@ impl Tpu {
             vortexor_receivers,
         } = sockets;
 
-        let (packet_sender, packet_receiver) = unbounded();
+        let (packet_sender, packet_receiver) = bounded(TPU_CHANNEL_SIZE);
         let (vote_packet_sender, vote_packet_receiver) = unbounded();
         let (forwarded_packet_sender, forwarded_packet_receiver) = unbounded();
         let fetch_stage = FetchStage::new_with_sender(


### PR DESCRIPTION
#### Problem

Streamer and sigverify exchange information using unbounded channels.
This leads to unnecessary allocations:

<img width="1302" height="588" alt="aaa" src="https://github.com/user-attachments/assets/c3d5ec65-28d8-4463-9e8b-08878fa1e4f0" />

#### Summary of Changes

Instead, use bounded channel between streamer and sigverify for TPU transactions. Votes and Fwd will be addressed separately. To determine the size of the channel I propose to use metric data. It should be noted that the version 3.1 and earlier do have separate batching stage between sigverify and streamer which is removed in 4.0. In this batching stage, we used  bounded channel of size [250k packets](https://github.com/anza-xyz/agave/blob/v3.1/streamer/src/quic.rs#L82). During the high load event 10-10-25, it was never saturated which means that this might be considered as upper bound. From the other hand, there is metric `tpu-verifier.max_packets` which indicates how many packets we consume at once from the input channel for the sigverify. The peak on the same date was 20k. Hence, I think that 50k is a more reasonable upper bound. 

<img width="947" height="397" alt="Screenshot 2026-01-04 at 15 26 33" src="https://github.com/user-attachments/assets/4778ac4f-ca47-4d27-9b6d-0b55883216ee" />


The results in profiler are the following:
<img width="1319" height="592" alt="Screenshot 2025-12-23 at 14 32 01" src="https://github.com/user-attachments/assets/cdef959a-074c-4751-95bd-0d1a598416fd" />

