### PR TITLE
chore: remove forwarding logic from FetchStage

### DIFF
--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -84,12 +84,9 @@ impl FetchStage {
             })
             .unwrap();
 
-        Self {
-            thread_hdls: [tpu_vote_threads, vec![metrics_thread_hdl]]
-                .into_iter()
-                .flatten()
-                .collect(),
-        }
+        let mut thread_hdls = tpu_vote_threads;
+        thread_hdls.push(metrics_thread_hdl);
+        Self { thread_hdls }
     }
 
     pub fn join(self) -> thread::Result<()> {

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -162,14 +162,10 @@ impl Tpu {
 
         let (packet_sender, packet_receiver) = bounded(TPU_CHANNEL_SIZE);
         let (vote_packet_sender, vote_packet_receiver) = unbounded();
-        let (forwarded_packet_sender, forwarded_packet_receiver) = unbounded();
         let fetch_stage = FetchStage::new_with_sender(
             tpu_vote_sockets,
             exit.clone(),
-            &packet_sender,
             &vote_packet_sender,
-            forwarded_packet_receiver,
-            poh_recorder,
             None, // coalesce
         );
 
@@ -217,7 +213,7 @@ impl Tpu {
             "quic_streamer_tpu",
             transactions_quic_sockets,
             keypair,
-            packet_sender,
+            packet_sender.clone(),
             staked_nodes.clone(),
             tpu_quic_server_config.quic_streamer_config,
             tpu_quic_server_config.qos_config,
@@ -235,7 +231,7 @@ impl Tpu {
             "quic_streamer_tpu_forwards",
             transactions_forwards_quic_sockets,
             keypair,
-            forwarded_packet_sender,
+            packet_sender,
             staked_nodes.clone(),
             tpu_fwd_quic_server_config.quic_streamer_config,
             tpu_fwd_quic_server_config.qos_config,


### PR DESCRIPTION
 #### Problem

  FetchStage contains unused forwarding code after normal transactions migrated to QUIC. 

  #### Summary of Changes

  - Remove handle_forwarded_packets() function and forwarding thread from FetchStage
  - Remove forwarded_packet_sender/receiver channel from tpu.rs
  - Simplify FetchStage to only handle vote packets over UDP
  - Both TPU and TPU forwards QUIC now send to the same packet_sender channel

  Follow-up to #9299