### PR TITLE
Update to wincode 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5161,9 +5161,15 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pbkdf2"
@@ -7181,7 +7187,7 @@ dependencies = [
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
- "wincode",
+ "wincode 0.2.5",
 ]
 
 [[package]]
@@ -8388,7 +8394,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "thiserror 2.0.18",
- "wincode",
+ "wincode 0.4.0",
 ]
 
 [[package]]
@@ -8852,7 +8858,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-sanitize",
- "wincode",
+ "wincode 0.2.5",
 ]
 
 [[package]]
@@ -9124,7 +9130,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "trees",
- "wincode",
+ "wincode 0.4.0",
 ]
 
 [[package]]
@@ -10641,7 +10647,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-sanitize",
- "wincode",
+ "wincode 0.2.5",
 ]
 
 [[package]]
@@ -11653,7 +11659,7 @@ dependencies = [
  "static_assertions",
  "test-case",
  "thiserror 2.0.18",
- "wincode",
+ "wincode 0.4.0",
 ]
 
 [[package]]
@@ -13534,9 +13540,22 @@ checksum = "d5cec722a3274e47d1524cbe2cea762f2c19d615bd9d73ada21db9066349d57e"
 dependencies = [
  "proc-macro2",
  "quote",
+ "thiserror 2.0.18",
+ "wincode-derive 0.2.3",
+]
+
+[[package]]
+name = "wincode"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70404f69984d4a07b1fd1baeec55f577c9fecdea55a9c7196fb32fd84f84955a"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
  "solana-short-vec",
  "thiserror 2.0.18",
- "wincode-derive",
+ "wincode-derive 0.4.0",
 ]
 
 [[package]]
@@ -13544,6 +13563,18 @@ name = "wincode-derive"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8961eb04054a1b2e026b5628e24da7e001350249a787e1a85aa961f33dc5f286"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6505f603ab2302ff300837c3c96e5b1c6e4b65a66b756e3eb07376c935ff1907"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -629,7 +629,7 @@ url = "2.5.8"
 vec_extract_if_polyfill = "0.1.0"
 wasm-bindgen = "0.2"
 winapi = "0.3.8"
-wincode = { version = "0.2.5", features = ["derive", "solana-short-vec"] }
+wincode = { version = "0.4.0", features = ["derive", "solana-short-vec"] }
 winreg = "0.55"
 x509-parser = "0.18.1"
 zstd = "0.13.3"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -4543,6 +4543,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6213,7 +6219,7 @@ dependencies = [
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
- "wincode",
+ "wincode 0.2.5",
 ]
 
 [[package]]
@@ -7200,7 +7206,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "thiserror 2.0.18",
- "wincode",
+ "wincode 0.4.0",
 ]
 
 [[package]]
@@ -7776,7 +7782,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "trees",
- "wincode",
+ "wincode 0.4.0",
 ]
 
 [[package]]
@@ -9012,7 +9018,7 @@ dependencies = [
  "serde-big-array",
  "serde_derive",
  "solana-sanitize",
- "wincode",
+ "wincode 0.2.5",
 ]
 
 [[package]]
@@ -9739,7 +9745,7 @@ dependencies = [
  "solana-transaction-error",
  "static_assertions",
  "thiserror 2.0.18",
- "wincode",
+ "wincode 0.4.0",
 ]
 
 [[package]]
@@ -11524,9 +11530,22 @@ checksum = "d5cec722a3274e47d1524cbe2cea762f2c19d615bd9d73ada21db9066349d57e"
 dependencies = [
  "proc-macro2",
  "quote",
+ "thiserror 2.0.18",
+ "wincode-derive 0.2.3",
+]
+
+[[package]]
+name = "wincode"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70404f69984d4a07b1fd1baeec55f577c9fecdea55a9c7196fb32fd84f84955a"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
  "solana-short-vec",
  "thiserror 2.0.18",
- "wincode-derive",
+ "wincode-derive 0.4.0",
 ]
 
 [[package]]
