### PR TITLE
ci: ensure all workspaces are updated when dependabot issues an update

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -47,6 +47,6 @@ jobs:
             git config user.name "dependabot[bot]"
             git add **/Cargo.toml
             git add **/Cargo.lock
-            git commit -am "update all workspaces"
+            git commit -am "Update all workspaces"
             git push
           fi

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -32,9 +32,11 @@ jobs:
           new_version="${BASH_REMATCH[3]}"
           echo "crate_name: $crate_name, old_version: $old_version, new_version: $new_version"
 
-          ./scripts/cargo-for-all-lock-files.sh -- update -p $crate_name:$old_version --precise $new_version || \
-          ./scripts/cargo-for-all-lock-files.sh -- update -p $crate_name --precise $new_version || \
-          ./scripts/cargo-for-all-lock-files.sh -- tree
+          cargo xtask update-crate --package $crate_name --from $old_version --to $new_version
+
+          ./scripts/cargo-for-all-lock-files.sh --ignore-exit-code -- update -p $crate_name:$old_version --precise $new_version
+
+          ./scripts/cargo-for-all-lock-files.sh tree
 
       - name: push
         run: |
@@ -43,7 +45,8 @@ jobs:
           else
             git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
             git config user.name "dependabot[bot]"
+            git add **/Cargo.toml
             git add **/Cargo.lock
-            git commit -am "Update all Cargo files"
+            git commit -am "update all workspaces"
             git push
           fi

--- a/ci/xtask/src/commands/update_crate.rs
+++ b/ci/xtask/src/commands/update_crate.rs
@@ -44,7 +44,9 @@ pub fn run(args: CommandArgs) -> Result<()> {
         // update workspace.dependencies
         if let Some(workspace_deps) = doc
             .get_mut("workspace")
+            .and_then(|ws| ws.as_table_mut())
             .and_then(|ws| ws.get_mut("dependencies"))
+            .and_then(|deps| deps.as_table_mut())
             .and_then(|deps| deps.get_mut(&args.package))
         {
             if update_dependency_spec(workspace_deps, &args.from, &args.to) {
@@ -56,6 +58,7 @@ pub fn run(args: CommandArgs) -> Result<()> {
         // update dependencies
         if let Some(deps) = doc
             .get_mut("dependencies")
+            .and_then(|deps| deps.as_table_mut())
             .and_then(|deps| deps.get_mut(&args.package))
         {
             if update_dependency_spec(deps, &args.from, &args.to) {


### PR DESCRIPTION
#### Problem

dependabot only updates Cargo.lock. Cargo.toml also needs to be updated.

#### Summary of Changes

1. ensure xtask doesn't write empty value back to Cargo.toml
2. improve the workflow that runs after dependabot updates