### PR TITLE
votor: move up initialization from ReplayStage to TVU

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -9,7 +9,7 @@ use {
             DuplicateConfirmedSlotsReceiver, GossipVerifiedVoteHashReceiver, VoteTracker,
         },
         cluster_slots_service::{cluster_slots::ClusterSlots, ClusterSlotsUpdateSender},
-        commitment_service::{AggregateCommitmentService, TowerCommitmentAggregationData},
+        commitment_service::TowerCommitmentAggregationData,
         consensus::{
             fork_choice::{select_vote_and_reset_forks, ForkChoice, SelectVoteAndResetForkResult},
             heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
@@ -34,16 +34,11 @@ use {
         window_service::DuplicateSlotReceiver,
     },
     agave_votor::{
-        consensus_metrics::{ConsensusMetricsEventReceiver, ConsensusMetricsEventSender},
-        event::{
-            CompletedBlock, LeaderWindowInfo, VotorEvent, VotorEventReceiver, VotorEventSender,
-        },
+        event::{CompletedBlock, VotorEvent, VotorEventSender},
         root_utils,
-        vote_history::VoteHistory,
-        vote_history_storage::{SavedVoteHistory, VoteHistoryStorage},
+        vote_history_storage::SavedVoteHistory,
         voting_service::BLSOp,
         voting_utils::{self, GenerateVoteTxResult},
-        votor::{Votor, VotorConfig},
     },
     agave_votor_messages::{
         consensus_message::ConsensusMessage,
@@ -281,8 +276,6 @@ pub struct ReplayStageConfig {
     pub poh_recorder: Arc<RwLock<PohRecorder>>,
     pub poh_controller: PohController,
     pub tower: Tower,
-    pub vote_history: VoteHistory,
-    pub vote_history_storage: Arc<dyn VoteHistoryStorage>,
     pub vote_tracker: Arc<VoteTracker>,
     pub cluster_slots: Arc<ClusterSlots>,
     pub log_messages_bytes_limit: Option<usize>,
@@ -290,10 +283,6 @@ pub struct ReplayStageConfig {
     pub banking_tracer: Arc<BankingTracer>,
     pub snapshot_controller: Option<Arc<SnapshotController>>,
     pub replay_highest_frozen: Arc<ReplayHighestFrozen>,
-    pub leader_window_info_sender: Sender<LeaderWindowInfo>,
-    pub highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
-    pub consensus_metrics_sender: ConsensusMetricsEventSender,
-    pub consensus_metrics_receiver: ConsensusMetricsEventReceiver,
     pub migration_status: Arc<MigrationStatus>,
 }
 
@@ -315,6 +304,7 @@ pub struct ReplaySenders {
     pub dumped_slots_sender: Sender<Vec<(u64, Hash)>>,
     pub votor_event_sender: VotorEventSender,
     pub own_vote_sender: Sender<ConsensusMessage>,
+    pub lockouts_sender: Sender<TowerCommitmentAggregationData>,
 }
 
 pub struct ReplayReceivers {
@@ -324,8 +314,6 @@ pub struct ReplayReceivers {
     pub duplicate_confirmed_slots_receiver: Receiver<Vec<(u64, Hash)>>,
     pub gossip_verified_vote_hash_receiver: Receiver<(Pubkey, u64, Hash)>,
     pub popular_pruned_forks_receiver: Receiver<Vec<u64>>,
-    pub consensus_message_receiver: Receiver<ConsensusMessage>,
-    pub votor_event_receiver: VotorEventReceiver,
 }
 
 /// Timing information for the ReplayStage main processing loop
@@ -574,8 +562,6 @@ impl ReplayLoopTiming {
 
 pub struct ReplayStage {
     t_replay: JoinHandle<()>,
-    votor: Votor,
-    commitment_service: AggregateCommitmentService,
 }
 
 impl ReplayStage {
@@ -601,8 +587,6 @@ impl ReplayStage {
             poh_recorder,
             mut poh_controller,
             mut tower,
-            vote_history,
-            vote_history_storage,
             vote_tracker,
             cluster_slots,
             log_messages_bytes_limit,
@@ -610,10 +594,6 @@ impl ReplayStage {
             banking_tracer,
             snapshot_controller,
             replay_highest_frozen,
-            leader_window_info_sender,
-            highest_parent_ready,
-            consensus_metrics_sender,
-            consensus_metrics_receiver,
             migration_status,
         } = config;
 
@@ -635,6 +615,7 @@ impl ReplayStage {
             dumped_slots_sender,
             votor_event_sender,
             own_vote_sender,
+            lockouts_sender,
         } = senders;
 
         let ReplayReceivers {
@@ -644,50 +625,12 @@ impl ReplayStage {
             duplicate_confirmed_slots_receiver,
             gossip_verified_vote_hash_receiver,
             popular_pruned_forks_receiver,
-            consensus_message_receiver,
-            votor_event_receiver,
         } = receivers;
 
         trace!("replay stage");
 
         let mut identity_keypair = cluster_info.keypair().clone();
         let mut my_pubkey = identity_keypair.pubkey();
-        let (lockouts_sender, votor_commitment_sender, commitment_service) =
-            AggregateCommitmentService::new(
-                exit.clone(),
-                block_commitment_cache.clone(),
-                rpc_subscriptions.clone(),
-            );
-
-        // Alpenglow specific objects
-        let votor_config = VotorConfig {
-            exit: exit.clone(),
-            vote_account,
-            wait_to_vote_slot,
-            wait_for_vote_to_start_leader,
-            vote_history,
-            vote_history_storage,
-            authorized_voter_keypairs: authorized_voter_keypairs.clone(),
-            blockstore: blockstore.clone(),
-            bank_forks: bank_forks.clone(),
-            cluster_info: cluster_info.clone(),
-            leader_schedule_cache: leader_schedule_cache.clone(),
-            rpc_subscriptions: rpc_subscriptions.clone(),
-            snapshot_controller: snapshot_controller.clone(),
-            bls_sender: bls_sender.clone(),
-            commitment_sender: votor_commitment_sender,
-            drop_bank_sender: drop_bank_sender.clone(),
-            bank_notification_sender: bank_notification_sender.clone(),
-            leader_window_info_sender,
-            highest_parent_ready,
-            event_sender: votor_event_sender.clone(),
-            event_receiver: votor_event_receiver.clone(),
-            own_vote_sender: own_vote_sender.clone(),
-            consensus_message_receiver,
-            consensus_metrics_sender,
-            consensus_metrics_receiver,
-        };
-        let votor = Votor::new(votor_config);
 
         let mut highest_frozen_slot = bank_forks
             .read()
@@ -1386,11 +1329,7 @@ impl ReplayStage {
             .spawn(run_replay)
             .unwrap();
 
-        Ok(Self {
-            t_replay,
-            votor,
-            commitment_service,
-        })
+        Ok(Self { t_replay })
     }
 
     /// Enables alpenglow
@@ -4707,8 +4646,6 @@ impl ReplayStage {
     }
 
     pub fn join(self) -> thread::Result<()> {
-        self.commitment_service.join()?;
-        self.votor.join()?;
         self.t_replay.join().map(|_| ())
     }
 }
@@ -4718,6 +4655,7 @@ pub(crate) mod tests {
     use {
         super::*,
         crate::{
+            commitment_service::AggregateCommitmentService,
             consensus::{
                 progress_map::{ValidatorStakeInfo, RETRANSMIT_BASE_DELAY_MS},
                 tower_storage::{FileTowerStorage, NullTowerStorage},

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -149,8 +149,8 @@ impl Default for TvuConfig {
     }
 }
 
-/// Shared state from validator necessary to insantiate votor
-pub struct VotorInitializationState {
+/// Shared state from validator necessary to instantiate votor and related services
+pub struct AlpenglowInitializationState {
     // Shared with block creation loop
     pub leader_window_info_sender: Sender<LeaderWindowInfo>,
     pub replay_highest_frozen: Arc<ReplayHighestFrozen>,
@@ -167,8 +167,6 @@ pub struct VotorInitializationState {
 
     // For BLS voting service
     pub bls_connection_cache: Arc<ConnectionCache>,
-
-    // For testing spies
     pub voting_service_test_override: Option<VotingServiceOverride>,
 }
 
@@ -227,7 +225,7 @@ impl Tvu {
         wen_restart_repair_slots: Option<Arc<RwLock<Vec<Slot>>>>,
         slot_status_notifier: Option<SlotStatusNotifier>,
         vote_connection_cache: Arc<ConnectionCache>,
-        votor_init: VotorInitializationState,
+        votor_init: AlpenglowInitializationState,
     ) -> Result<Self, String> {
         let in_wen_restart = wen_restart_repair_slots.is_some();
         let migration_status = bank_forks.read().unwrap().migration_status();
@@ -240,7 +238,7 @@ impl Tvu {
             alpenglow: bls_socket,
         } = sockets;
 
-        let VotorInitializationState {
+        let AlpenglowInitializationState {
             leader_window_info_sender,
             replay_highest_frozen,
             highest_parent_ready,
@@ -828,7 +826,7 @@ pub mod tests {
             wen_restart_repair_slots,
             None, // slot_status_notifier
             Arc::new(connection_cache),
-            VotorInitializationState {
+            AlpenglowInitializationState {
                 leader_window_info_sender,
                 replay_highest_frozen,
                 highest_parent_ready,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -12,6 +12,7 @@ use {
             VerifiedVoterSlotsReceiver, VerifiedVoterSlotsSender, VoteTracker,
         },
         cluster_slots_service::{cluster_slots::ClusterSlots, ClusterSlotsService},
+        commitment_service::AggregateCommitmentService,
         completed_data_sets_service::CompletedDataSetsSender,
         consensus::{tower_storage::TowerStorage, Tower},
         cost_update_service::CostUpdateService,
@@ -29,6 +30,7 @@ use {
         vote_history::VoteHistory,
         vote_history_storage::VoteHistoryStorage,
         voting_service::{VotingService as BLSVotingService, VotingServiceOverride},
+        votor::{Votor, VotorConfig},
     },
     bytes::Bytes,
     crossbeam_channel::{bounded, unbounded, Receiver, Sender},
@@ -105,6 +107,8 @@ pub struct Tvu {
     drop_bank_service: DropBankService,
     duplicate_shred_listener: DuplicateShredListener,
     bls_sigverify_threads: Option<(JoinHandle<()>, JoinHandle<()>)>,
+    votor: Votor,
+    commitment_service: AggregateCommitmentService,
 }
 
 pub struct TvuSockets {
@@ -143,6 +147,29 @@ impl Default for TvuConfig {
             xdp_sender: None,
         }
     }
+}
+
+/// Shared state from validator necessary to insantiate votor
+pub struct VotorInitializationState {
+    // Shared with block creation loop
+    pub leader_window_info_sender: Sender<LeaderWindowInfo>,
+    pub replay_highest_frozen: Arc<ReplayHighestFrozen>,
+    pub highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
+
+    // Main communication channel
+    pub votor_event_sender: VotorEventSender,
+    pub votor_event_receiver: VotorEventReceiver,
+
+    // For BLS streamer setup
+    pub cancel: CancellationToken,
+    pub staked_nodes: Arc<RwLock<StakedNodes>>,
+    pub key_notifiers: Arc<RwLock<KeyUpdaters>>,
+
+    // For BLS voting service
+    pub bls_connection_cache: Arc<ConnectionCache>,
+
+    // For testing spies
+    pub voting_service_test_override: Option<VotingServiceOverride>,
 }
 
 impl Tvu {
@@ -200,16 +227,7 @@ impl Tvu {
         wen_restart_repair_slots: Option<Arc<RwLock<Vec<Slot>>>>,
         slot_status_notifier: Option<SlotStatusNotifier>,
         vote_connection_cache: Arc<ConnectionCache>,
-        bls_connection_cache: Arc<ConnectionCache>,
-        replay_highest_frozen: Arc<ReplayHighestFrozen>,
-        leader_window_info_sender: Sender<LeaderWindowInfo>,
-        highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
-        voting_service_test_override: Option<VotingServiceOverride>,
-        votor_event_sender: VotorEventSender,
-        votor_event_receiver: VotorEventReceiver,
-        staked_nodes: Arc<RwLock<StakedNodes>>,
-        cancel: CancellationToken,
-        key_notifiers: Arc<RwLock<KeyUpdaters>>,
+        votor_init: VotorInitializationState,
     ) -> Result<Self, String> {
         let in_wen_restart = wen_restart_repair_slots.is_some();
         let migration_status = bank_forks.read().unwrap().migration_status();
@@ -221,6 +239,19 @@ impl Tvu {
             ancestor_hashes_requests: ancestor_hashes_socket,
             alpenglow: bls_socket,
         } = sockets;
+
+        let VotorInitializationState {
+            leader_window_info_sender,
+            replay_highest_frozen,
+            highest_parent_ready,
+            votor_event_sender,
+            votor_event_receiver,
+            cancel,
+            staked_nodes,
+            key_notifiers,
+            bls_connection_cache,
+            voting_service_test_override,
+        } = votor_init;
 
         // streamer and sigverify for A2A BLS messages
         let (consensus_message_sender, consensus_message_receiver) =
@@ -393,6 +424,42 @@ impl Tvu {
         let (voting_sender, voting_receiver) = unbounded();
         let (bls_sender, bls_receiver) = bounded(MAX_BLS_MESSAGES_TO_SEND);
 
+        let (lockouts_sender, votor_commitment_sender, commitment_service) =
+            AggregateCommitmentService::new(
+                exit.clone(),
+                block_commitment_cache.clone(),
+                rpc_subscriptions.clone(),
+            );
+
+        let votor_config = VotorConfig {
+            exit: exit.clone(),
+            vote_account: *vote_account,
+            wait_to_vote_slot,
+            wait_for_vote_to_start_leader: tvu_config.wait_for_vote_to_start_leader,
+            vote_history,
+            vote_history_storage: vote_history_storage.clone(),
+            authorized_voter_keypairs: authorized_voter_keypairs.clone(),
+            blockstore: blockstore.clone(),
+            bank_forks: bank_forks.clone(),
+            cluster_info: cluster_info.clone(),
+            leader_schedule_cache: leader_schedule_cache.clone(),
+            rpc_subscriptions: rpc_subscriptions.clone(),
+            snapshot_controller: snapshot_controller.clone(),
+            bls_sender: bls_sender.clone(),
+            commitment_sender: votor_commitment_sender,
+            drop_bank_sender: drop_bank_sender.clone(),
+            bank_notification_sender: bank_notification_sender.clone(),
+            leader_window_info_sender,
+            highest_parent_ready,
+            event_sender: votor_event_sender.clone(),
+            event_receiver: votor_event_receiver,
+            own_vote_sender: consensus_message_sender.clone(),
+            consensus_message_receiver,
+            consensus_metrics_sender,
+            consensus_metrics_receiver,
+        };
+        let votor = Votor::new(votor_config);
+
         let replay_senders = ReplaySenders {
             rpc_subscriptions,
             slot_status_notifier,
@@ -411,6 +478,7 @@ impl Tvu {
             dumped_slots_sender,
             votor_event_sender,
             own_vote_sender: consensus_message_sender,
+            lockouts_sender,
         };
 
         let replay_receivers = ReplayReceivers {
@@ -420,8 +488,6 @@ impl Tvu {
             duplicate_confirmed_slots_receiver,
             gossip_verified_vote_hash_receiver,
             popular_pruned_forks_receiver,
-            consensus_message_receiver,
-            votor_event_receiver,
         };
 
         let replay_stage_config = ReplayStageConfig {
@@ -441,8 +507,6 @@ impl Tvu {
             poh_recorder: poh_recorder.clone(),
             poh_controller,
             tower,
-            vote_history,
-            vote_history_storage: vote_history_storage.clone(),
             vote_tracker,
             cluster_slots,
             log_messages_bytes_limit,
@@ -450,10 +514,6 @@ impl Tvu {
             banking_tracer,
             snapshot_controller,
             replay_highest_frozen,
-            leader_window_info_sender,
-            highest_parent_ready,
-            consensus_metrics_sender,
-            consensus_metrics_receiver,
             migration_status,
         };
 
@@ -527,6 +587,8 @@ impl Tvu {
             drop_bank_service,
             duplicate_shred_listener,
             bls_sigverify_threads,
+            votor,
+            commitment_service,
         })
     }
 
@@ -554,6 +616,8 @@ impl Tvu {
             streamer.join()?;
             sigverifier.join()?;
         }
+        self.votor.join()?;
+        self.commitment_service.join()?;
         Ok(())
     }
 }
@@ -764,16 +828,18 @@ pub mod tests {
             wen_restart_repair_slots,
             None, // slot_status_notifier
             Arc::new(connection_cache),
-            Arc::new(bls_connection_cache),
-            replay_highest_frozen,
-            leader_window_info_sender,
-            highest_parent_ready,
-            None, // voting_service_test_override
-            votor_event_sender,
-            votor_event_receiver,
-            staked_nodes,
-            cancel,
-            key_notifiers,
+            VotorInitializationState {
+                leader_window_info_sender,
+                replay_highest_frozen,
+                highest_parent_ready,
+                votor_event_sender,
+                votor_event_receiver,
+                cancel,
+                staked_nodes,
+                key_notifiers,
+                bls_connection_cache: Arc::new(bls_connection_cache),
+                voting_service_test_override: None,
+            },
         )
         .expect("assume success");
         if enable_wen_restart {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -32,7 +32,7 @@ use {
             verify_net_stats_access, SystemMonitorService, SystemMonitorStatsReportConfig,
         },
         tpu::{Tpu, TpuSockets},
-        tvu::{Tvu, TvuConfig, TvuSockets, VotorInitializationState},
+        tvu::{AlpenglowInitializationState, Tvu, TvuConfig, TvuSockets},
     },
     agave_snapshots::{
         snapshot_archive_info::SnapshotArchiveInfoGetter as _, snapshot_config::SnapshotConfig,
@@ -1704,7 +1704,7 @@ impl Validator {
             wen_restart_repair_slots.clone(),
             slot_status_notifier,
             vote_connection_cache,
-            VotorInitializationState {
+            AlpenglowInitializationState {
                 leader_window_info_sender,
                 replay_highest_frozen: replay_highest_frozen.clone(),
                 highest_parent_ready: highest_parent_ready.clone(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -32,7 +32,7 @@ use {
             verify_net_stats_access, SystemMonitorService, SystemMonitorStatsReportConfig,
         },
         tpu::{Tpu, TpuSockets},
-        tvu::{Tvu, TvuConfig, TvuSockets},
+        tvu::{Tvu, TvuConfig, TvuSockets, VotorInitializationState},
     },
     agave_snapshots::{
         snapshot_archive_info::SnapshotArchiveInfoGetter as _, snapshot_config::SnapshotConfig,
@@ -1704,16 +1704,18 @@ impl Validator {
             wen_restart_repair_slots.clone(),
             slot_status_notifier,
             vote_connection_cache,
-            bls_connection_cache,
-            replay_highest_frozen.clone(),
-            leader_window_info_sender,
-            highest_parent_ready.clone(),
-            config.voting_service_test_override.clone(),
-            votor_event_sender.clone(),
-            votor_event_receiver,
-            staked_nodes.clone(),
-            cancel.clone(),
-            key_notifiers.clone(),
+            VotorInitializationState {
+                leader_window_info_sender,
+                replay_highest_frozen: replay_highest_frozen.clone(),
+                highest_parent_ready: highest_parent_ready.clone(),
+                votor_event_sender: votor_event_sender.clone(),
+                votor_event_receiver,
+                cancel: cancel.clone(),
+                staked_nodes: staked_nodes.clone(),
+                key_notifiers: key_notifiers.clone(),
+                bls_connection_cache,
+                voting_service_test_override: config.voting_service_test_override.clone(),
+            },
         )
         .map_err(ValidatorError::Other)?;
 


### PR DESCRIPTION
Follow up from here https://github.com/anza-xyz/agave/pull/10063#discussion_r2701834237

Move up initialization and reduce # of args to TVU
Also moved `commitment_service` to TVU as it now receives messages from either votor or replay