### PR TITLE
ci: move all agents to use the default queue

### DIFF
--- a/.buildkite/pipeline-upload.sh
+++ b/.buildkite/pipeline-upload.sh
@@ -20,12 +20,12 @@ steps:
     command: "ci/docker-run-default-image.sh ci/test-sanity.sh"
     timeout_in_minutes: 5
     agents:
-      queue: "check"
+      queue: "default"
   - name: "checks"
     command: "ci/docker-run-default-image.sh ci/test-checks.sh"
     timeout_in_minutes: 30
     agents:
-      queue: "check"
+      queue: "default"
 EOF
 
 else

--- a/.buildkite/scripts/build-stable.sh
+++ b/.buildkite/scripts/build-stable.sh
@@ -6,7 +6,7 @@ here=$(dirname "$0")
 # shellcheck source=.buildkite/scripts/common.sh
 source "$here"/common.sh
 
-agent="${1-solana}"
+agent="${1-default}"
 
 parallelism=5
 partitions=()

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -154,7 +154,7 @@ command_step() {
     timeout_in_minutes: $3
     artifact_paths: "log-*.txt"
     agents:
-      queue: "${4:-solana}"
+      queue: "${4:-default}"
 EOF
 }
 
@@ -191,7 +191,7 @@ EOF
         command: "ci/docker-run-default-image.sh ci/feature-check/test-feature.sh $i/$total_feature_checks"
         timeout_in_minutes: 20
         agents:
-          queue: "solana"
+          queue: "default"
 EOF
 	done
 	cat >> "$output_file" <<EOF
@@ -199,15 +199,15 @@ EOF
         command: "ci/docker-run-default-image.sh ci/feature-check/test-feature-dev-bins.sh"
         timeout_in_minutes: 20
         agents:
-          queue: "solana"
+          queue: "default"
 EOF
 }
 
 all_test_steps() {
-  command_step checks1 "ci/docker-run-default-image.sh ci/test-checks.sh" 20 check
+  command_step checks1 "ci/docker-run-default-image.sh ci/test-checks.sh" 20 default
   generate_feature_steps
-  command_step miri "ci/docker-run-default-image.sh ci/test-miri.sh" 5 check
-  command_step frozen-abi "ci/docker-run-default-image.sh ci/test-frozen-abi.sh" 30 check
+  command_step miri "ci/docker-run-default-image.sh ci/test-miri.sh" 5 default
+  command_step frozen-abi "ci/docker-run-default-image.sh ci/test-frozen-abi.sh" 30 default
   wait_step
 
   # Full test suite
@@ -249,7 +249,7 @@ all_test_steps() {
     name: "stable-sbf"
     timeout_in_minutes: 35
     agents:
-      queue: "solana"
+      queue: "default"
 EOF
   else
     annotate --style info \
@@ -285,17 +285,17 @@ EOF
         name: "coverage-1"
         timeout_in_minutes: 60
         agents:
-          queue: "solana"
+          queue: "default"
       - command: "ci/docker-run-default-image.sh ci/coverage/part-2.sh"
         name: "coverage-2"
         timeout_in_minutes: 60
         agents:
-          queue: "solana"
+          queue: "default"
       - command: "ci/docker-run-default-image.sh ci/coverage/part-3.sh"
         name: "coverage-3"
         timeout_in_minutes: 60
         agents:
-          queue: "solana"
+          queue: "default"
 EOF
   else
     annotate --style info --context test-coverage \
@@ -304,7 +304,7 @@ EOF
 }
 
 pull_or_push_steps() {
-  command_step sanity "ci/test-sanity.sh" 5 check
+  command_step sanity "ci/test-sanity.sh" 5 default
   wait_step
 
   # Check for any .sh file changes
@@ -312,7 +312,7 @@ pull_or_push_steps() {
               .sh$ \
               ^.buildkite/hooks \
       ; then
-    command_step shellcheck "ci/shellcheck.sh" 5 check
+    command_step shellcheck "ci/shellcheck.sh" 5 default
     wait_step
   fi
 


### PR DESCRIPTION
#### Problem

would like to have this feature in our ci:
<img width="424" height="249" alt="Screenshot 2026-02-03 at 11 20 20" src="https://github.com/user-attachments/assets/60c06c2d-4547-4a95-9e55-b03cffe7a21c" />

however, it needs migrate to their cluster feature, which only allows defining "queue" once. for now, I think we can move everything to the default queue, and we can always adjust it later if needed.

#### Summary of Changes

move all tests to use default queue
