### PR TITLE
gossip: fix duplicate shred handler buffer pruning

### DIFF
--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -187,7 +187,7 @@ impl DuplicateShredHandler {
                     }
             });
         }
-        if self.buffer.len() < BUFFER_CAPACITY {
+        if self.buffer.len() <= BUFFER_CAPACITY {
             return;
         }
         // Lookup stake for each entry.


### PR DESCRIPTION
#### Problem

Duplicate shred reassembly buffer cleanup procedure uses inappropriate threshold for cleanup heuristics

#### Summary of Changes

Fix the duplicate shred handler buffer pruning heuristics