### PR TITLE
cleanup(ledger): remove full_leader_cache process options

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -157,11 +157,8 @@ pub fn load_bank_forks(
             (bank_forks, None)
         };
 
-    let mut leader_schedule_cache =
+    let leader_schedule_cache =
         LeaderScheduleCache::new_from_bank(&bank_forks.read().unwrap().root_bank());
-    if process_options.full_leader_cache {
-        leader_schedule_cache.set_max_schedules(usize::MAX);
-    }
 
     if let Some(ref new_hard_forks) = process_options.new_hard_forks {
         let root_bank = bank_forks.read().unwrap().root_bank();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -835,7 +835,6 @@ pub type ProcessSlotCallback = Arc<dyn Fn(&Bank) + Sync + Send>;
 pub struct ProcessOptions {
     /// Run PoH, transaction signature and other transaction verification on the entries.
     pub run_verification: bool,
-    pub full_leader_cache: bool,
     pub halt_at_slot: Option<Slot>,
     pub slot_callback: Option<ProcessSlotCallback>,
     pub new_hard_forks: Option<Vec<Slot>>,
@@ -3167,21 +3166,6 @@ pub mod tests {
         assert_eq!(frozen_bank_slots(&bank_forks), vec![0]);
         let bank = bank_forks[0].clone();
         assert_eq!(bank.tick_height(), 1);
-    }
-
-    #[test]
-    fn test_process_ledger_options_full_leader_cache() {
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(123);
-        let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
-
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-        let opts = ProcessOptions {
-            full_leader_cache: true,
-            ..ProcessOptions::default()
-        };
-        let (_bank_forks, leader_schedule) =
-            test_process_blockstore(&genesis_config, &blockstore, &opts, Arc::default());
-        assert_eq!(leader_schedule.max_schedules(), usize::MAX);
     }
 
     #[test]

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -64,12 +64,6 @@ impl LeaderScheduleCache {
         cache
     }
 
-    pub fn set_max_schedules(&mut self, max_schedules: usize) {
-        if max_schedules > 0 {
-            self.max_schedules = CacheCapacity(max_schedules);
-        }
-    }
-
     pub fn max_schedules(&self) -> usize {
         self.max_schedules.0
     }
@@ -603,19 +597,5 @@ mod tests {
         assert!(cache.slot_leader_at(223, Some(&bank2)).is_some());
         assert_eq!(bank2.get_epoch_and_slot_index(224).0, 3);
         assert!(cache.slot_leader_at(224, Some(&bank2)).is_none());
-    }
-
-    #[test]
-    fn test_set_max_schedules() {
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-        let mut cache = LeaderScheduleCache::new_from_bank(&bank);
-
-        // Max schedules must be greater than 0
-        cache.set_max_schedules(0);
-        assert_eq!(cache.max_schedules(), MAX_SCHEDULES);
-
-        cache.set_max_schedules(usize::MAX);
-        assert_eq!(cache.max_schedules(), usize::MAX);
     }
 }


### PR DESCRIPTION
#### Problem
The `full_leader_cache` option in `ProcessOptions` is unused.
In consequence `LeaderScheduleCache::set_max_schedules` is dead code.
The flag is only set by a single test.

#### Summary of Changes
Remove the `set_max_schedules` API from `LeaderScheduleCache`.
Remove the `full_leader_cache` field from `ProcessOptions`.

Additional context: this `full_capacity` option originated in solana-labs#6248. It was never wired into the Validator and appears to be unused now. 