### PR TITLE
chore: remove redundant `wait_for_completed_scheduler` call in `process_single_slot`

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2152,10 +2152,6 @@ pub fn process_single_slot(
         err
     })?;
 
-    if let Some((result, _timings)) = bank.wait_for_completed_scheduler() {
-        result?
-    }
-
     let block_id = blockstore
         .check_last_fec_set_and_get_block_id(slot, bank.hash(), &bank.feature_set)
         .inspect_err(|err| {


### PR DESCRIPTION
The second `bank.wait_for_completed_scheduler()` call (after the `?` operator) in `process_single_slot` is dead code. The first call inside `.and_then()`  already transitions the scheduler status to `Unavailable`, which is a terminal state — there is no `transition_from_unavailable_to_*` in the codebase, and the `SchedulerStatus` docs explicitly state this transition is one-way.

As a result, the second call always sees `Unavailable` and returns `None`, making the `if let Some(...)` body unreachable. Every other call site (`process_bank_0`, `replay_stage`, `banking_simulation`, all tests) uses a single `wait_for_completed_scheduler()` call.

Removed the redundant second call.