### PR TITLE
ci: remove useless cargo hack check from ci/test-check.sh

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -11,15 +11,6 @@ source ci/_
 source ci/rust-version.sh stable
 source ci/rust-version.sh nightly
 eval "$(ci/channel-info.sh)"
-cargoNightly="$(readlink -f "./cargo") nightly"
-
-# check that cargo-hack has been installed
-if ! $cargoNightly hack --version >/dev/null 2>&1; then
-  cat >&2 <<EOF
-ERROR: cargo hack failed.
-       install 'cargo hack' with 'cargo install cargo-hack'
-EOF
-fi
 
 export RUST_BACKTRACE=1
 export RUSTFLAGS="-D warnings -A incomplete_features"


### PR DESCRIPTION
#### Problem

(split from https://github.com/anza-xyz/agave/pull/9651)

we don't run any cargo hack related commands in ci/test-check.sh

#### Summary of Changes

remove the check