### PR TITLE
Bump platform tools to v1.53

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -94,6 +94,11 @@ test-stable-sbf)
   _ make -C programs/sbf clean-all
   _ cargo_build_sbf_sanity "v2"
 
+  # SBPFv3 program tests
+  _ make -C programs/sbf clean-all test-v3
+  _ make -C programs/sbf clean-all
+  _ cargo_build_sbf_sanity "v3"
+
   exit 0
   ;;
 test-docs)

--- a/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
@@ -17,7 +17,7 @@ use {
     tar::Archive,
 };
 
-pub(crate) const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.52";
+pub(crate) const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.53";
 pub(crate) const DEFAULT_RUST_VERSION: &str = "1.89.0";
 
 // Common headers used for Github API.

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
@@ -12,7 +12,7 @@ fn platform_tools_path() -> PathBuf {
     PathBuf::from(tools_path)
         .join(".cache")
         .join("solana")
-        .join("v1.52")
+        .join("v1.53")
         .join("platform-tools")
 }
 
@@ -240,7 +240,6 @@ fn test_sbpfv2() {
 
 #[test]
 #[serial]
-#[ignore]
 fn test_sbpfv3() {
     let assert_v1 = build_noop_and_readelf("v3");
     assert_v1

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [package.metadata.solana]
-tools-version = "v1.52"
+tools-version = "v1.53"
 program-id = "MyProgram1111111111111111111111111111111111"
 
 [dependencies]

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -27,4 +27,4 @@ check-cfg = [
 [workspace]
 
 [workspace.metadata.solana]
-tools-version = "v1.52"
+tools-version = "v1.53"

--- a/platform-tools-sdk/sbf/scripts/install.sh
+++ b/platform-tools-sdk/sbf/scripts/install.sh
@@ -109,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install platform tools
-tools_version=v1.52
+tools_version=v1.53
 rust_version=1.89.0
 if [[ ! -e platform-tools-$tools_version.md || ! -e platform-tools ]]; then
   (

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -85,7 +85,7 @@ edition = "2021"
 level = "warn"
 check-cfg = [
     'cfg(target_os, values("solana"))',
-    'cfg(feature, values("custom-panic", "custom-heap"))',
+    'cfg(feature, values("custom-panic", "custom-heap", "sbpf-v3"))',
     'cfg(target_feature, values("dynamic-frames"))',
 ]
 
@@ -181,7 +181,8 @@ thiserror = "2.0"
 sbf_c = []
 sbf_rust = []
 sbf_sanity_list = []
-dummy-for-ci-check = ["sbf_c", "sbf_rust", "sbf_sanity_list"]
+sbpf-v3 = []
+dummy-for-ci-check = ["sbf_c", "sbf_rust", "sbf_sanity_list", "sbpf-v3"]
 # This was needed for ci
 frozen-abi = []
 

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -1,7 +1,12 @@
 SBF_SDK_PATH := ../../platform-tools-sdk/sbf
 SRC_DIR := c/src
 OUT_DIR := target/deploy
-TOOLCHAIN := 1.89.0-sbpf-solana-v1.52
+TOOLCHAIN := 1.89.0-sbpf-solana-v1.53
+
+test-v3:
+	mkdir -p target/deploy ; \
+	TEST_ARGS="--features=sbpf-v3" VER=v3 $(MAKE) rust-new ; \
+	TEST_ARGS="--features=sbpf-v3" $(MAKE) test-rust
 
 test-v2:
 	VER=v2 $(MAKE) test-version
@@ -30,7 +35,8 @@ rust-v0:
 	cp -r target/sbpf-solana-solana/release/* target/deploy
 
 rust-new:
-	RUSTFLAGS="-C instrument-coverage=no" cargo +$(TOOLCHAIN) build --release --target sbpf$(VER)-solana-solana --workspace ; \
+	RUSTFLAGS="-C instrument-coverage=no" cargo +$(TOOLCHAIN) build --release --target sbpf$(VER)-solana-solana \
+	--workspace $(TEST_ARGS) ; \
 	cp -r target/sbpf$(VER)-solana-solana/release/* target/deploy
 
 .PHONY: test-v0

--- a/programs/sbf/rust/invoke/Cargo.toml
+++ b/programs/sbf/rust/invoke/Cargo.toml
@@ -11,6 +11,9 @@ edition = { workspace = true }
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+sbpf-v3 = []
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -28,6 +31,3 @@ solana-system-interface = { workspace = true }
 
 [lints]
 workspace = true
-
-[features]
-sbpf-v3 = []

--- a/programs/sbf/rust/invoke/Cargo.toml
+++ b/programs/sbf/rust/invoke/Cargo.toml
@@ -28,3 +28,6 @@ solana-system-interface = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+sbpf-v3 = []

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -7,6 +7,8 @@
 #![allow(clippy::unnecessary_cast)]
 #![allow(clippy::uninlined_format_args)]
 
+#[cfg(all(feature = "sbf_rust", not(feature = "sbpf-v3")))]
+use solana_loader_v4_interface::state::{LoaderV4State, LoaderV4Status};
 #[cfg(feature = "sbf_rust")]
 use {
     agave_feature_set::{self as feature_set, FeatureSet},
@@ -26,10 +28,7 @@ use {
     solana_instruction::{error::InstructionError, AccountMeta, Instruction},
     solana_keypair::Keypair,
     solana_loader_v3_interface::instruction as loader_v3_instruction,
-    solana_loader_v4_interface::{
-        instruction as loader_v4_instruction,
-        state::{LoaderV4State, LoaderV4Status},
-    },
+    solana_loader_v4_interface::instruction as loader_v4_instruction,
     solana_message::{inner_instruction::InnerInstruction, Message, SanitizedMessage},
     solana_pubkey::Pubkey,
     solana_rent::Rent,
@@ -387,7 +386,7 @@ fn test_program_sbf_loader_deprecated() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", not(feature = "sbpf-v3")))]
 fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
     agave_logger::setup();
 
@@ -1741,7 +1740,7 @@ fn assert_instruction_count() {
     {
         programs.extend_from_slice(&[
             ("solana_sbf_rust_128bit", 784),
-            ("solana_sbf_rust_alloc", 4934),
+            ("solana_sbf_rust_alloc", 4940),
             ("solana_sbf_rust_custom_heap", 343),
             ("solana_sbf_rust_dep_crate", 22),
             ("solana_sbf_rust_iter", 1514),
@@ -1751,7 +1750,7 @@ fn assert_instruction_count() {
             ("solana_sbf_rust_noop", 342),
             ("solana_sbf_rust_param_passing", 108),
             ("solana_sbf_rust_rand", 315),
-            ("solana_sbf_rust_sanity", 14223),
+            ("solana_sbf_rust_sanity", 14228),
             ("solana_sbf_rust_secp256k1_recover", 88615),
             ("solana_sbf_rust_sha", 21998),
         ]);

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -387,6 +387,8 @@ fn test_program_sbf_loader_deprecated() {
 
 #[test]
 #[cfg(all(feature = "sbf_rust", not(feature = "sbpf-v3")))]
+// In SBPFv3, we don't have a verification step for undefined syscalls, and we don't do dynamic
+// symbol resolution, so this test would pass.
 fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
     agave_logger::setup();
 


### PR DESCRIPTION
#### Problem

We released platform tools with support for sbpfv3, but we haven't yet updated the repository.

#### Summary of Changes

1. Bump the platform tools version everywhere.
2. Adjust the tests so that we deal with the absence of stack gaps in v3.
3. Include sbpfv3 in CI.
