### PR TITLE
perf: avoid redundant Config::default() in ConfigInput

### DIFF
--- a/cli-config/src/config_input.rs
+++ b/cli-config/src/config_input.rs
@@ -116,10 +116,17 @@ impl ConfigInput {
 
 impl Default for ConfigInput {
     fn default() -> ConfigInput {
+        let Config {
+            json_rpc_url,
+            websocket_url,
+            keypair_path,
+            ..
+        } = Config::default();
+
         ConfigInput {
-            json_rpc_url: Self::default_json_rpc_url(),
-            websocket_url: Self::default_websocket_url(),
-            keypair_path: Self::default_keypair_path(),
+            json_rpc_url,
+            websocket_url,
+            keypair_path,
             commitment: CommitmentConfig::confirmed(),
         }
     }


### PR DESCRIPTION
<!-- в чем причина правок? тоесть понятным образом обьясняешь что не так было до наших правок -->
ConfigInput::default() indirectly called Config::default() multiple times, reconstructing the full Config and allocating repeatedly just to populate a few fields, which is unnecessary extra work on startup.

<!-- Четкое и лаконичное общее описание изменений, вносимых этим PR -->
Change ConfigInput::default() to build a single Config instance and move its json_rpc_url, websocket_url and keypair_path fields into ConfigInput, preserving behavior while avoiding redundant Config::default() calls.