### PR TITLE
runtime: genesis_utils: remove bls key feature override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9809,6 +9809,7 @@ dependencies = [
  "solana-cpi",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
+ "solana-feature-gate-interface",
  "solana-fee-calculator",
  "solana-genesis-config",
  "solana-hash 3.1.0",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8306,6 +8306,7 @@ dependencies = [
  "solana-compute-budget",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
+ "solana-feature-gate-interface",
  "solana-fee-calculator",
  "solana-genesis-config",
  "solana-hash 3.1.0",

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -5,7 +5,7 @@ use {
         integration_tests::{ValidatorKeys, DEFAULT_NODE_STAKE},
         validator_configs::*,
     },
-    agave_feature_set::FeatureSet,
+    agave_feature_set::{bls_pubkey_management_in_vote_account, vote_state_v4, FeatureSet},
     agave_snapshots::{paths::BANK_SNAPSHOTS_DIR, snapshot_config::SnapshotConfig},
     agave_votor_messages::migration::GENESIS_CERTIFICATE_ACCOUNT,
     itertools::izip,
@@ -55,7 +55,9 @@ use {
     solana_transaction_error::TransportError,
     solana_vote_program::{
         vote_instruction,
-        vote_state::{self, VoteInit, VoteStateV4},
+        vote_state::{
+            self, create_bls_pubkey_and_proof_of_possession, VoteInit, VoteInitV2, VoteStateV4,
+        },
     },
     std::{
         collections::HashMap,
@@ -1052,6 +1054,20 @@ impl LocalCluster {
             .expect("client transfer should succeed");
     }
 
+    fn is_feature_active(rpc_client: &RpcClient, feature_id: &Pubkey) -> bool {
+        rpc_client
+            .get_account_with_commitment(feature_id, CommitmentConfig::processed())
+            .ok()
+            .and_then(|r| r.value)
+            .and_then(|account| solana_feature_gate_interface::from_account(&account))
+            .is_some_and(|feature| feature.activated_at.is_some())
+    }
+
+    fn is_bls_pubkey_feature_enabled(rpc_client: &RpcClient) -> bool {
+        Self::is_feature_active(rpc_client, &bls_pubkey_management_in_vote_account::id())
+            && Self::is_feature_active(rpc_client, &vote_state_v4::id())
+    }
+
     fn setup_vote_and_stake_accounts(
         client: &QuicTpuClient,
         vote_account: &Keypair,
@@ -1074,21 +1090,41 @@ impl LocalCluster {
             == 0
         {
             // 1) Create vote account
-            let instructions = vote_instruction::create_account_with_config(
-                &from_account.pubkey(),
-                &vote_account_pubkey,
-                &VoteInit {
-                    node_pubkey,
-                    authorized_voter: vote_account_pubkey,
-                    authorized_withdrawer: vote_account_pubkey,
-                    commission: 0,
-                },
-                amount,
-                vote_instruction::CreateVoteAccountConfig {
-                    space: vote_state::VoteStateV4::size_of() as u64,
-                    ..vote_instruction::CreateVoteAccountConfig::default()
-                },
-            );
+            let config = vote_instruction::CreateVoteAccountConfig {
+                space: vote_state::VoteStateV4::size_of() as u64,
+                ..vote_instruction::CreateVoteAccountConfig::default()
+            };
+            let instructions = if Self::is_bls_pubkey_feature_enabled(client.rpc_client()) {
+                let (bls_pubkey, bls_proof_of_possession) =
+                    create_bls_pubkey_and_proof_of_possession(&vote_account_pubkey);
+                vote_instruction::create_account_with_config_v2(
+                    &from_account.pubkey(),
+                    &vote_account_pubkey,
+                    &VoteInitV2 {
+                        node_pubkey,
+                        authorized_voter: vote_account_pubkey,
+                        authorized_voter_bls_pubkey: bls_pubkey,
+                        authorized_voter_bls_proof_of_possession: bls_proof_of_possession,
+                        authorized_withdrawer: vote_account_pubkey,
+                        ..Default::default()
+                    },
+                    amount,
+                    config,
+                )
+            } else {
+                vote_instruction::create_account_with_config(
+                    &from_account.pubkey(),
+                    &vote_account_pubkey,
+                    &VoteInit {
+                        node_pubkey,
+                        authorized_voter: vote_account_pubkey,
+                        authorized_withdrawer: vote_account_pubkey,
+                        ..VoteInit::default()
+                    },
+                    amount,
+                    config,
+                )
+            };
             let message = Message::new(&instructions, Some(&from_account.pubkey()));
             let mut transaction = Transaction::new(
                 &[from_account.as_ref(), vote_account],

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -34,6 +34,7 @@ solana-commitment-config = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }
+solana-feature-gate-interface = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-hash = { workspace = true }

--- a/program-test/tests/setup.rs
+++ b/program-test/tests/setup.rs
@@ -1,4 +1,6 @@
 use {
+    agave_feature_set::{bls_pubkey_management_in_vote_account, vote_state_v4},
+    solana_banks_client::BanksClient,
     solana_keypair::Keypair,
     solana_program_test::ProgramTestContext,
     solana_pubkey::Pubkey,
@@ -12,9 +14,25 @@ use {
     solana_transaction::Transaction,
     solana_vote_program::{
         vote_instruction,
-        vote_state::{self, VoteInit, VoteStateV4},
+        vote_state::{
+            self, create_bls_pubkey_and_proof_of_possession, VoteInit, VoteInitV2, VoteStateV4,
+        },
     },
 };
+
+async fn is_feature_active(banks_client: &mut BanksClient, feature_id: Pubkey) -> bool {
+    banks_client
+        .get_account(feature_id)
+        .await
+        .unwrap()
+        .and_then(|account| solana_feature_gate_interface::from_account(&account))
+        .is_some_and(|feature| feature.activated_at.is_some())
+}
+
+async fn is_bls_pubkey_feature_enabled(banks_client: &mut BanksClient) -> bool {
+    is_feature_active(banks_client, bls_pubkey_management_in_vote_account::id()).await
+        && is_feature_active(banks_client, vote_state_v4::id()).await
+}
 
 pub async fn setup_stake(
     context: &mut ProgramTestContext,
@@ -57,20 +75,44 @@ pub async fn setup_vote(context: &mut ProgramTestContext) -> Pubkey {
     let vote_lamports = Rent::default().minimum_balance(VoteStateV4::size_of());
     let vote_keypair = Keypair::new();
     let user_keypair = Keypair::new();
-    instructions.append(&mut vote_instruction::create_account_with_config(
-        &context.payer.pubkey(),
-        &vote_keypair.pubkey(),
-        &VoteInit {
-            node_pubkey: validator_keypair.pubkey(),
-            authorized_voter: user_keypair.pubkey(),
-            ..VoteInit::default()
-        },
-        vote_lamports,
-        vote_instruction::CreateVoteAccountConfig {
-            space: vote_state::VoteStateV4::size_of() as u64,
-            ..vote_instruction::CreateVoteAccountConfig::default()
-        },
-    ));
+
+    if is_bls_pubkey_feature_enabled(&mut context.banks_client).await {
+        // Use V2 instruction with BLS pubkey.
+        let (bls_pubkey, bls_proof_of_possession) =
+            create_bls_pubkey_and_proof_of_possession(&vote_keypair.pubkey());
+        instructions.append(&mut vote_instruction::create_account_with_config_v2(
+            &context.payer.pubkey(),
+            &vote_keypair.pubkey(),
+            &VoteInitV2 {
+                node_pubkey: validator_keypair.pubkey(),
+                authorized_voter: user_keypair.pubkey(),
+                authorized_voter_bls_pubkey: bls_pubkey,
+                authorized_voter_bls_proof_of_possession: bls_proof_of_possession,
+                ..Default::default()
+            },
+            vote_lamports,
+            vote_instruction::CreateVoteAccountConfig {
+                space: vote_state::VoteStateV4::size_of() as u64,
+                ..vote_instruction::CreateVoteAccountConfig::default()
+            },
+        ));
+    } else {
+        // Use V1 instruction.
+        instructions.append(&mut vote_instruction::create_account_with_config(
+            &context.payer.pubkey(),
+            &vote_keypair.pubkey(),
+            &VoteInit {
+                node_pubkey: validator_keypair.pubkey(),
+                authorized_voter: user_keypair.pubkey(),
+                ..VoteInit::default()
+            },
+            vote_lamports,
+            vote_instruction::CreateVoteAccountConfig {
+                space: vote_state::VoteStateV4::size_of() as u64,
+                ..vote_instruction::CreateVoteAccountConfig::default()
+            },
+        ));
+    }
 
     let transaction = Transaction::new_signed_with_payer(
         &instructions,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8038,6 +8038,7 @@ dependencies = [
  "solana-compute-budget",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
+ "solana-feature-gate-interface",
  "solana-fee-calculator",
  "solana-genesis-config",
  "solana-hash 3.1.0",

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -647,10 +647,10 @@ mod tests {
         solana_system_transaction as system_transaction,
         solana_transaction::Transaction,
         solana_vote::vote_transaction::VoteTransaction,
-        solana_vote_interface::{
-            instruction::{self as vote_instruction, CreateVoteAccountConfig},
-            program as vote_program,
-            state::{Vote, VoteInit, VoteStateV4},
+        solana_vote_interface::{program as vote_program, state::Vote},
+        solana_vote_program::{
+            vote_instruction::{self, CreateVoteAccountConfig},
+            vote_state::{create_bls_pubkey_and_proof_of_possession, VoteInitV2, VoteStateV4},
         },
         std::{
             sync::{
@@ -929,14 +929,18 @@ mod tests {
             0,
             &system_program::id(),
         )];
-        ixs.append(&mut vote_instruction::create_account_with_config(
+        let (bls_pubkey, bls_proof_of_possession) =
+            create_bls_pubkey_and_proof_of_possession(&vote_account.pubkey());
+        ixs.append(&mut vote_instruction::create_account_with_config_v2(
             &from.pubkey(),
             &vote_account.pubkey(),
-            &VoteInit {
+            &VoteInitV2 {
                 node_pubkey: validator.pubkey(),
                 authorized_voter: voter.pubkey(),
+                authorized_voter_bls_pubkey: bls_pubkey,
+                authorized_voter_bls_proof_of_possession: bls_proof_of_possession,
                 authorized_withdrawer: Pubkey::new_unique(),
-                ..VoteInit::default()
+                ..Default::default()
             },
             vote_balance,
             CreateVoteAccountConfig {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -118,8 +118,9 @@ use {
     solana_vote_program::{
         vote_instruction,
         vote_state::{
-            self, create_v4_account_with_authorized, BlockTimestamp, VoteAuthorize, VoteInit,
-            VoteStateV4, VoteStateVersions, MAX_LOCKOUT_HISTORY,
+            self, create_bls_pubkey_and_proof_of_possession, create_v4_account_with_authorized,
+            BlockTimestamp, VoteAuthorize, VoteInit, VoteInitV2, VoteStateV4, VoteStateVersions,
+            VoterWithBLSArgs, MAX_LOCKOUT_HISTORY,
         },
     },
     spl_generic_token::token,
@@ -3225,13 +3226,22 @@ fn test_bank_inherit_fee_rate_governor() {
     );
 }
 
-#[test]
-fn test_bank_vote_accounts() {
+#[test_case(true; "bls_feature_active")]
+#[test_case(false; "bls_feature_inactive")]
+fn test_bank_vote_accounts(bls_feature_active: bool) {
     let GenesisConfigInfo {
-        genesis_config,
+        mut genesis_config,
         mint_keypair,
         ..
     } = create_genesis_config_with_leader(500, &solana_pubkey::new_rand(), 1);
+
+    if !bls_feature_active {
+        genesis_utils::deactivate_features(
+            &mut genesis_config,
+            &vec![feature_set::bls_pubkey_management_in_vote_account::id()],
+        );
+    }
+
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     let vote_accounts = bank.vote_accounts();
@@ -3239,21 +3249,43 @@ fn test_bank_vote_accounts() {
                                         // to have a vote account
 
     let vote_keypair = Keypair::new();
-    let instructions = vote_instruction::create_account_with_config(
-        &mint_keypair.pubkey(),
-        &vote_keypair.pubkey(),
-        &VoteInit {
-            node_pubkey: mint_keypair.pubkey(),
-            authorized_voter: vote_keypair.pubkey(),
-            authorized_withdrawer: vote_keypair.pubkey(),
-            commission: 0,
-        },
-        10,
-        vote_instruction::CreateVoteAccountConfig {
-            space: VoteStateV4::size_of() as u64,
-            ..vote_instruction::CreateVoteAccountConfig::default()
-        },
-    );
+    let instructions = if bls_feature_active {
+        let (bls_pubkey, bls_proof_of_possession) =
+            create_bls_pubkey_and_proof_of_possession(&vote_keypair.pubkey());
+        vote_instruction::create_account_with_config_v2(
+            &mint_keypair.pubkey(),
+            &vote_keypair.pubkey(),
+            &VoteInitV2 {
+                node_pubkey: mint_keypair.pubkey(),
+                authorized_voter: vote_keypair.pubkey(),
+                authorized_voter_bls_pubkey: bls_pubkey,
+                authorized_voter_bls_proof_of_possession: bls_proof_of_possession,
+                authorized_withdrawer: vote_keypair.pubkey(),
+                ..Default::default()
+            },
+            10,
+            vote_instruction::CreateVoteAccountConfig {
+                space: VoteStateV4::size_of() as u64,
+                ..vote_instruction::CreateVoteAccountConfig::default()
+            },
+        )
+    } else {
+        vote_instruction::create_account_with_config(
+            &mint_keypair.pubkey(),
+            &vote_keypair.pubkey(),
+            &VoteInit {
+                node_pubkey: mint_keypair.pubkey(),
+                authorized_voter: vote_keypair.pubkey(),
+                authorized_withdrawer: vote_keypair.pubkey(),
+                ..VoteInit::default()
+            },
+            10,
+            vote_instruction::CreateVoteAccountConfig {
+                space: VoteStateV4::size_of() as u64,
+                ..vote_instruction::CreateVoteAccountConfig::default()
+            },
+        )
+    };
 
     let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
     let transaction = Transaction::new(
@@ -3321,14 +3353,18 @@ fn test_bank_cloned_stake_delegations() {
     };
 
     let vote_keypair = Keypair::new();
-    let mut instructions = vote_instruction::create_account_with_config(
+    let (bls_pubkey, bls_proof_of_possession) =
+        create_bls_pubkey_and_proof_of_possession(&vote_keypair.pubkey());
+    let mut instructions = vote_instruction::create_account_with_config_v2(
         &mint_keypair.pubkey(),
         &vote_keypair.pubkey(),
-        &VoteInit {
+        &VoteInitV2 {
             node_pubkey: mint_keypair.pubkey(),
             authorized_voter: vote_keypair.pubkey(),
+            authorized_voter_bls_pubkey: bls_pubkey,
+            authorized_voter_bls_proof_of_possession: bls_proof_of_possession,
             authorized_withdrawer: vote_keypair.pubkey(),
-            commission: 0,
+            ..Default::default()
         },
         vote_balance,
         vote_instruction::CreateVoteAccountConfig {
@@ -3632,12 +3668,16 @@ fn test_add_builtin() {
 
     let mock_account = Keypair::new();
     let mock_validator_identity = Keypair::new();
-    let mut instructions = vote_instruction::create_account_with_config(
+    let (bls_pubkey, bls_proof_of_possession) =
+        create_bls_pubkey_and_proof_of_possession(&mock_account.pubkey());
+    let mut instructions = vote_instruction::create_account_with_config_v2(
         &mint_keypair.pubkey(),
         &mock_account.pubkey(),
-        &VoteInit {
+        &VoteInitV2 {
             node_pubkey: mock_validator_identity.pubkey(),
-            ..VoteInit::default()
+            authorized_voter_bls_pubkey: bls_pubkey,
+            authorized_voter_bls_proof_of_possession: bls_proof_of_possession,
+            ..Default::default()
         },
         1,
         vote_instruction::CreateVoteAccountConfig {
@@ -3679,12 +3719,16 @@ fn test_add_duplicate_static_program() {
 
     let mock_account = Keypair::new();
     let mock_validator_identity = Keypair::new();
-    let instructions = vote_instruction::create_account_with_config(
+    let (bls_pubkey, bls_proof_of_possession) =
+        create_bls_pubkey_and_proof_of_possession(&mock_account.pubkey());
+    let instructions = vote_instruction::create_account_with_config_v2(
         &mint_keypair.pubkey(),
         &mock_account.pubkey(),
-        &VoteInit {
+        &VoteInitV2 {
             node_pubkey: mock_validator_identity.pubkey(),
-            ..VoteInit::default()
+            authorized_voter_bls_pubkey: bls_pubkey,
+            authorized_voter_bls_proof_of_possession: bls_proof_of_possession,
+            ..Default::default()
         },
         1,
         vote_instruction::CreateVoteAccountConfig {
@@ -8450,16 +8494,20 @@ fn test_vote_epoch_panic() {
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     let vote_keypair = keypair_from_seed(&[1u8; 32]).unwrap();
+    let (bls_pubkey, bls_proof_of_possession) =
+        create_bls_pubkey_and_proof_of_possession(&vote_keypair.pubkey());
 
     let mut setup_ixs = Vec::new();
-    setup_ixs.extend(vote_instruction::create_account_with_config(
+    setup_ixs.extend(vote_instruction::create_account_with_config_v2(
         &mint_keypair.pubkey(),
         &vote_keypair.pubkey(),
-        &VoteInit {
+        &VoteInitV2 {
             node_pubkey: mint_keypair.pubkey(),
             authorized_voter: vote_keypair.pubkey(),
+            authorized_voter_bls_pubkey: bls_pubkey,
+            authorized_voter_bls_proof_of_possession: bls_proof_of_possession,
             authorized_withdrawer: mint_keypair.pubkey(),
-            commission: 0,
+            ..Default::default()
         },
         1_000_000_000,
         vote_instruction::CreateVoteAccountConfig {
@@ -10084,12 +10132,17 @@ fn test_rent_state_changes_sysvars() {
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     // Ensure transactions with sysvars succeed, even though sysvars appear RentPaying by balance
+    let (bls_pubkey, bls_proof_of_possession) =
+        create_bls_pubkey_and_proof_of_possession(&validator_vote_account_pubkey);
     let tx = Transaction::new_signed_with_payer(
         &[vote_instruction::authorize(
             &validator_vote_account_pubkey,
             &validator_voting_keypair.pubkey(),
             &Pubkey::new_unique(),
-            VoteAuthorize::Voter,
+            VoteAuthorize::VoterWithBLS(VoterWithBLSArgs {
+                bls_pubkey,
+                bls_proof_of_possession,
+            }),
         )],
         Some(&mint_keypair.pubkey()),
         &[&mint_keypair, &validator_voting_keypair],

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -334,11 +334,7 @@ pub fn activate_all_features(genesis_config: &mut GenesisConfig) {
 fn do_activate_all_features<const IS_ALPENGLOW: bool>(genesis_config: &mut GenesisConfig) {
     // Activate all features at genesis in development mode
     for feature_id in FeatureSet::default().inactive() {
-        if (IS_ALPENGLOW || *feature_id != agave_feature_set::alpenglow::id())
-            // Skip bls_pubkey_management_in_vote_account feature activation until cli change is in place
-            && *feature_id
-                != agave_feature_set::bls_pubkey_management_in_vote_account::id()
-        {
+        if IS_ALPENGLOW || *feature_id != agave_feature_set::alpenglow::id() {
             activate_feature(genesis_config, *feature_id);
         }
     }
@@ -510,10 +506,6 @@ pub fn create_genesis_config_with_leader_ex(
     for feature_id in feature_set.active().keys() {
         // Skip alpenglow (existing behavior)
         if *feature_id == agave_feature_set::alpenglow::id() {
-            continue;
-        }
-        // Skip bls_pubkey_management_in_vote_account feature activation until cli change is in place
-        if *feature_id == agave_feature_set::bls_pubkey_management_in_vote_account::id() {
             continue;
         }
         activate_feature(&mut genesis_config, *feature_id);


### PR DESCRIPTION
#### Problem

#9310 added support for BLS pubkey management in the Vote program, but it left
a number of TODOs in many of the monorepo's tests - including the CLI, RPC, and
runtime.

The reason for a lot of these TODOs is the fact that tests must be refactored to
either use the post-[SIMD-0387](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0387-bls-pubkey-management-in-vote-account.md) permitted Vote instructions
(ie. `InitializeAccountV2`) or toggle the feature on and off to test both cases.

#### Summmary of Changes

Refactor vote-program-related tests in RPC, runtime, ledger, and local-cluster
to allow removal of the BLS key feature override in runtime's `genesis_utils`,
then remove said override.

Note: Broken off of #9681.