### PR TITLE
QUIC votes with tpu-client-next

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -564,8 +564,8 @@ impl ForwardingClient for ConnectionCacheClient {
 
 #[async_trait]
 impl LeaderUpdater for ForwardAddressGetter {
-    fn next_leaders(&mut self, lookahead_slots: usize) -> Vec<SocketAddr> {
-        self.get_non_vote_forwarding_addresses(lookahead_slots as u64, Protocol::QUIC)
+    fn next_leaders(&mut self, lookahead_leaders: usize) -> Vec<SocketAddr> {
+        self.get_non_vote_forwarding_addresses(lookahead_leaders as u64, Protocol::QUIC)
     }
 
     async fn stop(&mut self) {}

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -564,8 +564,8 @@ impl ForwardingClient for ConnectionCacheClient {
 
 #[async_trait]
 impl LeaderUpdater for ForwardAddressGetter {
-    fn next_leaders(&mut self, lookahead_leaders: usize) -> Vec<SocketAddr> {
-        self.get_non_vote_forwarding_addresses(lookahead_leaders as u64, Protocol::QUIC)
+    fn next_leaders(&mut self, lookahead_slots: usize) -> Vec<SocketAddr> {
+        self.get_non_vote_forwarding_addresses(lookahead_slots as u64, Protocol::QUIC)
     }
 
     async fn stop(&mut self) {}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -53,6 +53,7 @@ pub mod tpu;
 mod tpu_entry_notifier;
 pub mod tvu;
 pub mod unfrozen_gossip_verified_vote_hashes;
+mod upcoming_leaders_cache;
 pub mod validator;
 mod vortexor_receiver_adapter;
 pub mod vote_simulator;

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -17,12 +17,10 @@ use {
         replay_stage::{ReplayReceivers, ReplaySenders, ReplayStage, ReplayStageConfig},
         shred_fetch_stage::{ShredFetchStage, SHRED_FETCH_CHANNEL_SIZE},
         voting_service::{VotingService, VoteSender},
-        warm_quic_cache_service::WarmQuicCacheService,
         window_service::{WindowService, WindowServiceChannels},
     },
     bytes::Bytes,
     crossbeam_channel::{unbounded, Receiver, Sender},
-    solana_client::connection_cache::ConnectionCache,
     solana_clock::Slot,
     solana_geyser_plugin_manager::block_metadata_notifier_interface::BlockMetadataNotifierArc,
     solana_gossip::{
@@ -428,6 +426,7 @@ pub mod tests {
             repair::quic_endpoint::RepairQuicAsyncSenders,
         },
         serial_test::serial,
+        solana_client::connection_cache::ConnectionCache,
         solana_gossip::{cluster_info::ClusterInfo, node::Node},
         solana_keypair::Keypair,
         solana_ledger::{

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -419,27 +419,6 @@ impl Tvu {
     }
 }
 
-fn create_cache_warmer_if_needed(
-    connection_cache: Option<&Arc<ConnectionCache>>,
-    vote_connection_cache: Arc<ConnectionCache>,
-    cluster_info: &Arc<ClusterInfo>,
-    poh_recorder: &Arc<RwLock<PohRecorder>>,
-    exit: &Arc<AtomicBool>,
-) -> Option<WarmQuicCacheService> {
-    let tpu_connection_cache = connection_cache.filter(|cache| cache.use_quic()).cloned();
-    let vote_connection_cache = Some(vote_connection_cache).filter(|cache| cache.use_quic());
-
-    (tpu_connection_cache.is_some() || vote_connection_cache.is_some()).then(|| {
-        WarmQuicCacheService::new(
-            tpu_connection_cache,
-            vote_connection_cache,
-            cluster_info.clone(),
-            poh_recorder.clone(),
-            exit.clone(),
-        )
-    })
-}
-
 #[cfg(test)]
 pub mod tests {
     use {

--- a/core/src/upcoming_leaders_cache.rs
+++ b/core/src/upcoming_leaders_cache.rs
@@ -1,11 +1,15 @@
-use std::net::SocketAddr;
-use std::sync::{Arc, RwLock};
-use async_trait::async_trait;
-use solana_clock::{NUM_CONSECUTIVE_LEADER_SLOTS, Slot};
-use solana_connection_cache::connection_cache::Protocol;
-use solana_gossip::cluster_info::ClusterInfo;
-use solana_poh::poh_recorder::PohRecorder;
-use solana_tpu_client_next::leader_updater::LeaderUpdater;
+use {
+    async_trait::async_trait,
+    solana_clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
+    solana_connection_cache::connection_cache::Protocol,
+    solana_gossip::cluster_info::ClusterInfo,
+    solana_poh::poh_recorder::PohRecorder,
+    solana_tpu_client_next::leader_updater::LeaderUpdater,
+    std::{
+        net::SocketAddr,
+        sync::{Arc, RwLock},
+    },
+};
 
 // Warning: this module assumes a leader window starts at a slot which is a multiple of NUM_CONSECUTIVE_LEADER_SLOTS.
 // Leader windows are identified by (first slot in window)/NUM_CONSECUTIVE_LEADER_SLOTS.

--- a/core/src/upcoming_leaders_cache.rs
+++ b/core/src/upcoming_leaders_cache.rs
@@ -1,0 +1,134 @@
+use std::net::SocketAddr;
+use std::sync::{Arc, RwLock};
+use async_trait::async_trait;
+use solana_clock::{NUM_CONSECUTIVE_LEADER_SLOTS, Slot};
+use solana_connection_cache::connection_cache::Protocol;
+use solana_gossip::cluster_info::ClusterInfo;
+use solana_poh::poh_recorder::PohRecorder;
+use solana_tpu_client_next::leader_updater::LeaderUpdater;
+
+// Warning: this module assumes a leader window starts at a slot which is a multiple of NUM_CONSECUTIVE_LEADER_SLOTS.
+// Leader windows are identified by (first slot in window)/NUM_CONSECUTIVE_LEADER_SLOTS.
+
+/// Number of leader windows in cache.
+/// Gossip database is queried when less than half of this buffer contains upcoming leaders.
+/// So must be at least lookahead_leaders * 2
+/// We accept to not adapt to an address change appearing on Gossip less than
+/// BUF_SIZE_WINDOWS * NUM_CONSECUTIVE_LEADER_SLOTS slots before the node becomes leader.
+/// 8 with 400ms slots => ~ 13 seconds
+const BUF_SIZE_WINDOWS: u64 = 8;
+
+pub struct UpcomingLeadersCache {
+    protocol: Protocol,
+    poh_recorder: Arc<RwLock<PohRecorder>>,
+    cluster_info: Arc<ClusterInfo>,
+    /// First window contained in the cache, inclusive
+    /// If greater or equal than window_end, the cache is empty.
+    window_start: Slot,
+    /// Last window contained in the cache, exclusive
+    window_end: Slot,
+    /// Ring buffer. The leader of window w is stored at w%BUF_SIZE_WINDOWS.
+    buf: [Option<SocketAddr>; BUF_SIZE_WINDOWS as usize]
+}
+
+impl UpcomingLeadersCache {
+    pub fn new(poh_recorder: Arc<RwLock<PohRecorder>>, cluster_info: Arc<ClusterInfo>, protocol: Protocol) -> Self {
+        UpcomingLeadersCache {
+            protocol,
+            poh_recorder,
+            cluster_info,
+            window_start: 0,
+            window_end: 0,
+            buf: [None; BUF_SIZE_WINDOWS as usize],
+        }
+    }
+
+    /// Request leader adresses between from_window (inclusive) and to_window (exclusive).
+    /// Fill `res_tpu_vote` vector with what we have in the buffer.
+    /// Return the first window not found.
+    fn get(&self, mut from_window: Slot, to_window: Slot, res_tpu_vote: &mut Vec<SocketAddr>) -> Slot {
+        while (self.window_start..self.window_end).contains(&from_window) && from_window < to_window {
+            if let Some(addr) = self.buf[(from_window % BUF_SIZE_WINDOWS) as usize] {
+                res_tpu_vote.push(addr);
+            }
+            from_window += 1;
+        }
+        from_window
+    }
+
+    /// Fetch information from leader schedule and Gossip starting `from_window` to fill out the buffer
+    /// (preserving entry self.window_start).
+    /// from_window >= window_start
+    fn fill(&mut self, from_window: Slot) {
+        let poh_recorder = self.poh_recorder.read().unwrap();
+        let mut leaders = Vec::with_capacity(BUF_SIZE_WINDOWS as usize);
+        let mut window = from_window;
+        let idx_to_keep = if self.window_start < self.window_end {
+            self.window_start
+        } else {
+            // Nothing valuable in the buffer
+            window
+        } % BUF_SIZE_WINDOWS;
+        loop {
+            let leader = poh_recorder.leader_of_slot(window * NUM_CONSECUTIVE_LEADER_SLOTS);
+            leaders.push(leader);
+            self.buf[(window%BUF_SIZE_WINDOWS) as usize] = None;
+            window += 1;
+            if window%BUF_SIZE_WINDOWS == idx_to_keep {
+                break;
+            }
+        }
+        drop(poh_recorder);
+        self.window_end = window;
+        self.cluster_info.lookup_contact_infos(&leaders, |idx, node| {
+            self.buf[((from_window + idx as u64) % BUF_SIZE_WINDOWS) as usize] = node.tpu_vote(self.protocol);
+        });
+    }
+}
+
+#[async_trait]
+impl LeaderUpdater for UpcomingLeadersCache {
+    /// Ensure at least 1 TPU is returned, returning self TPU if no other, and no more than lookahead_leaders
+    /// [ Not sure about the interest to return self TPU ]
+    fn next_leaders(&mut self, lookahead_leaders: usize) -> Vec<SocketAddr> {
+        let slot = self.poh_recorder.read().unwrap().current_poh_slot();
+        let from_window = slot / NUM_CONSECUTIVE_LEADER_SLOTS;
+        let to_window = from_window + lookahead_leaders as u64; // exclusive
+
+        self.window_start = from_window; // We can forget all previous windows.
+        // If ever the current poh is decreasing for some reason, we can have a
+        // a cache miss, but it's not a big deal.
+
+        let mut res_tpu_vote = Vec::with_capacity(lookahead_leaders);
+        let window = self.get(from_window, to_window, &mut res_tpu_vote);
+        if window < to_window {
+            // window >= window_end
+            warn!("Upcoming leaders cache miss");
+            self.fill(window);
+            if self.get(window, to_window, &mut res_tpu_vote) < to_window {
+                warn!("Could not fill requested upcoming leaders"); // Should never happen
+            }
+        }
+        if res_tpu_vote.is_empty() {
+            if let Some(me) = self.cluster_info.my_contact_info().tpu(self.protocol) {
+                res_tpu_vote.push(me);
+            }
+        } else {
+            res_tpu_vote.sort_unstable();
+            res_tpu_vote.dedup();
+        }
+        res_tpu_vote
+    }
+
+    /// Fill the buffer if it's at least half empty
+    /// Only call if `next_leaders` has been called at least once,
+    /// so that window_start and window_end are initialized.
+    fn update(&mut self) {
+        if self.window_end < self.window_start + BUF_SIZE_WINDOWS / 2 {
+            self.fill(self.window_end);
+        }
+    }
+
+    async fn stop(&mut self) {
+    }
+}

--- a/core/src/upcoming_leaders_cache.rs
+++ b/core/src/upcoming_leaders_cache.rs
@@ -12,7 +12,7 @@ use {
 };
 
 // Warning: this module assumes a leader window starts at a slot which is a multiple of NUM_CONSECUTIVE_LEADER_SLOTS.
-// Leader windows are identified by (first slot in window)/NUM_CONSECUTIVE_LEADER_SLOTS.
+// Leader windows are identified by (any slot in window)/NUM_CONSECUTIVE_LEADER_SLOTS.
 
 /// Number of leader windows in cache.
 /// Gossip database is queried when less than half of this buffer contains upcoming leaders.

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1192,18 +1192,17 @@ impl Validator {
                 .bind_socket(node.sockets.quic_vote_client)
                 .leader_send_fanout(voting_service::UPCOMING_LEADER_FANOUT)
                 .identity(Arc::as_ref(&identity_keypair))
-                 .metric_reporter(|stats: Arc<solana_tpu_client_next::send_transaction_stats::SendTransactionStats>, cancel: CancellationToken| async move {
-                let mut interval = tokio::time::interval(Duration::from_secs(10));
-                cancel
-                    .run_until_cancelled(async {
-                        loop {
-                            interval.tick().await;
-                            info!("{:?}", stats.read_and_reset());
-                        }
-                    })
-                    .await;
-            }
-        );
+                .metric_reporter(|stats: Arc<solana_tpu_client_next::send_transaction_stats::SendTransactionStats>, cancel: CancellationToken| async move {
+                    let mut interval = tokio::time::interval(Duration::from_secs(10));
+                    cancel
+                        .run_until_cancelled(async {
+                            loop {
+                                interval.tick().await;
+                                info!("{:?}", stats.read_and_reset());
+                            }
+                        })
+                        .await;
+                });
             builder = builder.runtime_handle(runtime_handle.clone());
             let (sender, client) = builder.build()?;
             voting_service::VoteSender::QUIC(sender, client)

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -457,7 +457,7 @@ impl ClusterInfo {
 
     pub fn lookup_contact_infos(
         &self,
-        ids: &Vec<Option<Pubkey>>,
+        ids: &[Option<Pubkey>],
         mut query: impl FnMut(usize, &ContactInfo)
     ) {
         let gossip_crds = self.gossip.crds.read().unwrap();

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -455,6 +455,21 @@ impl ClusterInfo {
         gossip_crds.get(*id).map(query)
     }
 
+    pub fn lookup_contact_infos(
+        &self,
+        ids: &Vec<Option<Pubkey>>,
+        mut query: impl FnMut(usize, &ContactInfo)
+    ) {
+        let gossip_crds = self.gossip.crds.read().unwrap();
+        for (idx, id) in ids.iter().enumerate() {
+            if let Some(id) = id {
+                if let Some(ci) = gossip_crds.get(*id) {
+                    query(idx, ci);
+                }
+            }
+        }
+    }
+
     pub fn lookup_contact_info_by_gossip_addr(
         &self,
         gossip_addr: &SocketAddr,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -462,10 +462,8 @@ impl ClusterInfo {
     ) {
         let gossip_crds = self.gossip.crds.read().unwrap();
         for (idx, id) in ids.iter().enumerate() {
-            if let Some(id) = id {
-                if let Some(ci) = gossip_crds.get(*id) {
-                    query(idx, ci);
-                }
+            if let Some(ci) = id.and_then(|id| gossip_crds.get(id)) {
+                query(idx, ci);
             }
         }
     }

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -632,13 +632,18 @@ impl PohRecorder {
     }
 
     /// Return the slot that PoH is currently ticking through.
-    fn current_poh_slot(&self) -> Slot {
+    pub fn current_poh_slot(&self) -> Slot {
         // The tick_height field is initialized to the last tick of the start
         // bank and generally indicates what tick height has already been
         // reached so use the next tick height to determine which slot poh is
         // ticking through.
         let next_tick_height = self.tick_height().saturating_add(1);
         self.slot_for_tick_height(next_tick_height)
+    }
+
+    pub fn leader_of_slot(&self, slot: Slot) -> Option<Pubkey> {
+        self.leader_schedule_cache
+            .slot_leader_at(slot, None)
     }
 
     pub fn leader_after_n_slots(&self, slots: u64) -> Option<Pubkey> {

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -292,6 +292,8 @@ impl ConnectionWorkersScheduler {
                 last_error = Some(error);
                 break;
             }
+
+            leader_updater.update()
         }
 
         workers.shutdown().await;

--- a/tpu-client-next/src/leader_updater.rs
+++ b/tpu-client-next/src/leader_updater.rs
@@ -24,6 +24,12 @@ pub trait LeaderUpdater: Send {
     /// only one estimated leader, there is a risk of losing all the transactions,
     /// depending on the forwarding policy.
     fn next_leaders(&mut self, lookahead_leaders: usize) -> Vec<SocketAddr>;
+    
+    /// Next leaders information can be updated upon request in `next_leaders`, but this can introduce unwanted
+    /// delays before tx can be sent. Instead, or in addition, `update` can be called after tx is sent, 
+    /// or periodically, to update information in advance and maximize the chance that it is immediately available
+    /// next time `next_leaders` is called.
+    fn update(&mut self) { }
 
     /// Stop [`LeaderUpdater`] and releases all associated resources.
     async fn stop(&mut self);


### PR DESCRIPTION
#### Overview

Replace connection cache with tpu-client-next for voting with QUIC.
It adds an `update` function in `LeaderUpdater`, and a new optimized implementation of the trait: `UpcomingLeadersCache` which maintains a ringing buffer of (currently 8) upcoming leaders ip:port.

`update` is called after a tx is sent. The idea is to avoid grabbing locks on poh and on gossip crds when we need to send a tx and thus add unpredictable delays. This works well for sending vote since we regularly send 1 tx every slot and we have plenty of time after sending 1 vote to fill the upcoming leader cache before the next vote. OTOH when we have a vote to send after a replay we want it to leave ASAP. Similar cache has been used on mainnet by validator Puffin for weeks (but to send UDP votes).

#### Todo

* During  the transition to QUIC, we might want to send with both QUIC and UDP. For now it's one or the other using the existing hidden `--vote-use-quic ` option.
* I preserved the ConnectionCache for sending UDP votes to minimize changes, but it would be logical and simpler to remove it for UDP too and to use `UpcomingLeaderCache` instead.
* Another implementation of `LeaderUpdater` is currently used from RPC. It would be better to use a single one.
* I added a simple metric logging but you might want a properly formatted datapoint instead.

This PR is currently running on devnet by pfdVFyrTftBPqSa6e5yK3Gm5dtavLGo8nod3rAEFiMa to send QUIC votes. Gossip vote push is disabled to be sure votes land with QUIC.

@KirillLykov, could you review ?