### PR TITLE
cli: remove `--bls-keypair` from `create-vote-account`

### DIFF
--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -5,10 +5,7 @@ use {
     },
     chrono::DateTime,
     clap::ArgMatches,
-    solana_bls_signatures::{
-        keypair::Keypair as BLSKeypair, Pubkey as BLSPubkey,
-        PubkeyCompressed as BLSPubkeyCompressed,
-    },
+    solana_bls_signatures::{Pubkey as BLSPubkey, PubkeyCompressed as BLSPubkeyCompressed},
     solana_clock::UnixTimestamp,
     solana_cluster_type::ClusterType,
     solana_commitment_config::CommitmentConfig,
@@ -106,12 +103,6 @@ pub fn pubkeys_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<Pubkey>> {
             })
             .collect()
     })
-}
-
-pub fn bls_keypair_of(matches: &ArgMatches<'_>, name: &str) -> Option<BLSKeypair> {
-    matches
-        .value_of(name)
-        .and_then(|path| BLSKeypair::read_json_file(path).ok())
 }
 
 pub fn bls_pubkeys_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<BLSPubkeyCompressed>> {
@@ -281,6 +272,7 @@ mod tests {
     use {
         super::*,
         clap::{App, Arg},
+        solana_bls_signatures::{keypair::Keypair as BLSKeypair, Pubkey as BLSPubkey},
         solana_keypair::write_keypair_file,
         std::fs,
     };
@@ -442,24 +434,6 @@ mod tests {
         assert_ne!(lamports_of_sol(&matches, "single"), Some(15_700_000));
         let matches = app().get_matches_from(vec!["test", "--single", "0.5025"]);
         assert_ne!(lamports_of_sol(&matches, "single"), Some(502_500_000));
-    }
-
-    #[test]
-    fn test_bls_keypair_of() {
-        let bls_keypair = BLSKeypair::new();
-        let outfile = tmp_file_path("test_bls_keypair_of.json", &Pubkey::new_unique());
-        bls_keypair.write_json_file(&outfile).unwrap();
-
-        let matches = app().get_matches_from(vec!["test", "--single", &outfile]);
-        let parsed = bls_keypair_of(&matches, "single").unwrap();
-        assert_eq!(parsed.public, bls_keypair.public);
-        assert!(bls_keypair_of(&matches, "multiple").is_none());
-
-        // Non-existent file should return None
-        let matches = app().get_matches_from(vec!["test", "--single", "random_bls_keypair.json"]);
-        assert!(bls_keypair_of(&matches, "single").is_none());
-
-        fs::remove_file(&outfile).unwrap();
     }
 
     #[test]

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -4,7 +4,6 @@ use {
         keypair::{parse_signer_source, SignerSourceKind, ASK_KEYWORD},
     },
     chrono::DateTime,
-    solana_bls_signatures::keypair::Keypair as BLSKeypair,
     solana_clock::{Epoch, Slot},
     solana_hash::Hash,
     solana_keypair::read_keypair_file,
@@ -91,16 +90,6 @@ where
         return Ok(());
     }
     read_keypair_file(string.as_ref())
-        .map(|_| ())
-        .map_err(|err| format!("{err}"))
-}
-
-// Return an error if a BLS keypair file cannot be parsed.
-pub fn is_bls_keypair<T>(string: T) -> Result<(), String>
-where
-    T: AsRef<str> + Display,
-{
-    BLSKeypair::read_json_file(string.as_ref())
         .map(|_| ())
         .map_err(|err| format!("{err}"))
 }
