### PR TITLE
clippy(networking): fix hidden cases of let_and_return violations

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1731,11 +1731,10 @@ impl ClusterInfo {
             } else {
                 score
             };
-            let score = match value.data() {
+            match value.data() {
                 CrdsData::ContactInfo(_) => 2 * score,
                 _ => score,
-            };
-            score
+            }
         };
         let mut num_crds_values = 0;
         let (scores, mut pull_responses): (Vec<_>, Vec<_>) = requests


### PR DESCRIPTION
#### Problem
Defining value with let and then just returning that value in block / function is unnecessary code. Normally it's checked by clippy:let_and_return warnings, but some places in code do not trigger it until codebase is switched to Rust 2024 edition.

Since the code can be fixed before [migration](https://github.com/anza-xyz/agave/issues/6203) is done, let's do it.

#### Summary of Changes
Simplify returning value to avoid extra local variable definition.
