### PR TITLE
svm: inline agave-logger in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11022,12 +11022,12 @@ dependencies = [
 name = "solana-svm"
 version = "4.0.0-alpha.0"
 dependencies = [
- "agave-logger",
  "agave-syscalls",
  "ahash 0.8.12",
  "assert_matches",
  "bincode",
  "ed25519-dalek 1.0.1",
+ "env_logger",
  "libsecp256k1",
  "log",
  "openssl",
@@ -11151,10 +11151,10 @@ name = "solana-svm-test-harness-instr"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
- "agave-logger",
  "agave-precompiles",
  "agave-syscalls",
  "bincode",
+ "env_logger",
  "prost",
  "solana-account",
  "solana-builtins",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9765,10 +9765,10 @@ name = "solana-svm-test-harness-instr"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
- "agave-logger",
  "agave-precompiles",
  "agave-syscalls",
  "bincode",
+ "env_logger",
  "solana-account",
  "solana-builtins",
  "solana-clock",

--- a/svm-test-harness/instr/Cargo.toml
+++ b/svm-test-harness/instr/Cargo.toml
@@ -21,10 +21,10 @@ fuzz = [
 
 [dependencies]
 agave-feature-set = { workspace = true }
-agave-logger = { workspace = true }
 agave-precompiles = { workspace = true }
 agave-syscalls = { workspace = true }
 bincode = { workspace = true }
+env_logger = { workspace = true }
 prost = { workspace = true, optional = true }
 solana-account = { workspace = true }
 solana-builtins = { workspace = true }

--- a/svm-test-harness/instr/src/fuzz.rs
+++ b/svm-test-harness/instr/src/fuzz.rs
@@ -7,6 +7,7 @@ use {
             instr_context::InstrContext,
             proto::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
         },
+        logger,
     },
     agave_feature_set::{increase_cpi_account_info_limit, raise_cpi_nesting_limit_to_8},
     agave_syscalls::create_program_runtime_environment_v1,
@@ -24,7 +25,7 @@ pub unsafe extern "C" fn sol_compat_init(_log_level: i32) {
     }
     if env::var("ENABLE_SOLANA_LOGGER").is_ok() {
         /* Pairs with RUST_LOG={trace,debug,info,etc} */
-        agave_logger::setup();
+        logger::setup();
     }
 }
 

--- a/svm-test-harness/instr/src/lib.rs
+++ b/svm-test-harness/instr/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod file;
 mod harness;
 pub mod keyed_account;
+pub mod logger;
 pub mod program_cache;
 pub mod sysvar_cache;
 

--- a/svm-test-harness/instr/src/logger.rs
+++ b/svm-test-harness/instr/src/logger.rs
@@ -1,0 +1,9 @@
+//! Logging utils.
+
+/// Initialize a test logger with default error filter.
+pub fn setup() {
+    let _ = env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("error"))
+        .format_timestamp_nanos()
+        .is_test(true)
+        .try_init();
+}

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -80,11 +80,11 @@ spl-generic-token = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
 agave-syscalls = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 ed25519-dalek = { workspace = true }
+env_logger = { workspace = true }
 libsecp256k1 = { workspace = true }
 openssl = { workspace = true }
 rand0-7 = { workspace = true }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -691,6 +691,13 @@ mod tests {
         },
     };
 
+    fn setup_test_logger() {
+        let _ = env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("error"))
+            .format_timestamp_nanos()
+            .is_test(true)
+            .try_init();
+    }
+
     #[derive(Clone)]
     struct TestCallbacks {
         accounts_map: HashMap<Pubkey, (AccountSharedData, Slot)>,
@@ -1062,7 +1069,7 @@ mod tests {
 
     #[test]
     fn test_instructions() {
-        agave_logger::setup();
+        setup_test_logger();
         let instructions_key = solana_sdk_ids::sysvar::instructions::id();
         let keypair = Keypair::new();
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0, 1])];
@@ -1086,7 +1093,7 @@ mod tests {
 
     #[test]
     fn test_overrides() {
-        agave_logger::setup();
+        setup_test_logger();
         let mut account_overrides = AccountOverrides::default();
         let slot_history_id = sysvar::slot_history::id();
         let account = AccountSharedData::new(42, 0, &Pubkey::default());


### PR DESCRIPTION
#### Problem
As we prepare to cut SVM out of Agave and into its own repository, we must reduce the number of circular dependencies we might end up with in tests.

#### Summary of Changes
In the following crates, inline logger setup instead of using `agave-logger`:
* `solana-svm` module `account_loader`
* `solana-svm-test-harness-instr`
