### PR TITLE
[zk-sdk, zk-keygen] Remove zk crates

### DIFF
--- a/zk-keygen/README.md
+++ b/zk-keygen/README.md
@@ -1,3 +1,0 @@
-# PLEASE READ: This repo no longer contains the Solana ZK-KEYGEN
-
-The solana-zk-keygen is currently developed at <https://github.com/solana-program/zk-elgamal-proof>.

--- a/zk-sdk/README.md
+++ b/zk-sdk/README.md
@@ -1,3 +1,0 @@
-# PLEASE READ: This repo no longer contains the Solana ZK-SDK
-
-The solana-zk-sdk is currently developed at https://github.com/solana-program/zk-elgamal-proof.


### PR DESCRIPTION
#### Problem
The `zk-sdk` and `zk-keygen` crates have been moved to the `solana-program/zk-elgamal-proof` repo and we just had the README file indicating that they have been moved. With the upcoming v4 release, I think we can remove these crates from the repo now.

#### Summary of Changes
Remove `zk-sdk` and `zk-keygen`.

We should also remove the `zk-token-sdk`, but I did this in a separate PR (https://github.com/anza-xyz/agave/pull/9765).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
