### PR TITLE
feat(ci): allow ci concurrent job count to be set explicitly

### DIFF
--- a/ci/common/limit-threads.sh
+++ b/ci/common/limit-threads.sh
@@ -4,13 +4,14 @@ set -e
 
 # limit jobs to 4gb/thread
 if [[ -f "/proc/meminfo" ]]; then
-  JOBS=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", ($2 / (4 * 1024 * 1024))}')
+  SYS_JOBS=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", ($2 / (4 * 1024 * 1024))}')
 else
-  JOBS=$(sysctl hw.memsize | awk '{printf "%.0f", ($2 / (4 * 1024**3))}')
+  SYS_JOBS=$(sysctl hw.memsize | awk '{printf "%.0f", ($2 / (4 * 1024**3))}')
 fi
 
 NPROC=$(nproc)
-JOBS=$((JOBS > NPROC ? NPROC : JOBS))
+SYS_JOBS=$((SYS_JOBS > NPROC ? NPROC : SYS_JOBS))
+: "${JOBS:=$SYS_JOBS}"
 
 export NPROC
 export JOBS


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/blob/1fc822722f4e4a3bfcf447820b1e37c43f4d061d/net-utils/src/sockets.rs#L16-L18

```
trent@morbo:~$ lscpu
Architecture:                x86_64
  CPU op-mode(s):            32-bit, 64-bit
  Address sizes:             52 bits physical, 57 bits virtual
  Byte Order:                Little Endian
CPU(s):                      128
  On-line CPU(s) list:       0-127
...
```

```
thread 'cluster_info::tests::new_with_external_ip_test_gossip' (1489651) panicked at net-utils/src/sockets.rs:39:42:
attempt to multiply with overflow
```

#### Summary of Changes
allow `JOBS` to be overridden from the environment