@@ -11534,6 +11553,18 @@ name = "wincode-derive"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8961eb04054a1b2e026b5628e24da7e001350249a787e1a85aa961f33dc5f286"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6505f603ab2302ff300837c3c96e5b1c6e4b65a66b756e3eb07376c935ff1907"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -139,55 +139,14 @@ use {
     solana_hash::Hash,
     std::mem::MaybeUninit,
     wincode::{
+        config::{Config, DefaultConfig},
         containers::{Pod, Vec as WincodeVec},
         error::write_length_encoding_overflow,
         io::{Reader, Writer},
-        len::{BincodeLen, SeqLen},
+        len::{BincodeLen, FixIntLen},
         ReadResult, SchemaRead, SchemaWrite, WriteResult,
     },
 };
-
-/// 1-byte length prefix (max 255 elements).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct U8Len;
-
-impl SeqLen for U8Len {
-    fn read<'de, T>(reader: &mut impl Reader<'de>) -> ReadResult<usize> {
-        u8::get(reader).map(|len| len as usize)
-    }
-
-    fn write(writer: &mut impl Writer, len: usize) -> WriteResult<()> {
-        let Ok(len) = len.try_into() else {
-            return Err(write_length_encoding_overflow("u8::MAX"));
-        };
-        Ok(writer.write(&[len])?)
-    }
-
-    fn write_bytes_needed(_len: usize) -> WriteResult<usize> {
-        Ok(1)
-    }
-}
-
-/// 2-byte length prefix (max 65535 elements).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct U16Len;
-
-impl SeqLen for U16Len {
-    fn read<'de, T>(reader: &mut impl Reader<'de>) -> ReadResult<usize> {
-        u16::get(reader).map(|len| len as usize)
-    }
-
-    fn write(writer: &mut impl Writer, len: usize) -> WriteResult<()> {
-        let Ok(len): Result<u16, _> = len.try_into() else {
-            return Err(write_length_encoding_overflow("u16::MAX"));
-        };
-        Ok(writer.write(&len.to_le_bytes())?)
-    }
-
-    fn write_bytes_needed(_len: usize) -> WriteResult<usize> {
-        Ok(2)
-    }
-}
 
 /// Placeholder for skip reward certificate.
 #[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
