### PR TITLE
Gossip: Key PingCache on peer ip

### DIFF
--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -946,14 +946,7 @@ impl ServeRepair {
         let mut rng = rand::rng();
         let (check, ping) = request
             .sender()
-            .map(|&sender| {
-                ping_cache.check(
-                    &mut rng,
-                    identity_keypair,
-                    Instant::now(),
-                    (sender, *from_addr),
-                )
-            })
+            .map(|_| ping_cache.check(&mut rng, identity_keypair, Instant::now(), *from_addr))
             .unwrap_or_default();
         let ping_pkt = if let Some(ping) = ping {
             match request {

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -397,10 +397,7 @@ pub(crate) fn maybe_ping_gossip_addresses<R: Rng + CryptoRng>(
             let Some(node_gossip) = node.gossip() else {
                 return false;
             };
-            let (check, ping) = {
-                let node = (*node.pubkey(), node_gossip);
-                ping_cache.check(rng, keypair, now, node)
-            };
+            let (check, ping) = ping_cache.check(rng, keypair, now, node_gossip);
             if let Some(ping) = ping {
                 pings.push((node_gossip, ping));
             }

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -972,7 +972,7 @@ pub(crate) mod tests {
         ping_cache
             .lock()
             .unwrap()
-            .mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
+            .mock_pong(new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::from(new));
         crds.write()
             .unwrap()
@@ -1035,13 +1035,13 @@ pub(crate) mod tests {
         crds.insert(entry, now, GossipRoute::LocalMessage).unwrap();
         let mut old = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
         old.set_gossip(([127, 0, 0, 1], 8020)).unwrap();
-        ping_cache.mock_pong(*old.pubkey(), old.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(old.gossip().unwrap(), Instant::now());
         let old = CrdsValue::new_unsigned(CrdsData::from(old));
         crds.insert(old.clone(), now, GossipRoute::LocalMessage)
             .unwrap();
         let mut new = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
         new.set_gossip(([127, 0, 0, 1], 8021)).unwrap();
-        ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::from(new));
         crds.insert(new, now, GossipRoute::LocalMessage).unwrap();
         let crds = RwLock::new(crds);
@@ -1096,7 +1096,7 @@ pub(crate) mod tests {
             .insert(entry, now, GossipRoute::LocalMessage)
             .unwrap();
         let new = ContactInfo::new_localhost(&solana_pubkey::new_rand(), now);
-        ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::from(new));
         node_crds
             .insert(new, now, GossipRoute::LocalMessage)
@@ -1214,7 +1214,7 @@ pub(crate) mod tests {
             .unwrap();
         let mut ping_cache = new_ping_cache();
         let new = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 1);
-        ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::from(new));
         node_crds.insert(new, 0, GossipRoute::LocalMessage).unwrap();
 
@@ -1222,7 +1222,7 @@ pub(crate) mod tests {
         let new_id = solana_pubkey::new_rand();
         let same_key = ContactInfo::new_localhost(&new_id, 0);
         let new = ContactInfo::new_localhost(&new_id, 1);
-        ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::from(new));
         dest_crds
             .insert(new.clone(), 0, GossipRoute::LocalMessage)
@@ -1230,11 +1230,7 @@ pub(crate) mod tests {
         let dest_crds = RwLock::new(dest_crds);
 
         // node contains a key from the dest node, but at an older local timestamp
-        ping_cache.mock_pong(
-            *same_key.pubkey(),
-            same_key.gossip().unwrap(),
-            Instant::now(),
-        );
+        ping_cache.mock_pong(same_key.gossip().unwrap(), Instant::now());
         let same_key = CrdsValue::new_unsigned(CrdsData::from(same_key));
         assert_eq!(same_key.label(), new.label());
         assert!(same_key.wallclock() < new.wallclock());

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -429,7 +429,7 @@ mod tests {
         let push = CrdsGossipPush::default();
         let mut ping_cache = new_ping_cache();
         let peer = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
-        ping_cache.mock_pong(*peer.pubkey(), peer.gossip().unwrap(), Instant::now());
+        ping_cache.mock_pong(peer.gossip().unwrap(), Instant::now());
         let peer = CrdsValue::new_unsigned(CrdsData::from(peer));
         assert_eq!(
             crds.insert(peer.clone(), now, GossipRoute::LocalMessage),
@@ -481,7 +481,7 @@ mod tests {
             .map(|wallclock| {
                 let mut peer = ContactInfo::new_rand(&mut rng, /*pubkey=*/ None);
                 peer.set_wallclock(wallclock);
-                ping_cache.mock_pong(*peer.pubkey(), peer.gossip().unwrap(), Instant::now());
+                ping_cache.mock_pong(peer.gossip().unwrap(), Instant::now());
                 CrdsValue::new_unsigned(CrdsData::from(peer))
             })
             .collect();

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -58,13 +58,44 @@ pub struct PingCache<const N: usize> {
     hashers: [SipHasher24; 2],
     // When hashers were last refreshed.
     key_refresh: Instant,
-    // Timestamp of last ping message sent to a remote node.
-    // Used to rate limit pings to remote nodes.
-    pings: LruCache<(Pubkey, SocketAddr), Instant>,
+    // Timestamp of last ping message sent to a remote address key.
+    // Used to rate limit pings to remote addresses.
+    pings: LruCache<PingCacheKey, Instant>,
     // Verified pong responses from remote nodes.
-    pongs: LruCache<(Pubkey, SocketAddr), Instant>,
-    // Timestamp of last ping message sent to a remote IP.
-    ping_times: LruCache<IpAddr, Instant>,
+    pongs: LruCache<PingCacheKey, Instant>,
+    // Timestamp of last ping message sent to a remote address key.
+    ping_times: LruCache<PingCacheKey, Instant>,
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+enum PingCacheKey {
+    Ip(IpAddr),
+    Socket(SocketAddr), // For loopback (local cluster tests)
+}
+
+impl PingCacheKey {
+    fn from_socket(socket: SocketAddr) -> Self {
+        if socket.ip().is_loopback() {
+            Self::Socket(socket)
+        } else {
+            Self::Ip(socket.ip())
+        }
+    }
+
+    fn ip(self) -> IpAddr {
+        match self {
+            Self::Ip(ip) => ip,
+            Self::Socket(socket) => socket.ip(),
+        }
+    }
+
+    fn is_loopback(self) -> bool {
+        self.ip().is_loopback()
+    }
+}
+
+fn ping_cache_key(socket: SocketAddr) -> PingCacheKey {
+    PingCacheKey::from_socket(socket)
 }
 
 impl<const N: usize> Ping<N> {
@@ -174,12 +205,12 @@ impl<const N: usize> PingCache<N> {
         }
     }
 
-    /// Checks if the pong hash, pubkey and socket match a ping message sent
-    /// out previously. If so records current timestamp for the remote node and
+    /// Checks if the pong hash and address match a ping message sent
+    /// out previously. If so records current timestamp for the remote address and
     /// returns true.
     /// Note: Does not verify the signature.
     pub fn add(&mut self, pong: &Pong, socket: SocketAddr, now: Instant) -> bool {
-        let remote_node = (pong.pubkey(), socket);
+        let remote_node = ping_cache_key(socket);
         if !self.hashers.iter().copied().any(|hasher| {
             let token = make_ping_token::<N>(hasher, &remote_node);
             hash_ping_token(&token) == pong.hash
@@ -187,7 +218,7 @@ impl<const N: usize> PingCache<N> {
             return false;
         };
         self.pongs.put(remote_node, now);
-        if let Some(sent_time) = self.ping_times.pop(&socket.ip())
+        if let Some(sent_time) = self.ping_times.pop(&remote_node)
             && should_report_message_signature(
                 pong.signature(),
                 PONG_SIGNATURE_SAMPLE_LEADING_ZEROS,
@@ -196,7 +227,7 @@ impl<const N: usize> PingCache<N> {
             let rtt = now.saturating_duration_since(sent_time);
             datapoint_info!(
                 "ping_rtt",
-                ("peer_ip", socket.ip().to_string(), String),
+                ("peer_ip", remote_node.ip().to_string(), String),
                 ("rtt_us", rtt.as_micros() as i64, i64),
             );
         }
@@ -211,18 +242,24 @@ impl<const N: usize> PingCache<N> {
         rng: &mut R,
         keypair: &Keypair,
         now: Instant,
-        remote_node: (Pubkey, SocketAddr),
+        remote_socket: SocketAddr,
     ) -> Option<Ping<N>> {
+        let remote_node = ping_cache_key(remote_socket);
         // Rate limit consecutive pings sent to a remote node.
-        if matches!(self.pings.peek(&remote_node),
-            Some(&t) if now.saturating_duration_since(t) < self.rate_limit_delay)
+        if !remote_node.is_loopback()
+            && matches!(
+                self.pings.peek(&remote_node),
+                Some(&t) if now.saturating_duration_since(t) < self.rate_limit_delay
+            )
         {
             return None;
         }
-        self.pings.put(remote_node, now);
+        if !remote_node.is_loopback() {
+            self.pings.put(remote_node, now);
+        }
         self.maybe_refresh_key(rng, now);
         let token = make_ping_token::<N>(self.hashers[0], &remote_node);
-        self.ping_times.put(remote_node.1.ip(), Instant::now());
+        self.ping_times.put(remote_node, now);
         Some(Ping::new(token, keypair))
     }
 
@@ -239,8 +276,9 @@ impl<const N: usize> PingCache<N> {
         rng: &mut R,
         keypair: &Keypair,
         now: Instant,
-        remote_node: (Pubkey, SocketAddr),
+        remote_socket: SocketAddr,
     ) -> (bool, Option<Ping<N>>) {
+        let remote_node = ping_cache_key(remote_socket);
         let (check, should_ping) = match self.pongs.get(&remote_node) {
             None => (false, true),
             Some(t) => {
@@ -257,7 +295,7 @@ impl<const N: usize> PingCache<N> {
             }
         };
         let ping = should_ping
-            .then(|| self.maybe_ping(rng, keypair, now, remote_node))
+            .then(|| self.maybe_ping(rng, keypair, now, remote_socket))
             .flatten();
         (check, ping)
     }
@@ -271,15 +309,12 @@ impl<const N: usize> PingCache<N> {
     }
 
     /// Only for tests and simulations.
-    pub fn mock_pong(&mut self, node: Pubkey, socket: SocketAddr, now: Instant) {
-        self.pongs.put((node, socket), now);
+    pub fn mock_pong(&mut self, socket: SocketAddr, now: Instant) {
+        self.pongs.put(ping_cache_key(socket), now);
     }
 }
 
-fn make_ping_token<const N: usize>(
-    mut hasher: SipHasher24,
-    remote_node: &(Pubkey, SocketAddr),
-) -> [u8; N] {
+fn make_ping_token<const N: usize>(mut hasher: SipHasher24, remote_node: &PingCacheKey) -> [u8; N] {
     // TODO: Consider including local node's (pubkey, socket-addr).
     remote_node.hash(&mut hasher);
     let hash = hasher.finish().to_le_bytes();
@@ -348,12 +383,12 @@ mod tests {
 
         // Initially all checks should fail. The first observation of each node
         // should create a ping packet.
-        let mut seen_nodes = HashSet::<(Pubkey, SocketAddr)>::new();
+        let mut seen_nodes = HashSet::<PingCacheKey>::new();
         let pings: Vec<Option<Ping<32>>> = remote_nodes
             .iter()
-            .map(|(keypair, socket)| {
-                let node = (keypair.pubkey(), *socket);
-                let (check, ping) = cache.check(&mut rng, &this_node, now, node);
+            .map(|(_keypair, socket)| {
+                let node = ping_cache_key(*socket);
+                let (check, ping) = cache.check(&mut rng, &this_node, now, *socket);
                 assert!(!check);
                 assert_eq!(seen_nodes.insert(node), ping.is_some());
                 ping
@@ -366,8 +401,7 @@ mod tests {
                 None => {
                     // Already have a recent ping packets for nodes, so no new
                     // ping packet will be generated.
-                    let node = (keypair.pubkey(), *socket);
-                    let (check, ping) = cache.check(&mut rng, &this_node, now, node);
+                    let (check, ping) = cache.check(&mut rng, &this_node, now, *socket);
                     assert!(check);
                     assert!(ping.is_none());
                 }
@@ -380,9 +414,8 @@ mod tests {
 
         let now = now + Duration::from_millis(1);
         // All nodes now have a recent pong packet.
-        for (keypair, socket) in &remote_nodes {
-            let node = (keypair.pubkey(), *socket);
-            let (check, ping) = cache.check(&mut rng, &this_node, now, node);
+        for (_keypair, socket) in &remote_nodes {
+            let (check, ping) = cache.check(&mut rng, &this_node, now, *socket);
             assert!(check);
             assert!(ping.is_none());
         }
@@ -391,9 +424,9 @@ mod tests {
         // All nodes still have a valid pong packet, but the cache will create
         // a new ping packet to extend verification.
         seen_nodes.clear();
-        for (keypair, socket) in &remote_nodes {
-            let node = (keypair.pubkey(), *socket);
-            let (check, ping) = cache.check(&mut rng, &this_node, now, node);
+        for (_keypair, socket) in &remote_nodes {
+            let node = ping_cache_key(*socket);
+            let (check, ping) = cache.check(&mut rng, &this_node, now, *socket);
             assert!(check);
             assert_eq!(seen_nodes.insert(node), ping.is_some());
         }
@@ -401,9 +434,8 @@ mod tests {
         let now = now + Duration::from_millis(1);
         // All nodes still have a valid pong packet, and a very recent ping
         // packet pending response. So no new ping packet will be created.
-        for (keypair, socket) in &remote_nodes {
-            let node = (keypair.pubkey(), *socket);
-            let (check, ping) = cache.check(&mut rng, &this_node, now, node);
+        for (_keypair, socket) in &remote_nodes {
+            let (check, ping) = cache.check(&mut rng, &this_node, now, *socket);
             assert!(check);
             assert!(ping.is_none());
         }
@@ -413,9 +445,9 @@ mod tests {
         // remove the expired pong packet from cache and create a new ping packet.
         // check should be false because the pong is expired
         seen_nodes.clear();
-        for (keypair, socket) in &remote_nodes {
-            let node = (keypair.pubkey(), *socket);
-            let (check, ping) = cache.check(&mut rng, &this_node, now, node);
+        for (_keypair, socket) in &remote_nodes {
+            let node = ping_cache_key(*socket);
+            let (check, ping) = cache.check(&mut rng, &this_node, now, *socket);
             if seen_nodes.insert(node) {
                 assert!(!check, "Expired pong should return check=false");
                 assert!(
@@ -431,9 +463,8 @@ mod tests {
         let now = now + Duration::from_millis(1);
         // No valid pong packet in the cache. A recent ping packet already
         // created, so no new one will be created.
-        for (keypair, socket) in &remote_nodes {
-            let node = (keypair.pubkey(), *socket);
-            let (check, ping) = cache.check(&mut rng, &this_node, now, node);
+        for (_keypair, socket) in &remote_nodes {
+            let (check, ping) = cache.check(&mut rng, &this_node, now, *socket);
             assert!(!check);
             assert!(ping.is_none());
         }
@@ -442,9 +473,9 @@ mod tests {
         // No valid pong packet in the cache. Another ping packet will be
         // created for the first observation of each node.
         seen_nodes.clear();
-        for (keypair, socket) in &remote_nodes {
-            let node = (keypair.pubkey(), *socket);
-            let (check, ping) = cache.check(&mut rng, &this_node, now, node);
+        for (_keypair, socket) in &remote_nodes {
+            let node = ping_cache_key(*socket);
+            let (check, ping) = cache.check(&mut rng, &this_node, now, *socket);
             assert!(!check);
             assert_eq!(seen_nodes.insert(node), ping.is_some());
         }
@@ -454,22 +485,20 @@ mod tests {
     fn test_expired_pong_returns_check_false() {
         let mut rng = rand::rng();
         let this_node = Keypair::new();
-        let remote_node_keypair = Keypair::new();
         let remote_socket = SocketAddr::V4(SocketAddrV4::new(
             Ipv4Addr::new(rng.random(), rng.random(), rng.random(), rng.random()),
             rng.random(),
         ));
-        let remote_node = (remote_node_keypair.pubkey(), remote_socket);
         let ttl = Duration::from_secs(20 * 60); // 20 minutes
         let delay = ttl / 64;
         let mut now = Instant::now();
         let mut cache = PingCache::<32>::new(&mut rng, now, ttl, delay, /*cap=*/ 1000);
 
         // Add a pong for the remote node
-        cache.mock_pong(remote_node.0, remote_node.1, now);
+        cache.mock_pong(remote_socket, now);
 
         // Verify the pong is valid. `check` should return true
-        let (check, ping) = cache.check(&mut rng, &this_node, now, remote_node);
+        let (check, ping) = cache.check(&mut rng, &this_node, now, remote_socket);
         assert!(check, "Pong should be valid immediately after adding");
         assert!(ping.is_none(), "Should not generate ping for recent pong");
 
@@ -477,7 +506,7 @@ mod tests {
         now = now + ttl + Duration::from_secs(1);
 
         // After expiration, check should return false but should_ping should be true (to re-verify)
-        let (check, ping) = cache.check(&mut rng, &this_node, now, remote_node);
+        let (check, ping) = cache.check(&mut rng, &this_node, now, remote_socket);
         assert!(!check, "Expired pong should return check=false");
         assert!(
             ping.is_some(),

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -503,11 +503,7 @@ fn network_run_pull(
         let mut ping_cache = node.ping_cache.lock().unwrap();
         for other in &network_values {
             if node.keypair.pubkey() != other.keypair.pubkey() {
-                ping_cache.mock_pong(
-                    other.keypair.pubkey(),
-                    other.contact_info.gossip().unwrap(),
-                    Instant::now(),
-                );
+                ping_cache.mock_pong(other.contact_info.gossip().unwrap(), Instant::now());
             }
         }
     }


### PR DESCRIPTION
#### Problem
`PingCache` is caching on overly specific data `(Pubkey, SocketAddr)`. We no longer support NATs, so let's remove Pubkey and the port from `SocketAddr`.

#### Summary of Changes
1) Change `PingCache` to hold ping and pong LRU caches that are keyed on destination IP rather than on (Pubkey, IP:port)
2) Assuming no NAT support
3) special case on loopback interfaces for local-cluster tests. we still ping localhost node for tests but we do not rate limit pings to these addresses


Set of PRs to merge in order
https://github.com/anza-xyz/agave/pull/9895 [MERGED]
https://github.com/anza-xyz/agave/pull/10153 [MERGED]
https://github.com/anza-xyz/agave/pull/10147 (this one)
https://github.com/anza-xyz/agave/pull/10154
