### PR TITLE
add solana-reward-info crate from SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10058,12 +10058,11 @@ dependencies = [
 
 [[package]]
 name = "solana-reward-info"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82be7946105c2ee6be9f9ee7bd18a068b558389221d29efa92b906476102bfcc"
+version = "4.0.0-alpha.0"
 dependencies = [
  "serde",
- "serde_derive",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -518,7 +518,7 @@ solana-quic-definitions = "3.0.0"
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-remote-wallet = { path = "remote-wallet", version = "=4.0.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-rent = "3.0.0"
-solana-reward-info = { path = "reward-info", version = "=4.0.0-alpha.0" }
+solana-reward-info = { path = "reward-info", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-rpc = { path = "rpc", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-rpc-client = { path = "rpc-client", version = "=4.0.0-alpha.0", default-features = false }
 solana-rpc-client-api = { path = "rpc-client-api", version = "=4.0.0-alpha.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ members = [
     "rbpf-cli",
     "remote-wallet",
     "reserved-account-keys",
+    "reward-info",
     "rpc",
     "rpc-client",
     "rpc-client-api",
@@ -517,7 +518,7 @@ solana-quic-definitions = "3.0.0"
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-remote-wallet = { path = "remote-wallet", version = "=4.0.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-rent = "3.0.0"
-solana-reward-info = "3.0.0"
+solana-reward-info = { path = "reward-info", version = "=4.0.0-alpha.0" }
 solana-rpc = { path = "rpc", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-rpc-client = { path = "rpc-client", version = "=4.0.0-alpha.0", default-features = false }
 solana-rpc-client-api = { path = "rpc-client-api", version = "=4.0.0-alpha.0" }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8432,12 +8432,9 @@ dependencies = [
 
 [[package]]
 name = "solana-reward-info"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82be7946105c2ee6be9f9ee7bd18a068b558389221d29efa92b906476102bfcc"
+version = "4.0.0-alpha.0"
 dependencies = [
  "serde",
- "serde_derive",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8162,12 +8162,9 @@ dependencies = [
 
 [[package]]
 name = "solana-reward-info"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82be7946105c2ee6be9f9ee7bd18a068b558389221d29efa92b906476102bfcc"
+version = "4.0.0-alpha.0"
 dependencies = [
  "serde",
- "serde_derive",
 ]
 
 [[package]]

--- a/reward-info/Cargo.toml
+++ b/reward-info/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "solana-reward-info"
+description = "Solana vote reward info types"
+documentation = "https://docs.rs/solana-reward-info"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
+serde = ["serde/derive"]
+
+[dependencies]
+serde = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/reward-info/Cargo.toml
+++ b/reward-info/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
+agave-unstable-api = []
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
 serde = ["serde/derive"]
 

--- a/reward-info/src/lib.rs
+++ b/reward-info/src/lib.rs
@@ -1,3 +1,12 @@
+#![cfg_attr(
+    not(feature = "agave-unstable-api"),
+    deprecated(
+        since = "3.1.0",
+        note = "This crate has been marked for formal inclusion in the Agave Unstable API. From \
+                v4.0.0 onward, the `agave-unstable-api` crate feature must be specified to \
+                acknowledge use of an interface that may break without warning."
+    )
+)]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #[cfg(feature = "serde")]

--- a/reward-info/src/lib.rs
+++ b/reward-info/src/lib.rs
@@ -1,0 +1,45 @@
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
+use std::fmt;
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum RewardType {
+    Fee,
+    Rent,
+    Staking,
+    Voting,
+}
+
+impl fmt::Display for RewardType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                RewardType::Fee => "fee",
+                RewardType::Rent => "rent",
+                RewardType::Staking => "staking",
+                RewardType::Voting => "voting",
+            }
+        )
+    }
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct RewardInfo {
+    pub reward_type: RewardType,
+    /// Reward amount
+    pub lamports: i64,
+    /// Account balance in lamports after `lamports` was applied
+    pub post_balance: u64,
+    /// Vote account commission when the reward was credited, only present for voting and staking rewards
+    pub commission: Option<u8>,
+}


### PR DESCRIPTION
#### Problem
TBD

#### Summary of Changes
Move the `solana-reward-info` crate into Agave.