### PR TITLE
SIMD-0123: Block Revenue Sharing: vote program piece

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11988,6 +11988,8 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-svm-feature-set",
+ "solana-system-interface 3.0.0",
+ "solana-system-program",
  "solana-transaction",
  "solana-transaction-context",
  "solana-vote-interface",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9906,6 +9906,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signer",
  "solana-slot-hashes",
+ "solana-system-interface 3.0.0",
  "solana-transaction",
  "solana-transaction-context",
  "solana-vote-interface",

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -172,7 +172,7 @@ impl FeatureSet {
             commission_rate_in_basis_points: self.is_active(&commission_rate_in_basis_points::id()),
             custom_commission_collector: self.is_active(&custom_commission_collector::id()),
             enable_bls12_381_syscall: self.is_active(&enable_bls12_381_syscall::id()),
-            block_revenue_sharing: self.is_active(&block_revenue_sharing::id()),
+            block_revenue_sharing: false, // Hard-coded as disabled for now. Not a fully-implemented feature yet.
         }
     }
 }
@@ -2310,10 +2310,6 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             limit_instruction_accounts::id(),
             "SIMD-406: Maximum instruction accounts",
-        ),
-        (
-            block_revenue_sharing::id(),
-            "SIMD-0123: Block Revenue Sharing",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -172,6 +172,7 @@ impl FeatureSet {
             commission_rate_in_basis_points: self.is_active(&commission_rate_in_basis_points::id()),
             custom_commission_collector: self.is_active(&custom_commission_collector::id()),
             enable_bls12_381_syscall: self.is_active(&enable_bls12_381_syscall::id()),
+            block_revenue_sharing: self.is_active(&block_revenue_sharing::id()),
         }
     }
 }
@@ -1291,6 +1292,10 @@ pub mod limit_instruction_accounts {
     solana_pubkey::declare_id!("DqbnFPASg7tHmZ6qfpdrt2M6MWoSeiicWPXxPhxqFCQ");
 }
 
+pub mod block_revenue_sharing {
+    solana_pubkey::declare_id!("HqUXZzYaxpbjHRCZHn8GLDCSecyCe2A7JD3An6asGdw4");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2305,6 +2310,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             limit_instruction_accounts::id(),
             "SIMD-406: Maximum instruction accounts",
+        ),
+        (
+            block_revenue_sharing::id(),
+            "SIMD-0123: Block Revenue Sharing",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10415,6 +10415,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signer",
  "solana-slot-hashes",
+ "solana-system-interface 3.0.0",
  "solana-transaction",
  "solana-transaction-context",
  "solana-vote-interface",

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -54,6 +54,7 @@ solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signer = { workspace = true }
 solana-slot-hashes = { workspace = true }
+solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true, features = ["bincode"] }
 solana-transaction-context = { workspace = true, features = ["bincode"] }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
