### PR TITLE
fix: external worker retry

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -357,7 +357,7 @@ pub(crate) mod external {
             // If we began execution when a slot was still in process, and could
             // not record at the end because the slot has ended, we will retry
             // on the next slot.
-            for _ in 0..1 {
+            for _ in 0..2 {
                 let Some(leader_state) =
                     active_leader_state_with_timeout(&self.shared_leader_state)
                 else {


### PR DESCRIPTION
according to the comment right above, this is intending to retry
https://github.com/anza-xyz/agave/blob/96306d7044ff98b70c6497a4c3956b46df574a8b/core/src/banking_stage/consume_worker.rs#L355-L359

via the `continue` further down in the loop:

https://github.com/anza-xyz/agave/blob/96306d7044ff98b70c6497a4c3956b46df574a8b/core/src/banking_stage/consume_worker.rs#L420-L431

but `for _ in 0..1` iterates exactly once always, so the `continue` just breaks.