### PR TITLE
QUIC votes with tpu-client-next

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -33,6 +33,8 @@ pub enum KeyUpdaterType {
     Bls,
     /// BLS all-to-all connection cache key updater
     BlsConnectionCache,
+    /// For QUIC voting
+    VoteClient,
 }
 
 /// Responsible for managing the updaters for identity key change

--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -1,5 +1,6 @@
 use {
     crate::banking_stage::LikeClusterInfo,
+    async_trait::async_trait,
     itertools::Itertools,
     solana_clock::{FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, NUM_CONSECUTIVE_LEADER_SLOTS},
     solana_gossip::{
@@ -7,7 +8,11 @@ use {
         contact_info::{ContactInfoQuery, Protocol},
     },
     solana_poh::poh_recorder::PohRecorder,
-    std::{net::SocketAddr, sync::RwLock},
+    solana_tpu_client_next::leader_updater::LeaderUpdater,
+    std::{
+        net::SocketAddr,
+        sync::{Arc, RwLock},
+    },
 };
 
 /// Returns a list of tpu vote sockets for the leaders of the next N fanout
@@ -58,4 +63,35 @@ pub(crate) fn next_leaders(
             cluster_info.lookup_contact_info(leader_pubkey, &port_selector)?
         })
         .collect()
+}
+
+pub(crate) struct VotingServiceLeaderUpdater {
+    cluster_info: Arc<ClusterInfo>,
+    poh_recorder: Arc<RwLock<PohRecorder>>,
+}
+
+impl VotingServiceLeaderUpdater {
+    pub(crate) fn new(
+        cluster_info: Arc<ClusterInfo>,
+        poh_recorder: Arc<RwLock<PohRecorder>>,
+    ) -> Self {
+        Self {
+            cluster_info,
+            poh_recorder,
+        }
+    }
+}
+
+#[async_trait]
+impl LeaderUpdater for VotingServiceLeaderUpdater {
+    fn next_leaders(&mut self, lookahead_leaders: usize) -> Vec<SocketAddr> {
+        upcoming_leader_tpu_vote_sockets(
+            &self.cluster_info,
+            &self.poh_recorder,
+            lookahead_leaders as u64 * NUM_CONSECUTIVE_LEADER_SLOTS,
+            Protocol::QUIC,
+        )
+    }
+
+    async fn stop(&mut self) {}
 }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -7989,7 +7989,8 @@ pub(crate) mod tests {
             &poh_recorder,
             &tower_storage,
             vote_info,
-            Arc::new(connection_cache),
+            &Arc::new(connection_cache),
+            &None,
         );
 
         let mut cursor = Cursor::default();
@@ -8087,7 +8088,8 @@ pub(crate) mod tests {
             &poh_recorder,
             &tower_storage,
             vote_info,
-            Arc::new(connection_cache),
+            &Arc::new(connection_cache),
+            &None,
         );
 
         let votes = cluster_info.get_votes(&mut cursor);
@@ -8215,7 +8217,8 @@ pub(crate) mod tests {
             &poh_recorder,
             &tower_storage,
             vote_info,
-            Arc::new(connection_cache),
+            &Arc::new(connection_cache),
+            &None,
         );
 
         assert!(last_vote_refresh_time.last_refresh_time > clone_refresh_time);
@@ -8357,7 +8360,8 @@ pub(crate) mod tests {
             poh_recorder,
             tower_storage,
             vote_info,
-            Arc::new(connection_cache),
+            &Arc::new(connection_cache),
+            &None,
         );
 
         let votes = cluster_info.get_votes(cursor);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -18,6 +18,7 @@ use {
             ExternalRootSource, Tower,
         },
         forwarding_stage::ForwardingClientConfig,
