### PR TITLE
v3.0 ignore byte audit

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -69,6 +69,15 @@ cargo_audit_ignores=(
   # URL:       https://rustsec.org/advisories/RUSTSEC-2025-0055
   # Solution:  Upgrade to >=0.3.20
   --ignore RUSTSEC-2025-0055
+
+	# Crate:     bytes
+	# Version:   1.10.1
+	# Title:     Integer overflow in `BytesMut::reserve`
+	# Date:      2026-02-03
+	# ID:        RUSTSEC-2026-0007
+	# URL:       https://github.com/advisories/GHSA-434x-w66g-qw3r
+	# Solution:  Upgrade to >=1.11.1
+	--ignore RUSTSEC-2026-0007
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s

--- a/clippy.toml
+++ b/clippy.toml
@@ -4,7 +4,10 @@ too-many-arguments-threshold = 9
 disallowed-methods = [
     { path = "std::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration." },
     { path = "tokio::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration." },
-    { path = "lazy_static::initialize", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." }
+    { path = "lazy_static::initialize", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." },
+    { path = "bytes::BytesMut::reserve", reason = "Branch is ignoring https://rustsec.org/advisories/RUSTSEC-2026-0007.html" },
+    { path = "bytes::BytesMut::put_bytes", reason = "Branch is ignoring https://rustsec.org/advisories/RUSTSEC-2026-0007.html" },
+    { path = "bytes::BytesMut::resize", reason = "Branch is ignoring https://rustsec.org/advisories/RUSTSEC-2026-0007.html" },
 ]
 
 disallowed-macros = [

--- a/ledger/src/shred/legacy.rs
+++ b/ledger/src/shred/legacy.rs
@@ -67,6 +67,10 @@ impl<'a> Shred<'a> for ShredData {
         if payload.len() < Self::SIZE_OF_HEADERS {
             return Err(Error::InvalidPayloadSize(payload.len()));
         }
+
+        // BytesMut::resize is only vulnerable for values near usize::MAX. This
+        // usage is much smaller and const
+        #[allow(clippy::disallowed_methods)]
         payload.resize(Self::SIZE_OF_PAYLOAD, 0u8);
         let shred = Self {
             common_header,


### PR DESCRIPTION
#### Problem
can't push to https://github.com/anza-xyz/agave/pull/10377

#### Summary of Changes
just @yihau's change plus preventing introduction of the vulnerable methods via clippy

