### PR TITLE
tune stale issue management:

### DIFF
--- a/.github/workflows/manage-stale-issues.yml
+++ b/.github/workflows/manage-stale-issues.yml
@@ -30,14 +30,14 @@ jobs:
           ascending: true # Spend API operations budget on older, more-likely-to-get-closed issues first
           close-issue-message: 'This issue was closed because it has been stale for 7 days with no activity.'
           close-pr-message: 'This pull request was closed because it has been stale for 7 days with no activity.'
-          days-before-issue-stale: 365
+          days-before-issue-stale: -1
           days-before-pr-stale: 60
           days-before-close: 7
           debug-only: ${{ github.event_name == 'pull_request' }} # Dry-run when true.
           exempt-all-milestones: true # There are some projects in the repo, so possibly milestones are relevant.
           exempt-issue-labels: do-not-close,feature-gate
           exempt-pr-labels: do-not-close,feature-gate
-          operations-per-run: ${{ github.event_name == 'pull_request' && 100 || 10 }}
+          operations-per-run: ${{ github.event_name == 'pull_request' && 300 || 30 }}
           stale-issue-label: stale
           stale-issue-message: 'This issue is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           stale-pr-label: stale


### PR DESCRIPTION
#### Problem

As discussed [here](https://github.com/anza-xyz/agave/pull/9958#issuecomment-3755709161) the stale bot is a bit slow now and wasting operations on issues, when we don't want it. 

#### Summary of Changes

- increase actions to 30 so that it processes ~15 issues in a single run
- disable issue checks so that it only processes prs
