### PR TITLE
vote-program: update `InitializeAccountV2` feature ordering

### DIFF
--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -65,6 +65,7 @@ fn is_init_account_v2_enabled(invoke_context: &InvokeContext) -> bool {
     feature_set.vote_state_v4
         && feature_set.commission_rate_in_basis_points
         && feature_set.custom_commission_collector
+        && feature_set.block_revenue_sharing
         && feature_set.bls_pubkey_management_in_vote_account
 }
 

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -488,20 +488,20 @@ mod tests {
     #[derive(Clone, Copy, Default)]
     struct VoteProgramFeatures {
         vote_state_v4: bool,
-        bls_pubkey_management_in_vote_account: bool,
         commission_rate_in_basis_points: bool,
         custom_commission_collector: bool,
         block_revenue_sharing: bool,
+        bls_pubkey_management_in_vote_account: bool,
     }
 
     impl VoteProgramFeatures {
         fn all_enabled() -> Self {
             Self {
                 vote_state_v4: true,
-                bls_pubkey_management_in_vote_account: true,
                 commission_rate_in_basis_points: true,
                 custom_commission_collector: true,
                 block_revenue_sharing: true,
+                bls_pubkey_management_in_vote_account: true,
             }
         }
     }
@@ -533,10 +533,10 @@ mod tests {
     ) -> Vec<AccountSharedData> {
         let VoteProgramFeatures {
             vote_state_v4,
-            bls_pubkey_management_in_vote_account,
             commission_rate_in_basis_points,
             custom_commission_collector,
             block_revenue_sharing,
+            bls_pubkey_management_in_vote_account,
         } = features;
         let cu_consumed = RefCell::new(0u64);
         let accounts = mock_process_instruction_with_feature_set(
@@ -564,10 +564,10 @@ mod tests {
             },
             &SVMFeatureSet {
                 vote_state_v4,
-                bls_pubkey_management_in_vote_account,
                 commission_rate_in_basis_points,
                 custom_commission_collector,
                 block_revenue_sharing,
+                bls_pubkey_management_in_vote_account,
                 ..SVMFeatureSet::all_enabled()
             },
         );
@@ -889,13 +889,15 @@ mod tests {
         [false, true],
         [false, true],
         [false, true],
+        [false, true],
         [false, true]
     )]
     fn test_initialize_vote_account(
         vote_state_v4: bool,
-        bls_pubkey_management_in_vote_account: bool,
         commission_rate_in_basis_points: bool,
         custom_commission_collector: bool,
+        block_revenue_sharing: bool,
+        bls_pubkey_management_in_vote_account: bool,
     ) {
         let vote_pubkey = solana_pubkey::new_rand();
         let vote_account = AccountSharedData::new(100, vote_state_size_of(vote_state_v4), &id());
@@ -933,15 +935,17 @@ mod tests {
 
         let features = VoteProgramFeatures {
             vote_state_v4,
-            bls_pubkey_management_in_vote_account,
             commission_rate_in_basis_points,
             custom_commission_collector,
+            block_revenue_sharing,
+            bls_pubkey_management_in_vote_account,
         };
 
         let all_v2_features_enabled = vote_state_v4
-            && bls_pubkey_management_in_vote_account
             && commission_rate_in_basis_points
-            && custom_commission_collector;
+            && custom_commission_collector
+            && block_revenue_sharing
+            && bls_pubkey_management_in_vote_account;
 
         // processing incompatible instruction should fail
         if all_v2_features_enabled {
@@ -1047,13 +1051,15 @@ mod tests {
         [false, true],
         [false, true],
         [false, true],
+        [false, true],
         [false, true]
     )]
     fn test_initialize_vote_account_v2(
         vote_state_v4: bool,
-        bls_pubkey_management_in_vote_account: bool,
         commission_rate_in_basis_points: bool,
         custom_commission_collector: bool,
+        block_revenue_sharing: bool,
+        bls_pubkey_management_in_vote_account: bool,
     ) {
         let vote_pubkey = solana_pubkey::new_rand();
         let vote_account = AccountSharedData::new(100, vote_state_size_of(vote_state_v4), &id());
@@ -1095,15 +1101,17 @@ mod tests {
 
         let features = VoteProgramFeatures {
             vote_state_v4,
-            bls_pubkey_management_in_vote_account,
             commission_rate_in_basis_points,
             custom_commission_collector,
+            block_revenue_sharing,
+            bls_pubkey_management_in_vote_account,
         };
 
         let all_v2_features_enabled = vote_state_v4
-            && bls_pubkey_management_in_vote_account
             && commission_rate_in_basis_points
-            && custom_commission_collector;
+            && custom_commission_collector
+            && block_revenue_sharing
+            && bls_pubkey_management_in_vote_account;
 
         // processing incompatible instruction should fail
         if all_v2_features_enabled {

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -287,7 +287,7 @@ impl VoteStateHandle for VoteStateV3 {
         if bls_pubkey.is_some() {
             // We should not be able to reach here because we only call this function
             // when both Vote State V4 and BLS features are enabled.
-            // See `is_bls_pubkey_feature_enabled` in vote_processor.rs.
+            // See `is_vote_authorize_with_bls_enabled` in vote_processor.rs.
             return Err(InstructionError::InvalidAccountData);
         }
 
@@ -972,7 +972,7 @@ impl VoteStateHandler {
             VoteStateTargetVersion::V3 => {
                 // We should not be able to reach here because we only call this function
                 // when both Vote State V4 and BLS features are enabled.
-                // See `is_bls_pubkey_feature_enabled` in vote_processor.rs.
+                // See `is_vote_authorize_with_bls_enabled` in vote_processor.rs.
                 Err(InstructionError::InvalidInstructionData)
             }
             VoteStateTargetVersion::V4 => {

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -725,7 +725,7 @@ pub fn authorize<S: std::hash::BuildHasher, F>(
     vote_authorize: VoteAuthorize,
     signers: &HashSet<Pubkey, S>,
     clock: &Clock,
-    is_bls_pubkey_feature_enabled: bool,
+    is_vote_authorize_with_bls_enabled: bool,
     consume_pop_compute_units: F,
 ) -> Result<(), InstructionError>
 where
@@ -738,7 +738,7 @@ where
 
     match vote_authorize {
         VoteAuthorize::Voter => {
-            if is_bls_pubkey_feature_enabled && vote_state.has_bls_pubkey() {
+            if is_vote_authorize_with_bls_enabled && vote_state.has_bls_pubkey() {
                 return Err(InstructionError::InvalidInstructionData);
             }
             let authorized_withdrawer_signer =
@@ -768,7 +768,7 @@ where
             vote_state.set_authorized_withdrawer(*authorized);
         }
         VoteAuthorize::VoterWithBLS(args) => {
-            if !is_bls_pubkey_feature_enabled {
+            if !is_vote_authorize_with_bls_enabled {
                 return Err(InstructionError::InvalidInstructionData);
             }
             let authorized_withdrawer_signer =


### PR DESCRIPTION
As per discussions offline, this bolsters the feature activation ordering for SIMD-0387's `InitializeAccountV2` and actually decouples it from the activation path for `VoteAuthorize::VoterWithBls`.

Two major points before this can come out of draft:
1. We need to also include [SIMD-0123](https://github.com/anza-xyz/agave/pull/10183) for the `InitializeAccountV2` gate.
2. We need to amend [SIMD-0387](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0387-bls-pubkey-management-in-vote-account.md) to mention these dependencies.