### PR TITLE
Moves snapshot packager niceness adj to SnapshotPackagerService::new()

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -44,6 +44,7 @@ impl SnapshotPackagerService {
         cluster_info: Arc<ClusterInfo>,
         snapshot_controller: Arc<SnapshotController>,
         enable_gossip_push: bool,
+        niceness_adj: i8,
     ) -> Self {
         let t_snapshot_packager = Builder::new()
             .name("solSnapshotPkgr".to_string())
@@ -53,7 +54,7 @@ impl SnapshotPackagerService {
                 }
                 info!("{} has started", Self::NAME);
                 let snapshot_config = snapshot_controller.snapshot_config();
-                renice_this_thread(snapshot_config.packager_thread_niceness_adj).unwrap();
+                renice_this_thread(niceness_adj).unwrap();
                 let mut snapshot_gossip_manager = enable_gossip_push
                     .then(|| SnapshotGossipManager::new(cluster_info, starting_snapshot_hashes));
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -421,6 +421,8 @@ pub struct ValidatorConfig {
     pub delay_leader_block_for_pending_fork: bool,
     pub voting_service_test_override: Option<VotingServiceOverride>,
     pub repair_handler_type: RepairHandlerType,
+    // Thread niceness adjustment for snapshot packager service
+    pub snapshot_packager_niceness_adj: i8,
 }
 
 impl ValidatorConfig {
@@ -504,6 +506,7 @@ impl ValidatorConfig {
             delay_leader_block_for_pending_fork: false,
             voting_service_test_override: None,
             repair_handler_type: RepairHandlerType::default(),
+            snapshot_packager_niceness_adj: 0,
         }
     }
 
@@ -1031,6 +1034,7 @@ impl Validator {
             cluster_info.clone(),
             snapshot_controller.clone(),
             enable_gossip_push,
+            config.snapshot_packager_niceness_adj,
         );
         let snapshot_request_handler = SnapshotRequestHandler {
             snapshot_controller: snapshot_controller.clone(),

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -641,6 +641,7 @@ fn test_snapshots_with_background_services() {
         cluster_info.clone(),
         snapshot_controller.clone(),
         false,
+        0,
     );
 
     let accounts_background_service =
@@ -805,6 +806,7 @@ fn test_fastboot_snapshots_teardown(exit_backpressure: bool) {
         cluster_info.clone(),
         snapshot_controller.clone(),
         false,
+        0,
     );
 
     let mint_keypair = &snapshot_test_config.genesis_config_info.mint_keypair;

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -82,6 +82,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
         voting_service_test_override: config.voting_service_test_override.clone(),
         repair_handler_type: config.repair_handler_type.clone(),
+        snapshot_packager_niceness_adj: config.snapshot_packager_niceness_adj,
     }
 }
 

--- a/snapshots/src/snapshot_config.rs
+++ b/snapshots/src/snapshot_config.rs
@@ -48,9 +48,6 @@ pub struct SnapshotConfig {
     /// Maximum number of incremental snapshot archives to retain
     /// NOTE: Incremental snapshots will only be kept for the latest full snapshot
     pub maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
-
-    // Thread niceness adjustment for snapshot packager service
-    pub packager_thread_niceness_adj: i8,
 }
 
 impl Default for SnapshotConfig {
@@ -73,7 +70,6 @@ impl Default for SnapshotConfig {
             maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             maximum_incremental_snapshot_archives_to_retain:
                 DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            packager_thread_niceness_adj: 0,
         }
     }
 }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -878,6 +878,11 @@ pub fn execute(
         )]
         .into(),
         voting_service_test_override: None,
+        snapshot_packager_niceness_adj: value_t_or_exit!(
+            matches,
+            "snapshot_packager_niceness_adj",
+            i8
+        ),
     };
 
     let vote_account = pubkey_of(matches, "vote_account").unwrap_or_else(|| {
@@ -1385,9 +1390,6 @@ fn new_snapshot_config(
         NonZeroUsize
     );
 
-    let snapshot_packager_niceness_adj =
-        value_t_or_exit!(matches, "snapshot_packager_niceness_adj", i8);
-
     let snapshot_config = SnapshotConfig {
         usage: if full_snapshot_archive_interval == SnapshotInterval::Disabled {
             SnapshotUsage::LoadOnly
@@ -1403,7 +1405,6 @@ fn new_snapshot_config(
         snapshot_version,
         maximum_full_snapshot_archives_to_retain,
         maximum_incremental_snapshot_archives_to_retain,
-        packager_thread_niceness_adj: snapshot_packager_niceness_adj,
     };
 
     if !is_snapshot_config_valid(&snapshot_config) {


### PR DESCRIPTION
#### Problem

The SnapshotPackagerService thread can have its niceness adjust by a cli arg (`--snapshot-packager-niceness-adjustment`). This value is stored in the SnapshotConfig. But it really isn't a parameter of the snapshots, rather the snapshot packager service itself.

(Big picture, there is value in reworking SnapshotConfig to better represent the various valid "modes" snapshots can be used for (e.g. disabled, or only for loading at startup, or for loading and generating, etc). This niceness value doesn't fit well in that model (because it isn't about the snapshot itself...). So moving niceness to SPS makes the future SnapshotConfig work simpler.)


#### Summary of Changes

Move the param out of the SnapshotConfig, and instead to SnapshotPackagerService::new().