### PR TITLE
blockstore: Remove oudated purge_and_compact_slots()

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -9961,14 +9961,14 @@ pub mod tests {
             .insert_shreds(all_shreds, Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot).unwrap();
+        blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
         // Test inserting just the codes, enough for recovery
         blockstore
             .insert_shreds(coding_shreds.clone(), Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot).unwrap();
+        blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
         // Test inserting some codes, but not enough for recovery
         blockstore
@@ -9979,7 +9979,7 @@ pub mod tests {
             )
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot).unwrap();
+        blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
         // Test inserting just the codes, and some data, enough for recovery
         let shreds: Vec<_> = data_shreds[..data_shreds.len() - 1]
@@ -9991,7 +9991,7 @@ pub mod tests {
             .insert_shreds(shreds, Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot).unwrap();
+        blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
         // Test inserting some codes, and some data, but enough for recovery
         let shreds: Vec<_> = data_shreds[..data_shreds.len() / 2 - 1]
@@ -10003,7 +10003,7 @@ pub mod tests {
             .insert_shreds(shreds, Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot).unwrap();
+        blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
         // Test inserting all shreds in 2 rounds, make sure nothing is lost
         let shreds1: Vec<_> = data_shreds[..data_shreds.len() / 2 - 1]
@@ -10023,7 +10023,7 @@ pub mod tests {
             .insert_shreds(shreds2, Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot).unwrap();
+        blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
         // Test not all, but enough data and coding shreds in 2 rounds to trigger recovery,
         // make sure nothing is lost
@@ -10048,7 +10048,7 @@ pub mod tests {
             .insert_shreds(shreds2, Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot).unwrap();
+        blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
         // Test insert shreds in 2 rounds, but not enough to trigger
         // recovery, make sure nothing is lost
@@ -10073,7 +10073,7 @@ pub mod tests {
             .insert_shreds(shreds2, Some(&leader_schedule_cache), false)
             .unwrap();
         verify_index_integrity(&blockstore, slot);
-        blockstore.purge_and_compact_slots(0, slot).unwrap();
+        blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
     }
 
     fn setup_erasure_shreds(

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -81,11 +81,6 @@ impl Blockstore {
         }
     }
 
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn purge_and_compact_slots(&self, from_slot: Slot, to_slot: Slot) -> Result<()> {
-        self.purge_slots(from_slot, to_slot, PurgeType::Exact)
-    }
-
     /// Ensures that the SlotMeta::next_slots vector for all slots contain no references in the
     /// \[from_slot,to_slot\] range
     ///
@@ -465,11 +460,11 @@ pub mod tests {
         let (shreds, _) = make_many_slot_entries(0, 50, 5);
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
-        blockstore.purge_and_compact_slots(0, 5).unwrap();
+        blockstore.purge_slots(0, 5, PurgeType::Exact).unwrap();
 
         test_all_empty_or_min(&blockstore, 6);
 
-        blockstore.purge_and_compact_slots(0, 50).unwrap();
+        blockstore.purge_slots(0, 50, PurgeType::Exact).unwrap();
 
         // min slot shouldn't matter, blockstore should be empty
         test_all_empty_or_min(&blockstore, 100);

--- a/ledger/tests/blockstore.rs
+++ b/ledger/tests/blockstore.rs
@@ -2,7 +2,7 @@ use {
     solana_entry::entry,
     solana_hash::Hash,
     solana_ledger::{
-        blockstore::{self, Blockstore},
+        blockstore::{self, Blockstore, PurgeType},
         get_tmp_ledger_path_auto_delete,
     },
     std::{sync::Arc, thread::Builder},
@@ -44,7 +44,7 @@ fn test_multiple_threads_insert_shred() {
 
         // Delete slots for next iteration
         blockstore
-            .purge_and_compact_slots(0, num_threads + 1)
+            .purge_slots(0, num_threads + 1, PurgeType::Exact)
             .unwrap();
     }
 }


### PR DESCRIPTION
#### Problem
This function stopped performing compaction a while back, so it is a misgnomer and redundant.

#### Summary of Changes
Tests have been updated to just use run_purge() directly
