### PR TITLE
test-validator: increase file descriptor limits for warp-slot operations

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1225,6 +1225,7 @@ impl TestValidator {
             accounts_db_config,
             runtime_config,
             enable_scheduler_bindings: config.enable_scheduler_bindings,
+            enforce_ulimit_nofile: true,
             ..ValidatorConfig::default_for_test()
         };
         if let Some(ref tower_storage) = config.tower_storage {


### PR DESCRIPTION
Fixes #10109

## Problem
When using `--warp-slot` with 62+ accounts, `solana-test-validator` panics with `PoisonError` in the accounts background service thread due to file descriptor exhaustion during snapshot creation.

## Solution
Set `enforce_ulimit_nofile: true` in the test-validator's ValidatorConfig. This lets `Validator::new()` call `adjust_nofile_limit()` to increase file descriptor limits, matching the behavior of the main validator.

## Testing
- Tested with MRE: 62 accounts + `--warp-slot 200`
- Validator starts successfully without panics