### PR TITLE
perf(accounts-db): use io-uring FileBufRead impl in index generation

### DIFF
--- a/snapshots/src/unarchive.rs
+++ b/snapshots/src/unarchive.rs
@@ -112,6 +112,6 @@ fn decompressed_tar_reader(
     buf_size: usize,
     io_setup: &IoSetupState,
 ) -> io::Result<ArchiveFormatDecompressor<impl BufRead + use<>>> {
-    let buf_reader = buffered_reader::large_file_buf_reader(archive_path, buf_size, io_setup)?;
+    let buf_reader = buffered_reader::buf_reader_from_path(archive_path, buf_size, io_setup)?;
     ArchiveFormatDecompressor::new(archive_format, buf_reader)
 }


### PR DESCRIPTION
#### Problem
When scanning accounts storage during index generation we use stack-based synchronous buf reader with just 32KiB buffer size, wrapped with overflow buf reader that reallocates on demand when reading large accounts.

Those readers will do unnecessary syscalls and buffer re-sizing and can be replaced with implementation that preallocates and reads farther ahead given that we now re-use them across whole index generation (per thread).

#### Summary of Changes
* use io-uring read-ahead reader with large read size (default 1MiB) as `FileBufRead` implementation used for "full" scan accounts reader (used to generate index) on linux
* set overflow capacity according to max account size for those "full" readers (since we are scanning all storages, it's very likely we will stumble upon very large account at some point)
* rename `buffered_reader::large_file_buf_reader` to `buffered_reader::buf_reader_from_path` to distinguish helper creating idle `FileBufRead` reader from one dedicated to reading single path
