### PR TITLE
Rekey `create_account_allow_prefund` feature

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1161,7 +1161,7 @@ pub mod provide_instruction_data_offset_in_vm_r2 {
 }
 
 pub mod create_account_allow_prefund {
-    solana_pubkey::declare_id!("8nZKHnryahsWXSvECnrm3rYsWbirpSQgjZAJCr7LzWsb");
+    solana_pubkey::declare_id!("caapcFpbcsJTMQMEMcpyx1m27DcXVp4MH6faHM5h5Z5");
 }
 
 pub mod static_instruction_limit {


### PR DESCRIPTION
#### Problem
`create_account_allow_prefund` feature needs a rekey

#### Summary of Changes
Rekey it

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
