### PR TITLE
startup: shred purge failures should be fatal

### DIFF
--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -733,7 +733,9 @@ impl BankingSimulator {
         {
             info!("purging slots {}, {}", self.first_simulated_slot, end_slot);
             blockstore.purge_from_next_slots(self.first_simulated_slot, end_slot);
-            blockstore.purge_slots(self.first_simulated_slot, end_slot, PurgeType::Exact);
+            blockstore
+                .purge_slots(self.first_simulated_slot, end_slot, PurgeType::Exact)
+                .unwrap();
             info!("done: purging");
         } else {
             info!("skipping purging...");

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2643,7 +2643,7 @@ fn cleanup_blockstore_incorrect_shred_versions(
     info!("Purging slots {start_slot} to {end_slot} from blockstore");
     let mut timer = Measure::start("blockstore purge");
     blockstore.purge_from_next_slots(start_slot, end_slot);
-    blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact);
+    blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact)?;
     timer.stop();
     info!("Purging slots done. {timer}");
 
@@ -3097,7 +3097,9 @@ mod tests {
 
         // Purge blockstore up to latest hard fork
         // No check since all blockstore data newer than latest hard fork
-        blockstore.purge_slots(0, latest_hard_fork, PurgeType::Exact);
+        blockstore
+            .purge_slots(0, latest_hard_fork, PurgeType::Exact)
+            .unwrap();
         assert_eq!(
             should_cleanup_blockstore_incorrect_shred_versions(
                 &validator_config,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7895,7 +7895,9 @@ pub mod tests {
         assert_eq!(blockstore.lowest_slot_with_genesis(), 0);
         assert_eq!(blockstore.lowest_slot(), 1);
 
-        blockstore.purge_slots(0, 1, PurgeType::CompactionFilter);
+        blockstore
+            .purge_slots(0, 1, PurgeType::CompactionFilter)
+            .unwrap();
         assert_eq!(blockstore.get_first_available_block().unwrap(), 3);
         assert_eq!(blockstore.lowest_slot_with_genesis(), 2);
         assert_eq!(blockstore.lowest_slot(), 2);
@@ -8768,7 +8770,9 @@ pub mod tests {
 
         if simulate_blockstore_cleanup_service {
             *blockstore.lowest_cleanup_slot.write().unwrap() = lowest_cleanup_slot;
-            blockstore.purge_slots(0, lowest_cleanup_slot, PurgeType::CompactionFilter);
+            blockstore
+                .purge_slots(0, lowest_cleanup_slot, PurgeType::CompactionFilter)
+                .unwrap();
         }
 
         let are_missing = check_for_missing();
@@ -9950,14 +9954,14 @@ pub mod tests {
             .insert_shreds(all_shreds, Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot);
+        blockstore.purge_and_compact_slots(0, slot).unwrap();
 
         // Test inserting just the codes, enough for recovery
         blockstore
             .insert_shreds(coding_shreds.clone(), Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot);
+        blockstore.purge_and_compact_slots(0, slot).unwrap();
 
         // Test inserting some codes, but not enough for recovery
         blockstore
@@ -9968,7 +9972,7 @@ pub mod tests {
             )
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot);
+        blockstore.purge_and_compact_slots(0, slot).unwrap();
 
         // Test inserting just the codes, and some data, enough for recovery
         let shreds: Vec<_> = data_shreds[..data_shreds.len() - 1]
@@ -9980,7 +9984,7 @@ pub mod tests {
             .insert_shreds(shreds, Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot);
+        blockstore.purge_and_compact_slots(0, slot).unwrap();
 
         // Test inserting some codes, and some data, but enough for recovery
         let shreds: Vec<_> = data_shreds[..data_shreds.len() / 2 - 1]
@@ -9992,7 +9996,7 @@ pub mod tests {
             .insert_shreds(shreds, Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot);
+        blockstore.purge_and_compact_slots(0, slot).unwrap();
 
         // Test inserting all shreds in 2 rounds, make sure nothing is lost
         let shreds1: Vec<_> = data_shreds[..data_shreds.len() / 2 - 1]
@@ -10012,7 +10016,7 @@ pub mod tests {
             .insert_shreds(shreds2, Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot);
+        blockstore.purge_and_compact_slots(0, slot).unwrap();
 
         // Test not all, but enough data and coding shreds in 2 rounds to trigger recovery,
         // make sure nothing is lost
@@ -10037,7 +10041,7 @@ pub mod tests {
             .insert_shreds(shreds2, Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot);
+        blockstore.purge_and_compact_slots(0, slot).unwrap();
 
         // Test insert shreds in 2 rounds, but not enough to trigger
         // recovery, make sure nothing is lost
@@ -10062,7 +10066,7 @@ pub mod tests {
             .insert_shreds(shreds2, Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot);
+        blockstore.purge_and_compact_slots(0, slot).unwrap();
     }
 
     fn setup_erasure_shreds(

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -11,7 +11,7 @@ pub struct PurgeStats {
     delete_file_in_range: u64,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 /// Controls how `blockstore::purge_slots` purges the data.
 pub enum PurgeType {
     /// A slower but more accurate way to purge slots by also ensuring higher
@@ -55,8 +55,11 @@ impl Blockstore {
                 i64
             )
         );
-        purge_result.inspect_err(|e| {
-            error!("Error: {e:?}; Purge failed in range {from_slot:?} to {to_slot:?}");
+        purge_result.map_err(|e| BlockstoreError::PurgeFailed {
+            from_slot,
+            to_slot,
+            purge_type,
+            inner: Box::new(e),
         })?;
         Ok(())
     }

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -38,7 +38,7 @@ impl Blockstore {
     /// while the non-slot-id based column families, `cf::TransactionStatus`,
     /// `AddressSignature`, and `cf::TransactionStatusIndex`, are cleaned-up
     /// based on the `purge_type` setting.
-    pub fn purge_slots(&self, from_slot: Slot, to_slot: Slot, purge_type: PurgeType) {
+    pub fn purge_slots(&self, from_slot: Slot, to_slot: Slot, purge_type: PurgeType) -> Result<()> {
         let mut purge_stats = PurgeStats::default();
         let purge_result =
             self.run_purge_with_stats(from_slot, to_slot, purge_type, &mut purge_stats);
@@ -55,9 +55,10 @@ impl Blockstore {
                 i64
             )
         );
-        if let Err(e) = purge_result {
+        purge_result.inspect_err(|e| {
             error!("Error: {e:?}; Purge failed in range {from_slot:?} to {to_slot:?}");
-        }
+        })?;
+        Ok(())
     }
 
     /// Usually this is paired with .purge_slots() but we can't internally call this in
@@ -77,8 +78,9 @@ impl Blockstore {
         }
     }
 
-    pub fn purge_and_compact_slots(&self, from_slot: Slot, to_slot: Slot) {
-        self.purge_slots(from_slot, to_slot, PurgeType::Exact);
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn purge_and_compact_slots(&self, from_slot: Slot, to_slot: Slot) -> Result<()> {
+        self.purge_slots(from_slot, to_slot, PurgeType::Exact)
     }
 
     /// Ensures that the SlotMeta::next_slots vector for all slots contain no references in the
@@ -532,11 +534,11 @@ pub mod tests {
         let (shreds, _) = make_many_slot_entries(0, 50, 5);
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
-        blockstore.purge_and_compact_slots(0, 5);
+        blockstore.purge_and_compact_slots(0, 5).unwrap();
 
         test_all_empty_or_min(&blockstore, 6);
 
-        blockstore.purge_and_compact_slots(0, 50);
+        blockstore.purge_and_compact_slots(0, 50).unwrap();
 
         // min slot shouldn't matter, blockstore should be empty
         test_all_empty_or_min(&blockstore, 100);

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -1,6 +1,9 @@
 //! The error that can be produced from Blockstore operations.
 
-use {agave_snapshots::hardened_unpack::UnpackError, solana_clock::Slot, thiserror::Error};
+use {
+    super::PurgeType, agave_snapshots::hardened_unpack::UnpackError, solana_clock::Slot,
+    thiserror::Error,
+};
 
 #[derive(Error, Debug)]
 pub enum BlockstoreError {
@@ -54,5 +57,13 @@ pub enum BlockstoreError {
     LegacyShred(Slot, u64),
     #[error("unable to read merkle root slot {0}, index {1}")]
     MissingMerkleRoot(Slot, u64),
+    #[error("unable to purge slots in range [{from_slot}, {to_slot}] {purge_type:?}: {inner:?}")]
+    PurgeFailed {
+        from_slot: Slot,
+        to_slot: Slot,
+        purge_type: PurgeType,
+        #[source]
+        inner: Box<BlockstoreError>,
+    },
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;

--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -216,7 +216,11 @@ impl BlockstoreCleanupService {
 
             let mut purge_time = Measure::start("purge_slots()");
             // purge any slots older than lowest_cleanup_slot.
-            blockstore.purge_slots(0, lowest_cleanup_slot, PurgeType::CompactionFilter);
+            let _ = blockstore
+                .purge_slots(0, lowest_cleanup_slot, PurgeType::CompactionFilter)
+                .inspect_err(|e| {
+                    error!("Purge failed when cleaning ledger to {lowest_cleanup_slot}: {e:?}")
+                });
             // Update only after purge operation.
             // Safety: This value can be used by compaction_filters shared via Arc<AtomicU64>.
             // Compactions are async and run as a multi-threaded background job. However, this

--- a/ledger/tests/blockstore.rs
+++ b/ledger/tests/blockstore.rs
@@ -43,6 +43,8 @@ fn test_multiple_threads_insert_shred() {
         assert_eq!(meta0.next_slots, expected_next_slots);
 
         // Delete slots for next iteration
-        blockstore.purge_and_compact_slots(0, num_threads + 1);
+        blockstore
+            .purge_and_compact_slots(0, num_threads + 1)
+            .unwrap();
     }
 }

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -152,7 +152,9 @@ pub fn open_blockstore(ledger_path: &Path) -> Blockstore {
 
 pub fn purge_slots_with_count(blockstore: &Blockstore, start_slot: Slot, slot_count: Slot) {
     blockstore.purge_from_next_slots(start_slot, start_slot + slot_count - 1);
-    blockstore.purge_slots(start_slot, start_slot + slot_count - 1, PurgeType::Exact);
+    blockstore
+        .purge_slots(start_slot, start_slot + slot_count - 1, PurgeType::Exact)
+        .expect("Purge must succeed");
 }
 
 // Fetches the last vote in the tower, blocking until it has also appeared in blockstore.


### PR DESCRIPTION
#### Problem
On startup we purge shreds from previous shred versions. this is critical for hard fork restarts as otherwise you end up observing multiple blocks per slot and consensus will stall.

#### Summary of Changes
Propagate the purge error so that if this shred purge fails we kill the validator on startup