### PR TITLE
Alpenglow: configure QUIC server to use fewer threads

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -268,8 +268,10 @@ impl Tvu {
                 thread: bls_streamer_t,
                 key_updater: bls_key_updater,
             } = {
-                // quic server params, 8 connections per min from an IP, num_threads 1
-                let quic_server_params = QuicStreamerConfig::default();
+                let quic_server_params = QuicStreamerConfig {
+                    num_threads: NonZeroUsize::new(4.min(num_cpus::get())).unwrap(),
+                    ..Default::default()
+                };
                 let qos_config = SimpleQosConfig {
                     max_streams_per_second: 30,
                     // Cap by # of active validators (some overhead for epoch boundaries)


### PR DESCRIPTION
#### Problem

- Alpenglow QUIC server was not configured optimally to the load profile (very many connections, very low traffic).

#### Summary of Changes

- Reduce max thread count to 4 (down from num-cpus)


