### PR TITLE
Do not store zero lamport single ref accounts

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5126,33 +5126,36 @@ impl AccountsDb {
         }
     }
 
-    /// Updates the accounts index with the given `infos` and `accounts`.
+    /// Updates the accounts index with the given accounts. If store_account is false, skip storing
+    /// the account in the index as the account was not stored in the cache
     /// Used for cached accounts only.
     fn update_index_cached_accounts<'a>(
         &self,
-        infos: Vec<AccountInfo>,
+        store_account: Vec<bool>,
         accounts: &impl StorableAccounts<'a>,
         update_index_thread_selection: UpdateIndexThreadSelection,
     ) {
         let target_slot = accounts.target_slot();
-        let len = std::cmp::min(accounts.len(), infos.len());
+        let len = std::cmp::min(accounts.len(), store_account.len());
 
         let update = |start, end| {
             (start..end).for_each(|i| {
-                accounts.account(i, |account| {
-                    let info = infos[i];
-                    debug_assert!(info.is_cached());
-                    self.accounts_index.upsert(
-                        target_slot,
-                        target_slot,
-                        account.pubkey(),
-                        &account,
-                        &self.account_indexes,
-                        info,
-                        ReclaimsSlotList::default().as_mut(),
-                        UpsertReclaim::PreviousSlotEntryWasCached,
-                    );
-                });
+                if store_account[i] {
+                    accounts.account(i, |account| {
+                        let info =
+                            AccountInfo::new(StorageLocation::Cached, account.is_zero_lamport());
+                        self.accounts_index.upsert(
+                            target_slot,
+                            target_slot,
+                            account.pubkey(),
+                            &account,
+                            &self.account_indexes,
+                            info,
+                            ReclaimsSlotList::default().as_mut(),
+                            UpsertReclaim::PreviousSlotEntryWasCached,
+                        );
+                    });
+                }
             });
         };
 
@@ -5622,7 +5625,8 @@ impl AccountsDb {
 
         // Store the accounts in the write cache
         let mut store_accounts_time = Measure::start("store_accounts");
-        let infos = self.write_accounts_to_cache(accounts.target_slot(), &accounts, transactions);
+        let (store_account, ephemeral_accounts_skipped) =
+            self.write_accounts_to_cache(accounts.target_slot(), &accounts, transactions);
         store_accounts_time.stop();
         self.stats
             .store_accounts_to_cache_us
@@ -5631,15 +5635,19 @@ impl AccountsDb {
         // Update the index
         let mut update_index_time = Measure::start("update_index");
 
-        self.update_index_cached_accounts(infos, &accounts, update_index_thread_selection);
+        self.update_index_cached_accounts(store_account, &accounts, update_index_thread_selection);
 
         update_index_time.stop();
         self.stats
             .store_update_index
             .fetch_add(update_index_time.as_us(), Ordering::Relaxed);
+        self.stats.num_store_accounts_to_cache.fetch_add(
+            (accounts.len() - ephemeral_accounts_skipped) as u64,
+            Ordering::Relaxed,
+        );
         self.stats
-            .num_store_accounts_to_cache
-            .fetch_add(accounts.len() as u64, Ordering::Relaxed);
+            .ephemeral_accounts_skipped
+            .fetch_add(ephemeral_accounts_skipped as u64, Ordering::Relaxed);
         self.report_store_timings();
     }
 
@@ -5761,12 +5769,17 @@ impl AccountsDb {
         }
     }
 
+    // Stores accounts in the write cache. If an account is zero-lamport and not present in the
+    // index, there is no need to store it in the write cache as it will not effect the database
+    // hash. The function returns a vector of booleans indicating whether each account was stored,
+    // and the number of accounts that were skipped.
     fn write_accounts_to_cache<'a, 'b>(
         &self,
         slot: Slot,
         accounts_and_meta_to_store: &impl StorableAccounts<'b>,
         txs: Option<&[&SanitizedTransaction]>,
-    ) -> Vec<AccountInfo> {
+    ) -> (Vec<bool>, usize) {
+        let mut accounts_skipped = 0;
         let mut current_write_version = if self.accounts_update_notifier.is_some() {
             self.write_version
                 .fetch_add(accounts_and_meta_to_store.len() as u64, Ordering::AcqRel)
@@ -5774,14 +5787,20 @@ impl AccountsDb {
             0
         };
 
-        (0..accounts_and_meta_to_store.len())
+        let store_account: Vec<bool> = (0..accounts_and_meta_to_store.len())
             .map(|index| {
                 let txn = txs.map(|txs| *txs.get(index).expect("txs must be present if provided"));
                 accounts_and_meta_to_store.account(index, |account| {
                     let account_shared_data = account.take_account();
                     let pubkey = account.pubkey();
-                    let account_info =
-                        AccountInfo::new(StorageLocation::Cached, account.is_zero_lamport());
+                    if account.is_zero_lamport()
+                        && self
+                            .accounts_index
+                            .get_and_then(pubkey, |account| (true, account.is_none()))
+                    {
+                        accounts_skipped += 1;
+                        return false;
+                    }
 
                     // if geyser is enabled, send the account update notification
                     // with the original version of the account
@@ -5802,10 +5821,12 @@ impl AccountsDb {
                         account_shared_data
                     };
                     self.accounts_cache.store(slot, pubkey, account_to_store);
-                    account_info
+                    true
                 })
             })
-            .collect()
+            .collect();
+
+        (store_account, accounts_skipped)
     }
 
     fn write_accounts_to_storage<'a>(
@@ -6056,6 +6077,13 @@ impl AccountsDb {
                     "num_zero_lamport_accounts_added",
                     self.stats
                         .num_zero_lamport_accounts_added
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "ephemeral_accounts_skipped",
+                    self.stats
+                        .ephemeral_accounts_skipped
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -30,7 +30,7 @@ pub struct AccountsStats {
     pub num_obsolete_bytes_removed: AtomicU64,
     pub add_zero_lamport_accounts_us: AtomicU64,
     pub num_zero_lamport_accounts_added: AtomicU64,
-    pub ephemeral_accounts_skipped: AtomicU64,
+    pub num_ephemeral_accounts_skipped: AtomicU64,
 }
 
 #[derive(Debug, Default)]

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -30,6 +30,7 @@ pub struct AccountsStats {
     pub num_obsolete_bytes_removed: AtomicU64,
     pub add_zero_lamport_accounts_us: AtomicU64,
     pub num_zero_lamport_accounts_added: AtomicU64,
+    pub ephemeral_accounts_skipped: AtomicU64,
 }
 
 #[derive(Debug, Default)]

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6656,11 +6656,7 @@ fn test_new_zero_lamport_accounts_skipped() {
 
     // Verify pubkey2 is present in slot in the index with a zero-lamport AccountInfo.
     assert!(accounts_db.accounts_index.get_and_then(&pubkey2, |entry| {
-        let account_info = *entry
-            .unwrap()
-            .slot_list_read_lock()
-            .first()
-            .unwrap();
+        let account_info = *entry.unwrap().slot_list_read_lock().first().unwrap();
         (false, account_info.1.is_zero_lamport())
     }));
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6576,3 +6576,86 @@ fn test_batch_insert_zero_lamport_single_ref_account_offsets() {
     assert_eq!(count5, 3, "Should insert only 3 new offsets (60, 70, 80)");
     assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 8);
 }
+
+#[test]
+fn test_new_zero_lamport_accounts_skipped() {
+    let accounts_db = AccountsDb::new_single_for_tests();
+    let pubkey1 = Pubkey::new_unique();
+    let pubkey2 = Pubkey::new_unique();
+    let pubkey3 = Pubkey::new_unique();
+    let zero_account = AccountSharedData::new(0, 0, &Pubkey::default());
+    let account = AccountSharedData::new(100, 0, &Pubkey::default());
+    let slot = 0;
+
+    // 1. Insert a single zero-lamport account and verify it is not added to the index.
+    accounts_db.store_accounts_unfrozen(
+        (slot, [(&pubkey1, &zero_account)].as_slice()),
+        None,
+        UpdateIndexThreadSelection::PoolWithThreshold,
+    );
+    assert!(!accounts_db.accounts_index.contains(&pubkey1));
+
+    // 2. Insert a zero-lamport (pubkey1) together with non-zero accounts (pubkey2, pubkey3)
+    //    in the same slot and verify only the non-zero pubkeys are indexed.
+    accounts_db.store_accounts_unfrozen(
+        (
+            slot,
+            [
+                (&pubkey1, &zero_account),
+                (&pubkey2, &account),
+                (&pubkey3, &account),
+            ]
+            .as_slice(),
+        ),
+        None,
+        UpdateIndexThreadSelection::PoolWithThreshold,
+    );
+    assert!(!accounts_db.accounts_index.contains(&pubkey1));
+    assert!(accounts_db.accounts_index.contains(&pubkey2));
+    assert!(accounts_db.accounts_index.contains(&pubkey3));
+
+    // 3. Insert a zero-lamport update for an already-indexed pubkey (pubkey2).
+    //    Verify pubkey2 remains in the index.
+    accounts_db.store_accounts_unfrozen(
+        (slot, [(&pubkey2, &zero_account)].as_slice()),
+        None,
+        UpdateIndexThreadSelection::PoolWithThreshold,
+    );
+    assert!(accounts_db.accounts_index.contains(&pubkey2));
+
+    // 4. Flush the slot to simulate write-cache -> storage transition and verify
+    //    pubkey1 is still not present while pubkey2 remains indexed.
+    accounts_db.add_root_and_flush_write_cache(slot);
+    assert!(!accounts_db.accounts_index.contains(&pubkey1));
+    assert!(accounts_db.accounts_index.contains(&pubkey2));
+    assert!(accounts_db.accounts_index.contains(&pubkey3));
+
+    // 5. Add a non-zero account for a pubkey that was previously only written as zero
+    //    (pubkey1) and verify the pubkey is added to the index.
+    let slot = slot + 1;
+    accounts_db.store_accounts_unfrozen(
+        (slot, [(&pubkey1, &account)].as_slice()),
+        None,
+        UpdateIndexThreadSelection::PoolWithThreshold,
+    );
+    assert!(accounts_db.accounts_index.contains(&pubkey1));
+
+    // 6. Set pubkey3 to zero lamports flush. Verify pubkey3 is present in the index with
+    // a zero-lamport AccountInfo after flushing.
+    accounts_db.store_accounts_unfrozen(
+        (slot, [(&pubkey3, &zero_account)].as_slice()),
+        None,
+        UpdateIndexThreadSelection::PoolWithThreshold,
+    );
+    accounts_db.add_root_and_flush_write_cache(slot);
+
+    // Verify pubkey3 is present in slot in the index with a zero-lamport AccountInfo.
+    let slot_list = accounts_db.accounts_index.get_and_then(&pubkey3, |entry| {
+        let entry = entry.expect("must exist");
+        (false, entry.slot_list_read_lock().clone_list())
+    });
+
+    // pubkey3 should be present in the index and marked as zero-lamport for this slot.
+    let account_info = slot_list.iter().find(|(s, _)| *s == slot).unwrap();
+    assert!(account_info.1.is_zero_lamport());
+}

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6656,12 +6656,11 @@ fn test_new_zero_lamport_accounts_skipped() {
 
     // Verify pubkey2 is present in slot in the index with a zero-lamport AccountInfo.
     assert!(accounts_db.accounts_index.get_and_then(&pubkey2, |entry| {
-        let account_info = entry
+        let account_info = *entry
             .unwrap()
             .slot_list_read_lock()
             .first()
-            .unwrap()
-            .clone();
+            .unwrap();
         (false, account_info.1.is_zero_lamport())
     }));
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8778,6 +8778,11 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
     bank1
         .transfer(amount, &mint_keypair, &key1.pubkey())
         .unwrap();
+    // Store accounts with lamports to populate the index
+    bank1.store_account(&key4.pubkey(), &AccountSharedData::new(1, 0, &owner));
+    bank1.store_account(&key5.pubkey(), &AccountSharedData::new(1, 0, &owner));
+
+    // Then set the accounts to zero lamports
     bank1.store_account(&key4.pubkey(), &AccountSharedData::new(0, 0, &owner));
     bank1.store_account(&key5.pubkey(), &AccountSharedData::new(0, 0, &owner));
 
@@ -11059,9 +11064,11 @@ where
     // create a bank a few epochs in the future..
     let bank = new_from_parent_next_epoch(bank, &bank_forks, 2);
 
-    // create the next bank in the current epoch
+    // create the next bank in the current epoch and populate bob's account with some lamports and data
     let slot = bank.slot() + 1;
     let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
+    let account = AccountSharedData::new(1, len1, &program);
+    bank.store_account(&bob_pubkey, &account);
 
     // create the next bank where we will store a zero-lamport account to be cleaned
     let slot = bank.slot() + 1;


### PR DESCRIPTION
#### Problem
Accounts that are created as zero lamport and never referenced again occur at a rate of ~ 50 per slot. These accounts must be allocated and then freed in the index, as well as kept in the storages until the next full snapshot. 

#### Summary of Changes
- Detect zero lamport single reference accounts during stores to write cache
- In this situation, skip storing the accounts. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
