### PR TITLE
tpu-client-next: use 1s for quic keep alive and 10s for timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11502,7 +11502,6 @@ dependencies = [
  "solana-net-utils",
  "solana-pubkey 4.0.0",
  "solana-pubsub-client",
- "solana-quic-definitions",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-signer",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9529,7 +9529,6 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-pubkey 4.0.0",
- "solana-quic-definitions",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-streamer",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10034,7 +10034,6 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-pubkey 4.0.0",
- "solana-quic-definitions",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-streamer",

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -34,7 +34,6 @@ solana-measure = { workspace = true }
 solana-metrics = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
 solana-pubsub-client = { workspace = true, optional = true }
-solana-quic-definitions = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-streamer = { workspace = true }


### PR DESCRIPTION
This PR decreases constants controling keep alive interval and connection timeout on the client side. For keep alive, 1 sec is chosen because on the mainnet most of the validators use timeout 2sec and if we employ 45s timeout as it is currently, all our connections timeout constantly.

See also https://github.com/anza-xyz/agave/issues/9213


