### PR TITLE
add required-features for solana-faucet bin

### DIFF
--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -19,6 +19,7 @@ name = "solana_faucet"
 [[bin]]
 name = "solana-faucet"
 path = "src/bin/faucet.rs"
+required-features = ["agave-unstable-api"]
 
 [features]
 agave-unstable-api = []


### PR DESCRIPTION
#### Problem

(ci update for #8935)

`agave-unstable-api` will become a hard error soon. the bin couldn't be compiled without this feature.

#### Summary of Changes

specify `required-features = ["agave-unstable-api"]` to avoid ci/build failures when the feature set does not match.

(btw, I think we should split the bin and the lib into separate crates. They share the same Cargo.toml now, which means the lib will be published with pinned version deps. This is not ideal. This PR is a stopgap, I will have another PR for the splitting work)
