### PR TITLE
refactor: remove the `reloading` `bool` argument thread

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -14,10 +14,10 @@ use {
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_program_runtime::{
         create_vm,
-        deploy::load_program_from_bytes,
         invoke_context::InvokeContext,
         loaded_programs::{
-            LoadProgramMetrics, ProgramCacheEntryType, DELAY_VISIBILITY_SLOT_OFFSET,
+            LoadProgramMetrics, ProgramCacheEntry, ProgramCacheEntryType,
+            DELAY_VISIBILITY_SLOT_OFFSET,
         },
         serialization::serialize_parameters,
         with_mock_invoke_context,
@@ -267,7 +267,6 @@ fn load_program<'a>(
     let mut contents = Vec::new();
     file.read_to_end(&mut contents).unwrap();
     let slot = Slot::default();
-    let log_collector = invoke_context.get_log_collector();
     let loader_key = bpf_loader_upgradeable::id();
     let mut load_program_metrics = LoadProgramMetrics {
         program_id: program_id.to_string(),
@@ -284,15 +283,14 @@ fn load_program<'a>(
     // Allowing mut here, since it may be needed for jit compile, which is under a config flag
     #[allow(unused_mut)]
     let mut verified_executable = if is_elf {
-        let result = load_program_from_bytes(
-            log_collector,
-            &mut load_program_metrics,
-            &contents,
+        let result = ProgramCacheEntry::new(
             &loader_key,
-            account_size,
-            slot,
             Arc::new(program_runtime_environment),
-            false,
+            slot,
+            slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
+            &contents,
+            account_size,
+            &mut load_program_metrics,
         );
         match result {
             Ok(loaded_program) => match loaded_program.program {
@@ -487,7 +485,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     for key in cached_account_keys {
         program_cache_for_tx_batch.replenish(
             key,
-            bank.load_program(&key, false, bank.epoch())
+            bank.load_program(&key, bank.epoch())
                 .expect("Couldn't find program account"),
         );
         debug!("Loaded program {key}");

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1546,7 +1546,6 @@ impl Bank {
                     &key,
                     self.slot,
                     &mut ExecuteTimings::default(),
-                    false,
                 ) {
                     recompiled.tx_usage_counter.fetch_add(
                         program_to_recompile
@@ -6110,7 +6109,6 @@ impl Bank {
     pub fn load_program(
         &self,
         pubkey: &Pubkey,
-        reload: bool,
         effective_epoch: Epoch,
     ) -> Option<Arc<ProgramCacheEntry>> {
         let environments = self
@@ -6122,7 +6120,6 @@ impl Bank {
             pubkey,
             self.slot(),
             &mut ExecuteTimings::default(), // Called by ledger-tool, metrics not accumulated.
-            reload,
         )
         .map(|(loaded_program, _last_modification_slot)| loaded_program)
     }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -2154,7 +2154,7 @@ pub(crate) mod tests {
 
         // Load the migrated program to the cache and run checks.
         let entry = roundtrip_bank
-            .load_program(&bpf_loader_v2_program_address, false, upgrade_slot)
+            .load_program(&bpf_loader_v2_program_address, upgrade_slot)
             .unwrap();
 
         let mut program_cache = roundtrip_bank

--- a/svm-test-harness/instr/src/program_cache.rs
+++ b/svm-test-harness/instr/src/program_cache.rs
@@ -107,7 +107,6 @@ pub fn fill_from_accounts(
                     &acc.0,
                     slot,
                     &mut ExecuteTimings::default(),
-                    false,
                 )
             {
                 program_cache.replenish(acc.0, loaded_program);

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -877,7 +877,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     &key,
                     self.slot,
                     execute_timings,
-                    false,
                 )
                 .expect("called load_program_with_pubkey() with nonexistent account");
                 (key, program, last_modification_slot)


### PR DESCRIPTION
Large majority of invocations of program loading have `reloading` set to `false`. The only non-test use where reloading is used is in deployment, where an inlined call to `reload` makes more sense anyhow.

Presence of this argument/option was making the code much more difficult to grok for me, so I went ahead and removed the argument in most places. It can be added back on a case-by-case basis as needed in the future, though due to the soundness requirements, I believe calling `reload` directly will always make more sense anyway.