### PR TITLE
chore: Remove deprecated functions and update tests in rpc-client

### DIFF
--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -3563,49 +3563,6 @@ impl RpcClient {
             })
     }
 
-    #[deprecated(
-        note = "Use `get_ui_account_with_config()` instead. This function will be removed in a \
-                future version of `solana_rpc_client`."
-    )]
-    pub async fn get_account_with_config(
-        &self,
-        pubkey: &Pubkey,
-        config: RpcAccountInfoConfig,
-    ) -> RpcResult<Option<Account>> {
-        #[allow(deprecated)]
-        let response = self
-            .send(
-                RpcRequest::GetAccountInfo,
-                json!([pubkey.to_string(), config]),
-            )
-            .await;
-
-        response
-            .map(|result_json: Value| {
-                if result_json.is_null() {
-                    return Err(
-                        RpcError::ForUser(format!("AccountNotFound: pubkey={pubkey}")).into(),
-                    );
-                }
-                let Response {
-                    context,
-                    value: rpc_account,
-                } = serde_json::from_value::<Response<Option<UiAccount>>>(result_json)?;
-                trace!("Response account {pubkey:?} {rpc_account:?}");
-                let account = rpc_account.and_then(|rpc_account| rpc_account.to_account());
-
-                Ok(Response {
-                    context,
-                    value: account,
-                })
-            })
-            .map_err(|err| {
-                Into::<ClientError>::into(RpcError::ForUser(format!(
-                    "AccountNotFound: pubkey={pubkey}: {err}"
-                )))
-            })?
-    }
-
     /// Returns all information associated with the account of the provided pubkey.
     ///
     /// If the account does not exist, this method returns `Ok(None)`.
@@ -3839,40 +3796,6 @@ impl RpcClient {
                 })
                 .collect(),
         })
-    }
-
-    #[deprecated(
-        note = "Use `get_multiple_ui_accounts_with_config()` instead. This function will be \
-                removed in a future version of `solana_rpc_client`."
-    )]
-    pub async fn get_multiple_accounts_with_config(
-        &self,
-        pubkeys: &[Pubkey],
-        config: RpcAccountInfoConfig,
-    ) -> RpcResult<Vec<Option<Account>>> {
-        #[allow(deprecated)]
-        {
-            let config = RpcAccountInfoConfig {
-                commitment: config.commitment.or_else(|| Some(self.commitment())),
-                ..config
-            };
-            let pubkeys: Vec<_> = pubkeys.iter().map(|pubkey| pubkey.to_string()).collect();
-            let response = self
-                .send(RpcRequest::GetMultipleAccounts, json!([pubkeys, config]))
-                .await?;
-            let Response {
-                context,
-                value: accounts,
-            } = serde_json::from_value::<Response<Vec<Option<UiAccount>>>>(response)?;
-            let accounts: Vec<Option<Account>> = accounts
-                .into_iter()
-                .map(|rpc_account| rpc_account.and_then(|a| a.to_account()))
-                .collect();
-            Ok(Response {
-                context,
-                value: accounts,
-            })
-        }
     }
 
     /// Returns the account information for a list of pubkeys.
@@ -4143,34 +4066,6 @@ impl RpcClient {
                 })
                 .collect()
         })
-    }
-
-    #[deprecated(
-        note = "Use `get_program_ui_accounts_with_config()` instead. This function will be \
-                removed in a future version of `solana_rpc_client`."
-    )]
-    pub async fn get_program_accounts_with_config(
-        &self,
-        pubkey: &Pubkey,
-        mut config: RpcProgramAccountsConfig,
-    ) -> ClientResult<Vec<(Pubkey, Account)>> {
-        #[allow(deprecated)]
-        {
-            let commitment = config
-                .account_config
-                .commitment
-                .unwrap_or_else(|| self.commitment());
-            config.account_config.commitment = Some(commitment);
-
-            let accounts = self
-                .send::<OptionalContext<Vec<RpcKeyedAccount>>>(
-                    RpcRequest::GetProgramAccounts,
-                    json!([pubkey.to_string(), config]),
-                )
-                .await?
-                .parse_value();
-            parse_keyed_accounts(accounts, RpcRequest::GetProgramAccounts)
-        }
     }
 
     /// Returns all accounts owned by the provided program pubkey.
@@ -4922,35 +4817,6 @@ pub(crate) fn get_rpc_request_str(rpc_addr: SocketAddr, tls: bool) -> String {
     } else {
         format!("http://{rpc_addr}")
     }
-}
-
-#[deprecated(
-    note = "Parsing accounts whose data is of type `UiAccountData::Json` will yield `None` when \
-            it should not. Do not use this function."
-)]
-pub(crate) fn parse_keyed_accounts(
-    accounts: Vec<RpcKeyedAccount>,
-    request: RpcRequest,
-) -> ClientResult<Vec<(Pubkey, Account)>> {
-    let mut pubkey_accounts: Vec<(Pubkey, Account)> = Vec::with_capacity(accounts.len());
-    for RpcKeyedAccount { pubkey, account } in accounts.into_iter() {
-        let pubkey = pubkey.parse().map_err(|_| {
-            ClientError::new_with_request(
-                RpcError::ParseError("Pubkey".to_string()).into(),
-                request,
-            )
-        })?;
-        pubkey_accounts.push((
-            pubkey,
-            account.to_account().ok_or_else(|| {
-                ClientError::new_with_request(
-                    RpcError::ParseError("Account from rpc".to_string()).into(),
-                    request,
-                )
-            })?,
-        ));
-    }
-    Ok(pubkey_accounts)
 }
 
 fn pubkey_ui_account_client_result_from_keyed_accounts(

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -3021,19 +3021,6 @@ impl RpcClient {
         )
     }
 
