### PR TITLE
Inserts into the in-mem index on startup

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6686,16 +6686,24 @@ impl AccountsDb {
 
         self.accounts_index.log_secondary_indexes();
 
-        // Now that the index is generated, get the total capacity of the in-mem maps
+        // Now that the index is generated, get the total length and capacity of the in-mem maps
         // across all the bins and set the initial value for the stat.
         // We do this all at once, at the end, since getting the capacity requires iterating all
         // the bins and grabbing a read lock, which we try to avoid whenever possible.
-        let index_capacity = self
+        let (index_len, index_capacity) = self
             .accounts_index
             .account_maps
             .iter()
-            .map(|bin| bin.capacity_for_startup())
-            .sum();
+            .map(|bin| bin.len_and_cap_for_startup())
+            .fold((0, 0), |mut accum, (len, cap)| {
+                accum.0 += len;
+                accum.1 += cap;
+                accum
+            });
+        self.accounts_index
+            .stats()
+            .count_in_mem
+            .store(index_len, Ordering::Relaxed);
         self.accounts_index
             .stats()
             .capacity_in_mem

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -92,7 +92,7 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
 
     /// Precomputed thresholds per bin for flushing and eviction
     /// None for Minimal/InMemOnly, Some(threshold_entries_per_bin) for Threshold
-    threshold_entries_per_bin: Option<ThresholdEntriesPerBin>,
+    pub(super) threshold_entries_per_bin: Option<ThresholdEntriesPerBin>,
 }
 
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Debug for BucketMapHolder<T, U> {
@@ -502,14 +502,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
 
 /// Precomputed thresholds derived from the configured per-bin target.
 #[derive(Clone, Copy, Debug)]
-struct ThresholdEntriesPerBin {
+pub struct ThresholdEntriesPerBin {
     /// Rounded target entries per bin used as the baseline for thresholds.
-    _target_entries: usize,
+    pub _target_entries: usize,
     /// Entry count above which a bin triggers flushing to disk and eviction
     /// from in-memory index.
-    high_water_mark: usize,
+    pub high_water_mark: usize,
     /// Entry count to reach after flushing/evicting from a bin.
-    low_water_mark: usize,
+    pub low_water_mark: usize,
 }
 
 #[cfg(test)]

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -970,7 +970,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         possible_evictions
     }
 
-    fn write_startup_info_to_disk(&self) {
+    /// Takes self's `startup_info` and writes it to disk and in-mem.
+    ///
+    /// If the configured memory limit is "minimal", nothing is writen to in-mem.
+    /// Otherwise write to in-mem (and respect the memory limit).
+    fn write_startup_info(&self) {
         let insert = std::mem::take(&mut *self.startup_info.insert.lock().unwrap());
         if insert.is_empty() {
             // nothing to insert for this bin
@@ -1127,7 +1131,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             // At startup we do not insert index entries into the normal in-mem index.
             // Instead, they are written to a startup-only struct.  Thus, at startup
             // we only need to flush that startup struct and then can return early.
-            self.write_startup_info_to_disk();
+            self.write_startup_info();
             if iterate_for_age {
                 // Note we still have to iterate ages too, since it is checked when
                 // transitioning from startup back to normal/steady state.

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1007,9 +1007,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                         // it is a duplicate.  We could merge them here, however duplicates
                         // handling happens later during startup/index generation, in
                         // populate_and_retrieve_duplicate_keys_from_startup(), which will insert
-                        // them back into the in-mem index.  Thus we should *not* insert them here!
-                        // Going further, we actually need to remove them here, so there aren't
-                        // issues later.
+                        // them back into the in-mem index.  Thus we should *not* insert any
+                        // accounts with duplicate entries here.
+                        // Additionally, once marking obsolete accounts is always on, we then
+                        // should no longer have any duplicates to worry about.
                         occupied.remove_entry();
                     }
                 }


### PR DESCRIPTION
#### Problem

If using the accounts index with a configured threshold via `--accounts-index-limit`, at startup all index entries are written to disk, but none to the in-mem index. This means that all first accesses to accounts will incur a disk read, which is slow.

This is unfortunate, since even if the configured threshold is large enough to hold everything in memory (e.g. `--accounts-index-limit 200GB`), the in-mem index will start off empty. And thus performance will be poor until all the accounts have be loaded back into memory.


#### Summary of Changes

At startup, if using a memory threshold for the index, insert into the in-mem index at the same time we also write the index entries to disk.

The resulting behavior is the validator is seeded with account index entries in-memory from the get go. When using a 200GB limit, the whole index fits in RAM, and performance is *immediately* high, instead of waiting for the long tail of accounts to be accessed one by one. Miss rate into the in-mem index is the same as in-mem-only.