### PR TITLE
SIMD-0388: Add BLS12-381 syscalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
 name = "agave-syscalls"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "agave-bls12-381",
  "assert_matches",
  "bincode",
  "libsecp256k1",

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -140,9 +140,9 @@ pub struct ComputeBudget {
     /// Number of compute units consumed to validate a bls12_381 g2 point.
     pub bls12_381_g2_validate_cost: u64,
     /// Base number of compute units consumed to perform a bls12_381 pairing.
-    pub bls12_381_pair_base_cost: u64,
+    pub bls12_381_one_pair_cost: u64,
     /// Incremental number of compute units consumed per pair in a bls12_381 pairing.
-    pub bls12_381_pair_per_pair_cost: u64,
+    pub bls12_381_additional_pair_cost: u64,
 }
 
 #[cfg(feature = "dev-context-only-utils")]
@@ -225,8 +225,8 @@ impl ComputeBudget {
             bls12_381_g2_decompress_cost: cost.bls12_381_g2_decompress_cost,
             bls12_381_g1_validate_cost: cost.bls12_381_g1_validate_cost,
             bls12_381_g2_validate_cost: cost.bls12_381_g2_validate_cost,
-            bls12_381_pair_base_cost: cost.bls12_381_pair_base_cost,
-            bls12_381_pair_per_pair_cost: cost.bls12_381_pair_per_pair_cost,
+            bls12_381_one_pair_cost: cost.bls12_381_one_pair_cost,
+            bls12_381_additional_pair_cost: cost.bls12_381_additional_pair_cost,
         }
     }
 
@@ -294,8 +294,8 @@ impl ComputeBudget {
             bls12_381_g2_decompress_cost: self.bls12_381_g2_decompress_cost,
             bls12_381_g1_validate_cost: self.bls12_381_g1_validate_cost,
             bls12_381_g2_validate_cost: self.bls12_381_g2_validate_cost,
-            bls12_381_pair_base_cost: self.bls12_381_pair_base_cost,
-            bls12_381_pair_per_pair_cost: self.bls12_381_pair_per_pair_cost,
+            bls12_381_one_pair_cost: self.bls12_381_one_pair_cost,
+            bls12_381_additional_pair_cost: self.bls12_381_additional_pair_cost,
         }
     }
 

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -119,6 +119,30 @@ pub struct ComputeBudget {
     pub alt_bn128_g2_compress: u64,
     /// Number of compute units consumed to call alt_bn128_g2_decompress.
     pub alt_bn128_g2_decompress: u64,
+    /// Number of compute units consumed to add two bls12_381 g1 points.
+    pub bls12_381_g1_add_cost: u64,
+    /// Number of compute units consumed to add two bls12_381 g2 points.
+    pub bls12_381_g2_add_cost: u64,
+    /// Number of compute units consumed to subtract two bls12_381 g1 points.
+    pub bls12_381_g1_subtract_cost: u64,
+    /// Number of compute units consumed to subtract two bls12_381 g2 points.
+    pub bls12_381_g2_subtract_cost: u64,
+    /// Number of compute units consumed to multiply a bls12_381 g1 point.
+    pub bls12_381_g1_multiply_cost: u64,
+    /// Number of compute units consumed to multiply a bls12_381 g2 point.
+    pub bls12_381_g2_multiply_cost: u64,
+    /// Number of compute units consumed to decompress a bls12_381 g1 point.
+    pub bls12_381_g1_decompress_cost: u64,
+    /// Number of compute units consumed to decompress a bls12_381 g2 point.
+    pub bls12_381_g2_decompress_cost: u64,
+    /// Number of compute units consumed to validate a bls12_381 g1 point.
+    pub bls12_381_g1_validate_cost: u64,
+    /// Number of compute units consumed to validate a bls12_381 g2 point.
+    pub bls12_381_g2_validate_cost: u64,
+    /// Base number of compute units consumed to perform a bls12_381 pairing.
+    pub bls12_381_pair_base_cost: u64,
+    /// Incremental number of compute units consumed per pair in a bls12_381 pairing.
+    pub bls12_381_pair_per_pair_cost: u64,
 }
 
 #[cfg(feature = "dev-context-only-utils")]
@@ -191,6 +215,18 @@ impl ComputeBudget {
             alt_bn128_g1_decompress: cost.alt_bn128_g1_decompress,
             alt_bn128_g2_compress: cost.alt_bn128_g2_compress,
             alt_bn128_g2_decompress: cost.alt_bn128_g2_decompress,
+            bls12_381_g1_add_cost: cost.bls12_381_g1_add_cost,
+            bls12_381_g2_add_cost: cost.bls12_381_g2_add_cost,
+            bls12_381_g1_subtract_cost: cost.bls12_381_g1_subtract_cost,
+            bls12_381_g2_subtract_cost: cost.bls12_381_g2_subtract_cost,
+            bls12_381_g1_multiply_cost: cost.bls12_381_g1_multiply_cost,
+            bls12_381_g2_multiply_cost: cost.bls12_381_g2_multiply_cost,
+            bls12_381_g1_decompress_cost: cost.bls12_381_g1_decompress_cost,
+            bls12_381_g2_decompress_cost: cost.bls12_381_g2_decompress_cost,
+            bls12_381_g1_validate_cost: cost.bls12_381_g1_validate_cost,
+            bls12_381_g2_validate_cost: cost.bls12_381_g2_validate_cost,
+            bls12_381_pair_base_cost: cost.bls12_381_pair_base_cost,
+            bls12_381_pair_per_pair_cost: cost.bls12_381_pair_per_pair_cost,
         }
     }
 
@@ -248,6 +284,18 @@ impl ComputeBudget {
             alt_bn128_g1_decompress: self.alt_bn128_g1_decompress,
             alt_bn128_g2_compress: self.alt_bn128_g2_compress,
             alt_bn128_g2_decompress: self.alt_bn128_g2_decompress,
+            bls12_381_g1_add_cost: self.bls12_381_g1_add_cost,
+            bls12_381_g2_add_cost: self.bls12_381_g2_add_cost,
+            bls12_381_g1_subtract_cost: self.bls12_381_g1_subtract_cost,
+            bls12_381_g2_subtract_cost: self.bls12_381_g2_subtract_cost,
+            bls12_381_g1_multiply_cost: self.bls12_381_g1_multiply_cost,
+            bls12_381_g2_multiply_cost: self.bls12_381_g2_multiply_cost,
+            bls12_381_g1_decompress_cost: self.bls12_381_g1_decompress_cost,
+            bls12_381_g2_decompress_cost: self.bls12_381_g2_decompress_cost,
+            bls12_381_g1_validate_cost: self.bls12_381_g1_validate_cost,
+            bls12_381_g2_validate_cost: self.bls12_381_g2_validate_cost,
+            bls12_381_pair_base_cost: self.bls12_381_pair_base_cost,
+            bls12_381_pair_per_pair_cost: self.bls12_381_pair_per_pair_cost,
         }
     }
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -72,7 +72,6 @@ dependencies = [
  "bytemuck_derive",
  "group",
  "pairing",
- "solana-define-syscall 5.0.0",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
  "bytemuck_derive",
  "group",
  "pairing",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.0.0",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -63,6 +63,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-bls12-381"
+version = "4.0.0-alpha.0"
+dependencies = [
+ "blst",
+ "blstrs",
+ "bytemuck",
+ "bytemuck_derive",
+ "group",
+ "pairing",
+ "solana-define-syscall 4.0.1",
+]
+
+[[package]]
 name = "agave-feature-set"
 version = "4.0.0-alpha.0"
 dependencies = [
@@ -306,6 +319,7 @@ dependencies = [
 name = "agave-syscalls"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "agave-bls12-381",
  "bincode",
  "libsecp256k1",
  "num-traits",

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -181,6 +181,7 @@ impl FeatureSet {
             enable_alt_bn128_g2_syscalls: self.is_active(&enable_alt_bn128_g2_syscalls::id()),
             commission_rate_in_basis_points: self.is_active(&commission_rate_in_basis_points::id()),
             custom_commission_collector: self.is_active(&custom_commission_collector::id()),
+            enable_bls12_381_syscall: self.is_active(&enable_bls12_381_syscall::id()),
         }
     }
 }
@@ -1239,6 +1240,10 @@ pub mod custom_commission_collector {
     solana_pubkey::declare_id!("GFZ5U5LUCWNecKMBJDuVR3vdepUMwSkwVUMxWKjJXkC4");
 }
 
+pub mod enable_bls12_381_syscall {
+    solana_pubkey::declare_id!("EGJLweNUVskAPEwpjvNB7JT6uUi6h4mFhowNYXVSrimG");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2221,6 +2226,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             custom_commission_collector::id(),
             "SIMD-0232: Custom Commission Collector Account",
+        ),
+        (
+            enable_bls12_381_syscall::id(),
+            "SIMD-0388: BLS12-381 syscalls",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1241,7 +1241,7 @@ pub mod custom_commission_collector {
 }
 
 pub mod enable_bls12_381_syscall {
-    solana_pubkey::declare_id!("EGJLweNUVskAPEwpjvNB7JT6uUi6h4mFhowNYXVSrimG");
+    solana_pubkey::declare_id!("b1sraWPVFdcUizB2LV5wQTeMuK8M313bi5bHjco5eVU");
 }
 
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {

--- a/platform-tools-sdk/cargo-build-sbf/src/syscalls.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/syscalls.rs
@@ -29,6 +29,7 @@ pub(crate) const SYSCALLS: &[&str] = &[
     "sol_curve_validate_point",
     "sol_curve_group_op",
     "sol_curve_multiscalar_mul",
+    "sol_curve_decompress",
     "sol_get_fees_sysvar",
     "sol_get_last_restart_slot",
     "sol_alloc_free_",

--- a/platform-tools-sdk/cargo-build-sbf/src/syscalls.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/syscalls.rs
@@ -30,6 +30,7 @@ pub(crate) const SYSCALLS: &[&str] = &[
     "sol_curve_group_op",
     "sol_curve_multiscalar_mul",
     "sol_curve_decompress",
+    "sol_curve_pairing_map",
     "sol_get_fees_sysvar",
     "sol_get_last_restart_slot",
     "sol_alloc_free_",

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -210,9 +210,9 @@ pub struct SVMTransactionExecutionCost {
     /// Number of compute units consumed to validate a bls12_381 g2 point.
     pub bls12_381_g2_validate_cost: u64,
     /// Base number of compute units consumed to perform a bls12_381 pairing.
-    pub bls12_381_pair_base_cost: u64,
+    pub bls12_381_one_pair_cost: u64,
     /// Incremental number of compute units consumed per pair in a bls12_381 pairing.
-    pub bls12_381_pair_per_pair_cost: u64,
+    pub bls12_381_additional_pair_cost: u64,
 }
 
 impl Default for SVMTransactionExecutionCost {
@@ -273,8 +273,8 @@ impl SVMTransactionExecutionCost {
             bls12_381_g2_decompress_cost: 3_050,
             bls12_381_g1_validate_cost: 1_565,
             bls12_381_g2_validate_cost: 1_968,
-            bls12_381_pair_base_cost: 12_422,
-            bls12_381_pair_per_pair_cost: 13_023,
+            bls12_381_one_pair_cost: 25_445,
+            bls12_381_additional_pair_cost: 13_023,
         }
     }
 

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -189,6 +189,30 @@ pub struct SVMTransactionExecutionCost {
     pub alt_bn128_g2_compress: u64,
     /// Number of compute units consumed to call alt_bn128_g2_decompress.
     pub alt_bn128_g2_decompress: u64,
+    /// Number of compute units consumed to add two bls12_381 g1 points.
+    pub bls12_381_g1_add_cost: u64,
+    /// Number of compute units consumed to add two bls12_381 g2 points.
+    pub bls12_381_g2_add_cost: u64,
+    /// Number of compute units consumed to subtract two bls12_381 g1 points.
+    pub bls12_381_g1_subtract_cost: u64,
+    /// Number of compute units consumed to subtract two bls12_381 g2 points.
+    pub bls12_381_g2_subtract_cost: u64,
+    /// Number of compute units consumed to multiply a bls12_381 g1 point.
+    pub bls12_381_g1_multiply_cost: u64,
+    /// Number of compute units consumed to multiply a bls12_381 g2 point.
+    pub bls12_381_g2_multiply_cost: u64,
+    /// Number of compute units consumed to decompress a bls12_381 g1 point.
+    pub bls12_381_g1_decompress_cost: u64,
+    /// Number of compute units consumed to decompress a bls12_381 g2 point.
+    pub bls12_381_g2_decompress_cost: u64,
+    /// Number of compute units consumed to validate a bls12_381 g1 point.
+    pub bls12_381_g1_validate_cost: u64,
+    /// Number of compute units consumed to validate a bls12_381 g2 point.
+    pub bls12_381_g2_validate_cost: u64,
+    /// Base number of compute units consumed to perform a bls12_381 pairing.
+    pub bls12_381_pair_base_cost: u64,
+    /// Incremental number of compute units consumed per pair in a bls12_381 pairing.
+    pub bls12_381_pair_per_pair_cost: u64,
 }
 
 impl Default for SVMTransactionExecutionCost {
@@ -239,6 +263,18 @@ impl SVMTransactionExecutionCost {
             alt_bn128_g1_decompress: 398,
             alt_bn128_g2_compress: 86,
             alt_bn128_g2_decompress: 13610,
+            bls12_381_g1_add_cost: 128,
+            bls12_381_g2_add_cost: 203,
+            bls12_381_g1_subtract_cost: 129,
+            bls12_381_g2_subtract_cost: 204,
+            bls12_381_g1_multiply_cost: 4_627,
+            bls12_381_g2_multiply_cost: 8_255,
+            bls12_381_g1_decompress_cost: 2_100,
+            bls12_381_g2_decompress_cost: 3_050,
+            bls12_381_g1_validate_cost: 1_565,
+            bls12_381_g2_validate_cost: 1_968,
+            bls12_381_pair_base_cost: 12_422,
+            bls12_381_pair_per_pair_cost: 13_023,
         }
     }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -63,6 +63,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-bls12-381"
+version = "4.0.0-alpha.0"
+dependencies = [
+ "blst",
+ "blstrs",
+ "bytemuck",
+ "bytemuck_derive",
+ "group",
+ "pairing",
+ "solana-define-syscall 4.0.1",
+]
+
+[[package]]
 name = "agave-feature-set"
 version = "4.0.0-alpha.0"
 dependencies = [
@@ -209,6 +222,7 @@ dependencies = [
 name = "agave-syscalls"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "agave-bls12-381",
  "bincode",
  "libsecp256k1 0.6.0",
  "num-traits",
@@ -1260,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd49896f12ac9b6dcd7a5998466b9b58263a695a3dd1ecc1aaca2e12a90b080"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
 dependencies = [
  "cc",
  "glob",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -72,7 +72,6 @@ dependencies = [
  "bytemuck_derive",
  "group",
  "pairing",
- "solana-define-syscall 5.0.0",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
  "bytemuck_derive",
  "group",
  "pairing",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.0.0",
 ]
 
 [[package]]

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -58,6 +58,7 @@ pub struct SVMFeatureSet {
     pub enable_alt_bn128_g2_syscalls: bool,
     pub commission_rate_in_basis_points: bool,
     pub custom_commission_collector: bool,
+    pub enable_bls12_381_syscall: bool,
 }
 
 impl SVMFeatureSet {
@@ -112,6 +113,7 @@ impl SVMFeatureSet {
             enable_alt_bn128_g2_syscalls: true,
             commission_rate_in_basis_points: true,
             custom_commission_collector: true,
+            enable_bls12_381_syscall: true,
         }
     }
 }

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -24,6 +24,7 @@ shuttle-test = [
 svm-internal = []
 
 [dependencies]
+agave-bls12-381 = { workspace = true }
 bincode = { workspace = true }
 libsecp256k1 = { workspace = true }
 num-traits = { workspace = true }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1210,13 +1210,7 @@ declare_builtin_function!(
                     Ok(1)
                 }
             }
-            _ => {
-                if invoke_context.get_feature_set().abort_on_invalid_curve {
-                    Err(SyscallError::InvalidAttribute.into())
-                } else {
-                    Ok(1)
-                }
-            }
+            _ => Err(SyscallError::InvalidAttribute.into()),
         }
     }
 );
@@ -1883,11 +1877,7 @@ declare_builtin_function!(
                 }
             }
             _ => {
-                if invoke_context.get_feature_set().abort_on_invalid_curve {
-                    Err(SyscallError::InvalidAttribute.into())
-                } else {
-                    Ok(1)
-                }
+                Err(SyscallError::InvalidAttribute.into())
             }
         }
     }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -264,8 +264,8 @@ impl HasherImpl for Keccak256Hasher {
     }
 }
 
