### PR TITLE
test: add coverage for packet size check in repair_response_packet_from_bytes

### DIFF
--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -91,4 +91,17 @@ mod test {
     fn test_sigverify_shred_cpu_repair() {
         run_test_sigverify_shred_cpu_repair(0xdead_c0de);
     }
+
+    #[test]
+    fn test_repair_response_packet_from_bytes_oversized() {
+        let packet = Packet::default();
+        let max_buffer_size = packet.buffer_mut().len();
+        // Create data that exceeds packet buffer size when combined with nonce
+        let oversized_data = vec![0u8; max_buffer_size - SIZE_OF_NONCE + 1];
+        let dest = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+        let nonce = 42;
+
+        let result = repair_response_packet_from_bytes(oversized_data, &dest, nonce);
+        assert!(result.is_none(), "Should return None for oversized data");
+    }
 }

--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -91,17 +91,4 @@ mod test {
     fn test_sigverify_shred_cpu_repair() {
         run_test_sigverify_shred_cpu_repair(0xdead_c0de);
     }
-
-    #[test]
-    fn test_repair_response_packet_from_bytes_oversized() {
-        let packet = Packet::default();
-        let max_buffer_size = packet.buffer_mut().len();
-        // Create data that exceeds packet buffer size when combined with nonce
-        let oversized_data = vec![0u8; max_buffer_size - SIZE_OF_NONCE + 1];
-        let dest = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
-        let nonce = 42;
-
-        let result = repair_response_packet_from_bytes(oversized_data, &dest, nonce);
-        assert!(result.is_none(), "Should return None for oversized data");
-    }
 }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -2054,8 +2054,6 @@ mod tests {
 
         assert_eq!(shreds[0].slot(), 1);
         assert_eq!(shreds[0].index(), 0);
-        // Packet size check in repair_response_packet_from_bytes is now
-        // covered by test_repair_response_packet_from_bytes_oversized in repair_response.rs
         shreds.retain(|shred| shred.slot() != 1);
         blockstore
             .insert_shreds(shreds, None, false)

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -2054,9 +2054,8 @@ mod tests {
 
         assert_eq!(shreds[0].slot(), 1);
         assert_eq!(shreds[0].index(), 0);
-        // TODO: The test previously relied on corrupting shred payload
-        // size which we no longer want to expose. Current test no longer
-        // covers packet size check in repair_response_packet_from_bytes.
+        // Packet size check in repair_response_packet_from_bytes is now
+        // covered by test_repair_response_packet_from_bytes_oversized in repair_response.rs
         shreds.retain(|shred| shred.slot() != 1);
         blockstore
             .insert_shreds(shreds, None, false)


### PR DESCRIPTION
### Fix
Adds test coverage for the packet size check in repair_response_packet_from_bytes that was missing after removing the corrupted payload size test.
### Changes
- Added test_repair_response_packet_from_bytes_oversized to verify None is returned for oversized data
- Updated TODO comment in serve_repair.rs to reflect test coverage