### PR TITLE
use -Clinker-plugin-lto=no for macos targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,5 +2,11 @@
 # When building for linux, target the minimal supported CPU
 rustflags = ["-Ctarget-cpu=x86-64-v2"]
 
+[target.aarch64-apple-darwin]
+rustflags = ["-Clinker-plugin-lto=no"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-Clinker-plugin-lto=no"]
+
 [alias]
 xtask = "run --manifest-path ci/xtask/Cargo.toml --bin xtask --"


### PR DESCRIPTION
#### Problem

got this

```
... (Producer: 'LLVM21.1.3-rust-1.92.0-stable' Reader: 'LLVM APPLE_1_1600.0.26.6_0')', using libLTO version 'LLVM version 16.0.0' in ...
```

#### Summary of Changes

disable `linker-plugin-lto` for macos targets