### PR TITLE
svm-test-harness: use agave libs only for `fuzz` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11143,6 +11143,7 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.0.0",
+ "solana-svm-feature-set",
  "thiserror 2.0.18",
 ]
 
@@ -11172,6 +11173,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm",
  "solana-svm-callback",
+ "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-test-harness-fixture",
  "solana-svm-timings",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9752,11 +9752,11 @@ version = "4.0.0-alpha.0"
 name = "solana-svm-test-harness-fixture"
 version = "4.0.0-alpha.0"
 dependencies = [
- "agave-feature-set",
  "solana-account",
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.0.0",
+ "solana-svm-feature-set",
  "thiserror 2.0.18",
 ]
 
@@ -9764,8 +9764,6 @@ dependencies = [
 name = "solana-svm-test-harness-instr"
 version = "4.0.0-alpha.0"
 dependencies = [
- "agave-feature-set",
- "agave-precompiles",
  "agave-syscalls",
  "bincode",
  "env_logger",
@@ -9785,6 +9783,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm",
  "solana-svm-callback",
+ "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-test-harness-fixture",
  "solana-svm-timings",

--- a/svm-test-harness/fixture/Cargo.toml
+++ b/svm-test-harness/fixture/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 agave-unstable-api = []
 dummy-for-ci-check = ["fuzz"]
 fuzz = [
+    "dep:agave-feature-set",
     "dep:bincode",
     "dep:prost",
     "dep:prost-build",
@@ -22,7 +23,7 @@ fuzz = [
 ]
 
 [dependencies]
-agave-feature-set = { workspace = true }
+agave-feature-set = { workspace = true, optional = true }
 bincode = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
 protosol = { workspace = true, optional = true }
@@ -30,6 +31,7 @@ solana-account = { workspace = true }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true, features = ["serde"] }
 solana-pubkey = { workspace = true }
+solana-svm-feature-set = { workspace = true }
 thiserror = { workspace = true }
 
 [build-dependencies]

--- a/svm-test-harness/fixture/src/instr_context.rs
+++ b/svm-test-harness/fixture/src/instr_context.rs
@@ -1,13 +1,13 @@
 //! Instruction context (input).
 
 use {
-    agave_feature_set::FeatureSet, solana_account::Account, solana_instruction::Instruction,
-    solana_pubkey::Pubkey,
+    solana_account::Account, solana_instruction::Instruction, solana_pubkey::Pubkey,
+    solana_svm_feature_set::SVMFeatureSet,
 };
 
 /// Instruction context fixture.
 pub struct InstrContext {
-    pub feature_set: FeatureSet,
+    pub feature_set: SVMFeatureSet,
     pub accounts: Vec<(Pubkey, Account)>,
     pub instruction: Instruction,
 }
@@ -15,6 +15,7 @@ pub struct InstrContext {
 #[cfg(feature = "fuzz")]
 use {
     crate::{error::FixtureError, proto::InstrContext as ProtoInstrContext},
+    agave_feature_set::FeatureSet,
     solana_instruction::AccountMeta,
 };
 
@@ -30,12 +31,13 @@ impl TryFrom<ProtoInstrContext> for InstrContext {
                 .map_err(FixtureError::InvalidPubkeyBytes)?,
         );
 
-        let feature_set: FeatureSet = value
+        let agave_feature_set: FeatureSet = value
             .epoch_context
             .as_ref()
             .and_then(|epoch_ctx| epoch_ctx.features.as_ref())
             .map(|fs| fs.into())
             .unwrap_or_default();
+        let feature_set = agave_feature_set.runtime_features();
 
         let accounts: Vec<(Pubkey, Account)> = value
             .accounts

--- a/svm-test-harness/instr/Cargo.toml
+++ b/svm-test-harness/instr/Cargo.toml
@@ -14,14 +14,16 @@ publish = false
 agave-unstable-api = []
 dummy-for-ci-check = ["fuzz"]
 fuzz = [
+    "dep:agave-feature-set",
+    "dep:agave-precompiles",
     "dep:prost",
     "solana-pubkey/default",
     "solana-svm-test-harness-fixture/fuzz",
 ]
 
 [dependencies]
-agave-feature-set = { workspace = true }
-agave-precompiles = { workspace = true }
+agave-feature-set = { workspace = true, optional = true }
+agave-precompiles = { workspace = true, optional = true }
 agave-syscalls = { workspace = true }
 bincode = { workspace = true }
 env_logger = { workspace = true }
@@ -42,6 +44,7 @@ solana-rent = { workspace = true, features = ["sysvar"] }
 solana-sdk-ids = { workspace = true }
 solana-svm = { workspace = true }
 solana-svm-callback = { workspace = true }
+solana-svm-feature-set = { workspace = true }
 solana-svm-log-collector = { workspace = true }
 solana-svm-test-harness-fixture = { workspace = true }
 solana-svm-timings = { workspace = true }

--- a/svm-test-harness/instr/src/fuzz.rs
+++ b/svm-test-harness/instr/src/fuzz.rs
@@ -2,20 +2,51 @@
 
 use {
     crate::{
-        execute_instr,
+        execute_instr_with_callback,
         fixture::{
             instr_context::InstrContext,
             proto::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
         },
         logger,
     },
-    agave_feature_set::{increase_cpi_account_info_limit, raise_cpi_nesting_limit_to_8},
+    agave_precompiles::{get_precompile, is_precompile},
     agave_syscalls::create_program_runtime_environment_v1,
     prost::Message,
     solana_compute_budget::compute_budget::ComputeBudget,
+    solana_precompile_error::PrecompileError,
     solana_program_runtime::loaded_programs::ProgramRuntimeEnvironments,
+    solana_pubkey::Pubkey,
+    solana_svm_callback::InvokeContextCallback,
     std::{env, ffi::c_int, sync::Arc},
 };
+
+/// Callback with full precompile support for fuzz testing.
+///
+/// All precompiles are enabled for fuzz testing.
+struct FuzzInstrContextCallback;
+
+impl InvokeContextCallback for FuzzInstrContextCallback {
+    fn is_precompile(&self, program_id: &Pubkey) -> bool {
+        is_precompile(program_id, |_| true)
+    }
+
+    fn process_precompile(
+        &self,
+        program_id: &Pubkey,
+        data: &[u8],
+        instruction_datas: Vec<&[u8]>,
+    ) -> std::result::Result<(), PrecompileError> {
+        if let Some(precompile) = get_precompile(program_id, |_| true) {
+            precompile.verify(
+                data,
+                &instruction_datas,
+                &agave_feature_set::FeatureSet::all_enabled(),
+            )
+        } else {
+            Err(PrecompileError::InvalidPublicKey)
+        }
+    }
+}
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sol_compat_init(_log_level: i32) {
@@ -40,8 +71,8 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects
     };
 
     let feature_set = &instr_context.feature_set;
-    let simd_0268_active = feature_set.is_active(&raise_cpi_nesting_limit_to_8::id());
-    let simd_0339_active = feature_set.is_active(&increase_cpi_account_info_limit::id());
+    let simd_0268_active = feature_set.raise_cpi_nesting_limit_to_8;
+    let simd_0339_active = feature_set.increase_cpi_account_info_limit;
 
     let compute_budget = {
         let mut budget = ComputeBudget::new_with_defaults(simd_0268_active, simd_0339_active);
@@ -62,7 +93,7 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects
         let environments = ProgramRuntimeEnvironments {
             program_runtime_v1: Arc::new(
                 create_program_runtime_environment_v1(
-                    &instr_context.feature_set.runtime_features(),
+                    &instr_context.feature_set,
                     &compute_budget.to_budget(),
                     false, /* deployment */
                     false, /* debugging_features */
@@ -72,7 +103,7 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects
             ..ProgramRuntimeEnvironments::default()
         };
 
-        let mut cache = crate::program_cache::new_with_builtins(&instr_context.feature_set, slot);
+        let mut cache = crate::program_cache::new_with_builtins(slot);
         crate::program_cache::fill_from_accounts(
             &mut cache,
             &environments,
@@ -84,8 +115,9 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects
         cache
     };
 
-    let instr_effects = execute_instr(
-        instr_context,
+    let instr_effects = execute_instr_with_callback(
+        &instr_context,
+        &FuzzInstrContextCallback,
         &compute_budget,
         &mut program_cache,
         &sysvar_cache,

--- a/svm-test-harness/instr/src/lib.rs
+++ b/svm-test-harness/instr/src/lib.rs
@@ -10,7 +10,10 @@ pub mod logger;
 pub mod program_cache;
 pub mod sysvar_cache;
 
-pub use {harness::execute_instr, solana_svm_test_harness_fixture as fixture};
+pub use {
+    harness::{execute_instr, execute_instr_with_callback},
+    solana_svm_test_harness_fixture as fixture,
+};
 
 #[cfg(feature = "fuzz")]
 pub mod fuzz;


### PR DESCRIPTION
#### Problem
As we prepare to cut SVM out of Agave and into its own repository, we must reduce the number of circular dependencies we might end up with in tests.

#### Summary of Changes
Here we're just moving the svm-test-harness to use `solana-svm-feature-set`. Note we can't eliminate the use of `agave-feature-set` in the `fuzz` feature just yet, since we have vectors for precompiles, but at least the path we'll use at first in the new repo is free of `agave-feature-set`.

This also moves programs/sbf closer to being decoupled, as well.