### PR TITLE
Deprecate "--tpu-connection-pool-size" ConnectionCache cli argument

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -155,6 +155,16 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             usage_warning:"tpu_coalesce will be dropped (currently ignored)",
     );
     add_arg!(
+        // deprecated in v4.0.0
+        Arg::with_name("tpu_connection_pool_size")
+            .long("tpu-connection-pool-size")
+            .takes_value(true)
+            .default_value( Box::leak( format!("{DEFAULT_TPU_CONNECTION_POOL_SIZE}").into_boxed_str()))
+            .validator(is_parsable::<usize>)
+            .help("Controls the TPU connection pool size per remote address"),
+         usage_warning:"This parameter is misleading, avoid setting it",
+    );
+    add_arg!(
         // deprecated in v3.1.0
         Arg::with_name("transaction_struct")
             .long("transaction-structure")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -705,14 +705,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("tpu_connection_pool_size")
-            .long("tpu-connection-pool-size")
-            .takes_value(true)
-            .default_value(&default_args.tpu_connection_pool_size)
-            .validator(is_parsable::<usize>)
-            .help("Controls the TPU connection pool size per remote address"),
-    )
-    .arg(
         Arg::with_name("tpu_max_connections_per_ipaddr_per_minute")
             .long("tpu-max-connections-per-ipaddr-per-minute")
             .takes_value(true)


### PR DESCRIPTION
#### Problem

The "--tpu-connection-pool-size" argument controls number of concurrent connections per peer that ConnectionCache will open. This has no practical applications, and should never be used. ConnectionCache is also on the way out so the CLI will point to nothing soon anyway.

#### Summary of Changes

Deprecate "--tpu-connection-pool-size" ConnectionCache cli argument.
