### PR TITLE
Optimize reblocking by using extract_if

### DIFF
--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -995,19 +995,13 @@ impl UsageQueueInner {
                     (Some(PriorityUsage::Readonly(current_tasks)), RequestedUsage::Writable) => {
                         // First, we need to determine whether the write-requesting new_task could
                         // reblock current read-only tasks _very efficiently while bounded under
-                        // the worst case_, to prevent large number of low priority tasks from
-                        // consuming undue amount of cpu cycles for nothing.
-
-                        // Use extract_if once stablized to remove Vec creation and the repeating
-                        // remove()s...
-                        let task_indexes = current_tasks
-                            .range(new_task.task_id()..)
-                            .filter_map(|(&task_id, task)| {
-                                task.try_reblock(token).then_some(task_id)
-                            })
-                            .collect::<Vec<OrderedTaskId>>();
-                        for task_id in task_indexes.into_iter() {
-                            let reblocked_task = current_tasks.remove(&task_id).unwrap();
+                        // the worst case_, to prevent large number of incoming low priority tasks
+                        // from consuming undue amount of cpu cycles for nothing.
+                        let reblocked_tasks = current_tasks
+                            .extract_if(new_task.task_id().., |_task_id, task| {
+                                task.try_reblock(token)
+                            });
+                        for (_task_id, reblocked_task) in reblocked_tasks {
                             blocked_usages_from_tasks
                                 .insert_usage_from_task((RequestedUsage::Readonly, reblocked_task));
                         }
@@ -1019,10 +1013,10 @@ impl UsageQueueInner {
                             // In this case, new_task will still be inserted as the
                             // highest-priority blocked writable task, nevertheless any of readonly
                             // tasks are reblocked above. That's because all of such tasks should
-                            // be of lower-priority than new_task by the very `range()` lookup
+                            // be of lower-priority than new_task by the very `extract_if()` lookup
                             // above. So, the write-always-follows-read critical invariant is still
                             // intact. So is the assertion in current-and-requested-readonly
-                            // match arm.
+                            // match arm just above.
                             Err(())
                         }
                     }


### PR DESCRIPTION
#### Problem

#7444 introduced sub-optimal impl for reblocking due to unsatified rust version.

However, it's been awhile since master switched rust toolchain to the required version: #9932

#### Summary of Changes

Remove the suboptimal impl with simpler, faster, more straight forward impl as commented previously.