### PR TITLE
Fix unused warning for `leader_for_tests`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1872,6 +1872,7 @@ impl Bank {
         let leader: SlotLeader;
         #[cfg(not(feature = "dev-context-only-utils"))]
         {
+            _ = leader_for_tests;
             leader = Self::slot_leader_from_epoch_stakes(
                 fields.slot,
                 &fields.epoch_schedule,


### PR DESCRIPTION
#### Problem

The `leader_for_tests` parameter is only used inside the `#[cfg(feature = "dev-context-only-utils")]` block, causing an unused variable warning in normal builds.

#### Summary of Changes

Explicitly discard it with `_ =` in the `#[cfg(not(feature = "dev-context-only-utils"))]` block.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
