### PR TITLE
runtime: Relax program data account check in migration

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1220,6 +1220,10 @@ pub mod bls_pubkey_management_in_vote_account {
     solana_pubkey::declare_id!("EGJLweNUVskAPEwpjvNB7JT6uUi6h4mFhowNYXVSrimG");
 }
 
+pub mod relax_programdata_account_check_migration {
+    solana_pubkey::declare_id!("rexav5eNTUSNT1K2N7cfRjnthwhcP5BC25v2tA4rW4h");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2186,6 +2190,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             bls_pubkey_management_in_vote_account::id(),
             "SIMD-0387: BLS Pubkey Management in Vote Account",
+        ),
+        (
+            relax_programdata_account_check_migration::id(),
+            "SIMD-0444: Relax program data account check in migration",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -62,7 +62,7 @@ use {
     accounts_lt_hash::{CacheValue as AccountsLtHashCacheValue, Stats as AccountsLtHashStats},
     agave_feature_set::{
         self as feature_set, increase_cpi_account_info_limit, raise_cpi_nesting_limit_to_8,
-        FeatureSet,
+        relax_programdata_account_check_migration, FeatureSet,
     },
     agave_precompiles::{get_precompile, get_precompiles, is_precompile},
     agave_reserved_account_keys::ReservedAccountKeys,
@@ -5441,6 +5441,8 @@ impl Bank {
             if let Err(e) = self.upgrade_loader_v2_program_with_loader_v3_program(
                 &feature_set::replace_spl_token_with_p_token::SPL_TOKEN_PROGRAM_ID,
                 &feature_set::replace_spl_token_with_p_token::PTOKEN_PROGRAM_BUFFER,
+                self.feature_set
+                    .is_active(&relax_programdata_account_check_migration::id()),
                 "replace_spl_token_with_p_token",
             ) {
                 warn!(
@@ -5475,9 +5477,12 @@ impl Bank {
                 // activation, perform the migration which will remove it from
                 // the builtins list and the cache.
                 if new_feature_activations.contains(&core_bpf_migration_config.feature_id) {
-                    if let Err(e) = self
-                        .migrate_builtin_to_core_bpf(&builtin.program_id, core_bpf_migration_config)
-                    {
+                    if let Err(e) = self.migrate_builtin_to_core_bpf(
+                        &builtin.program_id,
+                        core_bpf_migration_config,
+                        self.feature_set
+                            .is_active(&relax_programdata_account_check_migration::id()),
+                    ) {
                         warn!(
                             "Failed to migrate builtin {} to Core BPF: {}",
                             builtin.name, e
@@ -5496,6 +5501,8 @@ impl Bank {
                     if let Err(e) = self.migrate_builtin_to_core_bpf(
                         &stateless_builtin.program_id,
                         core_bpf_migration_config,
+                        self.feature_set
+                            .is_active(&relax_programdata_account_check_migration::id()),
                     ) {
                         warn!(
                             "Failed to migrate stateless builtin {} to Core BPF: {}",

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -267,12 +267,15 @@ impl Bank {
 
         // Calculate the lamports to burn.
         // The target program account will be replaced, so burn its lamports.
+        // The target program data account might have lamports if it existed,
+        // so burn its lamports if any.
         // The source buffer account will be cleared, so burn its lamports.
         // The two new program accounts will need to be funded.
         let lamports_to_burn = checked_add(
             target.program_account.lamports(),
             source.buffer_account.lamports(),
-        )?;
+        )
+        .and_then(|v| checked_add(v, target.program_data_account_lamports))?;
         let lamports_to_fund = checked_add(
             new_target_program_account.lamports(),
             new_target_program_data_account.lamports(),
@@ -437,12 +440,15 @@ impl Bank {
 
         // Calculate the lamports to burn.
         // The target program account will be replaced, so burn its lamports.
+        // The target program data account might have lamports if it existed,
+        // so burn its lamports if any.
         // The source buffer account will be cleared, so burn its lamports.
         // The two new program accounts will need to be funded.
         let lamports_to_burn = checked_add(
             target.program_account.lamports(),
             source.buffer_account.lamports(),
-        )?;
+        )
+        .and_then(|v| checked_add(v, target.program_data_account_lamports))?;
         let lamports_to_fund = checked_add(
             new_target_program_account.lamports(),
             new_target_program_data_account.lamports(),
@@ -520,7 +526,7 @@ pub(crate) mod tests {
         solana_native_token::LAMPORTS_PER_SOL,
         solana_program_runtime::loaded_programs::{ProgramCacheEntry, ProgramCacheEntryType},
         solana_pubkey::Pubkey,
-        solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, native_loader},
+        solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, native_loader, system_program},
         solana_signer::Signer,
         solana_transaction::Transaction,
         std::{fs::File, io::Read, sync::Arc},
@@ -2165,5 +2171,167 @@ pub(crate) mod tests {
         // Run the post-upgrade program checks on the restored bank.
         test_context.run_program_checks(&roundtrip_bank, upgrade_slot);
         assert_eq!(bank, roundtrip_bank);
+    }
+
+    #[test]
+    fn test_replace_spl_token_with_p_token_and_funded_program_data_account_e2e() {
+        let (mut genesis_config, mint_keypair) =
+            create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let slots_per_epoch = 32;
+        genesis_config.epoch_schedule =
+            EpochSchedule::custom(slots_per_epoch, slots_per_epoch, false);
+
+        let mut root_bank = Bank::new_for_tests(&genesis_config);
+
+        let feature_id = agave_feature_set::replace_spl_token_with_p_token::id();
+        let program_id = agave_feature_set::replace_spl_token_with_p_token::SPL_TOKEN_PROGRAM_ID;
+        let source_buffer_address =
+            agave_feature_set::replace_spl_token_with_p_token::PTOKEN_PROGRAM_BUFFER;
+
+        // Set up a mock BPF loader v2 program.
+        {
+            let program_account = mock_bpf_loader_v2_program(&root_bank);
+            root_bank.store_account_and_update_capitalization(&program_id, &program_account);
+            assert_eq!(
+                &root_bank.get_account(&program_id).unwrap(),
+                &program_account
+            );
+        };
+
+        // Set up the CPI mockup to test CPI'ing to the migrated program.
+        let cpi_program_id = Pubkey::new_unique();
+        let cpi_program_name = "mock_cpi_program";
+        root_bank.add_builtin(
+            cpi_program_id,
+            cpi_program_name,
+            ProgramCacheEntry::new_builtin(0, cpi_program_name.len(), cpi_mockup::Entrypoint::vm),
+        );
+
+        // Add the feature to the bank's inactive feature set.
+        // Note this will add the feature ID if it doesn't exist.
+        let mut feature_set = FeatureSet::all_enabled();
+        feature_set.deactivate(&feature_id);
+        root_bank.feature_set = Arc::new(feature_set);
+
+        // Initialize the source buffer account.
+        let test_context = TestContext::new(&root_bank, &program_id, &source_buffer_address, None);
+
+        // Fund the program data account so it will appear as an existing account.
+        let program_data_account = AccountSharedData::new(1_000_000_000, 0, &system_program::ID);
+        root_bank.store_account_and_update_capitalization(
+            &get_program_data_address(&program_id),
+            &program_data_account,
+        );
+
+        // Activate the feature and run the necessary checks.
+        activate_feature_and_run_checks(
+            root_bank,
+            &test_context,
+            &program_id,
+            &feature_id,
+            &source_buffer_address,
+            &mint_keypair,
+            slots_per_epoch,
+            &cpi_program_id,
+        );
+    }
+
+    #[test]
+    fn test_replace_spl_token_with_p_token_and_existing_program_data_account_failure() {
+        let (mut genesis_config, _mint_keypair) =
+            create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let slots_per_epoch = 32;
+        genesis_config.epoch_schedule =
+            EpochSchedule::custom(slots_per_epoch, slots_per_epoch, false);
+
+        let mut root_bank = Bank::new_for_tests(&genesis_config);
+
+        let feature_id = agave_feature_set::replace_spl_token_with_p_token::id();
+        let program_id = agave_feature_set::replace_spl_token_with_p_token::SPL_TOKEN_PROGRAM_ID;
+        let source_buffer_address =
+            agave_feature_set::replace_spl_token_with_p_token::PTOKEN_PROGRAM_BUFFER;
+
+        // Set up a mock BPF loader v2 program.
+        let program_account = mock_bpf_loader_v2_program(&root_bank);
+        root_bank.store_account_and_update_capitalization(&program_id, &program_account);
+        assert_eq!(
+            &root_bank.get_account(&program_id).unwrap(),
+            &program_account
+        );
+
+        // Set up the CPI mockup to test CPI'ing to the migrated program.
+        let cpi_program_id = Pubkey::new_unique();
+        let cpi_program_name = "mock_cpi_program";
+        root_bank.add_builtin(
+            cpi_program_id,
+            cpi_program_name,
+            ProgramCacheEntry::new_builtin(0, cpi_program_name.len(), cpi_mockup::Entrypoint::vm),
+        );
+
+        // Add the feature to the bank's inactive feature set.
+        // Note this will add the feature ID if it doesn't exist.
+        let mut feature_set = FeatureSet::all_enabled();
+        feature_set.deactivate(&feature_id);
+        root_bank.feature_set = Arc::new(feature_set);
+
+        // Initialize the source buffer account.
+        let _test_context = TestContext::new(&root_bank, &program_id, &source_buffer_address, None);
+
+        // Create the program data account to simulate existing account owned by
+        // the upgradeable loader.
+        let program_data_account =
+            AccountSharedData::new(1_000_000_000, 0, &bpf_loader_upgradeable::ID);
+        root_bank.store_account_and_update_capitalization(
+            &get_program_data_address(&program_id),
+            &program_data_account,
+        );
+
+        // Activate the feature and run the necessary checks.
+        let (bank, bank_forks) = root_bank.wrap_with_bank_forks_for_tests();
+
+        // Advance to the next epoch without activating the feature.
+        let mut first_slot_in_next_epoch = slots_per_epoch + 1;
+        let bank = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            &Pubkey::default(),
+            first_slot_in_next_epoch,
+        );
+
+        // Assert the feature was not activated and the program was not
+        // migrated.
+        assert!(!bank.feature_set.is_active(&feature_id));
+        assert!(bank.get_account(&source_buffer_address).is_some());
+
+        // Store the account to activate the feature.
+        bank.store_account_and_update_capitalization(
+            &feature_id,
+            &feature::create_account(&Feature::default(), 42),
+        );
+
+        // Advance the bank to cross the epoch boundary and activate the
+        // feature.
+        goto_end_of_slot(bank.clone());
+        first_slot_in_next_epoch += slots_per_epoch;
+        let _migration_slot = first_slot_in_next_epoch;
+        let bank = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            &Pubkey::default(),
+            first_slot_in_next_epoch,
+        );
+
+        // Check that the feature was activated.
+        assert!(bank.feature_set.is_active(&feature_id));
+        // The program should still be owned by the bpf loader v2.
+        let program_account = bank.get_account(&program_id).unwrap();
+        assert_eq!(program_account.owner(), &bpf_loader::id());
+        // The program data should have zero data and still have
+        // 1_000_000_000 lamports.
+        let program_data_account = bank
+            .get_account(&get_program_data_address(&program_id))
+            .unwrap();
+        assert_eq!(program_data_account.data().len(), 0);
+        assert_eq!(program_data_account.lamports(), 1_000_000_000);
     }
 }

--- a/runtime/src/bank/builtins/core_bpf_migration/target_bpf_v2.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_bpf_v2.rs
@@ -5,7 +5,7 @@ use {
     solana_account::{AccountSharedData, ReadableAccount},
     solana_loader_v3_interface::get_program_data_address,
     solana_pubkey::Pubkey,
-    solana_sdk_ids::bpf_loader,
+    solana_sdk_ids::{bpf_loader, system_program::ID as SYSTEM_PROGRAM_ID},
 };
 
 /// The account details of a Loader v2 BPF program slated to be upgraded.
@@ -24,6 +24,7 @@ impl TargetBpfV2 {
     pub(crate) fn new_checked(
         bank: &Bank,
         program_address: &Pubkey,
+        allow_prefunded: bool,
     ) -> Result<Self, CoreBpfMigrationError> {
         // The program account should exist.
         let program_account = bank
@@ -44,15 +45,32 @@ impl TargetBpfV2 {
 
         let program_data_address = get_program_data_address(program_address);
 
-        // The program data account should not exist.
-        if bank
-            .get_account_with_fixed_root(&program_data_address)
-            .is_some()
-        {
-            return Err(CoreBpfMigrationError::ProgramHasDataAccount(
-                *program_address,
-            ));
-        }
+        let program_data_account_lamports = if allow_prefunded {
+            // The program data account should not exist, but a system account with funded
+            // lamports is acceptable.
+            if let Some(account) = bank.get_account_with_fixed_root(&program_data_address) {
+                if account.owner() != &SYSTEM_PROGRAM_ID {
+                    return Err(CoreBpfMigrationError::ProgramHasDataAccount(
+                        *program_address,
+                    ));
+                }
+                account.lamports()
+            } else {
+                0
+            }
+        } else {
+            // The program data account should not exist and have zero lamports.
+            if bank
+                .get_account_with_fixed_root(&program_data_address)
+                .is_some()
+            {
+                return Err(CoreBpfMigrationError::ProgramHasDataAccount(
+                    *program_address,
+                ));
+            }
+
+            0
+        };
 
         Ok(Self {
             program_address: *program_address,
@@ -87,7 +105,7 @@ mod tests {
 
         // Fail if the program account does not exist.
         assert_matches!(
-            TargetBpfV2::new_checked(&bank, &program_address).unwrap_err(),
+            TargetBpfV2::new_checked(&bank, &program_address, true).unwrap_err(),
             CoreBpfMigrationError::AccountNotFound(..)
         );
 
@@ -100,7 +118,7 @@ mod tests {
             true,
         );
         assert_matches!(
-            TargetBpfV2::new_checked(&bank, &program_address).unwrap_err(),
+            TargetBpfV2::new_checked(&bank, &program_address, true).unwrap_err(),
             CoreBpfMigrationError::IncorrectOwner(..)
         );
 
@@ -113,14 +131,14 @@ mod tests {
             false, // Not executable
         );
         assert_matches!(
-            TargetBpfV2::new_checked(&bank, &program_address).unwrap_err(),
+            TargetBpfV2::new_checked(&bank, &program_address, true).unwrap_err(),
             CoreBpfMigrationError::ProgramAccountNotExecutable(..)
         );
 
         // Success
         store_account(&bank, &program_address, &elf, &bpf_loader::id(), true);
 
-        let target_bpf_v2 = TargetBpfV2::new_checked(&bank, &program_address).unwrap();
+        let target_bpf_v2 = TargetBpfV2::new_checked(&bank, &program_address, true).unwrap();
 
         assert_eq!(target_bpf_v2.program_address, program_address);
         assert_eq!(target_bpf_v2.program_account.data(), elf.as_slice());

--- a/runtime/src/bank/builtins/core_bpf_migration/target_bpf_v2.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_bpf_v2.rs
@@ -182,22 +182,26 @@ mod tests {
             false,
         );
 
-        // Fail if prefund is not allowed.
-        if !allow_prefund {
+        if allow_prefund {
+            // Succeed if prefund is allowed.
+            assert!(TargetBpfV2::new_checked(&bank, &program_address, allow_prefund).is_ok());
+        } else {
+            // Fail if prefund is not allowed.
             assert_matches!(
                 TargetBpfV2::new_checked(&bank, &program_address, allow_prefund).unwrap_err(),
                 CoreBpfMigrationError::ProgramHasDataAccount(..)
             );
-            // Clean up the program data account lamports.
-            store_account(
-                &bank,
-                &program_data_address,
-                &[],
-                0,
-                &SYSTEM_PROGRAM_ID,
-                false,
-            );
         }
+
+        // Clean up the program data account lamports for zero-lamport test.
+        store_account(
+            &bank,
+            &program_data_address,
+            &[],
+            0,
+            &SYSTEM_PROGRAM_ID,
+            false,
+        );
 
         // Success.
         let target_bpf_v2 =

--- a/runtime/src/bank/builtins/core_bpf_migration/target_bpf_v2.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_bpf_v2.rs
@@ -14,6 +14,7 @@ pub(crate) struct TargetBpfV2 {
     pub program_address: Pubkey,
     pub program_account: AccountSharedData,
     pub program_data_address: Pubkey,
+    pub program_data_account_lamports: u64,
 }
 
 impl TargetBpfV2 {
@@ -76,6 +77,7 @@ impl TargetBpfV2 {
             program_address: *program_address,
             program_account,
             program_data_address,
+            program_data_account_lamports,
         })
     }
 }

--- a/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
@@ -5,7 +5,9 @@ use {
     solana_builtins::core_bpf_migration::CoreBpfMigrationTargetType,
     solana_loader_v3_interface::get_program_data_address,
     solana_pubkey::Pubkey,
-    solana_sdk_ids::native_loader::ID as NATIVE_LOADER_ID,
+    solana_sdk_ids::{
+        native_loader::ID as NATIVE_LOADER_ID, system_program::ID as SYSTEM_PROGRAM_ID,
+    },
 };
 
 /// The account details of a built-in program to be migrated to Core BPF.
@@ -14,6 +16,7 @@ pub(crate) struct TargetBuiltin {
     pub program_address: Pubkey,
     pub program_account: AccountSharedData,
     pub program_data_address: Pubkey,
+    pub program_data_account_lamports: u64,
 }
 
 impl TargetBuiltin {
@@ -82,6 +85,7 @@ impl TargetBuiltin {
             program_address: *program_address,
             program_account,
             program_data_address,
+            program_data_account_lamports,
         })
     }
 }

--- a/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/target_builtin.rs
@@ -222,8 +222,17 @@ mod tests {
             &SYSTEM_PROGRAM_ID,
         );
 
-        // Fail if prefund is not allowed
-        if !allow_prefund {
+        if allow_prefund {
+            // Succeed if prefund is allowed
+            assert!(TargetBuiltin::new_checked(
+                &bank,
+                &program_address,
+                &migration_target,
+                allow_prefund,
+            )
+            .is_ok());
+        } else {
+            // Fail if prefund is not allowed
             assert_matches!(
                 TargetBuiltin::new_checked(
                     &bank,
@@ -234,12 +243,13 @@ mod tests {
                 .unwrap_err(),
                 CoreBpfMigrationError::ProgramHasDataAccount(..)
             );
-            // Clean up the program data account lamports
-            bank.store_account_and_update_capitalization(
-                &program_data_address,
-                &AccountSharedData::default(),
-            );
         }
+
+        // Clean up the program data account lamports for zero-lamport test
+        bank.store_account_and_update_capitalization(
+            &program_data_address,
+            &AccountSharedData::default(),
+        );
 
         // Success
         let target_builtin =


### PR DESCRIPTION
#### Problem

[SIMD-0444](https://github.com/solana-foundation/solana-improvement-documents/pull/444) enables runtime-level program migrations when the target program data accounts is already funded, which currently it is not possible.

#### Summary of Changes

This PR adds a feature gate for SIMD-0444 and updates the migration validation to allow pre-funded program data accounts.
