### PR TITLE
clippy: fix cases signaled by unnecessary_unwrap lint

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -860,16 +860,16 @@ pub async fn process_command(config: &CliConfig<'_>) -> ProcessResult {
         println_name_value("Commitment:", &config.commitment.commitment.to_string());
     }
 
-    let rpc_client = if config.rpc_client.is_none() {
+    let rpc_client = if let Some(rpc_client) = config.rpc_client.as_ref() {
+        // Primarily for testing
+        rpc_client.clone()
+    } else {
         Arc::new(RpcClient::new_with_timeouts_and_commitment(
             config.json_rpc_url.to_string(),
             config.rpc_timeout,
             config.commitment,
             config.confirm_transaction_initial_timeout,
         ))
-    } else {
-        // Primarily for testing
-        config.rpc_client.as_ref().unwrap().clone()
     };
 
     match &config.command {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -536,11 +536,11 @@ impl Tvu {
         self.cluster_slots_service.join()?;
         self.fetch_stage.join()?;
         self.shred_sigverify.join()?;
-        if self.blockstore_cleanup_service.is_some() {
-            self.blockstore_cleanup_service.unwrap().join()?;
+        if let Some(cleanup_service) = self.blockstore_cleanup_service {
+            cleanup_service.join()?;
         }
-        if self.replay_stage.is_some() {
-            self.replay_stage.unwrap().join()?;
+        if let Some(replay_stage) = self.replay_stage {
+            replay_stage.join()?;
         }
         self.cost_update_service.join()?;
         self.voting_service.join()?;

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -742,12 +742,14 @@ impl TransactionStatus {
         match &self.confirmation_status {
             Some(status) => status.clone(),
             None => {
-                if self.confirmations.is_none() {
-                    TransactionConfirmationStatus::Finalized
-                } else if self.confirmations.unwrap() > 0 {
-                    TransactionConfirmationStatus::Confirmed
+                if let Some(confirmations) = self.confirmations {
+                    if confirmations > 0 {
+                        TransactionConfirmationStatus::Confirmed
+                    } else {
+                        TransactionConfirmationStatus::Processed
+                    }
                 } else {
-                    TransactionConfirmationStatus::Processed
+                    TransactionConfirmationStatus::Finalized
                 }
             }
         }

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1026,13 +1026,12 @@ fn retain_peer_snapshot_hashes_that_match_known_snapshot_hashes(
         known_snapshot_hashes
             .get(&peer_snapshot_hash.snapshot_hash.full)
             .map(|known_incremental_hashes| {
-                if peer_snapshot_hash.snapshot_hash.incr.is_none() {
+                if let Some(incr) = peer_snapshot_hash.snapshot_hash.incr.as_ref() {
+                    known_incremental_hashes.contains(incr)
+                } else {
                     // If the peer's full snapshot hashes match, but doesn't have any
                     // incremental snapshots, that's fine; keep 'em!
                     true
-                } else {
-                    known_incremental_hashes
-                        .contains(peer_snapshot_hash.snapshot_hash.incr.as_ref().unwrap())
                 }
             })
             .unwrap_or(false)


### PR DESCRIPTION
#### Problem
Rust 1.93 clippy detects a few cases where we check `is_some()` and then `unwrap`, which can be turned into `if let Some` or similar.

#### Summary of Changes
Refactor conditions and deconstruction.