### PR TITLE
doc(sysvars): correct CU efficiency of usage

### DIFF
--- a/docs/src/runtime/sysvars.md
+++ b/docs/src/runtime/sysvars.md
@@ -35,7 +35,7 @@ let clock_sysvar_info = next_account_info(account_info_iter)?;
 let clock = Clock::from_account_info(&clock_sysvar_info)?;
 ```
 
-The first method is more efficient and does not require that the sysvar account
+The first method is less efficient but does not require that the sysvar account
 be passed to the program, or specified in the `Instruction` the program is
 processing.
 

--- a/docs/src/runtime/sysvars.md
+++ b/docs/src/runtime/sysvars.md
@@ -35,9 +35,12 @@ let clock_sysvar_info = next_account_info(account_info_iter)?;
 let clock = Clock::from_account_info(&clock_sysvar_info)?;
 ```
 
-The first method is less efficient but does not require that the sysvar account
-be passed to the program, or specified in the `Instruction` the program is
-processing.
+The first method incurs a base cost of 100 CU plus the size of the sysvar in
+bytes (e.g., ~140 CU for Clock), but does not require passing the sysvar account
+in the instruction. The second method avoids this syscall overhead and can be
+more efficient for programs that read the same sysvar multiple times, since the
+data is already in program memory — however, it requires including the sysvar
+account in the transaction.
 
 ## Clock
 


### PR DESCRIPTION
#### Problem

sysvar documentation has misleading information about efficiency of `account read VS syscall`.

#### Summary of Changes

corrected documentation based on the next calculations for `Clock`  sysvar as an example:

looking at [sysvar.rs](https://github.com/anza-xyz/agave/blob/master/syscalls/src/sysvar.rs#L13-L18), the `Clock::get()` syscall consumes: `sysvar_base_cost + size_of::<Clock>() = 100 + 40 = 140 CU`

when reading the Clock sysvar from account data, we have to:
1. read the account data - there's no explicit CU cost for just reading account data that's already loaded into the program's memory
2. deserialize the data - the only step which consumes extra CU, if im not mistaken even bincode deserialization of `40 bytes` is about `40 CU`.