### PR TITLE
v3.1: ignore byte security audit

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -59,6 +59,15 @@ cargo_audit_ignores=(
   # URL:       https://rustsec.org/advisories/RUSTSEC-2024-0376
   # Solution:  Upgrade to >=0.12.3
   --ignore RUSTSEC-2024-0376
+
+	# Crate:     bytes
+	# Version:   1.10.1
+	# Title:     Integer overflow in `BytesMut::reserve`
+	# Date:      2026-02-03
+	# ID:        RUSTSEC-2026-0007
+	# URL:       https://github.com/advisories/GHSA-434x-w66g-qw3r
+	# Solution:  Upgrade to >=1.11.1
+	--ignore RUSTSEC-2026-0007
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem

audit check failed. we usually ignore it so prepare this in case we want to do it

#### Summary of Changes

ignore