### PR TITLE
svm: remove redundant runtime environment clone

### DIFF
--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -40,7 +40,7 @@ pub(crate) fn load_program_from_bytes(
         unsafe {
             ProgramCacheEntry::reload(
                 loader_key,
-                program_runtime_environment.clone(),
+                program_runtime_environment,
                 deployment_slot,
                 deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
                 programdata,
@@ -51,7 +51,7 @@ pub(crate) fn load_program_from_bytes(
     } else {
         ProgramCacheEntry::new(
             loader_key,
-            program_runtime_environment.clone(),
+            program_runtime_environment,
             deployment_slot,
             deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
             programdata,


### PR DESCRIPTION
Before this change we cloned the program runtime environment twice per load call (once at the call site and again inside load_program_from_bytes), which was unnecessary because Arc cloning is already done when passing the environment in.
Removed the redundant internal clone so the runtime environment is moved into ProgramCacheEntry::new/reload without extra refcount churn.