### PR TITLE
clippy: fix hidden cases of let_and_return violations

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1299,24 +1299,21 @@ pub async fn process_program_subcommand(
 }
 
 fn get_default_program_keypair(program_location: &Option<String>) -> Keypair {
-    let program_keypair = {
-        if let Some(program_location) = program_location {
-            let mut keypair_file = PathBuf::new();
-            keypair_file.push(program_location);
-            let mut filename = keypair_file.file_stem().unwrap().to_os_string();
-            filename.push("-keypair");
-            keypair_file.set_file_name(filename);
-            keypair_file.set_extension("json");
-            if let Ok(keypair) = read_keypair_file(keypair_file.to_str().unwrap()) {
-                keypair
-            } else {
-                Keypair::new()
-            }
+    if let Some(program_location) = program_location {
+        let mut keypair_file = PathBuf::new();
+        keypair_file.push(program_location);
+        let mut filename = keypair_file.file_stem().unwrap().to_os_string();
+        filename.push("-keypair");
+        keypair_file.set_file_name(filename);
+        keypair_file.set_extension("json");
+        if let Ok(keypair) = read_keypair_file(keypair_file.to_str().unwrap()) {
+            keypair
         } else {
             Keypair::new()
         }
-    };
-    program_keypair
+    } else {
+        Keypair::new()
+    }
 }
 
 /// Deploy program using upgradeable loader. It also can process program upgrades

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -807,7 +807,7 @@ pub fn service_runtime(
     // negatively impact performance.
     let rpc_threads = 1.max(rpc_threads);
     let rpc_blocking_threads = 1.max(rpc_blocking_threads);
-    let runtime = Arc::new(
+    Arc::new(
         TokioBuilder::new_multi_thread()
             .worker_threads(rpc_threads)
             .max_blocking_threads(rpc_blocking_threads)
@@ -816,8 +816,7 @@ pub fn service_runtime(
             .enable_all()
             .build()
             .expect("Runtime"),
-    );
-    runtime
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
Defining value with let and then just returning that value in block / function is unnecessary code. Normally it's checked by clippy:let_and_return warnings, but some places in code do not trigger it until codebase is switched to Rust 2024 edition.

Since the code can be fixed before [migration](https://github.com/anza-xyz/agave/issues/6203) is done, let's do it.

#### Summary of Changes
Simplify returning value to avoid extra local variable definition.