-    #[deprecated(
-        note = "Use `get_ui_account_with_config()` instead. This function will be removed in a \
-                future version of `solana_rpc_client`."
-    )]
-    pub fn get_account_with_config(
-        &self,
-        pubkey: &Pubkey,
-        config: RpcAccountInfoConfig,
-    ) -> RpcResult<Option<Account>> {
-        #[allow(deprecated)]
-        self.invoke((self.rpc_client.as_ref()).get_account_with_config(pubkey, config))
-    }
-
     /// Returns all information associated with the account of the provided pubkey.
     ///
     /// If the account does not exist, this method returns `Ok(None)`.
@@ -3194,19 +3181,6 @@ impl RpcClient {
             (self.rpc_client.as_ref())
                 .get_multiple_accounts_with_commitment(pubkeys, commitment_config),
         )
-    }
-
-    #[deprecated(
-        note = "Use `get_multiple_ui_accounts_with_config()` instead. This function will be \
-                removed in a future version of `solana_rpc_client`."
-    )]
-    pub fn get_multiple_accounts_with_config(
-        &self,
-        pubkeys: &[Pubkey],
-        config: RpcAccountInfoConfig,
-    ) -> RpcResult<Vec<Option<Account>>> {
-        #[allow(deprecated)]
-        self.invoke((self.rpc_client.as_ref()).get_multiple_accounts_with_config(pubkeys, config))
     }
 
     /// Returns the account information for a list of pubkeys.
@@ -3401,19 +3375,6 @@ impl RpcClient {
     /// ```
     pub fn get_program_accounts(&self, pubkey: &Pubkey) -> ClientResult<Vec<(Pubkey, Account)>> {
         self.invoke((self.rpc_client.as_ref()).get_program_accounts(pubkey))
-    }
-
-    #[deprecated(
-        note = "Use `get_program_ui_accounts_with_config()` instead. This function will be \
-                removed in a future version of `solana_rpc_client`."
-    )]
-    pub fn get_program_accounts_with_config(
-        &self,
-        pubkey: &Pubkey,
-        config: RpcProgramAccountsConfig,
-    ) -> ClientResult<Vec<(Pubkey, Account)>> {
-        #[allow(deprecated)]
-        self.invoke((self.rpc_client.as_ref()).get_program_accounts_with_config(pubkey, config))
     }
 
     /// Returns all accounts owned by the provided program pubkey.
@@ -4098,7 +4059,7 @@ mod tests {
             pubkey: pubkey.to_string(),
             account: encode_ui_account(&pubkey, &account, UiAccountEncoding::Base64, None, None),
         };
-        let expected_result = vec![(pubkey, account.clone())];
+        let expected_result = vec![(pubkey, keyed_account.account.clone())];
         // Test: without context
         {
             let mocks: Mocks = [(
@@ -4109,9 +4070,8 @@ mod tests {
             .into_iter()
             .collect();
             let rpc_client = RpcClient::new_mock_with_mocks("mock_client".to_string(), mocks);
-            #[allow(deprecated)]
             let result = rpc_client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     &program_id,
                     RpcProgramAccountsConfig {
                         filters: None,
@@ -4145,9 +4105,8 @@ mod tests {
             .into_iter()
             .collect();
             let rpc_client = RpcClient::new_mock_with_mocks("mock_client".to_string(), mocks);
-            #[allow(deprecated)]
             let result = rpc_client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     &program_id,
                     RpcProgramAccountsConfig {
                         filters: None,
@@ -4168,11 +4127,11 @@ mod tests {
         // Test: Mock with duplicate requests
         {
             let expected_result = vec![
-                (pubkey, account.clone()),
-                (pubkey, account.clone()),
-                (pubkey, account.clone()),
-                (pubkey, account.clone()),
-                (pubkey, account.clone()),
+                (pubkey, keyed_account.account.clone()),
+                (pubkey, keyed_account.account.clone()),
+                (pubkey, keyed_account.account.clone()),
+                (pubkey, keyed_account.account.clone()),
+                (pubkey, keyed_account.account.clone()),
             ];
 
             let mut mocks: MocksMap = [
@@ -4231,9 +4190,8 @@ mod tests {
             );
 
             let rpc_client = RpcClient::new_mock_with_mocks_map("mock_client".to_string(), mocks);
-            #[allow(deprecated)]
             let mut result1 = rpc_client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     &program_id,
                     RpcProgramAccountsConfig {
                         filters: None,
@@ -4251,9 +4209,8 @@ mod tests {
 
             assert_eq!(result1.len(), 1);
 
-            #[allow(deprecated)]
             let result2 = rpc_client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     &program_id,
                     RpcProgramAccountsConfig {
                         filters: None,
@@ -4271,9 +4228,8 @@ mod tests {
 
             assert_eq!(result2.len(), 1);
 
-            #[allow(deprecated)]
             let result_3 = rpc_client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     &program_id,
                     RpcProgramAccountsConfig {
                         filters: None,
@@ -4291,9 +4247,8 @@ mod tests {
 
             assert_eq!(result_3.len(), 3);
 
-            #[allow(deprecated)]
             let result_4 = rpc_client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     &program_id,
                     RpcProgramAccountsConfig {
                         filters: None,


### PR DESCRIPTION
#### Problem
Deprecated functions in RPC client that already have recommended replacements can be removed. 

#### Summary of Changes
* Remove them before the next major release (v4.0).
* Update tests that were still using the old functions.

