### PR TITLE
Bump `bls-signatures` to v3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7494,9 +7494,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bls-signatures"
-version = "2.0.0-alpha.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acb2f8e2ce54f8798c8a5eb5d06f4cb4f596a5879be5ad81e95a60a1bde9359"
+checksum = "e21cad136370a83c91bbe9348c69a510222d8d70144154ca37edff59df789661"
 dependencies = [
  "base64 0.22.1",
  "blst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -408,7 +408,7 @@ solana-big-mod-exp = "3.0.0"
 solana-bincode = "3.1.0"
 solana-blake3-hasher = "3.1.0"
 solana-bloom = { path = "bloom", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-solana-bls-signatures = { version = "2.0.0-alpha.1", features = ["serde"] } #TODO: change to 2.0.0 before this gets into 4.0
+solana-bls-signatures = { version = "3.0.0", features = ["serde"] }
 solana-bn254 = "3.1.2"
 solana-borsh = "3.0.0"
 solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -438,8 +438,8 @@ mod tests {
 
     #[test]
     fn test_bls_pubkeys_of() {
-        let bls_pubkey1: BLSPubkey = BLSKeypair::new().public;
-        let bls_pubkey2: BLSPubkey = BLSKeypair::new().public;
+        let bls_pubkey1: BLSPubkey = BLSKeypair::new().public.into();
+        let bls_pubkey2: BLSPubkey = BLSKeypair::new().public.into();
         let bls_pubkey1_compressed: BLSPubkeyCompressed = bls_pubkey1.try_into().unwrap();
         let bls_pubkey2_compressed: BLSPubkeyCompressed = bls_pubkey2.try_into().unwrap();
         let matches = app().get_matches_from(vec![

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6467,9 +6467,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bls-signatures"
-version = "2.0.0-alpha.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acb2f8e2ce54f8798c8a5eb5d06f4cb4f596a5879be5ad81e95a60a1bde9359"
+checksum = "e21cad136370a83c91bbe9348c69a510222d8d70144154ca37edff59df789661"
 dependencies = [
  "base64 0.22.1",
  "blst",

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -1356,7 +1356,7 @@ mod tests {
 
         let generate_bls_pubkey = || {
             if add_bls_pubkey {
-                let bls_pubkey = BLSKeypair::new().public;
+                let bls_pubkey: BLSPubkey = BLSKeypair::new().public.into();
                 if use_compressed_pubkey {
                     let bls_pubkey_compressed: BLSPubkeyCompressed = bls_pubkey.try_into().unwrap();
                     Some(bls_pubkey_compressed.to_string())

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -532,7 +532,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
         ("bls_pubkey", matches) => {
             let keypair = get_keypair_from_matches(matches, config, &mut wallet_manager)?;
             let bls_keypair = BLSKeypair::derive_from_signer(&keypair, BLS_KEYPAIR_DERIVE_SEED)?;
-            let bls_pubkey: BLSPubkey = bls_keypair.public;
+            let bls_pubkey: BLSPubkey = bls_keypair.public.into();
 
             if matches.try_contains_id("outfile")? {
                 let outfile = matches.get_one::<String>("outfile").unwrap();
@@ -1269,7 +1269,7 @@ mod tests {
     fn test_read_write_bls_pubkey() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
         let filename = "test_bls_pubkey.json";
         let bls_keypair = BLSKeypair::new();
-        let bls_pubkey = bls_keypair.public;
+        let bls_pubkey: BLSPubkey = bls_keypair.public.into();
         write_bls_pubkey_file(filename, bls_pubkey)?;
         let read = read_bls_pubkey_file(filename)?;
         assert_eq!(read, bls_pubkey);
@@ -1300,6 +1300,6 @@ mod tests {
         let bls_keypair =
             BLSKeypair::derive_from_signer(&my_keypair, BLS_KEYPAIR_DERIVE_SEED).unwrap();
         let read_bls_pubkey = read_bls_pubkey_file(&outfile_path).unwrap();
-        assert_eq!(read_bls_pubkey, bls_keypair.public);
+        assert_eq!(read_bls_pubkey, bls_keypair.public.into());
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6276,9 +6276,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bls-signatures"
-version = "2.0.0-alpha.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acb2f8e2ce54f8798c8a5eb5d06f4cb4f596a5879be5ad81e95a60a1bde9359"
+checksum = "e21cad136370a83c91bbe9348c69a510222d8d70144154ca37edff59df789661"
 dependencies = [
  "base64 0.22.1",
  "blst",

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -303,7 +303,7 @@ pub(crate) mod tests {
                     iter::repeat_with(|| {
                         let authorized_voter = solana_pubkey::new_rand();
                         let bls_pubkey_compressed: BLSPubkeyCompressed =
-                            BLSKeypair::new().public.try_into().unwrap();
+                            BLSKeypair::new().public.into();
                         let bls_pubkey_compressed_serialized =
                             bincode::serialize(&bls_pubkey_compressed)
                                 .unwrap()

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -155,7 +155,7 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
             BLS_KEYPAIR_DERIVE_SEED,
         )
         .unwrap();
-        Some(bls_pubkey_to_compressed_bytes(&bls_keypair.public))
+        Some(bls_keypair.public.to_bytes_compressed())
     } else {
         None
     };
@@ -195,7 +195,7 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
                 BLS_KEYPAIR_DERIVE_SEED,
             )
             .unwrap();
-            Some(bls_pubkey_to_compressed_bytes(&bls_keypair.public))
+            Some(bls_keypair.public.to_bytes_compressed())
         } else {
             None
         };

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -2109,7 +2109,7 @@ mod tests {
         let bls_keypair =
             BLSKeypair::derive_from_signer(validator_vote_keypair, BLS_KEYPAIR_DERIVE_SEED)
                 .unwrap();
-        let bls_pubkey: BLSPubkey = bls_keypair.public;
+        let bls_pubkey: BLSPubkey = bls_keypair.public.into();
 
         let signed_message = bincode::serialize(&vote).unwrap();
 

--- a/votor/src/consensus_pool/certificate_builder.rs
+++ b/votor/src/consensus_pool/certificate_builder.rs
@@ -453,13 +453,9 @@ mod tests {
         let aggregate_pubkey = BLSPubkeyProjective::aggregate(keypairs.iter().map(|kp| &kp.public))
             .expect("Failed to aggregate public keys");
 
-        let verification_result =
-            aggregate_pubkey.verify_signature(&certificate_message.signature, &serialized_vote);
-
-        assert!(
-            verification_result.unwrap_or(false),
-            "BLS aggregate signature verification failed for base2 encoded certificate"
-        );
+        aggregate_pubkey
+            .verify_signature(&certificate_message.signature, &serialized_vote)
+            .expect("BLS aggregate signature verification failed for base2 encoded certificate");
     }
 
     #[test]

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -211,7 +211,7 @@ fn generate_vote_tx(vote: &Vote, bank: &Bank, context: &mut VotingContext) -> Ge
 
     let bls_keypair = get_bls_keypair(context, &authorized_voter_keypair)
         .unwrap_or_else(|e| panic!("Failed to derive my own BLS keypair: {e:?}"));
-    let my_bls_pubkey: BLSPubkey = bls_keypair.public;
+    let my_bls_pubkey: BLSPubkey = bls_keypair.public.into();
     if my_bls_pubkey != bls_pubkey_in_vote_account {
         panic!(
             "Vote account bls_pubkey mismatch: {bls_pubkey_in_vote_account:?} (expected: \


### PR DESCRIPTION
#### Problem

Next major release of `bls-signatures` is out.

#### Summary of Changes

Upgrade to `bls-signatures` v3.0.

I simplified the logic a little in the vote program with the improved API.

I had to make some edits in the other crates because a `Keypair` now holds `PubkeyAffine` as the public key type rather than `Pubkey`, so I added manual conversions, but this should be quite straightforward.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
