### PR TITLE
Upgrade Rust to 1.91.1

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2025-08-02
+  nightly_version=2025-09-14
 fi
 
 

--- a/core/src/consensus/tower1_14_11.rs
+++ b/core/src/consensus/tower1_14_11.rs
@@ -10,7 +10,7 @@ use {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "H3PUUxvCCu8MFwoXppzyJenXCJswSude7DiWK49yKKRo")
+    frozen_abi(digest = "A5VjnPLPpApf7kjBxMX89crYHxsk6XotSqpG6qXuuwS1")
 )]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower1_14_11 {

--- a/core/src/consensus/tower1_7_14.rs
+++ b/core/src/consensus/tower1_7_14.rs
@@ -42,7 +42,7 @@ pub struct Tower1_7_14 {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "8ASxminStCjs2Xcx2b6arJQBENyMV3H62zSoTvsLqFqP")
+    frozen_abi(digest = "82njBGFDS9sGdbSuqdeANPe8rmZW1zsrPRpdgnSmZkpY")
 )]
 #[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SavedTower1_7_14 {

--- a/core/src/consensus/tower_storage.rs
+++ b/core/src/consensus/tower_storage.rs
@@ -79,7 +79,7 @@ impl From<SavedTower1_7_14> for SavedTowerVersions {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "8T1GVMzNNWcHRQwyzPhFj5nErdazaBe3ZGKQdY7T89Zo")
+    frozen_abi(digest = "2Ne3NmHSeLpPfv38wn7ZRsuq4i56kqYzJeFLYmz6bw3Z")
 )]
 #[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SavedTower {

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -233,7 +233,7 @@ type PingCache = ping_pong::PingCache<REPAIR_PING_TOKEN_SIZE>;
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiEnumVisitor, AbiExample),
-    frozen_abi(digest = "fFcqrZWZX4WcorTUxfMCVWeh2QcwamXKdLTzsDj58Kn")
+    frozen_abi(digest = "HbUQDATKfpN8pjyyarSGa8uN4SuLNTvMf7T5b66ajnNZ")
 )]
 #[derive(Debug, Deserialize, Serialize)]
 pub enum RepairProtocol {

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -345,7 +345,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "368HqLKrMhTVTbue6c2SvgKmuzRGdvZUjNLFYL8BXBwj")
+            frozen_abi(digest = "CJvggTJcQUhgDFwKf1yuHUiwUBrnu9LmByfprqbvnCmE")
         )]
         #[derive(serde::Serialize)]
         pub struct BankAbiTestWrapper {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.91.1"

--- a/vote/src/vote_transaction.rs
+++ b/vote/src/vote_transaction.rs
@@ -11,7 +11,7 @@ use {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample, AbiEnumVisitor),
-    frozen_abi(digest = "3FNgMe2aFiwfwo97HvdFKGBXHK3PT1M87gA8utHY5VEG")
+    frozen_abi(digest = "BBjevJKZyxpH1c6op3oD7xpYwVuMxDR5MJhHN8W6z1u6")
 )]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum VoteTransaction {

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -17,7 +17,7 @@ pub type Block = (Slot, Hash);
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "4nTsJNvSwHrs8FHz2TPbSBiYc8Eattw4v31XDge2c5zA")
+    frozen_abi(digest = "5eorzdc18a1sNEUDLAKPgrHCqHmA8ssuTwKSGsZLwBqR")
 )]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct VoteMessage {
@@ -81,7 +81,7 @@ impl CertificateType {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "7AATkxH9takDKv4pGT3jsqC18nqEgdRTYGUP8G2bbnGp")
+    frozen_abi(digest = "B5NsoWZr2Lpbbjqj8udwEKvae6bA37Pm4R92udZHxwfU")
 )]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Certificate {
@@ -98,7 +98,7 @@ pub struct Certificate {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample, AbiEnumVisitor),
-    frozen_abi(digest = "DaXHFwdUAESLYZvyhsgwjeBUEeUqjp3t7WfkRsSp3cEE")
+    frozen_abi(digest = "BdKT6dbkLnTeGNMS8XtQkg6HTeHSQ6Z41Btc1rJ117PB")
 )]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]

