### PR TITLE
breaking(scheduler-bindings): leader_state enum; execute_slot

### DIFF
--- a/core/src/banking_stage/progress_tracker.rs
+++ b/core/src/banking_stage/progress_tracker.rs
@@ -118,7 +118,7 @@ impl ProgressTracker {
             }
 
             ProgressMessage {
-                leader_state: agave_scheduler_bindings::IS_LEADER,
+                leader_state: agave_scheduler_bindings::LEADER_READY,
                 current_slot: working_bank.slot(),
                 next_leader_slot: next_leader_range_start,
                 leader_range_end: next_leader_range_end,
@@ -131,8 +131,19 @@ impl ProgressTracker {
             }
         } else {
             let current_slot = slot_from_tick_height(tick_height, self.ticks_per_slot);
+
+            // We aren't ready to build a slot yet, however, it may already be our leader
+            // slot which is useful to tell the scheduler.
+            let leader_state = match leader_state
+                .leader_first_tick_height()
+                .is_some_and(|leader_height| tick_height >= leader_height)
+            {
+                true => agave_scheduler_bindings::LEADER_STARTING,
+                false => agave_scheduler_bindings::NOT_LEADER,
+            };
+
             ProgressMessage {
-                leader_state: agave_scheduler_bindings::IS_NOT_LEADER,
+                leader_state,
                 current_slot,
                 next_leader_slot: next_leader_range_start,
                 leader_range_end: next_leader_range_end,
@@ -188,10 +199,7 @@ mod tests {
 
         let (message, tick_height) = progress_tracker.produce_progress_message();
         assert_eq!(tick_height, 0);
-        assert_eq!(
-            message.leader_state,
-            agave_scheduler_bindings::IS_NOT_LEADER
-        );
+        assert_eq!(message.leader_state, agave_scheduler_bindings::NOT_LEADER);
         assert_eq!(message.current_slot, 0);
         assert_eq!(message.current_slot_progress, 0);
         assert_eq!(message.next_leader_slot, u64::MAX);
@@ -206,15 +214,13 @@ mod tests {
         )));
         let (message, tick_height) = progress_tracker.produce_progress_message();
         assert_eq!(tick_height, expected_tick_height);
-        assert_eq!(
-            message.leader_state,
-            agave_scheduler_bindings::IS_NOT_LEADER
-        );
+        assert_eq!(message.leader_state, agave_scheduler_bindings::NOT_LEADER);
         assert_eq!(message.current_slot, 2);
         assert_eq!(message.next_leader_slot, u64::MAX);
         assert_eq!(message.leader_range_end, u64::MAX);
         assert_eq!(message.current_slot_progress, 0);
 
+        // Next leader slot is in the future - should be NOT_LEADER.
         shared_leader_state.store(Arc::new(LeaderState::new(
             None,
             expected_tick_height,
@@ -223,14 +229,32 @@ mod tests {
         )));
         let (message, tick_height) = progress_tracker.produce_progress_message();
         assert_eq!(tick_height, expected_tick_height);
-        assert_eq!(
-            message.leader_state,
-            agave_scheduler_bindings::IS_NOT_LEADER
-        );
+        assert_eq!(message.leader_state, agave_scheduler_bindings::NOT_LEADER);
         assert_eq!(message.current_slot, 2);
         assert_eq!(message.next_leader_slot, 4);
         assert_eq!(message.leader_range_end, 7);
         assert_eq!(message.current_slot_progress, 0);
+
+        // In leader slot but no bank yet - should be LEADER_STARTING.
+        // leader_first_tick_height is at start of slot 4, and we're at tick_height
+        // that puts us in slot 4.
+        let leader_first_tick = 4 * ticks_per_slot + 1;
+        shared_leader_state.store(Arc::new(LeaderState::new(
+            None,
+            leader_first_tick, // tick_height >= leader_first_tick_height
+            Some(leader_first_tick),
+            Some((4, 7)),
+        )));
+        let (message, tick_height) = progress_tracker.produce_progress_message();
+        assert_eq!(tick_height, leader_first_tick);
+        assert_eq!(
+            message.leader_state,
+            agave_scheduler_bindings::LEADER_STARTING
+        );
+        assert_eq!(message.current_slot, 4);
+        assert_eq!(message.next_leader_slot, 4);
+        assert_eq!(message.leader_range_end, 7);
+        assert_eq!(message.current_slot_progress, 1);
 
         let bank = Arc::new(Bank::new_for_tests(
             &solana_genesis_config::create_genesis_config(1).0,
@@ -242,10 +266,11 @@ mod tests {
             Some((4, 7)),
         )));
 
+        // With a working bank - should be LEADER_READY.
         assert!(!bank.is_complete());
         let (message, tick_height) = progress_tracker.produce_progress_message();
         assert_eq!(tick_height, bank.tick_height());
-        assert_eq!(message.leader_state, agave_scheduler_bindings::IS_LEADER);
+        assert_eq!(message.leader_state, agave_scheduler_bindings::LEADER_READY);
         assert_eq!(message.current_slot, bank.slot());
         assert_eq!(message.next_leader_slot, 4);
         assert_eq!(message.leader_range_end, 7);
@@ -261,7 +286,7 @@ mod tests {
         )));
         let (message, tick_height) = progress_tracker.produce_progress_message();
         assert_eq!(tick_height, bank.tick_height());
