### PR TITLE
metrics: Log index_meta_time_us in BlockstoreInsertionMetrics

### DIFF
--- a/ledger/src/blockstore_metrics.rs
+++ b/ledger/src/blockstore_metrics.rs
@@ -74,6 +74,7 @@ impl BlockstoreInsertionMetrics {
                 self.write_batch_elapsed_us as i64,
                 i64
             ),
+            ("index_meta_time_us", self.index_meta_time_us as i64, i64),
             ("num_inserted", self.num_inserted as i64, i64),
             ("num_repair", self.num_repair as i64, i64),
             ("num_recovered", self.num_recovered as i64, i64),


### PR DESCRIPTION
index_meta_time_us was being measured and accumulated during shred insertion but never reported via datapoint_info!. This meant we were paying the cost of collecting the metric without exposing it to observability or dashboards.  This change adds index_meta_time_us to BlockstoreInsertionMetrics::report_metrics