### PR TITLE
Removes maybe_throttle_index_generation()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -89,7 +89,7 @@ use {
             atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering},
             Arc, Condvar, Mutex, RwLock,
         },
-        thread::{self, sleep},
+        thread,
         time::{Duration, Instant},
     },
     tempfile::TempDir,
@@ -3742,7 +3742,7 @@ impl AccountsDb {
         #[cfg(test)]
         {
             // Give some time for cache flushing to occur here for unit tests
-            sleep(Duration::from_millis(self.load_delay));
+            thread::sleep(Duration::from_millis(self.load_delay));
         }
 
         // Failsafe for potential race conditions with other subsystems
@@ -4908,7 +4908,7 @@ impl AccountsDb {
                 #[cfg(test)]
                 {
                     // Give some time for cache flushing to occur here for unit tests
-                    sleep(Duration::from_millis(self.load_delay));
+                    thread::sleep(Duration::from_millis(self.load_delay));
                 }
                 // Since we added the slot to `slots_under_contention` AND this slot
                 // still exists in the cache, we know the slot cannot be removed
@@ -6391,7 +6391,6 @@ impl AccountsDb {
                             let mut state = IndexGenerationThreadState::default();
                             let mut reader = append_vec::new_scan_accounts_reader();
                             for next_item in storages_orderer.iter() {
-                                self.maybe_throttle_index_generation();
                                 let storage = next_item.storage;
                                 let slot_info =
                                     self.generate_index_for_slot(&mut reader, &mut state, storage);
@@ -6744,32 +6743,6 @@ impl AccountsDb {
             })
             .sum();
         stats
-    }
-
-    /// Startup processes can consume large amounts of memory while inserting accounts into the index as fast as possible.
-    /// Calling this can slow down the insertion process to allow flushing to disk to keep pace.
-    fn maybe_throttle_index_generation(&self) {
-        // Only throttle if we are generating on-disk index. Throttling is not needed for in-mem index.
-        if !self.accounts_index.is_disk_index_enabled() {
-            return;
-        }
-        // This number is chosen to keep the initial ram usage sufficiently small
-        // The process of generating the index is governed entirely by how fast the disk index can be populated.
-        // 10M accounts is sufficiently small that it will never have memory usage. It seems sufficiently large that it will provide sufficient performance.
-        // Performance is measured by total time to generate the index.
-        // Just estimating - 150M accounts can easily be held in memory in the accounts index on a 256G machine. 2-300M are also likely 'fine' during startup.
-        // 550M was straining a 384G machine at startup.
-        // This is a tunable parameter that just needs to be small enough to keep the generation threads from overwhelming RAM and oom at startup.
-        const LIMIT: usize = 10_000_000;
-        while self
-            .accounts_index
-            .get_startup_remaining_items_to_flush_estimate()
-            > LIMIT
-        {
-            // 10 ms is long enough to allow some flushing to occur before insertion is resumed.
-            // callers of this are typically run in parallel, so many threads will be sleeping at different starting intervals, waiting to resume insertion.
-            sleep(Duration::from_millis(10));
-        }
     }
 
     /// Visit zero lamport pubkeys and populate zero_lamport_single_ref info on

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -20,7 +20,7 @@ use {
         ops::Range,
         str::FromStr,
         sync::{atomic::AtomicBool, RwLock},
-        thread::{self, Builder, JoinHandle},
+        thread::{self, sleep, Builder, JoinHandle},
     },
     test_case::{test_case, test_matrix},
 };

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1035,10 +1035,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         self.storage.set_startup(value);
     }
 
-    pub fn get_startup_remaining_items_to_flush_estimate(&self) -> usize {
-        self.storage.get_startup_remaining_items_to_flush_estimate()
-    }
-
     /// Scan AccountsIndex for a given iterator of Pubkeys.
     ///
     /// This fn takes 4 arguments.

--- a/accounts-db/src/accounts_index/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index/accounts_index_storage.rs
@@ -107,15 +107,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexStorage<
         self.storage.set_startup(is_startup);
     }
 
-    /// estimate how many items are still needing to be flushed to the disk cache.
-    pub fn get_startup_remaining_items_to_flush_estimate(&self) -> usize {
-        self.storage
-            .disk
-            .as_ref()
-            .map(|_| self.storage.stats.get_remaining_items_to_flush_estimate())
-            .unwrap_or_default()
-    }
-
     /// allocate BucketMapHolder and InMemAccountsIndex[]
     pub fn new(bins: usize, config: &AccountsIndexConfig, exit: Arc<AtomicBool>) -> Self {
         let num_flush_threads = config

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -179,20 +179,6 @@ impl Stats {
         self.count.load(Ordering::Relaxed)
     }
 
-    /// This is an estimate of the # of items in mem that are awaiting flushing to disk.
-    /// returns (# items in mem) - (# items we intend to hold in mem for performance heuristics)
-    /// The result is also an estimate because 'held_in_mem' is based on a stat that is swapped out when stats are reported.
-    pub fn get_remaining_items_to_flush_estimate(&self) -> usize {
-        let in_mem = self.count_in_mem.load(Ordering::Relaxed) as u64;
-        // Note, `held_in_mem.clean` is purposely not included in this
-        // summation because clean items do not need to be flushed.
-        let held_in_mem = self.held_in_mem.slot_list_cached.load(Ordering::Relaxed)
-            + self.held_in_mem.slot_list_len.load(Ordering::Relaxed)
-            + self.held_in_mem.ref_count.load(Ordering::Relaxed)
-            + self.held_in_mem.age.load(Ordering::Relaxed);
-        in_mem.saturating_sub(held_in_mem) as usize
-    }
-
     pub fn report_stats<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>(
         &self,
         storage: &BucketMapHolder<T, U>,


### PR DESCRIPTION
#### Problem

During index generation we call `maybe_throttle_index_generation()` when the disk index is enabled, as a means to let flushing to disk catch up so we don't OOM.

Well, turns out this function is checking the number of items in the in-mem index against a fixed limit. But... at startup we don't insert into the in-mem maps... We insert into a side-band struct, StartupInfo. So we don't check the right thing and thus this function does nothing useful/correct.


#### Summary of Changes

We *could* check StartupInfo instead. But there's one per index bin, and it is wrapped in a Mutex. So we'd need to lock that mutex, one per bin, per storage to get the actual number to potentially throttle index generation. (We can also be smarter and track this size in an atomic somewhere else instead.)

OR

We can realize that for multiple minor releases this code has been wrong, and I haven't heard of any OOMs happening. So instead lets remove this code. We can always add it back in later if we end up needing it.