### PR TITLE
cli: replace ConnectionCache with tpu-client-next for ping command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7706,6 +7706,7 @@ dependencies = [
  "solana-test-validator",
  "solana-tps-client",
  "solana-tpu-client",
+ "solana-tpu-client-next",
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status",
@@ -7719,6 +7720,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tiny-bip39",
  "tokio",
+ "tokio-util 0.7.18",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -75,6 +75,7 @@ solana-loader-v4-interface = "=3.1.0"
 solana-loader-v4-program = { workspace = true }
 solana-message = "=3.0.1"
 solana-native-token = "=3.0.0"
+solana-net-utils = { workspace = true }
 solana-nonce = "=3.0.0"
 solana-offchain-message = { version = "=3.0.0", features = ["verify"] }
 solana-packet = "=4.0.0"
@@ -97,6 +98,7 @@ solana-system-interface = { version = "=3.0", features = ["bincode"] }
 solana-sysvar = "=3.1.1"
 solana-tps-client = { workspace = true }
 solana-tpu-client = { workspace = true, features = ["default"] }
+solana-tpu-client-next = { workspace = true, features = ["websocket-node-address-service"] }
 solana-transaction = "=3.0.2"
 solana-transaction-error = "=3.0.0"
 solana-transaction-status = { workspace = true }
@@ -108,6 +110,7 @@ spl-memo-interface = { version = "=2.0.0" }
 thiserror = { workspace = true }
 tiny-bip39 = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }


### PR DESCRIPTION
Replace the cfg-gated new_quic_for_tests / new_quic pattern with a direct call to ConnectionCache::new_quic in the deprecated ping command handler.

Part of the ongoing migration away from dev-context-only-utils in non-test code.

Problem
cli/src/cli.rs uses ConnectionCache::new_quic_for_tests behind a #[cfg(feature = "dev-context-only-utils")] guard, with the production new_quic call gated behind #[cfg(not(...))]. This test-only API shouldn't be used in non-test CLI code.

Summary of Changes
Removed the #[cfg(feature = "dev-context-only-utils")] branch calling new_quic_for_tests
Removed the #[cfg(not(...))] guard from the new_quic call
No behavioral change — new_quic was already the production code path

Work towards #10206
