### PR TITLE
docs: fix zk elgamal proof program references

### DIFF
--- a/docs/src/runtime/zk-elgamal-proof.md
+++ b/docs/src/runtime/zk-elgamal-proof.md
@@ -10,9 +10,9 @@ encryption over the elliptic curve
 verification instructions in the ZK ElGamal Proof program are flexibly designed
 so that they can be combined to enable a number different applications.
 
-- Program id: `ZkE1Gama1Proof11111111111111111111111111111`
+- Program id: see `solana_sdk_ids::zk_elgamal_proof_program::ID`
 - Instructions:
-  [ProofInstruction](https://github.com/anza-xyz/agave/blob/master/zk-sdk/src/zk_elgamal_proof_program/instruction.rs)
+  [ProofInstruction](https://github.com/solana-program/zk-elgamal-proof/blob/main/zk-sdk/src/zk_elgamal_proof_program/instruction.rs)
 
 ### Pedersen commitments and ElGamal encryption
 
@@ -67,7 +67,7 @@ logically divided into two parts:
 - The <em>proof</em> component contains the actual mathematical pieces that
   certify different properties of the context data.
 
-The ZK Token proof program processes a proof instruction in two steps:
+The ZK ElGamal Proof program processes a proof instruction in two steps:
 
 1. Verify the zero-knowledge proof data associated with the proof instruction.
 2. If specified in the instruction, the program stores the context data in a


### PR DESCRIPTION
Replace the hardcoded zk-elgamal-proof program id in docs with a reference to the SDK constant so the documentation stays aligned with the actual deployed id. Update the program name from “ZK Token proof program” to “ZK ElGamal Proof program” in the context section and fix the ProofInstruction link to point at the upstream zk-elgamal-proof repository, matching where the instruction enum is now defined.