### PR TITLE
solana-test-validator: Use jemallocator

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -43,6 +43,10 @@ use {
     },
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 #[derive(PartialEq, Eq)]
 enum Output {
     None,


### PR DESCRIPTION
Agave is absurdly slow when using glibc allocator. Even though test validator should not be treated as a direct indicator of performance, it should still be fast enough for people to play with it.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
