### PR TITLE
switch solana-builtins-default-costs to use workspace rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7652,7 +7652,7 @@ dependencies = [
  "ahash 0.8.12",
  "log",
  "qualifier_attr",
- "rand 0.8.5",
+ "rand 0.9.2",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
  "solana-frozen-abi",

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -39,7 +39,7 @@ solana-system-program = { workspace = true }
 solana-vote-program = { workspace = true }
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = { workspace = true }
 static_assertions = { workspace = true }
 
 [lints]


### PR DESCRIPTION
#### Problem

context: https://github.com/anza-xyz/agave/pull/9974

not sure why solana-builtins-default-costs does not use workspace level rand dep

#### Summary of Changes

switch to it