### PR TITLE
Fix `get_current_instruction_index`

### DIFF
--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -239,8 +239,9 @@ impl<'ix_data> TransactionContext<'ix_data> {
 
     /// Returns the index in the instruction trace of the current executing instruction
     pub fn get_current_instruction_index(&self) -> Result<usize, InstructionError> {
-        self.get_instruction_stack_height()
-            .checked_sub(1)
+        self.instruction_stack
+            .last()
+            .copied()
             .ok_or(InstructionError::CallDepth)
     }
 
@@ -248,8 +249,8 @@ impl<'ix_data> TransactionContext<'ix_data> {
     pub fn get_current_instruction_context(
         &self,
     ) -> Result<InstructionContext<'_, '_>, InstructionError> {
-        let level = self.get_current_instruction_index()?;
-        self.get_instruction_context_at_nesting_level(level)
+        let index_in_trace = self.get_current_instruction_index()?;
+        self.get_instruction_context_at_index_in_trace(index_in_trace)
     }
 
     /// Returns a view on the next instruction. This function assumes it has already been


### PR DESCRIPTION
#### Problem

The function `get_current_instruction_index` was incorrectly implemented, returning the depth of the current executing instruction, not its index in trace. The issue was introduced in https://github.com/anza-xyz/agave/pull/9714.

Although `get_current_instruction_context` depended on it, the former was correctly using its results.

The other usage is in https://github.com/anza-xyz/agave/blob/01159e4643e1d8ee86d1ed0e58ea463b338d563f/program-runtime/src/invoke_context.rs#L433, but the index was there only for ABIv2 and had no real usage so far.

#### Summary of Changes

Implement the function correctly.
