### PR TITLE
refactor(ledger): remove bank_forks_utils::load

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -58,9 +58,6 @@ pub enum BankForksUtilsError {
 
     #[error("failed to process blockstore from genesis: {0}")]
     ProcessBlockstoreFromGenesis(#[source] BlockstoreProcessorError),
-
-    #[error("failed to process blockstore from root: {0}")]
-    ProcessBlockstoreFromRoot(#[source] BlockstoreProcessorError),
 }
 
 pub type LoadResult = result::Result<

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -72,47 +72,10 @@ pub type LoadResult = result::Result<
     BankForksUtilsError,
 >;
 
-/// Load the banks via genesis or a snapshot then processes all full blocks in blockstore
+/// Load the banks via genesis or a snapshot
 ///
-/// If a snapshot config is given, and a snapshot is found, it will be loaded.  Otherwise, load
+/// If a snapshot config is given, and a snapshot is found, it will be loaded. Otherwise, load
 /// from genesis.
-#[allow(clippy::too_many_arguments)]
-pub fn load(
-    genesis_config: &GenesisConfig,
-    blockstore: &Blockstore,
-    account_paths: Vec<PathBuf>,
-    snapshot_config: &SnapshotConfig,
-    process_options: ProcessOptions,
-    transaction_status_sender: Option<&TransactionStatusSender>,
-    entry_notification_sender: Option<&EntryNotifierSender>,
-    accounts_update_notifier: Option<AccountsUpdateNotifier>,
-    exit: Arc<AtomicBool>,
-) -> LoadResult {
-    let (bank_forks, leader_schedule_cache, starting_snapshot_hashes, ..) = load_bank_forks(
-        genesis_config,
-        blockstore,
-        account_paths,
-        snapshot_config,
-        &process_options,
-        transaction_status_sender,
-        entry_notification_sender,
-        accounts_update_notifier,
-        exit,
-    )?;
-    blockstore_processor::process_blockstore_from_root(
-        blockstore,
-        &bank_forks,
-        &leader_schedule_cache,
-        &process_options,
-        transaction_status_sender,
-        entry_notification_sender,
-        None, // snapshot_controller
-    )
-    .map_err(BankForksUtilsError::ProcessBlockstoreFromRoot)?;
-
-    Ok((bank_forks, leader_schedule_cache, starting_snapshot_hashes))
-}
-
 #[allow(clippy::too_many_arguments)]
 pub fn load_bank_forks(
     genesis_config: &GenesisConfig,


### PR DESCRIPTION
#### Problem
`bank_forks_utils::load` is not used in production and is a trival wrapper for `bank_forks_utils::load_bank_forks` + processing. It gets in a way to refactoring `load_bank_forks` (e.g. to split loading from snapshot vs genesis).

#### Summary of Changes
Inline it in the only place where it's used: local cluster test.
