### PR TITLE
fix(syscalls): add missing mock_set_remaining on get epochs test

### DIFF
--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -5441,6 +5441,7 @@ mod tests {
             &program_runtime_environments,
             &sysvar_cache,
         );
+        invoke_context.mock_set_remaining(compute_budget.compute_unit_limit);
 
         let null_pointer_var = std::ptr::null::<Pubkey>() as u64;
 


### PR DESCRIPTION
#### Problem
Compute budget is set-up, but not used in `test_syscall_get_epoch_stake_total_stake`

#### Summary of Changes
Set it with `invoke_context.mock_set_remaining` similar to other tests
