### PR TITLE
Disable new snapshot check when validator is not generating snapshots

### DIFF
--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -161,13 +161,10 @@ impl SnapshotController {
 
     // Returns true if either snapshot interval is enabled, indicating that the controller will
     // generate snapshots at some slot intervals
-    pub fn generating_snapshots(&self) -> bool {
+    pub fn is_generating_snapshots(&self) -> bool {
         let intervals = self.snapshot_generation_intervals();
-        !matches!(intervals.full_snapshot_interval, SnapshotInterval::Disabled)
-            || !matches!(
-                intervals.incremental_snapshot_interval,
-                SnapshotInterval::Disabled
-            )
+        !(intervals.full_snapshot_interval == SnapshotInterval::Disabled
+            && intervals.incremental_snapshot_interval == SnapshotInterval::Disabled)
     }
 }
 
@@ -289,7 +286,7 @@ mod tests {
         let (snapshot_request_sender, _snapshot_request_receiver) = unbounded();
         let snapshot_controller =
             SnapshotController::new(snapshot_request_sender, snapshot_config, 0);
-        assert_eq!(snapshot_controller.generating_snapshots(), expected);
+        assert_eq!(snapshot_controller.is_generating_snapshots(), expected);
     }
 
     #[test_case(SnapshotInterval::Disabled, SnapshotInterval::Disabled,

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -158,6 +158,14 @@ impl SnapshotController {
             }
         }
     }
+
+    // Returns true if either snapshot interval is enabled, indicating that the controller will
+    // generate snapshots at some slot intervals
+    pub fn generating_snapshots(&self) -> bool {
+        let intervals = self.snapshot_generation_intervals();
+        !matches!(intervals.full_snapshot_interval, SnapshotInterval::Disabled)
+            || !matches!(intervals.incremental_snapshot_interval, SnapshotInterval::Disabled)
+    }
 }
 
 #[cfg(test)]
@@ -255,6 +263,30 @@ mod tests {
                 "Expected no snapshot request to be sent"
             );
         }
+    }
+
+    #[test_case(SnapshotInterval::Disabled, SnapshotInterval::Disabled, false;
+        "both disabled")]
+    #[test_case(SnapshotInterval::Slots(10.try_into().unwrap()), SnapshotInterval::Disabled, true;
+        "full only")]
+    #[test_case(SnapshotInterval::Disabled, SnapshotInterval::Slots(5.try_into().unwrap()), true;
+        "incremental only")]
+    #[test_case(SnapshotInterval::Slots(10.try_into().unwrap()), SnapshotInterval::Slots(5.try_into().unwrap()), true;
+        "both enabled")]
+    fn test_is_generating_snapshots(
+        full_snapshot_archive_interval: SnapshotInterval,
+        incremental_snapshot_archive_interval: SnapshotInterval,
+        expected: bool,
+    ) {
+        let snapshot_config = SnapshotConfig {
+            full_snapshot_archive_interval,
+            incremental_snapshot_archive_interval,
+            ..Default::default()
+        };
+        let (snapshot_request_sender, _snapshot_request_receiver) = unbounded();
+        let snapshot_controller =
+            SnapshotController::new(snapshot_request_sender, snapshot_config, 0);
+        assert_eq!(snapshot_controller.generating_snapshots(), expected);
     }
 
     #[test_case(SnapshotInterval::Disabled, SnapshotInterval::Disabled,

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -164,7 +164,10 @@ impl SnapshotController {
     pub fn generating_snapshots(&self) -> bool {
         let intervals = self.snapshot_generation_intervals();
         !matches!(intervals.full_snapshot_interval, SnapshotInterval::Disabled)
-            || !matches!(intervals.incremental_snapshot_interval, SnapshotInterval::Disabled)
+            || !matches!(
+                intervals.incremental_snapshot_interval,
+                SnapshotInterval::Disabled
+            )
     }
 }
 

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -292,8 +292,8 @@ pub trait AdminRpc {
         scheduler_pacing: SchedulerPacing,
     ) -> Result<()>;
 
