### PR TITLE
stop using TransactionCost::SimpleVote

### DIFF
--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -927,7 +927,7 @@ mod tests {
         let programs_execution_cost = 10;
         let num_txs = 4;
 
-        let dummy_transaction = WritableKeysTransaction(vec![]);
+        let dummy_transaction = WritableKeysTransaction::new(vec![]);
         let tx_cost_results: Vec<_> = (0..num_txs)
             .map(|n| {
                 if n % 2 == 0 {

--- a/cost-model/benches/cost_tracker.rs
+++ b/cost-model/benches/cost_tracker.rs
@@ -33,7 +33,7 @@ fn setup(num_transactions: usize, contentious_transactions: bool) -> BenchSetup 
                 };
                 writable_accounts.push(writable_account_key)
             });
-            WritableKeysTransaction(writable_accounts)
+            WritableKeysTransaction::new(writable_accounts)
         })
         .collect_vec();
 

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -36,7 +36,9 @@ impl CostModel {
         transaction: &'a Tx,
         feature_set: &FeatureSet,
     ) -> TransactionCost<'a, Tx> {
-        if transaction.is_simple_vote_transaction() {
+        let stop_use_static_simple_vote_tx_cost =
+            feature_set.is_active(&feature_set::stop_use_static_simple_vote_tx_cost::id());
+        if transaction.is_simple_vote_transaction() && !stop_use_static_simple_vote_tx_cost {
             TransactionCost::SimpleVote { transaction }
         } else {
             let (programs_execution_cost, loaded_accounts_data_size_cost) =
@@ -62,7 +64,9 @@ impl CostModel {
         actual_loaded_accounts_data_size_bytes: u32,
         feature_set: &FeatureSet,
     ) -> TransactionCost<'a, Tx> {
-        if transaction.is_simple_vote_transaction() {
+        let stop_use_static_simple_vote_tx_cost =
+            feature_set.is_active(&feature_set::stop_use_static_simple_vote_tx_cost::id());
+        if transaction.is_simple_vote_transaction() && !stop_use_static_simple_vote_tx_cost {
             TransactionCost::SimpleVote { transaction }
         } else {
             let loaded_accounts_data_size_cost = Self::calculate_loaded_accounts_data_size_cost(
@@ -93,7 +97,9 @@ impl CostModel {
         num_write_locks: u64,
         feature_set: &FeatureSet,
     ) -> TransactionCost<'a, Tx> {
-        if transaction.is_simple_vote_transaction() {
+        let stop_use_static_simple_vote_tx_cost =
+            feature_set.is_active(&feature_set::stop_use_static_simple_vote_tx_cost::id());
+        if transaction.is_simple_vote_transaction() && !stop_use_static_simple_vote_tx_cost {
             return TransactionCost::SimpleVote { transaction };
         }
         let (programs_execution_cost, loaded_accounts_data_size_cost) =

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -526,7 +526,15 @@ mod tests {
     fn simple_vote_transaction_cost(
         transaction: &WritableKeysTransaction,
     ) -> TransactionCost<'_, WritableKeysTransaction> {
-        TransactionCost::SimpleVote { transaction }
+        TransactionCost::Transaction(UsageCostDetails {
+            transaction,
+            signature_cost: 1,
+            write_lock_cost: 2,
+            data_bytes_cost: 0,
+            programs_execution_cost: solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS,
+            loaded_accounts_data_size_cost: 8,
+            allocated_accounts_data_size: 0,
+        })
     }
 
     #[test]

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -495,7 +495,14 @@ mod tests {
     }
 
     fn build_simple_transaction(mint_keypair: &Keypair) -> WritableKeysTransaction {
-        WritableKeysTransaction(vec![mint_keypair.pubkey()])
+        WritableKeysTransaction::new(vec![mint_keypair.pubkey()])
+    }
+
+    fn build_simple_vote_transaction(mint_keypair: &Keypair) -> WritableKeysTransaction {
+        WritableKeysTransaction {
+            writable_keys: vec![mint_keypair.pubkey()],
+            is_simple_vote: true,
+        }
     }
 
     fn simple_usage_cost_details(
@@ -567,7 +574,7 @@ mod tests {
     #[test]
     fn test_cost_tracker_ok_add_one_vote() {
         let mint_keypair = test_setup();
-        let tx = build_simple_transaction(&mint_keypair);
+        let tx = build_simple_vote_transaction(&mint_keypair);
         let tx_cost = simple_vote_transaction_cost(&tx);
         let cost = tx_cost.sum();
 
@@ -712,10 +719,10 @@ mod tests {
         let mint_keypair = test_setup();
         // build two mocking vote transactions with diff accounts
         let second_account = Keypair::new();
-        let tx1 = build_simple_transaction(&mint_keypair);
+        let tx1 = build_simple_vote_transaction(&mint_keypair);
         let tx_cost1 = simple_vote_transaction_cost(&tx1);
         let cost1 = tx_cost1.sum();
-        let tx2 = build_simple_transaction(&second_account);
+        let tx2 = build_simple_vote_transaction(&second_account);
         let tx_cost2 = simple_vote_transaction_cost(&tx2);
         let cost2 = tx_cost2.sum();
 
@@ -819,7 +826,7 @@ mod tests {
         // | acct3 | $cost |
         // and block_cost = $cost
         {
-            let transaction = WritableKeysTransaction(vec![acct1, acct2, acct3]);
+            let transaction = WritableKeysTransaction::new(vec![acct1, acct2, acct3]);
             let tx_cost = simple_transaction_cost(&transaction, cost);
             assert!(testee.try_add(&tx_cost).is_ok());
             let (_costliest_account, costliest_account_cost) = testee.find_costliest_account();
@@ -834,7 +841,7 @@ mod tests {
         // | acct3 | $cost |
         // and block_cost = $cost * 2
         {
-            let transaction = WritableKeysTransaction(vec![acct2]);
+            let transaction = WritableKeysTransaction::new(vec![acct2]);
             let tx_cost = simple_transaction_cost(&transaction, cost);
             assert!(testee.try_add(&tx_cost).is_ok());
             let (costliest_account, costliest_account_cost) = testee.find_costliest_account();
@@ -851,7 +858,7 @@ mod tests {
         // | acct3 | $cost |
         // and block_cost = $cost * 2
         {
-            let transaction = WritableKeysTransaction(vec![acct1, acct2]);
+            let transaction = WritableKeysTransaction::new(vec![acct1, acct2]);
             let tx_cost = simple_transaction_cost(&transaction, cost);
             assert!(testee.try_add(&tx_cost).is_err());
             let (costliest_account, costliest_account_cost) = testee.find_costliest_account();
@@ -872,7 +879,7 @@ mod tests {
         let block_max = account_max * 3; // for three accts
 
         let mut testee = CostTracker::new(account_max, block_max, block_max);
-        let transaction = WritableKeysTransaction(vec![acct1, acct2, acct3]);
+        let transaction = WritableKeysTransaction::new(vec![acct1, acct2, acct3]);
         let tx_cost = simple_transaction_cost(&transaction, cost);
         let mut expected_block_cost = tx_cost.sum();
         let expected_tx_count = 1;
@@ -922,7 +929,7 @@ mod tests {
         let estimated_programs_execution_cost = 100;
         let estimated_loaded_accounts_data_size_cost = 200;
         let number_writeble_accounts = 3;
-        let transaction = WritableKeysTransaction(
+        let transaction = WritableKeysTransaction::new(
             std::iter::repeat_with(Pubkey::new_unique)
                 .take(number_writeble_accounts)
                 .collect(),
@@ -989,7 +996,7 @@ mod tests {
         let mut cost_tracker = CostTracker::default();
 
         let cost = 100u64;
-        let transaction = WritableKeysTransaction(vec![Pubkey::new_unique()]);
+        let transaction = WritableKeysTransaction::new(vec![Pubkey::new_unique()]);
         let tx_cost = simple_transaction_cost(&transaction, cost);
         cost_tracker.add_transaction_cost(&tx_cost);
         // assert cost_tracker is reverted to default
@@ -1012,7 +1019,7 @@ mod tests {
     fn test_get_cost_by_writable_accounts_post_analysis() {
         let mut cost_tracker = CostTracker::default();
         let cost = 100u64;
-        let transaction = WritableKeysTransaction(vec![Pubkey::new_unique()]);
+        let transaction = WritableKeysTransaction::new(vec![Pubkey::new_unique()]);
         let tx_cost = simple_transaction_cost(&transaction, cost);
         cost_tracker.add_transaction_cost(&tx_cost);
         let cost_by_writable_accounts = cost_tracker.get_cost_by_writable_accounts();

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -26,7 +26,7 @@ pub enum TransactionCost<'a, Tx> {
     Transaction(UsageCostDetails<'a, Tx>),
 }
 
-impl<Tx> TransactionCost<'_, Tx> {
+impl<Tx: StaticMeta> TransactionCost<'_, Tx> {
     pub fn sum(&self) -> u64 {
         #![allow(clippy::assertions_on_constants)]
         match self {
@@ -55,7 +55,9 @@ impl<Tx> TransactionCost<'_, Tx> {
     pub fn is_simple_vote(&self) -> bool {
         match self {
             Self::SimpleVote { .. } => true,
-            Self::Transaction(_) => false,
+            Self::Transaction(usage_details) => {
+                usage_details.transaction.is_simple_vote_transaction()
+            }
         }
     }
 
@@ -176,7 +178,20 @@ impl<Tx> UsageCostDetails<'_, Tx> {
 
 #[cfg(feature = "dev-context-only-utils")]
 #[derive(Debug)]
-pub struct WritableKeysTransaction(pub Vec<Pubkey>);
+pub struct WritableKeysTransaction {
+    pub writable_keys: Vec<Pubkey>,
+    pub is_simple_vote: bool,
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl WritableKeysTransaction {
+    pub fn new(writable_keys: Vec<Pubkey>) -> Self {
+        WritableKeysTransaction {
+            writable_keys,
+            is_simple_vote: false,
+        }
+    }
+}
 
 #[cfg(feature = "dev-context-only-utils")]
 impl solana_svm_transaction::svm_message::SVMStaticMessage for WritableKeysTransaction {
@@ -214,7 +229,7 @@ impl solana_svm_transaction::svm_message::SVMStaticMessage for WritableKeysTrans
     }
 
     fn static_account_keys(&self) -> &[Pubkey] {
-        &self.0
+        &self.writable_keys
     }
 
     fn fee_payer(&self) -> &Pubkey {
@@ -239,7 +254,7 @@ impl solana_svm_transaction::svm_message::SVMStaticMessage for WritableKeysTrans
 #[cfg(feature = "dev-context-only-utils")]
 impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction {
     fn account_keys(&self) -> solana_message::AccountKeys<'_> {
-        solana_message::AccountKeys::new(&self.0, None)
+        solana_message::AccountKeys::new(&self.writable_keys, None)
     }
 
     fn is_writable(&self, _index: usize) -> bool {
@@ -273,7 +288,7 @@ impl solana_runtime_transaction::transaction_meta::StaticMeta for WritableKeysTr
     }
 
     fn is_simple_vote_transaction(&self) -> bool {
-        unimplemented!("WritableKeysTransaction::is_simple_vote_transaction")
+        self.is_simple_vote
     }
 
     fn signature_details(&self) -> &solana_message::TransactionSignatureDetails {
@@ -321,6 +336,7 @@ mod tests {
         solana_transaction::{sanitized::MessageHash, versioned::VersionedTransaction},
         solana_vote::vote_transaction,
         solana_vote_program::vote_state::TowerSync,
+        test_case::test_case,
     };
 
     fn get_example_transaction() -> VersionedTransaction {
@@ -339,8 +355,9 @@ mod tests {
         VersionedTransaction::from(transaction)
     }
 
-    #[test]
-    fn test_vote_transaction_cost() {
+    #[test_case(false; "using static cost for simple vote")]
+    #[test_case(true; "not using static cost for simple vote")]
+    fn test_vote_transaction_cost(stop_use_static_simple_vote_tx_cost: bool) {
         agave_logger::setup();
 
         // Create a sanitized vote transaction.
@@ -355,8 +372,16 @@ mod tests {
         .unwrap();
 
         // Verify actual cost matches expected.
-        let vote_cost = CostModel::calculate_cost(&vote_transaction, &FeatureSet::all_enabled());
-        assert_eq!(SIMPLE_VOTE_USAGE_COST, vote_cost.sum());
+        let (feature_set, expected_cost) = if stop_use_static_simple_vote_tx_cost {
+            (FeatureSet::all_enabled(), 21443)
+        } else {
+            let mut feature_set = FeatureSet::all_enabled();
+            feature_set.deactivate(&agave_feature_set::stop_use_static_simple_vote_tx_cost::id());
+            (feature_set, SIMPLE_VOTE_USAGE_COST)
+        };
+
+        let vote_cost = CostModel::calculate_cost(&vote_transaction, &feature_set);
+        assert_eq!(expected_cost, vote_cost.sum());
     }
 
     #[test]

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1267,6 +1267,10 @@ pub mod set_lamports_per_byte_to_696 {
     pub const LAMPORTS_PER_BYTE: u64 = 696;
 }
 
+pub mod stop_use_static_simple_vote_tx_cost {
+    solana_pubkey::declare_id!("NSVt1s8oP1A9NjEc6UNcj2voeCcfzHaq4jZTiUL2Mf5");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2273,6 +2277,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             set_lamports_per_byte_to_696::id(),
             "SIMD-0437-5: Set lamports per byte to 696",
+        ),
+        (
+            stop_use_static_simple_vote_tx_cost::id(),
+            "stop use static SimpleVote transaction cost, issue #10227",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]


### PR DESCRIPTION
#### Problem

Vote will not be tracked as builtin program in cost modeling (#10199), `TransactionCost::SimpleVote` can no longer statically sets CU, and should be removed. In two steps: 
1. Stop using it with a feature gate (since TransactionCost::SimpleVote::sum() is used in block cost tracking, hence part of consensus)
2. remove then obsolete `TransactionCost::SimpleVote` from code.

#### Summary of Changes
- this PR does Step 1
- after feature activated everywhere, do step 2 to clean up code. 

Feature Gate Issue: #10227 
<!-- Don't forget to add the "feature-gate" label -->
