### PR TITLE
remove duplicated bank.is_complete() check in vote_worker

### DIFF
--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -417,17 +417,18 @@ impl VoteWorker {
         total_transaction_counts
             .accumulate(&transaction_counts, commit_transactions_result.is_ok());
 
-        let reached_max_poh_height = match (commit_transactions_result, bank.is_complete()) {
-            (Err(PohRecorderError::MaxHeightReached), _) | (_, true) => {
-                info!(
-                    "process transactions: max height reached slot: {} height: {}",
-                    bank.slot(),
-                    bank.tick_height()
-                );
-                true
-            }
-            _ => false,
-        };
+        let reached_max_poh_height = matches!(
+            commit_transactions_result,
+            Err(PohRecorderError::MaxHeightReached)
+        );
+
+        if reached_max_poh_height {
+            info!(
+                "process transactions: max height reached slot: {} height: {}",
+                bank.slot(),
+                bank.tick_height()
+            );
+        }
 
         ProcessTransactionsSummary {
             reached_max_poh_height,


### PR DESCRIPTION
#### Problem

- it can be confusing to include `bank.is_complete()` in `reached_max_poh_height`;
- it is redundant because `bank.is_complete()` is always checked when `*reached_end_of_slot = has_reached_end_of_slot(reached_max_poh_height, bank);`

#### Summary of Changes
remove duplicated `bank.is_complete()` so the code is easier to reason.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
