### PR TITLE
Gossip: add back in staked node ping bypass

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -137,7 +137,7 @@ pub const MINIMUM_NUM_TVU_RETRANSMIT_SOCKETS: NonZeroUsize = NonZeroUsize::new(1
 pub const DEFAULT_NUM_TVU_RETRANSMIT_SOCKETS: NonZeroUsize = NonZeroUsize::new(12).unwrap();
 
 /// Minimum stake required for a node to bypass the initial ping check when joining gossip.
-pub(crate) const MIN_STAKE_TO_SKIP_PING: u64 = solana_native_token::LAMPORTS_PER_SOL;
+pub(crate) const MIN_STAKE_TO_SKIP_PING: u64 = 10_000 * solana_native_token::LAMPORTS_PER_SOL;
 
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum ClusterInfoError {

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -136,6 +136,9 @@ pub const DEFAULT_NUM_TVU_RECEIVE_SOCKETS: NonZeroUsize = MINIMUM_NUM_TVU_RECEIV
 pub const MINIMUM_NUM_TVU_RETRANSMIT_SOCKETS: NonZeroUsize = NonZeroUsize::new(1).unwrap();
 pub const DEFAULT_NUM_TVU_RETRANSMIT_SOCKETS: NonZeroUsize = NonZeroUsize::new(12).unwrap();
 
+/// Minimum stake required for a node to bypass the initial ping check when joining gossip.
+pub(crate) const MIN_STAKE_TO_SKIP_PING: u64 = solana_native_token::LAMPORTS_PER_SOL;
+
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum ClusterInfoError {
     #[error("NoPeers")]
@@ -2016,6 +2019,7 @@ impl ClusterInfo {
                 &mut rng,
                 &self_keypair,
                 value,
+                stakes,
                 &self.socket_addr_space,
                 &self.ping_cache,
                 &mut pings,
@@ -2498,14 +2502,19 @@ fn verify_gossip_addr<R: Rng + CryptoRng>(
     rng: &mut R,
     keypair: &Keypair,
     value: &CrdsValue,
+    stakes: &HashMap<Pubkey, u64>,
     socket_addr_space: &SocketAddrSpace,
     ping_cache: &Mutex<PingCache>,
     pings: &mut Vec<(SocketAddr, Ping)>,
 ) -> bool {
-    let addr = match value.data() {
-        CrdsData::ContactInfo(node) => node.gossip(),
+    let (pubkey, addr) = match value.data() {
+        CrdsData::ContactInfo(node) => (node.pubkey(), node.gossip()),
         _ => return true, // If not a contact-info, nothing to verify.
     };
+    // For (sufficiently) staked nodes, don't bother with ping/pong.
+    if stakes.get(pubkey).copied() >= Some(MIN_STAKE_TO_SKIP_PING) {
+        return true;
+    }
     // Invalid addresses are not verifiable.
     let Some(addr) = addr.filter(|addr| socket_addr_space.check(addr)) else {
         return false;


### PR DESCRIPTION
#### Problem
when a node joins the network, it has to go through a set of ping/pong handshakes with every node in cluster. This can be slow and cause a network restart false start. So we allow nodes with sufficient stake to get the contactinfo propagated without the ping/pong handshake

NOTE: staked nodes must still go through a ping/pong handshake before receiving any push traffic, pull requests, or repair requests. 

#### Summary of Changes
nodes with >= 1 SOL stake are admitted into the crds without a ping/pong check

Set of PRs to merge in order
https://github.com/anza-xyz/agave/pull/9895 [MERGED]
https://github.com/anza-xyz/agave/pull/10153 [MERGED]
https://github.com/anza-xyz/agave/pull/10147 [MERGED]
https://github.com/anza-xyz/agave/pull/10154 (this one)