### PR TITLE
Removes AccountsDb::bank_hash_details_temp_dir field

### DIFF
--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -20,6 +20,10 @@ use {
 pub struct AccountsDbConfig {
     pub index: Option<AccountsIndexConfig>,
     pub account_indexes: Option<AccountSecondaryIndexes>,
+    // We need the Option wrapper until we're on Rust 1.91 or newer,
+    // because PathBuf::new() is non-const until then.
+    // For now, the only way for ACCOUNTS_DB_CONFIG_FOR_TESTING/BENCHMARKS
+    // to indicate they do not use bank_hash_details_dir is to use None.
     pub bank_hash_details_dir: Option<PathBuf>,
     pub shrink_paths: Option<Vec<PathBuf>>,
     pub shrink_ratio: AccountShrinkThreshold,
@@ -54,7 +58,7 @@ pub struct AccountsDbConfig {
 pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
     account_indexes: None,
-    bank_hash_details_dir: None,
+    bank_hash_details_dir: None, // tests don't use bank hash details
     shrink_paths: None,
     shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     read_cache_limit_bytes: None,
@@ -77,7 +81,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
     account_indexes: None,
-    bank_hash_details_dir: None,
+    bank_hash_details_dir: None, // benches don't use bank hash details
     shrink_paths: None,
     shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     read_cache_limit_bytes: None,


### PR DESCRIPTION
#### Problem

Instantiating AccountsDb is annoying because it internally will create temp directories in case it isn't given valid dirs. This makes some testing/validating less straight-forward. AccountsDb should always be given valid dirs as necessary, and managed by the caller.

For this PR I'm working on `bank_hash_details_temp_dir`.

We can easily ensure all AccountsDb users pass in a valid bank hash details dir if they intend to use it. This allows us to remove the temp dir entirely.


#### Summary of Changes

Removes the `bank_hash_details_temp_dir` field.
