### PR TITLE
ci: fix dependabot version parsing

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           input="${{ github.event.pull_request.title }}"
 
-          regex="[Bb]ump (.*) from (.*) to (.*)"
+          regex='[Bb]ump (.+) from ([^ ]+) to ([^ ]+)( in .*)?'
           if [[ ! "$input" =~ $regex ]]; then
             echo "unexpected pattern"
             exit 1


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/actions/runs/21251865826/job/61155342024?pr=10159#step:3:176

```
error: unexpected argument 'in' found
```
#### Summary of Changes

fix the regex