-        assert_eq!(message.leader_state, agave_scheduler_bindings::IS_LEADER);
+        assert_eq!(message.leader_state, agave_scheduler_bindings::LEADER_READY);
         assert_eq!(message.current_slot, bank.slot());
         assert_eq!(message.next_leader_slot, 4);
         assert_eq!(message.leader_range_end, 7);

--- a/scheduler-bindings/src/lib.rs
+++ b/scheduler-bindings/src/lib.rs
@@ -167,10 +167,23 @@ pub mod tpu_message_flags {
     pub const FROM_STAKED_NODE: u8 = 1 << 2;
 }
 
-/// Indicates the node is not leader.
-pub const IS_NOT_LEADER: u8 = 0;
-/// Indicates the node is leader.
-pub const IS_LEADER: u8 = 1;
+/// The node is not currently in a leader slot.
+pub const NOT_LEADER: u8 = 0;
+/// The node is in a leader slot but the working bank is not yet ready.
+///
+/// Transactions cannot be processed in this state.
+pub const LEADER_STARTING: u8 = 1;
+/// The node is in a leader slot and has a working bank ready.
+///
+/// Transactions can be processed in this state.
+pub const LEADER_READY: u8 = 2;
+
+#[allow(deprecated)]
+#[deprecated(since = "3.1.0", note = "Use NOT_LEADER instead")]
+pub const IS_NOT_LEADER: u8 = NOT_LEADER;
+#[allow(deprecated)]
+#[deprecated(since = "3.1.0", note = "Use LEADER_READY instead")]
+pub const IS_LEADER: u8 = LEADER_READY;
 
 /// Message: [Agave -> Pack]
 /// Agave passes leader status to the external pack process.
@@ -180,17 +193,18 @@ pub const IS_LEADER: u8 = 1;
 )]
 #[repr(C)]
 pub struct ProgressMessage {
-    /// Indicates if node is currently leader or not.
-    /// [`IS_LEADER`] if the node is leader.
-    /// [`IS_NOT_LEADER`] if the node is not leader.
-    /// Other values should be considered invalid.
+    /// Indicates the current leader status of the node.
+    ///
+    /// - [`NOT_LEADER`]: Node is not in a leader slot.
+    /// - [`LEADER_STARTING`]: Node is in a leader slot but bank is not ready.
+    /// - [`LEADER_READY`]: Node is in a leader slot with bank ready for transactions.
+    ///
+    /// # Usage
+    ///
+    /// - To check if within a leader slot: `leader_state != NOT_LEADER`.
+    /// - To check if transactions can be processed: `leader_state == LEADER_READY`.
     pub leader_state: u8,
-    /// The current slot. This along with a leader schedule is not sufficient
-    /// for determining if the node is currently leader. There is a slight
-    /// delay between when a node is supposed to begin its' leader slot, and
-    /// when a bank is ready for processing transactions as leader.
-    /// Using [`Self::leader_state`] for determining if the node is leader
-    /// and has a bank available.
+    /// The current slot.
     pub current_slot: u64,
     /// Next known leader slot or u64::MAX if unknown.
     /// This will **not** include the current slot if leader.

--- a/scheduler-bindings/src/lib.rs
+++ b/scheduler-bindings/src/lib.rs
@@ -350,6 +350,17 @@ pub mod worker_message_types {
     )]
     #[repr(C)]
     pub struct ExecutionResponse {
+        /// The slot this transaction was executed.
+        ///
+        /// # Note
+        ///
+        /// The current semantics are:
+        ///
+        /// - If we successfully get a bank and try your request, this slot is the latest
+        ///   bank we attempted (during a slot roll we can try 2 banks ).
+        /// - If we do not attempt or attemp and fail to get a bank, this field will be
+        ///   zero.
+        pub execution_slot: u64,
         /// Indicates if the transaction was included in the block or not.
         /// If [`not_included_reasons::NONE`], the transaction was included.
         pub not_included_reason: u8,

--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -1,6 +1,7 @@
 pub const MAX_WORKERS: usize = 64;
 
-pub(crate) const VERSION: u64 = 2;
+/// Protocol version.
+pub(crate) const VERSION: u64 = 3;
 pub(crate) const LOGON_SUCCESS: u8 = 0x01;
 pub(crate) const LOGON_FAILURE: u8 = 0x02;
 pub(crate) const MAX_ALLOCATOR_HANDLES: usize = 128;

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -30,7 +30,7 @@ fn message_passing_on_all_queues() {
         src_addr: [4; 16],
     };
     let progress_tracker = ProgressMessage {
-        leader_state: agave_scheduler_bindings::IS_LEADER,
+        leader_state: agave_scheduler_bindings::LEADER_READY,
         current_slot: 3,
         next_leader_slot: 12,
         leader_range_end: 16,


### PR DESCRIPTION
#### Problem

- The current `leader_state` defines two enums:
  - not_leader
  - is_leader
- However, is_leader is confusing because it will start off as false during our leader slot. It actually means something like "am i the leader and is my bank ready for transaction packing".

#### Summary of Changes

- Update the enum to be:
  - Not leader (NOT_LEADER)
  - In leader slot but bank not ready (LEADER_STARTING)
  - In leader slot and bank is ready (LEADER_READY)
