### PR TITLE
reuse buffers for external worker checks

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -340,8 +340,6 @@ pub(crate) mod external {
             if message.flags & pack_message_flags::EXECUTE != 0 {
                 self.execute_batch(message, should_drain_executes)
             } else {
-                parsing_results.clear();
-                parsed_transactions.clear();
                 self.check_batch(message, parsing_results, parsed_transactions)
                     .map(|()| false)
             }
@@ -472,6 +470,9 @@ pub(crate) mod external {
             parsing_results: &mut Vec<Result<(), TransactionViewError>>,
             parsed_transactions: &mut Vec<TxView>,
         ) -> Result<(), ExternalConsumeWorkerError> {
+            parsing_results.clear();
+            parsed_transactions.clear();
+
             let BankPair {
                 root_bank,
                 working_bank,

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -513,8 +513,8 @@ pub(crate) mod external {
             // Check fee-payer if requested.
             if message.flags & check_flags::LOAD_FEE_PAYER_BALANCE != 0 {
                 Self::check_load_fee_payer_balance(
-                    &parsing_results,
-                    &parsed_transactions,
+                    parsing_results,
+                    parsed_transactions,
                     response_slice,
                     &working_bank,
                 );
@@ -526,7 +526,7 @@ pub(crate) mod external {
 
             if message.flags & check_flags::LOAD_ADDRESS_LOOKUP_TABLES != 0 {
                 self.check_resolve_pubkeys(
-                    &parsing_results,
+                    parsing_results,
                     &parsing_and_resolve_results,
                     &txs,
                     &max_ages,
@@ -809,7 +809,7 @@ pub(crate) mod external {
 
             // SAFETY: `response_ptr` is valid and of length message.batch.num_transactions
             unsafe {
-                Self::check_populate_initial_messages(message, &parsing_results, responses_ptr)
+                Self::check_populate_initial_messages(message, parsing_results, responses_ptr)
             };
             // SAFETY: `response_ptr` is valid and of length message.batch.num_transactions
             //         initial messages populated immediately above, so not possible to have

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -470,9 +470,6 @@ pub(crate) mod external {
             parsing_results: &mut Vec<Result<(), TransactionViewError>>,
             parsed_transactions: &mut Vec<TxView>,
         ) -> Result<(), ExternalConsumeWorkerError> {
-            parsing_results.clear();
-            parsed_transactions.clear();
-
             let BankPair {
                 root_bank,
                 working_bank,
@@ -784,6 +781,9 @@ pub(crate) mod external {
             parsing_results: &mut Vec<Result<(), TransactionViewError>>,
             parsed_transactions: &mut Vec<TxView>,
         ) -> &'a mut [CheckResponse] {
+            parsing_results.clear();
+            parsed_transactions.clear();
+
             let enable_static_instruction_limit = bank
                 .feature_set
                 .is_active(&agave_feature_set::static_instruction_limit::ID);


### PR DESCRIPTION
#### Problem
Two vectors are allocated for each `Check` in the external worker

#### Summary of Changes
Allocate vectors only once and reuse them
