### PR TITLE
replace --build-plan with --unit-graph in cargo-install-all.sh

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -182,8 +182,9 @@ cargo_build() {
 # dcou, in order to make this rather fragile grep more resilient to bitrot...
 check_dcou() {
   RUSTC_BOOTSTRAP=1 \
-    cargo_build -Z unstable-options --build-plan "$@" | \
-    grep -q -F '"feature=\"dev-context-only-utils\""'
+    cargo_build -Z unstable-options --unit-graph "$@" | \
+    jq -r 'any(.units[].features[]?; . == "dev-context-only-utils")' | \
+    grep -q -F "true"
 }
 
 # Some binaries (like the notable agave-ledger-tool) need to activate


### PR DESCRIPTION
#### Problem

rust 1.93.0 removed --build-plan arg

context: https://www.github.com/rust-lang/cargo/issues/7614

#### Summary of Changes

replace with --unit-graph.

I tested it with

1. `./scripts/cargo-install-all.sh stable .` can generate tarballs correctly
2. add `solana-client = { workspace = true, features = ["dev-context-only-utils"] }` into `watchtower/Cargo.toml` and run the script again. it will fail with a dcou feature has been enabled message