### PR TITLE
cli: Reverse `test-case` and `tokio::test` order

### DIFF
--- a/cli/tests/cluster_query.rs
+++ b/cli/tests/cluster_query.rs
@@ -17,11 +17,11 @@ use {
     test_case::test_case,
 };
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(false, None; "rpc_base")]
 #[test_case(false, Some(1_000_000); "rpc_with_compute_unit_price")]
 #[test_case(true, None; "tpu_base")]
 #[test_case(true, Some(1_000_000); "tpu_with_compute_unit_price")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_ping(use_tpu_client: bool, compute_unit_price: Option<u64>) {
     agave_logger::setup();
     let fee = FeeStructure::default().get_max_fee(1, 0);

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -22,11 +22,11 @@ use {
     test_case::test_case,
 };
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(None, false, None; "base")]
 #[test_case(Some(String::from("seed")), false, None; "with_seed")]
 #[test_case(None, true, None; "with_authority")]
 #[test_case(None, false, Some(1_000_000); "with_compute_unit_price")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_nonce(
     seed: Option<String>,
     use_nonce_authority: bool,

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -416,11 +416,11 @@ async fn test_cli_program_deploy_no_authority() {
     .await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(true, true; "Feature enabled, skip preflight")]
 #[test_case(true, false; "Feature enabled, don't skip preflight")]
 #[test_case(false, true; "Feature disabled, skip preflight")]
 #[test_case(false, false; "Feature disabled, don't skip preflight")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_cli_program_deploy_feature(enable_feature: bool, skip_preflight: bool) {
     agave_logger::setup();
 
@@ -541,9 +541,9 @@ async fn test_cli_program_deploy_feature(enable_feature: bool, skip_preflight: b
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(true; "Feature enabled")]
 #[test_case(false; "Feature disabled")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_cli_program_upgrade_with_feature(enable_feature: bool) {
     agave_logger::setup();
 
@@ -1111,9 +1111,9 @@ async fn test_cli_program_deploy_with_authority() {
     assert_eq!("none", authority_pubkey_str);
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(true; "Skip preflight")]
 #[test_case(false; "Dont skip preflight")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_cli_program_upgrade_auto_extend(skip_preflight: bool) {
     agave_logger::setup();
 

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -198,9 +198,9 @@ async fn test_stake_delegation_force() {
     process_command(&config).await.unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_seed_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
     agave_logger::setup();
 
@@ -642,9 +642,9 @@ async fn test_stake_delegation_and_withdraw_all() {
     check_balance!(55 * LAMPORTS_PER_SOL, &rpc_client, &recipient_pubkey);
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
     agave_logger::setup();
 
@@ -739,9 +739,9 @@ async fn test_stake_delegation_and_deactivation(compute_unit_price: Option<u64>)
     process_command(&config_validator).await.unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_offline_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
     agave_logger::setup();
 
@@ -905,9 +905,9 @@ async fn test_offline_stake_delegation_and_deactivation(compute_unit_price: Opti
     process_command(&config_payer).await.unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_nonced_stake_delegation_and_deactivation(compute_unit_price: Option<u64>) {
     agave_logger::setup();
 
@@ -1042,9 +1042,9 @@ async fn test_nonced_stake_delegation_and_deactivation(compute_unit_price: Optio
     process_command(&config).await.unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_stake_authorize(compute_unit_price: Option<u64>) {
     agave_logger::setup();
 

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -27,9 +27,9 @@ use {
     test_case::test_case,
 };
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(true; "Skip Preflight")]
 #[test_case(false; "Don`t skip Preflight")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transfer(skip_preflight: bool) {
     agave_logger::setup();
     let fee_one_sig = FeeStructure::default().get_max_fee(1, 0);
@@ -485,9 +485,9 @@ async fn test_transfer_multisession_signing() {
     check_balance!(42 * LAMPORTS_PER_SOL, &rpc_client, &to_pubkey);
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(None; "default")]
 #[test_case(Some(100_000); "with_compute_unit_price")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_transfer_all(compute_unit_price: Option<u64>) {
     agave_logger::setup();
     let lamports_per_signature = FeeStructure::default().get_max_fee(1, 0);

--- a/cli/tests/validator_info.rs
+++ b/cli/tests/validator_info.rs
@@ -13,9 +13,9 @@ use {
     test_case::test_case,
 };
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_publish(compute_unit_price: Option<u64>) {
     agave_logger::setup();
 

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -20,9 +20,9 @@ use {
     test_case::test_case,
 };
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_vote_authorize_and_withdraw(compute_unit_price: Option<u64>) {
     let mint_keypair = Keypair::new();
     let faucet_addr = run_local_faucet_with_unique_port_for_tests(mint_keypair.insecure_clone());
@@ -237,9 +237,9 @@ async fn test_vote_authorize_and_withdraw(compute_unit_price: Option<u64>) {
     check_balance!(expected_balance, &rpc_client, &destination_account);
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[test_case(None; "base")]
 #[test_case(Some(1_000_000); "with_compute_unit_price")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_offline_vote_authorize_and_withdraw(compute_unit_price: Option<u64>) {
     let mint_keypair = Keypair::new();
     let faucet_addr = run_local_faucet_with_unique_port_for_tests(mint_keypair.insecure_clone());


### PR DESCRIPTION
`#[test-case]` and `#[tokio::test]` order matters : `test-case` must go first.

Tests are duplicated if in wrong order. 

```rust
#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
#[test_case(true)]
#[test_case(false)]
async fn test_test_case(b: bool) {
    println!("RUN {}", b);
}
```

```console
running 4 tests
RUN true
RUN false
RUN false
RUN true
test test_test_case::true_expects ... ok
test test_test_case::false_expects ... ok
test test_test_case::false_expects ... ok
test test_test_case::true_expects ... ok
```

```rust
#[test_case(true)]
#[test_case(false)]
#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
async fn test_test_case(b: bool) {
    println!("RUN {}", b);
}
```

```console
running 2 tests
RUN false
RUN true
test test_test_case::false_expects ... ok
test test_test_case::true_expects ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 34 filtered out; finished in 0.00s
```