### PR TITLE
Gossip: reduce keep alive ping frequency by half

### DIFF
--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -252,7 +252,7 @@ impl<const N: usize> PingCache<N> {
                 } else {
                     // If the pong message is not too recent, generate a new ping
                     // message to extend remote node verification.
-                    (true, age > self.ttl / 8)
+                    (true, age > self.ttl / 4)
                 }
             }
         };
@@ -387,7 +387,7 @@ mod tests {
             assert!(ping.is_none());
         }
 
-        let now = now + ttl / 8;
+        let now = now + ttl / 4 + Duration::from_millis(1);
         // All nodes still have a valid pong packet, but the cache will create
         // a new ping packet to extend verification.
         seen_nodes.clear();


### PR DESCRIPTION
Minor change
#### Problem
We refresh pings more times than we need. 

#### Summary of Changes
increase the refresh threshold from ttl/8 to ttl/4, so we only send a new ping after a pong is at least 25% of TTL old—roughly halving refresh frequency (about once every ~5 minutes at the default TTL).

Set of PRs to merge in order
https://github.com/anza-xyz/agave/pull/9895 [MERGED]
https://github.com/anza-xyz/agave/pull/10153 (this one)
https://github.com/anza-xyz/agave/pull/10147
https://github.com/anza-xyz/agave/pull/10154