### PR TITLE
program-runtime: Add direct account pointers in program input (SIMD-0449)

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -176,6 +176,8 @@ impl FeatureSet {
             enable_bls12_381_syscall: self.is_active(&enable_bls12_381_syscall::id()),
             block_revenue_sharing: self.is_active(&block_revenue_sharing::id()),
             vote_account_initialize_v2: self.is_active(&vote_account_initialize_v2::id()),
+            direct_account_pointers_in_program_input: self
+                .is_active(&direct_account_pointers_in_program_input::id()),
         }
     }
 }
@@ -1315,6 +1317,10 @@ pub mod validator_admission_ticket {
     solana_pubkey::declare_id!("VATtb1DepUwdPh5bFVasdtkbeDNsftZSRzr2aKpKWJA");
 }
 
+pub mod direct_account_pointers_in_program_input {
+    solana_pubkey::declare_id!("ptrXWLkSDMZZmZN8GAT6W5yW4EvYByfw6cRRHbXwQNS");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2346,6 +2352,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             validator_admission_ticket::id(),
             "SIMD-0357: Alpenglow VAT implementation",
+        ),
+        (
+            direct_account_pointers_in_program_input::id(),
+            "SIMD-0449: Direct Account Pointers in Program Input",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -509,6 +509,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 .unwrap(),
             false, // virtual_address_space_adjustments
             false, // account_data_direct_mapping
+            false, // direct_account_pointers_in_program_input
         )
         .unwrap();
 

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -510,9 +510,14 @@ fn serialize_parameters_for_abiv1(
             }
         }
     }
+
     size += size_of::<u64>() // data len
     + instruction_data.len()
