### PR TITLE
Disable snapshot_write_version serialization / deserialization

### DIFF
--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -30,7 +30,7 @@ mod tests {
             mem,
             ops::RangeFull,
             path::Path,
-            sync::{atomic::Ordering, Arc, OnceLock},
+            sync::{Arc, OnceLock},
         },
         tempfile::TempDir,
         test_case::{test_case, test_matrix},
@@ -126,7 +126,6 @@ mod tests {
                     versioned_epoch_stakes,
                     accounts_lt_hash,
                 },
-                accounts_db.write_version.load(Ordering::Acquire),
             )
             .unwrap();
         }
@@ -386,7 +385,6 @@ mod tests {
                     versioned_epoch_stakes,
                     accounts_lt_hash: Some(AccountsLtHash(LtHash::identity()).into()),
                 },
-                u64::default(), // obsolete, formerly write_version
             )
         }
     }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -358,14 +358,14 @@ impl<T> SnapshotAccountsDbFields<T> {
         }
     }
 
-    /// Extract final write version and bank hash info from full and incremental accounts db fields.
+    /// Extract final bank hash info from full and incremental accounts db fields.
     ///
-    /// If there is no incremental snapshot, this returns the fields from the full snapshot.
-    /// Otherwise, gets them from the incremental snapshot.
-    fn into_write_version_and_bank_hash_info(self) -> (u64, BankHashInfo) {
+    /// If there is no incremental snapshot, this returns the field from the full snapshot.
+    /// Otherwise, gets it from the incremental snapshot.
+    fn into_bank_hash_info(self) -> BankHashInfo {
         let AccountsDbFields(
             _snapshot_storages,
-            snapshot_write_version,
+            _snapshot_write_version,
             _snapshot_slot,
             snapshot_bank_hash_info,
             _snapshot_historical_roots,
@@ -373,7 +373,7 @@ impl<T> SnapshotAccountsDbFields<T> {
         ) = self
             .incremental_snapshot_accounts_db_fields
             .unwrap_or(self.full_snapshot_accounts_db_fields);
-        (snapshot_write_version, snapshot_bank_hash_info)
+        snapshot_bank_hash_info
     }
 }
 
@@ -1019,8 +1019,7 @@ where
         exit,
     );
 
-    let (snapshot_write_version, snapshot_bank_hash_info) =
-        snapshot_accounts_db_fields.into_write_version_and_bank_hash_info();
+    let snapshot_bank_hash_info = snapshot_accounts_db_fields.into_bank_hash_info();
 
     // Ensure all account paths exist
     for path in &accounts_db.paths {
@@ -1050,9 +1049,6 @@ where
     accounts_db
         .next_id
         .store(next_append_vec_id, Ordering::Release);
-    accounts_db
-        .write_version
-        .fetch_add(snapshot_write_version, Ordering::Release);
 
     info!("Building accounts index...");
     let start = Instant::now();

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -753,7 +753,7 @@ impl Serialize for SerializableAccountsDb<'_> {
         let mut serialize_account_storage_timer = Measure::start("serialize_account_storage_ms");
         let result = (
             entries,
-            0u64,
+            0u64, // obsolete, formerly write_version
             self.slot,
             bank_hash_info,
             historical_roots,

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -96,9 +96,8 @@ mod serde_snapshot_tests {
         )
     }
 
-    fn accountsdb_to_stream<W>(
+    fn account_storages_to_stream<W>(
         stream: &mut W,
-        accounts_db: &AccountsDb,
         slot: Slot,
         account_storage_entries: &[Arc<AccountStorageEntry>],
     ) -> Result<(), Error>
@@ -106,14 +105,12 @@ mod serde_snapshot_tests {
         W: Write,
     {
         let bank_hash_stats = BankHashStats::default();
-        let write_version = accounts_db.write_version.load(Ordering::Acquire);
         serialize_into(
             stream,
             &SerializableAccountsDb {
                 slot,
                 account_storage_entries,
                 bank_hash_stats,
-                write_version,
             },
         )
     }
@@ -162,7 +159,7 @@ mod serde_snapshot_tests {
     ) -> AccountsDb {
         let mut writer = Cursor::new(vec![]);
         let snapshot_storages = accounts.get_storages(..=slot).0;
-        accountsdb_to_stream(&mut writer, accounts, slot, &snapshot_storages).unwrap();
+        account_storages_to_stream(&mut writer, slot, &snapshot_storages).unwrap();
 
         let buf = writer.into_inner();
         let mut reader = BufReader::new(&buf[..]);
@@ -225,9 +222,8 @@ mod serde_snapshot_tests {
             .calculate_accounts_lt_hash_at_startup_from_index(&Ancestors::default(), slot);
 
         let mut writer = Cursor::new(vec![]);
-        accountsdb_to_stream(
+        account_storages_to_stream(
             &mut writer,
-            &accounts.accounts_db,
             slot,
             &accounts.accounts_db.get_storages(..=slot).0,
         )

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -869,12 +869,6 @@ mod tests {
             bank_fields: bank.get_fields_to_serialize(),
             bank_hash_stats: bank.get_bank_hash_stats(),
             status_cache_slot_deltas: bank.status_cache.read().unwrap().root_slot_deltas(),
-            write_version: bank
-                .rc
-                .accounts
-                .accounts_db
-                .write_version
-                .load(Ordering::Acquire),
         };
 
         let snapshot_storages = bank.get_snapshot_storages(None);

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -5,10 +5,7 @@ use {
     agave_snapshots::{snapshot_hash::SnapshotHash, SnapshotArchiveKind, SnapshotKind},
     solana_accounts_db::accounts_db::AccountStorageEntry,
     solana_clock::Slot,
-    std::{
-        sync::{atomic::Ordering, Arc},
-        time::Instant,
-    },
+    std::{sync::Arc, time::Instant},
 };
 
 mod compare;
@@ -52,12 +49,6 @@ impl SnapshotPackage {
             bank_fields: bank_fields_to_serialize,
             bank_hash_stats: bank.get_bank_hash_stats(),
             status_cache_slot_deltas,
-            write_version: bank
-                .rc
-                .accounts
-                .accounts_db
-                .write_version
-                .load(Ordering::Acquire),
         };
 
         Self {
@@ -80,7 +71,6 @@ impl SnapshotPackage {
             bank_fields: BankFieldsToSerialize::default_for_tests(),
             bank_hash_stats: BankHashStats::default(),
             status_cache_slot_deltas: Vec::default(),
-            write_version: u64::default(),
         };
 
         Self {
@@ -109,5 +99,4 @@ pub struct BankSnapshotPackage {
     pub bank_fields: BankFieldsToSerialize,
     pub bank_hash_stats: BankHashStats,
     pub status_cache_slot_deltas: Vec<BankSlotDelta>,
-    pub write_version: u64,
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -494,7 +494,6 @@ pub fn serialize_snapshot(
         mut bank_fields,
         bank_hash_stats,
         status_cache_slot_deltas,
-        write_version,
     } = bank_snapshot_package;
     let status_cache_slot_deltas = status_cache_slot_deltas.as_slice();
     let slot = bank_fields.slot;
@@ -536,7 +535,6 @@ pub fn serialize_snapshot(
                 bank_hash_stats,
                 snapshot_storages,
                 extra_fields,
-                write_version,
             )?;
             Ok(())
         };


### PR DESCRIPTION
#### Problem
The field in `AccountsDbFields.1` is obsolete.

#### Summary of Changes
Don't pass it around after it's deserialized. Serialize 0 instead of fetching value from accounts_db.
