### PR TITLE
update docker-solana content

### DIFF
--- a/docker-solana/Dockerfile
+++ b/docker-solana/Dockerfile
@@ -1,41 +1,10 @@
 ARG BASE_IMAGE=
 FROM ${BASE_IMAGE}
 
-# RPC JSON
-EXPOSE 8899/tcp
-# RPC pubsub
-EXPOSE 8900/tcp
-# entrypoint
-EXPOSE 8001/tcp
-# (future) bank service
-EXPOSE 8901/tcp
-# bank service
-EXPOSE 8902/tcp
-# faucet
-EXPOSE 9900/tcp
-# tvu
-EXPOSE 8000/udp
-# gossip
-EXPOSE 8001/udp
-# tpu
-EXPOSE 8003/udp
-# tpu_forwards
-EXPOSE 8004/udp
-# retransmit
-EXPOSE 8005/udp
-# repair
-EXPOSE 8006/udp
-# serve_repair
-EXPOSE 8007/udp
-# broadcast
-EXPOSE 8008/udp
-# tpu_vote
-EXPOSE 8009/udp
-
 RUN apt-get update && \
     apt-get install -y bzip2 libssl-dev ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 COPY usr/bin /usr/bin/
-ENTRYPOINT [ "/usr/bin/solana-run.sh" ]
-CMD [""]
+
+ENTRYPOINT [ "/usr/bin/solana" ]

--- a/docker-solana/README.md
+++ b/docker-solana/README.md
@@ -4,14 +4,7 @@ This image is automatically updated by CI
 https://hub.docker.com/r/anzaxyz/agave/
 
 ### Usage:
-Run the latest beta image:
-```bash
-$ docker run --rm -p 8899:8899 --ulimit nofile=1000000 anzaxyz/agave:beta
-```
 
-Run the latest edge image:
 ```bash
-$ docker run --rm -p 8899:8899 --ulimit nofile=1000000 anzaxyz/agave:edge
+$ docker run --rm anzaxyz/agave:edge --version
 ```
-
-Port *8899* is the JSON RPC port, which is used by clients to communicate with the network.

--- a/docker-solana/build.sh
+++ b/docker-solana/build.sh
@@ -20,18 +20,15 @@ if [[ -z $CHANNEL_OR_TAG ]]; then
 fi
 
 cd "$(dirname "$0")"
-rm -rf usr/
-../ci/docker-run-default-image.sh scripts/cargo-install-all.sh docker-solana/usr
 
-cp -f ../scripts/run.sh usr/bin/solana-run.sh
-cp -f ../fetch-core-bpf.sh usr/bin/
-cp -f ../fetch-spl.sh usr/bin/
-cp -f ../fetch-programs.sh usr/bin/
-(
-  cd usr/bin
-  ./fetch-core-bpf.sh
-  ./fetch-spl.sh
-)
+# download from release.anza.xyz
+rm -rf /tmp/docker-solana
+sh -c "$(curl -sSfL "https://release.anza.xyz/${CHANNEL_OR_TAG}/install")" init "${CHANNEL_OR_TAG}" --data-dir /tmp/docker-solana
+
+# prepare usr/bin
+rm -rf usr/
+mkdir -p usr/bin
+cp -r /tmp/docker-solana/active_release/bin/* usr/bin/
 
 docker build \
   --build-arg "BASE_IMAGE=${CI_DOCKER_ARG_BASE_IMAGE}" \


### PR DESCRIPTION
#### Problem

Our release tarball has changed. However, the docker image is still built and shipped as before.

#### Summary of Changes

- update the process to download artifacts directly
- update entrypoint to solana command