### PR TITLE
Rekey `alt_bn128_little_endian` feature

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1213,7 +1213,7 @@ pub mod replace_spl_token_with_p_token {
 }
 
 pub mod alt_bn128_little_endian {
-    solana_pubkey::declare_id!("bnS3pWfLrxHRJvMyLm6EaYQkP7A2Fe9DxoKv4aGA8YM");
+    solana_pubkey::declare_id!("bn2oPgpkzQPT3tohMaAsMVGjhDmmDa4jCaVPqCFmtxM");
 }
 
 pub mod bls_pubkey_management_in_vote_account {


### PR DESCRIPTION
#### Summary of Changes

Rekeying the `alt_bn128_little_endian` feature after a fix in the feature gate logic in https://github.com/anza-xyz/agave/pull/10087.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
