### PR TITLE
turbine: Combine counter into existing datapoint

### DIFF
--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -38,6 +38,7 @@ pub struct ProcessShredsStats {
     pub err_unknown_chained_merkle_root: u64,
     pub(crate) padding_bytes: usize,
     pub(crate) data_bytes: usize,
+    pub(crate) num_entries: usize,
     num_merkle_data_shreds: usize,
     num_merkle_coding_shreds: usize,
 }
@@ -87,6 +88,7 @@ impl ProcessShredsStats {
             ("slot", slot, i64),
             ("shredding_time", self.shredding_elapsed, i64),
             ("receive_time", self.receive_elapsed, i64),
+            ("num_entries", self.num_entries, i64),
             ("num_data_shreds", self.num_merkle_data_shreds, i64),
             ("num_coding_shreds", self.num_merkle_coding_shreds, i64),
             ("slot_broadcast_time", slot_broadcast_time, i64),
@@ -241,6 +243,7 @@ impl AddAssign<ProcessShredsStats> for ProcessShredsStats {
             err_unknown_chained_merkle_root,
             padding_bytes,
             data_bytes,
+            num_entries,
             num_merkle_data_shreds,
             num_merkle_coding_shreds,
         } = rhs;
@@ -260,6 +263,7 @@ impl AddAssign<ProcessShredsStats> for ProcessShredsStats {
         self.err_unknown_chained_merkle_root += err_unknown_chained_merkle_root;
         self.padding_bytes += padding_bytes;
         self.data_bytes += data_bytes;
+        self.num_entries += num_entries;
         self.num_merkle_data_shreds += num_merkle_data_shreds;
         self.num_merkle_coding_shreds += num_merkle_coding_shreds;
         for (i, bucket) in self.num_data_shreds_hist.iter_mut().enumerate() {

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -75,6 +75,7 @@ impl Shredder {
         reed_solomon_cache: &ReedSolomonCache,
         stats: &mut ProcessShredsStats,
     ) -> impl Iterator<Item = Shred> + use<> {
+        stats.num_entries += entries.len();
         let now = Instant::now();
         let entries = wincode::serialize(entries).unwrap();
         stats.serialize_elapsed += now.elapsed().as_micros() as u64;

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -22,7 +22,7 @@ use {
     solana_keypair::Keypair,
     solana_ledger::{blockstore::Blockstore, shred::Shred},
     solana_measure::measure::Measure,
-    solana_metrics::{inc_new_counter_error, inc_new_counter_info},
+    solana_metrics::inc_new_counter_error,
     solana_net_utils::SocketAddrSpace,
     solana_poh::poh_recorder::WorkingBankEntry,
     solana_pubkey::Pubkey,

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -190,8 +190,6 @@ impl StandardBroadcastRun {
             last_tick_height,
         } = receive_results;
 
-        inc_new_counter_info!("broadcast_service-entries_received", entries.len());
-
         let mut to_shreds_time = Measure::start("broadcast_to_shreds");
 
         if self.slot != bank.slot() {


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/issues/9185

#### Summary of Changes
Combine the counter into the existing struct. In addition to not having the `Counter`, the "num entries" field will now be per-slot instead of per-time which is often more useful for deep dives

The change is pretty straight forward, but threw it on a box and spot-checked a couple metrics submissions to see that `num_entries` reported by the metric matches what I get when inspecting the block (with `ledger-tool`)