### PR TITLE
Revert "QUIC votes with tpu-client-next (#10194)"

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -33,8 +33,6 @@ pub enum KeyUpdaterType {
     Bls,
     /// BLS all-to-all connection cache key updater
     BlsConnectionCache,
-    /// For QUIC voting
-    VoteClient,
 }
 
 /// Responsible for managing the updaters for identity key change

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -7979,8 +7979,7 @@ pub(crate) mod tests {
             &poh_recorder,
             &tower_storage,
             vote_info,
-            &Arc::new(connection_cache),
-            &None,
+            Arc::new(connection_cache),
         );
 
         let mut cursor = Cursor::default();
@@ -8078,8 +8077,7 @@ pub(crate) mod tests {
             &poh_recorder,
             &tower_storage,
             vote_info,
-            &Arc::new(connection_cache),
-            &None,
+            Arc::new(connection_cache),
         );
 
         let votes = cluster_info.get_votes(&mut cursor);
@@ -8207,8 +8205,7 @@ pub(crate) mod tests {
             &poh_recorder,
             &tower_storage,
             vote_info,
-            &Arc::new(connection_cache),
-            &None,
+            Arc::new(connection_cache),
         );
 
         assert!(last_vote_refresh_time.last_refresh_time > clone_refresh_time);
@@ -8350,8 +8347,7 @@ pub(crate) mod tests {
             poh_recorder,
             tower_storage,
             vote_info,
-            &Arc::new(connection_cache),
-            &None,
+            Arc::new(connection_cache),
         );
 
         let votes = cluster_info.get_votes(cursor);

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -20,7 +20,8 @@ use {
         repair::repair_service::{OutstandingShredRepairs, RepairInfo, RepairServiceChannels},
         replay_stage::{ReplayReceivers, ReplaySenders, ReplayStage, ReplayStageConfig},
         shred_fetch_stage::{ShredFetchStage, SHRED_FETCH_CHANNEL_SIZE},
-        voting_service::{QuicVoteSender, VotingService},
+        voting_service::VotingService,
+        warm_quic_cache_service::WarmQuicCacheService,
         window_service::{WindowService, WindowServiceChannels},
     },
     agave_votor::{
@@ -102,6 +103,7 @@ pub struct Tvu {
     cost_update_service: CostUpdateService,
     voting_service: VotingService,
     bls_voting_service: BLSVotingService,
+    warm_quic_cache_service: Option<WarmQuicCacheService>,
     drop_bank_service: DropBankService,
     duplicate_shred_listener: DuplicateShredListener,
     bls_sigverify_threads: Option<(JoinHandle<()>, JoinHandle<()>)>,
@@ -222,8 +224,7 @@ impl Tvu {
         cluster_slots: Arc<ClusterSlots>,
         wen_restart_repair_slots: Option<Arc<RwLock<Vec<Slot>>>>,
         slot_status_notifier: Option<SlotStatusNotifier>,
-        udp_vote_connection_cache: Arc<ConnectionCache>,
-        quic_vote_sender: Option<QuicVoteSender>,
+        vote_connection_cache: Arc<ConnectionCache>,
         votor_init: AlpenglowInitializationState,
     ) -> Result<Self, String> {
         let in_wen_restart = wen_restart_repair_slots.is_some();
@@ -519,8 +520,7 @@ impl Tvu {
             cluster_info.clone(),
             poh_recorder.clone(),
             tower_storage,
-            udp_vote_connection_cache,
-            quic_vote_sender,
+            vote_connection_cache.clone(),
         );
 
         let bls_voting_service = BLSVotingService::new(
@@ -530,6 +530,14 @@ impl Tvu {
             bls_connection_cache,
             bank_forks.clone(),
             voting_service_test_override,
+        );
+
+        let warm_quic_cache_service = create_cache_warmer_if_needed(
+            None,
+            vote_connection_cache,
+            cluster_info,
+            poh_recorder,
+            &exit,
         );
 
         let cost_update_service = CostUpdateService::new(cost_update_receiver);
@@ -573,6 +581,7 @@ impl Tvu {
             cost_update_service,
             voting_service,
             bls_voting_service,
+            warm_quic_cache_service,
             drop_bank_service,
             duplicate_shred_listener,
             bls_sigverify_threads,
@@ -596,6 +605,9 @@ impl Tvu {
         self.cost_update_service.join()?;
         self.voting_service.join()?;
         self.bls_voting_service.join()?;
+        if let Some(warmup_service) = self.warm_quic_cache_service {
+            warmup_service.join()?;
+        }
         self.drop_bank_service.join()?;
         self.duplicate_shred_listener.join()?;
         if let Some((streamer, sigverifier)) = self.bls_sigverify_threads {
@@ -606,6 +618,27 @@ impl Tvu {
         self.commitment_service.join()?;
         Ok(())
     }
+}
+
+fn create_cache_warmer_if_needed(
+    connection_cache: Option<&Arc<ConnectionCache>>,
+    vote_connection_cache: Arc<ConnectionCache>,
+    cluster_info: &Arc<ClusterInfo>,
+    poh_recorder: &Arc<RwLock<PohRecorder>>,
+    exit: &Arc<AtomicBool>,
+) -> Option<WarmQuicCacheService> {
+    let tpu_connection_cache = connection_cache.filter(|cache| cache.use_quic()).cloned();
+    let vote_connection_cache = Some(vote_connection_cache).filter(|cache| cache.use_quic());
+
+    (tpu_connection_cache.is_some() || vote_connection_cache.is_some()).then(|| {
+        WarmQuicCacheService::new(
+            tpu_connection_cache,
+            vote_connection_cache,
+            cluster_info.clone(),
+            poh_recorder.clone(),
+            exit.clone(),
+        )
+    })
 }
 
 #[cfg(test)]
@@ -793,7 +826,6 @@ pub mod tests {
             wen_restart_repair_slots,
             None, // slot_status_notifier
             Arc::new(connection_cache),
-            None,
             AlpenglowInitializationState {
                 leader_window_info_sender,
                 replay_highest_frozen,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -18,7 +18,6 @@ use {
             ExternalRootSource, Tower,
         },
         forwarding_stage::ForwardingClientConfig,
-        next_leader::VotingServiceLeaderUpdater,
         repair::{
             self,
             quic_endpoint::{RepairQuicAsyncSenders, RepairQuicSenders, RepairQuicSockets},
@@ -34,7 +33,6 @@ use {
         },
         tpu::{Tpu, TpuSockets},
         tvu::{AlpenglowInitializationState, Tvu, TvuConfig, TvuSockets},
-        voting_service,
     },
     agave_snapshots::{
         snapshot_archive_info::SnapshotArchiveInfoGetter as _, snapshot_config::SnapshotConfig,
@@ -55,8 +53,8 @@ use {
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         utils::move_and_async_delete_path_contents,
     },
-    solana_client::connection_cache::ConnectionCache,
-    solana_clock::{Slot, DEFAULT_MS_PER_SLOT},
+    solana_client::connection_cache::{ConnectionCache, Protocol},
+    solana_clock::Slot,
     solana_cluster_type::ClusterType,
     solana_entry::poh::compute_hash_time,
     solana_epoch_schedule::MAX_LEADER_SCHEDULE_EPOCH_OFFSET,
@@ -145,8 +143,7 @@ use {
         streamer::StakedNodes,
     },
     solana_time_utils::timestamp,
-    solana_tpu_client::tpu_client::DEFAULT_TPU_CONNECTION_POOL_SIZE,
-    solana_tpu_client_next::ClientBuilder,
+    solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC},
     solana_turbine::{
         self,
         broadcast_stage::BroadcastStageType,
@@ -645,7 +642,7 @@ impl ValidatorTpuConfig {
         };
 
         ValidatorTpuConfig {
-            vote_use_quic: true, // Test with QUIC, even if DEFAULT_VOTE_USE_QUIC if false
+            vote_use_quic: DEFAULT_VOTE_USE_QUIC,
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
             tpu_quic_server_config,
             tpu_fwd_quic_server_config,
@@ -690,11 +687,10 @@ pub struct Validator {
     repair_quic_endpoints_runtime: Option<TokioRuntime>,
     repair_quic_endpoints_join_handle: Option<repair::quic_endpoint::AsyncTryJoinHandle>,
     xdp_retransmitter: Option<XdpRetransmitter>,
-    // These runtimes are used to run the clients owned by SendTransactionService.
-    // We don't wait for their JoinHandle here because ownership and shutdown
-    // are managed elsewhere. These variables are intentionally unused.
-    _rpc_fwd_tpu_client_next_runtime: Option<TokioRuntime>,
-    _quic_vote_tpu_client_next_runtime: Option<TokioRuntime>,
+    // This runtime is used to run the client owned by SendTransactionService.
+    // We don't wait for its JoinHandle here because ownership and shutdown
+    // are managed elsewhere. This variable is intentionally unused.
+    _tpu_client_next_runtime: Option<TokioRuntime>,
 }
 
 impl Validator {
@@ -870,7 +866,7 @@ impl Validator {
         timer.stop();
         info!("Cleaning orphaned account snapshot directories done. {timer}");
 
-        // token used to cancel tpu-client-next, streamer, BLS streamer, and voting over quic service.
+        // token used to cancel tpu-client-next, streamer and BLS streamer.
         let cancel = CancellationToken::new();
         {
             let exit = exit.clone();
@@ -1209,10 +1205,29 @@ impl Validator {
         let mut tpu_transactions_forwards_client_sockets =
             Some(node.sockets.tpu_transaction_forwarding_clients);
 
-        let udp_vote_connection_cache = Arc::new(ConnectionCache::with_udp(
-            "connection_cache_vote_udp",
-            tpu_connection_pool_size,
-        ));
+        let vote_connection_cache = if vote_use_quic {
+            let vote_connection_cache = ConnectionCache::new_with_client_options(
+                "connection_cache_vote_quic",
+                tpu_connection_pool_size,
+                Some(node.sockets.quic_vote_client),
+                Some((
+                    &identity_keypair,
+                    node.info
+                        .tpu_vote(Protocol::QUIC)
+                        .ok_or_else(|| {
+                            ValidatorError::Other(String::from("Invalid QUIC address for TPU Vote"))
+                        })?
+                        .ip(),
+                )),
+                Some((&staked_nodes, &identity_keypair.pubkey())),
+            );
+            Arc::new(vote_connection_cache)
+        } else {
+            Arc::new(ConnectionCache::with_udp(
+                "connection_cache_vote_udp",
+                tpu_connection_pool_size,
+            ))
+        };
 
         let bls_connection_cache = Arc::new(ConnectionCache::new_with_client_options(
             "connection_cache_bls_quic",
@@ -1245,59 +1260,14 @@ impl Validator {
         // always need a tokio runtime (and the respective handle) to initialize
         // the QUIC endpoints.
         let current_runtime_handle = tokio::runtime::Handle::try_current();
-        let rpc_fwd_tpu_client_next_runtime = current_runtime_handle.is_err().then(|| {
+        let tpu_client_next_runtime = current_runtime_handle.is_err().then(|| {
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .worker_threads(2)
-                .thread_name("solRpcFwdRt")
+                .thread_name("solTpuClientRt")
                 .build()
                 .unwrap()
         });
-        let rpc_fwd_tpu_client_next_runtime_handle = rpc_fwd_tpu_client_next_runtime
-            .as_ref()
-            .map(TokioRuntime::handle)
-            .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap());
-
-        let (quic_vote_sender, quic_vote_tpu_client_next_runtime) = if vote_use_quic {
-            let rt = current_runtime_handle.is_err().then(|| {
-                tokio::runtime::Builder::new_multi_thread()
-                    .enable_all()
-                    .worker_threads(2)
-                    .thread_name("solQuicVoteRt")
-                    .build()
-                    .unwrap()
-            });
-            let rt_handle = rt
-                .as_ref()
-                .map(TokioRuntime::handle)
-                .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap());
-            let leader_updater = Box::new(VotingServiceLeaderUpdater::new(
-                cluster_info.clone(),
-                poh_recorder.clone(),
-            ));
-            let builder = ClientBuilder::new(leader_updater)
-                .bind_socket(node.sockets.quic_vote_client)
-                .leader_send_fanout(voting_service::QUIC_UPCOMING_LEADER_FANOUT_LEADERS)
-                .identity(Arc::as_ref(&identity_keypair))
-                .metric_reporter(|stats, cancel| {
-                    stats.report_to_influxdb(
-                        "vote_client_quic",
-                        Duration::from_millis(DEFAULT_MS_PER_SLOT * 2),
-                        cancel,
-                    )
-                })
-                .cancel_token(cancel.clone())
-                .runtime_handle(rt_handle.clone());
-            let (sender, client) = builder.build()?;
-            let quic_vote_sender = voting_service::QuicVoteSender(sender);
-            key_notifiers
-                .write()
-                .unwrap()
-                .add(KeyUpdaterType::VoteClient, Arc::new(client));
-            (Some(quic_vote_sender), rt)
-        } else {
-            (None, None)
-        };
 
         let rpc_override_health_check =
             Arc::new(AtomicBool::new(config.rpc_config.disable_health_check));
@@ -1325,10 +1295,15 @@ impl Validator {
             };
 
             let rpc_tpu_client_args = {
+                let runtime_handle = tpu_client_next_runtime
+                    .as_ref()
+                    .map(TokioRuntime::handle)
+                    .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap());
+
                 RpcTpuClientArgs(
                     Arc::as_ref(&identity_keypair),
                     node.sockets.rpc_sts_client,
-                    rpc_fwd_tpu_client_next_runtime_handle.clone(),
+                    runtime_handle.clone(),
                     cancel.clone(),
                 )
             };
@@ -1728,8 +1703,7 @@ impl Validator {
             cluster_slots.clone(),
             wen_restart_repair_slots.clone(),
             slot_status_notifier,
-            udp_vote_connection_cache,
-            quic_vote_sender,
+            vote_connection_cache,
             AlpenglowInitializationState {
                 leader_window_info_sender,
                 replay_highest_frozen: replay_highest_frozen.clone(),
@@ -1766,10 +1740,14 @@ impl Validator {
         }
 
         let tpu_forwaring_client_config = {
+            let runtime_handle = tpu_client_next_runtime
+                .as_ref()
+                .map(TokioRuntime::handle)
+                .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap());
             ForwardingClientConfig {
                 stake_identity: Arc::as_ref(&identity_keypair),
                 tpu_client_sockets: tpu_transactions_forwards_client_sockets.take().unwrap(),
-                runtime_handle: rpc_fwd_tpu_client_next_runtime_handle.clone(),
+                runtime_handle: runtime_handle.clone(),
                 cancel: cancel.clone(),
                 node_multihoming: node_multihoming.clone(),
             }
@@ -1898,8 +1876,7 @@ impl Validator {
             repair_quic_endpoints_runtime,
             repair_quic_endpoints_join_handle,
             xdp_retransmitter,
-            _rpc_fwd_tpu_client_next_runtime: rpc_fwd_tpu_client_next_runtime,
-            _quic_vote_tpu_client_next_runtime: quic_vote_tpu_client_next_runtime,
+            _tpu_client_next_runtime: tpu_client_next_runtime,
         })
     }
 

--- a/tpu-client-next/src/client_builder.rs
+++ b/tpu-client-next/src/client_builder.rs
@@ -50,8 +50,7 @@ use {
         ConnectionWorkersScheduler, ConnectionWorkersSchedulerError, SendTransactionStats,
     },
     solana_keypair::Keypair,
-    solana_tls_utils::NotifyKeyUpdate,
-    std::{error::Error, future::Future, net::UdpSocket, pin::Pin, sync::Arc},
+    std::{future::Future, net::UdpSocket, pin::Pin, sync::Arc},
     thiserror::Error,
     tokio::{
         runtime,
@@ -344,11 +343,5 @@ impl<T> CancellableHandle<T> {
     pub async fn shutdown(self) -> Result<T, JoinError> {
         self.cancel.cancel();
         self.handle.await
-    }
-}
-
-impl NotifyKeyUpdate for Client {
-    fn update_key(&self, key: &Keypair) -> Result<(), Box<dyn Error>> {
-        self.update_identity(key).map_err(|e| e.into())
     }
 }

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1642,7 +1642,6 @@ mod tests {
                     KeyUpdaterType::RpcService,
                     KeyUpdaterType::Bls,
                     KeyUpdaterType::BlsConnectionCache,
-                    KeyUpdaterType::VoteClient,
                 ])
             );
             let mut io = MetaIoHandler::default();

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -706,6 +706,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("vote-use-quic")
             .takes_value(true)
             .default_value(&default_args.vote_use_quic)
+            .hidden(hidden_unless_forced())
             .help("Controls if to use QUIC to send votes."),
     )
     .arg(


### PR DESCRIPTION
#### Problem
The reverted commit made `--vote-use-quic` a non-hidden arg. Unhiding the arg makes it something we "officially" support and then have to follow deprecate-then-remove process. I don't think we're at the point of committing to vote-over-QUIC at that level so back the change out

#### Summary of Changes
This reverts commit 49d8dccf4a08148a5abcebdfc97c14a6f9da8e6c.