### PR TITLE
changelog: geyser: Clarifies account update notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Release channels have their own copy of this changelog:
 * `cargo-build-sbf --debug` places all debug related objects inside `target/deploy/debug`.
 ### Geyser
 #### Changes
-* Account update notifications have their fields populated from the original account. This means notifications for closed accounts (accounts with a balance of zero lamports) will no longer have their `owner`/`data`/etc zeroed out.
+* Account update notifications have their fields populated from the account values post transaction execution. This means notifications for closed accounts (accounts with a balance of zero lamports) will no longer have their `owner`/`data`/etc manually zeroed out. Note that if the on-chain program *does* zero out any fields itself, those will remain zeroed out in the notification.
 
 
 ## 3.1.0


### PR DESCRIPTION
#### Problem

In PR #9666 I thought this would fix the long-standing issue of geyser account update notifications for closed accounts. Turns out that if an account has its fields zeroed out by the on-chain program itself[^1], then the notification will still have zeroed out fields in the account. Bummer.

PR #9670 updated the changelog, but it is worded in such a way that readers could interpret it to mean that the *pre-execution* account values are used for the geyser notification.

[^1]: This is precisely what happens with the token program.


#### Summary of Changes

Update the changelog to clarify this scenario.