### PR TITLE
ledger-tool: use feature set to choose vote state

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -82,7 +82,7 @@ use {
     solana_vote::vote_state_view::VoteStateView,
     solana_vote_program::{
         self,
-        vote_state::{self, VoteStateV4},
+        vote_state::{self, VoteStateV3, VoteStateV4},
     },
     std::{
         collections::{HashMap, HashSet},
@@ -2390,14 +2390,27 @@ fn main() {
                                 ),
                             );
 
-                            let vote_account = vote_state::create_v4_account_with_authorized(
-                                identity_pubkey,
-                                identity_pubkey,
-                                identity_pubkey,
-                                None,
-                                10000,
-                                rent.minimum_balance(VoteStateV4::size_of()).max(1),
-                            );
+                            let vote_account = if bank
+                                .feature_set
+                                .is_active(&feature_set::vote_state_v4::id())
+                            {
+                                vote_state::create_v4_account_with_authorized(
+                                    identity_pubkey,
+                                    identity_pubkey,
+                                    identity_pubkey,
+                                    None,
+                                    10000,
+                                    rent.minimum_balance(VoteStateV4::size_of()).max(1),
+                                )
+                            } else {
+                                vote_state::create_v3_account_with_authorized(
+                                    identity_pubkey,
+                                    identity_pubkey,
+                                    identity_pubkey,
+                                    100,
+                                    rent.minimum_balance(VoteStateV3::size_of()).max(1),
+                                )
+                            };
 
                             bank.store_account(
                                 stake_pubkey,


### PR DESCRIPTION
#### Problem
Similar to #9467, we need to only create vote accounts with vote state v4 if the feature is active. When it's not active, we should still be creating v3 vote accounts, since the program won't process v4 accounts without the feature active.

`agave-ledger-tool` always creates a v4 vote account when creating a snapshot (`create-snapshot` command). Instead it should query the feature status on the bank.

#### Summary of Changes
Query the `vote_state_v4` feature status in `agave-ledger-tool` `create-snapshot` command to determine which vote state to use.