### PR TITLE
feat(accounts-db): add config option whether to register buffers in io-uring

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -106,9 +106,7 @@ const DEFAULT_NUM_DIRS: u32 = 4;
 // This value reflects recommended memory lock limit documented in the validator's
 // setup instructions at docs/src/operations/guides/validator-start.md allowing use of
 // several io_uring instances with fixed buffers for large disk IO operations.
-pub const DEFAULT_MEMLOCK_BUDGET_SIZE: usize = 2_000_000_000;
-// Linux distributions often have some small memory lock limit (e.g. 8MB) that we can tap into.
-const MEMLOCK_BUDGET_SIZE_FOR_TESTS: usize = 4_000_000;
+pub const TOTAL_IO_URING_BUFFERS_SIZE_LIMIT: usize = 2_000_000_000;
 
 // When getting accounts for shrinking from the index, this is the # of accounts to lookup per thread.
 // This allows us to split up accounts index accesses across multiple threads.

--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -1,7 +1,6 @@
 use {
     super::{
         AccountShrinkThreshold, MarkObsoleteAccounts, DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
-        MEMLOCK_BUDGET_SIZE_FOR_TESTS,
     },
     crate::{
         accounts_file::StorageAccess,
@@ -49,10 +48,10 @@ pub struct AccountsDbConfig {
     pub num_background_threads: Option<NonZeroUsize>,
     /// Number of threads for foreground operations (`thread_pool_foreground`)
     pub num_foreground_threads: Option<NonZeroUsize>,
-    /// Amount of memory (in bytes) that is allowed to be locked during db operations.
-    /// On linux it's verified on start-up with the kernel limits, such that during runtime
-    /// parts of it can be utilized without panicking.
-    pub memlock_budget_size: usize,
+    /// Whether to register buffers as *fixed* in io_uring
+    ///
+    /// Requires memlock ulimit higher than sum of buffer sizes registered at the same time.
+    pub use_registered_io_uring_buffers: bool,
 }
 
 pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
@@ -75,7 +74,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     mark_obsolete_accounts: MarkObsoleteAccounts::Enabled,
     num_background_threads: None,
     num_foreground_threads: None,
-    memlock_budget_size: MEMLOCK_BUDGET_SIZE_FOR_TESTS,
+    use_registered_io_uring_buffers: true,
 };
 
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
@@ -98,5 +97,5 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     mark_obsolete_accounts: MarkObsoleteAccounts::Enabled,
     num_background_threads: None,
     num_foreground_threads: None,
-    memlock_budget_size: MEMLOCK_BUDGET_SIZE_FOR_TESTS,
+    use_registered_io_uring_buffers: true,
 };

--- a/core/src/resource_limits.rs
+++ b/core/src/resource_limits.rs
@@ -73,7 +73,7 @@ pub fn adjust_nofile_limit(enforce_nofile_limit: bool) -> Result<(), ResourceLim
 
 /// Check kernel memory lock limit and tires to increase it if necessary.
 ///
