### PR TITLE
clippy(svm): fix hidden cases of let_and_return violations

### DIFF
--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -594,7 +594,7 @@ fn load_transaction_account<CB: TransactionProcessingCallback>(
     rent: &Rent,
 ) -> LoadedTransactionAccount {
     let is_writable = message.is_writable(account_index);
-    let loaded_account = if solana_sdk_ids::sysvar::instructions::check_id(account_key) {
+    if solana_sdk_ids::sysvar::instructions::check_id(account_key) {
         // Since the instructions sysvar is constructed by the SVM and modified
         // for each transaction instruction, it cannot be loaded.
         LoadedTransactionAccount {
@@ -615,9 +615,7 @@ fn load_transaction_account<CB: TransactionProcessingCallback>(
             loaded_size: default_account.data().len(),
             account: default_account,
         }
-    };
-
-    loaded_account
+    }
 }
 
 fn construct_instructions_account(message: &impl SVMMessage) -> AccountSharedData {


### PR DESCRIPTION
#### Problem
Defining value with let and then just returning that value in block / function is unnecessary code. Normally it's checked by clippy:let_and_return warnings, but some places in code do not trigger it until codebase is switched to Rust 2024 edition.

Since the code can be fixed before [migration](https://github.com/anza-xyz/agave/issues/6203) is done, let's do it.

#### Summary of Changes
Simplify returning value to avoid extra local variable definition.