### PR TITLE
solana-test-validator: Use `release-with-debug` profile, include frame pointers

### DIFF
--- a/validator/solana-test-validator
+++ b/validator/solana-test-validator
@@ -2,4 +2,12 @@
 
 here="$(dirname "$0")"
 set -x
-exec cargo run --manifest-path="$here"/Cargo.toml --bin solana-test-validator -- "$@"
+
+export RUSTFLAGS="-C force-frame-pointers=yes -C target-cpu=native"
+export CFLAGS="-g -fno-omit-frame-pointer"
+export CXXFLAGS="-g -fno-omit-frame-pointer"
+
+exec cargo run --manifest-path="$here"/Cargo.toml \
+  --bin solana-test-validator \
+  --profile release-with-debug \
+  -- "$@"


### PR DESCRIPTION
#### Problem

Running solana-test-validator with debug profile affects the performance poorly, making it unusable.

#### Summary of Changes

Use `release-with-debug` profile, so the test validator can be still debugged. Add frame pointers, so it can be also profiled.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
