### PR TITLE
perf(accounts_db): don't check first account lens on gen_index

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6155,10 +6155,6 @@ impl AccountsDb {
         store_id: AccountsFileId,
         storage_info: &StorageSizeAndCountMap,
     ) -> SlotIndexGenerationInfo {
-        if storage.accounts.get_account_data_lens(&[0]).is_empty() {
-            return SlotIndexGenerationInfo::default();
-        }
-
         let mut accounts_data_len = 0;
         let mut stored_size_alive = 0;
         let mut zero_lamport_pubkeys = vec![];

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6256,7 +6256,7 @@ impl AccountsDb {
             .accounts_index
             .insert_new_if_missing_into_primary_index(slot, keyed_account_infos));
 
-        {
+        if insert_info.count > 0 {
             // second, collect into the shared DashMap once we've figured out all the info per store_id
             let mut info = storage_info.entry(store_id).or_default();
             info.stored_size += stored_size_alive;

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4973,7 +4973,14 @@ fn test_calculate_storage_count_and_alive_bytes_obsolete_account(
         info.num_obsolete_accounts_skipped,
         num_accounts_to_mark_obsolete as u64
     );
-    assert_eq!(storage_info.len(), 1);
+    assert_eq!(
+        storage_info.len(),
+        if num_accounts_to_mark_obsolete < account_sizes.len() {
+            1
+        } else {
+            0
+        }
+    );
 
     for entry in storage_info.iter() {
         // Sum up the stored size of all non obsolete accounts


### PR DESCRIPTION
#### Problem
When generating index for accounts-db, each storage processing is started with a special check whether account at offset 0 has length no larger than whole storage size.

In practice:
* this condition isn't normally (ever?) violated - tests with fastboot or unarchive from snapshot doesn't produce a single case
* if invalid storage like that is ever processed, `scan_accounts` called shortly after will detect this when trying to read the required contents of the first account, and we can instead just check if any account was scanned

The call does issue extra IO and allocates some vectors, which is basically wasted processing.

#### Summary of Changes
Remove the `get_account_data_lens` call from `generate_index_for_slot`
