### PR TITLE
svm-test-harness: add more program helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11045,6 +11045,7 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-last-restart-slot",
+ "solana-loader-v4-interface",
  "solana-message",
  "solana-precompile-error",
  "solana-program-runtime",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9787,6 +9787,7 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-last-restart-slot",
+ "solana-loader-v4-interface",
  "solana-message",
  "solana-precompile-error",
  "solana-program-runtime",

--- a/svm-test-harness/instr/Cargo.toml
+++ b/svm-test-harness/instr/Cargo.toml
@@ -36,6 +36,7 @@ solana-epoch-schedule = { workspace = true, features = ["sysvar"] }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true, features = ["serde"] }
 solana-last-restart-slot = { workspace = true, features = ["sysvar"] }
+solana-loader-v4-interface = { workspace = true }
 solana-message = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-program-runtime = { workspace = true }

--- a/svm-test-harness/instr/src/keyed_account.rs
+++ b/svm-test-harness/instr/src/keyed_account.rs
@@ -1,7 +1,11 @@
 //! Keyed account helpers.
 
 use {
-    solana_account::Account, solana_builtins::BUILTINS, solana_pubkey::Pubkey, solana_rent::Rent,
+    solana_account::Account,
+    solana_builtins::BUILTINS,
+    solana_loader_v4_interface::state::{LoaderV4State, LoaderV4Status},
+    solana_pubkey::Pubkey,
+    solana_rent::Rent,
 };
 
 fn create_keyed_account_for_builtin_program(program_id: &Pubkey, name: &str) -> (Pubkey, Account) {
@@ -19,4 +23,42 @@ fn create_keyed_account_for_builtin_program(program_id: &Pubkey, name: &str) -> 
 
 pub fn keyed_account_for_system_program() -> (Pubkey, Account) {
     create_keyed_account_for_builtin_program(&BUILTINS[0].program_id, BUILTINS[0].name)
+}
+
+pub fn keyed_account_for_compute_budget_program() -> (Pubkey, Account) {
+    create_keyed_account_for_builtin_program(&BUILTINS[5].program_id, BUILTINS[5].name)
+}
+
+pub fn keyed_account_for_loader_v4_program() -> (Pubkey, Account) {
+    create_keyed_account_for_builtin_program(&BUILTINS[7].program_id, BUILTINS[7].name)
+}
+
+pub fn create_program_account_loader_v4(
+    slot: u64,
+    authority_address_or_next_version: Pubkey,
+    status: LoaderV4Status,
+    elf: &[u8],
+) -> Account {
+    let data = unsafe {
+        let elf_offset = LoaderV4State::program_data_offset();
+        let data_len = elf_offset.saturating_add(elf.len());
+        let mut data = vec![0u8; data_len];
+        *std::mem::transmute::<&mut [u8; LoaderV4State::program_data_offset()], &mut LoaderV4State>(
+            (&mut data[0..elf_offset]).try_into().unwrap(),
+        ) = LoaderV4State {
+            slot,
+            authority_address_or_next_version,
+            status,
+        };
+        data[elf_offset..].copy_from_slice(elf);
+        data
+    };
+    let lamports = Rent::default().minimum_balance(data.len());
+    Account {
+        lamports,
+        data,
+        owner: solana_sdk_ids::loader_v4::id(),
+        executable: true,
+        ..Default::default()
+    }
 }


### PR DESCRIPTION
#### Problem
In order to prepare for refactoring the rest of programs/sbf tests away from Bank, we need a few more helpers in the svm-test-harness.

#### Summary of Changes
Add a few more builtin program "keyed account" builder helpers for tests.