### PR TITLE
feat: integer math for inflation calculations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9941,6 +9941,7 @@ dependencies = [
  "proptest",
  "qualifier_attr",
  "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rayon",
  "regex",
  "semver 1.0.27",

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1126,7 +1126,9 @@ pub mod alpenglow {
     // Used to activate alpenglow in local-cluster tests without exposing the actual feature's private key
     #[cfg(feature = "dev-context-only-utils")]
     pub static TEST_KEYPAIR: LazyLock<Keypair> = LazyLock::new(|| {
-        let keypair = Keypair::from_base58_string("2Vzd6oTWU4RtM5UmsSyBH3tAhPSi1sKqMeMC8bF1jzHHLBMRhEWtrfmBV4EmwQbGSwkunk5Wy67kXNAL1ZL1xQhR");
+        let keypair = Keypair::from_base58_string(
+            "2Vzd6oTWU4RtM5UmsSyBH3tAhPSi1sKqMeMC8bF1jzHHLBMRhEWtrfmBV4EmwQbGSwkunk5Wy67kXNAL1ZL1xQhR",
+        );
         assert_eq!(keypair.pubkey(), super::alpenglow::id());
         keypair
     });
@@ -1319,7 +1321,7 @@ pub mod upgrade_bpf_stake_program_to_v5 {
 }
 
 pub mod integer_inflation_rewards {
-    solana_pubkey::declare_id!("iiiiizJfxinmojuyTqKwoHp61ti6RGTkreBhU7SuNGb");
+    solana_pubkey::declare_id!("intsdD7D3LrPd9GAYgSvaUNJZc5ywoRKQfUeQrGCwtU");
 }
 
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
@@ -2359,13 +2361,12 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
             "SIMD-0449: Direct Account Pointers in Program Input",
         ),
         (
-<<<<<<< HEAD
             upgrade_bpf_stake_program_to_v5::id(),
             "SIMD-0490: Upgrade BPF Stake Program to v5.0.0",
-=======
+        ),
+        (
             integer_inflation_rewards::id(),
             "use integer math for inflation reward calculations",
->>>>>>> 515270e76e (feat: integer math for inflation calculations)
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1315,6 +1315,11 @@ pub mod upgrade_bpf_stake_program_to_v5 {
     pub mod buffer {
         solana_pubkey::declare_id!("4EBQBjw1kqF1dqUBb6fc5Ji4tCEQgNf9ESGGX3smwXwh");
     }
+
+}
+
+pub mod integer_inflation_rewards {
+    solana_pubkey::declare_id!("iiiiizJfxinmojuyTqKwoHp61ti6RGTkreBhU7SuNGb");
 }
 
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
@@ -2354,8 +2359,13 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
             "SIMD-0449: Direct Account Pointers in Program Input",
         ),
         (
+<<<<<<< HEAD
             upgrade_bpf_stake_program_to_v5::id(),
             "SIMD-0490: Upgrade BPF Stake Program to v5.0.0",
+=======
+            integer_inflation_rewards::id(),
+            "use integer math for inflation reward calculations",
+>>>>>>> 515270e76e (feat: integer math for inflation calculations)
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1317,7 +1317,6 @@ pub mod upgrade_bpf_stake_program_to_v5 {
     pub mod buffer {
         solana_pubkey::declare_id!("4EBQBjw1kqF1dqUBb6fc5Ji4tCEQgNf9ESGGX3smwXwh");
     }
-
 }
 
 pub mod integer_inflation_rewards {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -191,6 +191,7 @@ criterion = { workspace = true }
 libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }
 proptest = { workspace = true }
+rand_chacha = { workspace = true }
 solana-accounts-db = { path = "../accounts-db", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-builtins = { path = "../builtins", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-instruction-error = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -48,7 +48,9 @@ use {
             BLSPubkeyToRankMap, DeserializableVersionedEpochStakes, NodeVoteAccounts,
             VersionedEpochStakes,
         },
-        inflation_rewards::points::InflationPointCalculationEvent,
+        inflation_rewards::{
+            integer_inflation::IntegerInflation, points::InflationPointCalculationEvent,
+        },
         installed_scheduler_pool::{BankWithScheduler, InstalledSchedulerRwLock},
         leader_schedule_utils::leader_schedule_from_vote_accounts,
         rent_collector::RentCollector,
@@ -2591,9 +2593,24 @@ impl Bank {
             )
         };
 
-        let epoch_duration_in_years = self.epoch_duration_in_years(epoch);
-        let validator_rewards_lamports =
-            (validator_rate * capitalization as f64 * epoch_duration_in_years) as u64;
+        let validator_rewards_lamports = if self
+            .feature_set
+            .is_active(&feature_set::integer_inflation_rewards::id())
+        {
+            let inflation = self.inflation.read().unwrap();
+            let integer_inflation = IntegerInflation::from(&*inflation);
+            let num_slots = self.get_inflation_num_slots();
+            let slots_in_epoch = self.epoch_schedule().get_slots_in_epoch(epoch);
+
+            integer_inflation.calculate_validator_rewards_lamports(
+                num_slots,
+                slots_in_epoch,
+                capitalization,
+            )
+        } else {
+            let epoch_duration_in_years = self.epoch_duration_in_years(epoch);
+            (validator_rate * capitalization as f64 * epoch_duration_in_years) as u64
+        };
 
         EpochInflationRewards {
             validator_rewards_lamports,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2597,8 +2597,10 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::integer_inflation_rewards::id())
         {
-            let inflation = self.inflation.read().unwrap();
-            let integer_inflation = IntegerInflation::from(&*inflation);
+            let integer_inflation = {
+                let inflation = self.inflation.read().unwrap();
+                IntegerInflation::from(&*inflation)
+            };
             let num_slots = self.get_inflation_num_slots();
             let slots_in_epoch = self.epoch_schedule().get_slots_in_epoch(epoch);
 

--- a/runtime/src/inflation_rewards/integer_inflation.rs
+++ b/runtime/src/inflation_rewards/integer_inflation.rs
@@ -106,10 +106,13 @@ impl IntegerInflation {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use {
-        rand::Rng, rand::SeedableRng, rand_chacha::ChaChaRng,
-        solana_clock::DEFAULT_SLOTS_PER_EPOCH, solana_inflation::Inflation, test_case::test_matrix,
+        super::*,
+        rand::{Rng, SeedableRng},
+        rand_chacha::ChaChaRng,
+        solana_clock::DEFAULT_SLOTS_PER_EPOCH,
+        solana_inflation::Inflation,
+        test_case::test_matrix,
     };
 
     const SLOTS_PER_YEAR: f64 = NANOS_PER_YEAR as f64 / NS_PER_SLOT as f64;

--- a/runtime/src/inflation_rewards/integer_inflation.rs
+++ b/runtime/src/inflation_rewards/integer_inflation.rs
@@ -1,0 +1,180 @@
+//! Fixed-point integer replacement for the f64 inflation reward pipeline.
+use {
+    super::math::{fixed_exp, fixed_ln, fixed_pow, muldiv, SCALE},
+    solana_clock::DEFAULT_MS_PER_SLOT,
+    solana_inflation::Inflation,
+};
+
+// 365.242199 days in nanoseconds.
+pub const NANOS_PER_YEAR: u128 = 31_556_925_993_600_000;
+pub const NS_PER_SLOT: u128 = DEFAULT_MS_PER_SLOT as u128 * 1_000_000;
+
+#[derive(Debug, Clone)]
+pub(crate) struct IntegerInflation {
+    initial_scaled: u128,
+    terminal_scaled: u128,
+    decay_base_scaled: u128,
+    foundation_scaled: u128,
+    foundation_term_nanos: u128,
+}
+
+impl From<&Inflation> for IntegerInflation {
+    fn from(infl: &Inflation) -> Self {
+        let to_scaled = |v: f64| (v * SCALE as f64).round() as u128;
+        Self {
+            initial_scaled: to_scaled(infl.initial),
+            terminal_scaled: to_scaled(infl.terminal),
+            decay_base_scaled: to_scaled(1.0 - infl.taper),
+            foundation_scaled: to_scaled(infl.foundation),
+            foundation_term_nanos: (infl.foundation_term * NANOS_PER_YEAR as f64).round() as u128,
+        }
+    }
+}
+
+impl IntegerInflation {
+    /// max(terminal, initial * (1 - taper) ^ year), scaled.
+    pub(crate) fn total_inflation_scaled(&self, num_slots: u64) -> u128 {
+        let year_nanos = num_slots as u128 * NS_PER_SLOT;
+        let tapered = self.initial_scaled * self.compute_decay(year_nanos) / SCALE;
+        tapered.max(self.terminal_scaled)
+    }
+
+    pub(crate) fn validator_inflation_scaled(&self, num_slots: u64) -> u128 {
+        let total = self.total_inflation_scaled(num_slots);
+        total - self.foundation_from_total(num_slots, total)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn foundation_inflation_scaled(&self, num_slots: u64) -> u128 {
+        let total = self.total_inflation_scaled(num_slots);
+        self.foundation_from_total(num_slots, total)
+    }
+
+    fn foundation_from_total(&self, num_slots: u64, total_scaled: u128) -> u128 {
+        let year_nanos = num_slots as u128 * NS_PER_SLOT;
+        if year_nanos < self.foundation_term_nanos {
+            total_scaled * self.foundation_scaled / SCALE
+        } else {
+            0
+        }
+    }
+
+    /// Validator rewards in lamports for a single epoch.
+    pub(crate) fn calculate_validator_rewards_lamports(
+        &self,
+        num_slots: u64,
+        slots_in_epoch: u64,
+        capitalization: u64,
+    ) -> u64 {
+        let validator_scaled = self.validator_inflation_scaled(num_slots);
+        if validator_scaled == 0 || capitalization == 0 || slots_in_epoch == 0 {
+            return 0;
+        }
+
+        // reward = (validator_scaled / SCALE) * cap * (slots_in_epoch * ns_per_slot / NANOS_PER_YEAR)
+        // Split into two muldivs to stay within u128.
+        let epoch_nanos = slots_in_epoch as u128 * NS_PER_SLOT;
+        let rate_cap = muldiv(validator_scaled, capitalization as u128, SCALE);
+        muldiv(rate_cap, epoch_nanos, NANOS_PER_YEAR) as u64
+    }
+
+    // (1 - taper)^year as a SCALE-d value, decomposed into integer + fractional year.
+    fn compute_decay(&self, year_nanos: u128) -> u128 {
+        if year_nanos == 0 || self.decay_base_scaled == SCALE {
+            return SCALE; // no elapsed time, or taper == 0
+        }
+        if self.decay_base_scaled == 0 {
+            return 0; // taper == 1
+        }
+
+        let full_years = year_nanos / NANOS_PER_YEAR;
+        let remainder = year_nanos % NANOS_PER_YEAR;
+
+        let int_part = fixed_pow(self.decay_base_scaled, full_years);
+        if remainder == 0 {
+            return int_part;
+        }
+
+        // base^frac = exp(frac * ln(base))
+        let ln_base = fixed_ln(self.decay_base_scaled);
+        let arg = remainder as i128 * ln_base / NANOS_PER_YEAR as i128;
+        let frac_part = fixed_exp(arg);
+
+        int_part * frac_part / SCALE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use {
+        rand::Rng, rand::SeedableRng, rand_chacha::ChaChaRng,
+        solana_clock::DEFAULT_SLOTS_PER_EPOCH, solana_inflation::Inflation, test_case::test_matrix,
+    };
+
+    const SLOTS_PER_YEAR: f64 = NANOS_PER_YEAR as f64 / NS_PER_SLOT as f64;
+
+    fn to_scaled(v: f64) -> u128 {
+        (v * SCALE as f64).round() as u128
+    }
+
+    fn abs_diff(a: u128, b: u128) -> u128 {
+        a.max(b).saturating_sub(a.min(b))
+    }
+
+    #[test]
+    fn fuzz_rates_vs_f64() {
+        let infl = Inflation::default();
+        let ii = IntegerInflation::from(&infl);
+        let mut rng = ChaChaRng::seed_from_u64(0);
+
+        for _ in 0..1_000_000 {
+            // Compare all three rate functions against the f64 originals at random
+            // points in time. All functions must agree to 1 part in 10^15.
+            let approx_year: f64 = rng.random_range(0.0..100.0);
+            let ns = (approx_year * SLOTS_PER_YEAR).round() as u64;
+            let year = ns as f64 / SLOTS_PER_YEAR;
+
+            let expected = to_scaled(infl.total(year));
+            let actual = ii.total_inflation_scaled(ns);
+            assert!(abs_diff(expected, actual) < 1_000);
+
+            let expected = to_scaled(infl.validator(year));
+            let actual = ii.validator_inflation_scaled(ns);
+            assert!(abs_diff(expected, actual) < 1_000);
+
+            let expected = to_scaled(infl.foundation(year));
+            let actual = ii.foundation_inflation_scaled(ns);
+            assert!(abs_diff(expected, actual) < 1_000);
+        }
+    }
+
+    #[test_matrix(
+        [Inflation::default(), Inflation::pico()]
+    )]
+    fn test_rewards_match(infl: Inflation) {
+        let ii = IntegerInflation::from(&infl);
+        let cap = 500_000_000_000_000_000u64; // ~500M SOL
+        let dur = DEFAULT_SLOTS_PER_EPOCH as f64 / SLOTS_PER_YEAR;
+
+        for epoch in 0..1_000 {
+            let ns = epoch * DEFAULT_SLOTS_PER_EPOCH;
+            let actual = ii.calculate_validator_rewards_lamports(ns, DEFAULT_SLOTS_PER_EPOCH, cap);
+            let year = ns as f64 / SLOTS_PER_YEAR;
+            let expected = (infl.validator(year) * cap as f64 * dur) as u64;
+            assert!(abs_diff(expected as u128, actual as u128) <= 1);
+        }
+    }
+
+    #[test]
+    fn test_full_inflation() {
+        let ii = IntegerInflation::from(&Inflation::full());
+        for epoch in (0..500).step_by(50) {
+            let ns = epoch * DEFAULT_SLOTS_PER_EPOCH;
+            assert_eq!(
+                ii.validator_inflation_scaled(ns),
+                ii.total_inflation_scaled(ns)
+            );
+        }
+    }
+}

--- a/runtime/src/inflation_rewards/integer_inflation.rs
+++ b/runtime/src/inflation_rewards/integer_inflation.rs
@@ -31,7 +31,10 @@ impl From<&Inflation> for IntegerInflation {
 }
 
 fn f64_to_scaled(v: f64) -> ScaledU60 {
-    assert!(v >= 0.0 && v.is_finite(), "f64_to_scaled: {v} is negative, NaN, or infinite");
+    assert!(
+        v >= 0.0 && v.is_finite(),
+        "f64_to_scaled: {v} is negative, NaN, or infinite"
+    );
     if v == 0.0 {
         return 0;
     }

--- a/runtime/src/inflation_rewards/integer_inflation.rs
+++ b/runtime/src/inflation_rewards/integer_inflation.rs
@@ -1,6 +1,6 @@
 //! Fixed-point integer replacement for the f64 inflation reward pipeline.
 use {
-    super::math::{fixed_exp, fixed_ln, fixed_pow, muldiv, SCALE},
+    super::math::{SCALE, SCALE_SHIFT, fixed_exp, fixed_ln, fixed_pow, muldiv},
     solana_clock::DEFAULT_MS_PER_SLOT,
     solana_inflation::Inflation,
 };
@@ -20,13 +20,34 @@ pub(crate) struct IntegerInflation {
 
 impl From<&Inflation> for IntegerInflation {
     fn from(infl: &Inflation) -> Self {
-        let to_scaled = |v: f64| (v * SCALE as f64).round() as u128;
         Self {
-            initial_scaled: to_scaled(infl.initial),
-            terminal_scaled: to_scaled(infl.terminal),
-            decay_base_scaled: to_scaled(1.0 - infl.taper),
-            foundation_scaled: to_scaled(infl.foundation),
+            initial_scaled: f64_to_scaled(infl.initial),
+            terminal_scaled: f64_to_scaled(infl.terminal),
+            decay_base_scaled: f64_to_scaled(1.0 - infl.taper),
+            foundation_scaled: f64_to_scaled(infl.foundation),
             foundation_term_nanos: (infl.foundation_term * NANOS_PER_YEAR as f64).round() as u128,
+        }
+    }
+}
+
+fn f64_to_scaled(v: f64) -> u128 {
+    debug_assert!(v >= 0.0 && v.is_finite());
+    if v == 0.0 {
+        return 0;
+    }
+    let bits = v.to_bits();
+    let mantissa = (bits & 0x000F_FFFF_FFFF_FFFF) | 0x0010_0000_0000_0000; // 53-bit with implicit leading 1
+    let biased_exp = ((bits >> 52) & 0x7FF) as i32;
+    // v = mantissa * 2^(biased_exp - 1023 - 52)
+    // v * SCALE = mantissa * 2^(biased_exp - 1023 - 52 + SCALE_SHIFT)
+    let shift = biased_exp - 1023 - 52 + SCALE_SHIFT as i32;
+
+    match shift >= 0 {
+        true => (mantissa as u128) << (shift as u32),
+        false => {
+            // Round to nearest.
+            let right = (-shift) as u32;
+            ((mantissa as u128) + (1u128 << (right - 1))) >> right
         }
     }
 }
@@ -123,6 +144,24 @@ mod tests {
 
     fn abs_diff(a: u128, b: u128) -> u128 {
         a.max(b).saturating_sub(a.min(b))
+    }
+
+    #[test]
+    fn test_f64_to_scaled() {
+        assert_eq!(f64_to_scaled(0.0), 0);
+        assert_eq!(f64_to_scaled(1.0), SCALE);
+
+        // powers of two should be exact
+        assert_eq!(f64_to_scaled(0.5), SCALE / 2);
+        assert_eq!(f64_to_scaled(0.25), SCALE / 4);
+        assert_eq!(f64_to_scaled(0.125), SCALE / 8);
+
+        // check against naive f64 multiply (works because 2^60 is exact in f64)
+        // and round-trip back to f64
+        for v in [0.08, 0.015, 0.85, 0.05, 7.0] {
+            assert_eq!(f64_to_scaled(v), (v * SCALE as f64).round() as u128);
+            assert_eq!(f64_to_scaled(v) as f64 / SCALE as f64, v);
+        }
     }
 
     #[test]

--- a/runtime/src/inflation_rewards/integer_inflation.rs
+++ b/runtime/src/inflation_rewards/integer_inflation.rs
@@ -31,7 +31,7 @@ impl From<&Inflation> for IntegerInflation {
 }
 
 fn f64_to_scaled(v: f64) -> ScaledU60 {
-    debug_assert!(v >= 0.0 && v.is_finite());
+    assert!(v >= 0.0 && v.is_finite(), "f64_to_scaled: {v} is negative, NaN, or infinite");
     if v == 0.0 {
         return 0;
     }
@@ -43,10 +43,19 @@ fn f64_to_scaled(v: f64) -> ScaledU60 {
     let shift = biased_exp - 1023 - 52 + SCALE_SHIFT as i32;
 
     match shift >= 0 {
-        true => (mantissa as u128) << (shift as u32),
+        true => {
+            let shift = shift as u32;
+            if shift > 128 - 53 {
+                return u128::MAX;
+            }
+            (mantissa as u128) << shift
+        }
         false => {
-            // Round to nearest.
             let right = (-shift) as u32;
+            if right >= 128 {
+                return 0;
+            }
+            // Round to nearest.
             ((mantissa as u128) + (1u128 << (right - 1))) >> right
         }
     }
@@ -162,6 +171,18 @@ mod tests {
             assert_eq!(f64_to_scaled(v), (v * SCALE as f64).round() as u128);
             assert_eq!(f64_to_scaled(v) as f64 / SCALE as f64, v);
         }
+    }
+
+    #[test]
+    fn test_f64_to_scaled_saturates() {
+        assert_eq!(f64_to_scaled(4.0e21), u128::MAX);
+        assert_eq!(f64_to_scaled(1.0e-30), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "f64_to_scaled")]
+    fn test_f64_to_scaled_rejects_negative() {
+        f64_to_scaled(-1.0);
     }
 
     #[test]

--- a/runtime/src/inflation_rewards/integer_inflation.rs
+++ b/runtime/src/inflation_rewards/integer_inflation.rs
@@ -199,7 +199,8 @@ mod tests {
         let cap = 500_000_000_000_000_000u64; // ~500M SOL
         let dur = DEFAULT_SLOTS_PER_EPOCH as f64 / SLOTS_PER_YEAR;
 
-        for epoch in 0..1_000 {
+        // 100k epochs is ~210 years. Fingers crossed that this test still matters then.
+        for epoch in 0..100_000 {
             let ns = epoch * DEFAULT_SLOTS_PER_EPOCH;
             let actual = ii.calculate_validator_rewards_lamports(ns, DEFAULT_SLOTS_PER_EPOCH, cap);
             let year = ns as f64 / SLOTS_PER_YEAR;

--- a/runtime/src/inflation_rewards/integer_inflation.rs
+++ b/runtime/src/inflation_rewards/integer_inflation.rs
@@ -1,6 +1,6 @@
 //! Fixed-point integer replacement for the f64 inflation reward pipeline.
 use {
-    super::math::{SCALE, SCALE_SHIFT, fixed_exp, fixed_ln, fixed_pow, muldiv},
+    super::math::{SCALE, SCALE_SHIFT, ScaledU60, fixed_exp, fixed_ln, fixed_pow, muldiv},
     solana_clock::DEFAULT_MS_PER_SLOT,
     solana_inflation::Inflation,
 };
@@ -11,10 +11,10 @@ pub const NS_PER_SLOT: u128 = DEFAULT_MS_PER_SLOT as u128 * 1_000_000;
 
 #[derive(Debug, Clone)]
 pub(crate) struct IntegerInflation {
-    initial_scaled: u128,
-    terminal_scaled: u128,
-    decay_base_scaled: u128,
-    foundation_scaled: u128,
+    initial_scaled: ScaledU60,
+    terminal_scaled: ScaledU60,
+    decay_base_scaled: ScaledU60,
+    foundation_scaled: ScaledU60,
     foundation_term_nanos: u128,
 }
 
@@ -30,7 +30,7 @@ impl From<&Inflation> for IntegerInflation {
     }
 }
 
-fn f64_to_scaled(v: f64) -> u128 {
+fn f64_to_scaled(v: f64) -> ScaledU60 {
     debug_assert!(v >= 0.0 && v.is_finite());
     if v == 0.0 {
         return 0;
@@ -54,24 +54,24 @@ fn f64_to_scaled(v: f64) -> u128 {
 
 impl IntegerInflation {
     /// max(terminal, initial * (1 - taper) ^ year), scaled.
-    pub(crate) fn total_inflation_scaled(&self, num_slots: u64) -> u128 {
+    pub(crate) fn total_inflation_scaled(&self, num_slots: u64) -> ScaledU60 {
         let year_nanos = num_slots as u128 * NS_PER_SLOT;
         let tapered = self.initial_scaled * self.compute_decay(year_nanos) / SCALE;
         tapered.max(self.terminal_scaled)
     }
 
-    pub(crate) fn validator_inflation_scaled(&self, num_slots: u64) -> u128 {
+    pub(crate) fn validator_inflation_scaled(&self, num_slots: u64) -> ScaledU60 {
         let total = self.total_inflation_scaled(num_slots);
         total - self.foundation_from_total(num_slots, total)
     }
 
     #[cfg(test)]
-    pub(crate) fn foundation_inflation_scaled(&self, num_slots: u64) -> u128 {
+    pub(crate) fn foundation_inflation_scaled(&self, num_slots: u64) -> ScaledU60 {
         let total = self.total_inflation_scaled(num_slots);
         self.foundation_from_total(num_slots, total)
     }
 
-    fn foundation_from_total(&self, num_slots: u64, total_scaled: u128) -> u128 {
+    fn foundation_from_total(&self, num_slots: u64, total_scaled: ScaledU60) -> ScaledU60 {
         let year_nanos = num_slots as u128 * NS_PER_SLOT;
         if year_nanos < self.foundation_term_nanos {
             total_scaled * self.foundation_scaled / SCALE
@@ -100,7 +100,7 @@ impl IntegerInflation {
     }
 
     // (1 - taper)^year as a SCALE-d value, decomposed into integer + fractional year.
-    fn compute_decay(&self, year_nanos: u128) -> u128 {
+    fn compute_decay(&self, year_nanos: u128) -> ScaledU60 {
         if year_nanos == 0 || self.decay_base_scaled == SCALE {
             return SCALE; // no elapsed time, or taper == 0
         }

--- a/runtime/src/inflation_rewards/math.rs
+++ b/runtime/src/inflation_rewards/math.rs
@@ -38,7 +38,7 @@ pub(super) fn fixed_pow(base_scaled: u128, exp: u128) -> u128 {
 
 /// ln(x) via the atanh trick.
 pub(super) fn fixed_ln(x_scaled: u128) -> i128 {
-    debug_assert!(x_scaled >= SCALE / 2 && x_scaled <= SCALE);
+    debug_assert!((SCALE / 2..=SCALE).contains(&x_scaled));
 
     let x = x_scaled as i128;
     let s = SCALE as i128;

--- a/runtime/src/inflation_rewards/math.rs
+++ b/runtime/src/inflation_rewards/math.rs
@@ -1,0 +1,189 @@
+//! Fixed-point helpers for integer inflation.
+pub(super) const SCALE: u128 = 1_000_000_000_000_000_000;
+
+// a * b / d, handling u128 overflow via the identity:
+//
+//   a*b/d = (a/d)*b + (a%d)*b/d
+//
+// Result must fit within u128, or else this isn't reliable.
+pub(super) fn muldiv(a: u128, b: u128, d: u128) -> u128 {
+    match a.checked_mul(b) {
+        Some(product) => product / d,
+        None => {
+            let (a, b) = if a >= d { (a, b) } else { (b, a) };
+            (a / d) * b + muldiv(a % d, b, d)
+        }
+    }
+}
+
+/// base ** exp via repeated squaring.
+pub(super) fn fixed_pow(base_scaled: u128, exp: u128) -> u128 {
+    if exp == 0 {
+        return SCALE;
+    }
+    let mut result = SCALE;
+    let mut base = base_scaled;
+    let mut e = exp;
+    while e > 0 {
+        if e & 1 == 1 {
+            result = result * base / SCALE;
+        }
+        e >>= 1;
+        if e > 0 {
+            base = base * base / SCALE;
+        }
+    }
+    result
+}
+
+/// ln(x) via the atanh trick.
+pub(super) fn fixed_ln(x_scaled: u128) -> i128 {
+    debug_assert!(x_scaled >= SCALE / 2 && x_scaled <= SCALE);
+
+    let x = x_scaled as i128;
+    let s = SCALE as i128;
+    let z = (x - s) * s / (x + s);
+    let z_sq = z * z / s;
+
+    let mut sum = z;
+    let mut power = z;
+
+    for k in 1..=25u64 {
+        power = power * z_sq / s;
+        let term = power / (2 * k + 1) as i128;
+        if term == 0 {
+            break;
+        }
+        sum += term;
+    }
+    2 * sum
+}
+
+/// exp(x) via Taylor series.
+pub(super) fn fixed_exp(x_scaled: i128) -> u128 {
+    let s = SCALE as i128;
+    let mut sum = s;
+    let mut term = s;
+    for k in 1..=35u64 {
+        term = term * x_scaled / (k as i128 * s);
+        if term == 0 {
+            break;
+        }
+        sum += term;
+    }
+    sum.max(0) as u128
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::inflation_rewards::integer_inflation::NANOS_PER_YEAR,
+        rand::{Rng, SeedableRng},
+        rand_chacha::ChaChaRng,
+        solana_clock::{DEFAULT_MS_PER_SLOT, DEFAULT_SLOTS_PER_EPOCH},
+    };
+
+    fn to_scaled(v: f64) -> u128 {
+        (v * SCALE as f64).round() as u128
+    }
+
+    fn abs_diff(a: u128, b: u128) -> u128 {
+        (a as i128 - b as i128).unsigned_abs()
+    }
+
+    #[test]
+    fn test_agave_values() {
+        // decay_base = 1.0 - 0.15, where taper = 0.15
+        let decay_base = 0.85;
+        let base_scaled = to_scaled(decay_base);
+
+        for year in 0..=200u128 {
+            let actual = fixed_pow(base_scaled, year);
+            let expected = to_scaled(decay_base.powi(year as i32));
+            let err = abs_diff(actual, expected);
+            assert!(err < 1_000 || err * 1_000_000_000 < expected.max(1));
+        }
+
+        let actual = fixed_ln(base_scaled);
+        let expected = (decay_base.ln() * SCALE as f64).round() as i128;
+        assert!((actual - expected).unsigned_abs() < 100);
+
+        for tenths in 0..=10u64 {
+            let arg = (tenths as f64 / 10.0) * decay_base.ln();
+            let actual = fixed_exp((arg * SCALE as f64).round() as i128);
+            let expected = to_scaled(arg.exp());
+            assert!(abs_diff(actual, expected) < 1_000);
+        }
+
+        // muldiv with the exact shapes from calculate_validator_rewards_lamports
+        let rate = to_scaled(0.076);
+        let cap: u128 = 500_000_000_000_000_000;
+        let epoch_nanos: u128 = (1_000_000 * DEFAULT_MS_PER_SLOT * DEFAULT_SLOTS_PER_EPOCH).into();
+
+        let rate_cap = muldiv(rate, cap, SCALE);
+        assert_eq!(rate_cap, rate * cap / SCALE);
+
+        let actual = muldiv(rate_cap, epoch_nanos, NANOS_PER_YEAR);
+        let expected = (0.076 * cap as f64 * epoch_nanos as f64 / NANOS_PER_YEAR as f64) as u128;
+        assert!(abs_diff(actual, expected) <= 1);
+    }
+
+    #[test]
+    fn fuzz_muldiv() {
+        let mut rng = ChaChaRng::seed_from_u64(0);
+        // a * b fits in u128
+        for _ in 0..1_000_000 {
+            let a: u128 = rng.random_range(1..=u64::MAX as u128);
+            let b: u128 = rng.random_range(1..=u64::MAX as u128);
+            let d: u128 = rng.random_range(1..=u64::MAX as u128);
+            assert_eq!(muldiv(a, b, d), a * b / d);
+        }
+
+        // Force the overflow path. d >= b keeps the quotient in range.
+        for _ in 0..1_000_000 {
+            let a: u128 = rng.random_range(u64::MAX as u128..=u128::MAX / 2);
+            let b: u128 = rng.random_range(2..=1000);
+            let d: u128 = rng.random_range(b..=b * 1000);
+            let _ = muldiv(a, b, d);
+        }
+    }
+
+    #[test]
+    fn fuzz_fixed_pow() {
+        let mut rng = ChaChaRng::seed_from_u64(0);
+        for _ in 0..1_000_000 {
+            let base_f64: f64 = rng.random_range(0.5..=1.0);
+            let base_scaled = (base_f64 * SCALE as f64).round() as u128;
+            let exp: u128 = rng.random_range(0..=200);
+            let actual = fixed_pow(base_scaled, exp);
+            let expected = (base_f64.powf(exp as f64) * SCALE as f64).round() as u128;
+            let err = abs_diff(actual, expected);
+            assert!(err < 1_000 || err * 1_000_000_000 < expected.max(1));
+        }
+    }
+
+    #[test]
+    fn fuzz_fixed_ln() {
+        let mut rng = ChaChaRng::seed_from_u64(0);
+        for _ in 0..1_000_000 {
+            let x: f64 = rng.random_range(0.5..=1.0);
+            let actual = fixed_ln((x * SCALE as f64).round() as u128);
+            let expected = (x.ln() * SCALE as f64).round() as i128;
+            let err = (actual - expected).unsigned_abs();
+            assert!(err * 1_000_000_000 < expected.unsigned_abs().max(1));
+        }
+    }
+
+    #[test]
+    fn fuzz_fixed_exp() {
+        let mut rng = ChaChaRng::seed_from_u64(0);
+        for _ in 0..1_000_000 {
+            let x: f64 = rng.random_range(-2.0..2.0);
+            let actual = fixed_exp((x * SCALE as f64).round() as i128);
+            let expected = (x.exp() * SCALE as f64).round() as u128;
+            let err = abs_diff(actual, expected);
+            assert!(err * 1_000_000_000 < expected.max(1));
+        }
+    }
+}

--- a/runtime/src/inflation_rewards/math.rs
+++ b/runtime/src/inflation_rewards/math.rs
@@ -148,7 +148,11 @@ mod tests {
             let a: u128 = rng.random_range(1..=u64::MAX as u128);
             let b: u128 = rng.random_range(1..=u64::MAX as u128);
             let d: u128 = rng.random_range(1..=u64::MAX as u128);
-            assert_eq!(muldiv(a, b, d), a * b / d);
+            assert_eq!(
+                muldiv(a, b, d),
+                a * b / d,
+                "muldiv({a}, {b}, {d}) result is wrong"
+            );
         }
 
         // Force the overflow path. d >= b keeps the quotient in range.

--- a/runtime/src/inflation_rewards/math.rs
+++ b/runtime/src/inflation_rewards/math.rs
@@ -1,6 +1,12 @@
 //! Fixed-point helpers for integer inflation.
+
+/// A u128 whose value represents a real number multiplied by 2^60.
+pub(super) type ScaledU60 = u128;
+/// Signed variant, used for logarithm results and exp inputs.
+pub(super) type ScaledI60 = i128;
+
 pub(super) const SCALE_SHIFT: u32 = 60;
-pub(super) const SCALE: u128 = 1u128 << SCALE_SHIFT;
+pub(super) const SCALE: ScaledU60 = 1u128 << SCALE_SHIFT;
 
 // a * b / d, handling u128 overflow via the identity:
 //
@@ -18,7 +24,7 @@ pub(super) fn muldiv(a: u128, b: u128, d: u128) -> u128 {
 }
 
 /// base ** exp via repeated squaring.
-pub(super) fn fixed_pow(base_scaled: u128, exp: u128) -> u128 {
+pub(super) fn fixed_pow(base_scaled: ScaledU60, exp: u128) -> ScaledU60 {
     if exp == 0 {
         return SCALE;
     }
@@ -42,7 +48,7 @@ pub(super) fn fixed_pow(base_scaled: u128, exp: u128) -> u128 {
 // x is in [0.5, 1.0], so z = (x-1)/(x+1) is in [-1/3, 0].
 // Each term is bounded by |z|^(2k+1) / (2k+1) <= (1/3)^(2k+1).
 // At k=19: (1/3)^39 < 2^{-60}, so the term underflows SCALE. 25 is conservative.
-pub(super) fn fixed_ln(x_scaled: u128) -> i128 {
+pub(super) fn fixed_ln(x_scaled: ScaledU60) -> ScaledI60 {
     debug_assert!((SCALE / 2..=SCALE).contains(&x_scaled));
 
     let x = x_scaled as i128;
@@ -70,7 +76,7 @@ pub(super) fn fixed_ln(x_scaled: u128) -> i128 {
 // where remainder < 1 year and decay_base = 0.85, so in practice |x| < |ln(0.85)| ~ 0.163.
 // The k-th term is bounded by 0.163^k / k!. At k=12 this is < 2^{-60}, so it
 // underflows SCALE. 35 is conservative.
-pub(super) fn fixed_exp(x_scaled: i128) -> u128 {
+pub(super) fn fixed_exp(x_scaled: ScaledI60) -> ScaledU60 {
     debug_assert!(x_scaled.unsigned_abs() < SCALE * 2);
     let s = SCALE as i128;
     let mut sum = s;

--- a/runtime/src/inflation_rewards/math.rs
+++ b/runtime/src/inflation_rewards/math.rs
@@ -1,5 +1,6 @@
 //! Fixed-point helpers for integer inflation.
-pub(super) const SCALE: u128 = 1_000_000_000_000_000_000;
+pub(super) const SCALE_SHIFT: u32 = 60;
+pub(super) const SCALE: u128 = 1u128 << SCALE_SHIFT;
 
 // a * b / d, handling u128 overflow via the identity:
 //
@@ -36,7 +37,11 @@ pub(super) fn fixed_pow(base_scaled: u128, exp: u128) -> u128 {
     result
 }
 
-/// ln(x) via the atanh trick.
+// ln(x) = 2 * atanh((x-1)/(x+1)), where atanh(z) = z + z^3/3 + z^5/5 + ...
+//
+// x is in [0.5, 1.0], so z = (x-1)/(x+1) is in [-1/3, 0].
+// Each term is bounded by |z|^(2k+1) / (2k+1) <= (1/3)^(2k+1).
+// At k=19: (1/3)^39 < 2^{-60}, so the term underflows SCALE. 25 is conservative.
 pub(super) fn fixed_ln(x_scaled: u128) -> i128 {
     debug_assert!((SCALE / 2..=SCALE).contains(&x_scaled));
 
@@ -59,8 +64,14 @@ pub(super) fn fixed_ln(x_scaled: u128) -> i128 {
     2 * sum
 }
 
-/// exp(x) via Taylor series.
+// exp(x) = 1 + x + x^2/2! + x^3/3! + ..., computed as term_k = term_{k-1} * x / k.
+//
+// Only called from compute_decay with arg = remainder * ln(decay_base) / NANOS_PER_YEAR,
+// where remainder < 1 year and decay_base = 0.85, so in practice |x| < |ln(0.85)| ~ 0.163.
+// The k-th term is bounded by 0.163^k / k!. At k=12 this is < 2^{-60}, so it
+// underflows SCALE. 35 is conservative.
 pub(super) fn fixed_exp(x_scaled: i128) -> u128 {
+    debug_assert!(x_scaled.unsigned_abs() < SCALE * 2);
     let s = SCALE as i128;
     let mut sum = s;
     let mut term = s;

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -14,6 +14,8 @@ use {
     },
 };
 
+pub(crate) mod integer_inflation;
+mod math;
 pub mod points;
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
#### Problem
Inflation rewards are computed using `f64` arithmetic, which is non-deterministic across platforms.

#### Summary of Changes
We add in fixed-point math for rewards calculations, gated behind the `integer_inflation_rewards` feature. There are some cool math tricks here for those who care.

In rewards calculation, the integer and `f64` paths agree to within 1 lamport across all tested scenarios.