### PR TITLE
chore(deps): bump elf from 0.0.10 to 0.8.0 in /programs/sbf

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1388,12 +1388,6 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
-
-[[package]]
-name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
@@ -1562,7 +1556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
 dependencies = [
  "ascii",
- "byteorder 1.5.0",
+ "byteorder",
  "either",
  "memchr",
  "unreachable",
@@ -1800,7 +1794,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
- "byteorder 1.5.0",
+ "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
@@ -2210,12 +2204,9 @@ checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "elf"
-version = "0.0.10"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4841de15dbe0e49b9b62a417589299e3be0d557e0900d36acb87e6dae47197f5"
-dependencies = [
- "byteorder 0.5.3",
-]
+checksum = "55dd888a213fc57e957abf2aa305ee3e8a28dbe05687a251f33b637cd46b0070"
 
 [[package]]
 name = "elliptic-curve"
@@ -2784,7 +2775,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
- "byteorder 1.5.0",
+ "byteorder",
 ]
 
 [[package]]
@@ -4034,7 +4025,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
- "byteorder 1.5.0",
+ "byteorder",
  "keccak",
  "rand_core 0.6.4",
  "zeroize",
@@ -8533,7 +8524,7 @@ dependencies = [
  "agave-validator",
  "bincode",
  "borsh",
- "byteorder 1.5.0",
+ "byteorder",
  "elf",
  "itertools 0.14.0",
  "log",
@@ -8731,7 +8722,7 @@ dependencies = [
 name = "solana-sbf-rust-dep-crate"
 version = "4.0.0-alpha.0"
 dependencies = [
- "byteorder 1.5.0",
+ "byteorder",
  "solana-program-entrypoint",
 ]
 
@@ -9291,7 +9282,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15b079e08471a9dbfe1e48b2c7439c85aa2a055cbd54eddd8bd257b0a7dbb29"
 dependencies = [
- "byteorder 1.5.0",
+ "byteorder",
  "combine 3.8.1",
  "hash32",
  "libc",
@@ -10885,7 +10876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cca424247104946a59dacd27eaad296223b7feec3d168a6dd04585183091eb0b"
 dependencies = [
  "bitflags 2.10.0",
- "byteorder 1.5.0",
+ "byteorder",
  "enum-as-inner",
  "libc",
  "thiserror 2.0.17",
@@ -11539,7 +11530,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87873db279766278a7e56b01139943e00a45afc079fc8fa6651e949f2234c3f6"
 dependencies = [
- "byteorder 1.5.0",
+ "byteorder",
  "hex",
  "protobuf",
  "rusb",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -100,7 +100,7 @@ bincode = { version = "1.1.4", default-features = false }
 blake3 = "1.0.0"
 borsh = "1.5.1"
 byteorder = "1.3.2"
-elf = "0.0.10"
+elf = "0.8.0"
 getrandom = "0.2.10"
 itertools = "0.14.0"
 libsecp256k1 = { version = "0.7.0", default-features = false }


### PR DESCRIPTION
#### Problem

to avoid taking up dependabot queue slots, I closed https://github.com/anza-xyz/agave/pull/9751 and using this instead.

#### Summary of Changes

bump it