### PR TITLE
streamer: add WebTransport server for browser TPU access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-web-transport"
+version = "4.0.0-alpha.0"
+dependencies = [
+ "futures 0.3.31",
+ "http 1.1.0",
+ "log",
+ "quinn",
+ "rustls 0.23.36",
+ "thiserror 2.0.17",
+ "tokio",
+ "url 2.5.8",
+ "web-transport-proto 0.3.1",
+]
+
+[[package]]
 name = "agave-xdp"
 version = "4.0.0-alpha.0"
 dependencies = [
@@ -1238,6 +1253,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,10 +1876,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -2041,6 +2079,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -2737,6 +2784,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,6 +3147,12 @@ dependencies = [
  "redox_syscall 0.2.10",
  "winapi",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
 name = "five8"
@@ -5797,6 +5856,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "fastbloom",
  "getrandom 0.3.4",
@@ -6397,6 +6457,8 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6479,6 +6541,7 @@ version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -10934,6 +10997,7 @@ name = "solana-streamer"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-logger",
+ "agave-web-transport",
  "anyhow",
  "arc-swap",
  "assert_matches",
@@ -10976,6 +11040,8 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-util 0.7.18",
+ "url 2.5.8",
+ "web-transport-quinn",
  "x509-parser",
 ]
 
@@ -13648,6 +13714,60 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-transport-proto"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "974fa1e325e6cc5327de8887f189a441fcff4f8eedcd31ec87f0ef0cc5283fbc"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+ "thiserror 2.0.17",
+ "url 2.5.8",
+]
+
+[[package]]
+name = "web-transport-proto"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660175a6d1643adb93b71c4f853d4f20f0fce47f53ae579afe9f7711fe84870d"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+ "thiserror 2.0.17",
+ "tokio",
+ "url 2.5.8",
+]
+
+[[package]]
+name = "web-transport-quinn"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88e34f06fb4cd4760dc9bd348199d1759eed196ebb4ce0aa40b3817069cc58e8"
+dependencies = [
+ "bytes",
+ "futures 0.3.31",
+ "http 1.1.0",
+ "log",
+ "quinn",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "thiserror 2.0.17",
+ "tokio",
+ "url 2.5.8",
+ "web-transport-proto 0.2.8",
+ "web-transport-trait",
+]
+
+[[package]]
+name = "web-transport-trait"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07665af67c56637c938425911b9b5a4f6aaea45709354e4656b9e2de45768c68"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ members = [
     "votor",
     "votor-messages",
     "watchtower",
+    "web-transport",
     "wen-restart",
     "xdp",
     "xdp-ebpf",