-    #[rpc(meta, name = "generatingSnapshots")]
-    fn generating_snapshots(&self, meta: Self::Metadata) -> Result<bool>;
+    #[rpc(meta, name = "isGeneratingSnapshots")]
+    fn is_generating_snapshots(&self, meta: Self::Metadata) -> Result<bool>;
 }
 
 pub struct AdminRpcImpl;
@@ -886,9 +886,9 @@ impl AdminRpc for AdminRpcImpl {
         })
     }
 
-    fn generating_snapshots(&self, meta: Self::Metadata) -> Result<bool> {
+    fn is_generating_snapshots(&self, meta: Self::Metadata) -> Result<bool> {
         if let Some(snapshot_controller) = meta.snapshot_controller() {
-            Ok(snapshot_controller.generating_snapshots())
+            Ok(snapshot_controller.is_generating_snapshots())
         } else {
             Err(jsonrpc_core::error::Error::invalid_params(
                 "snapshot_controller unavailable",
@@ -1759,12 +1759,12 @@ mod tests {
     }
 
     #[test]
-    fn test_generating_snapshots() {
+    fn test_is_generating_snapshots() {
         // Test with snapshots enabled
         let rpc = RpcHandler::start_with_config(TestConfig::default());
         let RpcHandler { io, meta, .. } = rpc;
 
-        let request = r#"{"jsonrpc":"2.0","id":1,"method":"generatingSnapshots","params":[]}"#;
+        let request = r#"{"jsonrpc":"2.0","id":1,"method":"isGeneratingSnapshots","params":[]}"#;
         let response = io.handle_request_sync(request, meta.clone());
         let result: Value = serde_json::from_str(&response.expect("actual response"))
             .expect("actual response deserialization");
@@ -1776,13 +1776,13 @@ mod tests {
     }
 
     #[test]
-    fn test_generating_snapshots_no_controller() {
+    fn test_is_generating_snapshots_no_controller() {
         // Test with snapshots enabled
         let rpc = RpcHandler::start_with_config(TestConfig::default());
         let RpcHandler { io, .. } = rpc;
 
         // Test with no post_init (snapshot_controller unavailable)
-        let request = r#"{"jsonrpc":"2.0","id":1,"method":"generatingSnapshots","params":[]}"#;
+        let request = r#"{"jsonrpc":"2.0","id":1,"method":"isGeneratingSnapshots","params":[]}"#;
         let validator_exit = create_validator_exit(Arc::new(AtomicBool::new(false)));
         let authorized_voter_keypairs = Arc::new(RwLock::new(vec![Arc::new(Keypair::new())]));
         let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -889,8 +889,7 @@ impl AdminRpc for AdminRpcImpl {
     fn generating_snapshots(&self, meta: Self::Metadata) -> Result<bool> {
         if let Some(snapshot_controller) = meta.snapshot_controller() {
             Ok(snapshot_controller
-                .snapshot_config()
-                .should_generate_snapshots())
+                .generating_snapshots())
         } else {
             Err(jsonrpc_core::error::Error::invalid_params(
                 "snapshot_controller unavailable",

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -291,6 +291,9 @@ pub trait AdminRpc {
         num_workers: NonZeroUsize,
         scheduler_pacing: SchedulerPacing,
     ) -> Result<()>;
+
+    #[rpc(meta, name = "generatingSnapshots")]
+    fn generating_snapshots(&self, meta: Self::Metadata) -> Result<bool>;
 }
 
 pub struct AdminRpcImpl;
@@ -881,6 +884,18 @@ impl AdminRpc for AdminRpcImpl {
 
             Ok(())
         })
+    }
+
+    fn generating_snapshots(&self, meta: Self::Metadata) -> Result<bool> {
+        if let Some(snapshot_controller) = meta.snapshot_controller() {
+            Ok(snapshot_controller
+                .snapshot_config()
+                .should_generate_snapshots())
+        } else {
+            Err(jsonrpc_core::error::Error::invalid_params(
+                "snapshot_controller unavailable",
+            ))
+        }
     }
 }
 
@@ -1743,5 +1758,59 @@ mod tests {
             serde_json::from_str(&exit_response.expect("actual response"))
                 .expect("actual response deserialization");
         assert_eq!(actual_parsed_response, expected_parsed_response);
+    }
+
+    #[test]
+    fn test_generating_snapshots() {
+        // Test with snapshots enabled
+        let rpc = RpcHandler::start_with_config(TestConfig::default());
+        let RpcHandler { io, meta, .. } = rpc;
+
+        let request = r#"{"jsonrpc":"2.0","id":1,"method":"generatingSnapshots","params":[]}"#;
+        let response = io.handle_request_sync(request, meta.clone());
+        let result: Value = serde_json::from_str(&response.expect("actual response"))
+            .expect("actual response deserialization");
+
+        // Should return a boolean result indicating if snapshots are being generated
+        assert!(result["result"].is_boolean());
+        // Verify that snapshots are being generated since the test setup includes a snapshot controller
+        assert!(result["result"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_generating_snapshots_no_controller() {
+        // Test with snapshots enabled
+        let rpc = RpcHandler::start_with_config(TestConfig::default());
+        let RpcHandler { io, .. } = rpc;
+
+        // Test with no post_init (snapshot_controller unavailable)
+        let request = r#"{"jsonrpc":"2.0","id":1,"method":"generatingSnapshots","params":[]}"#;
+        let validator_exit = create_validator_exit(Arc::new(AtomicBool::new(false)));
+        let authorized_voter_keypairs = Arc::new(RwLock::new(vec![Arc::new(Keypair::new())]));
+        let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
+
+        let meta_no_post_init = AdminRpcRequestMetadata {
+            rpc_addr: None,
+            start_time: SystemTime::now(),
+            start_progress,
+            validator_exit,
+            validator_exit_backpressure: HashMap::default(),
+            authorized_voter_keypairs,
+            tower_storage: Arc::new(NullTowerStorage {}),
+            post_init: Arc::new(RwLock::new(None)),
+            staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
+            rpc_to_plugin_manager_sender: None,
+        };
+
+        let response = io.handle_request_sync(request, meta_no_post_init);
+        let result: Value = serde_json::from_str(&response.expect("actual response"))
+            .expect("actual response deserialization");
+
+        // Should return an error when snapshot_controller is unavailable
+        assert!(result["error"].is_object());
+        assert_eq!(
+            result["error"]["message"].as_str().unwrap(),
+            "snapshot_controller unavailable"
+        );
     }
 }

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -888,8 +888,7 @@ impl AdminRpc for AdminRpcImpl {
 
     fn generating_snapshots(&self, meta: Self::Metadata) -> Result<bool> {
         if let Some(snapshot_controller) = meta.snapshot_controller() {
-            Ok(snapshot_controller
-                .generating_snapshots())
+            Ok(snapshot_controller.generating_snapshots())
         } else {
             Err(jsonrpc_core::error::Error::invalid_params(
                 "snapshot_controller unavailable",

--- a/validator/src/commands/wait_for_restart_window/mod.rs
+++ b/validator/src/commands/wait_for_restart_window/mod.rs
@@ -110,6 +110,9 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Returns whether to skip the check that requires a new snapshot to have been generated before
+/// restarting. If the validator is not generating snapshots, this check can never be satisfied
+/// and must be skipped.
 fn should_skip_snapshot_check(
     skip_new_snapshot_check_arg: bool,
     is_generating_snapshots: Option<bool>,
@@ -167,8 +170,6 @@ pub fn wait_for_restart_window(
         }
     };
 
-    // Check if the snapshot check should be skipped. The snapshot check is only relevant if the validator is
-    // generating snapshots.
     let skip_new_snapshot_check =
         should_skip_snapshot_check(skip_new_snapshot_check, is_generating_snapshots);
 


### PR DESCRIPTION
#### Problem
If validator exit is called with the snapshot check enabled (which is enabled by default) on a validator that is not generating snapshots, the validator exit will never complete as it will wait for the next snapshot to be generated which will never occur. 

#### Summary of Changes
- Skip new snapshot check in the event the validator is not generating snapshots. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
