### PR TITLE
Removes Option wrapper on AccountsDbConfig::bank_hash_details_dir

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1029,11 +1029,6 @@ impl AccountsDb {
         let accounts_index_config = accounts_db_config.index.unwrap_or_default();
         let accounts_index = AccountsIndex::new(&accounts_index_config, exit);
 
-        let bank_hash_details_dir = accounts_db_config.bank_hash_details_dir.unwrap_or_else(|| {
-            warn!("bank hash details dir is unset");
-            PathBuf::new()
-        });
-
         let (paths, temp_paths) = if paths.is_empty() {
             // Create a temporary set of accounts directories, used primarily
             // for testing
@@ -1083,7 +1078,7 @@ impl AccountsDb {
         let new = Self {
             accounts_index,
             paths,
-            bank_hash_details_dir,
+            bank_hash_details_dir: accounts_db_config.bank_hash_details_dir,
             temp_paths,
             shrink_paths,
             skip_initial_hash_calc: accounts_db_config.skip_initial_hash_calc,

--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -19,11 +19,7 @@ use {
 pub struct AccountsDbConfig {
     pub index: Option<AccountsIndexConfig>,
     pub account_indexes: Option<AccountSecondaryIndexes>,
-    // We need the Option wrapper until we're on Rust 1.91 or newer,
-    // because PathBuf::new() is non-const until then.
-    // For now, the only way for ACCOUNTS_DB_CONFIG_FOR_TESTING/BENCHMARKS
-    // to indicate they do not use bank_hash_details_dir is to use None.
-    pub bank_hash_details_dir: Option<PathBuf>,
+    pub bank_hash_details_dir: PathBuf,
     pub shrink_paths: Option<Vec<PathBuf>>,
     pub shrink_ratio: AccountShrinkThreshold,
     /// The low and high watermark sizes for the read cache, in bytes.
@@ -57,7 +53,7 @@ pub struct AccountsDbConfig {
 pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
     account_indexes: None,
-    bank_hash_details_dir: None, // tests don't use bank hash details
+    bank_hash_details_dir: PathBuf::new(), // tests don't use bank hash details
     shrink_paths: None,
     shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     read_cache_limit_bytes: None,
@@ -80,7 +76,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
     account_indexes: None,
-    bank_hash_details_dir: None, // benches don't use bank hash details
+    bank_hash_details_dir: PathBuf::new(), // benches don't use bank hash details
     shrink_paths: None,
     shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     read_cache_limit_bytes: None,

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -328,7 +328,7 @@ pub fn get_accounts_db_config(
 
     AccountsDbConfig {
         index: Some(accounts_index_config),
-        bank_hash_details_dir: Some(ledger_tool_ledger_path),
+        bank_hash_details_dir: ledger_tool_ledger_path,
         ancient_append_vec_offset: value_t!(arg_matches, "accounts_db_ancient_append_vecs", i64)
             .ok(),
         ancient_storage_ideal_size: value_t!(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -432,7 +432,7 @@ pub fn execute(
     let accounts_db_config = AccountsDbConfig {
         index: Some(accounts_index_config),
         account_indexes: Some(account_indexes.clone()),
-        bank_hash_details_dir: Some(ledger_path.clone()),
+        bank_hash_details_dir: ledger_path.clone(),
         shrink_paths: account_shrink_run_paths,
         shrink_ratio,
         read_cache_limit_bytes,


### PR DESCRIPTION
#### Problem

The `AccountsDbConfig::bank_hash_details_dir` field is `Option`-wrapped only because Rust in versions 1.90 and older does not have a way to create a PathBuf in const contexts, which is needed for the `ACCOUNTS_DB_CONFIG_FOR_TESTING/BENCHMARKS` constants.


#### Summary of Changes

We're now on Rust 1.91.1, so remove the Option wrapper.