### PR TITLE
use TransactionView in sigverify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9131,6 +9131,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "agave-logger",
  "agave-random",
+ "agave-transaction-view",
  "ahash 0.8.12",
  "assert_matches",
  "bencher",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7921,6 +7921,7 @@ dependencies = [
 name = "solana-perf"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-transaction-view",
  "ahash 0.8.12",
  "bincode",
  "bytes",

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -36,6 +36,7 @@ frozen-abi = [
 ]
 
 [dependencies]
+agave-transaction-view = { workspace = true }
 ahash = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true, features = ["serde"] }

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -17,7 +17,6 @@ pub mod thread;
 extern crate log;
 
 #[cfg(test)]
-#[macro_use]
 extern crate assert_matches;
 
 #[macro_use]

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -3,62 +3,20 @@
 //! cores.
 use {
     crate::{
-        packet::{
-            BytesPacketBatch, PacketBatch, PacketFlags, PacketRef, PacketRefMut,
-            RecycledPacketBatch,
-        },
+        packet::{BytesPacketBatch, PacketBatch, PacketFlags, PacketRefMut, RecycledPacketBatch},
         recycled_vec::RecycledVec,
     },
     agave_transaction_view::{
         transaction_data::TransactionData, transaction_version::TransactionVersion,
         transaction_view::SanitizedTransactionView,
     },
-    rayon::{prelude::*, ThreadPool},
-    solana_hash::Hash,
-    solana_message::{MESSAGE_HEADER_LENGTH, MESSAGE_VERSION_PREFIX},
-    solana_pubkey::Pubkey,
-    solana_short_vec::decode_shortu16_len,
-    solana_signature::Signature,
-    std::{convert::TryFrom, mem::size_of},
+    rayon::prelude::*,
 };
 
 // Empirically derived to constrain max verify latency to ~8ms at lower packet counts
 pub const VERIFY_PACKET_CHUNK_SIZE: usize = 128;
 
 pub type TxOffset = RecycledVec<u32>;
