### PR TITLE
Reapply ephemeral accounts

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5139,33 +5139,37 @@ impl AccountsDb {
         }
     }
 
-    /// Updates the accounts index with the given `infos` and `accounts`.
+    /// Updates the accounts index with the given accounts. If store_account is false, skip storing
+    /// the account in the index as the account was not stored in the cache
     /// Used for cached accounts only.
     fn update_index_cached_accounts<'a>(
         &self,
-        infos: Vec<AccountInfo>,
         accounts: &impl StorableAccounts<'a>,
+        store_account: &[bool],
         update_index_thread_selection: UpdateIndexThreadSelection,
     ) {
         let target_slot = accounts.target_slot();
-        let len = std::cmp::min(accounts.len(), infos.len());
+        let len = accounts.len();
+        assert_eq!(accounts.len(), store_account.len());
 
         let update = |start, end| {
             (start..end).for_each(|i| {
-                accounts.account(i, |account| {
-                    let info = infos[i];
-                    debug_assert!(info.is_cached());
-                    self.accounts_index.upsert(
-                        target_slot,
-                        target_slot,
-                        account.pubkey(),
-                        &account,
-                        &self.account_indexes,
-                        info,
-                        ReclaimsSlotList::default().as_mut(),
-                        UpsertReclaim::PreviousSlotEntryWasCached,
-                    );
-                });
+                if store_account[i] {
+                    accounts.account(i, |account| {
+                        let info =
+                            AccountInfo::new(StorageLocation::Cached, account.is_zero_lamport());
+                        self.accounts_index.upsert(
+                            target_slot,
+                            target_slot,
+                            account.pubkey(),
+                            &account,
+                            &self.account_indexes,
+                            info,
+                            ReclaimsSlotList::default().as_mut(),
+                            UpsertReclaim::PreviousSlotEntryWasCached,
+                        );
+                    });
+                }
             });
         };
 
@@ -5634,7 +5638,8 @@ impl AccountsDb {
 
         // Store the accounts in the write cache
         let mut store_accounts_time = Measure::start("store_accounts");
-        let infos = self.write_accounts_to_cache(accounts.target_slot(), &accounts);
+        let (store_account, num_ephemeral_accounts_skipped) =
+            self.write_accounts_to_cache(accounts.target_slot(), &accounts);
         store_accounts_time.stop();
         self.stats
             .store_accounts_to_cache_us
@@ -5643,15 +5648,19 @@ impl AccountsDb {
         // Update the index
         let mut update_index_time = Measure::start("update_index");
 
-        self.update_index_cached_accounts(infos, &accounts, update_index_thread_selection);
+        self.update_index_cached_accounts(&accounts, &store_account, update_index_thread_selection);
 
         update_index_time.stop();
         self.stats
             .store_update_index
             .fetch_add(update_index_time.as_us(), Ordering::Relaxed);
+        self.stats.num_store_accounts_to_cache.fetch_add(
+            (accounts.len() - num_ephemeral_accounts_skipped) as u64,
+            Ordering::Relaxed,
+        );
         self.stats
-            .num_store_accounts_to_cache
-            .fetch_add(accounts.len() as u64, Ordering::Relaxed);
+            .num_ephemeral_accounts_skipped
+            .fetch_add(num_ephemeral_accounts_skipped as u64, Ordering::Relaxed);
         self.report_store_timings();
     }
 
@@ -5773,22 +5782,35 @@ impl AccountsDb {
         }
     }
 
+    // Stores accounts in the write cache. If an account is zero-lamport and not present in the
+    // index, there is no need to store it in the write cache as it will not effect the database
+    // hash. The function returns a vector of booleans indicating whether each account was stored,
+    // and the number of accounts that were skipped.
     fn write_accounts_to_cache<'a, 'b>(
         &self,
         slot: Slot,
         accounts_and_meta_to_store: &impl StorableAccounts<'b>,
-    ) -> Vec<AccountInfo> {
-        (0..accounts_and_meta_to_store.len())
+    ) -> (Vec<bool>, usize) {
+        let mut accounts_skipped = 0;
+        let store_account = (0..accounts_and_meta_to_store.len())
             .map(|index| {
                 accounts_and_meta_to_store.account_default_if_zero_lamport(index, |account| {
-                    let account_info =
-                        AccountInfo::new(StorageLocation::Cached, account.is_zero_lamport());
+                    if account.is_zero_lamport()
+                        && self
+                            .accounts_index
+                            .get_and_then(account.pubkey(), |account| (true, account.is_none()))
+                    {
+                        accounts_skipped += 1;
+                        return false;
+                    }
                     self.accounts_cache
                         .store(slot, account.pubkey(), account.take_account());
-                    account_info
+                    true
                 })
             })
-            .collect()
+            .collect();
+
+        (store_account, accounts_skipped)
     }
 
     fn write_accounts_to_storage<'a>(
@@ -6039,6 +6061,13 @@ impl AccountsDb {
                     "num_zero_lamport_accounts_added",
                     self.stats
                         .num_zero_lamport_accounts_added
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "num_ephemeral_accounts_skipped",
+                    self.stats
+                        .num_ephemeral_accounts_skipped
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -38,7 +38,7 @@ use {
         account_storage_entry::AccountStorageEntry,
         accounts_cache::{AccountsCache, CachedAccount, SlotCache},
         accounts_db::stats::{
-            AccountsStats, CacheAccountsStoreStats, CleanAccountsStats, FlushStats,
+            AccountsStats, CacheAccountStoreStats, CleanAccountsStats, FlushStats,
             ObsoleteAccountsStats, PurgeStats, ShrinkAncientStats, ShrinkStats, ShrinkStatsSub,
             StoreAccountsTiming,
         },
@@ -5791,18 +5791,17 @@ impl AccountsDb {
 
     // Stores accounts in the write cache. If an account is zero-lamport and not present in the
     // index, there is no need to store it in the write cache as it will not effect the accounts
-    // hash. The function returns a vector of booleans indicating whether each account was stored,
-    // and the number of accounts that were skipped.
+    // hash. The function returns a BitVec indicating whether each account was stored in the cache.
     // Ordering of account is important as duplicate pubkeys are possible. The last account in
     // accounts_and_meta_to_store for each pubkey is stored in the write cache
     fn write_accounts_to_cache<'a, 'b>(
         &self,
         slot: Slot,
         accounts_and_meta_to_store: &impl StorableAccounts<'b>,
-    ) -> (BitVec, CacheAccountsStoreStats) {
+    ) -> (BitVec, CacheAccountStoreStats) {
         let len = accounts_and_meta_to_store.len();
         let mut pubkey_set = HashSet::with_capacity_and_hasher(len, PubkeyHasherBuilder::default());
-        let mut cache_account_store_stats = CacheAccountsStoreStats::default();
+        let mut cache_account_store_stats = CacheAccountStoreStats::default();
         let mut store_account = BitVec::new_fill(false, len as u64);
 
         (0..len).rev().for_each(|index| {

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -30,6 +30,7 @@ pub struct AccountsStats {
     pub num_obsolete_bytes_removed: AtomicU64,
     pub add_zero_lamport_accounts_us: AtomicU64,
     pub num_zero_lamport_accounts_added: AtomicU64,
+    pub num_ephemeral_accounts_skipped: AtomicU64,
 }
 
 #[derive(Debug, Default)]

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -786,8 +786,8 @@ impl Sum<Self> for ObsoleteAccountsStats {
     }
 }
 
-#[derive(Default)]
-pub struct CacheAccountsStoreStats {
+#[derive(Debug, Default)]
+pub struct CacheAccountStoreStats {
     pub num_accounts_stored: u64,
     pub num_ephemeral_accounts_skipped: u64,
     pub num_duplicate_accounts_skipped: u64,

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -31,6 +31,18 @@ pub struct AccountsStats {
     pub add_zero_lamport_accounts_us: AtomicU64,
     pub num_zero_lamport_accounts_added: AtomicU64,
     pub num_ephemeral_accounts_skipped: AtomicU64,
+    pub num_duplicate_accounts_skipped: AtomicU64,
+}
+
+impl AccountsStats {
+    pub fn accumulate(&self, other: &CacheAccountsStoreStats) {
+        self.num_ephemeral_accounts_skipped
+            .fetch_add(other.num_ephemeral_accounts_skipped, Ordering::Relaxed);
+        self.num_duplicate_accounts_skipped
+            .fetch_add(other.num_duplicate_accounts_skipped, Ordering::Relaxed);
+        self.num_store_accounts_to_cache
+            .fetch_add(other.num_accounts_stored, Ordering::Relaxed);
+    }
 }
 
 #[derive(Debug, Default)]
@@ -783,4 +795,11 @@ impl Sum<Self> for ObsoleteAccountsStats {
             accumulated_stats
         })
     }
+}
+
+#[derive(Default)]
+pub struct CacheAccountsStoreStats {
+    pub num_accounts_stored: u64,
+    pub num_ephemeral_accounts_skipped: u64,
+    pub num_duplicate_accounts_skipped: u64,
 }

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -34,17 +34,6 @@ pub struct AccountsStats {
     pub num_duplicate_accounts_skipped: AtomicU64,
 }
 
-impl AccountsStats {
-    pub fn accumulate(&self, other: &CacheAccountsStoreStats) {
-        self.num_ephemeral_accounts_skipped
-            .fetch_add(other.num_ephemeral_accounts_skipped, Ordering::Relaxed);
-        self.num_duplicate_accounts_skipped
-            .fetch_add(other.num_duplicate_accounts_skipped, Ordering::Relaxed);
-        self.num_store_accounts_to_cache
-            .fetch_add(other.num_accounts_stored, Ordering::Relaxed);
-    }
-}
-
 #[derive(Debug, Default)]
 pub struct PurgeStats {
     pub last_report: AtomicInterval,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6596,3 +6596,111 @@ fn test_batch_insert_zero_lamport_single_ref_account_offsets() {
     assert_eq!(count5, 3, "Should insert only 3 new offsets (60, 70, 80)");
     assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 8);
 }
+
+#[test]
+fn test_new_zero_lamport_accounts_skipped() {
+    let accounts_db = AccountsDb::new_single_for_tests();
+    let pubkey1 = Pubkey::new_unique();
+    let pubkey2 = Pubkey::new_unique();
+    let pubkey3 = Pubkey::new_unique();
+    let zero_account = AccountSharedData::new(0, 0, &Pubkey::default());
+    let account = AccountSharedData::new(100, 0, &Pubkey::default());
+    let slot = 0;
+
+    // 1. Insert a single zero-lamport account and verify it is not added to the index or the
+    //    write cache. Since this is the first write to this slot, the slot cache should not be
+    //    created.
+    accounts_db.store_accounts_unfrozen(
+        (slot, [(&pubkey1, &zero_account)].as_slice()),
+        UpdateIndexThreadSelection::PoolWithThreshold,
+    );
+    assert!(!accounts_db.accounts_index.contains(&pubkey1));
+    assert!(accounts_db.accounts_cache.slot_cache(slot).is_none());
+
+    // 2. Insert a zero-lamport (pubkey1) together with non-zero lamport accounts
+    //    (pubkey2, pubkey3) in the same slot and verify only the non-zero lamport pubkeys are
+    //    indexed.
+    accounts_db.store_accounts_unfrozen(
+        (
+            slot,
+            [
+                (&pubkey1, &zero_account),
+                (&pubkey2, &account),
+                (&pubkey3, &account),
+            ]
+            .as_slice(),
+        ),
+        UpdateIndexThreadSelection::PoolWithThreshold,
+    );
+    assert!(!accounts_db.accounts_index.contains(&pubkey1));
+    assert!(!accounts_db
+        .accounts_cache
+        .slot_cache(slot)
+        .unwrap()
+        .contains_key(&pubkey1));
+    assert!(accounts_db.accounts_index.contains(&pubkey2));
+    assert!(accounts_db
+        .accounts_cache
+        .slot_cache(slot)
+        .unwrap()
+        .contains_key(&pubkey2));
+    assert!(accounts_db.accounts_index.contains(&pubkey3));
+    assert!(accounts_db
+        .accounts_cache
+        .slot_cache(slot)
+        .unwrap()
+        .contains_key(&pubkey3));
+
+    // 3. Insert a zero-lamport update for an already-indexed pubkey (pubkey2).
+    //    Verify pubkey2 remains in the index and gets added to the slot cache.
+    accounts_db.store_accounts_unfrozen(
+        (slot, [(&pubkey2, &zero_account)].as_slice()),
+        UpdateIndexThreadSelection::PoolWithThreshold,
+    );
+    assert!(accounts_db.accounts_index.contains(&pubkey2));
+    assert!(accounts_db
+        .accounts_cache
+        .slot_cache(slot)
+        .unwrap()
+        .contains_key(&pubkey2));
+
+    // 4. Flush the slot to simulate write-cache -> storage transition and verify
+    //    pubkey1 is still not present while pubkey2 remains indexed but is now zero-lamport.
+    accounts_db.add_root_and_flush_write_cache(slot);
+    assert!(!accounts_db.accounts_index.contains(&pubkey1));
+    assert!(accounts_db.accounts_index.contains(&pubkey2));
+    assert!(accounts_db.accounts_index.contains(&pubkey3));
+
+    // Verify pubkey2 is present in slot in the index with a zero-lamport AccountInfo.
+    assert!(accounts_db.accounts_index.get_and_then(&pubkey2, |entry| {
+        let account_info = *entry.unwrap().slot_list_read_lock().first().unwrap();
+        (false, account_info.1.is_zero_lamport())
+    }));
+
+    // 5. Add a non-zero lamport account for a pubkey that was previously only written as zero
+    //    (pubkey1) and verify the pubkey is added to the index.
+    let slot = slot + 1;
+    accounts_db.store_accounts_unfrozen(
+        (slot, [(&pubkey1, &account)].as_slice()),
+        UpdateIndexThreadSelection::PoolWithThreshold,
+    );
+    assert!(accounts_db.accounts_index.contains(&pubkey1));
+
+    // 6. Set pubkey3 to zero lamports and flush. Verify pubkey3 is present in the index with
+    // a zero-lamport AccountInfo after flushing.
+    accounts_db.store_accounts_unfrozen(
+        (slot, [(&pubkey3, &zero_account)].as_slice()),
+        UpdateIndexThreadSelection::PoolWithThreshold,
+    );
+    accounts_db.add_root_and_flush_write_cache(slot);
+
+    // Verify pubkey3 is present in slot in the index with a zero-lamport AccountInfo.
+    let slot_list = accounts_db.accounts_index.get_and_then(&pubkey3, |entry| {
+        let entry = entry.expect("must exist");
+        (false, entry.slot_list_read_lock().clone_list())
+    });
+
+    // pubkey3 should be present in the index and marked as zero-lamport for this slot.
+    let account_info = slot_list.iter().find(|(s, _)| *s == slot).unwrap();
+    assert!(account_info.1.is_zero_lamport());
+}

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6612,7 +6612,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     //    created.
     accounts_db.store_accounts_unfrozen(
         (slot, [(&pubkey1, &zero_account)].as_slice()),
-        UpdateIndexThreadSelection::PoolWithThreshold,
+        UpdateIndexThreadSelection::Inline,
     );
     assert!(!accounts_db.accounts_index.contains(&pubkey1));
     assert!(accounts_db.accounts_cache.slot_cache(slot).is_none());
@@ -6630,7 +6630,7 @@ fn test_new_zero_lamport_accounts_skipped() {
             ]
             .as_slice(),
         ),
-        UpdateIndexThreadSelection::PoolWithThreshold,
+        UpdateIndexThreadSelection::Inline,
     );
     assert!(!accounts_db.accounts_index.contains(&pubkey1));
     assert!(!accounts_db
@@ -6655,7 +6655,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     //    Verify pubkey2 remains in the index and gets added to the slot cache.
     accounts_db.store_accounts_unfrozen(
         (slot, [(&pubkey2, &zero_account)].as_slice()),
-        UpdateIndexThreadSelection::PoolWithThreshold,
+        UpdateIndexThreadSelection::Inline,
     );
     assert!(accounts_db.accounts_index.contains(&pubkey2));
     assert!(accounts_db
@@ -6682,7 +6682,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     let slot = slot + 1;
     accounts_db.store_accounts_unfrozen(
         (slot, [(&pubkey1, &account)].as_slice()),
-        UpdateIndexThreadSelection::PoolWithThreshold,
+        UpdateIndexThreadSelection::Inline,
     );
     assert!(accounts_db.accounts_index.contains(&pubkey1));
 
@@ -6690,7 +6690,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     // a zero-lamport AccountInfo after flushing.
     accounts_db.store_accounts_unfrozen(
         (slot, [(&pubkey3, &zero_account)].as_slice()),
-        UpdateIndexThreadSelection::PoolWithThreshold,
+        UpdateIndexThreadSelection::Inline,
     );
     accounts_db.add_root_and_flush_write_cache(slot);
 
@@ -6757,7 +6757,7 @@ fn test_write_accounts_to_cache_scenarios(
             let account = AccountSharedData::new(lamports, 0, &Pubkey::default());
             db.store_accounts_unfrozen(
                 (slot, [(&key, &account)].as_slice()),
-                UpdateIndexThreadSelection::PoolWithThreshold,
+                UpdateIndexThreadSelection::Inline,
             );
         }
         InitialState::WithoutLamports => {
@@ -6766,12 +6766,12 @@ fn test_write_accounts_to_cache_scenarios(
             // Store a non-zero account first to create the index entry
             db.store_accounts_unfrozen(
                 (slot, [(&key, &account)].as_slice()),
-                UpdateIndexThreadSelection::PoolWithThreshold,
+                UpdateIndexThreadSelection::Inline,
             );
             // Overwrite with a zero-lamport account to simulate ephemeral setup
             db.store_accounts_unfrozen(
                 (slot, [(&key, &account_zero)].as_slice()),
-                UpdateIndexThreadSelection::PoolWithThreshold,
+                UpdateIndexThreadSelection::Inline,
             );
         }
     }
@@ -6784,10 +6784,7 @@ fn test_write_accounts_to_cache_scenarios(
         .collect();
     let batch: Vec<_> = accounts.iter().map(|account| (&key, account)).collect();
 
-    db.store_accounts_unfrozen(
-        (slot, batch.as_slice()),
-        UpdateIndexThreadSelection::PoolWithThreshold,
-    );
+    db.store_accounts_unfrozen((slot, batch.as_slice()), UpdateIndexThreadSelection::Inline);
 
     // Verify results
     let loaded = db.load_without_fixed_root(&ancestors, &key);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8917,6 +8917,11 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
     bank1
         .transfer(amount, &mint_keypair, &key1.pubkey())
         .unwrap();
+    // Store accounts with lamports to populate the index
+    bank1.store_account(&key4.pubkey(), &AccountSharedData::new(1, 0, &owner));
+    bank1.store_account(&key5.pubkey(), &AccountSharedData::new(1, 0, &owner));
+
+    // Then set the accounts to zero lamports
     bank1.store_account(&key4.pubkey(), &AccountSharedData::new(0, 0, &owner));
     bank1.store_account(&key5.pubkey(), &AccountSharedData::new(0, 0, &owner));
 
@@ -11245,9 +11250,11 @@ where
     // create a bank a few epochs in the future..
     let bank = new_from_parent_next_epoch(bank, &bank_forks, 2);
 
-    // create the next bank in the current epoch
+    // create the next bank in the current epoch and populate bob's account with some lamports and data
     let slot = bank.slot() + 1;
     let bank = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &collector, slot);
+    let account = AccountSharedData::new(1, len1, &program);
+    bank.store_account(&bob_pubkey, &account);
 
     // create the next bank where we will store a zero-lamport account to be cleaned
     let slot = bank.slot() + 1;


### PR DESCRIPTION
#### Problem
Original ephemeral accounts push was reverted here due to a conflict with SIMD-83. SIMD-83 added the possibility of duplicate transactions in a single batch which would result in mismatches with this code

#### Summary of Changes
- Re-applied original ephemeral accounts patch after rebase
- Added duplicate handling to store_to_cache
-- Reversed the order of iteration in store_accounts_to_cache
-- Collect a hashset of seen pubkeys. If I pubkey has been seen, skip storing. 
-- Added a structure to store stats
-- Added a bunch of test cases 

Store performance graph:
MCE4: orange: Running with the original broken change
MCE2: purple: baseline, no ephemeral accounts
Rory: light blue: Running with this changeset.
<img width="1830" height="405" alt="image" src="https://github.com/user-attachments/assets/26d29d23-97b2-419d-8270-df4fde7306bc" />
No downside in store times due to the hashset


Duplicate/Ephemeral Counter graph
MCE4: orange: Ephemeral Accounts running with the original broken change
Rory: Purple: Ephemeral Accounts running with this change
Rory: light blue: Duplicates running with this change
<img width="1830" height="405" alt="image" src="https://github.com/user-attachments/assets/7c1ed3d6-2ad6-4e52-bca1-50d70504bf32" />
No duplicates are found for now as SIMD83 is not enabled on mainnet. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
