### PR TITLE
repair: use bounded channels and add some handling of backpressure

### DIFF
--- a/core/src/repair/serve_repair_service.rs
+++ b/core/src/repair/serve_repair_service.rs
@@ -1,10 +1,13 @@
 use {
     crate::repair::{quic_endpoint::RemoteRequest, serve_repair::ServeRepair},
     bytes::Bytes,
-    crossbeam_channel::{unbounded, Receiver, Sender},
+    crossbeam_channel::{bounded, Receiver, Sender},
     solana_net_utils::SocketAddrSpace,
     solana_perf::{packet::PacketBatch, recycler::Recycler},
-    solana_streamer::streamer::{self, StreamerReceiveStats},
+    solana_streamer::{
+        evicting_sender::EvictingSender,
+        streamer::{self, StreamerReceiveStats},
+    },
     std::{
         net::{SocketAddr, UdpSocket},
         sync::{atomic::AtomicBool, Arc},
@@ -29,7 +32,8 @@ impl ServeRepairService {
         stats_reporter_sender: Sender<Box<dyn FnOnce() + Send>>,
         exit: Arc<AtomicBool>,
     ) -> Self {
-        let (request_sender, request_receiver) = unbounded();
+        const REQUEST_CHANNEL_SIZE: usize = 4096;
+        let (request_sender, request_receiver) = EvictingSender::new_bounded(REQUEST_CHANNEL_SIZE);
         let serve_repair_socket = Arc::new(serve_repair_socket);
         let t_receiver = streamer::receiver(
             "solRcvrServeRep".to_string(),
@@ -46,7 +50,13 @@ impl ServeRepairService {
             .name(String::from("solServRAdapt"))
             .spawn(|| adapt_repair_requests_packets(request_receiver, remote_request_sender))
             .unwrap();
-        let (response_sender, response_receiver) = unbounded();
+        // NOTE: we use a larger sending channel here compared to the receiving one.
+        //
+        // That's because by the time we're done with the work to compute the repair packets,
+        // discarding the packet because of a full channel seems like a waste. For that reason the
+        // push to this channel is blocking and having more space here gives the sending thread an
+        // much greater chance to get to pulling from this channel before the channel fills up.
+        let (response_sender, response_receiver) = bounded(3 * REQUEST_CHANNEL_SIZE);
         let t_responder = streamer::responder(
             "Repair",
             serve_repair_socket,
@@ -85,8 +95,9 @@ pub(crate) fn adapt_repair_requests_packets(
                 remote_address: packet.meta().socket_addr(),
                 bytes: Bytes::from(bytes),
             };
-            if remote_request_sender.send(request).is_err() {
-                return; // The receiver end of the channel is disconnected.
+            if remote_request_sender.try_send(request).is_err() {
+                // The receiver end of the channel is disconnected or full, discard this request.
+                return;
             }
         }
     }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -176,6 +176,7 @@ use {
 };
 
 const MAX_COMPLETED_DATA_SETS_IN_CHANNEL: usize = 100_000;
+const MAX_PENDING_REPAIR_REQUESTS_RESPONSES: usize = 1024;
 const WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT: u64 = 80;
 // Right now since we reuse the wait for supermajority code, the
 // following threshold should always greater than or equal to
@@ -1459,8 +1460,10 @@ impl Validator {
                 bank_forks_r.migration_status(),
             )
         };
-        let (repair_request_quic_sender, repair_request_quic_receiver) = unbounded();
-        let (repair_response_quic_sender, repair_response_quic_receiver) = unbounded();
+        let (repair_request_quic_sender, repair_request_quic_receiver) =
+            bounded(MAX_PENDING_REPAIR_REQUESTS_RESPONSES);
+        let (repair_response_quic_sender, repair_response_quic_receiver) =
+            bounded(MAX_PENDING_REPAIR_REQUESTS_RESPONSES);
         let (ancestor_hashes_response_quic_sender, ancestor_hashes_response_quic_receiver) =
             unbounded();
 


### PR DESCRIPTION
Backpressure occurs at the point of packet decode – if the channels are full at any further layer, the intermediate threads will eventually stop pulling from this decoding channel and this decoding will start discarding requests.

The channel sizes have been chosen largely based on guesstimates and what appear to be roughly the actual sizes based on alessandro's profiles.