### PR TITLE
ledger: Require leader schedules to be repeat-aligned

### DIFF
--- a/ledger/src/leader_schedule.rs
+++ b/ledger/src/leader_schedule.rs
@@ -78,6 +78,10 @@ fn stake_weighted_slot_leaders(
     len: u64,
     repeat: u64,
 ) -> Vec<Pubkey> {
+    debug_assert!(
+        len.is_multiple_of(repeat),
+        "expected `len` {len} to be divisible by `repeat` {repeat}"
+    );
     sort_stakes(&mut keyed_stakes);
     let (keys, stakes): (Vec<_>, Vec<_>) = keyed_stakes.into_iter().unzip();
     let weighted_index = WeightedU64Index::new(stakes).unwrap();
@@ -192,7 +196,6 @@ mod tests {
     #[test_case(457470, &[10, 20, 30], 12, 1, &[2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 0, 2])]
     #[test_case(3466545, &[10, 20, 30], 12, 1, &[2, 2, 0, 0, 2, 1, 1, 1, 0, 0, 2, 2])]
     #[test_case(3466545, &[10, 20, 30], 13, 1, &[2, 2, 0, 0, 2, 1, 1, 1, 0, 0, 2, 2, 1])]
-    #[test_case(3466545, &[10, 20, 30], 13, 2, &[2, 2, 2, 2, 0, 0, 0, 0, 2, 2, 1, 1, 1])]
     #[test_case(3466545, &[10, 20, 30], 14, 1, &[2, 2, 0, 0, 2, 1, 1, 1, 0, 0, 2, 2, 1, 2])]
     #[test_case(3466545, &[10, 20, 30], 14, 2, &[2, 2, 2, 2, 0, 0, 0, 0, 2, 2, 1, 1, 1, 1])]
     fn test_stake_leader_schedule_exact_order(

--- a/ledger/src/leader_schedule/identity_keyed.rs
+++ b/ledger/src/leader_schedule/identity_keyed.rs
@@ -104,8 +104,8 @@ mod tests {
             .collect();
 
         let epoch = rand::random::<Epoch>();
-        let len = num_keys * 10;
         let repeat = 8;
+        let len = num_keys * repeat;
         let leader_schedule = LeaderSchedule::new(&stakes, epoch, len, repeat);
         assert_eq!(leader_schedule.num_slots() as u64, len);
         let mut leader_node = Pubkey::default();

--- a/ledger/src/leader_schedule/vote_keyed.rs
+++ b/ledger/src/leader_schedule/vote_keyed.rs
@@ -181,8 +181,8 @@ mod tests {
             .collect();
 
         let epoch = rand::random::<Epoch>();
-        let len = num_keys * 10;
         let repeat = 8;
+        let len = num_keys * repeat;
         let leader_schedule = LeaderSchedule::new(&vote_accounts_map, epoch, len, repeat);
         assert_eq!(leader_schedule.num_slots() as u64, len);
         let mut leader_node = Pubkey::default();

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4608,7 +4608,7 @@ pub mod tests {
 
     const TEST_MINT_LAMPORTS: u64 = 1_000_000_000;
     const TEST_SIGNATURE_FEE: u64 = 5_000;
-    const TEST_SLOTS_PER_EPOCH: u64 = DELINQUENT_VALIDATOR_SLOT_DISTANCE + 1;
+    const TEST_SLOTS_PER_EPOCH: u64 = 256;
 
     pub(crate) fn new_test_cluster_info() -> ClusterInfo {
         let keypair = Arc::new(Keypair::new());
@@ -5483,7 +5483,7 @@ pub mod tests {
                 parse_success_result(rpc.handle_request_sync(request));
             let expected = Some(HashMap::from_iter(std::iter::once((
                 rpc.leader_pubkey().to_string(),
-                Vec::from_iter(0..=128),
+                Vec::from_iter(0..TEST_SLOTS_PER_EPOCH as usize),
             ))));
             assert_eq!(result, expected);
         }


### PR DESCRIPTION
#### Problem

Tests were constructing schedules with `repeat > 1` but feeding arrays whose length wasn’t a multiple of `repeat`, so some leaders never repeated the expected number of times. That inconsistency also blocks follow-up work on optimizing the schedule calculation (see https://github.com/anza-xyz/agave/pull/9126).

#### Summary of Changes

Add a debug assert that the schedule length is divisible by `repeat`, and fix the tests to generate properly aligned schedules.

Change `TEST_SLOTS_PER_EPOCH` in rpc from 129 (an incorrect, unaligned value) to 256, which stays above the delinquent-slot threshold while keeping the tests fast.

Ref: https://github.com/anza-xyz/agave/issues/8280

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
