### PR TITLE
Bump rust to 1.92

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2025-09-14
+  nightly_version=2025-10-25
 fi
 
 

--- a/programs/sbf/rust/128bit/src/lib.rs
+++ b/programs/sbf/rust/128bit/src/lib.rs
@@ -10,7 +10,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     let y = x.rotate_right(1);
     assert_eq!(y, 170_141_183_460_469_231_731_687_303_715_884_105_728);
 
-    #[allow(clippy::eq_op)]
+    #[expect(clippy::eq_op)]
     {
         assert_eq!(
             u128::MAX,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.92.0"


### PR DESCRIPTION
#### Problem
[Rust 1.92](https://releases.rs/docs/1.92.0/) release is available.

#### Summary of Changes
Switch agave to
* stable rust 1.92
* nightly 2025-10-25

Switch warning from allowed to expected in `programs/sbf` (note: one of the added warnings isn't updated, since it's a bug in the rust 1.92 compiler, which goes away in 1.93 and it is also tooling dependent failing `stable-sbf` test - it should be removed soon instead).

Fixes #10219
