### PR TITLE
perf: avoid double deserialization of ConfigKeys for config accounts

### DIFF
--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -22,7 +22,7 @@ use {
     solana_cli_output::{CliValidatorInfo, CliValidatorInfoVec},
     solana_config_interface::{
         instruction::{self as config_instruction},
-        state::{get_config_data, ConfigKeys},
+        state::ConfigKeys,
     },
     solana_keypair::Keypair,
     solana_message::Message,
@@ -138,7 +138,9 @@ fn parse_validator_info(
     let key_list: ConfigKeys = deserialize(&account.data)?;
     if !key_list.keys.is_empty() {
         let (validator_pubkey, _) = key_list.keys[1];
-        let validator_info_string: String = deserialize(get_config_data(&account.data)?)?;
+        let offset = serialized_size(&key_list)?;
+        let config_data_slice = &account.data[offset as usize..];
+        let validator_info_string: String = deserialize(config_data_slice)?;
         let validator_info: Map<_, _> = serde_json::from_str(&validator_info_string)?;
         Ok((validator_pubkey, validator_info))
     } else {


### PR DESCRIPTION
#### Problem

Double parsing of the ConfigKeys header (unnecessary work).
In the ValidatorInfo branch:first, deserialize::<ConfigKeys>(data) is called to get key_list,then, inside parse_config_data, get_config_data(data) is called again, which, judging by its purpose, parses the same account data again to find the config_data section.

#### Summary of Changes


Reuse the already parsed ConfigKeys to compute the offset of the config payload and deserialize validator info directly from the config-data slice instead of calling get_config_data again. This removes redundant deserialization work in both the account-decoder and CLI validator-info paths while preserving the existing on-chain account layout and behavior.
