### PR TITLE
Return error for unsupported BankClient method

### DIFF
--- a/tps-client/src/bank_client.rs
+++ b/tps-client/src/bank_client.rs
@@ -130,7 +130,9 @@ impl TpsClient for BankClient {
         _end_slot: Option<u64>,
         _commitment_config: CommitmentConfig,
     ) -> TpsClientResult<Vec<u64>> {
-        unimplemented!("BankClient doesn't support get_blocks");
+        Err(TpsClientError::Custom(
+            "BankClient doesn't support get_blocks"
+        ));
     }
 
     fn get_block_with_config(


### PR DESCRIPTION
#### Problem
BankClient` implements `TpsClient`, but several methods use `unimplemented!()` which panics at runtime if called, violating the `TpsClientResult` error contract.

#### Summary of Changes
- Replace `unimplemented!()` in `BankClient` unsupported methods with `TpsClientError::Custom(...)` to return a structured error instead of panicking.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->



