### PR TITLE
fix docs typo

### DIFF
--- a/docs/src/validator/runtime.md
+++ b/docs/src/validator/runtime.md
@@ -41,7 +41,7 @@ Execution of the program involves mapping the program's public key to an entrypo
 The interface is best described by the `Instruction::data` that the user encodes.
 
 - `CreateAccount` - This allows the user to create an account with an allocated data array and assign it to a Program.
-- `CreateAccountAllowPrefund` - Same as `CreateAccount`, but does not check (and fail) if lamports are 0
+- `CreateAccountAllowPrefund` - Same as `CreateAccount`, but does not check (and fail) if the account has lamports.
 - `CreateAccountWithSeed` - Same as `CreateAccount`, but the new account's address is derived from
   - the funding account's pubkey,
   - a mnemonic string (seed), and


### PR DESCRIPTION
#### Problem
A typo in validator docs' runtime.md results in a confusing description of `CreateAccountAllowPrefund`. This follows #9647; the typo was not significant enough to restart the review cycle.

#### Summary of Changes
Fix the sentence.