### PR TITLE
svm-test-harness: add txn fixture types

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9193,15 +9193,25 @@ name = "solana-svm-test-harness-fixture"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-precompiles",
  "bincode",
  "prost 0.14.3",
  "prost-build 0.14.3",
  "protosol",
  "solana-account 4.3.0",
+ "solana-address-lookup-table-interface",
+ "solana-fee-structure",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instruction-error",
+ "solana-message",
  "solana-pubkey 4.2.0",
+ "solana-signature",
+ "solana-stable-layout",
  "solana-svm-feature-set",
+ "solana-svm-transaction",
+ "solana-transaction",
+ "solana-transaction-error",
  "thiserror 2.0.18",
 ]
 

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -88,6 +88,7 @@ signal-hook = "0.4.4"
 solana-account = "4.3.0"
 solana-account-decoder = { path = "../account-decoder", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-accounts-db = { path = "../accounts-db", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-address-lookup-table-interface = "3.0.1"
 solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-builtins = { path = "../builtins", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-clap-utils = { path = "../clap-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -107,6 +108,7 @@ solana-entry = { path = "../entry", version = "=4.1.0-alpha.0", features = ["aga
 solana-faucet = { path = "../faucet", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-feature-gate-interface = "4.0.0"
 solana-fee-calculator = "3.2.0"
+solana-fee-structure = "3.0.0"
 solana-genesis = { path = "../genesis", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-genesis-config = "4.0.0"
 solana-genesis-utils = { path = "../genesis-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -142,6 +144,7 @@ solana-sdk-ids = "3.1.0"
 solana-shred-version = "3.0.1"
 solana-signature = { version = "3.4.0", default-features = false }
 solana-signer = "3.0.0"
+solana-stable-layout = "3.0.1"
 solana-stake-interface = "3.0.0"
 solana-storage-bigtable = { path = "../storage-bigtable", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-streamer = { path = "../streamer", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -163,6 +166,7 @@ solana-tps-client = { path = "../tps-client", version = "=4.1.0-alpha.0", featur
 solana-tpu-client = { path = "../tpu-client", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-transaction = "4.1.0"
 solana-transaction-context = { path = "../transaction-context", version = "=4.1.0-alpha.0", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-error = "3.1.0"
 solana-transaction-status = { path = "../transaction-status", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-version = { path = "../version", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9540,10 +9540,15 @@ name = "solana-svm-test-harness-fixture"
 version = "4.1.0-alpha.0"
 dependencies = [
  "solana-account 4.3.0",
+ "solana-fee-structure",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
+ "solana-stable-layout",
  "solana-svm-feature-set",
+ "solana-transaction",
+ "solana-transaction-error",
  "thiserror 2.0.18",
 ]
 

--- a/svm-test-harness/fixture/Cargo.toml
+++ b/svm-test-harness/fixture/Cargo.toml
@@ -17,23 +17,38 @@ dev-context-only-utils = []
 dummy-for-ci-check = ["fuzz"]
 fuzz = [
     "dep:agave-feature-set",
+    "dep:agave-precompiles",
     "dep:bincode",
     "dep:prost",
     "dep:prost-build",
     "dep:protosol",
+    "dep:solana-address-lookup-table-interface",
+    "dep:solana-message",
+    "dep:solana-signature",
+    "dep:solana-svm-transaction",
     "solana-pubkey/default",
 ]
 
 [dependencies]
 agave-feature-set = { workspace = true, optional = true }
+agave-precompiles = { workspace = true, optional = true }
 bincode = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
 protosol = { workspace = true, optional = true }
 solana-account = { workspace = true }
+solana-address-lookup-table-interface = { workspace = true, optional = true, features = ["bincode", "bytemuck"] }
+solana-fee-structure = { workspace = true }
+solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true, features = ["serde"] }
+solana-message = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
+solana-signature = { workspace = true, optional = true }
+solana-stable-layout = { workspace = true }
 solana-svm-feature-set = { workspace = true }
+solana-svm-transaction = { workspace = true, optional = true }
+solana-transaction = { workspace = true, features = ["blake3"] }
+solana-transaction-error = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
 
 [build-dependencies]

--- a/svm-test-harness/fixture/src/error.rs
+++ b/svm-test-harness/fixture/src/error.rs
@@ -12,6 +12,12 @@ pub enum FixtureError {
     #[error("Invalid public key bytes")]
     InvalidPubkeyBytes(Vec<u8>),
 
+    #[error("Invalid hash bytes")]
+    InvalidHashBytes(Vec<u8>),
+
     #[error("An account is missing for instruction account index {0}")]
     AccountMissingForInstrAccount(usize),
+
+    #[error("Invalid address lookup table")]
+    InvalidAddressLookupTable,
 }

--- a/svm-test-harness/fixture/src/error.rs
+++ b/svm-test-harness/fixture/src/error.rs
@@ -15,6 +15,9 @@ pub enum FixtureError {
     #[error("Invalid hash bytes")]
     InvalidHashBytes(Vec<u8>),
 
+    #[error("Invalid signature bytes")]
+    InvalidSignatureBytes(Vec<u8>),
+
     #[error("An account is missing for instruction account index {0}")]
     AccountMissingForInstrAccount(usize),
 

--- a/svm-test-harness/fixture/src/lib.rs
+++ b/svm-test-harness/fixture/src/lib.rs
@@ -9,6 +9,9 @@ pub mod error;
 pub mod feature_set;
 pub mod instr_context;
 pub mod instr_effects;
+pub mod message;
+pub mod txn_context;
+pub mod txn_result;
 
 #[cfg(feature = "fuzz")]
 pub mod proto {

--- a/svm-test-harness/fixture/src/message.rs
+++ b/svm-test-harness/fixture/src/message.rs
@@ -21,7 +21,10 @@ use {
         v0::{self, LoadedAddresses, LoadedMessage, MessageAddressTableLookup},
     },
     solana_pubkey::Pubkey,
-    std::{cmp::max, collections::HashSet},
+    std::{
+        cmp::max,
+        collections::{HashMap, HashSet},
+    },
 };
 
 impl From<&ProtoMessageHeader> for MessageHeader {
@@ -75,14 +78,21 @@ fn resolve_address_table_lookups(
     lookups: &[MessageAddressTableLookup],
     accounts: &[(Pubkey, Account)],
 ) -> Result<LoadedAddresses, FixtureError> {
+    if lookups.is_empty() {
+        return Ok(LoadedAddresses::default());
+    }
+
+    let account_map: HashMap<&Pubkey, &Account> = accounts
+        .iter()
+        .map(|(pubkey, account)| (pubkey, account))
+        .collect();
+
     let mut writable = Vec::new();
     let mut readonly = Vec::new();
 
     for lookup in lookups {
-        let alt_account = accounts
-            .iter()
-            .find(|(pubkey, _)| *pubkey == lookup.account_key)
-            .map(|(_, account)| account)
+        let alt_account = account_map
+            .get(&lookup.account_key)
             .ok_or(FixtureError::InvalidAddressLookupTable)?;
 
         let alt = AddressLookupTable::deserialize(&alt_account.data)

--- a/svm-test-harness/fixture/src/message.rs
+++ b/svm-test-harness/fixture/src/message.rs
@@ -44,10 +44,19 @@ impl From<&ProtoCompiledInstruction> for CompiledInstruction {
     }
 }
 
-impl From<&ProtoMessageAddressTableLookup> for MessageAddressTableLookup {
-    fn from(value: &ProtoMessageAddressTableLookup) -> Self {
-        MessageAddressTableLookup {
-            account_key: Pubkey::new_from_array(value.account_key.clone().try_into().unwrap()),
+impl TryFrom<&ProtoMessageAddressTableLookup> for MessageAddressTableLookup {
+    type Error = FixtureError;
+
+    fn try_from(value: &ProtoMessageAddressTableLookup) -> Result<Self, Self::Error> {
+        let account_key = Pubkey::new_from_array(
+            value
+                .account_key
+                .clone()
+                .try_into()
+                .map_err(FixtureError::InvalidPubkeyBytes)?,
+        );
+        Ok(MessageAddressTableLookup {
+            account_key,
             writable_indexes: value
                 .writable_indexes
                 .iter()
@@ -58,7 +67,7 @@ impl From<&ProtoMessageAddressTableLookup> for MessageAddressTableLookup {
                 .iter()
                 .map(|idx| *idx as u8)
                 .collect(),
-        }
+        })
     }
 }
 
@@ -102,26 +111,34 @@ pub fn build_sanitized_message(
     value: &ProtoTransactionMessage,
     accounts: &[(Pubkey, Account)],
 ) -> Result<SanitizedMessage, FixtureError> {
-    let header = if let Some(ref value_header) = value.header {
-        MessageHeader::from(value_header)
-    } else {
-        MessageHeader {
-            num_required_signatures: 1,
-            num_readonly_signed_accounts: 0,
-            num_readonly_unsigned_accounts: 0,
-        }
-    };
+    let header = value
+        .header
+        .as_ref()
+        .map(MessageHeader::from)
+        .ok_or(FixtureError::InvalidFixtureInput)?;
 
     let account_keys = value
         .account_keys
         .iter()
-        .map(|key| Pubkey::new_from_array(key.clone().try_into().unwrap()))
-        .collect::<Vec<Pubkey>>();
+        .map(|key| {
+            Ok(Pubkey::new_from_array(
+                key.clone()
+                    .try_into()
+                    .map_err(FixtureError::InvalidPubkeyBytes)?,
+            ))
+        })
+        .collect::<Result<Vec<Pubkey>, FixtureError>>()?;
 
     let recent_blockhash = if value.recent_blockhash.is_empty() {
         Hash::new_from_array([0u8; 32])
     } else {
-        Hash::new_from_array(value.recent_blockhash.clone().try_into().unwrap())
+        Hash::new_from_array(
+            value
+                .recent_blockhash
+                .clone()
+                .try_into()
+                .map_err(FixtureError::InvalidHashBytes)?,
+        )
     };
 
     let instructions = value
@@ -145,8 +162,8 @@ pub fn build_sanitized_message(
         let address_table_lookups = value
             .address_table_lookups
             .iter()
-            .map(MessageAddressTableLookup::from)
-            .collect::<Vec<MessageAddressTableLookup>>();
+            .map(MessageAddressTableLookup::try_from)
+            .collect::<Result<Vec<MessageAddressTableLookup>, FixtureError>>()?;
 
         let loaded_addresses = resolve_address_table_lookups(&address_table_lookups, accounts)?;
 

--- a/svm-test-harness/fixture/src/message.rs
+++ b/svm-test-harness/fixture/src/message.rs
@@ -1,0 +1,167 @@
+//! Transaction message utilities.
+
+#![cfg(feature = "fuzz")]
+
+use {
+    super::{
+        error::FixtureError,
+        proto::{
+            CompiledInstruction as ProtoCompiledInstruction,
+            MessageAddressTableLookup as ProtoMessageAddressTableLookup,
+            MessageHeader as ProtoMessageHeader, TransactionMessage as ProtoTransactionMessage,
+        },
+    },
+    solana_account::Account,
+    solana_address_lookup_table_interface::state::AddressLookupTable,
+    solana_hash::Hash,
+    solana_message::{
+        LegacyMessage, MessageHeader, SanitizedMessage,
+        compiled_instruction::CompiledInstruction,
+        legacy,
+        v0::{self, LoadedAddresses, LoadedMessage, MessageAddressTableLookup},
+    },
+    solana_pubkey::Pubkey,
+    std::{cmp::max, collections::HashSet},
+};
+
+impl From<&ProtoMessageHeader> for MessageHeader {
+    fn from(value: &ProtoMessageHeader) -> Self {
+        MessageHeader {
+            num_required_signatures: max(1, value.num_required_signatures as u8),
+            num_readonly_signed_accounts: value.num_readonly_signed_accounts as u8,
+            num_readonly_unsigned_accounts: value.num_readonly_unsigned_accounts as u8,
+        }
+    }
+}
+
+impl From<&ProtoCompiledInstruction> for CompiledInstruction {
+    fn from(value: &ProtoCompiledInstruction) -> Self {
+        CompiledInstruction {
+            program_id_index: value.program_id_index as u8,
+            accounts: value.accounts.iter().map(|idx| *idx as u8).collect(),
+            data: value.data.clone(),
+        }
+    }
+}
+
+impl From<&ProtoMessageAddressTableLookup> for MessageAddressTableLookup {
+    fn from(value: &ProtoMessageAddressTableLookup) -> Self {
+        MessageAddressTableLookup {
+            account_key: Pubkey::new_from_array(value.account_key.clone().try_into().unwrap()),
+            writable_indexes: value
+                .writable_indexes
+                .iter()
+                .map(|idx| *idx as u8)
+                .collect(),
+            readonly_indexes: value
+                .readonly_indexes
+                .iter()
+                .map(|idx| *idx as u8)
+                .collect(),
+        }
+    }
+}
+
+fn resolve_address_table_lookups(
+    lookups: &[MessageAddressTableLookup],
+    accounts: &[(Pubkey, Account)],
+) -> Result<LoadedAddresses, FixtureError> {
+    let mut writable = Vec::new();
+    let mut readonly = Vec::new();
+
+    for lookup in lookups {
+        let alt_account = accounts
+            .iter()
+            .find(|(pubkey, _)| *pubkey == lookup.account_key)
+            .map(|(_, account)| account)
+            .ok_or(FixtureError::InvalidAddressLookupTable)?;
+
+        let alt = AddressLookupTable::deserialize(&alt_account.data)
+            .map_err(|_| FixtureError::InvalidAddressLookupTable)?;
+
+        for &idx in &lookup.writable_indexes {
+            writable.push(
+                *alt.addresses
+                    .get(idx as usize)
+                    .ok_or(FixtureError::InvalidAddressLookupTable)?,
+            );
+        }
+        for &idx in &lookup.readonly_indexes {
+            readonly.push(
+                *alt.addresses
+                    .get(idx as usize)
+                    .ok_or(FixtureError::InvalidAddressLookupTable)?,
+            );
+        }
+    }
+
+    Ok(LoadedAddresses { writable, readonly })
+}
+
+pub fn build_sanitized_message(
+    value: &ProtoTransactionMessage,
+    accounts: &[(Pubkey, Account)],
+) -> Result<SanitizedMessage, FixtureError> {
+    let header = if let Some(ref value_header) = value.header {
+        MessageHeader::from(value_header)
+    } else {
+        MessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 0,
+        }
+    };
+
+    let account_keys = value
+        .account_keys
+        .iter()
+        .map(|key| Pubkey::new_from_array(key.clone().try_into().unwrap()))
+        .collect::<Vec<Pubkey>>();
+
+    let recent_blockhash = if value.recent_blockhash.is_empty() {
+        Hash::new_from_array([0u8; 32])
+    } else {
+        Hash::new_from_array(value.recent_blockhash.clone().try_into().unwrap())
+    };
+
+    let instructions = value
+        .instructions
+        .iter()
+        .map(CompiledInstruction::from)
+        .collect::<Vec<CompiledInstruction>>();
+
+    if value.is_legacy {
+        let message = legacy::Message {
+            header,
+            account_keys,
+            recent_blockhash,
+            instructions,
+        };
+        Ok(SanitizedMessage::Legacy(LegacyMessage::new(
+            message,
+            &HashSet::new(),
+        )))
+    } else {
+        let address_table_lookups = value
+            .address_table_lookups
+            .iter()
+            .map(MessageAddressTableLookup::from)
+            .collect::<Vec<MessageAddressTableLookup>>();
+
+        let loaded_addresses = resolve_address_table_lookups(&address_table_lookups, accounts)?;
+
+        let message = v0::Message {
+            header,
+            account_keys,
+            recent_blockhash,
+            instructions,
+            address_table_lookups,
+        };
+
+        Ok(SanitizedMessage::V0(LoadedMessage::new(
+            message,
+            loaded_addresses,
+            &HashSet::new(),
+        )))
+    }
+}

--- a/svm-test-harness/fixture/src/txn_context.rs
+++ b/svm-test-harness/fixture/src/txn_context.rs
@@ -101,21 +101,17 @@ impl TryFrom<ProtoTxnContext> for TxnContext {
             Hash::new_from_array(hash_array)
         };
 
-        let mut signatures: Vec<Signature> = proto_tx
+        let signatures: Vec<Signature> = proto_tx
             .signatures
             .iter()
             .map(|sig_bytes| {
                 let sig_array: [u8; 64] = sig_bytes
                     .clone()
                     .try_into()
-                    .map_err(|_| FixtureError::InvalidFixtureInput)?;
+                    .map_err(FixtureError::InvalidSignatureBytes)?;
                 Ok(Signature::from(sig_array))
             })
             .collect::<Result<Vec<_>, FixtureError>>()?;
-
-        if signatures.is_empty() {
-            signatures.push(Signature::default());
-        }
 
         let transaction = SanitizedTransaction::try_new_from_fields(
             message,

--- a/svm-test-harness/fixture/src/txn_context.rs
+++ b/svm-test-harness/fixture/src/txn_context.rs
@@ -1,0 +1,136 @@
+//! Transaction context (input).
+
+use {
+    solana_account::Account,
+    solana_hash::Hash,
+    solana_pubkey::Pubkey,
+    solana_svm_feature_set::SVMFeatureSet,
+    solana_transaction::{Transaction, sanitized::SanitizedTransaction},
+};
+
+/// Transaction context fixture.
+pub struct TxnContext {
+    pub feature_set: SVMFeatureSet,
+    pub blockhash_queue: Vec<Hash>,
+    pub slot: u64,
+    pub accounts: Vec<(Pubkey, Account)>,
+    pub transaction: SanitizedTransaction,
+}
+
+impl TxnContext {
+    pub fn new(
+        feature_set: SVMFeatureSet,
+        blockhash_queue: Vec<Hash>,
+        slot: u64,
+        accounts: Vec<(Pubkey, Account)>,
+        transaction: Transaction,
+    ) -> Self {
+        let transaction = SanitizedTransaction::from_transaction_for_tests(transaction);
+        Self {
+            feature_set,
+            blockhash_queue,
+            slot,
+            accounts,
+            transaction,
+        }
+    }
+}
+
+#[cfg(feature = "fuzz")]
+use {
+    super::{
+        error::FixtureError, message::build_sanitized_message, proto::TxnContext as ProtoTxnContext,
+    },
+    agave_feature_set::FeatureSet,
+    solana_signature::Signature,
+};
+
+#[cfg(feature = "fuzz")]
+impl TryFrom<ProtoTxnContext> for TxnContext {
+    type Error = FixtureError;
+
+    fn try_from(value: ProtoTxnContext) -> Result<Self, Self::Error> {
+        let feature_set: SVMFeatureSet = value
+            .epoch_ctx
+            .as_ref()
+            .and_then(|epoch_ctx| epoch_ctx.features.as_ref())
+            .map(|fs| {
+                let agave_feature_set: FeatureSet = fs.into();
+                agave_feature_set.runtime_features()
+            })
+            .unwrap_or_default();
+
+        let blockhash_queue: Vec<Hash> = if value.blockhash_queue.is_empty() {
+            vec![Hash::default()]
+        } else {
+            value
+                .blockhash_queue
+                .into_iter()
+                .map(|hash_bytes| {
+                    let hash_array: [u8; 32] = hash_bytes
+                        .try_into()
+                        .map_err(FixtureError::InvalidHashBytes)?;
+                    Ok(Hash::new_from_array(hash_array))
+                })
+                .collect::<Result<Vec<_>, FixtureError>>()?
+        };
+
+        let slot = value
+            .slot_ctx
+            .as_ref()
+            .map(|slot_ctx| slot_ctx.slot)
+            .unwrap_or_default();
+
+        let accounts: Vec<(Pubkey, Account)> = value
+            .account_shared_data
+            .into_iter()
+            .map(|acct_state| acct_state.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let proto_tx = value.tx.ok_or(FixtureError::InvalidFixtureInput)?;
+        let proto_message = proto_tx.message.ok_or(FixtureError::InvalidFixtureInput)?;
+
+        let message = build_sanitized_message(&proto_message, &accounts)?;
+        let message_hash: Hash = if proto_tx.message_hash.is_empty() {
+            Hash::default()
+        } else {
+            let hash_array: [u8; 32] = proto_tx
+                .message_hash
+                .try_into()
+                .map_err(FixtureError::InvalidHashBytes)?;
+            Hash::new_from_array(hash_array)
+        };
+
+        let mut signatures: Vec<Signature> = proto_tx
+            .signatures
+            .iter()
+            .map(|sig_bytes| {
+                let sig_array: [u8; 64] = sig_bytes
+                    .clone()
+                    .try_into()
+                    .map_err(|_| FixtureError::InvalidFixtureInput)?;
+                Ok(Signature::from(sig_array))
+            })
+            .collect::<Result<Vec<_>, FixtureError>>()?;
+
+        if signatures.is_empty() {
+            signatures.push(Signature::default());
+        }
+
+        let transaction = SanitizedTransaction::try_new_from_fields(
+            message,
+            message_hash,
+            /* is_simple_vote_tx */ false,
+            signatures,
+        )
+        .map_err(|_| FixtureError::InvalidFixtureInput)?;
+
+        Ok(Self {
+            feature_set,
+            blockhash_queue,
+            slot,
+            accounts,
+            transaction,
+        })
+    }
+}

--- a/svm-test-harness/fixture/src/txn_result.rs
+++ b/svm-test-harness/fixture/src/txn_result.rs
@@ -1,0 +1,136 @@
+//! Transaction result (output).
+
+use {
+    solana_account::Account, solana_fee_structure::FeeDetails, solana_pubkey::Pubkey,
+    solana_transaction_error::TransactionResult,
+};
+
+/// Transaction execution result.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TxnResult {
+    pub status: TransactionResult<()>,
+    pub resulting_accounts: Vec<(Pubkey, Account)>,
+    pub return_data: Vec<u8>,
+    pub executed_units: u64,
+    pub fee_details: FeeDetails,
+    pub loaded_accounts_data_size: u64,
+}
+
+#[cfg(feature = "fuzz")]
+use {
+    super::proto::{
+        FeeDetails as ProtoFeeDetails, ResultingState as ProtoResultingState,
+        TxnResult as ProtoTxnResult,
+    },
+    agave_precompiles::get_precompile,
+    solana_instruction_error::InstructionError,
+    solana_svm_transaction::svm_message::SVMMessage,
+    solana_transaction_error::TransactionError,
+};
+
+#[cfg(feature = "fuzz")]
+fn transaction_error_to_err_nums(error: &TransactionError) -> (u32, u32, u32, u32) {
+    let (instr_err_no, custom_err_no, instr_err_idx) = match error.clone() {
+        TransactionError::InstructionError(idx, instr_err) => {
+            let instr_err_no = {
+                let serialized = bincode::serialize(&instr_err).unwrap_or(vec![0, 0, 0, 0]);
+                u32::from_le_bytes(serialized[0..4].try_into().unwrap()).saturating_add(1)
+            };
+            let custom_err_no = match instr_err {
+                InstructionError::Custom(code) => code,
+                _ => 0,
+            };
+            (instr_err_no, custom_err_no, idx)
+        }
+        _ => (0, 0, 0),
+    };
+
+    let txn_err_no = {
+        let serialized = bincode::serialize(error).unwrap_or(vec![0, 0, 0, 0]);
+        u32::from_le_bytes(serialized[0..4].try_into().unwrap()).saturating_add(1)
+    };
+
+    (
+        txn_err_no,
+        instr_err_no,
+        custom_err_no,
+        instr_err_idx.into(),
+    )
+}
+
+/// Convert a `TxnResult` to a protobuf `TxnResult`, filtering accounts to only
+/// those marked writable in the message.
+#[cfg(feature = "fuzz")]
+pub fn txn_result_to_proto(result: TxnResult, message: &impl SVMMessage) -> ProtoTxnResult {
+    let acct_states: Vec<_> = result
+        .resulting_accounts
+        .into_iter()
+        .enumerate()
+        .filter(|&(i, _)| message.is_writable(i))
+        .map(|(_, acct)| acct.into())
+        .collect();
+
+    let (
+        executed,
+        sanitization_error,
+        is_ok,
+        status,
+        instruction_error,
+        instruction_error_index,
+        custom_error,
+    ) = match &result.status {
+        Ok(()) => (true, false, true, 0, 0, 0, 0),
+        Err(err) => {
+            let (status, instr_err, custom_err, instr_err_idx) = transaction_error_to_err_nums(err);
+            // Set custom err to 0 if the failing instruction is a precompile.
+            let custom_err = message
+                .instructions_iter()
+                .nth(instr_err_idx as usize)
+                .and_then(|instr| {
+                    message
+                        .account_keys()
+                        .get(usize::from(instr.program_id_index))
+                        .map(|program_id| {
+                            if get_precompile(program_id, |_| true).is_some() {
+                                0
+                            } else {
+                                custom_err
+                            }
+                        })
+                })
+                .unwrap_or(custom_err);
+            (
+                true,
+                false,
+                false,
+                status,
+                instr_err,
+                instr_err_idx,
+                custom_err,
+            )
+        }
+    };
+
+    ProtoTxnResult {
+        executed,
+        sanitization_error,
+        resulting_state: Some(ProtoResultingState {
+            acct_states,
+            rent_debits: vec![],
+            transaction_rent: 0,
+        }),
+        rent: 0,
+        is_ok,
+        status,
+        instruction_error,
+        instruction_error_index,
+        custom_error,
+        return_data: result.return_data,
+        executed_units: result.executed_units,
+        fee_details: Some(ProtoFeeDetails {
+            transaction_fee: result.fee_details.transaction_fee(),
+            prioritization_fee: result.fee_details.prioritization_fee(),
+        }),
+        loaded_accounts_data_size: result.loaded_accounts_data_size,
+    }
+}

--- a/svm-test-harness/fixture/src/txn_result.rs
+++ b/svm-test-harness/fixture/src/txn_result.rs
@@ -28,14 +28,35 @@ use {
     solana_transaction_error::TransactionError,
 };
 
+/// Numeric error codes derived from a [`TransactionError`], matching the
+/// proto fixture format.
 #[cfg(feature = "fuzz")]
-fn transaction_error_to_err_nums(error: &TransactionError) -> (u32, u32, u32, u32) {
-    let (instr_err_no, custom_err_no, instr_err_idx) = match error.clone() {
+struct TransactionErrorNums {
+    /// Discriminant of the top-level `TransactionError`, offset by +1 so that
+    /// `0` stays reserved for success.
+    txn_err: u32,
+    /// Discriminant of the inner `InstructionError` (if any), offset by +1 so
+    /// that `0` stays reserved for "no instruction error".
+    instr_err: u32,
+    /// Payload of `InstructionError::Custom`, zero otherwise.
+    custom_err: u32,
+    /// Index of the instruction that failed, zero if the error is not an
+    /// `InstructionError`.
+    instr_err_idx: u32,
+}
+
+#[cfg(feature = "fuzz")]
+fn transaction_error_to_err_nums(error: &TransactionError) -> TransactionErrorNums {
+    let (instr_err, custom_err, instr_err_idx) = match error.clone() {
         TransactionError::InstructionError(idx, instr_err) => {
-            let instr_err_no = {
-                let serialized = bincode::serialize(&instr_err).unwrap_or(vec![0, 0, 0, 0]);
-                u32::from_le_bytes(serialized[0..4].try_into().unwrap()).saturating_add(1)
-            };
+            let instr_err_no = bincode::serialize(&instr_err)
+                .ok()
+                .and_then(|b| {
+                    b.get(0..4)
+                        .map(|s| u32::from_le_bytes(s.try_into().unwrap()))
+                })
+                .map(|n| n.saturating_add(1))
+                .unwrap_or(0);
             let custom_err_no = match instr_err {
                 InstructionError::Custom(code) => code,
                 _ => 0,
@@ -45,17 +66,21 @@ fn transaction_error_to_err_nums(error: &TransactionError) -> (u32, u32, u32, u3
         _ => (0, 0, 0),
     };
 
-    let txn_err_no = {
-        let serialized = bincode::serialize(error).unwrap_or(vec![0, 0, 0, 0]);
-        u32::from_le_bytes(serialized[0..4].try_into().unwrap()).saturating_add(1)
-    };
+    let txn_err = bincode::serialize(error)
+        .ok()
+        .and_then(|b| {
+            b.get(0..4)
+                .map(|s| u32::from_le_bytes(s.try_into().unwrap()))
+        })
+        .map(|n| n.saturating_add(1))
+        .unwrap_or(0);
 
-    (
-        txn_err_no,
-        instr_err_no,
-        custom_err_no,
-        instr_err_idx.into(),
-    )
+    TransactionErrorNums {
+        txn_err,
+        instr_err,
+        custom_err,
+        instr_err_idx: instr_err_idx.into(),
+    }
 }
 
 /// Convert a `TxnResult` to a protobuf `TxnResult`, filtering accounts to only
@@ -70,55 +95,55 @@ pub fn txn_result_to_proto(result: TxnResult, message: &impl SVMMessage) -> Prot
         .map(|(_, acct)| acct.into())
         .collect();
 
-    let (
-        executed,
-        sanitization_error,
-        is_ok,
-        status,
-        instruction_error,
-        instruction_error_index,
-        custom_error,
-    ) = match &result.status {
-        Ok(()) => (true, false, true, 0, 0, 0, 0),
-        Err(err) => {
-            let (status, instr_err, custom_err, instr_err_idx) = transaction_error_to_err_nums(err);
-            // Set custom err to 0 if the failing instruction is a precompile.
-            let custom_err = message
-                .instructions_iter()
-                .nth(instr_err_idx as usize)
-                .and_then(|instr| {
-                    message
-                        .account_keys()
-                        .get(usize::from(instr.program_id_index))
-                        .map(|program_id| {
-                            if get_precompile(program_id, |_| true).is_some() {
-                                0
-                            } else {
-                                custom_err
-                            }
-                        })
-                })
-                .unwrap_or(custom_err);
-            (
-                true,
-                false,
-                false,
-                status,
-                instr_err,
-                instr_err_idx,
-                custom_err,
-            )
-        }
-    };
+    let (executed, is_ok, status, instruction_error, instruction_error_index, custom_error) =
+        match &result.status {
+            Ok(()) => (true, true, 0, 0, 0, 0),
+            Err(err) => {
+                let nums = transaction_error_to_err_nums(err);
+                // Set custom err to 0 if the failing instruction is a precompile.
+                let custom_err = message
+                    .instructions_iter()
+                    .nth(nums.instr_err_idx as usize)
+                    .and_then(|instr| {
+                        message
+                            .account_keys()
+                            .get(usize::from(instr.program_id_index))
+                            .map(|program_id| {
+                                if get_precompile(program_id, |_| true).is_some() {
+                                    0
+                                } else {
+                                    nums.custom_err
+                                }
+                            })
+                    })
+                    .unwrap_or(nums.custom_err);
+                (
+                    true,
+                    false,
+                    nums.txn_err,
+                    nums.instr_err,
+                    nums.instr_err_idx,
+                    custom_err,
+                )
+            }
+        };
 
     ProtoTxnResult {
         executed,
-        sanitization_error,
+        // TODO: Duplicate of `executed`; remove from proto definition on next
+        // protosol crate bump.
+        sanitization_error: false,
         resulting_state: Some(ProtoResultingState {
             acct_states,
+            // TODO: Rent fields are stubbed; they are being removed from the
+            // proto definition and will go away once the protosol crate is
+            // bumped.
             rent_debits: vec![],
             transaction_rent: 0,
         }),
+        // TODO: Rent fields are stubbed; they are being removed from the
+        // proto definition and will go away once the protosol crate is
+        // bumped.
         rent: 0,
         is_ok,
         status,


### PR DESCRIPTION
#### Problem
The next half or so of the tests in programs/sbf have to be converted away from using Bank. However, most of them require transaction-level testing capabilities.

#### Summary of Changes
Start the work of implementing a `txn` SVM test harness by introducing its fixtures.