### PR TITLE
Bump `zk-sdk` to v5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7754,7 +7754,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-system-interface 3.0.0",
- "solana-zk-sdk",
+ "solana-zk-sdk 5.0.0",
  "tempfile",
  "thiserror 2.0.17",
  "tiny-bip39",
@@ -12053,7 +12053,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk-ids",
  "solana-svm-log-collector",
- "solana-zk-sdk",
+ "solana-zk-sdk 5.0.0",
 ]
 
 [[package]]
@@ -12072,7 +12072,7 @@ dependencies = [
  "solana-system-interface 3.0.0",
  "solana-transaction",
  "solana-transaction-error",
- "solana-zk-sdk",
+ "solana-zk-sdk 5.0.0",
 ]
 
 [[package]]
@@ -12109,6 +12109,40 @@ dependencies = [
  "subtle",
  "thiserror 2.0.17",
  "wasm-bindgen",
+ "zeroize",
+]
+
+[[package]]
+name = "solana-zk-sdk"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89042b5867c7440526d47085db2cd11a7ae557461a4f41a3b3a569799dd9d6"
+dependencies = [
+ "aes-gcm-siv",
+ "base64 0.22.1",
+ "bincode",
+ "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek 4.1.3",
+ "itertools 0.14.0",
+ "merlin",
+ "num-derive",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha3",
+ "solana-address 2.0.0",
+ "solana-derivation-path",
+ "solana-instruction",
+ "solana-sdk-ids",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+ "subtle",
+ "thiserror 2.0.17",
  "zeroize",
 ]
 
@@ -12217,7 +12251,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-option",
  "solana-pubkey 3.0.0",
- "solana-zk-sdk",
+ "solana-zk-sdk 4.0.0",
  "thiserror 2.0.17",
 ]
 
