### PR TITLE
Removes pub from more accounts-db test modules

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -21,7 +21,7 @@
 mod accounts_db_config;
 mod geyser_plugin_utils;
 pub mod stats;
-pub mod tests;
+pub(crate) mod tests;
 
 pub use accounts_db_config::{
     AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3,7 +3,7 @@ use {
     super::*,
     crate::{
         accounts_file::AccountsFileProvider,
-        accounts_index::{tests::*, AccountSecondaryIndexesIncludeExclude},
+        accounts_index::{test_utils::*, AccountSecondaryIndexesIncludeExclude},
         append_vec::{test_utils::TempFile, AppendVec},
         storable_accounts::AccountForStorage,
     },
@@ -2055,11 +2055,6 @@ fn test_hash_stored_account() {
         "Account-based hashing must be consistent with StoredAccountInfo-based one."
     );
 }
-
-// something we can get a ref to
-
-pub static EPOCH_SCHEDULE: std::sync::LazyLock<EpochSchedule> =
-    std::sync::LazyLock::new(EpochSchedule::default);
 
 #[test]
 fn test_verify_bank_capitalization() {

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1740,7 +1740,31 @@ pub(crate) enum Startup {
 }
 
 #[cfg(test)]
-pub mod tests {
+pub(crate) mod test_utils {
+    use {
+        super::{secondary::AccountSecondaryIndexes, AccountIndex},
+        std::collections::HashSet,
+    };
+    pub fn spl_token_mint_index_enabled() -> AccountSecondaryIndexes {
+        let mut account_indexes = HashSet::new();
+        account_indexes.insert(AccountIndex::SplTokenMint);
+        AccountSecondaryIndexes {
+            indexes: account_indexes,
+            keys: None,
+        }
+    }
+    pub fn spl_token_owner_index_enabled() -> AccountSecondaryIndexes {
+        let mut account_indexes = HashSet::new();
+        account_indexes.insert(AccountIndex::SplTokenOwner);
+        AccountSecondaryIndexes {
+            indexes: account_indexes,
+            keys: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
     use {
         super::{bucket_map_holder::BucketMapHolder, *},
         crate::accounts_index::account_map_entry::AccountMapEntryMeta,
@@ -1754,26 +1778,10 @@ pub mod tests {
         test_case::test_matrix,
     };
 
-    pub enum SecondaryIndexTypes<'a> {
+    enum SecondaryIndexTypes<'a> {
+        // We don't access the inner value, but we do use it for type checking during cmopilation.
+        #[allow(dead_code)]
         RwLock(&'a SecondaryIndex<RwLockSecondaryIndexEntry>),
-    }
-
-    pub fn spl_token_mint_index_enabled() -> AccountSecondaryIndexes {
-        let mut account_indexes = HashSet::new();
-        account_indexes.insert(AccountIndex::SplTokenMint);
-        AccountSecondaryIndexes {
-            indexes: account_indexes,
-            keys: None,
-        }
-    }
-
-    pub fn spl_token_owner_index_enabled() -> AccountSecondaryIndexes {
-        let mut account_indexes = HashSet::new();
-        account_indexes.insert(AccountIndex::SplTokenOwner);
-        AccountSecondaryIndexes {
-            indexes: account_indexes,
-            keys: None,
-        }
     }
 
     fn create_spl_token_mint_secondary_index_state() -> (usize, usize, AccountSecondaryIndexes) {
@@ -1783,7 +1791,7 @@ pub mod tests {
             let _type_check = SecondaryIndexTypes::RwLock(&index.spl_token_mint_index);
         }
 
-        (0, PUBKEY_BYTES, spl_token_mint_index_enabled())
+        (0, PUBKEY_BYTES, test_utils::spl_token_mint_index_enabled())
     }
 
     fn create_spl_token_owner_secondary_index_state() -> (usize, usize, AccountSecondaryIndexes) {
@@ -1796,7 +1804,7 @@ pub mod tests {
         (
             SPL_TOKEN_ACCOUNT_OWNER_OFFSET,
             SPL_TOKEN_ACCOUNT_OWNER_OFFSET + PUBKEY_BYTES,
-            spl_token_owner_index_enabled(),
+            test_utils::spl_token_owner_index_enabled(),
         )
     }
 
@@ -3929,10 +3937,6 @@ pub mod tests {
                 reclaim_method,
             );
             assert!(gc.is_empty());
-        }
-
-        pub fn clear_roots(&self) {
-            self.roots_tracker.write().unwrap().alive_roots.clear()
         }
     }
 


### PR DESCRIPTION
#### Problem

There are `tests` submodules in the accounts-db crate that are public.

There's no reason for tests to be public. It makes the build slower, and makes it too convenient for inappropriate coupling between modules.


#### Summary of Changes

* Move accounts-index shared/util test functions to their own submodule
* Remove pub from the accounts-index tests
* Reduce the accounts-db tests submodule to crate-only