+        next_leader::VotingServiceLeaderUpdater,
         repair::{
             self,
             quic_endpoint::{RepairQuicAsyncSenders, RepairQuicSenders, RepairQuicSockets},
@@ -33,6 +34,7 @@ use {
         },
         tpu::{Tpu, TpuSockets},
         tvu::{AlpenglowInitializationState, Tvu, TvuConfig, TvuSockets},
+        voting_service,
     },
     agave_snapshots::{
         snapshot_archive_info::SnapshotArchiveInfoGetter as _, snapshot_config::SnapshotConfig,
@@ -53,8 +55,8 @@ use {
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         utils::move_and_async_delete_path_contents,
     },
-    solana_client::connection_cache::{ConnectionCache, Protocol},
-    solana_clock::Slot,
+    solana_client::connection_cache::ConnectionCache,
+    solana_clock::{Slot, DEFAULT_MS_PER_SLOT},
     solana_cluster_type::ClusterType,
     solana_entry::poh::compute_hash_time,
     solana_epoch_schedule::MAX_LEADER_SCHEDULE_EPOCH_OFFSET,
@@ -143,7 +145,8 @@ use {
         streamer::StakedNodes,
     },
     solana_time_utils::timestamp,
-    solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC},
+    solana_tpu_client::tpu_client::DEFAULT_TPU_CONNECTION_POOL_SIZE,
+    solana_tpu_client_next::ClientBuilder,
     solana_turbine::{
         self,
         broadcast_stage::BroadcastStageType,
@@ -642,7 +645,7 @@ impl ValidatorTpuConfig {
         };
 
         ValidatorTpuConfig {
-            vote_use_quic: DEFAULT_VOTE_USE_QUIC,
+            vote_use_quic: true, // Test with QUIC, even if DEFAULT_VOTE_USE_QUIC if false
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
             tpu_quic_server_config,
             tpu_fwd_quic_server_config,
@@ -687,10 +690,11 @@ pub struct Validator {
     repair_quic_endpoints_runtime: Option<TokioRuntime>,
     repair_quic_endpoints_join_handle: Option<repair::quic_endpoint::AsyncTryJoinHandle>,
     xdp_retransmitter: Option<XdpRetransmitter>,
-    // This runtime is used to run the client owned by SendTransactionService.
-    // We don't wait for its JoinHandle here because ownership and shutdown
-    // are managed elsewhere. This variable is intentionally unused.
-    _tpu_client_next_runtime: Option<TokioRuntime>,
+    // These runtimes are used to run the clients owned by SendTransactionService.
+    // We don't wait for their JoinHandle here because ownership and shutdown
+    // are managed elsewhere. These variables are intentionally unused.
+    _rpc_fwd_tpu_client_next_runtime: Option<TokioRuntime>,
+    _quic_vote_tpu_client_next_runtime: Option<TokioRuntime>,
 }
 
 impl Validator {
@@ -866,7 +870,7 @@ impl Validator {
         timer.stop();
         info!("Cleaning orphaned account snapshot directories done. {timer}");
 
-        // token used to cancel tpu-client-next, streamer and BLS streamer.
+        // token used to cancel tpu-client-next, streamer, BLS streamer, and voting over quic service.
         let cancel = CancellationToken::new();
         {
             let exit = exit.clone();
@@ -1205,29 +1209,10 @@ impl Validator {
         let mut tpu_transactions_forwards_client_sockets =
             Some(node.sockets.tpu_transaction_forwarding_clients);
 
-        let vote_connection_cache = if vote_use_quic {
-            let vote_connection_cache = ConnectionCache::new_with_client_options(
-                "connection_cache_vote_quic",
-                tpu_connection_pool_size,
-                Some(node.sockets.quic_vote_client),
-                Some((
-                    &identity_keypair,
-                    node.info
-                        .tpu_vote(Protocol::QUIC)
-                        .ok_or_else(|| {
-                            ValidatorError::Other(String::from("Invalid QUIC address for TPU Vote"))
-                        })?
-                        .ip(),
-                )),
-                Some((&staked_nodes, &identity_keypair.pubkey())),
-            );
-            Arc::new(vote_connection_cache)
-        } else {
-            Arc::new(ConnectionCache::with_udp(
-                "connection_cache_vote_udp",
-                tpu_connection_pool_size,
-            ))
-        };
+        let udp_vote_connection_cache = Arc::new(ConnectionCache::with_udp(
+            "connection_cache_vote_udp",
+            tpu_connection_pool_size,
+        ));
 
         let bls_connection_cache = Arc::new(ConnectionCache::new_with_client_options(
             "connection_cache_bls_quic",
@@ -1260,14 +1245,59 @@ impl Validator {
         // always need a tokio runtime (and the respective handle) to initialize
         // the QUIC endpoints.
         let current_runtime_handle = tokio::runtime::Handle::try_current();
-        let tpu_client_next_runtime = current_runtime_handle.is_err().then(|| {
+        let rpc_fwd_tpu_client_next_runtime = current_runtime_handle.is_err().then(|| {
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .worker_threads(2)
-                .thread_name("solTpuClientRt")
+                .thread_name("solRpcFwdRt")
                 .build()
                 .unwrap()
         });
+        let rpc_fwd_tpu_client_next_runtime_handle = rpc_fwd_tpu_client_next_runtime
+            .as_ref()
+            .map(TokioRuntime::handle)
+            .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap());
+
+        let (quic_vote_sender, quic_vote_tpu_client_next_runtime) = if vote_use_quic {
+            let rt = current_runtime_handle.is_err().then(|| {
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .worker_threads(2)
+                    .thread_name("solQuicVoteRt")
+                    .build()
+                    .unwrap()
+            });
+            let rt_handle = rt
+                .as_ref()
+                .map(TokioRuntime::handle)
+                .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap());
+            let leader_updater = Box::new(VotingServiceLeaderUpdater::new(
+                cluster_info.clone(),
+                poh_recorder.clone(),
+            ));
+            let builder = ClientBuilder::new(leader_updater)
+                .bind_socket(node.sockets.quic_vote_client)
+                .leader_send_fanout(voting_service::QUIC_UPCOMING_LEADER_FANOUT_LEADERS)
+                .identity(Arc::as_ref(&identity_keypair))
+                .metric_reporter(|stats, cancel| {
+                    stats.report_to_influxdb(
+                        "vote_client_quic",
+                        Duration::from_millis(DEFAULT_MS_PER_SLOT * 2),
+                        cancel,
+                    )
+                })
+                .cancel_token(cancel.clone())
+                .runtime_handle(rt_handle.clone());
+            let (sender, client) = builder.build()?;
+            let quic_vote_sender = voting_service::QuicVoteSender(sender);
+            key_notifiers
+                .write()
+                .unwrap()
+                .add(KeyUpdaterType::VoteClient, Arc::new(client));
+            (Some(quic_vote_sender), rt)
+        } else {
+            (None, None)
+        };
 
         let rpc_override_health_check =
             Arc::new(AtomicBool::new(config.rpc_config.disable_health_check));
@@ -1295,15 +1325,10 @@ impl Validator {
             };
 
             let rpc_tpu_client_args = {
-                let runtime_handle = tpu_client_next_runtime
-                    .as_ref()
-                    .map(TokioRuntime::handle)
-                    .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap());
-
                 RpcTpuClientArgs(
                     Arc::as_ref(&identity_keypair),
                     node.sockets.rpc_sts_client,
-                    runtime_handle.clone(),
+                    rpc_fwd_tpu_client_next_runtime_handle.clone(),
                     cancel.clone(),
                 )
             };
@@ -1703,7 +1728,8 @@ impl Validator {
             cluster_slots.clone(),
             wen_restart_repair_slots.clone(),
             slot_status_notifier,
-            vote_connection_cache,
+            udp_vote_connection_cache,
+            quic_vote_sender,
             AlpenglowInitializationState {
                 leader_window_info_sender,
                 replay_highest_frozen: replay_highest_frozen.clone(),
@@ -1740,14 +1766,10 @@ impl Validator {
         }
 
         let tpu_forwaring_client_config = {
-            let runtime_handle = tpu_client_next_runtime
-                .as_ref()
-                .map(TokioRuntime::handle)
-                .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap());
             ForwardingClientConfig {
                 stake_identity: Arc::as_ref(&identity_keypair),
                 tpu_client_sockets: tpu_transactions_forwards_client_sockets.take().unwrap(),
-                runtime_handle: runtime_handle.clone(),
+                runtime_handle: rpc_fwd_tpu_client_next_runtime_handle.clone(),
                 cancel: cancel.clone(),
                 node_multihoming: node_multihoming.clone(),
             }
@@ -1876,7 +1898,8 @@ impl Validator {
             repair_quic_endpoints_runtime,
             repair_quic_endpoints_join_handle,
             xdp_retransmitter,
-            _tpu_client_next_runtime: tpu_client_next_runtime,
+            _rpc_fwd_tpu_client_next_runtime: rpc_fwd_tpu_client_next_runtime,
+            _quic_vote_tpu_client_next_runtime: quic_vote_tpu_client_next_runtime,
         })
     }
 

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -7,10 +7,11 @@ use {
     crossbeam_channel::Receiver,
     solana_client::connection_cache::ConnectionCache,
     solana_clock::{Slot, FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET},
-    solana_connection_cache::client_connection::ClientConnection,
+    solana_connection_cache::{client_connection::ClientConnection, connection_cache::Protocol},
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure::Measure,
     solana_poh::poh_recorder::PohRecorder,
+    solana_tpu_client_next::TransactionSender,
     solana_transaction::Transaction,
     solana_transaction_error::TransportError,
     std::{
@@ -20,6 +21,18 @@ use {
     },
     thiserror::Error,
 };
+
+pub(crate) const QUIC_UPCOMING_LEADER_FANOUT_LEADERS: usize = 2;
+
+// Attempt to send our vote transaction to the leaders for the next few
+// slots. From the current slot to the forwarding slot offset
+// (inclusive).
+const UDP_UPCOMING_LEADER_FANOUT_SLOTS: u64 =
+    FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET.saturating_add(1);
+#[cfg(test)]
+static_assertions::const_assert_eq!(UDP_UPCOMING_LEADER_FANOUT_SLOTS, 3);
+
+pub struct QuicVoteSender(pub TransactionSender);
 
 pub enum VoteOp {
     PushVote {
@@ -84,7 +97,8 @@ impl VotingService {
         cluster_info: Arc<ClusterInfo>,
         poh_recorder: Arc<RwLock<PohRecorder>>,
         tower_storage: Arc<dyn TowerStorage>,
-        connection_cache: Arc<ConnectionCache>,
+        udp_connection_cache: Arc<ConnectionCache>,
+        quic_sender: Option<QuicVoteSender>,
     ) -> Self {
         let thread_hdl = Builder::new()
             .name("solVoteService".to_string())
@@ -96,7 +110,8 @@ impl VotingService {
                             &poh_recorder,
                             tower_storage.as_ref(),
                             vote_op,
-                            connection_cache.clone(),
+                            &udp_connection_cache,
+                            &quic_sender,
                         );
                     }
                 }
@@ -110,7 +125,8 @@ impl VotingService {
         poh_recorder: &RwLock<PohRecorder>,
         tower_storage: &dyn TowerStorage,
         vote_op: VoteOp,
-        connection_cache: Arc<ConnectionCache>,
+        udp_connection_cache: &Arc<ConnectionCache>,
+        quic_sender: &Option<QuicVoteSender>,
     ) {
         if let VoteOp::PushVote { saved_tower, .. } = &vote_op {
             let mut measure = Measure::start("tower storage save");
@@ -122,32 +138,38 @@ impl VotingService {
             trace!("{measure}");
         }
 
-        // Attempt to send our vote transaction to the leaders for the next few
-        // slots. From the current slot to the forwarding slot offset
-        // (inclusive).
-        const UPCOMING_LEADER_FANOUT_SLOTS: u64 =
-            FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET.saturating_add(1);
-        #[cfg(test)]
-        static_assertions::const_assert_eq!(UPCOMING_LEADER_FANOUT_SLOTS, 3);
-        let upcoming_leader_sockets = upcoming_leader_tpu_vote_sockets(
+        let udp_upcoming_leader_sockets = upcoming_leader_tpu_vote_sockets(
             cluster_info,
             poh_recorder,
-            UPCOMING_LEADER_FANOUT_SLOTS,
-            connection_cache.protocol(),
+            UDP_UPCOMING_LEADER_FANOUT_SLOTS,
+            Protocol::UDP,
         );
 
-        if !upcoming_leader_sockets.is_empty() {
-            for tpu_vote_socket in upcoming_leader_sockets {
+        if !udp_upcoming_leader_sockets.is_empty() {
+            for tpu_vote_socket in udp_upcoming_leader_sockets {
                 let _ = send_vote_transaction(
                     cluster_info,
                     vote_op.tx(),
                     Some(tpu_vote_socket),
-                    &connection_cache,
+                    udp_connection_cache,
                 );
             }
         } else {
             // Send to our own tpu vote socket if we cannot find a leader to send to
-            let _ = send_vote_transaction(cluster_info, vote_op.tx(), None, &connection_cache);
+            let _ = send_vote_transaction(cluster_info, vote_op.tx(), None, udp_connection_cache);
+        }
+
+        if let Some(quic_sender) = quic_sender {
+            if let Ok(serialized) = serialize(vote_op.tx()) {
+                if let Err(e) = quic_sender
+                    .0
+                    .try_send_transactions_in_batch(vec![serialized])
+                {
+                    warn!("Error sending vote transaction with QUIC: {e}");
+                }
+            } else {
+                warn!("Failed to serialize vote");
+            }
         }
 
         match vote_op {

--- a/tpu-client-next/src/client_builder.rs
+++ b/tpu-client-next/src/client_builder.rs
@@ -50,7 +50,8 @@ use {
         ConnectionWorkersScheduler, ConnectionWorkersSchedulerError, SendTransactionStats,
     },
     solana_keypair::Keypair,
-    std::{future::Future, net::UdpSocket, pin::Pin, sync::Arc},
+    solana_tls_utils::NotifyKeyUpdate,
+    std::{error::Error, future::Future, net::UdpSocket, pin::Pin, sync::Arc},
     thiserror::Error,
     tokio::{
         runtime,
@@ -343,5 +344,11 @@ impl<T> CancellableHandle<T> {
     pub async fn shutdown(self) -> Result<T, JoinError> {
         self.cancel.cancel();
         self.handle.await
+    }
+}
+
+impl NotifyKeyUpdate for Client {
+    fn update_key(&self, key: &Keypair) -> Result<(), Box<dyn Error>> {
+        self.update_identity(key).map_err(|e| e.into())
     }
 }

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1642,6 +1642,7 @@ mod tests {
                     KeyUpdaterType::RpcService,
                     KeyUpdaterType::Bls,
                     KeyUpdaterType::BlsConnectionCache,
+                    KeyUpdaterType::VoteClient,
                 ])
             );
             let mut io = MetaIoHandler::default();

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -706,7 +706,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("vote-use-quic")
             .takes_value(true)
             .default_value(&default_args.vote_use_quic)
-            .hidden(hidden_unless_forced())
             .help("Controls if to use QUIC to send votes."),
     )
     .arg(


### PR DESCRIPTION
Replace connection cache with tpu-client-next for voting with QUIC.
The existing UDP voting is preserved as much as possible.
When QUIC is enabled with `--vote-use-quic true`, votes are sent with both UDP and QUIC.
This option should probably be unhidden, maybe renamed, its argument removed, and its description updated.