### PR TITLE
sbpf-debugger: control the debug port through the invocation context

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -203,6 +203,9 @@ pub struct InvokeContext<'a, 'ix_data> {
     pub syscall_context: Vec<Option<SyscallContext>>,
     /// Pairs of index in TX instruction trace and VM register trace
     register_traces: Vec<(usize, Vec<[u64; 12]>)>,
+    /// Debug port to use for this executing transaction.
+    #[cfg(feature = "sbpf-debugger")]
+    pub debug_port: Option<u16>,
 }
 
 impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
@@ -227,6 +230,8 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             timings: ExecuteDetailsTimings::default(),
             syscall_context: Vec::new(),
             register_traces: Vec::new(),
+            #[cfg(feature = "sbpf-debugger")]
+            debug_port: None,
         }
     }
 

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -178,6 +178,8 @@ pub fn execute<'a, 'b: 'a>(
             feature = "sbpf-debugger"
         ))] {
             let use_jit = false;
+            #[cfg(feature = "sbpf-debugger")]
+            let debug_port = invoke_context.debug_port;
         } else {
             let use_jit = executable.get_compiled_program().is_some();
         }
@@ -229,6 +231,10 @@ pub fn execute<'a, 'b: 'a>(
         };
         create_vm_time.stop();
 
+        #[cfg(feature = "sbpf-debugger")]
+        {
+            vm.debug_port = debug_port;
+        }
         vm.context_object_pointer.execute_time = Some(Measure::start("execute"));
         vm.registers[1] = ebpf::MM_INPUT_START;
 


### PR DESCRIPTION
#### Problem

Currently the debug_port is taken from the `VM_DEBUG_PORT` environment variable that gets parsed in `solana-sbpf` (https://github.com/anza-xyz/sbpf/blob/62e40d2c433efa1f7248bf166d9a2b49ecace3c0/src/vm.rs#L345).
This is inconvenient as this means that once set it will apply to every TX / ix. Initially the idea of a more fine-grained control has popped up here (https://github.com/anza-xyz/sbpf/pull/80#issuecomment-3737523288, https://github.com/anza-xyz/sbpf/pull/80#issuecomment-3744793077). This mechanism can give users the ability to filter by TX signature / program_id / etc.

#### Summary of Changes

Basically if the debug_port is `Some` in the `InvokeContext` structure that would be the port in use. ~~However, taking into account that `solana-sbpf` is a standalone crate it's better to leave the `VM_DEBUG_PORT` logic intact and if user is willing to rely on it I believe it's better to respect this decision and in this case to disregard the `InvokeContext`'s passed debug_port.~~
