### PR TITLE
agave-xdp: add AF-XDP receive path for agave-xdp

### DIFF
--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -5,8 +5,8 @@ use {
         umem::{Frame, FrameOffset},
     },
     libc::{
-        AF_INET, IF_NAMESIZE, SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, SYS_ioctl,
-        ifreq, mmap, munmap, socket, syscall, xdp_ring_offset,
+        ifreq, mmap, munmap, sendto, socket, syscall, xdp_ring_offset, AF_INET, IF_NAMESIZE,
+        SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, SYS_ioctl, XDP_RING_NEED_WAKEUP,
     },
     std::{
         ffi::{CStr, CString, c_char},
@@ -356,6 +356,111 @@ pub(crate) struct XdpDesc {
     pub(crate) addr: u64,
     pub(crate) len: u32,
     pub(crate) options: u32,
+}
+
+pub struct TxRing<F: Frame> {
+    mmap: RingMmap<XdpDesc>,
+    producer: RingProducer,
+    size: u32,
+    fd: RawFd,
+    _frame: PhantomData<F>,
+}
+
+#[derive(Debug)]
+pub struct RingFull<F: Frame>(pub F);
+
+impl<F: Frame> TxRing<F> {
+    pub (crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            producer: RingProducer::new(mmap.producer, mmap.consumer, size),
+            mmap,
+            size,
+            fd,
+            _frame: PhantomData,
+        }
+    }
+
+    pub fn write(&mut self, frame: F, options: u32) -> Result<(), RingFull<F>> {
+        let Some(index) = self.producer.produce() else {
+            return Err(RingFull(frame));
+        };
+        let index = index & self.size.saturating_sub(1);
+        unsafe {
+            let desc = self.mmap.desc.add(index as usize);
+            desc.write(XdpDesc {
+                addr: frame.offset().0 as u64,
+                len: frame.len() as u32,
+                options,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn needs_wakeup(&self) -> bool {
+        unsafe { (*self.mmap.flags).load(Ordering::Relaxed) & XDP_RING_NEED_WAKEUP != 0 }
+    }
+
+    pub fn wake(&self) -> Result<u64, io::Error> {
+        let result = unsafe { sendto(self.fd, ptr::null(), 0, libc::MSG_DONTWAIT, ptr::null(), 0) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(result as u64)
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.size as usize
+    }
+
+    pub fn available(&self) -> usize {
+        self.producer.available() as usize
+    }
+
+    pub fn commit(&mut self) {
+        self.producer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.producer.sync(commit);
+    }
+}
+
+pub struct RxRing {
+    #[allow(dead_code)]
+    mmap: RingMmap<XdpDesc>,
+    consumer: RingConsumer,
+    size: u32,
+    #[allow(dead_code)]
+    fd: RawFd,
+}
+
+impl RxRing {
+    pub (crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            consumer: RingConsumer::new(mmap.producer, mmap.consumer),
+            mmap,
+            size,
+            fd,
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.size as usize
+    }
+
+    pub fn available(&self) -> usize {
+        self.consumer.available() as usize
+    }
+
+    pub fn commit(&mut self) {
+        self.consumer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.consumer.sync(commit);
+    }
 }
 
 pub struct TxCompletionRing {

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         netlink::MacAddress,
         route::Router,
-        umem::{Frame, FrameOffset},
+        umem::{Frame, FrameOffset, SliceUmem, Umem},
     },
     libc::{
         ifreq, mmap, munmap, sendto, socket, syscall, xdp_ring_offset, AF_INET, IF_NAMESIZE,
@@ -289,6 +289,14 @@ impl RingConsumer {
         Some(index)
     }
 
+    pub fn consume_till(&mut self, offset: u32) {
+        self.cached_consumer = self.cached_consumer.wrapping_add(offset);
+    }
+
+    pub fn get_index(&self) -> u32 {
+        self.cached_consumer
+    }
+
     pub fn commit(&mut self) {
         unsafe { (*self.consumer).store(self.cached_consumer, Ordering::Release) };
     }
@@ -351,11 +359,11 @@ impl RingProducer {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone)]
-pub(crate) struct XdpDesc {
-    pub(crate) addr: u64,
-    pub(crate) len: u32,
-    pub(crate) options: u32,
+#[derive(Debug, Clone, Copy)]
+pub struct XdpDesc {
+    pub addr: u64,
+    pub len: u32,
+    pub options: u32,
 }
 
 pub struct TxRing<F: Frame> {
@@ -370,7 +378,7 @@ pub struct TxRing<F: Frame> {
 pub struct RingFull<F: Frame>(pub F);
 
 impl<F: Frame> TxRing<F> {
-    pub (crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+    pub(crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
         debug_assert!(size.is_power_of_two());
         Self {
             producer: RingProducer::new(mmap.producer, mmap.consumer, size),
@@ -436,7 +444,7 @@ pub struct RxRing {
 }
 
 impl RxRing {
-    pub (crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+    pub(crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
         debug_assert!(size.is_power_of_two());
         Self {
             consumer: RingConsumer::new(mmap.producer, mmap.consumer),
@@ -460,6 +468,31 @@ impl RxRing {
 
     pub fn sync(&mut self, commit: bool) {
         self.consumer.sync(commit);
+    }
+
+    pub fn read(&mut self) -> Option<XdpDesc> {
+        let index = self.consumer.consume()? & self.size.saturating_sub(1);
+        let desc = unsafe { ptr::read(self.mmap.desc.add(index as usize)) };
+        Some(desc)
+    }
+
+    pub fn read_batch<const N: usize>(&mut self, out: &mut [XdpDesc; N]) -> Option<usize> {
+        self.consumer.sync(true);
+
+        let avail = self.consumer.available() as usize;
+
+        let to_read = core::cmp::min(N, avail);
+        let idx = self.consumer.get_index() as usize;
+
+        for (i, slot) in out.iter_mut().enumerate().take(to_read) {
+            let ring_index = idx.wrapping_add(i) & (self.size.saturating_sub(1) as usize);
+            *slot = unsafe { *self.mmap.desc.add(ring_index) };
+        }
+
+        self.consumer.consume_till(to_read as u32);
+        self.consumer.sync(true);
+
+        Some(to_read)
     }
 }
 
@@ -498,7 +531,7 @@ pub struct RxFillRing<F: Frame> {
     mmap: RingMmap<u64>,
     producer: RingProducer,
     size: u32,
-    _fd: RawFd,
+    fd: RawFd,
     _frame: PhantomData<F>,
 }
 
@@ -509,7 +542,7 @@ impl<F: Frame> RxFillRing<F> {
             producer: RingProducer::new(mmap.producer, mmap.consumer, size),
             mmap,
             size,
-            _fd: fd,
+            fd,
             _frame: PhantomData,
         }
     }
@@ -534,6 +567,48 @@ impl<F: Frame> RxFillRing<F> {
 
     pub fn sync(&mut self, commit: bool) {
         self.producer.sync(commit);
+    }
+
+    pub fn available(&self) -> usize {
+        self.producer.available() as usize
+    }
+
+    pub fn needs_wakeup(&self) -> bool {
+        unsafe { (*self.mmap.flags).load(Ordering::Relaxed) & XDP_RING_NEED_WAKEUP != 0 }
+    }
+
+    pub fn wake(&self) -> Result<u64, io::Error> {
+        let result = unsafe { sendto(self.fd, ptr::null(), 0, libc::MSG_DONTWAIT, ptr::null(), 0) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(result as u64)
+    }
+
+    pub fn write_batch<'a>(
+        &mut self,
+        umem: &mut SliceUmem<'a>,
+        frames: &[FrameOffset],
+    ) -> Result<usize, io::Error> {
+        let n = frames.len() as u32;
+        let mask = self.size.saturating_sub(1);
+        let start_idx = self.producer.cached_producer;
+
+        for i in 0..frames.len() {
+            let Some(frame) = umem.reserve() else {
+                return Err(io::Error::other("Failed to reserve frame for RX fill ring"));
+            };
+            let ring_idx = (start_idx.wrapping_add(i as u32) & mask) as usize;
+            unsafe {
+                *self.mmap.desc.add(ring_idx) = frame.offset().0 as u64;
+            }
+        }
+
+        self.producer.cached_producer = start_idx.wrapping_add(n);
+        self.producer.cached_consumer = unsafe { (*self.mmap.consumer).load(Ordering::Acquire) };
+        self.producer.commit();
+
+        Ok(n as usize)
     }
 }
 

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -5,8 +5,8 @@ use {
         umem::{Frame, FrameOffset, SliceUmem, Umem},
     },
     libc::{
-        ifreq, mmap, munmap, sendto, socket, syscall, xdp_ring_offset, AF_INET, IF_NAMESIZE,
-        SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, SYS_ioctl, XDP_RING_NEED_WAKEUP,
+        AF_INET, IF_NAMESIZE, SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, SYS_ioctl,
+        XDP_RING_NEED_WAKEUP, ifreq, mmap, munmap, sendto, socket, syscall, xdp_ring_offset,
     },
     std::{
         ffi::{CStr, CString, c_char},

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -5,8 +5,8 @@ use {
         umem::{CompletedFrameOffset, Frame, FrameOffset},
     },
     libc::{
-        AF_INET, IF_NAMESIZE, SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, SYS_ioctl,
-        ifreq, mmap, munmap, socket, syscall, xdp_ring_offset,
+        ifreq, mmap, munmap, sendto, socket, syscall, xdp_ring_offset, AF_INET, IF_NAMESIZE,
+        SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, SYS_ioctl, XDP_RING_NEED_WAKEUP,
     },
     std::{
         ffi::{CStr, CString, c_char},
@@ -356,6 +356,111 @@ pub(crate) struct XdpDesc {
     pub(crate) addr: u64,
     pub(crate) len: u32,
     pub(crate) options: u32,
+}
+
+pub struct TxRing<F: Frame> {
+    mmap: RingMmap<XdpDesc>,
+    producer: RingProducer,
+    size: u32,
+    fd: RawFd,
+    _frame: PhantomData<F>,
+}
+
+#[derive(Debug)]
+pub struct RingFull<F: Frame>(pub F);
+
+impl<F: Frame> TxRing<F> {
+    pub (crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            producer: RingProducer::new(mmap.producer, mmap.consumer, size),
+            mmap,
+            size,
+            fd,
+            _frame: PhantomData,
+        }
+    }
+
+    pub fn write(&mut self, frame: F, options: u32) -> Result<(), RingFull<F>> {
+        let Some(index) = self.producer.produce() else {
+            return Err(RingFull(frame));
+        };
+        let index = index & self.size.saturating_sub(1);
+        unsafe {
+            let desc = self.mmap.desc.add(index as usize);
+            desc.write(XdpDesc {
+                addr: frame.offset().0 as u64,
+                len: frame.len() as u32,
+                options,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn needs_wakeup(&self) -> bool {
+        unsafe { (*self.mmap.flags).load(Ordering::Relaxed) & XDP_RING_NEED_WAKEUP != 0 }
+    }
+
+    pub fn wake(&self) -> Result<u64, io::Error> {
+        let result = unsafe { sendto(self.fd, ptr::null(), 0, libc::MSG_DONTWAIT, ptr::null(), 0) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(result as u64)
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.size as usize
+    }
+
+    pub fn available(&self) -> usize {
+        self.producer.available() as usize
+    }
+
+    pub fn commit(&mut self) {
+        self.producer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.producer.sync(commit);
+    }
+}
+
+pub struct RxRing {
+    #[allow(dead_code)]
+    mmap: RingMmap<XdpDesc>,
+    consumer: RingConsumer,
+    size: u32,
+    #[allow(dead_code)]
+    fd: RawFd,
+}
+
+impl RxRing {
+    pub (crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            consumer: RingConsumer::new(mmap.producer, mmap.consumer),
+            mmap,
+            size,
+            fd,
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.size as usize
+    }
+
+    pub fn available(&self) -> usize {
+        self.consumer.available() as usize
+    }
+
+    pub fn commit(&mut self) {
+        self.consumer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.consumer.sync(commit);
+    }
 }
 
 pub struct TxCompletionRing {

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         netlink::MacAddress,
         route::Router,
-        umem::{CompletedFrameOffset, Frame, FrameOffset, SliceUmem, Umem},
+        umem::{CompletedFrameOffset, Frame, FrameOffset},
     },
     libc::{
         AF_INET, IF_NAMESIZE, SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, SYS_ioctl,
@@ -585,22 +585,16 @@ impl<F: Frame> RxFillRing<F> {
         Ok(result as u64)
     }
 
-    pub fn write_batch<'a>(
-        &mut self,
-        umem: &mut SliceUmem<'a>,
-        frames: &[FrameOffset],
-    ) -> Result<usize, io::Error> {
+    pub fn write_batch(&mut self, frames: &[FrameOffset]) -> Result<usize, io::Error> {
         let n = frames.len() as u32;
         let mask = self.size.saturating_sub(1);
         let start_idx = self.producer.cached_producer;
 
-        for i in 0..frames.len() {
-            let Some(frame) = umem.reserve() else {
-                return Err(io::Error::other("Failed to reserve frame for RX fill ring"));
-            };
+        for (i, frame) in frames.iter().enumerate() {
             let ring_idx = (start_idx.wrapping_add(i as u32) & mask) as usize;
+            // Safety: ring_idx is masked to the ring size so the pointer is valid
             unsafe {
-                *self.mmap.desc.add(ring_idx) = frame.offset().0 as u64;
+                *self.mmap.desc.add(ring_idx) = frame.0 as u64;
             }
         }
 

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         netlink::MacAddress,
         route::Router,
-        umem::{CompletedFrameOffset, Frame, FrameOffset},
+        umem::{CompletedFrameOffset, Frame, FrameOffset, SliceUmem, Umem},
     },
     libc::{
         ifreq, mmap, munmap, sendto, socket, syscall, xdp_ring_offset, AF_INET, IF_NAMESIZE,
@@ -289,6 +289,14 @@ impl RingConsumer {
         Some(index)
     }
 
+    pub fn consume_till(&mut self, offset: u32) {
+        self.cached_consumer = self.cached_consumer.wrapping_add(offset);
+    }
+
+    pub fn get_index(&self) -> u32 {
+        self.cached_consumer
+    }
+
     pub fn commit(&mut self) {
         unsafe { (*self.consumer).store(self.cached_consumer, Ordering::Release) };
     }
@@ -351,11 +359,11 @@ impl RingProducer {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone)]
-pub(crate) struct XdpDesc {
-    pub(crate) addr: u64,
-    pub(crate) len: u32,
-    pub(crate) options: u32,
+#[derive(Debug, Clone, Copy)]
+pub struct XdpDesc {
+    pub addr: u64,
+    pub len: u32,
+    pub options: u32,
 }
 
 pub struct TxRing<F: Frame> {
@@ -370,7 +378,7 @@ pub struct TxRing<F: Frame> {
 pub struct RingFull<F: Frame>(pub F);
 
 impl<F: Frame> TxRing<F> {
-    pub (crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+    pub(crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
         debug_assert!(size.is_power_of_two());
         Self {
             producer: RingProducer::new(mmap.producer, mmap.consumer, size),
@@ -436,7 +444,7 @@ pub struct RxRing {
 }
 
 impl RxRing {
-    pub (crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+    pub(crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
         debug_assert!(size.is_power_of_two());
         Self {
             consumer: RingConsumer::new(mmap.producer, mmap.consumer),
@@ -460,6 +468,31 @@ impl RxRing {
 
     pub fn sync(&mut self, commit: bool) {
         self.consumer.sync(commit);
+    }
+
+    pub fn read(&mut self) -> Option<XdpDesc> {
+        let index = self.consumer.consume()? & self.size.saturating_sub(1);
+        let desc = unsafe { ptr::read(self.mmap.desc.add(index as usize)) };
+        Some(desc)
+    }
+
+    pub fn read_batch<const N: usize>(&mut self, out: &mut [XdpDesc; N]) -> Option<usize> {
+        self.consumer.sync(true);
+
+        let avail = self.consumer.available() as usize;
+
+        let to_read = core::cmp::min(N, avail);
+        let idx = self.consumer.get_index() as usize;
+
+        for (i, slot) in out.iter_mut().enumerate().take(to_read) {
+            let ring_index = idx.wrapping_add(i) & (self.size.saturating_sub(1) as usize);
+            *slot = unsafe { *self.mmap.desc.add(ring_index) };
+        }
+
+        self.consumer.consume_till(to_read as u32);
+        self.consumer.sync(true);
+
+        Some(to_read)
     }
 }
 
@@ -498,7 +531,7 @@ pub struct RxFillRing<F: Frame> {
     mmap: RingMmap<u64>,
     producer: RingProducer,
     size: u32,
-    _fd: RawFd,
+    fd: RawFd,
     _frame: PhantomData<F>,
 }
 
@@ -509,7 +542,7 @@ impl<F: Frame> RxFillRing<F> {
             producer: RingProducer::new(mmap.producer, mmap.consumer, size),
             mmap,
             size,
-            _fd: fd,
+            fd,
             _frame: PhantomData,
         }
     }
@@ -534,6 +567,48 @@ impl<F: Frame> RxFillRing<F> {
 
     pub fn sync(&mut self, commit: bool) {
         self.producer.sync(commit);
+    }
+
+    pub fn available(&self) -> usize {
+        self.producer.available() as usize
+    }
+
+    pub fn needs_wakeup(&self) -> bool {
+        unsafe { (*self.mmap.flags).load(Ordering::Relaxed) & XDP_RING_NEED_WAKEUP != 0 }
+    }
+
+    pub fn wake(&self) -> Result<u64, io::Error> {
+        let result = unsafe { sendto(self.fd, ptr::null(), 0, libc::MSG_DONTWAIT, ptr::null(), 0) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(result as u64)
+    }
+
+    pub fn write_batch<'a>(
+        &mut self,
+        umem: &mut SliceUmem<'a>,
+        frames: &[FrameOffset],
+    ) -> Result<usize, io::Error> {
+        let n = frames.len() as u32;
+        let mask = self.size.saturating_sub(1);
+        let start_idx = self.producer.cached_producer;
+
+        for i in 0..frames.len() {
+            let Some(frame) = umem.reserve() else {
+                return Err(io::Error::other("Failed to reserve frame for RX fill ring"));
+            };
+            let ring_idx = (start_idx.wrapping_add(i as u32) & mask) as usize;
+            unsafe {
+                *self.mmap.desc.add(ring_idx) = frame.offset().0 as u64;
+            }
+        }
+
+        self.producer.cached_producer = start_idx.wrapping_add(n);
+        self.producer.cached_consumer = unsafe { (*self.mmap.consumer).load(Ordering::Acquire) };
+        self.producer.commit();
+
+        Ok(n as usize)
     }
 }
 

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -5,8 +5,8 @@ use {
         umem::{CompletedFrameOffset, Frame, FrameOffset, SliceUmem, Umem},
     },
     libc::{
-        ifreq, mmap, munmap, sendto, socket, syscall, xdp_ring_offset, AF_INET, IF_NAMESIZE,
-        SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, SYS_ioctl, XDP_RING_NEED_WAKEUP,
+        AF_INET, IF_NAMESIZE, SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, SYS_ioctl,
+        XDP_RING_NEED_WAKEUP, ifreq, mmap, munmap, sendto, socket, syscall, xdp_ring_offset,
     },
     std::{
         ffi::{CStr, CString, c_char},

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -17,6 +17,8 @@ pub mod route;
 #[cfg(target_os = "linux")]
 pub mod route_monitor;
 #[cfg(target_os = "linux")]
+pub mod rx_loop;
+#[cfg(target_os = "linux")]
 pub mod socket;
 #[cfg(target_os = "linux")]
 pub mod tx_loop;

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -24,6 +24,8 @@ pub mod route;
 #[cfg(target_os = "linux")]
 pub mod route_monitor;
 #[cfg(target_os = "linux")]
+pub mod rx_loop;
+#[cfg(target_os = "linux")]
 pub mod socket;
 #[cfg(target_os = "linux")]
 pub mod tx_loop;

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -19,6 +19,8 @@ pub mod route;
 #[cfg(target_os = "linux")]
 pub mod route_monitor;
 #[cfg(target_os = "linux")]
+pub mod rx_loop;
+#[cfg(target_os = "linux")]
 pub mod socket;
 #[cfg(target_os = "linux")]
 pub mod tx_loop;

--- a/xdp/src/rx_loop.rs
+++ b/xdp/src/rx_loop.rs
@@ -1,0 +1,168 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+use {
+    crate::{
+        device::{NetworkDevice, QueueId, RingSizes, RxFillRing, XdpDesc},
+        set_cpu_affinity,
+        socket::{Rx, Socket},
+        umem::{FrameOffset, PageAlignedMemory, SliceUmem, SliceUmemFrame, Umem},
+    },
+    aya::{maps::XskMap, Ebpf},
+    bytes::Bytes,
+    caps::{
+        CapSet,
+        Capability::{CAP_NET_ADMIN, CAP_NET_RAW},
+    },
+    crossbeam_channel::Sender,
+    libc::{sysconf, _SC_PAGESIZE},
+    std::os::fd::AsFd,
+};
+
+const BATCH_SIZE: usize = 512;
+
+pub fn rx_loop(
+    cpu_id: usize,
+    dev: &NetworkDevice,
+    queue_id: QueueId,
+    zero_copy: bool,
+    sender: Sender<Bytes>,
+    bpf_opt: Option<&mut Ebpf>,
+) {
+    log::info!(
+        "starting xdp rx loop on {} queue {queue_id:?} cpu {cpu_id}",
+        dev.name()
+    );
+
+    set_cpu_affinity([cpu_id]).unwrap();
+
+    let frame_size = unsafe { sysconf(_SC_PAGESIZE) } as usize;
+
+    let queue = dev
+        .open_queue(queue_id)
+        .expect("failed to open queue for AF_XDP socket");
+
+    let RingSizes {
+        rx: rx_size,
+        tx: tx_size,
+    } = queue.ring_sizes().unwrap_or_else(|| {
+        log::info!(
+            "using default ring sizes for {} queue {queue_id:?}",
+            dev.name()
+        );
+        RingSizes::default()
+    });
+
+    let frame_count = (rx_size + tx_size) * 2;
+
+    const HUGE_2MB: usize = 2 * 1024 * 1024;
+    let mut memory =
+        PageAlignedMemory::alloc_with_page_size(frame_size, frame_count, HUGE_2MB, true)
+            .or_else(|_| PageAlignedMemory::alloc(frame_size, frame_count))
+            .unwrap();
+    let umem = SliceUmem::new(&mut memory, frame_size as u32).unwrap();
+
+    for cap in [CAP_NET_ADMIN, CAP_NET_RAW] {
+        caps::raise(None, CapSet::Effective, cap).unwrap();
+    }
+
+    let Ok((mut socket, rx)) = Socket::rx(queue, umem, zero_copy, rx_size * 2, rx_size) else {
+        panic!("failed to create AF_XDP socket on queue {queue_id:?}");
+    };
+
+    // Register socket in xsks_map for XDP_REDIRECT
+    if let Some(bpf) = bpf_opt {
+        let queue_id = socket.queue().id().0 as u32;
+        let fd = socket.as_fd();
+        if let Some(map) = bpf.map_mut("xsks_map") {
+            if let Ok(mut xsk_map) = XskMap::try_from(map) {
+                if let Err(e) = xsk_map.set(queue_id, fd, 0) {
+                    log::error!("Failed to set xsks_map[{queue_id}]: {e:?}");
+                }
+            }
+        }
+    }
+
+    let umem = socket.umem();
+
+    let Rx {
+        fill: mut fill_ring,
+        ring: rx_ring,
+    } = rx;
+
+    let mut rx_ring = rx_ring.unwrap();
+
+    for cap in [CAP_NET_ADMIN, CAP_NET_RAW] {
+        caps::drop(None, CapSet::Effective, cap).unwrap();
+    }
+
+    let umem_base = umem.as_ptr();
+
+    let mut descs: [XdpDesc; BATCH_SIZE] = unsafe { std::mem::zeroed() };
+    let mut frames: [FrameOffset; BATCH_SIZE] = unsafe { std::mem::zeroed() };
+
+    kick(&fill_ring);
+
+    loop {
+        let available = rx_ring.read_batch(&mut descs).unwrap_or(0);
+
+        for (chunk, frame) in descs[..available]
+            .chunks_exact(4)
+            .zip(frames[..available].chunks_exact_mut(4))
+        {
+            unsafe {
+                let p0 = umem_base.add(chunk[0].addr as usize);
+                let p1 = umem_base.add(chunk[1].addr as usize);
+                let p2 = umem_base.add(chunk[2].addr as usize);
+                let p3 = umem_base.add(chunk[3].addr as usize);
+
+                handle_packet(p0, chunk[0].len as usize, &sender);
+                handle_packet(p1, chunk[1].len as usize, &sender);
+                handle_packet(p2, chunk[2].len as usize, &sender);
+                handle_packet(p3, chunk[3].len as usize, &sender);
+
+                umem.release(FrameOffset(chunk[0].addr as usize));
+                umem.release(FrameOffset(chunk[1].addr as usize));
+                umem.release(FrameOffset(chunk[2].addr as usize));
+                umem.release(FrameOffset(chunk[3].addr as usize));
+
+                frame[0] = FrameOffset(chunk[0].addr as usize);
+                frame[1] = FrameOffset(chunk[1].addr as usize);
+                frame[2] = FrameOffset(chunk[2].addr as usize);
+                frame[3] = FrameOffset(chunk[3].addr as usize);
+            }
+        }
+
+        let _ = fill_ring.write_batch(umem, &frames);
+    }
+}
+
+#[inline(always)]
+fn kick(ring: &RxFillRing<SliceUmemFrame<'_>>) {
+    if !ring.needs_wakeup() {
+        return;
+    }
+
+    if let Err(e) = ring.wake() {
+        kick_error(e);
+    }
+}
+
+#[inline(never)]
+fn kick_error(e: std::io::Error) {
+    match e.raw_os_error() {
+        Some(libc::EBUSY | libc::ENOBUFS | libc::EAGAIN) => {}
+        Some(libc::ENETDOWN) => {
+            log::warn!("network interface is down")
+        }
+        _ => {
+            log::error!("network interface driver error: {e:?}");
+        }
+    }
+}
+
+#[inline(always)]
+unsafe fn handle_packet(raw_packet: *const u8, len: usize, sender: &Sender<Bytes>) {
+    let byte_slice = unsafe { std::slice::from_raw_parts(raw_packet, len) };
+    let bytes = Bytes::copy_from_slice(byte_slice);
+    let _ = sender.try_send(bytes);
+}

--- a/xdp/src/rx_loop.rs
+++ b/xdp/src/rx_loop.rs
@@ -7,10 +7,10 @@ use {
         socket::{Rx, Socket},
         umem::{FrameOffset, PageAlignedMemory, SliceUmem, SliceUmemFrame, Umem},
     },
-    aya::{maps::XskMap, Ebpf},
+    aya::{Ebpf, maps::XskMap},
     bytes::Bytes,
     crossbeam_channel::Sender,
-    libc::{sysconf, _SC_PAGESIZE},
+    libc::{_SC_PAGESIZE, sysconf},
     std::os::fd::AsFd,
 };
 

--- a/xdp/src/rx_loop.rs
+++ b/xdp/src/rx_loop.rs
@@ -3,10 +3,10 @@
 use {
     crate::{
         device::{NetworkDevice, QueueId, RingSizes, RxFillRing, XdpDesc},
-        set_cpu_affinity,
         socket::{Rx, Socket},
         umem::{FrameOffset, PageAlignedMemory, SliceUmem, SliceUmemFrame, Umem},
     },
+    agave_cpu_utils::{CpuId, set_cpu_affinity},
     aya::{Ebpf, maps::XskMap},
     bytes::Bytes,
     crossbeam_channel::Sender,
@@ -29,7 +29,7 @@ pub fn rx_loop(
         dev.name()
     );
 
-    set_cpu_affinity([cpu_id]).unwrap();
+    set_cpu_affinity(None, [CpuId::new(cpu_id).unwrap()]).unwrap();
 
     let frame_size = unsafe { sysconf(_SC_PAGESIZE) } as usize;
 
@@ -65,12 +65,11 @@ pub fn rx_loop(
     if let Some(bpf) = bpf_opt {
         let queue_id = socket.queue().id().0 as u32;
         let fd = socket.as_fd();
-        if let Some(map) = bpf.map_mut("xsks_map") {
-            if let Ok(mut xsk_map) = XskMap::try_from(map) {
-                if let Err(e) = xsk_map.set(queue_id, fd, 0) {
-                    log::error!("Failed to set xsks_map[{queue_id}]: {e:?}");
-                }
-            }
+        if let Some(map) = bpf.map_mut("xsks_map")
+            && let Ok(mut xsk_map) = XskMap::try_from(map)
+            && let Err(e) = xsk_map.set(queue_id, fd, 0)
+        {
+            log::error!("Failed to set xsks_map[{queue_id}]: {e:?}");
         }
     }
 

--- a/xdp/src/rx_loop.rs
+++ b/xdp/src/rx_loop.rs
@@ -93,6 +93,8 @@ pub fn rx_loop(
     loop {
         let available = rx_ring.read_batch(&mut descs).unwrap_or(0);
 
+        let mut recycled = 0usize;
+        let bulk = available & !3;
         for (chunk, frame) in descs[..available]
             .chunks_exact(4)
             .zip(frames[..available].chunks_exact_mut(4))
@@ -118,9 +120,24 @@ pub fn rx_loop(
                 frame[2] = FrameOffset(chunk[2].addr as usize);
                 frame[3] = FrameOffset(chunk[3].addr as usize);
             }
+            recycled += 4;
         }
 
-        let _ = fill_ring.write_batch(umem, &frames);
+        // remainder of packets not divisible by 4
+        if bulk != available {
+            for d in &descs[bulk..available] {
+                unsafe {
+                    let p = umem_base.add(d.addr as usize);
+                    handle_packet(p, d.len as usize, &sender);
+                }
+                let off = FrameOffset(d.addr as usize);
+                umem.release(off);
+                frames[recycled] = off;
+                recycled += 1;
+            }
+        }
+
+        let _ = fill_ring.write_batch(umem, &frames[..recycled]);
     }
 }
 

--- a/xdp/src/rx_loop.rs
+++ b/xdp/src/rx_loop.rs
@@ -57,7 +57,7 @@ pub fn rx_loop(
             .unwrap();
     let umem = SliceUmem::new(&mut memory, frame_size as u32).unwrap();
 
-    let Ok((mut socket, rx)) = Socket::rx(queue, umem, zero_copy, rx_size * 2, rx_size) else {
+    let Ok((socket, rx)) = Socket::rx(queue, umem, zero_copy, rx_size * 2, rx_size) else {
         panic!("failed to create AF_XDP socket on queue {queue_id:?}");
     };
 
@@ -95,8 +95,10 @@ pub fn rx_loop(
         let mut recycled = 0usize;
         let bulk = available & !3;
         for (chunk, frame) in descs[..available]
-            .chunks_exact(4)
-            .zip(frames[..available].chunks_exact_mut(4))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .zip(frames[..available].as_chunks_mut::<4>().0.iter_mut())
         {
             unsafe {
                 let p0 = umem_base.add(chunk[0].addr as usize);
@@ -108,17 +110,13 @@ pub fn rx_loop(
                 handle_packet(p1, chunk[1].len as usize, &sender);
                 handle_packet(p2, chunk[2].len as usize, &sender);
                 handle_packet(p3, chunk[3].len as usize, &sender);
-
-                umem.release(FrameOffset(chunk[0].addr as usize));
-                umem.release(FrameOffset(chunk[1].addr as usize));
-                umem.release(FrameOffset(chunk[2].addr as usize));
-                umem.release(FrameOffset(chunk[3].addr as usize));
-
-                frame[0] = FrameOffset(chunk[0].addr as usize);
-                frame[1] = FrameOffset(chunk[1].addr as usize);
-                frame[2] = FrameOffset(chunk[2].addr as usize);
-                frame[3] = FrameOffset(chunk[3].addr as usize);
             }
+
+            // recycle the frames straight back into the fill ring
+            frame[0] = FrameOffset(chunk[0].addr as usize);
+            frame[1] = FrameOffset(chunk[1].addr as usize);
+            frame[2] = FrameOffset(chunk[2].addr as usize);
+            frame[3] = FrameOffset(chunk[3].addr as usize);
             recycled += 4;
         }
 
@@ -129,14 +127,12 @@ pub fn rx_loop(
                     let p = umem_base.add(d.addr as usize);
                     handle_packet(p, d.len as usize, &sender);
                 }
-                let off = FrameOffset(d.addr as usize);
-                umem.release(off);
-                frames[recycled] = off;
+                frames[recycled] = FrameOffset(d.addr as usize);
                 recycled += 1;
             }
         }
 
-        let _ = fill_ring.write_batch(umem, &frames[..recycled]);
+        let _ = fill_ring.write_batch(&frames[..recycled]);
     }
 }
 

--- a/xdp/src/socket.rs
+++ b/xdp/src/socket.rs
@@ -1,26 +1,21 @@
 use {
     crate::{
         device::{
-            DeviceQueue, RingConsumer, RingMmap, RingProducer, RxFillRing, TxCompletionRing,
-            XdpDesc, mmap_ring,
+            mmap_ring, DeviceQueue, RxFillRing, RxRing, TxCompletionRing, TxRing, XdpDesc,
         },
         umem::{Frame, Umem},
     },
     libc::{
-        AF_XDP, SOCK_RAW, SOL_XDP, XDP_COPY, XDP_MMAP_OFFSETS, XDP_PGOFF_RX_RING,
-        XDP_PGOFF_TX_RING, XDP_RING_NEED_WAKEUP, XDP_RX_RING, XDP_TX_RING,
+        bind, getsockopt, sa_family_t, setsockopt, sockaddr, sockaddr_xdp, socket,
+        socklen_t, xdp_mmap_offsets, xdp_umem_reg, AF_XDP, SOCK_RAW, SOL_XDP, XDP_COPY,
+        XDP_MMAP_OFFSETS, XDP_PGOFF_RX_RING, XDP_PGOFF_TX_RING, XDP_RX_RING, XDP_TX_RING,
         XDP_UMEM_COMPLETION_RING, XDP_UMEM_FILL_RING, XDP_UMEM_PGOFF_COMPLETION_RING,
-        XDP_UMEM_PGOFF_FILL_RING, XDP_USE_NEED_WAKEUP, XDP_ZEROCOPY, bind, getsockopt, sa_family_t,
-        sendto, setsockopt, sockaddr, sockaddr_xdp, socket, socklen_t, xdp_mmap_offsets,
-        xdp_umem_reg,
+        XDP_UMEM_PGOFF_FILL_RING, XDP_USE_NEED_WAKEUP, XDP_ZEROCOPY,
     },
     std::{
         io,
-        marker::PhantomData,
         mem,
-        os::fd::{AsFd, AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd, RawFd},
-        ptr,
-        sync::atomic::Ordering,
+        os::fd::{AsFd, AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd},
     },
 };
 
@@ -265,109 +260,4 @@ pub struct Tx<F: Frame> {
 pub struct Rx<F: Frame> {
     pub fill: RxFillRing<F>,
     pub ring: Option<RxRing>,
-}
-
-pub struct TxRing<F: Frame> {
-    mmap: RingMmap<XdpDesc>,
-    producer: RingProducer,
-    size: u32,
-    fd: RawFd,
-    _frame: PhantomData<F>,
-}
-
-#[derive(Debug)]
-pub struct RingFull<F: Frame>(pub F);
-
-impl<F: Frame> TxRing<F> {
-    fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
-        debug_assert!(size.is_power_of_two());
-        Self {
-            producer: RingProducer::new(mmap.producer, mmap.consumer, size),
-            mmap,
-            size,
-            fd,
-            _frame: PhantomData,
-        }
-    }
-
-    pub fn write(&mut self, frame: F, options: u32) -> Result<(), RingFull<F>> {
-        let Some(index) = self.producer.produce() else {
-            return Err(RingFull(frame));
-        };
-        let index = index & self.size.saturating_sub(1);
-        unsafe {
-            let desc = self.mmap.desc.add(index as usize);
-            desc.write(XdpDesc {
-                addr: frame.offset().0 as u64,
-                len: frame.len() as u32,
-                options,
-            });
-        }
-        Ok(())
-    }
-
-    pub fn needs_wakeup(&self) -> bool {
-        unsafe { (*self.mmap.flags).load(Ordering::Relaxed) & XDP_RING_NEED_WAKEUP != 0 }
-    }
-
-    pub fn wake(&self) -> Result<u64, io::Error> {
-        let result = unsafe { sendto(self.fd, ptr::null(), 0, libc::MSG_DONTWAIT, ptr::null(), 0) };
-        if result < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        Ok(result as u64)
-    }
-
-    pub fn capacity(&self) -> usize {
-        self.size as usize
-    }
-
-    pub fn available(&self) -> usize {
-        self.producer.available() as usize
-    }
-
-    pub fn commit(&mut self) {
-        self.producer.commit();
-    }
-
-    pub fn sync(&mut self, commit: bool) {
-        self.producer.sync(commit);
-    }
-}
-
-pub struct RxRing {
-    #[allow(dead_code)]
-    mmap: RingMmap<XdpDesc>,
-    consumer: RingConsumer,
-    size: u32,
-    #[allow(dead_code)]
-    fd: RawFd,
-}
-
-impl RxRing {
-    fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
-        debug_assert!(size.is_power_of_two());
-        Self {
-            consumer: RingConsumer::new(mmap.producer, mmap.consumer),
-            mmap,
-            size,
-            fd,
-        }
-    }
-
-    pub fn capacity(&self) -> usize {
-        self.size as usize
-    }
-
-    pub fn available(&self) -> usize {
-        self.consumer.available() as usize
-    }
-
-    pub fn commit(&mut self) {
-        self.consumer.commit();
-    }
-
-    pub fn sync(&mut self, commit: bool) {
-        self.consumer.sync(commit);
-    }
 }

--- a/xdp/src/socket.rs
+++ b/xdp/src/socket.rs
@@ -1,20 +1,17 @@
 use {
     crate::{
-        device::{
-            mmap_ring, DeviceQueue, RxFillRing, RxRing, TxCompletionRing, TxRing, XdpDesc,
-        },
+        device::{mmap_ring, DeviceQueue, RxFillRing, RxRing, TxCompletionRing, TxRing, XdpDesc},
         umem::{Frame, Umem},
     },
     libc::{
-        bind, getsockopt, sa_family_t, setsockopt, sockaddr, sockaddr_xdp, socket,
-        socklen_t, xdp_mmap_offsets, xdp_umem_reg, AF_XDP, SOCK_RAW, SOL_XDP, XDP_COPY,
-        XDP_MMAP_OFFSETS, XDP_PGOFF_RX_RING, XDP_PGOFF_TX_RING, XDP_RX_RING, XDP_TX_RING,
-        XDP_UMEM_COMPLETION_RING, XDP_UMEM_FILL_RING, XDP_UMEM_PGOFF_COMPLETION_RING,
-        XDP_UMEM_PGOFF_FILL_RING, XDP_USE_NEED_WAKEUP, XDP_ZEROCOPY,
+        bind, getsockopt, sa_family_t, setsockopt, sockaddr, sockaddr_xdp, socket, socklen_t,
+        xdp_mmap_offsets, xdp_umem_reg, AF_XDP, SOCK_RAW, SOL_XDP, XDP_COPY, XDP_MMAP_OFFSETS,
+        XDP_PGOFF_RX_RING, XDP_PGOFF_TX_RING, XDP_RX_RING, XDP_TX_RING, XDP_UMEM_COMPLETION_RING,
+        XDP_UMEM_FILL_RING, XDP_UMEM_PGOFF_COMPLETION_RING, XDP_UMEM_PGOFF_FILL_RING,
+        XDP_USE_NEED_WAKEUP, XDP_ZEROCOPY,
     },
     std::{
-        io,
-        mem,
+        io, mem,
         os::fd::{AsFd, AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd},
     },
 };

--- a/xdp/src/socket.rs
+++ b/xdp/src/socket.rs
@@ -1,14 +1,14 @@
 use {
     crate::{
-        device::{mmap_ring, DeviceQueue, RxFillRing, RxRing, TxCompletionRing, TxRing, XdpDesc},
+        device::{DeviceQueue, RxFillRing, RxRing, TxCompletionRing, TxRing, XdpDesc, mmap_ring},
         umem::{Frame, Umem},
     },
     libc::{
-        bind, getsockopt, sa_family_t, setsockopt, sockaddr, sockaddr_xdp, socket, socklen_t,
-        xdp_mmap_offsets, xdp_umem_reg, AF_XDP, SOCK_RAW, SOL_XDP, XDP_COPY, XDP_MMAP_OFFSETS,
-        XDP_PGOFF_RX_RING, XDP_PGOFF_TX_RING, XDP_RX_RING, XDP_TX_RING, XDP_UMEM_COMPLETION_RING,
-        XDP_UMEM_FILL_RING, XDP_UMEM_PGOFF_COMPLETION_RING, XDP_UMEM_PGOFF_FILL_RING,
-        XDP_USE_NEED_WAKEUP, XDP_ZEROCOPY,
+        AF_XDP, SOCK_RAW, SOL_XDP, XDP_COPY, XDP_MMAP_OFFSETS, XDP_PGOFF_RX_RING,
+        XDP_PGOFF_TX_RING, XDP_RX_RING, XDP_TX_RING, XDP_UMEM_COMPLETION_RING, XDP_UMEM_FILL_RING,
+        XDP_UMEM_PGOFF_COMPLETION_RING, XDP_UMEM_PGOFF_FILL_RING, XDP_USE_NEED_WAKEUP,
+        XDP_ZEROCOPY, bind, getsockopt, sa_family_t, setsockopt, sockaddr, sockaddr_xdp, socket,
+        socklen_t, xdp_mmap_offsets, xdp_umem_reg,
     },
     std::{
         io, mem,

--- a/xdp/src/socket.rs
+++ b/xdp/src/socket.rs
@@ -1,26 +1,21 @@
 use {
     crate::{
         device::{
-            DeviceQueue, RingConsumer, RingMmap, RingProducer, RxFillRing, TxCompletionRing,
-            XdpDesc, mmap_ring,
+            mmap_ring, DeviceQueue, RxFillRing, RxRing, TxCompletionRing, TxRing, XdpDesc,
         },
         umem::{Frame, Umem},
     },
     libc::{
-        AF_XDP, SOCK_RAW, SOL_XDP, XDP_COPY, XDP_MMAP_OFFSETS, XDP_PGOFF_RX_RING,
-        XDP_PGOFF_TX_RING, XDP_RING_NEED_WAKEUP, XDP_RX_RING, XDP_TX_RING,
+        bind, getsockopt, sa_family_t, setsockopt, sockaddr, sockaddr_xdp, socket,
+        socklen_t, xdp_mmap_offsets, xdp_umem_reg, AF_XDP, SOCK_RAW, SOL_XDP, XDP_COPY,
+        XDP_MMAP_OFFSETS, XDP_PGOFF_RX_RING, XDP_PGOFF_TX_RING, XDP_RX_RING, XDP_TX_RING,
         XDP_UMEM_COMPLETION_RING, XDP_UMEM_FILL_RING, XDP_UMEM_PGOFF_COMPLETION_RING,
-        XDP_UMEM_PGOFF_FILL_RING, XDP_USE_NEED_WAKEUP, XDP_ZEROCOPY, bind, getsockopt, sa_family_t,
-        sendto, setsockopt, sockaddr, sockaddr_xdp, socket, socklen_t, xdp_mmap_offsets,
-        xdp_umem_reg,
+        XDP_UMEM_PGOFF_FILL_RING, XDP_USE_NEED_WAKEUP, XDP_ZEROCOPY,
     },
     std::{
         io,
-        marker::PhantomData,
         mem,
-        os::fd::{AsFd, AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd, RawFd},
-        ptr,
-        sync::atomic::Ordering,
+        os::fd::{AsFd, AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd},
     },
 };
 
@@ -44,11 +39,7 @@ impl<U: Umem> Socket<U> {
         unsafe {
             let fd = socket(AF_XDP, SOCK_RAW, 0);
             if fd < 0 {
-                return Err(Error::syscall(
-                    "socket(AF_XDP, SOCK_RAW) failed",
-                    io::Error::last_os_error(),
-                )
-                .into());
+                return Err(io::Error::last_os_error());
             }
             let fd = OwnedFd::from_raw_fd(fd);
 
@@ -69,11 +60,7 @@ impl<U: Umem> Socket<U> {
                 mem::size_of::<xdp_umem_reg>() as libc::socklen_t,
             ) < 0
             {
-                return Err(Error::syscall(
-                    "setsockopt(XDP_UMEM_REG) failed",
-                    io::Error::last_os_error(),
-                )
-                .into());
+                return Err(io::Error::last_os_error());
             }
 
             for (ring, size) in [
@@ -95,11 +82,7 @@ impl<U: Umem> Socket<U> {
                     mem::size_of::<u32>() as socklen_t,
                 ) < 0
                 {
-                    return Err(Error::syscall(
-                        format!("setsockopt(SOL_XDP, ring={ring}, size={size}) failed",),
-                        io::Error::last_os_error(),
-                    )
-                    .into());
+                    return Err(io::Error::last_os_error());
                 }
             }
 
@@ -113,11 +96,7 @@ impl<U: Umem> Socket<U> {
                 &mut optlen,
             ) < 0
             {
-                return Err(Error::syscall(
-                    "getsockopt(XDP_MMAP_OFFSETS) failed",
-                    io::Error::last_os_error(),
-                )
-                .into());
+                return Err(io::Error::last_os_error());
             }
 
             let tx_completion_ring = TxCompletionRing::new(
@@ -126,8 +105,7 @@ impl<U: Umem> Socket<U> {
                     tx_completion_ring_size.saturating_mul(mem::size_of::<u64>()),
                     &offsets.cr,
                     XDP_UMEM_PGOFF_COMPLETION_RING,
-                )
-                .map_err(|source| Error::syscall("mmap completion ring failed", source))?,
+                )?,
                 tx_completion_ring_size as u32,
             );
 
@@ -137,8 +115,7 @@ impl<U: Umem> Socket<U> {
                     rx_fill_ring_size.saturating_mul(mem::size_of::<u64>()),
                     &offsets.fr,
                     XDP_UMEM_PGOFF_FILL_RING,
-                )
-                .map_err(|source| Error::syscall("mmap fill ring failed", source))?,
+                )?,
                 rx_fill_ring_size as u32,
                 fd.as_raw_fd(),
             );
@@ -148,15 +125,9 @@ impl<U: Umem> Socket<U> {
                 // pre-populated before calling bind()
                 for _ in 0..rx_fill_ring_size {
                     let Some(frame) = umem.reserve() else {
-                        return Err(Error::InsufficientUmemFrames {
-                            required: rx_fill_ring_size,
-                            available: umem.available(),
-                        }
-                        .into());
+                        return Err(io::Error::other("Failed to reserve frame for RX fill ring"));
                     };
-                    rx_fill_ring
-                        .write(frame)
-                        .map_err(|source| Error::syscall("RX fill ring write failed", source))?;
+                    rx_fill_ring.write(frame)?;
                 }
                 rx_fill_ring.commit();
             }
@@ -167,8 +138,7 @@ impl<U: Umem> Socket<U> {
                     tx_ring_size.saturating_mul(mem::size_of::<XdpDesc>()),
                     &offsets.tx,
                     XDP_PGOFF_TX_RING as u64,
-                )
-                .map_err(|source| Error::syscall("mmap tx ring failed", source))?,
+                )?,
                 tx_ring_size as u32,
                 fd.as_raw_fd(),
             ));
@@ -180,8 +150,7 @@ impl<U: Umem> Socket<U> {
                         rx_ring_size.saturating_mul(mem::size_of::<XdpDesc>()),
                         &offsets.rx,
                         XDP_PGOFF_RX_RING as u64,
-                    )
-                    .map_err(|source| Error::syscall("mmap rx ring failed", source))?,
+                    )?,
                     rx_ring_size as u32,
                     fd.as_raw_fd(),
                 ))
@@ -204,14 +173,7 @@ impl<U: Umem> Socket<U> {
                 mem::size_of::<sockaddr_xdp>() as socklen_t,
             ) < 0
             {
-                return Err(Error::syscall(
-                    format!(
-                        "bind(AF_XDP, ifindex={}, queue={}, flags=0x{:x}) failed",
-                        sxdp.sxdp_ifindex, sxdp.sxdp_queue_id, sxdp.sxdp_flags
-                    ),
-                    io::Error::last_os_error(),
-                )
-                .into());
+                return Err(io::Error::last_os_error());
             }
 
             let tx = Tx {
@@ -298,139 +260,4 @@ pub struct Tx<F: Frame> {
 pub struct Rx<F: Frame> {
     pub fill: RxFillRing<F>,
     pub ring: Option<RxRing>,
-}
-
-pub struct TxRing<F: Frame> {
-    mmap: RingMmap<XdpDesc>,
-    producer: RingProducer,
-    size: u32,
-    fd: RawFd,
-    _frame: PhantomData<F>,
-}
-
-#[derive(Debug)]
-pub struct RingFull<F: Frame>(pub F);
-
-impl<F: Frame> TxRing<F> {
-    fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
-        debug_assert!(size.is_power_of_two());
-        Self {
-            producer: RingProducer::new(mmap.producer, mmap.consumer, size),
-            mmap,
-            size,
-            fd,
-            _frame: PhantomData,
-        }
-    }
-
-    pub fn write(&mut self, frame: F, options: u32) -> Result<(), RingFull<F>> {
-        let Some(index) = self.producer.produce() else {
-            return Err(RingFull(frame));
-        };
-        let index = index & self.size.saturating_sub(1);
-        unsafe {
-            let desc = self.mmap.desc.add(index as usize);
-            desc.write(XdpDesc {
-                addr: frame.offset().0 as u64,
-                len: frame.len() as u32,
-                options,
-            });
-        }
-        Ok(())
-    }
-
-    pub fn needs_wakeup(&self) -> bool {
-        unsafe { (*self.mmap.flags).load(Ordering::Relaxed) & XDP_RING_NEED_WAKEUP != 0 }
-    }
-
-    pub fn wake(&self) -> Result<u64, io::Error> {
-        let result = unsafe { sendto(self.fd, ptr::null(), 0, libc::MSG_DONTWAIT, ptr::null(), 0) };
-        if result < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        Ok(result as u64)
-    }
-
-    pub fn capacity(&self) -> usize {
-        self.size as usize
-    }
-
-    pub fn available(&self) -> usize {
-        self.producer.available() as usize
-    }
-
-    pub fn commit(&mut self) {
-        self.producer.commit();
-    }
-
-    pub fn sync(&mut self, commit: bool) {
-        self.producer.sync(commit);
-    }
-}
-
-pub struct RxRing {
-    #[allow(dead_code)]
-    mmap: RingMmap<XdpDesc>,
-    consumer: RingConsumer,
-    size: u32,
-    #[allow(dead_code)]
-    fd: RawFd,
-}
-
-impl RxRing {
-    fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
-        debug_assert!(size.is_power_of_two());
-        Self {
-            consumer: RingConsumer::new(mmap.producer, mmap.consumer),
-            mmap,
-            size,
-            fd,
-        }
-    }
-
-    pub fn capacity(&self) -> usize {
-        self.size as usize
-    }
-
-    pub fn available(&self) -> usize {
-        self.consumer.available() as usize
-    }
-
-    pub fn commit(&mut self) {
-        self.consumer.commit();
-    }
-
-    pub fn sync(&mut self, commit: bool) {
-        self.consumer.sync(commit);
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-enum Error {
-    #[error("{message}: {source}")]
-    Syscall {
-        message: String,
-        #[source]
-        source: io::Error,
-    },
-    #[error(
-        "insufficient UMEM frames for RX fill ring prefill: required={required}, \
-         available={available}"
-    )]
-    InsufficientUmemFrames { required: usize, available: usize },
-}
-
-impl Error {
-    fn syscall(message: impl Into<String>, source: io::Error) -> Self {
-        Self::Syscall {
-            message: message.into(),
-            source,
-        }
-    }
-}
-
-impl From<Error> for io::Error {
-    fn from(error: Error) -> io::Error {
-        io::Error::other(error)
-    }
 }

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        device::{DeviceQueue, NetworkDevice, QueueId, RingSizes, TxCompletionRing},
+        device::{DeviceQueue, NetworkDevice, QueueId, RingSizes, TxCompletionRing, TxRing},
         gre::{construct_gre_packet, gre_packet_size},
         netlink::MacAddress,
         packet::{
@@ -11,7 +11,7 @@ use {
         },
         route::NextHop,
         set_cpu_affinity,
-        socket::{Socket, Tx, TxRing},
+        socket::{Socket, Tx},
         umem::{Frame, OwnedUmem, PageAlignedMemory, Umem},
     },
     crossbeam_channel::{Receiver, Sender, TryRecvError},

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        device::{DeviceQueue, NetworkDevice, QueueId, RingSizes, TxCompletionRing},
+        device::{DeviceQueue, NetworkDevice, QueueId, RingSizes, TxCompletionRing, TxRing},
         ecn_codepoint::EcnCodepoint,
         gre::{
             construct_gre_packet, gre_packet_size,
@@ -14,7 +14,7 @@ use {
             construct_packet, construct_vlan_packet,
         },
         route::NextHop,
-        socket::{Socket, Tx, TxRing},
+        socket::{Socket, Tx},
         umem::{Frame, OwnedUmem, PageAlignedMemory, Umem},
     },
     agave_cpu_utils::set_cpu_affinity,


### PR DESCRIPTION
#### Problem
agave-xdp crate only contained the tx path represented by `tx_loop()` so it could only transmit, there was no receiver. This PR add a receiver via `rx_loop()`, also add helpers to read and write packets in batches.


#### Summary of Changes

- added `rx_loop()`
- added `read_batch()` in `RxRing`
- added `write_batch()` in `RxFillRing`
- Added helper methods: `consume_till()`, `get_index()` on RingConsumer
- Added `available()`, `needs_wakeup()`, `wake()` methods for RxFillRing.
- `kick()` / `kick_error()`: Driver wakeup helpers
- `handle_packet()`: Copies packet bytes to channel sender (simplest way)
- Made `XdpDesc` public with `Copy` trait for batch operations


pinging @alessandrod 
