### PR TITLE
chore: stop publishing solana-keygen to crates.io

### DIFF
--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
#### Problem

we don't encourage people to do `cargo install solana-keygen`

https://crates.io/crates/solana-keygen

#### Summary of Changes

stop shipping it