### PR TITLE
Adds --accounts-index-limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Release channels have their own copy of this changelog:
   * `--wait-for-exit` (`exit` subcommand)
 #### Deprecations
 * Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.
-* The `--enable-accounts-disk-index` flag is now deprecated. Use `--accounts-index-limit` instead.
+* The `--enable-accounts-disk-index` flag is now deprecated. Use `--accounts-index-limit` instead. To retain the same behavior, use `--accounts-index-limit minimal`.
 #### Changes
 * `agave-validator exit` now saves bank state before exiting. This enables restarts from local state when snapshot generation is disabled.
 * Added `--accounts-index-limit` to specify the memory limit of the accounts index.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,10 @@ Release channels have their own copy of this changelog:
   * `--wait-for-exit` (`exit` subcommand)
 #### Deprecations
 * Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.
+* The `--enable-accounts-disk-index` flag is now deprecated. Use `--accounts-index-limit` instead.
 #### Changes
 * `agave-validator exit` now saves bank state before exiting. This enables restarts from local state when snapshot generation is disabled.
+* Added `--accounts-index-limit` to specify the memory limit of the accounts index.
 ### CLI
 #### Changes
 * Support Trezor hardware wallets using `usb://trezor`

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -137,6 +137,14 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         usage_warning: "CUDA support will be dropped"
     );
     add_arg!(
+        // deprecated in v4.0.0
+        Arg::with_name("enable_accounts_disk_index")
+            .long("enable-accounts-disk-index")
+            .help("Enables the disk-based accounts index")
+            .conflicts_with("accounts_index_limit"),
+        replaced_by: "accounts-index-limit",
+    );
+    add_arg!(
         // deprecated in v3.1.0
         Arg::with_name("tpu_coalesce_ms")
             .long("tpu-coalesce-ms")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1086,6 +1086,32 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Number of bins to divide the accounts index into"),
     )
     .arg(
+        Arg::with_name("accounts_index_limit")
+            .long("accounts-index-limit")
+            .value_name("VALUE")
+            .takes_value(true)
+            .possible_values(&[
+                "minimal",
+                "25GB",
+                "50GB",
+                "100GB",
+                "200GB",
+                "400GB",
+                "800GB",
+                "unlimited",
+            ])
+            .default_value("unlimited")
+            .help("Sets the memory limit for the accounts index")
+            .long_help(
+                "Sets the memory limit for the accounts index. The size options will limit the \
+                 accounts index memory to the specified value. E.g. \"50GB\" means the accounts \
+                 index may use up to 50 GB of memory. The \"unlimited\" option keeps the entire \
+                 accounts index in memory. The \"minimal\" option reduces memory usage as much as \
+                 possible. All index entries that are not in memory are kept in the disk-backed \
+                 index. The disk-backed index has lower performance; prefer higher limits here.",
+            ),
+    )
+    .arg(
         Arg::with_name("accounts_index_initial_accounts_count")
             .long("accounts-index-initial-accounts-count")
             .value_name("NUMBER")
@@ -1100,19 +1126,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("PATH")
             .takes_value(true)
             .multiple(true)
-            .requires("enable_accounts_disk_index")
             .help(
                 "Persistent accounts-index location. May be specified multiple times. [default: \
                  <LEDGER>/accounts_index]",
-            ),
-    )
-    .arg(
-        Arg::with_name("enable_accounts_disk_index")
-            .long("enable-accounts-disk-index")
-            .help("Enables the disk-based accounts index")
-            .long_help(
-                "Enables the disk-based accounts index. Reduce the memory footprint of the \
-                 accounts index at the cost of index performance.",
             ),
     )
     .arg(


### PR DESCRIPTION
#### Problem

There's not a way to specify the threshold/limit for the accounts index.


#### Summary of Changes

- Adds --accounts-index-limit
- Deprecates --enable-accounts-disk-index

Note that this PR does *not* change the default index setting. The default is still in-mem only.



#### Motivation

The threshold-based accounts index that this PR enables is all about performance.

Currently, operators either chose to have the index fully in memory, or to using the disk index. When the disk index is enabled, it aggressively evicts entries from in memory.

Here's a chart showing the in-mem miss rate of the index:
<img width="923" height="444" alt="Screenshot 2026-01-13 at 11 04 14 AM" src="https://github.com/user-attachments/assets/ad66e32d-6de5-4f85-abb7-6ccf4e6cd1b1" />
`brux1`: index is in-mem only
`Btj`: index uses disk

We can see the disk index misses way more. This is expected, as it has far fewer entries kept in memory.

The result is the time it takes to load accounts.

Here's two more charts. On the left is `brux1`, which shows how much time (on average) is spent loading accounts (over a 10 second window). This is all the in memory. On the right is `BtJ`. When it misses in-mem, it must load from disk. The right side shows how much time (on average) is spent loading accounts from disk (also over a 10 second window). It is much longer:
<img width="1841" height="444" alt="Screenshot 2026-01-13 at 11 05 27 AM" src="https://github.com/user-attachments/assets/56d1a504-2917-4791-9cd4-aa391e3b2714" />

Can we have both?

With the disk index, what if we do not evict from the in-mem index as aggressively? That's exactly what this index threshold enables. We specify a max amount of memory to use, and only evict from memory once that threshold is hit.

This next graph is again of the miss rate, now with a new node, `9eN`, with a 25 GB in-mem index limit. We can already see the miss rate is dramatically reduced.
<img width="922" height="453" alt="Screenshot 2026-01-13 at 11 15 49 AM" src="https://github.com/user-attachments/assets/d9753a7f-47e5-4ab4-a7e3-6f1641d393d1" />

There are also nodes running with 50 GB, 100 GB, and 200 GB thresholds. However they haven't hit steady state yet (aka loaded in all the accounts into memory). IOW, when an account is accessed for the first time, its index entry must be loaded from disk. Afterwards, it stays in memory.

Lastly, here's the index's background thread that handles flushing and evicting. These charts compare `BtJ` with a new node, `9H6`. This new node has a 200 GB threshold, which basically matches the in-mem index's footprint today. So it should be able to keep all index entries in memory, and never evict.

Here's the time spent scanning the in-mem index bins for evictions. We can see `9H6` never scans, because it is always below the limit.
<img width="923" height="444" alt="Screenshot 2026-01-13 at 11 19 32 AM" src="https://github.com/user-attachments/assets/9076858c-2228-4a39-950c-04fcf5547ac4" />

Here's the time spent evicting entries from the in-mem index bins. Again, `9H6` never evicts.
<img width="923" height="445" alt="Screenshot 2026-01-13 at 11 19 42 AM" src="https://github.com/user-attachments/assets/05f11ddc-4a2a-4659-b955-319d354e946e" />

And lastly here's the time spent writing entries to disk, as part of 'flush'. `9H6` avoids this entirely as well.
<img width="924" height="446" alt="Screenshot 2026-01-13 at 11 19 51 AM" src="https://github.com/user-attachments/assets/888c7eb9-b6a5-40a8-ae3f-ff69c72c057f" />