### PR TITLE
system-program: tests: remove unused agave-feature-set dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11248,7 +11248,6 @@ dependencies = [
 name = "solana-system-program"
 version = "4.0.0-alpha.0"
 dependencies = [
- "agave-feature-set",
  "assert_matches",
  "bincode",
  "criterion",

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -40,7 +40,6 @@ solana-sysvar = { workspace = true }
 solana-transaction-context = { workspace = true, features = ["bincode"] }
 
 [dev-dependencies]
-agave-feature-set = { workspace = true }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 solana-compute-budget = { workspace = true }


### PR DESCRIPTION
#### Problem
As we prepare to cut SVM out of Agave and into its own repository, we must reduce the number of circular dependencies we might end up with in tests.

#### Summary of Changes
It turns out the System program's tests already don't use `agave-feature-set` but instead use `solana-svm-feature-set`.

Remove the unused dependency.
