### PR TITLE
implement simd-376

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,8 +125,8 @@ version = "4.0.0-alpha.0"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash 3.1.0",
  "solana-pubkey 4.0.0",
  "solana-sha256-hasher",
@@ -268,8 +268,8 @@ name = "agave-reserved-account-keys"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-message",
  "solana-pubkey 4.0.0",
  "solana-sdk-ids",
@@ -566,8 +566,8 @@ dependencies = [
  "solana-connection-cache",
  "solana-entry",
  "solana-epoch-schedule",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-genesis-config",
  "solana-gossip",
  "solana-hash 3.1.0",
@@ -612,8 +612,8 @@ dependencies = [
  "solana-bls-signatures",
  "solana-clock",
  "solana-epoch-schedule",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash 3.1.0",
  "solana-pubkey 4.0.0",
  "tempfile",
@@ -2302,14 +2302,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
-source = "git+https://github.com/anza-xyz/crossbeam?rev=fd279d707025f0e60951e429bf778b4813d1b6bf#fd279d707025f0e60951e429bf778b4813d1b6bf"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "cfg-if 1.0.4",
  "crossbeam-utils",
- "lazy_static",
- "memoffset 0.6.4",
- "scopeguard",
 ]
 
 [[package]]
@@ -2506,6 +2503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2793,6 +2791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
+ "serde",
  "signature 2.2.0",
 ]
 
@@ -2835,6 +2834,23 @@ dependencies = [
  "ed25519-dalek 2.2.0",
  "hmac 0.12.1",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "ed25519-zebra"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0017d969298eec91e3db7a2985a8cab4df6341d86e6f3a6f5878b13fb7846bc9"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
+ "hashbrown 0.15.1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3108,15 +3124,6 @@ dependencies = [
  "libc",
  "redox_syscall 0.2.10",
  "winapi",
-]
-
-[[package]]
-name = "five8"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75b8549488b4715defcb0d8a8a1c1c76a80661b5fa106b4ca0e7fce59d7d875"
-dependencies = [
- "five8_core",
 ]
 
 [[package]]
