### PR TITLE
Removes useless param from BgThreads::new()

### DIFF
--- a/accounts-db/src/accounts_index/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index/accounts_index_storage.rs
@@ -53,7 +53,6 @@ impl BgThreads {
         storage: &Arc<BucketMapHolder<T, U>>,
         in_mem: &[Arc<InMemAccountsIndex<T, U>>],
         threads: NonZeroUsize,
-        can_advance_age: bool,
         exit: Arc<AtomicBool>,
     ) -> Self {
         let is_disk_index_enabled = storage.is_disk_index_enabled();
@@ -70,7 +69,7 @@ impl BgThreads {
             (0..num_threads)
                 .map(|idx| {
                     // the first thread we start is special
-                    let can_advance_age = can_advance_age && idx == 0;
+                    let can_advance_age = idx == 0;
                     let storage_ = Arc::clone(storage);
                     let local_exit = local_exit.clone();
                     let system_exit = exit.clone();
@@ -131,7 +130,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexStorage<
             .collect();
 
         Self {
-            _bg_threads: BgThreads::new(&storage, &in_mem, num_flush_threads, true, exit),
+            _bg_threads: BgThreads::new(&storage, &in_mem, num_flush_threads, exit),
             storage,
             in_mem,
         }


### PR DESCRIPTION
#### Problem

`BgThreads::new()` take a param, `can_advance_age`. However it is always called with `true`, rendering this param useless.


#### Summary of Changes

Remove it.