@@ -73,6 +74,7 @@ solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-svm-feature-set = { workspace = true }
+solana-system-program = { workspace = true }
 solana-vote-program = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 test-case = { workspace = true }
 

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -68,6 +68,8 @@ pub trait VoteStateHandle {
 
     fn set_block_revenue_collector(&mut self, collector: Pubkey);
 
+    fn pending_delegator_rewards(&self) -> u64;
+
     fn add_pending_delegator_rewards(&mut self, amount: u64) -> Result<(), InstructionError>;
 
     fn votes(&self) -> &VecDeque<LandedVote>;
@@ -386,6 +388,11 @@ impl VoteStateHandle for VoteStateV3 {
         // No-op for v3: field does not exist.
     }
 
+    fn pending_delegator_rewards(&self) -> u64 {
+        // V3 doesn't have this field.
+        0
+    }
+
     fn add_pending_delegator_rewards(&mut self, _amount: u64) -> Result<(), InstructionError> {
         // No-op. We can never reach this callsite, since SIMD-0123 depends on
         // SIMD-0185: the activation of VoteStateV4.
@@ -573,6 +580,10 @@ impl VoteStateHandle for VoteStateV4 {
 
     fn set_block_revenue_collector(&mut self, collector: Pubkey) {
         self.block_revenue_collector = collector;
+    }
+
+    fn pending_delegator_rewards(&self) -> u64 {
+        self.pending_delegator_rewards
     }
 
     fn add_pending_delegator_rewards(&mut self, amount: u64) -> Result<(), InstructionError> {
@@ -806,6 +817,13 @@ impl VoteStateHandle for VoteStateHandler {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_block_revenue_collector(collector),
             TargetVoteState::V4(v4) => v4.set_block_revenue_collector(collector),
+        }
+    }
+
+    fn pending_delegator_rewards(&self) -> u64 {
+        match &self.target_state {
+            TargetVoteState::V3(v3) => v3.pending_delegator_rewards(),
+            TargetVoteState::V4(v4) => v4.pending_delegator_rewards(),
         }
     }
 

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -58,6 +58,8 @@ pub trait VoteStateHandle {
 
     fn set_inflation_rewards_commission_bps(&mut self, commission_bps: u16);
 
+    fn set_block_revenue_commission_bps(&mut self, commission_bps: u16);
+
     fn node_pubkey(&self) -> &Pubkey;
 
     fn set_node_pubkey(&mut self, node_pubkey: Pubkey);
@@ -363,6 +365,11 @@ impl VoteStateHandle for VoteStateV3 {
         // SIMD-0185: the activation of VoteStateV4.
     }
 
+    fn set_block_revenue_commission_bps(&mut self, _commission_bps: u16) {
+        // No-op. We can never reach this callsite, since SIMD-0123 depends on
+        // SIMD-0185: the activation of VoteStateV4.
+    }
+
     fn node_pubkey(&self) -> &Pubkey {
         &self.node_pubkey
     }
@@ -546,6 +553,10 @@ impl VoteStateHandle for VoteStateV4 {
 
     fn set_inflation_rewards_commission_bps(&mut self, commission_bps: u16) {
         self.inflation_rewards_commission_bps = commission_bps;
+    }
+
+    fn set_block_revenue_commission_bps(&mut self, commission_bps: u16) {
+        self.block_revenue_commission_bps = commission_bps;
     }
 
     fn node_pubkey(&self) -> &Pubkey {
@@ -760,6 +771,13 @@ impl VoteStateHandle for VoteStateHandler {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_inflation_rewards_commission_bps(commission_bps),
             TargetVoteState::V4(v4) => v4.set_inflation_rewards_commission_bps(commission_bps),
+        }
+    }
+
+    fn set_block_revenue_commission_bps(&mut self, commission_bps: u16) {
+        match &mut self.target_state {
+            TargetVoteState::V3(v3) => v3.set_block_revenue_commission_bps(commission_bps),
+            TargetVoteState::V4(v4) => v4.set_block_revenue_commission_bps(commission_bps),
         }
     }
 

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -50,6 +50,7 @@ pub struct SVMFeatureSet {
     pub commission_rate_in_basis_points: bool,
     pub custom_commission_collector: bool,
     pub enable_bls12_381_syscall: bool,
+    pub block_revenue_sharing: bool,
 }
 
 impl SVMFeatureSet {
@@ -104,6 +105,7 @@ impl SVMFeatureSet {
             commission_rate_in_basis_points: true,
             custom_commission_collector: true,
             enable_bls12_381_syscall: true,
+            block_revenue_sharing: true,
         }
     }
 }


### PR DESCRIPTION
#### Problem
[SIMD-0123](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0123-block-revenue-distribution.md) introduces a mechanism for validators to share block rewards with stakers by accumulating rewards in their vote account and distributing them at epoch boundaries.

The Vote program must be updated to support configuring block revenue commission, depositing rewards, and withdrawing excess lamports.

#### Summary of Changes
 Three main changes to the Vote Program, as defined by SIMD-0123:

  1. New `DepositDelegatorRewards` instruction allows a source account to deposit lamports into a vote account's `pending_delegator_rewards` field.
  2. Update `UpdateCommissionBps` to allow configuring block revenue commission in basis-points (`block_revenue_commission_bps`). This was previously not allowed, as SIMD-0291 only permitted setting `inflation_rewards_commission_bps`.
  3. Update `Withdraw` to consider the balance locked by `pending_delegator_rewards` when withdrawing. Withdrawable balance is limited to `total_lamports - pending_delegator_rewards - rent_exempt_minimum` and vote accounts cannot be closed (fully withdrawn) while `pending_delegator_rewards` > 0.