### PR TITLE
Streamer: add BDP scaling

### DIFF
--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -571,4 +571,26 @@ pub mod test {
             QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS
         );
     }
+
+    #[test]
+    fn test_max_allowed_uni_streams_with_rtt() {
+        assert_eq!(
+            compute_max_allowed_uni_streams_with_rtt(
+                REFERENCE_RTT_MS / 2,
+                ConnectionPeerType::Unstaked,
+                10000
+            ),
+            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,
+            "Max streams should not be less than normal for low RTT"
+        );
+        assert_eq!(
+            compute_max_allowed_uni_streams_with_rtt(
+                REFERENCE_RTT_MS + REFERENCE_RTT_MS / 2,
+                ConnectionPeerType::Unstaked,
+                10000
+            ),
+            QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS + QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS / 2,
+            "Max streams should scale with BDP in high-RTT connections"
+        );
+    }
 }

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -49,6 +49,12 @@ pub const QUIC_MAX_STAKED_CONCURRENT_STREAMS: usize = 512;
 
 pub const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: usize = 100_000;
 
+/// RTT after which we start BDP scaling
+const REFERENCE_RTT_MS: u64 = 50;
+
+/// Above this RTT we stop scaling for BDP
+const MAX_RTT_MS: u64 = 350;
+
 #[derive(Clone)]
 pub struct SwQosConfig {
     pub max_streams_per_ms: u64,
@@ -140,8 +146,12 @@ impl SwQos {
     }
 }
 
-fn compute_max_allowed_uni_streams(peer_type: ConnectionPeerType, total_stake: u64) -> usize {
-    match peer_type {
+fn compute_max_allowed_uni_streams_with_rtt(
+    rtt_millis: u64,
+    peer_type: ConnectionPeerType,
+    total_stake: u64,
+) -> usize {
+    let streams = match peer_type {
         ConnectionPeerType::Staked(peer_stake) => {
             // No checked math for f64 type. So let's explicitly check for 0 here
             if total_stake == 0 || peer_stake > total_stake {
@@ -164,7 +174,10 @@ fn compute_max_allowed_uni_streams(peer_type: ConnectionPeerType, total_stake: u
             }
         }
         ConnectionPeerType::Unstaked => QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,
-    }
+    };
+    // scale amount of streams based on RTT if RTT is larger than REFERENCE_RTT_MS
+    // multiply first then divide to avoid rounding errors.
+    (streams * rtt_millis.clamp(REFERENCE_RTT_MS, MAX_RTT_MS) as usize) / REFERENCE_RTT_MS as usize
 }
 
 impl SwQos {
@@ -182,7 +195,10 @@ impl SwQos {
         ),
         ConnectionHandlerError,
     > {
-        if let Ok(max_uni_streams) = VarInt::from_u64(compute_max_allowed_uni_streams(
+        // get current RTT and limit it to MAX_RTT_MS
+        let rtt_millis = connection.rtt().as_millis() as u64;
+        if let Ok(max_uni_streams) = VarInt::from_u64(compute_max_allowed_uni_streams_with_rtt(
+            rtt_millis,
             conn_context.peer_type(),
             conn_context.total_stake,
         ) as u64)
@@ -524,6 +540,10 @@ impl QosController<SwQosConnectionContext> for SwQos {
 #[cfg(test)]
 pub mod test {
     use super::*;
+
+    fn compute_max_allowed_uni_streams(peer_type: ConnectionPeerType, total_stake: u64) -> usize {
+        compute_max_allowed_uni_streams_with_rtt(REFERENCE_RTT_MS, peer_type, total_stake)
+    }
 
     #[test]
     fn test_max_allowed_uni_streams() {


### PR DESCRIPTION
#### Problem
Streamer ignores RTT in all its calculations. This means that connections with high latency are heavily rate limited, **much more than the stake amount would suggest**. This happens before the actual stake-based stream throttling even has a change to kick in, and is thus very counterintuitive to the client. 

A more principled version of https://github.com/anza-xyz/agave/pull/7954. 

#### Some preliminary concepts:
- Sender can not have more than max_concurrent_streams worth of open streams at any time
- These together limit how many TXs can be “in flight” between client and server and not yet ACKd. Currently, these limits are computed based on stake. We need to compute them based on stake and RTT  (as longer RTT means you need to have more things on the wire before you see an ACK).
- Beyond the limit mentioned above, there is an overall stream limit imposed by the code in stream_throttle.rs. That is out of scope of this PR, we are not modifying SWQOS here.

**This mechanism is not intended as the actual rate limiter for complaint clients, just as a limit on network buffers. This will never  allocate less bandwidth than what you'd get today.**


#### Summary of Changes

- Assume that in the original code the RTT was expected to be ~50ms
- Scale  max_concurrent_uni_streams with RTT if it is above 50ms

50 ms was chosen as a compromise between allowing more TPS and keeping impact small.

### Impact 
Before:
<img width="640" height="480" alt="plot_old_512_bytes" src="https://github.com/user-attachments/assets/80adc209-6465-4b79-8417-ca9fc231529b" />

After:
<img width="640" height="480" alt="plot_new_512_bytes" src="https://github.com/user-attachments/assets/f638c707-6f01-4892-a354-c2e4e93cd399" />

Related:  https://github.com/anza-xyz/agave/pull/8948 (which was reverted)
