### PR TITLE
docs: fix "from from" typo in gossip-validator help text

### DIFF
--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -701,7 +701,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .help(
                 "A list of validators to gossip with. If specified, gossip will not push/pull \
-                 from from validators outside this set. [default: all validators]",
+                 from validators outside this set. [default: all validators]",
             ),
     )
     .arg(


### PR DESCRIPTION
#### Problem

A typo with double "from"

#### Summary of Changes

I removed one "from" from the doc sentence