### PR TITLE
tpu-client-next: use `get` instead of `peek` in `ensure_worker`

### DIFF
--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -184,7 +184,7 @@ impl WorkersCache {
         handshake_timeout: Duration,
         stats: Arc<SendTransactionStats>,
     ) -> Option<ShutdownWorker> {
-        if let Some(worker) = self.workers.peek(&peer) {
+        if let Some(worker) = self.workers.get(&peer) {
             // if worker is active, we will reuse it. Otherwise, we will spawn
             // the new one and the existing will be popped out.
             if worker.is_active() {


### PR DESCRIPTION
#### Problem

When peek is used it doesn't change the position of the head. It is undesirable because we ensure_worker only when we get the next leaders for which we might want to open connections. Hence, if we don't touch these entries it might happen that they are old and will be replaced but something else. This happens when the cache is very small like 4.

For example, assuming that we have in cache [A, B, C] and since we added them in this order they will be ordered in how recent they are like [0, 1, 2]. Now we send to A only, and this changes order to [3, 1, 2]. On the next iteration we add a new leader D. B will be evicted.

#### Summary of Changes

Use get instead of peek to change the head position. This fix has been A/B tested on mainnet with cache size 4. With this fix I don't see log lines `No existing worker for ` which add written when we evict the connection just before using it. 

The long term fix would be to implement different cache https://github.com/anza-xyz/agave/issues/10098