### PR TITLE
Remove flush_accounts_cache_slot_for_tests

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1146,7 +1146,7 @@ mod tests {
         /// to use the write cache
         pub fn add_root_and_flush_write_cache(&self, slot: Slot) {
             self.add_root(slot);
-            self.accounts_db.flush_accounts_cache_slot_for_tests(slot);
+            self.accounts_db.flush_accounts_cache(true, Some(slot));
         }
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7095,19 +7095,6 @@ impl AccountsDb {
         self.clean_accounts(None, false, &EpochSchedule::default())
     }
 
-    pub fn flush_accounts_cache_slot_for_tests(&self, slot: Slot) {
-        assert!(
-            self.accounts_index
-                .roots_tracker
-                .read()
-                .unwrap()
-                .alive_roots
-                .contains(&slot),
-            "slot: {slot}"
-        );
-        self.flush_slot_cache(slot, None::<&mut fn(&_) -> bool>, None);
-    }
-
     /// useful to adapt tests written prior to introduction of the write cache
     /// to use the write cache
     pub fn add_root_and_flush_write_cache(&self, slot: Slot) {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6482,13 +6482,13 @@ fn test_mark_obsolete_accounts_at_startup_purge_slot() {
     // Store other pubkey in slot0 to ensure slot is not purged
     accounts_db.store_for_tests((0, [(&pubkey1, &account), (&pubkey2, &account)].as_slice()));
     accounts_db.add_root(0);
-    accounts_db.flush_accounts_cache_slot_for_tests(0);
+    accounts_db.flush_rooted_accounts_cache_without_clean();
     accounts_db.store_for_tests((1, [(&pubkey1, &account)].as_slice()));
     accounts_db.add_root(1);
-    accounts_db.flush_accounts_cache_slot_for_tests(1);
+    accounts_db.flush_rooted_accounts_cache_without_clean();
     accounts_db.store_for_tests((2, [(&pubkey1, &account)].as_slice()));
     accounts_db.add_root(2);
-    accounts_db.flush_accounts_cache_slot_for_tests(2);
+    accounts_db.flush_rooted_accounts_cache_without_clean();
 
     let pubkeys_with_duplicates_by_bin = vec![vec![pubkey1]];
 
@@ -6521,7 +6521,7 @@ fn test_mark_obsolete_accounts_at_startup_multiple_bins() {
             [(&pubkey1, &account), (&pubkey2, &account)].as_slice(),
         ));
         accounts_db.add_root(slot);
-        accounts_db.flush_accounts_cache_slot_for_tests(slot);
+        accounts_db.flush_rooted_accounts_cache_without_clean();
     }
 
     let pubkeys_with_duplicates_by_bin = vec![vec![pubkey1], vec![pubkey2]];


### PR DESCRIPTION
#### Problem
flush_accounts_cache_slot_for_tests is unnecessary when non test functions can do the same thing

#### Summary of Changes
- Replace flush_accounts_cache_slot_for_tests with 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
