### PR TITLE
[syscalls] Fix feature gate logic for alt_bn128 LE ops

### DIFF
--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1586,6 +1586,18 @@ declare_builtin_function!(
             ALT_BN128_PAIRING_LE
         };
 
+        // SIMD-0284: Block LE ops if the feature is not active.
+        if !invoke_context.get_feature_set().alt_bn128_little_endian &&
+            matches!(
+                group_op,
+                ALT_BN128_G1_ADD_LE
+                    | ALT_BN128_G1_MUL_LE
+                    | ALT_BN128_PAIRING_LE
+            )
+        {
+            return Err(SyscallError::InvalidAttribute.into());
+        }
+
         let execution_cost = invoke_context.get_execution_cost();
         let (cost, output): (u64, usize) = match group_op {
             ALT_BN128_G1_ADD_BE | ALT_BN128_G1_ADD_LE => (
@@ -1636,11 +1648,7 @@ declare_builtin_function!(
                 alt_bn128_versioned_g1_addition(VersionedG1Addition::V0, input, Endianness::BE)
             }
             ALT_BN128_G1_ADD_LE => {
-                if invoke_context.get_feature_set().alt_bn128_little_endian {
-                    alt_bn128_versioned_g1_addition(VersionedG1Addition::V0, input, Endianness::LE)
-                } else {
-                    return Err(SyscallError::InvalidAttribute.into());
-                }
+                alt_bn128_versioned_g1_addition(VersionedG1Addition::V0, input, Endianness::LE)
             }
             ALT_BN128_G1_MUL_BE => {
                 alt_bn128_versioned_g1_multiplication(
@@ -1650,15 +1658,11 @@ declare_builtin_function!(
                 )
             }
             ALT_BN128_G1_MUL_LE => {
-                if invoke_context.get_feature_set().alt_bn128_little_endian {
-                    alt_bn128_versioned_g1_multiplication(
-                        VersionedG1Multiplication::V1,
-                        input,
-                        Endianness::LE
-                    )
-                } else {
-                    return Err(SyscallError::InvalidAttribute.into());
-                }
+                alt_bn128_versioned_g1_multiplication(
+                    VersionedG1Multiplication::V1,
+                    input,
+                    Endianness::LE
+                )
             }
             ALT_BN128_PAIRING_BE => {
                 let version = if invoke_context
@@ -1671,11 +1675,7 @@ declare_builtin_function!(
                 alt_bn128_versioned_pairing(version, input, Endianness::BE)
             }
             ALT_BN128_PAIRING_LE => {
-                if invoke_context.get_feature_set().alt_bn128_little_endian {
-                    alt_bn128_versioned_pairing(VersionedPairing::V1, input, Endianness::LE)
-                } else {
-                    return Err(SyscallError::InvalidAttribute.into());
-                }
+                alt_bn128_versioned_pairing(VersionedPairing::V1, input, Endianness::LE)
             }
             _ => {
                 return Err(SyscallError::InvalidAttribute.into());
@@ -1881,6 +1881,20 @@ declare_builtin_function!(
                 ALT_BN128_G1_DECOMPRESS_LE, ALT_BN128_G2_DECOMPRESS_LE,
             }
         };
+
+        // SIMD-0284: Block LE ops if the feature is not active.
+        if !invoke_context.get_feature_set().alt_bn128_little_endian &&
+            matches!(
+                op,
+                ALT_BN128_G1_COMPRESS_LE
+                    | ALT_BN128_G2_COMPRESS_LE
+                    | ALT_BN128_G1_DECOMPRESS_LE
+                    | ALT_BN128_G2_DECOMPRESS_LE
+            )
+        {
+            return Err(SyscallError::InvalidAttribute.into());
+        }
+
         let execution_cost = invoke_context.get_execution_cost();
         let base_cost = execution_cost.syscall_base_cost;
         let (cost, output): (u64, usize) = match op {
@@ -1925,14 +1939,10 @@ declare_builtin_function!(
                 call_result.copy_from_slice(&result_point);
             }
             ALT_BN128_G1_COMPRESS_LE => {
-                if invoke_context.get_feature_set().alt_bn128_little_endian {
-                    let Ok(result_point) = alt_bn128_g1_compress_le(input) else {
-                        return Ok(1);
-                    };
-                    call_result.copy_from_slice(&result_point);
-                } else {
-                    return Err(SyscallError::InvalidAttribute.into());
-                }
+                let Ok(result_point) = alt_bn128_g1_compress_le(input) else {
+                    return Ok(1);
+                };
+                call_result.copy_from_slice(&result_point);
             }
             ALT_BN128_G1_DECOMPRESS_BE => {
                 let Ok(result_point) = alt_bn128_g1_decompress(input) else {
@@ -1941,14 +1951,10 @@ declare_builtin_function!(
                 call_result.copy_from_slice(&result_point);
             }
             ALT_BN128_G1_DECOMPRESS_LE => {
-                if invoke_context.get_feature_set().alt_bn128_little_endian {
-                    let Ok(result_point) = alt_bn128_g1_decompress_le(input) else {
-                        return Ok(1);
-                    };
-                    call_result.copy_from_slice(&result_point);
-                } else {
-                    return Err(SyscallError::InvalidAttribute.into());
-                }
+                let Ok(result_point) = alt_bn128_g1_decompress_le(input) else {
+                    return Ok(1);
+                };
+                call_result.copy_from_slice(&result_point);
             }
             ALT_BN128_G2_COMPRESS_BE => {
                 let Ok(result_point) = alt_bn128_g2_compress(input) else {
@@ -1957,14 +1963,10 @@ declare_builtin_function!(
                 call_result.copy_from_slice(&result_point);
             }
             ALT_BN128_G2_COMPRESS_LE => {
-                if invoke_context.get_feature_set().alt_bn128_little_endian {
-                    let Ok(result_point) = alt_bn128_g2_compress_le(input) else {
-                        return Ok(1);
-                    };
-                    call_result.copy_from_slice(&result_point);
-                } else {
-                    return Err(SyscallError::InvalidAttribute.into());
-                }
+                let Ok(result_point) = alt_bn128_g2_compress_le(input) else {
+                    return Ok(1);
+                };
+                call_result.copy_from_slice(&result_point);
             }
             ALT_BN128_G2_DECOMPRESS_BE => {
                 let Ok(result_point) = alt_bn128_g2_decompress(input) else {
@@ -1973,14 +1975,10 @@ declare_builtin_function!(
                 call_result.copy_from_slice(&result_point);
             }
             ALT_BN128_G2_DECOMPRESS_LE => {
-                if invoke_context.get_feature_set().alt_bn128_little_endian {
-                    let Ok(result_point) = alt_bn128_g2_decompress_le(input) else {
-                        return Ok(1);
-                    };
-                    call_result.copy_from_slice(&result_point);
-                } else {
-                    return Err(SyscallError::InvalidAttribute.into());
-                }
+                let Ok(result_point) = alt_bn128_g2_decompress_le(input) else {
+                    return Ok(1);
+                };
+                call_result.copy_from_slice(&result_point);
             }
             _ => return Err(SyscallError::InvalidAttribute.into()),
         }


### PR DESCRIPTION
#### Problem
#8771 added little-endian ops for alt_bn128, but introduced a bug that can break the consensus. Before this PR if the wrong group_op was provided (e.g. `ALT_BN128_G1_ADD_LE`) the code threw `SyscallError::InvalidAttribute.into())` [here](https://github.com/anza-xyz/agave/blob/74ee02a474f68ab621b6c7a7083b8ab1436b3cb3/syscalls/src/lib.rs#L1606). After 
the PR the match passes, and an error from `consume_compute_meter` can be returned [here](https://github.com/anza-xyz/agave/blob/0356684899aaa85a647dcc599090bfe92bddb91c/syscalls/src/lib.rs#L1611). 
The same applies to `SyscallAltBn128Compression`.

#### Summary of Changes
Fix the logic

Update: rekeyed in #10101
