### PR TITLE
sbpf-debugger: pass debug_metadata to sbpf

### DIFF
--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -182,8 +182,7 @@ pub fn execute<'a, 'b: 'a>(
             let (debug_port, debug_metadata) = (
                 invoke_context.debug_port,
                 format!(
-                    "index_in_trace={};program_id={};cpi_level={};caller={}",
-                    instruction_context.get_index_in_trace(),
+                    "program_id={};cpi_level={};caller={}",
                     program_id,
                     instruction_context.get_stack_height().saturating_sub(1),
                     invoke_context

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -179,7 +179,26 @@ pub fn execute<'a, 'b: 'a>(
         ))] {
             let use_jit = false;
             #[cfg(feature = "sbpf-debugger")]
-            let debug_port = invoke_context.debug_port;
+            let (debug_port, debug_metadata) = (
+                invoke_context.debug_port,
+                format!(
+                    "index_in_trace={};program_id={};cpi_level={};caller={}",
+                    instruction_context.get_index_in_trace(),
+                    program_id,
+                    instruction_context.get_stack_height().saturating_sub(1),
+                    invoke_context
+                        .get_stack_height()
+                        .checked_sub(2)
+                        .and_then(|nesting_level| {
+                            transaction_context
+                                .get_instruction_context_at_nesting_level(nesting_level)
+                                .ok()
+                        })
+                        .and_then(|ctx| ctx.get_program_key().ok())
+                        .map(|key| key.to_string())
+                        .unwrap_or_else(|| "none".into())
+                ),
+            );
         } else {
             let use_jit = executable.get_compiled_program().is_some();
         }
@@ -234,6 +253,7 @@ pub fn execute<'a, 'b: 'a>(
         #[cfg(feature = "sbpf-debugger")]
         {
             vm.debug_port = debug_port;
+            vm.debug_metadata = Some(debug_metadata);
         }
         vm.context_object_pointer.execute_time = Some(Measure::start("execute"));
         vm.registers[1] = ebpf::MM_INPUT_START;


### PR DESCRIPTION
#### Problem

We need to know deterministically what we're going to debug.

#### Summary of Changes

Take advantage of the recent merge at solana-sbpf (https://github.com/anza-xyz/sbpf/pull/80) where VM creators could pass debug metadata that can later be visible to the debugger client.
