### PR TITLE
SIMD-406: Limit number of accounts in an instruction

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -180,6 +180,8 @@ fn simulate_transaction(
         bank.get_reserved_account_keys(),
         bank.feature_set
             .is_active(&agave_feature_set::static_instruction_limit::id()),
+        bank.feature_set
+            .is_active(&agave_feature_set::limit_instruction_accounts::id()),
     ) {
         Err(err) => {
             return BanksTransactionResultWithSimulation {

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1443,6 +1443,8 @@ mod tests {
             &ReservedAccountKeys::empty_key_set(),
             bank.feature_set
                 .is_active(&agave_feature_set::static_instruction_limit::id()),
+            bank.feature_set
+                .is_active(&agave_feature_set::limit_instruction_accounts::id()),
         )
         .unwrap();
         let batch_transactions_inner = [&sanitized_tx]

--- a/core/src/banking_stage/latest_validator_vote_packet.rs
+++ b/core/src/banking_stage/latest_validator_vote_packet.rs
@@ -109,6 +109,7 @@ impl LatestValidatorVote {
         let vote = SanitizedTransactionView::try_new_sanitized(
             std::sync::Arc::new(packet.data(..).unwrap().to_vec()),
             false,
+            true,
         )
         .unwrap();
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -474,7 +474,7 @@ mod tests {
 
         let reserved_addresses = HashSet::default();
         let packet_parser = |data, priority, cost| {
-            let view = SanitizedTransactionView::try_new_sanitized(data, true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(data, true, true).unwrap();
             let view = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 view,
                 MessageHash::Compute,

--- a/core/src/banking_stage/vote_packet_receiver.rs
+++ b/core/src/banking_stage/vote_packet_receiver.rs
@@ -110,6 +110,9 @@ impl VotePacketReceiver {
                     // NB: It's safe to always pass false in here as simple vote
                     // transactions are guaranteed to be a single instruction.
                     false,
+                    // Vote instructions are created in the validator code, and they are not
+                    // referencing more than 255 accounts, so it is safe to set this to true.
+                    true,
                 ) {
                     Ok(pkt) => Some(pkt),
                     Err(err) => {

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -393,7 +393,7 @@ pub(crate) mod tests {
     }
 
     fn to_sanitized_view(packet: BytesPacket) -> SanitizedTransactionView<SharedBytes> {
-        SanitizedTransactionView::try_new_sanitized(Arc::new(packet.buffer().to_vec()), false)
+        SanitizedTransactionView::try_new_sanitized(Arc::new(packet.buffer().to_vec()), false, true)
             .unwrap()
     }
 

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -587,9 +587,12 @@ mod tests {
     };
 
     fn to_runtime_transaction_view(packet: BytesPacket) -> RuntimeTransactionView {
-        let tx =
-            SanitizedTransactionView::try_new_sanitized(Arc::new(packet.buffer().to_vec()), false)
-                .unwrap();
+        let tx = SanitizedTransactionView::try_new_sanitized(
+            Arc::new(packet.buffer().to_vec()),
+            false,
+            true,
+        )
+        .unwrap();
         let tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
             tx,
             MessageHash::Compute,

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -294,6 +294,9 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
         let enable_static_instruction_limit = bank
             .feature_set
             .is_active(&agave_feature_set::static_instruction_limit::id());
+        let enable_instruction_accounts_limit = bank
+            .feature_set
+            .is_active(&agave_feature_set::limit_instruction_accounts::id());
         for batch in packet_batches.iter() {
             for packet in batch
                 .iter()
@@ -317,6 +320,7 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
                 let Some(priority) = SanitizedTransactionView::try_new_sanitized(
                     packet_data,
                     enable_static_instruction_limit,
+                    enable_instruction_accounts_limit,
                 )
                 .map_err(|_| ())
                 .and_then(|transaction| {

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -375,6 +375,7 @@ mod tests {
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
             true,
+            true,
         )
         .unwrap();
 
@@ -429,6 +430,7 @@ mod tests {
             Some(false),
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
+            true,
             true,
         )
         .unwrap();

--- a/entry/benches/entry_sigverify.rs
+++ b/entry/benches/entry_sigverify.rs
@@ -37,6 +37,7 @@ fn bench_cpusigverify(bencher: &mut Bencher) {
                     SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),
                     true,
+                    true,
                 )
             }?;
 

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -698,6 +698,7 @@ mod tests {
                         SimpleAddressLoader::Disabled,
                         &ReservedAccountKeys::empty_key_set(),
                         true,
+                        true,
                     )
                 }?;
 

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -2304,7 +2304,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         ),
         (
             limit_instruction_accounts::id(),
-            "SIMD-406: Limit the number of accounts a top-level instruction may reference",
+            "SIMD-406: Maximum instruction accounts",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1287,6 +1287,10 @@ pub mod stop_use_static_simple_vote_tx_cost {
     solana_pubkey::declare_id!("NSVt1s8oP1A9NjEc6UNcj2voeCcfzHaq4jZTiUL2Mf5");
 }
 
+pub mod limit_instruction_accounts {
+    solana_pubkey::declare_id!("DqbnFPASg7tHmZ6qfpdrt2M6MWoSeiicWPXxPhxqFCQ");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2297,6 +2301,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             stop_use_static_simple_vote_tx_cost::id(),
             "stop use static SimpleVote transaction cost, issue #10227",
+        ),
+        (
+            limit_instruction_accounts::id(),
+            "SIMD-406: Limit the number of accounts a top-level instruction may reference",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -468,6 +468,7 @@ fn compute_slot_cost(
                     SimpleAddressLoader::Disabled,
                     &reserved_account_keys.active,
                     feature_set.is_active(&agave_feature_set::static_instruction_limit::id()),
+                    feature_set.is_active(&agave_feature_set::limit_instruction_accounts::id()),
                 )
                 .map_err(|err| {
                     warn!("Failed to compute cost of transaction: {err:?}");

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3837,6 +3837,9 @@ pub mod rpc_full {
                 preflight_bank
                     .feature_set
                     .is_active(&agave_feature_set::static_instruction_limit::id()),
+                preflight_bank
+                    .feature_set
+                    .is_active(&agave_feature_set::limit_instruction_accounts::id()),
             )?;
             let blockhash = *transaction.message().recent_blockhash();
             let message_hash = *transaction.message_hash();
@@ -3999,6 +4002,8 @@ pub mod rpc_full {
                 bank.get_reserved_account_keys(),
                 bank.feature_set
                     .is_active(&agave_feature_set::static_instruction_limit::id()),
+                bank.feature_set
+                    .is_active(&agave_feature_set::limit_instruction_accounts::id()),
             )?;
 
             let verification_error = if sig_verify {
@@ -4411,6 +4416,7 @@ fn sanitize_transaction(
     address_loader: impl AddressLoader,
     reserved_account_keys: &HashSet<Pubkey>,
     enable_static_instruction_limit: bool,
+    enable_instruction_accounts_limit: bool,
 ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
     RuntimeTransaction::try_create(
         transaction,
@@ -4419,6 +4425,7 @@ fn sanitize_transaction(
         address_loader,
         reserved_account_keys,
         enable_static_instruction_limit,
+        enable_instruction_accounts_limit,
     )
     .map_err(|err| Error::invalid_params(format!("invalid transaction: {err}")))
 }
@@ -9211,6 +9218,7 @@ pub mod tests {
                 SimpleAddressLoader::Disabled,
                 &ReservedAccountKeys::empty_key_set(),
                 true,
+                true,
             )
             .unwrap_err(),
             expect58
@@ -9236,6 +9244,7 @@ pub mod tests {
                 versioned_tx,
                 SimpleAddressLoader::Disabled,
                 &ReservedAccountKeys::empty_key_set(),
+                true,
                 true,
             )
             .unwrap_err(),

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -240,7 +240,8 @@ mod tests {
 
         let hash = Hash::new_unique();
         let transaction =
-            SanitizedTransactionView::try_new_sanitized(&serialized_transaction[..], true).unwrap();
+            SanitizedTransactionView::try_new_sanitized(&serialized_transaction[..], true, true)
+                .unwrap();
         let static_runtime_transaction =
             RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 transaction,
@@ -273,7 +274,7 @@ mod tests {
         ) {
             let bytes = bincode::serialize(&original_transaction).unwrap();
             let transaction_view =
-                SanitizedTransactionView::try_new_sanitized(&bytes[..], true).unwrap();
+                SanitizedTransactionView::try_new_sanitized(&bytes[..], true, true).unwrap();
             let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 transaction_view,
                 MessageHash::Compute,
@@ -340,7 +341,7 @@ mod tests {
             let bytes =
                 bincode::serialize(&original_transaction.to_versioned_transaction()).unwrap();
             let transaction_view =
-                SanitizedTransactionView::try_new_sanitized(&bytes[..], true).unwrap();
+                SanitizedTransactionView::try_new_sanitized(&bytes[..], true, true).unwrap();
             let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 transaction_view,
                 MessageHash::Compute,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3030,6 +3030,9 @@ impl Bank {
         let enable_static_instruction_limit = self
             .feature_set
             .is_active(&agave_feature_set::static_instruction_limit::id());
+        let enable_instruction_account_limit = self
+            .feature_set
+            .is_active(&agave_feature_set::limit_instruction_accounts::id());
         let sanitized_txs = txs
             .into_iter()
             .map(|tx| {
@@ -3040,6 +3043,7 @@ impl Bank {
                     self,
                     self.get_reserved_account_keys(),
                     enable_static_instruction_limit,
+                    enable_instruction_account_limit,
                 )
             })
             .collect::<Result<Vec<_>>>()?;
@@ -4808,6 +4812,10 @@ impl Bank {
         let enable_static_instruction_limit = self
             .feature_set
             .is_active(&agave_feature_set::static_instruction_limit::id());
+        let enable_instruction_account_limit = self
+            .feature_set
+            .is_active(&agave_feature_set::limit_instruction_accounts::id());
+
         let sanitized_tx = {
             let size =
                 bincode::serialized_size(&tx).map_err(|_| TransactionError::SanitizeFailure)?;
@@ -4835,6 +4843,7 @@ impl Bank {
                 self,
                 self.get_reserved_account_keys(),
                 enable_static_instruction_limit,
+                enable_instruction_account_limit,
             )
         }?;
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9328,6 +9328,53 @@ fn test_verify_transactions_instruction_limit(simd_0160_enabled: bool) {
     }
 }
 
+#[test_case(false; "pre_simd406_limit_instruction_accounts")]
+#[test_case(true; "simd406_limit_instruction_accounts")]
+fn test_verify_transactions_accounts_limit(simd_406_enabled: bool) {
+    let GenesisConfigInfo { genesis_config, .. } =
+        create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
+    let mut bank = Bank::new_for_tests(&genesis_config);
+    if !simd_406_enabled {
+        bank.deactivate_feature(&feature_set::limit_instruction_accounts::id());
+    }
+
+    let recent_blockhash = Hash::new_unique();
+    let keypair = Keypair::new();
+    let pubkey = keypair.pubkey();
+    let mut accounts_keys = vec![Pubkey::new_unique(); 10];
+    accounts_keys.insert(0, pubkey);
+    let mut accounts: Vec<u8> = (0..10).collect();
+    while accounts.len() < 255 {
+        accounts.extend(0..10);
+    }
+    let instruction = CompiledInstruction {
+        program_id_index: 1,
+        data: vec![],
+        accounts,
+    };
+
+    let message = Message::new_with_compiled_instructions(
+        1,
+        0,
+        1,
+        accounts_keys,
+        recent_blockhash,
+        vec![instruction],
+    );
+    let tx = Transaction::new(&[&keypair], message, recent_blockhash);
+
+    if simd_406_enabled {
+        assert_matches!(
+            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
+            Err(TransactionError::SanitizeFailure)
+        );
+    } else {
+        assert!(bank
+            .verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
+            .is_ok());
+    }
+}
+
 #[test]
 fn test_check_reserved_keys() {
     let (genesis_config, _mint_keypair) = create_genesis_config(1);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9343,10 +9343,7 @@ fn test_verify_transactions_accounts_limit(simd_406_enabled: bool) {
     let pubkey = keypair.pubkey();
     let mut accounts_keys = vec![Pubkey::new_unique(); 10];
     accounts_keys.insert(0, pubkey);
-    let mut accounts: Vec<u8> = (0..10).collect();
-    while accounts.len() < 255 {
-        accounts.extend(0..10);
-    }
+    let accounts: Vec<u8> = (0..10).cycle().take(256).collect();
     let instruction = CompiledInstruction {
         program_id_index: 1,
         data: vec![],

--- a/transaction-view/benches/transaction_view.rs
+++ b/transaction-view/benches/transaction_view.rs
@@ -65,8 +65,8 @@ fn bench_transactions_parsing(
     group.bench_function("TransactionView (Sanitized)", |c| {
         c.iter(|| {
             for bytes in serialized_transactions.iter() {
-                let _ =
-                    TransactionView::try_new_sanitized(black_box(bytes.as_ref()), true).unwrap();
+                let _ = TransactionView::try_new_sanitized(black_box(bytes.as_ref()), true, true)
+                    .unwrap();
             }
         });
     });

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -290,7 +290,7 @@ mod tests {
             }),
         };
         let bytes = bincode::serialize(&transaction).unwrap();
-        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
         let result = ResolvedTransactionView::try_new(view, None, &HashSet::default());
         assert!(matches!(
             result,
@@ -321,7 +321,7 @@ mod tests {
             }),
         };
         let bytes = bincode::serialize(&transaction).unwrap();
-        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
         let result =
             ResolvedTransactionView::try_new(view, Some(loaded_addresses), &HashSet::default());
         assert!(matches!(
@@ -358,7 +358,7 @@ mod tests {
             }),
         };
         let bytes = bincode::serialize(&transaction).unwrap();
-        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
         let result =
             ResolvedTransactionView::try_new(view, Some(loaded_addresses), &HashSet::default());
         assert!(matches!(
@@ -408,7 +408,8 @@ mod tests {
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+            let view =
+                SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses),
@@ -431,7 +432,8 @@ mod tests {
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+            let view =
+                SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses),
@@ -454,7 +456,8 @@ mod tests {
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+            let view =
+                SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses),
@@ -515,7 +518,8 @@ mod tests {
             let static_keys = vec![key0, key1, key2];
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+            let view =
+                SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses.clone()),
@@ -534,7 +538,8 @@ mod tests {
             let static_keys = vec![key0, key1, bpf_loader_upgradeable::ID];
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+            let view =
+                SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses.clone()),
@@ -557,7 +562,8 @@ mod tests {
             };
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+            let view =
+                SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
 
             let resolved_view = ResolvedTransactionView::try_new(
                 view,

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -7,10 +7,15 @@ use crate::{
 pub(crate) fn sanitize(
     view: &UnsanitizedTransactionView<impl TransactionData>,
     enable_static_instruction_limit: bool,
+    enable_instruction_accounts_limit: bool,
 ) -> Result<()> {
     sanitize_signatures(view)?;
     sanitize_account_access(view)?;
-    sanitize_instructions(view, enable_static_instruction_limit)?;
+    sanitize_instructions(
+        view,
+        enable_static_instruction_limit,
+        enable_instruction_accounts_limit,
+    )?;
     sanitize_address_table_lookups(view)
 }
 
@@ -57,6 +62,7 @@ fn sanitize_account_access(view: &UnsanitizedTransactionView<impl TransactionDat
 fn sanitize_instructions(
     view: &UnsanitizedTransactionView<impl TransactionData>,
     enable_static_instruction_limit: bool,
+    enable_instruction_accounts_limit: bool,
 ) -> Result<()> {
     // SIMD-160: transaction can not have more than 64 top level instructions
     if enable_static_instruction_limit
@@ -87,6 +93,12 @@ fn sanitize_instructions(
             if account_index > max_account_index {
                 return Err(TransactionViewError::SanitizeError);
             }
+        }
+
+        if enable_instruction_accounts_limit
+            && instruction.accounts.len() > solana_transaction_context::MAX_ACCOUNTS_PER_INSTRUCTION
+        {
+            return Err(TransactionViewError::SanitizeError);
         }
     }
 
@@ -186,7 +198,7 @@ mod tests {
         let transaction = multiple_transfers();
         let data = bincode::serialize(&transaction).unwrap();
         let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-        assert!(view.sanitize(true).is_ok());
+        assert!(view.sanitize(true, true).is_ok());
     }
 
     #[test]
@@ -393,7 +405,7 @@ mod tests {
             );
             let data = bincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-            assert!(sanitize_instructions(&view, true).is_ok());
+            assert!(sanitize_instructions(&view, true, true).is_ok());
 
             let transaction = create_v0_transaction(
                 num_signatures,
@@ -404,7 +416,7 @@ mod tests {
             );
             let data = bincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-            assert!(sanitize_instructions(&view, true).is_ok());
+            assert!(sanitize_instructions(&view, true, true).is_ok());
         }
 
         for instruction_index in 0..valid_instructions.len() {
@@ -421,7 +433,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true),
+                    sanitize_instructions(&view, true, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -440,7 +452,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true),
+                    sanitize_instructions(&view, true, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -458,7 +470,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true),
+                    sanitize_instructions(&view, true, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -478,7 +490,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true),
+                    sanitize_instructions(&view, true, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -502,7 +514,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true),
+                    sanitize_instructions(&view, true, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -525,10 +537,10 @@ mod tests {
             let data = bincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
-                sanitize_instructions(&view, true),
+                sanitize_instructions(&view, true, true),
                 Err(TransactionViewError::SanitizeError)
             );
-            assert!(sanitize_instructions(&view, false).is_ok());
+            assert!(sanitize_instructions(&view, false, true).is_ok());
 
             let transaction = create_v0_transaction(
                 num_signatures,
@@ -540,10 +552,30 @@ mod tests {
             let data = bincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
-                sanitize_instructions(&view, true),
+                sanitize_instructions(&view, true, true),
                 Err(TransactionViewError::SanitizeError)
             );
-            assert!(sanitize_instructions(&view, false).is_ok());
+            assert!(sanitize_instructions(&view, false, true).is_ok());
+        }
+
+        // SIMD-406: Limit instruction accounts to 255
+        {
+            let mut accounts: Vec<u8> = vec![0; 254];
+            accounts.push(1);
+            accounts.push(2);
+            let instr = CompiledInstruction::new_from_raw_parts(2, Vec::new(), accounts);
+            let transaction = create_legacy_transaction(
+                num_signatures,
+                header,
+                account_keys.clone(),
+                vec![instr],
+            );
+            let data = bincode::serialize(&transaction).unwrap();
+            let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
+            assert_eq!(
+                sanitize_instructions(&view, false, true),
+                Err(TransactionViewError::SanitizeError)
+            );
         }
     }
 

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -42,8 +42,13 @@ impl<D: TransactionData> TransactionView<false, D> {
     pub fn sanitize(
         self,
         enable_static_instruction_limit: bool,
+        enable_instruction_accounts_limit: bool,
     ) -> Result<SanitizedTransactionView<D>> {
-        sanitize(&self, enable_static_instruction_limit)?;
+        sanitize(
+            &self,
+            enable_static_instruction_limit,
+            enable_instruction_accounts_limit,
+        )?;
         Ok(SanitizedTransactionView {
             data: self.data,
             frame: self.frame,
@@ -53,9 +58,16 @@ impl<D: TransactionData> TransactionView<false, D> {
 
 impl<D: TransactionData> TransactionView<true, D> {
     /// Creates a new `TransactionView`, running sanitization checks.
-    pub fn try_new_sanitized(data: D, enable_static_instruction_limit: bool) -> Result<Self> {
+    pub fn try_new_sanitized(
+        data: D,
+        enable_static_instruction_limit: bool,
+        enable_instruction_accounts_limit: bool,
+    ) -> Result<Self> {
         let unsanitized_view = TransactionView::try_new_unsanitized(data)?;
-        unsanitized_view.sanitize(enable_static_instruction_limit)
+        unsanitized_view.sanitize(
+            enable_static_instruction_limit,
+            enable_instruction_accounts_limit,
+        )
     }
 }
 


### PR DESCRIPTION
#### Problem

Currently, there is no restriction on how many accounts an instruction may reference. Even though transactions may be limited to 256 account keys, an instruction may reference up to `u16::MAX` keys with duplicates. In [SIMD-406](https://github.com/solana-foundation/solana-improvement-documents/pull/406), we proposed restricting the number of accounts an instruction may reference to 255 to remove complexity from runtime.

It was decided that such a check belongs in message sanitization, and the implementation fitted best in the validator code rather than the SDK (see https://github.com/anza-xyz/solana-sdk/pull/520#discussion_r2676648087).

The check only affects transactions v0 and legacy. Moreover, it will only impact top-level instructions that invoke native programs and pre-compiles, since the runtime serialization cannot serialize more than 255 accounts and will already throw an error for that case.

#### Summary of Changes

1. Create a feature gate.
2. Add the check to `fn RuntimeTransaction<SanitizedTransaction>::try_create` in `sdk_transactions.rs`.
3. Add the check to `fn sanitize_instructions` in `sanitize.rs`.
4. Fix affected code.
5. Created two tests: one in `sanitize.rs` and the other one in `bank/tests.rs`.