### PR TITLE
refactor: Fix execute flag check

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -325,7 +325,7 @@ pub(crate) mod external {
                 .num_messages_processed
                 .fetch_add(1, Ordering::Relaxed);
 
-            if message.flags & pack_message_flags::EXECUTE == 1 {
+            if message.flags & pack_message_flags::EXECUTE != 0 {
                 self.execute_batch(message, should_drain_executes)
             } else {
                 self.check_batch(message).map(|()| false)


### PR DESCRIPTION
#### Problem
- EXECUTE messages were detected using flags & EXECUTE == 1. This is inconsistent with other checks and only works because EXECUTE == 1.

#### Summary of Changes
- Use a nonzero bit check (flags & EXECUTE != 0) when deciding between EXECUTE vs CHECK processing in ExternalWorker.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
