### PR TITLE
Create `Bank` with `SlotLeader` struct

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -30,7 +30,10 @@ use {
     solana_perf::packet::{to_packet_batches, PacketBatch},
     solana_poh::poh_recorder::{create_test_recorder, PohRecorder, WorkingBankEntry},
     solana_pubkey::{self as pubkey, Pubkey},
-    solana_runtime::{bank::Bank, bank_forks::BankForks},
+    solana_runtime::{
+        bank::{Bank, SlotLeader},
+        bank_forks::BankForks,
+    },
     solana_signature::Signature,
     solana_signer::Signer,
     solana_system_interface::instruction as system_instruction,
@@ -520,7 +523,7 @@ fn main() {
     let mut tx_total_us = 0;
     let base_tx_count = bank.transaction_count();
     let mut txs_processed = 0;
-    let collector = solana_pubkey::new_rand();
+    let leader = SlotLeader::new_unique();
     let mut total_sent = 0;
     for current_iteration_index in 0..iterations {
         trace!("RUNNING ITERATION {current_iteration_index}");
@@ -582,7 +585,7 @@ fn main() {
                 assert_matches!(result, Ok(_));
             }
             let new_slot = bank.slot() + 1;
-            let new_bank = Bank::new_from_parent(bank.clone(), &collector, new_slot);
+            let new_bank = Bank::new_from_parent(bank.clone(), leader, new_slot);
             new_bank_time.stop();
 
             let mut insert_time = Measure::start("insert_time");

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -24,7 +24,7 @@ use {
         response::SlotInfo,
     },
     solana_runtime::{
-        bank::Bank,
+        bank::{Bank, SlotLeader},
         bank_forks::BankForks,
         commitment::{BlockCommitmentCache, CommitmentSlots},
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
@@ -131,7 +131,7 @@ fn test_account_subscription() {
     let blockhash = bank.last_blockhash();
     let bank_forks = BankForks::new_rw_arc(bank);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-    let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
     let bob = Keypair::new();
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -333,7 +333,7 @@ fn test_program_subscription() {
     let blockhash = bank.last_blockhash();
     let bank_forks = BankForks::new_rw_arc(bank);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-    let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
     let bob = Keypair::new();
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -418,7 +418,7 @@ fn test_root_subscription() {
     let bank = Bank::new_for_tests(&genesis_config);
     let bank_forks = BankForks::new_rw_arc(bank);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-    let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
     let subscriptions = Arc::new(RpcSubscriptions::new_for_tests(

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -481,10 +481,9 @@ impl SimulatorLoop {
                 let new_leader = self
                     .leader_schedule_cache
                     .slot_leader_at(new_slot, None)
-                    .unwrap()
-                    .id;
-                if new_leader != self.simulated_leader {
-                    logger.on_new_leader(&bank, bank_created.elapsed(), new_slot, new_leader);
+                    .unwrap();
+                if new_leader.id != self.simulated_leader {
+                    logger.on_new_leader(&bank, bank_created.elapsed(), new_slot, new_leader.id);
                     break;
                 } else if sender_thread.is_finished() {
                     warn!("sender thread existed maybe due to completion of sending traced events");
@@ -492,11 +491,8 @@ impl SimulatorLoop {
                 } else {
                     info!("new leader bank slot: {new_slot}");
                 }
-                let new_bank = Bank::new_from_parent(
-                    bank.clone_without_scheduler(),
-                    &self.simulated_leader,
-                    new_slot,
-                );
+                let new_bank =
+                    Bank::new_from_parent(bank.clone_without_scheduler(), new_leader, new_slot);
                 // make sure parent is frozen for finalized hashes via the above
                 // new()-ing of its child bank
                 self.retracer

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -2158,6 +2158,7 @@ mod tests {
         solana_clock::{Slot, MAX_PROCESSING_AGE},
         solana_genesis_config::GenesisConfig,
         solana_keypair::Keypair,
+        solana_leader_schedule::SlotLeader,
         solana_ledger::genesis_utils::GenesisConfigInfo,
         solana_message::{
             v0::{self, LoadedAddresses},
@@ -2218,7 +2219,7 @@ mod tests {
         // Warp to next epoch for MaxAge tests.
         let mut bank = Bank::new_from_parent(
             bank.clone(),
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             bank.get_epoch_info().slots_in_epoch,
         );
         if !relax_intrabatch_account_locks {

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -548,6 +548,7 @@ mod tests {
         solana_hash::Hash,
         solana_instruction::error::InstructionError,
         solana_keypair::Keypair,
+        solana_leader_schedule::SlotLeader,
         solana_ledger::{
             blockstore_processor::{TransactionStatusMessage, TransactionStatusSender},
             genesis_utils::{
@@ -1408,7 +1409,7 @@ mod tests {
         let address_table_state = generate_new_address_lookup_table(None, 2);
         store_address_lookup_table(&bank, address_table_key, address_table_state);
 
-        let new_bank = Bank::new_from_parent(bank, &Pubkey::new_unique(), 2);
+        let new_bank = Bank::new_from_parent(bank, SlotLeader::new_unique(), 2);
         let bank = bank_forks
             .write()
             .unwrap()

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -789,7 +789,7 @@ impl LeaderSlotMetricsTracker {
 mod tests {
     use {
         super::*,
-        solana_pubkey::Pubkey,
+        solana_leader_schedule::SlotLeader,
         solana_runtime::{bank::Bank, genesis_utils::create_genesis_config},
         std::{mem, sync::Arc},
     };
@@ -807,7 +807,7 @@ mod tests {
         // Create a child descended from the first bank
         let next_bank = Arc::new(Bank::new_from_parent(
             first_bank.clone(),
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             first_bank.slot() + 1,
         ));
 

--- a/core/src/banking_stage/read_write_account_set.rs
+++ b/core/src/banking_stage/read_write_account_set.rs
@@ -87,6 +87,7 @@ mod tests {
         },
         solana_hash::Hash,
         solana_keypair::Keypair,
+        solana_leader_schedule::SlotLeader,
         solana_ledger::genesis_utils::GenesisConfigInfo,
         solana_message::{
             v0::{self, MessageAddressTableLookup},
@@ -167,7 +168,7 @@ mod tests {
 
         let slot = bank.slot() + 1;
         (
-            Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), slot)),
+            Arc::new(Bank::new_from_parent(bank, SlotLeader::new_unique(), slot)),
             address_table_key,
         )
     }

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -350,6 +350,7 @@ pub(crate) mod tests {
         solana_epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
         solana_genesis_config::GenesisConfig,
         solana_hash::Hash,
+        solana_leader_schedule::SlotLeader,
         solana_perf::packet::{BytesPacket, PacketFlags},
         solana_runtime::genesis_utils::{self, ValidatorVoteKeypairs},
         solana_signer::Signer,
@@ -696,7 +697,7 @@ pub(crate) mod tests {
         let bank_0 = Bank::new_for_tests(&config);
         let bank = Bank::new_from_parent(
             Arc::new(bank_0),
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             MINIMUM_SLOTS_PER_EPOCH - 1,
         );
         assert_eq!(bank.epoch(), 0);
@@ -711,7 +712,7 @@ pub(crate) mod tests {
         let bank_0 = Bank::new_for_tests(&config);
         let bank = Bank::new_from_parent(
             Arc::new(bank_0),
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             MINIMUM_SLOTS_PER_EPOCH,
         );
         assert_eq!(bank.epoch(), 1);
@@ -730,7 +731,7 @@ pub(crate) mod tests {
         let bank_0 = Bank::new_for_tests(&config);
         let bank = Bank::new_from_parent(
             Arc::new(bank_0),
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             3 * MINIMUM_SLOTS_PER_EPOCH,
         );
         assert_eq!(bank.epoch(), 2);

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -764,6 +764,7 @@ mod tests {
         itertools::Itertools,
         solana_hash::Hash,
         solana_keypair::Keypair,
+        solana_leader_schedule::SlotLeader,
         solana_perf::packet,
         solana_pubkey::Pubkey,
         solana_rpc::optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
@@ -826,7 +827,7 @@ mod tests {
             .read()
             .unwrap()
             .contains_key(&bank.slot()));
-        let bank1 = Bank::new_from_parent(bank.clone(), &Pubkey::default(), bank.slot() + 1);
+        let bank1 = Bank::new_from_parent(bank.clone(), SlotLeader::default(), bank.slot() + 1);
         vote_tracker.progress_with_new_root_bank(&bank1);
         assert!(!vote_tracker
             .slot_vote_trackers
@@ -840,7 +841,7 @@ mod tests {
         let new_epoch_slot = bank
             .epoch_schedule()
             .get_first_slot_in_epoch(current_epoch + 1);
-        let new_epoch_bank = Bank::new_from_parent(bank, &Pubkey::default(), new_epoch_slot);
+        let new_epoch_bank = Bank::new_from_parent(bank, SlotLeader::default(), new_epoch_slot);
         vote_tracker.progress_with_new_root_bank(&new_epoch_bank);
     }
 
@@ -895,7 +896,7 @@ mod tests {
         // Votes for slots less than the provided root bank's slot should not be processed
         let bank3 = Arc::new(Bank::new_from_parent(
             Arc::new(bank0),
-            &Pubkey::default(),
+            SlotLeader::default(),
             3,
         ));
         let vote_slots = vec![1, 2];
@@ -1461,7 +1462,7 @@ mod tests {
             .collect();
 
         let new_root_bank =
-            Bank::new_from_parent(bank, &Pubkey::default(), first_slot_in_new_epoch - 2);
+            Bank::new_from_parent(bank, SlotLeader::default(), first_slot_in_new_epoch - 2);
         ClusterInfoVoteListener::filter_and_confirm_with_new_votes(
             &vote_tracker,
             vote_txs,

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -326,6 +326,7 @@ mod tests {
     use {
         super::*,
         solana_account::{state_traits::StateMut, Account, ReadableAccount},
+        solana_leader_schedule::SlotLeader,
         solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
         solana_pubkey::Pubkey,
         solana_runtime::{
@@ -650,7 +651,7 @@ mod tests {
             let bank = Bank::new_from_parent_with_bank_forks(
                 bank_forks.as_ref(),
                 previous_bank.clone(),
-                &Pubkey::default(),
+                SlotLeader::default(),
                 x + 1,
             );
             let tower_sync = TowerSync::new_from_slot(x, previous_bank.hash());
@@ -679,7 +680,7 @@ mod tests {
         let bank34 = Bank::new_from_parent_with_bank_forks(
             bank_forks.as_ref(),
             bank33.clone(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             34,
         );
         let tower_sync = TowerSync::new_from_slot(33, bank33.hash());
@@ -725,7 +726,7 @@ mod tests {
         let _bank35 = Bank::new_from_parent_with_bank_forks(
             bank_forks.as_ref(),
             bank33,
-            &Pubkey::default(),
+            SlotLeader::default(),
             35,
         );
 
@@ -756,7 +757,7 @@ mod tests {
             let bank = Bank::new_from_parent_with_bank_forks(
                 bank_forks.as_ref(),
                 previous_bank.clone(),
-                &Pubkey::default(),
+                SlotLeader::default(),
                 x + 1,
             );
             // Skip 34 as it is not part of this fork.

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -138,9 +138,9 @@ impl OptimisticConfirmationVerifier {
 #[cfg(test)]
 mod test {
     use {
-        super::*, crate::vote_simulator::VoteSimulator,
-        solana_ledger::get_tmp_ledger_path_auto_delete, solana_pubkey::Pubkey,
-        solana_runtime::bank::Bank, std::collections::HashMap, trees::tr,
+        super::*, crate::vote_simulator::VoteSimulator, solana_leader_schedule::SlotLeader,
+        solana_ledger::get_tmp_ledger_path_auto_delete, solana_runtime::bank::Bank,
+        std::collections::HashMap, trees::tr,
     };
 
     #[test]
@@ -270,7 +270,7 @@ mod test {
             .bank_forks
             .write()
             .unwrap()
-            .insert(Bank::new_from_parent(bank6, &Pubkey::default(), 7));
+            .insert(Bank::new_from_parent(bank6, SlotLeader::default(), 7));
         let bank7 = vote_simulator.bank_forks.read().unwrap().get(7).unwrap();
         assert!(!bank7.ancestors.contains_key(&3));
 

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -921,6 +921,7 @@ mod test {
         },
         solana_hash::Hash,
         solana_keypair::Keypair,
+        solana_leader_schedule::SlotLeader,
         solana_ledger::{
             blockstore::make_many_slot_entries, get_tmp_ledger_path,
             get_tmp_ledger_path_auto_delete, shred::Nonce,
@@ -1913,7 +1914,7 @@ mod test {
         let bank_forks = &repair_info.bank_forks;
         let root_bank = bank_forks.read().unwrap().root_bank();
         let new_root_slot = dead_duplicate_confirmed_slot_2 + 1;
-        let new_root_bank = Bank::new_from_parent(root_bank, &Pubkey::default(), new_root_slot);
+        let new_root_bank = Bank::new_from_parent(root_bank, SlotLeader::default(), new_root_slot);
         new_root_bank.freeze();
         {
             let mut w_bank_forks = bank_forks.write().unwrap();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -78,7 +78,7 @@ use {
     solana_hard_forks::HardForks,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_leader_schedule::FixedSchedule,
+    solana_leader_schedule::{FixedSchedule, SlotLeader},
     solana_ledger::{
         bank_forks_utils,
         blockstore::{
@@ -2523,7 +2523,7 @@ fn maybe_warp_slot(
 
         bank_forks.insert(Bank::warp_from_parent(
             root_bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             warp_slot,
         ));
         bank_forks.set_root(warp_slot, Some(snapshot_controller), Some(warp_slot));
@@ -2980,6 +2980,7 @@ mod tests {
         solana_entry::entry,
         solana_genesis_config::create_genesis_config,
         solana_gossip::contact_info::ContactInfo,
+        solana_leader_schedule::SlotLeader,
         solana_ledger::{
             blockstore, create_new_tmp_ledger, genesis_utils::create_genesis_config_with_leader,
             get_tmp_ledger_path_auto_delete,
@@ -3313,7 +3314,7 @@ mod tests {
         // bank=1, wait=0, should pass, bank is past the wait slot
         let bank_forks = BankForks::new_rw_arc(Bank::new_from_parent(
             bank_forks.read().unwrap().root_bank(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             1,
         ));
         config.wait_for_supermajority = Some(0);

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -21,6 +21,7 @@ use {
     solana_clock::Slot,
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
+    solana_leader_schedule::SlotLeader,
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank,
@@ -95,7 +96,7 @@ impl VoteSimulator {
             }
             let parent = *walk.get_parent().unwrap().data();
             let parent_bank = self.bank_forks.read().unwrap().get(parent).unwrap();
-            let new_bank = Bank::new_from_parent(parent_bank.clone(), &Pubkey::default(), slot);
+            let new_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), slot);
             let new_bank = self
                 .bank_forks
                 .write()

--- a/core/tests/scheduler_cost_adjustment.rs
+++ b/core/tests/scheduler_cost_adjustment.rs
@@ -8,6 +8,7 @@ use {
     solana_genesis_config::{create_genesis_config, GenesisConfig},
     solana_instruction::{error::InstructionError, AccountMeta, Instruction},
     solana_keypair::Keypair,
+    solana_leader_schedule::SlotLeader,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_message::Message,
     solana_native_token::LAMPORTS_PER_SOL,
@@ -66,7 +67,7 @@ impl TestSetup {
         let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             self.genesis_config
                 .epoch_schedule
                 .get_first_slot_in_epoch(1),

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -20,13 +20,13 @@ use {
     },
     solana_entry::entry::Entry,
     solana_hash::Hash,
+    solana_leader_schedule::SlotLeader,
     solana_ledger::{
         blockstore::Blockstore, create_new_tmp_ledger_auto_delete,
         genesis_utils::create_genesis_config, leader_schedule_cache::LeaderScheduleCache,
     },
     solana_perf::packet::to_packet_batches,
     solana_poh::poh_recorder::create_test_recorder,
-    solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, genesis_utils::GenesisConfigInfo,
         installed_scheduler_pool::SchedulingContext,
@@ -94,12 +94,12 @@ fn test_scheduler_waited_by_drop_bank_service() {
 
     // Create bank, which is pruned later
     let pruned = 2;
-    let pruned_bank = Bank::new_from_parent(genesis_bank.clone(), &Pubkey::default(), pruned);
+    let pruned_bank = Bank::new_from_parent(genesis_bank.clone(), SlotLeader::default(), pruned);
     let pruned_bank = bank_forks.write().unwrap().insert(pruned_bank);
 
     // Create new root bank
     let root = 3;
-    let root_bank = Bank::new_from_parent(genesis_bank.clone(), &Pubkey::default(), root);
+    let root_bank = Bank::new_from_parent(genesis_bank.clone(), SlotLeader::default(), root);
     root_bank.freeze();
     let root_hash = root_bank.hash();
     bank_forks.write().unwrap().insert(root_bank);
@@ -260,7 +260,7 @@ fn test_scheduler_producing_blocks() {
     let tx = RuntimeTransaction::from_transaction_for_tests(tx);
 
     // Crate tpu_bank
-    let tpu_bank = Bank::new_from_parent(genesis_bank.clone(), &Pubkey::default(), 2);
+    let tpu_bank = Bank::new_from_parent(genesis_bank.clone(), SlotLeader::default(), 2);
     let tpu_bank = bank_forks
         .write()
         .unwrap()

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -242,7 +242,7 @@ mod tests {
             get_tmp_ledger_path_auto_delete,
             shred::Shredder,
         },
-        solana_runtime::bank::Bank,
+        solana_runtime::bank::{Bank, SlotLeader},
         solana_signer::Signer,
         solana_time_utils::timestamp,
     };
@@ -303,7 +303,11 @@ mod tests {
         {
             let mut bank_forks = bank_forks_arc.write().unwrap();
             let bank0 = bank_forks.get(0).unwrap();
-            bank_forks.insert(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 9));
+            bank_forks.insert(Bank::new_from_parent(
+                bank0.clone(),
+                SlotLeader::default(),
+                9,
+            ));
             bank_forks.set_root(9, None, None);
         }
         assert!(blockstore.set_roots([0, 9].iter()).is_ok());
@@ -395,7 +399,11 @@ mod tests {
         {
             let mut bank_forks = bank_forks_arc.write().unwrap();
             let bank0 = bank_forks.get(0).unwrap();
-            bank_forks.insert(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 9));
+            bank_forks.insert(Bank::new_from_parent(
+                bank0.clone(),
+                SlotLeader::default(),
+                9,
+            ));
             bank_forks.set_root(9, None, None);
         }
         blockstore.set_roots([0, 9].iter()).unwrap();

--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -87,7 +87,10 @@ mod tests {
     use {
         super::*,
         solana_clock::Slot,
-        solana_runtime::genesis_utils::{GenesisConfigInfo, create_genesis_config},
+        solana_runtime::{
+            bank::SlotLeader,
+            genesis_utils::{GenesisConfigInfo, create_genesis_config},
+        },
     };
 
     #[test]
@@ -103,7 +106,7 @@ mod tests {
             Duration::from_millis(num_slots * 400)
         );
         for slot in 1..32 {
-            bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::new_unique(), slot);
+            bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::new_unique(), slot);
             assert_eq!(bank.epoch(), epoch);
             assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
             assert_eq!(
@@ -114,7 +117,7 @@ mod tests {
         let epoch = 1;
         let num_slots = 64;
         for slot in 32..32 + num_slots {
-            bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::new_unique(), slot);
+            bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::new_unique(), slot);
             assert_eq!(bank.epoch(), epoch);
             assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
             assert_eq!(
@@ -125,7 +128,7 @@ mod tests {
         let epoch = 2;
         let num_slots = 128;
         for slot in 96..96 + num_slots {
-            bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::new_unique(), slot);
+            bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::new_unique(), slot);
             assert_eq!(bank.epoch(), epoch);
             assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
             assert_eq!(
@@ -161,7 +164,7 @@ mod tests {
         let mut epoch_specs = EpochSpecs::from(bank_forks.clone());
         for slot in 1..100 {
             let bank = bank_forks.read().unwrap().get(slot - 1).unwrap();
-            let bank = Bank::new_from_parent(bank, &Pubkey::new_unique(), slot);
+            let bank = Bank::new_from_parent(bank, SlotLeader::new_unique(), slot);
             bank_forks.write().unwrap().insert(bank);
         }
         // root is still 0, epoch 0.

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2203,7 +2203,7 @@ fn main() {
 
                     if child_bank_required {
                         let mut child_bank =
-                            Bank::new_from_parent(bank.clone(), bank.leader_id(), bank.slot() + 1);
+                            Bank::new_from_parent(bank.clone(), *bank.leader(), bank.slot() + 1);
 
                         if let Ok(rent_burn_percentage) = rent_burn_percentage {
                             child_bank.set_rent_burn_percentage(rent_burn_percentage);
@@ -2507,7 +2507,7 @@ fn main() {
                         bank.force_flush_accounts_cache();
                         Arc::new(Bank::warp_from_parent(
                             bank.clone(),
-                            bank.leader_id(),
+                            *bank.leader(),
                             warp_slot,
                         ))
                     } else {
@@ -2999,7 +2999,7 @@ fn main() {
                         };
                         let warped_bank = Bank::new_from_parent_with_tracer(
                             base_bank.clone(),
-                            base_bank.leader_id(),
+                            *base_bank.leader(),
                             next_epoch,
                             tracer,
                         );

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1787,10 +1787,9 @@ fn process_next_slots(
         if next_meta.is_full() {
             let next_bank = Bank::new_from_parent(
                 bank.clone(),
-                &leader_schedule_cache
+                leader_schedule_cache
                     .slot_leader_at(*next_slot, Some(bank))
-                    .unwrap()
-                    .id,
+                    .unwrap(),
                 *next_slot,
             );
             set_alpenglow_ticks(&next_bank, migration_status);
@@ -2308,6 +2307,7 @@ pub mod tests {
         solana_hash::Hash,
         solana_instruction::{error::InstructionError, Instruction},
         solana_keypair::Keypair,
+        solana_leader_schedule::SlotLeader,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_program_runtime::declare_process_instruction,
         solana_pubkey::Pubkey,
@@ -4188,7 +4188,7 @@ pub mod tests {
         let bank0_last_blockhash = bank0.last_blockhash();
         let bank1 = bank_forks.write().unwrap().insert(Bank::new_from_parent(
             bank0.clone_without_scheduler(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             1,
         ));
         confirm_full_slot(
@@ -4343,7 +4343,7 @@ pub mod tests {
             i += 1;
 
             let slot = bank.slot() + rng().random_range(1..3);
-            bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), slot));
+            bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::default(), slot));
         }
     }
 
@@ -4469,7 +4469,7 @@ pub mod tests {
             .unwrap()
             .insert(Bank::new_from_parent(
                 bank0.clone(),
-                &solana_pubkey::new_rand(),
+                SlotLeader::new_unique(),
                 1,
             ))
             .clone_without_scheduler();
@@ -5204,7 +5204,7 @@ pub mod tests {
         const HASHES_PER_TICK: u64 = 10;
         const TICKS_PER_SLOT: u64 = 2;
 
-        let leader_id = Pubkey::new_unique();
+        let leader = SlotLeader::new_unique();
 
         let GenesisConfigInfo {
             mut genesis_config,
@@ -5230,7 +5230,7 @@ pub mod tests {
         assert_eq!(slot_0_bank.get_hash_age(&genesis_hash), Some(1));
         assert_eq!(slot_0_bank.get_hash_age(&slot_0_hash), Some(0));
 
-        let new_bank = Bank::new_from_parent(slot_0_bank, &leader_id, 2);
+        let new_bank = Bank::new_from_parent(slot_0_bank, leader, 2);
         let slot_2_bank = bank_forks
             .write()
             .unwrap()

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -537,7 +537,11 @@ mod tests {
         let bank = bank_forks
             .write()
             .unwrap()
-            .insert(Bank::new_from_parent(bank, &Pubkey::default(), target_slot))
+            .insert(Bank::new_from_parent(
+                bank,
+                SlotLeader::default(),
+                target_slot,
+            ))
             .clone_without_scheduler();
         let mut expected_slot = 0;
         let epoch = bank.get_leader_schedule_epoch(target_slot);
@@ -598,7 +602,7 @@ mod tests {
         assert_eq!(bank.get_epoch_and_slot_index(96).0, 2);
         assert!(cache.slot_leader_at(96, Some(&bank)).is_none());
 
-        let bank2 = Bank::new_from_parent(bank, &solana_pubkey::new_rand(), 95);
+        let bank2 = Bank::new_from_parent(bank, SlotLeader::new_unique(), 95);
         assert!(bank2.epoch_vote_accounts(2).is_some());
 
         // Set root for a slot in epoch 1, so that epoch 2 is now confirmed

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -4,6 +4,7 @@ use {
     crossbeam_channel::bounded,
     solana_hash::Hash,
     solana_keypair::Keypair,
+    solana_leader_schedule::SlotLeader,
     solana_ledger::{
         blockstore::Blockstore, genesis_utils::create_genesis_config,
         get_tmp_ledger_path_auto_delete, leader_schedule_cache::LeaderScheduleCache,
@@ -111,7 +112,7 @@ fn bench_record_transactions(c: &mut Criterion) {
                     .unwrap();
                 bank = Arc::new(Bank::new_from_parent(
                     bank.clone(),
-                    &Pubkey::default(),
+                    SlotLeader::default(),
                     next_slot,
                 ));
                 poh_controller

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -1253,7 +1253,7 @@ mod tests {
         );
 
         bank0.fill_bank_with_ticks_for_tests();
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
 
         // Set a working bank
         poh_recorder.set_bank_for_test(bank1.clone());
@@ -1357,7 +1357,7 @@ mod tests {
         );
 
         bank0.fill_bank_with_ticks_for_tests();
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
         poh_recorder.set_bank_for_test(bank1.clone());
         // Let poh_recorder tick up to bank1.tick_height() - 1
         for _ in 0..bank1.tick_height() - 1 {
@@ -1434,7 +1434,7 @@ mod tests {
         );
 
         bank0.fill_bank_with_ticks_for_tests();
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
         poh_recorder.set_bank_for_test(bank1.clone());
 
         // Record up to exactly min tick height
@@ -1522,7 +1522,7 @@ mod tests {
         );
 
         bank0.fill_bank_with_ticks_for_tests();
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
         poh_recorder.set_bank_for_test(bank1);
 
         // Check we can make two ticks without hitting min_tick_height
@@ -1885,7 +1885,7 @@ mod tests {
         // Reset onto Leader A's last slot.
         for _ in leader_a_start_slot + 1..leader_b_start_slot {
             let child_slot = bank.slot() + 1;
-            bank = Arc::new(Bank::new_from_parent(bank, &leader_a.id, child_slot));
+            bank = Arc::new(Bank::new_from_parent(bank, leader_a, child_slot));
         }
         poh_recorder.reset(bank.clone(), Some((leader_b_start_slot, leader_b_end_slot)));
 
@@ -1907,7 +1907,7 @@ mod tests {
 
         // Simulate generating Leader B's second slot.
         let child_slot = bank.slot() + 1;
-        bank = Arc::new(Bank::new_from_parent(bank, &leader_b.id, child_slot));
+        bank = Arc::new(Bank::new_from_parent(bank, leader_b, child_slot));
 
         // Reset PoH targeting Leader D's slots.
         poh_recorder.reset(bank, Some((leader_d_start_slot, leader_d_end_slot)));
@@ -2016,7 +2016,7 @@ mod tests {
         );
 
         // reset poh now. we should immediately be leader
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
         assert_eq!(bank1.slot(), 1);
         poh_recorder.reset(bank1.clone(), Some((2, 2)));
         assert_eq!(
@@ -2067,7 +2067,11 @@ mod tests {
 
         // Let's test that correct grace ticks are reported
         // Set the leader slot one slot down
-        let bank2 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 2));
+        let bank2 = Arc::new(Bank::new_from_parent(
+            bank1.clone(),
+            SlotLeader::default(),
+            2,
+        ));
         poh_recorder.reset(bank2.clone(), Some((4, 4)));
 
         // send ticks for a slot
@@ -2080,7 +2084,7 @@ mod tests {
             poh_recorder.reached_leader_slot(&test_validator_pubkey),
             PohLeaderStatus::NotReached
         );
-        let bank3 = Arc::new(Bank::new_from_parent(bank2, &Pubkey::default(), 3));
+        let bank3 = Arc::new(Bank::new_from_parent(bank2, SlotLeader::default(), 3));
         assert_eq!(bank3.slot(), 3);
         poh_recorder.reset(bank3.clone(), Some((4, 4)));
 
@@ -2096,7 +2100,7 @@ mod tests {
         // Let's test that if a node overshoots the ticks for its target
         // leader slot, reached_leader_slot() will return true, because it's overdue
         // Set the leader slot one slot down
-        let bank4 = Arc::new(Bank::new_from_parent(bank3, &Pubkey::default(), 4));
+        let bank4 = Arc::new(Bank::new_from_parent(bank3, SlotLeader::default(), 4));
         poh_recorder.reset(bank4.clone(), Some((5, 5)));
 
         // Overshoot ticks for the slot
@@ -2211,7 +2215,7 @@ mod tests {
         assert!(!poh_recorder.would_be_leader(2 * bank.ticks_per_slot()));
 
         // Move the bank up a slot (so that max_tick_height > slot 0's tick_height)
-        let bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 1));
+        let bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::default(), 1));
         // If we set the working bank, the node should be leader within next 2 slots
         poh_recorder.set_bank_for_test(bank.clone());
         assert!(poh_recorder.would_be_leader(2 * bank.ticks_per_slot()));
@@ -2239,7 +2243,7 @@ mod tests {
             Arc::new(AtomicBool::default()),
         );
         //create a new bank
-        let bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), 2));
+        let bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::default(), 2));
         // add virtual ticks into poh for slots 0, 1, and 2
         for _ in 0..(bank.ticks_per_slot() * 3) {
             poh_recorder.tick();

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -679,6 +679,7 @@ mod tests {
         rand::{rng, Rng},
         solana_clock::{DEFAULT_HASHES_PER_TICK, DEFAULT_MS_PER_SLOT, DEFAULT_TICKS_PER_SLOT},
         solana_hash::Hash,
+        solana_leader_schedule::SlotLeader,
         solana_ledger::{
             blockstore::Blockstore,
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
@@ -773,7 +774,7 @@ mod tests {
                                 .reset(bank.clone(), next_leader_slot);
                             bank = Arc::new(Bank::new_from_parent(
                                 bank.clone(),
-                                &solana_pubkey::new_rand(),
+                                SlotLeader::new_unique(),
                                 bank.slot() + 1,
                             ));
                             poh_recorder

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -43,7 +43,7 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_runtime::{
-        bank::Bank,
+        bank::{Bank, SlotLeader},
         bank_forks::BankForks,
         commitment::BlockCommitmentCache,
         genesis_utils::{create_genesis_config_with_leader_ex, GenesisConfigInfo},
@@ -895,7 +895,7 @@ impl ProgramTest {
         let bank = {
             let bank = Arc::new(bank);
             bank.fill_bank_with_ticks_for_tests();
-            let bank = Bank::new_from_parent(bank.clone(), bank.leader_id(), bank.slot() + 1);
+            let bank = Bank::new_from_parent(bank.clone(), *bank.leader(), bank.slot() + 1);
             debug!("Bank slot: {}", bank.slot());
             bank
         };
@@ -1191,7 +1191,7 @@ impl ProgramTestContext {
             bank_forks
                 .insert(Bank::warp_from_parent(
                     bank,
-                    &Pubkey::default(),
+                    SlotLeader::default(),
                     pre_warp_slot,
                 ))
                 .clone_without_scheduler()
@@ -1206,7 +1206,7 @@ impl ProgramTestContext {
         // warp_bank is frozen so go forward to get unfrozen bank at warp_slot
         bank_forks.insert(Bank::new_from_parent(
             warp_bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             warp_slot,
         ));
 
@@ -1250,7 +1250,7 @@ impl ProgramTestContext {
 
         // warp_bank is frozen so go forward to get unfrozen bank at warp_slot
         let warp_slot = pre_warp_slot + 1;
-        let mut warp_bank = Bank::new_from_parent(bank, &Pubkey::default(), warp_slot);
+        let mut warp_bank = Bank::new_from_parent(bank, SlotLeader::default(), warp_slot);
 
         warp_bank.force_reward_interval_end_for_tests();
         bank_forks.insert(warp_bank);

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -34,7 +34,7 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_runtime::{
-        bank::Bank,
+        bank::{Bank, SlotLeader},
         bank_client::BankClient,
         bank_forks::BankForks,
         genesis_utils::{
@@ -173,7 +173,7 @@ fn bank_with_feature_activated(
     feature_id: &Pubkey,
 ) -> Arc<Bank> {
     let slot = parent.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(parent, &Pubkey::new_unique(), slot);
+    let mut bank = Bank::new_from_parent(parent, SlotLeader::new_unique(), slot);
     bank.activate_feature(feature_id);
     bank_forks
         .write()
@@ -189,7 +189,7 @@ fn bank_with_feature_deactivated(
     feature_id: &Pubkey,
 ) -> Arc<Bank> {
     let slot = parent.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(parent, &Pubkey::new_unique(), slot);
+    let mut bank = Bank::new_from_parent(parent, SlotLeader::new_unique(), slot);
     bank.deactivate_feature(feature_id);
     bank_forks
         .write()
@@ -2641,7 +2641,7 @@ fn test_program_sbf_upgrade() {
             .unwrap();
     }
     bank_client
-        .advance_slot(1, &bank_forks, &Pubkey::default())
+        .advance_slot(1, &bank_forks, SlotLeader::default())
         .expect("Failed to advance the slot");
 
     // Call upgraded program
@@ -2756,7 +2756,7 @@ fn test_program_sbf_upgrade_via_cpi() {
         .send_and_confirm_message(&[&mint_keypair, &new_authority_keypair], message)
         .unwrap();
     bank_client
-        .advance_slot(1, &bank_forks, &Pubkey::default())
+        .advance_slot(1, &bank_forks, SlotLeader::default())
         .expect("Failed to advance the slot");
 
     // Call the upgraded program via CPI
@@ -4106,7 +4106,7 @@ fn test_program_sbf_inner_instruction_alignment_checks() {
     // unaligned should be allowed once invoke completes
     let mut bank_client = BankClient::new_shared(bank);
     bank_client
-        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .advance_slot(1, bank_forks.as_ref(), SlotLeader::default())
         .expect("Failed to advance the slot");
     let mut instruction = Instruction::new_with_bytes(
         inner_instruction_alignment_check,

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -417,8 +417,7 @@ mod tests {
         super::*,
         crossbeam_channel::unbounded,
         solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
-        solana_pubkey::Pubkey,
-        solana_runtime::{commitment::BlockCommitmentCache, dependency_tracker},
+        solana_runtime::{bank::SlotLeader, commitment::BlockCommitmentCache, dependency_tracker},
         std::sync::atomic::AtomicU64,
     };
 
@@ -439,13 +438,13 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
-        let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
+        let bank2 = Bank::new_from_parent(bank1, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
         let bank2 = bank_forks.read().unwrap().get(2).unwrap();
-        let bank3 = Bank::new_from_parent(bank2, &Pubkey::default(), 3);
+        let bank3 = Bank::new_from_parent(bank2, SlotLeader::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
         let optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>> =
@@ -555,7 +554,7 @@ mod tests {
 
         // Test higher root will be cached and clear pending_optimistically_confirmed_banks
         let bank3 = bank_forks.read().unwrap().get(3).unwrap();
-        let bank4 = Bank::new_from_parent(bank3, &Pubkey::default(), 4);
+        let bank4 = Bank::new_from_parent(bank3, SlotLeader::default(), 4);
         bank_forks.write().unwrap().insert(bank4);
         OptimisticallyConfirmedBankTracker::process_notification(
             (
@@ -579,7 +578,7 @@ mod tests {
         assert_eq!(highest_confirmed_slot, 4);
 
         let bank4 = bank_forks.read().unwrap().get(4).unwrap();
-        let bank5 = Bank::new_from_parent(bank4, &Pubkey::default(), 5);
+        let bank5 = Bank::new_from_parent(bank4, SlotLeader::default(), 5);
         bank_forks.write().unwrap().insert(bank5);
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
 
@@ -638,10 +637,10 @@ mod tests {
 
         // Banks <= root do not get added to pending list, even if not frozen
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
-        let bank6 = Bank::new_from_parent(bank5, &Pubkey::default(), 6);
+        let bank6 = Bank::new_from_parent(bank5, SlotLeader::default(), 6);
         bank_forks.write().unwrap().insert(bank6);
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
-        let bank7 = Bank::new_from_parent(bank5, &Pubkey::default(), 7);
+        let bank7 = Bank::new_from_parent(bank5, SlotLeader::default(), 7);
         bank_forks.write().unwrap().insert(bank7);
         bank_forks.write().unwrap().set_root(7, None, None);
         OptimisticallyConfirmedBankTracker::process_notification(
@@ -730,7 +729,7 @@ mod tests {
 
             // Test bank will only be cached when frozen
             let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-            let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+            let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
             bank_forks.write().unwrap().insert(bank1);
 
             let mut pending_optimistically_confirmed_banks: HashSet<u64> = HashSet::new();

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4575,7 +4575,7 @@ pub mod tests {
             filter::MemcmpEncodedBytes,
         },
         solana_runtime::{
-            bank::BankTestConfig,
+            bank::{BankTestConfig, SlotLeader},
             commitment::{BlockCommitment, CommitmentSlots},
             non_circulating_supply::non_circulating_accounts,
         },
@@ -4994,7 +4994,7 @@ pub mod tests {
             let mut parent_bank = self.bank_forks.read().unwrap().working_bank();
             for (i, root) in roots.iter().enumerate() {
                 let new_bank =
-                    Bank::new_from_parent(parent_bank.clone(), parent_bank.leader_id(), *root);
+                    Bank::new_from_parent(parent_bank.clone(), *parent_bank.leader(), *root);
                 parent_bank = self
                     .bank_forks
                     .write()
@@ -5013,7 +5013,7 @@ pub mod tests {
             self.blockstore.set_roots(roots.iter()).unwrap();
             let new_bank = Bank::new_from_parent(
                 parent_bank.clone(),
-                parent_bank.leader_id(),
+                *parent_bank.leader(),
                 roots.iter().max().unwrap() + 1,
             );
             self.bank_forks.write().unwrap().insert(new_bank);
@@ -5041,7 +5041,11 @@ pub mod tests {
                 .bank_forks
                 .write()
                 .unwrap()
-                .insert(Bank::new_from_parent(parent_bank, &Pubkey::default(), slot))
+                .insert(Bank::new_from_parent(
+                    parent_bank,
+                    SlotLeader::default(),
+                    slot,
+                ))
                 .clone_without_scheduler();
 
             let new_block_commitment = BlockCommitmentCache::new(
@@ -8906,13 +8910,13 @@ pub mod tests {
 
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
-        let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
+        let bank2 = Bank::new_from_parent(bank1, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
         let bank2 = bank_forks.read().unwrap().get(2).unwrap();
-        let bank3 = Bank::new_from_parent(bank2, &Pubkey::default(), 3);
+        let bank3 = Bank::new_from_parent(bank2, SlotLeader::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
         let prioritization_fee_cache_inner = None;

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -135,8 +135,10 @@ pub mod tests {
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
             get_tmp_ledger_path_auto_delete,
         },
-        solana_pubkey::Pubkey,
-        solana_runtime::{bank::Bank, bank_forks::BankForks},
+        solana_runtime::{
+            bank::{Bank, SlotLeader},
+            bank_forks::BankForks,
+        },
     };
 
     #[test]
@@ -178,25 +180,25 @@ pub mod tests {
         assert_eq!(health.check(), RpcHealthStatus::Behind { num_slots: 15 });
 
         // Simulate this node observing slot 4 as optimistically confirmed - status still behind
-        let bank4 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 4));
+        let bank4 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 4));
         optimistically_confirmed_bank.write().unwrap().bank = bank4.clone();
         assert_eq!(health.check(), RpcHealthStatus::Behind { num_slots: 11 });
 
         // Simulate this node observing slot 5 as optimistically confirmed - status now ok
         // as distance is <= health_check_slot_distance
-        let bank5 = Arc::new(Bank::new_from_parent(bank4, &Pubkey::default(), 5));
+        let bank5 = Arc::new(Bank::new_from_parent(bank4, SlotLeader::default(), 5));
         optimistically_confirmed_bank.write().unwrap().bank = bank5.clone();
         assert_eq!(health.check(), RpcHealthStatus::Ok);
 
         // Node now up with tip of cluster
-        let bank15 = Arc::new(Bank::new_from_parent(bank5, &Pubkey::default(), 15));
+        let bank15 = Arc::new(Bank::new_from_parent(bank5, SlotLeader::default(), 15));
         optimistically_confirmed_bank.write().unwrap().bank = bank15.clone();
         assert_eq!(health.check(), RpcHealthStatus::Ok);
 
         // Node "beyond" tip of cluster - this technically isn't possible but could be
         // observed locally due to a race between updates to Blockstore and
         // OptimisticallyConfirmedBank. Either way, not a problem and status is ok.
-        let bank16 = Arc::new(Bank::new_from_parent(bank15, &Pubkey::default(), 16));
+        let bank16 = Arc::new(Bank::new_from_parent(bank15, SlotLeader::default(), 16));
         optimistically_confirmed_bank.write().unwrap().bank = bank16.clone();
         assert_eq!(health.check(), RpcHealthStatus::Ok);
     }

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -634,7 +634,7 @@ mod tests {
             ProcessedSignatureResult, ReceivedSignatureResult, RpcSignatureResult, SlotInfo,
         },
         solana_runtime::{
-            bank::Bank,
+            bank::{Bank, SlotLeader},
             bank_forks::BankForks,
             commitment::{BlockCommitmentCache, CommitmentSlots},
             genesis_utils::{
@@ -881,7 +881,7 @@ mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::new_for_tests(
@@ -997,7 +997,7 @@ mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::new_for_tests(
@@ -1180,7 +1180,7 @@ mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bob = Keypair::new();
 

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1231,6 +1231,7 @@ pub(crate) mod tests {
             RpcTransactionLogsFilter,
         },
         solana_runtime::{
+            bank::SlotLeader,
             commitment::BlockCommitment,
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
             prioritization_fee_cache::PrioritizationFeeCache,
@@ -1287,7 +1288,7 @@ pub(crate) mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let alice = Keypair::new();
 
@@ -1891,7 +1892,7 @@ pub(crate) mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
 
@@ -1908,7 +1909,7 @@ pub(crate) mod tests {
 
         bank1.process_transaction(&tx).unwrap();
 
-        let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
+        let bank2 = Bank::new_from_parent(bank1, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
         // add account for bob and process the transaction at bank2
@@ -1925,7 +1926,7 @@ pub(crate) mod tests {
 
         bank2.process_transaction(&tx).unwrap();
 
-        let bank3 = Bank::new_from_parent(bank2, &Pubkey::default(), 3);
+        let bank3 = Bank::new_from_parent(bank2, SlotLeader::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
         // add account for joe and process the transaction at bank3
@@ -2093,7 +2094,7 @@ pub(crate) mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
 
@@ -2110,7 +2111,7 @@ pub(crate) mod tests {
 
         bank1.process_transaction(&tx).unwrap();
 
-        let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
+        let bank2 = Bank::new_from_parent(bank1, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
         // add account for bob and process the transaction at bank2
@@ -2212,7 +2213,7 @@ pub(crate) mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
 
@@ -2229,7 +2230,7 @@ pub(crate) mod tests {
 
         bank1.process_transaction(&tx).unwrap();
 
-        let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
+        let bank2 = Bank::new_from_parent(bank1, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
         // add account for bob and process the transaction at bank2
@@ -2337,7 +2338,7 @@ pub(crate) mod tests {
             })
         };
 
-        let bank3 = Bank::new_from_parent(bank2, &Pubkey::default(), 3);
+        let bank3 = Bank::new_from_parent(bank2, SlotLeader::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
         // add account for joe and process the transaction at bank3
@@ -2424,7 +2425,7 @@ pub(crate) mod tests {
 
         let next_bank = Bank::new_from_parent(
             bank_forks.read().unwrap().get(0).unwrap(),
-            &solana_pubkey::new_rand(),
+            SlotLeader::new_unique(),
             1,
         );
         bank_forks.write().unwrap().insert(next_bank);
@@ -2722,9 +2723,9 @@ pub(crate) mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        let bank2 = Bank::new_from_parent(bank0, &Pubkey::default(), 2);
+        let bank2 = Bank::new_from_parent(bank0, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
         let alice = Keypair::from_base58_string("sfLnS4rZ5a8gXke3aGxCgM6usFAVPxLUaBSRdssGY9uS5eoiEWQ41CqDcpXbcekpKsie8Lyy3LNFdhEvjUE1wd9");

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -7,6 +7,7 @@ use {
     solana_account::{AccountSharedData, ReadableAccount},
     solana_genesis_config::create_genesis_config,
     solana_instruction::error::LamportsError,
+    solana_leader_schedule::SlotLeader,
     solana_pubkey::Pubkey,
     solana_runtime::bank::*,
     std::{path::PathBuf, sync::Arc},
@@ -54,7 +55,7 @@ fn bench_accounts_squash(bencher: &mut Bencher) {
     bencher.iter(|| {
         let next_bank = Arc::new(Bank::new_from_parent(
             prev_bank.clone(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             slot,
         ));
         test_utils::deposit(&next_bank, &pubkeys[0], 1).unwrap();

--- a/runtime/benches/prioritization_fee_cache.rs
+++ b/runtime/benches/prioritization_fee_cache.rs
@@ -4,6 +4,7 @@ extern crate test;
 use {
     rand::{rng, Rng},
     solana_compute_budget_interface::ComputeBudgetInstruction,
+    solana_leader_schedule::SlotLeader,
     solana_message::Message,
     solana_pubkey::Pubkey,
     solana_runtime::{
@@ -101,9 +102,9 @@ fn bench_process_transactions_multiple_slots(bencher: &mut Bencher) {
     let bank0 = Bank::new_for_benches(&genesis_config);
     let bank_forks = BankForks::new_rw_arc(bank0);
     let bank = bank_forks.read().unwrap().working_bank();
-    let collector = solana_pubkey::new_rand();
+    let leader = SlotLeader::new_unique();
     let banks = (1..=NUM_SLOTS)
-        .map(|n| Arc::new(Bank::new_from_parent(bank.clone(), &collector, n as u64)))
+        .map(|n| Arc::new(Bank::new_from_parent(bank.clone(), leader, n as u64)))
         .collect::<Vec<_>>();
 
     bencher.iter(|| {

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -723,7 +723,7 @@ mod test {
         super::*, crate::genesis_utils::create_genesis_config,
         agave_snapshots::snapshot_config::SnapshotConfig, crossbeam_channel::unbounded,
         solana_account::AccountSharedData, solana_epoch_schedule::EpochSchedule,
-        solana_pubkey::Pubkey,
+        solana_leader_schedule::SlotLeader, solana_pubkey::Pubkey,
     };
 
     #[test]
@@ -834,7 +834,7 @@ mod test {
                 let slot = bank.slot() + 1;
                 bank = Arc::new(Bank::new_from_parent(
                     bank.clone(),
-                    &Pubkey::new_unique(),
+                    SlotLeader::new_unique(),
                     slot,
                 ));
 
@@ -921,37 +921,37 @@ mod test {
         let fork0_bank0 = Arc::new(bank);
         let fork0_bank1 = Arc::new(Bank::new_from_parent(
             fork0_bank0.clone(),
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             fork0_bank0.slot() + 1,
         ));
         let fork1_bank1 = Arc::new(Bank::new_from_parent(
             fork0_bank0.clone(),
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             fork0_bank0.slot() + 1,
         ));
         let fork2_bank1 = Arc::new(Bank::new_from_parent(
             fork0_bank0.clone(),
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             fork0_bank0.slot() + 1,
         ));
         let fork0_bank2 = Arc::new(Bank::new_from_parent(
             fork0_bank1.clone(),
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             fork0_bank1.slot() + 1,
         ));
         let fork1_bank2 = Arc::new(Bank::new_from_parent(
             fork1_bank1.clone(),
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             fork1_bank1.slot() + 1,
         ));
         let fork0_bank3 = Arc::new(Bank::new_from_parent(
             fork0_bank2.clone(),
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             fork0_bank2.slot() + 1,
         ));
         let fork3_bank3 = Arc::new(Bank::new_from_parent(
             fork0_bank2.clone(),
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             fork0_bank2.slot() + 1,
         ));
         fork0_bank3.squash();

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -502,7 +502,7 @@ pub(crate) mod tests {
             bank::{
                 test_utils::goto_end_of_slot,
                 tests::{create_genesis_config, create_simple_test_bank},
-                Bank,
+                Bank, SlotLeader,
             },
             genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo},
             runtime_config::RuntimeConfig,
@@ -1303,7 +1303,7 @@ pub(crate) mod tests {
         let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             first_slot_in_next_epoch,
         );
 
@@ -1326,7 +1326,7 @@ pub(crate) mod tests {
         let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             first_slot_in_next_epoch,
         );
 
@@ -1338,8 +1338,12 @@ pub(crate) mod tests {
         // effective in the program cache.
         goto_end_of_slot(bank.clone());
         let next_slot = bank.slot() + 1;
-        let bank =
-            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), next_slot);
+        let bank = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            SlotLeader::default(),
+            next_slot,
+        );
 
         // Successfully invoke the new BPF loader v3 program.
         bank.process_transaction(&Transaction::new(
@@ -1373,7 +1377,7 @@ pub(crate) mod tests {
         let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             first_slot_in_next_epoch,
         );
 
@@ -1513,7 +1517,8 @@ pub(crate) mod tests {
         // Advance the bank to cross the epoch boundary and activate the
         // feature.
         goto_end_of_slot(bank.clone());
-        let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
+        let bank =
+            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), 33);
 
         // Assert the feature _was_ activated but the program was not migrated.
         assert!(bank.feature_set.is_active(feature_id));
@@ -1530,7 +1535,8 @@ pub(crate) mod tests {
 
         // Simulate crossing an epoch boundary again.
         goto_end_of_slot(bank.clone());
-        let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 96);
+        let bank =
+            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), 96);
 
         // Again, assert the feature is still active and the program still was
         // not migrated.
@@ -1617,7 +1623,8 @@ pub(crate) mod tests {
         // Simulate crossing an epoch boundary for a new bank.
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         goto_end_of_slot(bank.clone());
-        let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
+        let bank =
+            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), 33);
 
         // Assert the feature is active but the builtin was not migrated.
         assert!(bank.feature_set.is_active(feature_id));
@@ -2034,7 +2041,8 @@ pub(crate) mod tests {
         // Advance the bank to cross the epoch boundary and activate the
         // feature.
         goto_end_of_slot(bank.clone());
-        let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
+        let bank =
+            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), 33);
 
         // Assert the feature _was_ activated but the program was not migrated.
         assert!(bank.feature_set.is_active(feature_id));
@@ -2045,7 +2053,8 @@ pub(crate) mod tests {
 
         // Simulate crossing an epoch boundary again.
         goto_end_of_slot(bank.clone());
-        let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 96);
+        let bank =
+            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), 96);
 
         // Again, assert the feature is still active and the program still was
         // not migrated.
@@ -2302,7 +2311,7 @@ pub(crate) mod tests {
         let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             first_slot_in_next_epoch,
         );
 
@@ -2325,7 +2334,7 @@ pub(crate) mod tests {
         let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             first_slot_in_next_epoch,
         );
 

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -37,13 +37,13 @@ impl FeeDistribution {
 }
 
 impl Bank {
-    // Distribute collected transaction fees for this slot to leader_id (= current leader).
+    // Distribute collected transaction fees for this slot to leader.id (= current leader).
     //
     // Each validator is incentivized to process more transactions to earn more transaction fees.
     // Transaction fees are rewarded for the computing resource utilization cost, directly
     // proportional to their actual processing power.
     //
-    // leader_id is rotated according to stake-weighted leader schedule. So the opportunity of
+    // leader.id is rotated according to stake-weighted leader schedule. So the opportunity of
     // earning transaction fees are fairly distributed by stake. And missing the opportunity
     // (not producing a block as a leader) earns nothing. So, being online is incentivized as a
     // form of transaction fees as well.
@@ -114,10 +114,10 @@ impl Bank {
             return 0;
         }
 
-        match self.deposit_fees(&self.leader_id, deposit) {
+        match self.deposit_fees(&self.leader.id, deposit) {
             Ok(post_balance) => {
                 self.rewards.write().unwrap().push((
-                    self.leader_id,
+                    self.leader.id,
                     RewardInfo {
                         reward_type: RewardType::Fee,
                         lamports: deposit as i64,
@@ -130,7 +130,7 @@ impl Bank {
             Err(err) => {
                 debug!(
                     "Burned {} lamport tx fee instead of sending to {} due to {}",
-                    deposit, self.leader_id, err
+                    deposit, self.leader.id, err
                 );
                 datapoint_warn!(
                     "bank-burned_fee",

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -775,7 +775,7 @@ mod tests {
                     StartBlockHeightAndPartitionedRewards,
                 },
                 tests::create_genesis_config,
-                RewardInfo, VoteReward,
+                RewardInfo, SlotLeader, VoteReward,
             },
             genesis_utils::{self, deactivate_features, GenesisConfigInfo},
             stake_account::StakeAccount,
@@ -1135,7 +1135,7 @@ mod tests {
         // Advance bank to next epoch
         let slot = bank.slot + SLOTS_PER_EPOCH;
         let prev_bank = Arc::new(bank);
-        bank = Bank::new_from_parent(prev_bank.clone(), &Pubkey::new_unique(), slot);
+        bank = Bank::new_from_parent(prev_bank.clone(), SlotLeader::new_unique(), slot);
 
         for (vote_address, vote_op) in &op.vote_operations {
             let expected_commission = vote_op.expected_reward_commission;
@@ -1628,7 +1628,7 @@ mod tests {
         // boundary; slot is advanced 2 to demonstrate that distribution works
         // on block-height, not slot
         let new_slot = bank.slot() + 2;
-        let bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), new_slot));
+        let bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::default(), new_slot));
 
         let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
         let (_, recalculated_rewards, recalculated_partition_indices) =
@@ -1661,7 +1661,7 @@ mod tests {
 
         // Advance to last distribution slot
         let new_slot = bank.slot() + 1;
-        let bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), new_slot));
+        let bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::default(), new_slot));
 
         let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
         assert!(!epoch_rewards_sysvar.active);
@@ -1726,7 +1726,7 @@ mod tests {
 
         // Advance to first distribution slot
         let new_slot = bank.slot() + 1;
-        let bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), new_slot));
+        let bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::default(), new_slot));
 
         let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
         assert!(!epoch_rewards_sysvar.active);
@@ -1753,7 +1753,7 @@ mod tests {
         // Advance to next epoch boundary to update EpochStakes Kludgy because
         // mutable Bank methods require the bank not be Arc-wrapped.
         let new_slot = bank.slot() + 1;
-        let mut bank = Bank::new_from_parent(bank, &Pubkey::default(), new_slot);
+        let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), new_slot);
         let expected_starting_block_height = bank.block_height() + 1;
 
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
@@ -1819,7 +1819,7 @@ mod tests {
 
         // Advance to first distribution slot
         let mut bank =
-            Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), SLOTS_PER_EPOCH + 1);
+            Bank::new_from_parent(Arc::new(bank), SlotLeader::default(), SLOTS_PER_EPOCH + 1);
 
         bank.recalculate_partitioned_rewards_if_active(|| &thread_pool);
         let EpochRewardStatus::Active(EpochRewardPhase::Distribution(
@@ -1862,7 +1862,7 @@ mod tests {
 
         // Advance to last distribution slot
         let mut bank =
-            Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), SLOTS_PER_EPOCH + 2);
+            Bank::new_from_parent(Arc::new(bank), SlotLeader::default(), SLOTS_PER_EPOCH + 2);
         bank.recalculate_partitioned_rewards_if_active(|| &thread_pool);
         assert_eq!(bank.epoch_reward_status, EpochRewardStatus::Inactive);
     }
@@ -1886,7 +1886,7 @@ mod tests {
 
         // Advance to next epoch boundary
         let new_slot = bank.slot() + 1;
-        let mut bank = Bank::new_from_parent(bank, &Pubkey::default(), new_slot);
+        let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), new_slot);
 
         let EpochRewardStatus::Active(EpochRewardPhase::Calculation(calculation_status)) =
             bank.epoch_reward_status.clone()
@@ -2097,7 +2097,7 @@ mod tests {
         }
 
         let bank_fork1 =
-            Bank::new_from_parent(Arc::clone(&bank), &Pubkey::default(), next_epoch_slot);
+            Bank::new_from_parent(Arc::clone(&bank), SlotLeader::default(), next_epoch_slot);
         {
             let cache = bank_fork1.epoch_rewards_calculation_cache.lock().unwrap();
             assert!(
@@ -2106,7 +2106,7 @@ mod tests {
             );
         }
 
-        let bank_fork2 = Bank::new_from_parent(bank, &Pubkey::default(), next_epoch_slot);
+        let bank_fork2 = Bank::new_from_parent(bank, SlotLeader::default(), next_epoch_slot);
         {
             let cache = bank_fork2.epoch_rewards_calculation_cache.lock().unwrap();
             assert!(
@@ -2226,7 +2226,7 @@ mod tests {
 
         let bank2 = Arc::new(Bank::new_from_parent(
             Arc::clone(&bank1),
-            &Pubkey::default(),
+            SlotLeader::default(),
             SLOTS_PER_EPOCH * 2,
         ));
 
@@ -2247,7 +2247,7 @@ mod tests {
 
         let bank3 = Arc::new(Bank::new_from_parent(
             Arc::clone(&bank2),
-            &Pubkey::default(),
+            SlotLeader::default(),
             SLOTS_PER_EPOCH * 3,
         ));
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -414,7 +414,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            bank::tests::create_genesis_config,
+            bank::{tests::create_genesis_config, SlotLeader},
             bank_forks::BankForks,
             genesis_utils::{
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
@@ -591,7 +591,7 @@ mod tests {
             None,
             accounts_db_config,
             None,
-            Some(Pubkey::new_unique()),
+            Some(SlotLeader::new_unique()),
             Arc::default(),
             None,
             None,
@@ -611,7 +611,7 @@ mod tests {
         let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             advance_num_slots,
         );
 
@@ -706,7 +706,7 @@ mod tests {
             None,
             accounts_db_config,
             None,
-            Some(Pubkey::new_unique()),
+            Some(SlotLeader::new_unique()),
             Arc::default(),
             None,
             None,
@@ -820,7 +820,7 @@ mod tests {
             let curr_bank = Bank::new_from_parent_with_bank_forks(
                 bank_forks.as_ref(),
                 previous_bank.clone(),
-                &Pubkey::default(),
+                SlotLeader::default(),
                 slot,
             );
             let post_cap = curr_bank.capitalization();
@@ -913,7 +913,7 @@ mod tests {
             let curr_bank = Bank::new_from_parent_with_bank_forks(
                 bank_forks.as_ref(),
                 previous_bank.clone(),
-                &Pubkey::default(),
+                SlotLeader::default(),
                 slot,
             );
             let post_cap = curr_bank.capitalization();
@@ -1053,7 +1053,7 @@ mod tests {
             let bank = Bank::new_from_parent_with_bank_forks(
                 bank_forks.as_ref(),
                 previous_bank.clone(),
-                &Pubkey::default(),
+                SlotLeader::default(),
                 slot,
             );
 
@@ -1110,7 +1110,7 @@ mod tests {
 
         let epoch_boundary_bank = Arc::new(Bank::new_from_parent(
             bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             SLOTS_PER_EPOCH,
         ));
         // Slot at the epoch boundary contains voting rewards only, as well as partition data
@@ -1131,7 +1131,7 @@ mod tests {
 
         let partition0_bank = Arc::new(Bank::new_from_parent(
             epoch_boundary_bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             SLOTS_PER_EPOCH + 1,
         ));
         // Slot after the epoch boundary contains first partition of staking
@@ -1148,7 +1148,7 @@ mod tests {
 
         let partition1_bank = Arc::new(Bank::new_from_parent(
             partition0_bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             SLOTS_PER_EPOCH + 2,
         ));
         // Slot 2 after the epoch boundary contains second partition of staking
@@ -1166,7 +1166,8 @@ mod tests {
         // All rewards are recorded
         assert_eq!(total_staking_rewards, num_rewards);
 
-        let bank = Bank::new_from_parent(partition1_bank, &Pubkey::default(), SLOTS_PER_EPOCH + 3);
+        let bank =
+            Bank::new_from_parent(partition1_bank, SlotLeader::default(), SLOTS_PER_EPOCH + 3);
         // Next slot contains empty rewards (since fees are off), and no
         // partitions because not at the epoch boundary
         assert_eq!(

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -105,9 +105,12 @@ impl Bank {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::bank::tests::create_genesis_config, solana_account::ReadableAccount,
-        solana_epoch_schedule::EpochSchedule, solana_native_token::LAMPORTS_PER_SOL,
-        solana_pubkey::Pubkey, std::sync::Arc,
+        super::*,
+        crate::bank::{tests::create_genesis_config, SlotLeader},
+        solana_account::ReadableAccount,
+        solana_epoch_schedule::EpochSchedule,
+        solana_native_token::LAMPORTS_PER_SOL,
+        std::sync::Arc,
     };
 
     /// Test `EpochRewards` sysvar creation, distribution, and burning.
@@ -156,7 +159,7 @@ mod tests {
         // Create a child bank to test parent_blockhash
         let parent_blockhash = bank.last_blockhash();
         let parent_slot = bank.slot();
-        let bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), parent_slot + 1);
+        let bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::default(), parent_slot + 1);
         // Also note that running `create_epoch_rewards_sysvar()` against a bank
         // with an existing EpochRewards sysvar clobbers the previous values
         bank.create_epoch_rewards_sysvar(10, 42, num_partitions, &point_value);

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -89,14 +89,14 @@ mod tests {
         genesis_config.epoch_schedule = EpochSchedule::custom(400, 400, false);
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let deposit_amount = bank0.get_minimum_balance_for_rent_exemption(0);
-        let bank1 = Bank::new_from_parent(bank0.clone(), &leader_id, 1);
+        let bank1 = Bank::new_from_parent(bank0.clone(), *bank0.leader(), 1);
 
         // Create an account on a non-root fork
         let key1 = Pubkey::new_unique();
         bank_test_utils::deposit(&bank1, &key1, deposit_amount).unwrap();
 
         let bank2_slot = 2;
-        let bank2 = Bank::new_from_parent(bank0, &leader_id, bank2_slot);
+        let bank2 = Bank::new_from_parent(bank0.clone(), *bank0.leader(), bank2_slot);
 
         // Test new account
         let key2 = Pubkey::new_unique();
@@ -192,7 +192,7 @@ mod tests {
 
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         bank0.squash();
-        let mut bank = Bank::new_from_parent(bank0.clone(), &leader_id, 1);
+        let mut bank = Bank::new_from_parent(bank0.clone(), *bank0.leader(), 1);
         bank.freeze();
         add_root_and_flush_write_cache(&bank0);
 
@@ -273,7 +273,7 @@ mod tests {
         activate_all_features(&mut genesis_config);
 
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
-        let mut bank = Bank::new_from_parent(bank0, &leader_id, 1);
+        let mut bank = Bank::new_from_parent(bank0.clone(), *bank0.leader(), 1);
         while !bank.is_complete() {
             bank.fill_bank_with_ticks_for_tests();
         }

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -5,7 +5,7 @@ use super::Bank;
 mod tests {
     use {
         super::*, crate::inflation_rewards::points::PointValue,
-        solana_genesis_config::create_genesis_config, solana_pubkey::Pubkey,
+        solana_genesis_config::create_genesis_config, solana_leader_schedule::SlotLeader,
         solana_sysvar::epoch_rewards::EpochRewards, std::sync::Arc,
     };
 
@@ -29,7 +29,7 @@ mod tests {
         let bank1_slot = bank0.slot() + 1;
         let bank1 = Arc::new(Bank::new_from_parent(
             bank0.clone(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             bank1_slot,
         ));
 
@@ -49,7 +49,7 @@ mod tests {
         assert_eq!(bank0_cached_rent, bank1_cached_rent);
 
         let bank2_slot = bank1.slot() + 1;
-        let bank2 = Bank::new_from_parent(bank1.clone(), &Pubkey::default(), bank2_slot);
+        let bank2 = Bank::new_from_parent(bank1.clone(), SlotLeader::default(), bank2_slot);
 
         let bank2_sysvar_cache = bank2.transaction_processor.sysvar_cache();
         let bank2_cached_clock = bank2_sysvar_cache.get_clock();
@@ -77,7 +77,7 @@ mod tests {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank1_slot = bank0.slot() + 1;
-        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), bank1_slot);
+        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), bank1_slot);
 
         let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache();
         let bank1_cached_clock = bank1_sysvar_cache.get_clock();

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -440,7 +440,7 @@ fn test_bank_capitalization() {
         42 * 42 + genesis_sysvar_and_builtin_program_lamports() + bank0_sysvar_delta(),
     );
 
-    let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
     assert_eq!(
         bank1.capitalization(),
         42 * 42
@@ -610,7 +610,7 @@ pub(in crate::bank) fn new_from_parent_next_epoch(
         epoch = parent.epoch_schedule().get_epoch(slot);
     }
 
-    Bank::new_from_parent_with_bank_forks(bank_forks, parent, &Pubkey::default(), slot)
+    Bank::new_from_parent_with_bank_forks(bank_forks, parent, SlotLeader::default(), slot)
 }
 
 #[test]
@@ -795,7 +795,7 @@ where
     // put a child bank in epoch 1
     let bank1 = Arc::new(Bank::new_from_parent(
         bank0.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         bank0.get_slots_in_epoch(bank0.epoch()) + 1,
     ));
 
@@ -820,7 +820,7 @@ where
     // advance past partitioned epoch staking rewards delivery
     let bank2 = Arc::new(Bank::new_from_parent(
         bank1.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         bank1.slot() + 1,
     ));
     // verify that there's inflation
@@ -945,7 +945,7 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
     // put a child bank in epoch 1, which calls update_rewards()...
     let bank1 = Arc::new(Bank::new_from_parent(
         bank.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         bank.get_slots_in_epoch(bank.epoch()) + 1,
     ));
     // verify that there's inflation
@@ -968,7 +968,7 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
 
     // put another child bank, since partitioned staking rewards are delivered
     // after the epoch-boundary slot
-    let bank2 = Bank::new_from_parent(bank1.clone(), &Pubkey::default(), bank1.slot() + 1);
+    let bank2 = Bank::new_from_parent(bank1.clone(), SlotLeader::default(), bank1.slot() + 1);
     let rewards = bank2.rewards.read().unwrap();
     rewards
         .iter()
@@ -1295,7 +1295,7 @@ fn test_executed_transaction_count_post_bank_transaction_count_fix() {
     let bank2 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank,
-        &Pubkey::default(),
+        SlotLeader::default(),
         genesis_config.epoch_schedule.first_normal_slot,
     );
 
@@ -1416,12 +1416,12 @@ fn test_bank_tx_fee() {
 
     let arbitrary_transfer_amount = 42_000;
     let mint = arbitrary_transfer_amount * 100;
-    let leader = solana_pubkey::new_rand();
+    let leader = SlotLeader::new_unique();
     let GenesisConfigInfo {
         mut genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_leader(mint, &leader, 3);
+    } = create_genesis_config_with_leader(mint, &leader.id, 3);
     genesis_config.fee_rate_governor = FeeRateGovernor::new(5000, 0); // something divisible by 2
 
     let expected_fee_paid = genesis_config
@@ -1443,7 +1443,7 @@ fn test_bank_tx_fee() {
         bank.last_blockhash(),
     );
 
-    let initial_balance = bank.get_balance(&leader);
+    let initial_balance = bank.get_balance(&leader.id);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), arbitrary_transfer_amount);
     assert_eq!(
@@ -1451,11 +1451,11 @@ fn test_bank_tx_fee() {
         mint - arbitrary_transfer_amount - expected_fee_paid
     );
 
-    assert_eq!(bank.get_balance(&leader), initial_balance);
+    assert_eq!(bank.get_balance(&leader.id), initial_balance);
     goto_end_of_slot(bank.clone());
     assert_eq!(bank.signature_count(), 1);
     assert_eq!(
-        bank.get_balance(&leader),
+        bank.get_balance(&leader.id),
         initial_balance + expected_fee_collected
     ); // Leader collects fee after the bank is frozen
 
@@ -1469,7 +1469,7 @@ fn test_bank_tx_fee() {
     assert_eq!(
         *bank.rewards.read().unwrap(),
         vec![(
-            leader,
+            leader.id,
             RewardInfo {
                 reward_type: RewardType::Fee,
                 lamports: expected_fee_collected as i64,
@@ -1480,7 +1480,7 @@ fn test_bank_tx_fee() {
     );
 
     // Verify that an InstructionError collects fees, too
-    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, leader, 1);
     let mut tx = system_transaction::transfer(&mint_keypair, &key, 1, bank.last_blockhash());
     // Create a bogus instruction to system_program to cause an instruction error
     tx.message.instructions[0].data[0] = 40;
@@ -1497,14 +1497,14 @@ fn test_bank_tx_fee() {
 
     // Profit! 2 transaction signatures processed at 3 lamports each
     assert_eq!(
-        bank.get_balance(&leader),
+        bank.get_balance(&leader.id),
         initial_balance + 2 * expected_fee_collected
     );
 
     assert_eq!(
         *bank.rewards.read().unwrap(),
         vec![(
-            leader,
+            leader.id,
             RewardInfo {
                 reward_type: RewardType::Fee,
                 lamports: expected_fee_collected as i64,
@@ -1522,12 +1522,12 @@ fn test_bank_tx_compute_unit_fee() {
     let key = solana_pubkey::new_rand();
     let arbitrary_transfer_amount = 42;
     let mint = arbitrary_transfer_amount * 10_000_000;
-    let leader = solana_pubkey::new_rand();
+    let leader = SlotLeader::new_unique();
     let GenesisConfigInfo {
         mut genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_leader(mint, &leader, 3);
+    } = create_genesis_config_with_leader(mint, &leader.id, 3);
     genesis_config.fee_rate_governor = FeeRateGovernor::new(4, 0); // something divisible by 2
 
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
@@ -1553,7 +1553,7 @@ fn test_bank_tx_compute_unit_fee() {
         bank.last_blockhash(),
     );
 
-    let initial_balance = bank.get_balance(&leader);
+    let initial_balance = bank.get_balance(&leader.id);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), arbitrary_transfer_amount);
     assert_eq!(
@@ -1561,11 +1561,11 @@ fn test_bank_tx_compute_unit_fee() {
         mint - arbitrary_transfer_amount - expected_fee_paid
     );
 
-    assert_eq!(bank.get_balance(&leader), initial_balance);
+    assert_eq!(bank.get_balance(&leader.id), initial_balance);
     goto_end_of_slot(bank.clone());
     assert_eq!(bank.signature_count(), 1);
     assert_eq!(
-        bank.get_balance(&leader),
+        bank.get_balance(&leader.id),
         initial_balance + expected_fee_collected
     ); // Leader collects fee after the bank is frozen
 
@@ -1579,7 +1579,7 @@ fn test_bank_tx_compute_unit_fee() {
     assert_eq!(
         *bank.rewards.read().unwrap(),
         vec![(
-            leader,
+            leader.id,
             RewardInfo {
                 reward_type: RewardType::Fee,
                 lamports: expected_fee_collected as i64,
@@ -1590,7 +1590,7 @@ fn test_bank_tx_compute_unit_fee() {
     );
 
     // Verify that an InstructionError collects fees, too
-    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, leader, 1);
     let mut tx = system_transaction::transfer(&mint_keypair, &key, 1, bank.last_blockhash());
     // Create a bogus instruction to system_program to cause an instruction error
     tx.message.instructions[0].data[0] = 40;
@@ -1607,14 +1607,14 @@ fn test_bank_tx_compute_unit_fee() {
 
     // Profit! 2 transaction signatures processed at 3 lamports each
     assert_eq!(
-        bank.get_balance(&leader),
+        bank.get_balance(&leader.id),
         initial_balance + 2 * expected_fee_collected
     );
 
     assert_eq!(
         *bank.rewards.read().unwrap(),
         vec![(
-            leader,
+            leader.id,
             RewardInfo {
                 reward_type: RewardType::Fee,
                 lamports: expected_fee_collected as i64,
@@ -1629,12 +1629,12 @@ fn test_bank_tx_compute_unit_fee() {
 fn test_bank_blockhash_fee_structure() {
     //agave_logger::setup();
 
-    let leader = solana_pubkey::new_rand();
+    let leader = SlotLeader::new_unique();
     let GenesisConfigInfo {
         mut genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_leader(1_000_000, &leader, 3);
+    } = create_genesis_config_with_leader(1_000_000, &leader.id, 3);
     genesis_config
         .fee_rate_governor
         .target_lamports_per_signature = 5000;
@@ -1646,13 +1646,13 @@ fn test_bank_blockhash_fee_structure() {
     let cheap_lamports_per_signature = bank.get_lamports_per_signature();
     assert_eq!(cheap_lamports_per_signature, 0);
 
-    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, leader, 1);
     goto_end_of_slot(bank.clone());
     let expensive_blockhash = bank.last_blockhash();
     let expensive_lamports_per_signature = bank.get_lamports_per_signature();
     assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
 
-    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, leader, 2);
 
     // Send a transfer using cheap_blockhash
     let key = solana_pubkey::new_rand();
@@ -1691,12 +1691,12 @@ fn test_bank_blockhash_fee_structure() {
 fn test_bank_blockhash_compute_unit_fee_structure() {
     //agave_logger::setup();
 
-    let leader = solana_pubkey::new_rand();
+    let leader = SlotLeader::new_unique();
     let GenesisConfigInfo {
         mut genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_leader(1_000_000_000, &leader, 3);
+    } = create_genesis_config_with_leader(1_000_000_000, &leader.id, 3);
     genesis_config
         .fee_rate_governor
         .target_lamports_per_signature = 1000;
@@ -1708,13 +1708,13 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
     let cheap_lamports_per_signature = bank.get_lamports_per_signature();
     assert_eq!(cheap_lamports_per_signature, 0);
 
-    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, leader, 1);
     goto_end_of_slot(bank.clone());
     let expensive_blockhash = bank.last_blockhash();
     let expensive_lamports_per_signature = bank.get_lamports_per_signature();
     assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
 
-    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, leader, 2);
 
     // Send a transfer using cheap_blockhash
     let key = solana_pubkey::new_rand();
@@ -1790,7 +1790,7 @@ fn test_readonly_accounts(relax_intrabatch_account_locks: bool) {
     }
 
     let next_slot = bank.slot() + 1;
-    let bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), next_slot);
+    let bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::default(), next_slot);
     let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
 
     let vote_pubkey0 = solana_pubkey::new_rand();
@@ -1951,7 +1951,7 @@ fn test_load_and_execute_commit_transactions_fees_only() {
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let bank = Bank::new_from_parent(
         bank,
-        &Pubkey::new_unique(),
+        SlotLeader::new_unique(),
         genesis_config.epoch_schedule.get_first_slot_in_epoch(1),
     );
 
@@ -2029,7 +2029,7 @@ fn test_load_and_execute_commit_transactions_failure() {
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let bank = Bank::new_from_parent(
         bank,
-        &Pubkey::new_unique(),
+        SlotLeader::new_unique(),
         genesis_config.epoch_schedule.get_first_slot_in_epoch(1),
     );
 
@@ -2104,7 +2104,7 @@ fn test_load_and_execute_commit_transactions_success() {
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let bank = Bank::new_from_parent(
         bank,
-        &Pubkey::new_unique(),
+        SlotLeader::new_unique(),
         genesis_config.epoch_schedule.get_first_slot_in_epoch(1),
     );
 
@@ -2268,13 +2268,12 @@ fn test_bank_pay_to_self() {
 
 fn new_from_parent(parent: Arc<Bank>) -> Bank {
     let slot = parent.slot() + 1;
-    let leader_id = Pubkey::default();
-    Bank::new_from_parent(parent, &leader_id, slot)
+    Bank::new_from_parent(parent, SlotLeader::default(), slot)
 }
 
 fn new_from_parent_with_fork_next_slot(parent: Arc<Bank>, fork: &RwLock<BankForks>) -> Arc<Bank> {
     let slot = parent.slot() + 1;
-    Bank::new_from_parent_with_bank_forks(fork, parent, &Pubkey::default(), slot)
+    Bank::new_from_parent_with_bank_forks(fork, parent, SlotLeader::default(), slot)
 }
 
 /// Verify that the parent's vector is computed correctly
@@ -2405,7 +2404,7 @@ fn test_bank_hash_internal_state_verify() {
         let bank2 = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank0.clone(),
-            &solana_pubkey::new_rand(),
+            SlotLeader::new_unique(),
             2,
         );
         assert_ne!(bank0_state, bank2.hash_internal_state());
@@ -2425,7 +2424,7 @@ fn test_bank_hash_internal_state_verify() {
         let bank3 = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank0.clone(),
-            &solana_pubkey::new_rand(),
+            SlotLeader::new_unique(),
             3,
         );
         assert_eq!(bank0_state, bank0.hash_internal_state());
@@ -2511,7 +2510,7 @@ fn test_bank_hash_same_transactions_different_fork() {
     let bank1 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         1,
     );
     bank1.transfer(amount, &mint_keypair, &pubkey).unwrap();
@@ -2520,7 +2519,7 @@ fn test_bank_hash_same_transactions_different_fork() {
     let bank2 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         2,
     );
     bank2.transfer(amount, &mint_keypair, &pubkey).unwrap();
@@ -2585,13 +2584,12 @@ fn test_hash_internal_state_error() {
 
 #[test]
 fn test_bank_hash_internal_state_squash() {
-    let leader_id = Pubkey::default();
     let bank0 = Arc::new(Bank::new_for_tests(&create_genesis_config(10).0));
     let hash0 = bank0.hash_internal_state();
     // save hash0 because new_from_parent
     // updates sysvar entries
 
-    let bank1 = Bank::new_from_parent(bank0, &leader_id, 1);
+    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
 
     // no delta in bank1, hashes should always update
     assert_ne!(hash0, bank1.hash_internal_state());
@@ -2708,7 +2706,7 @@ fn test_bank_get_account_in_parent_after_squash2() {
     let bank1 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         1,
     );
     bank1
@@ -2717,7 +2715,7 @@ fn test_bank_get_account_in_parent_after_squash2() {
     let bank2 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         2,
     );
     bank2
@@ -2727,7 +2725,7 @@ fn test_bank_get_account_in_parent_after_squash2() {
     let bank3 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank1.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         3,
     );
     bank1.squash();
@@ -2744,7 +2742,7 @@ fn test_bank_get_account_in_parent_after_squash2() {
     let bank4 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank3.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         4,
     );
     bank4
@@ -2756,12 +2754,12 @@ fn test_bank_get_account_in_parent_after_squash2() {
     let bank5 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank4.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         5,
     );
     bank5.squash();
     let bank6 =
-        Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank5, &Pubkey::default(), 6);
+        Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank5, SlotLeader::default(), 6);
     bank6.squash();
 
     // This picks up the values from 4 which is the highest root:
@@ -2790,7 +2788,7 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
     let bank2 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank1.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         1,
     );
     assert!(bank2
@@ -2811,7 +2809,7 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
     bank1.squash();
 
     let bank3 =
-        Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &Pubkey::default(), 3);
+        Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, SlotLeader::default(), 3);
     assert_eq!(
         None,
         bank3.get_account_modified_since_parent_with_fixed_root(&pubkey)
@@ -2907,7 +2905,11 @@ fn test_bank_update_sysvar_account() {
         }
 
         // Updating should increment the clock's slot
-        let bank2 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 1));
+        let bank2 = Arc::new(Bank::new_from_parent(
+            bank1.clone(),
+            SlotLeader::default(),
+            1,
+        ));
         add_root_and_flush_write_cache(&bank1);
         assert_capitalization_diff(
             &bank2,
@@ -2980,10 +2982,10 @@ fn test_bank_update_sysvar_account() {
 
 #[test]
 fn test_bank_epoch_vote_accounts() {
-    let leader_pubkey = solana_pubkey::new_rand();
+    let leader = SlotLeader::new_unique();
     let leader_lamports = 3;
     let mut genesis_config =
-        create_genesis_config_with_leader(5, &leader_pubkey, leader_lamports).genesis_config;
+        create_genesis_config_with_leader(5, &leader.id, leader_lamports).genesis_config;
 
     // set this up weird, forces future generation, odd mod(), etc.
     //  this says: "vote_accounts for epoch X should be generated at slot index 3 in epoch X-2...
@@ -3000,7 +3002,7 @@ fn test_bank_epoch_vote_accounts() {
             accounts
                 .iter()
                 .filter_map(|(pubkey, (stake, account))| {
-                    if account.node_pubkey() == &leader_pubkey {
+                    if account.node_pubkey() == &leader.id {
                         Some((*pubkey, *stake))
                     } else {
                         None
@@ -3043,7 +3045,7 @@ fn test_bank_epoch_vote_accounts() {
     // child crosses epoch boundary and is the first slot in the epoch
     let child = Bank::new_from_parent(
         parent.clone(),
-        &leader_pubkey,
+        leader,
         SLOTS_PER_EPOCH - (LEADER_SCHEDULE_SLOT_OFFSET % SLOTS_PER_EPOCH),
     );
 
@@ -3062,7 +3064,7 @@ fn test_bank_epoch_vote_accounts() {
     //  makes an epoch stakes snapshot at 1
     let child = Bank::new_from_parent(
         parent,
-        &leader_pubkey,
+        leader,
         SLOTS_PER_EPOCH - (LEADER_SCHEDULE_SLOT_OFFSET % SLOTS_PER_EPOCH) + 1,
     );
     assert!(child.epoch_vote_accounts(epoch).is_some());
@@ -3164,14 +3166,14 @@ fn test_bank_inherit_tx_count() {
     let bank1 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
-        &solana_pubkey::new_rand(),
+        SlotLeader::new_unique(),
         1,
     );
     // Bank 2
     let bank2 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0.clone(),
-        &solana_pubkey::new_rand(),
+        SlotLeader::new_unique(),
         2,
     );
 
@@ -3205,7 +3207,7 @@ fn test_bank_inherit_tx_count() {
     let bank6 = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank1.clone(),
-        &solana_pubkey::new_rand(),
+        SlotLeader::new_unique(),
         3,
     );
     assert_eq!(bank1.transaction_count(), 1);
@@ -3311,7 +3313,7 @@ fn test_bank_cloned_stake_delegations() {
 
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     bank.squash();
-    let bank = Bank::new_from_parent(bank, &Pubkey::new_unique(), 1);
+    let bank = Bank::new_from_parent(bank, SlotLeader::new_unique(), 1);
 
     let stake_delegations = bank.stakes_cache.stakes().stake_delegations().clone();
     assert_eq!(stake_delegations.len(), 1); // bootstrap validator has
@@ -3712,7 +3714,7 @@ fn test_add_duplicate_static_program() {
     );
 
     let slot = bank.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(bank, &Pubkey::default(), slot);
+    let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), slot);
     bank.add_mockup_builtin(solana_vote_program::id(), MockBuiltin::vm);
     let bank = bank_forks
         .write()
@@ -3875,7 +3877,7 @@ fn test_hash_internal_state_unchanged() {
     let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
     bank0.freeze();
     let bank0_hash = bank0.hash();
-    let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
     bank1.freeze();
     let bank1_hash = bank1.hash();
     // Checkpointing should always result in a new state
@@ -5001,7 +5003,7 @@ fn test_account_ids_after_program_ids() {
     tx.message.account_keys.push(solana_pubkey::new_rand());
 
     let slot = bank.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(bank, &Pubkey::default(), slot);
+    let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), slot);
     bank.add_mockup_builtin(solana_vote_program::id(), MockBuiltin::vm);
     let bank = bank_forks
         .write()
@@ -5025,7 +5027,7 @@ fn test_incinerator() {
     let bank = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank0,
-        &Pubkey::default(),
+        SlotLeader::default(),
         genesis_config.epoch_schedule.first_normal_slot,
     );
     let pre_capitalization = bank.capitalization();
@@ -5169,7 +5171,7 @@ fn test_ref_account_key_after_program_id() {
     ];
 
     let slot = bank.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(bank, &Pubkey::default(), slot);
+    let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), slot);
     bank.add_mockup_builtin(solana_vote_program::id(), MockBuiltin::vm);
     let bank = bank_forks
         .write()
@@ -5388,7 +5390,10 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
         None,
         BankTestConfig::default().accounts_db_config,
         None,
-        Some(Pubkey::from([42; 32])),
+        Some(SlotLeader {
+            id: Pubkey::from([42; 32]),
+            vote_address: Pubkey::from([67; 32]),
+        }),
         Arc::default(),
         None,
         Some(feature_set),
@@ -5497,7 +5502,11 @@ fn test_clean_nonrooted() {
 
     // Store some lamports in bank 1
     let some_lamports = 123;
-    let bank1 = Arc::new(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1));
+    let bank1 = Arc::new(Bank::new_from_parent(
+        bank0.clone(),
+        SlotLeader::default(),
+        1,
+    ));
     test_utils::deposit(&bank1, &pubkey0, some_lamports).unwrap();
     goto_end_of_slot(bank1.clone());
     bank1.freeze();
@@ -5510,7 +5519,7 @@ fn test_clean_nonrooted() {
 
     // Store some lamports for pubkey1 in bank 2, root bank 2
     // bank2's parent is bank0
-    let bank2 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 2));
+    let bank2 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 2));
     test_utils::deposit(&bank2, &pubkey1, some_lamports).unwrap();
     bank2.store_account(&pubkey0, &account_zero);
     goto_end_of_slot(bank2.clone());
@@ -5525,7 +5534,7 @@ fn test_clean_nonrooted() {
     // candidate set
     bank2.clean_accounts_for_tests();
 
-    let bank3 = Arc::new(Bank::new_from_parent(bank2, &Pubkey::default(), 3));
+    let bank3 = Arc::new(Bank::new_from_parent(bank2, SlotLeader::default(), 3));
     test_utils::deposit(&bank3, &pubkey1, some_lamports + 1).unwrap();
     goto_end_of_slot(bank3.clone());
     bank3.freeze();
@@ -5624,7 +5633,11 @@ fn test_add_builtin_no_overwrite() {
     let program_id = solana_pubkey::new_rand();
 
     let (parent_bank, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let mut bank = Arc::new(Bank::new_from_parent(parent_bank, &Pubkey::default(), slot));
+    let mut bank = Arc::new(Bank::new_from_parent(
+        parent_bank,
+        SlotLeader::default(),
+        slot,
+    ));
     assert_eq!(bank.get_account_modified_slot(&program_id), None);
 
     Arc::get_mut(&mut bank)
@@ -5645,7 +5658,11 @@ fn test_add_builtin_loader_no_overwrite() {
     let loader_id = solana_pubkey::new_rand();
 
     let (parent_bank, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let mut bank = Arc::new(Bank::new_from_parent(parent_bank, &Pubkey::default(), slot));
+    let mut bank = Arc::new(Bank::new_from_parent(
+        parent_bank,
+        SlotLeader::default(),
+        slot,
+    ));
     assert_eq!(bank.get_account_modified_slot(&loader_id), None);
 
     Arc::get_mut(&mut bank)
@@ -5672,7 +5689,7 @@ fn test_add_builtin_account() {
 
         let bank = Arc::new(Bank::new_from_parent(
             Arc::new(Bank::new_for_tests(&genesis_config)),
-            &Pubkey::default(),
+            SlotLeader::default(),
             slot,
         ));
         add_root_and_flush_write_cache(&bank.parent().unwrap());
@@ -5829,7 +5846,7 @@ fn test_add_builtin_account_after_frozen() {
     let program_id = Pubkey::from_str("CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre").unwrap();
 
     let (parent_bank, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let bank = Bank::new_from_parent(parent_bank, &Pubkey::default(), slot);
+    let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), slot);
     bank.freeze();
 
     bank.add_builtin_account("mock_program", &program_id);
@@ -5846,7 +5863,7 @@ fn test_add_precompiled_account() {
 
         let bank = Arc::new(Bank::new_from_parent(
             Arc::new(Bank::new_for_tests(&genesis_config)),
-            &Pubkey::default(),
+            SlotLeader::default(),
             slot,
         ));
         add_root_and_flush_write_cache(&bank.parent().unwrap());
@@ -5978,7 +5995,7 @@ fn test_add_precompiled_account_after_frozen() {
     let program_id = Pubkey::from_str("CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre").unwrap();
 
     let (parent_bank, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let bank = Bank::new_from_parent(parent_bank, &Pubkey::default(), slot);
+    let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), slot);
     bank.freeze();
 
     bank.add_precompiled_account(&program_id);
@@ -6005,8 +6022,8 @@ fn test_bank_load_program() {
     let bank = Bank::new_for_tests(&genesis_config);
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
     goto_end_of_slot(bank.clone());
-    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 42);
-    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 50);
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), 42);
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), 50);
 
     let program_key = solana_pubkey::new_rand();
     let programdata_key = solana_pubkey::new_rand();
@@ -6117,7 +6134,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     // processed.
     goto_end_of_slot(bank.clone());
     let bank = bank_client
-        .advance_slot(1, bank_forks.as_ref(), &mint_keypair.pubkey())
+        .advance_slot(1, bank_forks.as_ref(), SlotLeader::default())
         .unwrap();
 
     // Load program file
@@ -6309,7 +6326,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     // Advance the bank so that the program becomes effective
     goto_end_of_slot(bank.clone());
     let bank = bank_client
-        .advance_slot(1, bank_forks.as_ref(), &mint_keypair.pubkey())
+        .advance_slot(1, bank_forks.as_ref(), SlotLeader::default())
         .unwrap();
 
     // Invoke the deployed program
@@ -6335,7 +6352,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     bank.clear_signatures();
     bank.store_account(&buffer_address, &buffer_account);
     let bank = bank_client
-        .advance_slot(1, bank_forks.as_ref(), &mint_keypair.pubkey())
+        .advance_slot(1, bank_forks.as_ref(), SlotLeader::default())
         .unwrap();
     let message = Message::new(
         &[Instruction::new_with_bincode(
@@ -6852,7 +6869,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
 #[test]
 fn test_compute_active_feature_set() {
     let (bank0, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+    let mut bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
 
     let test_feature = "TestFeature11111111111111111111111111111111"
         .parse::<Pubkey>()
@@ -6903,7 +6920,7 @@ fn test_compute_active_feature_set() {
 #[test]
 fn test_reserved_account_keys() {
     let (bank0, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+    let mut bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
     let test_feature_id = Pubkey::new_unique();
     bank.feature_set = Arc::new(FeatureSet::new(
         AHashMap::new(),
@@ -6938,7 +6955,7 @@ fn test_block_limits() {
     const MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_FIRST: u64 = 24_000_000;
     const MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_SECOND: u64 = 40_000_000;
     let (bank0, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+    let mut bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
 
     // Ensure increased block limits features are inactive.
     assert!(!bank
@@ -6985,7 +7002,7 @@ fn test_block_limits() {
     );
 
     // Make sure the limits propagate to the child-bank.
-    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), 2);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::default(), 2);
     assert_eq!(
         bank.read_cost_tracker().unwrap().get_block_limit(),
         MAX_BLOCK_UNITS_SIMD_0286,
@@ -7016,7 +7033,7 @@ fn test_block_limits() {
 
     // Test SIMD-0306 getting activated first
     let (bank0, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+    let mut bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
 
     // Activate `raise_account_cu_limit` feature
     bank.store_account(
@@ -7736,7 +7753,7 @@ fn test_store_scan_consistency_unrooted() {
                     let slot = current_minor_fork_bank.slot() + 2;
                     current_minor_fork_bank = Arc::new(Bank::new_from_parent(
                         current_minor_fork_bank,
-                        &solana_pubkey::new_rand(),
+                        SlotLeader::new_unique(),
                         slot,
                     ));
                     let account = AccountSharedData::new(lamports, 0, &program_id);
@@ -7761,7 +7778,7 @@ fn test_store_scan_consistency_unrooted() {
                 // *partial* clean of the banks < `next_major_bank`.
                 current_major_fork_bank = Arc::new(Bank::new_from_parent(
                     current_major_fork_bank,
-                    &solana_pubkey::new_rand(),
+                    SlotLeader::new_unique(),
                     current_minor_fork_bank.slot() - 1,
                 ));
                 let lamports = current_major_fork_bank.slot() + starting_lamports + 1;
@@ -7847,7 +7864,7 @@ fn test_store_scan_consistency_root() {
                 let slot = current_bank.slot() + 1;
                 current_bank = Arc::new(Bank::new_from_parent(
                     current_bank,
-                    &solana_pubkey::new_rand(),
+                    SlotLeader::new_unique(),
                     slot,
                 ));
 
@@ -7893,7 +7910,7 @@ fn setup_banks_on_fork_to_remove(
             let slot = bank_at_fork_tip.slot() + 1;
             bank_at_fork_tip = Arc::new(Bank::new_from_parent(
                 bank_at_fork_tip,
-                &solana_pubkey::new_rand(),
+                SlotLeader::new_unique(),
                 slot,
             ));
             if lamports_this_round == 0 {
@@ -8500,7 +8517,7 @@ fn test_vote_epoch_panic() {
     let _bank = Bank::new_from_parent_with_bank_forks(
         bank_forks.as_ref(),
         bank,
-        &mint_keypair.pubkey(),
+        SlotLeader::new_unique(),
         genesis_config.epoch_schedule.get_first_slot_in_epoch(1),
     );
 }
@@ -8908,7 +8925,7 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
     let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
 
-    let collector = Pubkey::new_unique();
+    let leader = SlotLeader::new_unique();
     let owner = Pubkey::new_unique();
 
     let key1 = Keypair::new(); // only touched in bank1
@@ -8923,7 +8940,7 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
 
     let slot = 1;
     let bank1 =
-        Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0.clone(), &collector, slot);
+        Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0.clone(), leader, slot);
     add_root_and_flush_write_cache(&bank0);
     bank1
         .transfer(amount, &mint_keypair, &key1.pubkey())
@@ -8936,7 +8953,7 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
     }
 
     let slot = slot + 1;
-    let bank2 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+    let bank2 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, leader, slot);
     bank2
         .transfer(amount * 2, &mint_keypair, &key2.pubkey())
         .unwrap();
@@ -9371,7 +9388,7 @@ fn test_verify_transactions_accounts_limit(simd_406_enabled: bool) {
 fn test_check_reserved_keys() {
     let (genesis_config, _mint_keypair) = create_genesis_config(1);
     let bank = Bank::new_for_tests(&genesis_config);
-    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::new_unique(), 1);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::new_unique(), 1);
 
     let transaction =
         SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
@@ -10757,7 +10774,7 @@ fn test_accounts_data_size_from_genesis() {
         bank = Bank::new_from_parent_with_bank_forks(
             bank_forks.as_ref(),
             bank,
-            &Pubkey::default(),
+            SlotLeader::default(),
             slot,
         );
 
@@ -10959,7 +10976,7 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase() {
 
     // Advance the bank to middle of epoch to start the recompilation phase.
     goto_end_of_slot(bank.clone());
-    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 16);
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), 16);
     let current_env = bank
         .transaction_processor
         .get_environments_for_epoch(0)
@@ -11005,7 +11022,7 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase() {
 
     // Advance the bank to cross the epoch boundary and activate the feature.
     goto_end_of_slot(bank.clone());
-    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 33);
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), 33);
 
     // Load the program with the new environment.
     let transaction = Transaction::new(&signers, message, bank.last_blockhash());
@@ -11069,11 +11086,11 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
 
     // Advance the bank to the end of the epoch to update the epoch_boundary_preparation.
     goto_end_of_slot(bank.clone());
-    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 31);
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), 31);
 
     // Advance the bank to cross the epoch boundary and activate the feature.
     goto_end_of_slot(bank.clone());
-    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), 32);
+    let bank = Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), 32);
 
     // Load the program with the new environment.
     let transaction = Transaction::new(&signers, message.clone(), bank.last_blockhash());
@@ -11149,7 +11166,7 @@ fn test_verify_accounts() {
         bank = Bank::new_from_parent_with_bank_forks(
             bank_forks.as_ref(),
             bank,
-            &Pubkey::new_unique(),
+            SlotLeader::new_unique(),
             slot,
         );
         do_transfers(&bank);
@@ -11239,7 +11256,7 @@ where
     let bob_pubkey = bob_keypair.pubkey();
 
     let program = Pubkey::new_unique();
-    let collector = Pubkey::new_unique();
+    let leader = SlotLeader::new_unique();
 
     let mint_lamports = LAMPORTS_PER_SOL;
     let len1 = 123;
@@ -11258,17 +11275,17 @@ where
 
     // create the next bank in the current epoch
     let slot = bank.slot() + 1;
-    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, leader, slot);
 
     // create the next bank where we will store a zero-lamport account to be cleaned
     let slot = bank.slot() + 1;
-    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, leader, slot);
     let account = AccountSharedData::new(0, len1, &program);
     bank.store_account(&bob_pubkey, &account);
 
     // transfer some to bogus pubkey just to make previous bank (=slot) really cleanable
     let slot = bank.slot() + 1;
-    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, leader, slot);
     let bank_client = BankClient::new_shared(bank.clone());
     bank_client
         .transfer_and_confirm(
@@ -11280,13 +11297,13 @@ where
 
     // super fun time; callback chooses to .clean_accounts() or not
     let slot = bank.slot() + 1;
-    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, leader, slot);
     callback(&bank);
 
     // create a normal account at the same pubkey as the zero-lamports account
     let lamports = genesis_config.rent.minimum_balance(len2);
     let slot = bank.slot() + 1;
-    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
+    let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, leader, slot);
     let bank_client = BankClient::new_shared(bank);
     let ix = system_instruction::create_account(
         &alice_pubkey,
@@ -11475,14 +11492,14 @@ fn test_register_hard_fork() {
     let (genesis_config, _mint_keypair) = create_genesis_config(10);
     let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
 
-    let bank7 = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 7);
+    let bank7 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 7);
     bank7.register_hard_fork(6);
     bank7.register_hard_fork(7);
     bank7.register_hard_fork(8);
     // Bank7 will reject slot 6 since it is older, but allow the other two hard forks
     assert_eq!(get_hard_forks(&bank7), vec![7, 8]);
 
-    let bank9 = Bank::new_from_parent(bank0, &Pubkey::default(), 9);
+    let bank9 = Bank::new_from_parent(bank0, SlotLeader::default(), 9);
     bank9.freeze();
     bank9.register_hard_fork(9);
     bank9.register_hard_fork(10);
@@ -11529,7 +11546,7 @@ fn test_last_restart_slot() {
     assert!(!last_restart_slot_dirty(&bank0));
     assert_eq!(get_last_restart_slot(&bank0), None);
 
-    let mut bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
+    let mut bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
     assert!(!last_restart_slot_dirty(&bank1));
     assert_eq!(get_last_restart_slot(&bank1), None);
 
@@ -11537,29 +11554,33 @@ fn test_last_restart_slot() {
     Arc::get_mut(&mut bank1)
         .unwrap()
         .activate_feature(&feature_set::last_restart_slot_sysvar::id());
-    let bank2 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 2));
+    let bank2 = Arc::new(Bank::new_from_parent(
+        bank1.clone(),
+        SlotLeader::default(),
+        2,
+    ));
     assert!(last_restart_slot_dirty(&bank2));
     assert_eq!(get_last_restart_slot(&bank2), Some(0));
-    let bank3 = Arc::new(Bank::new_from_parent(bank1, &Pubkey::default(), 3));
+    let bank3 = Arc::new(Bank::new_from_parent(bank1, SlotLeader::default(), 3));
     assert!(last_restart_slot_dirty(&bank3));
     assert_eq!(get_last_restart_slot(&bank3), Some(0));
 
     // Not dirty in children where the last restart slot has not changed
-    let bank4 = Arc::new(Bank::new_from_parent(bank2, &Pubkey::default(), 4));
+    let bank4 = Arc::new(Bank::new_from_parent(bank2, SlotLeader::default(), 4));
     assert!(!last_restart_slot_dirty(&bank4));
     assert_eq!(get_last_restart_slot(&bank4), Some(0));
-    let bank5 = Arc::new(Bank::new_from_parent(bank3, &Pubkey::default(), 5));
+    let bank5 = Arc::new(Bank::new_from_parent(bank3, SlotLeader::default(), 5));
     assert!(!last_restart_slot_dirty(&bank5));
     assert_eq!(get_last_restart_slot(&bank5), Some(0));
 
     // Last restart slot has now changed so it will be dirty again
-    let bank6 = Arc::new(Bank::new_from_parent(bank4, &Pubkey::default(), 6));
+    let bank6 = Arc::new(Bank::new_from_parent(bank4, SlotLeader::default(), 6));
     assert!(last_restart_slot_dirty(&bank6));
     assert_eq!(get_last_restart_slot(&bank6), Some(6));
 
     // Last restart will not change for a hard fork that has not occurred yet
     bank6.register_hard_fork(10);
-    let bank7 = Arc::new(Bank::new_from_parent(bank6, &Pubkey::default(), 7));
+    let bank7 = Arc::new(Bank::new_from_parent(bank6, SlotLeader::default(), 7));
     assert!(!last_restart_slot_dirty(&bank7));
     assert_eq!(get_last_restart_slot(&bank7), Some(6));
 }
@@ -11715,7 +11736,7 @@ fn test_deploy_last_epoch_slot() {
     let bank = Bank::new_from_parent_with_bank_forks(
         &bank_forks,
         bank,
-        &Pubkey::default(),
+        SlotLeader::default(),
         slots_in_epoch - 1,
     );
     eprintln!("now at slot {} epoch {}", bank.slot(), bank.epoch());
@@ -11787,7 +11808,7 @@ fn test_deploy_last_epoch_slot() {
     let bank = Bank::new_from_parent_with_bank_forks(
         &bank_forks,
         bank,
-        &Pubkey::default(),
+        SlotLeader::default(),
         slots_in_epoch,
     );
     eprintln!("now at slot {} epoch {}", bank.slot(), bank.epoch());
@@ -11951,7 +11972,7 @@ fn test_loader_v3_to_v4_migration() {
     let bank = Bank::new_from_parent_with_bank_forks(
         &bank_forks,
         bank.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         next_slot,
     );
     next_slot += 1;
@@ -12077,7 +12098,7 @@ fn test_loader_v3_to_v4_migration() {
         let bank = Bank::new_from_parent_with_bank_forks(
             &bank_forks,
             bank.clone(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             next_slot,
         );
         next_slot += 1;
@@ -12096,8 +12117,12 @@ fn test_loader_v3_to_v4_migration() {
         assert!(result.is_ok(), "result: {result:?}");
 
         goto_end_of_slot(bank.clone());
-        let bank =
-            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), next_slot);
+        let bank = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            SlotLeader::default(),
+            next_slot,
+        );
         next_slot += 1;
 
         let instruction = Instruction::new_with_bytes(program_keypair.pubkey(), &[], Vec::new());
@@ -12174,7 +12199,7 @@ fn test_bank_epoch_stakes() {
     let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
     let mut bank1 = Bank::new_from_parent(
         bank0.clone(),
-        &Pubkey::default(),
+        SlotLeader::default(),
         bank0.get_slots_in_epoch(0) + 1,
     );
 
@@ -12448,7 +12473,7 @@ fn test_parent_block_id() {
 
     // Create child from parent and ensure parent block ID links back to the
     // expected value.
-    let child_bank = Bank::new_from_parent(parent_bank, &Pubkey::new_unique(), 1);
+    let child_bank = Bank::new_from_parent(parent_bank, SlotLeader::new_unique(), 1);
     assert_eq!(parent_block_id, child_bank.parent_block_id());
 }
 

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -27,7 +27,10 @@ mod transaction {
     pub use solana_transaction_error::TransactionResult as Result;
 }
 #[cfg(feature = "dev-context-only-utils")]
-use {crate::bank_forks::BankForks, solana_clock as clock, std::sync::RwLock};
+use {
+    crate::bank_forks::BankForks, solana_clock as clock, solana_leader_schedule::SlotLeader,
+    std::sync::RwLock,
+};
 
 pub struct BankClient {
     bank: Arc<Bank>,
@@ -280,13 +283,10 @@ impl BankClient {
         &mut self,
         by: u64,
         bank_forks: &RwLock<BankForks>,
-        leader_id: &Pubkey,
+        leader: SlotLeader,
     ) -> Option<Arc<Bank>> {
-        let new_bank = Bank::new_from_parent(
-            self.bank.clone(),
-            leader_id,
-            self.bank.slot().checked_add(by)?,
-        );
+        let new_bank =
+            Bank::new_from_parent(self.bank.clone(), leader, self.bank.slot().checked_add(by)?);
         self.bank = bank_forks
             .write()
             .unwrap()

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -775,7 +775,7 @@ mod tests {
         solana_clock::UnixTimestamp,
         solana_epoch_schedule::EpochSchedule,
         solana_keypair::Keypair,
-        solana_pubkey::Pubkey,
+        solana_leader_schedule::SlotLeader,
         solana_signer::Signer,
         solana_vote_program::vote_state::BlockTimestamp,
     };
@@ -809,7 +809,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
         let mut bank_forks = bank_forks.write().unwrap();
-        let child_bank = Bank::new_from_parent(bank_forks[0].clone(), &Pubkey::default(), 1);
+        let child_bank = Bank::new_from_parent(bank_forks[0].clone(), SlotLeader::default(), 1);
         child_bank.register_default_tick_for_test();
         bank_forks.insert(child_bank);
         assert_eq!(bank_forks[1u64].tick_height(), 1);
@@ -823,9 +823,9 @@ mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
         let mut bank_forks = bank_forks.write().unwrap();
         let bank0 = bank_forks[0].clone();
-        let bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
+        let bank = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
         bank_forks.insert(bank);
-        let bank = Bank::new_from_parent(bank0, &Pubkey::default(), 2);
+        let bank = Bank::new_from_parent(bank0, SlotLeader::default(), 2);
         bank_forks.insert(bank);
         let descendants = bank_forks.descendants();
         let children: HashSet<u64> = [1u64, 2u64].iter().copied().collect();
@@ -841,9 +841,9 @@ mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
         let mut bank_forks = bank_forks.write().unwrap();
         let bank0 = bank_forks[0].clone();
-        let bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
+        let bank = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
         bank_forks.insert(bank);
-        let bank = Bank::new_from_parent(bank0, &Pubkey::default(), 2);
+        let bank = Bank::new_from_parent(bank0, SlotLeader::default(), 2);
         bank_forks.insert(bank);
         let ancestors = bank_forks.ancestors();
         assert!(ancestors[&0].is_empty());
@@ -860,7 +860,7 @@ mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
         let mut bank_forks = bank_forks.write().unwrap();
         let bank0 = bank_forks[0].clone();
-        let child_bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        let child_bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
         bank_forks.insert(child_bank);
 
         let frozen_slots: HashSet<Slot> = bank_forks
@@ -878,7 +878,7 @@ mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
         let mut bank_forks = bank_forks.write().unwrap();
         let bank0 = bank_forks[0].clone();
-        let child_bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        let child_bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
         bank_forks.insert(child_bank);
         assert_eq!(bank_forks.active_bank_slots(), vec![1]);
     }
@@ -913,9 +913,9 @@ mod tests {
             let update_timestamp_case = slot == slots_in_epoch;
 
             let child1 =
-                Bank::new_from_parent(bank_forks0[slot - 1].clone(), &Pubkey::default(), slot);
+                Bank::new_from_parent(bank_forks0[slot - 1].clone(), SlotLeader::default(), slot);
             let child2 =
-                Bank::new_from_parent(bank_forks1[slot - 1].clone(), &Pubkey::default(), slot);
+                Bank::new_from_parent(bank_forks1[slot - 1].clone(), SlotLeader::default(), slot);
 
             if update_timestamp_case {
                 for child in &[&child1, &child2] {
@@ -960,7 +960,7 @@ mod tests {
             let parent: Arc<Bank> = bank_forks.read().unwrap().banks[parent].clone();
             bank_forks.write().unwrap().insert(Bank::new_from_parent(
                 parent,
-                &Pubkey::default(),
+                SlotLeader::default(),
                 *child,
             ));
         }

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -7,6 +7,7 @@ use {
     solana_clock::Clock,
     solana_instruction::{AccountMeta, Instruction},
     solana_keypair::Keypair,
+    solana_leader_schedule::SlotLeader,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_loader_v4_interface::instruction,
     solana_message::Message,
@@ -202,11 +203,11 @@ pub fn load_upgradeable_program_and_advance_slot(
     // load_upgradeable_program sets clock sysvar to 1, which causes the program to be effective
     // after 2 slots. They need to be called individually to create the correct fork graph in between.
     bank_client
-        .advance_slot(1, bank_forks, &Pubkey::default())
+        .advance_slot(1, bank_forks, SlotLeader::default())
         .expect("Failed to advance the slot");
 
     let bank = bank_client
-        .advance_slot(1, bank_forks, &Pubkey::default())
+        .advance_slot(1, bank_forks, SlotLeader::default())
         .expect("Failed to advance the slot");
 
     (bank, program_id)
@@ -362,7 +363,7 @@ pub fn load_program_of_loader_v4(
             .unwrap();
     }
     let bank = bank_client
-        .advance_slot(1, bank_forks, &Pubkey::default())
+        .advance_slot(1, bank_forks, SlotLeader::default())
         .expect("Failed to advance the slot");
     (bank, program_keypair.pubkey())
 }

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -222,14 +222,14 @@ mod tests {
         solana_cluster_type::ClusterType,
         solana_epoch_schedule::EpochSchedule,
         solana_genesis_config::GenesisConfig,
+        solana_leader_schedule::SlotLeader,
         solana_stake_interface::state::{Authorized, Lockup, Meta},
         std::{collections::BTreeMap, sync::Arc},
     };
 
     fn new_from_parent(parent: Arc<Bank>) -> Bank {
         let slot = parent.slot() + 1;
-        let leader_id = Pubkey::default();
-        Bank::new_from_parent(parent, &leader_id, slot)
+        Bank::new_from_parent(parent, SlotLeader::default(), slot)
     }
 
     #[test]

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -461,6 +461,7 @@ mod tests {
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
         },
         solana_compute_budget_interface::ComputeBudgetInstruction,
+        solana_leader_schedule::SlotLeader,
         solana_message::Message,
         solana_pubkey::Pubkey,
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
@@ -586,9 +587,9 @@ mod tests {
         let bank0 = Bank::new_for_benches(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank0);
         let bank = bank_forks.read().unwrap().working_bank();
-        let collector = solana_pubkey::new_rand();
+        let leader = SlotLeader::new_unique();
 
-        let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 1));
+        let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), leader, 1));
         sync_update(
             &prioritization_fee_cache,
             bank1.clone(),
@@ -602,7 +603,7 @@ mod tests {
         sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 1, bank1.bank_id());
 
         // add slot 2 entry to cache, but not finalize it
-        let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 2));
+        let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), leader, 2));
         let txs = [build_sanitized_transaction_for_test(
             1,
             &Pubkey::new_unique(),
@@ -610,7 +611,7 @@ mod tests {
         )];
         sync_update(&prioritization_fee_cache, bank2.clone(), txs.iter());
 
-        let bank3 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 3));
+        let bank3 = Arc::new(Bank::new_from_parent(bank.clone(), leader, 3));
         sync_update(
             &prioritization_fee_cache,
             bank3.clone(),
@@ -638,10 +639,10 @@ mod tests {
         let bank0 = Bank::new_for_benches(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank0);
         let bank = bank_forks.read().unwrap().working_bank();
-        let collector = solana_pubkey::new_rand();
-        let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 1));
-        let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 2));
-        let bank3 = Arc::new(Bank::new_from_parent(bank, &collector, 3));
+        let leader = SlotLeader::new_unique();
+        let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), leader, 1));
+        let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), leader, 2));
+        let bank3 = Arc::new(Bank::new_from_parent(bank, leader, 3));
 
         let prioritization_fee_cache = PrioritizationFeeCache::default();
 
@@ -890,10 +891,10 @@ mod tests {
         let bank0 = Bank::new_for_benches(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank0);
         let bank = bank_forks.read().unwrap().working_bank();
-        let collector = solana_pubkey::new_rand();
+        let leader = SlotLeader::new_unique();
         let slot: Slot = 999;
-        let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, slot));
-        let bank2 = Arc::new(Bank::new_from_parent(bank, &collector, slot + 1));
+        let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), leader, slot));
+        let bank2 = Arc::new(Bank::new_from_parent(bank, leader, slot + 1));
 
         let prioritization_fee_cache = PrioritizationFeeCache::default();
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -838,7 +838,7 @@ mod tests {
         let mut bank = Arc::new(Bank::new_for_tests(genesis_config));
         for _i in 0..num_total {
             let slot = bank.slot() + 1;
-            bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), slot));
+            bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::new_unique(), slot));
             bank.fill_bank_with_ticks_for_tests();
 
             create_bank_snapshot_from_bank(
@@ -924,10 +924,7 @@ mod tests {
             &genesis_config,
             &RuntimeConfig::default(),
             None,
-            Some(SlotLeader {
-                id: *original_bank.leader_id(),
-                ..SlotLeader::new_unique()
-            }), // genesis doesn't have a staked node
+            Some(*original_bank.leader()), // genesis doesn't have a staked node
             None,
             false,
             false,
@@ -944,7 +941,6 @@ mod tests {
     /// marked in the accounts database. This test injects them directly
     #[test]
     fn test_roundtrip_bank_to_and_from_full_snapshot_with_obsolete_account() {
-        let collector = Pubkey::new_unique();
         let key1 = Keypair::new();
         let key2 = Keypair::new();
         let key3 = Keypair::new();
@@ -956,7 +952,7 @@ mod tests {
             ..
         } = create_genesis_config_with_leader(
             1_000_000 * LAMPORTS_PER_SOL,
-            &collector,
+            &Pubkey::new_unique(),
             1_000_000 * LAMPORTS_PER_SOL,
         );
 
@@ -970,6 +966,7 @@ mod tests {
         let bank = Bank::new_with_config_for_tests(&genesis_config, bank_test_config);
 
         let (bank0, bank_forks) = Bank::wrap_with_bank_forks_for_tests(bank);
+        let leader = *bank0.leader();
         bank0
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -987,8 +984,7 @@ mod tests {
 
         // Create a new slot, and invalidate the account for key1 in slot0
         let slot = 1;
-        let bank1 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+        let bank1 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, leader, slot);
         bank1
             .transfer(LAMPORTS_PER_SOL, &key3, &key1.pubkey())
             .unwrap();
@@ -1036,7 +1032,6 @@ mod tests {
     /// multiple transfers.  So this full snapshot should contain more data.
     #[test]
     fn test_roundtrip_bank_to_and_from_snapshot_complex() {
-        let collector = Pubkey::new_unique();
         let key1 = Keypair::new();
         let key2 = Keypair::new();
         let key3 = Keypair::new();
@@ -1049,10 +1044,11 @@ mod tests {
             ..
         } = create_genesis_config_with_leader(
             1_000_000 * LAMPORTS_PER_SOL,
-            &collector,
+            &Pubkey::new_unique(),
             1_000_000 * LAMPORTS_PER_SOL,
         );
         let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        let leader = *bank0.leader();
         bank0
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1065,8 +1061,7 @@ mod tests {
         bank0.fill_bank_with_ticks_for_tests();
 
         let slot = 1;
-        let bank1 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+        let bank1 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, leader, slot);
         bank1
             .transfer(3 * LAMPORTS_PER_SOL, &mint_keypair, &key3.pubkey())
             .unwrap();
@@ -1079,24 +1074,21 @@ mod tests {
         bank1.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
-        let bank2 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+        let bank2 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, leader, slot);
         bank2
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
         bank2.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
-        let bank3 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
+        let bank3 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, leader, slot);
         bank3
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
         bank3.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
-        let bank4 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
+        let bank4 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, leader, slot);
         bank4
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1150,7 +1142,6 @@ mod tests {
     /// of the accounts are not modified often, and are captured by the full snapshot.
     #[test]
     fn test_roundtrip_bank_to_and_from_incremental_snapshot() {
-        let collector = Pubkey::new_unique();
         let key1 = Keypair::new();
         let key2 = Keypair::new();
         let key3 = Keypair::new();
@@ -1163,10 +1154,11 @@ mod tests {
             ..
         } = create_genesis_config_with_leader(
             1_000_000 * LAMPORTS_PER_SOL,
-            &collector,
+            &Pubkey::new_unique(),
             1_000_000 * LAMPORTS_PER_SOL,
         );
         let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        let leader = *bank0.leader();
         bank0
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1179,8 +1171,7 @@ mod tests {
         bank0.fill_bank_with_ticks_for_tests();
 
         let slot = 1;
-        let bank1 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+        let bank1 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, leader, slot);
         bank1
             .transfer(3 * LAMPORTS_PER_SOL, &mint_keypair, &key3.pubkey())
             .unwrap();
@@ -1210,24 +1201,21 @@ mod tests {
         .unwrap();
 
         let slot = slot + 1;
-        let bank2 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+        let bank2 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, leader, slot);
         bank2
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
         bank2.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
-        let bank3 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
+        let bank3 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, leader, slot);
         bank3
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
         bank3.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
-        let bank4 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
+        let bank4 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, leader, slot);
         bank4
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1268,7 +1256,6 @@ mod tests {
     /// Test rebuilding bank from the latest snapshot archives
     #[test]
     fn test_bank_from_latest_snapshot_archives() {
-        let collector = Pubkey::new_unique();
         let key1 = Keypair::new();
         let key2 = Keypair::new();
         let key3 = Keypair::new();
@@ -1279,10 +1266,11 @@ mod tests {
             ..
         } = create_genesis_config_with_leader(
             1_000_000 * LAMPORTS_PER_SOL,
-            &collector,
+            &Pubkey::new_unique(),
             1_000_000 * LAMPORTS_PER_SOL,
         );
         let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        let leader = *bank0.leader();
         bank0
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1295,8 +1283,7 @@ mod tests {
         bank0.fill_bank_with_ticks_for_tests();
 
         let slot = 1;
-        let bank1 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+        let bank1 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, leader, slot);
         bank1
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1326,24 +1313,21 @@ mod tests {
         .unwrap();
 
         let slot = slot + 1;
-        let bank2 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+        let bank2 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, leader, slot);
         bank2
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
         bank2.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
-        let bank3 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
+        let bank3 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, leader, slot);
         bank3
             .transfer(2 * LAMPORTS_PER_SOL, &mint_keypair, &key2.pubkey())
             .unwrap();
         bank3.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
-        let bank4 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
+        let bank4 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, leader, slot);
         bank4
             .transfer(3 * LAMPORTS_PER_SOL, &mint_keypair, &key3.pubkey())
             .unwrap();
@@ -1404,7 +1388,6 @@ mod tests {
     /// no longer correct!
     #[test]
     fn test_incremental_snapshots_handle_zero_lamport_accounts() {
-        let collector = Pubkey::new_unique();
         let key1 = Keypair::new();
         let key2 = Keypair::new();
 
@@ -1420,7 +1403,7 @@ mod tests {
             ..
         } = create_genesis_config_with_leader(
             1_000_000 * LAMPORTS_PER_SOL,
-            &collector,
+            &Pubkey::new_unique(),
             1_000_000 * LAMPORTS_PER_SOL,
         );
         // test expects 0 transaction fee
@@ -1434,14 +1417,14 @@ mod tests {
             vec![accounts_dir.clone()],
         )
         .wrap_with_bank_forks_for_tests();
+        let leader = *bank0.leader();
         bank0
             .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
             .unwrap();
         bank0.fill_bank_with_ticks_for_tests();
 
         let slot = 1;
-        let bank1 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+        let bank1 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, leader, slot);
         bank1
             .transfer(lamports_to_transfer, &key2, &key1.pubkey())
             .unwrap();
@@ -1459,8 +1442,7 @@ mod tests {
         .unwrap();
 
         let slot = slot + 1;
-        let bank2 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+        let bank2 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, leader, slot);
         let blockhash = bank2.last_blockhash();
         let tx = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
             &key1,
@@ -1519,8 +1501,7 @@ mod tests {
         );
 
         let slot = slot + 1;
-        let bank3 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
+        let bank3 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, leader, slot);
         // Update Account2 so that it no longer holds a reference to slot2
         bank3
             .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
@@ -1528,8 +1509,7 @@ mod tests {
         bank3.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
-        let bank4 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
+        let bank4 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, leader, slot);
         bank4.fill_bank_with_ticks_for_tests();
 
         // Ensure account1 has been cleaned/purged from everywhere
@@ -1586,7 +1566,6 @@ mod tests {
     #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_bank_fields_from_snapshot(storage_access: StorageAccess) {
-        let collector = Pubkey::new_unique();
         let key1 = Keypair::new();
 
         let GenesisConfigInfo {
@@ -1595,15 +1574,15 @@ mod tests {
             ..
         } = create_genesis_config_with_leader(
             1_000_000 * LAMPORTS_PER_SOL,
-            &collector,
+            &Pubkey::new_unique(),
             1_000_000 * LAMPORTS_PER_SOL,
         );
         let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        let leader = *bank0.leader();
         bank0.fill_bank_with_ticks_for_tests();
 
         let slot = 1;
-        let bank1 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+        let bank1 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, leader, slot);
         bank1.fill_bank_with_ticks_for_tests();
 
         let all_snapshots_dir = tempfile::TempDir::new().unwrap();
@@ -1621,8 +1600,7 @@ mod tests {
         .unwrap();
 
         let slot = slot + 1;
-        let bank2 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+        let bank2 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, leader, slot);
         bank2
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
@@ -1889,7 +1867,6 @@ mod tests {
     #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_snapshots_handle_zero_lamport_accounts(storage_access: StorageAccess) {
-        let collector = Pubkey::new_unique();
         let key1 = Keypair::new();
         let key2 = Keypair::new();
         let key3 = Keypair::new();
@@ -1904,7 +1881,7 @@ mod tests {
             ..
         } = create_genesis_config_with_leader(
             1_000_000 * LAMPORTS_PER_SOL,
-            &collector,
+            &Pubkey::new_unique(),
             1_000_000 * LAMPORTS_PER_SOL,
         );
 
@@ -1919,6 +1896,7 @@ mod tests {
         let bank0 = Bank::new_with_config_for_tests(&genesis_config, bank_test_config);
 
         let (bank0, bank_forks) = Bank::wrap_with_bank_forks_for_tests(bank0);
+        let leader = *bank0.leader();
 
         bank0
             .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
@@ -1927,8 +1905,7 @@ mod tests {
         bank0.fill_bank_with_ticks_for_tests();
 
         let slot = 1;
-        let bank1 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+        let bank1 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, leader, slot);
         bank1
             .transfer(lamports_to_transfer, &key2, &key1.pubkey())
             .unwrap();
@@ -1943,8 +1920,7 @@ mod tests {
         bank1.force_flush_accounts_cache();
 
         let slot = slot + 1;
-        let bank2 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+        let bank2 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, leader, slot);
         let blockhash = bank2.last_blockhash();
         let tx = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
             &key1,
@@ -1966,8 +1942,7 @@ mod tests {
         bank2.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
-        let bank3 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, slot);
+        let bank3 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, leader, slot);
         // Update Account2 so that it no longer holds a reference to slot2
         bank3
             .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
@@ -2039,7 +2014,6 @@ mod tests {
     #[test_case(MarkObsoleteAccounts::Disabled)]
     #[test_case(MarkObsoleteAccounts::Enabled)]
     fn test_fastboot_handle_zero_lamport_accounts(mark_obsolete_accounts: MarkObsoleteAccounts) {
-        let collector = Pubkey::new_unique();
         let key1 = Keypair::new();
         let key2 = Keypair::new();
 
@@ -2050,7 +2024,7 @@ mod tests {
             ..
         } = create_genesis_config_with_leader(
             1_000_000 * LAMPORTS_PER_SOL,
-            &collector,
+            &Pubkey::new_unique(),
             1_000_000 * LAMPORTS_PER_SOL,
         );
 
@@ -2067,6 +2041,7 @@ mod tests {
 
         let bank0 = Bank::new_with_config_for_tests(&genesis_config, bank_test_config);
         let (bank0, bank_forks) = Bank::wrap_with_bank_forks_for_tests(bank0);
+        let leader = *bank0.leader();
         bank0.transfer(lamports, &mint, &key2.pubkey()).unwrap();
         bank0.transfer(lamports, &mint, &key1.pubkey()).unwrap();
         bank0.fill_bank_with_ticks_for_tests();
@@ -2077,16 +2052,14 @@ mod tests {
 
         // In slot 1 transfer from key1 to key2, such that key1 becomes zero lamport
         let slot = 1;
-        let bank1 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+        let bank1 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, leader, slot);
         bank1.transfer(lamports, &key1, &key2.pubkey()).unwrap();
         assert_eq!(bank1.get_balance(&key1.pubkey()), 0,);
         bank1.fill_bank_with_ticks_for_tests();
 
         // In slot 2 transfer into key2 to mint such that key2 becomes zero lamport
         let slot = slot + 1;
-        let bank2 =
-            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot);
+        let bank2 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, leader, slot);
         bank2.transfer(lamports * 2, &key2, &mint.pubkey()).unwrap();
         bank2.fill_bank_with_ticks_for_tests();
         assert_eq!(bank2.get_balance(&key2.pubkey()), 0);
@@ -2165,7 +2138,11 @@ mod tests {
     #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
     fn test_bank_from_snapshot_dir(storage_access: StorageAccess) {
-        let genesis_config = GenesisConfig::default();
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config_with_leader(
+            1_000_000 * LAMPORTS_PER_SOL,
+            &Pubkey::new_unique(),
+            1_000_000 * LAMPORTS_PER_SOL,
+        );
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let bank = Bank::new_for_tests(&genesis_config);
         bank.fill_bank_with_ticks_for_tests();
@@ -2190,10 +2167,7 @@ mod tests {
             &genesis_config,
             &RuntimeConfig::default(),
             None,
-            Some(SlotLeader {
-                id: *bank.leader_id(),
-                ..SlotLeader::new_unique()
-            }), // genesis doesn't have a staked node
+            None, // leader_for_tests
             None,
             false,
             AccountsDbConfig {

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -165,8 +165,8 @@ mod tests {
     use {
         super::*, crate::accounts_background_service::SnapshotRequestKind,
         agave_snapshots::snapshot_config::SnapshotConfig, crossbeam_channel::unbounded,
-        solana_genesis_config::create_genesis_config, solana_pubkey::Pubkey, std::sync::Arc,
-        test_case::test_case,
+        solana_genesis_config::create_genesis_config, solana_leader_schedule::SlotLeader,
+        std::sync::Arc, test_case::test_case,
     };
 
     fn create_banks(num_banks: u64) -> Vec<Arc<Bank>> {
@@ -178,7 +178,7 @@ mod tests {
         for _ in 1..=num_banks {
             let new_bank = Arc::new(Bank::new_from_parent(
                 parent_bank.clone(),
-                &Pubkey::default(),
+                SlotLeader::default(),
                 parent_bank.slot() + 1,
             ));
             parent_bank = new_bank;

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -608,7 +608,7 @@ mod tests {
         // write to multiple accounts and keep track of one, for minimization later
         let pubkey_to_keep = Pubkey::new_unique();
         let slot = bank.slot() + 1;
-        let bank = Bank::new_from_parent(bank.clone(), bank.leader_id(), slot);
+        let bank = Bank::new_from_parent(bank.clone(), *bank.leader(), slot);
         let bank = bank_forks
             .write()
             .unwrap()

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -12,6 +12,7 @@ use {
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::utils::create_account_shared_data,
     solana_clock::Epoch,
+    solana_leader_schedule::SlotLeader,
     solana_pubkey::Pubkey,
     solana_stake_interface::{
         program as stake_program,
@@ -462,9 +463,12 @@ impl Stakes<StakeAccount> {
         self.stake_delegations.iter().collect()
     }
 
-    pub(crate) fn highest_staked_node(&self) -> Option<&Pubkey> {
-        let vote_account = self.vote_accounts.find_max_by_delegated_stake()?;
-        Some(vote_account.node_pubkey())
+    pub(crate) fn highest_staked_node(&self) -> Option<SlotLeader> {
+        let (vote_address, vote_account) = self.vote_accounts.find_max_by_delegated_stake()?;
+        Some(SlotLeader {
+            id: *vote_account.node_pubkey(),
+            vote_address: *vote_address,
+        })
     }
 }
 
@@ -731,8 +735,14 @@ pub(crate) mod tests {
             .unwrap()
             .node_pubkey;
 
-        let highest_staked_node = stakes_cache.stakes().highest_staked_node().copied();
-        assert_eq!(highest_staked_node, Some(vote11_node_pubkey));
+        let highest_staked_node = stakes_cache.stakes().highest_staked_node();
+        assert_eq!(
+            highest_staked_node,
+            Some(SlotLeader {
+                id: vote11_node_pubkey,
+                vote_address: vote11_pubkey,
+            })
+        );
     }
 
     #[test]

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -536,7 +536,7 @@ mod test {
         solana_account::AccountSharedData,
         solana_genesis_config::create_genesis_config,
         solana_nonce::{self as nonce, state::DurableNonce},
-        solana_pubkey::Pubkey,
+        solana_runtime::bank::SlotLeader,
         solana_signer::Signer,
         solana_system_interface::program as system_program,
         solana_system_transaction as system_transaction,
@@ -629,7 +629,7 @@ mod test {
 
         let root_bank = Bank::new_from_parent(
             bank_forks.read().unwrap().working_bank(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             1,
         );
         let root_bank = bank_forks
@@ -655,7 +655,7 @@ mod test {
             .unwrap()
             .insert(Bank::new_from_parent(
                 root_bank.clone(),
-                &Pubkey::default(),
+                SlotLeader::default(),
                 2,
             ))
             .clone_without_scheduler();
@@ -911,7 +911,7 @@ mod test {
 
         let root_bank = Bank::new_from_parent(
             bank_forks.read().unwrap().working_bank(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             1,
         );
         let root_bank = bank_forks
@@ -946,7 +946,7 @@ mod test {
             .unwrap()
             .insert(Bank::new_from_parent(
                 root_bank.clone(),
-                &Pubkey::default(),
+                SlotLeader::default(),
                 2,
             ))
             .clone_without_scheduler();

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -297,7 +297,11 @@ mod tests {
         solana_client_traits::SyncClient,
         solana_genesis_config::create_genesis_config,
         solana_keypair::Keypair,
-        solana_runtime::{bank::Bank, bank_client::BankClient, bank_forks::BankForks},
+        solana_runtime::{
+            bank::{Bank, SlotLeader},
+            bank_client::BankClient,
+            bank_forks::BankForks,
+        },
         solana_signer::Signer,
         solana_stake_interface::state::StakeStateV2,
         solana_sysvar::epoch_rewards::EpochRewards,
@@ -322,7 +326,7 @@ mod tests {
 
         let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         bank.squash();
-        let bank = Bank::new_from_parent(bank, &Pubkey::new_unique(), 1);
+        let bank = Bank::new_from_parent(bank, SlotLeader::new_unique(), 1);
         bank.set_sysvar_for_tests(&EpochRewards::default());
 
         let stake_rent = bank.get_minimum_balance_for_rent_exemption(StakeStateV2::size_of());

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -218,7 +218,7 @@ mod tests {
         crossbeam_channel::unbounded,
         solana_genesis_config::GenesisConfig,
         solana_ledger::genesis_utils::{GenesisConfigInfo, create_genesis_config},
-        solana_pubkey::Pubkey,
+        solana_runtime::bank::SlotLeader,
         solana_system_transaction as system_transaction,
         solana_transaction::Transaction,
     };
@@ -247,7 +247,7 @@ mod tests {
     fn test_recv_slot_entries_1() {
         let (genesis_config, bank0, tx) = setup_test();
 
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
         let (s, r) = unbounded();
         let mut last_hash = genesis_config.hash();
 
@@ -277,8 +277,12 @@ mod tests {
     fn test_recv_slot_entries_2() {
         let (genesis_config, bank0, tx) = setup_test();
 
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
-        let bank2 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 2));
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
+        let bank2 = Arc::new(Bank::new_from_parent(
+            bank1.clone(),
+            SlotLeader::default(),
+            2,
+        ));
         let (s, r) = unbounded();
 
         let mut last_hash = genesis_config.hash();

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -658,7 +658,7 @@ mod test {
 
         // Step 2: Make a transmission for another bank that interrupts the transmission for
         // slot 0
-        let bank2 = Arc::new(Bank::new_from_parent(bank0, &leader_keypair.pubkey(), 2));
+        let bank2 = Arc::new(Bank::new_from_parent(bank0.clone(), *bank0.leader(), 2));
         let interrupted_slot = standard_broadcast_run.slot;
         // Interrupting the slot should cause the unfinished_slot and stats to reset
         let num_shreds = 1;

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -2944,7 +2944,7 @@ mod tests {
         solana_poh::record_channels::record_channels,
         solana_pubkey::Pubkey,
         solana_runtime::{
-            bank::Bank,
+            bank::{Bank, SlotLeader},
             bank_forks::BankForks,
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
             installed_scheduler_pool::{
@@ -3704,7 +3704,7 @@ mod tests {
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-        let child_bank = Bank::new_from_parent(bank, &Pubkey::default(), 1);
+        let child_bank = Bank::new_from_parent(bank, SlotLeader::default(), 1);
 
         let pool = DefaultSchedulerPool::new_dyn_for_verification(None, None, None, None, None);
 
@@ -4165,7 +4165,7 @@ mod tests {
         // Create new bank to observe behavior difference around session ending
         let bank = Arc::new(Bank::new_from_parent(
             bank.clone_without_scheduler(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             bank.slot().checked_add(1).unwrap(),
         ));
         assert_eq!(bank.transaction_count(), expected_transaction_count.0);
@@ -4246,7 +4246,7 @@ mod tests {
 
         let bank = Arc::new(Bank::new_from_parent(
             bank.clone(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             bank.slot().checked_add(1).unwrap(),
         ));
         // Immediately trigger WouldExceedMaxBlockCostLimit by setting all cost limits to 0
@@ -4273,7 +4273,7 @@ mod tests {
         record_receiver.shutdown();
         let bank = Arc::new(Bank::new_from_parent(
             bank.clone_without_scheduler(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             bank.slot().checked_add(1).unwrap(),
         ));
         // Revert the block cost limit
@@ -4328,7 +4328,7 @@ mod tests {
         let bank0 = setup_dummy_fork_graph(bank0).0;
         let bank1 = Arc::new(Bank::new_from_parent(
             bank0.clone(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             bank0.slot().checked_add(1).unwrap(),
         ));
 
@@ -4552,7 +4552,7 @@ mod tests {
             let slot = bank.slot();
             bank = Bank::new_from_parent(
                 Arc::new(bank),
-                &Pubkey::default(),
+                SlotLeader::default(),
                 slot.checked_add(1).unwrap(),
             );
         }

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -183,10 +183,10 @@ impl VoteAccounts {
             .map(|(vote_pubkey, (stake, _vote_account))| (vote_pubkey, *stake))
     }
 
-    pub fn find_max_by_delegated_stake(&self) -> Option<&VoteAccount> {
+    pub fn find_max_by_delegated_stake(&self) -> Option<(&Pubkey, &VoteAccount)> {
         let key = |(_pubkey, (stake, _vote_account)): &(_, &(u64, _))| *stake;
-        let (_pubkey, (_stake, vote_account)) = self.vote_accounts.iter().max_by_key(key)?;
-        Some(vote_account)
+        let (vote_address, (_stake, vote_account)) = self.vote_accounts.iter().max_by_key(key)?;
+        Some((vote_address, vote_account))
     }
 
     pub fn insert(

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -818,7 +818,7 @@ mod tests {
         },
         solana_net_utils::SocketAddrSpace,
         solana_runtime::{
-            bank::Bank,
+            bank::{Bank, SlotLeader},
             bank_forks::BankForks,
             genesis_utils::{
                 create_genesis_config_with_alpenglow_vote_accounts, ValidatorVoteKeypairs,
@@ -1134,7 +1134,7 @@ mod tests {
         }
 
         fn create_block_only(&mut self, slot: Slot, parent_bank: Arc<Bank>) -> Arc<Bank> {
-            let bank = Bank::new_from_parent(parent_bank, &Pubkey::new_unique(), slot);
+            let bank = Bank::new_from_parent(parent_bank, SlotLeader::new_unique(), slot);
             bank.set_block_id(Some(Hash::new_unique()));
             bank.freeze();
             let mut bank_forks_w = self.bank_forks.write().unwrap();

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -331,7 +331,7 @@ mod tests {
         crossbeam_channel::unbounded,
         solana_hash::Hash,
         solana_runtime::{
-            bank::Bank,
+            bank::{Bank, SlotLeader},
             bank_forks::BankForks,
             epoch_stakes::VersionedEpochStakes,
             genesis_utils::{
@@ -620,7 +620,7 @@ mod tests {
                 (authorized_voter, (stake as u64, vote_account))
             })
             .collect();
-        let mut new_bank = Bank::new_from_parent(bank, &Pubkey::default(), 1);
+        let mut new_bank = Bank::new_from_parent(bank, SlotLeader::default(), 1);
         assert!(new_bank.epoch_stakes(2).is_none());
         let epoch2_epoch_stakes = VersionedEpochStakes::new_for_tests(vote_accounts_hash_map, 2);
         new_bank.set_epoch_stakes_for_test(2, epoch2_epoch_stakes);

--- a/wen-restart/src/last_voted_fork_slots_aggregate.rs
+++ b/wen-restart/src/last_voted_fork_slots_aggregate.rs
@@ -248,7 +248,7 @@ mod tests {
         solana_gossip::restart_crds_values::RestartLastVotedForkSlots,
         solana_hash::Hash,
         solana_runtime::{
-            bank::Bank,
+            bank::{Bank, SlotLeader},
             epoch_stakes::VersionedEpochStakes,
             genesis_utils::{
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
@@ -285,7 +285,7 @@ mod tests {
         );
         let (_, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         let bank0 = bank_forks.read().unwrap().root_bank();
-        let bank1 = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
+        let bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         bank_forks.write().unwrap().set_root(1, None, None);
         let root_bank = bank_forks.read().unwrap().root_bank();
@@ -762,7 +762,7 @@ mod tests {
         let (_, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         let root_bank = bank_forks.read().unwrap().root_bank();
         // Add bank 1 linking directly to 0, tweak its epoch_stakes, and then add it to bank_forks.
-        let mut new_root_bank = Bank::new_from_parent(root_bank.clone(), &Pubkey::default(), 1);
+        let mut new_root_bank = Bank::new_from_parent(root_bank.clone(), SlotLeader::default(), 1);
 
         // For epoch 1, let our validator have 90% of the stake.
         let vote_accounts_hash_map = validator_voting_keypairs

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -628,10 +628,9 @@ pub(crate) fn find_bankhash_of_heaviest_fork(
         let bank_with_scheduler = saved_bank.unwrap_or_else(|| {
             let new_bank = Bank::new_from_parent(
                 parent_bank.clone(),
-                &leader_schedule_cache
+                leader_schedule_cache
                     .slot_leader_at(slot, Some(&parent_bank))
-                    .unwrap()
-                    .id,
+                    .unwrap(),
                 slot,
             );
             bank_forks.write().unwrap().insert_from_ledger(new_bank)
@@ -1438,6 +1437,7 @@ mod tests {
         solana_net_utils::SocketAddrSpace,
         solana_pubkey::Pubkey,
         solana_runtime::{
+            bank::SlotLeader,
             epoch_stakes::VersionedEpochStakes,
             genesis_utils::{
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
@@ -1967,7 +1967,7 @@ mod tests {
         let my_heaviest_fork_slot = last_vote_slot + 1;
         let mut new_root_bank = Bank::new_from_parent(
             old_root_bank.clone(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             my_heaviest_fork_slot,
         );
         assert_eq!(new_root_bank.epoch(), 1);
@@ -3787,7 +3787,7 @@ mod tests {
         );
         let new_bank = Bank::new_from_parent(
             test_state.bank_forks.read().unwrap().get(new_slot).unwrap(),
-            &Pubkey::default(),
+            SlotLeader::default(),
             slot_full_but_not_replayed,
         );
         let _ = test_state


### PR DESCRIPTION
#### Problem
In order to implement changes for fee distribution per SIMD's 232 and 123, each Bank must be associated with the correct vote address for the slot leader.

#### Summary of Changes
Require `SlotLeader` as a parameter for `Bank` constructors


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