@@ -12239,7 +12273,7 @@ dependencies = [
  "solana-program-pack",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-zk-sdk",
+ "solana-zk-sdk 4.0.0",
  "spl-pod",
  "spl-token-confidential-transfer-proof-extraction",
  "spl-token-confidential-transfer-proof-generation",
@@ -12264,7 +12298,7 @@ dependencies = [
  "solana-program-error",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-zk-sdk",
+ "solana-zk-sdk 4.0.0",
  "spl-pod",
  "thiserror 2.0.17",
 ]
@@ -12276,7 +12310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a2b41095945dc15274b924b21ccae9b3ec9dc2fdd43dbc08de8c33bbcd915"
 dependencies = [
  "curve25519-dalek 4.1.3",
- "solana-zk-sdk",
+ "solana-zk-sdk 4.0.0",
  "thiserror 2.0.17",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -581,7 +581,7 @@ solana-vote-interface = "5.0.0"
 solana-vote-program = { path = "programs/vote", version = "=4.0.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-wen-restart = { path = "wen-restart", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
-solana-zk-sdk = "4.0.0"
+solana-zk-sdk = "5.0.0"
 solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 spl-associated-token-account-interface = "2.0.0"
 spl-generic-token = "2.0.0"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9917,7 +9917,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk-ids",
  "solana-svm-log-collector",
- "solana-zk-sdk",
+ "solana-zk-sdk 5.0.0",
 ]
 
 [[package]]
@@ -9954,6 +9954,40 @@ dependencies = [
  "subtle",
  "thiserror 2.0.17",
  "wasm-bindgen",
+ "zeroize",
+]
+
+[[package]]
+name = "solana-zk-sdk"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89042b5867c7440526d47085db2cd11a7ae557461a4f41a3b3a569799dd9d6"
+dependencies = [
+ "aes-gcm-siv",
+ "base64 0.22.1",
+ "bincode",
+ "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek 4.1.3",
+ "itertools 0.14.0",
+ "merlin",
+ "num-derive",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha3",
+ "solana-address 2.0.0",
+ "solana-derivation-path",
+ "solana-instruction",
+ "solana-sdk-ids",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+ "subtle",
+ "thiserror 2.0.17",
  "zeroize",
 ]
 
@@ -10074,7 +10108,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-option",
  "solana-pubkey 3.0.0",
- "solana-zk-sdk",
+ "solana-zk-sdk 4.0.0",
  "thiserror 2.0.17",
 ]
 
@@ -10096,7 +10130,7 @@ dependencies = [
  "solana-program-pack",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-zk-sdk",
+ "solana-zk-sdk 4.0.0",
  "spl-pod",
  "spl-token-confidential-transfer-proof-extraction",
  "spl-token-confidential-transfer-proof-generation",
@@ -10121,7 +10155,7 @@ dependencies = [
  "solana-program-error",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-zk-sdk",
+ "solana-zk-sdk 4.0.0",
  "spl-pod",
  "thiserror 2.0.17",
 ]
@@ -10133,7 +10167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a2b41095945dc15274b924b21ccae9b3ec9dc2fdd43dbc08de8c33bbcd915"
 dependencies = [
  "curve25519-dalek 4.1.3",
- "solana-zk-sdk",
+ "solana-zk-sdk 4.0.0",
  "thiserror 2.0.17",
 ]
 

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1133,7 +1133,7 @@ pub mod disable_zk_elgamal_proof_program {
 }
 
 pub mod reenable_zk_elgamal_proof_program {
-    solana_pubkey::declare_id!("zkesAyFB19sTkX8i9ReoKaMNDA4YNTPYJpZKPDt7FMW");
+    solana_pubkey::declare_id!("zkexuyPRdyTVbZqEAREueqL2xvvoBhRgth9xGSc1tMN");
 }
 
 pub mod raise_block_limits_to_100m {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10423,7 +10423,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk-ids",
  "solana-svm-log-collector",
- "solana-zk-sdk",
+ "solana-zk-sdk 5.0.0",
 ]
 
 [[package]]
@@ -10460,6 +10460,40 @@ dependencies = [
  "subtle",
  "thiserror 2.0.17",
  "wasm-bindgen",
+ "zeroize",
+]
+
+[[package]]
+name = "solana-zk-sdk"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89042b5867c7440526d47085db2cd11a7ae557461a4f41a3b3a569799dd9d6"
+dependencies = [
+ "aes-gcm-siv",
+ "base64 0.22.1",
+ "bincode",
+ "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek 4.1.3",
+ "itertools 0.14.0",
+ "merlin",
+ "num-derive",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha3",
+ "solana-address 2.0.0",
+ "solana-derivation-path",
+ "solana-instruction",
+ "solana-sdk-ids",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+ "subtle",
+ "thiserror 2.0.17",
  "zeroize",
 ]
 
@@ -10568,7 +10602,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-option",
  "solana-pubkey 3.0.0",
- "solana-zk-sdk",
+ "solana-zk-sdk 4.0.0",
  "thiserror 2.0.17",
 ]
 
@@ -10590,7 +10624,7 @@ dependencies = [
  "solana-program-pack",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-zk-sdk",
+ "solana-zk-sdk 4.0.0",
  "spl-pod",
  "spl-token-confidential-transfer-proof-extraction",
  "spl-token-confidential-transfer-proof-generation",
@@ -10615,7 +10649,7 @@ dependencies = [
  "solana-program-error",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-zk-sdk",
+ "solana-zk-sdk 4.0.0",
  "spl-pod",
  "thiserror 2.0.17",
 ]
@@ -10627,7 +10661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a2b41095945dc15274b924b21ccae9b3ec9dc2fdd43dbc08de8c33bbcd915"
 dependencies = [
  "curve25519-dalek 4.1.3",
- "solana-zk-sdk",
+ "solana-zk-sdk 4.0.0",
  "thiserror 2.0.17",
 ]
 

--- a/programs/zk-elgamal-proof-tests/tests/process_transaction.rs
+++ b/programs/zk-elgamal-proof-tests/tests/process_transaction.rs
@@ -11,7 +11,7 @@ use {
     solana_transaction_error::TransactionError,
     solana_zk_sdk::{
         encryption::{
-            elgamal::{ElGamalKeypair, ElGamalSecretKey},
+            elgamal::{ElGamalKeypair, ElGamalPubkey, ElGamalSecretKey},
             grouped_elgamal::GroupedElGamal,
             pedersen::{Pedersen, PedersenOpening},
         },
@@ -43,12 +43,12 @@ async fn test_zero_balance() {
     let success_proof_data =
         ZeroCiphertextProofData::new(&elgamal_keypair, &zero_ciphertext).unwrap();
 
-    let incorrect_pubkey = elgamal_keypair.pubkey();
-    let incorrect_secret = ElGamalSecretKey::new_rand();
-    let incorrect_keypair = ElGamalKeypair::new_for_tests(*incorrect_pubkey, incorrect_secret);
-
-    let fail_proof_data =
-        ZeroCiphertextProofData::new(&incorrect_keypair, &zero_ciphertext).unwrap();
+    let mut fail_proof_context = success_proof_data.context;
+    fail_proof_context.pubkey = ElGamalPubkey::default().into();
+    let fail_proof_data = ZeroCiphertextProofData {
+        context: fail_proof_context,
+        proof: success_proof_data.proof,
+    };
 
     test_verify_proof_without_context(
         ProofInstruction::VerifyZeroCiphertext,
@@ -104,19 +104,12 @@ async fn test_ciphertext_ciphertext_equality() {
     )
     .unwrap();
 
-    let incorrect_pubkey = source_keypair.pubkey();
-    let incorrect_secret = ElGamalSecretKey::new_rand();
-    let incorrect_keypair = ElGamalKeypair::new_for_tests(*incorrect_pubkey, incorrect_secret);
-
-    let fail_proof_data = CiphertextCiphertextEqualityProofData::new(
-        &incorrect_keypair,
-        destination_keypair.pubkey(),
-        &source_ciphertext,
-        &destination_ciphertext,
-        &destination_opening,
-        amount,
-    )
-    .unwrap();
+    let mut fail_proof_context = success_proof_data.context;
+    fail_proof_context.first_pubkey = ElGamalPubkey::default().into();
+    let fail_proof_data = CiphertextCiphertextEqualityProofData {
+        context: fail_proof_context,
+        proof: success_proof_data.proof,
+    };
 
     test_verify_proof_without_context(
         ProofInstruction::VerifyCiphertextCiphertextEquality,
@@ -379,18 +372,12 @@ async fn test_ciphertext_commitment_equality() {
     )
     .unwrap();
 
-    let incorrect_pubkey = keypair.pubkey();
-    let incorrect_secret = ElGamalSecretKey::new_rand();
-    let incorrect_keypair = ElGamalKeypair::new_for_tests(*incorrect_pubkey, incorrect_secret);
-
-    let fail_proof_data = CiphertextCommitmentEqualityProofData::new(
-        &incorrect_keypair,
-        &ciphertext,
-        &commitment,
-        &opening,
-        amount,
-    )
-    .unwrap();
+    let mut fail_proof_context = success_proof_data.context;
+    fail_proof_context.pubkey = ElGamalPubkey::default().into();
+    let fail_proof_data = CiphertextCommitmentEqualityProofData {
+        context: fail_proof_context,
+        proof: success_proof_data.proof,
+    };
 
     test_verify_proof_without_context(
         ProofInstruction::VerifyCiphertextCommitmentEquality,
@@ -445,15 +432,12 @@ async fn test_grouped_ciphertext_2_handles_validity() {
     )
     .unwrap();
 
-    let incorrect_opening = PedersenOpening::new_rand();
-    let fail_proof_data = GroupedCiphertext2HandlesValidityProofData::new(
-        destination_pubkey,
-        auditor_pubkey,
-        &grouped_ciphertext,
-        amount,
-        &incorrect_opening,
-    )
-    .unwrap();
+    let mut fail_proof_context = success_proof_data.context;
+    fail_proof_context.first_pubkey = ElGamalPubkey::default().into();
+    let fail_proof_data = GroupedCiphertext2HandlesValidityProofData {
+        context: fail_proof_context,
+        proof: success_proof_data.proof,
+    };
 
     test_verify_proof_without_context(
         ProofInstruction::VerifyGroupedCiphertext2HandlesValidity,
@@ -517,18 +501,12 @@ async fn test_batched_grouped_ciphertext_2_handles_validity() {
     )
     .unwrap();
 
-    let incorrect_opening = PedersenOpening::new_rand();
-    let fail_proof_data = BatchedGroupedCiphertext2HandlesValidityProofData::new(
-        destination_pubkey,
-        auditor_pubkey,
-        &grouped_ciphertext_lo,
-        &grouped_ciphertext_hi,
-        amount_lo,
-        amount_hi,
-        &incorrect_opening,
-        &opening_hi,
-    )
-    .unwrap();
+    let mut fail_proof_context = success_proof_data.context;
+    fail_proof_context.first_pubkey = ElGamalPubkey::default().into();
+    let fail_proof_data = BatchedGroupedCiphertext2HandlesValidityProofData {
+        context: fail_proof_context,
+        proof: success_proof_data.proof,
+    };
 
     test_verify_proof_without_context(
         ProofInstruction::VerifyBatchedGroupedCiphertext2HandlesValidity,
@@ -590,16 +568,12 @@ async fn test_grouped_ciphertext_3_handles_validity() {
     )
     .unwrap();
 
-    let incorrect_opening = PedersenOpening::new_rand();
-    let fail_proof_data = GroupedCiphertext3HandlesValidityProofData::new(
-        source_pubkey,
-        destination_pubkey,
-        auditor_pubkey,
-        &grouped_ciphertext,
-        amount,
-        &incorrect_opening,
-    )
-    .unwrap();
+    let mut fail_proof_context = success_proof_data.context;
+    fail_proof_context.first_pubkey = ElGamalPubkey::default().into();
+    let fail_proof_data = GroupedCiphertext3HandlesValidityProofData {
+        context: fail_proof_context,
+        proof: success_proof_data.proof,
+    };
 
     test_verify_proof_without_context(
         ProofInstruction::VerifyGroupedCiphertext3HandlesValidity,
@@ -665,19 +639,12 @@ async fn test_batched_grouped_ciphertext_3_handles_validity() {
     )
     .unwrap();
 
-    let incorrect_opening = PedersenOpening::new_rand();
-    let fail_proof_data = BatchedGroupedCiphertext3HandlesValidityProofData::new(
-        source_pubkey,
-        destination_pubkey,
-        auditor_pubkey,
-        &grouped_ciphertext_lo,
-        &grouped_ciphertext_hi,
-        amount_lo,
-        amount_hi,
-        &incorrect_opening,
-        &opening_hi,
-    )
-    .unwrap();
+    let mut fail_proof_context = success_proof_data.context;
+    fail_proof_context.first_pubkey = ElGamalPubkey::default().into();
+    let fail_proof_data = BatchedGroupedCiphertext3HandlesValidityProofData {
+        context: fail_proof_context,
+        proof: success_proof_data.proof,
+    };
 
     test_verify_proof_without_context(
         ProofInstruction::VerifyBatchedGroupedCiphertext3HandlesValidity,


### PR DESCRIPTION
#### Problem

The zk-sdk went through a couple of audits. Nothing major in terms of security has been found, but there have been a number of additional sanity checks that have been added to v5.0.0.

You can refer to the release [notes](https://github.com/solana-program/zk-elgamal-proof/releases), but most of the changes are non-breaking internal changes or proof generation, which doesn't affect proof verification in agave. The only breaking changes are the following:
- add domain separation for fiat-shamir https://github.com/solana-program/zk-elgamal-proof/pull/197
- reject identify inputs to the proof verification functions (https://github.com/solana-program/zk-elgamal-proof/pull/198 and https://github.com/solana-program/zk-elgamal-proof/pull/199)
- some clean up of error codes https://github.com/solana-program/zk-elgamal-proof/pull/216

Currently, the only place in the repo that depends on the `solana-zk-sdk` is the zk-elgamal proof program, which is currently DISABLED.

#### Summary of Changes

- Bump `solana-zk-sdk` to v5.0
- For the proof constructor functions in versions of the `solana-zk-sdk`, if it took in invalid inputs, it just produced invalid proofs. We used this to generate wrong proof instances in the zk-elgamal-proof-tests. However, now with v5.0, these invalid proofs are outright rejected by the constructor. So I updated the proof logic to manually generate invalid proofs for tests.
- I rekeyed the `reenable-zk-elgamal-proof-program` feature gate.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
