### PR TITLE
clippy(programs): use repr(u64) to fix repr_c_enums_larger_than_int

### DIFF
--- a/programs/sbf/rust/sanity/src/lib.rs
+++ b/programs/sbf/rust/sanity/src/lib.rs
@@ -30,8 +30,7 @@ enum TestEnum {
 }
 
 #[allow(dead_code)]
-#[allow(clippy::enum_clike_unportable_variant)]
-#[repr(C)]
+#[repr(u64)]
 enum Test64BitEnum {
     VariantOne,
     VariantTwo = 0xFFFFFFFFF,


### PR DESCRIPTION
#### Problem
Rust 1.93 [deprecated](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/builtin/static.REPR_C_ENUMS_LARGER_THAN_INT.html) use of `repr(C)` on enums with 64-bit discriminants

#### Summary of Changes
Switch to `repr(u64)`, which I believe is desired to check in the test.

On the other hand - we were already silencing `enum_clike_unportable_variant`, which is now not necessary, so maybe the intention of this test / struct was really to check how `repr(C)` on `u64` behaves - since Rust will deny this kind of pattern, maybe it needs to be removed or turned into some other (unsafe?) approach? 