### PR TITLE
bls syscall: change result from Ok(1) to InvalidAttribute

### DIFF
--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1550,7 +1550,7 @@ declare_builtin_function!(
                             Ok(1)
                         }
                     }
-                    _ => Ok(1),
+                    _ => Err(SyscallError::InvalidAttribute.into()),
                 }
             }
 
@@ -1663,7 +1663,7 @@ declare_builtin_function!(
                             Ok(1)
                         }
                     }
-                    _ => Ok(1),
+                    _ => Err(SyscallError::InvalidAttribute.into()),
                 }
             }
 


### PR DESCRIPTION
SIMD-0388 specifies error should be InvalidAttribute cc @samkim-crypto
