### PR TITLE
Make flushing of unrooted slots explicit

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7012,7 +7012,7 @@ impl AccountsDb {
     }
 
     pub fn flush_accounts_cache_slot_for_tests(&self, slot: Slot) {
-        self.flush_slot_cache_with_clean(slot, None::<&mut fn(&_) -> bool>, None)
+        self.flush_slot_cache_with_clean(slot, None::<&mut fn(&_) -> bool>, None);
     }
 
     /// useful to adapt tests written prior to introduction of the write cache

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4610,7 +4610,7 @@ impl AccountsDb {
                 // The unrootable slots will get purged later.
                 if old_slot > max_flushed_root {
                     if self.should_aggressively_flush_cache() {
-                        if let Some(stats) = self.flush_unrooted_cache_slot(old_slot) {
+                        if let Some(stats) = self.flush_unrooted_slot_cache(old_slot) {
                             flush_stats.accumulate(&stats);
                         }
                     }
@@ -4863,7 +4863,7 @@ impl AccountsDb {
 
     /// Flushes an unrooted slot from the write cache to storage to free up memory
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-    fn flush_unrooted_cache_slot(&self, slot: Slot) -> Option<FlushStats> {
+    fn flush_unrooted_slot_cache(&self, slot: Slot) -> Option<FlushStats> {
         self.flush_slot_cache_with_clean(slot, None::<&mut fn(&_) -> bool>, None)
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4861,11 +4861,6 @@ impl AccountsDb {
         flush_stats
     }
 
-    /// flush all accounts in this slot
-    fn flush_slot_cache(&self, slot: Slot) -> Option<FlushStats> {
-        self.flush_slot_cache_with_clean(slot, None::<&mut fn(&_) -> bool>, None)
-    }
-
     /// Flushes an unrooted slot from the write cache to storage to free up memory
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn flush_unrooted_slot_cache(&self, slot: Slot) -> Option<FlushStats> {
@@ -7017,7 +7012,7 @@ impl AccountsDb {
     }
 
     pub fn flush_accounts_cache_slot_for_tests(&self, slot: Slot) {
-        self.flush_slot_cache(slot);
+        self.flush_slot_cache_with_clean(slot, None::<&mut fn(&_) -> bool>, None)
     }
 
     /// useful to adapt tests written prior to introduction of the write cache

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4605,10 +4605,12 @@ impl AccountsDb {
             excess_slot_count = old_slots.len();
             let mut flush_stats = FlushStats::default();
             old_slots.into_iter().for_each(|old_slot| {
-                // Don't flush slots that are known to be unrooted
+                // Only flush unrooted slots > max_flushed_root. Slots older < max_flushed_root
+                // cannot have max_flushed_root as an ancestor, and thus will never become rooted.
+                // The unrootable slots will get purged later.
                 if old_slot > max_flushed_root {
                     if self.should_aggressively_flush_cache() {
-                        if let Some(stats) = self.flush_slot_cache(old_slot) {
+                        if let Some(stats) = self.flush_unrooted_cache_slot(old_slot) {
                             flush_stats.accumulate(&stats);
                         }
                     }
@@ -4859,8 +4861,9 @@ impl AccountsDb {
         flush_stats
     }
 
-    /// flush all accounts in this slot
-    fn flush_slot_cache(&self, slot: Slot) -> Option<FlushStats> {
+    /// Flushes an unrooted slot from the write cache to storage to free up memory
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    fn flush_unrooted_cache_slot(&self, slot: Slot) -> Option<FlushStats> {
         self.flush_slot_cache_with_clean(slot, None::<&mut fn(&_) -> bool>, None)
     }
 
@@ -6999,7 +7002,16 @@ impl AccountsDb {
     }
 
     pub fn flush_accounts_cache_slot_for_tests(&self, slot: Slot) {
-        self.flush_slot_cache(slot);
+        assert!(
+            self.accounts_index
+                .roots_tracker
+                .read()
+                .unwrap()
+                .alive_roots
+                .contains(&slot),
+            "slot: {slot}"
+        );
+        self.flush_slot_cache_with_clean(slot, None::<&mut fn(&_) -> bool>, None);
     }
 
     /// useful to adapt tests written prior to introduction of the write cache

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4496,7 +4496,7 @@ fn test_cache_flush_delayed_remove_unrooted_race() {
                 if flush_trial_start_receiver.recv().is_err() {
                     return;
                 }
-                db.flush_slot_cache(10);
+                db.flush_unrooted_cache_slot(10);
                 flush_done_sender.send(()).unwrap();
             })
             .unwrap()
@@ -4558,7 +4558,7 @@ fn test_cache_flush_remove_unrooted_race_multiple_slots() {
                     return;
                 }
                 for slot in 0..num_cached_slots {
-                    db.flush_slot_cache(slot);
+                    db.flush_unrooted_cache_slot(slot);
                 }
                 flush_done_sender.send(()).unwrap();
             })
@@ -6478,10 +6478,13 @@ fn test_mark_obsolete_accounts_at_startup_purge_slot() {
     // Store the same pubkey in multiple slots
     // Store other pubkey in slot0 to ensure slot is not purged
     accounts_db.store_for_tests((0, [(&pubkey1, &account), (&pubkey2, &account)].as_slice()));
+    accounts_db.add_root(0);
     accounts_db.flush_accounts_cache_slot_for_tests(0);
     accounts_db.store_for_tests((1, [(&pubkey1, &account)].as_slice()));
+    accounts_db.add_root(1);
     accounts_db.flush_accounts_cache_slot_for_tests(1);
     accounts_db.store_for_tests((2, [(&pubkey1, &account)].as_slice()));
+    accounts_db.add_root(2);
     accounts_db.flush_accounts_cache_slot_for_tests(2);
 
     let pubkeys_with_duplicates_by_bin = vec![vec![pubkey1]];
@@ -6514,6 +6517,7 @@ fn test_mark_obsolete_accounts_at_startup_multiple_bins() {
             slot,
             [(&pubkey1, &account), (&pubkey2, &account)].as_slice(),
         ));
+        accounts_db.add_root(slot);
         accounts_db.flush_accounts_cache_slot_for_tests(slot);
     }
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4496,7 +4496,7 @@ fn test_cache_flush_delayed_remove_unrooted_race() {
                 if flush_trial_start_receiver.recv().is_err() {
                     return;
                 }
-                db.flush_unrooted_cache_slot(10);
+                db.flush_unrooted_slot_cache(10);
                 flush_done_sender.send(()).unwrap();
             })
             .unwrap()
@@ -4558,7 +4558,7 @@ fn test_cache_flush_remove_unrooted_race_multiple_slots() {
                     return;
                 }
                 for slot in 0..num_cached_slots {
-                    db.flush_unrooted_cache_slot(slot);
+                    db.flush_unrooted_slot_cache(slot);
                 }
                 flush_done_sender.send(()).unwrap();
             })

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6478,13 +6478,10 @@ fn test_mark_obsolete_accounts_at_startup_purge_slot() {
     // Store the same pubkey in multiple slots
     // Store other pubkey in slot0 to ensure slot is not purged
     accounts_db.store_for_tests((0, [(&pubkey1, &account), (&pubkey2, &account)].as_slice()));
-    accounts_db.add_root(0);
     accounts_db.flush_accounts_cache_slot_for_tests(0);
     accounts_db.store_for_tests((1, [(&pubkey1, &account)].as_slice()));
-    accounts_db.add_root(1);
     accounts_db.flush_accounts_cache_slot_for_tests(1);
     accounts_db.store_for_tests((2, [(&pubkey1, &account)].as_slice()));
-    accounts_db.add_root(2);
     accounts_db.flush_accounts_cache_slot_for_tests(2);
 
     let pubkeys_with_duplicates_by_bin = vec![vec![pubkey1]];
@@ -6517,7 +6514,6 @@ fn test_mark_obsolete_accounts_at_startup_multiple_bins() {
             slot,
             [(&pubkey1, &account), (&pubkey2, &account)].as_slice(),
         ));
-        accounts_db.add_root(slot);
         accounts_db.flush_accounts_cache_slot_for_tests(slot);
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5489,7 +5489,7 @@ fn test_clean_nonrooted() {
     bank1
         .accounts()
         .accounts_db
-        .flush_unrooted_cache_slot(bank1.slot());
+        .flush_unrooted_slot_cache(bank1.slot());
 
     bank1.print_accounts_stats();
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5486,7 +5486,10 @@ fn test_clean_nonrooted() {
     test_utils::deposit(&bank1, &pubkey0, some_lamports).unwrap();
     goto_end_of_slot(bank1.clone());
     bank1.freeze();
-    bank1.flush_accounts_cache_slot_for_tests();
+    bank1
+        .accounts()
+        .accounts_db
+        .flush_unrooted_cache_slot(bank1.slot());
 
     bank1.print_accounts_stats();
 


### PR DESCRIPTION
#### Problem
Flushing unrooted slots should only be done when the accounts cache exceeds the expected size. Make flushing of unrooted slots explicit in general to avoid unintentionally flushing unrooted slots


#### Summary of Changes
- Added new function flush_unrooted_cache_slot
- Switched all callers that are intending to flush unrooted cacheslots to call flush_unrooted_cache_slot
- Added assert to flush_cache_slot that slots are rooted. 
- removed flush_slot_cache

Note:
This is currently relevant as some of the expectations around clean will need to change as the handling of zero lamport accounts only accessed in a single slot (aka ephemeral accounts) will change. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
