### PR TITLE
refactor(ledger): create LeaderScheduleCache outside of load_bank_forks

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -27,6 +27,7 @@ use {
         blockstore_processor::{
             self, BlockstoreProcessorError, ProcessOptions, TransactionStatusSender,
         },
+        leader_schedule_cache::LeaderScheduleCache,
         use_snapshot_archives_at_startup::UseSnapshotArchivesAtStartup,
     },
     solana_measure::measure_time,
@@ -337,19 +338,21 @@ pub fn load_and_process_ledger(
             (transaction_status_sender, None)
         };
 
-    let (bank_forks, leader_schedule_cache, starting_snapshot_hashes, ..) =
-        bank_forks_utils::load_bank_forks(
-            genesis_config,
-            blockstore.as_ref(),
-            account_paths,
-            &snapshot_config,
-            &process_options,
-            transaction_status_sender.as_ref(),
-            None, // Maybe support this later, though
-            accounts_update_notifier,
-            exit.clone(),
-        )
-        .map_err(LoadAndProcessLedgerError::LoadBankForks)?;
+    let (bank_forks, starting_snapshot_hashes) = bank_forks_utils::load_bank_forks(
+        genesis_config,
+        blockstore.as_ref(),
+        account_paths,
+        &snapshot_config,
+        &process_options,
+        transaction_status_sender.as_ref(),
+        None, // Maybe support this later, though
+        accounts_update_notifier,
+        exit.clone(),
+    )
+    .map_err(LoadAndProcessLedgerError::LoadBankForks)?;
+    let leader_schedule_cache =
+        LeaderScheduleCache::new_from_bank(&bank_forks.read().unwrap().root_bank());
+
     let block_verification_method = value_t_or_exit!(
         arg_matches,
         "block_verification_method",

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -5,7 +5,6 @@ use {
             self, BlockstoreProcessorError, ProcessOptions, TransactionStatusSender,
         },
         entry_notifier_service::EntryNotifierSender,
-        leader_schedule_cache::LeaderScheduleCache,
         use_snapshot_archives_at_startup::{self, UseSnapshotArchivesAtStartup},
     },
     agave_snapshots::{
@@ -60,14 +59,8 @@ pub enum BankForksUtilsError {
     ProcessBlockstoreFromGenesis(#[source] BlockstoreProcessorError),
 }
 
-pub type LoadResult = result::Result<
-    (
-        Arc<RwLock<BankForks>>,
-        LeaderScheduleCache,
-        Option<StartingSnapshotHashes>,
-    ),
-    BankForksUtilsError,
->;
+pub type LoadResult =
+    result::Result<(Arc<RwLock<BankForks>>, Option<StartingSnapshotHashes>), BankForksUtilsError>;
 
 /// Load the banks via genesis or a snapshot
 ///
@@ -157,9 +150,6 @@ pub fn load_bank_forks(
             (bank_forks, None)
         };
 
-    let leader_schedule_cache =
-        LeaderScheduleCache::new_from_bank(&bank_forks.read().unwrap().root_bank());
-
     if let Some(ref new_hard_forks) = process_options.new_hard_forks {
         let root_bank = bank_forks.read().unwrap().root_bank();
         new_hard_forks
@@ -167,7 +157,7 @@ pub fn load_bank_forks(
             .for_each(|hard_fork_slot| root_bank.register_hard_fork(*hard_fork_slot));
     }
 
-    Ok((bank_forks, leader_schedule_cache, starting_snapshot_hashes))
+    Ok((bank_forks, starting_snapshot_hashes))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -862,7 +862,7 @@ pub fn test_process_blockstore(
     opts: &ProcessOptions,
     exit: Arc<AtomicBool>,
 ) -> (Arc<RwLock<BankForks>>, LeaderScheduleCache) {
-    let (bank_forks, leader_schedule_cache, ..) = crate::bank_forks_utils::load_bank_forks(
+    let (bank_forks, _) = crate::bank_forks_utils::load_bank_forks(
         genesis_config,
         blockstore,
         Vec::new(),
@@ -874,6 +874,9 @@ pub fn test_process_blockstore(
         exit.clone(),
     )
     .unwrap();
+
+    let leader_schedule_cache =
+        LeaderScheduleCache::new_from_bank(&bank_forks.read().unwrap().root_bank());
 
     process_blockstore_from_root(
         blockstore,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -43,6 +43,7 @@ use {
         bank_forks_utils,
         blockstore::{entries_to_test_shreds, Blockstore},
         blockstore_processor::{self, ProcessOptions},
+        leader_schedule_cache::LeaderScheduleCache,
         shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
         use_snapshot_archives_at_startup::UseSnapshotArchivesAtStartup,
     },
@@ -2348,7 +2349,7 @@ fn create_snapshot_to_hard_fork(
     let ledger_path = blockstore.ledger_path();
     let genesis_config = open_genesis_config(ledger_path, u64::MAX).unwrap();
     let snapshot_config = create_simple_snapshot_config(ledger_path);
-    let (bank_forks, leader_schedule_cache, _) = bank_forks_utils::load_bank_forks(
+    let (bank_forks, _) = bank_forks_utils::load_bank_forks(
         &genesis_config,
         blockstore,
         vec![
@@ -2364,6 +2365,10 @@ fn create_snapshot_to_hard_fork(
         Arc::default(),
     )
     .expect("must load bank forks");
+
+    let leader_schedule_cache =
+        LeaderScheduleCache::new_from_bank(&bank_forks.read().unwrap().root_bank());
+
     blockstore_processor::process_blockstore_from_root(
         blockstore,
         &bank_forks,


### PR DESCRIPTION
#### Problem
One of the things `load_bank_forks` does is create `LeaderScheduleCache`, but the logic it executes is quite short and independent from actually loading bank forks. It can be extracted and put on a few call sites instead.

Context: `load_bank_forks` should be split such that loading bank forks from snapshot and from genesis can be done on independent code paths (loading from snapshot doesn't depend on blockstore and can be done earlier / in background).

#### Summary of Changes
* move creation of `LeaderScheduleCache` after calls to `load_bank_forks`
* remove it from return value of `load_bank_forks`
* add `with_full_capacity` for easier update based on process options' `full_leader_cache`
