### PR TITLE
limit the number of ops during stalebot operation

### DIFF
--- a/.github/workflows/manage-stale-issues.yml
+++ b/.github/workflows/manage-stale-issues.yml
@@ -37,7 +37,6 @@ jobs:
           exempt-all-milestones: true # There are some projects in the repo, so possibly milestones are relevant.
           exempt-issue-labels: do-not-close,feature-gate
           exempt-pr-labels: do-not-close,feature-gate
-          exempt-draft-pr: true
           operations-per-run: ${{ github.event_name == 'pull_request' && 100 || 10 }}
           stale-issue-label: stale
           stale-issue-message: 'This issue is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 7 days.'

--- a/.github/workflows/manage-stale-issues.yml
+++ b/.github/workflows/manage-stale-issues.yml
@@ -37,7 +37,8 @@ jobs:
           exempt-all-milestones: true # There are some projects in the repo, so possibly milestones are relevant.
           exempt-issue-labels: do-not-close,feature-gate
           exempt-pr-labels: do-not-close,feature-gate
-          operations-per-run: ${{ github.event_name == 'pull_request' && 1000 || 900}}
+          exempt-draft-pr: true
+          operations-per-run: ${{ github.event_name == 'pull_request' && 100 || 10 }}
           stale-issue-label: stale
           stale-issue-message: 'This issue is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           stale-pr-label: stale


### PR DESCRIPTION
#### Problem

Letting the bot loose on our repo generated an overwhelming amount of stale labels.

#### Summary of Changes

Limit the operations stale bot is allowed to do so that we can get a handle on things.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
