### PR TITLE
Cap active unified scheduler bp tasks to avoid oom

### DIFF
--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -1137,6 +1137,9 @@ impl SchedulingStateMachine {
     /// Returns `Some(task)` if it's immediately scheduled. Otherwise, returns `None`,
     /// indicating the scheduled task is blocked currently.
     ///
+    /// Alternatively, the task might be silently ignored instead (= dropped), when
+    /// [`SchedulingStateMachine`] is capped with max_unique_active_task_count, returning `None`.
+    ///
     /// Note that this function takes ownership of the task to allow for future optimizations.
     #[cfg(any(test, doc))]
     #[must_use]
@@ -1153,12 +1156,18 @@ impl SchedulingStateMachine {
     /// task is blocked or not. Eventually, the buffered task will be returned by one of later
     /// invocations [`schedule_next_unblocked_task()`](Self::schedule_next_unblocked_task).
     ///
+    /// Alternatively, the task might be silently ignored instead (= dropped), when
+    /// [`SchedulingStateMachine`] is capped with max_unique_active_task_count.
+    ///
     /// Note that this function takes ownership of the task to allow for future optimizations.
     pub fn buffer_task(&mut self, task: Task) {
         self.schedule_or_buffer_task(task, true).unwrap_none();
     }
 
     /// Schedules or buffers given `task`, returning successful one unless buffering is forced.
+    ///
+    /// Alternatively, the task might be silently ignored instead (= dropped), when
+    /// [`SchedulingStateMachine`] is capped with max_unique_active_task_count.
     ///
     /// Refer to [`schedule_task()`](Self::schedule_task) and
     /// [`buffer_task()`](Self::buffer_task) for the difference between _scheduling_ and

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -2293,10 +2293,12 @@ mod tests {
         let sanitized1 = transaction_with_readonly_address(Pubkey::new_unique());
         let sanitized2 = transaction_with_readonly_address(Pubkey::new_unique());
         let sanitized3 = transaction_with_readonly_address(Pubkey::new_unique());
+        let sanitized4 = transaction_with_readonly_address(Pubkey::new_unique());
         let address_loader = &mut create_address_loader(None, &capability);
         let task1 = SchedulingStateMachine::create_task(sanitized1, 101, address_loader);
         let task2 = SchedulingStateMachine::create_task(sanitized2, 102, address_loader);
         let task3 = SchedulingStateMachine::create_task(sanitized3, 103, address_loader);
+        let task4 = SchedulingStateMachine::create_task(sanitized4, 104, address_loader);
 
         assert_matches!(
             state_machine
@@ -2323,6 +2325,15 @@ mod tests {
         state_machine.deschedule_task(&task1.clone());
         state_machine.deschedule_task(&task2.clone());
         assert!(state_machine.has_no_active_task());
+
+        assert_matches!(
+            state_machine
+                .schedule_task(task4.clone())
+                .map(|t| t.task_id()),
+            Some(104)
+        );
+        state_machine.deschedule_task(&task4.clone());
+
         assert_eq!(state_machine.dropped_task_count(), 1);
         assert_eq!(state_machine.active_task_count(), 0);
         assert_eq!(state_machine.peak_active_task_count(), 2);

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -110,11 +110,11 @@ use {
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
-    solana_transaction::sanitized::SanitizedTransaction,
+    solana_transaction::{sanitized::SanitizedTransaction, Hash},
     static_assertions::const_assert_eq,
     std::{
         cmp::Ordering,
-        collections::{BTreeMap, VecDeque},
+        collections::{BTreeMap, HashSet, VecDeque},
         mem,
         sync::Arc,
     },
@@ -205,6 +205,11 @@ mod utils {
 
         pub(super) fn decrement_self(&mut self) -> &mut Self {
             *self = self.decrement();
+            self
+        }
+
+        pub(super) fn max_self(&mut self, other: &Self) -> &mut Self {
+            self.0 = self.0.max(other.0);
             self
         }
 
@@ -510,6 +515,10 @@ impl TaskInner {
 
     pub fn transaction(&self) -> &RuntimeTransaction<SanitizedTransaction> {
         &self.transaction
+    }
+
+    pub fn hash(&self) -> &TaskHash {
+        self.transaction.message_hash()
     }
 
     fn lock_contexts(&self) -> &[LockContext] {
@@ -1041,6 +1050,8 @@ impl UsageQueue {
     }
 }
 
+type TaskHash = Hash;
+
 /// A high-level `struct`, managing the overall scheduling of [tasks](Task), to be used by
 /// `solana-unified-scheduler-pool`.
 pub struct SchedulingStateMachine {
@@ -1050,6 +1061,10 @@ pub struct SchedulingStateMachine {
     /// words, they are running right now or buffered by explicit request or by implicit blocking
     /// due to one of other _active_ (= running or buffered) conflicting tasks.
     active_task_count: ShortCounter,
+    peak_active_task_count: ShortCounter,
+    dropped_task_count: ShortCounter,
+    max_unique_active_task_count: Option<usize>,
+    unique_active_task_hashes: HashSet<TaskHash>,
     /// The number of tasks which are running right now.
     running_task_count: ShortCounter,
     /// The maximum number of running tasks at any given moment. While this could be tightly
@@ -1063,7 +1078,6 @@ pub struct SchedulingStateMachine {
     count_token: BlockedUsageCountToken,
     usage_queue_token: UsageQueueToken,
 }
-const_assert_eq!(mem::size_of::<SchedulingStateMachine>(), 56);
 
 impl SchedulingStateMachine {
     pub fn has_no_running_task(&self) -> bool {
@@ -1095,6 +1109,14 @@ impl SchedulingStateMachine {
         self.active_task_count.current()
     }
 
+    pub fn peak_active_task_count(&self) -> usize {
+        self.peak_active_task_count.current().try_into().unwrap()
+    }
+
+    pub fn dropped_task_count(&self) -> usize {
+        self.dropped_task_count.current().try_into().unwrap()
+    }
+
     #[cfg(test)]
     fn handled_task_count(&self) -> CounterInner {
         self.handled_task_count.current()
@@ -1105,9 +1127,8 @@ impl SchedulingStateMachine {
         self.unblocked_task_count.current()
     }
 
-    #[cfg(test)]
-    fn total_task_count(&self) -> CounterInner {
-        self.total_task_count.current()
+    pub fn total_task_count(&self) -> usize {
+        self.total_task_count.current().try_into().unwrap()
     }
 
     /// Schedules given `task`, returning it if successful.
@@ -1146,7 +1167,21 @@ impl SchedulingStateMachine {
     #[must_use]
     pub fn schedule_or_buffer_task(&mut self, task: Task, force_buffering: bool) -> Option<Task> {
         self.total_task_count.increment_self();
+        if let Some(max_unique_active_task_count) = self.max_unique_active_task_count {
+            let is_excess = self.unique_active_task_hashes.len() >= max_unique_active_task_count;
+            if is_excess {
+                self.dropped_task_count.increment_self();
+                return None;
+            }
+            let is_duplicate = !self.unique_active_task_hashes.insert(*task.hash());
+            if is_duplicate {
+                self.dropped_task_count.increment_self();
+                return None;
+            }
+        }
         self.active_task_count.increment_self();
+        self.peak_active_task_count
+            .max_self(&self.active_task_count);
         self.try_lock_usage_queues(task).and_then(|task| {
             // locking succeeded, and then ...
             if !self.is_task_runnable() || force_buffering {
@@ -1186,6 +1221,9 @@ impl SchedulingStateMachine {
     /// opportunity for callers.
     pub fn deschedule_task(&mut self, task: &Task) {
         self.running_task_count.decrement_self();
+        if self.max_unique_active_task_count.is_some() {
+            assert!(self.unique_active_task_hashes.remove(task.hash()));
+        }
         self.active_task_count.decrement_self();
         self.handled_task_count.increment_self();
         self.unlock_usage_queues(task);
@@ -1372,12 +1410,17 @@ impl SchedulingStateMachine {
     /// There's a related method called [`clear_and_reinitialize()`](Self::clear_and_reinitialize).
     pub fn reinitialize(&mut self) {
         assert!(self.has_no_active_task());
+        assert_eq!(self.unique_active_task_hashes.len(), 0);
         assert_eq!(self.running_task_count.current(), 0);
         assert_eq!(self.unblocked_task_queue.len(), 0);
         // nice trick to ensure all fields are handled here if new one is added.
         let Self {
             unblocked_task_queue: _,
             active_task_count,
+            peak_active_task_count,
+            dropped_task_count,
+            max_unique_active_task_count: _,
+            unique_active_task_hashes: _,
             running_task_count: _,
             max_running_task_count: _,
             handled_task_count,
@@ -1388,6 +1431,8 @@ impl SchedulingStateMachine {
             // don't add ".." here
         } = self;
         active_task_count.reset_to_zero();
+        peak_active_task_count.reset_to_zero();
+        dropped_task_count.reset_to_zero();
         handled_task_count.reset_to_zero();
         unblocked_task_count.reset_to_zero();
         total_task_count.reset_to_zero();
@@ -1434,6 +1479,7 @@ impl SchedulingStateMachine {
     #[must_use]
     pub unsafe fn exclusively_initialize_current_thread_for_scheduling(
         max_running_task_count: Option<usize>,
+        max_unique_active_task_count: Option<usize>,
     ) -> Self {
         // As documented at `CounterInner`, don't expose rather opinionated choice of unsigned
         // integer type (`u32`) to outer world. So, take more conventional `usize` and convert it
@@ -1448,6 +1494,10 @@ impl SchedulingStateMachine {
             // `UsageQueueInner::blocked_usages_from_tasks`'s cap.
             unblocked_task_queue: VecDeque::with_capacity(1024),
             active_task_count: ShortCounter::zero(),
+            peak_active_task_count: ShortCounter::zero(),
+            dropped_task_count: ShortCounter::zero(),
+            max_unique_active_task_count,
+            unique_active_task_hashes: HashSet::default(),
             running_task_count: ShortCounter::zero(),
             max_running_task_count,
             handled_task_count: ShortCounter::zero(),
@@ -1460,7 +1510,7 @@ impl SchedulingStateMachine {
 
     #[cfg(test)]
     unsafe fn exclusively_initialize_current_thread_for_scheduling_for_test() -> Self {
-        unsafe { Self::exclusively_initialize_current_thread_for_scheduling(None) }
+        unsafe { Self::exclusively_initialize_current_thread_for_scheduling(None, None) }
     }
 }
 
@@ -2171,5 +2221,166 @@ mod tests {
             s.deschedule_task(&t1_reblocked);
             assert!(s.has_no_active_task());
         }
+    }
+
+    #[test_matrix([Capability::FifoQueueing, Capability::PriorityQueueing])]
+    fn test_max_unique_active_task_no_drop_under_cap(capability: Capability) {
+        let mut state_machine = unsafe {
+            SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling(
+                None,
+                Some(3),
+            )
+        };
+        let sanitized1 = transaction_with_readonly_address(Pubkey::new_unique());
+        let sanitized2 = transaction_with_readonly_address(Pubkey::new_unique());
+        let sanitized3 = transaction_with_readonly_address(Pubkey::new_unique());
+        let address_loader = &mut create_address_loader(None, &capability);
+        let task1 = SchedulingStateMachine::create_task(sanitized1, 101, address_loader);
+        let task2 = SchedulingStateMachine::create_task(sanitized2, 102, address_loader);
+        let task3 = SchedulingStateMachine::create_task(sanitized3, 103, address_loader);
+
+        assert_matches!(
+            state_machine
+                .schedule_task(task1.clone())
+                .map(|t| t.task_id()),
+            Some(101)
+        );
+        assert_matches!(
+            state_machine
+                .schedule_task(task2.clone())
+                .map(|t| t.task_id()),
+            Some(102)
+        );
+        assert_matches!(
+            state_machine
+                .schedule_task(task3.clone())
+                .map(|t| t.task_id()),
+            Some(103)
+        );
+
+        assert_eq!(state_machine.dropped_task_count(), 0);
+        assert_eq!(state_machine.active_task_count(), 3);
+        assert_eq!(state_machine.peak_active_task_count(), 3);
+        state_machine.deschedule_task(&task1.clone());
+        state_machine.deschedule_task(&task2.clone());
+        state_machine.deschedule_task(&task3.clone());
+        assert!(state_machine.has_no_active_task());
+        assert_eq!(state_machine.dropped_task_count(), 0);
+        assert_eq!(state_machine.active_task_count(), 0);
+        assert_eq!(state_machine.peak_active_task_count(), 3);
+        state_machine.reinitialize();
+        assert_eq!(state_machine.peak_active_task_count(), 0);
+    }
+
+    #[test_matrix([Capability::FifoQueueing, Capability::PriorityQueueing])]
+    fn test_max_unique_active_task_drop_excess(capability: Capability) {
+        let mut state_machine = unsafe {
+            SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling(
+                None,
+                Some(2),
+            )
+        };
+        let sanitized1 = transaction_with_readonly_address(Pubkey::new_unique());
+        let sanitized2 = transaction_with_readonly_address(Pubkey::new_unique());
+        let sanitized3 = transaction_with_readonly_address(Pubkey::new_unique());
+        let address_loader = &mut create_address_loader(None, &capability);
+        let task1 = SchedulingStateMachine::create_task(sanitized1, 101, address_loader);
+        let task2 = SchedulingStateMachine::create_task(sanitized2, 102, address_loader);
+        let task3 = SchedulingStateMachine::create_task(sanitized3, 103, address_loader);
+
+        assert_matches!(
+            state_machine
+                .schedule_task(task1.clone())
+                .map(|t| t.task_id()),
+            Some(101)
+        );
+        assert_matches!(
+            state_machine
+                .schedule_task(task2.clone())
+                .map(|t| t.task_id()),
+            Some(102)
+        );
+        assert_matches!(
+            state_machine
+                .schedule_task(task3.clone())
+                .map(|t| t.task_id()),
+            None
+        );
+
+        assert_eq!(state_machine.dropped_task_count(), 1);
+        assert_eq!(state_machine.active_task_count(), 2);
+        assert_eq!(state_machine.peak_active_task_count(), 2);
+        state_machine.deschedule_task(&task1.clone());
+        state_machine.deschedule_task(&task2.clone());
+        assert!(state_machine.has_no_active_task());
+        assert_eq!(state_machine.dropped_task_count(), 1);
+        assert_eq!(state_machine.active_task_count(), 0);
+        assert_eq!(state_machine.peak_active_task_count(), 2);
+        state_machine.reinitialize();
+        assert_eq!(state_machine.dropped_task_count(), 0);
+        assert_eq!(state_machine.peak_active_task_count(), 0);
+    }
+
+    #[test_matrix([Capability::FifoQueueing, Capability::PriorityQueueing])]
+    fn test_max_unique_active_task_drop_duplicate(capability: Capability) {
+        let mut state_machine = unsafe {
+            SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling(
+                None,
+                Some(100),
+            )
+        };
+        let sanitized1 = transaction_with_readonly_address(Pubkey::new_unique());
+        let sanitized2 = transaction_with_readonly_address(Pubkey::new_unique());
+        let address_loader = &mut create_address_loader(None, &capability);
+        let task1 = SchedulingStateMachine::create_task(sanitized1, 101, address_loader);
+        let task2a = SchedulingStateMachine::create_task(sanitized2.clone(), 102, address_loader);
+        let task2b = SchedulingStateMachine::create_task(sanitized2, 103, address_loader);
+
+        assert_matches!(
+            state_machine
+                .schedule_task(task1.clone())
+                .map(|t| t.task_id()),
+            Some(101)
+        );
+        assert_matches!(
+            state_machine
+                .schedule_task(task2a.clone())
+                .map(|t| t.task_id()),
+            Some(102)
+        );
+        assert_matches!(
+            state_machine
+                .schedule_task(task2b.clone())
+                .map(|t| t.task_id()),
+            None
+        );
+
+        assert_eq!(state_machine.dropped_task_count(), 1);
+        assert_eq!(state_machine.active_task_count(), 2);
+        assert_eq!(state_machine.peak_active_task_count(), 2);
+        state_machine.deschedule_task(&task1.clone());
+        state_machine.deschedule_task(&task2a.clone());
+        assert!(state_machine.has_no_active_task());
+        assert_matches!(
+            state_machine
+                .schedule_task(task2b.clone())
+                .map(|t| t.task_id()),
+            Some(103)
+        );
+        state_machine.deschedule_task(&task2b.clone());
+        assert!(state_machine.has_no_active_task());
+        assert_eq!(state_machine.dropped_task_count(), 1);
+        assert_eq!(state_machine.peak_active_task_count(), 2);
+        state_machine.reinitialize();
+        assert_eq!(state_machine.dropped_task_count(), 0);
+        assert_eq!(state_machine.peak_active_task_count(), 0);
+        assert_matches!(
+            state_machine
+                .schedule_task(task2b.clone())
+                .map(|t| t.task_id()),
+            Some(103)
+        );
+        state_machine.deschedule_task(&task2b.clone());
+        state_machine.reinitialize();
     }
 }

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -1078,6 +1078,7 @@ pub struct SchedulingStateMachine {
     count_token: BlockedUsageCountToken,
     usage_queue_token: UsageQueueToken,
 }
+const_assert_eq!(mem::size_of::<SchedulingStateMachine>(), 128);
 
 impl SchedulingStateMachine {
     pub fn has_no_running_task(&self) -> bool {

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -82,6 +82,10 @@ use {
 // assumption these days...
 const MAX_BLOCK_SIZE_THRESHOLD: BlockSize = 20 * 1024 * 1024;
 
+// This const is intentionally aligned with central scheduler's corresponding const called
+// TOTAL_BUFFERED_PACKETS.
+const MAX_UNIQUE_ACTIVE_TASK_COUNT: usize = 100_000;
+
 mod sleepless_testing;
 use crate::sleepless_testing::BuilderTracked;
 
@@ -1855,6 +1859,32 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
         }
     }
 
+    fn max_unique_active_task_count(mode: SchedulingMode) -> Option<usize> {
+        match mode {
+            BlockVerification => {
+                // We can't silently drop block verification tasks by imposing some arbitrary limit
+                // here; otherwise same transactions could be allowed in the same block!
+                // The block size (i.e. shred count) limit is already enforced before unified
+                // scheduler.
+                None
+            }
+            BlockProduction => {
+                // Unlike BlockVerification, we need to cap the maximum number of tasks at hand at
+                // any given moment, in order to avoid unbounded memory consumption, which is
+                // remotely controllable. Also, drop duplicate tasks to make better use of the now
+                // constrained space.
+                // Note that this deduplication isn't perfect because it searches duplicates only
+                // among the _current_ active task set, allowing false negatives (i.e. failure of
+                // duplicate detection) in the already handled tasks. However, it's effective
+                // enough, given that significant buffering just before the first leader slot.
+                // This naive impl is chosen; otherwise proper eviction would rather be hard here,
+                // considering the existence of transaction retires (same tx but with different
+                // task id).
+                Some(MAX_UNIQUE_ACTIVE_TASK_COUNT)
+            }
+        }
+    }
+
     fn can_receive_unblocked_task(
         session_ending: bool,
         mode: SchedulingMode,
@@ -2197,6 +2227,7 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
                 let mut state_machine = unsafe {
                     SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling(
                         Self::max_running_task_count(scheduling_mode, handler_context.thread_count),
+                        Self::max_unique_active_task_count(scheduling_mode),
                     )
                 };
 
@@ -2330,6 +2361,17 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
                             "unified_scheduler-bp_session_stats",
                             ("slot", current_slot.unwrap_or_default(), i64),
                             ("block_size_estimate", block_size_estimate, i64),
+                            ("total_task_count", state_machine.total_task_count(), i64),
+                            (
+                                "peak_active_task_count",
+                                state_machine.peak_active_task_count(),
+                                i64
+                            ),
+                            (
+                                "dropped_task_count",
+                                state_machine.dropped_task_count(),
+                                i64
+                            ),
                         );
                     }
                     if matches!(scheduling_mode, BlockVerification) {
@@ -3000,6 +3042,7 @@ mod tests {
         BeforeEndSession,
         AfterSession,
         AfterDiscarded,
+        BeforeDiscardRequested,
     }
 
     #[test]
@@ -5197,15 +5240,13 @@ mod tests {
 
         agave_logger::setup();
 
-        let GenesisConfigInfo {
-            genesis_config,
-            mint_keypair,
-            ..
-        } = create_genesis_config_for_block_production(10_000);
+        let GenesisConfigInfo { genesis_config, .. } =
+            create_genesis_config_for_block_production(10_000);
 
         const DISCARDED_TASK_COUNT: OrderedTaskId = 3;
         let _progress = sleepless_testing::setup(&[
             &CheckPoint::NewBufferedTask(DISCARDED_TASK_COUNT - 1),
+            &TestCheckPoint::BeforeDiscardRequested,
             &CheckPoint::DiscardRequested,
             &CheckPoint::Discarded(DISCARDED_TASK_COUNT.try_into().unwrap()),
             &TestCheckPoint::AfterDiscarded,
@@ -5227,16 +5268,18 @@ mod tests {
             DEFAULT_TIMEOUT_DURATION,
         );
 
-        let tx0 = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
-            &mint_keypair,
-            &solana_pubkey::new_rand(),
-            2,
-            genesis_config.hash(),
-        ));
         let fixed_banking_packet_handler =
             Box::new(move |helper: &BankingStageHelper, _banking_packet| {
                 for task_id in 0..DISCARDED_TASK_COUNT {
-                    helper.send_new_task(helper.create_new_unconstrained_task(tx0.clone(), task_id))
+                    let tx = RuntimeTransaction::from_transaction_for_tests(
+                        system_transaction::transfer(
+                            &Keypair::new(),
+                            &solana_pubkey::new_rand(),
+                            2,
+                            genesis_config.hash(),
+                        ),
+                    );
+                    helper.send_new_task(helper.create_new_unconstrained_task(tx, task_id))
                 }
             });
 
@@ -5256,6 +5299,7 @@ mod tests {
             Box::new(SimpleBankingMinitor),
         );
 
+        sleepless_testing::at(TestCheckPoint::BeforeDiscardRequested);
         // By now, there should be a buffered transaction. Let's discard it.
         *START_DISCARD.lock().unwrap() = true;
 


### PR DESCRIPTION
#### Problem

BP unified scheduler grows memory consumption unbounded when there are many incoming transactions. 

#### Summary of Changes

Limit it for security reasons.

also note that there should be no functional change for the block verification code-path.