### PR TITLE
fix: correct SlotSupporters recycle resize heuristic

### DIFF
--- a/core/src/cluster_slots_service/slot_supporters.rs
+++ b/core/src/cluster_slots_service/slot_supporters.rs
@@ -123,7 +123,7 @@ impl SlotSupporters {
         if !same_epoch {
             let old_len = self.supporting_stakes.len();
             let new_len = index_map.len();
-            if new_len < old_len * 2 {
+            if new_len * 2 < old_len {
                 // if new length is much less than allocation, reallocate
                 self.supporting_stakes = Vec::from_iter(repeat_atomic_u64(new_len));
             } else {


### PR DESCRIPTION
Adjust the resize condition in SlotSupporters::recycle so that we only reallocate the supporting_stakes vector when the new index_map length is significantly smaller than the existing allocation (new_len * 2 < old_len). This matches the intent expressed by the comment and reduces unnecessary allocations when validator count changes modestly between epochs, while still shrinking the buffer when the number of validators drops substantially.