### PR TITLE
remove fake vote_only_bank markers

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -142,7 +142,6 @@ fn main() -> Result<()> {
                 stats.clone(),
                 None, // coalesce
                 true,
-                None,
                 false,
             );
 

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -306,7 +306,6 @@ fn main() -> Result<()> {
                     stats.clone(),
                     None,  // coalesce
                     true,  // use_pinned_memory
-                    None,  // in_vote_only_mode
                     false, // is_staked_service
                 ));
             }

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -142,7 +142,6 @@ impl FetchStage {
                     tpu_vote_stats.clone(),
                     coalesce,
                     true,
-                    None,
                     true, // only staked connections should be voting
                 )
             })

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -171,7 +171,6 @@ impl AncestorHashesService {
             )),
             Some(Duration::from_millis(1)), // coalesce
             false,                          // use_pinned_memory
-            None,                           // in_vote_only_mode
             false,                          // is_staked_service
         );
 
@@ -1314,7 +1313,6 @@ mod test {
                 Arc::new(StreamerReceiveStats::new("repair_request_receiver")),
                 Some(Duration::from_millis(1)), // coalesce
                 false,
-                None,
                 false,
             );
             let (remote_request_sender, remote_request_receiver) = unbounded();

--- a/core/src/repair/serve_repair_service.rs
+++ b/core/src/repair/serve_repair_service.rs
@@ -40,7 +40,6 @@ impl ServeRepairService {
             Arc::new(StreamerReceiveStats::new("serve_repair_receiver")),
             Some(Duration::from_millis(1)), // coalesce
             false,                          // use_pinned_memory
-            None,                           // in_vote_only_mode
             false,                          // is_staked_service
         );
         let t_packet_adapter = Builder::new()

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -84,7 +84,7 @@ use {
     solana_rpc_client_api::response::SlotUpdate,
     solana_runtime::{
         bank::{bank_hash_details, Bank, NewBankOptions},
-        bank_forks::{BankForks, MAX_ROOT_DISTANCE_FOR_VOTE_ONLY},
+        bank_forks::BankForks,
         commitment::BlockCommitmentCache,
         installed_scheduler_pool::BankWithScheduler,
         leader_schedule_utils::first_of_consecutive_leader_slots,
@@ -2449,10 +2449,7 @@ impl ReplayStage {
             datapoint_info!("replay_stage-my_leader_slot", ("slot", poh_slot, i64),);
             info!("new fork:{poh_slot} parent:{parent_slot} (leader) root:{root_slot}");
 
-            let root_distance = poh_slot - root_slot;
-            let vote_only_bank = if root_distance > MAX_ROOT_DISTANCE_FOR_VOTE_ONLY
-                || migration_status.should_bank_be_vote_only(poh_slot)
-            {
+            let vote_only_bank = if migration_status.should_bank_be_vote_only(poh_slot) {
                 info!("{my_pubkey}: Creating block in slot {poh_slot} in VoM");
                 datapoint_info!("vote-only-bank", ("slot", poh_slot, i64));
                 true

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -764,12 +764,9 @@ impl ReplayStage {
                 unfrozen_gossip_verified_vote_hashes,
                 epoch_slots_frozen_slots,
             };
-            let (working_bank, in_vote_only_mode) = {
+            let working_bank = {
                 let r_bank_forks = bank_forks.read().unwrap();
-                (
-                    r_bank_forks.working_bank(),
-                    r_bank_forks.get_vote_only_mode_signal(),
-                )
+                r_bank_forks.working_bank()
             };
             let mut last_threshold_failure_slot = 0;
             // Thread pool to (maybe) replay multiple threads in parallel
@@ -1070,13 +1067,6 @@ impl ReplayStage {
                         .heaviest_subtree_fork_choice
                         .select_forks(&frozen_banks, &tower, &progress, &ancestors, &bank_forks);
                     select_forks_time.stop();
-
-                    Self::check_for_vote_only_mode(
-                        heaviest_bank.slot(),
-                        forks_root,
-                        &in_vote_only_mode,
-                        &bank_forks,
-                    );
 
                     let mut select_vote_and_reset_forks_time =
                         Measure::start("select_vote_and_reset_forks");
@@ -1590,41 +1580,6 @@ impl ReplayStage {
                 ))
             }
             Err(err) => Err(err),
-        }
-    }
-
-    fn check_for_vote_only_mode(
-        heaviest_bank_slot: Slot,
-        forks_root: Slot,
-        in_vote_only_mode: &AtomicBool,
-        bank_forks: &RwLock<BankForks>,
-    ) {
-        if heaviest_bank_slot.saturating_sub(forks_root) > MAX_ROOT_DISTANCE_FOR_VOTE_ONLY {
-            if !in_vote_only_mode.load(Ordering::Relaxed)
-                && in_vote_only_mode
-                    .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
-                    .is_ok()
-            {
-                let bank_forks = bank_forks.read().unwrap();
-                datapoint_warn!(
-                    "bank_forks-entering-vote-only-mode",
-                    ("banks_len", bank_forks.len(), i64),
-                    ("heaviest_bank", heaviest_bank_slot, i64),
-                    ("root", bank_forks.root(), i64),
-                );
-            }
-        } else if in_vote_only_mode.load(Ordering::Relaxed)
-            && in_vote_only_mode
-                .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-        {
-            let bank_forks = bank_forks.read().unwrap();
-            datapoint_warn!(
-                "bank_forks-exiting-vote-only-mode",
-                ("banks_len", bank_forks.len(), i64),
-                ("heaviest_bank", heaviest_bank_slot, i64),
-                ("root", bank_forks.root(), i64),
-            );
         }
     }
 
@@ -9235,18 +9190,6 @@ pub(crate) mod tests {
         while poh_controller.has_pending_message() {
             std::hint::spin_loop();
         }
-    }
-
-    #[test]
-    fn test_check_for_vote_only_mode() {
-        let in_vote_only_mode = AtomicBool::new(false);
-        let genesis_config = create_genesis_config(10_000).genesis_config;
-        let bank0 = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new_rw_arc(bank0);
-        ReplayStage::check_for_vote_only_mode(1000, 0, &in_vote_only_mode, &bank_forks);
-        assert!(in_vote_only_mode.load(Ordering::Relaxed));
-        ReplayStage::check_for_vote_only_mode(10, 0, &in_vote_only_mode, &bank_forks);
-        assert!(!in_vote_only_mode.load(Ordering::Relaxed));
     }
 
     #[test]

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -228,7 +228,6 @@ impl ShredFetchStage {
                     receiver_stats.clone(),
                     Some(Duration::from_millis(5)), // coalesce
                     true,                           // use_pinned_memory
-                    None,                           // in_vote_only_mode
                     false,                          // is_staked_service
                 )
             })

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -71,7 +71,6 @@ impl GossipService {
             gossip_receiver_stats.clone(),
             Some(Duration::from_millis(1)), // coalesce
             false,
-            None,
             false,
         );
         let (consume_sender, listen_receiver) =

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -22,7 +22,7 @@ use {
         collections::{hash_map::Entry, HashMap, HashSet},
         ops::Index,
         sync::{
-            atomic::{AtomicBool, AtomicU64, Ordering},
+            atomic::{AtomicU64, Ordering},
             Arc, RwLock,
         },
         time::Instant,
@@ -99,7 +99,6 @@ pub struct BankForks {
     root: Arc<AtomicSlot>,
     working_slot: Slot,
     sharable_banks: SharableBanks,
-    in_vote_only_mode: Arc<AtomicBool>,
     highest_slot_at_startup: Slot,
     scheduler_pool: Option<InstalledSchedulerPoolArc>,
     dumped_slot_subscribers: Vec<DumpedSlotSubscription>,
@@ -159,7 +158,6 @@ impl BankForks {
             },
             banks,
             descendants,
-            in_vote_only_mode: Arc::new(AtomicBool::new(false)),
             highest_slot_at_startup: 0,
             scheduler_pool: None,
             dumped_slot_subscribers: vec![],
@@ -185,10 +183,6 @@ impl BankForks {
 
     pub fn banks(&self) -> &HashMap<Slot, BankWithScheduler> {
         &self.banks
-    }
-
-    pub fn get_vote_only_mode_signal(&self) -> Arc<AtomicBool> {
-        self.in_vote_only_mode.clone()
     }
 
     pub fn migration_status(&self) -> Arc<MigrationStatus> {


### PR DESCRIPTION
#### Problem
- Alpenglow requires a consensus agreed upon vote-only bank mode. We currently have an existing vote-only bank that has several issues:
	- not properly enforced during block-construction (not addressed by this PR)
	- not agreed upon network wide (removed in this PR)
- There are also other places in network code which show in searches for vote_only but are completely unused

#### Summary of Changes
- Remove BankForks vote_only_mode
- Remove streams vote_only_mode
- remove root_distance condition for setting vote_only_bank on a leader bank

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