@@ -492,7 +481,7 @@ pub fn is_non_zero(value: impl AsRef<str>) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, tempfile::NamedTempFile};
+    use super::*;
 
     #[test]
     fn test_is_derivation() {
@@ -505,23 +494,6 @@ mod tests {
         assert!(is_derivation("4294967296").is_err());
         assert!(is_derivation("a/b").is_err());
         assert!(is_derivation("0/4294967296").is_err());
-    }
-
-    #[test]
-    fn test_is_bls_keypair() {
-        // Non-existent file should error
-        assert!(is_bls_keypair("nonexistent_file.json").is_err());
-
-        // Invalid content should error
-        let invalid_file = NamedTempFile::new().unwrap();
-        std::fs::write(invalid_file.path(), "invalid content").unwrap();
-        assert!(is_bls_keypair(invalid_file.path().to_str().unwrap()).is_err());
-
-        // Valid BLS keypair file should succeed
-        let bls_keypair = BLSKeypair::new();
-        let valid_file = NamedTempFile::new().unwrap();
-        bls_keypair.write_json_file(valid_file.path()).unwrap();
-        assert!(is_bls_keypair(valid_file.path().to_str().unwrap()).is_ok());
     }
 
     #[test]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -6,7 +6,6 @@ use {
     clap::{crate_description, crate_name, value_t_or_exit, ArgMatches, Shell},
     num_traits::FromPrimitive,
     serde_json::{self, Value},
-    solana_bls_signatures::keypair::Keypair as BLSKeypair,
     solana_clap_utils::{self, input_parsers::*, keypair::*},
     solana_cli_config::ConfigInput,
     solana_cli_output::{
@@ -331,7 +330,6 @@ pub enum CliCommand {
         commission: Option<u8>,
         // VoteInitV2 args (SIMD-0387).
         use_v2_instruction: bool,
-        bls_keypair: Option<BLSKeypair>,
         inflation_rewards_commission_bps: Option<u16>,
         inflation_rewards_collector: Option<Pubkey>,
         block_revenue_commission_bps: Option<u16>,
@@ -1581,7 +1579,6 @@ pub async fn process_command(config: &CliConfig<'_>) -> ProcessResult {
             authorized_withdrawer,
             commission,
             use_v2_instruction,
-            bls_keypair,
             inflation_rewards_commission_bps,
             inflation_rewards_collector,
             block_revenue_commission_bps,
@@ -1605,7 +1602,6 @@ pub async fn process_command(config: &CliConfig<'_>) -> ProcessResult {
                 *authorized_withdrawer,
                 *commission,
                 *use_v2_instruction,
-                bls_keypair.as_ref(),
                 *inflation_rewards_commission_bps,
                 inflation_rewards_collector.as_ref(),
                 *block_revenue_commission_bps,
@@ -2327,7 +2323,7 @@ mod tests {
             authorized_withdrawer: bob_pubkey,
             commission: Some(0),
             use_v2_instruction: false,
-            bls_keypair: None,
+
             inflation_rewards_commission_bps: None,
             inflation_rewards_collector: None,
             block_revenue_commission_bps: None,
@@ -2612,7 +2608,7 @@ mod tests {
             authorized_withdrawer: bob_pubkey,
             commission: Some(0),
             use_v2_instruction: false,
-            bls_keypair: None,
+
             inflation_rewards_commission_bps: None,
             inflation_rewards_collector: None,
             block_revenue_commission_bps: None,

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -86,7 +86,6 @@ async fn test_stake_delegation_force() {
         authorized_withdrawer,
         commission: Some(0),
         use_v2_instruction: false,
-        bls_keypair: None,
         inflation_rewards_commission_bps: None,
         inflation_rewards_collector: None,
         block_revenue_commission_bps: None,

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -57,7 +57,7 @@ async fn test_vote_authorize_and_withdraw(compute_unit_price: Option<u64>) {
         authorized_withdrawer: config.signers[0].pubkey(),
         commission: Some(0),
         use_v2_instruction: false,
-        bls_keypair: None,
+
         inflation_rewards_commission_bps: None,
         inflation_rewards_collector: None,
         block_revenue_commission_bps: None,
@@ -304,7 +304,7 @@ async fn test_offline_vote_authorize_and_withdraw(compute_unit_price: Option<u64
         authorized_withdrawer: offline_keypair.pubkey(),
         commission: Some(0),
         use_v2_instruction: false,
-        bls_keypair: None,
+
         inflation_rewards_commission_bps: None,
         inflation_rewards_collector: None,
         block_revenue_commission_bps: None,


### PR DESCRIPTION
#### Problem
After further discussion, we figured it's probably best to avoid an explicit `--bls-keypair` argument in the CLI (for SIMD-0387) and just instead derive all BLS pubkeys/keypairs behind the scenes.

#### Summary of Changes
Remove the explicit arg and always derive the BLS keypair on-the-fly from the identity keypair.
Also removes the BLS keypair input validators added in #10130.