### PR TITLE
Sigverify: spawn verify_and_send_packets

### DIFF
--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -69,6 +69,10 @@ impl SigVerifier for BenchSigVerifier {
             .fetch_add(num_valid_packets, Ordering::Relaxed);
         Ok(())
     }
+
+    fn capacity(&self) -> usize {
+        usize::MAX
+    }
 }
 
 fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -50,8 +50,6 @@ struct BenchSigVerifier {
 }
 
 impl SigVerifier for BenchSigVerifier {
-    type SendType = ();
-
     fn verify_and_send_packets(
         &mut self,
         mut batches: Vec<PacketBatch>,
@@ -59,7 +57,7 @@ impl SigVerifier for BenchSigVerifier {
         _in_flight_count: Arc<AtomicUsize>,
         total_valid_packets: Arc<AtomicUsize>,
         total_verify_time_us: Arc<AtomicUsize>,
-    ) -> Result<(), SigVerifyServiceError<Self::SendType>> {
+    ) -> Result<(), SigVerifyServiceError> {
         let mut verify_time = Measure::start("sigverify_batch_time");
         sigverify::ed25519_verify(&self.thread_pool, &mut batches, false, valid_packets);
         verify_time.stop();

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -9,11 +9,7 @@ use {
         distr::{Distribution, Uniform},
         rng,
     },
-    solana_core::{
-        banking_trace::BankingTracer,
-        sigverify::TransactionSigVerifier,
-        sigverify_stage::{SigVerifier, SigVerifyStage},
-    },
+    solana_core::sigverify_stage::{SigVerifier, SigVerifyServiceError, SigVerifyStage},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_measure::measure::Measure,
@@ -27,8 +23,11 @@ use {
     std::{
         borrow::Cow,
         hint::black_box,
-        sync::Arc,
-        time::{Duration, Instant},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Instant,
     },
 };
 
@@ -41,6 +40,28 @@ where
 {
     fn run(&self, harness: &mut Bencher) {
         (self.0)(harness)
+    }
+}
+
+#[derive(Clone)]
+struct BenchSigVerifier {
+    completed: Arc<AtomicUsize>,
+    thread_pool: Arc<rayon::ThreadPool>,
+}
+
+impl SigVerifier for BenchSigVerifier {
+    type SendType = ();
+
+    fn verify_and_send_packets(
+        &mut self,
+        mut batches: Vec<PacketBatch>,
+        valid_packets: usize,
+    ) -> Result<usize, SigVerifyServiceError<Self::SendType>> {
+        sigverify::ed25519_verify(&self.thread_pool, &mut batches, false, valid_packets);
+        let num_valid_packets = sigverify::count_valid_packets(&batches);
+        self.completed
+            .fetch_add(num_valid_packets, Ordering::Relaxed);
+        Ok(num_valid_packets)
     }
 }
 
@@ -165,10 +186,15 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
     agave_logger::setup();
     trace!("start");
     let (packet_s, packet_r) = unbounded();
-    let (verified_s, verified_r) = BankingTracer::channel_for_test();
-    let threadpool = Arc::new(sigverify::threadpool_for_benches());
-    let verifier = TransactionSigVerifier::new(threadpool, verified_s, None);
+    let completed = Arc::new(AtomicUsize::new(0));
+    let verifier = BenchSigVerifier {
+        completed: completed.clone(),
+        thread_pool: Arc::new(sigverify::threadpool_for_benches()),
+    };
     let stage = SigVerifyStage::new(packet_r, verifier, "solSigVerBench", "bench");
+    let packet_s = packet_s;
+    let packet_s_for_bench = packet_s.clone();
+    let completed_for_bench = completed.clone();
 
     bencher.iter(move || {
         let now = Instant::now();
@@ -179,26 +205,24 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
             batches.len()
         );
 
+        let start = completed_for_bench.load(Ordering::Relaxed);
         let mut sent_len = 0;
         for batch in batches.into_iter() {
             sent_len += batch.len();
-            packet_s.send(batch).unwrap();
+            packet_s_for_bench.send(batch).unwrap();
         }
-        let mut received = 0;
         let expected = if use_same_tx { 1 } else { sent_len };
         trace!("sent: {sent_len}, expected: {expected}");
-        loop {
-            if let Ok(verifieds) = verified_r.recv_timeout(Duration::from_millis(10)) {
-                received += verifieds.iter().map(|batch| batch.len()).sum::<usize>();
-                black_box(verifieds);
-                if received >= expected {
-                    break;
-                }
-            }
+        while completed_for_bench.load(Ordering::Relaxed) < start + expected {
+            std::hint::spin_loop();
         }
-        trace!("received: {received}");
+        trace!(
+            "received: {}",
+            completed_for_bench.load(Ordering::Relaxed) - start
+        );
     });
     // This will wait for all packets to make it through sigverify.
+    drop(packet_s);
     stage.join().unwrap();
 }
 
@@ -240,17 +264,18 @@ fn prepare_batches(discard_factor: i32) -> (Vec<PacketBatch>, usize) {
 
 fn bench_shrink_sigverify_stage_core(bencher: &mut Bencher, discard_factor: i32) {
     let (batches0, num_valid_packets) = prepare_batches(discard_factor);
-    let (verified_s, _verified_r) = BankingTracer::channel_for_test();
     let threadpool = Arc::new(sigverify::threadpool_for_benches());
-    let verifier = TransactionSigVerifier::new(threadpool, verified_s, None);
 
     let mut c = 0;
     let mut total_verify_time = 0;
 
     bencher.iter(|| {
+        let mut batches = batches0.clone();
+
         let mut verify_time = Measure::start("sigverify_batch_time");
-        let _batches = verifier.verify_batches(batches0.clone(), num_valid_packets);
+        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_valid_packets);
         verify_time.stop();
+        black_box(sigverify::count_valid_packets(&batches));
 
         c += 1;
         total_verify_time += verify_time.as_us();

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -56,12 +56,18 @@ impl SigVerifier for BenchSigVerifier {
         &mut self,
         mut batches: Vec<PacketBatch>,
         valid_packets: usize,
-    ) -> Result<usize, SigVerifyServiceError<Self::SendType>> {
+        total_valid_packets: Arc<AtomicUsize>,
+        total_verify_time_us: Arc<AtomicUsize>,
+    ) -> Result<(), SigVerifyServiceError<Self::SendType>> {
+        let mut verify_time = Measure::start("sigverify_batch_time");
         sigverify::ed25519_verify(&self.thread_pool, &mut batches, false, valid_packets);
+        verify_time.stop();
         let num_valid_packets = sigverify::count_valid_packets(&batches);
+        total_valid_packets.fetch_add(num_valid_packets, Ordering::Relaxed);
+        total_verify_time_us.fetch_add(verify_time.as_us() as usize, Ordering::Relaxed);
         self.completed
             .fetch_add(num_valid_packets, Ordering::Relaxed);
-        Ok(num_valid_packets)
+        Ok(())
     }
 }
 

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -56,6 +56,7 @@ impl SigVerifier for BenchSigVerifier {
         &mut self,
         mut batches: Vec<PacketBatch>,
         valid_packets: usize,
+        _in_flight_count: Arc<AtomicUsize>,
         total_valid_packets: Arc<AtomicUsize>,
         total_verify_time_us: Arc<AtomicUsize>,
     ) -> Result<(), SigVerifyServiceError<Self::SendType>> {

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -414,6 +414,7 @@ impl BankingTracer {
 /// and the flag are expected to be shared among all of traced sender instances, which will be used
 /// by the trio of sources respectively. This routing functionality is needed for unified scheduler
 /// and its runtime switching.
+#[derive(Clone)]
 pub struct TracedSender {
     label: ChannelLabel,
     sender: Sender<BankingPacketBatch>,

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -56,8 +56,6 @@ impl TransactionSigVerifier {
 }
 
 impl SigVerifier for TransactionSigVerifier {
-    type SendType = BankingPacketBatch;
-
     fn verify_and_send_packets(
         &mut self,
         batches: Vec<PacketBatch>,
@@ -65,7 +63,7 @@ impl SigVerifier for TransactionSigVerifier {
         in_flight_count: Arc<AtomicUsize>,
         total_valid_packets: Arc<AtomicUsize>,
         total_verify_time_us: Arc<AtomicUsize>,
-    ) -> Result<(), SigVerifyServiceError<Self::SendType>> {
+    ) -> Result<(), SigVerifyServiceError> {
         let thread_pool = self.thread_pool.clone();
         let banking_stage_sender = self.banking_stage_sender.clone();
         let forward_stage_sender = self.forward_stage_sender.clone();

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -12,8 +12,15 @@ use {
     },
     agave_banking_stage_ingress_types::BankingPacketBatch,
     crossbeam_channel::{Sender, TrySendError},
-    solana_perf::{packet::PacketBatch, sigverify},
-    std::sync::Arc,
+    solana_measure::measure::Measure,
+    solana_perf::{
+        packet::PacketBatch,
+        sigverify::{self},
+    },
+    std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
 pub struct TransactionSigVerifier {
@@ -53,30 +60,43 @@ impl SigVerifier for TransactionSigVerifier {
 
     fn verify_and_send_packets(
         &mut self,
-        mut batches: Vec<PacketBatch>,
+        batches: Vec<PacketBatch>,
         valid_packets: usize,
-    ) -> Result<usize, SigVerifyServiceError<Self::SendType>> {
-        sigverify::ed25519_verify(
-            &self.thread_pool,
-            &mut batches,
-            self.reject_non_vote,
-            valid_packets,
-        );
-        let num_valid_packets = sigverify::count_valid_packets(&batches);
+        total_valid_packets: Arc<AtomicUsize>,
+        total_verify_time_us: Arc<AtomicUsize>,
+    ) -> Result<(), SigVerifyServiceError<Self::SendType>> {
+        let thread_pool = self.thread_pool.clone();
+        let banking_stage_sender = self.banking_stage_sender.clone();
+        let forward_stage_sender = self.forward_stage_sender.clone();
+        let reject_non_vote = self.reject_non_vote;
 
-        let banking_packet_batch = BankingPacketBatch::new(batches);
-        if let Some(forward_stage_sender) = &self.forward_stage_sender {
-            self.banking_stage_sender
-                .send(banking_packet_batch.clone())?;
-            if let Err(TrySendError::Full(_)) =
-                forward_stage_sender.try_send((banking_packet_batch, self.reject_non_vote))
-            {
-                warn!("forwarding stage channel is full, dropping packets.");
+        self.thread_pool.spawn(move || {
+            let mut verify_time = Measure::start("sigverify_batch_time");
+            let mut batches = batches;
+            sigverify::ed25519_verify(&thread_pool, &mut batches, reject_non_vote, valid_packets);
+            verify_time.stop();
+            let num_valid_packets = sigverify::count_valid_packets(&batches);
+
+            let banking_packet_batch = BankingPacketBatch::new(batches);
+            if let Some(forward_stage_sender) = &forward_stage_sender {
+                if let Err(err) = banking_stage_sender.send(banking_packet_batch.clone()) {
+                    error!("sigverify send failed: {err:?}");
+                    return;
+                }
+                if let Err(TrySendError::Full(_)) =
+                    forward_stage_sender.try_send((banking_packet_batch, reject_non_vote))
+                {
+                    warn!("forwarding stage channel is full, dropping packets.");
+                }
+            } else if let Err(err) = banking_stage_sender.send(banking_packet_batch) {
+                error!("sigverify send failed: {err:?}");
+                return;
             }
-        } else {
-            self.banking_stage_sender.send(banking_packet_batch)?;
-        }
 
-        Ok(num_valid_packets)
+            total_valid_packets.fetch_add(num_valid_packets, Ordering::Relaxed);
+            total_verify_time_us.fetch_add(verify_time.as_us() as usize, Ordering::Relaxed);
+        });
+
+        Ok(())
     }
 }

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -51,11 +51,20 @@ impl TransactionSigVerifier {
 impl SigVerifier for TransactionSigVerifier {
     type SendType = BankingPacketBatch;
 
-    fn send_packets(
+    fn verify_and_send_packets(
         &mut self,
-        packet_batches: Vec<PacketBatch>,
-    ) -> Result<(), SigVerifyServiceError<Self::SendType>> {
-        let banking_packet_batch = BankingPacketBatch::new(packet_batches);
+        mut batches: Vec<PacketBatch>,
+        valid_packets: usize,
+    ) -> Result<usize, SigVerifyServiceError<Self::SendType>> {
+        sigverify::ed25519_verify(
+            &self.thread_pool,
+            &mut batches,
+            self.reject_non_vote,
+            valid_packets,
+        );
+        let num_valid_packets = sigverify::count_valid_packets(&batches);
+
+        let banking_packet_batch = BankingPacketBatch::new(batches);
         if let Some(forward_stage_sender) = &self.forward_stage_sender {
             self.banking_stage_sender
                 .send(banking_packet_batch.clone())?;
@@ -68,20 +77,6 @@ impl SigVerifier for TransactionSigVerifier {
             self.banking_stage_sender.send(banking_packet_batch)?;
         }
 
-        Ok(())
-    }
-
-    fn verify_batches(
-        &self,
-        mut batches: Vec<PacketBatch>,
-        valid_packets: usize,
-    ) -> Vec<PacketBatch> {
-        sigverify::ed25519_verify(
-            &self.thread_pool,
-            &mut batches,
-            self.reject_non_vote,
-            valid_packets,
-        );
-        batches
+        Ok(num_valid_packets)
     }
 }

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -84,6 +84,7 @@ impl SigVerifier for TransactionSigVerifier {
             if let Some(forward_stage_sender) = &forward_stage_sender {
                 if let Err(err) = banking_stage_sender.send(banking_packet_batch.clone()) {
                     error!("sigverify send failed: {err:?}");
+                    in_flight_count.fetch_sub(valid_packets, Ordering::Release);
                     return;
                 }
                 if let Err(TrySendError::Full(_)) =
@@ -93,6 +94,7 @@ impl SigVerifier for TransactionSigVerifier {
                 }
             } else if let Err(err) = banking_stage_sender.send(banking_packet_batch) {
                 error!("sigverify send failed: {err:?}");
+                in_flight_count.fetch_sub(valid_packets, Ordering::Release);
                 return;
             }
 

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -62,6 +62,7 @@ impl SigVerifier for TransactionSigVerifier {
         &mut self,
         batches: Vec<PacketBatch>,
         valid_packets: usize,
+        in_flight_count: Arc<AtomicUsize>,
         total_valid_packets: Arc<AtomicUsize>,
         total_verify_time_us: Arc<AtomicUsize>,
     ) -> Result<(), SigVerifyServiceError<Self::SendType>> {
@@ -69,6 +70,8 @@ impl SigVerifier for TransactionSigVerifier {
         let banking_stage_sender = self.banking_stage_sender.clone();
         let forward_stage_sender = self.forward_stage_sender.clone();
         let reject_non_vote = self.reject_non_vote;
+
+        in_flight_count.fetch_add(valid_packets, Ordering::Release);
 
         self.thread_pool.spawn(move || {
             let mut verify_time = Measure::start("sigverify_batch_time");
@@ -95,6 +98,7 @@ impl SigVerifier for TransactionSigVerifier {
 
             total_valid_packets.fetch_add(num_valid_packets, Ordering::Relaxed);
             total_verify_time_us.fetch_add(verify_time.as_us() as usize, Ordering::Relaxed);
+            in_flight_count.fetch_sub(valid_packets, Ordering::Release);
         });
 
         Ok(())

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -99,4 +99,14 @@ impl SigVerifier for TransactionSigVerifier {
 
         Ok(())
     }
+
+    fn capacity(&self) -> usize {
+        const CAPACITY_PER_THREAD: usize = {
+            15_000 // ~15k packets per second throughput
+            * 2 // 2 seconds worth
+        };
+        self.thread_pool
+            .current_num_threads()
+            .saturating_mul(CAPACITY_PER_THREAD)
+    }
 }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -53,6 +53,9 @@ pub trait SigVerifier {
         total_valid_packets: Arc<AtomicUsize>,
         total_verify_time_us: Arc<AtomicUsize>,
     ) -> Result<(), Self::SendType>;
+
+    /// Return maximum number of packets that are allowed to be in the verification pool.
+    fn capacity(&self) -> usize;
 }
 
 #[derive(Clone)]
@@ -174,6 +177,10 @@ impl SigVerifier for DisabledSigVerifier {
         total_valid_packets.fetch_add(count_valid_packets(&batches), Ordering::Relaxed);
         total_verify_time_us.fetch_add(verify_time.as_us() as usize, Ordering::Relaxed);
         Ok(())
+    }
+
+    fn capacity(&self) -> usize {
+        usize::MAX
     }
 }
 

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -50,6 +50,7 @@ pub trait SigVerifier {
         &mut self,
         batches: Vec<PacketBatch>,
         valid_packets: usize,
+        in_flight_count: Arc<AtomicUsize>,
         total_valid_packets: Arc<AtomicUsize>,
         total_verify_time_us: Arc<AtomicUsize>,
     ) -> Result<(), Self::SendType>;
@@ -168,6 +169,7 @@ impl SigVerifier for DisabledSigVerifier {
         &mut self,
         mut batches: Vec<PacketBatch>,
         _valid_packets: usize,
+        _in_flight_count: Arc<AtomicUsize>,
         total_valid_packets: Arc<AtomicUsize>,
         total_verify_time_us: Arc<AtomicUsize>,
     ) -> Result<(), Self::SendType> {
@@ -226,10 +228,16 @@ impl SigVerifyStage {
         recvr: &Receiver<PacketBatch>,
         verifier: &mut T,
         stats: &mut SigVerifierStats,
+        in_flight_count: &Arc<AtomicUsize>,
     ) -> Result<(), T::SendType> {
         const SOFT_RECEIVE_CAP: usize = 5_000;
         let (mut batches, num_packets, recv_duration) =
             streamer::recv_packet_batches(recvr, SOFT_RECEIVE_CAP)?;
+
+        // If we're already at capacity immediately drop the packets
+        if in_flight_count.load(Ordering::Acquire) >= verifier.capacity() {
+            return Ok(());
+        }
 
         let batches_len = batches.len();
         debug!(
@@ -248,6 +256,7 @@ impl SigVerifyStage {
         verifier.verify_and_send_packets(
             batches,
             num_packets_to_verify,
+            in_flight_count.clone(),
             stats.total_valid_packets.clone(),
             stats.total_verify_time_us.clone(),
         )?;
@@ -293,13 +302,18 @@ impl SigVerifyStage {
             .spawn(move || {
                 let mut rng = rand::rng();
                 let mut deduper = Deduper::<2, [u8]>::new(&mut rng, DEDUPER_NUM_BITS);
+                let in_flight_count = Arc::new(AtomicUsize::new(0));
                 loop {
                     if deduper.maybe_reset(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, MAX_DEDUPER_AGE) {
                         stats.num_deduper_saturations += 1;
                     }
-                    if let Err(e) =
-                        Self::verifier(&deduper, &packet_receiver, &mut verifier, &mut stats)
-                    {
+                    if let Err(e) = Self::verifier(
+                        &deduper,
+                        &packet_receiver,
+                        &mut verifier,
+                        &mut stats,
+                        &in_flight_count,
+                    ) {
                         match e {
                             SigVerifyServiceError::Streamer(StreamerError::RecvTimeout(
                                 RecvTimeoutError::Disconnected,

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -77,6 +77,7 @@ struct SigVerifierStats {
     total_valid_packets: Arc<AtomicUsize>,
     total_dedup_time_us: usize,
     total_verify_time_us: Arc<AtomicUsize>,
+    total_dropped_on_capacity: usize,
 }
 
 impl SigVerifierStats {
@@ -149,6 +150,11 @@ impl SigVerifierStats {
             ("total_packets", self.total_packets, i64),
             ("total_dedup", self.total_dedup, i64),
             ("total_dedup_time_us", self.total_dedup_time_us, i64),
+            (
+                "total_dropped_on_capacity",
+                self.total_dropped_on_capacity,
+                i64
+            ),
             (
                 "total_valid_packets",
                 self.total_valid_packets.load(Ordering::Relaxed) as i64,
@@ -236,6 +242,7 @@ impl SigVerifyStage {
 
         // If we're already at capacity immediately drop the packets
         if in_flight_count.load(Ordering::Acquire) >= verifier.capacity() {
+            stats.total_dropped_on_capacity += num_packets;
             return Ok(());
         }
 

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -7,7 +7,7 @@
 use {
     crate::sigverify,
     core::time::Duration,
-    crossbeam_channel::{Receiver, RecvTimeoutError, SendError},
+    crossbeam_channel::{Receiver, RecvTimeoutError},
     itertools::Itertools,
     rayon::ThreadPool,
     solana_measure::measure::Measure,
@@ -30,22 +30,18 @@ use {
 };
 
 #[derive(Error, Debug)]
-pub enum SigVerifyServiceError<SendType> {
-    #[error("send packets batch error")]
-    Send(#[from] SendError<SendType>),
-
+pub enum SigVerifyServiceError {
     #[error("streamer error")]
     Streamer(#[from] StreamerError),
 }
 
-type Result<T, SendType> = std::result::Result<T, SigVerifyServiceError<SendType>>;
+type Result<T> = std::result::Result<T, SigVerifyServiceError>;
 
 pub struct SigVerifyStage {
     thread_hdl: JoinHandle<()>,
 }
 
 pub trait SigVerifier {
-    type SendType: std::fmt::Debug;
     fn verify_and_send_packets(
         &mut self,
         batches: Vec<PacketBatch>,
@@ -53,7 +49,7 @@ pub trait SigVerifier {
         in_flight_count: Arc<AtomicUsize>,
         total_valid_packets: Arc<AtomicUsize>,
         total_verify_time_us: Arc<AtomicUsize>,
-    ) -> Result<(), Self::SendType>;
+    ) -> Result<()>;
 
     /// Return maximum number of packets that are allowed to be in the verification pool.
     fn capacity(&self) -> usize;
@@ -170,7 +166,6 @@ impl SigVerifierStats {
 }
 
 impl SigVerifier for DisabledSigVerifier {
-    type SendType = ();
     fn verify_and_send_packets(
         &mut self,
         mut batches: Vec<PacketBatch>,
@@ -178,7 +173,7 @@ impl SigVerifier for DisabledSigVerifier {
         _in_flight_count: Arc<AtomicUsize>,
         total_valid_packets: Arc<AtomicUsize>,
         total_verify_time_us: Arc<AtomicUsize>,
-    ) -> Result<(), Self::SendType> {
+    ) -> Result<()> {
         let mut verify_time = Measure::start("sigverify_batch_time");
         sigverify::ed25519_verify_disabled(&self.thread_pool, &mut batches);
         verify_time.stop();
@@ -235,7 +230,7 @@ impl SigVerifyStage {
         verifier: &mut T,
         stats: &mut SigVerifierStats,
         in_flight_count: &Arc<AtomicUsize>,
-    ) -> Result<(), T::SendType> {
+    ) -> Result<()> {
         const SOFT_RECEIVE_CAP: usize = 5_000;
         let (mut batches, num_packets, recv_duration) =
             streamer::recv_packet_batches(recvr, SOFT_RECEIVE_CAP)?;
@@ -330,9 +325,6 @@ impl SigVerifyStage {
                             SigVerifyServiceError::Streamer(StreamerError::RecvTimeout(
                                 RecvTimeoutError::Timeout,
                             )) => (),
-                            SigVerifyServiceError::Send(_) => {
-                                break;
-                            }
                             _ => error!("{e:?}"),
                         }
                     }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -77,7 +77,7 @@ struct SigVerifierStats {
 }
 
 impl SigVerifierStats {
-    fn maybe_report(&self, name: &'static str) {
+    fn maybe_report_and_reset(&mut self, name: &'static str) {
         // No need to report a datapoint if no batches/packets received
         if self.total_batches == 0 {
             return;
@@ -141,27 +141,48 @@ impl SigVerifierStats {
             ("packets_min", self.packets_hist.minimum().unwrap_or(0), i64),
             ("packets_max", self.packets_hist.maximum().unwrap_or(0), i64),
             ("packets_mean", self.packets_hist.mean().unwrap_or(0), i64),
-            ("num_deduper_saturations", self.num_deduper_saturations, i64),
-            ("total_batches", self.total_batches, i64),
-            ("total_packets", self.total_packets, i64),
-            ("total_dedup", self.total_dedup, i64),
-            ("total_dedup_time_us", self.total_dedup_time_us, i64),
+            (
+                "num_deduper_saturations",
+                core::mem::take(&mut self.num_deduper_saturations),
+                i64
+            ),
+            (
+                "total_batches",
+                core::mem::take(&mut self.total_batches),
+                i64
+            ),
+            (
+                "total_packets",
+                core::mem::take(&mut self.total_packets),
+                i64
+            ),
+            ("total_dedup", core::mem::take(&mut self.total_dedup), i64),
+            (
+                "total_dedup_time_us",
+                core::mem::take(&mut self.total_dedup_time_us),
+                i64
+            ),
             (
                 "total_dropped_on_capacity",
-                self.total_dropped_on_capacity,
+                core::mem::take(&mut self.total_dropped_on_capacity),
                 i64
             ),
             (
                 "total_valid_packets",
-                self.total_valid_packets.load(Ordering::Relaxed) as i64,
+                self.total_valid_packets.swap(0, Ordering::Relaxed) as i64,
                 i64
             ),
             (
                 "total_verify_time_us",
-                self.total_verify_time_us.load(Ordering::Relaxed) as i64,
+                self.total_verify_time_us.swap(0, Ordering::Relaxed) as i64,
                 i64
             ),
         );
+
+        self.recv_batches_us_hist = histogram::Histogram::new();
+        self.dedup_packets_pp_us_hist = histogram::Histogram::new();
+        self.batches_hist = histogram::Histogram::new();
+        self.packets_hist = histogram::Histogram::new();
     }
 }
 
@@ -329,8 +350,7 @@ impl SigVerifyStage {
                         }
                     }
                     if last_print.elapsed().as_secs() > 2 {
-                        stats.maybe_report(metrics_name);
-                        stats = SigVerifierStats::default();
+                        stats.maybe_report_and_reset(metrics_name);
                         last_print = Instant::now();
                     }
                 }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -241,54 +241,56 @@ impl SigVerifyStage {
             streamer::recv_packet_batches(recvr, SOFT_RECEIVE_CAP)?;
 
         // If we're already at capacity immediately drop the packets
+        let mut should_drop = false;
         if in_flight_count.load(Ordering::Acquire) >= verifier.capacity() {
             stats.total_dropped_on_capacity += num_packets;
-            return Ok(());
+            should_drop = true;
         }
 
         let batches_len = batches.len();
-        debug!(
-            "@{:?} verifier: verifying: {}",
-            timing::timestamp(),
-            num_packets,
-        );
-
-        let mut dedup_time = Measure::start("sigverify_dedup_time");
-        let discard_or_dedup_fail =
-            deduper::dedup_packets_and_count_discards(deduper, &mut batches) as usize;
-        dedup_time.stop();
-        let num_unique = num_packets.saturating_sub(discard_or_dedup_fail);
-        let num_packets_to_verify = num_unique;
-
-        verifier.verify_and_send_packets(
-            batches,
-            num_packets_to_verify,
-            in_flight_count.clone(),
-            stats.total_valid_packets.clone(),
-            stats.total_verify_time_us.clone(),
-        )?;
-
-        debug!(
-            "@{:?} verifier: done. batches: {} packets: {}",
-            timing::timestamp(),
-            batches_len,
-            num_packets
-        );
 
         stats
             .recv_batches_us_hist
             .increment(recv_duration.as_micros() as u64)
             .unwrap();
-        stats
-            .dedup_packets_pp_us_hist
-            .increment(dedup_time.as_us() / (num_packets as u64))
-            .unwrap();
         stats.batches_hist.increment(batches_len as u64).unwrap();
         stats.packets_hist.increment(num_packets as u64).unwrap();
         stats.total_batches += batches_len;
         stats.total_packets += num_packets;
-        stats.total_dedup += discard_or_dedup_fail;
-        stats.total_dedup_time_us += dedup_time.as_us() as usize;
+
+        if !should_drop {
+            debug!(
+                "@{:?} verifier: verifying: {}",
+                timing::timestamp(),
+                num_packets,
+            );
+            let mut dedup_time = Measure::start("sigverify_dedup_time");
+            let discard_or_dedup_fail =
+                deduper::dedup_packets_and_count_discards(deduper, &mut batches) as usize;
+            dedup_time.stop();
+            let num_unique = num_packets.saturating_sub(discard_or_dedup_fail);
+            let num_packets_to_verify = num_unique;
+
+            verifier.verify_and_send_packets(
+                batches,
+                num_packets_to_verify,
+                in_flight_count.clone(),
+                stats.total_valid_packets.clone(),
+                stats.total_verify_time_us.clone(),
+            )?;
+            debug!(
+                "@{:?} verifier: done. batches: {} packets: {}",
+                timing::timestamp(),
+                batches_len,
+                num_packets
+            );
+            stats
+                .dedup_packets_pp_us_hist
+                .increment(dedup_time.as_us() / (num_packets as u64))
+                .unwrap();
+            stats.total_dedup += discard_or_dedup_fail;
+            stats.total_dedup_time_us += dedup_time.as_us() as usize;
+        }
 
         Ok(())
     }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -19,7 +19,10 @@ use {
     solana_streamer::streamer::{self, StreamerError},
     solana_time_utils as timing,
     std::{
-        sync::Arc,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
         thread::{self, Builder, JoinHandle},
         time::Instant,
     },
@@ -47,7 +50,9 @@ pub trait SigVerifier {
         &mut self,
         batches: Vec<PacketBatch>,
         valid_packets: usize,
-    ) -> Result<usize, Self::SendType>;
+        total_valid_packets: Arc<AtomicUsize>,
+        total_verify_time_us: Arc<AtomicUsize>,
+    ) -> Result<(), Self::SendType>;
 }
 
 #[derive(Clone)]
@@ -58,7 +63,6 @@ pub struct DisabledSigVerifier {
 #[derive(Default)]
 struct SigVerifierStats {
     recv_batches_us_hist: histogram::Histogram, // time to call recv_batch
-    verify_batches_pp_us_hist: histogram::Histogram, // per-packet time to call verify_batch
     dedup_packets_pp_us_hist: histogram::Histogram, // per-packet time to call verify_batch
     batches_hist: histogram::Histogram,         // number of packet batches per verify call
     packets_hist: histogram::Histogram,         // number of packets per verify call
@@ -66,9 +70,9 @@ struct SigVerifierStats {
     total_batches: usize,
     total_packets: usize,
     total_dedup: usize,
-    total_valid_packets: usize,
+    total_valid_packets: Arc<AtomicUsize>,
     total_dedup_time_us: usize,
-    total_verify_time_us: usize,
+    total_verify_time_us: Arc<AtomicUsize>,
 }
 
 impl SigVerifierStats {
@@ -98,26 +102,6 @@ impl SigVerifierStats {
             (
                 "recv_batches_us_mean",
                 self.recv_batches_us_hist.mean().unwrap_or(0),
-                i64
-            ),
-            (
-                "verify_batches_pp_us_90pct",
-                self.verify_batches_pp_us_hist.percentile(90.0).unwrap_or(0),
-                i64
-            ),
-            (
-                "verify_batches_pp_us_min",
-                self.verify_batches_pp_us_hist.minimum().unwrap_or(0),
-                i64
-            ),
-            (
-                "verify_batches_pp_us_max",
-                self.verify_batches_pp_us_hist.maximum().unwrap_or(0),
-                i64
-            ),
-            (
-                "verify_batches_pp_us_mean",
-                self.verify_batches_pp_us_hist.mean().unwrap_or(0),
                 i64
             ),
             (
@@ -160,9 +144,17 @@ impl SigVerifierStats {
             ("total_batches", self.total_batches, i64),
             ("total_packets", self.total_packets, i64),
             ("total_dedup", self.total_dedup, i64),
-            ("total_valid_packets", self.total_valid_packets, i64),
             ("total_dedup_time_us", self.total_dedup_time_us, i64),
-            ("total_verify_time_us", self.total_verify_time_us, i64),
+            (
+                "total_valid_packets",
+                self.total_valid_packets.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "total_verify_time_us",
+                self.total_verify_time_us.load(Ordering::Relaxed) as i64,
+                i64
+            ),
         );
     }
 }
@@ -173,9 +165,15 @@ impl SigVerifier for DisabledSigVerifier {
         &mut self,
         mut batches: Vec<PacketBatch>,
         _valid_packets: usize,
-    ) -> Result<usize, Self::SendType> {
+        total_valid_packets: Arc<AtomicUsize>,
+        total_verify_time_us: Arc<AtomicUsize>,
+    ) -> Result<(), Self::SendType> {
+        let mut verify_time = Measure::start("sigverify_batch_time");
         sigverify::ed25519_verify_disabled(&self.thread_pool, &mut batches);
-        Ok(count_valid_packets(&batches))
+        verify_time.stop();
+        total_valid_packets.fetch_add(count_valid_packets(&batches), Ordering::Relaxed);
+        total_verify_time_us.fetch_add(verify_time.as_us() as usize, Ordering::Relaxed);
+        Ok(())
     }
 }
 
@@ -240,26 +238,23 @@ impl SigVerifyStage {
         let num_unique = num_packets.saturating_sub(discard_or_dedup_fail);
         let num_packets_to_verify = num_unique;
 
-        let mut verify_time = Measure::start("sigverify_batch_time");
-        let num_valid_packets = verifier.verify_and_send_packets(batches, num_packets_to_verify)?;
-        verify_time.stop();
+        verifier.verify_and_send_packets(
+            batches,
+            num_packets_to_verify,
+            stats.total_valid_packets.clone(),
+            stats.total_verify_time_us.clone(),
+        )?;
 
         debug!(
-            "@{:?} verifier: done. batches: {} total verify time: {:?} verified: {} v/s {}",
+            "@{:?} verifier: done. batches: {} packets: {}",
             timing::timestamp(),
             batches_len,
-            verify_time.as_ms(),
-            num_packets,
-            (num_packets as f32 / verify_time.as_s())
+            num_packets
         );
 
         stats
             .recv_batches_us_hist
             .increment(recv_duration.as_micros() as u64)
-            .unwrap();
-        stats
-            .verify_batches_pp_us_hist
-            .increment(verify_time.as_us() / (num_packets as u64))
             .unwrap();
         stats
             .dedup_packets_pp_us_hist
@@ -270,9 +265,7 @@ impl SigVerifyStage {
         stats.total_batches += batches_len;
         stats.total_packets += num_packets;
         stats.total_dedup += discard_or_dedup_fail;
-        stats.total_valid_packets += num_valid_packets;
         stats.total_dedup_time_us += dedup_time.as_us() as usize;
-        stats.total_verify_time_us += verify_time.as_us() as usize;
 
         Ok(())
     }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -237,7 +237,7 @@ impl SigVerifyStage {
 
         // If we're already at capacity immediately drop the packets
         let mut should_drop = false;
-        if in_flight_count.load(Ordering::Acquire) >= verifier.capacity() {
+        if in_flight_count.load(Ordering::Relaxed) >= verifier.capacity() {
             stats.total_dropped_on_capacity += num_packets;
             should_drop = true;
         }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -43,8 +43,11 @@ pub struct SigVerifyStage {
 
 pub trait SigVerifier {
     type SendType: std::fmt::Debug;
-    fn verify_batches(&self, batches: Vec<PacketBatch>, valid_packets: usize) -> Vec<PacketBatch>;
-    fn send_packets(&mut self, packet_batches: Vec<PacketBatch>) -> Result<(), Self::SendType>;
+    fn verify_and_send_packets(
+        &mut self,
+        batches: Vec<PacketBatch>,
+        valid_packets: usize,
+    ) -> Result<usize, Self::SendType>;
 }
 
 #[derive(Clone)]
@@ -166,17 +169,13 @@ impl SigVerifierStats {
 
 impl SigVerifier for DisabledSigVerifier {
     type SendType = ();
-    fn verify_batches(
-        &self,
+    fn verify_and_send_packets(
+        &mut self,
         mut batches: Vec<PacketBatch>,
         _valid_packets: usize,
-    ) -> Vec<PacketBatch> {
+    ) -> Result<usize, Self::SendType> {
         sigverify::ed25519_verify_disabled(&self.thread_pool, &mut batches);
-        batches
-    }
-
-    fn send_packets(&mut self, _packet_batches: Vec<PacketBatch>) -> Result<(), Self::SendType> {
-        Ok(())
+        Ok(count_valid_packets(&batches))
     }
 }
 
@@ -242,11 +241,8 @@ impl SigVerifyStage {
         let num_packets_to_verify = num_unique;
 
         let mut verify_time = Measure::start("sigverify_batch_time");
-        let batches = verifier.verify_batches(batches, num_packets_to_verify);
-        let num_valid_packets = count_valid_packets(&batches);
+        let num_valid_packets = verifier.verify_and_send_packets(batches, num_packets_to_verify)?;
         verify_time.stop();
-
-        verifier.send_packets(batches)?;
 
         debug!(
             "@{:?} verifier: done. batches: {} total verify time: {:?} verified: {} v/s {}",


### PR DESCRIPTION
#### Problem
- SV uses pool to verify packets and then send the batches
- This stalls waiting for last packets to come in when we could be popping more packets off the channel

#### Summary of Changes
- Remove shrink post verification
- Simply spawn a joint verify_and_send that does both and moves on
- Remove histogram that relied on verify time
	- alternatively could lock this but. that seems bad 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
