### PR TITLE
SIMD-0437: Incremental 10x Rent Reduction Schedule

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1244,6 +1244,37 @@ pub mod enable_bls12_381_syscall {
     solana_pubkey::declare_id!("b1sraWPVFdcUizB2LV5wQTeMuK8M313bi5bHjco5eVU");
 }
 
+// SIMD-0437 feature gates
+pub mod set_lamports_per_byte_to_6333 {
+    solana_pubkey::declare_id!("4a6f7o7iTcA8hRDCrPLkSatnt5Ykxiu36wo5p1Tt12wC");
+
+    pub const LAMPORTS_PER_BYTE: u64 = 6333;
+}
+
+pub mod set_lamports_per_byte_to_5080 {
+    solana_pubkey::declare_id!("61BtM7BkDEE8Yq5fskEVAQT9mYA8qCejJWoLe5apqg81");
+
+    pub const LAMPORTS_PER_BYTE: u64 = 5080;
+}
+
+pub mod set_lamports_per_byte_to_2575 {
+    solana_pubkey::declare_id!("Ftxb3ZKq7aNqgxDBbP7EonvR2RszZk9ctjdsTX38kQaz");
+
+    pub const LAMPORTS_PER_BYTE: u64 = 2575;
+}
+
+pub mod set_lamports_per_byte_to_1322 {
+    solana_pubkey::declare_id!("GsUBNYNDPdMLHPD37TToHzrzcNcjpC9w5n1EcJk5iTaM");
+
+    pub const LAMPORTS_PER_BYTE: u64 = 1322;
+}
+
+pub mod set_lamports_per_byte_to_696 {
+    solana_pubkey::declare_id!("mZdnRh9T2EbDNvqKjkCR3bvo5c816tJaojtE9Xs7iuY");
+
+    pub const LAMPORTS_PER_BYTE: u64 = 696;
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2230,6 +2261,26 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             enable_bls12_381_syscall::id(),
             "SIMD-0388: BLS12-381 syscalls",
+        ),
+        (
+            set_lamports_per_byte_to_6333::id(),
+            "SIMD-0437-1: Set lamports per byte to 6333",
+        ),
+        (
+            set_lamports_per_byte_to_5080::id(),
+            "SIMD-0437-2: Set lamports per byte to 5080",
+        ),
+        (
+            set_lamports_per_byte_to_2575::id(),
+            "SIMD-0437-3: Set lamports per byte to 2575",
+        ),
+        (
+            set_lamports_per_byte_to_1322::id(),
+            "SIMD-0437-4: Set lamports per byte to 1322",
+        ),
+        (
+            set_lamports_per_byte_to_696::id(),
+            "SIMD-0437-5: Set lamports per byte to 696",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5398,6 +5398,33 @@ impl Bank {
             self.update_rent();
         }
 
+        // SIMD-0437 feature gates: all assume rent exemption threshold has been deprecated (SIMD-0194),
+        // so rent.lamports_per_byte_year can be set directly
+        {
+            if new_feature_activations.contains(&feature_set::set_lamports_per_byte_to_6333::id()) {
+                self.rent_collector.rent.lamports_per_byte_year =
+                    feature_set::set_lamports_per_byte_to_6333::LAMPORTS_PER_BYTE;
+            }
+            if new_feature_activations.contains(&feature_set::set_lamports_per_byte_to_5080::id()) {
+                self.rent_collector.rent.lamports_per_byte_year =
+                    feature_set::set_lamports_per_byte_to_5080::LAMPORTS_PER_BYTE;
+            }
+            if new_feature_activations.contains(&feature_set::set_lamports_per_byte_to_2575::id()) {
+                self.rent_collector.rent.lamports_per_byte_year =
+                    feature_set::set_lamports_per_byte_to_2575::LAMPORTS_PER_BYTE;
+            }
+            if new_feature_activations.contains(&feature_set::set_lamports_per_byte_to_1322::id()) {
+                self.rent_collector.rent.lamports_per_byte_year =
+                    feature_set::set_lamports_per_byte_to_1322::LAMPORTS_PER_BYTE;
+            }
+            if new_feature_activations.contains(&feature_set::set_lamports_per_byte_to_696::id()) {
+                self.rent_collector.rent.lamports_per_byte_year =
+                    feature_set::set_lamports_per_byte_to_696::LAMPORTS_PER_BYTE;
+            }
+
+            self.update_rent();
+        }
+
         if new_feature_activations.contains(&feature_set::pico_inflation::id()) {
             *self.inflation.write().unwrap() = Inflation::pico();
             self.fee_rate_governor.burn_percent = solana_fee_calculator::DEFAULT_BURN_PERCENT; // 50% fee burn

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5398,31 +5398,38 @@ impl Bank {
             self.update_rent();
         }
 
-        // SIMD-0437 feature gates: all assume rent exemption threshold has been deprecated (SIMD-0194),
-        // so rent.lamports_per_byte_year can be set directly
-        {
-            if new_feature_activations.contains(&feature_set::set_lamports_per_byte_to_6333::id()) {
-                self.rent_collector.rent.lamports_per_byte_year =
-                    feature_set::set_lamports_per_byte_to_6333::LAMPORTS_PER_BYTE;
+        // SIMD-0437 feature gates: all assume rent exemption threshold has been deprecated
+        // (SIMD-0194), so rent.lamports_per_byte_year can be set directly. These gates are
+        // expected to activate in order; if multiple activate in one epoch, the lowest
+        // activated lamports_per_byte value will be used. If features are activated out of
+        // order, the most recently activated value will be used.
+        let rent_feature_gates = [
+            (
+                feature_set::set_lamports_per_byte_to_6333::id(),
+                feature_set::set_lamports_per_byte_to_6333::LAMPORTS_PER_BYTE,
+            ),
+            (
+                feature_set::set_lamports_per_byte_to_5080::id(),
+                feature_set::set_lamports_per_byte_to_5080::LAMPORTS_PER_BYTE,
+            ),
+            (
+                feature_set::set_lamports_per_byte_to_2575::id(),
+                feature_set::set_lamports_per_byte_to_2575::LAMPORTS_PER_BYTE,
+            ),
+            (
+                feature_set::set_lamports_per_byte_to_1322::id(),
+                feature_set::set_lamports_per_byte_to_1322::LAMPORTS_PER_BYTE,
+            ),
+            (
+                feature_set::set_lamports_per_byte_to_696::id(),
+                feature_set::set_lamports_per_byte_to_696::LAMPORTS_PER_BYTE,
+            ),
+        ];
+        for (feature_id, lamports_per_byte_year) in rent_feature_gates {
+            if new_feature_activations.contains(&feature_id) {
+                self.rent_collector.rent.lamports_per_byte_year = lamports_per_byte_year;
+                self.update_rent();
             }
-            if new_feature_activations.contains(&feature_set::set_lamports_per_byte_to_5080::id()) {
-                self.rent_collector.rent.lamports_per_byte_year =
-                    feature_set::set_lamports_per_byte_to_5080::LAMPORTS_PER_BYTE;
-            }
-            if new_feature_activations.contains(&feature_set::set_lamports_per_byte_to_2575::id()) {
-                self.rent_collector.rent.lamports_per_byte_year =
-                    feature_set::set_lamports_per_byte_to_2575::LAMPORTS_PER_BYTE;
-            }
-            if new_feature_activations.contains(&feature_set::set_lamports_per_byte_to_1322::id()) {
-                self.rent_collector.rent.lamports_per_byte_year =
-                    feature_set::set_lamports_per_byte_to_1322::LAMPORTS_PER_BYTE;
-            }
-            if new_feature_activations.contains(&feature_set::set_lamports_per_byte_to_696::id()) {
-                self.rent_collector.rent.lamports_per_byte_year =
-                    feature_set::set_lamports_per_byte_to_696::LAMPORTS_PER_BYTE;
-            }
-
-            self.update_rent();
         }
 
         if new_feature_activations.contains(&feature_set::pico_inflation::id()) {


### PR DESCRIPTION
#### Summary of Changes

Implementation of [SIMD-0437](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0437-incremental-rent-reduction.md):
- 5 feature gates, each intended to activate a specific step in the rent reduction schedule defined in the SIMD
- Implementation (not feature itself) depends on SIMD-0194 activation (deprecation of rent exemption threshold), so `rent.lamports_per_byte_year` can be set directly and floating point division can be avoided. 
