### PR TITLE
SIMD-0438: Rent Increase Safeguard

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1539,6 +1539,12 @@ pub mod define_ltds_fee_only_semantics {
     solana_pubkey::declare_id!("LTDSzjZKFJMKHYpNycG1FrWwGGTaFFwqEFjB5GGLNVD");
 }
 
+pub mod set_lamports_per_byte_to_6960 {
+    solana_pubkey::declare_id!("5AqsUgSb6cgLizSaNiFn3o9XB7VUtKDtDZfcKEjEDmni");
+
+    pub const LAMPORTS_PER_BYTE: u64 = 6960;
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2592,6 +2598,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             define_ltds_fee_only_semantics::id(),
             "SIMD-0186 Amendment: Define fee-only semantics",
+        ),
+        (
+            set_lamports_per_byte_to_6960::id(),
+            "SIMD-0438: Reset lamports per byte to legacy value of 6960",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
         /***** ADD NEW FEATURE BOOL TO `FeatureSnapshot` *****/

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5734,7 +5734,7 @@ impl Bank {
         }
 
         // SIMD-0437 feature gates: all assume rent exemption threshold has been deprecated
-        // (SIMD-0194), so rent.lamports_per_byte_year can be set directly. These gates are
+        // (SIMD-0194), so rent.lamports_per_byte can be set directly. These gates are
         // expected to activate in order; if multiple activate in one epoch, the lowest
         // activated lamports_per_byte value will be used. If features are activated out of
         // order, the most recently activated value will be used.
@@ -5760,9 +5760,9 @@ impl Bank {
                 feature_set::set_lamports_per_byte_to_696::LAMPORTS_PER_BYTE,
             ),
         ];