@@ -210,6 +211,7 @@ agave-snapshots = { path = "snapshots", version = "=4.0.0-alpha.0", features = [
 agave-syscalls = { path = "syscalls", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 agave-thread-manager = { path = "thread-manager", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 agave-transaction-view = { path = "transaction-view", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
+agave-web-transport = { path = "web-transport" }
 agave-verified-packet-receiver = { path = "verified-packet-receiver", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 agave-votor = { path = "votor", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 agave-votor-messages = { path = "votor-messages", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
@@ -626,6 +628,7 @@ uriparse = "0.6.4"
 url = "2.5.8"
 vec_extract_if_polyfill = "0.1.0"
 wasm-bindgen = "0.2"
+web-transport-proto = "0.3.1"
 winapi = "0.3.8"
 wincode = { version = "0.2.5", features = ["derive", "solana-short-vec"] }
 winreg = "0.55"

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -19,8 +19,10 @@ name = "solana_streamer"
 [features]
 agave-unstable-api = []
 dev-context-only-utils = []
+webtransport = ["dep:agave-web-transport"]
 
 [dependencies]
+agave-web-transport = { workspace = true, optional = true }
 arc-swap = { workspace = true }
 bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -68,3 +70,5 @@ chrono = { workspace = true, features = ["now"] }
 clap = { version = "4.5.31", features = ["cargo", "derive", "error-context"] }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-streamer = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+web-transport-quinn = "0.9"
+url = { workspace = true }

--- a/streamer/src/lib.rs
+++ b/streamer/src/lib.rs
@@ -17,6 +17,9 @@ pub mod recvmmsg;
 pub mod sendmmsg;
 pub mod streamer;
 
+#[cfg(feature = "webtransport")]
+pub use nonblocking::webtransport::spawn_webtransport_server;
+
 #[macro_use]
 extern crate log;
 

--- a/streamer/src/nonblocking/mod.rs
+++ b/streamer/src/nonblocking/mod.rs
@@ -9,3 +9,5 @@ mod stream_throttle;
 pub mod swqos;
 #[cfg(feature = "dev-context-only-utils")]
 pub mod testing_utilities;
+#[cfg(feature = "webtransport")]
+pub mod webtransport;

--- a/streamer/src/nonblocking/webtransport.rs
+++ b/streamer/src/nonblocking/webtransport.rs
@@ -1,0 +1,227 @@
+use {
+    agave_web_transport::ServerBuilder,
+    bytes::Bytes,
+    solana_packet::{Meta, PACKET_DATA_SIZE},
+    solana_perf::packet::{BytesPacket, PacketBatch},
+    std::net::SocketAddr,
+    tokio::task::JoinHandle,
+    tokio_util::sync::CancellationToken,
+};
+
+const MAX_TX_SIZE: usize = PACKET_DATA_SIZE;
+
+pub fn spawn_webtransport_server(
+    addr: SocketAddr,
+    cert_chain: Vec<rustls::pki_types::CertificateDer<'static>>,
+    key: rustls::pki_types::PrivateKeyDer<'static>,
+    packet_sender: crossbeam_channel::Sender<PacketBatch>,
+    cancel: CancellationToken,
+) -> std::io::Result<JoinHandle<()>> {
+    let server = ServerBuilder::new(addr)
+        .build(cert_chain, key)
+        .map_err(|e| std::io::Error::other(format!("WebTransport server error: {e}")))?;
+
+    let handle = tokio::spawn(run_server(server, packet_sender, cancel));
+
+    Ok(handle)
+}
+
+async fn run_server(
+    mut server: agave_web_transport::Server,
+    packet_sender: crossbeam_channel::Sender<PacketBatch>,
+    cancel: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                log::info!("WebTransport server shutting down");
+                break;
+            }
+            request = server.accept() => {
+                let Some(request) = request else {
+                    log::warn!("WebTransport server accept returned None");
+                    break;
+                };
+
+                let sender = packet_sender.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = handle_session(request, sender).await {
+                        log::debug!("WebTransport session error: {e}");
+                    }
+                });
+            }
+        }
+    }
+}
+
+async fn handle_session(
+    request: agave_web_transport::Request,
+    packet_sender: crossbeam_channel::Sender<PacketBatch>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let remote_addr = request.remote_address();
+    let session = request.ok().await?;
+
+    log::debug!("WebTransport session established from {remote_addr}");
+
+    loop {
+        let mut stream = session.accept_uni().await?;
+        let data = stream.read_to_end(MAX_TX_SIZE).await?;
+
+        if data.is_empty() {
+            continue;
+        }
+
+        let mut meta = Meta::default();
+        meta.size = data.len();
+        meta.set_socket_addr(&remote_addr);
+
+        let packet = BytesPacket::new(Bytes::from(data), meta);
+        let batch = PacketBatch::Single(packet);
+
+        if packet_sender.send(batch).is_err() {
+            log::warn!("WebTransport packet_sender disconnected");
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossbeam_channel::unbounded;
+    use solana_keypair::Keypair;
+    use solana_tls_utils::new_dummy_x509_certificate;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    fn generate_test_certs() -> (
+        Vec<rustls::pki_types::CertificateDer<'static>>,
+        rustls::pki_types::PrivateKeyDer<'static>,
+    ) {
+        let keypair = Keypair::new();
+        let (cert, key) = new_dummy_x509_certificate(&keypair);
+        (vec![cert], key)
+    }
+
+    async fn create_test_client(
+        server_addr: SocketAddr,
+    ) -> Result<web_transport_quinn::Session, Box<dyn std::error::Error + Send + Sync>> {
+        let client = web_transport_quinn::ClientBuilder::new()
+            .dangerous()
+            .with_no_certificate_verification()?;
+
+        let url = url::Url::parse(&format!("https://{}", server_addr))?;
+        let session = client.connect(url).await?;
+        Ok(session)
+    }
+
+    #[tokio::test]
+    async fn test_webtransport_server_receives_packet() {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .ok();
+
+        let (cert_chain, key) = generate_test_certs();
+        let (packet_sender, packet_receiver) = unbounded();
+        let cancel = CancellationToken::new();
+
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let server = ServerBuilder::new(addr)
+            .build(cert_chain, key)
+            .expect("Failed to build server");
+
+        let server_addr = server.local_addr().expect("Failed to get local addr");
+
+        let cancel_clone = cancel.clone();
+        let server_handle = tokio::spawn(run_server(server, packet_sender, cancel_clone));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let session = create_test_client(server_addr)
+            .await
+            .expect("Failed to connect client");
+
+        let test_data = b"hello webtransport";
+        let mut send_stream = session.open_uni().await.expect("Failed to open uni stream");
+        send_stream
+            .write_all(test_data)
+            .await
+            .expect("Failed to write");
+        send_stream.finish().expect("Failed to finish stream");
+
+        let received = timeout(Duration::from_secs(5), async {
+            loop {
+                if let Ok(batch) = packet_receiver.try_recv() {
+                    return batch;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("Timeout waiting for packet");
+
+        assert_eq!(received.len(), 1);
+        let packet = received.iter().next().unwrap();
+        assert_eq!(packet.meta().size, test_data.len());
+        assert_eq!(&packet.data(..test_data.len()).unwrap(), test_data);
+
+        cancel.cancel();
+        let _ = server_handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_webtransport_server_multiple_streams() {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .ok();
+
+        let (cert_chain, key) = generate_test_certs();
+        let (packet_sender, packet_receiver) = unbounded();
+        let cancel = CancellationToken::new();
+
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let server = ServerBuilder::new(addr)
+            .build(cert_chain, key)
+            .expect("Failed to build server");
+
+        let server_addr = server.local_addr().expect("Failed to get local addr");
+
+        let cancel_clone = cancel.clone();
+        let server_handle = tokio::spawn(run_server(server, packet_sender, cancel_clone));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let session = create_test_client(server_addr)
+            .await
+            .expect("Failed to connect client");
+
+        let num_streams = 5;
+        for i in 0..num_streams {
+            let data = format!("packet {}", i);
+            let mut send_stream = session.open_uni().await.expect("Failed to open uni stream");
+            send_stream
+                .write_all(data.as_bytes())
+                .await
+                .expect("Failed to write");
+            send_stream.finish().expect("Failed to finish stream");
+        }
+
+        let mut received_count = 0;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+
+        while received_count < num_streams && tokio::time::Instant::now() < deadline {
+            if let Ok(batch) = packet_receiver.try_recv() {
+                received_count += batch.len();
+            } else {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        }
+
+        assert_eq!(received_count, num_streams);
+
+        cancel.cancel();
+        let _ = server_handle.await;
+    }
+}

--- a/web-transport/Cargo.toml
+++ b/web-transport/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "agave-web-transport"
+version = { workspace = true }
+authors = { workspace = true }
+description = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = false
+
+[dependencies]
+futures = { workspace = true }
+# Required by web-transport-proto; v1 differs from workspace v0.2 but is isolated
+http = "1"
+log = { workspace = true }
+quinn = { workspace = true }
+rustls = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
+url = { workspace = true }
+web-transport-proto = { workspace = true }
+
+[lints]
+workspace = true

--- a/web-transport/src/connect.rs
+++ b/web-transport/src/connect.rs
@@ -1,0 +1,48 @@
+use web_transport_proto::{ConnectRequest, ConnectResponse, VarInt};
+
+use crate::ConnectError;
+
+pub struct Connect {
+    request: ConnectRequest,
+    send: quinn::SendStream,
+
+    #[allow(dead_code)]
+    recv: quinn::RecvStream,
+}
+
+impl Connect {
+    pub async fn accept(conn: &quinn::Connection) -> Result<Self, ConnectError> {
+        let (send, mut recv) = conn.accept_bi().await?;
+
+        let request = ConnectRequest::read(&mut recv).await?;
+        log::debug!("received CONNECT request: {request:?}");
+
+        Ok(Self {
+            request,
+            send,
+            recv,
+        })
+    }
+
+    pub async fn respond(&mut self, status: http::StatusCode) -> Result<(), ConnectError> {
+        let resp = ConnectResponse { status };
+
+        log::debug!("sending CONNECT response: {resp:?}");
+        resp.write(&mut self.send).await?;
+
+        Ok(())
+    }
+
+    pub fn session_id(&self) -> VarInt {
+        let stream_id = quinn::VarInt::from(self.send.id());
+        VarInt::try_from(stream_id.into_inner()).unwrap()
+    }
+
+    pub fn url(&self) -> &url::Url {
+        &self.request.url
+    }
+
+    pub fn into_inner(self) -> (quinn::SendStream, quinn::RecvStream) {
+        (self.send, self.recv)
+    }
+}

--- a/web-transport/src/error.rs
+++ b/web-transport/src/error.rs
@@ -1,0 +1,157 @@
+use std::sync::Arc;
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone)]
+pub enum SettingsError {
+    #[error("quic stream was closed early")]
+    UnexpectedEnd,
+
+    #[error("protocol error: {0}")]
+    ProtoError(#[from] web_transport_proto::SettingsError),
+
+    #[error("WebTransport is not supported")]
+    WebTransportUnsupported,
+
+    #[error("connection error")]
+    ConnectionError(#[from] quinn::ConnectionError),
+
+    #[error("read error")]
+    ReadError(#[from] quinn::ReadError),
+
+    #[error("write error")]
+    WriteError(#[from] quinn::WriteError),
+}
+
+#[derive(Error, Debug, Clone)]
+pub enum ConnectError {
+    #[error("quic stream was closed early")]
+    UnexpectedEnd,
+
+    #[error("protocol error: {0}")]
+    ProtoError(#[from] web_transport_proto::ConnectError),
+
+    #[error("connection error")]
+    ConnectionError(#[from] quinn::ConnectionError),
+
+    #[error("read error")]
+    ReadError(#[from] quinn::ReadError),
+
+    #[error("write error")]
+    WriteError(#[from] quinn::WriteError),
+}
+
+#[derive(Error, Debug, Clone)]
+pub enum ServerError {
+    #[error("unexpected end of stream")]
+    UnexpectedEnd,
+
+    #[error("connection error")]
+    Connection(#[from] quinn::ConnectionError),
+
+    #[error("failed to write")]
+    WriteError(#[from] quinn::WriteError),
+
+    #[error("failed to read")]
+    ReadError(#[from] quinn::ReadError),
+
+    #[error("failed to exchange h3 settings")]
+    SettingsError(#[from] SettingsError),
+
+    #[error("failed to exchange h3 connect")]
+    ConnectError(#[from] ConnectError),
+
+    #[error("io error: {0}")]
+    IoError(Arc<std::io::Error>),
+}
+
+#[derive(Clone, Error, Debug)]
+pub enum SessionError {
+    #[error("connection error: {0}")]
+    ConnectionError(quinn::ConnectionError),
+
+    #[error("webtransport error: {0}")]
+    WebTransportError(#[from] WebTransportError),
+}
+
+impl From<quinn::ConnectionError> for SessionError {
+    fn from(e: quinn::ConnectionError) -> Self {
+        match &e {
+            quinn::ConnectionError::ApplicationClosed(close) => {
+                match web_transport_proto::error_from_http3(close.error_code.into_inner()) {
+                    Some(code) => WebTransportError::Closed(
+                        code,
+                        String::from_utf8_lossy(&close.reason).into_owned(),
+                    )
+                    .into(),
+                    None => SessionError::ConnectionError(e),
+                }
+            }
+            _ => SessionError::ConnectionError(e),
+        }
+    }
+}
+
+#[derive(Clone, Error, Debug)]
+pub enum WebTransportError {
+    #[error("closed: code={0} reason={1}")]
+    Closed(u32, String),
+
+    #[error("unknown session")]
+    UnknownSession,
+
+    #[error("read error: {0}")]
+    ReadError(#[from] quinn::ReadExactError),
+}
+
+#[derive(Clone, Error, Debug)]
+pub enum ReadError {
+    #[error("session error: {0}")]
+    SessionError(#[from] SessionError),
+
+    #[error("RESET_STREAM: {0}")]
+    Reset(u32),
+
+    #[error("invalid RESET_STREAM: {0}")]
+    InvalidReset(quinn::VarInt),
+
+    #[error("stream already closed")]
+    ClosedStream,
+
+    #[error("ordered read on unordered stream")]
+    IllegalOrderedRead,
+}
+
+impl From<quinn::ReadError> for ReadError {
+    fn from(e: quinn::ReadError) -> Self {
+        match e {
+            quinn::ReadError::Reset(code) => {
+                match web_transport_proto::error_from_http3(code.into_inner()) {
+                    Some(code) => ReadError::Reset(code),
+                    None => ReadError::InvalidReset(code),
+                }
+            }
+            quinn::ReadError::ConnectionLost(e) => ReadError::SessionError(e.into()),
+            quinn::ReadError::IllegalOrderedRead => ReadError::IllegalOrderedRead,
+            quinn::ReadError::ClosedStream => ReadError::ClosedStream,
+            quinn::ReadError::ZeroRttRejected => unreachable!("0-RTT not supported"),
+        }
+    }
+}
+
+#[derive(Clone, Error, Debug)]
+pub enum ReadToEndError {
+    #[error("too long")]
+    TooLong,
+
+    #[error("read error: {0}")]
+    ReadError(#[from] ReadError),
+}
+
+impl From<quinn::ReadToEndError> for ReadToEndError {
+    fn from(e: quinn::ReadToEndError) -> Self {
+        match e {
+            quinn::ReadToEndError::TooLong => ReadToEndError::TooLong,
+            quinn::ReadToEndError::Read(e) => ReadToEndError::ReadError(e.into()),
+        }
+    }
+}

--- a/web-transport/src/lib.rs
+++ b/web-transport/src/lib.rs
@@ -1,0 +1,14 @@
+mod connect;
+mod error;
+mod recv;
+mod server;
+mod session;
+mod settings;
+
+pub use error::{
+    ConnectError, ReadError, ReadToEndError, ServerError, SessionError, SettingsError,
+    WebTransportError,
+};
+pub use recv::RecvStream;
+pub use server::{Request, Server, ServerBuilder, ALPN};
+pub use session::Session;

--- a/web-transport/src/recv.rs
+++ b/web-transport/src/recv.rs
@@ -1,0 +1,26 @@
+use crate::{ReadError, ReadToEndError};
+
+#[derive(Debug)]
+pub struct RecvStream {
+    inner: quinn::RecvStream,
+}
+
+impl RecvStream {
+    pub(crate) fn new(stream: quinn::RecvStream) -> Self {
+        Self { inner: stream }
+    }
+
+    pub async fn read_to_end(&mut self, size_limit: usize) -> Result<Vec<u8>, ReadToEndError> {
+        self.inner.read_to_end(size_limit).await.map_err(Into::into)
+    }
+
+    pub async fn read(&mut self, buf: &mut [u8]) -> Result<Option<usize>, ReadError> {
+        self.inner.read(buf).await.map_err(Into::into)
+    }
+
+    pub fn stop(&mut self, code: u32) -> Result<(), quinn::ClosedStream> {
+        let code = web_transport_proto::error_to_http3(code);
+        let code = quinn::VarInt::try_from(code).unwrap();
+        self.inner.stop(code)
+    }
+}

--- a/web-transport/src/server.rs
+++ b/web-transport/src/server.rs
@@ -1,0 +1,123 @@
+use std::sync::Arc;
+
+use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
+
+use crate::{connect::Connect, settings::Settings, ServerError, Session};
+
+pub const ALPN: &[u8] = b"h3";
+
+pub struct ServerBuilder {
+    addr: std::net::SocketAddr,
+}
+
+impl ServerBuilder {
+    pub fn new(addr: std::net::SocketAddr) -> Self {
+        Self { addr }
+    }
+
+    pub fn build(
+        self,
+        cert_chain: Vec<rustls::pki_types::CertificateDer<'static>>,
+        key: rustls::pki_types::PrivateKeyDer<'static>,
+    ) -> Result<Server, ServerError> {
+        let mut config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(cert_chain, key)
+            .map_err(|e| ServerError::IoError(Arc::new(std::io::Error::other(e))))?;
+
+        config.alpn_protocols = vec![ALPN.to_vec()];
+
+        let config: quinn::crypto::rustls::QuicServerConfig = config
+            .try_into()
+            .map_err(|e| ServerError::IoError(Arc::new(std::io::Error::other(e))))?;
+
+        let server_config = quinn::ServerConfig::with_crypto(Arc::new(config));
+
+        let endpoint = quinn::Endpoint::server(server_config, self.addr)
+            .map_err(|e| ServerError::IoError(Arc::new(e)))?;
+
+        Ok(Server::new(endpoint))
+    }
+
+    pub fn build_from_endpoint(endpoint: quinn::Endpoint) -> Server {
+        Server::new(endpoint)
+    }
+}
+
+pub struct Server {
+    endpoint: quinn::Endpoint,
+    accept: FuturesUnordered<BoxFuture<'static, Result<Request, ServerError>>>,
+}
+
+impl Server {
+    fn new(endpoint: quinn::Endpoint) -> Self {
+        Self {
+            endpoint,
+            accept: FuturesUnordered::new(),
+        }
+    }
+
+    pub async fn accept(&mut self) -> Option<Request> {
+        loop {
+            tokio::select! {
+                res = self.endpoint.accept() => {
+                    let incoming = res?;
+                    self.accept.push(Box::pin(async move {
+                        let conn = incoming.await?;
+                        Request::accept(conn).await
+                    }));
+                }
+                Some(res) = self.accept.next() => {
+                    match res {
+                        Ok(request) => return Some(request),
+                        Err(e) => {
+                            log::warn!("failed to accept WebTransport session: {e}");
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn local_addr(&self) -> std::io::Result<std::net::SocketAddr> {
+        self.endpoint.local_addr()
+    }
+}
+
+pub struct Request {
+    conn: quinn::Connection,
+    settings: Settings,
+    connect: Connect,
+}
+
+impl Request {
+    async fn accept(conn: quinn::Connection) -> Result<Self, ServerError> {
+        let settings = Settings::connect(&conn).await?;
+        let connect = Connect::accept(&conn).await?;
+
+        Ok(Self {
+            conn,
+            settings,
+            connect,
+        })
+    }
+
+    pub fn url(&self) -> &url::Url {
+        self.connect.url()
+    }
+
+    pub fn remote_address(&self) -> std::net::SocketAddr {
+        self.conn.remote_address()
+    }
+
+    pub async fn ok(mut self) -> Result<Session, ServerError> {
+        self.connect.respond(http::StatusCode::OK).await?;
+        Ok(Session::new(self.conn, self.settings, self.connect))
+    }
+
+    pub async fn reject(mut self, status: http::StatusCode) -> Result<(), ServerError> {
+        self.connect.respond(status).await?;
+        Ok(())
+    }
+}

--- a/web-transport/src/session.rs
+++ b/web-transport/src/session.rs
@@ -1,0 +1,148 @@
+use std::{
+    future::{poll_fn, Future},
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{ready, Context, Poll},
+};
+
+use futures::stream::{FuturesUnordered, Stream, StreamExt};
+use web_transport_proto::{StreamUni, VarInt};
+
+use crate::{
+    connect::Connect, recv::RecvStream, settings::Settings, SessionError, WebTransportError,
+};
+
+type PendingUni = Pin<Box<dyn Future<Output = Result<quinn::RecvStream, SessionError>> + Send>>;
+
+#[derive(Clone)]
+pub struct Session {
+    conn: quinn::Connection,
+    _session_id: VarInt,
+    accept: Arc<Mutex<SessionAccept>>,
+
+    #[allow(dead_code)]
+    _settings: Arc<Settings>,
+}
+
+impl Session {
+    pub(crate) fn new(conn: quinn::Connection, settings: Settings, connect: Connect) -> Self {
+        let session_id = connect.session_id();
+        let accept = SessionAccept::new(conn.clone(), session_id);
+
+        let this = Self {
+            conn,
+            _session_id: session_id,
+            accept: Arc::new(Mutex::new(accept)),
+            _settings: Arc::new(settings),
+        };
+
+        let conn_clone = this.conn.clone();
+        tokio::spawn(async move {
+            let (code, reason) = Self::run_closed(connect).await;
+            let code = web_transport_proto::error_to_http3(code)
+                .try_into()
+                .unwrap();
+            conn_clone.close(code, reason.as_bytes());
+        });
+
+        this
+    }
+
+    async fn run_closed(connect: Connect) -> (u32, String) {
+        let (_send, mut recv) = connect.into_inner();
+
+        loop {
+            match web_transport_proto::Capsule::read(&mut recv).await {
+                Ok(web_transport_proto::Capsule::CloseWebTransportSession { code, reason }) => {
+                    return (code, reason);
+                }
+                Ok(web_transport_proto::Capsule::Unknown { .. }) => continue,
+                Err(_) => return (1, "capsule error".to_string()),
+            }
+        }
+    }
+
+    pub async fn accept_uni(&self) -> Result<RecvStream, SessionError> {
+        poll_fn(|cx| self.accept.lock().unwrap().poll_accept_uni(cx)).await
+    }
+
+    pub fn remote_address(&self) -> std::net::SocketAddr {
+        self.conn.remote_address()
+    }
+
+    pub fn close(&self, code: u32, reason: &[u8]) {
+        let code = web_transport_proto::error_to_http3(code)
+            .try_into()
+            .unwrap();
+        self.conn.close(code, reason)
+    }
+
+    pub async fn closed(&self) -> SessionError {
+        self.conn.closed().await.into()
+    }
+}
+
+struct SessionAccept {
+    session_id: VarInt,
+    accept_uni:
+        Pin<Box<dyn Stream<Item = Result<quinn::RecvStream, quinn::ConnectionError>> + Send>>,
+    pending_uni: FuturesUnordered<PendingUni>,
+}
+
+impl SessionAccept {
+    fn new(conn: quinn::Connection, session_id: VarInt) -> Self {
+        Self {
+            session_id,
+            accept_uni: Box::pin(futures::stream::unfold(conn, |conn| async move {
+                Some((conn.accept_uni().await, conn))
+            })),
+            pending_uni: FuturesUnordered::new(),
+        }
+    }
+
+    fn poll_accept_uni(&mut self, cx: &mut Context<'_>) -> Poll<Result<RecvStream, SessionError>> {
+        loop {
+            if let Poll::Ready(Some(res)) = self.accept_uni.poll_next_unpin(cx) {
+                let recv = res?;
+                let session_id = self.session_id;
+                self.pending_uni
+                    .push(Box::pin(Self::decode_uni(recv, session_id)));
+                continue;
+            }
+
+            let res = match ready!(self.pending_uni.poll_next_unpin(cx)) {
+                Some(Ok(recv)) => recv,
+                Some(Err(err)) => {
+                    log::warn!("failed to decode uni stream: {err:?}");
+                    continue;
+                }
+                None => return Poll::Pending,
+            };
+
+            return Poll::Ready(Ok(RecvStream::new(res)));
+        }
+    }
+
+    async fn decode_uni(
+        mut recv: quinn::RecvStream,
+        expected_session: VarInt,
+    ) -> Result<quinn::RecvStream, SessionError> {
+        let typ = VarInt::read(&mut recv)
+            .await
+            .map_err(|_| WebTransportError::UnknownSession)?;
+
+        if StreamUni(typ) != StreamUni::WEBTRANSPORT {
+            return Err(WebTransportError::UnknownSession.into());
+        }
+
+        let session_id = VarInt::read(&mut recv)
+            .await
+            .map_err(|_| WebTransportError::UnknownSession)?;
+
+        if session_id != expected_session {
+            return Err(WebTransportError::UnknownSession.into());
+        }
+
+        Ok(recv)
+    }
+}

--- a/web-transport/src/settings.rs
+++ b/web-transport/src/settings.rs
@@ -1,0 +1,46 @@
+use futures::try_join;
+
+use crate::SettingsError;
+
+pub struct Settings {
+    #[allow(dead_code)]
+    send: quinn::SendStream,
+
+    #[allow(dead_code)]
+    recv: quinn::RecvStream,
+}
+
+impl Settings {
+    pub async fn connect(conn: &quinn::Connection) -> Result<Self, SettingsError> {
+        let recv = Self::accept(conn);
+        let send = Self::open(conn);
+
+        let (send, recv) = try_join!(send, recv)?;
+        Ok(Self { send, recv })
+    }
+
+    async fn accept(conn: &quinn::Connection) -> Result<quinn::RecvStream, SettingsError> {
+        let mut recv = conn.accept_uni().await?;
+        let settings = web_transport_proto::Settings::read(&mut recv).await?;
+
+        log::debug!("received SETTINGS frame: {settings:?}");
+
+        if settings.supports_webtransport() == 0 {
+            return Err(SettingsError::WebTransportUnsupported);
+        }
+
+        Ok(recv)
+    }
+
+    async fn open(conn: &quinn::Connection) -> Result<quinn::SendStream, SettingsError> {
+        let mut settings = web_transport_proto::Settings::default();
+        settings.enable_webtransport(1);
+
+        log::debug!("sending SETTINGS frame: {settings:?}");
+
+        let mut send = conn.open_uni().await?;
+        settings.write(&mut send).await?;
+
+        Ok(send)
+    }
+}


### PR DESCRIPTION
#### Problem

Browsers cannot send transactions directly to Solana validator TPUs. The TPU uses QUIC with the `solana-tpu` ALPN protocol, but browsers only support HTTP/3 with the `h3` ALPN. This forces all browser-based transaction submission through RPC intermediaries, adding latency and centralization.

#### Summary of Changes

Adds WebTransport support to enable browsers to send transactions directly to validators, bypassing RPC.

**New crate: `agave-web-transport`**
- Minimal server-only WebTransport implementation stripped from `web-transport-quinn`
- Handles HTTP/3 SETTINGS exchange and CONNECT handshake
- Accepts unidirectional streams and strips WebTransport framing

**Streamer integration: `streamer/src/nonblocking/webtransport.rs`**
- `spawn_webtransport_server()` outputs `PacketBatch` compatible with banking stage
- Uses same channel as existing QUIC server
- Feature-gated behind `webtransport` flag (disabled by default)

**Testing:**
```bash
cargo test -p solana-streamer --features webtransport test_webtransport
```

This is a foundational PR. CLI flags (`--enable-webtransport`, `--webtransport-port`) and validator integration will follow in a separate PR.
