### PR TITLE
Inserts into the in-mem index on startup, take two

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6696,16 +6696,24 @@ impl AccountsDb {
 
         self.accounts_index.log_secondary_indexes();
 
-        // Now that the index is generated, get the total capacity of the in-mem maps
+        // Now that the index is generated, get the total length and capacity of the in-mem maps
         // across all the bins and set the initial value for the stat.
         // We do this all at once, at the end, since getting the capacity requires iterating all
         // the bins and grabbing a read lock, which we try to avoid whenever possible.
-        let index_capacity = self
+        let (index_len, index_capacity) = self
             .accounts_index
             .account_maps
             .iter()
-            .map(|bin| bin.capacity_for_startup())
-            .sum();
+            .map(|bin| bin.len_and_cap_for_startup())
+            .fold((0, 0), |mut accum, (len, cap)| {
+                accum.0 += len;
+                accum.1 += cap;
+                accum
+            });
+        self.accounts_index
+            .stats()
+            .count_in_mem
+            .store(index_len, Ordering::Relaxed);
         self.accounts_index
             .stats()
             .capacity_in_mem

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -92,7 +92,7 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
 
     /// Precomputed thresholds per bin for flushing and eviction
     /// None for Minimal/InMemOnly, Some(threshold_entries_per_bin) for Threshold
-    threshold_entries_per_bin: Option<ThresholdEntriesPerBin>,
+    pub(super) threshold_entries_per_bin: Option<ThresholdEntriesPerBin>,
 }
 
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Debug for BucketMapHolder<T, U> {
@@ -502,14 +502,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
 
 /// Precomputed thresholds derived from the configured per-bin target.
 #[derive(Clone, Copy, Debug)]
-struct ThresholdEntriesPerBin {
+pub struct ThresholdEntriesPerBin {
     /// Rounded target entries per bin used as the baseline for thresholds.
-    _target_entries: usize,
+    pub _target_entries: usize,
     /// Entry count above which a bin triggers flushing to disk and eviction
     /// from in-memory index.
-    high_water_mark: usize,
+    pub high_water_mark: usize,
     /// Entry count to reach after flushing/evicting from a bin.
-    low_water_mark: usize,
+    pub low_water_mark: usize,
 }
 
 #[cfg(test)]

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -970,30 +970,29 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         possible_evictions
     }
 
-    fn write_startup_info_to_disk(&self) {
+    /// Takes self's `startup_info` and writes it to disk and in-mem.
+    ///
+    /// If the configured memory limit is "minimal", nothing is writen to in-mem.
+    /// Otherwise write to in-mem (and respect the memory limit).
+    fn write_startup_info(&self) {
         let insert = std::mem::take(&mut *self.startup_info.insert.lock().unwrap());
         if insert.is_empty() {
             // nothing to insert for this bin
             return;
         }
 
-        // during startup, nothing should be in the in-mem map
-        let map_internal = self.map_internal.read().unwrap();
-        assert!(
-            map_internal.is_empty(),
-            "len: {}, first: {:?}",
-            map_internal.len(),
-            map_internal.iter().take(1).collect::<Vec<_>>()
-        );
-        drop(map_internal);
-
         // this fn should only be called from a single thread, so holding the lock is fine
         let mut duplicates = self.startup_info.duplicates.lock().unwrap();
 
         // merge all items into the disk index now
         let disk = self.bucket.as_ref().unwrap();
+        let duplicate_entries_and_indices = disk.batch_insert_non_duplicates(&insert);
+        let duplicate_addresses: HashSet<_> = duplicate_entries_and_indices
+            .iter()
+            .map(|(index, _entry)| &insert[*index].0)
+            .collect();
         let mut count = insert.len() as u64;
-        for (i, duplicate_entry) in disk.batch_insert_non_duplicates(&insert) {
+        for (i, duplicate_entry) in duplicate_entries_and_indices {
             let (k, entry) = &insert[i];
             duplicates.duplicates.push((entry.0, *k, entry.1.into()));
             // accurately account for there being a duplicate for the first entry that was previously added to the disk index.
@@ -1003,6 +1002,65 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 .duplicates_put_on_disk
                 .insert((duplicate_entry.0, *k));
             count -= 1;
+        }
+
+        if let Some(threshold_entries_per_bin) = self.storage.threshold_entries_per_bin.as_ref() {
+            // If a memory threshold is set, then insert into the in-mem index here,
+            // up to that limit.  This way we pre-populate the in-mem index, and can
+            // avoid having to load some entries from disk on first access.
+            let mut map = self.map_internal.write().unwrap();
+            // Insert up to the low water mark.  Purposely do not insert all the way up  to the
+            // high water mark, as that then causes the flush loop condition to immediately trigger
+            // and evict down to the low water mark anyway.
+            let num_available = threshold_entries_per_bin
+                .low_water_mark
+                .saturating_sub(map.len());
+            for (address, (slot, disk_index_value)) in insert
+                .iter()
+                .filter(|(address, _entry)| !duplicate_addresses.contains(address)) // <- skip known duplicates
+                .take(num_available)
+            {
+                match map.entry(*address) {
+                    Entry::Vacant(vacant) => {
+                        let index_value = (*disk_index_value).into();
+                        let slot_list = SlotList::from([(*slot, index_value)]);
+                        let ref_count = 1;
+                        let meta = AccountMapEntryMeta::new_clean(&self.storage);
+                        let account_map_entry = AccountMapEntry::new(slot_list, ref_count, meta);
+                        vacant.insert(Box::new(account_map_entry));
+                    }
+                    Entry::Occupied(_occupied) => {
+                        // If the account already has an entry in the in-mem index, then that means
+                        // it is a duplicate.  We could merge them here, however duplicates
+                        // handling happens later during startup/index generation, in
+                        // populate_and_retrieve_duplicate_keys_from_startup(), which will insert
+                        // them back into the in-mem index.  Thus we should *not* insert any
+                        // accounts with duplicate entries here.
+                        // Additionally, once marking obsolete accounts is always on, we then
+                        // should no longer have any duplicates to worry about.
+                    }
+                }
+            }
+
+            // Related to the comment in the Entry::Occupied match arm above, if inserting
+            // into disk (batch_insert_non_duplicates()) returned duplicates, we need to check
+            // and make sure they are not in the in-mem index.  (Since the first time we encounter
+            // a duplicate we do not know it is a duplicate, so it will have been inserted
+            // in mem.)  We must remove them here.
+            for duplicate_address in duplicate_addresses {
+                map.remove(duplicate_address);
+            }
+            drop(map);
+        } else {
+            // Else, we should not have anything in the in-mem index at all.
+            let map_internal = self.map_internal.read().unwrap();
+            assert!(
+                map_internal.is_empty(),
+                "len: {}, first: {:?}",
+                map_internal.len(),
+                map_internal.iter().take(1).collect::<Vec<_>>()
+            );
+            drop(map_internal);
         }
 
         self.stats().inc_insert_count(count);
@@ -1092,7 +1150,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             // At startup we do not insert index entries into the normal in-mem index.
             // Instead, they are written to a startup-only struct.  Thus, at startup
             // we only need to flush that startup struct and then can return early.
-            self.write_startup_info_to_disk();
+            self.write_startup_info();
+
             if iterate_for_age {
                 // Note we still have to iterate ages too, since it is checked when
                 // transitioning from startup back to normal/steady state.
@@ -1276,11 +1335,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         Self::update_stat(stat, value);
     }
 
-    /// Returns the capacity for this bin's map
+    /// Returns the length and capacity of this bin's map
     ///
     /// Only intended to be called at startup, since it grabs the map's read lock.
-    pub(crate) fn capacity_for_startup(&self) -> usize {
-        self.map_internal.read().unwrap().capacity()
+    pub(crate) fn len_and_cap_for_startup(&self) -> (usize, usize) {
+        let map = self.map_internal.read().unwrap();
+        (map.len(), map.capacity())
     }
 }
 
@@ -1441,9 +1501,13 @@ enum ReasonToNotFlush {
 mod tests {
     use {
         super::*,
-        crate::accounts_index::{AccountsIndexConfig, IndexLimit, BINS_FOR_TESTING},
+        crate::accounts_index::{
+            bucket_map_holder::ThresholdEntriesPerBin, AccountsIndexConfig, IndexLimit,
+            ACCOUNTS_INDEX_CONFIG_FOR_TESTING, BINS_FOR_TESTING,
+        },
         assert_matches::assert_matches,
         itertools::Itertools,
+        std::iter,
         test_case::test_case,
     };
 
@@ -2494,5 +2558,73 @@ mod tests {
                 assert_eq!(total_capacity, 0);
             }
         }
+    }
+
+    /// Ensure `write_startup_info()` populates the in-mem index,
+    /// while also respecting the configured memory threshold.
+    #[test]
+    fn test_write_startup_info() {
+        let num_bins = 1;
+        let config = AccountsIndexConfig {
+            bins: Some(num_bins),
+            index_limit: {
+                // Ensure we use an IndexLimit that (1) enables the disk index,
+                // and (2) is a valid threshold, as per the logic in BucketMapHolder::new().
+                // We will override the threshold afterwards, so the actual value doesn't matter.
+                IndexLimit::Threshold(25_000_000_000)
+            },
+            ..ACCOUNTS_INDEX_CONFIG_FOR_TESTING
+        };
+        let mut holder = BucketMapHolder::new(num_bins, &config, 1);
+
+        // Override the threshold values to make testing faster.
+        let low_water_mark = 100;
+        let high_water_mark = low_water_mark + 200;
+        holder.threshold_entries_per_bin = Some(ThresholdEntriesPerBin {
+            _target_entries: high_water_mark + 300,
+            high_water_mark,
+            low_water_mark,
+        });
+        let holder = Arc::new(holder);
+        let index = InMemAccountsIndex::<u64, u64>::new(&holder, num_bins - 1, None);
+
+        // Emulate index generation where we push startup values into the `startup_info`
+        // side-band struct when disk index is enabled.  Ensure we push more than
+        // `low_water_mark` number of values.
+        let to_insert = iter::repeat_with(|| {
+            // the addresses need to be unique, but the actual values do not matter
+            (Pubkey::new_unique(), (/*slot*/ 11, /*T*/ 42))
+        })
+        .take(high_water_mark);
+        index.startup_info.insert.lock().unwrap().extend(to_insert);
+
+        // Also push some duplicates, to ensure we do not put those in-mem
+        let duplicate_pubkey = Pubkey::new_unique();
+        {
+            let mut startup_info_insert = index.startup_info.insert.lock().unwrap();
+            // Yes, we want three duplicates.  Two is the minimum (by definition), but we want
+            // three to ensure we don't see the first two, remove 'em, then see a third and think
+            // "oh, this is a new non-duplicate!" and erroneously insert it in-mem.
+            startup_info_insert.push((duplicate_pubkey, (/*slot*/ 13, /*T*/ 43)));
+            startup_info_insert.push((duplicate_pubkey, (/*slot*/ 14, /*T*/ 44)));
+            startup_info_insert.push((duplicate_pubkey, (/*slot*/ 15, /*T*/ 45)));
+            // Reverse the vec to ensure the duplicates end up at the front.
+            // Otherwise they would not be selected to be put in-mem.
+            startup_info_insert.reverse();
+        }
+        assert!(index.map_internal.read().unwrap().is_empty());
+
+        // Index generation calls `write_startup_info()`, which is responsible for writing the
+        // values to disk, and also populating the in-mem index. So call `write_startup_info()`
+        // here, and ensure:
+        // - we end up with the expected number of items in the in-mem index
+        // - duplicates do not end up in-mem
+        index.write_startup_info();
+        assert_eq!(index.map_internal.read().unwrap().len(), low_water_mark);
+        assert!(!index
+            .map_internal
+            .read()
+            .unwrap()
+            .contains_key(&duplicate_pubkey));
     }
 }


### PR DESCRIPTION
#### Problem

If using the accounts index with a configured threshold via `--accounts-index-limit`, at startup all index entries are written to disk, but none to the in-mem index. This means that all first accesses to accounts will incur a disk read, which is slow.

This is unfortunate, since even if the configured threshold is large enough to hold everything in memory (e.g. `--accounts-index-limit 200GB`), the in-mem index will start off empty. And thus performance will be poor until all the accounts have be loaded back into memory.


#### Summary of Changes

At startup, if using a memory threshold for the index, insert into the in-mem index at the same time we also write the index entries to disk.

The resulting behavior is the validator is seeded with account index entries in-memory from the get go. When using a 200GB limit, the whole index fits in RAM, and performance is *immediately* high, instead of waiting for the long tail of accounts to be accessed one by one. Miss rate into the in-mem index is the same as in-mem-only.

This PR is take 2, as the original PR, #10162, was incorrect and needed to be reverted.


#### Issues with original PR

The original PR caused startup fails when loading from snapshots, as opposed to fastboot.

The root case is because the original PR did not actually remove the duplicates from the in-mem index while within `write_startup_info()`. If there were three duplicates, the first would be inserted, the second would be flagged as a duplicate then delete the key, but then the third would come along and would see a vacant spot for its key. So it would incorrectly be inserted into the in-mem index.

The new impl in this PR fixes that issue by using the duplicates as returned from the function that inserts into the disk index. That fn already identifies duplicates, so we can leverage it here.


#### Additional testing for this PR

I spun up five nodes against mnb with different configurations and had them restart every two hours for the whole weekend. All of them restarted successfully every time. There were no accounts lattice hash mismatches, nor stakes cache issues.

Here were the configurations:

| host | index limit | startup source |
|--------|--------|--------|
| DoC | minimal | fastboot |
| Bnk | 25 GB | fastboot |
| brux | 50 GB | snapshot |
| 3XU | 100 GB | fastboot |
| BtJ | 200 GB | snapshot | 