### PR TITLE
breaking(scheduler-bindings): remove vote flags

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -757,15 +757,8 @@ mod external {
             );
             assert!(workers.len() <= BankingStage::max_num_workers().get());
 
-            // Potentially spawn vote worker.
-            let mut threads = Vec::with_capacity(workers.len() + 3);
-            let tpu_to_pack_receivers = BankingPacketReceivers {
-                non_vote_receiver: self.non_vote_receiver.clone(),
-                gossip_vote_receiver: Some(self.gossip_vote_receiver.clone()),
-                tpu_vote_receiver: Some(self.tpu_vote_receiver.clone()),
-            };
-
             // Spawn the external consumer workers.
+            let mut threads = Vec::with_capacity(workers.len() + 2);
             let mut worker_metrics = Vec::with_capacity(workers.len());
             for (
                 index,
@@ -806,6 +799,11 @@ mod external {
             }
 
             // Spawn tpu to pack.
+            let tpu_to_pack_receivers = BankingPacketReceivers {
+                non_vote_receiver: self.non_vote_receiver.clone(),
+                gossip_vote_receiver: Some(self.gossip_vote_receiver.clone()),
+                tpu_vote_receiver: Some(self.tpu_vote_receiver.clone()),
+            };
             threads.push(tpu_to_pack::spawn(
                 self.worker_exit_signal.clone(),
                 self.banking_shutdown_signal.clone(),

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -732,10 +732,7 @@ mod external {
     use {
         super::*,
         crate::banking_stage::consume_worker::external::ExternalWorker,
-        agave_scheduling_utils::handshake::{
-            logon_flags,
-            server::{AgaveSession, AgaveWorkerSession},
-        },
+        agave_scheduling_utils::handshake::server::{AgaveSession, AgaveWorkerSession},
         tpu_to_pack::BankingPacketReceivers,
     };
 
@@ -743,7 +740,7 @@ mod external {
         pub(super) fn spawn_external(
             &self,
             AgaveSession {
-                flags,
+                flags: _,
                 tpu_to_pack,
                 progress_tracker,
                 workers,
@@ -762,20 +759,10 @@ mod external {
 
             // Potentially spawn vote worker.
             let mut threads = Vec::with_capacity(workers.len() + 3);
-            let tpu_to_pack_receivers = if flags & logon_flags::REROUTE_VOTES != 0 {
-                BankingPacketReceivers {
-                    non_vote_receiver: self.non_vote_receiver.clone(),
-                    gossip_vote_receiver: Some(self.gossip_vote_receiver.clone()),
-                    tpu_vote_receiver: Some(self.tpu_vote_receiver.clone()),
-                }
-            } else {
-                threads.push(self.spawn_vote_worker());
-
-                BankingPacketReceivers {
-                    non_vote_receiver: self.non_vote_receiver.clone(),
-                    gossip_vote_receiver: None,
-                    tpu_vote_receiver: None,
-                }
+            let tpu_to_pack_receivers = BankingPacketReceivers {
+                non_vote_receiver: self.non_vote_receiver.clone(),
+                gossip_vote_receiver: Some(self.gossip_vote_receiver.clone()),
+                tpu_vote_receiver: Some(self.tpu_vote_receiver.clone()),
             };
 
             // Spawn the external consumer workers.

--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -48,7 +48,4 @@ impl ClientLogon {
     }
 }
 
-pub mod logon_flags {
-    /// Send the votes to the external scheduler instead of processing them internally.
-    pub const REROUTE_VOTES: u16 = 1 << 0;
-}
+pub mod logon_flags {}


### PR DESCRIPTION
#### Problem

- The vote worker will be removed soon, external schedulers should be ahead of this curve and required to handle vote transactions now.

#### Summary of Changes

- Remove the reroute votes flag & force votes to external scheduler always.
