### PR TITLE
streamer: remove useless type conversion

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -61,10 +61,6 @@ const CONNECTION_CLOSE_REASON_DROPPED_ENTRY: &[u8] = b"dropped";
 pub(crate) const CONNECTION_CLOSE_CODE_DISALLOWED: u32 = 2;
 pub(crate) const CONNECTION_CLOSE_REASON_DISALLOWED: &[u8] = b"disallowed";
 
-pub(crate) const CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT: u32 = 3;
-pub(crate) const CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT: &[u8] =
-    b"exceed_max_stream_count";
-
 const CONNECTION_CLOSE_CODE_TOO_MANY: u32 = 4;
 const CONNECTION_CLOSE_REASON_TOO_MANY: &[u8] = b"too_many";
 
@@ -414,7 +410,6 @@ pub fn get_connection_stake(
 #[derive(Debug)]
 pub(crate) enum ConnectionHandlerError {
     ConnectionAddError,
-    MaxStreamError,
 }
 
 pub(crate) fn update_open_connections_stat<S: OpaqueStreamerCounter>(

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -6,8 +6,7 @@ use {
                 get_connection_stake, update_open_connections_stat, ClientConnectionTracker,
                 ConnectionHandlerError, ConnectionPeerType, ConnectionTable, ConnectionTableKey,
                 ConnectionTableType, CONNECTION_CLOSE_CODE_DISALLOWED,
-                CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT, CONNECTION_CLOSE_REASON_DISALLOWED,
-                CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT,
+                CONNECTION_CLOSE_REASON_DISALLOWED,
             },
             stream_throttle::{
                 throttle_stream, ConnectionStreamCounter, StakedStreamLoadEMA,
@@ -38,22 +37,22 @@ use {
 // Empirically found max number of concurrent streams
 // that seems to maximize TPS on GCE (higher values don't seem to
 // give significant improvement or seem to impact stability)
-pub const QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS: usize = 128;
-pub const QUIC_MIN_STAKED_CONCURRENT_STREAMS: usize = 128;
+pub const QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS: u32 = 128;
+pub const QUIC_MIN_STAKED_CONCURRENT_STREAMS: u32 = 128;
 
 // Set the maximum concurrent stream numbers to avoid excessive streams.
 // The value was lowered from 2048 to reduce contention of the limited
 // receive_window among the streams which is observed in CI bench-tests with
 // forwarded packets from staked nodes.
-pub const QUIC_MAX_STAKED_CONCURRENT_STREAMS: usize = 512;
+pub const QUIC_MAX_STAKED_CONCURRENT_STREAMS: u32 = 512;
 
-pub const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: usize = 100_000;
+pub const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: u32 = 100_000;
 
 /// RTT after which we start BDP scaling
-const REFERENCE_RTT_MS: u64 = 50;
+const REFERENCE_RTT_MS: u32 = 50;
 
 /// Above this RTT we stop scaling for BDP
-const MAX_RTT_MS: u64 = 350;
+const MAX_RTT_MS: u32 = 350;
 
 #[derive(Clone)]
 pub struct SwQosConfig {
@@ -147,10 +146,10 @@ impl SwQos {
 }
 
 fn compute_max_allowed_uni_streams_with_rtt(
-    rtt_millis: u64,
+    rtt_millis: u32,
     peer_type: ConnectionPeerType,
     total_stake: u64,
-) -> usize {
+) -> u32 {
     let streams = match peer_type {
         ConnectionPeerType::Staked(peer_stake) => {
             // No checked math for f64 type. So let's explicitly check for 0 here
@@ -165,7 +164,7 @@ fn compute_max_allowed_uni_streams_with_rtt(
                 let delta = (QUIC_TOTAL_STAKED_CONCURRENT_STREAMS
                     - QUIC_MIN_STAKED_CONCURRENT_STREAMS) as f64;
 
-                (((peer_stake as f64 / total_stake as f64) * delta) as usize
+                (((peer_stake as f64 / total_stake as f64) * delta) as u32
                     + QUIC_MIN_STAKED_CONCURRENT_STREAMS)
                     .clamp(
                         QUIC_MIN_STAKED_CONCURRENT_STREAMS,
@@ -177,7 +176,7 @@ fn compute_max_allowed_uni_streams_with_rtt(
     };
     // scale amount of streams based on RTT if RTT is larger than REFERENCE_RTT_MS
     // multiply first then divide to avoid rounding errors.
-    (streams * rtt_millis.clamp(REFERENCE_RTT_MS, MAX_RTT_MS) as usize) / REFERENCE_RTT_MS as usize
+    (streams.saturating_mul(rtt_millis.clamp(REFERENCE_RTT_MS, MAX_RTT_MS))) / REFERENCE_RTT_MS
 }
 
 impl SwQos {
@@ -195,16 +194,35 @@ impl SwQos {
         ),
         ConnectionHandlerError,
     > {
-        // get current RTT and limit it to MAX_RTT_MS
-        let rtt_millis = connection.rtt().as_millis() as u64;
-        if let Ok(max_uni_streams) = VarInt::from_u64(compute_max_allowed_uni_streams_with_rtt(
+        // get current RTT and limit it to MAX_RTT_MS right away
+        let rtt_millis = connection.rtt().as_millis().min(MAX_RTT_MS as u128) as u32;
+        let max_uni_streams = VarInt::from_u32(compute_max_allowed_uni_streams_with_rtt(
             rtt_millis,
             conn_context.peer_type(),
             conn_context.total_stake,
-        ) as u64)
-        {
-            let remote_addr = connection.remote_address();
+        ));
+        let remote_addr = connection.remote_address();
 
+        let max_connections_per_peer = match conn_context.peer_type() {
+            ConnectionPeerType::Unstaked => self.config.max_connections_per_unstaked_peer,
+            ConnectionPeerType::Staked(_) => self.config.max_connections_per_staked_peer,
+        };
+        if let Some((last_update, cancel_connection, stream_counter)) = connection_table_l
+            .try_add_connection(
+                ConnectionTableKey::new(remote_addr.ip(), conn_context.remote_pubkey),
+                remote_addr.port(),
+                client_connection_tracker,
+                Some(connection.clone()),
+                conn_context.peer_type(),
+                conn_context.last_update.clone(),
+                max_connections_per_peer,
+                || Arc::new(ConnectionStreamCounter::new()),
+            )
+        {
+            update_open_connections_stat(&self.stats, &connection_table_l);
+            drop(connection_table_l);
+
+            connection.set_max_concurrent_uni_streams(max_uni_streams);
             debug!(
                 "Peer type {:?}, total stake {}, max streams {} from peer {}",
                 conn_context.peer_type(),
@@ -212,44 +230,12 @@ impl SwQos {
                 max_uni_streams.into_inner(),
                 remote_addr,
             );
-
-            let max_connections_per_peer = match conn_context.peer_type() {
-                ConnectionPeerType::Unstaked => self.config.max_connections_per_unstaked_peer,
-                ConnectionPeerType::Staked(_) => self.config.max_connections_per_staked_peer,
-            };
-            if let Some((last_update, cancel_connection, stream_counter)) = connection_table_l
-                .try_add_connection(
-                    ConnectionTableKey::new(remote_addr.ip(), conn_context.remote_pubkey),
-                    remote_addr.port(),
-                    client_connection_tracker,
-                    Some(connection.clone()),
-                    conn_context.peer_type(),
-                    conn_context.last_update.clone(),
-                    max_connections_per_peer,
-                    || Arc::new(ConnectionStreamCounter::new()),
-                )
-            {
-                update_open_connections_stat(&self.stats, &connection_table_l);
-                drop(connection_table_l);
-
-                connection.set_max_concurrent_uni_streams(max_uni_streams);
-
-                Ok((last_update, cancel_connection, stream_counter))
-            } else {
-                self.stats
-                    .connection_add_failed
-                    .fetch_add(1, Ordering::Relaxed);
-                Err(ConnectionHandlerError::ConnectionAddError)
-            }
+            Ok((last_update, cancel_connection, stream_counter))
         } else {
-            connection.close(
-                CONNECTION_CLOSE_CODE_EXCEED_MAX_STREAM_COUNT.into(),
-                CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT,
-            );
             self.stats
-                .connection_add_failed_invalid_stream_count
+                .connection_add_failed
                 .fetch_add(1, Ordering::Relaxed);
-            Err(ConnectionHandlerError::MaxStreamError)
+            Err(ConnectionHandlerError::ConnectionAddError)
         }
     }
 
@@ -541,7 +527,7 @@ impl QosController<SwQosConnectionContext> for SwQos {
 pub mod test {
     use super::*;
 
-    fn compute_max_allowed_uni_streams(peer_type: ConnectionPeerType, total_stake: u64) -> usize {
+    fn compute_max_allowed_uni_streams(peer_type: ConnectionPeerType, total_stake: u64) -> u32 {
         compute_max_allowed_uni_streams_with_rtt(REFERENCE_RTT_MS, peer_type, total_stake)
     }
 
@@ -563,7 +549,7 @@ pub mod test {
         );
         assert_eq!(
             compute_max_allowed_uni_streams(ConnectionPeerType::Staked(100), 10000),
-            ((delta / (100_f64)) as usize + QUIC_MIN_STAKED_CONCURRENT_STREAMS)
+            ((delta / (100_f64)) as u32 + QUIC_MIN_STAKED_CONCURRENT_STREAMS)
                 .min(QUIC_MAX_STAKED_CONCURRENT_STREAMS)
         );
         assert_eq!(

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -190,7 +190,6 @@ pub struct StreamerStats {
     pub(crate) connection_added_from_staked_peer: AtomicUsize,
     pub(crate) connection_added_from_unstaked_peer: AtomicUsize,
     pub(crate) connection_add_failed: AtomicUsize,
-    pub(crate) connection_add_failed_invalid_stream_count: AtomicUsize,
     pub(crate) connection_add_failed_staked_node: AtomicUsize,
     pub(crate) connection_add_failed_unstaked_node: AtomicUsize,
     pub(crate) connection_add_failed_on_pruning: AtomicUsize,
@@ -288,12 +287,6 @@ impl StreamerStats {
             (
                 "connection_add_failed",
                 self.connection_add_failed.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "connection_add_failed_invalid_stream_count",
-                self.connection_add_failed_invalid_stream_count
-                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem

- Changes to stream throttle left a bunch of unneeded type conversions 
- Those type conversions were in fact infallible but we were logging failures for them into metrics anyway.

#### Summary of Changes

- Remove type conversions
- Stop reporting errors that were never possible