### PR TITLE
streamer: optionally enable early data for 0rtt connections

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -150,7 +150,7 @@ where
 {
     let sockets: Vec<_> = sockets.into_iter().collect();
     info!("Start {name} quic server on {sockets:?}");
-    let (config, _) = configure_server(keypair)?;
+    let (config, _) = configure_server(keypair, quic_server_params.enable_0rtt)?;
 
     let endpoints = sockets
         .into_iter()

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -332,7 +332,7 @@ mod tests {
         client_keypair: &Keypair,
     ) -> (Connection, Endpoint, Endpoint) {
         // Create server endpoint
-        let (server_config, _) = configure_server(server_keypair).unwrap();
+        let (server_config, _) = configure_server(server_keypair, false).unwrap();
         let server_socket = bind_to_localhost_unique().expect("should bind - server");
         let server_addr = server_socket.local_addr().unwrap();
         let server_endpoint = Endpoint::new(

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -4,7 +4,7 @@ use {
             qos::{ConnectionContext, QosController},
             quic::{ALPN_TPU_PROTOCOL_ID, DEFAULT_WAIT_FOR_CHUNK_TIMEOUT},
             simple_qos::{SimpleQos, SimpleQosConfig},
-            swqos::{SwQos, SwQosConfig},
+            swqos::{SwQos, SwQosConfig, QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS},
         },
         streamer::StakedNodes,
     },
@@ -14,7 +14,7 @@ use {
         crypto::rustls::{NoInitialCipherSuite, QuicServerConfig},
         Endpoint, IdleTimeout, ServerConfig, VarInt,
     },
-    rustls::KeyLogFile,
+    rustls::{server::ServerSessionMemoryCache, KeyLogFile},
     solana_keypair::Keypair,
     solana_packet::PACKET_DATA_SIZE,
     solana_perf::packet::PacketBatch,
@@ -88,6 +88,7 @@ pub struct SpawnServerResult {
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
 pub(crate) fn configure_server(
     identity_keypair: &Keypair,
+    enable_0rtt: bool,
 ) -> Result<(ServerConfig, String), QuicServerError> {
     let (cert, priv_key) = new_dummy_x509_certificate(identity_keypair);
     let cert_chain_pem_parts = vec![Pem {
@@ -100,6 +101,11 @@ pub(crate) fn configure_server(
         tls_server_config_builder().with_single_cert(vec![cert], priv_key)?;
     server_tls_config.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
     server_tls_config.key_log = Arc::new(KeyLogFile::new());
+    if enable_0rtt {
+        // Enable early data for 0-RTT connections
+        server_tls_config.max_early_data_size = u32::MAX;
+        server_tls_config.session_storage = ServerSessionMemoryCache::new(4096);
+    }
     let quic_server_config = QuicServerConfig::try_from(server_tls_config)?;
 
     let mut server_config = ServerConfig::with_crypto(Arc::new(quic_server_config));
@@ -115,8 +121,14 @@ pub(crate) fn configure_server(
     // set the receive window really small initially to prevent the fresh connections
     // from slamming us with traffic.
     config.receive_window((PACKET_DATA_SIZE as u32).into());
-    // disable uni_streams until handshake is complete
-    config.max_concurrent_uni_streams(0u32.into());
+
+    let initial_max_concurrent_streams = if enable_0rtt {
+        // set max concurrent streams to a small default for 0rtt
+        QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS as u32
+    } else {
+        0
+    };
+    config.max_concurrent_uni_streams(initial_max_concurrent_streams.into());
     config.receive_window(CONNECTION_RECEIVE_WINDOW_BYTES);
     let timeout = IdleTimeout::try_from(QUIC_MAX_TIMEOUT).unwrap();
     config.max_idle_timeout(Some(timeout));
@@ -155,11 +167,12 @@ pub enum QuicServerError {
 
 pub struct EndpointKeyUpdater {
     endpoints: Vec<Endpoint>,
+    enable_0rtt: bool,
 }
 
 impl NotifyKeyUpdate for EndpointKeyUpdater {
     fn update_key(&self, key: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
-        let (config, _) = configure_server(key)?;
+        let (config, _) = configure_server(key, self.enable_0rtt)?;
         for endpoint in &self.endpoints {
             endpoint.set_server_config(Some(config.clone()));
         }
@@ -574,6 +587,7 @@ pub struct QuicStreamerConfig {
     pub max_connections_per_ipaddr_per_min: u64,
     pub wait_for_chunk_timeout: Duration,
     pub num_threads: NonZeroUsize,
+    pub enable_0rtt: bool,
 }
 
 #[derive(Clone)]
@@ -594,6 +608,7 @@ impl Default for QuicStreamerConfig {
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
+            enable_0rtt: false,
         }
     }
 }
@@ -628,6 +643,7 @@ where
     Q: QosController<C> + Send + Sync + 'static,
     C: ConnectionContext + Send + Sync + 'static,
 {
+    let enable_0rtt = quic_server_params.enable_0rtt;
     let runtime = rt(format!("{thread_name}Rt"), quic_server_params.num_threads);
     let result = {
         let _guard = runtime.enter();
@@ -652,6 +668,7 @@ where
         .unwrap();
     let updater = EndpointKeyUpdater {
         endpoints: result.endpoints.clone(),
+        enable_0rtt,
     };
     Ok(SpawnServerResult {
         endpoints: result.endpoints,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1299,6 +1299,13 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .requires("retransmit_xdp_cpu_cores")
             .help("EXPERIMENTAL: Enable XDP zero copy. Requires hardware support"),
     )
+    .arg(
+        Arg::with_name("enable_tpu_quic_0rtt")
+            .hidden(hidden_unless_forced())
+            .long("enable-tpu-quic-0rtt")
+            .takes_value(false)
+            .help("EXPERIMENTAL: Enable 0-RTT for TPU QUIC connections"),
+    )
     .args(&pub_sub_config::args(/*test_validator:*/ false))
     .args(&json_rpc_config::args())
     .args(&rpc_bigtable_config::args())

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1064,10 +1064,13 @@ pub fn execute(
     // the one pushed by bootstrap.
     node.info.hot_swap_pubkey(identity_keypair.pubkey());
 
+    let enable_0rtt = matches.is_present("enable_tpu_quic_0rtt");
+
     let tpu_quic_server_config = SwQosQuicStreamerConfig {
         quic_streamer_config: QuicStreamerConfig {
             max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
             num_threads: tpu_transaction_receive_threads,
+            enable_0rtt,
             ..Default::default()
         },
         qos_config: SwQosConfig {
@@ -1087,6 +1090,7 @@ pub fn execute(
         quic_streamer_config: QuicStreamerConfig {
             max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
             num_threads: tpu_transaction_forward_receive_threads,
+            enable_0rtt,
             ..Default::default()
         },
         qos_config: SwQosConfig {
@@ -1106,6 +1110,7 @@ pub fn execute(
         quic_streamer_config: QuicStreamerConfig {
             max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
             num_threads: tpu_vote_transaction_receive_threads,
+            enable_0rtt,
             ..Default::default()
         },
         qos_config: SimpleQosConfig {


### PR DESCRIPTION
#### Problem

The change enables 0rtt connections on the streamer side. Resolves https://github.com/anza-xyz/agave/issues/1726

#### Summary of Changes

