### PR TITLE
perf: avoid cloning errored error units in ProgramTiming

### DIFF
--- a/svm-timings/src/lib.rs
+++ b/svm-timings/src/lib.rs
@@ -36,9 +36,8 @@ impl ProgramTiming {
         self.accumulated_us += other.accumulated_us;
         self.accumulated_units += other.accumulated_units;
         self.count += other.count;
-        // Clones the entire vector, maybe not great...
         self.errored_txs_compute_consumed
-            .extend(other.errored_txs_compute_consumed.clone());
+            .extend(other.errored_txs_compute_consumed.iter().copied());
         self.total_errored_units += other.total_errored_units;
     }
 }


### PR DESCRIPTION
#### Problem

ProgramTiming::accumulate_program_timings cloned the entire errored_txs_compute_consumed vector on each accumulation, causing an unnecessary allocation and extra copy of all elements for every merge of per-program timings.

#### Summary of Changes

Change accumulate_program_timings to extend errored_txs_compute_consumed from an iterator over other’s slice (iter().copied()), preserving behavior and invariants while removing the temporary vector clone and reducing memory and CPU overhead during timing aggregation.


