### PR TITLE
Renames AccountsDb::bank_hash_details_dir field

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1115,11 +1115,11 @@ pub struct AccountsDb {
     /// Set of storage paths to pick from
     pub paths: Vec<PathBuf>,
 
-    /// Base directory for various necessary files
-    base_working_path: PathBuf,
+    /// directory for bank hash details files
+    bank_hash_details_dir: PathBuf,
     // used by tests - held until we are dropped
     #[allow(dead_code)]
-    base_working_temp_dir: Option<TempDir>,
+    bank_hash_details_temp_dir: Option<TempDir>,
 
     shrink_paths: Vec<PathBuf>,
 
@@ -1264,14 +1264,14 @@ impl AccountsDb {
         let accounts_index_config = accounts_db_config.index.unwrap_or_default();
         let accounts_index = AccountsIndex::new(&accounts_index_config, exit);
 
-        let base_working_path = accounts_db_config.base_working_path.clone();
-        let (base_working_path, base_working_temp_dir) =
-            if let Some(base_working_path) = base_working_path {
-                (base_working_path, None)
+        let bank_hash_details_dir = accounts_db_config.bank_hash_details_dir.clone();
+        let (bank_hash_details_dir, bank_hash_details_temp_dir) =
+            if let Some(bank_hash_details_dir) = bank_hash_details_dir {
+                (bank_hash_details_dir, None)
             } else {
-                let base_working_temp_dir = TempDir::new().unwrap();
-                let base_working_path = base_working_temp_dir.path().to_path_buf();
-                (base_working_path, Some(base_working_temp_dir))
+                let bank_hash_details_temp_dir = TempDir::new().unwrap();
+                let bank_hash_details_dir = bank_hash_details_temp_dir.path().to_path_buf();
+                (bank_hash_details_dir, Some(bank_hash_details_temp_dir))
             };
 
         let (paths, temp_paths) = if paths.is_empty() {
@@ -1323,8 +1323,8 @@ impl AccountsDb {
         let new = Self {
             accounts_index,
             paths,
-            base_working_path,
-            base_working_temp_dir,
+            bank_hash_details_dir,
+            bank_hash_details_temp_dir,
             temp_paths,
             shrink_paths,
             skip_initial_hash_calc: accounts_db_config.skip_initial_hash_calc,
@@ -1387,9 +1387,8 @@ impl AccountsDb {
         new
     }
 
-    /// Get the base working directory
-    pub fn get_base_working_path(&self) -> PathBuf {
-        self.base_working_path.clone()
+    pub fn bank_hash_details_dir(&self) -> &Path {
+        &self.bank_hash_details_dir
     }
 
     /// Returns true if there is an accounts update notifier.

--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -20,8 +20,7 @@ use {
 pub struct AccountsDbConfig {
     pub index: Option<AccountsIndexConfig>,
     pub account_indexes: Option<AccountSecondaryIndexes>,
-    /// Base directory for various necessary files
-    pub base_working_path: Option<PathBuf>,
+    pub bank_hash_details_dir: Option<PathBuf>,
     pub shrink_paths: Option<Vec<PathBuf>>,
     pub shrink_ratio: AccountShrinkThreshold,
     /// The low and high watermark sizes for the read cache, in bytes.
@@ -55,7 +54,7 @@ pub struct AccountsDbConfig {
 pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
     account_indexes: None,
-    base_working_path: None,
+    bank_hash_details_dir: None,
     shrink_paths: None,
     shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     read_cache_limit_bytes: None,
@@ -78,7 +77,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
     account_indexes: None,
-    base_working_path: None,
+    bank_hash_details_dir: None,
     shrink_paths: None,
     shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     read_cache_limit_bytes: None,

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -300,7 +300,7 @@ pub fn get_accounts_db_config(
 
     AccountsDbConfig {
         index: Some(accounts_index_config),
-        base_working_path: Some(ledger_tool_ledger_path),
+        bank_hash_details_dir: Some(ledger_tool_ledger_path),
         ancient_append_vec_offset: value_t!(arg_matches, "accounts_db_ancient_append_vecs", i64)
             .ok(),
         ancient_storage_ideal_size: value_t!(

--- a/runtime/src/bank/bank_hash_details.rs
+++ b/runtime/src/bank/bank_hash_details.rs
@@ -249,7 +249,7 @@ pub fn write_bank_hash_details_file(bank: &Bank) -> std::result::Result<(), Stri
         .rc
         .accounts
         .accounts_db
-        .get_base_working_path()
+        .bank_hash_details_dir()
         .join("bank_hash_details");
     let path = parent_dir.join(details.filename()?);
     // A file with the same name implies the same hash for this slot. Skip

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -421,7 +421,7 @@ pub fn execute(
     let accounts_db_config = AccountsDbConfig {
         index: Some(accounts_index_config),
         account_indexes: Some(account_indexes.clone()),
-        base_working_path: Some(ledger_path.clone()),
+        bank_hash_details_dir: Some(ledger_path.clone()),
         shrink_paths: account_shrink_run_paths,
         shrink_ratio,
         read_cache_limit_bytes,


### PR DESCRIPTION
#### Problem

Instantiating AccountsDb is annoying because it internally will create temp directories in case it isn't given valid dirs. This makes some testing/validating less straight-forward. AccountsDb should always be given valid dirs as necessary, and managed by the caller.

For this PR I'm beginning on `base_working_path`.

Now that we've removed the merkle-based accounts hash calculation, we no longer need to store those hash cache files. They were previously stored in a subdir of the base working path, if a path wasn't passed in explicitly.

The only user of the base working path is the bank hash details files. So let's be explicit about the use. This will prevent new uses of this dir. And then a follow-up PR can remove the temp dir as well.


#### Summary of Changes

Rename the field to `bank_hash_details_dir`.