### PR TITLE
Fix assumptions in test_purge_alive_unrooted_slots_after_clean

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -5068,17 +5068,17 @@ define_accounts_db_test!(test_purge_alive_unrooted_slots_after_clean, |accounts|
     // Simulate adding dirty pubkeys on bank freeze, set root
     accounts.add_root_and_flush_write_cache(slot1);
 
-    // Account is referenced in the zero lamport slot. Since the other copy is in an unrooted slot,
+    // Account is referenced in the zero lamport slot. Since the other copy is in an unflushed slot,
     // it does not count as a reference.
     accounts.assert_ref_count(&shared_key, 1);
 
     // The later rooted zero-lamport update to 'shared_key' can be purged
     // as there are no rooted ancestors
-    // The key itself cannot be purged as it is still referenced in the unrooted slot
+    // The key itself cannot be purged as it is still contained in the unrooted slot
     accounts.clean_accounts_for_tests();
     assert!(accounts.accounts_index.contains(&shared_key));
 
-    // Zero lamport reference was removed
+    // Account now has a reference count of zero as it is not contained in any storages
     accounts.assert_ref_count(&shared_key, 0);
 
     // Simulate purge_slot() all from AccountsBackgroundService

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -5068,16 +5068,23 @@ define_accounts_db_test!(test_purge_alive_unrooted_slots_after_clean, |accounts|
     // Simulate adding dirty pubkeys on bank freeze, set root
     accounts.add_root_and_flush_write_cache(slot1);
 
-    // The later rooted zero-lamport update to `shared_key` cannot be cleaned
-    // because it is kept alive by the unrooted slot.
+    // Account is referenced in the zero lamport slot. Since the other copy is in an unrooted slot,
+    // it does not count as a reference.
+    accounts.assert_ref_count(&shared_key, 1);
+
+    // The later rooted zero-lamport update to 'shared_key' can be purged
+    // as there are no rooted ancestors
+    // The key itself cannot be purged as it is still referenced in the unrooted slot
     accounts.clean_accounts_for_tests();
     assert!(accounts.accounts_index.contains(&shared_key));
+
+    // Zero lamport reference was removed
+    accounts.assert_ref_count(&shared_key, 0);
 
     // Simulate purge_slot() all from AccountsBackgroundService
     accounts.purge_slot(slot0, 0, true);
 
-    // Now clean should clean up the remaining key
-    accounts.clean_accounts_for_tests();
+    // Now the key and slot are purged from the index
     assert!(!accounts.accounts_index.contains(&shared_key));
     assert_no_storages_at_slot(&accounts, slot0);
 });


### PR DESCRIPTION
#### Problem
Test description does not match the actual behaviour. I verified that this has been broken since at least v2.3. 

#### Summary of Changes
- Fixed test comments
- Added new asserts to verify correct behaviour
- Removed unnecessary clean. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
