### PR TITLE
Enabling snapshot generation when loading from ledger tool

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -408,11 +408,19 @@ pub fn load_and_process_ledger(
     };
 
     let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();
-    let snapshot_controller = Arc::new(SnapshotController::new(
-        snapshot_request_sender,
-        SnapshotConfig::new_load_only(),
-        bank_forks.read().unwrap().root(),
-    ));
+    let snapshot_controller = if arg_matches.is_present("snapshot_slot") {
+        Arc::new(SnapshotController::new(
+            snapshot_request_sender,
+            SnapshotConfig::new_generate_snapshots_externally(),
+            bank_forks.read().unwrap().root(),
+        ))
+    } else {
+        Arc::new(SnapshotController::new(
+            snapshot_request_sender,
+            SnapshotConfig::new_load_only(),
+            bank_forks.read().unwrap().root(),
+        ))
+    };
     let pending_snapshot_packages = Arc::new(Mutex::new(PendingSnapshotPackages::default()));
     let snapshot_request_handler = SnapshotRequestHandler {
         snapshot_controller: snapshot_controller.clone(),

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2175,6 +2175,15 @@ fn main() {
                             exit(1);
                         });
 
+                    // If we are creating an incremental snapshot, it must be based on a full snapshot
+                    if is_incremental {
+                        assert!(bank
+                            .accounts()
+                            .accounts_db
+                            .latest_full_snapshot_slot()
+                            .is_some());
+                    }
+
                     // Snapshot creation will implicitly perform AccountsDb
                     // flush and clean operations. These operations cannot be
                     // run concurrently, so ensure ABS is stopped to avoid that

--- a/snapshots/src/snapshot_config.rs
+++ b/snapshots/src/snapshot_config.rs
@@ -147,14 +147,14 @@ mod tests {
         assert!(!cfg.should_generate_snapshots());
         assert!(cfg.should_load_snapshots());
 
-        assert!(matches!(
+        assert_eq!(
             cfg.full_snapshot_archive_interval,
             SnapshotInterval::Disabled
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             cfg.incremental_snapshot_archive_interval,
             SnapshotInterval::Disabled
-        ));
+        );
     }
 
     #[test]
@@ -164,14 +164,14 @@ mod tests {
         assert!(!cfg.should_generate_snapshots());
         assert!(!cfg.should_load_snapshots());
 
-        assert!(matches!(
+        assert_eq!(
             cfg.full_snapshot_archive_interval,
             SnapshotInterval::Disabled
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             cfg.incremental_snapshot_archive_interval,
             SnapshotInterval::Disabled
-        ));
+        );
     }
 
     #[test]
@@ -184,13 +184,13 @@ mod tests {
         assert!(cfg.should_generate_snapshots());
         assert!(cfg.should_load_snapshots());
 
-        assert!(matches!(
+        assert_eq!(
             cfg.full_snapshot_archive_interval,
             SnapshotInterval::Disabled
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             cfg.incremental_snapshot_archive_interval,
             SnapshotInterval::Disabled
-        ));
+        );
     }
 }

--- a/snapshots/src/snapshot_config.rs
+++ b/snapshots/src/snapshot_config.rs
@@ -89,6 +89,18 @@ impl SnapshotConfig {
         }
     }
 
+    /// A new snapshot config used for loading at startup and generating
+    /// snapshots during runtime. Snapshot generation intervals are disabled
+    /// to indicate that snapshots will be generated externally.
+    pub fn new_generate_snapshots_externally() -> Self {
+        Self {
+            usage: SnapshotUsage::LoadAndGenerate,
+            full_snapshot_archive_interval: SnapshotInterval::Disabled,
+            incremental_snapshot_archive_interval: SnapshotInterval::Disabled,
+            ..Self::default()
+        }
+    }
+
     /// A new snapshot config used to disable snapshot generation and loading at
     /// startup
     pub fn new_disabled() -> Self {
@@ -122,4 +134,63 @@ pub enum SnapshotUsage {
     /// Snapshots are used everywhere; both at startup (i.e. load) and steady-state (i.e.
     /// generate).  This enables taking snapshots.
     LoadAndGenerate,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_load_only() {
+        let cfg = SnapshotConfig::new_load_only();
+
+        assert!(!cfg.should_generate_snapshots());
+        assert!(cfg.should_load_snapshots());
+
+        assert!(matches!(
+            cfg.full_snapshot_archive_interval,
+            SnapshotInterval::Disabled
+        ));
+        assert!(matches!(
+            cfg.incremental_snapshot_archive_interval,
+            SnapshotInterval::Disabled
+        ));
+    }
+
+    #[test]
+    fn test_new_disabled() {
+        let cfg = SnapshotConfig::new_disabled();
+
+        assert!(!cfg.should_generate_snapshots());
+        assert!(!cfg.should_load_snapshots());
+
+        assert!(matches!(
+            cfg.full_snapshot_archive_interval,
+            SnapshotInterval::Disabled
+        ));
+        assert!(matches!(
+            cfg.incremental_snapshot_archive_interval,
+            SnapshotInterval::Disabled
+        ));
+    }
+
+    #[test]
+    fn test_new_generate_snapshots_externally() {
+        let cfg = SnapshotConfig::new_generate_snapshots_externally();
+
+        // Even though intervals are disabled (snapshots handled externally),
+        // usage indicates load+generate semantics.
+        assert_eq!(cfg.usage, SnapshotUsage::LoadAndGenerate);
+        assert!(cfg.should_generate_snapshots());
+        assert!(cfg.should_load_snapshots());
+
+        assert!(matches!(
+            cfg.full_snapshot_archive_interval,
+            SnapshotInterval::Disabled
+        ));
+        assert!(matches!(
+            cfg.incremental_snapshot_archive_interval,
+            SnapshotInterval::Disabled
+        ));
+    }
 }


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/issues/9496

When creating a snapshot with ledger-tool, snapshot generation is disabled, and the last full snapshot slot isn't set. This allows zero lamport single reference accounts can be removed improperly

#### Summary of Changes
- Create a snapshot constructor: new_generate_snapshots_externally
- Use the the new snapshot constructor if load_and_process_ledger is called with snapshot_slot populated.
- Assert that latest_full_snapshot_slot is set if building an incremental snapshot in ledger tool

Fixes https://github.com/anza-xyz/agave/issues/9496
