### PR TITLE
cleanup(accounts-db): remove redundant params from generate_index_for_slot

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6151,9 +6151,10 @@ impl AccountsDb {
         reader: &mut impl RequiredLenBufFileRead<'a>,
         thread_state: &mut IndexGenerationThreadState,
         storage: &'a AccountStorageEntry,
-        slot: Slot,
-        store_id: AccountsFileId,
     ) -> SlotIndexGenerationInfo {
+        let slot = storage.slot();
+        let store_id = storage.id();
+
         let mut accounts_data_len = 0;
         let mut stored_size_alive = 0;
         let mut zero_lamport_pubkeys = vec![];
@@ -6392,15 +6393,8 @@ impl AccountsDb {
                             for next_item in storages_orderer.iter() {
                                 self.maybe_throttle_index_generation();
                                 let storage = next_item.storage;
-                                let store_id = storage.id();
-                                let slot = storage.slot();
-                                let slot_info = self.generate_index_for_slot(
-                                    &mut reader,
-                                    &mut state,
-                                    storage,
-                                    slot,
-                                    store_id,
-                                );
+                                let slot_info =
+                                    self.generate_index_for_slot(&mut reader, &mut state, storage);
                                 thread_accum.insert_us += slot_info.insert_time_us;
                                 thread_accum.num_accounts += slot_info.num_accounts;
                                 thread_accum.accounts_data_len += slot_info.accounts_data_len;
@@ -6410,7 +6404,7 @@ impl AccountsDb {
                                 if slot_info.all_accounts_are_zero_lamports {
                                     thread_accum.all_accounts_are_zero_lamports_slots += 1;
                                     thread_accum.all_zeros_slots.push((
-                                        slot,
+                                        storage.slot(),
                                         Arc::clone(&storages[next_item.original_index]),
                                     ));
                                 }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -188,13 +188,7 @@ fn run_generate_index_duplicates_within_slot_test(db: AccountsDb, reverse: bool)
     let storage = db.get_storage_for_slot(slot0).unwrap();
     let mut reader = append_vec::new_scan_accounts_reader();
     let mut state = IndexGenerationThreadState::default();
-    db.generate_index_for_slot(
-        &mut reader,
-        &mut state,
-        &storage,
-        storage.slot(),
-        storage.id(),
-    );
+    db.generate_index_for_slot(&mut reader, &mut state, &storage);
 }
 
 define_accounts_db_test!(
@@ -4854,7 +4848,7 @@ define_accounts_db_test!(test_calculate_storage_count_and_alive_bytes, |accounts
     let storage = accounts.storage.get_slot_storage_entry(slot0).unwrap();
     let mut reader = append_vec::new_scan_accounts_reader();
     let mut state = IndexGenerationThreadState::default();
-    accounts.generate_index_for_slot(&mut reader, &mut state, &storage, slot0, 0);
+    accounts.generate_index_for_slot(&mut reader, &mut state, &storage);
     assert_eq!(state.storage_info.len(), 1);
     for (slot, value) in state.storage_info {
         let expected_stored_size =
@@ -4878,7 +4872,7 @@ define_accounts_db_test!(
         let storage = accounts.create_and_insert_store(0, 1, "test");
         let mut reader = append_vec::new_scan_accounts_reader();
         let mut state = IndexGenerationThreadState::default();
-        accounts.generate_index_for_slot(&mut reader, &mut state, &storage, 0, 0);
+        accounts.generate_index_for_slot(&mut reader, &mut state, &storage);
         assert!(state.storage_info.is_empty());
     }
 );
@@ -4915,7 +4909,7 @@ define_accounts_db_test!(
 
         let mut reader = append_vec::new_scan_accounts_reader();
         let mut state = IndexGenerationThreadState::default();
-        accounts.generate_index_for_slot(&mut reader, &mut state, &storage, 0, 0);
+        accounts.generate_index_for_slot(&mut reader, &mut state, &storage);
         assert_eq!(state.storage_info.len(), 1);
         for (slot, value) in state.storage_info {
             let expected_stored_size =
@@ -4983,7 +4977,7 @@ fn test_calculate_storage_count_and_alive_bytes_obsolete_account(
 
     let mut reader = append_vec::new_scan_accounts_reader();
     let mut state = IndexGenerationThreadState::default();
-    let info = accounts.generate_index_for_slot(&mut reader, &mut state, &storage, 0, 0);
+    let info = accounts.generate_index_for_slot(&mut reader, &mut state, &storage);
     assert_eq!(
         info.num_obsolete_accounts_skipped,
         num_accounts_to_mark_obsolete as u64


### PR DESCRIPTION
#### Problem
`slot` and `store_id` can be accessed from `storage` instead of passed as parameters (in fact they are accessed from there just before calling the function)

#### Summary of Changes
Remove params.
