### PR TITLE
Fix QUIC rate limiter shard count on non-power-of-two CPUs

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -253,12 +253,13 @@ where
     C: ConnectionContext + Send + Sync + 'static,
 {
     let quic_server_params = Arc::new(quic_server_params);
+    let num_shards = (quic_server_params.num_threads.get() * 2).next_power_of_two();
     let rate_limiter = Arc::new(ConnectionRateLimiter::new(
         quic_server_params.max_connections_per_ipaddr_per_min,
         // allow for 10x burst to make sure we can accommodate legitimate
         // bursts from container environments running multiple pods on same IP
         quic_server_params.max_connections_per_ipaddr_per_min * 10,
-        quic_server_params.num_threads.get() * 2,
+        num_shards,
     ));
     let overall_connection_rate_limiter = Arc::new(TokenBucket::new(
         MAX_CONNECTION_BURST,


### PR DESCRIPTION
Problem: ConnectionRateLimiter requires shard count to be a power of two, but QUIC derives it as num_threads * 2. On machines with 10 or 12 cores this becomes 20/24 and panics during validator startup, default flags.

Summary of Changes
Fix: Round the shard count to the next power of two before constructing the rate limiter.
