### PR TITLE
repair: throttle requests during leader slot

### DIFF
--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -18,6 +18,7 @@ use {
         shred::Nonce,
     },
     solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, RecycledPacketBatch},
+    solana_poh::poh_recorder::SharedLeaderState,
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::SharableBanks,
     std::{
@@ -153,13 +154,15 @@ impl RepairHandlerType {
         cluster_info: Arc<ClusterInfo>,
         sharable_banks: SharableBanks,
         serve_repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
+        leader_state: SharedLeaderState,
         migration_status: Arc<MigrationStatus>,
     ) -> ServeRepair {
-        ServeRepair::new(
+        ServeRepair::new_with_leader_state(
             cluster_info,
             sharable_banks,
             serve_repair_whitelist,
             self.to_handler(blockstore),
+            leader_state,
             migration_status,
         )
     }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -46,6 +46,7 @@ use {
         data_budget::DataBudget,
         packet::{Packet, PacketBatch, PacketBatchRecycler, RecycledPacketBatch},
     },
+    solana_poh::poh_recorder::SharedLeaderState,
     solana_pubkey::{Pubkey, PUBKEY_BYTES},
     solana_runtime::bank_forks::SharableBanks,
     solana_signature::{Signature, SIGNATURE_BYTES},
@@ -346,6 +347,7 @@ pub struct ServeRepair {
     sharable_banks: SharableBanks,
     repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
     repair_handler: Box<dyn RepairHandler + Send + Sync>,
+    leader_state: Option<SharedLeaderState>,
     migration_status: Arc<MigrationStatus>,
 }
 
@@ -417,6 +419,25 @@ impl ServeRepair {
             sharable_banks,
             repair_whitelist,
             repair_handler,
+            leader_state: None,
+            migration_status,
+        }
+    }
+
+    pub fn new_with_leader_state(
+        cluster_info: Arc<ClusterInfo>,
+        sharable_banks: SharableBanks,
+        repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
+        repair_handler: Box<dyn RepairHandler + Send + Sync>,
+        leader_state: SharedLeaderState,
+        migration_status: Arc<MigrationStatus>,
+    ) -> Self {
+        Self {
+            cluster_info,
+            sharable_banks,
+            repair_whitelist,
+            repair_handler,
+            leader_state: Some(leader_state),
             migration_status,
         }
     }
@@ -674,6 +695,8 @@ impl ServeRepair {
         stats: &mut ServeRepairStats,
         data_budget: &DataBudget,
     ) -> std::result::Result<(), RecvTimeoutError> {
+        /// How much more expensive it is to serve bytes if we are a leader
+        const LEADER_BYTE_COST_MULTIPLIER: usize = 10;
         const TIMEOUT: Duration = Duration::from_secs(1);
         let mut requests = vec![requests_receiver.recv_timeout(TIMEOUT)?];
         const MAX_REQUESTS_PER_ITERATION: usize = 1024;
@@ -738,6 +761,19 @@ impl ServeRepair {
             decoded_requests.truncate(MAX_REQUESTS_PER_ITERATION);
         }
 
+        // Check if we are currently a leader, so we can limit the service rate
+        // If information is not available, assume we are not a leader.
+        let is_leader = self
+            .leader_state
+            .as_ref()
+            .map(|ls| ls.load().working_bank().is_some())
+            .unwrap_or(false);
+        // assign extra cost to served bytes if we are a leader
+        let byte_cost_multiplier = if is_leader {
+            LEADER_BYTE_COST_MULTIPLIER
+        } else {
+            1
+        };
         let handle_requests_start = Instant::now();
         self.handle_requests(
             ping_cache,
@@ -747,6 +783,7 @@ impl ServeRepair {
             repair_response_quic_sender,
             stats,
             data_budget,
+            byte_cost_multiplier,
         );
         stats.handle_requests_time_us += handle_requests_start.elapsed().as_micros() as u64;
 
@@ -1012,6 +1049,7 @@ impl ServeRepair {
         repair_response_quic_sender: &AsyncSender<(SocketAddr, Bytes)>,
         stats: &mut ServeRepairStats,
         data_budget: &DataBudget,
+        byte_cost_multiplier: usize,
     ) {
         let identity_keypair = self.cluster_info.keypair();
         let mut pending_pings = Vec::default();
@@ -1024,7 +1062,7 @@ impl ServeRepair {
             whitelisted: _,
         } in requests.into_iter()
         {
-            if !data_budget.check(request.max_response_bytes()) {
+            if !data_budget.check(request.max_response_bytes() * byte_cost_multiplier) {
                 stats.dropped_requests_outbound_bandwidth += 1;
                 continue;
             }
@@ -1046,8 +1084,8 @@ impl ServeRepair {
                 continue;
             };
             let num_response_packets = rsp.len();
-            let num_response_bytes = rsp.iter().map(|p| p.meta().size).sum();
-            if data_budget.take(num_response_bytes)
+            let num_response_bytes: usize = rsp.iter().map(|p| p.meta().size).sum();
+            if data_budget.take(num_response_bytes * byte_cost_multiplier)
                 && send_response(
                     rsp,
                     protocol,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1449,11 +1449,13 @@ impl Validator {
         );
         let serve_repair = {
             let bank_forks_r = bank_forks.read().unwrap();
+            let leader_state = poh_recorder.read().unwrap().shared_leader_state();
             config.repair_handler_type.create_serve_repair(
                 blockstore.clone(),
                 cluster_info.clone(),
                 bank_forks_r.sharable_banks(),
                 config.repair_whitelist.clone(),
+                leader_state,
                 bank_forks_r.migration_status(),
             )
         };


### PR DESCRIPTION
#### Problem

- Leader has better things to do than serve repairs
Fixes: https://github.com/anza-xyz/agave/issues/10261

#### Summary of Changes

- Throttle repair service rate by 10x during leader slots

Before the patch: 
16.6K response packets served in 2 seconds (~10 Mbps)
<img width="1283" height="535" alt="Screenshot 2026-02-05 at 23 19 11" src="https://github.com/user-attachments/assets/9a063399-d3be-4209-b066-df1e24cc9efc" />


With the patch:

4.5K response packets get served in 2 seconds (~2.7 Mbps)     
<img width="1299" height="545" alt="Screenshot 2026-02-05 at 23 04 30" src="https://github.com/user-attachments/assets/69465c75-79c4-4017-83ae-70c988dd44a1" />

