### PR TITLE
fix: add missing dep qualifiers to program-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9857,6 +9857,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "percentage",
+ "qualifier_attr",
  "rand 0.9.2",
  "serde",
  "solana-account",

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -24,7 +24,7 @@ frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 metrics = []
 sbpf-debugger = ["solana-sbpf/debugger"]
 shuttle-test = ["solana-sbpf/shuttle-test", "solana-svm-type-overrides/shuttle-test"]
-svm-internal = []
+svm-internal = ["dep:qualifier_attr"]
 
 [dependencies]
 base64 = { workspace = true }
@@ -33,6 +33,7 @@ cfg-if = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 percentage = { workspace = true }
+qualifier_attr = { workspace = true, optional = true }
 rand = { workspace = true }
 serde = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -23,6 +23,8 @@ use {
     solana_transaction_context::{IndexOfAccount, TransactionContext},
     std::{cell::RefCell, mem},
 };
+#[cfg(feature = "svm-internal")]
+use qualifier_attr::qualifiers;
 
 thread_local! {
     pub static MEMORY_POOL: RefCell<VmMemoryPool> = RefCell::new(VmMemoryPool::new());

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -1,5 +1,7 @@
 //! SBF virtual machine provisioning and execution.
 
+#[cfg(feature = "svm-internal")]
+use qualifier_attr::qualifiers;
 use {
     crate::{
         execution_budget::MAX_INSTRUCTION_STACK_DEPTH,
@@ -23,8 +25,6 @@ use {
     solana_transaction_context::{IndexOfAccount, TransactionContext},
     std::{cell::RefCell, mem},
 };
-#[cfg(feature = "svm-internal")]
-use qualifier_attr::qualifiers;
 
 thread_local! {
     pub static MEMORY_POOL: RefCell<VmMemoryPool> = RefCell::new(VmMemoryPool::new());


### PR DESCRIPTION
#### Problem

(split from https://github.com/anza-xyz/agave/pull/9456)

failed to compline:

```
cargo +nightly-2025-09-14 check --manifest-path program-runtime/Cargo.toml --no-default-features --features svm-internal
```

#### Summary of Changes

add missing dep qualifier_attr