### PR TITLE
ibrl: improve vote processing

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -44,6 +44,7 @@ frozen-abi = [
 agave-banking-stage-ingress-types = { workspace = true }
 agave-feature-set = { workspace = true }
 agave-logger = { workspace = true }
+agave-reserved-account-keys = { workspace = true }
 agave-scheduler-bindings = { workspace = true }
 agave-scheduling-utils = { workspace = true }
 agave-snapshots = { workspace = true }
@@ -193,7 +194,6 @@ shaq = { workspace = true }
 sysctl = { workspace = true }
 
 [dev-dependencies]
-agave-reserved-account-keys = { workspace = true }
 agave-scheduler-bindings = { workspace = true, features = ["dev-context-only-utils"] }
 bencher = { workspace = true }
 criterion = { workspace = true }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6864,6 +6864,7 @@ dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
  "agave-logger",
+ "agave-reserved-account-keys",
  "agave-scheduler-bindings",
  "agave-scheduling-utils",
  "agave-snapshots",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6673,6 +6673,7 @@ dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
  "agave-logger",
+ "agave-reserved-account-keys",
  "agave-scheduler-bindings",
  "agave-scheduling-utils",
  "agave-snapshots",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5303,6 +5303,12 @@ impl Bank {
         &self.reserved_account_keys.active
     }
 
+    /// Get the Arc-wrapped reserved account keys. This is useful for caching
+    /// the reserved keys without cloning the underlying HashSet.
+    pub fn get_reserved_account_keys_arc(&self) -> Arc<ReservedAccountKeys> {
+        Arc::clone(&self.reserved_account_keys)
+    }
+
     /// Compute and apply all activated features, initialize the transaction
     /// processor, and recalculate partitioned rewards if needed
     fn initialize_after_snapshot_restore<F, TP>(&mut self, rewards_thread_pool_builder: F)


### PR DESCRIPTION
#### Problem
vote worker stores transaction views instead of runtime transactions (vanilla scheduler stores runtime transactions). **this requires us to rehash the message and do additional parsing every time a vote is retried instead of just doing it once**:

https://github.com/anza-xyz/agave/blob/cd96cc221804934ed8788a13c32ed3c644e63cb8/runtime-transaction/src/runtime_transaction/transaction_view.rs#L71-L98


#### Summary of Changes
store runtime transactions