-/// Returns `Ok(false)` when current limit is below `min_required` and cannot be increased.
+/// Returns `false` when current limit is below `min_required` and cannot be increased.
 #[cfg(target_os = "linux")]
 fn try_adjust_ulimit_memlock(min_required: usize) -> bool {
     fn get_memlock() -> libc::rlimit {

--- a/core/src/resource_limits.rs
+++ b/core/src/resource_limits.rs
@@ -1,4 +1,4 @@
-use {std::io, thiserror::Error};
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ResourceLimitError {
@@ -71,11 +71,11 @@ pub fn adjust_nofile_limit(enforce_nofile_limit: bool) -> Result<(), ResourceLim
     Ok(())
 }
 
-/// Check kernel memory lock limit and increase it if necessary.
+/// Check kernel memory lock limit and tires to increase it if necessary.
 ///
-/// Returns `Err` when current limit is below `min_required` and cannot be increased.
+/// Returns `Ok(false)` when current limit is below `min_required` and cannot be increased.
 #[cfg(target_os = "linux")]
-fn adjust_ulimit_memlock(min_required: usize) -> io::Result<()> {
+fn try_adjust_ulimit_memlock(min_required: usize) -> bool {
     fn get_memlock() -> libc::rlimit {
         let mut memlock = libc::rlimit {
             rlim_cur: 0,
@@ -93,37 +93,34 @@ fn adjust_ulimit_memlock(min_required: usize) -> io::Result<()> {
         memlock.rlim_cur = min_required as u64;
         memlock.rlim_max = min_required as u64;
         if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &memlock) } != 0 {
-            log::error!(
+            log::warn!(
                 "Unable to increase the maximum memory lock limit to {min_required} from {current}"
             );
 
             if cfg!(target_os = "macos") {
-                log::error!(
+                log::warn!(
                     "On mac OS you may need to run |sudo launchctl limit memlock {min_required} \
                      {min_required}| first"
                 );
             }
-            return Err(io::Error::new(
-                io::ErrorKind::OutOfMemory,
-                "unable to set memory lock limit",
-            ));
+            return false;
         }
 
         memlock = get_memlock();
         log::info!("Bumped maximum memory lock limit: {}", memlock.rlim_cur);
     }
-    Ok(())
+    true
 }
 
-pub fn validate_memlock_limit_for_disk_io(required_size: usize) -> io::Result<()> {
+pub fn check_memlock_limit_for_disk_io(required_size: usize) -> bool {
     #[cfg(target_os = "linux")]
     {
         // memory locked requirement is only necessary on linux where io_uring is used
-        adjust_ulimit_memlock(required_size)
+        try_adjust_ulimit_memlock(required_size)
     }
     #[cfg(not(target_os = "linux"))]
     {
         let _ = required_size;
-        Ok(())
+        false
     }
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -23,9 +23,7 @@ use {
             repair_handler::RepairHandlerType,
             serve_repair_service::ServeRepairService,
         },
-        resource_limits::{
-            adjust_nofile_limit, validate_memlock_limit_for_disk_io, ResourceLimitError,
-        },
+        resource_limits::{adjust_nofile_limit, ResourceLimitError},
         sample_performance_service::SamplePerformanceService,
         snapshot_packager_service::SnapshotPackagerService,
         stats_reporter_service::StatsReporterService,
@@ -801,8 +799,6 @@ impl Validator {
         for cluster_entrypoint in &cluster_entrypoints {
             info!("entrypoint: {cluster_entrypoint:?}");
         }
-
-        validate_memlock_limit_for_disk_io(config.accounts_db_config.memlock_budget_size)?;
 
         if !ledger_path.is_dir() {
             return Err(anyhow!(

--- a/fs/src/buffered_reader.rs
+++ b/fs/src/buffered_reader.rs
@@ -401,6 +401,7 @@ pub fn large_file_buf_reader(
 
         SequentialFileReaderBuilder::new()
             .shared_sqpoll(io_setup.shared_sqpoll_fd())
+            .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
             .build(path, buf_size)
     }
     #[cfg(not(target_os = "linux"))]

--- a/fs/src/file_io.rs
+++ b/fs/src/file_io.rs
@@ -155,6 +155,7 @@ pub fn file_creator<'a>(
 
         if buf_size >= DEFAULT_WRITE_SIZE {
             let io_uring_creator = IoUringFileCreatorBuilder::new()
+                .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
                 .shared_sqpoll(io_setup.shared_sqpoll_fd())
                 .build(buf_size, file_complete)?;
             return Ok(Box::new(io_uring_creator));

--- a/fs/src/io_setup.rs
+++ b/fs/src/io_setup.rs
@@ -21,6 +21,7 @@ use {
 pub struct IoSetupState {
     #[cfg(target_os = "linux")]
     shared_sqpoll: Option<SharedSqPoll>,
+    pub use_registered_io_uring_buffers: bool,
 }
 
 impl IoSetupState {
@@ -33,7 +34,16 @@ impl IoSetupState {
         Ok(Self {
             #[cfg(target_os = "linux")]
             shared_sqpoll: Some(SharedSqPoll::new()?),
+            ..self
         })
+    }
+
+    /// Enables registering of buffers in io-uring (as `fixed`).
+    ///
+    /// Speeds up kernel operations on the memory, but requires appropriate memlock ulimit.
+    pub fn with_buffers_registered(mut self, fixed: bool) -> Self {
+        self.use_registered_io_uring_buffers = fixed;
+        self
     }
 
     #[cfg(target_os = "linux")]

--- a/fs/src/io_uring/file_creator.rs
+++ b/fs/src/io_uring/file_creator.rs
@@ -84,7 +84,6 @@ impl<'sp> IoUringFileCreatorBuilder<'sp> {
     /// Set whether to register buffer with `io_uring` for improved performance.
     ///
     /// Enabling requires available memlock ulimit to be higher than sizes of registered buffers.
-    #[cfg(test)]
     pub fn use_registered_buffers(mut self, register_buffers: bool) -> Self {
         self.register_buffer = register_buffers;
         self

--- a/fs/src/io_uring/sequential_file_reader.rs
+++ b/fs/src/io_uring/sequential_file_reader.rs
@@ -45,7 +45,7 @@ impl<'sp> SequentialFileReaderBuilder<'sp> {
             max_iowq_workers: DEFAULT_MAX_IOWQ_WORKERS,
             ring_squeue_size: None,
             shared_sqpoll_fd: None,
-            register_buffer: true,
+            register_buffer: false,
         }
     }
 
@@ -61,7 +61,6 @@ impl<'sp> SequentialFileReaderBuilder<'sp> {
     /// Set whether to register buffer with `io_uring` for improved performance.
     ///
     /// Enabling requires available memlock ulimit to be higher than sizes of registered buffers.
-    #[cfg(test)]
     pub fn use_registered_buffers(mut self, register_buffers: bool) -> Self {
         self.register_buffer = register_buffers;
         self

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -4,7 +4,7 @@ use {
     log::*,
     solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
     solana_accounts_db::{
-        accounts_db::{AccountsDbConfig, DEFAULT_MEMLOCK_BUDGET_SIZE},
+        accounts_db::AccountsDbConfig,
         accounts_file::StorageAccess,
         accounts_index::{AccountsIndexConfig, IndexLimit, ScanFilter},
     },
@@ -15,6 +15,7 @@ use {
     },
     solana_cli_output::CliAccountNewConfig,
     solana_clock::Slot,
+    solana_core::resource_limits,
     solana_ledger::{
         blockstore_processor::ProcessOptions,
         use_snapshot_archives_at_startup::{self, UseSnapshotArchivesAtStartup},
@@ -314,7 +315,9 @@ pub fn get_accounts_db_config(
         skip_initial_hash_calc: arg_matches.is_present("accounts_db_skip_initial_hash_calculation"),
         storage_access,
         scan_filter_for_shrinking,
-        memlock_budget_size: DEFAULT_MEMLOCK_BUDGET_SIZE,
+        use_registered_io_uring_buffers: resource_limits::check_memlock_limit_for_disk_io(
+            solana_accounts_db::accounts_db::TOTAL_IO_URING_BUFFERS_SIZE_LIMIT,
+        ),
         ..AccountsDbConfig::default()
     }
 }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -33,6 +33,7 @@ use {
         banking_trace::DISABLED_BAKING_TRACE_DIR,
         consensus::tower_storage,
         repair::repair_handler::RepairHandlerType,
+        resource_limits,
         snapshot_packager_service::SnapshotPackagerService,
         system_monitor_service::SystemMonitorService,
         tpu::MAX_VOTES_PER_SECOND,
@@ -442,7 +443,9 @@ pub fn execute(
         num_background_threads: Some(accounts_db_background_threads),
         num_foreground_threads: Some(accounts_db_foreground_threads),
         mark_obsolete_accounts,
-        memlock_budget_size: solana_accounts_db::accounts_db::DEFAULT_MEMLOCK_BUDGET_SIZE,
+        use_registered_io_uring_buffers: resource_limits::check_memlock_limit_for_disk_io(
+            solana_accounts_db::accounts_db::TOTAL_IO_URING_BUFFERS_SIZE_LIMIT,
+        ),
         ..AccountsDbConfig::default()
     };
 


### PR DESCRIPTION
#### Problem
Currently accounts db config has a memlock budget size field that influences sizing of buffers when creating io-uring utilities. This logic ensures that io-uring can register buffers in kernel for more efficient operations.

In reality registering buffers is an optional performance booster, not a required feature. Io-uring does require some amount of memlock for operation (squeue space also needs to be memlocked), however this is much lower than buffer sizes and is more easily available on any linux setups (e.g. operating systems typically default to 8MB memlock ulimit).
We can simplify the initialization logic and instead of budgeting memlock space, we can just check at startup how much ulimit is available and disable registering buffers if it's not enough.

#### Summary of Changes
* replace `memlock_budget_size` with `use_registered_io_uring_buffers`  in `AccountsDbConfig`
* let resource limits check for memlock ulimit return false when requirement is not fullfilled and use that to decide value of `use_registered_io_uring_buffers` in `AccountsDbConfig`
* add `use_registered_io_uring_buffers` flag to `IoSetupState` and use it for enabling the feature through sequential reader and file creator builders
