### PR TITLE
Add WFSM stake metric

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2840,7 +2840,6 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
 
     let online_stake_percentage = (online_stake as f64 / total_activated_stake as f64) * 100.;
     if log {
-        trace!("cluster_info peers: {:?}", peers);
         info!("{online_stake_percentage:.3}% of active stake visible in gossip");
 
         if !wrong_shred_nodes.is_empty() {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2840,6 +2840,7 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
 
     let online_stake_percentage = (online_stake as f64 / total_activated_stake as f64) * 100.;
     if log {
+        trace!("cluster_info peers: {:?}", peers);
         info!("{online_stake_percentage:.3}% of active stake visible in gossip");
 
         if !wrong_shred_nodes.is_empty() {
@@ -2871,6 +2872,13 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
                 );
             }
         }
+        datapoint_info!(
+            "wfsm_gossip",
+            ("online_stake", online_stake, i64),
+            ("wrong_shred_stake", wrong_shred_stake, i64),
+            ("offline_stake", offline_stake, i64),
+            ("total_activated_stake", total_activated_stake, i64),
+        );
     }
 
     online_stake_percentage as u64

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2874,7 +2874,6 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
         datapoint_info!(
             "wfsm_gossip",
             ("online_stake", online_stake, i64),
-            ("wrong_shred_stake", wrong_shred_stake, i64),
             ("offline_stake", offline_stake, i64),
             ("total_activated_stake", total_activated_stake, i64),
         );


### PR DESCRIPTION
#### Problem
The [2025-12-03 testnet restart](https://github.com/anza-xyz/agave/wiki/2025-12-03-Testnet-rollback-and-restart) failed because some nodes saw 80% of stake online and some did not. 

#### Summary of Changes
Add a metric to make it easier to monitor WFSM status in future restarts.