### PR TITLE
ledger-tool: Remove compaction args from blockstore purge command

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -15,7 +15,7 @@ use {
     log::*,
     regex::Regex,
     serde_json::json,
-    solana_clap_utils::{hidden_unless_forced, input_validators::is_slot},
+    solana_clap_utils::input_validators::is_slot,
     solana_cli_output::OutputFormat,
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
@@ -478,29 +478,6 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                     .help("Removes at most BATCH_SIZE slots while purging in loop"),
             )
             .arg(
-                Arg::with_name("no_compaction")
-                    .long("no-compaction")
-                    .required(false)
-                    .takes_value(false)
-                    .help(
-                        "--no-compaction is deprecated, ledger compaction after purge is disabled \
-                         by default",
-                    )
-                    .conflicts_with("enable_compaction")
-                    .hidden(hidden_unless_forced()),
-            )
-            .arg(
-                Arg::with_name("enable_compaction")
-                    .long("enable-compaction")
-                    .required(false)
-                    .takes_value(false)
-                    .help(
-                        "Perform ledger compaction after purge. Compaction will optimize storage \
-                         space, but may take a long time to complete.",
-                    )
-                    .conflicts_with("no_compaction"),
-            )
-            .arg(
                 Arg::with_name("dead_slots_only")
                     .long("dead-slots-only")
                     .required(false)
@@ -854,10 +831,6 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
         ("purge", Some(arg_matches)) => {
             let start_slot = value_t_or_exit!(arg_matches, "start_slot", Slot);
             let end_slot = value_t!(arg_matches, "end_slot", Slot).ok();
-            let perform_compaction = arg_matches.is_present("enable_compaction");
-            if arg_matches.is_present("no_compaction") {
-                warn!("--no-compaction is deprecated and is now the default behavior.");
-            }
             let dead_slots_only = arg_matches.is_present("dead_slots_only");
             let batch_size = value_t_or_exit!(arg_matches, "batch_size", usize);
 
@@ -886,22 +859,16 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             }
 
             info!(
-                "Purging data from slots {} to {} ({} slots) (do compaction: {}) (dead slot only: \
-                 {})",
+                "Purging data from slots {} to {} ({} slots) (dead slot only: {})",
                 start_slot,
                 end_slot,
                 end_slot - start_slot,
-                perform_compaction,
                 dead_slots_only,
             );
             let purge_from_blockstore =
                 |start_slot, end_slot| -> std::result::Result<(), BlockstoreError> {
                     blockstore.purge_from_next_slots(start_slot, end_slot);
-                    if perform_compaction {
-                        blockstore.purge_and_compact_slots(start_slot, end_slot)
-                    } else {
-                        blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact)
-                    }
+                    blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact)
                 };
             if !dead_slots_only {
                 let slots_iter = &(start_slot..=end_slot).chunks(batch_size);


### PR DESCRIPTION
#### Problem
These flags have been non-functional and deprecated for a while. Also, `purge_and_compact_slots()` is misleading as no compaction is actually done. This function will be removed in a subsequent PR

#### Summary of Changes
Remove the deprecated args and avoid using the misnomer function `purge_and_compact_slots()`. As seen below, the update matches the old underlying behavior
https://github.com/anza-xyz/agave/blob/dabf8cc11c342db07aa57e47567e96cd4cd99d30/ledger/src/blockstore/blockstore_purge.rs#L84-L87