### PR TITLE
cli: deprecate ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Release channels have their own copy of this changelog:
 * `agave-validator exit` now saves bank state before exiting. This enables restarts from local state when snapshot generation is disabled.
 * Added `--accounts-index-limit` to specify the memory limit of the accounts index.
 ### CLI
+#### Deprecations
+* The `ping` command is deprecated and will be removed in v4.1.
 #### Changes
 * Support Trezor hardware wallets using `usb://trezor`
 ### Platform tools

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -944,6 +944,10 @@ pub async fn process_command(config: &CliConfig<'_>) -> ProcessResult {
             print_timestamp,
             compute_unit_price,
         } => {
+            eprintln!(
+                "Warning: The 'ping' command is deprecated in v4.0 and will be removed in v4.1."
+            );
+
             let connection_cache = if config.use_tpu_client {
                 Some({
                     #[cfg(feature = "dev-context-only-utils")]

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -258,6 +258,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         .subcommand(
             SubCommand::with_name("ping")
                 .about("Submit transactions sequentially")
+                .setting(AppSettings::Hidden)
                 .arg(
                     Arg::with_name("interval")
                         .short("i")


### PR DESCRIPTION
#### Description
This PR is the pre-requirement to the https://github.com/anza-xyz/agave/issues/10122

#### Summary of Changes
Adds a deprecation warning for the `ping` CLI command in preparation for its removal in v4.1:

- Added deprecation warning message displayed when `ping` command is invoked
- Added hidden option to subcommand config
- Updated CHANGELOG.md with deprecation notice in the v4.0.0 section