### PR TITLE
refactor: removes an unused field

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -967,8 +967,6 @@ struct EpochInflationRewards {
     /// the epoch and its stake is equal to the network capitalization i.e.
     /// the total supply.
     validator_rewards_lamports: u64,
-    /// How long a single epoch lasts in years.
-    epoch_duration_in_years: f64,
     /// The current inflation rate for the validators.
     validator_rate: f64,
     /// The current inflation rate for the foundation.
@@ -2413,7 +2411,6 @@ impl Bank {
 
         EpochInflationRewards {
             validator_rewards_lamports,
-            epoch_duration_in_years,
             validator_rate,
             foundation_rate,
         }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -207,7 +207,6 @@ impl Bank {
             stake_rewards,
             validator_rate,
             foundation_rate,
-            prev_epoch_duration_in_years,
             capitalization,
             point_value,
             ..
@@ -252,11 +251,6 @@ impl Bank {
             ("epoch", prev_epoch, i64),
             ("validator_rate", *validator_rate, f64),
             ("foundation_rate", *foundation_rate, f64),
-            (
-                "epoch_duration_in_years",
-                *prev_epoch_duration_in_years,
-                f64
-            ),
             ("validator_rewards", total_vote_rewards, i64),
             ("active_stake", active_stake, i64),
             ("pre_capitalization", *capitalization, i64),
@@ -298,7 +292,6 @@ impl Bank {
         let capitalization = self.capitalization();
         let EpochInflationRewards {
             validator_rewards_lamports,
-            epoch_duration_in_years,
             validator_rate,
             foundation_rate,
         } = self.calculate_epoch_inflation_rewards(capitalization, rewarded_epoch);
@@ -330,7 +323,6 @@ impl Bank {
             stake_rewards,
             validator_rate,
             foundation_rate,
-            prev_epoch_duration_in_years: epoch_duration_in_years,
             capitalization,
             point_value,
         }

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -303,7 +303,6 @@ pub(super) struct PartitionedRewardsCalculation {
     pub(super) stake_rewards: StakeRewardCalculation,
     pub(super) validator_rate: f64,
     pub(super) foundation_rate: f64,
-    pub(super) prev_epoch_duration_in_years: f64,
     pub(super) capitalization: u64,
     point_value: PointValue,
 }


### PR DESCRIPTION
#### Problem

`epoch_duration_in_years` appears to be unused


#### Summary of Changes

Removes `epoch_duration_in_years`
