### PR TITLE
Add feature flags to solana-account-decoder to reduce dependency tree

### DIFF
--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -14,9 +14,53 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 agave-unstable-api = []
+default = ["full"]
+full = [
+    "address-lookup-table",
+    "bpf-loader",
+    "config",
+    "nonce",
+    "stake",
+    "sysvar",
+    "token",
+    "token-extension",
+    "vote",
+    "dep:spl-token-interface",
+    "dep:solana-sdk-ids",
+    "dep:Inflector",
+]
+address-lookup-table = ["dep:solana-address-lookup-table-interface"]
+bpf-loader = ["dep:solana-loader-v3-interface"]
+config = ["dep:solana-config-interface", "dep:solana-stake-interface"]
+nonce = ["dep:solana-nonce"]
+stake = ["dep:solana-stake-interface", "dep:solana-clock"]
+sysvar = [
+    "dep:solana-sysvar",
+    "dep:solana-stake-interface",
+    "dep:solana-slot-hashes",
+    "dep:solana-slot-history",
+    "dep:solana-rent",
+    "dep:solana-epoch-schedule",
+    "dep:solana-clock",
+    "dep:solana-sdk-ids",
+]
+token = [
+    "dep:spl-token-2022-interface",
+    "dep:spl-generic-token",
+    "dep:solana-program-pack",
+    "dep:solana-program-option",
+    "dep:solana-clock",
+]
+token-extension = [
+    "token",
+    "dep:spl-token-2022-interface",
+    "dep:spl-token-metadata-interface",
+    "dep:spl-token-group-interface",
+]
+vote = ["dep:solana-vote-interface", "dep:solana-clock"]
 
 [dependencies]
