### PR TITLE
ci: stop sccache server if it exists

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -151,9 +151,6 @@ command_step() {
   cat >> "$output_file" <<EOF
   - name: "$1"
     command: "$2"
-    retry:
-      manual:
-        permit_on_passed: true
     timeout_in_minutes: $3
     artifact_paths: "log-*.txt"
     agents:

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -151,6 +151,9 @@ command_step() {
   cat >> "$output_file" <<EOF
   - name: "$1"
     command: "$2"
+    retry:
+      manual:
+        permit_on_passed: true
     timeout_in_minutes: $3
     artifact_paths: "log-*.txt"
     agents:

--- a/ci/test-dev-context-only-utils.sh
+++ b/ci/test-dev-context-only-utils.sh
@@ -26,4 +26,4 @@ scripts/check-dev-context-only-utils.sh check-bins-and-lib "$@" --features agave
 # This shows final stats while stopping the sccache background server as well
 # for later normal sccache use (if any). Remember that sccache is now
 # temporarily and experimtally running with the local disk storage.
-_ sccache --stop-server
+_ sccache --stop-server || echo "no sccache is started"


### PR DESCRIPTION
#### Problem

we stop sccache server here: https://github.com/anza-xyz/agave/blob/729712bf1d037f4358ca2ded0f25425e10677d3f/ci/test-dev-context-only-utils.sh#L29

however, when we retry >= 3 times, we will disable sccache: https://github.com/anza-xyz/agave/blob/729712bf1d037f4358ca2ded0f25425e10677d3f/ci/docker-run.sh#L52

this means it must fail after sccache is disabled 🫠 

(like: https://buildkite.com/anza/agave/builds/38385/steps/canvas?jid=019bbb74-0a39-4fb4-b29a-960f2ff8ca80)

#### Summary of Changes

get it always success. (it's safe because we will clean up container)

current:
<img width="1482" height="623" alt="Screenshot 2026-01-14 at 19 25 58" src="https://github.com/user-attachments/assets/ddabe116-e983-42ab-8755-0770f1509f35" />

this PR:
<img width="1493" height="544" alt="Screenshot 2026-01-14 at 19 26 41" src="https://github.com/user-attachments/assets/a7150e1f-b4a1-438a-baa6-7cb32e70217f" />

