### PR TITLE
Zero lamport flag not properly updated for accounts in cache

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1325,6 +1325,14 @@ fn test_shrink_zero_lamport_single_ref_account() {
             [(&pubkey_zero, &zero_lamport_account), (&pubkey2, &account)].as_slice(),
         ));
 
+        accounts.accounts_index.get_and_then(&pubkey_zero, |entry| {
+            let entry = entry.unwrap();
+            let slot_list = entry.slot_list_read_lock();
+            let (_, account_info) = slot_list.iter().max_by_key(|(s, _)| *s).cloned().unwrap();
+            assert!(account_info.is_zero_lamport());
+            (false, false)
+        });
+
         // Simulate rooting the zero-lamport account, should be a
         // candidate for cleaning
         accounts.add_root_and_flush_write_cache(slot);

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -7,7 +7,7 @@ use {
     solana_clock::Slot,
     std::{
         fmt::Debug,
-        ops::Deref,
+        ops::{Deref, DerefMut},
         sync::{
             atomic::{AtomicBool, Ordering},
             RwLock, RwLockReadGuard, RwLockWriteGuard,
@@ -207,6 +207,12 @@ impl<T> Deref for SlotListWriteGuard<'_, T> {
 
     fn deref(&self) -> &Self::Target {
         self.0.as_slice()
+    }
+}
+
+impl<T> DerefMut for SlotListWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut_slice()
     }
 }
 

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -416,10 +416,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     fn cache_entry_at_slot(current: &AccountMapEntry<T>, new_value: SlotListItem<T>) {
         let mut slot_list = current.slot_list_write_lock();
         let (slot, new_entry) = new_value;
-        if !slot_list
-            .iter()
-            .any(|(existing_slot, _)| *existing_slot == slot)
-        {
+        // Find and replace existing entry at this slot, or append if not found
+        if let Some(existing_entry) = slot_list.iter_mut().find(|(s, _)| *s == slot) {
+            existing_entry.1 = new_entry;
+        } else {
             slot_list.push((slot, new_entry));
         }
         current.set_dirty(true);


### PR DESCRIPTION
#### Problem
In some situations the zero lamport flag in the accounts index is not set correctly for accounts stored in the write cache 

#### Summary of Changes
- Always replace the existing item in the accounts index
- Modify a test to catch the scenario. 

#### Testing
- I wanted to verify that this is not a consensus breaking change. To verify this I added an assert to is_zero_lamport for account info that asserted the entry was not cached:
```
impl IsZeroLamport for AccountInfo {
    fn is_zero_lamport(&self) -> bool {
        assert!(!self.is_cached());
        self.account_offset_and_flags.is_zero_lamport()
    }
}
```
- The assert triggered on 6 tests. All tests failures had a similar signature. They either called calculate_capitalization_at_startup_from_index or calculate_accounts_lt_hash_at_startup_from_index. This isn't runtime behaviour as both these functions are only intended to be called at startup, when no entires are in the cache. 
- This means technically that this does not fix or break any behaviour, but it does make behaviour more consistent. Another option would be deciding on a fixed value and always returning that for cached entries.

Issue was introduced in https://github.com/anza-xyz/agave/pull/7282/

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
