### PR TITLE
vote-program: support more fields in v4 create-account helper

### DIFF
--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -82,7 +82,7 @@ use {
         stake_flags::StakeFlags,
         state::{Authorized, Delegation, Meta, Stake, StakeStateV2},
     },
-    solana_vote_program::vote_state,
+    solana_vote_program::vote_state::{self, BLS_PUBLIC_KEY_COMPRESSED_SIZE},
 };
 
 // These functions/fields are only usable from a dev context (i.e. tests and benches)
@@ -101,9 +101,12 @@ impl StakeReward {
         let validator_vote_account = vote_state::create_v4_account_with_authorized(
             &validator_pubkey,
             &validator_voting_keypair.pubkey(),
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &validator_voting_keypair.pubkey(),
-            None,
             1000,
+            &validator_voting_keypair.pubkey(),
+            0,
+            &validator_voting_keypair.pubkey(),
             validator_stake_lamports,
         );
 

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -282,7 +282,7 @@ mod tests {
         solana_vote::vote_transaction,
         solana_vote_program::vote_state::{
             self, process_slot_vote_unchecked, TowerSync, VoteStateV4, VoteStateVersions,
-            MAX_LOCKOUT_HISTORY,
+            BLS_PUBLIC_KEY_COMPRESSED_SIZE, MAX_LOCKOUT_HISTORY,
         },
     };
 
@@ -404,9 +404,12 @@ mod tests {
         let mut vote_account1 = vote_state::create_v4_account_with_authorized(
             &solana_pubkey::new_rand(),
             &pk1,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &pk1,
-            None,
             0,
+            &pk1,
+            0,
+            &pk1,
             100,
         );
         let stake_account1 = stake_utils::create_stake_account(
@@ -421,9 +424,12 @@ mod tests {
         let mut vote_account2 = vote_state::create_v4_account_with_authorized(
             &solana_pubkey::new_rand(),
             &pk2,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &pk2,
-            None,
             0,
+            &pk2,
+            0,
+            &pk2,
             50,
         );
         let stake_account2 =
@@ -433,9 +439,12 @@ mod tests {
         let mut vote_account3 = vote_state::create_v4_account_with_authorized(
             &solana_pubkey::new_rand(),
             &pk3,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &pk3,
-            None,
             0,
+            &pk3,
+            0,
+            &pk3,
             1,
         );
         let stake_account3 = stake_utils::create_stake_account(
@@ -450,9 +459,12 @@ mod tests {
         let mut vote_account4 = vote_state::create_v4_account_with_authorized(
             &solana_pubkey::new_rand(),
             &pk4,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &pk4,
-            None,
             0,
+            &pk4,
+            0,
+            &pk4,
             1,
         );
         let stake_account4 = stake_utils::create_stake_account(

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -48,7 +48,9 @@ use {
     solana_sdk_ids::system_program,
     solana_signer::Signer,
     solana_stake_interface::state::StakeStateV2,
-    solana_vote_program::vote_state::{self, VoteStateV3, VoteStateV4},
+    solana_vote_program::vote_state::{
+        self, VoteStateV3, VoteStateV4, BLS_PUBLIC_KEY_COMPRESSED_SIZE,
+    },
     std::{
         collections::HashMap,
         error,
@@ -279,14 +281,20 @@ fn add_validator_accounts(
             AccountSharedData::new(lamports, 0, &system_program::id()),
         );
 
-        let bls_pubkey_compressed_bytes = bls_pubkeys_iter.next().map(|bls_pubkey| bls_pubkey.0);
+        let bls_pubkey_compressed_bytes = bls_pubkeys_iter
+            .next()
+            .map(|bls_pubkey| bls_pubkey.0)
+            .unwrap_or([0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]);
         let vote_account = if vote_state_v4_enabled {
             vote_state::create_v4_account_with_authorized(
                 identity_pubkey,
                 identity_pubkey,
-                identity_pubkey,
                 bls_pubkey_compressed_bytes,
+                identity_pubkey,
                 u16::from(commission) * 100,
+                identity_pubkey,
+                0,
+                identity_pubkey,
                 rent.minimum_balance(VoteStateV4::size_of()).max(1),
             )
         } else {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -82,7 +82,7 @@ use {
     solana_vote::vote_state_view::VoteStateView,
     solana_vote_program::{
         self,
-        vote_state::{self, VoteStateV3, VoteStateV4},
+        vote_state::{self, VoteStateV3, VoteStateV4, BLS_PUBLIC_KEY_COMPRESSED_SIZE},
     },
     std::{
         collections::{HashMap, HashSet},
@@ -2406,9 +2406,12 @@ fn main() {
                                 vote_state::create_v4_account_with_authorized(
                                     identity_pubkey,
                                     identity_pubkey,
+                                    [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                                     identity_pubkey,
-                                    None,
                                     10000,
+                                    identity_pubkey,
+                                    0,
+                                    identity_pubkey,
                                     rent.minimum_balance(VoteStateV4::size_of()).max(1),
                                 )
                             } else {

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -27,7 +27,7 @@ use {
     solana_sysvar::{clock, SysvarSerialize},
     solana_transaction::Transaction,
     solana_transaction_error::TransactionError,
-    solana_vote_program::vote_state,
+    solana_vote_program::vote_state::{self, BLS_PUBLIC_KEY_COMPRESSED_SIZE},
     std::{convert::TryInto, slice},
 };
 
@@ -223,9 +223,12 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
     let vote_account = vote_state::create_v4_account_with_authorized(
         &node_address,
         &vote_address,
+        [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
         &vote_address,
-        None,
         0,
+        &vote_address,
+        0,
+        &vote_address,
         1_000_000_000,
     );
     program_test.add_account(vote_address, vote_account.clone().into());

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8597,6 +8597,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-vote",
+ "solana-vote-interface",
  "solana-vote-program",
  "test-case",
 ]

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -172,6 +172,7 @@ solana-sysvar = "=3.1.1"
 solana-transaction-context = { path = "../../transaction-context", version = "=4.0.0-alpha.0" }
 solana-transaction-status = { path = "../../transaction-status", version = "=4.0.0-alpha.0" }
 solana-vote = { path = "../../vote", version = "=4.0.0-alpha.0" }
+solana-vote-interface = "5.0.0"
 solana-vote-program = { path = "../../programs/vote", version = "=4.0.0-alpha.0" }
 test-case = "3.3.1"
 thiserror = "2.0"
@@ -257,6 +258,7 @@ solana-transaction-context = { workspace = true, features = [
 solana-transaction-error = "3.0.0"
 solana-transaction-status = { workspace = true }
 solana-vote = { workspace = true }
+solana-vote-interface = { workspace = true }
 solana-vote-program = { workspace = true }
 test-case = { workspace = true }
 

--- a/programs/sbf/tests/syscall_get_epoch_stake.rs
+++ b/programs/sbf/tests/syscall_get_epoch_stake.rs
@@ -17,6 +17,7 @@ use {
     solana_signer::Signer,
     solana_transaction::Transaction,
     solana_vote::vote_account::VoteAccount,
+    solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
     solana_vote_program::vote_state::create_v4_account_with_authorized,
     std::collections::HashMap,
 };
@@ -53,9 +54,12 @@ fn test_syscall_get_epoch_stake() {
                 let vote_account = VoteAccount::try_from(create_v4_account_with_authorized(
                     &node_id,
                     &authorized_voter,
+                    [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                     &node_id,
-                    None,
                     0,
+                    &node_id,
+                    0,
+                    &node_id,
                     100,
                 ))
                 .unwrap();

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -15,6 +15,7 @@ use {
     solana_sdk_ids::{sysvar, vote::id},
     solana_slot_hashes::{SlotHashes, MAX_ENTRIES},
     solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
+    solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
     solana_vote_program::{
         vote_instruction::VoteInstruction,
         vote_processor::Entrypoint,
@@ -136,9 +137,12 @@ fn create_test_account() -> (Pubkey, AccountSharedData) {
         create_v4_account_with_authorized(
             &solana_pubkey::new_rand(),
             &vote_pubkey,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &vote_pubkey,
-            None,
             0,
+            &vote_pubkey,
+            0,
+            &vote_pubkey,
             balance,
         ),
     )
@@ -156,9 +160,12 @@ fn create_test_account_with_authorized() -> (Pubkey, Pubkey, Pubkey, AccountShar
         create_v4_account_with_authorized(
             &solana_pubkey::new_rand(),
             &authorized_voter,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &authorized_withdrawer,
-            None,
             0,
+            &authorized_withdrawer,
+            0,
+            &authorized_withdrawer,
             100,
         ),
     )
@@ -727,9 +734,12 @@ impl BenchAuthorizeWithSeed {
         let vote_account = create_v4_account_with_authorized(
             &Pubkey::new_unique(),
             &authorized_voter,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &authorized_withdrawer,
-            None,
             0,
+            &authorized_withdrawer,
+            0,
+            &authorized_withdrawer,
             100,
         );
         let clock_account = account::create_account_shared_data_for_test(&clock);
@@ -816,9 +826,12 @@ impl BenchAuthorizeCheckedWithSeed {
         let vote_account = create_v4_account_with_authorized(
             &Pubkey::new_unique(),
             &authorized_voter,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &authorized_withdrawer,
-            None,
             0,
+            &authorized_withdrawer,
+            0,
+            &authorized_withdrawer,
             100,
         );
         let new_authority_pubkey = Pubkey::new_unique();

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -514,9 +514,12 @@ mod tests {
             vote_state::create_v4_account_with_authorized(
                 &node_pubkey,
                 &vote_pubkey,
+                [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                 &vote_pubkey,
-                None,
                 0,
+                &vote_pubkey,
+                0,
+                &vote_pubkey,
                 balance,
             )
         } else {
@@ -564,9 +567,12 @@ mod tests {
             vote_state::create_v4_account_with_authorized(
                 &node_pubkey,
                 authorized_voter,
+                [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                 authorized_withdrawer,
-                None,
                 0,
+                authorized_withdrawer,
+                0,
+                authorized_withdrawer,
                 100,
             )
         } else {
@@ -604,9 +610,12 @@ mod tests {
             vote_state::create_v4_account_with_authorized(
                 &node_pubkey,
                 &authorized_voter,
+                [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                 &authorized_withdrawer,
-                None,
                 0,
+                &authorized_withdrawer,
+                0,
+                &authorized_withdrawer,
                 100,
             )
         } else {

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1234,22 +1234,31 @@ pub fn create_v3_account_with_authorized(
 pub fn create_v4_account_with_authorized(
     node_pubkey: &Pubkey,
     authorized_voter: &Pubkey,
+    authorized_voter_bls_pubkey: [u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
     authorized_withdrawer: &Pubkey,
-    bls_pubkey_compressed: Option<[u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]>,
     inflation_rewards_commission_bps: u16,
+    inflation_rewards_collector: &Pubkey,
+    block_revenue_commission_bps: u16,
+    block_revenue_collector: &Pubkey,
     lamports: u64,
 ) -> AccountSharedData {
     let mut vote_account = AccountSharedData::new(lamports, VoteStateV4::size_of(), &id());
+
+    // PoP is stubbed here, since creation of an account assumes the account
+    // was already initialized via `IntializeAccount` or `InitializeAccountV2`.
+    let authorized_voter_bls_proof_of_possession = [0; BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE];
 
     let vote_state = VoteStateV4::new(
         &VoteInitV2 {
             node_pubkey: *node_pubkey,
             authorized_voter: *authorized_voter,
+            authorized_voter_bls_pubkey,
+            authorized_voter_bls_proof_of_possession,
             authorized_withdrawer: *authorized_withdrawer,
-            authorized_voter_bls_pubkey: bls_pubkey_compressed
-                .unwrap_or([0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]),
             inflation_rewards_commission_bps,
-            ..Default::default()
+            inflation_rewards_collector: *inflation_rewards_collector,
+            block_revenue_commission_bps,
+            block_revenue_collector: *block_revenue_collector,
         },
         &Clock::default(),
     );
@@ -4028,9 +4037,12 @@ mod tests {
         let vote_account = create_v4_account_with_authorized(
             &node_pubkey,
             &authorized_voter,
+            bls_pubkey_compressed,
             &authorized_withdrawer,
-            Some(bls_pubkey_compressed),
             inflation_rewards_commission_bps,
+            &authorized_withdrawer,
+            0,
+            &authorized_withdrawer,
             lamports,
         );
         assert_eq!(vote_account.lamports(), lamports);
@@ -4142,9 +4154,12 @@ mod tests {
         let vote_account = create_v4_account_with_authorized(
             &node_pubkey,
             &authorized_voter,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &authorized_withdrawer,
-            None,
             inflation_rewards_commission_bps,
+            &authorized_withdrawer,
+            0,
+            &authorized_withdrawer,
             lamports,
         );
         assert_eq!(vote_account.lamports(), lamports);

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -804,7 +804,9 @@ mod tests {
             stake_flags::StakeFlags,
             state::{Authorized, Delegation, Meta, Stake, StakeStateV2},
         },
-        solana_vote_interface::state::{VoteInit, VoteStateV4, VoteStateVersions},
+        solana_vote_interface::state::{
+            VoteInit, VoteStateV4, VoteStateVersions, BLS_PUBLIC_KEY_COMPRESSED_SIZE,
+        },
         solana_vote_program::vote_state,
         std::{
             collections::HashSet,
@@ -1938,9 +1940,12 @@ mod tests {
         let vote_account_a = vote_state::create_v4_account_with_authorized(
             &node_pubkey_a,
             &vote_pubkey_a,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &vote_pubkey_a,
-            None,
             2000,
+            &vote_pubkey_a,
+            0,
+            &vote_pubkey_a,
             100,
         );
         let vote_pubkey_b = Pubkey::new_unique();
@@ -1948,9 +1953,12 @@ mod tests {
         let vote_account_b = vote_state::create_v4_account_with_authorized(
             &node_pubkey_b,
             &vote_pubkey_b,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &vote_pubkey_b,
-            None,
             2000,
+            &vote_pubkey_b,
+            0,
+            &vote_pubkey_b,
             100,
         );
         let vote_pubkey_c = Pubkey::new_unique();
@@ -1958,9 +1966,12 @@ mod tests {
         let vote_account_c = vote_state::create_v4_account_with_authorized(
             &node_pubkey_c,
             &vote_pubkey_c,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &vote_pubkey_c,
-            None,
             2000,
+            &vote_pubkey_c,
+            0,
+            &vote_pubkey_c,
             100,
         );
 
@@ -2048,10 +2059,13 @@ mod tests {
                 vote_pubkey,
                 vote_state::create_v4_account_with_authorized(
                     &vote_pubkey,
-                    &Pubkey::new_unique(),
-                    &Pubkey::new_unique(),
-                    None,
+                    &vote_pubkey,
+                    [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
+                    &vote_pubkey,
                     0,
+                    &vote_pubkey,
+                    0,
+                    &vote_pubkey,
                     100_000_000_000,
                 )
                 .into(),
@@ -2063,10 +2077,13 @@ mod tests {
                 &vote_pubkey,
                 &vote_state::create_v4_account_with_authorized(
                     &vote_pubkey,
-                    &Pubkey::new_unique(),
-                    &Pubkey::new_unique(),
-                    None,
+                    &vote_pubkey,
+                    [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
+                    &vote_pubkey,
                     0,
+                    &vote_pubkey,
+                    0,
+                    &vote_pubkey,
                     100_000_000_000,
                 ),
                 &genesis_config.rent,

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -333,6 +333,7 @@ mod tests {
             state::{Meta, Stake},
         },
         solana_sysvar as sysvar,
+        solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
         solana_vote_program::vote_state,
         std::sync::Arc,
     };
@@ -409,9 +410,12 @@ mod tests {
         let validator_vote_account = vote_state::create_v4_account_with_authorized(
             &validator_pubkey,
             &validator_vote_pubkey,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &validator_vote_pubkey,
-            None,
             1000,
+            &validator_vote_pubkey,
+            0,
+            &validator_vote_pubkey,
             20,
         );
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -114,7 +114,7 @@ use {
         sanitized::SanitizedTransaction, Transaction, TransactionVerificationMode,
     },
     solana_transaction_error::{TransactionError, TransactionResult as Result},
-    solana_vote_interface::state::TowerSync,
+    solana_vote_interface::state::{TowerSync, BLS_PUBLIC_KEY_COMPRESSED_SIZE},
     solana_vote_program::{
         vote_instruction,
         vote_state::{
@@ -154,9 +154,12 @@ impl VoteReward {
         let validator_vote_account = vote_state::create_v4_account_with_authorized(
             &validator_pubkey,
             &validator_voting_keypair.pubkey(),
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &validator_voting_keypair.pubkey(),
-            None,
             commission_bps,
+            &validator_voting_keypair.pubkey(),
+            0,
+            &validator_voting_keypair.pubkey(),
             validator_stake_lamports,
         );
 
@@ -904,9 +907,12 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
     let mut vote_account = vote_state::create_v4_account_with_authorized(
         &node_pubkey,
         &vote_id,
+        [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
         &vote_id,
-        None,
         0,
+        &vote_id,
+        0,
+        &vote_id,
         100,
     );
     let stake_id1 = solana_pubkey::new_rand();
@@ -1798,25 +1804,34 @@ fn test_readonly_accounts(relax_intrabatch_account_locks: bool) {
     let vote_account0 = vote_state::create_v4_account_with_authorized(
         &vote_pubkey0,
         &authorized_voter.pubkey(),
+        [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
         &authorized_voter.pubkey(),
-        None,
         0,
+        &authorized_voter.pubkey(),
+        0,
+        &authorized_voter.pubkey(),
         100,
     );
     let vote_account1 = vote_state::create_v4_account_with_authorized(
         &vote_pubkey1,
         &authorized_voter.pubkey(),
+        [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
         &authorized_voter.pubkey(),
-        None,
         0,
+        &authorized_voter.pubkey(),
+        0,
+        &authorized_voter.pubkey(),
         100,
     );
     let vote_account2 = vote_state::create_v4_account_with_authorized(
         &vote_pubkey2,
         &authorized_voter.pubkey(),
+        [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
         &authorized_voter.pubkey(),
-        None,
         0,
+        &authorized_voter.pubkey(),
+        0,
+        &authorized_voter.pubkey(),
         100,
     );
     bank.store_account(&vote_pubkey0, &vote_account0);
@@ -9876,9 +9891,12 @@ fn test_rent_state_changes_sysvars() {
     let validator_vote_account = vote_state::create_v4_account_with_authorized(
         &validator_pubkey,
         &validator_voting_keypair.pubkey(),
+        [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
         &validator_voting_keypair.pubkey(),
-        None,
         0,
+        &validator_voting_keypair.pubkey(),
+        0,
+        &validator_voting_keypair.pubkey(),
         validator_stake_lamports,
     );
 
@@ -12077,9 +12095,12 @@ fn test_bank_epoch_stakes() {
                     let vote_account = VoteAccount::try_from(create_v4_account_with_authorized(
                         &node_id,
                         &authorized_voter,
+                        [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                         &node_id,
-                        None,
                         0,
+                        &node_id,
+                        0,
+                        &node_id,
                         100,
                     ))
                     .unwrap();

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -279,6 +279,7 @@ pub(crate) mod tests {
         super::*, solana_account::AccountSharedData,
         solana_bls_signatures::keypair::Keypair as BLSKeypair,
         solana_vote::vote_account::VoteAccount,
+        solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
         solana_vote_program::vote_state::create_v4_account_with_authorized, std::iter,
         test_case::test_case,
     };
@@ -310,25 +311,22 @@ pub(crate) mod tests {
                                 .try_into()
                                 .unwrap();
 
-                        let account = if is_alpenglow {
-                            create_v4_account_with_authorized(
-                                &node_id,
-                                &authorized_voter,
-                                &node_id,
-                                Some(bls_pubkey_compressed_serialized),
-                                0,
-                                100,
-                            )
+                        let bls_pubkey = if is_alpenglow {
+                            bls_pubkey_compressed_serialized
                         } else {
-                            create_v4_account_with_authorized(
-                                &node_id,
-                                &authorized_voter,
-                                &node_id,
-                                None,
-                                0,
-                                100,
-                            )
+                            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]
                         };
+                        let account = create_v4_account_with_authorized(
+                            &node_id,
+                            &authorized_voter,
+                            bls_pubkey,
+                            &node_id,
+                            0,
+                            &node_id,
+                            0,
+                            &node_id,
+                            100,
+                        );
                         VoteAccountInfo {
                             vote_account: solana_pubkey::new_rand(),
                             account,

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -195,28 +195,24 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
                 BLS_KEYPAIR_DERIVE_SEED,
             )
             .unwrap();
-            Some(bls_keypair.public.to_bytes_compressed())
+            bls_keypair.public.to_bytes_compressed()
         } else {
-            None
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]
         };
         let vote_account = if feature_set.is_active(&vote_state_v4::id()) {
             // Vote state v4 feature active. Create a v4 account.
             vote_state::create_v4_account_with_authorized(
                 &node_pubkey,
                 &vote_pubkey,
-                &vote_pubkey,
                 bls_pubkey_compressed,
+                &vote_pubkey,
                 0,
+                &vote_pubkey,
+                0,
+                &vote_pubkey,
                 *stake,
             )
         } else {
-            // Vote state v4 feature inactive. Create a v3 account.
-            if bls_pubkey_compressed.is_some() {
-                warn!(
-                    "BLS pubkey provided but vote_state_v4 feature is not active. BLS pubkey will \
-                     be ignored."
-                );
-            }
             vote_state::create_v3_account_with_authorized(
                 &node_pubkey,
                 &vote_pubkey,
@@ -381,9 +377,12 @@ pub fn create_genesis_config_with_leader_ex_no_features(
         vote_state::create_v4_account_with_authorized(
             validator_pubkey,
             validator_vote_account_pubkey,
+            validator_bls_pubkey.unwrap_or([0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]),
             validator_vote_account_pubkey,
-            validator_bls_pubkey,
             0,
+            validator_vote_account_pubkey,
+            0,
+            validator_vote_account_pubkey,
             validator_stake_lamports,
         )
     } else {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -582,7 +582,7 @@ pub(crate) mod tests {
         solana_pubkey::Pubkey,
         solana_rent::Rent,
         solana_stake_interface::{self as stake, state::StakeStateV2},
-        solana_vote_interface::state::VoteStateV4,
+        solana_vote_interface::state::{VoteStateV4, BLS_PUBLIC_KEY_COMPRESSED_SIZE},
         solana_vote_program::vote_state,
     };
 
@@ -595,9 +595,12 @@ pub(crate) mod tests {
         let vote_account = vote_state::create_v4_account_with_authorized(
             &node_pubkey,
             &vote_pubkey,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &vote_pubkey,
-            None,
             0,
+            &vote_pubkey,
+            0,
+            &vote_pubkey,
             1,
         );
         let stake_pubkey = solana_pubkey::new_rand();
@@ -623,9 +626,12 @@ pub(crate) mod tests {
             &vote_state::create_v4_account_with_authorized(
                 &node_pubkey,
                 vote_pubkey,
+                [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                 vote_pubkey,
-                None,
                 0,
+                vote_pubkey,
+                0,
+                vote_pubkey,
                 1,
             ),
             &Rent::free(),

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -197,6 +197,7 @@ mod tests {
         serde::Deserialize,
         solana_rent::Rent,
         solana_stake_interface::state::Delegation,
+        solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
         solana_vote_program::vote_state,
     };
 
@@ -213,9 +214,12 @@ mod tests {
                 &vote_state::create_v4_account_with_authorized(
                     &node_pubkey,
                     &vote_pubkey,
+                    [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                     &vote_pubkey,
-                    None,
                     0,
+                    &vote_pubkey,
+                    0,
+                    &vote_pubkey,
                     1_000_000_000,
                 ),
                 &Rent::default(),
@@ -272,9 +276,12 @@ mod tests {
             let vote_account = vote_state::create_v4_account_with_authorized(
                 &node_pubkey,
                 &vote_pubkey,
+                [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                 &vote_pubkey,
-                None,
                 commission_bps,
+                &vote_pubkey,
+                0,
+                &vote_pubkey,
                 rng.random_range(0..1_000_000), // lamports
             );
             stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);

--- a/wen-restart/src/last_voted_fork_slots_aggregate.rs
+++ b/wen-restart/src/last_voted_fork_slots_aggregate.rs
@@ -257,6 +257,7 @@ mod tests {
         solana_signer::Signer,
         solana_time_utils::timestamp,
         solana_vote::vote_account::VoteAccount,
+        solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
         solana_vote_program::vote_state::create_v4_account_with_authorized,
     };
 
@@ -782,9 +783,12 @@ mod tests {
                         VoteAccount::try_from(create_v4_account_with_authorized(
                             &node_id,
                             &authorized_voter,
+                            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                             &node_id,
-                            None,
                             0,
+                            &node_id,
+                            0,
+                            &node_id,
                             100,
                         ))
                         .unwrap(),

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -1444,7 +1444,7 @@ mod tests {
         solana_signer::Signer,
         solana_time_utils::timestamp,
         solana_vote::vote_account::VoteAccount,
-        solana_vote_interface::state::{TowerSync, Vote},
+        solana_vote_interface::state::{TowerSync, Vote, BLS_PUBLIC_KEY_COMPRESSED_SIZE},
         solana_vote_program::vote_state::create_v4_account_with_authorized,
         std::{fs::remove_file, sync::Arc, thread::Builder},
         tempfile::TempDir,
@@ -1989,9 +1989,12 @@ mod tests {
                         VoteAccount::try_from(create_v4_account_with_authorized(
                             &node_id,
                             &authorized_voter,
+                            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                             &node_id,
-                            None,
                             0,
+                            &node_id,
+                            0,
+                            &node_id,
                             100,
                         ))
                         .unwrap(),


### PR DESCRIPTION
#### Problem
As pointed out in [this comment](https://github.com/anza-xyz/agave/pull/9687#pullrequestreview-3684398112) here by @AshwinSekar, we should probably expand the Vote program helper `create_v4_account_with_authorized` to include more of the inputs from `VoteInitV2` in order to expand test coverage.

In most callsites, these extra fields are set to default/random values, but for the areas we need them, it's good to test with proper values.

#### Summary of Changes
Expand the inputs for `create_v4_account_with_authorized` to include all fields from `VoteInitV2` except for the proof-of-possession, which does nothing for an already-initialized Vote account.