-    + size_of::<Pubkey>(); // program id;
+    + size_of::<Pubkey>(); // program id
+
+    // account pointers array
+    let accounts_pointer_offset = (size as *const u8).align_offset(BPF_ALIGN_OF_U128);
+    size += accounts_pointer_offset + accounts.len() * size_of::<u64>();
 
     let mut s = Serializer::new(
         size,
@@ -522,12 +527,14 @@ fn serialize_parameters_for_abiv1(
         account_data_direct_mapping,
     );
 
+    let mut accounts_pointer = Vec::with_capacity(accounts.len());
     // Serialize into the buffer
     s.write::<u64>((accounts.len() as u64).to_le());
     for account in accounts {
         match account {
             SerializeAccount::Account(_, mut borrowed_account) => {
-                s.write::<u8>(NON_DUP_MARKER);
+                // Store the pointer for the account
+                accounts_pointer.push(s.write::<u8>(NON_DUP_MARKER));
                 s.write::<u8>(borrowed_account.is_signer() as u8);
                 s.write::<u8>(borrowed_account.is_writable() as u8);
                 #[expect(deprecated)]
@@ -549,6 +556,8 @@ fn serialize_parameters_for_abiv1(
                 });
             }
             SerializeAccount::Duplicate(position) => {
+                // Use the same pointer as the original account
+                accounts_pointer.push(*accounts_pointer.get(position as usize).unwrap());
                 accounts_metadata.push(accounts_metadata.get(position as usize).unwrap().clone());
                 s.write::<u8>(position as u8);
                 s.write_all(&[0u8, 0, 0, 0, 0, 0, 0]);
@@ -558,6 +567,11 @@ fn serialize_parameters_for_abiv1(
     s.write::<u64>((instruction_data.len() as u64).to_le());
     let instruction_data_offset = s.write_all(instruction_data);
     s.write_all(program_id.as_ref());
+    s.fill_write(accounts_pointer_offset, 0)
+        .map_err(|_| InstructionError::InvalidArgument)?;
+    accounts_pointer.iter().for_each(|offset| {
+        s.write::<u64>(offset.to_le());
+    });
 
     let (mem, regions) = s.finish();
     Ok((

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -510,14 +510,13 @@ fn serialize_parameters_for_abiv1(
             }
         }
     }
-
     size += size_of::<u64>() // data len
     + instruction_data.len()
-    + size_of::<Pubkey>(); // program id
+    + size_of::<Pubkey>(); // program id;
 
-    // account pointers array
-    let accounts_pointer_offset = (size as *const u8).align_offset(BPF_ALIGN_OF_U128);
-    size += accounts_pointer_offset + accounts.len() * size_of::<u64>();
+    // reserve space for account pointer array
+    let account_pointers_offset = (size as *const u8).align_offset(BPF_ALIGN_OF_U128);
+    size += account_pointers_offset + accounts.len() * size_of::<u64>();
 
     let mut s = Serializer::new(
         size,
@@ -527,14 +526,12 @@ fn serialize_parameters_for_abiv1(
         account_data_direct_mapping,
     );
 
-    let mut accounts_pointer = Vec::with_capacity(accounts.len());
     // Serialize into the buffer
     s.write::<u64>((accounts.len() as u64).to_le());
     for account in accounts {
         match account {
             SerializeAccount::Account(_, mut borrowed_account) => {
-                // Store the pointer for the account
-                accounts_pointer.push(s.write::<u8>(NON_DUP_MARKER));
+                s.write::<u8>(NON_DUP_MARKER);
                 s.write::<u8>(borrowed_account.is_signer() as u8);
                 s.write::<u8>(borrowed_account.is_writable() as u8);
                 #[expect(deprecated)]
@@ -556,8 +553,6 @@ fn serialize_parameters_for_abiv1(
                 });
             }
             SerializeAccount::Duplicate(position) => {
-                // Use the same pointer as the original account
-                accounts_pointer.push(*accounts_pointer.get(position as usize).unwrap());
                 accounts_metadata.push(accounts_metadata.get(position as usize).unwrap().clone());
                 s.write::<u8>(position as u8);
                 s.write_all(&[0u8, 0, 0, 0, 0, 0, 0]);
@@ -567,11 +562,11 @@ fn serialize_parameters_for_abiv1(
     s.write::<u64>((instruction_data.len() as u64).to_le());
     let instruction_data_offset = s.write_all(instruction_data);
     s.write_all(program_id.as_ref());
-    s.fill_write(accounts_pointer_offset, 0)
+    s.fill_write(account_pointers_offset, 0)
         .map_err(|_| InstructionError::InvalidArgument)?;
-    accounts_pointer.iter().for_each(|offset| {
-        s.write::<u64>(offset.to_le());
-    });
+    for entry in accounts_metadata.iter() {
+        s.write::<u64>(entry.vm_data_addr.to_le());
+    }
 
     let (mem, regions) = s.finish();
     Ok((

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -573,6 +573,8 @@ fn serialize_parameters_for_abiv1(
     s.write_all(program_id.as_ref());
 
     if let Some(offset) = account_pointers_offset {
+        // Add padding before the account pointer array to reach 8-byte alignment
+        // (BPF_ALIGN_OF_U128).
         s.fill_write(offset, 0)
             .map_err(|_| InstructionError::InvalidArgument)?;
         for entry in accounts_metadata.iter() {

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -223,6 +223,7 @@ pub fn serialize_parameters(
     instruction_context: &InstructionContext,
     virtual_address_space_adjustments: bool,
     account_data_direct_mapping: bool,
+    direct_account_pointers_in_program_input: bool,
 ) -> Result<
     (
         AlignedMemory<HOST_ALIGN>,
@@ -278,6 +279,8 @@ pub fn serialize_parameters(
             &program_id,
             virtual_address_space_adjustments,
             account_data_direct_mapping,
+            // SIMD-0449: only available on ABIv1
+            direct_account_pointers_in_program_input,
         )
     }
 }
@@ -473,6 +476,7 @@ fn serialize_parameters_for_abiv1(
     program_id: &Pubkey,
     virtual_address_space_adjustments: bool,
     account_data_direct_mapping: bool,
+    direct_account_pointers_program_input: bool,
 ) -> Result<
     (
         AlignedMemory<HOST_ALIGN>,
@@ -515,8 +519,13 @@ fn serialize_parameters_for_abiv1(
     + size_of::<Pubkey>(); // program id;
 
     // reserve space for account pointer array
-    let account_pointers_offset = (size as *const u8).align_offset(BPF_ALIGN_OF_U128);
-    size += account_pointers_offset + accounts.len() * size_of::<u64>();
+    let account_pointers_offset = if direct_account_pointers_program_input {
+        let offset = (size as *const u8).align_offset(BPF_ALIGN_OF_U128);
+        size += offset + accounts.len() * size_of::<u64>();
+        offset
+    } else {
+        0
+    };
 
     let mut s = Serializer::new(
         size,
@@ -562,10 +571,14 @@ fn serialize_parameters_for_abiv1(
     s.write::<u64>((instruction_data.len() as u64).to_le());
     let instruction_data_offset = s.write_all(instruction_data);
     s.write_all(program_id.as_ref());
-    s.fill_write(account_pointers_offset, 0)
-        .map_err(|_| InstructionError::InvalidArgument)?;
-    for entry in accounts_metadata.iter() {
-        s.write::<u64>(entry.vm_data_addr.to_le());
+
+    // Write account pointer array if requested
+    if direct_account_pointers_program_input {
+        s.fill_write(account_pointers_offset, 0)
+            .map_err(|_| InstructionError::InvalidArgument)?;
+        for entry in accounts_metadata.iter() {
+            s.write::<u64>(entry.vm_data_addr.to_le());
+        }
     }
 
     let (mem, regions) = s.finish();
@@ -690,6 +703,7 @@ mod tests {
             rc::Rc,
             slice::{self, from_raw_parts, from_raw_parts_mut},
         },
+        test_case::test_case,
     };
 
     fn deduplicated_instruction_accounts(
@@ -709,8 +723,11 @@ mod tests {
             .collect()
     }
 
-    #[test]
-    fn test_serialize_parameters_with_many_accounts() {
+    #[test_case(false; "direct_account_pointers_in_program_input disabled")]
+    #[test_case(true; "direct_account_pointers_in_program_input enabled")]
+    fn test_serialize_parameters_with_many_accounts(
+        direct_account_pointers_in_program_input: bool,
+    ) {
         struct TestCase {
             num_ix_accounts: usize,
             append_dup_account: bool,
@@ -818,6 +835,7 @@ mod tests {
                     &instruction_context,
                     virtual_address_space_adjustments,
                     false, // account_data_direct_mapping
+                    direct_account_pointers_in_program_input,
                 );
                 assert_eq!(
                     serialization_result.as_ref().err(),
@@ -868,8 +886,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_serialize_parameters() {
+    #[test_case(false; "direct_account_pointers_in_program_input disabled")]
+    #[test_case(true; "direct_account_pointers_in_program_input enabled")]
+    fn test_serialize_parameters(direct_account_pointers_in_program_input: bool) {
         for virtual_address_space_adjustments in [false, true] {
             let program_id = solana_pubkey::new_rand();
             let transaction_accounts = vec![
@@ -979,6 +998,7 @@ mod tests {
                     &instruction_context,
                     virtual_address_space_adjustments,
                     false, // account_data_direct_mapping
+                    direct_account_pointers_in_program_input,
                 )
                 .unwrap();
 
@@ -1078,6 +1098,7 @@ mod tests {
                     &instruction_context,
                     virtual_address_space_adjustments,
                     false, // account_data_direct_mapping
+                    direct_account_pointers_in_program_input,
                 )
                 .unwrap();
             let mut serialized_regions = concat_regions(&regions);
@@ -1136,8 +1157,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_serialize_parameters_mask_out_rent_epoch_in_vm_serialization() {
+    #[test_case(false; "direct_account_pointers_in_program_input disabled")]
+    #[test_case(true; "direct_account_pointers_in_program_input enabled")]
+    fn test_serialize_parameters_mask_out_rent_epoch_in_vm_serialization(
+        direct_account_pointers_in_program_input: bool,
+    ) {
         let transaction_accounts = vec![
             (
                 solana_pubkey::new_rand(),
@@ -1239,6 +1263,7 @@ mod tests {
                 &instruction_context,
                 true,
                 false, // account_data_direct_mapping
+                direct_account_pointers_in_program_input,
             )
             .unwrap();
 
@@ -1271,6 +1296,7 @@ mod tests {
                 &instruction_context,
                 true,
                 false, // account_data_direct_mapping
+                direct_account_pointers_in_program_input,
             )
             .unwrap();
         let mut serialized_regions = concat_regions(&regions);

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -209,6 +209,9 @@ pub fn execute<'a, 'b: 'a>(
     let provide_instruction_data_offset_in_vm_r2 = invoke_context
         .get_feature_set()
         .provide_instruction_data_offset_in_vm_r2;
+    let direct_account_pointers_in_program_input = invoke_context
+        .get_feature_set()
+        .direct_account_pointers_in_program_input;
 
     let mut serialize_time = Measure::start("serialize");
     let (parameter_bytes, regions, accounts_metadata, instruction_data_offset) =
@@ -216,6 +219,7 @@ pub fn execute<'a, 'b: 'a>(
             &instruction_context,
             virtual_address_space_adjustments,
             account_data_direct_mapping,
+            direct_account_pointers_in_program_input,
         )?;
     serialize_time.stop();
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -141,7 +141,7 @@ pub fn invoke_builtin_function(
             &instruction_context,
             false, // There is no VM so virtual_address_space_adjustments can not be implemented here
             false, // There is no VM so account_data_direct_mapping can not be implemented here
-            false, // There is no VM so direct_account_pointers_in_program_input can not be implemented here
+            true,  // There is no VM but we still want direct_account_pointers_in_program_input
         )?;
 
     // Deserialize data back into instruction params

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -135,13 +135,17 @@ pub fn invoke_builtin_function(
     // Copy indices_in_instruction into a HashSet to ensure there are no duplicates
     let deduplicated_indices: HashSet<IndexOfAccount> = instruction_account_indices.collect();
 
+    let direct_account_pointers_in_program_input = invoke_context
+        .get_feature_set()
+        .direct_account_pointers_in_program_input;
+
     // Serialize entrypoint parameters with SBF ABI
     let (mut parameter_bytes, _regions, _account_lengths, _instruction_data_offset) =
         serialize_parameters(
             &instruction_context,
             false, // There is no VM so virtual_address_space_adjustments can not be implemented here
             false, // There is no VM so account_data_direct_mapping can not be implemented here
-            true,  // There is no VM but we still want direct_account_pointers_in_program_input
+            direct_account_pointers_in_program_input,
         )?;
 
     // Deserialize data back into instruction params

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -141,6 +141,7 @@ pub fn invoke_builtin_function(
             &instruction_context,
             false, // There is no VM so virtual_address_space_adjustments can not be implemented here
             false, // There is no VM so account_data_direct_mapping can not be implemented here
+            false, // There is no VM so direct_account_pointers_in_program_input can not be implemented here
         )?;
 
     // Deserialize data back into instruction params

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -118,8 +118,9 @@ fn bench_serialize_unaligned(c: &mut Criterion) {
         b.iter(|| {
             let _ = serialize_parameters(
                 &instruction_context,
-                true, // virtual_address_space_adjustments
-                true, // account_data_direct_mapping
+                true,  // virtual_address_space_adjustments
+                true,  // account_data_direct_mapping
+                false, // direct_account_pointers_in_program_input
             )
             .unwrap();
         });
@@ -137,6 +138,7 @@ fn bench_serialize_unaligned_copy_account_data(c: &mut Criterion) {
                 &instruction_context,
                 false, // virtual_address_space_adjustments
                 false, // account_data_direct_mapping
+                false, // direct_account_pointers_in_program_input
             )
             .unwrap();
         });
@@ -155,6 +157,7 @@ fn bench_serialize_aligned(c: &mut Criterion) {
                 &instruction_context,
                 true, // virtual_address_space_adjustments
                 true, // account_data_direct_mapping
+                true, // direct_account_pointers_in_program_input
             )
             .unwrap();
         });
@@ -173,6 +176,7 @@ fn bench_serialize_aligned_copy_account_data(c: &mut Criterion) {
                 &instruction_context,
                 false, // virtual_address_space_adjustments
                 false, // account_data_direct_mapping
+                true,  // direct_account_pointers_in_program_input
             )
             .unwrap();
         });
@@ -191,6 +195,7 @@ fn bench_serialize_unaligned_max_accounts(c: &mut Criterion) {
                 &instruction_context,
                 true, // virtual_address_space_adjustments
                 true, // account_data_direct_mapping
+                true, // direct_account_pointers_in_program_input
             )
             .unwrap();
         });
@@ -209,6 +214,7 @@ fn bench_serialize_aligned_max_accounts(c: &mut Criterion) {
                 &instruction_context,
                 true, // virtual_address_space_adjustments
                 true, // account_data_direct_mapping
+                true, // direct_account_pointers_in_program_input
             )
             .unwrap();
         });

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -176,7 +176,7 @@ fn bench_serialize_aligned_copy_account_data(c: &mut Criterion) {
                 &instruction_context,
                 false, // virtual_address_space_adjustments
                 false, // account_data_direct_mapping
-                true,  // direct_account_pointers_in_program_input
+                false, // direct_account_pointers_in_program_input
             )
             .unwrap();
         });

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6055,7 +6055,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37ca34c37f92ee341b73d5ce7c8ef5bb38e9a87955b4bd343c63fa18b149215"
 dependencies = [
- "solana-address 2.1.0",
+ "solana-address 2.2.0",
  "solana-program-error",
 ]
 
@@ -7362,18 +7362,6 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-program-error",
-]
-
-[[package]]
-name = "solana-instruction-view"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60147e4d0a4620013df40bf30a86dd299203ff12fcb8b593cd51014fce0875d8"
-dependencies = [
- "solana-account-view",
- "solana-address 2.1.0",
- "solana-define-syscall 4.0.1",
  "solana-program-error",
 ]
 
@@ -8800,9 +8788,11 @@ dependencies = [
 name = "solana-sbf-rust-direct-account-pointers"
 version = "4.0.0-alpha.0"
 dependencies = [
- "pinocchio",
+ "solana-account-view",
+ "solana-address 2.2.0",
  "solana-cpi",
  "solana-program-entrypoint",
+ "solana-program-error",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6050,6 +6050,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-account-view"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37ca34c37f92ee341b73d5ce7c8ef5bb38e9a87955b4bd343c63fa18b149215"
+dependencies = [
+ "solana-address 2.1.0",
+ "solana-program-error",
+]
+
+[[package]]
 name = "solana-accounts-db"
 version = "4.1.0-alpha.0"
 dependencies = [
@@ -7352,6 +7362,18 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
+ "solana-program-error",
+]
+
+[[package]]
+name = "solana-instruction-view"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60147e4d0a4620013df40bf30a86dd299203ff12fcb8b593cd51014fce0875d8"
+dependencies = [
+ "solana-account-view",
+ "solana-address 2.1.0",
+ "solana-define-syscall 4.0.1",
  "solana-program-error",
 ]
 
@@ -8772,6 +8794,15 @@ dependencies = [
  "solana-sbf-rust-invoke-dep",
  "solana-sbf-rust-realloc-dep",
  "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-sbf-rust-direct-account-pointers"
+version = "4.0.0-alpha.0"
+dependencies = [
+ "pinocchio",
+ "solana-cpi",
+ "solana-program-entrypoint",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8786,7 +8786,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-direct-account-pointers"
-version = "4.0.0-alpha.0"
+version = "4.1.0-alpha.0"
 dependencies = [
  "solana-account-view",
  "solana-address 2.2.0",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "rust/custom_heap",
     "rust/dep_crate",
     "rust/deprecated_loader",
+    "rust/direct_account_pointers_in_program_input",
     "rust/divide_by_zero",
     "rust/dup_accounts",
     "rust/error_handling",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -115,7 +115,9 @@ sha2 = "0.10.8"
 sha3 = "0.10.8"
 solana-account-decoder = { path = "../../account-decoder", version = "=4.1.0-alpha.0" }
 solana-account-info = "=3.1.0"
+solana-account-view = "=1.0.0"
 solana-accounts-db = { path = "../../accounts-db", version = "=4.1.0-alpha.0" }
+solana-address = "=2.2.0"
 solana-big-mod-exp = "=3.0.0"
 solana-blake3-hasher = { version = "=3.1.0", features = ["blake3"] }
 solana-bn254 = "=3.2.1"

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -233,6 +233,9 @@ fn bench_create_vm(bencher: &mut Bencher) {
         .get_feature_set()
         .virtual_address_space_adjustments;
     let account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
+    let direct_account_pointers_in_program_input = invoke_context
+        .get_feature_set()
+        .direct_account_pointers_in_program_input;
     let raise_cpi_nesting_limit_to_8 = invoke_context
         .get_feature_set()
         .raise_cpi_nesting_limit_to_8;
@@ -256,6 +259,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .unwrap(),
         virtual_address_space_adjustments,
         account_data_direct_mapping,
+        direct_account_pointers_in_program_input,
     )
     .unwrap();
 
@@ -282,6 +286,9 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         .get_feature_set()
         .virtual_address_space_adjustments;
     let account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
+    let direct_account_pointers_in_program_input = invoke_context
+        .get_feature_set()
+        .direct_account_pointers_in_program_input;
 
     // Serialize account data
     let (_serialized, regions, account_lengths, _instruction_data_offset) = serialize_parameters(
@@ -291,6 +298,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .unwrap(),
         virtual_address_space_adjustments,
         account_data_direct_mapping,
+        direct_account_pointers_in_program_input,
     )
     .unwrap();
 

--- a/programs/sbf/rust/direct_account_pointers_in_program_input/Cargo.toml
+++ b/programs/sbf/rust/direct_account_pointers_in_program_input/Cargo.toml
@@ -12,8 +12,8 @@ edition = { workspace = true }
 crate-type = ["cdylib"]
 
 [dependencies]
-solana-account-view = "1.0"
-solana-address = "2.0"
+solana-account-view = { workspace = true }
+solana-address = { workspace = true }
 solana-cpi = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }

--- a/programs/sbf/rust/direct_account_pointers_in_program_input/Cargo.toml
+++ b/programs/sbf/rust/direct_account_pointers_in_program_input/Cargo.toml
@@ -12,9 +12,11 @@ edition = { workspace = true }
 crate-type = ["cdylib"]
 
 [dependencies]
-pinocchio = "0.10.0"
+solana-account-view = "1.0"
+solana-address = "2.0"
 solana-cpi = { workspace = true }
 solana-program-entrypoint = { workspace = true }
+solana-program-error = { workspace = true }
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/direct_account_pointers_in_program_input/Cargo.toml
+++ b/programs/sbf/rust/direct_account_pointers_in_program_input/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "solana-sbf-rust-direct-account-pointers"
+version = { workspace = true }
+description = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+pinocchio = "0.10.0"
+solana-cpi = { workspace = true }
+solana-program-entrypoint = { workspace = true }
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/direct_account_pointers_in_program_input/src/lib.rs
+++ b/programs/sbf/rust/direct_account_pointers_in_program_input/src/lib.rs
@@ -5,7 +5,9 @@
 
 use {
     core::{mem::size_of, ptr::with_exposed_provenance_mut, slice::from_raw_parts},
-    pinocchio::{error::ProgramError, AccountView, Address, ProgramResult},
+    solana_account_view::AccountView,
+    solana_address::Address,
+    solana_program_error::{ProgramError, ProgramResult},
 };
 
 /// `assert_eq(core::mem::align_of::<u128>(), 8)` is true for BPF but not

--- a/programs/sbf/rust/direct_account_pointers_in_program_input/src/lib.rs
+++ b/programs/sbf/rust/direct_account_pointers_in_program_input/src/lib.rs
@@ -1,0 +1,74 @@
+//! Test program that reads account pointers directly from the program input.
+
+#![allow(clippy::arithmetic_side_effects)]
+#![allow(clippy::missing_safety_doc)]
+
+use {
+    core::{mem::size_of, ptr::with_exposed_provenance_mut, slice::from_raw_parts},
+    pinocchio::{error::ProgramError, AccountView, Address, ProgramResult},
+};
+
+/// `assert_eq(core::mem::align_of::<u128>(), 8)` is true for BPF but not
+/// for some host machines.
+const BPF_ALIGN_OF_U128: usize = 8;
+
+/// Align a pointer to the BPF alignment of [`u128`].
+macro_rules! align_pointer {
+    ($ptr:ident) => {
+        with_exposed_provenance_mut(
+            ($ptr.expose_provenance() + (BPF_ALIGN_OF_U128 - 1)) & !(BPF_ALIGN_OF_U128 - 1),
+        )
+    };
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn entrypoint(program_input: *mut u8, instruction_data: *mut u8) -> u64 {
+    // First 8-bytes of program_input contains the number of accounts.
+    let accounts = program_input as *mut u64;
+
+    // The 8-bytes before the instruction data contains the length of
+    // the instruction data, even if the instruction data is empty.
+    let ix_data_len = *(instruction_data.sub(size_of::<u64>()) as *mut u64) as usize;
+
+    // The program_id is located right after the instruction data.
+    let program_id = &*(instruction_data.add(ix_data_len) as *const Address);
+
+    // The slice of account pointers is located right after the program_id.
+    let slice_ptr = instruction_data.add(ix_data_len + size_of::<Address>());
+    let accounts = from_raw_parts(
+        align_pointer!(slice_ptr) as *const AccountView,
+        *accounts as usize,
+    );
+
+    // The instruction data slice.
+    let instruction_data = from_raw_parts(instruction_data, ix_data_len);
+
+    match process_instruction(program_id, accounts, instruction_data) {
+        Ok(_) => solana_program_entrypoint::SUCCESS,
+        Err(e) => e.into(),
+    }
+}
+
+pub fn process_instruction(
+    _program_id: &Address,
+    accounts: &[AccountView],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    // The program expects the accounts to be duplicated in the input.
+    let non_duplicated = accounts.len() / 2;
+
+    for i in 0..non_duplicated {
+        let account = &accounts[i];
+        let duplicate = &accounts[i + non_duplicated];
+
+        if account != duplicate || account.address() != duplicate.address() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+    }
+
+    solana_cpi::set_return_data(&accounts.len().to_le_bytes());
+    Ok(())
+}
+
+solana_program_entrypoint::custom_heap_default!();
+solana_program_entrypoint::custom_panic_default!();

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -5832,7 +5832,7 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
 }
 
 #[test_matrix(
-    [0, 1, 2, 5, 10, 15, 20],
+    [0, 1, 2, 5, 10, 15, 20, 32],
     [1, 10, 50, 100, 255, 500, 1000, 1024]
 )]
 #[allow(clippy::arithmetic_side_effects)]
@@ -5877,7 +5877,6 @@ fn test_program_sbf_rust_direct_account_pointers(num_accounts: usize, input_data
         account_metas.push(AccountMeta::new(pubkey, false));
     }
 
-    // `num_accounts * 2` will be added as return data.
     let input_data: Vec<u8> = (0..input_data_len).map(|i| (i % 256) as u8).collect();
 
     let instruction = Instruction::new_with_bytes(program_id, &input_data, account_metas);
@@ -5893,6 +5892,7 @@ fn test_program_sbf_rust_direct_account_pointers(num_accounts: usize, input_data
             .unwrap();
 
     assert!(effects.result.is_none());
+    // `num_accounts * 2` will be added as return data.
     assert_eq!(
         (num_accounts * 2).to_le_bytes().to_vec(),
         effects.return_data

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -5830,3 +5830,71 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
         }
     }
 }
+
+#[test_matrix(
+    [0, 1, 2, 5, 10, 15, 20],
+    [1, 10, 50, 100, 255, 500, 1000, 1024]
+)]
+#[allow(clippy::arithmetic_side_effects)]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_rust_direct_account_pointers(num_accounts: usize, input_data_len: usize) {
+    agave_logger::setup();
+
+    let program_elf = harness::file::load_program_elf("solana_sbf_rust_direct_account_pointers");
+    let program_id = Pubkey::new_unique();
+
+    let feature_set = SVMFeatureSet::all_enabled();
+    let compute_budget = ComputeBudget::new_with_defaults(false, false);
+
+    let mut program_cache = default_program_cache_with_program(
+        &program_id,
+        &program_elf,
+        &feature_set,
+        &compute_budget,
+    );
+    let sysvar_cache = default_sysvar_cache();
+
+    let mut accounts = Vec::new();
+    let mut account_metas = Vec::new();
+
+    for i in 0..num_accounts {
+        let pubkey = Pubkey::new_unique();
+
+        // Mixed account sizes.
+        accounts.push((pubkey, Account::new(0, 100 + (i * 50), &program_id)));
+
+        // Mixed account roles.
+        if i % 2 == 0 {
+            account_metas.push(AccountMeta::new(pubkey, false));
+        } else {
+            account_metas.push(AccountMeta::new_readonly(pubkey, false));
+        }
+    }
+
+    // Add `num_accounts` duplicated accounts.
+    for i in 0..num_accounts {
+        let pubkey = accounts[i].0;
+        account_metas.push(AccountMeta::new(pubkey, false));
+    }
+
+    // `num_accounts * 2` will be added as return data.
+    let input_data: Vec<u8> = (0..input_data_len).map(|i| (i % 256) as u8).collect();
+
+    let instruction = Instruction::new_with_bytes(program_id, &input_data, account_metas);
+
+    let context = InstrContext {
+        feature_set,
+        accounts,
+        instruction,
+    };
+
+    let effects =
+        harness::execute_instr(context, &compute_budget, &mut program_cache, &sysvar_cache)
+            .unwrap();
+
+    assert!(effects.result.is_none());
+    assert_eq!(
+        (num_accounts * 2).to_le_bytes().to_vec(),
+        effects.return_data
+    );
+}

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -53,6 +53,7 @@ pub struct SVMFeatureSet {
     pub enable_bls12_381_syscall: bool,
     pub block_revenue_sharing: bool,
     pub vote_account_initialize_v2: bool,
+    pub direct_account_pointers_in_program_input: bool,
 }
 
 impl SVMFeatureSet {
@@ -110,6 +111,7 @@ impl SVMFeatureSet {
             enable_bls12_381_syscall: true,
             block_revenue_sharing: true,
             vote_account_initialize_v2: true,
+            direct_account_pointers_in_program_input: true,
         }
     }
 }


### PR DESCRIPTION
#### Problem

[SIMD-0449](https://github.com/solana-foundation/solana-improvement-documents/pull/449) proposes to serialize pointers for instruction accounts to allow direct account access without requiring parsing of the account section.

#### Summary of Changes

Add a feature to `feature-set` and updated the logic of `serialize_parameters` to write the additional account pointers.