### PR TITLE
Allow ip-echo-server to run with 1 thread

### DIFF
--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -19,13 +19,11 @@ use {
 
 pub type IpEchoServer = Runtime;
 
-// Enforce a minimum of two threads:
-// - One thread to monitor the TcpListener and spawn async tasks
-// - One thread to service the spawned tasks
-pub const MINIMUM_IP_ECHO_SERVER_THREADS: NonZeroUsize = NonZeroUsize::new(2).unwrap();
+// The IP echo server does minimal work and can function with a single thread
+pub const MINIMUM_IP_ECHO_SERVER_THREADS: NonZeroUsize = NonZeroUsize::new(1).unwrap();
 // IP echo requests require little computation and come in fairly infrequently,
 // so keep the number of server workers small to avoid overhead
-pub const DEFAULT_IP_ECHO_SERVER_THREADS: NonZeroUsize = MINIMUM_IP_ECHO_SERVER_THREADS;
+pub const DEFAULT_IP_ECHO_SERVER_THREADS: NonZeroUsize = NonZeroUsize::new(2).unwrap();
 pub const MAX_PORT_COUNT_PER_MESSAGE: usize = 4;
 
 const IO_TIMEOUT: Duration = Duration::from_secs(5);

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -19,10 +19,10 @@ use {
 
 pub type IpEchoServer = Runtime;
 
-// The IP echo server does minimal work and can function with a single thread
-pub const MINIMUM_IP_ECHO_SERVER_THREADS: NonZeroUsize = NonZeroUsize::new(1).unwrap();
 // IP echo requests require little computation and come in fairly infrequently,
-// so keep the number of server workers small to avoid overhead
+// so default to two server workers to avoid overhead:
+// - One thread to monitor the TcpListener and spawn async tasks
+// - One thread to service the spawned tasks
 pub const DEFAULT_IP_ECHO_SERVER_THREADS: NonZeroUsize = NonZeroUsize::new(2).unwrap();
 pub const MAX_PORT_COUNT_PER_MESSAGE: usize = 4;
 

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -31,8 +31,7 @@ use {
 };
 pub use {
     ip_echo_server::{
-        DEFAULT_IP_ECHO_SERVER_THREADS, IpEchoServer, MAX_PORT_COUNT_PER_MESSAGE,
-        MINIMUM_IP_ECHO_SERVER_THREADS, ip_echo_server,
+        DEFAULT_IP_ECHO_SERVER_THREADS, IpEchoServer, MAX_PORT_COUNT_PER_MESSAGE, ip_echo_server,
     },
     socket_addr_space::SocketAddrSpace,
 };

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -263,9 +263,6 @@ impl ThreadArg for IpEchoServerThreadsArg {
     fn default() -> usize {
         solana_net_utils::DEFAULT_IP_ECHO_SERVER_THREADS.get()
     }
-    fn min() -> usize {
-        solana_net_utils::MINIMUM_IP_ECHO_SERVER_THREADS.get()
-    }
 }
 
 struct RayonGlobalThreadsArg;


### PR DESCRIPTION
#### Problem

On low-CPU environments (e.g. 1 vCPU sidecar container), the
`--ip-echo-server-threads` arg range becomes invalid (`2..=1`) because
`MINIMUM_IP_ECHO_SERVER_THREADS` is 2 and `num_cpus::get()` returns 1.
This causes Clap validation to fail even for commands that don't use the
IP echo server, such as `set-identity` and `contact-info`.

#### Summary of Changes

- Lower `MINIMUM_IP_ECHO_SERVER_THREADS` from 2 to 1 — (the echo server
  does minimal work and can function on a single thread)
- Decouple `DEFAULT_IP_ECHO_SERVER_THREADS` from `MINIMUM` so existing
  validators still default to 2 threads with no behavior change

Fixes #10112