-
-#[derive(Debug, PartialEq, Eq)]
-struct PacketOffsets {
-    pub sig_len: u32,
-    pub sig_start: u32,
-    pub msg_start: u32,
-    pub pubkey_start: u32,
-    pub pubkey_len: u32,
-    pub instruction_len: u32,
-    pub instruction_start: u32,
-}
-
-impl PacketOffsets {
-    pub fn new(
-        sig_len: u32,
-        sig_start: u32,
-        msg_start: u32,
-        pubkey_start: u32,
-        pubkey_len: u32,
-        instruction_len: u32,
-        instruction_start: u32,
-    ) -> Self {
-        Self {
-            sig_len,
-            sig_start,
-            msg_start,
-            pubkey_start,
-            pubkey_len,
-            instruction_len,
-            instruction_start,
-        }
-    }
-}
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum PacketError {
@@ -99,7 +57,7 @@ fn verify_packet(packet: &mut PacketRefMut, reject_non_vote: bool) -> bool {
     };
 
     let (is_simple_vote_tx, verified) = {
-        let Ok(view) = SanitizedTransactionView::try_new_sanitized(data, true, true) else {
+        let Ok(view) = SanitizedTransactionView::try_new_sanitized(data, true) else {
             return false;
         };
 
@@ -145,246 +103,6 @@ pub fn count_discarded_packets(batches: &[PacketBatch]) -> usize {
         .iter()
         .map(|batch| batch.iter().filter(|p| p.meta().discard()).count())
         .sum()
-}
-
-// internal function to be unit-tested; should be used only by get_packet_offsets
-fn do_get_packet_offsets(
-    packet: PacketRef,
-    current_offset: usize,
-) -> Result<PacketOffsets, PacketError> {
-    // should have at least 1 signature and sig lengths
-    let _ = 1usize
-        .checked_add(size_of::<Signature>())
-        .filter(|v| *v <= packet.meta().size)
-        .ok_or(PacketError::InvalidLen)?;
-
-    // read the length of Transaction.signatures (serialized with short_vec)
-    let (sig_len_untrusted, sig_size) = packet
-        .data(..)
-        .and_then(|bytes| decode_shortu16_len(bytes).ok())
-        .ok_or(PacketError::InvalidShortVec)?;
-    // Using msg_start_offset which is based on sig_len_untrusted introduces uncertainty.
-    // Ultimately, the actual sigverify will determine the uncertainty.
-    let msg_start_offset = sig_len_untrusted
-        .checked_mul(size_of::<Signature>())
-        .and_then(|v| v.checked_add(sig_size))
-        .ok_or(PacketError::InvalidLen)?;
-
-    // Determine the start of the message header by checking the message prefix bit.
-    let msg_header_offset = {
-        // Packet should have data for prefix bit
-        if msg_start_offset >= packet.meta().size {
-            return Err(PacketError::InvalidSignatureLen);
-        }
-
-        // next byte indicates if the transaction is versioned. If the top bit
-        // is set, the remaining bits encode a version number. If the top bit is
-        // not set, this byte is the first byte of the message header.
-        let message_prefix = *packet
-            .data(msg_start_offset)
-            .ok_or(PacketError::InvalidSignatureLen)?;
-        if message_prefix & MESSAGE_VERSION_PREFIX != 0 {
-            let version = message_prefix & !MESSAGE_VERSION_PREFIX;
-            match version {
-                0 => {
-                    // header begins immediately after prefix byte
-                    msg_start_offset
-                        .checked_add(1)
-                        .ok_or(PacketError::InvalidLen)?
-                }
-
-                // currently only v0 is supported
-                _ => return Err(PacketError::UnsupportedVersion),
-            }
-        } else {
-            msg_start_offset
-        }
-    };
-
-    let msg_header_offset_plus_one = msg_header_offset
-        .checked_add(1)
-        .ok_or(PacketError::InvalidLen)?;
-
-    // Packet should have data at least for MessageHeader and 1 byte for Message.account_keys.len
-    let _ = msg_header_offset_plus_one
-        .checked_add(MESSAGE_HEADER_LENGTH)
-        .filter(|v| *v <= packet.meta().size)
-        .ok_or(PacketError::InvalidSignatureLen)?;
-
-    // read MessageHeader.num_required_signatures (serialized with u8)
-    let sig_len_maybe_trusted = *packet
-        .data(msg_header_offset)
-        .ok_or(PacketError::InvalidSignatureLen)?;
-    let message_account_keys_len_offset = msg_header_offset
-        .checked_add(MESSAGE_HEADER_LENGTH)
-        .ok_or(PacketError::InvalidSignatureLen)?;
-
-    // This reads and compares the MessageHeader num_required_signatures and
-    // num_readonly_signed_accounts bytes. If num_required_signatures is not larger than
-    // num_readonly_signed_accounts, the first account is not debitable, and cannot be charged
-    // required transaction fees.
-    let readonly_signer_offset = msg_header_offset_plus_one;
-    if sig_len_maybe_trusted
-        <= *packet
-            .data(readonly_signer_offset)
-            .ok_or(PacketError::InvalidSignatureLen)?
-    {
-        return Err(PacketError::PayerNotWritable);
-    }
-
-    if usize::from(sig_len_maybe_trusted) != sig_len_untrusted {
-        return Err(PacketError::MismatchSignatureLen);
-    }
-
-    // read the length of Message.account_keys (serialized with short_vec)
-    let (pubkey_len, pubkey_len_size) = packet
-        .data(message_account_keys_len_offset..)
-        .and_then(|bytes| decode_shortu16_len(bytes).ok())
-        .ok_or(PacketError::InvalidShortVec)?;
-    let pubkey_start = message_account_keys_len_offset
-        .checked_add(pubkey_len_size)
-        .ok_or(PacketError::InvalidPubkeyLen)?;
-
-    let blockhash_offset = pubkey_len
-        .checked_mul(size_of::<Pubkey>())
-        .and_then(|v| v.checked_add(pubkey_start))
-        .filter(|v| *v <= packet.meta().size)
-        .ok_or(PacketError::InvalidPubkeyLen)?;
-
-    if pubkey_len < sig_len_untrusted {
-        return Err(PacketError::InvalidPubkeyLen);
-    }
-
-    // read instruction length
-    let instructions_len_offset = blockhash_offset
-        .checked_add(size_of::<Hash>())
-        .ok_or(PacketError::InvalidLen)?;
-
-    // Packet should have at least 1 more byte for instructions.len
-    let _ = instructions_len_offset
-        .checked_add(1usize)
-        .filter(|v| *v <= packet.meta().size)
-        .ok_or(PacketError::InvalidLen)?;
-
-    let (instruction_len, instruction_len_size) = packet
-        .data(instructions_len_offset..)
-        .and_then(|bytes| decode_shortu16_len(bytes).ok())
-        .ok_or(PacketError::InvalidLen)?;
-
-    // SIMD-0160: skip if has more than 64 top instructions
-    if instruction_len > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH {
-        return Err(PacketError::InvalidNumberOfInstructions);
-    }
-
-    let instruction_start = instructions_len_offset
-        .checked_add(instruction_len_size)
-        .ok_or(PacketError::InvalidLen)?;
-
-    // Packet should have at least 1 more byte for one instructions_program_id
-    let _ = instruction_start
-        .checked_add(1usize)
-        .filter(|v| *v <= packet.meta().size)
-        .ok_or(PacketError::InvalidLen)?;
-
-    let sig_start = current_offset
-        .checked_add(sig_size)
-        .ok_or(PacketError::InvalidLen)?;
-    let msg_start = current_offset
-        .checked_add(msg_start_offset)
-        .ok_or(PacketError::InvalidLen)?;
-    let pubkey_start = current_offset
-        .checked_add(pubkey_start)
-        .ok_or(PacketError::InvalidLen)?;
-    let instruction_start = current_offset
-        .checked_add(instruction_start)
-        .ok_or(PacketError::InvalidLen)?;
-
-    Ok(PacketOffsets::new(
-        u32::try_from(sig_len_untrusted)?,
-        u32::try_from(sig_start)?,
-        u32::try_from(msg_start)?,
-        u32::try_from(pubkey_start)?,
-        u32::try_from(pubkey_len)?,
-        u32::try_from(instruction_len)?,
-        u32::try_from(instruction_start)?,
-    ))
-}
-
-fn get_packet_offsets(
-    packet: &mut PacketRefMut,
-    current_offset: usize,
-    reject_non_vote: bool,
-) -> PacketOffsets {
-    let unsanitized_packet_offsets = do_get_packet_offsets(packet.as_ref(), current_offset);
-    if let Ok(offsets) = unsanitized_packet_offsets {
-        check_for_simple_vote_transaction(packet, &offsets, current_offset).ok();
-        if !reject_non_vote || packet.meta().is_simple_vote_tx() {
-            return offsets;
-        }
-    }
-    // force sigverify to fail by returning zeros
-    PacketOffsets::new(0, 0, 0, 0, 0, 0, 0)
-}
-
-fn check_for_simple_vote_transaction(
-    packet: &mut PacketRefMut,
-    packet_offsets: &PacketOffsets,
-    current_offset: usize,
-) -> Result<(), PacketError> {
-    // vote could have 1 or 2 sigs; zero sig has already been excluded at
-    // do_get_packet_offsets.
-    if packet_offsets.sig_len > 2 {
-        return Err(PacketError::InvalidSignatureLen);
-    }
-
-    // simple vote should only be legacy message
-    let msg_start = (packet_offsets.msg_start as usize)
-        .checked_sub(current_offset)
-        .ok_or(PacketError::InvalidLen)?;
-    let message_prefix = *packet.data(msg_start).ok_or(PacketError::InvalidLen)?;
-    if message_prefix & MESSAGE_VERSION_PREFIX != 0 {
-        return Ok(());
-    }
-
-    let pubkey_start = (packet_offsets.pubkey_start as usize)
-        .checked_sub(current_offset)
-        .ok_or(PacketError::InvalidLen)?;
-
-    // skip if has more than 1 instruction
-    if packet_offsets.instruction_len != 1 {
-        return Err(PacketError::InvalidNumberOfInstructions);
-    }
-
-    let instruction_start = (packet_offsets.instruction_start as usize)
-        .checked_sub(current_offset)
-        .ok_or(PacketError::InvalidLen)?;
-
-    let instruction_program_id_index: usize = usize::from(
-        *packet
-            .data(instruction_start)
-            .ok_or(PacketError::InvalidLen)?,
-    );
-
-    if instruction_program_id_index >= packet_offsets.pubkey_len as usize {
-        return Err(PacketError::InvalidProgramIdIndex);
-    }
-
-    let instruction_program_id_start = instruction_program_id_index
-        .checked_mul(size_of::<Pubkey>())
-        .and_then(|v| v.checked_add(pubkey_start))
-        .ok_or(PacketError::InvalidLen)?;
-    let instruction_program_id_end = instruction_program_id_start
-        .checked_add(size_of::<Pubkey>())
-        .ok_or(PacketError::InvalidLen)?;
-
-    if packet
-        .data(instruction_program_id_start..instruction_program_id_end)
-        .ok_or(PacketError::InvalidLen)?
-        == solana_sdk_ids::vote::id().as_ref()
-    {
-        packet.meta_mut().flags |= PacketFlags::SIMPLE_VOTE_TX;
-    }
-    Ok(())
 }
 
 fn is_simple_vote_transaction_view<D: TransactionData>(view: &SanitizedTransactionView<D>) -> bool {
@@ -555,29 +273,41 @@ mod tests {
                 BytesPacket, BytesPacketBatch, PACKETS_PER_BATCH, Packet, RecycledPacketBatch,
                 to_packet_batches,
             },
-            sigverify::{self, PacketOffsets},
+            sigverify::{self},
             test_tx::{
                 new_test_tx_with_number_of_ixs, new_test_vote_tx, test_multisig_tx, test_tx,
             },
         },
-        bincode::{deserialize, serialize},
-        bytes::{BufMut, Bytes, BytesMut},
+        bytes::Bytes,
         rand::Rng,
+        solana_hash::Hash,
         solana_keypair::Keypair,
-        solana_message::{Message, MessageHeader, compiled_instruction::CompiledInstruction},
-        solana_packet::PACKET_DATA_SIZE,
+        solana_message::{
+            AccountMeta, Instruction, MESSAGE_VERSION_PREFIX, Message, MessageHeader,
+            VersionedMessage, compiled_instruction::CompiledInstruction,
+        },
+        solana_pubkey::Pubkey,
         solana_signature::Signature,
         solana_signer::Signer,
         solana_transaction::{Transaction, versioned::VersionedTransaction},
         test_case::test_case,
     };
 
-    const SIG_OFFSET: usize = 1;
-
-    pub fn memfind<A: Eq>(a: &[A], b: &[A]) -> Option<usize> {
-        assert!(a.len() >= b.len());
-        let end = a.len() - b.len() + 1;
-        (0..end).find(|&i| a[i..i + b.len()] == b[..])
+    fn new_test_vote_tx_v0() -> VersionedTransaction {
+        let payer = Keypair::new();
+        let instruction = Instruction {
+            program_id: solana_vote_program::id(),
+            accounts: vec![AccountMeta::new(payer.pubkey(), true)],
+            data: vec![1, 2, 3],
+        };
+        let message = solana_message::v0::Message::try_compile(
+            &payer.pubkey(),
+            &[instruction],
+            &[],
+            Hash::new_unique(),
+        )
+        .unwrap();
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&payer]).unwrap()
     }
 
     #[test]
@@ -591,43 +321,6 @@ mod tests {
         batches[0].get_mut(0).unwrap().meta_mut().set_discard(false);
         mark_disabled(&mut batches, &[vec![1]]);
         assert!(!batches[0].get(0).unwrap().meta().discard());
-    }
-
-    #[test]
-    fn test_layout() {
-        let tx = test_tx();
-        let tx_bytes = serialize(&tx).unwrap();
-        let packet = serialize(&tx).unwrap();
-        assert_matches!(memfind(&packet, &tx_bytes), Some(0));
-        assert_matches!(memfind(&packet, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), None);
-    }
-
-    #[test]
-    fn test_system_transaction_layout() {
-        let tx = test_tx();
-        let tx_bytes = serialize(&tx).unwrap();
-        let message_data = tx.message_data();
-        let mut packet = BytesPacket::from_data(None, tx.clone()).unwrap();
-
-        let packet_offsets = sigverify::get_packet_offsets(&mut packet.as_mut(), 0, false);
-
-        assert_eq!(
-            memfind(&tx_bytes, tx.signatures[0].as_ref()),
-            Some(SIG_OFFSET)
-        );
-        assert_eq!(
-            memfind(&tx_bytes, tx.message().account_keys[0].as_ref()),
-            Some(packet_offsets.pubkey_start as usize)
-        );
-        assert_eq!(
-            memfind(&tx_bytes, &message_data),
-            Some(packet_offsets.msg_start as usize)
-        );
-        assert_eq!(
-            memfind(&tx_bytes, tx.signatures[0].as_ref()),
-            Some(packet_offsets.sig_start as usize)
-        );
-        assert_eq!(packet_offsets.sig_len, 1);
     }
 
     fn packet_from_num_sigs(required_num_sigs: u8, actual_num_sigs: usize) -> BytesPacket {
@@ -651,14 +344,8 @@ mod tests {
         let required_num_sigs = 14;
         let actual_num_sigs = 5;
 
-        let packet = packet_from_num_sigs(required_num_sigs, actual_num_sigs);
-
-        let unsanitized_packet_offsets = sigverify::do_get_packet_offsets(packet.as_ref(), 0);
-
-        assert_eq!(
-            unsanitized_packet_offsets,
-            Err(PacketError::MismatchSignatureLen)
-        );
+        let mut packet = packet_from_num_sigs(required_num_sigs, actual_num_sigs);
+        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
     }
 
     #[test]
@@ -670,9 +357,8 @@ mod tests {
         data[1] = 0xff;
         data.truncate(2);
 
-        let packet = BytesPacket::from_bytes(None, Bytes::from(data));
-        let res = sigverify::do_get_packet_offsets(packet.as_ref(), 0);
-        assert_eq!(res, Err(PacketError::InvalidLen));
+        let mut packet = BytesPacket::from_bytes(None, Bytes::from(data));
+        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
     }
 
     #[test]
@@ -685,9 +371,6 @@ mod tests {
         tx.message.account_keys = vec![];
         tx.message.header.num_required_signatures = NUM_SIG as u8;
         let mut packet = BytesPacket::from_data(None, tx).unwrap();
-
-        let res = sigverify::do_get_packet_offsets(packet.as_ref(), 0);
-        assert_eq!(res, Err(PacketError::InvalidPubkeyLen));
 
         assert!(!verify_packet(&mut packet.as_mut(), false));
 
@@ -720,9 +403,6 @@ mod tests {
 
         let mut packet = BytesPacket::from_data(None, tx).unwrap();
 
-        let res = sigverify::do_get_packet_offsets(packet.as_ref(), 0);
-        assert_eq!(res, Err(PacketError::InvalidPubkeyLen));
-
         assert!(!verify_packet(&mut packet.as_mut(), false));
 
         packet.meta_mut().set_discard(false);
@@ -739,9 +419,8 @@ mod tests {
         // Make the signatures len huge
         data[0] = 0x7f;
 
-        let packet = BytesPacket::from_bytes(None, Bytes::from(data));
-        let res = sigverify::do_get_packet_offsets(packet.as_ref(), 0);
-        assert_eq!(res, Err(PacketError::InvalidSignatureLen));
+        let mut packet = BytesPacket::from_bytes(None, Bytes::from(data));
+        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
     }
 
     #[test]
@@ -755,25 +434,22 @@ mod tests {
         data[2] = 0xff;
         data[3] = 0xff;
 
-        let packet = BytesPacket::from_bytes(None, Bytes::from(data));
-        let res = sigverify::do_get_packet_offsets(packet.as_ref(), 0);
-        assert_eq!(res, Err(PacketError::InvalidShortVec));
+        let mut packet = BytesPacket::from_bytes(None, Bytes::from(data));
+        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
     }
 
     #[test]
     fn test_invalid_pubkey_len() {
         let tx = test_tx();
         let mut data = bincode::serialize(&tx).unwrap();
-        let packet = BytesPacket::from_bytes(None, Bytes::from(data.clone()));
-
-        let offsets = sigverify::do_get_packet_offsets(packet.as_ref(), 0).unwrap();
 
         // make pubkey len huge
-        data[offsets.pubkey_start as usize - 1] = 0x7f;
+        const PUBKEY_OFFSET: usize =
+            1 + core::mem::size_of::<Signature>() + core::mem::size_of::<MessageHeader>();
+        data[PUBKEY_OFFSET] = 0x7f;
 
-        let packet = BytesPacket::from_bytes(None, Bytes::from(data));
-        let res = sigverify::do_get_packet_offsets(packet.as_ref(), 0);
-        assert_eq!(res, Err(PacketError::InvalidPubkeyLen));
+        let mut packet = BytesPacket::from_bytes(None, Bytes::from(data));
+        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
     }
 
     #[test]
@@ -790,112 +466,21 @@ mod tests {
         };
         let mut tx = Transaction::new_unsigned(message);
         tx.signatures = vec![Signature::default()];
-        let packet = BytesPacket::from_data(None, tx).unwrap();
-        let res = sigverify::do_get_packet_offsets(packet.as_ref(), 0);
-
-        assert_eq!(res, Err(PacketError::PayerNotWritable));
+        let mut packet = BytesPacket::from_data(None, tx).unwrap();
+        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
     }
 
     #[test]
     fn test_unsupported_version() {
         let tx = test_tx();
         let mut data = bincode::serialize(&tx).unwrap();
-        let packet = BytesPacket::from_bytes(None, Bytes::from(data.clone()));
-
-        let res = sigverify::do_get_packet_offsets(packet.as_ref(), 0);
 
         // set message version to 1
-        data[res.unwrap().msg_start as usize] = MESSAGE_VERSION_PREFIX + 1;
+        const MESSAGE_OFFSET: usize = 1 + core::mem::size_of::<Signature>();
+        data[MESSAGE_OFFSET] = MESSAGE_VERSION_PREFIX + 1;
 
-        let packet = BytesPacket::from_bytes(None, Bytes::from(data));
-        let res = sigverify::do_get_packet_offsets(packet.as_ref(), 0);
-        assert_eq!(res, Err(PacketError::UnsupportedVersion));
-    }
-
-    #[test]
-    fn test_versioned_message() {
-        let tx = test_tx();
-        let packet = BytesPacket::from_data(None, tx).unwrap();
-
-        let mut legacy_offsets = sigverify::do_get_packet_offsets(packet.as_ref(), 0).unwrap();
-
-        // set message version to 0
-        let msg_start = legacy_offsets.msg_start as usize;
-        let msg_bytes = packet.data(msg_start..).unwrap();
-        let mut buf = BytesMut::with_capacity(packet.meta().size + 1);
-        buf.put_slice(packet.data(..msg_start).unwrap());
-        buf.put_u8(MESSAGE_VERSION_PREFIX);
-        buf.put_slice(msg_bytes);
-        let packet = BytesPacket::from_bytes(None, buf.freeze());
-
-        let offsets = sigverify::do_get_packet_offsets(packet.as_ref(), 0).unwrap();
-        let expected_offsets = {
-            legacy_offsets.pubkey_start += 1;
-            legacy_offsets.instruction_start += 1;
-            legacy_offsets
-        };
-
-        assert_eq!(expected_offsets, offsets);
-    }
-
-    #[test]
-    fn test_system_transaction_data_layout() {
-        let mut tx0 = test_tx();
-        tx0.message.instructions[0].data = vec![1, 2, 3];
-        let message0a = tx0.message_data();
-        let tx_bytes = serialize(&tx0).unwrap();
-        assert!(tx_bytes.len() <= PACKET_DATA_SIZE);
-        assert_eq!(
-            memfind(&tx_bytes, tx0.signatures[0].as_ref()),
-            Some(SIG_OFFSET)
-        );
-        let tx1 = deserialize(&tx_bytes).unwrap();
-        assert_eq!(tx0, tx1);
-        assert_eq!(tx1.message().instructions[0].data, vec![1, 2, 3]);
-
-        tx0.message.instructions[0].data = vec![1, 2, 4];
-        let message0b = tx0.message_data();
-        assert_ne!(message0a, message0b);
-    }
-
-    // Just like get_packet_offsets, but not returning redundant information.
-    fn get_packet_offsets_from_tx(tx: Transaction, current_offset: u32) -> PacketOffsets {
-        let mut packet = BytesPacket::from_data(None, tx).unwrap();
-        let packet_offsets =
-            sigverify::get_packet_offsets(&mut packet.as_mut(), current_offset as usize, false);
-        PacketOffsets::new(
-            packet_offsets.sig_len,
-            packet_offsets.sig_start - current_offset,
-            packet_offsets.msg_start - packet_offsets.sig_start,
-            packet_offsets.pubkey_start - packet_offsets.msg_start,
-            packet_offsets.pubkey_len,
-            packet_offsets.instruction_len,
-            packet_offsets.instruction_start - packet_offsets.pubkey_start,
-        )
-    }
-
-    #[test]
-    fn test_get_packet_offsets() {
-        assert_eq!(
-            get_packet_offsets_from_tx(test_tx(), 0),
-            PacketOffsets::new(1, 1, 64, 4, 2, 1, 97)
-        );
-        assert_eq!(
-            get_packet_offsets_from_tx(test_tx(), 100),
-            PacketOffsets::new(1, 1, 64, 4, 2, 1, 97)
-        );
-
-        // Ensure we're not indexing packet by the `current_offset` parameter.
-        assert_eq!(
-            get_packet_offsets_from_tx(test_tx(), 1_000_000),
-            PacketOffsets::new(1, 1, 64, 4, 2, 1, 97)
-        );
-
-        // Ensure we're returning sig_len, not sig_size.
-        assert_eq!(
-            get_packet_offsets_from_tx(test_multisig_tx(), 0),
-            PacketOffsets::new(2, 1, 128, 4, 4, 1, 161)
-        );
+        let mut packet = BytesPacket::from_bytes(None, Bytes::from(data));
+        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
     }
 
     fn generate_bytes_packet_batches(
@@ -1078,40 +663,39 @@ mod tests {
         {
             let mut tx = test_tx();
             tx.message.instructions[0].data = vec![1, 2, 3];
-            let mut packet = BytesPacket::from_data(None, tx).unwrap();
-            let packet_offsets = do_get_packet_offsets(packet.as_ref(), 0).unwrap();
-            check_for_simple_vote_transaction(&mut packet.as_mut(), &packet_offsets, 0).ok();
-            assert!(!packet.meta().is_simple_vote_tx());
+            let packet = BytesPacket::from_data(None, tx).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(
+                packet.as_ref().data(..).unwrap(),
+                true,
+            )
+            .unwrap();
+            assert!(!is_simple_vote_transaction_view(&view));
         }
 
         // single legacy vote tx is
         {
             let mut tx = new_test_vote_tx(&mut rng);
             tx.message.instructions[0].data = vec![1, 2, 3];
-            let mut packet = BytesPacket::from_data(None, tx).unwrap();
-            let packet_offsets = do_get_packet_offsets(packet.as_ref(), 0).unwrap();
-            check_for_simple_vote_transaction(&mut packet.as_mut(), &packet_offsets, 0).ok();
-            assert!(packet.meta().is_simple_vote_tx());
+            let packet = BytesPacket::from_data(None, tx).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(
+                packet.as_ref().data(..).unwrap(),
+                true,
+            )
+            .unwrap();
+            assert!(is_simple_vote_transaction_view(&view));
         }
 
         // single versioned vote tx is not
         {
-            let mut tx = new_test_vote_tx(&mut rng);
-            tx.message.instructions[0].data = vec![1, 2, 3];
+            let tx = new_test_vote_tx_v0();
             let packet = BytesPacket::from_data(None, tx).unwrap();
 
-            // set messager version to v0
-            let mut packet_offsets = do_get_packet_offsets(packet.as_ref(), 0).unwrap();
-            let msg_start = packet_offsets.msg_start as usize;
-            let msg_bytes = packet.data(msg_start..).unwrap();
-            let mut buf = BytesMut::with_capacity(packet.meta().size + 1);
-            buf.put_slice(packet.data(..msg_start).unwrap());
-            buf.put_u8(MESSAGE_VERSION_PREFIX);
-            buf.put_slice(msg_bytes);
-            let mut packet = BytesPacket::from_bytes(None, buf.freeze());
-
-            packet_offsets = do_get_packet_offsets(packet.as_ref(), 0).unwrap();
-            check_for_simple_vote_transaction(&mut packet.as_mut(), &packet_offsets, 0).ok();
+            let view = SanitizedTransactionView::try_new_sanitized(
+                packet.as_ref().data(..).unwrap(),
+                true,
+            )
+            .unwrap();
+            assert!(!is_simple_vote_transaction_view(&view));
             assert!(!packet.meta().is_simple_vote_tx());
         }
 
@@ -1130,10 +714,13 @@ mod tests {
                     CompiledInstruction::new(4, &(), vec![0, 2]),
                 ],
             );
-            let mut packet = BytesPacket::from_data(None, tx).unwrap();
-            let packet_offsets = do_get_packet_offsets(packet.as_ref(), 0).unwrap();
-            check_for_simple_vote_transaction(&mut packet.as_mut(), &packet_offsets, 0).ok();
-            assert!(!packet.meta().is_simple_vote_tx());
+            let packet = BytesPacket::from_data(None, tx).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(
+                packet.as_ref().data(..).unwrap(),
+                true,
+            )
+            .unwrap();
+            assert!(!is_simple_vote_transaction_view(&view));
         }
 
         // single legacy vote tx with extra (invalid) signature is not
@@ -1142,79 +729,13 @@ mod tests {
             tx.signatures.push(Signature::default());
             tx.message.header.num_required_signatures = 3;
             tx.message.instructions[0].data = vec![1, 2, 3];
-            let mut packet = BytesPacket::from_data(None, tx).unwrap();
-            let packet_offsets = do_get_packet_offsets(packet.as_ref(), 0).unwrap();
-            assert_eq!(
-                Err(PacketError::InvalidSignatureLen),
-                check_for_simple_vote_transaction(&mut packet.as_mut(), &packet_offsets, 0)
-            );
-            assert!(!packet.meta().is_simple_vote_tx());
-        }
-    }
-
-    #[test]
-    fn test_is_simple_vote_transaction_with_offsets() {
-        agave_logger::setup();
-        let mut rng = rand::rng();
-
-        // batch of legacy messages
-        {
-            let mut current_offset = 0usize;
-            let mut batch = BytesPacketBatch::default();
-            batch.push(BytesPacket::from_data(None, test_tx()).unwrap());
-            let tx = new_test_vote_tx(&mut rng);
-            batch.push(BytesPacket::from_data(None, tx).unwrap());
-            batch.iter_mut().enumerate().for_each(|(index, packet)| {
-                let packet_offsets =
-                    do_get_packet_offsets(packet.as_ref(), current_offset).unwrap();
-                check_for_simple_vote_transaction(
-                    &mut packet.as_mut(),
-                    &packet_offsets,
-                    current_offset,
-                )
-                .ok();
-                if index == 1 {
-                    assert!(packet.meta().is_simple_vote_tx());
-                } else {
-                    assert!(!packet.meta().is_simple_vote_tx());
-                }
-
-                current_offset = current_offset.saturating_add(size_of::<Packet>());
-            });
-        }
-
-        // batch of mixed legacy messages and versioned vote tx, which won't be flagged as
-        // simple_vote_tx
-        {
-            let mut current_offset = 0usize;
-            let mut batch = BytesPacketBatch::default();
-            batch.push(BytesPacket::from_data(None, test_tx()).unwrap());
-            // versioned vote tx
-            let tx = new_test_vote_tx(&mut rng);
             let packet = BytesPacket::from_data(None, tx).unwrap();
-            let packet_offsets = do_get_packet_offsets(packet.as_ref(), 0).unwrap();
-            let msg_start = packet_offsets.msg_start as usize;
-            let msg_bytes = packet.data(msg_start..).unwrap();
-            let mut buf = BytesMut::with_capacity(packet.meta().size + 1);
-            buf.put_slice(packet.data(..msg_start).unwrap());
-            buf.put_u8(MESSAGE_VERSION_PREFIX);
-            buf.put_slice(msg_bytes);
-            let packet = BytesPacket::from_bytes(None, buf.freeze());
-            batch.push(packet);
-
-            batch.iter_mut().for_each(|packet| {
-                let packet_offsets =
-                    do_get_packet_offsets(packet.as_ref(), current_offset).unwrap();
-                check_for_simple_vote_transaction(
-                    &mut packet.as_mut(),
-                    &packet_offsets,
-                    current_offset,
-                )
-                .ok();
-                assert!(!packet.meta().is_simple_vote_tx());
-
-                current_offset = current_offset.saturating_add(size_of::<Packet>());
-            });
+            let view = SanitizedTransactionView::try_new_sanitized(
+                packet.as_ref().data(..).unwrap(),
+                true,
+            )
+            .unwrap();
+            assert!(!is_simple_vote_transaction_view(&view));
         }
     }
 
@@ -1497,7 +1018,7 @@ mod tests {
             number_of_ixs += 1;
         }
 
-        let packet = if is_versioned_tx {
+        let mut packet = if is_versioned_tx {
             let tx: VersionedTransaction = new_test_tx_with_number_of_ixs(number_of_ixs);
             BytesPacket::from_data(None, tx.clone()).unwrap()
         } else {
@@ -1505,13 +1026,9 @@ mod tests {
             BytesPacket::from_data(None, tx.clone()).unwrap()
         };
 
-        if too_many_ixs {
-            assert_eq!(
-                do_get_packet_offsets(packet.as_ref(), 0),
-                Err(PacketError::InvalidNumberOfInstructions),
-            );
-        } else {
-            assert!(do_get_packet_offsets(packet.as_ref(), 0).is_ok());
-        }
+        assert_eq!(
+            sigverify::verify_packet(&mut packet.as_mut(), false),
+            !too_many_ixs
+        );
     }
 }

--- a/perf/src/test_tx.rs
+++ b/perf/src/test_tx.rs
@@ -41,7 +41,7 @@ pub fn test_multisig_tx() -> Transaction {
     let program_ids = vec![system_program::id(), stake::id()];
 
     let instructions = vec![CompiledInstruction::new(
-        0,
+        3,
         &bincode::serialize(&transfer_instruction).unwrap(),
         vec![0, 1],
     )];

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7513,6 +7513,7 @@ dependencies = [
 name = "solana-perf"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-transaction-view",
  "ahash 0.8.12",
  "bincode",
  "bytes",


### PR DESCRIPTION
#### Problem
- We have some code duplication in finding offsets of signatures in transactions
- We will soon be adding a new transaction version which changes the signature location based on version
- Rather than continue to maintain duplicate versions of offset finding we can re-use our code and get the new version parsing for free when `TransactionView` is updated

#### Summary of Changes
- Use `TransactionView` parsing functions instead of separate sigverify parsing code
	- This is NOT a pure refactor. It does additional work to make sure a transaction is valid prior to validating signatures. IMO this is likely a good change as the feed that makes it to the scheduler will be cleaner and done in parallel rather than serially in scheduler
- Remove now unused functions

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
