### PR TITLE
refactor: improves the naming of some methods in `Bank`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -963,7 +963,9 @@ impl Default for BankTestConfig {
 
 /// Data returned from [`Bank::calculate_epoch_inflation_rewards()`].
 struct EpochInflationRewards {
-    /// Amount of rewards a validator should get if it voted in every slot in the epoch and its stake is equal to the network capitalization i.e. the total supply.
+    /// Amount of rewards a validator should get if it voted in every slot in
+    /// the epoch and its stake is equal to the network capitalization i.e.
+    /// the total supply.
     validator_rewards_lamports: u64,
     /// How long a single epoch lasts in years.
     epoch_duration_in_years: f64,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -961,11 +961,15 @@ impl Default for BankTestConfig {
     }
 }
 
-#[derive(Debug)]
-struct PrevEpochInflationRewards {
-    validator_rewards: u64,
-    prev_epoch_duration_in_years: f64,
+/// Data returned from [`Bank::calculate_epoch_inflation_rewards()`].
+struct EpochInflationRewards {
+    /// Amount of rewards a validator should get if it voted in every slot in the epoch and its stake is equal to the network capitalization i.e. the total supply.
+    validator_rewards_lamports: u64,
+    /// How long a single epoch lasts in years.
+    epoch_duration_in_years: f64,
+    /// The current inflation rate for the validators.
     validator_rate: f64,
+    /// The current inflation rate for the foundation.
     foundation_rate: f64,
 }
 
@@ -2341,11 +2345,11 @@ impl Bank {
         });
     }
 
-    pub fn epoch_duration_in_years(&self, prev_epoch: Epoch) -> f64 {
+    pub fn epoch_duration_in_years(&self, epoch: Epoch) -> f64 {
         // period: time that has passed as a fraction of a year, basically the length of
         //  an epoch as a fraction of a year
         //  calculated as: slots_elapsed / (slots / year)
-        self.epoch_schedule().get_slots_in_epoch(prev_epoch) as f64 / self.slots_per_year
+        self.epoch_schedule().get_slots_in_epoch(epoch) as f64 / self.slots_per_year
     }
 
     // Calculates the starting-slot for inflation from the activation slot.
@@ -2386,11 +2390,12 @@ impl Bank {
         num_slots as f64 / self.slots_per_year
     }
 
-    fn calculate_previous_epoch_inflation_rewards(
+    /// For a given [`capitalization`] (total_supply in lamports) and [`epoch`], calculates various inflation related info.
+    fn calculate_epoch_inflation_rewards(
         &self,
-        prev_epoch_capitalization: u64,
-        prev_epoch: Epoch,
-    ) -> PrevEpochInflationRewards {
+        capitalization: u64,
+        epoch: Epoch,
+    ) -> EpochInflationRewards {
         let slot_in_year = self.slot_in_year_for_inflation();
         let (validator_rate, foundation_rate) = {
             let inflation = self.inflation.read().unwrap();
@@ -2400,14 +2405,13 @@ impl Bank {
             )
         };
 
-        let prev_epoch_duration_in_years = self.epoch_duration_in_years(prev_epoch);
-        let validator_rewards = (validator_rate
-            * prev_epoch_capitalization as f64
-            * prev_epoch_duration_in_years) as u64;
+        let epoch_duration_in_years = self.epoch_duration_in_years(epoch);
+        let validator_rewards_lamports =
+            (validator_rate * capitalization as f64 * epoch_duration_in_years) as u64;
 
-        PrevEpochInflationRewards {
-            validator_rewards,
-            prev_epoch_duration_in_years,
+        EpochInflationRewards {
+            validator_rewards_lamports,
+            epoch_duration_in_years,
             validator_rate,
             foundation_rate,
         }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -8,7 +8,7 @@ use {
     },
     crate::{
         bank::{
-            null_tracer, PrevEpochInflationRewards, RewardCalcTracer, RewardCalculationEvent,
+            null_tracer, EpochInflationRewards, RewardCalcTracer, RewardCalculationEvent,
             RewardsMetrics, VoteReward, VoteRewards,
         },
         inflation_rewards::{
@@ -296,12 +296,12 @@ impl Bank {
         metrics: &mut RewardsMetrics,
     ) -> PartitionedRewardsCalculation {
         let capitalization = self.capitalization();
-        let PrevEpochInflationRewards {
-            validator_rewards,
-            prev_epoch_duration_in_years,
+        let EpochInflationRewards {
+            validator_rewards_lamports,
+            epoch_duration_in_years,
             validator_rate,
             foundation_rate,
-        } = self.calculate_previous_epoch_inflation_rewards(capitalization, rewarded_epoch);
+        } = self.calculate_epoch_inflation_rewards(capitalization, rewarded_epoch);
 
         let CalculateValidatorRewardsResult {
             vote_rewards_accounts: vote_account_rewards,
@@ -313,7 +313,7 @@ impl Bank {
                 stake_delegations,
                 cached_vote_accounts,
                 rewarded_epoch,
-                validator_rewards,
+                validator_rewards_lamports,
                 reward_calc_tracer,
                 thread_pool,
                 metrics,
@@ -330,7 +330,7 @@ impl Bank {
             stake_rewards,
             validator_rate,
             foundation_rate,
-            prev_epoch_duration_in_years,
+            prev_epoch_duration_in_years: epoch_duration_in_years,
             capitalization,
             point_value,
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -831,21 +831,22 @@ where
         - bank2_sysvar_delta();
 
     // this assumes that no new builtins or precompiles were activated in bank1 or bank2
-    let PrevEpochInflationRewards {
-        validator_rewards, ..
-    } = bank2.calculate_previous_epoch_inflation_rewards(bank0.capitalization(), bank0.epoch());
+    let EpochInflationRewards {
+        validator_rewards_lamports,
+        ..
+    } = bank2.calculate_epoch_inflation_rewards(bank0.capitalization(), bank0.epoch());
 
     // verify the stake and vote accounts are the right size
     assert!(
         ((bank2.get_balance(&stake_id) - stake_account.lamports() + bank2.get_balance(&vote_id)
             - vote_account.lamports()) as f64
-            - validator_rewards as f64)
+            - validator_rewards_lamports as f64)
             .abs()
             < 1.0
     );
 
     // verify the rewards are the right size
-    assert!((validator_rewards as f64 - paid_rewards as f64).abs() < 1.0); // rounding, truncating
+    assert!((validator_rewards_lamports as f64 - paid_rewards as f64).abs() < 1.0); // rounding, truncating
 
     // verify validator rewards show up in rewards vectors
     assert_eq!(
@@ -854,7 +855,7 @@ where
             stake_id,
             RewardInfo {
                 reward_type: RewardType::Staking,
-                lamports: validator_rewards as i64,
+                lamports: validator_rewards_lamports as i64,
                 post_balance: bank2.get_balance(&stake_id),
                 commission: Some(0),
             }


### PR DESCRIPTION
#### Problem

Some methods in `Bank` are referring to the previous epoch but the logic in the methods does not care that which epoch the inputs were.


#### Summary of Changes

- Renames `calculate_previous_epoch_inflation_rewards()` to `calculate_epoch_inflation_rewards()` and removes the `prev_` prefixes from the inputs
- Correspondingly renames `PrevEpochInflationRewards` to `EpochInflationRewards` and removes the `prev_` prefix in one of the fields.
- Removes the `prev_` prefix from the input in `epoch_duration_in_years()`
- Also adds some documentation

#### Context

When paying calculating rewards in Alpenglow, I need to perform similar calculations and want to reuse some of this code.  https://github.com/anza-xyz/alpenglow/pull/682/changes#r2698882426