### PR TITLE
Fix: extra lamports were always paid during program deployment

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1785,7 +1785,7 @@ async fn process_write_buffer(
         program_data.len()
     };
     let min_rent_exempt_program_data_balance = rpc_client
-        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_buffer(
             buffer_data_max_len,
         ))
         .await?;

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1784,7 +1784,7 @@ async fn process_write_buffer(
     } else {
         program_data.len()
     };
-    let min_rent_exempt_program_data_balance = rpc_client
+    let min_rent_exempt_program_buffer_balance = rpc_client
         .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_buffer(
             buffer_data_max_len,
         ))
@@ -1795,7 +1795,7 @@ async fn process_write_buffer(
         config,
         &program_data,
         program_data.len(),
-        min_rent_exempt_program_data_balance,
+        min_rent_exempt_program_buffer_balance,
         fee_payer_signer,
         buffer_signer,
         &buffer_pubkey,
@@ -2827,7 +2827,7 @@ async fn do_process_write_buffer(
     config: &CliConfig<'_>,
     program_data: &[u8], // can be empty, hence we have program_len
     program_len: usize,
-    min_rent_exempt_program_data_balance: u64,
+    min_rent_exempt_program_buffer_balance: u64,
     fee_payer_signer: &dyn Signer,
     buffer_signer: Option<&dyn Signer>,
     buffer_pubkey: &Pubkey,
@@ -2850,10 +2850,10 @@ async fn do_process_write_buffer(
                     &fee_payer_signer.pubkey(),
                     buffer_pubkey,
                     &buffer_authority_signer.pubkey(),
-                    min_rent_exempt_program_data_balance,
+                    min_rent_exempt_program_buffer_balance,
                     program_len,
                 )?,
-                min_rent_exempt_program_data_balance,
+                min_rent_exempt_program_buffer_balance,
                 vec![0; program_len],
             )
         };

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1700,15 +1700,11 @@ async fn test_cli_program_write_buffer() {
     file.read_to_end(&mut program_data).unwrap();
     let max_len = program_data.len();
     let minimum_balance_for_buffer = rpc_client
-        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
-            max_len,
-        ))
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_buffer(max_len))
         .await
         .unwrap();
     let minimum_balance_for_buffer_default = rpc_client
-        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
-            max_len,
-        ))
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_buffer(max_len))
         .await
         .unwrap();
 
@@ -2105,9 +2101,7 @@ async fn test_cli_program_write_buffer_feature(enable_feature: bool) {
     file.read_to_end(&mut program_data).unwrap();
     let max_len = program_data.len();
     let minimum_balance_for_buffer = rpc_client
-        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
-            max_len,
-        ))
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_buffer(max_len))
         .await
         .unwrap();
 


### PR DESCRIPTION
#### Problem

The calculated size of `size_of_programdata` is always 8 larger than the result calculated by `size_of_buffer`. My intuition tells me that the code should use `size_of_buffer` here because a program buffer account is being created here. I've tested it; the modified Solana CLI can deploy the program correctly and interact with it.

I'm not entirely sure if this modification is "correct," so please review it.

(If I am wrong, please explain why size_of_programdata is used here. thank you)

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
