### PR TITLE
Sigverify - remove excess and random discard

### DIFF
--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -26,14 +26,6 @@ use {
     thiserror::Error,
 };
 
-// Try to target 50ms, rough timings from mainnet machines
-//
-// 50ms/(300ns/packet) = 166666 packets ~ 1300 batches
-const MAX_DEDUP_BATCH: usize = 165_000;
-
-// 50ms/(10us/packet) = 5000 packets
-const MAX_SIGVERIFY_BATCH: usize = 5_000;
-
 // Packet batch shrinker will reorganize packets into compacted batches if 10%
 // or more of the packets in a group of packet batches have been discarded.
 const MAX_DISCARDED_PACKET_RATE: f64 = 0.10;
@@ -66,7 +58,6 @@ pub struct DisabledSigVerifier {}
 struct SigVerifierStats {
     recv_batches_us_hist: histogram::Histogram, // time to call recv_batch
     verify_batches_pp_us_hist: histogram::Histogram, // per-packet time to call verify_batch
-    discard_packets_pp_us_hist: histogram::Histogram, // per-packet time to call verify_batch
     dedup_packets_pp_us_hist: histogram::Histogram, // per-packet time to call verify_batch
     batches_hist: histogram::Histogram,         // number of packet batches per verify call
     packets_hist: histogram::Histogram,         // number of packets per verify call
@@ -74,13 +65,9 @@ struct SigVerifierStats {
     total_batches: usize,
     total_packets: usize,
     total_dedup: usize,
-    total_excess_fail: usize,
     total_valid_packets: usize,
     total_shrinks: usize,
-    total_discard_random: usize,
     total_dedup_time_us: usize,
-    total_discard_time_us: usize,
-    total_discard_random_time_us: usize,
     total_verify_time_us: usize,
     total_shrink_time_us: usize,
 }
@@ -135,28 +122,6 @@ impl SigVerifierStats {
                 i64
             ),
             (
-                "discard_packets_pp_us_90pct",
-                self.discard_packets_pp_us_hist
-                    .percentile(90.0)
-                    .unwrap_or(0),
-                i64
-            ),
-            (
-                "discard_packets_pp_us_min",
-                self.discard_packets_pp_us_hist.minimum().unwrap_or(0),
-                i64
-            ),
-            (
-                "discard_packets_pp_us_max",
-                self.discard_packets_pp_us_hist.maximum().unwrap_or(0),
-                i64
-            ),
-            (
-                "discard_packets_pp_us_mean",
-                self.discard_packets_pp_us_hist.mean().unwrap_or(0),
-                i64
-            ),
-            (
                 "dedup_packets_pp_us_90pct",
                 self.dedup_packets_pp_us_hist.percentile(90.0).unwrap_or(0),
                 i64
@@ -196,17 +161,9 @@ impl SigVerifierStats {
             ("total_batches", self.total_batches, i64),
             ("total_packets", self.total_packets, i64),
             ("total_dedup", self.total_dedup, i64),
-            ("total_excess_fail", self.total_excess_fail, i64),
             ("total_valid_packets", self.total_valid_packets, i64),
-            ("total_discard_random", self.total_discard_random, i64),
             ("total_shrinks", self.total_shrinks, i64),
             ("total_dedup_time_us", self.total_dedup_time_us, i64),
-            ("total_discard_time_us", self.total_discard_time_us, i64),
-            (
-                "total_discard_random_time_us",
-                self.total_discard_random_time_us,
-                i64
-            ),
             ("total_verify_time_us", self.total_verify_time_us, i64),
             ("total_shrink_time_us", self.total_shrink_time_us, i64),
         );
@@ -303,29 +260,12 @@ impl SigVerifyStage {
             num_packets,
         );
 
-        let mut discard_random_time = Measure::start("sigverify_discard_random_time");
-        let non_discarded_packets = solana_perf::discard::discard_batches_randomly(
-            &mut batches,
-            MAX_DEDUP_BATCH,
-            num_packets,
-        );
-        let num_discarded_randomly = num_packets.saturating_sub(non_discarded_packets);
-        discard_random_time.stop();
-
         let mut dedup_time = Measure::start("sigverify_dedup_time");
         let discard_or_dedup_fail =
             deduper::dedup_packets_and_count_discards(deduper, &mut batches) as usize;
         dedup_time.stop();
-        let num_unique = non_discarded_packets.saturating_sub(discard_or_dedup_fail);
-
-        let mut discard_time = Measure::start("sigverify_discard_time");
-        let mut num_packets_to_verify = num_unique;
-        if num_unique > MAX_SIGVERIFY_BATCH {
-            Self::discard_excess_packets(&mut batches, MAX_SIGVERIFY_BATCH);
-            num_packets_to_verify = MAX_SIGVERIFY_BATCH;
-        }
-        let excess_fail = num_unique.saturating_sub(MAX_SIGVERIFY_BATCH);
-        discard_time.stop();
+        let num_unique = num_packets.saturating_sub(discard_or_dedup_fail);
+        let num_packets_to_verify = num_unique;
 
         // Pre-shrink packet batches if many packets are discarded from dedup / discard
         let (pre_shrink_time_us, pre_shrink_total, batches) = Self::maybe_shrink_batches(batches);
@@ -358,10 +298,6 @@ impl SigVerifyStage {
             .increment(verify_time.as_us() / (num_packets as u64))
             .unwrap();
         stats
-            .discard_packets_pp_us_hist
-            .increment(discard_time.as_us() / (num_packets as u64))
-            .unwrap();
-        stats
             .dedup_packets_pp_us_hist
             .increment(dedup_time.as_us() / (num_packets as u64))
             .unwrap();
@@ -371,12 +307,8 @@ impl SigVerifyStage {
         stats.total_packets += num_packets;
         stats.total_dedup += discard_or_dedup_fail;
         stats.total_valid_packets += num_valid_packets;
-        stats.total_discard_random_time_us += discard_random_time.as_us() as usize;
-        stats.total_discard_random += num_discarded_randomly;
-        stats.total_excess_fail += excess_fail;
         stats.total_shrinks += pre_shrink_total + post_shrink_total;
         stats.total_dedup_time_us += dedup_time.as_us() as usize;
-        stats.total_discard_time_us += discard_time.as_us() as usize;
         stats.total_verify_time_us += verify_time.as_us() as usize;
         stats.total_shrink_time_us += (pre_shrink_time_us + post_shrink_time_us) as usize;
 
@@ -509,9 +441,7 @@ mod tests {
         let now = Instant::now();
         let packets_per_batch = 128;
         let total_packets = 1920;
-        // This is important so that we don't discard any packets and fail asserts below about
-        // `total_excess_tracer_packets`
-        assert!(total_packets < MAX_SIGVERIFY_BATCH);
+
         let batches = gen_batches(use_same_tx, packets_per_batch, total_packets);
         trace!(
             "starting... generation took: {} ms batches: {}",


### PR DESCRIPTION
#### Problem
- #10428 makes sigverify stage do smaller loops on up to 5k packets at a time.
- this effectively made this discard code obsolete and not actually discard, or discard a very small amount of packets (since 5000 is a soft cap)  

#### Summary of Changes
- Remove excess discard and associated metrics
- Remove random discard and associated metrics

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
