### PR TITLE
Repair: drop packets that would exceed quota early

### DIFF
--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -179,6 +179,7 @@ struct ServeRepairStats {
     total_requests: usize,
     dropped_requests_outbound_bandwidth: usize,
     dropped_requests_load_shed: usize,
+    dropped_requests_load_shed_sigverify: usize,
     dropped_requests_low_stake: usize,
     whitelisted_requests: usize,
     total_dropped_response_packets: usize,
@@ -666,7 +667,7 @@ impl ServeRepair {
         const MIN_RESPONSE_SIZE: usize = PACKET_DATA_SIZE + SIZE_OF_NONCE;
         let decode_request = |request| {
             if remaining_budget_estimate < MIN_RESPONSE_SIZE {
-                stats.dropped_requests_load_shed += 1;
+                stats.dropped_requests_load_shed_sigverify += 1;
                 return None;
             }
             let result = Self::decode_request(
@@ -823,6 +824,11 @@ impl ServeRepair {
             (
                 "dropped_requests_load_shed",
                 stats.dropped_requests_load_shed,
+                i64
+            ),
+            (
+                "dropped_requests_load_shed_sigverify",
+                stats.dropped_requests_load_shed_sigverify,
                 i64
             ),
             (

--- a/perf/src/data_budget.rs
+++ b/perf/src/data_budget.rs
@@ -18,6 +18,15 @@ impl DataBudget {
         }
     }
 
+    pub fn get(&self) -> usize {
+        self.bytes.load(Ordering::Relaxed)
+    }
+
+    /// Unconditionally adds size bytes to the budget
+    pub fn put(&self, size: usize) -> usize {
+        self.bytes.fetch_add(size, Ordering::Relaxed)
+    }
+
     // If there are enough bytes in the budget, consumes from
     // the budget and returns true. Otherwise returns false.
     #[must_use]


### PR DESCRIPTION
#### Problem

- We keep doing sigverify on repair packets even after data budget is exhausted which is wasteful
- We keep doing expensive operations without explicit quota on their quantity

#### Summary of Changes

- Estimate remaining data budget and avoid sigverify for packets that would not be able to get served anyway
- Consume budget before accessing blockstore



#### Before the patch:

 
<img width="1276" height="534" alt="Screenshot 2026-02-05 at 23 15 37" src="https://github.com/user-attachments/assets/7c662a43-5624-42f5-82ec-64d2ffb0429f" />

Most of the rejected packets are dropped via load_shed path https://github.com/anza-xyz/agave/blob/94d4f8d2b2e3598562ccd9b199701d180a2e06f9/core/src/repair/serve_repair.rs#L739 this happens before sigverify.  At this point 90K packets get sent to sigverify over 2 seconds, resulting in substantial usage of CPU.

#### After the patch:

<img width="2536" height="1056" alt="repair_mds1" src="https://github.com/user-attachments/assets/afa56708-193c-44e3-8aea-966af0d40073" />

out of 950K requests,
896K packets are dropped before sigverify is performed

950-786-110 = 54K packets are sent to sigverify

we are serving around 4000 requests over 2 seconds, i.e. 2000 pps, or 2.4 Mbytes/s (which is a bit more than intended 1.2 Mbytes/s due to DataBudget refill cycles impacting actual rate limiting.

**Another load spike:**
<img width="2572" height="1068" alt="image" src="https://github.com/user-attachments/assets/d63e846f-2bf3-4c0b-ac4d-9be42c30ae16" />

1.7M packets ingested, 1.38M packets shed due to new code, 220K packets dropped due to existing shedding logic 85K packets were invalid and could not be parsed

1.71e6 - (1.38e6 +220e3+85e3 ) = 25K packets sent to sigverify


The purpose of this change was not to serve more or less requests than before, it was to shed them early (before sigverify), which is exactly what it does (see also profiler run below which indicates that solRepairListen thread is idle most of the time except for 2 large spikes, each lasting ~50ms 

The service rate is not hampered (total amount of requests served bumps against outbound_bandwidth as intended), but we are shedding much of the excess load before sigverify. Sigverify load reduced by anywhere between 2x and 4x depending on DataBudget refill timings vs arrival of repair burst.
