### PR TITLE
Supports more configurable accounts index threshold

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -43,6 +43,7 @@ use {
     thiserror::Error,
 };
 pub use {
+    bucket_map_holder::{DEFAULT_NUM_ENTRIES_OVERHEAD, DEFAULT_NUM_ENTRIES_TO_EVICT},
     iter::ITER_BATCH_SIZE,
     secondary::{
         AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude, IndexKey,
@@ -229,14 +230,25 @@ enum ScanTypes<R: RangeBounds<Pubkey>> {
 }
 
 /// specification of how much memory the in-mem portion of account index can hold
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub enum IndexLimit {
     /// use disk index while keeping a minimal amount in-mem
     Minimal,
     /// in-mem-only was specified, no disk index
     InMemOnly,
     /// evict from in-mem when usage exceeds threshold in bytes
-    Threshold(u64),
+    Threshold(IndexLimitThreshold),
+}
+
+/// Configuration for threshold-based accounts index limit
+#[derive(Debug, Clone)]
+pub struct IndexLimitThreshold {
+    /// The memory limit, in bytes, for the entire accounts index.
+    pub num_bytes: u64,
+    /// Number of entries below an in-mem index bin's usable capacity at which to begin evicting.
+    pub num_entries_overhead: usize,
+    /// Number of entries to evict, once we've hit the high watermark.
+    pub num_entries_to_evict: usize,
 }
 
 #[derive(Debug, Clone)]

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -35,7 +35,7 @@ const _: () = assert!(std::mem::size_of::<Age>() == std::mem::size_of::<AtomicAg
 /// higher the utilization of the in-mem index bins.
 ///
 /// This value is used to compute the high watermark.
-const NUM_ENTRIES_OVERHEAD: usize = 5_000;
+pub const DEFAULT_NUM_ENTRIES_OVERHEAD: usize = 5_000;
 
 /// The number of entries to evict, once we've hit the high watermark.
 ///
@@ -46,7 +46,7 @@ const NUM_ENTRIES_OVERHEAD: usize = 5_000;
 /// with that goal.
 ///
 /// This value is used to compute the low watermark.
-const NUM_ENTRIES_TO_EVICT: usize = 10_000;
+pub const DEFAULT_NUM_ENTRIES_TO_EVICT: usize = 10_000;
 
 pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     pub disk: Option<BucketMap<(Slot, U)>>,
@@ -265,9 +265,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         };
 
         // Compute threshold_entries once here
-        let threshold_entries_per_bin = match config.index_limit {
+        let threshold_entries_per_bin = match &config.index_limit {
             IndexLimit::InMemOnly | IndexLimit::Minimal => None,
-            IndexLimit::Threshold(limit_bytes) => {
+            IndexLimit::Threshold(threshold) => {
+                let limit_bytes = threshold.num_bytes;
                 let bytes_per_entry = InMemAccountsIndex::<T, U>::size_of_uninitialized()
                     + InMemAccountsIndex::<T, U>::size_of_single_entry();
                 let limit_entries = (limit_bytes as usize) / bytes_per_entry;
@@ -275,10 +276,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
                 let target_entries_per_bin =
                     Self::calculate_target_entries_per_bin(entries_per_bin);
                 let high_water_mark = target_entries_per_bin
-                    .checked_sub(NUM_ENTRIES_OVERHEAD)
+                    .checked_sub(threshold.num_entries_overhead)
                     .expect("limit too small for high watermark");
                 let low_water_mark = high_water_mark
-                    .checked_sub(NUM_ENTRIES_TO_EVICT)
+                    .checked_sub(threshold.num_entries_to_evict)
                     .expect("limit too small for low watermark");
                 #[rustfmt::skip]
                 info!(
@@ -514,7 +515,10 @@ pub struct ThresholdEntriesPerBin {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, rayon::prelude::*, std::time::Instant, test_case::test_case};
+    use {
+        super::*, crate::accounts_index::IndexLimitThreshold, rayon::prelude::*,
+        std::time::Instant, test_case::test_case,
+    };
 
     #[test]
     fn test_next_bucket_to_flush() {
@@ -624,11 +628,17 @@ mod tests {
     #[test]
     fn test_should_flush_threshold() {
         let bins = 1;
-        let num_entries = (NUM_ENTRIES_OVERHEAD + NUM_ENTRIES_TO_EVICT) * 3;
+        let num_entries_overhead = DEFAULT_NUM_ENTRIES_OVERHEAD;
+        let num_entries_to_evict = DEFAULT_NUM_ENTRIES_TO_EVICT;
+        let num_entries = (num_entries_overhead + num_entries_to_evict) * 3;
         let bytes_per_entry = InMemAccountsIndex::<u64, u64>::size_of_uninitialized()
             + InMemAccountsIndex::<u64, u64>::size_of_single_entry();
         let config = AccountsIndexConfig {
-            index_limit: IndexLimit::Threshold((num_entries * bytes_per_entry) as u64),
+            index_limit: IndexLimit::Threshold(IndexLimitThreshold {
+                num_bytes: (num_entries * bytes_per_entry) as u64,
+                num_entries_overhead,
+                num_entries_to_evict,
+            }),
             ..Default::default()
         };
         let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
@@ -705,7 +715,11 @@ mod tests {
             + InMemAccountsIndex::<u64, u64>::size_of_single_entry();
         let limit_bytes = (num_entries * bytes_per_entry) as u64;
         let config = AccountsIndexConfig {
-            index_limit: IndexLimit::Threshold(limit_bytes),
+            index_limit: IndexLimit::Threshold(IndexLimitThreshold {
+                num_bytes: limit_bytes,
+                num_entries_overhead: DEFAULT_NUM_ENTRIES_OVERHEAD,
+                num_entries_to_evict: DEFAULT_NUM_ENTRIES_TO_EVICT,
+            }),
             ..Default::default()
         };
         let test = BucketMapHolder::<u64, u64>::new(num_bins, &config, 1);

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -6,7 +6,10 @@ use {
     solana_accounts_db::{
         accounts_db::AccountsDbConfig,
         accounts_file::StorageAccess,
-        accounts_index::{AccountsIndexConfig, IndexLimit, ScanFilter},
+        accounts_index::{
+            AccountsIndexConfig, IndexLimit, IndexLimitThreshold, ScanFilter,
+            DEFAULT_NUM_ENTRIES_OVERHEAD, DEFAULT_NUM_ENTRIES_TO_EVICT,
+        },
     },
     solana_clap_utils::{
         hidden_unless_forced,
@@ -271,18 +274,34 @@ pub fn get_accounts_db_config(
         value_t!(arg_matches, "accounts_index_initial_accounts_count", usize).ok();
     let accounts_index_limit =
         value_t!(arg_matches, "accounts_index_limit", String).unwrap_or_else(|err| err.exit());
-    let index_limit = match accounts_index_limit.as_str() {
-        "minimal" => IndexLimit::Minimal,
-        "25GB" => IndexLimit::Threshold(25_000_000_000),
-        "50GB" => IndexLimit::Threshold(50_000_000_000),
-        "100GB" => IndexLimit::Threshold(100_000_000_000),
-        "200GB" => IndexLimit::Threshold(200_000_000_000),
-        "400GB" => IndexLimit::Threshold(400_000_000_000),
-        "800GB" => IndexLimit::Threshold(800_000_000_000),
-        "unlimited" => IndexLimit::InMemOnly,
-        x => {
-            // clap will enforce only the above values are possible
-            unreachable!("invalid value given to `--accounts-index-limit`: '{x}'")
+    let index_limit = {
+        enum CliIndexLimit {
+            Minimal,
+            Unlimited,
+            Threshold(u64),
+        }
+        let cli_index_limit = match accounts_index_limit.as_str() {
+            "minimal" => CliIndexLimit::Minimal,
+            "unlimited" => CliIndexLimit::Unlimited,
+            "25GB" => CliIndexLimit::Threshold(25_000_000_000),
+            "50GB" => CliIndexLimit::Threshold(50_000_000_000),
+            "100GB" => CliIndexLimit::Threshold(100_000_000_000),
+            "200GB" => CliIndexLimit::Threshold(200_000_000_000),
+            "400GB" => CliIndexLimit::Threshold(400_000_000_000),
+            "800GB" => CliIndexLimit::Threshold(800_000_000_000),
+            x => {
+                // clap will enforce only the above values are possible
+                unreachable!("invalid value given to `--accounts-index-limit`: '{x}'")
+            }
+        };
+        match cli_index_limit {
+            CliIndexLimit::Minimal => IndexLimit::Minimal,
+            CliIndexLimit::Unlimited => IndexLimit::InMemOnly,
+            CliIndexLimit::Threshold(num_bytes) => IndexLimit::Threshold(IndexLimitThreshold {
+                num_bytes,
+                num_entries_overhead: DEFAULT_NUM_ENTRIES_OVERHEAD,
+                num_entries_to_evict: DEFAULT_NUM_ENTRIES_TO_EVICT,
+            }),
         }
     };
     let accounts_index_drives = values_t!(arg_matches, "accounts_index_path", String)


### PR DESCRIPTION
#### Problem

Configuring the accounts index threshold is limited to only setting the maximum number of bytes to use. The number of entries of overhead, and the number of entries to evict are both hard coded.

This makes writing tests more cumbersome when we want a small bytes limit, and also makes experimenting/testing with non-default values for the overhead/evict difficult.


#### Summary of Changes

Step one, internally support configuring all three of the values.