--- a/votor/src/vote_history_storage.rs
+++ b/votor/src/vote_history_storage.rs
@@ -67,7 +67,7 @@ impl From<SavedVoteHistory> for SavedVoteHistoryVersions {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "42PkuFNWFBZ6X7QoPKtpLu6SY8bxmd6KVGJbVsNBm46m")
+    frozen_abi(digest = "J6vB6FWFT8CFEvxndXWes461hroo8Q5L9Wq9cv4FEzaQ")
 )]
 #[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SavedVoteHistory {


### PR DESCRIPTION
#### Problem
Frozen ABI test failures prevented upgrade to newer Rust toolchain. The breakage of the frozen ABI utility was fixed in https://github.com/anza-xyz/solana-sdk/pull/509, though the tests still generate different hashes if the type serializing some field contains a lifetime (in Rust 1.91 the signature of the type includes `<'_` part).

#### Summary of Changes
* bump rust toolchain to 1.91.1 and nightly 2025-09-14
* update hashes for affected frozen ABI tests - not that there are neigther API nor serialized format changes, it's just the internal machinery of frozen ABI tests that operates on different type names

Example difference in the frozen ABI structure:
```
_VoteTransaction_frozen_abi__test_api_digest_BBjevJKZyxpH1c6op3oD7xpYwVuMxDR5MJhHN8W6z1u6
--- frodir/vote_transaction__VoteTransaction_frozen_abi__test_api_digest_3FNgMe2aFiwfwo97HvdFKGBXHK3PT1M87gA8utHY5VEG	2026-01-12 19:41:18.291606992 +0800
+++ frodir/vote_transaction__VoteTransaction_frozen_abi__test_api_digest_BBjevJKZyxpH1c6op3oD7xpYwVuMxDR5MJhHN8W6z1u6	2026-01-12 15:28:27.221760272 +0800
@@ -164,7 +164,7 @@
                     variant(0) None (unit)
                     variant(1) Some(i64) (newtype)
                         primitive i64
-    variant(2) CompactVoteStateUpdate(solana_vote::vote_transaction::_::<impl serde_core::ser::Serialize for solana_vote::vote_transaction::VoteTransaction>::serialize::__SerializeWith) (newtype)
+    variant(2) CompactVoteStateUpdate(solana_vote::vote_transaction::_::<impl serde_core::ser::Serialize for solana_vote::vote_transaction::VoteTransaction>::serialize::__SerializeWith<'_>) (newtype)
         struct CompactVoteStateUpdate (fields = 4)
             field root: u64
                 primitive u64
@@ -254,7 +254,7 @@
                     variant(0) None (unit)
                     variant(1) Some(i64) (newtype)
                         primitive i64
-    variant(3) TowerSync(solana_vote::vote_transaction::_::<impl serde_core::ser::Serialize for solana_vote::vote_transaction::VoteTransaction>::serialize::__SerializeWith) (newtype)
+    variant(3) TowerSync(solana_vote::vote_transaction::_::<impl serde_core::ser::Serialize for solana_vote::vote_transaction::VoteTransaction>::serialize::__SerializeWith<'_>) (newtype)
         struct CompactTowerSync (fields = 5)
             field root: u64
                 primitive u64


@@ -829,7 +829,7 @@
         field header: solana_core::repair::serve_repair::RepairRequestHeader
             struct RepairRequestHeader (fields = 5)
                 field signature: solana_signature::Signature
-                    struct Signature(solana_signature::_::<impl serde_core::ser::Serialize for solana_signature::Signature>::serialize::__SerializeWith) (newtype)
+                    struct Signature(solana_signature::_::<impl serde_core::ser::Serialize for solana_signature::Signature>::serialize::__SerializeWith<'_>) (newtype)
                         tuple (elements = 64)
                             element u8
                                 primitive u8
```

Fixes #8117
