### PR TITLE
SIMD-0459 and SIMD-0460

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -105,8 +105,10 @@ impl FeatureSet {
         SVMFeatureSet {
             move_precompile_verification_to_svm: self
                 .is_active(&move_precompile_verification_to_svm::id()),
-            stricter_abi_and_runtime_constraints: self
-                .is_active(&stricter_abi_and_runtime_constraints::id()),
+            syscall_parameter_address_restrictions: self
+                .is_active(&syscall_parameter_address_restrictions::id()),
+            virtual_address_space_adjustments: self
+                .is_active(&virtual_address_space_adjustments::id()),
             account_data_direct_mapping: self.is_active(&account_data_direct_mapping::id()),
             enable_bpf_loader_set_authority_checked_ix: self
                 .is_active(&enable_bpf_loader_set_authority_checked_ix::id()),
@@ -768,12 +770,16 @@ pub mod apply_cost_tracker_during_replay {
     solana_pubkey::declare_id!("2ry7ygxiYURULZCrypHhveanvP5tzZ4toRwVp89oCNSj");
 }
 
-pub mod stricter_abi_and_runtime_constraints {
-    solana_pubkey::declare_id!("StricterAbiAndRuntimeConstraints11111111111");
+pub mod syscall_parameter_address_restrictions {
+    solana_pubkey::declare_id!("EDGMC5kxFxGk4ixsNkGt8bW7QL5hDMXnbwaZvYMwNfzF");
+}
+
+pub mod virtual_address_space_adjustments {
+    solana_pubkey::declare_id!("7VgiehxNxu53KdxgLspGQY8myE6f7UokaWa4jsGcaSz");
 }
 
 pub mod account_data_direct_mapping {
-    solana_pubkey::declare_id!("AccountDataDirectMapping1111111111111111111");
+    solana_pubkey::declare_id!("CR3dVN2Yoo95Y96kLSTaziWDAQT2MNEpiWh5cqVq2pNE");
 }
 
 pub mod add_set_tx_loaded_accounts_data_size_instruction {
@@ -1877,8 +1883,12 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
             "checked arithmetic in fee validation #31273",
         ),
         (
-            stricter_abi_and_runtime_constraints::id(),
-            "SIMD-0219: Stricter ABI and Runtime Constraints",
+            syscall_parameter_address_restrictions::id(),
+            "SIMD-0459: Syscall Parameter Address Restrictions",
+        ),
+        (
+            virtual_address_space_adjustments::id(),
+            "SIMD-0460: Virtual Address Space Adjustments",
         ),
         (
             account_data_direct_mapping::id(),

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -507,7 +507,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 .transaction_context
                 .get_current_instruction_context()
                 .unwrap(),
-            false, // stricter_abi_and_runtime_constraints
+            false, // virtual_address_space_adjustments
             false, // account_data_direct_mapping
         )
         .unwrap();

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -139,7 +139,7 @@ pub fn invoke_builtin_function(
     let (mut parameter_bytes, _regions, _account_lengths, _instruction_data_offset) =
         serialize_parameters(
             &instruction_context,
-            false, // There is no VM so stricter_abi_and_runtime_constraints can not be implemented here
+            false, // There is no VM so virtual_address_space_adjustments can not be implemented here
             false, // There is no VM so account_data_direct_mapping can not be implemented here
         )?;
 

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -118,7 +118,7 @@ fn bench_serialize_unaligned(c: &mut Criterion) {
         b.iter(|| {
             let _ = serialize_parameters(
                 &instruction_context,
-                true, // stricter_abi_and_runtime_constraints
+                true, // virtual_address_space_adjustments
                 true, // account_data_direct_mapping
             )
             .unwrap();
@@ -135,7 +135,7 @@ fn bench_serialize_unaligned_copy_account_data(c: &mut Criterion) {
         b.iter(|| {
             let _ = serialize_parameters(
                 &instruction_context,
-                false, // stricter_abi_and_runtime_constraints
+                false, // virtual_address_space_adjustments
                 false, // account_data_direct_mapping
             )
             .unwrap();
@@ -153,7 +153,7 @@ fn bench_serialize_aligned(c: &mut Criterion) {
         b.iter(|| {
             let _ = serialize_parameters(
                 &instruction_context,
-                true, // stricter_abi_and_runtime_constraints
+                true, // virtual_address_space_adjustments
                 true, // account_data_direct_mapping
             )
             .unwrap();
@@ -171,7 +171,7 @@ fn bench_serialize_aligned_copy_account_data(c: &mut Criterion) {
         b.iter(|| {
             let _ = serialize_parameters(
                 &instruction_context,
-                false, // stricter_abi_and_runtime_constraints
+                false, // virtual_address_space_adjustments
                 false, // account_data_direct_mapping
             )
             .unwrap();
@@ -189,7 +189,7 @@ fn bench_serialize_unaligned_max_accounts(c: &mut Criterion) {
         b.iter(|| {
             let _ = serialize_parameters(
                 &instruction_context,
-                true, // stricter_abi_and_runtime_constraints
+                true, // virtual_address_space_adjustments
                 true, // account_data_direct_mapping
             )
             .unwrap();
@@ -207,7 +207,7 @@ fn bench_serialize_aligned_max_accounts(c: &mut Criterion) {
         b.iter(|| {
             let _ = serialize_parameters(
                 &instruction_context,
-                true, // stricter_abi_and_runtime_constraints
+                true, // virtual_address_space_adjustments
                 true, // account_data_direct_mapping
             )
             .unwrap();

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -229,9 +229,9 @@ fn bench_create_vm(bencher: &mut Bencher) {
     const BUDGET: u64 = 200_000;
     invoke_context.mock_set_remaining(BUDGET);
 
-    let stricter_abi_and_runtime_constraints = invoke_context
+    let virtual_address_space_adjustments = invoke_context
         .get_feature_set()
-        .stricter_abi_and_runtime_constraints;
+        .virtual_address_space_adjustments;
     let account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
     let raise_cpi_nesting_limit_to_8 = invoke_context
         .get_feature_set()
@@ -254,7 +254,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        stricter_abi_and_runtime_constraints,
+        virtual_address_space_adjustments,
         account_data_direct_mapping,
     )
     .unwrap();
@@ -278,9 +278,9 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     const BUDGET: u64 = 200_000;
     invoke_context.mock_set_remaining(BUDGET);
 
-    let stricter_abi_and_runtime_constraints = invoke_context
+    let virtual_address_space_adjustments = invoke_context
         .get_feature_set()
-        .stricter_abi_and_runtime_constraints;
+        .virtual_address_space_adjustments;
     let account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
 
     // Serialize account data
@@ -289,7 +289,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        stricter_abi_and_runtime_constraints,
+        virtual_address_space_adjustments,
         account_data_direct_mapping,
     )
     .unwrap();

--- a/programs/sbf/rust/deprecated_loader/src/lib.rs
+++ b/programs/sbf/rust/deprecated_loader/src/lib.rs
@@ -74,9 +74,9 @@ fn process_instruction(
             let expected = {
                 let data = &instruction_data[1..];
                 let prev_len = account.data_len();
-                // when stricter_abi_and_runtime_constraints is off, this will accidentally clobber
+                // when virtual_address_space_adjustments is off, this will accidentally clobber
                 // whatever comes after the data slice (owner, executable, rent
-                // epoch etc). When stricter_abi_and_runtime_constraints is on, you get an
+                // epoch etc). When virtual_address_space_adjustments is on, you get an
                 // InvalidRealloc error.
                 account.resize(prev_len + data.len())?;
                 account.data.borrow_mut()[prev_len..].copy_from_slice(data);
@@ -147,7 +147,7 @@ fn process_instruction(
             let realloc_program_id = accounts[REALLOC_PROGRAM_INDEX].key;
             let realloc_program_owner = accounts[REALLOC_PROGRAM_INDEX].owner;
             let invoke_program_id = accounts[INVOKE_PROGRAM_INDEX].key;
-            let stricter_abi_and_runtime_constraints = instruction_data[1];
+            let virtual_address_space_adjustments = instruction_data[1];
             let new_len = usize::from_le_bytes(instruction_data[2..10].try_into().unwrap());
             let prev_len = account.data_len();
             let expected = account.data.borrow()[..new_len].to_vec();
@@ -170,7 +170,7 @@ fn process_instruction(
             // deserialize_parameters_for_abiv0 predates realloc support, and
             // hardcodes the account data length to the original length.
             if !solana_program::bpf_loader_deprecated::check_id(realloc_program_owner)
-                && stricter_abi_and_runtime_constraints == 0
+                && virtual_address_space_adjustments == 0
             {
                 assert_eq!(&*account.data.borrow(), &expected);
                 assert_eq!(
@@ -211,7 +211,7 @@ fn process_instruction(
             };
 
             let mut expected = account.data.borrow().to_vec();
-            let stricter_abi_and_runtime_constraints = instruction_data[1];
+            let virtual_address_space_adjustments = instruction_data[1];
             let new_len = usize::from_le_bytes(instruction_data[2..10].try_into().unwrap());
             expected.extend_from_slice(&instruction_data[10..]);
             let mut instruction_data =
@@ -231,7 +231,7 @@ fn process_instruction(
             .unwrap();
 
             assert_eq!(*account.data.borrow(), &prev_data[..new_len]);
-            if stricter_abi_and_runtime_constraints == 0 {
+            if virtual_address_space_adjustments == 0 {
                 assert_eq!(
                     unsafe {
                         std::slice::from_raw_parts(

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -913,7 +913,7 @@ fn process_instruction<'a>(
                         // TEST_FORBID_LEN_UPDATE_AFTER_OWNERSHIP_CHANGE_MOVING_DATA_POINTER
                         // is that we don't move the data pointer past the
                         // RcBox. This is needed to avoid the "Invalid account
-                        // info pointer" check when stricter_abi_and_runtime_constraints is enabled.
+                        // info pointer" check when syscall_parameter_address_restrictions is enabled.
                         // This also means we don't need to update the
                         // serialized len like we do in the other test.
                         value: RefCell::new(slice::from_raw_parts_mut(
@@ -1068,7 +1068,7 @@ fn process_instruction<'a>(
             let realloc_program_id = accounts[REALLOC_PROGRAM_INDEX].key;
             let realloc_program_owner = accounts[REALLOC_PROGRAM_INDEX].owner;
             let invoke_program_id = accounts[INVOKE_PROGRAM_INDEX].key;
-            let stricter_abi_and_runtime_constraints = instruction_data[1];
+            let virtual_address_space_adjustments = instruction_data[1];
             let new_len = usize::from_le_bytes(instruction_data[2..10].try_into().unwrap());
             let prev_len = account.data_len();
             let expected = account.data.borrow()[..new_len].to_vec();
@@ -1091,7 +1091,7 @@ fn process_instruction<'a>(
             // deserialize_parameters_for_abiv0 predates realloc support, and
             // hardcodes the account data length to the original length.
             if !bpf_loader_deprecated::check_id(realloc_program_owner)
-                && stricter_abi_and_runtime_constraints == 0
+                && virtual_address_space_adjustments == 0
             {
                 assert_eq!(&*account.data.borrow(), &expected);
                 assert_eq!(
@@ -1131,7 +1131,7 @@ fn process_instruction<'a>(
             };
 
             let mut expected = account.data.borrow().to_vec();
-            let stricter_abi_and_runtime_constraints = instruction_data[1];
+            let virtual_address_space_adjustments = instruction_data[1];
             let new_len = usize::from_le_bytes(instruction_data[2..10].try_into().unwrap());
             expected.extend_from_slice(&instruction_data[10..]);
             let mut instruction_data =
@@ -1151,7 +1151,7 @@ fn process_instruction<'a>(
             .unwrap();
 
             assert_eq!(*account.data.borrow(), &prev_data[..new_len]);
-            if stricter_abi_and_runtime_constraints == 0 {
+            if virtual_address_space_adjustments == 0 {
                 assert_eq!(
                     unsafe {
                         slice::from_raw_parts(
@@ -1340,7 +1340,7 @@ fn process_instruction<'a>(
             }
 
             if !invoke_struction.is_empty() {
-                // Invoke another program. With stricter_abi_and_runtime_constraints, before CPI the callee will update the accounts (incl resizing)
+                // Invoke another program. With virtual_address_space_adjustments, before CPI the callee will update the accounts (incl resizing)
                 // so the pointer may change.
                 let invoked_program_id = accounts[INVOKED_PROGRAM_INDEX].key;
 

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -1394,7 +1394,7 @@ fn process_instruction<'a>(
             let stack = unsafe {
                 slice::from_raw_parts_mut(
                     MM_STACK_START as *mut u8,
-                    MAX_CALL_DEPTH * STACK_FRAME_SIZE * 2,
+                    MAX_CALL_DEPTH * STACK_FRAME_SIZE,
                 )
             };
 
@@ -1407,7 +1407,7 @@ fn process_instruction<'a>(
             // When we don't have dynamic stack frames, the stack grows from lower addresses
             // to higher addresses, so we compare accordingly.
             for i in 10..MAX_CALL_DEPTH {
-                let stack = &mut stack[i * STACK_FRAME_SIZE * 2..][..STACK_FRAME_SIZE];
+                let stack = &mut stack[i * STACK_FRAME_SIZE..(i + 1) * STACK_FRAME_SIZE];
                 assert!(stack == &ZEROS[..STACK_FRAME_SIZE], "stack not zeroed");
                 stack.fill(42);
             }

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -2,7 +2,8 @@
 #[derive(Clone, Copy, Default)]
 pub struct SVMFeatureSet {
     pub move_precompile_verification_to_svm: bool,
-    pub stricter_abi_and_runtime_constraints: bool,
+    pub syscall_parameter_address_restrictions: bool,
+    pub virtual_address_space_adjustments: bool,
     pub account_data_direct_mapping: bool,
     pub enable_bpf_loader_set_authority_checked_ix: bool,
     pub enable_loader_v4: bool,
@@ -58,7 +59,8 @@ impl SVMFeatureSet {
     pub fn all_enabled() -> Self {
         Self {
             move_precompile_verification_to_svm: true,
-            stricter_abi_and_runtime_constraints: true,
+            syscall_parameter_address_restrictions: true,
+            virtual_address_space_adjustments: true,
             account_data_direct_mapping: true,
             enable_bpf_loader_set_authority_checked_ix: true,
             enable_loader_v4: true,

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -342,7 +342,7 @@ pub fn create_program_runtime_environment_v1<'a, 'ix_data>(
         sanitize_user_provided_values: true,
         enabled_sbpf_versions: min_sbpf_version..=max_sbpf_version,
         optimize_rodata: false,
-        aligned_memory_mapping: !feature_set.stricter_abi_and_runtime_constraints,
+        aligned_memory_mapping: !feature_set.virtual_address_space_adjustments,
         allow_memory_region_zero: feature_set.enable_sbpf_v3_deployment_and_execution,
         // Warning, do not use `Config::default()` so that configuration here is explicit.
     };

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -332,7 +332,7 @@ pub fn create_program_runtime_environment_v1<'a, 'ix_data>(
         max_call_depth: compute_budget.max_call_depth,
         stack_frame_size: compute_budget.stack_frame_size,
         enable_address_translation: true,
-        enable_stack_frame_gaps: true,
+        enable_stack_frame_gaps: !feature_set.virtual_address_space_adjustments,
         instruction_meter_checkpoint_distance: 10000,
         enable_instruction_meter: true,
         enable_register_tracing: debugging_features,

--- a/syscalls/src/sysvar.rs
+++ b/syscalls/src/sysvar.rs
@@ -21,7 +21,7 @@ fn get_sysvar<T: std::fmt::Debug + SysvarSerialize + Clone>(
     if var_addr >= ebpf::MM_INPUT_START
         && invoke_context
             .get_feature_set()
-            .stricter_abi_and_runtime_constraints
+            .syscall_parameter_address_restrictions
     {
         return Err(SyscallError::InvalidPointer.into());
     }
@@ -214,7 +214,7 @@ declare_builtin_function!(
         if var_addr >= ebpf::MM_INPUT_START
             && invoke_context
                 .get_feature_set()
-                .stricter_abi_and_runtime_constraints
+                .syscall_parameter_address_restrictions
         {
             return Err(SyscallError::InvalidPointer.into());
         }

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -17,7 +17,7 @@ pub const MAX_ACCOUNTS_PER_TRANSACTION: usize = 256;
 pub const MAX_ACCOUNTS_PER_INSTRUCTION: usize = 255;
 pub const MAX_INSTRUCTION_DATA_LEN: usize = 10 * 1024;
 pub const MAX_ACCOUNT_DATA_LEN: u64 = 10 * 1024 * 1024;
-// Note: With stricter_abi_and_runtime_constraints programs can grow accounts
+// Note: With virtual_address_space_adjustments programs can grow accounts
 // faster than they intend to, because the AccessViolationHandler might grow
 // an account up to MAX_ACCOUNT_DATA_GROWTH_PER_INSTRUCTION at once.
 pub const MAX_ACCOUNT_DATA_GROWTH_PER_TRANSACTION: i64 = MAX_ACCOUNT_DATA_LEN as i64 * 2;

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -476,7 +476,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
     /// Returns a new account data write access handler
     pub fn access_violation_handler(
         &self,
-        stricter_abi_and_runtime_constraints: bool,
+        virtual_address_space_adjustments: bool,
         account_data_direct_mapping: bool,
     ) -> AccessViolationHandler {
         let accounts = Rc::clone(&self.accounts);
@@ -537,7 +537,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
                 }
 
                 // Potentially unshare / make the account shared data unique (CoW logic).
-                if stricter_abi_and_runtime_constraints && account_data_direct_mapping {
+                if virtual_address_space_adjustments && account_data_direct_mapping {
                     region.host_addr = account.data_as_mut_slice().as_mut_ptr() as u64;
                     region.writable = true;
                 }


### PR DESCRIPTION
#### Problem
In a recent meeting between the Agave and Firedancer core developers it was
decided that [SIMD-0219](https://github.com/solana-foundation/solana-improvement-documents/pull/219) should be split into two feature gates: [SIMD-0459](https://github.com/solana-foundation/solana-improvement-documents/pull/459) and [SIMD-0460](https://github.com/solana-foundation/solana-improvement-documents/pull/460).

#### Summary of Changes

- Keys `syscall_parameter_address_restrictions`, `virtual_address_space_adjustments` and `account_data_direct_mapping`.
- Splits `stricter_abi_and_runtime_constraints` into `syscall_parameter_address_restrictions` and `virtual_address_space_adjustments`.

Feature Gate Issue: [#116](https://github.com/anza-xyz/feature-gate-tracker/issues/116) [#117](https://github.com/anza-xyz/feature-gate-tracker/issues/117) [#118](https://github.com/anza-xyz/feature-gate-tracker/issues/118)