### PR TITLE
Run tests with accounts cache cleaning

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -86,10 +86,7 @@ where
     .collect();
     let storable_accounts: Vec<_> = pubkeys.iter().zip(accounts_data.iter()).collect();
     accounts.store_accounts_par((slot, storable_accounts.as_slice()), None);
-    accounts.add_root(slot);
-    accounts
-        .accounts_db
-        .flush_accounts_cache_slot_for_tests(slot);
+    accounts.accounts_db.add_root_and_flush_write_cache(slot);
 
     let pubkeys = Arc::new(pubkeys);
     for i in 0..num_readers {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6045,14 +6045,6 @@ impl Bank {
         self.try_process_entry_transactions(txs).unwrap()
     }
 
-    #[cfg(test)]
-    pub fn flush_accounts_cache_slot_for_tests(&self) {
-        self.rc
-            .accounts
-            .accounts_db
-            .flush_accounts_cache_slot_for_tests(self.slot())
-    }
-
     pub fn get_sysvar_cache_for_tests(&self) -> SysvarCache {
         self.transaction_processor.get_sysvar_cache_for_tests()
     }

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -174,7 +174,7 @@ mod tests {
 
     fn add_root_and_flush_write_cache(bank: &Bank) {
         bank.rc.accounts.add_root(bank.slot());
-        bank.flush_accounts_cache_slot_for_tests()
+        bank.force_flush_accounts_cache();
     }
 
     #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5718,7 +5718,7 @@ fn test_add_builtin_account() {
 /// to use the write cache
 fn add_root_and_flush_write_cache(bank: &Bank) {
     bank.rc.accounts.add_root(bank.slot());
-    bank.flush_accounts_cache_slot_for_tests()
+    bank.force_flush_accounts_cache();
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
Some tests are unintentionally running without clean during accounts cache flush, as flush_accounts_cache_slot_for_tests runs without cleaning. 

#### Summary of Changes
- Moved all runtime tests to use force_flush_accounts_cache and removed runtime test function as no longer needed
- Moved bench to use add_root_and_flush_write_cache

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
