### PR TITLE
pin solana-instruction version for solana-cli, solana-faucet and solana-keygen

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -66,7 +66,7 @@ solana-feature-gate-interface = { version = "=3.0.0", features = ["bincode"] }
 solana-fee-calculator = "=3.0.0"
 solana-fee-structure = "=3.0.0"
 solana-hash = "=3.1.0"
-solana-instruction = { workspace = true }
+solana-instruction = "=3.1.0"
 solana-keypair = "=3.1.0"
 solana-loader-v3-interface = { version = "=6.1.0", features = ["bincode"] }
 solana-loader-v4-interface = "=3.1.0"

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -35,7 +35,7 @@ solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-cli-output = { workspace = true }
 solana-hash = "=3.1.0"
-solana-instruction = { workspace = true }
+solana-instruction = "=3.1.0"
 solana-keypair = "=3.1.0"
 solana-message = "=3.0.1"
 solana-metrics = { workspace = true }

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -33,7 +33,7 @@ solana-bls-signatures = { workspace = true }
 solana-clap-v3-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-derivation-path = "=3.0.0"
-solana-instruction = { workspace = true, features = ["bincode"] }
+solana-instruction = { version = "=3.1.0", features = ["bincode"] }
 solana-keypair = "=3.1.0"
 solana-message = { version = "=3.0.1", features = ["bincode"] }
 solana-pubkey = { version = "=4.0.0", default-features = false }


### PR DESCRIPTION
#### Problem

iirc we pin dep version for bins. however, some solana-instruction versions were relaxed by https://github.com/anza-xyz/agave/pull/9341

#### Summary of Changes

recover them