### PR TITLE
cost-model: simd-0387: remove vote program on feature activation

### DIFF
--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -5,6 +5,7 @@
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::field_qualifiers;
 use {
+    agave_feature_set::bls_pubkey_management_in_vote_account,
     ahash::AHashMap,
     solana_pubkey::Pubkey,
     solana_sdk_ids::{
@@ -91,12 +92,21 @@ static_assertions::const_assert_eq!(
     TOTAL_COUNT_BUILTINS
 );
 
-/// MIGRATING_BUILTINS_COSTS is empty as no builtins are presently being migrated.
-/// We leave it and the related scaffolding in place for future planned migrations.
-pub const MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[];
+pub const MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
+    // The Vote program is NOT migrating to on-chain BPF.
+    // However, SIMD-0387 states that the Vote program will be removed from
+    // builtin program cost modeling, so we use the same mechanism to evict
+    // it from the list.
+    (
+        vote::id(),
+        BuiltinCost::Migrating(MigratingBuiltinCost {
+            core_bpf_migration_feature: bls_pubkey_management_in_vote_account::id(),
+            position: 0,
+        }),
+    ),
+];
 
 const NON_MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
-    (vote::id(), BuiltinCost::NotMigrating),
     (system_program::id(), BuiltinCost::NotMigrating),
     (compute_budget::id(), BuiltinCost::NotMigrating),
     (bpf_loader_upgradeable::id(), BuiltinCost::NotMigrating),

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -363,6 +363,11 @@ mod tests {
         stop_use_static_simple_vote_tx_cost: bool,
         simd_0387_enabled: bool,
     ) {
+        // SIMD-0387 requires `stop_use_static_simple_vote_tx_cost`.
+        if simd_0387_enabled && !stop_use_static_simple_vote_tx_cost {
+            return;
+        }
+
         agave_logger::setup();
 
         use {
@@ -395,8 +400,6 @@ mod tests {
 
         // Verify actual cost matches expected.
         let expected_cost = if !stop_use_static_simple_vote_tx_cost {
-            // Simple vote shortcut is active - use static cost regardless of
-            // SIMD-0387 status.
             SIMPLE_VOTE_USAGE_COST
         } else {
             // when feature `stop-use-static-simple-vote-tx-cost` is enabled, vote transaction

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -336,7 +336,7 @@ mod tests {
         solana_transaction::{sanitized::MessageHash, versioned::VersionedTransaction},
         solana_vote::vote_transaction,
         solana_vote_program::vote_state::TowerSync,
-        test_case::test_case,
+        test_case::test_matrix,
     };
 
     fn get_example_transaction() -> VersionedTransaction {
@@ -355,15 +355,26 @@ mod tests {
         VersionedTransaction::from(transaction)
     }
 
-    #[test_case(false; "using static cost for simple vote")]
-    #[test_case(true; "not using static cost for simple vote")]
-    fn test_vote_transaction_cost(stop_use_static_simple_vote_tx_cost: bool) {
+    #[test_matrix(
+        [false, true],
+        [false, true]
+    )]
+    fn test_vote_transaction_cost(
+        stop_use_static_simple_vote_tx_cost: bool,
+        simd_0387_enabled: bool,
+    ) {
+        // SIMD-0387 requires `stop_use_static_simple_vote_tx_cost`.
+        if simd_0387_enabled && !stop_use_static_simple_vote_tx_cost {
+            return;
+        }
+
         agave_logger::setup();
 
         use {
             crate::block_cost_limits::INSTRUCTION_DATA_BYTES_COST,
             solana_compute_budget::compute_budget_limits::{
-                MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT, MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
+                DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT, MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
+                MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
             },
         };
 
@@ -379,9 +390,18 @@ mod tests {
         )
         .unwrap();
 
+        let mut feature_set = FeatureSet::all_enabled();
+        if !stop_use_static_simple_vote_tx_cost {
+            feature_set.deactivate(&agave_feature_set::stop_use_static_simple_vote_tx_cost::id());
+        }
+        if !simd_0387_enabled {
+            feature_set.deactivate(&bls_pubkey_management_in_vote_account::id());
+        }
+
         // Verify actual cost matches expected.
-        let (feature_set, expected_cost) = if stop_use_static_simple_vote_tx_cost {
-            let feature_set = FeatureSet::all_enabled();
+        let expected_cost = if !stop_use_static_simple_vote_tx_cost {
+            SIMPLE_VOTE_USAGE_COST
+        } else {
             // when feature `stop-use-static-simple-vote-tx-cost` is enabled, vote transaction
             // cost is calculated based on its UsageCostDetails too:
             //
@@ -391,8 +411,14 @@ mod tests {
             let write_lock_cost = 2 * block_cost_limits::WRITE_LOCK_UNITS;
             let data_bytes_cost =
                 vote_transaction.instruction_data_len() / (INSTRUCTION_DATA_BYTES_COST as u16);
-            // it's estimated execution cost is default builtin cost
-            let programs_execution_cost = MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT as u64;
+            // Estimated execution cost depends on whether the Vote program is
+            // tracked in cost modeling as a builtin.
+            let programs_execution_cost = if simd_0387_enabled {
+                // SIMD-0387: Vote program removed from builtin cost modeling.
+                DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64
+            } else {
+                MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT as u64
+            };
             // and it has default loaded_account_data_size
             let loaded_accounts_data_size_cost =
                 CostModel::calculate_loaded_accounts_data_size_cost(
@@ -408,11 +434,7 @@ mod tests {
                 loaded_accounts_data_size_cost,
                 allocated_accounts_data_size: 0,
             };
-            (feature_set, vote_program_usage_details.sum())
-        } else {
-            let mut feature_set = FeatureSet::all_enabled();
-            feature_set.deactivate(&agave_feature_set::stop_use_static_simple_vote_tx_cost::id());
-            (feature_set, SIMPLE_VOTE_USAGE_COST)
+            vote_program_usage_details.sum()
         };
 
         let vote_cost = CostModel::calculate_cost(&vote_transaction, &feature_set);

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -363,11 +363,6 @@ mod tests {
         stop_use_static_simple_vote_tx_cost: bool,
         simd_0387_enabled: bool,
     ) {
-        // SIMD-0387 requires `stop_use_static_simple_vote_tx_cost`.
-        if simd_0387_enabled && !stop_use_static_simple_vote_tx_cost {
-            return;
-        }
-
         agave_logger::setup();
 
         use {
@@ -400,6 +395,8 @@ mod tests {
 
         // Verify actual cost matches expected.
         let expected_cost = if !stop_use_static_simple_vote_tx_cost {
+            // Simple vote shortcut is active - use static cost regardless of
+            // SIMD-0387 status.
             SIMPLE_VOTE_USAGE_COST
         } else {
             // when feature `stop-use-static-simple-vote-tx-cost` is enabled, vote transaction


### PR DESCRIPTION
#### Problem
[SIMD-0387](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0387-bls-pubkey-management-in-vote-account.md) states that the Vote program will be removed from builtin cost modeling.

The builtin cost modeling apparatus allows for programs to be "migrated out" using feature gates - a functionality typically used for builtins that migrate to on-chain Core BPF. We can use this same mechanism to evict the Vote program.

#### Summary of Changes
Configure the Vote program as a "migrating builtin" in the builtin cost modeling apparatus and evict it upon activation of SIMD-0387.