### PR TITLE
perf: avoid extra clone before TPU send

### DIFF
--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -202,7 +202,7 @@ async fn send_transaction_with_rpc_fallback(
     let send_over_rpc = if let Some(tpu_client) = tpu_client {
         !tokio::time::timeout(
             SEND_TIMEOUT_INTERVAL,
-            tpu_client.send_wire_transaction(serialized_transaction.clone()),
+            tpu_client.send_wire_transaction(serialized_transaction),
         )
         .await
         .unwrap_or(false)


### PR DESCRIPTION
#### Problem

Previously `send_transaction_with_rpc_fallback` cloned the serialized transaction buffer right before calling `tpu_client.send_wire_transaction`, even though ownership of the `Vec<u8>` was not needed afterward and a separate copy is already stored in TransactionData for resends.

#### Summary of Changes

Passed the serialized transaction buffer by value into `send_wire_transaction` instead of cloning it