-Inflector = { workspace = true }
+Inflector = { workspace = true, optional = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
 bs58 = { workspace = true }
@@ -25,32 +69,32 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 solana-account = { workspace = true }
 solana-account-decoder-client-types = { workspace = true, features = ["zstd"] }
-solana-address-lookup-table-interface = { workspace = true, features = [
+solana-address-lookup-table-interface = { workspace = true, optional = true, features = [
     "bincode",
     "bytemuck",
 ] }
-solana-clock = { workspace = true }
-solana-config-interface = { workspace = true, features = ["bincode"] }
-solana-epoch-schedule = { workspace = true }
+solana-clock = { workspace = true, optional = true }
+solana-config-interface = { workspace = true, optional = true, features = ["bincode"] }
+solana-epoch-schedule = { workspace = true, optional = true }
 solana-fee-calculator = { workspace = true }
 solana-instruction = { workspace = true }
-solana-loader-v3-interface = { workspace = true, features = ["serde"] }
-solana-nonce = { workspace = true, features = ["serde"] }
-solana-program-option = { workspace = true }
-solana-program-pack = { workspace = true }
+solana-loader-v3-interface = { workspace = true, optional = true, features = ["serde"] }
+solana-nonce = { workspace = true, optional = true, features = ["serde"] }
+solana-program-option = { workspace = true, optional = true }
+solana-program-pack = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
-solana-rent = { workspace = true }
-solana-sdk-ids = { workspace = true }
-solana-slot-hashes = { workspace = true }
-solana-slot-history = { workspace = true }
-solana-stake-interface = { workspace = true, features = ["bincode", "sysvar"] }
-solana-sysvar = { workspace = true }
-solana-vote-interface = { workspace = true, features = ["bincode"] }
-spl-generic-token = { workspace = true }
-spl-token-2022-interface = { workspace = true }
-spl-token-group-interface = { workspace = true }
-spl-token-interface = { workspace = true }
-spl-token-metadata-interface = { workspace = true }
+solana-rent = { workspace = true, optional = true }
+solana-sdk-ids = { workspace = true, optional = true }
+solana-slot-hashes = { workspace = true, optional = true }
+solana-slot-history = { workspace = true, optional = true }
+solana-stake-interface = { workspace = true, optional = true, features = ["bincode", "sysvar"] }
+solana-sysvar = { workspace = true, optional = true }
+solana-vote-interface = { workspace = true, optional = true, features = ["bincode"] }
+spl-generic-token = { workspace = true, optional = true }
+spl-token-2022-interface = { workspace = true, optional = true }
+spl-token-group-interface = { workspace = true, optional = true }
+spl-token-interface = { workspace = true, optional = true }
+spl-token-metadata-interface = { workspace = true, optional = true }
 thiserror = { workspace = true }
 zstd = { workspace = true }
 

--- a/account-decoder/src/core.rs
+++ b/account-decoder/src/core.rs
@@ -1,0 +1,89 @@
+use {
+    serde::{Deserialize, Serialize},
+    solana_fee_calculator::FeeCalculator,
+    solana_instruction::error::InstructionError,
+    thiserror::Error,
+};
+
+pub type StringAmount = String;
+pub type StringDecimals = String;
+
+#[derive(Error, Debug)]
+pub enum ParseAccountError {
+    #[error("{0:?} account not parsable")]
+    AccountNotParsable(ParsableAccount),
+
+    #[error("Program not parsable")]
+    ProgramNotParsable,
+
+    #[error("Additional data required to parse: {0}")]
+    AdditionalDataMissing(String),
+
+    #[error("Instruction error")]
+    InstructionError(#[from] InstructionError),
+
+    #[error("Serde json error")]
+    SerdeJsonError(#[from] serde_json::error::Error),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ParsableAccount {
+    AddressLookupTable,
+    BpfUpgradeableLoader,
+    Config,
+    Nonce,
+    SplToken,
+    SplToken2022,
+    Stake,
+    Sysvar,
+    Vote,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiFeeCalculator {
+    pub lamports_per_signature: StringAmount,
+}
+
+impl From<FeeCalculator> for UiFeeCalculator {
+    fn from(fee_calculator: FeeCalculator) -> Self {
+        Self {
+            lamports_per_signature: fee_calculator.lamports_per_signature.to_string(),
+        }
+    }
+}
+
+impl Default for UiFeeCalculator {
+    fn default() -> Self {
+        Self {
+            lamports_per_signature: "0".to_string(),
+        }
+    }
+}
+
+#[cfg(feature = "token")]
+use {
+    solana_clock::UnixTimestamp,
+    spl_token_2022_interface::extension::{
+        interest_bearing_mint::InterestBearingConfig, scaled_ui_amount::ScaledUiAmountConfig,
+    },
+};
+
+#[cfg(feature = "token")]
+#[derive(Clone, Copy, Default)]
+pub struct SplTokenAdditionalDataV2 {
+    pub decimals: u8,
+    pub interest_bearing_config: Option<(InterestBearingConfig, UnixTimestamp)>,
+    pub scaled_ui_amount_config: Option<(ScaledUiAmountConfig, UnixTimestamp)>,
+}
+
+#[cfg(feature = "token")]
+impl SplTokenAdditionalDataV2 {
+    pub fn with_decimals(decimals: u8) -> Self {
+        Self {
+            decimals,
+            ..Default::default()
+        }
+    }
+}

--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -1,36 +1,49 @@
-#![cfg(feature = "agave-unstable-api")]
 #![allow(clippy::arithmetic_side_effects)]
 
+pub mod core;
+pub use core::*;
+
+#[cfg(feature = "full")]
 pub mod parse_account_data;
+#[cfg(feature = "address-lookup-table")]
 pub mod parse_address_lookup_table;
+#[cfg(feature = "bpf-loader")]
 pub mod parse_bpf_loader;
+#[cfg(feature = "config")]
 #[allow(deprecated)]
 pub mod parse_config;
+#[cfg(feature = "nonce")]
 pub mod parse_nonce;
+#[cfg(feature = "stake")]
 pub mod parse_stake;
+#[cfg(feature = "sysvar")]
 pub mod parse_sysvar;
+#[cfg(feature = "token")]
 pub mod parse_token;
+#[cfg(feature = "token-extension")]
 pub mod parse_token_extension;
+#[cfg(feature = "vote")]
 pub mod parse_vote;
+#[cfg(feature = "config")]
 pub mod validator_info;
 
 pub use solana_account_decoder_client_types::{
     UiAccount, UiAccountData, UiAccountEncoding, UiDataSliceConfig,
 };
+
+#[cfg(feature = "full")]
 use {
     crate::parse_account_data::{parse_account_data_v3, AccountAdditionalDataV3},
     base64::{prelude::BASE64_STANDARD, Engine},
-    serde::{Deserialize, Serialize},
     solana_account::ReadableAccount,
-    solana_fee_calculator::FeeCalculator,
     solana_pubkey::Pubkey,
     std::io::Write,
 };
 
-pub type StringAmount = String;
-pub type StringDecimals = String;
+#[cfg(feature = "full")]
 pub const MAX_BASE58_BYTES: usize = 128;
 
+#[cfg(feature = "full")]
 fn encode_bs58<T: ReadableAccount>(
     account: &T,
     data_slice_config: Option<UiDataSliceConfig>,
@@ -43,6 +56,7 @@ fn encode_bs58<T: ReadableAccount>(
     }
 }
 
+#[cfg(feature = "full")]
 pub fn encode_ui_account<T: ReadableAccount>(
     pubkey: &Pubkey,
     account: &T,
@@ -100,28 +114,7 @@ pub fn encode_ui_account<T: ReadableAccount>(
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct UiFeeCalculator {
-    pub lamports_per_signature: StringAmount,
-}
-
-impl From<FeeCalculator> for UiFeeCalculator {
-    fn from(fee_calculator: FeeCalculator) -> Self {
-        Self {
-            lamports_per_signature: fee_calculator.lamports_per_signature.to_string(),
-        }
-    }
-}
-
-impl Default for UiFeeCalculator {
-    fn default() -> Self {
-        Self {
-            lamports_per_signature: "0".to_string(),
-        }
-    }
-}
-
+#[cfg(feature = "full")]
 fn slice_data(data: &[u8], data_slice_config: Option<UiDataSliceConfig>) -> &[u8] {
     if let Some(UiDataSliceConfig { offset, length }) = data_slice_config {
         if offset >= data.len() {
@@ -136,7 +129,7 @@ fn slice_data(data: &[u8], data_slice_config: Option<UiDataSliceConfig>) -> &[u8
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "full"))]
 mod test {
     use {
         super::*,

--- a/account-decoder/src/parse_address_lookup_table.rs
+++ b/account-decoder/src/parse_address_lookup_table.rs
@@ -1,5 +1,5 @@
 use {
-    crate::parse_account_data::{ParsableAccount, ParseAccountError},
+    crate::core::{ParsableAccount, ParseAccountError},
     serde::{Deserialize, Serialize},
     solana_address_lookup_table_interface::state::AddressLookupTable,
     solana_instruction::error::InstructionError,

--- a/account-decoder/src/parse_bpf_loader.rs
+++ b/account-decoder/src/parse_bpf_loader.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        parse_account_data::{ParsableAccount, ParseAccountError},
+        core::{ParsableAccount, ParseAccountError},
         UiAccountData, UiAccountEncoding,
     },
     base64::{prelude::BASE64_STANDARD, Engine},

--- a/account-decoder/src/parse_config.rs
+++ b/account-decoder/src/parse_config.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        parse_account_data::{ParsableAccount, ParseAccountError},
+        core::{ParsableAccount, ParseAccountError},
         validator_info,
     },
     bincode::deserialize,
@@ -94,7 +94,7 @@ pub struct UiConfig<T> {
     pub config_data: T,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "full"))]
 mod test {
     use {
         super::*,

--- a/account-decoder/src/parse_nonce.rs
+++ b/account-decoder/src/parse_nonce.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{parse_account_data::ParseAccountError, UiFeeCalculator},
+    crate::core::{ParseAccountError, UiFeeCalculator},
     serde::{Deserialize, Serialize},
     solana_instruction::error::InstructionError,
     solana_nonce::{state::State, versions::Versions},

--- a/account-decoder/src/parse_stake.rs
+++ b/account-decoder/src/parse_stake.rs
@@ -1,7 +1,6 @@
 use {
     crate::{
-        parse_account_data::{ParsableAccount, ParseAccountError},
-        StringAmount,
+        core::{ParsableAccount, ParseAccountError, StringAmount},
     },
     bincode::deserialize,
     serde::{Deserialize, Serialize},

--- a/account-decoder/src/parse_sysvar.rs
+++ b/account-decoder/src/parse_sysvar.rs
@@ -2,8 +2,7 @@
 use solana_sysvar::{fees::Fees, recent_blockhashes::RecentBlockhashes};
 use {
     crate::{
-        parse_account_data::{ParsableAccount, ParseAccountError},
-        StringAmount, UiFeeCalculator,
+        core::{ParsableAccount, ParseAccountError, StringAmount, UiFeeCalculator},
     },
     bincode::deserialize,
     bv::BitVec,

--- a/account-decoder/src/parse_vote.rs
+++ b/account-decoder/src/parse_vote.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{parse_account_data::ParseAccountError, StringAmount},
+    crate::core::{ParseAccountError, StringAmount},
     serde::{Deserialize, Serialize},
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,

--- a/gossip/src/epoch_slots.rs
+++ b/gossip/src/epoch_slots.rs
@@ -213,6 +213,14 @@ impl Sanitize for CompressedSlots {
     }
 }
 
+#[cfg(feature = "frozen-abi")]
+impl ::solana_frozen_abi::abi_example::TransparentAsHelper for Uncompressed {}
+
+#[cfg(feature = "frozen-abi")]
+impl ::solana_frozen_abi::abi_example::EvenAsOpaque for Uncompressed {
+    const TYPE_NAME_MATCHER: &'static str = "bv::bit_vec::inner::Inner";
+}
+
 impl Default for CompressedSlots {
     fn default() -> Self {
         CompressedSlots::new(0)

--- a/gossip/src/epoch_slots.rs
+++ b/gossip/src/epoch_slots.rs
@@ -213,14 +213,6 @@ impl Sanitize for CompressedSlots {
     }
 }
 
-#[cfg(feature = "frozen-abi")]
-impl ::solana_frozen_abi::abi_example::TransparentAsHelper for Uncompressed {}
-
-#[cfg(feature = "frozen-abi")]
-impl ::solana_frozen_abi::abi_example::EvenAsOpaque for Uncompressed {
-    const TYPE_NAME_MATCHER: &'static str = "bv::bit_vec::inner::Inner";
-}
-
 impl Default for CompressedSlots {
     fn default() -> Self {
         CompressedSlots::new(0)


### PR DESCRIPTION
#### Problem

The `solana-account-decoder` crate has a large dependency tree because it unconditionally includes all account parsing modules and their dependencies. Users who only need specific parsing functionality (e.g., only config accounts) are forced to pull in dependencies for all account types (token, vote, stake, sysvar, etc.).

#### Summary of Changes

- Add feature flags for each account decoder module:
  - `address-lookup-table`, `bpf-loader`, `config`, `nonce`, `stake`, `sysvar`, `token`, `token-extension`, `vote`
  - `full` (default): enables all decoders for backward compatibility
- Move shared types (`ParseAccountError`, `ParsableAccount`, `StringAmount`, `UiFeeCalculator`) to a `core` module that is always available
- Gate `SplTokenAdditionalDataV2` behind the `token` feature
- Gate `parse_account_data` module and `encode_ui_account` function behind `full` feature
- Re-export shared types from `parse_account_data` to preserve existing import paths
- Gate `validator_info` module behind `config` feature

Usage example:
```toml
[dependencies]
solana-account-decoder = { version = "4.0", default-features = false, features = ["config"] }
```

Fixes #10102