### PR TITLE
perf(serde_snapshot): deserialize stakes in bank fields into Vec

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -43,7 +43,9 @@ use {
             },
         },
         bank_forks::BankForks,
-        epoch_stakes::{NodeVoteAccounts, VersionedEpochStakes},
+        epoch_stakes::{
+            DeserializableVersionedEpochStakes, NodeVoteAccounts, VersionedEpochStakes,
+        },
         inflation_rewards::points::InflationPointCalculationEvent,
         installed_scheduler_pool::{BankWithScheduler, InstalledSchedulerRwLock},
         rent_collector::RentCollector,
@@ -54,7 +56,7 @@ use {
             calculate_stake_weighted_timestamp, MaxAllowableDrift,
             MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2,
         },
-        stakes::{SerdeStakesToStakeFormat, Stakes, StakesCache},
+        stakes::{DeserializableStakes, SerdeStakesToStakeFormat, Stakes, StakesCache},
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
@@ -427,7 +429,6 @@ impl TransactionLogCollector {
 /// new fields can be optionally serialized and optionally deserialized. At some point, the serialization and
 /// deserialization will use a new mechanism or otherwise be in sync more clearly.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct BankFieldsToDeserialize {
     pub(crate) blockhash_queue: BlockhashQueue,
     pub(crate) ancestors: AncestorsForSerialization,
@@ -454,8 +455,8 @@ pub struct BankFieldsToDeserialize {
     pub(crate) rent_collector: RentCollector,
     pub(crate) epoch_schedule: EpochSchedule,
     pub(crate) inflation: Inflation,
-    pub(crate) stakes: Stakes<Delegation>,
-    pub(crate) versioned_epoch_stakes: HashMap<Epoch, VersionedEpochStakes>,
+    pub(crate) stakes: DeserializableStakes<Delegation>,
+    pub(crate) versioned_epoch_stakes: HashMap<Epoch, DeserializableVersionedEpochStakes>,
     pub(crate) is_delta: bool,
     pub(crate) accounts_data_len: u64,
     pub(crate) accounts_lt_hash: AccountsLtHash,
@@ -1827,12 +1828,15 @@ impl Bank {
         // Note that we are disabling the read cache while we populate the stakes cache.
         // The stakes accounts will not be expected to be loaded again.
         // If we populate the read cache with these loads, then we'll just soon have to evict these.
-        let (stakes, stakes_time) = measure_time!(Stakes::new(&fields.stakes, |pubkey| {
-            let (account, _slot) = bank_rc
-                .accounts
-                .load_with_fixed_root_do_not_populate_read_cache(&ancestors, pubkey)?;
-            Some(account)
-        })
+        let (stakes, stakes_time) = measure_time!(Stakes::load_from_deserialized_delegations(
+            fields.stakes,
+            |pubkey| {
+                let (account, _slot) = bank_rc
+                    .accounts
+                    .load_with_fixed_root_do_not_populate_read_cache(&ancestors, pubkey)?;
+                Some(account)
+            }
+        )
         .expect(
             "Stakes cache is inconsistent with accounts-db. This can indicate a corrupted \
              snapshot or bugs in cached accounts or accounts-db.",
@@ -1874,7 +1878,11 @@ impl Bank {
             epoch_schedule: fields.epoch_schedule,
             inflation: Arc::new(RwLock::new(fields.inflation)),
             stakes_cache: StakesCache::new(stakes),
-            epoch_stakes: fields.versioned_epoch_stakes,
+            epoch_stakes: fields
+                .versioned_epoch_stakes
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
             is_delta: AtomicBool::new(fields.is_delta),
             rewards: RwLock::new(vec![]),
             cluster_type: Some(genesis_config.cluster_type),

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -6,12 +6,12 @@ use std::{
 use {
     crate::{
         bank::{Bank, BankFieldsToDeserialize, BankFieldsToSerialize, BankHashStats, BankRc},
-        epoch_stakes::VersionedEpochStakes,
+        epoch_stakes::{DeserializableVersionedEpochStakes, VersionedEpochStakes},
         rent_collector::RentCollector,
         runtime_config::RuntimeConfig,
         snapshot_utils::StorageAndNextAccountsFileId,
         stake_account::StakeAccount,
-        stakes::{serialize_stake_accounts_to_delegation_format, Stakes},
+        stakes::{serialize_stake_accounts_to_delegation_format, DeserializableStakes, Stakes},
     },
     agave_fs::FileInfo,
     agave_snapshots::error::SnapshotError,
@@ -181,7 +181,7 @@ struct DeserializableVersionedBank {
     rent_collector: RentCollector,
     epoch_schedule: EpochSchedule,
     inflation: Inflation,
-    stakes: Stakes<Delegation>,
+    stakes: DeserializableStakes<Delegation>,
     #[allow(dead_code)]
     unused_accounts: UnusedAccounts,
     unused_epoch_stakes: HashMap<Epoch, ()>,
@@ -416,7 +416,6 @@ where
 /// added to this struct a minor release before they are added to the serialize
 /// struct.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 #[derive(Clone, Debug, Deserialize)]
 struct ExtraFieldsToDeserialize {
     #[serde(deserialize_with = "default_on_eof")]
@@ -426,7 +425,7 @@ struct ExtraFieldsToDeserialize {
     #[serde(deserialize_with = "default_on_eof")]
     _obsolete_epoch_accounts_hash: Option<Hash>,
     #[serde(deserialize_with = "default_on_eof")]
-    versioned_epoch_stakes: HashMap<u64, VersionedEpochStakes>,
+    versioned_epoch_stakes: HashMap<u64, DeserializableVersionedEpochStakes>,
     #[serde(deserialize_with = "default_on_eof")]
     accounts_lt_hash: Option<SerdeAccountsLtHash>,
 }


### PR DESCRIPTION
#### Problem
Building `im::HashMap` is quite slow and its creation for stakes maps dominates deserializing snaphsot, which is on critical path for startup. Bincode serialization format doesn't distinguish map from vector of `(key, value)` pairs, so we can instead quickly deserialize just a collection and then create final maps out of that, which may happen concurrently out of critical path or with use of rayon.

In fact currently stakes map is constructed by collecting deserialized delegations im hashmap back into vector (sic!) and running rayon fold to generate stakes map with account data (also fetches the account contents).

#### Summary of Changes
* add `DeserializableStakes<T>` and `DeserializableVersionedEpochStakes` structs that use `Vec` instead of `im::HashMap` to store stakes (address, X) entries
* never deserialize `Stakes`
* deserialize bank fields using cheaper representation for stakes, which shorten time before we start accounts db initialization
* move conversion of deserialized stakes in bank fields into real stakes maps after accounts db is initialized
* in case of initialization from archive, this skips expensive deserialization that happens currently for both full and incremental snapshots, since we only run conversion after selecting one of the field sets

Note: this change opens up opportunity to parallelize the longest operation (building of epoch stakes `im` map) with accounts db initialization, not included in this PR as it's a bit larger refactor.

##### Performance change
* Initializing from dir (fastboot) - speed up comes from building stakes delegation map, the epoch stakes cost is mostly shifted from beginning of `bank_from_snapshot_dir` to its later stage:
  * master - `solana_runtime::serde_snapshot::deserialize_bank_fields` 5.25s (before accountds db can run generate index) + `solana_runtime::bank::Bank::new_from_snapshot` 2.34s (after accountds db is initialized), 
  * PR - `solana_runtime::serde_snapshot::deserialize_bank_fields` 1.4s  + `solana_runtime::bank::Bank::new_from_snapshot` 5.2s

* Initializing from archive - we skip one round of `deserialize_bank_fields`, since we only create expensive stakes maps for one of the snapshots instead of both (from full and incremental), so it brings some ~5s speedup