-// NOTE: These constants are temporarily added here to avoid immediate
-// dependency conflicts.
+// NOTE: These constants are temporarily defined here and will be
+// moved to a dedicated crate in the future.
 mod bls12_381_curve_id {
     /// Curve ID for BLS12-381 pairing operations
     pub(crate) const BLS12_381_LE: u64 = 4;
@@ -986,7 +986,9 @@ declare_builtin_function!(
 declare_builtin_function!(
     // Elliptic Curve Point Validation
     //
-    // Currently, only curve25519 Edwards and Ristretto representations are supported
+    // Currently, the following curves are supported:
+    // - Curve25519 Edwards and Ristretto representations
+    // - BLS12-381
     SyscallCurvePointValidation,
     fn rust(
         invoke_context: &mut InvokeContext,
@@ -1117,7 +1119,10 @@ declare_builtin_function!(
 );
 
 declare_builtin_function!(
-    /// Elliptic Curve Point Decompression
+    // Elliptic Curve Point Decompression
+    //
+    // Currently, the following curves are supported:
+    // - BLS12-381
     SyscallCurveDecompress,
     fn rust(
         invoke_context: &mut InvokeContext,
@@ -1131,9 +1136,8 @@ declare_builtin_function!(
         use {
             crate::bls12_381_curve_id::*,
             agave_bls12_381::{
-                PodG1Point as PodBLSG1Point, PodG2Point as PodBLSG2Point,
-                PodG1Compressed as PodBLSG1Compressed, PodG2Compressed as
-                PodBLSG2Compressed
+                PodG1Compressed as PodBLSG1Compressed, PodG1Point as PodBLSG1Point,
+                PodG2Compressed as PodBLSG2Compressed, PodG2Point as PodBLSG2Point,
             },
         };
 
@@ -1220,7 +1224,9 @@ declare_builtin_function!(
 declare_builtin_function!(
     // Elliptic Curve Group Operations
     //
-    // Currently, only curve25519 Edwards and Ristretto representations are supported
+    // Currently, the following curves are supported:
+    // - Curve25519 Edwards and Ristretto representations
+    // - BLS12-381
     SyscallCurveGroupOps,
     fn rust(
         invoke_context: &mut InvokeContext,
@@ -1689,7 +1695,8 @@ declare_builtin_function!(
 declare_builtin_function!(
     // Elliptic Curve Multiscalar Multiplication
     //
-    // Currently, only curve25519 Edwards and Ristretto representations are supported
+    // Currently, the following curves are supported:
+    // - Curve25519 Edwards and Ristretto representations
     SyscallCurveMultiscalarMultiplication,
     fn rust(
         invoke_context: &mut InvokeContext,
@@ -1805,6 +1812,9 @@ declare_builtin_function!(
 
 declare_builtin_function!(
     /// Elliptic Curve Pairing Map
+    ///
+    // Currently, the following curves are supported:
+    // - BLS12-381
     SyscallCurvePairingMap,
     fn rust(
         invoke_context: &mut InvokeContext,

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -5827,8 +5827,10 @@ mod tests {
         };
 
         let config = Config::default();
-        let mut feature_set = SVMFeatureSet::default();
-        feature_set.enable_bls12_381_syscall = true;
+        let feature_set = SVMFeatureSet {
+            enable_bls12_381_syscall: true,
+            ..Default::default()
+        };
         let feature_set = &feature_set;
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set);
 
@@ -5898,8 +5900,10 @@ mod tests {
         };
 
         let config = Config::default();
-        let mut feature_set = SVMFeatureSet::default();
-        feature_set.enable_bls12_381_syscall = true;
+        let feature_set = SVMFeatureSet {
+            enable_bls12_381_syscall: true,
+            ..Default::default()
+        };
         let feature_set = &feature_set;
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set);
 
@@ -5971,8 +5975,10 @@ mod tests {
         };
 
         let config = Config::default();
-        let mut feature_set = SVMFeatureSet::default();
-        feature_set.enable_bls12_381_syscall = true;
+        let feature_set = SVMFeatureSet {
+            enable_bls12_381_syscall: true,
+            ..Default::default()
+        };
         let feature_set = &feature_set;
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set);
 
@@ -6034,12 +6040,16 @@ mod tests {
 
     #[test]
     fn test_syscall_bls12_381_g2_add() {
-        use crate::bls12_381_curve_id::BLS12_381_G2_BE;
-        use solana_curve25519::curve_syscall_traits::ADD;
+        use {
+            crate::bls12_381_curve_id::BLS12_381_G2_BE,
+            solana_curve25519::curve_syscall_traits::ADD,
+        };
 
         let config = Config::default();
-        let mut feature_set = SVMFeatureSet::default();
-        feature_set.enable_bls12_381_syscall = true;
+        let feature_set = SVMFeatureSet {
+            enable_bls12_381_syscall: true,
+            ..Default::default()
+        };
         let feature_set = &feature_set;
 
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set,);
@@ -6125,8 +6135,10 @@ mod tests {
         };
 
         let config = Config::default();
-        let mut feature_set = SVMFeatureSet::default();
-        feature_set.enable_bls12_381_syscall = true;
+        let feature_set = SVMFeatureSet {
+            enable_bls12_381_syscall: true,
+            ..Default::default()
+        };
         let feature_set = &feature_set;
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set);
 
@@ -6214,8 +6226,10 @@ mod tests {
         };
 
         let config = Config::default();
-        let mut feature_set = SVMFeatureSet::default();
-        feature_set.enable_bls12_381_syscall = true;
+        let feature_set = SVMFeatureSet {
+            enable_bls12_381_syscall: true,
+            ..Default::default()
+        };
         let feature_set = &feature_set;
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set);
 
@@ -6291,8 +6305,10 @@ mod tests {
         use crate::bls12_381_curve_id::BLS12_381_BE;
 
         let config = Config::default();
-        let mut feature_set = SVMFeatureSet::default();
-        feature_set.enable_bls12_381_syscall = true;
+        let feature_set = SVMFeatureSet {
+            enable_bls12_381_syscall: true,
+            ..Default::default()
+        };
         let feature_set = &feature_set;
 
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set,);
@@ -6396,8 +6412,10 @@ mod tests {
         use crate::bls12_381_curve_id::BLS12_381_G1_BE;
 
         let config = Config::default();
-        let mut feature_set = SVMFeatureSet::default();
-        feature_set.enable_bls12_381_syscall = true;
+        let feature_set = SVMFeatureSet {
+            enable_bls12_381_syscall: true,
+            ..Default::default()
+        };
         let feature_set = &feature_set;
 
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set,);
@@ -6454,8 +6472,10 @@ mod tests {
         use crate::bls12_381_curve_id::BLS12_381_G1_BE;
 
         let config = Config::default();
-        let mut feature_set = SVMFeatureSet::default();
-        feature_set.enable_bls12_381_syscall = true;
+        let feature_set = SVMFeatureSet {
+            enable_bls12_381_syscall: true,
+            ..Default::default()
+        };
         let feature_set = &feature_set;
 
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set,);

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1827,11 +1827,11 @@ declare_builtin_function!(
             BLS12_381_LE | BLS12_381_BE => {
                 let execution_cost = invoke_context.get_execution_cost();
                 let cost = execution_cost
-                    .bls12_381_pair_base_cost
+                    .bls12_381_one_pair_cost
                     .saturating_add(
                         execution_cost
-                            .bls12_381_pair_per_pair_cost
-                            .saturating_mul(num_pairs),
+                            .bls12_381_additional_pair_cost
+                            .saturating_mul(num_pairs.saturating_sub(1)),
                     );
                 consume_compute_meter(invoke_context, cost)?;
 
@@ -6385,14 +6385,8 @@ mod tests {
         )
         .unwrap();
 
-        let bls12_381_pair_base_cost = invoke_context.get_execution_cost().bls12_381_pair_base_cost;
-        let bls12_381_pair_per_pair_cost = invoke_context
-            .get_execution_cost()
-            .bls12_381_pair_per_pair_cost;
-        let bls12_381_pair_cost = bls12_381_pair_base_cost
-            .checked_add(bls12_381_pair_per_pair_cost)
-            .unwrap();
-        invoke_context.mock_set_remaining(bls12_381_pair_cost);
+        let bls12_381_one_pair_cost = invoke_context.get_execution_cost().bls12_381_one_pair_cost;
+        invoke_context.mock_set_remaining(bls12_381_one_pair_cost);
 
         let result = SyscallCurvePairingMap::rust(
             &mut invoke_context,

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -5823,7 +5823,7 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g1_add() {
         use {
-            crate::bls12_381_curve_id::BLS12_381_G1_BE,
+            crate::bls12_381_curve_id::{BLS12_381_G1_BE, BLS12_381_G1_LE},
             solana_curve25519::curve_syscall_traits::ADD,
         };
 
@@ -5835,7 +5835,7 @@ mod tests {
         let feature_set = &feature_set;
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set);
 
-        let p1_bytes: [u8; 96] = [
+        let p1_bytes_be: [u8; 96] = [
             9, 86, 169, 212, 236, 245, 17, 101, 127, 183, 56, 13, 99, 100, 183, 133, 57, 107, 96,
             220, 198, 197, 2, 215, 225, 175, 212, 57, 168, 143, 104, 127, 117, 242, 180, 200, 162,
             135, 72, 155, 88, 154, 58, 90, 58, 46, 248, 176, 10, 206, 25, 112, 240, 1, 57, 89, 10,
@@ -5843,14 +5843,14 @@ mod tests {
             112, 117, 241, 247, 185, 195, 232, 36, 123, 31, 221, 6, 57, 176, 251, 163, 195, 39, 35,
             175,
         ];
-        let p2_bytes: [u8; 96] = [
+        let p2_bytes_be: [u8; 96] = [
             13, 32, 61, 215, 83, 124, 186, 189, 82, 0, 79, 244, 67, 167, 21, 50, 48, 229, 8, 107,
             51, 15, 19, 47, 75, 77, 246, 185, 63, 66, 143, 109, 237, 211, 153, 146, 163, 175, 74,
             69, 50, 198, 235, 218, 9, 170, 225, 46, 22, 211, 116, 84, 32, 115, 130, 224, 106, 250,
             205, 143, 238, 115, 74, 207, 238, 193, 232, 16, 59, 140, 20, 252, 7, 34, 144, 47, 137,
             56, 190, 170, 235, 189, 238, 45, 97, 58, 199, 202, 45, 164, 139, 200, 190, 215, 9, 59,
         ];
-        let expected_sum: [u8; 96] = [
+        let expected_sum_be: [u8; 96] = [
             23, 62, 255, 137, 157, 188, 98, 86, 192, 102, 136, 171, 187, 49, 155, 83, 204, 133,
             217, 144, 137, 103, 15, 4, 116, 75, 127, 65, 29, 89, 223, 147, 32, 161, 91, 104, 96,
             211, 239, 102, 233, 95, 48, 130, 207, 154, 19, 189, 18, 112, 102, 145, 36, 73, 17, 27,
@@ -5858,18 +5858,47 @@ mod tests {
             84, 185, 134, 138, 64, 68, 55, 161, 55, 153, 214, 155, 250, 21, 233, 4, 3, 117, 41,
             239,
         ];
+        let p1_bytes_le: [u8; 96] = [
+            176, 248, 46, 58, 90, 58, 154, 88, 155, 72, 135, 162, 200, 180, 242, 117, 127, 104,
+            143, 168, 57, 212, 175, 225, 215, 2, 197, 198, 220, 96, 107, 57, 133, 183, 100, 99, 13,
+            56, 183, 127, 101, 17, 245, 236, 212, 169, 86, 9, 175, 35, 39, 195, 163, 251, 176, 57,
+            6, 221, 31, 123, 36, 232, 195, 185, 247, 241, 117, 112, 255, 233, 53, 57, 53, 123, 177,
+            118, 4, 161, 214, 133, 225, 219, 252, 164, 94, 165, 30, 10, 89, 57, 1, 240, 112, 25,
+            206, 10,
+        ];
+        let p2_bytes_le: [u8; 96] = [
+            46, 225, 170, 9, 218, 235, 198, 50, 69, 74, 175, 163, 146, 153, 211, 237, 109, 143, 66,
+            63, 185, 246, 77, 75, 47, 19, 15, 51, 107, 8, 229, 48, 50, 21, 167, 67, 244, 79, 0, 82,
+            189, 186, 124, 83, 215, 61, 32, 13, 59, 9, 215, 190, 200, 139, 164, 45, 202, 199, 58,
+            97, 45, 238, 189, 235, 170, 190, 56, 137, 47, 144, 34, 7, 252, 20, 140, 59, 16, 232,
+            193, 238, 207, 74, 115, 238, 143, 205, 250, 106, 224, 130, 115, 32, 84, 116, 211, 22,
+        ];
+        let expected_sum_le: [u8; 96] = [
+            189, 19, 154, 207, 130, 48, 95, 233, 102, 239, 211, 96, 104, 91, 161, 32, 147, 223, 89,
+            29, 65, 127, 75, 116, 4, 15, 103, 137, 144, 217, 133, 204, 83, 155, 49, 187, 171, 136,
+            102, 192, 86, 98, 188, 157, 137, 255, 62, 23, 239, 41, 117, 3, 4, 233, 21, 250, 155,
+            214, 153, 55, 161, 55, 68, 64, 138, 134, 185, 84, 51, 29, 31, 158, 71, 207, 245, 133,
+            216, 86, 21, 56, 191, 16, 25, 56, 45, 116, 96, 47, 27, 17, 73, 36, 145, 102, 112, 18,
+        ];
 
-        let p1_va = 0x100000000;
-        let p2_va = 0x200000000;
-        let result_va = 0x300000000;
+        let p1_be_va = 0x100000000;
+        let p2_be_va = 0x200000000;
+        let p1_le_va = 0x300000000;
+        let p2_le_va = 0x400000000;
+        let result_be_va = 0x500000000;
+        let result_le_va = 0x600000000;
 
-        let mut result_buf = [0u8; 96];
+        let mut result_be_buf = [0u8; 96];
+        let mut result_le_buf = [0u8; 96];
 
         let mut memory_mapping = MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&p1_bytes, p1_va),
-                MemoryRegion::new_readonly(&p2_bytes, p2_va),
-                MemoryRegion::new_writable(&mut result_buf, result_va),
+                MemoryRegion::new_readonly(&p1_bytes_be, p1_be_va),
+                MemoryRegion::new_readonly(&p2_bytes_be, p2_be_va),
+                MemoryRegion::new_writable(&mut result_be_buf, result_be_va),
+                MemoryRegion::new_readonly(&p1_bytes_le, p1_le_va),
+                MemoryRegion::new_readonly(&p2_bytes_le, p2_le_va),
+                MemoryRegion::new_writable(&mut result_le_buf, result_le_va),
             ],
             &config,
             SBPFVersion::V3,
@@ -5877,26 +5906,39 @@ mod tests {
         .unwrap();
 
         let bls12_381_g1_add_cost = invoke_context.get_execution_cost().bls12_381_g1_add_cost;
-        invoke_context.mock_set_remaining(bls12_381_g1_add_cost);
+        invoke_context.mock_set_remaining(2 * bls12_381_g1_add_cost);
 
         let result = SyscallCurveGroupOps::rust(
             &mut invoke_context,
             BLS12_381_G1_BE,
             ADD,
-            p1_va,
-            p2_va,
-            result_va,
+            p1_be_va,
+            p2_be_va,
+            result_be_va,
             &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
-        assert_eq!(result_buf, expected_sum);
+        assert_eq!(result_be_buf, expected_sum_be);
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            BLS12_381_G1_LE,
+            ADD,
+            p1_le_va,
+            p2_le_va,
+            result_le_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        assert_eq!(result_le_buf, expected_sum_le);
     }
 
     #[test]
     fn test_syscall_bls12_381_g1_sub() {
         use {
-            crate::bls12_381_curve_id::BLS12_381_G1_BE,
+            crate::bls12_381_curve_id::{BLS12_381_G1_BE, BLS12_381_G1_LE},
             solana_curve25519::curve_syscall_traits::SUB,
         };
 
@@ -5908,7 +5950,7 @@ mod tests {
         let feature_set = &feature_set;
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set);
 
-        let sub_p1: [u8; 96] = [
+        let sub_p1_be: [u8; 96] = [
             6, 126, 67, 177, 221, 168, 219, 147, 17, 32, 109, 112, 204, 95, 207, 179, 227, 202, 32,
             250, 118, 43, 195, 105, 176, 47, 188, 43, 181, 226, 123, 119, 132, 240, 97, 172, 225,
             247, 180, 76, 58, 229, 188, 121, 247, 28, 245, 198, 17, 128, 94, 239, 206, 10, 10, 20,
@@ -5916,14 +5958,14 @@ mod tests {
             165, 178, 8, 221, 0, 21, 154, 72, 160, 158, 70, 46, 244, 127, 4, 250, 158, 31, 2, 130,
             152,
         ];
-        let sub_p2: [u8; 96] = [
+        let sub_p2_be: [u8; 96] = [
             12, 173, 131, 106, 17, 172, 169, 46, 205, 228, 83, 25, 204, 216, 118, 223, 16, 102, 52,
             235, 202, 255, 183, 91, 99, 78, 141, 169, 14, 244, 161, 28, 240, 32, 214, 46, 0, 93,
             106, 73, 41, 176, 220, 160, 251, 37, 18, 110, 15, 86, 67, 210, 137, 114, 71, 220, 167,
             121, 177, 224, 142, 151, 152, 29, 206, 12, 35, 6, 46, 60, 53, 127, 84, 78, 231, 88, 49,
             95, 219, 36, 224, 182, 0, 253, 136, 115, 59, 15, 80, 229, 136, 103, 27, 211, 120, 90,
         ];
-        let expected_sub: [u8; 96] = [
+        let expected_sub_be: [u8; 96] = [
             13, 144, 131, 116, 67, 229, 136, 165, 135, 146, 181, 191, 197, 215, 68, 126, 103, 158,
             231, 50, 49, 105, 8, 243, 53, 209, 99, 16, 39, 177, 211, 99, 128, 164, 37, 101, 139,
             186, 14, 225, 84, 210, 120, 16, 203, 115, 160, 49, 10, 243, 68, 241, 87, 193, 186, 179,
@@ -5931,18 +5973,48 @@ mod tests {
             93, 145, 136, 148, 174, 238, 159, 0, 117, 212, 171, 247, 148, 197, 206, 7, 225, 81,
             114, 74, 63, 201,
         ];
+        let sub_p1_le: [u8; 96] = [
+            198, 245, 28, 247, 121, 188, 229, 58, 76, 180, 247, 225, 172, 97, 240, 132, 119, 123,
+            226, 181, 43, 188, 47, 176, 105, 195, 43, 118, 250, 32, 202, 227, 179, 207, 95, 204,
+            112, 109, 32, 17, 147, 219, 168, 221, 177, 67, 126, 6, 152, 130, 2, 31, 158, 250, 4,
+            127, 244, 46, 70, 158, 160, 72, 154, 21, 0, 221, 8, 178, 165, 113, 166, 6, 218, 238,
+            214, 24, 64, 87, 44, 167, 72, 71, 196, 12, 202, 226, 186, 148, 20, 10, 10, 206, 239,
+            94, 128, 17,
+        ];
+        let sub_p2_le: [u8; 96] = [
+            110, 18, 37, 251, 160, 220, 176, 41, 73, 106, 93, 0, 46, 214, 32, 240, 28, 161, 244,
+            14, 169, 141, 78, 99, 91, 183, 255, 202, 235, 52, 102, 16, 223, 118, 216, 204, 25, 83,
+            228, 205, 46, 169, 172, 17, 106, 131, 173, 12, 90, 120, 211, 27, 103, 136, 229, 80, 15,
+            59, 115, 136, 253, 0, 182, 224, 36, 219, 95, 49, 88, 231, 78, 84, 127, 53, 60, 46, 6,
+            35, 12, 206, 29, 152, 151, 142, 224, 177, 121, 167, 220, 71, 114, 137, 210, 67, 86, 15,
+        ];
+        let expected_sub_le: [u8; 96] = [
+            49, 160, 115, 203, 16, 120, 210, 84, 225, 14, 186, 139, 101, 37, 164, 128, 99, 211,
+            177, 39, 16, 99, 209, 53, 243, 8, 105, 49, 50, 231, 158, 103, 126, 68, 215, 197, 191,
+            181, 146, 135, 165, 136, 229, 67, 116, 131, 144, 13, 201, 63, 74, 114, 81, 225, 7, 206,
+            197, 148, 247, 171, 212, 117, 0, 159, 238, 174, 148, 136, 145, 93, 183, 135, 240, 218,
+            206, 127, 222, 203, 134, 178, 31, 136, 126, 123, 39, 88, 214, 87, 179, 186, 193, 87,
+            241, 68, 243, 10,
+        ];
 
-        let p1_va = 0x100000000;
-        let p2_va = 0x200000000;
-        let result_va = 0x300000000;
+        let p1_be_va = 0x100000000;
+        let p2_be_va = 0x200000000;
+        let p1_le_va = 0x300000000;
+        let p2_le_va = 0x400000000;
+        let result_be_va = 0x500000000;
+        let result_le_va = 0x600000000;
 
-        let mut result_buf = [0u8; 96];
+        let mut result_be_buf = [0u8; 96];
+        let mut result_le_buf = [0u8; 96];
 
         let mut memory_mapping = MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&sub_p1, p1_va),
-                MemoryRegion::new_readonly(&sub_p2, p2_va),
-                MemoryRegion::new_writable(&mut result_buf, result_va),
+                MemoryRegion::new_readonly(&sub_p1_be, p1_be_va),
+                MemoryRegion::new_readonly(&sub_p2_be, p2_be_va),
+                MemoryRegion::new_writable(&mut result_be_buf, result_be_va),
+                MemoryRegion::new_readonly(&sub_p1_le, p1_le_va),
+                MemoryRegion::new_readonly(&sub_p2_le, p2_le_va),
+                MemoryRegion::new_writable(&mut result_le_buf, result_le_va),
             ],
             &config,
             SBPFVersion::V3,
@@ -5952,26 +6024,39 @@ mod tests {
         let bls12_381_g1_subtract_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g1_subtract_cost;
-        invoke_context.mock_set_remaining(bls12_381_g1_subtract_cost);
+        invoke_context.mock_set_remaining(2 * bls12_381_g1_subtract_cost);
 
         let result = SyscallCurveGroupOps::rust(
             &mut invoke_context,
             BLS12_381_G1_BE,
             SUB,
-            p1_va,
-            p2_va,
-            result_va,
+            p1_be_va,
+            p2_be_va,
+            result_be_va,
             &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
-        assert_eq!(result_buf, expected_sub);
+        assert_eq!(result_be_buf, expected_sub_be);
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            BLS12_381_G1_LE,
+            SUB,
+            p1_le_va,
+            p2_le_va,
+            result_le_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        assert_eq!(result_le_buf, expected_sub_le);
     }
 
     #[test]
     fn test_syscall_bls12_381_g1_mul() {
         use {
-            crate::bls12_381_curve_id::BLS12_381_G1_BE,
+            crate::bls12_381_curve_id::{BLS12_381_G1_BE, BLS12_381_G1_LE},
             solana_curve25519::curve_syscall_traits::MUL,
         };
 
@@ -5983,18 +6068,18 @@ mod tests {
         let feature_set = &feature_set;
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set);
 
-        let mul_point: [u8; 96] = [
+        let mul_point_be: [u8; 96] = [
             20, 18, 233, 201, 110, 206, 56, 32, 8, 44, 140, 121, 37, 196, 157, 56, 180, 134, 164,
             33, 180, 130, 147, 7, 26, 239, 183, 163, 219, 85, 143, 197, 247, 243, 117, 252, 201,
             171, 156, 90, 210, 7, 43, 92, 89, 130, 165, 224, 5, 101, 24, 54, 189, 22, 73, 76, 145,
             136, 99, 59, 51, 255, 124, 43, 61, 8, 121, 30, 118, 90, 254, 12, 126, 92, 152, 78, 44,
             231, 126, 56, 220, 35, 54, 117, 2, 175, 190, 105, 138, 188, 202, 36, 171, 12, 231, 225,
         ];
-        let mul_scalar: [u8; 32] = [
+        let mul_scalar_be: [u8; 32] = [
             29, 192, 111, 151, 187, 37, 109, 91, 129, 223, 188, 225, 117, 3, 120, 162, 107, 66,
             159, 255, 61, 128, 41, 32, 242, 95, 232, 202, 106, 188, 154, 147,
         ];
-        let expected_mul: [u8; 96] = [
+        let expected_mul_be: [u8; 96] = [
             22, 101, 72, 255, 3, 247, 39, 218, 234, 117, 208, 91, 158, 114, 126, 55, 166, 71, 227,
             205, 6, 124, 55, 255, 167, 66, 154, 237, 83, 143, 8, 179, 98, 185, 162, 164, 170, 62,
             141, 4, 1, 179, 41, 49, 95, 212, 139, 227, 18, 125, 245, 10, 169, 201, 171, 172, 152,
@@ -6002,18 +6087,45 @@ mod tests {
             200, 221, 204, 9, 120, 153, 142, 88, 240, 228, 164, 157, 79, 72, 55, 119, 239, 56, 104,
             54, 58,
         ];
+        let mul_point_le: [u8; 96] = [
+            224, 165, 130, 89, 92, 43, 7, 210, 90, 156, 171, 201, 252, 117, 243, 247, 197, 143, 85,
+            219, 163, 183, 239, 26, 7, 147, 130, 180, 33, 164, 134, 180, 56, 157, 196, 37, 121,
+            140, 44, 8, 32, 56, 206, 110, 201, 233, 18, 20, 225, 231, 12, 171, 36, 202, 188, 138,
+            105, 190, 175, 2, 117, 54, 35, 220, 56, 126, 231, 44, 78, 152, 92, 126, 12, 254, 90,
+            118, 30, 121, 8, 61, 43, 124, 255, 51, 59, 99, 136, 145, 76, 73, 22, 189, 54, 24, 101,
+            5,
+        ];
+        let mul_scalar_le: [u8; 32] = [
+            147, 154, 188, 106, 202, 232, 95, 242, 32, 41, 128, 61, 255, 159, 66, 107, 162, 120, 3,
+            117, 225, 188, 223, 129, 91, 109, 37, 187, 151, 111, 192, 29,
+        ];
+        let expected_mul_le: [u8; 96] = [
+            227, 139, 212, 95, 49, 41, 179, 1, 4, 141, 62, 170, 164, 162, 185, 98, 179, 8, 143, 83,
+            237, 154, 66, 167, 255, 55, 124, 6, 205, 227, 71, 166, 55, 126, 114, 158, 91, 208, 117,
+            234, 218, 39, 247, 3, 255, 72, 101, 22, 58, 54, 104, 56, 239, 119, 55, 72, 79, 157,
+            164, 228, 240, 88, 142, 153, 120, 9, 204, 221, 200, 229, 111, 228, 208, 248, 114, 185,
+            170, 165, 59, 80, 184, 252, 160, 159, 81, 105, 1, 152, 172, 171, 201, 169, 10, 245,
+            125, 18,
+        ];
 
-        let scalar_va = 0x100000000;
-        let point_va = 0x200000000;
-        let result_va = 0x300000000;
+        let scalar_be_va = 0x100000000;
+        let point_be_va = 0x200000000;
+        let scalar_le_va = 0x300000000;
+        let point_le_va = 0x400000000;
+        let result_be_va = 0x500000000;
+        let result_le_va = 0x600000000;
 
-        let mut result_buf = [0u8; 96];
+        let mut result_be_buf = [0u8; 96];
+        let mut result_le_buf = [0u8; 96];
 
         let mut memory_mapping = MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&mul_scalar, scalar_va),
-                MemoryRegion::new_readonly(&mul_point, point_va),
-                MemoryRegion::new_writable(&mut result_buf, result_va),
+                MemoryRegion::new_readonly(&mul_scalar_be, scalar_be_va),
+                MemoryRegion::new_readonly(&mul_point_be, point_be_va),
+                MemoryRegion::new_writable(&mut result_be_buf, result_be_va),
+                MemoryRegion::new_readonly(&mul_scalar_le, scalar_le_va),
+                MemoryRegion::new_readonly(&mul_point_le, point_le_va),
+                MemoryRegion::new_writable(&mut result_le_buf, result_le_va),
             ],
             &config,
             SBPFVersion::V3,
@@ -6023,26 +6135,39 @@ mod tests {
         let bls12_381_g1_multiply_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g1_multiply_cost;
-        invoke_context.mock_set_remaining(bls12_381_g1_multiply_cost);
+        invoke_context.mock_set_remaining(2 * bls12_381_g1_multiply_cost);
 
         let result = SyscallCurveGroupOps::rust(
             &mut invoke_context,
             BLS12_381_G1_BE,
             MUL,
-            scalar_va,
-            point_va,
-            result_va,
+            scalar_be_va,
+            point_be_va,
+            result_be_va,
             &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
-        assert_eq!(result_buf, expected_mul);
+        assert_eq!(result_be_buf, expected_mul_be);
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            BLS12_381_G1_LE,
+            MUL,
+            scalar_le_va,
+            point_le_va,
+            result_le_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        assert_eq!(result_le_buf, expected_mul_le);
     }
 
     #[test]
     fn test_syscall_bls12_381_g2_add() {
         use {
-            crate::bls12_381_curve_id::BLS12_381_G2_BE,
+            crate::bls12_381_curve_id::{BLS12_381_G2_BE, BLS12_381_G2_LE},
             solana_curve25519::curve_syscall_traits::ADD,
         };
 
@@ -6055,7 +6180,7 @@ mod tests {
 
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set,);
 
-        let p1_bytes: [u8; 192] = [
+        let p1_bytes_be: [u8; 192] = [
             11, 83, 21, 62, 4, 174, 123, 131, 163, 19, 62, 216, 192, 48, 25, 184, 57, 207, 80, 70,
             253, 51, 129, 169, 87, 182, 142, 1, 148, 102, 203, 99, 86, 111, 207, 55, 204, 117, 82,
             138, 199, 89, 131, 207, 158, 244, 204, 139, 18, 151, 214, 201, 158, 39, 101, 252, 189,
@@ -6068,7 +6193,7 @@ mod tests {
             121, 166, 10, 186, 122, 40, 222, 87, 34, 227, 49, 166, 195, 139, 37, 221, 44, 227, 86,
             119, 190, 41,
         ];
-        let p2_bytes: [u8; 192] = [
+        let p2_bytes_be: [u8; 192] = [
             14, 110, 180, 174, 46, 74, 145, 125, 94, 28, 39, 205, 107, 126, 53, 188, 36, 69, 162,
             98, 105, 79, 49, 148, 136, 229, 5, 128, 197, 187, 0, 234, 141, 201, 246, 223, 103, 75,
             177, 33, 2, 75, 90, 33, 139, 152, 156, 89, 25, 91, 158, 100, 20, 12, 135, 130, 191,
@@ -6081,7 +6206,7 @@ mod tests {
             191, 232, 59, 3, 86, 78, 78, 149, 165, 179, 145, 161, 190, 247, 67, 243, 252, 137, 1,
             39, 71,
         ];
-        let expected_sum: [u8; 192] = [
+        let expected_sum_be: [u8; 192] = [
             21, 157, 10, 251, 156, 56, 24, 174, 24, 91, 98, 201, 33, 37, 68, 76, 41, 161, 12, 166,
             16, 128, 161, 31, 108, 31, 92, 216, 56, 197, 198, 66, 210, 6, 64, 106, 154, 96, 135,
             57, 170, 119, 220, 210, 238, 73, 98, 83, 15, 146, 74, 122, 70, 40, 186, 123, 191, 139,
@@ -6093,18 +6218,63 @@ mod tests {
             125, 201, 200, 13, 68, 244, 39, 207, 70, 206, 12, 117, 206, 192, 9, 232, 62, 33, 137,
             88, 73, 16, 121, 190, 139, 91, 158, 80, 147, 207, 125, 23, 177, 93, 227, 132, 103, 89,
         ];
+        let p1_bytes_le: [u8; 192] = [
+            174, 86, 176, 144, 185, 218, 229, 146, 169, 183, 164, 172, 247, 55, 127, 55, 220, 42,
+            122, 99, 249, 111, 113, 182, 70, 241, 238, 18, 197, 53, 101, 232, 163, 152, 27, 205,
+            236, 251, 53, 189, 252, 101, 39, 158, 201, 214, 151, 18, 139, 204, 244, 158, 207, 131,
+            89, 199, 138, 82, 117, 204, 55, 207, 111, 86, 99, 203, 102, 148, 1, 142, 182, 87, 169,
+            129, 51, 253, 70, 80, 207, 57, 184, 25, 48, 192, 216, 62, 19, 163, 131, 123, 174, 4,
+            62, 21, 83, 11, 41, 190, 119, 86, 227, 44, 221, 37, 139, 195, 166, 49, 227, 34, 87,
+            222, 40, 122, 186, 10, 166, 121, 96, 200, 223, 151, 95, 74, 212, 2, 211, 10, 219, 153,
+            33, 38, 201, 179, 108, 244, 7, 9, 114, 99, 22, 160, 27, 24, 7, 17, 5, 87, 125, 46, 210,
+            56, 197, 188, 40, 6, 12, 150, 213, 146, 243, 215, 169, 220, 178, 250, 8, 158, 150, 183,
+            253, 85, 214, 181, 72, 85, 191, 189, 90, 23, 103, 238, 75, 12, 77, 215, 241, 241, 29,
+            150, 132, 21,
+        ];
+        let p2_bytes_le: [u8; 192] = [
+            41, 218, 188, 63, 251, 224, 11, 143, 16, 209, 165, 29, 2, 90, 27, 176, 195, 185, 134,
+            184, 203, 68, 181, 17, 143, 179, 178, 187, 24, 238, 111, 181, 36, 89, 195, 94, 41, 5,
+            181, 191, 130, 135, 12, 20, 100, 158, 91, 25, 89, 156, 152, 139, 33, 90, 75, 2, 33,
+            177, 75, 103, 223, 246, 201, 141, 234, 0, 187, 197, 128, 5, 229, 136, 148, 49, 79, 105,
+            98, 162, 69, 36, 188, 53, 126, 107, 205, 39, 28, 94, 125, 145, 74, 46, 174, 180, 110,
+            14, 71, 39, 1, 137, 252, 243, 67, 247, 190, 161, 145, 179, 165, 149, 78, 78, 86, 3, 59,
+            232, 191, 33, 215, 14, 195, 17, 207, 90, 39, 136, 176, 195, 19, 92, 136, 152, 208, 132,
+            95, 205, 49, 85, 17, 120, 4, 11, 222, 7, 65, 18, 214, 8, 210, 17, 201, 173, 64, 49,
+            248, 162, 127, 36, 93, 133, 71, 22, 247, 253, 83, 161, 183, 253, 254, 148, 139, 221,
+            247, 43, 245, 156, 102, 5, 96, 200, 109, 162, 194, 200, 160, 80, 108, 202, 90, 91, 71,
+            23,
+        ];
+        let expected_sum_le: [u8; 192] = [
+            55, 189, 126, 92, 213, 154, 199, 192, 190, 176, 205, 252, 198, 98, 236, 59, 15, 252, 6,
+            187, 220, 228, 157, 29, 124, 78, 113, 248, 22, 191, 37, 81, 62, 12, 20, 221, 249, 11,
+            139, 191, 123, 186, 40, 70, 122, 74, 146, 15, 83, 98, 73, 238, 210, 220, 119, 170, 57,
+            135, 96, 154, 106, 64, 6, 210, 66, 198, 197, 56, 216, 92, 31, 108, 31, 161, 128, 16,
+            166, 12, 161, 41, 76, 68, 37, 33, 201, 98, 91, 24, 174, 24, 56, 156, 251, 10, 157, 21,
+            89, 103, 132, 227, 93, 177, 23, 125, 207, 147, 80, 158, 91, 139, 190, 121, 16, 73, 88,
+            137, 33, 62, 232, 9, 192, 206, 117, 12, 206, 70, 207, 39, 244, 68, 13, 200, 201, 125,
+            201, 202, 118, 116, 201, 193, 247, 36, 248, 5, 17, 54, 207, 123, 28, 35, 76, 41, 116,
+            186, 203, 179, 254, 157, 220, 143, 98, 51, 199, 230, 157, 212, 46, 7, 47, 128, 209, 65,
+            28, 83, 119, 71, 124, 11, 50, 125, 215, 96, 130, 180, 106, 31, 190, 128, 15, 8, 109, 2,
+        ];
 
-        let p1_va = 0x100000000;
-        let p2_va = 0x200000000;
-        let result_va = 0x300000000;
+        let p1_be_va = 0x100000000;
+        let p2_be_va = 0x200000000;
+        let p1_le_va = 0x300000000;
+        let p2_le_va = 0x400000000;
+        let result_be_va = 0x500000000;
+        let result_le_va = 0x600000000;
 
-        let mut result_buf = [0u8; 192];
+        let mut result_be_buf = [0u8; 192];
+        let mut result_le_buf = [0u8; 192];
 
         let mut memory_mapping = MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&p1_bytes, p1_va),
-                MemoryRegion::new_readonly(&p2_bytes, p2_va),
-                MemoryRegion::new_writable(&mut result_buf, result_va),
+                MemoryRegion::new_readonly(&p1_bytes_be, p1_be_va),
+                MemoryRegion::new_readonly(&p2_bytes_be, p2_be_va),
+                MemoryRegion::new_writable(&mut result_be_buf, result_be_va),
+                MemoryRegion::new_readonly(&p1_bytes_le, p1_le_va),
+                MemoryRegion::new_readonly(&p2_bytes_le, p2_le_va),
+                MemoryRegion::new_writable(&mut result_le_buf, result_le_va),
             ],
             &config,
             SBPFVersion::V3,
@@ -6112,26 +6282,39 @@ mod tests {
         .unwrap();
 
         let bls12_381_g2_add_cost = invoke_context.get_execution_cost().bls12_381_g2_add_cost;
-        invoke_context.mock_set_remaining(bls12_381_g2_add_cost);
+        invoke_context.mock_set_remaining(2 * bls12_381_g2_add_cost);
 
         let result = SyscallCurveGroupOps::rust(
             &mut invoke_context,
             BLS12_381_G2_BE,
             ADD,
-            p1_va,
-            p2_va,
-            result_va,
+            p1_be_va,
+            p2_be_va,
+            result_be_va,
             &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
-        assert_eq!(result_buf, expected_sum);
+        assert_eq!(result_be_buf, expected_sum_be);
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            BLS12_381_G2_LE,
+            ADD,
+            p1_le_va,
+            p2_le_va,
+            result_le_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        assert_eq!(result_le_buf, expected_sum_le);
     }
 
     #[test]
     fn test_syscall_bls12_381_g2_sub() {
         use {
-            crate::bls12_381_curve_id::BLS12_381_G2_BE,
+            crate::bls12_381_curve_id::{BLS12_381_G2_BE, BLS12_381_G2_LE},
             solana_curve25519::curve_syscall_traits::SUB,
         };
 
@@ -6143,7 +6326,7 @@ mod tests {
         let feature_set = &feature_set;
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set);
 
-        let sub_p1: [u8; 192] = [
+        let sub_p1_be: [u8; 192] = [
             1, 111, 113, 42, 165, 128, 194, 26, 130, 142, 58, 198, 61, 244, 113, 64, 25, 96, 196,
             12, 211, 55, 213, 85, 109, 210, 211, 177, 96, 48, 15, 122, 155, 173, 166, 16, 113, 95,
             253, 69, 196, 15, 187, 201, 207, 255, 81, 176, 15, 77, 24, 199, 78, 142, 23, 177, 55,
@@ -6156,7 +6339,7 @@ mod tests {
             35, 127, 109, 7, 202, 220, 208, 97, 11, 167, 119, 94, 192, 92, 165, 215, 230, 160, 16,
             56,
         ];
-        let sub_p2: [u8; 192] = [
+        let sub_p2_be: [u8; 192] = [
             14, 73, 101, 89, 211, 85, 5, 115, 148, 81, 82, 216, 141, 148, 50, 174, 17, 86, 246,
             146, 42, 230, 181, 250, 40, 64, 248, 121, 6, 167, 117, 190, 219, 96, 57, 80, 127, 234,
             141, 179, 154, 109, 5, 82, 233, 254, 7, 48, 5, 108, 253, 196, 16, 144, 81, 140, 252,
@@ -6169,7 +6352,7 @@ mod tests {
             63, 49, 204, 138, 108, 195, 10, 233, 81, 79, 215, 107, 43, 197, 190, 231, 15, 14, 251,
             203, 179, 205, 224, 195,
         ];
-        let expected_sub: [u8; 192] = [
+        let expected_sub_be: [u8; 192] = [
             15, 192, 220, 234, 246, 126, 141, 163, 107, 162, 43, 117, 171, 158, 195, 132, 196, 214,
             237, 133, 98, 133, 112, 248, 161, 148, 3, 163, 20, 26, 49, 136, 161, 244, 36, 179, 237,
             204, 58, 22, 51, 106, 0, 4, 239, 244, 242, 89, 5, 14, 149, 31, 78, 213, 70, 153, 147,
@@ -6182,18 +6365,64 @@ mod tests {
             71, 126, 29, 81, 217, 43, 157, 12, 100, 105, 211, 172, 101, 212, 73, 140, 149, 109,
             252, 180, 98, 22,
         ];
+        let sub_p1_le: [u8; 192] = [
+            23, 238, 44, 185, 68, 52, 241, 246, 36, 102, 72, 13, 199, 231, 9, 202, 162, 117, 37,
+            36, 92, 190, 219, 5, 1, 62, 158, 197, 176, 5, 177, 169, 72, 213, 41, 123, 248, 62, 118,
+            55, 177, 23, 142, 78, 199, 24, 77, 15, 176, 81, 255, 207, 201, 187, 15, 196, 69, 253,
+            95, 113, 16, 166, 173, 155, 122, 15, 48, 96, 177, 211, 210, 109, 85, 213, 55, 211, 12,
+            196, 96, 25, 64, 113, 244, 61, 198, 58, 142, 130, 26, 194, 128, 165, 42, 113, 111, 1,
+            56, 16, 160, 230, 215, 165, 92, 192, 94, 119, 167, 11, 97, 208, 220, 202, 7, 109, 127,
+            35, 140, 143, 51, 17, 10, 28, 70, 20, 241, 147, 13, 15, 226, 109, 116, 121, 232, 148,
+            172, 124, 196, 203, 33, 211, 2, 156, 203, 8, 215, 107, 241, 40, 210, 73, 11, 199, 21,
+            96, 132, 210, 79, 28, 208, 154, 176, 61, 135, 93, 184, 108, 234, 101, 215, 114, 139,
+            166, 7, 142, 201, 46, 186, 208, 243, 194, 67, 64, 28, 46, 74, 236, 103, 61, 28, 192, 1,
+            23,
+        ];
+        let sub_p2_le: [u8; 192] = [
+            212, 172, 219, 32, 238, 55, 169, 54, 120, 166, 185, 81, 66, 54, 112, 207, 127, 108,
+            224, 60, 180, 181, 43, 77, 33, 60, 129, 129, 121, 135, 28, 132, 223, 129, 200, 97, 193,
+            236, 184, 252, 140, 81, 144, 16, 196, 253, 108, 5, 48, 7, 254, 233, 82, 5, 109, 154,
+            179, 141, 234, 127, 80, 57, 96, 219, 190, 117, 167, 6, 121, 248, 64, 40, 250, 181, 230,
+            42, 146, 246, 86, 17, 174, 50, 148, 141, 216, 82, 81, 148, 115, 5, 85, 211, 89, 101,
+            73, 14, 195, 224, 205, 179, 203, 251, 14, 15, 231, 190, 197, 43, 107, 215, 79, 81, 233,
+            10, 195, 108, 138, 204, 49, 63, 238, 20, 89, 172, 19, 59, 152, 68, 238, 158, 104, 98,
+            223, 42, 60, 87, 57, 232, 165, 118, 248, 79, 121, 10, 59, 203, 120, 111, 106, 33, 182,
+            94, 150, 74, 142, 144, 218, 35, 232, 203, 149, 8, 94, 124, 172, 50, 133, 167, 15, 67,
+            136, 114, 219, 126, 182, 189, 88, 174, 112, 157, 17, 177, 75, 190, 233, 130, 68, 20,
+            207, 106, 165, 24,
+        ];
+        let expected_sub_le: [u8; 192] = [
+            19, 114, 246, 112, 36, 230, 22, 224, 12, 9, 243, 191, 147, 186, 58, 77, 35, 187, 144,
+            171, 208, 198, 46, 207, 136, 168, 81, 11, 201, 136, 66, 172, 61, 235, 100, 223, 19, 84,
+            43, 147, 153, 70, 213, 78, 31, 149, 14, 5, 89, 242, 244, 239, 4, 0, 106, 51, 22, 58,
+            204, 237, 179, 36, 244, 161, 136, 49, 26, 20, 163, 3, 148, 161, 248, 112, 133, 98, 133,
+            237, 214, 196, 132, 195, 158, 171, 117, 43, 162, 107, 163, 141, 126, 246, 234, 220,
+            192, 15, 22, 98, 180, 252, 109, 149, 140, 73, 212, 101, 172, 211, 105, 100, 12, 157,
+            43, 217, 81, 29, 126, 71, 213, 227, 190, 186, 50, 115, 67, 165, 215, 245, 16, 94, 95,
+            29, 179, 254, 52, 156, 180, 8, 216, 162, 104, 62, 42, 15, 212, 106, 14, 252, 93, 236,
+            247, 91, 86, 19, 70, 45, 101, 144, 25, 133, 115, 99, 251, 166, 156, 179, 104, 195, 167,
+            229, 17, 238, 184, 50, 212, 90, 174, 178, 108, 140, 135, 32, 13, 187, 150, 201, 176,
+            158, 62, 186, 116, 13,
+        ];
 
-        let p1_va = 0x100000000;
-        let p2_va = 0x200000000;
-        let result_va = 0x300000000;
+        let p1_be_va = 0x100000000;
+        let p2_be_va = 0x200000000;
+        let p1_le_va = 0x300000000;
+        let p2_le_va = 0x400000000;
+        let result_be_va = 0x500000000;
+        let result_le_va = 0x600000000;
 
-        let mut result_buf = [0u8; 192];
+        let mut result_be_buf = [0u8; 192];
+        let mut result_le_buf = [0u8; 192];
 
         let mut memory_mapping = MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&sub_p1, p1_va),
-                MemoryRegion::new_readonly(&sub_p2, p2_va),
-                MemoryRegion::new_writable(&mut result_buf, result_va),
+                MemoryRegion::new_readonly(&sub_p1_be, p1_be_va),
+                MemoryRegion::new_readonly(&sub_p2_be, p2_be_va),
+                MemoryRegion::new_writable(&mut result_be_buf, result_be_va),
+                MemoryRegion::new_readonly(&sub_p1_le, p1_le_va),
+                MemoryRegion::new_readonly(&sub_p2_le, p2_le_va),
+                MemoryRegion::new_writable(&mut result_le_buf, result_le_va),
             ],
             &config,
             SBPFVersion::V3,
@@ -6203,26 +6432,39 @@ mod tests {
         let bls12_381_g2_subtract_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g2_subtract_cost;
-        invoke_context.mock_set_remaining(bls12_381_g2_subtract_cost);
+        invoke_context.mock_set_remaining(2 * bls12_381_g2_subtract_cost);
 
         let result = SyscallCurveGroupOps::rust(
             &mut invoke_context,
             BLS12_381_G2_BE,
             SUB,
-            p1_va,
-            p2_va,
-            result_va,
+            p1_be_va,
+            p2_be_va,
+            result_be_va,
             &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
-        assert_eq!(result_buf, expected_sub);
+        assert_eq!(result_be_buf, expected_sub_be);
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            BLS12_381_G2_LE,
+            SUB,
+            p1_le_va,
+            p2_le_va,
+            result_le_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        assert_eq!(result_le_buf, expected_sub_le);
     }
 
     #[test]
     fn test_syscall_bls12_381_g2_mul() {
         use {
-            crate::bls12_381_curve_id::BLS12_381_G2_BE,
+            crate::bls12_381_curve_id::{BLS12_381_G2_BE, BLS12_381_G2_LE},
             solana_curve25519::curve_syscall_traits::MUL,
         };
 
@@ -6234,7 +6476,7 @@ mod tests {
         let feature_set = &feature_set;
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set);
 
-        let mul_point: [u8; 192] = [
+        let mul_point_be: [u8; 192] = [
             1, 95, 16, 90, 117, 185, 253, 76, 25, 68, 54, 111, 154, 161, 125, 203, 121, 4, 154, 67,
             205, 157, 76, 9, 128, 224, 37, 81, 214, 226, 71, 59, 224, 187, 152, 153, 199, 62, 58,
             74, 137, 245, 46, 101, 155, 17, 212, 64, 5, 134, 0, 185, 19, 132, 205, 101, 77, 204,
@@ -6247,11 +6489,11 @@ mod tests {
             4, 58, 238, 59, 77, 242, 56, 88, 96, 150, 146, 247, 137, 230, 137, 35, 9, 108, 95, 127,
             75, 78,
         ];
-        let mul_scalar: [u8; 32] = [
+        let mul_scalar_be: [u8; 32] = [
             29, 192, 111, 151, 187, 37, 109, 91, 129, 223, 188, 225, 117, 3, 120, 162, 107, 66,
             159, 255, 61, 128, 41, 32, 242, 95, 232, 202, 106, 188, 154, 147,
         ];
-        let expected_mul: [u8; 192] = [
+        let expected_mul_be: [u8; 192] = [
             10, 92, 88, 192, 26, 200, 38, 128, 188, 148, 254, 16, 202, 39, 174, 252, 33, 111, 41,
             121, 211, 9, 209, 138, 43, 104, 122, 214, 4, 251, 34, 81, 36, 92, 143, 19, 151, 213,
             111, 240, 100, 15, 33, 74, 123, 143, 181, 153, 6, 107, 82, 96, 141, 147, 63, 200, 13,
@@ -6264,18 +6506,55 @@ mod tests {
             111, 183, 169, 222, 228, 191, 53, 129, 53, 186, 94, 97, 144, 31, 117, 218, 207, 214,
             189,
         ];
+        let mul_point_le: [u8; 192] = [
+            16, 169, 176, 201, 219, 166, 255, 227, 234, 252, 83, 128, 161, 231, 169, 235, 184, 210,
+            84, 56, 57, 204, 245, 105, 175, 211, 191, 190, 4, 51, 61, 210, 29, 208, 172, 71, 63,
+            118, 204, 77, 101, 205, 132, 19, 185, 0, 134, 5, 64, 212, 17, 155, 101, 46, 245, 137,
+            74, 58, 62, 199, 153, 152, 187, 224, 59, 71, 226, 214, 81, 37, 224, 128, 9, 76, 157,
+            205, 67, 154, 4, 121, 203, 125, 161, 154, 111, 54, 68, 25, 76, 253, 185, 117, 90, 16,
+            95, 1, 78, 75, 127, 95, 108, 9, 35, 137, 230, 137, 247, 146, 150, 96, 88, 56, 242, 77,
+            59, 238, 58, 4, 129, 110, 161, 183, 146, 191, 235, 246, 93, 55, 202, 136, 211, 135, 76,
+            27, 183, 240, 38, 132, 111, 111, 247, 18, 171, 16, 36, 122, 78, 200, 209, 123, 76, 133,
+            220, 124, 99, 221, 27, 160, 216, 235, 36, 212, 56, 197, 12, 79, 176, 201, 231, 206,
+            161, 230, 233, 67, 137, 29, 86, 42, 95, 4, 201, 230, 123, 152, 89, 213, 98, 181, 38,
+            203, 218, 20,
+        ];
+        let mul_scalar_le: [u8; 32] = [
+            147, 154, 188, 106, 202, 232, 95, 242, 32, 41, 128, 61, 255, 159, 66, 107, 162, 120, 3,
+            117, 225, 188, 223, 129, 91, 109, 37, 187, 151, 111, 192, 29,
+        ];
+        let expected_mul_le: [u8; 192] = [
+            179, 97, 99, 239, 22, 225, 246, 148, 92, 98, 137, 164, 201, 221, 90, 38, 241, 191, 33,
+            252, 238, 31, 240, 23, 13, 132, 61, 48, 250, 58, 240, 189, 82, 24, 135, 184, 5, 66, 31,
+            13, 200, 63, 147, 141, 96, 82, 107, 6, 153, 181, 143, 123, 74, 33, 15, 100, 240, 111,
+            213, 151, 19, 143, 92, 36, 81, 34, 251, 4, 214, 122, 104, 43, 138, 209, 9, 211, 121,
+            41, 111, 33, 252, 174, 39, 202, 16, 254, 148, 188, 128, 38, 200, 26, 192, 88, 92, 10,
+            189, 214, 207, 218, 117, 31, 144, 97, 94, 186, 53, 129, 53, 191, 228, 222, 169, 183,
+            111, 74, 196, 243, 134, 51, 2, 77, 183, 162, 113, 38, 145, 39, 246, 63, 153, 185, 104,
+            41, 133, 64, 4, 211, 11, 175, 184, 38, 76, 18, 182, 59, 76, 44, 11, 12, 201, 82, 219,
+            87, 4, 33, 122, 208, 15, 250, 197, 212, 58, 149, 43, 84, 14, 161, 17, 146, 126, 223,
+            175, 50, 206, 40, 103, 119, 59, 34, 41, 100, 233, 58, 182, 165, 156, 14, 114, 39, 251,
+            20,
+        ];
 
-        let scalar_va = 0x100000000;
-        let point_va = 0x200000000;
-        let result_va = 0x300000000;
+        let scalar_be_va = 0x100000000;
+        let point_be_va = 0x200000000;
+        let scalar_le_va = 0x300000000;
+        let point_le_va = 0x400000000;
+        let result_be_va = 0x500000000;
+        let result_le_va = 0x600000000;
 
-        let mut result_buf = [0u8; 192];
+        let mut result_be_buf = [0u8; 192];
+        let mut result_le_buf = [0u8; 192];
 
         let mut memory_mapping = MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&mul_scalar, scalar_va),
-                MemoryRegion::new_readonly(&mul_point, point_va),
-                MemoryRegion::new_writable(&mut result_buf, result_va),
+                MemoryRegion::new_readonly(&mul_scalar_be, scalar_be_va),
+                MemoryRegion::new_readonly(&mul_point_be, point_be_va),
+                MemoryRegion::new_writable(&mut result_be_buf, result_be_va),
+                MemoryRegion::new_readonly(&mul_scalar_le, scalar_le_va),
+                MemoryRegion::new_readonly(&mul_point_le, point_le_va),
+                MemoryRegion::new_writable(&mut result_le_buf, result_le_va),
             ],
             &config,
             SBPFVersion::V3,
@@ -6285,24 +6564,37 @@ mod tests {
         let bls12_381_g2_multiply_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g2_multiply_cost;
-        invoke_context.mock_set_remaining(bls12_381_g2_multiply_cost);
+        invoke_context.mock_set_remaining(2 * bls12_381_g2_multiply_cost);
 
         let result = SyscallCurveGroupOps::rust(
             &mut invoke_context,
             BLS12_381_G2_BE,
             MUL,
-            scalar_va,
-            point_va,
-            result_va,
+            scalar_be_va,
+            point_be_va,
+            result_be_va,
             &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
-        assert_eq!(result_buf, expected_mul);
+        assert_eq!(result_be_buf, expected_mul_be);
+
+        let result = SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            BLS12_381_G2_LE,
+            MUL,
+            scalar_le_va,
+            point_le_va,
+            result_le_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        assert_eq!(result_le_buf, expected_mul_le);
     }
 
     #[test]
-    fn test_syscall_bls12_381_pairing() {
+    fn test_syscall_bls12_381_pairing_be() {
         use crate::bls12_381_curve_id::BLS12_381_BE;
 
         let config = Config::default();
@@ -6315,57 +6607,57 @@ mod tests {
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set,);
 
         let g1_bytes: [u8; 96] = [
-            14, 109, 179, 165, 174, 150, 53, 65, 12, 65, 27, 45, 194, 213, 151, 119, 31, 9, 194,
-            218, 211, 97, 143, 55, 132, 10, 10, 7, 104, 36, 23, 203, 71, 135, 56, 38, 9, 165, 177,
-            68, 248, 225, 230, 200, 147, 186, 63, 233, 21, 191, 133, 37, 160, 52, 2, 249, 115, 111,
-            217, 16, 135, 98, 243, 12, 166, 50, 1, 39, 253, 40, 48, 101, 13, 108, 76, 237, 12, 58,
-            245, 113, 75, 90, 47, 216, 156, 35, 223, 160, 84, 160, 16, 120, 6, 103, 132, 45,
+            3, 161, 104, 54, 242, 116, 16, 50, 15, 113, 42, 38, 108, 11, 127, 64, 43, 249, 50, 133,
+            105, 8, 133, 238, 34, 6, 189, 119, 153, 36, 75, 65, 87, 249, 90, 109, 133, 200, 203,
+            25, 127, 68, 251, 243, 14, 210, 204, 35, 18, 124, 149, 5, 68, 178, 57, 230, 253, 154,
+            192, 163, 5, 146, 144, 100, 7, 102, 9, 76, 67, 251, 147, 45, 27, 111, 204, 213, 219,
+            141, 58, 11, 235, 100, 6, 220, 77, 230, 232, 200, 210, 200, 3, 184, 10, 80, 23, 164,
         ];
         let g2_bytes: [u8; 192] = [
-            15, 28, 53, 78, 205, 37, 201, 37, 205, 66, 121, 138, 56, 120, 211, 146, 62, 157, 236,
-            102, 230, 5, 117, 56, 119, 245, 49, 92, 180, 132, 179, 13, 134, 141, 118, 41, 212, 62,
-            195, 177, 51, 52, 191, 208, 220, 201, 90, 107, 13, 181, 66, 54, 203, 86, 69, 137, 40,
-            184, 192, 93, 191, 235, 165, 80, 4, 38, 89, 135, 14, 18, 234, 249, 67, 193, 188, 223,
-            62, 250, 122, 158, 179, 30, 56, 95, 176, 0, 239, 3, 155, 141, 171, 224, 6, 198, 246,
-            205, 6, 159, 251, 49, 151, 133, 155, 57, 7, 59, 182, 22, 210, 145, 203, 209, 62, 59,
-            188, 64, 10, 195, 114, 199, 159, 219, 25, 179, 2, 23, 18, 62, 254, 101, 113, 141, 109,
-            175, 167, 124, 251, 150, 153, 231, 34, 234, 175, 52, 24, 151, 67, 45, 189, 197, 212,
-            143, 102, 25, 192, 143, 11, 184, 18, 229, 147, 145, 193, 201, 144, 5, 38, 33, 182, 18,
-            92, 144, 146, 21, 74, 61, 179, 104, 196, 158, 244, 63, 172, 73, 22, 70, 100, 202, 90,
-            139, 102, 98,
+            8, 249, 218, 154, 232, 125, 250, 185, 153, 60, 132, 155, 188, 119, 50, 205, 32, 76,
+            184, 181, 164, 158, 64, 12, 179, 181, 150, 95, 226, 9, 175, 51, 169, 185, 34, 178, 249,
+            161, 27, 164, 210, 107, 171, 203, 246, 11, 158, 86, 14, 135, 197, 225, 7, 44, 94, 243,
+            216, 200, 100, 199, 118, 14, 106, 181, 88, 202, 207, 156, 227, 101, 126, 236, 46, 189,
+            238, 73, 220, 118, 151, 73, 255, 249, 103, 103, 255, 185, 91, 82, 212, 148, 110, 19,
+            212, 111, 199, 197, 4, 144, 25, 145, 196, 142, 205, 252, 85, 85, 48, 243, 209, 62, 57,
+            212, 44, 149, 81, 113, 171, 60, 193, 73, 40, 11, 36, 120, 19, 62, 2, 25, 22, 232, 227,
+            50, 35, 75, 172, 205, 2, 37, 27, 65, 182, 6, 74, 43, 1, 239, 105, 129, 184, 98, 215,
+            81, 15, 19, 171, 39, 252, 57, 176, 171, 181, 71, 124, 251, 53, 202, 213, 33, 58, 175,
+            52, 41, 89, 230, 217, 177, 32, 24, 82, 166, 240, 232, 223, 24, 141, 70, 121, 25, 51,
+            173, 30, 6,
         ];
         let expected_gt: [u8; 576] = [
-            15, 124, 219, 251, 80, 222, 126, 43, 196, 49, 34, 25, 153, 233, 75, 211, 42, 192, 212,
-            47, 166, 9, 195, 137, 10, 35, 193, 182, 166, 62, 203, 209, 114, 113, 49, 238, 59, 132,
-            83, 7, 201, 153, 94, 103, 238, 38, 46, 65, 24, 238, 46, 54, 251, 113, 78, 88, 118, 210,
-            42, 173, 49, 235, 34, 119, 182, 188, 84, 157, 108, 155, 133, 112, 91, 220, 108, 130,
-            37, 245, 120, 246, 152, 201, 30, 73, 98, 226, 186, 91, 221, 33, 124, 121, 240, 115,
-            217, 139, 0, 76, 30, 151, 238, 121, 241, 41, 110, 37, 191, 196, 47, 131, 231, 124, 230,
-            162, 114, 111, 209, 71, 210, 58, 12, 203, 213, 51, 134, 225, 104, 113, 58, 71, 229, 65,
-            151, 115, 104, 25, 44, 57, 243, 39, 102, 13, 144, 200, 15, 88, 112, 64, 33, 170, 119,
-            93, 19, 156, 108, 29, 198, 39, 166, 48, 23, 74, 155, 223, 42, 172, 198, 112, 219, 243,
-            55, 173, 86, 90, 91, 200, 75, 132, 111, 74, 52, 155, 78, 78, 103, 251, 35, 177, 14, 75,
-            131, 163, 7, 89, 200, 246, 231, 130, 166, 139, 189, 229, 65, 8, 248, 174, 254, 151, 73,
-            215, 90, 237, 189, 155, 173, 55, 74, 177, 209, 235, 254, 87, 18, 175, 120, 153, 71,
-            112, 51, 104, 126, 107, 29, 240, 156, 107, 44, 244, 49, 210, 9, 255, 160, 66, 243, 94,
-            2, 213, 65, 92, 123, 138, 42, 60, 163, 203, 26, 228, 174, 224, 119, 252, 51, 37, 21,
-            211, 101, 222, 41, 123, 220, 123, 206, 62, 235, 209, 132, 71, 145, 101, 86, 192, 65,
-            97, 4, 64, 112, 128, 20, 188, 225, 66, 2, 121, 250, 44, 15, 111, 14, 46, 90, 145, 158,
-            141, 164, 140, 221, 75, 157, 244, 85, 6, 108, 104, 222, 142, 17, 157, 236, 111, 67, 41,
-            237, 242, 44, 9, 83, 142, 146, 85, 204, 94, 111, 124, 233, 150, 16, 243, 161, 196, 153,
-            36, 162, 27, 203, 69, 247, 195, 31, 24, 69, 138, 191, 107, 221, 159, 51, 24, 170, 218,
-            132, 249, 30, 160, 130, 230, 3, 251, 36, 125, 152, 249, 16, 96, 56, 14, 37, 1, 56, 146,
-            210, 78, 201, 45, 11, 77, 198, 95, 103, 57, 51, 124, 247, 176, 78, 84, 148, 48, 135,
-            203, 66, 216, 134, 116, 101, 52, 136, 60, 221, 177, 111, 145, 41, 95, 184, 75, 145, 7,
-            209, 62, 33, 132, 45, 53, 254, 247, 34, 115, 154, 24, 142, 146, 8, 203, 106, 160, 213,
-            238, 51, 215, 213, 212, 4, 27, 35, 214, 79, 198, 97, 99, 93, 255, 88, 169, 38, 41, 253,
-            166, 173, 203, 111, 138, 3, 145, 135, 250, 220, 58, 135, 173, 142, 37, 244, 251, 227,
-            36, 184, 214, 100, 121, 14, 100, 53, 57, 225, 209, 242, 136, 154, 24, 95, 240, 144,
-            111, 180, 30, 215, 146, 64, 189, 2, 26, 90, 224, 86, 231, 207, 151, 147, 232, 57, 219,
-            32, 135, 0, 91, 207, 185, 15, 72, 146, 240, 12, 212, 172, 147, 185, 17, 1, 180, 121,
-            38, 146, 36, 24, 48, 50, 240, 230, 140, 143, 243, 205, 247, 103, 162, 166, 14, 130, 18,
-            69, 54, 148, 184, 201, 27, 25, 5, 131, 197, 244, 196, 7, 104, 245, 12, 32, 24, 183,
-            219, 165, 214, 144, 163, 9, 157,
+            14, 57, 164, 128, 118, 229, 58, 194, 163, 179, 7, 155, 19, 27, 195, 184, 247, 246, 83,
+            76, 63, 71, 120, 72, 143, 130, 2, 192, 35, 251, 36, 232, 229, 122, 68, 126, 54, 228,
+            197, 249, 112, 234, 93, 130, 133, 246, 75, 41, 13, 31, 232, 225, 105, 219, 180, 105,
+            225, 184, 43, 57, 184, 10, 228, 147, 245, 227, 40, 68, 215, 217, 15, 164, 14, 231, 119,
+            134, 120, 33, 210, 52, 64, 47, 39, 42, 171, 221, 225, 58, 249, 247, 204, 161, 20, 16,
+            103, 1, 0, 168, 109, 157, 223, 60, 147, 11, 76, 2, 95, 86, 174, 4, 100, 125, 124, 226,
+            31, 159, 199, 160, 49, 98, 76, 124, 221, 101, 6, 213, 111, 44, 24, 172, 78, 42, 216,
+            137, 91, 68, 211, 40, 210, 172, 242, 29, 115, 220, 11, 156, 249, 117, 118, 12, 59, 59,
+            87, 137, 217, 190, 144, 62, 249, 103, 244, 247, 152, 112, 238, 31, 122, 136, 39, 9, 49,
+            215, 22, 180, 164, 120, 166, 115, 62, 130, 4, 216, 57, 155, 8, 214, 116, 9, 222, 168,
+            34, 242, 19, 47, 183, 124, 196, 222, 58, 135, 75, 97, 242, 231, 190, 238, 162, 50, 124,
+            230, 229, 172, 156, 140, 196, 163, 213, 49, 153, 144, 167, 118, 122, 167, 70, 203, 145,
+            120, 237, 46, 135, 130, 0, 204, 139, 61, 22, 10, 243, 232, 15, 38, 161, 146, 106, 138,
+            86, 198, 8, 167, 229, 125, 95, 28, 120, 51, 23, 161, 250, 105, 125, 177, 169, 168, 97,
+            5, 0, 231, 143, 141, 22, 92, 143, 148, 95, 66, 151, 154, 55, 169, 0, 91, 107, 5, 59,
+            252, 8, 140, 0, 195, 64, 135, 197, 226, 235, 170, 127, 176, 217, 7, 180, 235, 222, 58,
+            195, 221, 192, 130, 86, 143, 0, 199, 225, 53, 57, 181, 151, 152, 81, 183, 252, 251, 5,
+            124, 61, 164, 133, 169, 14, 20, 206, 36, 56, 1, 197, 214, 23, 10, 32, 223, 128, 87,
+            166, 33, 61, 29, 190, 90, 150, 82, 121, 109, 255, 211, 79, 46, 57, 48, 213, 125, 8, 93,
+            10, 151, 162, 137, 133, 129, 237, 101, 77, 39, 85, 94, 234, 43, 85, 101, 240, 233, 93,
+            57, 171, 13, 18, 38, 31, 29, 41, 169, 193, 49, 108, 119, 231, 130, 97, 45, 35, 252,
+            149, 125, 116, 64, 163, 70, 40, 143, 160, 14, 15, 91, 168, 207, 77, 40, 74, 208, 114,
+            50, 64, 119, 216, 182, 96, 218, 0, 185, 69, 105, 194, 103, 19, 129, 33, 204, 250, 237,
+            191, 143, 122, 56, 234, 62, 8, 224, 1, 242, 110, 10, 194, 178, 198, 220, 151, 167, 234,
+            235, 207, 148, 93, 249, 221, 153, 15, 86, 89, 76, 49, 29, 18, 74, 0, 246, 42, 143, 89,
+            60, 48, 96, 23, 173, 209, 213, 156, 80, 154, 159, 161, 12, 178, 225, 226, 77, 99, 249,
+            154, 246, 110, 96, 176, 79, 90, 2, 190, 63, 189, 123, 170, 206, 119, 142, 138, 15, 93,
+            191, 230, 100, 159, 142, 50, 119, 204, 157, 201, 230, 93, 57, 3, 125, 96, 195, 247,
+            195, 76, 24, 176, 99, 88, 206, 86, 63, 204, 37, 173, 182, 116, 51, 240, 15, 155, 199,
+            199, 198, 183, 44, 241, 251, 236, 35, 178, 36, 8, 107, 82, 153, 144, 28, 29, 229, 150,
+            157, 37, 216, 96, 116,
         ];
 
         let g1_va = 0x100000000;
@@ -6403,8 +6695,8 @@ mod tests {
     }
 
     #[test]
-    fn test_syscall_bls12_381_decompress() {
-        use crate::bls12_381_curve_id::BLS12_381_G1_BE;
+    fn test_syscall_bls12_381_pairing_le() {
+        use crate::bls12_381_curve_id::BLS12_381_LE;
 
         let config = Config::default();
         let feature_set = SVMFeatureSet {
@@ -6415,12 +6707,113 @@ mod tests {
 
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set,);
 
-        let compressed: [u8; 48] = [
+        let g1_bytes: [u8; 96] = [
+            35, 204, 210, 14, 243, 251, 68, 127, 25, 203, 200, 133, 109, 90, 249, 87, 65, 75, 36,
+            153, 119, 189, 6, 34, 238, 133, 8, 105, 133, 50, 249, 43, 64, 127, 11, 108, 38, 42,
+            113, 15, 50, 16, 116, 242, 54, 104, 161, 3, 164, 23, 80, 10, 184, 3, 200, 210, 200,
+            232, 230, 77, 220, 6, 100, 235, 11, 58, 141, 219, 213, 204, 111, 27, 45, 147, 251, 67,
+            76, 9, 102, 7, 100, 144, 146, 5, 163, 192, 154, 253, 230, 57, 178, 68, 5, 149, 124, 18,
+        ];
+        let g2_bytes: [u8; 192] = [
+            197, 199, 111, 212, 19, 110, 148, 212, 82, 91, 185, 255, 103, 103, 249, 255, 73, 151,
+            118, 220, 73, 238, 189, 46, 236, 126, 101, 227, 156, 207, 202, 88, 181, 106, 14, 118,
+            199, 100, 200, 216, 243, 94, 44, 7, 225, 197, 135, 14, 86, 158, 11, 246, 203, 171, 107,
+            210, 164, 27, 161, 249, 178, 34, 185, 169, 51, 175, 9, 226, 95, 150, 181, 179, 12, 64,
+            158, 164, 181, 184, 76, 32, 205, 50, 119, 188, 155, 132, 60, 153, 185, 250, 125, 232,
+            154, 218, 249, 8, 6, 30, 173, 51, 25, 121, 70, 141, 24, 223, 232, 240, 166, 82, 24, 32,
+            177, 217, 230, 89, 41, 52, 175, 58, 33, 213, 202, 53, 251, 124, 71, 181, 171, 176, 57,
+            252, 39, 171, 19, 15, 81, 215, 98, 184, 129, 105, 239, 1, 43, 74, 6, 182, 65, 27, 37,
+            2, 205, 172, 75, 35, 50, 227, 232, 22, 25, 2, 62, 19, 120, 36, 11, 40, 73, 193, 60,
+            171, 113, 81, 149, 44, 212, 57, 62, 209, 243, 48, 85, 85, 252, 205, 142, 196, 145, 25,
+            144, 4,
+        ];
+        let expected_gt: [u8; 576] = [
+            116, 96, 216, 37, 157, 150, 229, 29, 28, 144, 153, 82, 107, 8, 36, 178, 35, 236, 251,
+            241, 44, 183, 198, 199, 199, 155, 15, 240, 51, 116, 182, 173, 37, 204, 63, 86, 206, 88,
+            99, 176, 24, 76, 195, 247, 195, 96, 125, 3, 57, 93, 230, 201, 157, 204, 119, 50, 142,
+            159, 100, 230, 191, 93, 15, 138, 142, 119, 206, 170, 123, 189, 63, 190, 2, 90, 79, 176,
+            96, 110, 246, 154, 249, 99, 77, 226, 225, 178, 12, 161, 159, 154, 80, 156, 213, 209,
+            173, 23, 96, 48, 60, 89, 143, 42, 246, 0, 74, 18, 29, 49, 76, 89, 86, 15, 153, 221,
+            249, 93, 148, 207, 235, 234, 167, 151, 220, 198, 178, 194, 10, 110, 242, 1, 224, 8, 62,
+            234, 56, 122, 143, 191, 237, 250, 204, 33, 129, 19, 103, 194, 105, 69, 185, 0, 218, 96,
+            182, 216, 119, 64, 50, 114, 208, 74, 40, 77, 207, 168, 91, 15, 14, 160, 143, 40, 70,
+            163, 64, 116, 125, 149, 252, 35, 45, 97, 130, 231, 119, 108, 49, 193, 169, 41, 29, 31,
+            38, 18, 13, 171, 57, 93, 233, 240, 101, 85, 43, 234, 94, 85, 39, 77, 101, 237, 129,
+            133, 137, 162, 151, 10, 93, 8, 125, 213, 48, 57, 46, 79, 211, 255, 109, 121, 82, 150,
+            90, 190, 29, 61, 33, 166, 87, 128, 223, 32, 10, 23, 214, 197, 1, 56, 36, 206, 20, 14,
+            169, 133, 164, 61, 124, 5, 251, 252, 183, 81, 152, 151, 181, 57, 53, 225, 199, 0, 143,
+            86, 130, 192, 221, 195, 58, 222, 235, 180, 7, 217, 176, 127, 170, 235, 226, 197, 135,
+            64, 195, 0, 140, 8, 252, 59, 5, 107, 91, 0, 169, 55, 154, 151, 66, 95, 148, 143, 92,
+            22, 141, 143, 231, 0, 5, 97, 168, 169, 177, 125, 105, 250, 161, 23, 51, 120, 28, 95,
+            125, 229, 167, 8, 198, 86, 138, 106, 146, 161, 38, 15, 232, 243, 10, 22, 61, 139, 204,
+            0, 130, 135, 46, 237, 120, 145, 203, 70, 167, 122, 118, 167, 144, 153, 49, 213, 163,
+            196, 140, 156, 172, 229, 230, 124, 50, 162, 238, 190, 231, 242, 97, 75, 135, 58, 222,
+            196, 124, 183, 47, 19, 242, 34, 168, 222, 9, 116, 214, 8, 155, 57, 216, 4, 130, 62,
+            115, 166, 120, 164, 180, 22, 215, 49, 9, 39, 136, 122, 31, 238, 112, 152, 247, 244,
+            103, 249, 62, 144, 190, 217, 137, 87, 59, 59, 12, 118, 117, 249, 156, 11, 220, 115, 29,
+            242, 172, 210, 40, 211, 68, 91, 137, 216, 42, 78, 172, 24, 44, 111, 213, 6, 101, 221,
+            124, 76, 98, 49, 160, 199, 159, 31, 226, 124, 125, 100, 4, 174, 86, 95, 2, 76, 11, 147,
+            60, 223, 157, 109, 168, 0, 1, 103, 16, 20, 161, 204, 247, 249, 58, 225, 221, 171, 42,
+            39, 47, 64, 52, 210, 33, 120, 134, 119, 231, 14, 164, 15, 217, 215, 68, 40, 227, 245,
+            147, 228, 10, 184, 57, 43, 184, 225, 105, 180, 219, 105, 225, 232, 31, 13, 41, 75, 246,
+            133, 130, 93, 234, 112, 249, 197, 228, 54, 126, 68, 122, 229, 232, 36, 251, 35, 192, 2,
+            130, 143, 72, 120, 71, 63, 76, 83, 246, 247, 184, 195, 27, 19, 155, 7, 179, 163, 194,
+            58, 229, 118, 128, 164, 57, 14,
+        ];
+
+        let g1_va = 0x100000000;
+        let g2_va = 0x200000000;
+        let result_va = 0x300000000;
+
+        let mut result_buf = [0u8; 576]; // GT size
+
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&g1_bytes, g1_va),
+                MemoryRegion::new_readonly(&g2_bytes, g2_va),
+                MemoryRegion::new_writable(&mut result_buf, result_va),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let bls12_381_one_pair_cost = invoke_context.get_execution_cost().bls12_381_one_pair_cost;
+        invoke_context.mock_set_remaining(bls12_381_one_pair_cost);
+
+        let result = SyscallCurvePairingMap::rust(
+            &mut invoke_context,
+            BLS12_381_LE,
+            1,
+            g1_va,
+            g2_va,
+            result_va,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        assert_eq!(result_buf, expected_gt);
+    }
+
+    #[test]
+    fn test_syscall_bls12_381_decompress_g1() {
+        use crate::bls12_381_curve_id::{BLS12_381_G1_BE, BLS12_381_G1_LE};
+
+        let config = Config::default();
+        let feature_set = SVMFeatureSet {
+            enable_bls12_381_syscall: true,
+            ..Default::default()
+        };
+        let feature_set = &feature_set;
+
+        prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set,);
+
+        let compressed_be: [u8; 48] = [
             175, 159, 245, 68, 142, 96, 188, 154, 113, 143, 70, 58, 193, 2, 189, 111, 135, 114,
             230, 70, 12, 25, 7, 106, 108, 137, 213, 128, 110, 90, 142, 244, 75, 111, 59, 138, 240,
             158, 55, 164, 229, 100, 152, 122, 38, 185, 222, 218,
         ];
-        let expected_affine: [u8; 96] = [
+        let expected_affine_be: [u8; 96] = [
             15, 159, 245, 68, 142, 96, 188, 154, 113, 143, 70, 58, 193, 2, 189, 111, 135, 114, 230,
             70, 12, 25, 7, 106, 108, 137, 213, 128, 110, 90, 142, 244, 75, 111, 59, 138, 240, 158,
             55, 164, 229, 100, 152, 122, 38, 185, 222, 218, 18, 79, 1, 246, 62, 35, 162, 234, 146,
@@ -6428,15 +6821,33 @@ mod tests {
             168, 51, 41, 200, 58, 4, 107, 95, 246, 171, 241, 202, 120, 228, 135, 135, 100, 50, 123,
             58,
         ];
+        let compressed_le: [u8; 48] = [
+            218, 222, 185, 38, 122, 152, 100, 229, 164, 55, 158, 240, 138, 59, 111, 75, 244, 142,
+            90, 110, 128, 213, 137, 108, 106, 7, 25, 12, 70, 230, 114, 135, 111, 189, 2, 193, 58,
+            70, 143, 113, 154, 188, 96, 142, 68, 245, 159, 175,
+        ];
+        let expected_affine_le: [u8; 96] = [
+            218, 222, 185, 38, 122, 152, 100, 229, 164, 55, 158, 240, 138, 59, 111, 75, 244, 142,
+            90, 110, 128, 213, 137, 108, 106, 7, 25, 12, 70, 230, 114, 135, 111, 189, 2, 193, 58,
+            70, 143, 113, 154, 188, 96, 142, 68, 245, 159, 15, 58, 123, 50, 100, 135, 135, 228,
+            120, 202, 241, 171, 246, 95, 107, 4, 58, 200, 41, 51, 168, 237, 160, 79, 184, 53, 27,
+            193, 117, 244, 181, 31, 158, 250, 10, 104, 44, 85, 7, 109, 146, 234, 162, 35, 62, 246,
+            1, 79, 18,
+        ];
 
-        let input_va = 0x100000000;
-        let result_va = 0x200000000;
-        let mut result_buf = [0u8; 96];
+        let input_be_va = 0x100000000;
+        let result_be_va = 0x200000000;
+        let input_le_va = 0x300000000;
+        let result_le_va = 0x400000000;
+        let mut result_be_buf = [0u8; 96];
+        let mut result_le_buf = [0u8; 96];
 
         let mut memory_mapping = MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&compressed, input_va),
-                MemoryRegion::new_writable(&mut result_buf, result_va),
+                MemoryRegion::new_readonly(&compressed_be, input_be_va),
+                MemoryRegion::new_writable(&mut result_be_buf, result_be_va),
+                MemoryRegion::new_readonly(&compressed_le, input_le_va),
+                MemoryRegion::new_writable(&mut result_le_buf, result_le_va),
             ],
             &config,
             SBPFVersion::V3,
@@ -6446,25 +6857,38 @@ mod tests {
         let bls12_381_g2_decompress_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g2_decompress_cost;
-        invoke_context.mock_set_remaining(bls12_381_g2_decompress_cost);
+        invoke_context.mock_set_remaining(2 * bls12_381_g2_decompress_cost);
 
         let result = SyscallCurveDecompress::rust(
             &mut invoke_context,
             BLS12_381_G1_BE,
-            input_va,
-            result_va,
+            input_be_va,
+            result_be_va,
             0,
             0,
             &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
-        assert_eq!(result_buf, expected_affine);
+        assert_eq!(result_be_buf, expected_affine_be);
+
+        let result = SyscallCurveDecompress::rust(
+            &mut invoke_context,
+            BLS12_381_G1_LE,
+            input_le_va,
+            result_le_va,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        assert_eq!(result_le_buf, expected_affine_le);
     }
 
     #[test]
-    fn test_syscall_bls12_381_validate() {
-        use crate::bls12_381_curve_id::BLS12_381_G1_BE;
+    fn test_syscall_bls12_381_decompress_g2() {
+        use crate::bls12_381_curve_id::{BLS12_381_G2_BE, BLS12_381_G2_LE};
 
         let config = Config::default();
         let feature_set = SVMFeatureSet {
@@ -6475,17 +6899,137 @@ mod tests {
 
         prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set,);
 
-        let point_bytes: [u8; 96] = [
+        let compressed_be: [u8; 96] = [
+            143, 106, 18, 220, 40, 152, 4, 228, 139, 35, 104, 146, 179, 74, 205, 172, 146, 137, 11,
+            106, 74, 42, 135, 137, 53, 249, 64, 251, 173, 232, 48, 209, 125, 222, 13, 209, 121,
+            238, 185, 179, 111, 105, 71, 223, 39, 48, 195, 104, 23, 24, 170, 59, 111, 106, 167, 51,
+            231, 186, 224, 182, 172, 73, 15, 18, 211, 143, 59, 2, 115, 190, 196, 163, 111, 11, 36,
+            133, 86, 96, 188, 135, 16, 37, 216, 175, 71, 182, 222, 31, 207, 155, 16, 255, 112, 78,
+            242, 111,
+        ];
+        let expected_affine_be: [u8; 192] = [
+            15, 106, 18, 220, 40, 152, 4, 228, 139, 35, 104, 146, 179, 74, 205, 172, 146, 137, 11,
+            106, 74, 42, 135, 137, 53, 249, 64, 251, 173, 232, 48, 209, 125, 222, 13, 209, 121,
+            238, 185, 179, 111, 105, 71, 223, 39, 48, 195, 104, 23, 24, 170, 59, 111, 106, 167, 51,
+            231, 186, 224, 182, 172, 73, 15, 18, 211, 143, 59, 2, 115, 190, 196, 163, 111, 11, 36,
+            133, 86, 96, 188, 135, 16, 37, 216, 175, 71, 182, 222, 31, 207, 155, 16, 255, 112, 78,
+            242, 111, 11, 217, 244, 83, 201, 111, 182, 168, 171, 205, 183, 118, 199, 85, 130, 157,
+            95, 69, 159, 126, 122, 27, 92, 84, 253, 147, 96, 176, 74, 57, 13, 228, 178, 111, 246,
+            157, 74, 120, 174, 255, 146, 92, 32, 214, 164, 56, 206, 144, 13, 59, 111, 251, 170, 85,
+            159, 219, 108, 187, 31, 15, 106, 176, 64, 191, 56, 77, 217, 87, 144, 196, 148, 21, 12,
+            171, 99, 121, 128, 120, 187, 224, 192, 107, 104, 178, 75, 205, 118, 64, 234, 168, 214,
+            11, 125, 153, 55, 5,
+        ];
+        let compressed_le: [u8; 96] = [
+            111, 242, 78, 112, 255, 16, 155, 207, 31, 222, 182, 71, 175, 216, 37, 16, 135, 188, 96,
+            86, 133, 36, 11, 111, 163, 196, 190, 115, 2, 59, 143, 211, 18, 15, 73, 172, 182, 224,
+            186, 231, 51, 167, 106, 111, 59, 170, 24, 23, 104, 195, 48, 39, 223, 71, 105, 111, 179,
+            185, 238, 121, 209, 13, 222, 125, 209, 48, 232, 173, 251, 64, 249, 53, 137, 135, 42,
+            74, 106, 11, 137, 146, 172, 205, 74, 179, 146, 104, 35, 139, 228, 4, 152, 40, 220, 18,
+            106, 143,
+        ];
+        let expected_affine_le: [u8; 192] = [
+            111, 242, 78, 112, 255, 16, 155, 207, 31, 222, 182, 71, 175, 216, 37, 16, 135, 188, 96,
+            86, 133, 36, 11, 111, 163, 196, 190, 115, 2, 59, 143, 211, 18, 15, 73, 172, 182, 224,
+            186, 231, 51, 167, 106, 111, 59, 170, 24, 23, 104, 195, 48, 39, 223, 71, 105, 111, 179,
+            185, 238, 121, 209, 13, 222, 125, 209, 48, 232, 173, 251, 64, 249, 53, 137, 135, 42,
+            74, 106, 11, 137, 146, 172, 205, 74, 179, 146, 104, 35, 139, 228, 4, 152, 40, 220, 18,
+            106, 15, 5, 55, 153, 125, 11, 214, 168, 234, 64, 118, 205, 75, 178, 104, 107, 192, 224,
+            187, 120, 128, 121, 99, 171, 12, 21, 148, 196, 144, 87, 217, 77, 56, 191, 64, 176, 106,
+            15, 31, 187, 108, 219, 159, 85, 170, 251, 111, 59, 13, 144, 206, 56, 164, 214, 32, 92,
+            146, 255, 174, 120, 74, 157, 246, 111, 178, 228, 13, 57, 74, 176, 96, 147, 253, 84, 92,
+            27, 122, 126, 159, 69, 95, 157, 130, 85, 199, 118, 183, 205, 171, 168, 182, 111, 201,
+            83, 244, 217, 11,
+        ];
+
+        let input_be_va = 0x100000000;
+        let result_be_va = 0x200000000;
+        let input_le_va = 0x300000000;
+        let result_le_va = 0x400000000;
+        let mut result_be_buf = [0u8; 192];
+        let mut result_le_buf = [0u8; 192];
+
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&compressed_be, input_be_va),
+                MemoryRegion::new_writable(&mut result_be_buf, result_be_va),
+                MemoryRegion::new_readonly(&compressed_le, input_le_va),
+                MemoryRegion::new_writable(&mut result_le_buf, result_le_va),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let bls12_381_g2_decompress_cost = invoke_context
+            .get_execution_cost()
+            .bls12_381_g2_decompress_cost;
+        invoke_context.mock_set_remaining(2 * bls12_381_g2_decompress_cost);
+
+        let result = SyscallCurveDecompress::rust(
+            &mut invoke_context,
+            BLS12_381_G2_BE,
+            input_be_va,
+            result_be_va,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        assert_eq!(result_be_buf, expected_affine_be);
+
+        let result = SyscallCurveDecompress::rust(
+            &mut invoke_context,
+            BLS12_381_G2_LE,
+            input_le_va,
+            result_le_va,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+        assert_eq!(result_le_buf, expected_affine_le);
+    }
+
+    #[test]
+    fn test_syscall_bls12_381_validate_g1() {
+        use crate::bls12_381_curve_id::{BLS12_381_G1_BE, BLS12_381_G1_LE};
+
+        let config = Config::default();
+        let feature_set = SVMFeatureSet {
+            enable_bls12_381_syscall: true,
+            ..Default::default()
+        };
+        let feature_set = &feature_set;
+
+        prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set,);
+
+        let point_bytes_be: [u8; 96] = [
             22, 163, 250, 67, 197, 168, 103, 201, 128, 33, 170, 96, 74, 40, 45, 90, 105, 181, 244,
             124, 128, 107, 27, 142, 158, 96, 0, 46, 144, 27, 61, 205, 65, 38, 141, 165, 55, 113,
             114, 23, 36, 105, 252, 115, 147, 16, 12, 39, 11, 19, 53, 215, 107, 128, 94, 68, 22, 46,
             74, 179, 236, 232, 220, 30, 48, 169, 85, 16, 70, 112, 26, 37, 73, 104, 203, 189, 42,
             96, 141, 90, 167, 41, 61, 82, 184, 80, 93, 112, 204, 140, 225, 245, 103, 130, 184, 194,
         ];
-        let point_va = 0x100000000;
+
+        let point_bytes_le: [u8; 96] = [
+            39, 12, 16, 147, 115, 252, 105, 36, 23, 114, 113, 55, 165, 141, 38, 65, 205, 61, 27,
+            144, 46, 0, 96, 158, 142, 27, 107, 128, 124, 244, 181, 105, 90, 45, 40, 74, 96, 170,
+            33, 128, 201, 103, 168, 197, 67, 250, 163, 22, 194, 184, 130, 103, 245, 225, 140, 204,
+            112, 93, 80, 184, 82, 61, 41, 167, 90, 141, 96, 42, 189, 203, 104, 73, 37, 26, 112, 70,
+            16, 85, 169, 48, 30, 220, 232, 236, 179, 74, 46, 22, 68, 94, 128, 107, 215, 53, 19, 11,
+        ];
+
+        let point_be_va = 0x100000000;
+        let point_le_va = 0x200000000;
 
         let mut memory_mapping = MemoryMapping::new(
-            vec![MemoryRegion::new_readonly(&point_bytes, point_va)],
+            vec![
+                MemoryRegion::new_readonly(&point_bytes_be, point_be_va),
+                MemoryRegion::new_readonly(&point_bytes_le, point_le_va),
+            ],
             &config,
             SBPFVersion::V3,
         )
@@ -6494,12 +7038,108 @@ mod tests {
         let bls12_381_g2_validate_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g2_validate_cost;
-        invoke_context.mock_set_remaining(bls12_381_g2_validate_cost);
+        invoke_context.mock_set_remaining(2 * bls12_381_g2_validate_cost);
 
         let result = SyscallCurvePointValidation::rust(
             &mut invoke_context,
             BLS12_381_G1_BE,
-            point_va,
+            point_be_va,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+
+        let result = SyscallCurvePointValidation::rust(
+            &mut invoke_context,
+            BLS12_381_G1_LE,
+            point_le_va,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+    }
+
+    #[test]
+    fn test_syscall_bls12_381_validate_g2() {
+        use crate::bls12_381_curve_id::{BLS12_381_G2_BE, BLS12_381_G2_LE};
+
+        let config = Config::default();
+        let feature_set = SVMFeatureSet {
+            enable_bls12_381_syscall: true,
+            ..Default::default()
+        };
+        let feature_set = &feature_set;
+
+        prepare_mock_with_feature_set!(invoke_context, program_id, bpf_loader::id(), feature_set,);
+
+        let point_bytes_be: [u8; 192] = [
+            0, 79, 207, 115, 91, 72, 0, 80, 49, 59, 203, 189, 178, 240, 18, 141, 223, 147, 62, 79,
+            98, 131, 147, 33, 103, 151, 137, 12, 160, 13, 78, 180, 13, 221, 89, 239, 178, 249, 141,
+            8, 38, 137, 23, 71, 213, 2, 28, 13, 24, 168, 51, 6, 34, 184, 228, 22, 173, 11, 224,
+            168, 14, 103, 154, 18, 166, 51, 255, 154, 45, 230, 253, 149, 145, 16, 251, 107, 248,
+            55, 53, 150, 37, 131, 133, 138, 156, 195, 70, 202, 131, 144, 166, 164, 80, 251, 179,
+            167, 8, 54, 188, 153, 10, 235, 83, 14, 211, 95, 212, 54, 120, 175, 148, 83, 253, 106,
+            53, 178, 157, 118, 208, 110, 0, 187, 111, 14, 140, 246, 139, 200, 205, 178, 72, 36, 67,
+            140, 39, 100, 163, 104, 140, 78, 91, 123, 130, 197, 12, 176, 70, 104, 65, 43, 104, 232,
+            102, 238, 229, 115, 253, 62, 61, 207, 116, 223, 245, 206, 250, 163, 30, 200, 76, 101,
+            93, 69, 216, 240, 189, 198, 253, 27, 199, 32, 215, 224, 12, 50, 78, 204, 106, 40, 117,
+            68, 44, 113,
+        ];
+
+        let point_bytes_le: [u8; 192] = [
+            167, 179, 251, 80, 164, 166, 144, 131, 202, 70, 195, 156, 138, 133, 131, 37, 150, 53,
+            55, 248, 107, 251, 16, 145, 149, 253, 230, 45, 154, 255, 51, 166, 18, 154, 103, 14,
+            168, 224, 11, 173, 22, 228, 184, 34, 6, 51, 168, 24, 13, 28, 2, 213, 71, 23, 137, 38,
+            8, 141, 249, 178, 239, 89, 221, 13, 180, 78, 13, 160, 12, 137, 151, 103, 33, 147, 131,
+            98, 79, 62, 147, 223, 141, 18, 240, 178, 189, 203, 59, 49, 80, 0, 72, 91, 115, 207, 79,
+            0, 113, 44, 68, 117, 40, 106, 204, 78, 50, 12, 224, 215, 32, 199, 27, 253, 198, 189,
+            240, 216, 69, 93, 101, 76, 200, 30, 163, 250, 206, 245, 223, 116, 207, 61, 62, 253,
+            115, 229, 238, 102, 232, 104, 43, 65, 104, 70, 176, 12, 197, 130, 123, 91, 78, 140,
+            104, 163, 100, 39, 140, 67, 36, 72, 178, 205, 200, 139, 246, 140, 14, 111, 187, 0, 110,
+            208, 118, 157, 178, 53, 106, 253, 83, 148, 175, 120, 54, 212, 95, 211, 14, 83, 235, 10,
+            153, 188, 54, 8,
+        ];
+
+        let point_be_va = 0x100000000;
+        let point_le_va = 0x200000000;
+
+        let mut memory_mapping = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&point_bytes_be, point_be_va),
+                MemoryRegion::new_readonly(&point_bytes_le, point_le_va),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+
+        let bls12_381_g2_validate_cost = invoke_context
+            .get_execution_cost()
+            .bls12_381_g2_validate_cost;
+        invoke_context.mock_set_remaining(2 * bls12_381_g2_validate_cost);
+
+        let result = SyscallCurvePointValidation::rust(
+            &mut invoke_context,
+            BLS12_381_G2_BE,
+            point_be_va,
+            0,
+            0,
+            0,
+            &mut memory_mapping,
+        );
+
+        assert_eq!(0, result.unwrap());
+
+        let result = SyscallCurvePointValidation::rust(
+            &mut invoke_context,
+            BLS12_381_G2_LE,
+            point_le_va,
             0,
             0,
             0,

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -309,6 +309,7 @@ pub fn create_program_runtime_environment_v1<'a, 'ix_data>(
     let enable_big_mod_exp_syscall = feature_set.enable_big_mod_exp_syscall;
     let blake3_syscall_enabled = feature_set.blake3_syscall_enabled;
     let curve25519_syscall_enabled = feature_set.curve25519_syscall_enabled;
+    let enable_bls12_381_syscall = feature_set.enable_bls12_381_syscall;
     let disable_fees_sysvar = feature_set.disable_fees_sysvar;
     let disable_deploy_of_alloc_free_syscall =
         reject_deployment_of_broken_elfs && feature_set.disable_deploy_of_alloc_free_syscall;
@@ -419,13 +420,13 @@ pub fn create_program_runtime_environment_v1<'a, 'ix_data>(
     )?;
     register_feature_gated_function!(
         result,
-        enable_alt_bn128_syscall,
+        enable_bls12_381_syscall,
         "sol_curve_decompress",
         SyscallCurveDecompress::vm,
     )?;
     register_feature_gated_function!(
         result,
-        enable_alt_bn128_syscall,
+        enable_bls12_381_syscall,
         "sol_curve_pairing_map",
         SyscallCurvePairingMap::vm,
     )?;


### PR DESCRIPTION
#### Summary of Changes

Adding the `bls12-381` syscalls as specified in [simd-388](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0388-bls12-381-syscalls.md).

The actual syscall functions have been added in the `agave-bls12-381` crate (https://github.com/anza-xyz/agave/pull/9759). This PR just binds the functions contained in the `agave-bls12-381` crate to the appropriate syscalls.

This PR achieves the following:
- add the `enable-bls12-381-syscall` feature
- assign compute units for all the bls12-381 syscall functions
- update the `solana-syscall` crate to bind the syscall functions
- add tests in `solana-syscall`

This seems like a big PR, but the majority of the lines added are tests and the actual logic changes are not that large.

Would be really great to get this in for agave v4.0

##### Compute Units

I benchmarked the functions on my x86 dev box, which get pretty consistent numbers for the ed25519 precompile CUs and also curve25519 syscalls. I am getting the following numbers:

```
G1 Operations/Addition/BE
                        time:   [4.2066 µs 4.2085 µs 4.2103 µs]
                        change: [−0.0227% +0.0166% +0.0552%] (p = 0.43 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
G1 Operations/Subtraction/BE
                        time:   [4.2114 µs 4.2125 µs 4.2136 µs]
                        change: [−0.1315% −0.0919% −0.0499%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
G1 Operations/Multiplication/BE
                        time:   [152.52 µs 152.55 µs 152.59 µs]
                        change: [−0.1074% −0.0710% −0.0349%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
G1 Operations/Decompression/BE
                        time:   [69.169 µs 69.203 µs 69.239 µs]
                        change: [+0.0070% +0.0684% +0.1316%] (p = 0.03 < 0.05)
                        Change within noise threshold.
G1 Operations/Validation/BE
                        time:   [51.623 µs 51.648 µs 51.673 µs]
                        change: [+0.0769% +0.1304% +0.1874%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

G2 Operations/Addition/BE
                        time:   [6.6765 µs 6.6801 µs 6.6839 µs]
                        change: [+0.7319% +0.8000% +0.8677%] (p = 0.00 < 0.05)
                        Change within noise threshold.
G2 Operations/Subtraction/BE
                        time:   [6.6496 µs 6.6542 µs 6.6588 µs]
                        change: [+0.0136% +0.1388% +0.2334%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
G2 Operations/Multiplication/BE
                        time:   [272.66 µs 272.77 µs 272.90 µs]
                        change: [+0.0833% +0.1156% +0.1475%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 17 outliers among 100 measurements (17.00%)
  12 (12.00%) high mild
  5 (5.00%) high severe
G2 Operations/Decompression/BE
                        time:   [100.79 µs 100.84 µs 100.88 µs]
                        change: [+0.1665% +0.2156% +0.2773%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
G2 Operations/Validation/BE
                        time:   [64.936 µs 64.980 µs 65.019 µs]
                        change: [−0.0841% −0.0253% +0.0316%] (p = 0.37 > 0.05)
                        No change in performance detected.

Pairing/BE/1            time:   [838.16 µs 838.31 µs 838.48 µs]
                        change: [−0.0777% −0.0468% −0.0180%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
Pairing/BE/2            time:   [1.2675 ms 1.2677 ms 1.2678 ms]
                        change: [−0.0528% −0.0351% −0.0157%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
Pairing/BE/4            time:   [2.1263 ms 2.1265 ms 2.1267 ms]
                        change: [−0.1650% −0.1274% −0.0924%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
Pairing/BE/8            time:   [3.8427 ms 3.8434 ms 3.8442 ms]
                        change: [−0.0724% −0.0484% −0.0248%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
```

I took these numbers and divided them by ~33ns to get the approximate CUs for each of these operations.

##### `solana-syscall`

- The `sol_curve_validate_point` and `sol_curve_group_op` syscalls were extended to support the bls12-381 inputs
- The `sol_curve_decompress` and `sol_curve_pairing_map` syscalls were added for the first time with bls12-381 support

Elliptic curve syscalls require a curve ID to determine which curve to use for input interpretation. Currently, the curve25519 IDs live in solana-curve25519, but I believe the most natural home for them is solana-define-syscall. To expedite shipping SIMD, I have temporarily placed the bls12-381 curve ID in agave-syscalls. I will refactor both sets of IDs into solana-define-syscall (or a dedicated crate) in a follow-up.

##### Tests

The majority of the lines added in this PR are tests in the `agave-syscalls` crate. The `agave-bls12-381` crate doesn't run on sbf target and we don't yet have an sdk crate that invoke the functions in `agave-bls12-381` in the sbf target, so I didn't add the tests in `programs/sbf/rust` as was done for the `alt_bn128` syscalls. Instead, I added the tests directly in the `agave-syscalls` crate.