@@ -4748,15 +4755,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -4919,7 +4917,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -5343,6 +5341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -7103,8 +7110,8 @@ dependencies = [
  "serde_derive",
  "solana-account-info",
  "solana-clock",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-instruction-error",
  "solana-pubkey 4.0.0",
  "solana-sdk-ids",
@@ -7248,7 +7255,7 @@ dependencies = [
  "log",
  "lz4",
  "memmap2 0.9.9",
- "memoffset 0.9.1",
+ "memoffset",
  "modular-bitfield",
  "num_cpus",
  "num_enum",
@@ -7268,8 +7275,8 @@ dependencies = [
  "solana-compute-budget",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-genesis-config",
  "solana-hash 3.1.0",
  "solana-instruction",
@@ -7329,15 +7336,15 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "five8 1.0.0",
+ "five8",
  "five8_const",
  "rand 0.8.5",
  "serde",
  "serde_derive",
  "solana-atomic-u64",
  "solana-define-syscall 4.0.1",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
@@ -7529,8 +7536,8 @@ dependencies = [
  "rayon",
  "serde",
  "solana-bloom",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash 3.1.0",
  "solana-sanitize",
  "solana-sha256-hasher",
@@ -7556,8 +7563,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-signature",
  "solana-signer",
  "subtle",
@@ -7700,7 +7707,7 @@ dependencies = [
  "rand 0.9.2",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
- "solana-frozen-abi",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-loader-v4-program",
  "solana-pubkey 4.0.0",
  "solana-sdk-ids",
@@ -8103,7 +8110,7 @@ version = "4.0.0-alpha.0"
 dependencies = [
  "qualifier_attr",
  "solana-fee-structure",
- "solana-frozen-abi",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-program-runtime",
 ]
 
@@ -8292,8 +8299,8 @@ dependencies = [
  "solana-fee",
  "solana-fee-calculator",
  "solana-fee-structure",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-genesis-config",
  "solana-genesis-utils",
  "solana-geyser-plugin-manager",
@@ -8394,8 +8401,8 @@ dependencies = [
  "solana-compute-budget-program",
  "solana-cost-model",
  "solana-fee-structure",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-keypair",
@@ -8615,8 +8622,8 @@ checksum = "6e5481e72cc4d52c169db73e4c0cd16de8bc943078aac587ec4817a75cc6388f"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -8722,8 +8729,8 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -8734,7 +8741,7 @@ checksum = "5e2abdb1223eea8ec64136f39cb1ffcf257e00f915c957c35c0dd9e3f4e700b0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-frozen-abi",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -8770,7 +8777,31 @@ dependencies = [
  "serde_derive",
  "serde_with",
  "sha2 0.10.9",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "solana-frozen-abi"
+version = "3.1.2"
+source = "git+https://github.com/zz-sol/solana-sdk.git?branch=zz%2Fimpl_simd_376#5dd641bcddfcce87b97342f1793f596b73a854f4"
+dependencies = [
+ "bincode",
+ "boxcar",
+ "bs58",
+ "bv",
+ "bytes",
+ "dashmap",
+ "im",
+ "log",
+ "memmap2 0.5.10",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "serde",
+ "serde_derive",
+ "serde_with",
+ "sha2 0.10.9",
+ "solana-frozen-abi-macro 3.2.1 (git+https://github.com/zz-sol/solana-sdk.git?branch=zz%2Fimpl_simd_376)",
  "thiserror 2.0.18",
 ]
 
@@ -8779,6 +8810,16 @@ name = "solana-frozen-abi-macro"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5396c179ca7d76f866b102eb3819ca3922bdaa33c9ada8005f4e98fd59ab65f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "solana-frozen-abi-macro"
+version = "3.2.1"
+source = "git+https://github.com/zz-sol/solana-sdk.git?branch=zz%2Fimpl_simd_376#5dd641bcddfcce87b97342f1793f596b73a854f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8946,8 +8987,8 @@ dependencies = [
  "solana-connection-cache",
  "solana-entry",
  "solana-epoch-schedule",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-gossip",
  "solana-hash 3.1.0",
  "solana-keypair",
@@ -9004,8 +9045,8 @@ checksum = "0abacc4b66ce471f135f48f22facf75cbbb0f8a252fbe2c1e0aa59d5b203f519"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -9026,12 +9067,12 @@ dependencies = [
  "borsh",
  "bytemuck",
  "bytemuck_derive",
- "five8 1.0.0",
+ "five8",
  "serde",
  "serde_derive",
  "solana-atomic-u64",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sanitize",
 ]
 
@@ -9043,8 +9084,8 @@ checksum = "e92f37a14e7c660628752833250dd3dcd8e95309876aee751d7f8769a27947c6"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -9058,8 +9099,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-define-syscall 4.0.1",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-instruction-error",
  "solana-pubkey 4.0.0",
 ]
@@ -9073,8 +9114,8 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-program-error",
 ]
 
@@ -9141,7 +9182,7 @@ checksum = "5ac8be597c9e231b0cab2928ce3bc3e4ee77d9c0ad92977b9d901f3879f25a7a"
 dependencies = [
  "ed25519-dalek 2.2.0",
  "ed25519-dalek-bip32",
- "five8 1.0.0",
+ "five8",
  "rand 0.8.5",
  "solana-address 2.0.0",
  "solana-derivation-path",
@@ -9230,8 +9271,8 @@ dependencies = [
  "solana-cost-model",
  "solana-entry",
  "solana-epoch-schedule",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-genesis-config",
  "solana-genesis-utils",
  "solana-hash 3.1.0",
@@ -9601,8 +9642,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_with",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-pubkey 4.0.0",
 ]
 
@@ -9630,8 +9671,8 @@ dependencies = [
  "rayon",
  "serde",
  "solana-clock",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash 3.1.0",
  "solana-keypair",
  "solana-message",
@@ -9758,7 +9799,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91b12305dd81045d705f427acd0435a2e46444b65367d7179d7bdcfc3bc5f5eb"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "solana-account-info",
  "solana-big-mod-exp",
  "solana-blake3-hasher",
@@ -9879,8 +9920,8 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-structure",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-instruction-error",
@@ -10100,8 +10141,8 @@ checksum = "b702d8c43711e3c8a9284a4f1bbc6a3de2553deb25b0c8142f9a44ef0ce5ddc1"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -10421,7 +10462,7 @@ dependencies = [
  "log",
  "lz4",
  "memmap2 0.9.9",
- "memoffset 0.9.1",
+ "memoffset",
  "mockall",
  "modular-bitfield",
  "num-derive",
@@ -10466,8 +10507,8 @@ dependencies = [
  "solana-fee",
  "solana-fee-calculator",
  "solana-fee-structure",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-genesis-config",
  "solana-hard-forks",
  "solana-hash 3.1.0",
@@ -10572,8 +10613,7 @@ dependencies = [
 [[package]]
 name = "solana-sanitize"
 version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
+source = "git+https://github.com/zz-sol/solana-sdk.git?branch=zz%2Fimpl_simd_376#5dd641bcddfcce87b97342f1793f596b73a854f4"
 
 [[package]]
 name = "solana-sbpf"
@@ -10756,8 +10796,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79fb1809a32cfcf7d9c47b7070a92fa17cdb620ab5829e9a8a9ff9d138a7a175"
 dependencies = [
  "serde_core",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10774,18 +10814,19 @@ dependencies = [
 [[package]]
 name = "solana-signature"
 version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb8057cc0e9f7b5e89883d49de6f407df655bb6f3a71d0b7baf9986a2218fd9"
+source = "git+https://github.com/zz-sol/solana-sdk.git?branch=zz%2Fimpl_simd_376#5dd641bcddfcce87b97342f1793f596b73a854f4"
 dependencies = [
  "ed25519-dalek 2.2.0",
- "five8 0.2.1",
- "rand 0.8.5",
+ "ed25519-zebra",
+ "five8",
+ "rand 0.9.2",
  "serde",
  "serde-big-array",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (git+https://github.com/zz-sol/solana-sdk.git?branch=zz%2Fimpl_simd_376)",
+ "solana-frozen-abi-macro 3.2.1 (git+https://github.com/zz-sol/solana-sdk.git?branch=zz%2Fimpl_simd_376)",
  "solana-sanitize",
+ "wincode",
 ]
 
 [[package]]
@@ -10890,8 +10931,8 @@ dependencies = [
  "serde_derive",
  "solana-clock",
  "solana-cpi",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 3.0.0",
@@ -11046,8 +11087,8 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-fee-calculator",
  "solana-fee-structure",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-instructions-sysvar",
@@ -11312,8 +11353,8 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash 4.0.1",
  "solana-instruction",
  "solana-last-restart-slot",
@@ -11647,8 +11688,8 @@ checksum = "4222065402340d7e6aec9dc3e54d22992ddcf923d91edcd815443c2bfca3144a"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-instruction-error",
  "solana-sanitize",
 ]
@@ -11880,8 +11921,8 @@ dependencies = [
  "rand 0.9.2",
  "semver 1.0.27",
  "serde",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sanitize",
  "solana-serde-varint",
 ]
@@ -11953,8 +11994,8 @@ dependencies = [
  "solana-account",
  "solana-bincode",
  "solana-clock",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-keypair",
@@ -11988,8 +12029,8 @@ dependencies = [
  "serde_derive",
  "serde_with",
  "solana-clock",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash 4.0.1",
  "solana-instruction",
  "solana-instruction-error",
@@ -12021,8 +12062,8 @@ dependencies = [
  "solana-clock",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-keypair",
@@ -14480,3 +14521,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "git+https://github.com/anza-xyz/crossbeam?rev=fd279d707025f0e60951e429bf778b4813d1b6bf#fd279d707025f0e60951e429bf778b4813d1b6bf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -538,7 +538,7 @@ solana-serialize-utils = "3.1.0"
 solana-sha256-hasher = "3.1.0"
 solana-short-vec = "3.1.0"
 solana-shred-version = "3.0.0"
-solana-signature = { version = "3.1.0", default-features = false }
+solana-signature = { git = "https://github.com/zz-sol/solana-sdk.git", branch = "zz/impl_simd_376", default-features = false }
 solana-signer = "3.0.0"
 solana-signer-store = "0.1.0"
 solana-slot-hashes = "3.0.0"
@@ -668,3 +668,6 @@ opt-level = 3
 [patch.crates-io]
 # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
+# SIMD-376: Use solana-signature fork with zebra verification support
+solana-signature = { git = "https://github.com/zz-sol/solana-sdk.git", branch = "zz/impl_simd_376" }
+solana-sanitize = { git = "https://github.com/zz-sol/solana-sdk.git", branch = "zz/impl_simd_376" }

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -165,7 +165,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
     trace!("start");
     let (packet_s, packet_r) = unbounded();
     let (verified_s, verified_r) = BankingTracer::channel_for_test();
-    let verifier = TransactionSigVerifier::new(verified_s, None);
+    let verifier = TransactionSigVerifier::new(verified_s, None, None);
     let stage = SigVerifyStage::new(packet_r, verifier, "solSigVerBench", "bench");
 
     bencher.iter(move || {
@@ -239,7 +239,7 @@ fn prepare_batches(discard_factor: i32) -> (Vec<PacketBatch>, usize) {
 fn bench_shrink_sigverify_stage_core(bencher: &mut Bencher, discard_factor: i32) {
     let (batches0, num_valid_packets) = prepare_batches(discard_factor);
     let (verified_s, _verified_r) = BankingTracer::channel_for_test();
-    let verifier = TransactionSigVerifier::new(verified_s, None);
+    let verifier = TransactionSigVerifier::new(verified_s, None, None);
 
     let mut c = 0;
     let mut total_shrink_time = 0;

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -501,7 +501,7 @@ mod tests {
         trace!("start");
         let (packet_s, packet_r) = unbounded();
         let (verified_s, verified_r) = BankingTracer::channel_for_test();
-        let verifier = TransactionSigVerifier::new(verified_s, None);
+        let verifier = TransactionSigVerifier::new(verified_s, None, None);
         let stage = SigVerifyStage::new(packet_r, verifier, "solSigVerTest", "test");
 
         let now = Instant::now();

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -287,6 +287,7 @@ impl Tpu {
             let verifier = TransactionSigVerifier::new(
                 non_vote_sender,
                 enable_block_production_forwarding.then(|| forward_stage_sender.clone()),
+                Some(bank_forks.clone()),
             );
             SigVerifier::Local(SigVerifyStage::new(
                 packet_receiver,
@@ -300,6 +301,7 @@ impl Tpu {
             let verifier = TransactionSigVerifier::new_reject_non_vote(
                 tpu_vote_sender,
                 Some(forward_stage_sender),
+                Some(bank_forks.clone()),
             );
             SigVerifyStage::new(
                 vote_packet_receiver,

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1004,6 +1004,10 @@ pub mod ed25519_precompile_verify_strict {
     solana_pubkey::declare_id!("ed9tNscbWLYBooxWA7FE2B5KHWs8A6sxfY8EzezEcoo");
 }
 
+pub mod ed25519_verify_zebra {
+    solana_pubkey::declare_id!("5QNgSrr2CtajX3ykBpaZzzUycvVRUZBYv8RbUf7pNbtx");
+}
+
 pub mod vote_only_retransmitter_signed_fec_sets {
     solana_pubkey::declare_id!("RfEcA95xnhuwooVAhUUksEJLZBF7xKCLuqrJoqk4Zph");
 }
@@ -1994,6 +1998,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             ed25519_precompile_verify_strict::id(),
             "SIMD-0152: Use strict verification in ed25519 precompile",
+        ),
+        (
+            ed25519_verify_zebra::id(),
+            "SIMD-0376: ed25519-verify-zebra",
         ),
         (
             vote_only_retransmitter_signed_fec_sets::id(),

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -31,7 +31,7 @@ fn bench_sigverify_simple(b: &mut Bencher) {
 
     // verify packets
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, false, num_packets);
+        sigverify::ed25519_verify(&mut batches, false, num_packets, false);
     })
 }
 
@@ -55,7 +55,7 @@ fn bench_sigverify_low_packets_small_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE - 1;
     let mut batches = gen_batches(false, 1, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, false, num_packets);
+        sigverify::ed25519_verify(&mut batches, false, num_packets, false);
     })
 }
 
@@ -63,7 +63,7 @@ fn bench_sigverify_low_packets_large_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE - 1;
     let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, false, num_packets);
+        sigverify::ed25519_verify(&mut batches, false, num_packets, false);
     })
 }
 
@@ -71,7 +71,7 @@ fn bench_sigverify_medium_packets_small_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE * 8;
     let mut batches = gen_batches(false, 1, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, false, num_packets);
+        sigverify::ed25519_verify(&mut batches, false, num_packets, false);
     })
 }
 
@@ -79,7 +79,7 @@ fn bench_sigverify_medium_packets_large_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE * 8;
     let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, false, num_packets);
+        sigverify::ed25519_verify(&mut batches, false, num_packets, false);
     })
 }
 
@@ -87,7 +87,7 @@ fn bench_sigverify_high_packets_small_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE * 32;
     let mut batches = gen_batches(false, 1, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, false, num_packets);
+        sigverify::ed25519_verify(&mut batches, false, num_packets, false);
     })
 }
 
@@ -96,7 +96,7 @@ fn bench_sigverify_high_packets_large_batch(b: &mut Bencher) {
     let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     // verify packets
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, false, num_packets);
+        sigverify::ed25519_verify(&mut batches, false, num_packets, false);
     })
 }
 
@@ -139,7 +139,7 @@ fn bench_sigverify_uneven(b: &mut Bencher) {
 
     // verify packets
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, false, num_packets);
+        sigverify::ed25519_verify(&mut batches, false, num_packets, false);
     })
 }
 

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -94,7 +94,7 @@ impl Vortexor {
         tpu_receiver: Receiver<PacketBatch>,
         non_vote_sender: TracedSender,
     ) -> SigVerifyStage {
-        let verifier = TransactionSigVerifier::new(non_vote_sender, None);
+        let verifier = TransactionSigVerifier::new(non_vote_sender, None, None);
         SigVerifyStage::new(
             tpu_receiver,
             verifier,


### PR DESCRIPTION
#### Problem

See [SIMD-376](https://github.com/solana-foundation/solana-improvement-documents/pull/376)

#### Summary of Changes

Implements SIMD-376: Relaxing Transaction Signature Verification by adding support for ZIP-215 (zebra) Ed25519 verification, gated behind the `ed25519_verify_zebra` feature flag.

- Add `ed25519_verify_zebra` feature gate in feature-set/src/lib.rs
- Add `use_zebra: bool` parameter to `ed25519_verify()` and `verify_packet()` in `perf/src/sigverify.rs`
- When `use_zebra` is true, use `signature.verify()` (ZIP-215); otherwise use `signature.verify_strict()` (legacy)
- `TransactionSigVerifier` checks the feature from `root_bank().feature_set` and passes the flag

**Note**: Ed25519 precompile continues to use `verify_strict` per SIMD-376 spec. There is a separate [SIMD-453](https://github.com/solana-foundation/solana-improvement-documents/pull/453) for precompile.


**Fixes** [SIMD-376](https://github.com/solana-foundation/solana-improvement-documents/pull/376)
**Require** https://github.com/anza-xyz/solana-sdk/pull/551

