### PR TITLE
v3.1: runtime: Rekey p-token feature

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1190,7 +1190,7 @@ pub mod fix_alt_bn128_pairing_length_check {
 pub mod replace_spl_token_with_p_token {
     use super::Pubkey;
 
-    solana_pubkey::declare_id!("ptokSWRqZz5u2xdqMdstkMKpFurauUpVen7TZXgDpkQ");
+    solana_pubkey::declare_id!("ptokEXBPT9HuYdAQRysaStZNTY9bHsAcQzNscEoA6HC");
 
     pub const SPL_TOKEN_PROGRAM_ID: Pubkey =
         Pubkey::from_str_const("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");


### PR DESCRIPTION
#### Problem

p-token feature needs a rekey to go with the changes in SIMD-0444 (https://github.com/anza-xyz/agave/pull/9891). The new key is already on master but not on `v3.1`.

#### Summary of Changes

Rekey it.