### PR TITLE
genesis: fix primordial accounts feature override for vote state

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -740,9 +740,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             std::process::exit(1);
         });
 
-    // Determine if vote_state_v4 will be active at genesis
-    let vote_state_v4_enabled = !features_to_deactivate.contains(&vote_state_v4::id());
-
     match matches.value_of("hashes_per_tick").unwrap() {
         "auto" => match cluster_type {
             ClusterType::Development => {
@@ -803,18 +800,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let is_alpenglow = matches.is_present("alpenglow");
 
-    add_validator_accounts(
-        &mut genesis_config,
-        &mut bootstrap_validator_pubkeys.iter(),
-        &mut bootstrap_validator_bls_pubkeys.unwrap_or_default().iter(),
-        bootstrap_validator_lamports,
-        bootstrap_validator_stake_lamports,
-        commission,
-        &rent,
-        bootstrap_stake_authorized_pubkey.as_ref(),
-        vote_state_v4_enabled,
-    )?;
-
     if let Some(creation_time) = unix_timestamp_from_rfc3339_datetime(&matches, "creation_time") {
         genesis_config.creation_time = creation_time;
     }
@@ -847,6 +832,34 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             load_genesis_accounts(file, &mut genesis_config)?;
         }
     }
+
+    // After primordial accounts are read in, check to see if vote state v4
+    // was manually deactivated by providing an inactive Feature account.
+    let vote_state_v4_enabled = {
+        use solana_feature_gate_interface::from_account;
+
+        let is_primordial_inactive_feature = genesis_config
+            .accounts
+            .iter()
+            .find(|(key, _)| key.eq(&&vote_state_v4::id()))
+            .is_some_and(|(_, acct)| from_account(acct).is_none());
+
+        let is_explicitly_deactivated = features_to_deactivate.contains(&vote_state_v4::id());
+
+        !is_primordial_inactive_feature && !is_explicitly_deactivated
+    };
+
+    add_validator_accounts(
+        &mut genesis_config,
+        &mut bootstrap_validator_pubkeys.iter(),
+        &mut bootstrap_validator_bls_pubkeys.unwrap_or_default().iter(),
+        bootstrap_validator_lamports,
+        bootstrap_validator_stake_lamports,
+        commission,
+        &rent,
+        bootstrap_stake_authorized_pubkey.as_ref(),
+        vote_state_v4_enabled,
+    )?;
 
     if let Some(files) = matches.values_of("validator_accounts_file") {
         for file in files {


### PR DESCRIPTION
#### Problem
Some configurations - like the invalidator - use "primordial accounts" that can be read in from one or more config files and used as initial accounts in genesis. If an account is provided for a feature ID and it's not owned by `Feature1111...` or has invalid state, it will be considered an inactive feature.

The conditional logic added to enable or disable vote state v4 depending on the feature status must also consider primordial accounts.

#### Summary of Changes
Move the call to `add_validator_accounts` lower in the workflow, then evaluate `vote_state_v4_enabled` based on a combination of primordial account inputs and explicitly deactivated features.

Fixes issues reported by @fkouteib.