### PR TITLE
fix(transaction-status): report ATA parse errors correctly

### DIFF
--- a/transaction-status/src/parse_associated_token.rs
+++ b/transaction-status/src/parse_associated_token.rs
@@ -24,8 +24,11 @@ pub fn parse_associated_token(
     let ata_instruction = if instruction.data.is_empty() {
         AssociatedTokenAccountInstruction::Create
     } else {
-        AssociatedTokenAccountInstruction::try_from_slice(&instruction.data)
-            .map_err(|_| ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken))?
+        AssociatedTokenAccountInstruction::try_from_slice(&instruction.data).map_err(|_| {
+            ParseInstructionError::InstructionNotParsable(
+                ParsableProgram::SplAssociatedTokenAccount,
+            )
+        })?
     };
 
     match ata_instruction {


### PR DESCRIPTION
Fixed the associated token account parser to emit InstructionNotParsable with the correct program enum instead of SplToken, so error reporting matches the actual program and downstream handlers can classify it reliably.