### PR TITLE
fix: explicitly set burn_percent to match implicit feature gate activation behavior

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -293,7 +293,7 @@ fn test_bank_new() {
     genesis_config.rent = Rent {
         lamports_per_byte_year: 5,
         exemption_threshold: 1.2,
-        burn_percent: 5,
+        ..Rent::default()
     };
 
     let bank = Bank::new_for_tests(&genesis_config);
@@ -307,7 +307,7 @@ fn test_bank_new() {
     let rent_account = bank.get_account(&sysvar::rent::id()).unwrap();
     let rent = from_account::<sysvar::rent::Rent, _>(&rent_account).unwrap();
 
-    assert_eq!(rent.burn_percent, 5);
+    assert_eq!(rent.burn_percent, Rent::default().burn_percent);
     assert_eq!(rent.exemption_threshold, 1.0);
     assert_eq!(rent.lamports_per_byte_year, 6);
 }

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -1,6 +1,5 @@
 use {
-    solana_clock::Epoch, solana_epoch_schedule::EpochSchedule,
-    solana_genesis_config::GenesisConfig, solana_rent::Rent,
+    solana_clock::Epoch, solana_epoch_schedule::EpochSchedule, solana_genesis_config::GenesisConfig, solana_rent::{Rent, DEFAULT_BURN_PERCENT}
 };
 
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
@@ -50,6 +49,6 @@ impl RentCollector {
         self.rent.lamports_per_byte_year =
             (self.rent.lamports_per_byte_year as f64 * self.rent.exemption_threshold) as u64;
         self.rent.exemption_threshold = 1.0;
-        self.rent.burn_percent = Rent::DEFAULT_BURN_PERCENT;
+        self.rent.burn_percent = DEFAULT_BURN_PERCENT;
     }
 }

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -50,5 +50,6 @@ impl RentCollector {
         self.rent.lamports_per_byte_year =
             (self.rent.lamports_per_byte_year as f64 * self.rent.exemption_threshold) as u64;
         self.rent.exemption_threshold = 1.0;
+        self.rent.burn_percent = Rent::DEFAULT_BURN_PERCENT;
     }
 }

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -50,7 +50,8 @@ impl RentCollector {
 
     pub(crate) fn deprecate_rent_exemption_threshold(&mut self) {
         let new_rent = Rent {
-            lamports_per_byte_year: (self.rent.lamports_per_byte_year as f64 * self.rent.exemption_threshold) as u64,
+            lamports_per_byte_year: (self.rent.lamports_per_byte_year as f64
+                * self.rent.exemption_threshold) as u64,
             exemption_threshold: 1.0,
             burn_percent: DEFAULT_BURN_PERCENT,
         };

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -49,9 +49,11 @@ impl RentCollector {
     }
 
     pub(crate) fn deprecate_rent_exemption_threshold(&mut self) {
-        self.rent.lamports_per_byte_year =
-            (self.rent.lamports_per_byte_year as f64 * self.rent.exemption_threshold) as u64;
-        self.rent.exemption_threshold = 1.0;
-        self.rent.burn_percent = DEFAULT_BURN_PERCENT;
+        let new_rent = Rent {
+            lamports_per_byte_year: (self.rent.lamports_per_byte_year as f64 * self.rent.exemption_threshold) as u64,
+            exemption_threshold: 1.0,
+            burn_percent: DEFAULT_BURN_PERCENT,
+        };
+        self.rent = new_rent;
     }
 }

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -1,5 +1,8 @@
 use {
-    solana_clock::Epoch, solana_epoch_schedule::EpochSchedule, solana_genesis_config::GenesisConfig, solana_rent::{Rent, DEFAULT_BURN_PERCENT}
+    solana_clock::Epoch,
+    solana_epoch_schedule::EpochSchedule,
+    solana_genesis_config::GenesisConfig,
+    solana_rent::{Rent, DEFAULT_BURN_PERCENT},
 };
 
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -2,7 +2,7 @@ use {
     solana_clock::Epoch,
     solana_epoch_schedule::EpochSchedule,
     solana_genesis_config::GenesisConfig,
-    solana_rent::{Rent, DEFAULT_BURN_PERCENT},
+    solana_rent::{DEFAULT_BURN_PERCENT, Rent},
 };
 
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
@@ -49,12 +49,11 @@ impl RentCollector {
     }
 
     pub(crate) fn deprecate_rent_exemption_threshold(&mut self) {
-        let new_rent = Rent {
+        self.rent = Rent {
             lamports_per_byte_year: (self.rent.lamports_per_byte_year as f64
                 * self.rent.exemption_threshold) as u64,
             exemption_threshold: 1.0,
             burn_percent: DEFAULT_BURN_PERCENT,
-        };
-        self.rent = new_rent;
+        }
     }
 }


### PR DESCRIPTION
#### Problem
When activating `deprecate_rent_exemption_threshold`, due to an unmitigated divergence in the value of `burn_percent` in `Rent`, when invoking `update_rent()`, the bank implicitly sets `burn_percent` from the cluster genesis value of `100` to the updated value of `50`. As this change is implicit and undocumented, this PR seeks to make it explicit for visibility so that any non-agave clients implementing the feature can achieve the same behavior. This change is non-breaking and backwards-compatible with respect to the existing feature gate code.

#### Summary of Changes
Explicitly set `burn_percent` in `Rent` to Rent::DEFAULT_BURN_PERCENT` to match the implicit behavior of `deprecate_rent_exemption_threshold` feature gate activation.