### PR TITLE
chore(deps): bump miow from 0.3.7 to 0.6.1 in /programs/sbf

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4080,11 +4080,11 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.7"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "winapi",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -105,7 +105,7 @@ getrandom = "0.2.10"
 itertools = "0.14.0"
 libsecp256k1 = { version = "0.7.0", default-features = false }
 log = "0.4.11"
-miow = "0.3.6"
+miow = "0.6.1"
 net2 = "0.2.37"
 num-derive = "0.4.2"
 num-traits = "0.2"


### PR DESCRIPTION
#### Problem

to avoid taking up dependabot queue slots, I closed https://github.com/anza-xyz/agave/pull/9750 and using this instead.

#### Summary of Changes

bump it