### PR TITLE
perf: remove redundant file flush before mmap

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -424,11 +424,6 @@ impl<O: BucketOccupied> BucketStorage<O> {
             data.write_all(&[0]).unwrap();
             data.rewind().unwrap();
             measure_new_file.stop();
-            let measure_flush = Measure::start("measure_flush");
-            data.flush().unwrap(); // can we skip this?
-            stats
-                .flush_file_us
-                .fetch_add(measure_flush.end_as_us(), Ordering::Relaxed);
         }
         let mut measure_mmap = Measure::start("measure_mmap");
         let mmap = unsafe { MmapMut::map_mut(&data) }.unwrap_or_else(|err| {


### PR DESCRIPTION
#### Problem

File::flush() before mapping the bucket file was not required for correctness and added extra synchronous IO every time a bucket file was created, increasing startup and resize latency without improving durability.

#### Summary of Changes

Removed the explicit data.flush() call and its timing from map_open_file in bucket_storage.rs, keeping file preallocation and mmap timing logic unchanged.

