### PR TITLE
Make ALT program buildable for sbpf target

### DIFF
--- a/programs/address-lookup-table/Cargo.toml
+++ b/programs/address-lookup-table/Cargo.toml
@@ -17,7 +17,6 @@ crate-type = ["lib"]
 name = "solana_address_lookup_table_program"
 
 [dependencies]
-agave-feature-set = { workspace = true }
 bincode = { workspace = true }
 bytemuck = { workspace = true }
 log = { workspace = true }


### PR DESCRIPTION
#### Problem
The ALT program is not buildable on 2.x on sbpf currently due to `agave-feature-set` depending on `ahash` which depends on `rand`.

#### Summary of Changes
`agave-feature-set` is not needed, so we remove it.

