### PR TITLE
Compute slot leader during block creation

### DIFF
--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -481,7 +481,8 @@ impl SimulatorLoop {
                 let new_leader = self
                     .leader_schedule_cache
                     .slot_leader_at(new_slot, None)
-                    .unwrap();
+                    .unwrap()
+                    .id;
                 if new_leader != self.simulated_leader {
                     logger.on_new_leader(&bank, bank_created.elapsed(), new_slot, new_leader);
                     break;
@@ -717,7 +718,8 @@ impl BankingSimulator {
 
         let simulated_leader = leader_schedule_cache
             .slot_leader_at(self.first_simulated_slot, None)
-            .unwrap();
+            .unwrap()
+            .id;
         info!(
             "Simulated leader and slot: {}, {}",
             simulated_leader, self.first_simulated_slot,

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -537,6 +537,25 @@ fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut L
         ctx.my_pubkey
     );
 
+    let Some(leader) = ctx
+        .leader_schedule_cache
+        .slot_leader_at(slot, Some(&parent_bank))
+    else {
+        panic!(
+            "{}: No leader found for slot {slot} with parent {parent_slot}. Something has gone \
+             wrong with the block creation loop. exiting",
+            ctx.my_pubkey,
+        );
+    };
+
+    if ctx.my_pubkey != leader.id {
+        panic!(
+            "{}: Attempting to produce a block for {slot}, however the leader is {}. Something \
+             has gone wrong with the block creation loop. exiting",
+            ctx.my_pubkey, leader.id,
+        );
+    }
+
     if let Some(bank) = ctx.poh_recorder.read().unwrap().bank() {
         panic!(
             "{}: Attempting to produce a block for {slot}, however we still are in production of \
@@ -556,7 +575,7 @@ fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut L
         parent_bank.clone(),
         slot,
         root_slot,
-        &ctx.my_pubkey,
+        leader,
         ctx.rpc_subscriptions.as_deref(),
         &ctx.slot_status_notifier,
         NewBankOptions::default(),

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -143,7 +143,7 @@ impl DuplicateShredHandler {
                 .slot_leader_at(slot, /*bank:*/ None)
                 .ok_or(Error::UnknownSlotLeader(slot))?;
             let (shred1, shred2) =
-                duplicate_shred::into_shreds(&slot_leader, chunks, self.shred_version)?;
+                duplicate_shred::into_shreds(&slot_leader.id, chunks, self.shred_version)?;
             if !self.blockstore.has_duplicate_shreds_in_slot(slot) {
                 self.blockstore.store_duplicate_slot(
                     slot,

--- a/leader-schedule/src/lib.rs
+++ b/leader-schedule/src/lib.rs
@@ -97,7 +97,7 @@ mod tests {
             .collect();
         let schedule = LeaderSchedule::new_from_schedule(schedule);
         let leaders = (0..NUM_SLOTS)
-            .map(|i| (schedule[i as u64], i))
+            .map(|i| (schedule[i as u64].id, i))
             .into_group_map();
         for leader in &unique_leaders {
             let index = leaders.get(&leader.id).cloned().unwrap_or_default();

--- a/leader-schedule/src/vote_keyed.rs
+++ b/leader-schedule/src/vote_keyed.rs
@@ -102,9 +102,9 @@ impl LeaderSchedule {
 }
 
 impl Index<u64> for LeaderSchedule {
-    type Output = Pubkey;
-    fn index(&self, index: u64) -> &Pubkey {
-        &self.slot_leaders[index as usize % self.num_slots()].id
+    type Output = SlotLeader;
+    fn index(&self, index: u64) -> &SlotLeader {
+        &self.slot_leaders[index as usize % self.num_slots()]
     }
 }
 
@@ -116,9 +116,9 @@ mod tests {
     fn test_index() {
         let slot_leaders = vec![SlotLeader::new_unique(), SlotLeader::new_unique()];
         let leader_schedule = LeaderSchedule::new_from_schedule(slot_leaders.clone());
-        assert_eq!(leader_schedule[0], slot_leaders[0].id);
-        assert_eq!(leader_schedule[1], slot_leaders[1].id);
-        assert_eq!(leader_schedule[2], slot_leaders[0].id);
+        assert_eq!(leader_schedule[0], slot_leaders[0]);
+        assert_eq!(leader_schedule[1], slot_leaders[1]);
+        assert_eq!(leader_schedule[2], slot_leaders[0]);
     }
 
     #[test]

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1774,7 +1774,8 @@ fn process_next_slots(
                 bank.clone(),
                 &leader_schedule_cache
                     .slot_leader_at(*next_slot, Some(bank))
-                    .unwrap(),
+                    .unwrap()
+                    .id,
                 *next_slot,
             );
             set_alpenglow_ticks(&next_bank);

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3311,7 +3311,7 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
         validator_to_slots.into_iter(),
     ));
     for slot in 0..=validator_b_last_leader_slot {
-        assert_eq!(leader_schedule[slot], validator_b_pubkey);
+        assert_eq!(leader_schedule[slot].id, validator_b_pubkey);
     }
 
     default_config.fixed_leader_schedule = Some(FixedSchedule {

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -644,6 +644,7 @@ impl PohRecorder {
     pub fn leader_after_n_slots(&self, slots: u64) -> Option<Pubkey> {
         self.leader_schedule_cache
             .slot_leader_at(self.current_poh_slot() + slots, None)
+            .map(|leader| leader.id)
     }
 
     /// Return the leader and slot pair after `slots_in_the_future` slots.
@@ -654,7 +655,7 @@ impl PohRecorder {
         let target_slot = self.current_poh_slot().checked_add(slots_in_the_future)?;
         self.leader_schedule_cache
             .slot_leader_at(target_slot, None)
-            .map(|leader| (leader, target_slot))
+            .map(|leader| (leader.id, target_slot))
     }
 
     pub fn shared_leader_state(&self) -> SharedLeaderState {
@@ -811,7 +812,7 @@ impl PohRecorder {
 
             // If the leader for this slot is not me, then it's the previous
             // leader's last slot.
-            if leader_for_slot != *my_pubkey {
+            if leader_for_slot.id != *my_pubkey {
                 // Check if the last slot PoH reset onto was the previous leader's last slot.
                 return slot == self.start_slot();
             }

--- a/runtime/src/leader_schedule_utils.rs
+++ b/runtime/src/leader_schedule_utils.rs
@@ -43,7 +43,7 @@ pub fn leader_schedule_by_identity<'a>(
 pub fn slot_leader_at(slot: Slot, bank: &Bank) -> Option<Pubkey> {
     let (epoch, slot_index) = bank.get_epoch_and_slot_index(slot);
 
-    leader_schedule(epoch, bank).map(|leader_schedule| leader_schedule[slot_index])
+    leader_schedule(epoch, bank).map(|leader_schedule| leader_schedule[slot_index].id)
 }
 
 // Returns the number of ticks remaining from the specified tick_height to the end of the
@@ -96,9 +96,9 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let leader_schedule = leader_schedule(0, &bank).unwrap();
 
-        assert_eq!(leader_schedule[0], pubkey);
-        assert_eq!(leader_schedule[1], pubkey);
-        assert_eq!(leader_schedule[2], pubkey);
+        assert_eq!(leader_schedule[0].id, pubkey);
+        assert_eq!(leader_schedule[1].id, pubkey);
+        assert_eq!(leader_schedule[2].id, pubkey);
     }
 
     #[test]

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -377,7 +377,7 @@ fn retransmit(
             };
             let cluster_nodes =
                 cluster_nodes_cache.get(slot, &root_bank, &working_bank, cluster_info);
-            Some((slot, (slot_leader, cluster_nodes)))
+            Some((slot, (slot_leader.id, cluster_nodes)))
         })
         .collect();
     let socket_addr_space = cluster_info.socket_addr_space();
@@ -578,7 +578,7 @@ fn cache_retransmit_addrs(
             let slot_leader = leader_schedule_cache.slot_leader_at(slot, Some(&working_bank))?;
             let cluster_nodes =
                 cluster_nodes_cache.get(slot, &root_bank, &working_bank, cluster_info);
-            Some((slot, (slot_leader, cluster_nodes)))
+            Some((slot, (slot_leader.id, cluster_nodes)))
         })
         .collect();
     if cache.is_empty() {

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -358,7 +358,7 @@ fn verify_retransmitter_signature(
     };
     let cluster_nodes =
         cluster_nodes_cache.get(shred.slot(), root_bank, working_bank, cluster_info);
-    let parent = match cluster_nodes.get_retransmit_parent(&leader, &shred, DATA_PLANE_FANOUT) {
+    let parent = match cluster_nodes.get_retransmit_parent(&leader.id, &shred, DATA_PLANE_FANOUT) {
         Ok(Some(parent)) => parent,
         Ok(None) => {
             stats
@@ -421,6 +421,7 @@ fn get_slot_leaders<'a>(
             let slot = shred.and_then(shred::layout::get_slot)?;
             let leader = leader_schedule_cache
                 .slot_leader_at(slot, Some(bank))
+                .map(|leader| leader.id)
                 .filter(|leader| leader != self_pubkey);
             if leader.is_none() {
                 packet.meta_mut().set_discard(true);

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -377,7 +377,7 @@ impl ConsensusPoolService {
         *highest_parent_ready = new_highest_parent_ready;
 
         let root_bank = ctx.sharable_banks.root();
-        let Some(leader_pubkey) = ctx
+        let Some(slot_leader) = ctx
             .leader_schedule_cache
             .slot_leader_at(*highest_parent_ready, Some(&root_bank))
         else {
@@ -389,7 +389,7 @@ impl ConsensusPoolService {
             return;
         };
 
-        if &leader_pubkey != my_pubkey {
+        if &slot_leader.id != my_pubkey {
             return;
         }
 

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -629,7 +629,8 @@ pub(crate) fn find_bankhash_of_heaviest_fork(
                 parent_bank.clone(),
                 &leader_schedule_cache
                     .slot_leader_at(slot, Some(&parent_bank))
-                    .unwrap(),
+                    .unwrap()
+                    .id,
                 slot,
             );
             bank_forks.write().unwrap().insert_from_ledger(new_bank)


### PR DESCRIPTION
#### Problem
In order to implement SIMDs 232 and 123, each Bank must be associated with the vote address assigned in the leader schedule for the bank's slot. However, the slot vote address is not currently available when creating new banks in the block creation loop. 

#### Summary of Changes
- Update leader schedule APIs to return `SlotLeader` which includes the vote address in addition to the leader id
- During block creation, check the leader schedule for the `SlotLeader` of the new bank's slot. If there is a mismatch, panic.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
