### PR TITLE
turbine: rm fanout experiments code

### DIFF
--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -44,7 +44,7 @@ thread_local! {
     );
 }
 
-const DATA_PLANE_FANOUT: usize = 200;
+pub(crate) const DATA_PLANE_FANOUT: usize = 200;
 pub(crate) const MAX_NUM_TURBINE_HOPS: usize = 4;
 
 #[derive(Debug, Error)]
@@ -719,45 +719,6 @@ pub fn make_test_cluster<R: Rng>(
         }
     }
     (nodes, stakes, cluster_info)
-}
-
-pub(crate) fn get_data_plane_fanout(shred_slot: Slot, root_bank: &Bank) -> usize {
-    if check_feature_activation(
-        &feature_set::disable_turbine_fanout_experiments::id(),
-        shred_slot,
-        root_bank,
-    ) {
-        DATA_PLANE_FANOUT
-    } else if check_feature_activation(
-        &feature_set::enable_turbine_extended_fanout_experiments::id(),
-        shred_slot,
-        root_bank,
-    ) {
-        // Allocate ~2% of slots to turbine fanout experiments.
-        match shred_slot % 359 {
-            11 => 1152,
-            61 => 1280,
-            111 => 1024,
-            161 => 1408,
-            211 => 896,
-            261 => 1536,
-            311 => 768,
-            _ => DATA_PLANE_FANOUT,
-        }
-    } else {
-        // feature_set::enable_turbine_fanout_experiments
-        // is already activated on all clusters.
-        match shred_slot % 359 {
-            11 => 64,
-            61 => 768,
-            111 => 128,
-            161 => 640,
-            211 => 256,
-            261 => 512,
-            311 => 384,
-            _ => DATA_PLANE_FANOUT,
-        }
-    }
 }
 
 // Returns true if the feature is effective for the shred slot.

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -3,7 +3,9 @@
 use {
     crate::{
         addr_cache::AddrCache,
-        cluster_nodes::{self, ClusterNodes, ClusterNodesCache, Error, MAX_NUM_TURBINE_HOPS},
+        cluster_nodes::{
+            self, ClusterNodes, ClusterNodesCache, Error, DATA_PLANE_FANOUT, MAX_NUM_TURBINE_HOPS,
+        },
         xdp::XdpSender,
     },
     agave_votor::event::VotorEvent,
@@ -471,7 +473,7 @@ fn retransmit_shred(
     }
     let mut compute_turbine_peers = Measure::start("turbine_start");
     let (root_distance, addrs) =
-        get_retransmit_addrs(&key, root_bank, cache, addr_cache, socket_addr_space, stats)?;
+        get_retransmit_addrs(&key, cache, addr_cache, socket_addr_space, stats)?;
     compute_turbine_peers.stop();
     stats
         .compute_turbine_peers_total
@@ -540,7 +542,6 @@ fn retransmit_shred(
 
 fn get_retransmit_addrs<'a>(
     shred: &ShredId,
-    root_bank: &Bank,
     cache: &HashMap<Slot, (/*leader:*/ Pubkey, Arc<ClusterNodes<RetransmitStage>>)>,
     addr_cache: &'a AddrCache,
     socket_addr_space: &SocketAddrSpace,
@@ -551,9 +552,8 @@ fn get_retransmit_addrs<'a>(
         return Some((root_distance, Cow::Borrowed(addrs)));
     }
     let (slot_leader, cluster_nodes) = cache.get(&shred.slot())?;
-    let data_plane_fanout = cluster_nodes::get_data_plane_fanout(shred.slot(), root_bank);
     let (root_distance, addrs) = cluster_nodes
-        .get_retransmit_addrs(slot_leader, shred, data_plane_fanout, socket_addr_space)
+        .get_retransmit_addrs(slot_leader, shred, DATA_PLANE_FANOUT, socket_addr_space)
         .inspect_err(|err| match err {
             Error::Loopback { .. } => {
                 stats.num_loopback_errs.fetch_add(1, Ordering::Relaxed);
@@ -600,10 +600,9 @@ fn cache_retransmit_addrs(
     }
     let socket_addr_space = cluster_info.socket_addr_space();
     let get_retransmit_addrs = |shred: ShredId| {
-        let data_plane_fanout = cluster_nodes::get_data_plane_fanout(shred.slot(), &root_bank);
         let (slot_leader, cluster_nodes) = cache.get(&shred.slot())?;
         let (root_distance, addrs) = cluster_nodes
-            .get_retransmit_addrs(slot_leader, &shred, data_plane_fanout, socket_addr_space)
+            .get_retransmit_addrs(slot_leader, &shred, DATA_PLANE_FANOUT, socket_addr_space)
             .ok()?;
         Some((shred, (root_distance, addrs.into_boxed_slice())))
     };

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        cluster_nodes::{self, check_feature_activation, ClusterNodesCache},
+        cluster_nodes::{check_feature_activation, ClusterNodesCache, DATA_PLANE_FANOUT},
         retransmit_stage::RetransmitStage,
     },
     agave_feature_set as feature_set,
@@ -358,8 +358,7 @@ fn verify_retransmitter_signature(
     };
     let cluster_nodes =
         cluster_nodes_cache.get(shred.slot(), root_bank, working_bank, cluster_info);
-    let data_plane_fanout = cluster_nodes::get_data_plane_fanout(shred.slot(), root_bank);
-    let parent = match cluster_nodes.get_retransmit_parent(&leader, &shred, data_plane_fanout) {
+    let parent = match cluster_nodes.get_retransmit_parent(&leader, &shred, DATA_PLANE_FANOUT) {
         Ok(Some(parent)) => parent,
         Ok(None) => {
             stats


### PR DESCRIPTION
#### Problem

disable_turbine_fanout_experiments ("turbnbNRp22nwZCmgVVXFSshz7H7V23zMzQgA46YpmQ") has been activated, we no longer need the code supporting turning it on in the validator.

#### Summary of Changes

- rm code surrounding enabling/disabling the fanout experiments