### PR TITLE
Revert "runtime: genesis_utils: remove bls key ... (#10003)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9782,7 +9782,6 @@ dependencies = [
  "solana-cpi",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
- "solana-feature-gate-interface",
  "solana-fee-calculator",
  "solana-genesis-config",
  "solana-hash 4.1.0",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8302,7 +8302,6 @@ dependencies = [
  "solana-compute-budget",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
- "solana-feature-gate-interface",
  "solana-fee-calculator",
  "solana-genesis-config",
  "solana-hash 4.1.0",

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 pub(crate) mod tests {
     use {
-        agave_feature_set::{bls_pubkey_management_in_vote_account, vote_state_v4},
         rand::Rng,
         solana_account::AccountSharedData,
         solana_clock::Clock,
@@ -19,19 +18,10 @@ pub(crate) mod tests {
         solana_vote::vote_account::{VoteAccount, VoteAccounts},
         solana_vote_program::{
             vote_instruction,
-            vote_state::{
-                create_bls_pubkey_and_proof_of_possession, VoteInit, VoteInitV2, VoteStateV4,
-                VoteStateVersions,
-            },
+            vote_state::{VoteInit, VoteStateV4, VoteStateVersions},
         },
         std::sync::Arc,
     };
-
-    fn is_bls_pubkey_feature_enabled(bank: &Bank) -> bool {
-        bank.feature_set
-            .is_active(&bls_pubkey_management_in_vote_account::id())
-            && bank.feature_set.is_active(&vote_state_v4::id())
-    }
 
     pub(crate) fn setup_vote_and_stake_accounts(
         bank: &Bank,
@@ -51,47 +41,24 @@ pub(crate) mod tests {
             bank.process_transaction(&tx).unwrap();
         }
 
-        let instructions = if is_bls_pubkey_feature_enabled(bank) {
-            let (bls_pubkey, bls_proof_of_possession) =
-                create_bls_pubkey_and_proof_of_possession(&vote_pubkey);
-            vote_instruction::create_account_with_config_v2(
-                &from_account.pubkey(),
-                &vote_pubkey,
-                &VoteInitV2 {
-                    node_pubkey: validator_identity_account.pubkey(),
-                    authorized_voter: vote_pubkey,
-                    authorized_voter_bls_pubkey: bls_pubkey,
-                    authorized_voter_bls_proof_of_possession: bls_proof_of_possession,
-                    authorized_withdrawer: vote_pubkey,
-                    ..Default::default()
-                },
-                amount,
-                vote_instruction::CreateVoteAccountConfig {
-                    space: VoteStateV4::size_of() as u64,
-                    ..vote_instruction::CreateVoteAccountConfig::default()
-                },
-            )
-        } else {
-            vote_instruction::create_account_with_config(
+        process_instructions(
+            bank,
+            &[from_account, vote_account, validator_identity_account],
+            &vote_instruction::create_account_with_config(
                 &from_account.pubkey(),
                 &vote_pubkey,
                 &VoteInit {
                     node_pubkey: validator_identity_account.pubkey(),
                     authorized_voter: vote_pubkey,
                     authorized_withdrawer: vote_pubkey,
-                    ..VoteInit::default()
+                    commission: 0,
                 },
                 amount,
                 vote_instruction::CreateVoteAccountConfig {
                     space: VoteStateV4::size_of() as u64,
                     ..vote_instruction::CreateVoteAccountConfig::default()
                 },
-            )
-        };
-        process_instructions(
-            bank,
-            &[from_account, vote_account, validator_identity_account],
-            &instructions,
+            ),
         );
 
         let stake_account_keypair = Keypair::new();

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -5,7 +5,7 @@ use {
         integration_tests::{ValidatorKeys, DEFAULT_NODE_STAKE},
         validator_configs::*,
     },
-    agave_feature_set::{bls_pubkey_management_in_vote_account, vote_state_v4, FeatureSet},
+    agave_feature_set::FeatureSet,
     agave_snapshots::{paths::BANK_SNAPSHOTS_DIR, snapshot_config::SnapshotConfig},
     agave_votor_messages::migration::GENESIS_CERTIFICATE_ACCOUNT,
     itertools::izip,
@@ -55,9 +55,7 @@ use {
     solana_transaction_error::TransportError,
     solana_vote_program::{
         vote_instruction,
-        vote_state::{
-            self, create_bls_pubkey_and_proof_of_possession, VoteInit, VoteInitV2, VoteStateV4,
-        },
+        vote_state::{self, VoteInit, VoteStateV4},
     },
     std::{
         collections::HashMap,
@@ -1054,20 +1052,6 @@ impl LocalCluster {
             .expect("client transfer should succeed");
     }
 
-    fn is_feature_active(rpc_client: &RpcClient, feature_id: &Pubkey) -> bool {
-        rpc_client
-            .get_account_with_commitment(feature_id, CommitmentConfig::processed())
-            .ok()
-            .and_then(|r| r.value)
-            .and_then(|account| solana_feature_gate_interface::from_account(&account))
-            .is_some_and(|feature| feature.activated_at.is_some())
-    }
-
-    fn is_bls_pubkey_feature_enabled(rpc_client: &RpcClient) -> bool {
-        Self::is_feature_active(rpc_client, &bls_pubkey_management_in_vote_account::id())
-            && Self::is_feature_active(rpc_client, &vote_state_v4::id())
-    }
-
     fn setup_vote_and_stake_accounts(
         client: &QuicTpuClient,
         vote_account: &Keypair,
@@ -1090,41 +1074,21 @@ impl LocalCluster {
             == 0
         {
             // 1) Create vote account
-            let config = vote_instruction::CreateVoteAccountConfig {
-                space: vote_state::VoteStateV4::size_of() as u64,
-                ..vote_instruction::CreateVoteAccountConfig::default()
-            };
-            let instructions = if Self::is_bls_pubkey_feature_enabled(client.rpc_client()) {
-                let (bls_pubkey, bls_proof_of_possession) =
-                    create_bls_pubkey_and_proof_of_possession(&vote_account_pubkey);
-                vote_instruction::create_account_with_config_v2(
-                    &from_account.pubkey(),
-                    &vote_account_pubkey,
-                    &VoteInitV2 {
-                        node_pubkey,
-                        authorized_voter: vote_account_pubkey,
-                        authorized_voter_bls_pubkey: bls_pubkey,
-                        authorized_voter_bls_proof_of_possession: bls_proof_of_possession,
-                        authorized_withdrawer: vote_account_pubkey,
-                        ..Default::default()
-                    },
-                    amount,
-                    config,
-                )
-            } else {
-                vote_instruction::create_account_with_config(
-                    &from_account.pubkey(),
-                    &vote_account_pubkey,
-                    &VoteInit {
-                        node_pubkey,
-                        authorized_voter: vote_account_pubkey,
-                        authorized_withdrawer: vote_account_pubkey,
-                        ..VoteInit::default()
-                    },
-                    amount,
-                    config,
-                )
-            };
+            let instructions = vote_instruction::create_account_with_config(
+                &from_account.pubkey(),
+                &vote_account_pubkey,
+                &VoteInit {
+                    node_pubkey,
+                    authorized_voter: vote_account_pubkey,
+                    authorized_withdrawer: vote_account_pubkey,
+                    commission: 0,
+                },
+                amount,
+                vote_instruction::CreateVoteAccountConfig {
+                    space: vote_state::VoteStateV4::size_of() as u64,
+                    ..vote_instruction::CreateVoteAccountConfig::default()
+                },
+            );
             let message = Message::new(&instructions, Some(&from_account.pubkey()));
             let mut transaction = Transaction::new(
                 &[from_account.as_ref(), vote_account],

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -34,7 +34,6 @@ solana-commitment-config = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }
-solana-feature-gate-interface = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-hash = { workspace = true }

--- a/program-test/tests/setup.rs
+++ b/program-test/tests/setup.rs
@@ -1,6 +1,4 @@
 use {
-    agave_feature_set::{bls_pubkey_management_in_vote_account, vote_state_v4},
-    solana_banks_client::BanksClient,
     solana_keypair::Keypair,
     solana_program_test::ProgramTestContext,
     solana_pubkey::Pubkey,
@@ -14,25 +12,9 @@ use {
     solana_transaction::Transaction,
     solana_vote_program::{
         vote_instruction,
-        vote_state::{
-            self, create_bls_pubkey_and_proof_of_possession, VoteInit, VoteInitV2, VoteStateV4,
-        },
+        vote_state::{self, VoteInit, VoteStateV4},
     },
 };
-
-async fn is_feature_active(banks_client: &mut BanksClient, feature_id: Pubkey) -> bool {
-    banks_client
-        .get_account(feature_id)
-        .await
-        .unwrap()
-        .and_then(|account| solana_feature_gate_interface::from_account(&account))
-        .is_some_and(|feature| feature.activated_at.is_some())
-}
-
-async fn is_bls_pubkey_feature_enabled(banks_client: &mut BanksClient) -> bool {
-    is_feature_active(banks_client, bls_pubkey_management_in_vote_account::id()).await
-        && is_feature_active(banks_client, vote_state_v4::id()).await
-}
 
 pub async fn setup_stake(
     context: &mut ProgramTestContext,
@@ -75,44 +57,20 @@ pub async fn setup_vote(context: &mut ProgramTestContext) -> Pubkey {
     let vote_lamports = Rent::default().minimum_balance(VoteStateV4::size_of());
     let vote_keypair = Keypair::new();
     let user_keypair = Keypair::new();
-
-    if is_bls_pubkey_feature_enabled(&mut context.banks_client).await {
-        // Use V2 instruction with BLS pubkey.
-        let (bls_pubkey, bls_proof_of_possession) =
-            create_bls_pubkey_and_proof_of_possession(&vote_keypair.pubkey());
-        instructions.append(&mut vote_instruction::create_account_with_config_v2(
-            &context.payer.pubkey(),
-            &vote_keypair.pubkey(),
-            &VoteInitV2 {
-                node_pubkey: validator_keypair.pubkey(),
-                authorized_voter: user_keypair.pubkey(),
-                authorized_voter_bls_pubkey: bls_pubkey,
-                authorized_voter_bls_proof_of_possession: bls_proof_of_possession,
-                ..Default::default()
-            },
-            vote_lamports,
-            vote_instruction::CreateVoteAccountConfig {
-                space: vote_state::VoteStateV4::size_of() as u64,
-                ..vote_instruction::CreateVoteAccountConfig::default()
-            },
-        ));
-    } else {
-        // Use V1 instruction.
-        instructions.append(&mut vote_instruction::create_account_with_config(
-            &context.payer.pubkey(),
-            &vote_keypair.pubkey(),
-            &VoteInit {
-                node_pubkey: validator_keypair.pubkey(),
-                authorized_voter: user_keypair.pubkey(),
-                ..VoteInit::default()
-            },
-            vote_lamports,
-            vote_instruction::CreateVoteAccountConfig {
-                space: vote_state::VoteStateV4::size_of() as u64,
-                ..vote_instruction::CreateVoteAccountConfig::default()
-            },
-        ));
-    }
+    instructions.append(&mut vote_instruction::create_account_with_config(
+        &context.payer.pubkey(),
+        &vote_keypair.pubkey(),
+        &VoteInit {
+            node_pubkey: validator_keypair.pubkey(),
+            authorized_voter: user_keypair.pubkey(),
+            ..VoteInit::default()
+        },
+        vote_lamports,
+        vote_instruction::CreateVoteAccountConfig {
+            space: vote_state::VoteStateV4::size_of() as u64,
+            ..vote_instruction::CreateVoteAccountConfig::default()
+        },
+    ));
 
     let transaction = Transaction::new_signed_with_payer(
         &instructions,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8036,7 +8036,6 @@ dependencies = [
  "solana-compute-budget",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
- "solana-feature-gate-interface",
  "solana-fee-calculator",
  "solana-genesis-config",
  "solana-hash 4.1.0",

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -647,10 +647,10 @@ mod tests {
         solana_system_transaction as system_transaction,
         solana_transaction::Transaction,
         solana_vote::vote_transaction::VoteTransaction,
-        solana_vote_interface::{program as vote_program, state::Vote},
-        solana_vote_program::{
-            vote_instruction::{self, CreateVoteAccountConfig},
-            vote_state::{create_bls_pubkey_and_proof_of_possession, VoteInitV2, VoteStateV4},
+        solana_vote_interface::{
+            instruction::{self as vote_instruction, CreateVoteAccountConfig},
+            program as vote_program,
+            state::{Vote, VoteInit, VoteStateV4},
         },
         std::{
             sync::{
@@ -929,18 +929,14 @@ mod tests {
             0,
             &system_program::id(),
         )];
-        let (bls_pubkey, bls_proof_of_possession) =
-            create_bls_pubkey_and_proof_of_possession(&vote_account.pubkey());
-        ixs.append(&mut vote_instruction::create_account_with_config_v2(
+        ixs.append(&mut vote_instruction::create_account_with_config(
             &from.pubkey(),
             &vote_account.pubkey(),
-            &VoteInitV2 {
+            &VoteInit {
                 node_pubkey: validator.pubkey(),
                 authorized_voter: voter.pubkey(),
-                authorized_voter_bls_pubkey: bls_pubkey,
-                authorized_voter_bls_proof_of_possession: bls_proof_of_possession,
                 authorized_withdrawer: Pubkey::new_unique(),
-                ..Default::default()
+                ..VoteInit::default()
             },
             vote_balance,
             CreateVoteAccountConfig {

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -334,7 +334,11 @@ pub fn activate_all_features(genesis_config: &mut GenesisConfig) {
 fn do_activate_all_features<const IS_ALPENGLOW: bool>(genesis_config: &mut GenesisConfig) {
     // Activate all features at genesis in development mode
     for feature_id in FeatureSet::default().inactive() {
-        if IS_ALPENGLOW || *feature_id != agave_feature_set::alpenglow::id() {
+        if (IS_ALPENGLOW || *feature_id != agave_feature_set::alpenglow::id())
+            // Skip bls_pubkey_management_in_vote_account feature activation until cli change is in place
+            && *feature_id
+                != agave_feature_set::bls_pubkey_management_in_vote_account::id()
+        {
             activate_feature(genesis_config, *feature_id);
         }
     }
@@ -506,6 +510,10 @@ pub fn create_genesis_config_with_leader_ex(
     for feature_id in feature_set.active().keys() {
         // Skip alpenglow (existing behavior)
         if *feature_id == agave_feature_set::alpenglow::id() {
+            continue;
+        }
+        // Skip bls_pubkey_management_in_vote_account feature activation until cli change is in place
+        if *feature_id == agave_feature_set::bls_pubkey_management_in_vote_account::id() {
             continue;
         }
         activate_feature(&mut genesis_config, *feature_id);


### PR DESCRIPTION
This reverts commit 6c996e55899c4e2ea001754ac8c50b7304a163ca.

#### Problem
CI fails in master with the reverted change:
```
$ git checkout 6c996e55899c4e2ea001754ac8c50b7304a163ca
$ cargo test stake_merge_immediately_after_activation
...
test stake_merge_immediately_after_activation ... FAILED

failures:

---- stake_merge_immediately_after_activation stdout ----

$ git checkout 6c996e55899c4e2ea001754ac8c50b7304a163ca~
$ cargo test stake_merge_immediately_after_activation
...
test stake_merge_immediately_after_activation ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.33s
```

#### Summary of Changes
Back it out to get master CI functional again