### PR TITLE
feat(accounts-db): add config for enabling direct-io for snapshots operations

### DIFF
--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -48,6 +48,8 @@ pub struct AccountsDbConfig {
     ///
     /// Requires memlock ulimit higher than sum of buffer sizes registered at the same time.
     pub use_registered_io_uring_buffers: bool,
+    /// Enables direct I/O for operations on snapshots, their archives and contents being unpacked
+    pub snapshots_use_direct_io: bool,
 }
 
 pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
@@ -71,6 +73,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     num_background_threads: None,
     num_foreground_threads: None,
     use_registered_io_uring_buffers: true,
+    snapshots_use_direct_io: true,
 };
 
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
@@ -94,4 +97,5 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     num_background_threads: None,
     num_foreground_threads: None,
     use_registered_io_uring_buffers: true,
+    snapshots_use_direct_io: true,
 };

--- a/fs/src/buffered_reader.rs
+++ b/fs/src/buffered_reader.rs
@@ -403,6 +403,7 @@ pub fn large_file_buf_reader(
 
         let mut reader = SequentialFileReaderBuilder::new()
             .shared_sqpoll(io_setup.shared_sqpoll_fd())
+            .use_direct_io(io_setup.use_direct_io)
             .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
             .build(buf_size)?;
         reader.set_path(path)?;

--- a/fs/src/file_io.rs
+++ b/fs/src/file_io.rs
@@ -157,6 +157,7 @@ pub fn file_creator<'a>(
         if buf_size >= DEFAULT_WRITE_SIZE as usize {
             let io_uring_creator = IoUringFileCreatorBuilder::new()
                 .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
+                .write_with_direct_io(io_setup.use_direct_io)
                 .shared_sqpoll(io_setup.shared_sqpoll_fd())
                 .build(buf_size, file_complete)?;
             return Ok(Box::new(io_uring_creator));

--- a/fs/src/io_setup.rs
+++ b/fs/src/io_setup.rs
@@ -21,6 +21,7 @@ use {
 pub struct IoSetupState {
     #[cfg(target_os = "linux")]
     shared_sqpoll: Option<SharedSqPoll>,
+    pub use_direct_io: bool,
     pub use_registered_io_uring_buffers: bool,
 }
 
@@ -43,6 +44,17 @@ impl IoSetupState {
     /// Speeds up kernel operations on the memory, but requires appropriate memlock ulimit.
     pub fn with_buffers_registered(mut self, fixed: bool) -> Self {
         self.use_registered_io_uring_buffers = fixed;
+        self
+    }
+
+    /// Enables direct I/O for operations that bypass the operating system's caching layer.
+    ///
+    /// File system is required to support opening files with `O_DIRECT` flag.
+    ///
+    /// This can improve performance when allocation and checking of caches by the kernel is slower
+    /// than the overall savings from re-using cached file data (e.g. for read / write once data).
+    pub fn with_direct_io(mut self, use_direct_io: bool) -> Self {
+        self.use_direct_io = use_direct_io;
         self
     }
 

--- a/fs/src/io_uring/file_creator.rs
+++ b/fs/src/io_uring/file_creator.rs
@@ -102,7 +102,6 @@ impl<'sp> IoUringFileCreatorBuilder<'sp> {
     /// Write files in direct-IO mode (disables kernel caching of written contents).
     ///
     /// Note that `File` passed in completion callback is still switched to non-direct IO mode.
-    #[cfg(test)]
     pub fn write_with_direct_io(mut self, enable_direct_io: bool) -> Self {
         self.write_with_direct_io = enable_direct_io;
         self

--- a/fs/src/io_uring/sequential_file_reader.rs
+++ b/fs/src/io_uring/sequential_file_reader.rs
@@ -80,7 +80,6 @@ impl<'sp> SequentialFileReaderBuilder<'sp> {
     ///
     /// Enabling requires the filesystem to support directio and `read_capacity`
     /// to be a multiple of 4096.
-    #[cfg(test)]
     pub fn use_direct_io(mut self, use_direct_io: bool) -> Self {
         self.use_direct_io = use_direct_io;
         self

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1267,6 +1267,7 @@ fn unarchive_snapshot(
 
     let io_setup = IoSetupState::default()
         .with_shared_sqpoll()?
+        .with_direct_io(accounts_db_config.snapshots_use_direct_io)
         .with_buffers_registered(accounts_db_config.use_registered_io_uring_buffers);
 
     let (file_sender, file_receiver) = crossbeam_channel::unbounded();


### PR DESCRIPTION
#### Problem
Processing snapshot archives is IO intensive and creates lots of pressure on kernel buffer cache, which is not beneficial:
* reading archive is usually done only once, so no point in having it cached by kernel
* according to measurements when unpacking account storages kernel slows down writes significantly and by the time the files are read (during index generation) having them cached isn't very helpful (at least with decently fast SSDs where reads are done faster than we can calculate hashes and populate in-mem index)

With added support for direct-io in `agave-fs` we should have it enabled.

#### Summary of Changes
Add an `AccountsDbConfig` field to control enabling direct-io for snapshot related operations. It is disabled by default except for tests / benchmark configs. It will be enabled with opt-out ability for validator and ledger-tool separately.

Note: this is a generic flag that might increase its application scope going forward. Right now it's limited to unpacking snapshot archive, but in the future it will also control snapshot operations during regular runtime (e.g. creating snapshots).

##### Performance impact
Using this option for validator / ledger-tool unpacking snapshot archive and building index:
* master:
```
snapshot untar took 111.8s
Building accounts index... Done in 45.027711636s
```
* PR:
```
snapshot untar took 78.8s
Building accounts index... Done in 38.569151364s
```