### PR TITLE
Remove Ancient Counters and Epoch Slots from clean

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1708,11 +1708,7 @@ impl AccountsDb {
     // collection
     // Only remove those accounts where the entire rooted history of the account
     // can be purged because there are no live append vecs in the ancestors
-    pub fn clean_accounts(
-        &self,
-        max_clean_root_inclusive: Option<Slot>,
-        is_startup: bool,
-    ) {
+    pub fn clean_accounts(&self, max_clean_root_inclusive: Option<Slot>, is_startup: bool) {
         if self.exhaustively_verify_refcounts {
             //at startup use all cores to verify refcounts
             if is_startup {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1755,7 +1755,7 @@ fn test_clean_max_slot_zero_lamport_account(mark_obsolete_accounts: MarkObsolete
         // updates in later slots in slot 1
         assert_eq!(accounts.alive_account_count_in_slot(0), 1);
         assert_eq!(accounts.alive_account_count_in_slot(1), 1);
-        accounts.clean_accounts(Some(0), false, &EpochSchedule::default());
+        accounts.clean_accounts(Some(0), false);
         assert_eq!(accounts.alive_account_count_in_slot(0), 1);
     }
 
@@ -1763,7 +1763,7 @@ fn test_clean_max_slot_zero_lamport_account(mark_obsolete_accounts: MarkObsolete
     assert!(accounts.accounts_index.contains_with(&pubkey, None, None));
 
     // Now the account can be cleaned up
-    accounts.clean_accounts(Some(1), false, &EpochSchedule::default());
+    accounts.clean_accounts(Some(1), false);
     assert_eq!(accounts.alive_account_count_in_slot(0), 0);
     assert_eq!(accounts.alive_account_count_in_slot(1), 0);
 
@@ -2353,7 +2353,7 @@ fn test_shrink_all_slots_none() {
             accounts.shrink_candidate_slots(&epoch_schedule);
         }
 
-        accounts.shrink_all_slots(*startup, &EpochSchedule::default(), None);
+        accounts.shrink_all_slots(*startup, None);
     }
 }
 
@@ -2409,7 +2409,7 @@ fn test_shrink_candidate_slots() {
     );
 
     // Now, do full-shrink.
-    accounts.shrink_all_slots(false, &EpochSchedule::default(), None);
+    accounts.shrink_all_slots(false, None);
     assert_eq!(
         pubkey_count_after_shrink,
         accounts.all_account_count_in_accounts_file(shrink_slot)
@@ -2967,7 +2967,7 @@ fn test_zero_lamport_new_root_not_cleaned() {
     db.add_root_and_flush_write_cache(1);
 
     // Only clean zero lamport accounts up to slot 0
-    db.clean_accounts(Some(0), false, &EpochSchedule::default());
+    db.clean_accounts(Some(0), false);
 
     // Should still be able to find zero lamport account in slot 1
     assert_eq!(
@@ -4080,7 +4080,7 @@ fn test_shrink_unref() {
     db.flush_rooted_accounts_cache_without_clean();
 
     // Clean to remove outdated entry from slot 0
-    db.clean_accounts(Some(1), false, &EpochSchedule::default());
+    db.clean_accounts(Some(1), false);
 
     // Shrink Slot 0
     {
@@ -4098,7 +4098,7 @@ fn test_shrink_unref() {
 
     // Should be one store before clean for slot 0
     db.get_and_assert_single_storage(0);
-    db.clean_accounts(Some(2), false, &EpochSchedule::default());
+    db.clean_accounts(Some(2), false);
 
     // No stores should exist for slot 0 after clean
     assert_no_storages_at_slot(&db, 0);
@@ -4112,7 +4112,6 @@ fn test_shrink_unref() {
 #[test]
 fn test_clean_drop_dead_zero_lamport_single_ref_accounts() {
     let accounts_db = AccountsDb::new_single_for_tests();
-    let epoch_schedule = EpochSchedule::default();
     let key1 = Pubkey::new_unique();
 
     let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
@@ -4131,7 +4130,7 @@ fn test_clean_drop_dead_zero_lamport_single_ref_accounts() {
     accounts_db.flush_accounts_cache(true, None);
 
     // run clean
-    accounts_db.clean_accounts(Some(1), false, &epoch_schedule);
+    accounts_db.clean_accounts(Some(1), false);
 
     // After clean, both slot0 and slot1 should be marked dead and dropped
     // from the store map.
@@ -4161,7 +4160,7 @@ fn test_clean_drop_dead_storage_handle_zero_lamport_single_ref_accounts() {
 
     // Clean should mark slot 0 dead and drop it. During the dropping, it
     // will find that slot 1 has a single ref zero accounts and mark it.
-    db.clean_accounts(Some(1), false, &EpochSchedule::default());
+    db.clean_accounts(Some(1), false);
 
     // Assert that after clean, slot 0 is dropped.
     assert!(db.storage.get_slot_storage_entry(0).is_none());
@@ -4203,7 +4202,7 @@ fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
     db.flush_rooted_accounts_cache_without_clean();
 
     // Clean to remove outdated entry from slot 0
-    db.clean_accounts(Some(1), false, &EpochSchedule::default());
+    db.clean_accounts(Some(1), false);
 
     // Shrink Slot 0
     {
@@ -4235,7 +4234,7 @@ fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
 
     // Should be one store before clean for slot 1
     db.get_and_assert_single_storage(1);
-    db.clean_accounts(Some(2), false, &EpochSchedule::default());
+    db.clean_accounts(Some(2), false);
 
     // No stores should exist for slot 0. If obsolete accounts are enabled, slot 0 stores are
     // cleaned when slot 2 is flushed. If obsolete accounts are disabled, slot 0 stores are
@@ -5127,15 +5126,15 @@ define_accounts_db_test!(
         accounts_db.assert_ref_count(&pubkey, 3);
 
         accounts_db.set_latest_full_snapshot_slot(slot2);
-        accounts_db.clean_accounts(Some(slot2), false, &EpochSchedule::default());
+        accounts_db.clean_accounts(Some(slot2), false);
         accounts_db.assert_ref_count(&pubkey, 2);
 
         accounts_db.set_latest_full_snapshot_slot(slot2);
-        accounts_db.clean_accounts(None, false, &EpochSchedule::default());
+        accounts_db.clean_accounts(None, false);
         accounts_db.assert_ref_count(&pubkey, 1);
 
         accounts_db.set_latest_full_snapshot_slot(slot3);
-        accounts_db.clean_accounts(None, false, &EpochSchedule::default());
+        accounts_db.clean_accounts(None, false);
         accounts_db.assert_ref_count(&pubkey, 0);
     }
 );

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -547,7 +547,6 @@ impl AccountsBackgroundService {
                                 bank.rc.accounts.accounts_db.clean_accounts(
                                     Some(max_clean_slot_inclusive),
                                     false,
-                                    bank.epoch_schedule(),
                                 );
                                 last_cleaned_slot = max_clean_slot_inclusive;
                                 previous_clean_time = Instant::now();

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -544,10 +544,10 @@ impl AccountsBackgroundService {
                                 .flush_accounts_cache(force_flush, Some(max_clean_slot_inclusive));
 
                             if should_clean {
-                                bank.rc.accounts.accounts_db.clean_accounts(
-                                    Some(max_clean_slot_inclusive),
-                                    false,
-                                );
+                                bank.rc
+                                    .accounts
+                                    .accounts_db
+                                    .clean_accounts(Some(max_clean_slot_inclusive), false);
                                 last_cleaned_slot = max_clean_slot_inclusive;
                                 previous_clean_time = Instant::now();
                             }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4945,10 +4945,10 @@ impl Bank {
                 // perform an accounts hash calculation *up to that slot*.  If we cleaned *past*
                 // that slot, then accounts could be removed from older storages, which would
                 // change the accounts hash.
-                self.rc.accounts.accounts_db.clean_accounts(
-                    Some(latest_full_snapshot_slot),
-                    true,
-                );
+                self.rc
+                    .accounts
+                    .accounts_db
+                    .clean_accounts(Some(latest_full_snapshot_slot), true);
                 info!("Cleaning... Done.");
             } else {
                 info!("Cleaning... Skipped.");
@@ -5247,10 +5247,10 @@ impl Bank {
         // So when we're snapshotting, the highest slot to clean is lowered by one.
         let highest_slot_to_clean = self.slot().saturating_sub(1);
 
-        self.rc.accounts.accounts_db.clean_accounts(
-            Some(highest_slot_to_clean),
-            false,
-        );
+        self.rc
+            .accounts
+            .accounts_db
+            .clean_accounts(Some(highest_slot_to_clean), false);
     }
 
     pub fn print_accounts_stats(&self) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4948,7 +4948,6 @@ impl Bank {
                 self.rc.accounts.accounts_db.clean_accounts(
                     Some(latest_full_snapshot_slot),
                     true,
-                    self.epoch_schedule(),
                 );
                 info!("Cleaning... Done.");
             } else {
@@ -4962,7 +4961,6 @@ impl Bank {
                 info!("Shrinking...");
                 self.rc.accounts.accounts_db.shrink_all_slots(
                     true,
-                    self.epoch_schedule(),
                     // we cannot allow the snapshot slot to be shrunk
                     Some(self.slot()),
                 );
@@ -5252,7 +5250,6 @@ impl Bank {
         self.rc.accounts.accounts_db.clean_accounts(
             Some(highest_slot_to_clean),
             false,
-            self.epoch_schedule(),
         );
     }
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -28,7 +28,6 @@ mod serde_snapshot_tests {
             ObsoleteAccounts,
         },
         solana_clock::Slot,
-        solana_epoch_schedule::EpochSchedule,
         solana_pubkey::Pubkey,
         std::{
             fs::File,
@@ -839,14 +838,13 @@ mod serde_snapshot_tests {
                 pubkey_count,
                 accounts.all_account_count_in_accounts_file(shrink_slot)
             );
-            accounts.shrink_all_slots(*startup, &EpochSchedule::default(), None);
+            accounts.shrink_all_slots(*startup, None);
             assert_eq!(
                 pubkey_count_after_shrink,
                 accounts.all_account_count_in_accounts_file(shrink_slot)
             );
 
             let no_ancestors = Ancestors::default();
-            let epoch_schedule = EpochSchedule::default();
 
             let calculated_capitalization = accounts
                 .calculate_capitalization_at_startup_from_index(&no_ancestors, current_slot);
@@ -866,7 +864,7 @@ mod serde_snapshot_tests {
             assert_eq!(accounts_lt_hash_pre, accounts_lt_hash_post);
 
             // repeating should be no-op
-            accounts.shrink_all_slots(*startup, &epoch_schedule, None);
+            accounts.shrink_all_slots(*startup, None);
             assert_eq!(
                 pubkey_count_after_shrink,
                 accounts.all_account_count_in_accounts_file(shrink_slot)


### PR DESCRIPTION
#### Problem
Clean accounts is coupled to EpochSchedule for the sole purpose of incrementing two counters tracking ancient account stats. Both counters are not useful

#### Summary of Changes
- Remove the counters
- Remove EpochSchedule from clean. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
