### PR TITLE
fix: remove dead batch_success metric from connection cache stats

### DIFF
--- a/connection-cache/src/connection_cache_stats.rs
+++ b/connection-cache/src/connection_cache_stats.rs
@@ -11,7 +11,6 @@ pub struct ConnectionCacheStats {
     pub eviction_time_ms: AtomicU64,
     pub sent_packets: AtomicU64,
     pub total_batches: AtomicU64,
-    pub batch_success: AtomicU64,
     pub batch_failure: AtomicU64,
     pub get_connection_ms: AtomicU64,
     pub get_connection_lock_ms: AtomicU64,
@@ -75,9 +74,7 @@ impl ConnectionCacheStats {
         self.sent_packets
             .fetch_add(num_packets as u64, Ordering::Relaxed);
         self.total_batches.fetch_add(1, Ordering::Relaxed);
-        if is_success {
-            self.batch_success.fetch_add(1, Ordering::Relaxed);
-        } else {
+        if !is_success {
             self.batch_failure.fetch_add(1, Ordering::Relaxed);
         }
     }


### PR DESCRIPTION
Reason for changes:
The batch_success counter in ConnectionCacheStats was incremented but never reported via datapoint_info!, while successful batches can be derived from total_batches - batch_failure. This made the field dead/unused and could confuse readers of the stats code.

Summary of changes:
Removed the batch_success field from ConnectionCacheStats and its increment in add_client_stats, keeping total_batches and batch_failure as the authoritative batch metrics.