### PR TITLE
Fix QuicPool drop blocking in async context

### DIFF
--- a/quic-client/tests/quicpool_drop.rs
+++ b/quic-client/tests/quicpool_drop.rs
@@ -1,0 +1,23 @@
+use {
+    solana_connection_cache::connection_cache::{ConnectionCache, NewConnectionConfig},
+    solana_quic_client::{QuicConfig, QuicConnectionManager},
+    std::net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+
+#[tokio::test(flavor = "current_thread")]
+async fn quicpool_drop_does_not_block_in_async_context() {
+    let config = QuicConfig::new().expect("create quic config");
+    let manager = QuicConnectionManager::new_with_connection_config(config);
+    let cache = ConnectionCache::new("quicpool_drop_async", manager, 1)
+        .expect("create quic connection cache");
+    const MAX_CONNECTIONS: usize = 1024;
+
+    for i in 0..(MAX_CONNECTIONS + 1) {
+        let b = ((i / 250) + 1) as u8;
+        let c = ((i % 250) + 1) as u8;
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, b, c, 1)), 12345);
+        let conn = cache.get_nonblocking_connection(&addr);
+        drop(conn);
+    }
+    // Eviction should drop a QuicPool while still inside the tokio runtime.
+}


### PR DESCRIPTION
Move blocking drop operation to dedicated thread pool to prevent file descriptor exhaustion when QuicPool is dropped inside the tokio runtime.

Fixes #8861

#### Problem

When a `QuicPool` is dropped while already inside the tokio async runtime (e.g., during connection cache eviction), the `close_quic_connection()` function calls `RUNTIME.block_on()`, which attempts to block the current thread to wait for the async close operation. However, tokio runtimes cannot block on themselves, causing the operation to hang indefinitely. This leads to file descriptor exhaustion as QUIC connections are never properly closed, eventually causing "Too many open files" errors.

#### Summary of Changes

* Modified `close_quic_connection()` to detect if already running inside a tokio runtime using `Handle::try_current()`
* When inside a runtime, spawn the close operation as a background task on the global runtime instead of blocking
* When outside a runtime, continue using `block_on()` as before for synchronous contexts
* Added regression test `quicpool_drop_does_not_block_in_async_context()` that creates 1025 connections to trigger eviction and verify drop doesn't hang

Fixes #8861