### PR TITLE
Add io uring file writer

### DIFF
--- a/fs/src/buffered_writer.rs
+++ b/fs/src/buffered_writer.rs
@@ -10,7 +10,7 @@ use {
 /// Default buffer size for writing large files to disks. Since current implementation does not do
 /// background writing, this size is set above minimum reasonable SSD write sizes to also reduce
 /// number of syscalls.
-const DEFAULT_BUFFER_SIZE: usize = 2 * 1024 * 1024;
+const DEFAULT_BUFFER_SIZE: usize = 4 * crate::io_uring::file_writer::DEFAULT_WRITE_SIZE as usize;
 
 /// Return a buffered writer for creating a new file at `path`
 ///

--- a/fs/src/io_uring/file_creator.rs
+++ b/fs/src/io_uring/file_creator.rs
@@ -49,7 +49,7 @@ const MAX_OPEN_FILES: usize = 512;
 // (on open, since in accounts-db most files land in a single dir).
 const DEFAULT_MAX_IOWQ_WORKERS: u32 = 4;
 
-const CHECK_PROGRESS_AFTER_SUBMIT_TIMEOUT: Option<Duration> = Some(Duration::from_millis(10));
+pub(crate) const CHECK_PROGRESS_AFTER_SUBMIT_TIMEOUT: Option<Duration> = Some(Duration::from_millis(10));
 
 /// Utility for building [`IoUringFileCreator`] with specified tuning options.
 pub struct IoUringFileCreatorBuilder<'sp> {

--- a/fs/src/io_uring/file_creator.rs
+++ b/fs/src/io_uring/file_creator.rs
@@ -49,7 +49,8 @@ const MAX_OPEN_FILES: usize = 512;
 // (on open, since in accounts-db most files land in a single dir).
 const DEFAULT_MAX_IOWQ_WORKERS: u32 = 4;
 
-pub(crate) const CHECK_PROGRESS_AFTER_SUBMIT_TIMEOUT: Option<Duration> = Some(Duration::from_millis(10));
+pub(crate) const CHECK_PROGRESS_AFTER_SUBMIT_TIMEOUT: Option<Duration> =
+    Some(Duration::from_millis(10));
 
 /// Utility for building [`IoUringFileCreator`] with specified tuning options.
 pub struct IoUringFileCreatorBuilder<'sp> {

--- a/fs/src/io_uring/memory.rs
+++ b/fs/src/io_uring/memory.rs
@@ -252,3 +252,9 @@ impl IoBufferChunk {
         unsafe { ring.register_buffers(&iovecs) }
     }
 }
+
+impl AsMut<[u8]> for IoBufferChunk {
+    fn as_mut(&mut self) -> &mut [u8] {
+        unsafe { slice::from_raw_parts_mut(self.ptr, self.size as usize) }
+    }
+}

--- a/fs/src/io_uring/mod.rs
+++ b/fs/src/io_uring/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod dir_remover;
 pub mod file_creator;
+pub mod file_writer;
 pub mod memory;
 pub mod sequential_file_reader;
 pub(crate) mod sqpoll;


### PR DESCRIPTION
#### Problem
Writing to file currently just uses `BufWriter` without `IoUring`.
#### Summary of Changes
Add IoUringFileWriter which allows writing to a single file using io uring.

bench results:
```
files writer stats - num_direct_io_writes: 0 num_regular_io_writes: 5000 avg_num_buffers_free_during_write: 0.0028
files writer stats - num_direct_io_writes: 5000 num_regular_io_writes: 0 avg_num_buffers_free_during_write: 0.0042
io_uring: 1.133726434s
io_uring direct io: 1.051639206s
BufWriter: 1.506094476s
```

cc @kskalski

I copied most of the code from `SequentialFileReader` and `IoUringFileCreator` and didn't touch `max_iowq_workers`, `ring_squeue_size`, `shared_sqpoll_fd`.