-        for (feature_id, lamports_per_byte_year) in rent_feature_gates {
+        for (feature_id, lamports_per_byte) in rent_feature_gates {
             if new_feature_activations.contains(&feature_id) {
-                self.rent_collector.rent.lamports_per_byte = lamports_per_byte_year;
+                self.rent_collector.rent.lamports_per_byte = lamports_per_byte;
                 self.update_rent();
             }
         }
@@ -5772,7 +5772,7 @@ impl Bank {
         // Note: if this is activated in the same epoch as a 437 feature gate (above), the
         // safeguard must override it.
         if new_feature_activations.contains(&feature_set::set_lamports_per_byte_to_6960::id()) {
-            self.rent_collector.rent.lamports_per_byte_year =
+            self.rent_collector.rent.lamports_per_byte =
                 feature_set::set_lamports_per_byte_to_6960::LAMPORTS_PER_BYTE;
             self.update_rent();
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5767,6 +5767,16 @@ impl Bank {
             }
         }
 
+        // SIMD-0438 feature gate: reset lamports per byte to legacy value of 6960. Safeguard
+        // intended to be activated if rent reduction causes issues in the cluster.
+        // Note: if this is activated in the same epoch as a 437 feature gate (above), the
+        // safeguard must override it.
+        if new_feature_activations.contains(&feature_set::set_lamports_per_byte_to_6960::id()) {
+            self.rent_collector.rent.lamports_per_byte_year =
+                feature_set::set_lamports_per_byte_to_6960::LAMPORTS_PER_BYTE;
+            self.update_rent();
+        }
+
         if new_feature_activations.contains(&feature_set::pico_inflation::id()) {
             *self.inflation.write().unwrap() = Inflation::pico();
             self.fee_rate_governor.burn_percent = solana_fee_calculator::DEFAULT_BURN_PERCENT;

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6286,7 +6286,7 @@ fn test_block_limits() {
 }
 
 #[test]
-fn test_simd_0437_rent_feature_gates_epoch_transition() {
+fn test_rent_feature_gates_epoch_transition() {
     let (mut genesis_config, _mint_keypair) = create_genesis_config(1_000_000);
     genesis_config.rent.lamports_per_byte = 0;
     let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
@@ -6311,6 +6311,10 @@ fn test_simd_0437_rent_feature_gates_epoch_transition() {
         (
             feature_set::set_lamports_per_byte_to_696::id(),
             feature_set::set_lamports_per_byte_to_696::LAMPORTS_PER_BYTE,
+        ),
+        (
+            feature_set::set_lamports_per_byte_to_6960::id(),
+            feature_set::set_lamports_per_byte_to_6960::LAMPORTS_PER_BYTE,
         ),
     ];
     let feature_account_balance =
@@ -6357,7 +6361,8 @@ fn test_simd_0437_rent_feature_gate_activation_ordering() {
     let feature_account_balance =
         std::cmp::max(genesis_config.rent.minimum_balance(Feature::size_of()), 1);
 
-    // Multiple activations in a single epoch boundary should settle on the lowest value.
+    // Multiple activations in a single epoch boundary should settle on the lowest value,
+    // unless the SIMD-0438 safeguard is present, which must override.
     let multiple_activation_features = [
         (
             feature_set::set_lamports_per_byte_to_6333::id(),
@@ -6409,6 +6414,37 @@ fn test_simd_0437_rent_feature_gate_activation_ordering() {
         bank.rent_collector.rent.lamports_per_byte,
         feature_set::set_lamports_per_byte_to_5080::LAMPORTS_PER_BYTE,
         "most recent activation should win even when out of order"
+    );
+
+    // safeguard override
+    let multiple_activation_features = [
+        (
+            feature_set::set_lamports_per_byte_to_6960::id(),
+            feature_set::set_lamports_per_byte_to_6960::LAMPORTS_PER_BYTE,
+        ),
+        (
+            feature_set::set_lamports_per_byte_to_696::id(),
+            feature_set::set_lamports_per_byte_to_696::LAMPORTS_PER_BYTE,
+        ),
+    ];
+    for (feature_id, _) in multiple_activation_features {
+        bank.store_account(
+            &feature_id,
+            &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
+        );
+    }
+    goto_end_of_slot(bank.clone());
+    bank = new_from_parent_next_epoch(bank, &bank_forks, 1);
+    assert!(bank
+        .feature_set
+        .is_active(&feature_set::set_lamports_per_byte_to_6960::id()));
+    assert!(bank
+        .feature_set
+        .is_active(&feature_set::set_lamports_per_byte_to_696::id()));
+    assert_eq!(
+        bank.rent_collector.rent.lamports_per_byte_year,
+        feature_set::set_lamports_per_byte_to_6960::LAMPORTS_PER_BYTE,
+        "SIMD-0438 safeguard should override later activations"
     );
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6435,14 +6435,16 @@ fn test_simd_0437_rent_feature_gate_activation_ordering() {
     }
     goto_end_of_slot(bank.clone());
     bank = new_from_parent_next_epoch(bank, &bank_forks, 1);
-    assert!(bank
-        .feature_set
-        .is_active(&feature_set::set_lamports_per_byte_to_6960::id()));
-    assert!(bank
-        .feature_set
-        .is_active(&feature_set::set_lamports_per_byte_to_696::id()));
+    assert!(
+        bank.feature_set
+            .is_active(&feature_set::set_lamports_per_byte_to_6960::id())
+    );
+    assert!(
+        bank.feature_set
+            .is_active(&feature_set::set_lamports_per_byte_to_696::id())
+    );
     assert_eq!(
-        bank.rent_collector.rent.lamports_per_byte_year,
+        bank.rent_collector.rent.lamports_per_byte,
         feature_set::set_lamports_per_byte_to_6960::LAMPORTS_PER_BYTE,
         "SIMD-0438 safeguard should override later activations"
     );


### PR DESCRIPTION
#### Summary of Changes

Implementation of [SIMD-0438](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0438-rent-increase-safeguard.md): Proactive Rent-Increase Safeguard. This is a "latent" feature gate that should only be activated if rent reduction causes unexpected issues.
