### PR TITLE
validator: Remove admin rpc method for secondary indexes size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,8 +472,6 @@ dependencies = [
  "solana-validator-exit",
  "solana-version",
  "solana-vote-program",
- "spl-generic-token",
- "spl-token-2022-interface",
  "symlink",
  "tempfile",
  "test-case",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -114,7 +114,5 @@ solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-time-utils = { workspace = true }
-spl-generic-token = { workspace = true }
-spl-token-2022-interface = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }


### PR DESCRIPTION
#### Problem
This logic was added in 2022 for some features that I believe we abandoned and were at least partially reverted. Did some digging to trace the history on this:
- Several PR's were added for https://github.com/solana-labs/solana/issues/28666
    1. The code being removed in this PR was added to RPC interface with https://github.com/solana-labs/solana/pull/28383
    2. The code being removed in this PR was shifted to admin RPC interface with https://github.com/solana-labs/solana/pull/29003
    3. https://github.com/solana-labs/solana/pull/28887 added an additional feature
    4. https://github.com/solana-labs/solana/pull/29352 hooked up the feature in **iii.** to admin interface
    5. https://github.com/solana-labs/solana/pull/33121 reverted **iii.** and **iv.**

#### Solution
Rip the remaining code out (items **i. / ii.** from above)