### PR TITLE
Revert "Inserts into the in-mem index on startup (#10162)"

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6700,24 +6700,16 @@ impl AccountsDb {
 
         self.accounts_index.log_secondary_indexes();
 
-        // Now that the index is generated, get the total length and capacity of the in-mem maps
+        // Now that the index is generated, get the total capacity of the in-mem maps
         // across all the bins and set the initial value for the stat.
         // We do this all at once, at the end, since getting the capacity requires iterating all
         // the bins and grabbing a read lock, which we try to avoid whenever possible.
-        let (index_len, index_capacity) = self
+        let index_capacity = self
             .accounts_index
             .account_maps
             .iter()
-            .map(|bin| bin.len_and_cap_for_startup())
-            .fold((0, 0), |mut accum, (len, cap)| {
-                accum.0 += len;
-                accum.1 += cap;
-                accum
-            });
-        self.accounts_index
-            .stats()
-            .count_in_mem
-            .store(index_len, Ordering::Relaxed);
+            .map(|bin| bin.capacity_for_startup())
+            .sum();
         self.accounts_index
             .stats()
             .capacity_in_mem

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -92,7 +92,7 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
 
     /// Precomputed thresholds per bin for flushing and eviction
     /// None for Minimal/InMemOnly, Some(threshold_entries_per_bin) for Threshold
-    pub(super) threshold_entries_per_bin: Option<ThresholdEntriesPerBin>,
+    threshold_entries_per_bin: Option<ThresholdEntriesPerBin>,
 }
 
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Debug for BucketMapHolder<T, U> {
@@ -502,14 +502,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
 
 /// Precomputed thresholds derived from the configured per-bin target.
 #[derive(Clone, Copy, Debug)]
-pub struct ThresholdEntriesPerBin {
+struct ThresholdEntriesPerBin {
     /// Rounded target entries per bin used as the baseline for thresholds.
-    pub _target_entries: usize,
+    _target_entries: usize,
     /// Entry count above which a bin triggers flushing to disk and eviction
     /// from in-memory index.
-    pub high_water_mark: usize,
+    high_water_mark: usize,
     /// Entry count to reach after flushing/evicting from a bin.
-    pub low_water_mark: usize,
+    low_water_mark: usize,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem

After merging #10162, I restarted some nodes and two of them errored at startup.

One's accounts hash mismatched:
```
[2026-01-28T20:33:35.071428409Z ERROR solana_metrics::metrics] datapoint: panic program="validator" thread="main" one=1i message="panicked at /home/sol/src/agave/runtime/src/snapshot_bank_utils.rs:251:9:
    Snapshot bank for slot 396551747 failed to verify" location="/home/sol/src/agave/runtime/src/snapshot_bank_utils.rs:251:9" version="4.0.0 (src:37dec143; feat:2247900066, client:Agave)"
```

And the other's stake's cache was bad:
```
[2026-01-28T19:40:36.022218044Z ERROR solana_metrics::metrics] datapoint: panic program="validator" thread="main" one=1i message="panicked at runtime/src/bank.rs:1848:10:
    Stakes cache is inconsistent with accounts-db. This can indicate a corrupted snapshot or bugs in cached accounts or accounts-db.: InvalidDelegation(4sWJHcdDwHHFYPi8QfUSMk1u3assPg93F5qZ5RRn1PGz)" location="runtime/src/bank.rs:1848:10" version="4.0.0 (src:37dec143; feat:2247900066, client:Agave)"
```

I recompiled with the commit earlier, and both machines restarted just fine. Reverting now to unblock master. Will debug subsequently.


#### Summary of Changes

This reverts commit 37dec1435ae9ad1564c23f216025319d8b0c2d72.