### PR TITLE
streamer: decrease QUIC_MAX_TIMEOUT from 60s to 30s (quinn default)

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -33,9 +33,9 @@ use {
     tokio_util::sync::CancellationToken,
 };
 
-/// QUIC connection idle timeout. The connection will be closed if
-/// there are no activities on it within the timeout window.
-pub const QUIC_MAX_TIMEOUT: Duration = Duration::from_secs(60);
+/// QUIC connection idle timeout. The connection will be closed if there are no activities on it
+/// within the timeout window. The chosen value is default for quinn.
+pub const QUIC_MAX_TIMEOUT: Duration = Duration::from_secs(30);
 
 // allow multiple connections for NAT and any open/close overlap
 pub const DEFAULT_MAX_QUIC_CONNECTIONS_PER_UNSTAKED_PEER: usize = 8;


### PR DESCRIPTION
#### Problem

60s timeout might be too high due to NAT timeouts, see https://github.com/anza-xyz/agave/issues/9213#issuecomment-3563851159. The 30sec is safe default idle timeout and used as default in quinn.

To address https://github.com/anza-xyz/agave/issues/9213

