### PR TITLE
align memoffset version to 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,7 @@ log = "0.4.29"
 lru = "0.7.7"
 lz4 = "1.28.1"
 memmap2 = "0.9.9"
-memoffset = "0.9"
+memoffset = "0.9.1"
 merlin = { version = "3", default-features = false }
 min-max-heap = "1.3.0"
 mockall = "0.14.0"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4021,9 +4021,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -4178,7 +4178,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.0",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -7838,7 +7838,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91b12305dd81045d705f427acd0435a2e46444b65367d7179d7bdcfc3bc5f5eb"
 dependencies = [
- "memoffset 0.9.0",
+ "memoffset 0.9.1",
  "solana-account-info",
  "solana-big-mod-exp",
  "solana-blake3-hasher",


### PR DESCRIPTION
#### Problem

to avoid taking up dependabot queue slots, I closed https://github.com/anza-xyz/agave/pull/9749 and using this instead.

#### Summary of Changes

align memoffset version to 0.9.1