### PR TITLE
fix: remove unused core_allocations map in ThreadManager

### DIFF
--- a/thread-manager/src/lib.rs
+++ b/thread-manager/src/lib.rs
@@ -170,7 +170,6 @@ impl ThreadManager {
     }
 
     pub fn new(config: ThreadManagerConfig) -> anyhow::Result<Self> {
-        let mut core_allocations = HashMap::<String, Vec<usize>>::new();
         Self::set_process_affinity(&config)?;
         let mut manager = ThreadManagerInner::default();
         manager.populate_mappings(&config);
@@ -186,7 +185,6 @@ impl ThreadManager {
         for (name, cfg) in config.tokio_configs.iter() {
             let tokiort = TokioRuntime::new(name.clone(), cfg.clone())?;
 
-            core_allocations.insert(name.clone(), cfg.core_allocation.as_core_mask_vector());
             manager.tokio_runtimes.insert(name.clone(), tokiort);
         }
         Ok(Self {


### PR DESCRIPTION
#### Problem

ThreadManager::new built a core_allocations HashMap for Tokio runtimes but never read it, which introduced unnecessary allocations and left dead code in the initialization path.

#### Summary of Changes

Remove the unused core_allocations map and its insert call from ThreadManager::new, keeping runtime creation and affinity behavior unchanged while avoiding redundant work.
