### PR TITLE
chore: Remove deprecated compute_unit_price module

### DIFF
--- a/clap-utils/src/compute_unit_price.rs
+++ b/clap-utils/src/compute_unit_price.rs
@@ -1,2 +1,0 @@
-#[deprecated(since = "2.0.0", note = "Please use `compute_budget` instead")]
-pub use crate::compute_budget::{compute_unit_price_arg, COMPUTE_UNIT_PRICE_ARG};

--- a/clap-utils/src/lib.rs
+++ b/clap-utils/src/lib.rs
@@ -29,7 +29,6 @@ pub fn hidden_unless_forced() -> bool {
 }
 
 pub mod compute_budget;
-pub mod compute_unit_price;
 pub mod fee_payer;
 pub mod input_parsers;
 pub mod input_validators;


### PR DESCRIPTION
#### Problem
Compute unit price module is deprecated and no longer used, and can be removed before the next major release (v4.0).

#### Summary of Changes
Remove the deprecated module from clap-utils.