@@ -204,13 +163,16 @@ pub struct NotarRewardCertificate {
 /// Wraps a value with a u16 length prefix for TLV-style serialization.
 ///
 /// The length prefix represents the serialized byte size of the inner value.
-#[derive(Debug, Clone, PartialEq, Eq, SchemaWrite, SchemaRead)]
-pub struct LengthPrefixed<T: SchemaWrite<Src = T> + for<'a> SchemaRead<'a, Dst = T>> {
+#[derive(Debug, Clone, PartialEq, Eq, SchemaRead, SchemaWrite)]
+pub struct LengthPrefixed<T> {
     len: u16,
     inner: T,
 }
 
-impl<T: SchemaWrite<Src = T> + for<'a> SchemaRead<'a, Dst = T>> LengthPrefixed<T> {
+impl<T> LengthPrefixed<T>
+where
+    T: SchemaWrite<DefaultConfig, Src = T>,
+{
     pub fn new(inner: T) -> Self {
         let inner_size = T::size_of(&inner).unwrap();
         let len = inner_size
@@ -219,7 +181,9 @@ impl<T: SchemaWrite<Src = T> + for<'a> SchemaRead<'a, Dst = T>> LengthPrefixed<T
             .unwrap();
         Self { len, inner }
     }
+}
 
+impl<T> LengthPrefixed<T> {
     pub fn inner(&self) -> &T {
         &self.inner
     }
@@ -243,7 +207,7 @@ pub struct BlockFooterV1 {
     #[wincode(with = "Pod<Hash>")]
     pub bank_hash: Hash,
     pub block_producer_time_nanos: u64,
-    #[wincode(with = "WincodeVec<u8, U8Len>")]
+    #[wincode(with = "WincodeVec<u8, FixIntLen<u8>>")]
     pub block_user_agent: Vec<u8>,
     pub final_cert: Option<FinalCertificate>,
     pub skip_reward_cert: Option<SkipRewardCertificate>,
@@ -342,7 +306,7 @@ impl FinalCertificate {
 pub struct VotesAggregate {
     #[wincode(with = "Pod<BLSSignatureCompressed>")]
     signature: BLSSignatureCompressed,
-    #[wincode(with = "WincodeVec<u8, U16Len>")]
+    #[wincode(with = "WincodeVec<u8, FixIntLen<u16>>")]
     bitmap: Vec<u8>,
 }
 
@@ -509,34 +473,34 @@ impl BlockComponent {
     }
 }
 
-impl SchemaWrite for BlockComponent {
+unsafe impl<C: Config> SchemaWrite<C> for BlockComponent {
     type Src = Self;
 
     fn size_of(src: &Self::Src) -> WriteResult<usize> {
         match src {
-            Self::EntryBatch(entries) => <Vec<Entry>>::size_of(entries),
+            Self::EntryBatch(entries) => <Vec<Entry> as SchemaWrite<C>>::size_of(entries),
             Self::BlockMarker(marker) => {
-                let marker_size = VersionedBlockMarker::size_of(marker)?;
+                let marker_size = <VersionedBlockMarker as SchemaWrite<C>>::size_of(marker)?;
                 Ok(Self::ENTRY_COUNT_SIZE + marker_size)
             }
         }
     }
 
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+    fn write(mut writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
         match src {
-            Self::EntryBatch(entries) => <Vec<Entry>>::write(writer, entries),
+            Self::EntryBatch(entries) => <Vec<Entry> as SchemaWrite<C>>::write(writer, entries),
             Self::BlockMarker(marker) => {
                 writer.write(&0u64.to_le_bytes())?;
-                VersionedBlockMarker::write(writer, marker)
+                <VersionedBlockMarker as SchemaWrite<C>>::write(writer, marker)
             }
         }
     }
 }
 
-impl<'de> SchemaRead<'de> for BlockComponent {
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for BlockComponent {
     type Dst = Self;
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
         // Read the entry count (first 8 bytes) to determine variant
         let count_bytes = reader.fill_array::<8>()?;
         let entry_count = u64::from_le_bytes(*count_bytes);
@@ -545,9 +509,11 @@ impl<'de> SchemaRead<'de> for BlockComponent {
             // This is a BlockMarker - consume the count bytes and read the marker
             // SAFETY: fill_array::<8>() above guarantees at least 8 bytes are available
             unsafe { reader.consume_unchecked(8) };
-            dst.write(Self::BlockMarker(VersionedBlockMarker::get(reader)?));
+            dst.write(Self::BlockMarker(<VersionedBlockMarker as SchemaRead<
+                C,
+            >>::get(reader)?));
         } else {
-            let entries: Vec<Entry> = <Vec<Entry>>::get(reader)?;
+            let entries: Vec<Entry> = <Vec<Entry> as SchemaRead<C>>::get(reader)?;
 
             if entries.len() >= Self::MAX_ENTRIES {
                 return Err(wincode::ReadError::Custom("Too many entries"));

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -913,10 +913,7 @@ fn make_stub_shred(
         // For coding shreds {common,coding} headers are not part of the
         // erasure coded slice and need to be written to the payload here.
         let mut payload = vec![0u8; ShredCode::SIZE_OF_PAYLOAD];
-        wincode::serialize_into(
-            &mut payload.as_mut_slice(),
-            &(&common_header, &coding_header),
-        )?;
+        wincode::serialize_into(&mut payload[..], &(&common_header, &coding_header))?;
         Shred::ShredCode(ShredCode {
             common_header,
             coding_header,
@@ -1512,8 +1509,7 @@ mod test {
                 ..data_header
             };
             let mut payload = vec![0u8; ShredData::SIZE_OF_PAYLOAD];
-            wincode::serialize_into(&mut payload.as_mut_slice(), &(&common_header, &data_header))
-                .unwrap();
+            wincode::serialize_into(&mut payload[..], &(&common_header, &data_header)).unwrap();
             rng.fill(&mut payload[ShredData::SIZE_OF_HEADERS..size]);
             let shred = ShredData {
                 common_header,
@@ -1547,11 +1543,7 @@ mod test {
                 ..coding_header
             };
             let mut payload = vec![0u8; ShredCode::SIZE_OF_PAYLOAD];
-            wincode::serialize_into(
-                &mut payload.as_mut_slice(),
-                &(&common_header, &coding_header),
-            )
-            .unwrap();
+            wincode::serialize_into(&mut payload[..], &(&common_header, &coding_header)).unwrap();
 
             payload[ShredCode::SIZE_OF_HEADERS..ShredCode::SIZE_OF_HEADERS + code.len()]
                 .copy_from_slice(&code);

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4512,9 +4512,15 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pbkdf2"
@@ -6135,7 +6141,7 @@ dependencies = [
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
- "wincode",
+ "wincode 0.2.5",
 ]
 
 [[package]]
@@ -6976,7 +6982,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "thiserror 2.0.18",
- "wincode",
+ "wincode 0.4.0",
 ]
 
 [[package]]
@@ -7318,7 +7324,7 @@ dependencies = [
  "serde_derive",
  "solana-atomic-u64",
  "solana-sanitize",
- "wincode",
+ "wincode 0.2.5",
 ]
 
 [[package]]
@@ -7538,7 +7544,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "trees",
- "wincode",
+ "wincode 0.4.0",
 ]
 
 [[package]]
@@ -9508,7 +9514,7 @@ dependencies = [
  "serde-big-array",
  "serde_derive",
  "solana-sanitize",
- "wincode",
+ "wincode 0.2.5",
 ]
 
 [[package]]
@@ -10251,7 +10257,7 @@ dependencies = [
  "solana-transaction-error",
  "static_assertions",
  "thiserror 2.0.18",
- "wincode",
+ "wincode 0.4.0",
 ]
 
 [[package]]
@@ -12015,9 +12021,22 @@ checksum = "d5cec722a3274e47d1524cbe2cea762f2c19d615bd9d73ada21db9066349d57e"
 dependencies = [
  "proc-macro2",
  "quote",
+ "thiserror 2.0.18",
+ "wincode-derive 0.2.3",
+]
+
+[[package]]
+name = "wincode"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70404f69984d4a07b1fd1baeec55f577c9fecdea55a9c7196fb32fd84f84955a"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
  "solana-short-vec",
  "thiserror 2.0.18",
- "wincode-derive",
+ "wincode-derive 0.4.0",
 ]
 
 [[package]]
@@ -12025,6 +12044,18 @@ name = "wincode-derive"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8961eb04054a1b2e026b5628e24da7e001350249a787e1a85aa961f33dc5f286"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6505f603ab2302ff300837c3c96e5b1c6e4b65a66b756e3eb07376c935ff1907"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
[wincode `0.3.0`](https://github.com/anza-xyz/wincode/releases/tag/wincode%40v0.3.0):
- adds a new `Config` type parameter to `SchemaRead` and `SchemaWrite`
- marks `SchemaRead` and `SchemaWrite` as `unsafe` traits
- provides built-in support for customizable length encodings

[wincode `0.4.0`](https://github.com/anza-xyz/wincode/releases/tag/wincode%40v0.4.0):
- enables deriving `SchemaRead` and `SchemaWrite` on types with with generic type parameters 
- adjusts `SchemaRead` and `SchemaWrite` trait definitions to use `impl Reader` and `impl Writer` rather than `&mut impl Reader` and `&mut impl Writer`, respectively

