### PR TITLE
switch solana-cost-model to use workspace rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8339,7 +8339,7 @@ dependencies = [
  "ahash 0.8.12",
  "itertools 0.14.0",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
  "solana-bincode",
  "solana-borsh",
  "solana-builtins-default-costs",

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -69,7 +69,7 @@ solana-vote-program = { workspace = true }
 agave-logger = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 itertools = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-compute-budget-instruction = { workspace = true, features = [
     "dev-context-only-utils",


### PR DESCRIPTION
#### Problem

context: https://github.com/anza-xyz/agave/pull/9974

not sure why solana-cost-model does not use workspace level rand dep

#### Summary of Changes

switch to it