### PR TITLE
Switch to Rust 1.93

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2025-10-25
+  nightly_version=2025-12-05
 fi
 
 

--- a/programs/sbf/rust/sanity/src/lib.rs
+++ b/programs/sbf/rust/sanity/src/lib.rs
@@ -81,8 +81,7 @@ pub fn process_instruction(
         #[cfg(not(target_os = "solana"))]
         panic!();
     }
-    // clippy 1.92 started marking `num` as unused in the assert below
-    #[allow(unused_variables)]
+
     {
         // Test - float math functions
         let zero = accounts[0].try_borrow_mut_data()?.len() as f64;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.0"


### PR DESCRIPTION
#### Problem
New Rust toolchain is available.

#### Summary of Changes
* Switch to stable `1.93` and nightly `2025-12-05`
* Remove buggy unused var warning allow, since it was only triggered in 1.92