### PR TITLE
Add FADV_RANDOM to accountsdb appendvec impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7197,6 +7197,7 @@ dependencies = [
  "dashmap",
  "indexmap 2.12.1",
  "itertools 0.14.0",
+ "libc",
  "libsecp256k1",
  "log",
  "lz4",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -48,6 +48,7 @@ crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api"] }
 indexmap = { workspace = true }
 itertools = { workspace = true }
+libc = { workspace = true }
 log = { workspace = true }
 lz4 = { workspace = true }
 memmap2 = { workspace = true }


### PR DESCRIPTION
#### Problem
When running a validator, basically all of memory is used up by kernel page cache trying to guess what we want to cache. By explicitly marking appendvec files as FADV_RANDOM, the kernel should stop trying to cache accounts for us. In the future, we should try to explicitly cache what we need.

#### Summary of Changes
Mark appendvec files as FADV_RANDOM.
https://www.man7.org/linux/man-pages/man2/posix_fadvise.2.html
