### PR TITLE
fix: ledger-tool TransactionStatusService start condition

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -300,7 +300,7 @@ pub fn load_and_process_ledger(
     let enable_rpc_transaction_history = arg_matches.is_present("enable_rpc_transaction_history");
 
     let (transaction_status_sender, transaction_status_service) =
-        if geyser_plugin_active || enable_rpc_transaction_history {
+        if enable_rpc_transaction_history || transaction_notifier.is_some() {
             // Need Primary (R/W) access to insert transaction and rewards data;
             // obtain Primary access if we do not already have it
             let write_blockstore =


### PR DESCRIPTION
TransactionStatusService in ledger-tool was started whenever any geyser plugin was configured, even if no transaction notifier existed. This caused the service to process batches and build transaction metadata that was never used, wasting CPU and allocations.
Align ledger-tool startup logic with validator behavior by only starting TransactionStatusService when RPC transaction history is enabled or a transaction notifier is present.