### PR TITLE
chore(deps): bump rts-alloc from 1.0.0 to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6286,9 +6286,9 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd8c332d71e3025b63eb4df047f91ce34873b196dd59b07540a91756ba97e05"
+checksum = "8a0d46bfcacc6e65b67c547e5083ffd549fe80dee8ec337507dd7f01d26763f4"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,7 +374,7 @@ reqwest = { version = "0.12.28", default-features = false }
 reqwest-middleware = "0.4.2"
 rolling-file = "0.2.0"
 rpassword = "7.4"
-rts-alloc = { version = "1.0.0" }
+rts-alloc = { version = "2.0.0" }
 rustls = { version = "0.23.36", features = ["std"], default-features = false }
 scopeguard = "1.2.0"
 semver = "1.0.27"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -5392,9 +5392,9 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd8c332d71e3025b63eb4df047f91ce34873b196dd59b07540a91756ba97e05"
+checksum = "8a0d46bfcacc6e65b67c547e5083ffd549fe80dee8ec337507dd7f01d26763f4"
 dependencies = [
  "libc",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5353,9 +5353,9 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd8c332d71e3025b63eb4df047f91ce34873b196dd59b07540a91756ba97e05"
+checksum = "8a0d46bfcacc6e65b67c547e5083ffd549fe80dee8ec337507dd7f01d26763f4"
 dependencies = [
  "libc",
 ]

--- a/scheduling-utils/src/pubkeys_ptr.rs
+++ b/scheduling-utils/src/pubkeys_ptr.rs
@@ -30,6 +30,7 @@ impl PubkeysPtr {
     ///
     /// # Safety
     ///
+    /// - `sharable_pubkeys.offset` must have been allocated by `allocator`.
     /// - The allocation pointed to by this region must not have previously been freed.
     /// - Pointer must be exclusive so that calling [`Self::free`] is safe.
     /// - `sharable_pubkeys.num_pubkeys` must be accurate and not overrun the allocation.
@@ -38,7 +39,8 @@ impl PubkeysPtr {
         allocator: &Allocator,
     ) -> Self {
         assert_ne!(sharable_pubkeys.num_pubkeys, 0);
-        let ptr = allocator.ptr_from_offset(sharable_pubkeys.offset).cast();
+        // SAFETY: `sharable_pubkeys.offset` was allocated by `allocator`.
+        let ptr = unsafe { allocator.ptr_from_offset(sharable_pubkeys.offset) }.cast();
 
         Self {
             ptr,

--- a/scheduling-utils/src/responses_region.rs
+++ b/scheduling-utils/src/responses_region.rs
@@ -124,7 +124,7 @@ impl CheckResponsesPtr {
     ///
     /// - The provided [`TransactionResponseRegion`] must be of type
     ///   [`worker_message_types::CHECK_RESPONSE`].
-    /// - The allocation pointed to by this region must not have previously been freed.
+    /// - The allocation pointed to by this region must be valid and not previously freed.
     pub unsafe fn from_transaction_response_region(
         transaction_response_region: &TransactionResponseRegion,
         allocator: &Allocator,
@@ -132,9 +132,11 @@ impl CheckResponsesPtr {
         debug_assert!(transaction_response_region.tag == worker_message_types::CHECK_RESPONSE);
 
         Self {
-            ptr: allocator
-                .ptr_from_offset(transaction_response_region.transaction_responses_offset)
-                .cast(),
+            // SAFETY: `transaction_response_region.transaction_responses_offset` was allocated by `allocator`.
+            ptr: unsafe {
+                allocator.ptr_from_offset(transaction_response_region.transaction_responses_offset)
+            }
+            .cast(),
             count: transaction_response_region.num_transaction_responses as usize,
         }
     }
@@ -193,7 +195,7 @@ impl ExecutionResponsesPtr {
     ///
     /// - The provided [`TransactionResponseRegion`] must be of type
     ///   [`worker_message_types::EXECUTION_RESPONSE`].
-    /// - The allocation pointed to by this region must not have previously been freed.
+    /// - The allocation pointed to by this region must be valid and not previously freed.
     pub unsafe fn from_transaction_response_region(
         transaction_response_region: &TransactionResponseRegion,
         allocator: &Allocator,
@@ -201,9 +203,11 @@ impl ExecutionResponsesPtr {
         debug_assert!(transaction_response_region.tag == worker_message_types::EXECUTION_RESPONSE);
 
         Self {
-            ptr: allocator
-                .ptr_from_offset(transaction_response_region.transaction_responses_offset)
-                .cast(),
+            // SAFETY: `transaction_response_region.transaction_responses_offset` was allocated by `allocator`.
+            ptr: unsafe {
+                allocator.ptr_from_offset(transaction_response_region.transaction_responses_offset)
+            }
+            .cast(),
             count: transaction_response_region.num_transaction_responses as usize,
         }
     }

--- a/scheduling-utils/src/transaction_ptr.rs
+++ b/scheduling-utils/src/transaction_ptr.rs
@@ -50,7 +50,8 @@ impl TransactionPtr {
         sharable_transaction_region: &SharableTransactionRegion,
         allocator: &Allocator,
     ) -> Self {
-        let ptr = allocator.ptr_from_offset(sharable_transaction_region.offset);
+        // SAFETY: `sharable_transaction_region.offset` was allocated by `allocator`.
+        let ptr = unsafe { allocator.ptr_from_offset(sharable_transaction_region.offset) };
         Self {
             ptr,
             count: sharable_transaction_region.length as usize,
@@ -116,7 +117,10 @@ impl<'a, M> TransactionPtrBatch<'a, M> {
         sharable_transaction_batch_region: &SharableTransactionBatchRegion,
         allocator: &'a Allocator,
     ) -> Self {
-        let base = allocator.ptr_from_offset(sharable_transaction_batch_region.transactions_offset);
+        // SAFETY: `sharable_transaction_batch_region.transactions_offset` was allocated by `allocator`.
+        let base = unsafe {
+            allocator.ptr_from_offset(sharable_transaction_batch_region.transactions_offset)
+        };
         let tx_ptr = base.cast();
         // SAFETY:
         // - Assuming the batch was originally allocated to support `M`, this call will also be


### PR DESCRIPTION
#### Problem
- New version of rts-alloc with more correctly marked safety on functions

#### Summary of Changes
- Bump rts-alloc to 2.0.0
- Add unsafe and safety annotations to function calls now marked unsafe

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
