### PR TITLE
streamer: reduce malloc in reassembly

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -94,7 +94,9 @@ pub(crate) const MIN_RTT: Duration = Duration::from_millis(2);
 #[derive(Clone)]
 struct PacketAccumulator {
     pub meta: Meta,
-    pub chunks: SmallVec<[Bytes; 2]>,
+    // the capacity here should match or exceed the capacity of the chunks
+    // array used by handle_connection()
+    pub chunks: SmallVec<[Bytes; 4]>,
     pub start_time: Instant,
 }
 
@@ -779,7 +781,6 @@ fn handle_chunks(
     // done receiving chunks
     let bytes_sent = accum.meta.size;
 
-    //
     // 86% of transactions/packets come in one chunk. In that case,
     // we can just move the chunk to the `Packet` and no copy is
     // made.
@@ -792,8 +793,7 @@ fn handle_chunks(
             accum.meta.clone(),
         )
     } else {
-        let size: usize = accum.chunks.iter().map(Bytes::len).sum();
-        let mut buf = BytesMut::with_capacity(size);
+        let mut buf = BytesMut::with_capacity(bytes_sent);
         for chunk in &accum.chunks {
             buf.put_slice(chunk);
         }


### PR DESCRIPTION
#### Problem

The current PacketAccumulator allocates statically space for 2 Bytes objects, while the logic calling read_chunks can read up to 4 at a time. We probably do not want to start spilling on the heap so soon. 

This was reported by @diman-io .

#### Summary of Changes

Bump the amount of preallocated Bytes objects to 4.
Drop unneeded iteration which repeats calculations already made previously.