### PR TITLE
Removing unused function

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4123,13 +4123,6 @@ impl Bank {
             .flush_accounts_cache(true, Some(self.slot()))
     }
 
-    pub fn flush_accounts_cache_if_needed(&self) {
-        self.rc
-            .accounts
-            .accounts_db
-            .flush_accounts_cache(false, Some(self.slot()))
-    }
-
     /// Technically this issues (or even burns!) new lamports,
     /// so be extra careful for its usage
     fn store_account_and_update_capitalization(


### PR DESCRIPTION
#### Problem
Function flush_accounts_cache_if_needed has no callers, so it can be removed.

#### Summary of Changes
Remove it

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
