### PR TITLE
Remove old log

### DIFF
--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -206,22 +206,12 @@ impl<'a> SnapshotMinimizer<'a> {
         );
         info!("{process_snapshot_storages_measure}");
 
-        // Avoid excessive logging
-        self.accounts_db()
-            .log_dead_slots
-            .store(false, Ordering::Relaxed);
-
         let (_, purge_dead_slots_measure) =
             measure_time!(self.purge_dead_slots(dead_slots), "purge dead slots");
         info!("{purge_dead_slots_measure}");
 
         let (_, drop_storages_measure) = measure_time!(drop(dead_storages), "drop storages");
         info!("{drop_storages_measure}");
-
-        // Turn logging back on after minimization
-        self.accounts_db()
-            .log_dead_slots
-            .store(true, Ordering::Relaxed);
     }
 
     /// Determines minimum set of slots that accounts in `minimized_account_set` are in


### PR DESCRIPTION
#### Problem
Log is missing roots cleaned during ancient shrink. It is also spammy and likely never used. There are better ways of logging things (eg chronograph).

#### Summary of Changes
- Remove the counter and the configuration. 
- This is setup for moving clean_dead_slots_from_accounts_index to the accounts_index. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
