### PR TITLE
tpu-client: propagate send error in async_send_versioned_transaction

### DIFF
--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -250,8 +250,9 @@ where
     ) -> TransportResult<Signature> {
         let wire_transaction =
             bincode::serialize(&transaction).expect("serialize Transaction in send_batch");
-        self.send_wire_transaction(wire_transaction);
-        Ok(transaction.signatures[0])
+        let signature = transaction.signatures[0];
+        self.try_send_wire_transaction(wire_transaction)?;
+        Ok(signature)
     }
 
     fn async_send_versioned_transaction_batch(


### PR DESCRIPTION
`async_send_versioned_transaction` was calling `send_wire_transaction()` (returns bool) and silently discarding the result, always returning `Ok(signature)` even when all sends failed. This broke the `AsyncClient` trait contract — callers like `async_transfer` expect errors to be propagated via `Result`.

Replaced `send_wire_transaction` with `try_send_wire_transaction` + `?` to properly propagate transport errors, consistent with how the sibling `async_send_versioned_transaction_batch` already handles it in the same impl block.