### PR TITLE
Makes append_vec::ValidSlice private

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -89,16 +89,16 @@ pub enum AppendVecError {
 /// A slice whose contents are known to be valid.
 /// The slice contains no undefined bytes.
 #[derive(Debug, Copy, Clone)]
-pub(crate) struct ValidSlice<'a>(&'a [u8]);
+struct ValidSlice<'a>(&'a [u8]);
 
 impl<'a> ValidSlice<'a> {
     #[inline(always)]
-    pub(crate) fn new(data: &'a [u8]) -> Self {
+    fn new(data: &'a [u8]) -> Self {
         Self(data)
     }
 
     #[inline(always)]
-    pub(crate) fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.0.len()
     }
 }


### PR DESCRIPTION
#### Problem

`append_vec::ValidSlice` is public (to the crate) unnecessarily.


#### Summary of Changes

Make it private.