### PR TITLE
ci: only check default feature and all features for dev-bins

### DIFF
--- a/ci/feature-check/test-feature-dev-bins.sh
+++ b/ci/feature-check/test-feature-dev-bins.sh
@@ -14,9 +14,5 @@ fi
 # shellcheck source=ci/rust-version.sh
 source "$here"/../rust-version.sh nightly
 
-partition="${1:-1/1}"
-
-cargo +"$rust_nightly" hack --manifest-path "$here/../../dev-bins/Cargo.toml" check \
-	--each-feature \
-	--exclude-all-features \
-	--partition "$partition"
+cargo +"$rust_nightly" hack --manifest-path "$here/../../dev-bins/Cargo.toml" check
+cargo +"$rust_nightly" hack --manifest-path "$here/../../dev-bins/Cargo.toml" check --all-features


### PR DESCRIPTION
#### Problem

(ci update for #8935)

It's not worth checking each feature for binaries. They won't be used as dependencies by anyone.

#### Summary of Changes

only check default and all feature for dev-bins