### PR TITLE
feat(accounts-db): implement iterator over AccountStoragesConcurrentConsumer

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6398,7 +6398,7 @@ impl AccountsDb {
                         .spawn_scoped(s, || {
                             let mut thread_accum = IndexGenerationAccumulator::new();
                             let mut reader = append_vec::new_scan_accounts_reader();
-                            while let Some(next_item) = storages_orderer.next() {
+                            for next_item in storages_orderer.iter() {
                                 self.maybe_throttle_index_generation();
                                 let storage = next_item.storage;
                                 let store_id = storage.id();


### PR DESCRIPTION
#### Problem
`AccountStoragesConcurrentConsumer` has `next` function, which we use similarly to iterator, it doesn't however implement `Iterator` trait, since its iteration uses read-only references. It is however possible to create trivial wrapper over reference to the consumer, which will implement `Iterator`.

This will open up using regular utils and patterns available for iterators (namely `peekable` will help improving performance for io-uring reader, since it will be easy to add prefetching).

#### Summary of Changes
Add `iter` function to `AccountStoragesConcurrentConsumer` returning internal implementation of `Iterator`.
