### PR TITLE
Avoid extra Vec allocation in accounts index pubkey iterator

### DIFF
--- a/accounts-db/src/accounts_index/iter.rs
+++ b/accounts-db/src/accounts_index/iter.rs
@@ -71,9 +71,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Iterator
             let bin = self.start_bin;
             let map = &self.account_maps[bin];
             let mut items = map.keys();
-            if !(self.start_bound == Bound::Unbounded
-                && self.end_bound == Bound::Unbounded)
-            {
+            if !(self.start_bound == Bound::Unbounded && self.end_bound == Bound::Unbounded) {
                 items.retain(|k| range.contains(k));
             }
             if self.iter_order == AccountsIndexPubkeyIterOrder::Sorted {

--- a/accounts-db/src/accounts_index/iter.rs
+++ b/accounts-db/src/accounts_index/iter.rs
@@ -71,8 +71,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Iterator
             let bin = self.start_bin;
             let map = &self.account_maps[bin];
             let mut items = map.keys();
-            if !(matches!(self.start_bound, Bound::Unbounded)
-                && matches!(self.end_bound, Bound::Unbounded))
+            if !(self.start_bound == Bound::Unbounded
+                && self.end_bound == Bound::Unbounded)
             {
                 items.retain(|k| range.contains(k));
             }

--- a/accounts-db/src/accounts_index/iter.rs
+++ b/accounts-db/src/accounts_index/iter.rs
@@ -70,11 +70,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Iterator
 
             let bin = self.start_bin;
             let map = &self.account_maps[bin];
-            let mut items = map
-                .keys()
-                .into_iter()
-                .filter(|k| range.contains(&k))
-                .collect::<Vec<_>>();
+            let mut items = map.keys();
+            if !(matches!(self.start_bound, Bound::Unbounded)
+                && matches!(self.end_bound, Bound::Unbounded))
+            {
+                items.retain(|k| range.contains(k));
+            }
             if self.iter_order == AccountsIndexPubkeyIterOrder::Sorted {
                 items.sort_unstable();
             }


### PR DESCRIPTION
Removed an unnecessary second Vec allocation in AccountsIndexPubkeyIterator::next by reusing the Vec returned from InMemAccountsIndex::keys. Instead of collecting filtered keys into a new vector, the iterator now filters the existing vector in place with retain when a bounded pubkey range is specified, and then optionally sorts it. This preserves the existing behavior for both sorted and unsorted iteration while reducing per-bin allocations and copies on the hot scan path.
