### PR TITLE
ci: remove duplicate check

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -29,25 +29,6 @@ _ scripts/check-dev-context-only-utils.sh tree
 # fmt
 _ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" fmt --all -- --check
 
-# run cargo check for all rust files in this monorepo for faster turnaround in
-# case of any compilation/build error for nightly
-
-# Only force up-to-date lock files on edge
-if [[ $CI_BASE_BRANCH = "$EDGE_CHANNEL" ]]; then
-  if _ scripts/cargo-for-all-lock-files.sh "+${rust_nightly}" check \
-    --locked --workspace --all-targets --features dummy-for-ci-check,frozen-abi; then
-    true
-  else
-    check_status=$?
-    echo "$0: Some Cargo.lock might be outdated; sync them (or just be a compilation error?)" >&2
-    echo "$0: protip: $ ./scripts/cargo-for-all-lock-files.sh [--ignore-exit-code] ... \\" >&2
-    echo "$0:   [tree (for outdated Cargo.lock sync)|check (for compilation error)|update -p foo --precise x.y.z (for your Cargo.toml update)] ..." >&2
-    exit "$check_status"
-  fi
-else
-  echo "Note: cargo-for-all-lock-files.sh skipped because $CI_BASE_BRANCH != $EDGE_CHANNEL"
-fi
-
 _ ci/order-crates-for-publishing.py
 
 _ scripts/cargo-clippy.sh


### PR DESCRIPTION
#### Problem

afaik, the check I removed was doing 2 things:
1. ensure the lockfile is up to date
2. checking the repo can be compiled

(1) should already be covered by

https://github.com/anza-xyz/agave/blob/e749c1753e91dbd52ad77d089740c6f4c585d6b3/ci/test-sanity.sh#L61-L67

(2) is subtle. we already run clippy
https://github.com/anza-xyz/agave/blob/e749c1753e91dbd52ad77d089740c6f4c585d6b3/scripts/cargo-clippy-nightly.sh#L25-L27

and have feature checks for each crate, so I'm not sure it's still worth keeping this one. in other words, I'm not sure there are cases that would only be caught by this check.

#### Summary of Changes

remove it