### PR TITLE
Return error on tx execution failure

### DIFF
--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -114,7 +114,7 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher + Sync + Send>(
                 continue;
             }
             let client = new_tpu_quic_client(ingress_node, connection_cache.clone()).unwrap();
-            LocalCluster::poll_for_processed_transaction(&client, &transaction)
+            LocalCluster::poll_for_successfully_processed_transaction(&client, &transaction)
                 .unwrap()
                 .unwrap();
         }
@@ -670,7 +670,7 @@ fn poll_all_nodes_for_signature(
             continue;
         }
         let client = new_tpu_quic_client(validator, connection_cache.clone()).unwrap();
-        LocalCluster::poll_for_processed_transaction(&client, transaction)?.unwrap();
+        LocalCluster::poll_for_successfully_processed_transaction(&client, transaction)?.unwrap();
     }
 
     Ok(())

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -80,6 +80,7 @@ use {
     solana_stake_interface::{self as stake, state::NEW_WARMUP_COOLDOWN_RATE},
     solana_system_interface::program as system_program,
     solana_system_transaction as system_transaction,
+    solana_transaction_error::TransportError,
     solana_turbine::broadcast_stage::{
         broadcast_duplicates_run::{BroadcastDuplicatesConfig, ClusterPartition},
         BroadcastStageType,
@@ -2884,13 +2885,17 @@ fn test_oc_bad_signatures() {
                     &bad_authorized_signer_keypair,
                     None,
                 );
-                LocalCluster::send_transaction_with_retries(
-                    &client,
-                    &[&node_keypair, &bad_authorized_signer_keypair],
-                    &mut vote_tx,
-                    5,
-                )
-                .unwrap();
+
+                // Send the bad vote and expect transaction error.
+                assert_matches!(
+                    LocalCluster::send_transaction_with_retries(
+                        &client,
+                        &[&node_keypair, &bad_authorized_signer_keypair],
+                        &mut vote_tx,
+                        5,
+                    ),
+                    Err(TransportError::TransactionError(_))
+                );
 
                 num_votes_simulated.fetch_add(1, Ordering::Relaxed);
             }


### PR DESCRIPTION
#### Problem
A bunch of local cluster tests use the `poll_for_processed_transaction` helper function to check if a transaction landed. However, all of these tests (w/ the exception of `test_oc_bad_signatures`) not only expect the transaction to land, but expect it to have executed successfully.

In some cases, the failure to execute successfully leads to tests hanging forever and difficult debugs. For example, see #3483

#### Summary of Changes

1. Rename `poll_for_processed_transaction` to `poll_for_successfully_processed_transaction`
2. Return Err if tx result is Err
3. Modify `test_oc_bad_signatures` to check for tx error after submitting vote w/ bad signature