### PR TITLE
feat(alpenglow): introducing `BlockComponent`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8504,6 +8504,7 @@ version = "4.0.0-alpha.0"
 dependencies = [
  "agave-logger",
  "agave-reserved-account-keys",
+ "agave-votor-messages",
  "assert_matches",
  "bincode",
  "crossbeam-channel",
@@ -8515,6 +8516,8 @@ dependencies = [
  "rayon",
  "serde",
  "solana-address 2.0.0",
+ "solana-bls-signatures",
+ "solana-clock",
  "solana-entry",
  "solana-hash 3.1.0",
  "solana-keypair",
@@ -8533,6 +8536,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-transaction",
  "solana-transaction-error",
+ "thiserror 2.0.17",
  "wincode",
 ]
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7179,6 +7179,7 @@ dependencies = [
 name = "solana-entry"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "agave-votor-messages",
  "bincode",
  "crossbeam-channel",
  "dlopen2",
@@ -7187,6 +7188,8 @@ dependencies = [
  "rayon",
  "serde",
  "solana-address 2.0.0",
+ "solana-bls-signatures",
+ "solana-clock",
  "solana-hash 3.1.0",
  "solana-measure",
  "solana-merkle-tree",
@@ -7200,6 +7203,7 @@ dependencies = [
  "solana-signature",
  "solana-transaction",
  "solana-transaction-error",
+ "thiserror 2.0.17",
  "wincode",
 ]
 

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -21,6 +21,7 @@ agave-unstable-api = []
 dev-context-only-utils = []
 
 [dependencies]
+agave-votor-messages = { workspace = true }
 bincode = { workspace = true }
 crossbeam-channel = { workspace = true }
 dlopen2 = { workspace = true }
@@ -29,6 +30,8 @@ num_cpus = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 solana-address = { workspace = true }
+solana-bls-signatures = { workspace = true }
+solana-clock = { workspace = true }
 solana-hash = { workspace = true }
 solana-measure = { workspace = true }
 solana-merkle-tree = { workspace = true }
@@ -42,6 +45,7 @@ solana-short-vec = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
+thiserror = { workspace = true }
 wincode = { workspace = true }
 
 [dev-dependencies]

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -1,0 +1,699 @@
+/// Block components using wincode serialization.
+///
+/// A `BlockComponent` represents either an entry batch or a special block marker.
+/// Most of the time, a block component contains a vector of entries. However, periodically,
+/// there are special messages that a block needs to contain. To accommodate these special
+/// messages, `BlockComponent` allows for the inclusion of special data via `VersionedBlockMarker`.
+///
+/// ## Serialization Layouts
+///
+/// All numeric fields use little-endian encoding.
+///
+/// ### BlockComponent with EntryBatch
+/// ```text
+/// ┌─────────────────────────────────────────┐
+/// │ Entry Count                  (8 bytes)  │
+/// ├─────────────────────────────────────────┤
+/// │ bincode Entry 0           (variable)    │
+/// ├─────────────────────────────────────────┤
+/// │ bincode Entry 1           (variable)    │
+/// ├─────────────────────────────────────────┤
+/// │ ...                                     │
+/// ├─────────────────────────────────────────┤
+/// │ bincode Entry N-1         (variable)    │
+/// └─────────────────────────────────────────┘
+/// ```
+///
+/// ### BlockComponent with BlockMarker
+/// ```text
+/// ┌─────────────────────────────────────────┐
+/// │ Entry Count = 0              (8 bytes)  │
+/// ├─────────────────────────────────────────┤
+/// │ Marker Version               (2 bytes)  │
+/// ├─────────────────────────────────────────┤
+/// │ Marker Data               (variable)    │
+/// └─────────────────────────────────────────┘
+/// ```
+///
+/// ### BlockMarkerV1 Layout
+/// ```text
+/// ┌─────────────────────────────────────────┐
+/// │ Variant ID                   (1 byte)   │
+/// ├─────────────────────────────────────────┤
+/// │ Byte Length                  (2 bytes)  │
+/// ├─────────────────────────────────────────┤
+/// │ Variant Data              (variable)    │
+/// └─────────────────────────────────────────┘
+/// ```
+///
+/// ### BlockHeaderV1 Layout
+/// ```text
+/// ┌─────────────────────────────────────────┐
+/// │ Parent Slot                  (8 bytes)  │
+/// ├─────────────────────────────────────────┤
+/// │ Parent Block ID             (32 bytes)  │
+/// └─────────────────────────────────────────┘
+/// ```
+///
+/// ### UpdateParentV1 Layout
+/// ```text
+/// ┌─────────────────────────────────────────┐
+/// │ Parent Slot                  (8 bytes)  │
+/// ├─────────────────────────────────────────┤
+/// │ Parent Block ID             (32 bytes)  │
+/// └─────────────────────────────────────────┘
+/// ```
+///
+/// ### BlockFooterV1 Layout
+/// ```text
+/// ┌─────────────────────────────────────────┐
+/// │ Bank Hash                   (32 bytes)  │
+/// ├─────────────────────────────────────────┤
+/// │ Producer Time Nanos          (8 bytes)  │
+/// ├─────────────────────────────────────────┤
+/// │ User Agent Length            (1 byte)   │
+/// ├─────────────────────────────────────────┤
+/// │ User Agent Bytes          (0-255 bytes) │
+/// ├─────────────────────────────────────────┤
+/// │ Final Cert Present           (1 byte)   │
+/// ├─────────────────────────────────────────┤
+/// │ FinalCertificate (if present, variable) │
+/// ├─────────────────────────────────────────┤
+/// │ Skip reward cert Present     (1 byte)   │
+/// ├─────────────────────────────────────────┤
+/// │ SkipRewardCert (if present, variable)   │
+/// ├─────────────────────────────────────────┤
+/// │ Notar reward cert Present    (1 byte)   │
+/// ├─────────────────────────────────────────┤
+/// │ NotarRewardCert (if present, variable)  │
+/// └─────────────────────────────────────────┘
+/// ```
+///
+/// ### FinalCertificate Layout
+/// ```text
+/// ┌─────────────────────────────────────────┐
+/// │ Slot                         (8 bytes)  │
+/// ├─────────────────────────────────────────┤
+/// │ Block ID                    (32 bytes)  │
+/// ├─────────────────────────────────────────┤
+/// │ Final Aggregate (VotesAggregate)        │
+/// ├─────────────────────────────────────────┤
+/// │ Notar Aggregate Present      (1 byte)   │
+/// ├─────────────────────────────────────────┤
+/// │ Notar Aggregate (if present)            │
+/// └─────────────────────────────────────────┘
+/// ```
+///
+/// ### VotesAggregate Layout
+/// ```text
+/// ┌─────────────────────────────────────────┐
+/// │ BLS Signature Compressed    (96 bytes)  │
+/// ├─────────────────────────────────────────┤
+/// │ Bitmap Length                (2 bytes)  │
+/// ├─────────────────────────────────────────┤
+/// │ Bitmap                    (variable)    │
+/// └─────────────────────────────────────────┘
+/// ```
+///
+/// ### GenesisCertificate Layout
+/// ```text
+/// ┌─────────────────────────────────────────┐
+/// │ Genesis Slot                  (8 bytes) │
+/// ├─────────────────────────────────────────┤
+/// │ Genesis Block ID             (32 bytes) │
+/// ├─────────────────────────────────────────┤
+/// │ BLS Signature               (192 bytes) │
+/// ├─────────────────────────────────────────┤
+/// │ Bitmap length (max 512)       (8 bytes) │
+/// ├─────────────────────────────────────────┤
+/// │ Bitmap                (up to 512 bytes) │
+/// └─────────────────────────────────────────┘
+/// ```
+use {
+    crate::entry::Entry,
+    agave_votor_messages::consensus_message::{Certificate, CertificateType},
+    solana_bls_signatures::{
+        Signature as BLSSignature, SignatureCompressed as BLSSignatureCompressed,
+    },
+    solana_clock::Slot,
+    solana_hash::Hash,
+    std::mem::MaybeUninit,
+    wincode::{
+        containers::{Pod, Vec as WincodeVec},
+        error::write_length_encoding_overflow,
+        io::{Reader, Writer},
+        len::{BincodeLen, SeqLen},
+        ReadResult, SchemaRead, SchemaWrite, TypeMeta, WriteResult,
+    },
+};
+
+/// 1-byte length prefix (max 255 elements).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct U8Len;
+
+impl SeqLen for U8Len {
+    fn read<'de, T>(reader: &mut impl Reader<'de>) -> ReadResult<usize> {
+        u8::get(reader).map(|len| len as usize)
+    }
+
+    fn write(writer: &mut impl Writer, len: usize) -> WriteResult<()> {
+        let Ok(len) = len.try_into() else {
+            return Err(write_length_encoding_overflow("u8::MAX"));
+        };
+        Ok(writer.write(&[len])?)
+    }
+
+    fn write_bytes_needed(_len: usize) -> WriteResult<usize> {
+        Ok(1)
+    }
+}
+
+/// 2-byte length prefix (max 65535 elements).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct U16Len;
+
+impl SeqLen for U16Len {
+    fn read<'de, T>(reader: &mut impl Reader<'de>) -> ReadResult<usize> {
+        u16::get(reader).map(|len| len as usize)
+    }
+
+    fn write(writer: &mut impl Writer, len: usize) -> WriteResult<()> {
+        let Ok(len): Result<u16, _> = len.try_into() else {
+            return Err(write_length_encoding_overflow("u16::MAX"));
+        };
+        Ok(writer.write(&len.to_le_bytes())?)
+    }
+
+    fn write_bytes_needed(_len: usize) -> WriteResult<usize> {
+        Ok(2)
+    }
+}
+
+/// Placeholder for skip reward certificate.
+#[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
+pub struct SkipRewardCertificate {
+    pub data: Vec<u8>,
+}
+
+/// Placeholder for notar reward certificate.
+#[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
+pub struct NotarRewardCertificate {
+    pub data: Vec<u8>,
+}
+
+/// Wraps a value with a u16 length prefix for TLV-style serialization.
+///
+/// The length prefix represents the serialized byte size of the inner value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LengthPrefixed<T> {
+    inner: T,
+}
+
+impl<T> LengthPrefixed<T> {
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T: SchemaWrite<Src = T>> SchemaWrite for LengthPrefixed<T> {
+    type Src = Self;
+
+    const TYPE_META: TypeMeta = match T::TYPE_META {
+        TypeMeta::Static { size, zero_copy } => TypeMeta::Static {
+            size: size + std::mem::size_of::<u16>(),
+            zero_copy,
+        },
+        TypeMeta::Dynamic => TypeMeta::Dynamic,
+    };
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        let inner_size = T::size_of(&src.inner)?;
+        Ok(std::mem::size_of::<u16>() + inner_size)
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        let inner_size = T::size_of(&src.inner)?;
+        let Ok(len): Result<u16, _> = inner_size.try_into() else {
+            return Err(write_length_encoding_overflow("u16::MAX"));
+        };
+        u16::write(writer, &len)?;
+        T::write(writer, &src.inner)
+    }
+}
+
+impl<'de, T: SchemaRead<'de, Dst = T>> SchemaRead<'de> for LengthPrefixed<T> {
+    type Dst = Self;
+
+    const TYPE_META: TypeMeta = match T::TYPE_META {
+        TypeMeta::Static { size, zero_copy } => TypeMeta::Static {
+            size: size + std::mem::size_of::<u16>(),
+            zero_copy,
+        },
+        TypeMeta::Dynamic => TypeMeta::Dynamic,
+    };
+
+    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let _len = u16::get(reader)?;
+        let inner_dst = unsafe { &mut *(&raw mut (*dst.as_mut_ptr()).inner).cast() };
+        T::read(reader, inner_dst)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BlockComponentError {
+    #[error("Entry count {count} exceeds max {max}")]
+    TooManyEntries { count: usize, max: usize },
+    #[error("Entry batch cannot be empty")]
+    EmptyEntryBatch,
+}
+
+/// Block production metadata. User agent is capped at 255 bytes.
+#[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
+pub struct BlockFooterV1 {
+    #[wincode(with = "Pod<Hash>")]
+    pub bank_hash: Hash,
+    pub block_producer_time_nanos: u64,
+    #[wincode(with = "WincodeVec<u8, U8Len>")]
+    pub block_user_agent: Vec<u8>,
+    pub final_cert: Option<FinalCertificate>,
+    pub skip_reward_cert: Option<SkipRewardCertificate>,
+    pub notar_reward_cert: Option<NotarRewardCertificate>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
+pub struct BlockHeaderV1 {
+    pub parent_slot: Slot,
+    #[wincode(with = "Pod<Hash>")]
+    pub parent_block_id: Hash,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
+pub struct UpdateParentV1 {
+    pub new_parent_slot: Slot,
+    #[wincode(with = "Pod<Hash>")]
+    pub new_parent_block_id: Hash,
+}
+
+/// Attests to genesis block finalization with a BLS aggregate signature.
+#[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
+pub struct GenesisCertificate {
+    pub slot: Slot,
+    #[wincode(with = "Pod<Hash>")]
+    pub block_id: Hash,
+    #[wincode(with = "Pod<BLSSignature>")]
+    pub bls_signature: BLSSignature,
+    #[wincode(with = "WincodeVec<u8, BincodeLen>")]
+    pub bitmap: Vec<u8>,
+}
+
+impl GenesisCertificate {
+    /// Max bitmap size in bytes (supports up to 4096 validators).
+    pub const MAX_BITMAP_SIZE: usize = 512;
+}
+
+impl TryFrom<Certificate> for GenesisCertificate {
+    type Error = String;
+
+    fn try_from(cert: Certificate) -> Result<Self, Self::Error> {
+        let CertificateType::Genesis(slot, block_id) = cert.cert_type else {
+            return Err("expected genesis certificate".into());
+        };
+        if cert.bitmap.len() > Self::MAX_BITMAP_SIZE {
+            return Err(format!(
+                "bitmap size {} exceeds max {}",
+                cert.bitmap.len(),
+                Self::MAX_BITMAP_SIZE
+            ));
+        }
+        Ok(Self {
+            slot,
+            block_id,
+            bls_signature: cert.signature,
+            bitmap: cert.bitmap,
+        })
+    }
+}
+
+impl From<GenesisCertificate> for Certificate {
+    fn from(cert: GenesisCertificate) -> Self {
+        Self {
+            cert_type: CertificateType::Genesis(cert.slot, cert.block_id),
+            signature: cert.bls_signature,
+            bitmap: cert.bitmap,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
+pub struct FinalCertificate {
+    pub slot: Slot,
+    #[wincode(with = "Pod<Hash>")]
+    pub block_id: Hash,
+    pub final_aggregate: VotesAggregate,
+    pub notar_aggregate: Option<VotesAggregate>,
+}
+
+impl FinalCertificate {
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn new_for_tests() -> FinalCertificate {
+        FinalCertificate {
+            slot: 1234567890,
+            block_id: Hash::new_from_array([1u8; 32]),
+            final_aggregate: VotesAggregate {
+                signature: BLSSignatureCompressed::default(),
+                bitmap: vec![42; 64],
+            },
+            notar_aggregate: None,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, SchemaRead, SchemaWrite)]
+pub struct VotesAggregate {
+    #[wincode(with = "Pod<BLSSignatureCompressed>")]
+    signature: BLSSignatureCompressed,
+    #[wincode(with = "WincodeVec<u8, U16Len>")]
+    bitmap: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, SchemaWrite, SchemaRead)]
+#[wincode(tag_encoding = "u8")]
+pub enum VersionedBlockFooter {
+    #[wincode(tag = 1)]
+    V1(BlockFooterV1),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, SchemaWrite, SchemaRead)]
+#[wincode(tag_encoding = "u8")]
+pub enum VersionedBlockHeader {
+    #[wincode(tag = 1)]
+    V1(BlockHeaderV1),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, SchemaWrite, SchemaRead)]
+#[wincode(tag_encoding = "u8")]
+pub enum VersionedUpdateParent {
+    #[wincode(tag = 1)]
+    V1(UpdateParentV1),
+}
+
+/// TLV-encoded marker variants.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq, Eq, SchemaWrite, SchemaRead)]
+#[wincode(tag_encoding = "u8")]
+pub enum BlockMarkerV1 {
+    BlockFooter(LengthPrefixed<VersionedBlockFooter>),
+    BlockHeader(LengthPrefixed<VersionedBlockHeader>),
+    UpdateParent(LengthPrefixed<VersionedUpdateParent>),
+    GenesisCertificate(LengthPrefixed<GenesisCertificate>),
+}
+
+impl BlockMarkerV1 {
+    pub fn new_block_footer(f: VersionedBlockFooter) -> Self {
+        Self::BlockFooter(LengthPrefixed::new(f))
+    }
+
+    pub fn new_block_header(h: VersionedBlockHeader) -> Self {
+        Self::BlockHeader(LengthPrefixed::new(h))
+    }
+
+    pub fn new_update_parent(u: VersionedUpdateParent) -> Self {
+        Self::UpdateParent(LengthPrefixed::new(u))
+    }
+
+    pub fn new_genesis_certificate(c: GenesisCertificate) -> Self {
+        Self::GenesisCertificate(LengthPrefixed::new(c))
+    }
+
+    pub fn as_block_footer(&self) -> Option<&VersionedBlockFooter> {
+        match self {
+            Self::BlockFooter(lp) => Some(lp.inner()),
+            _ => None,
+        }
+    }
+
+    pub fn as_block_header(&self) -> Option<&VersionedBlockHeader> {
+        match self {
+            Self::BlockHeader(lp) => Some(lp.inner()),
+            _ => None,
+        }
+    }
+
+    pub fn as_update_parent(&self) -> Option<&VersionedUpdateParent> {
+        match self {
+            Self::UpdateParent(lp) => Some(lp.inner()),
+            _ => None,
+        }
+    }
+
+    pub fn as_genesis_certificate(&self) -> Option<&GenesisCertificate> {
+        match self {
+            Self::GenesisCertificate(lp) => Some(lp.inner()),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, SchemaWrite, SchemaRead)]
+#[wincode(tag_encoding = "u16")]
+pub enum VersionedBlockMarker {
+    #[wincode(tag = 1)]
+    V1(BlockMarkerV1),
+}
+
+impl VersionedBlockMarker {
+    pub const fn new(marker: BlockMarkerV1) -> Self {
+        Self::V1(marker)
+    }
+
+    pub fn new_block_footer(f: BlockFooterV1) -> Self {
+        let f = VersionedBlockFooter::V1(f);
+        let f = BlockMarkerV1::BlockFooter(LengthPrefixed::new(f));
+        VersionedBlockMarker::V1(f)
+    }
+
+    pub fn new_block_header(h: BlockHeaderV1) -> Self {
+        let h = VersionedBlockHeader::V1(h);
+        let h = BlockMarkerV1::BlockHeader(LengthPrefixed::new(h));
+        VersionedBlockMarker::V1(h)
+    }
+
+    pub fn new_update_parent(u: UpdateParentV1) -> Self {
+        let u = VersionedUpdateParent::V1(u);
+        let u = BlockMarkerV1::UpdateParent(LengthPrefixed::new(u));
+        VersionedBlockMarker::V1(u)
+    }
+
+    pub fn new_genesis_certificate(g: GenesisCertificate) -> Self {
+        let g = BlockMarkerV1::GenesisCertificate(LengthPrefixed::new(g));
+        VersionedBlockMarker::V1(g)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
+pub enum BlockComponent {
+    EntryBatch(Vec<Entry>),
+    BlockMarker(VersionedBlockMarker),
+}
+
+impl BlockComponent {
+    const MAX_ENTRIES: usize = u32::MAX as usize;
+    const ENTRY_COUNT_SIZE: usize = 8;
+
+    pub fn new_entry_batch(entries: Vec<Entry>) -> Result<Self, BlockComponentError> {
+        if entries.is_empty() {
+            return Err(BlockComponentError::EmptyEntryBatch);
+        }
+
+        if entries.len() >= Self::MAX_ENTRIES {
+            return Err(BlockComponentError::TooManyEntries {
+                count: entries.len(),
+                max: Self::MAX_ENTRIES,
+            });
+        }
+
+        Ok(Self::EntryBatch(entries))
+    }
+
+    pub const fn new_block_marker(marker: VersionedBlockMarker) -> Self {
+        Self::BlockMarker(marker)
+    }
+
+    pub const fn as_marker(&self) -> Option<&VersionedBlockMarker> {
+        match self {
+            Self::BlockMarker(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    pub fn infer_is_entry_batch(data: &[u8]) -> Option<bool> {
+        data.get(..Self::ENTRY_COUNT_SIZE)?
+            .try_into()
+            .ok()
+            .map(|b| u64::from_le_bytes(b) != 0)
+    }
+
+    pub fn infer_is_block_marker(data: &[u8]) -> Option<bool> {
+        Self::infer_is_entry_batch(data).map(|is_entry_batch| !is_entry_batch)
+    }
+}
+
+impl SchemaWrite for BlockComponent {
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        match src {
+            Self::EntryBatch(entries) => {
+                // TODO(ksn): replace with wincode:: upon upstreaming to Agave. This also removes
+                // the map_err.
+                let size = bincode::serialized_size(entries).map_err(|_| {
+                    wincode::WriteError::Custom("Couldn't invoke bincode::serialized_size")
+                })?;
+                Ok(size as usize)
+            }
+            Self::BlockMarker(marker) => {
+                let marker_size = wincode::serialized_size(marker)? as usize;
+                Ok(Self::ENTRY_COUNT_SIZE + marker_size)
+            }
+        }
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        match src {
+            Self::EntryBatch(entries) => {
+                // TODO(ksn): replace with wincode:: upon upstreaming to Agave. This also removes
+                // the map_err.
+                let bytes = bincode::serialize(entries).map_err(|_| {
+                    wincode::WriteError::Custom("Couldn't invoke bincode::serialize")
+                })?;
+                writer.write(&bytes)?;
+                Ok(())
+            }
+            Self::BlockMarker(marker) => {
+                writer.write(&0u64.to_le_bytes())?;
+                <VersionedBlockMarker as SchemaWrite>::write(writer, marker)
+            }
+        }
+    }
+}
+
+impl<'de> SchemaRead<'de> for BlockComponent {
+    type Dst = Self;
+
+    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        // Read the entry count (first 8 bytes) to determine variant
+        let count_bytes = reader.fill_array::<8>()?;
+        let entry_count = u64::from_le_bytes(*count_bytes);
+
+        if entry_count == 0 {
+            // This is a BlockMarker - consume the count bytes and read the marker
+            reader.consume(8)?;
+            dst.write(Self::BlockMarker(VersionedBlockMarker::get(reader)?));
+        } else {
+            // This is an EntryBatch - read in the rest of the data. We do not anticipate having
+            // cases where we need to deserialize multiple BlockComponents from a single slice, and
+            // do not know where the delimiters are ahead of time.
+            // First, get all remaining bytes to deserialize
+            let data = reader.fill_buf(usize::MAX)?;
+
+            // TODO(ksn): replace with wincode:: upon upstreaming to Agave. This also removes the
+            // map_err.
+            let entries: Vec<Entry> = bincode::deserialize(data)
+                .map_err(|_| wincode::ReadError::Custom("Couldn't deserialize entries."))?;
+
+            if entries.len() >= Self::MAX_ENTRIES {
+                return Err(wincode::ReadError::Custom("Too many entries"));
+            }
+
+            // TODO(ksn): replace with wincode:: upon upstreaming to Agave. This also removes the
+            // map_err.
+            let consumed = bincode::serialized_size(&entries)
+                .map_err(|_| wincode::ReadError::Custom("Couldn't determine serialized size."))?
+                as usize;
+            reader.consume(consumed)?;
+
+            dst.write(Self::EntryBatch(entries));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::iter::repeat_n};
+
+    fn mock_entries(n: usize) -> Vec<Entry> {
+        repeat_n(Entry::default(), n).collect()
+    }
+
+    fn sample_footer() -> BlockFooterV1 {
+        BlockFooterV1 {
+            bank_hash: Hash::new_unique(),
+            block_producer_time_nanos: 1234567890,
+            block_user_agent: b"test-agent".to_vec(),
+            final_cert: Some(FinalCertificate::new_for_tests()),
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        }
+    }
+
+    #[test]
+    fn round_trips() {
+        let header = BlockHeaderV1 {
+            parent_slot: 12345,
+            parent_block_id: Hash::new_unique(),
+        };
+        let bytes = wincode::serialize(&header).unwrap();
+        assert_eq!(
+            header,
+            wincode::deserialize::<BlockHeaderV1>(&bytes).unwrap()
+        );
+
+        let footer = sample_footer();
+        let bytes = wincode::serialize(&footer).unwrap();
+        assert_eq!(
+            footer,
+            wincode::deserialize::<BlockFooterV1>(&bytes).unwrap()
+        );
+
+        let cert = GenesisCertificate {
+            slot: 999,
+            block_id: Hash::new_unique(),
+            bls_signature: BLSSignature::default(),
+            bitmap: vec![1, 2, 3],
+        };
+        let bytes = wincode::serialize(&cert).unwrap();
+        assert_eq!(
+            cert,
+            wincode::deserialize::<GenesisCertificate>(&bytes).unwrap()
+        );
+
+        let marker = VersionedBlockMarker::new_block_footer(footer.clone());
+        let bytes = wincode::serialize(&marker).unwrap();
+        assert_eq!(
+            marker,
+            wincode::deserialize::<VersionedBlockMarker>(&bytes).unwrap()
+        );
+
+        let comp = BlockComponent::new_entry_batch(mock_entries(5)).unwrap();
+        let bytes = wincode::serialize(&comp).unwrap();
+        let deser: BlockComponent = wincode::deserialize(&bytes).unwrap();
+        assert_eq!(comp, deser);
+
+        let comp = BlockComponent::new_block_marker(marker);
+        let bytes = wincode::serialize(&comp).unwrap();
+        let deser: BlockComponent = wincode::deserialize(&bytes).unwrap();
+        assert_eq!(comp, deser);
+    }
+}

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -143,7 +143,7 @@ use {
         error::write_length_encoding_overflow,
         io::{Reader, Writer},
         len::{BincodeLen, SeqLen},
-        ReadResult, SchemaRead, SchemaWrite, TypeMeta, WriteResult,
+        ReadResult, SchemaRead, SchemaWrite, WriteResult,
     },
 };
 

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -227,9 +227,9 @@ impl<T: SchemaWrite<Src = T>> SchemaWrite for LengthPrefixed<T> {
     type Src = Self;
 
     const TYPE_META: TypeMeta = match T::TYPE_META {
-        TypeMeta::Static { size, zero_copy } => TypeMeta::Static {
+        TypeMeta::Static { size, .. } => TypeMeta::Static {
             size: size + std::mem::size_of::<u16>(),
-            zero_copy,
+            zero_copy: false,
         },
         TypeMeta::Dynamic => TypeMeta::Dynamic,
     };
@@ -253,9 +253,9 @@ impl<'de, T: SchemaRead<'de, Dst = T>> SchemaRead<'de> for LengthPrefixed<T> {
     type Dst = Self;
 
     const TYPE_META: TypeMeta = match T::TYPE_META {
-        TypeMeta::Static { size, zero_copy } => TypeMeta::Static {
+        TypeMeta::Static { size, .. } => TypeMeta::Static {
             size: size + std::mem::size_of::<u16>(),
-            zero_copy,
+            zero_copy: false,
         },
         TypeMeta::Dynamic => TypeMeta::Dynamic,
     };

--- a/entry/src/lib.rs
+++ b/entry/src/lib.rs
@@ -8,6 +8,7 @@
     )
 )]
 #![allow(clippy::arithmetic_side_effects)]
+pub mod block_component;
 pub mod entry;
 pub mod poh;
 mod wincode;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6953,6 +6953,7 @@ dependencies = [
 name = "solana-entry"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "agave-votor-messages",
  "bincode",
  "crossbeam-channel",
  "dlopen2",
@@ -6961,6 +6962,8 @@ dependencies = [
  "rayon",
  "serde",
  "solana-address 2.0.0",
+ "solana-bls-signatures",
+ "solana-clock",
  "solana-hash 3.1.0",
  "solana-measure",
  "solana-merkle-tree",
@@ -6974,6 +6977,7 @@ dependencies = [
  "solana-signature",
  "solana-transaction",
  "solana-transaction-error",
+ "thiserror 2.0.17",
  "wincode",
 ]
 


### PR DESCRIPTION
#### Problem
We need a unified, extensible data structure to represent the components of a Solana block, covering both normal transaction entries and special markers.

The structure must support a number of Alpenglow-related needs, e.g.:

- Markers for Fast Leader Handover: https://github.com/solana-foundation/solana-improvement-documents/pull/337

- Reasoning about the Alpenglow clock: https://github.com/solana-foundation/solana-improvement-documents/pull/363

- Block footer markers: https://github.com/solana-foundation/solana-improvement-documents/pull/307

- Validator tickets: https://github.com/solana-foundation/solana-improvement-documents/pull/357

- Storing double-Merkle roots

... all the while remaining flexible for new marker types in the future.

#### Summary of Changes

We introduce a new enum, `BlockComponent`, which represents one logical element within a block. This code was originally designed in the [`alpenglow`](https://github.com/anza-xyz/alpenglow) repository.