### PR TITLE
perf(serde_snapshot): build versioned epoch stakes in thread

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -457,7 +457,7 @@ pub struct BankFieldsToDeserialize {
     pub(crate) epoch_schedule: EpochSchedule,
     pub(crate) inflation: Inflation,
     pub(crate) stakes: DeserializableStakes<Delegation>,
-    pub(crate) versioned_epoch_stakes: HashMap<Epoch, DeserializableVersionedEpochStakes>,
+    pub(crate) versioned_epoch_stakes: Vec<(Epoch, DeserializableVersionedEpochStakes)>,
     pub(crate) is_delta: bool,
     pub(crate) accounts_data_len: u64,
     pub(crate) accounts_lt_hash: AccountsLtHash,
@@ -1816,6 +1816,7 @@ impl Bank {
         fields: BankFieldsToDeserialize,
         debug_keys: Option<Arc<HashSet<Pubkey>>>,
         accounts_data_size_initial: u64,
+        epoch_stakes: HashMap<Epoch, VersionedEpochStakes>,
     ) -> Self {
         let now = Instant::now();
         let ancestors = Ancestors::from(&fields.ancestors);
@@ -1879,11 +1880,7 @@ impl Bank {
             epoch_schedule: fields.epoch_schedule,
             inflation: Arc::new(RwLock::new(fields.inflation)),
             stakes_cache: StakesCache::new(stakes),
-            epoch_stakes: fields
-                .versioned_epoch_stakes
-                .into_iter()
-                .map(|(k, v)| (k, v.into()))
-                .collect(),
+            epoch_stakes,
             is_delta: AtomicBool::new(fields.is_delta),
             rewards: RwLock::new(vec![]),
             cluster_type: Some(genesis_config.cluster_type),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -457,6 +457,8 @@ pub struct BankFieldsToDeserialize {
     pub(crate) epoch_schedule: EpochSchedule,
     pub(crate) inflation: Inflation,
     pub(crate) stakes: DeserializableStakes<Delegation>,
+    /// Transformed into `HashMap<Epoch, VersionedEpochStakes>` in `serde_snapshot` and passed to
+    /// `Bank::new_from_snapshot` as separate parameter for performance (conversion is time consuming)
     pub(crate) versioned_epoch_stakes: Vec<(Epoch, DeserializableVersionedEpochStakes)>,
     pub(crate) is_delta: bool,
     pub(crate) accounts_data_len: u64,
@@ -1844,6 +1846,14 @@ impl Bank {
              snapshot or bugs in cached accounts or accounts-db.",
         ));
         info!("Loading Stakes took: {stakes_time}");
+        assert!(
+            fields.versioned_epoch_stakes.is_empty(),
+            "should be already converted and passed in epoch_stakes parameter"
+        );
+        assert!(
+            !epoch_stakes.is_empty(),
+            "should be populated (from fields.versioned_epoch_stakes)"
+        );
         let stakes_accounts_load_duration = now.elapsed();
         let mut bank = Self {
             rc: bank_rc,


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/9831 changed deserialization of epoch stakes to intermediate representation as cheaper vectors, but at some point the final `im::HashMap` need to be constructed, which is a slow CPU-bound process (can take even >8s). Current this is done serially after accounts db index is built.

Since this part of bank data initialization is independent from calculating accounts db, it could be done in separate thread such that it's ready once accounts db reconstruction is done.

#### Summary of Changes
* change `versioned_epoch_stakes` in `BankFieldsToDeserialize` to `Vec` (this makes deserialization even slightly cheaper), since it's intermediate representation that is only iterated on later
* create final `HashMap<Epoch, VersionedEpochStakes>` in separate thread spawned before `reconstruct_accountsdb_from_fields`
* pass the map to `Bank::new_from_snapshot` to be used instead of reading from `fields.versioned_epoch_stakes`

##### Performance change
Time between loading stakes and finishing `new_from_snapshot` (`rent_collector` log line) shrinks from `4.22s` to `0.011s`

PR
```
[2026-01-14T06:53:03.140175595Z INFO  solana_runtime::bank] Loading Stakes took:  took 2.4s
[2026-01-14T06:53:03.151382107Z INFO  solana_runtime::serde_snapshot] rent_collector: RentCollector { epoch: 910, epoch_schedule: EpochSchedule { slots_per_epoch: 432000, leader_schedule_slot_offset: 432000, warmup: false, first_normal_epoch: 0, first_normal_slot: 0 }, slots_per_year: 78892314.984, rent: Rent { lamports_per_byte_year: 3480, exemption_threshold: 2.0, burn_percent: 50 } }
[2026-01-14T06:53:03.151403837Z INFO  solana_runtime::snapshot_bank_utils] rebuild bank from snapshots took 61.1s
```

master
```
[2026-01-14T07:11:55.046225292Z INFO  solana_runtime::bank] Loading Stakes took:  took 2.5s
[2026-01-14T07:11:59.261691409Z INFO  solana_runtime::serde_snapshot] rent_collector: RentCollector { epoch: 910, epoch_schedule: EpochSchedule { slots_per_epoch: 432000, leader_schedule_slot_offset: 432000, warmup: false, first_normal_epoch: 0, first_normal_slot: 0 }, slots_per_year: 78892314.984, rent: Rent { lamports_per_byte_year: 3480, exemption_threshold: 2.0, burn_percent: 50 } }
[2026-01-14T07:11:59.261725947Z INFO  solana_runtime::snapshot_bank_utils] rebuild bank from snapshots took 66.3s
```