### PR TITLE
remove unused gpu sigverify functions

### DIFF
--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -6,7 +6,6 @@ use {
     rand::Rng,
     solana_perf::{
         packet::{to_packet_batches, BytesPacket, BytesPacketBatch, PacketBatch},
-        recycler::Recycler,
         sigverify,
         test_tx::{test_multisig_tx, test_tx},
     },
@@ -143,22 +142,8 @@ fn bench_sigverify_uneven(b: &mut Bencher) {
     })
 }
 
-fn bench_get_offsets(b: &mut Bencher) {
-    let tx = test_tx();
-
-    // generate packet vector
-    let mut batches = to_packet_batches(&std::iter::repeat_n(tx, 1024).collect::<Vec<_>>(), 1024);
-
-    let recycler = Recycler::default();
-    // verify packets
-    b.iter(|| {
-        let _ans = sigverify::generate_offsets(&mut batches, &recycler, false);
-    })
-}
-
 benchmark_group!(
     benches,
-    bench_get_offsets,
     bench_sigverify_uneven,
     bench_sigverify_high_packets_large_batch,
     bench_sigverify_high_packets_small_batch,

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -483,21 +483,6 @@ pub fn ed25519_verify_disabled(batches: &mut [PacketBatch]) {
     });
 }
 
-pub fn copy_return_values<I, T>(sig_lens: I, out: &RecycledVec<u8>, rvs: &mut [Vec<u8>])
-where
-    I: IntoIterator<Item = T>,
-    T: IntoIterator<Item = u32>,
-{
-    debug_assert!(rvs.iter().flatten().all(|&rv| rv == 0u8));
-    let mut offset = 0usize;
-    let rvs = rvs.iter_mut().flatten();
-    for (k, rv) in sig_lens.into_iter().flatten().zip(rvs) {
-        let out = out[offset..].iter().take(k as usize).all(|&x| x == 1u8);
-        *rv = u8::from(k != 0u32 && out);
-        offset = offset.saturating_add(k as usize);
-    }
-}
-
 pub fn mark_disabled(batches: &mut [PacketBatch], r: &[Vec<u8>]) {
     for (batch, v) in batches.iter_mut().zip(r) {
         for (mut pkt, f) in batch.iter_mut().zip(v) {
@@ -532,7 +517,6 @@ mod tests {
         solana_signature::Signature,
         solana_signer::Signer,
         solana_transaction::{versioned::VersionedTransaction, Transaction},
-        std::iter::repeat_with,
         test_case::test_case,
     };
 
@@ -542,46 +526,6 @@ mod tests {
         assert!(a.len() >= b.len());
         let end = a.len() - b.len() + 1;
         (0..end).find(|&i| a[i..i + b.len()] == b[..])
-    }
-
-    #[test]
-    fn test_copy_return_values() {
-        let mut rng = rand::rng();
-        let sig_lens: Vec<Vec<u32>> = {
-            let size = rng.random_range(0..64);
-            repeat_with(|| {
-                let size = rng.random_range(0..16);
-                repeat_with(|| rng.random_range(0..5)).take(size).collect()
-            })
-            .take(size)
-            .collect()
-        };
-        let out: Vec<Vec<Vec<bool>>> = sig_lens
-            .iter()
-            .map(|sig_lens| {
-                sig_lens
-                    .iter()
-                    .map(|&size| repeat_with(|| rng.random()).take(size as usize).collect())
-                    .collect()
-            })
-            .collect();
-        let expected: Vec<Vec<u8>> = out
-            .iter()
-            .map(|out| {
-                out.iter()
-                    .map(|out| u8::from(!out.is_empty() && out.iter().all(|&k| k)))
-                    .collect()
-            })
-            .collect();
-        let out = RecycledVec::<u8>::from_vec(
-            out.into_iter().flatten().flatten().map(u8::from).collect(),
-        );
-        let mut rvs: Vec<Vec<u8>> = sig_lens
-            .iter()
-            .map(|sig_lens| vec![0u8; sig_lens.len()])
-            .collect();
-        copy_return_values(sig_lens, &out, &mut rvs);
-        assert_eq!(rvs, expected);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
- `generate_offsets` and `copy_return_values` are not used anywhere except a benchmark since GPU code path has been removed

#### Summary of Changes
- Remove the unused functions

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
