### PR TITLE
refactor(programs): use if let Some instead of unwrap for not is_none

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1211,21 +1211,23 @@ fn process_loader_upgradeable_instruction(
                     &[],
                 )?;
 
-                if upgrade_authority_address.is_none() {
+                if let Some(upgrade_authority_address) = upgrade_authority_address {
+                    if migration_authority::check_id(&provided_authority_address) {
+                        invoke_context.native_invoke(
+                            solana_loader_v4_interface::instruction::transfer_authority(
+                                &program_address,
+                                &provided_authority_address,
+                                &upgrade_authority_address,
+                            ),
+                            &[],
+                        )?;
+                    }
+                } else {
                     invoke_context.native_invoke(
                         solana_loader_v4_interface::instruction::finalize(
                             &program_address,
                             &provided_authority_address,
                             &program_address,
-                        ),
-                        &[],
-                    )?;
-                } else if migration_authority::check_id(&provided_authority_address) {
-                    invoke_context.native_invoke(
-                        solana_loader_v4_interface::instruction::transfer_authority(
-                            &program_address,
-                            &provided_authority_address,
-                            &upgrade_authority_address.unwrap(),
                         ),
                         &[],
                     )?;


### PR DESCRIPTION
#### Problem
The code in `process_loader_upgradeable_instruction(`  is checking option twice:
```
if x.is_none() {  // here
} else {
   ... x.unwrap()  // again here
} 
```

#### Summary of Changes
Flip if branches such that `if let Some(x) = x` can be used instead

Note: this was caught with newer (1.92) rust toolchain and emits warning, which this PR is fixing
