### PR TITLE
Remove unneeded flush for tests

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -86,10 +86,7 @@ where
     .collect();
     let storable_accounts: Vec<_> = pubkeys.iter().zip(accounts_data.iter()).collect();
     accounts.store_accounts_par((slot, storable_accounts.as_slice()), None);
-    accounts.add_root(slot);
-    accounts
-        .accounts_db
-        .flush_accounts_cache_slot_for_tests(slot);
+    accounts.add_root_and_flush_write_cache(slot);
 
     let pubkeys = Arc::new(pubkeys);
     for i in 0..num_readers {

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1145,8 +1145,7 @@ mod tests {
         /// useful to adapt tests written prior to introduction of the write cache
         /// to use the write cache
         pub fn add_root_and_flush_write_cache(&self, slot: Slot) {
-            self.add_root(slot);
-            self.accounts_db.flush_accounts_cache_slot_for_tests(slot);
+            self.accounts_db.add_root_and_flush_write_cache(slot);
         }
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7052,19 +7052,6 @@ impl AccountsDb {
         self.clean_accounts(None, false, &EpochSchedule::default())
     }
 
-    pub fn flush_accounts_cache_slot_for_tests(&self, slot: Slot) {
-        assert!(
-            self.accounts_index
-                .roots_tracker
-                .read()
-                .unwrap()
-                .alive_roots
-                .contains(&slot),
-            "slot: {slot}"
-        );
-        self.flush_slot_cache_with_clean(slot, None::<&mut fn(&_) -> bool>, None);
-    }
-
     /// useful to adapt tests written prior to introduction of the write cache
     /// to use the write cache
     pub fn add_root_and_flush_write_cache(&self, slot: Slot) {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6479,13 +6479,13 @@ fn test_mark_obsolete_accounts_at_startup_purge_slot() {
     // Store other pubkey in slot0 to ensure slot is not purged
     accounts_db.store_for_tests((0, [(&pubkey1, &account), (&pubkey2, &account)].as_slice()));
     accounts_db.add_root(0);
-    accounts_db.flush_accounts_cache_slot_for_tests(0);
+    accounts_db.flush_rooted_accounts_cache(Some(0), false);
     accounts_db.store_for_tests((1, [(&pubkey1, &account)].as_slice()));
     accounts_db.add_root(1);
-    accounts_db.flush_accounts_cache_slot_for_tests(1);
+    accounts_db.flush_rooted_accounts_cache(Some(1), false);
     accounts_db.store_for_tests((2, [(&pubkey1, &account)].as_slice()));
     accounts_db.add_root(2);
-    accounts_db.flush_accounts_cache_slot_for_tests(2);
+    accounts_db.flush_rooted_accounts_cache(Some(2), false);
 
     let pubkeys_with_duplicates_by_bin = vec![vec![pubkey1]];
 
@@ -6518,7 +6518,7 @@ fn test_mark_obsolete_accounts_at_startup_multiple_bins() {
             [(&pubkey1, &account), (&pubkey2, &account)].as_slice(),
         ));
         accounts_db.add_root(slot);
-        accounts_db.flush_accounts_cache_slot_for_tests(slot);
+        accounts_db.flush_rooted_accounts_cache(Some(slot), false);
     }
 
     let pubkeys_with_duplicates_by_bin = vec![vec![pubkey1], vec![pubkey2]];

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6045,14 +6045,6 @@ impl Bank {
         self.try_process_entry_transactions(txs).unwrap()
     }
 
-    #[cfg(test)]
-    pub fn flush_accounts_cache_slot_for_tests(&self) {
-        self.rc
-            .accounts
-            .accounts_db
-            .flush_accounts_cache_slot_for_tests(self.slot())
-    }
-
     pub fn get_sysvar_cache_for_tests(&self) -> SysvarCache {
         self.transaction_processor.get_sysvar_cache_for_tests()
     }

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -174,7 +174,7 @@ mod tests {
 
     fn add_root_and_flush_write_cache(bank: &Bank) {
         bank.rc.accounts.add_root(bank.slot());
-        bank.flush_accounts_cache_slot_for_tests()
+        bank.force_flush_accounts_cache();
     }
 
     #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5718,7 +5718,7 @@ fn test_add_builtin_account() {
 /// to use the write cache
 fn add_root_and_flush_write_cache(bank: &Bank) {
     bank.rc.accounts.add_root(bank.slot());
-    bank.flush_accounts_cache_slot_for_tests()
+    bank.force_flush_accounts_cache();
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
There are multiple flush_accounts_cache_slot_for_tests functions (one in the runtime and one in the accounts_db) that are easy to mis-use. Some tests are probably in fact unintentionally misusing them. 

#### Summary of Changes
- Removed flush_accounts_cache_slot_for_tests from runtime and replaced callsites with force_flush_accounts_cache (PR1)
- Remove flush_accounts_cache_slot_for_tests from accounts-db and replace with appropriate flush_accounts_cache with clean set to false (PR2)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
