### PR TITLE
Removing unused dependencies (`qstring`, `dir-diff` and `fnv`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,15 +2539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dir-diff"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ad16bf5f84253b50d6557681c58c3ab67c47c77d39fed9aeb56e947290bd10"
-dependencies = [
- "walkdir",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9924,7 +9915,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "parking_lot 0.12.3",
- "qstring",
  "semver 1.0.27",
  "serial_test",
  "solana-derivation-path",
@@ -10265,9 +10255,7 @@ dependencies = [
  "bytemuck",
  "crossbeam-channel",
  "dashmap",
- "dir-diff",
  "ed25519-dalek 1.0.1",
- "fnv",
  "im",
  "itertools 0.14.0",
  "libc",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -2127,15 +2127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dir-diff"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ad16bf5f84253b50d6557681c58c3ab67c47c77d39fed9aeb56e947290bd10"
-dependencies = [
- "walkdir",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8430,7 +8421,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "parking_lot 0.12.5",
- "qstring",
  "semver",
  "solana-derivation-path",
  "solana-offchain-message",
@@ -8677,8 +8667,6 @@ dependencies = [
  "bytemuck",
  "crossbeam-channel",
  "dashmap",
- "dir-diff",
- "fnv",
  "im",
  "itertools 0.14.0",
  "libc",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2029,15 +2029,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dir-diff"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ad16bf5f84253b50d6557681c58c3ab67c47c77d39fed9aeb56e947290bd10"
-dependencies = [
- "walkdir",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8164,7 +8155,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "parking_lot 0.12.2",
- "qstring",
  "semver",
  "solana-derivation-path",
  "solana-offchain-message",
@@ -8411,8 +8401,6 @@ dependencies = [
  "bytemuck",
  "crossbeam-channel",
  "dashmap",
- "dir-diff",
- "fnv",
  "im",
  "itertools 0.14.0",
  "libc",

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -28,7 +28,6 @@ log = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 parking_lot = { workspace = true }
-qstring = { workspace = true }
 semver = { workspace = true }
 solana-derivation-path = { workspace = true }
 solana-offchain-message = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -70,8 +70,6 @@ bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api", "serde"] }
-dir-diff = { workspace = true }
-fnv = { workspace = true }
 im = { workspace = true, features = ["rayon", "serde"] }
 itertools = { workspace = true }
 libc = { workspace = true }


### PR DESCRIPTION
#### Problem

We have the following dependencies that we never use:

 - `qstring`(`remote-wallet/Cargo.toml`) — listed as a dependency but never imported anywhere in the codebase.                                                                                      
 - `dir-diff` (`runtime/Cargo.toml`) — listed as a dependency but never imported anywhere in the codebase.                                                                                                    
  - `fnv` (`runtime/Cargo.toml`) — dead in `runtime` specifically. Legitimate usage in `bloom` crate.                                                                                                             

#### Summary of Changes

Remove them
