### PR TITLE
clippy: fixes for a couple of lints appearing with rust 1.94

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1175,11 +1175,7 @@ impl AppendVec {
             AppendVecFileBacking::Mmap(mmap) => {
                 let mut offset = 0;
                 let slice = self.get_valid_slice_from_mmap(mmap);
-                loop {
-                    let Some((stored_meta, next)) = Self::get_type::<StoredMeta>(slice, offset)
-                    else {
-                        break;
-                    };
+                while let Some((stored_meta, next)) = Self::get_type::<StoredMeta>(slice, offset) {
                     let Some((account_meta, _)) = Self::get_type::<AccountMeta>(slice, next) else {
                         break;
                     };

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -156,6 +156,7 @@ use {
     solana_wen_restart::wen_restart::{wait_for_wen_restart, WenRestartConfig},
     std::{
         borrow::Cow,
+        cmp,
         collections::{HashMap, HashSet},
         net::SocketAddr,
         num::{NonZeroU64, NonZeroUsize},
@@ -2924,7 +2925,7 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
                 "{:.3}% of active stake is not visible in gossip",
                 (offline_stake as f64 / total_activated_stake as f64) * 100.
             );
-            offline_nodes.sort_by(|b, a| a.0.cmp(&b.0)); // sort by reverse stake weight
+            offline_nodes.sort_by_key(|a| cmp::Reverse(a.0)); // sort by reverse stake weight
             for (stake, identity) in offline_nodes {
                 info!(
                     "    {:.3}% - {}",

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -269,10 +269,7 @@ fn add_validator_accounts(
         rent.minimum_balance(StakeStateV2::size_of()),
     )?;
 
-    loop {
-        let Some(identity_pubkey) = pubkeys_iter.next() else {
-            break;
-        };
+    while let Some(identity_pubkey) = pubkeys_iter.next() {
         let vote_pubkey = pubkeys_iter.next().unwrap();
         let stake_pubkey = pubkeys_iter.next().unwrap();
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -832,7 +832,7 @@ fn record_transactions(
     }
 
     for slot in slots.lock().unwrap().iter_mut() {
-        slot.transactions.sort_by(|a, b| a.index.cmp(&b.index));
+        slot.transactions.sort_by_key(|a| a.index);
     }
 }
 
@@ -2383,11 +2383,7 @@ fn main() {
                         // validators
                         let mut bootstrap_validator_pubkeys_iter =
                             bootstrap_validator_pubkeys.iter();
-                        loop {
-                            let Some(identity_pubkey) = bootstrap_validator_pubkeys_iter.next()
-                            else {
-                                break;
-                            };
+                        while let Some(identity_pubkey) = bootstrap_validator_pubkeys_iter.next() {
                             let vote_pubkey = bootstrap_validator_pubkeys_iter.next().unwrap();
                             let stake_pubkey = bootstrap_validator_pubkeys_iter.next().unwrap();
 

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -37,6 +37,7 @@ use {
     },
     std::{
         cell::RefCell,
+        cmp,
         collections::HashMap,
         fmt::{self, Display, Formatter},
         io::{stdout, Write},
@@ -745,7 +746,7 @@ pub fn output_ledger(
 pub fn output_sorted_program_ids(program_ids: HashMap<Pubkey, u64>) {
     let mut program_ids_array: Vec<_> = program_ids.into_iter().collect();
     // Sort descending by count of program id
-    program_ids_array.sort_by(|a, b| b.1.cmp(&a.1));
+    program_ids_array.sort_by_key(|b| cmp::Reverse(b.1));
     for (program_id, count) in program_ids_array.iter() {
         println!("{:<44}: {}", program_id.to_string(), count);
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7709,10 +7709,7 @@ pub mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         // slot 5 does not exist, iter should be ok and should be a noop
-        blockstore
-            .slot_meta_iterator(5)
-            .unwrap()
-            .for_each(|_| panic!());
+        assert_eq!(blockstore.slot_meta_iterator(5).unwrap().next(), None);
     }
 
     #[test]
@@ -9747,7 +9744,7 @@ pub mod tests {
 
         for i in 0..num_entries {
             let mut expected_samples = perf_samples[num_entries - 1 - i..].to_vec();
-            expected_samples.sort_by(|a, b| b.0.cmp(&a.0));
+            expected_samples.sort_by_key(|b| cmp::Reverse(b.0));
             assert_eq!(
                 blockstore.get_recent_perf_samples(i + 1).unwrap(),
                 expected_samples
@@ -9781,7 +9778,7 @@ pub mod tests {
 
         for i in 0..num_entries {
             let mut expected_samples = perf_samples[num_entries - 1 - i..].to_vec();
-            expected_samples.sort_by(|a, b| b.0.cmp(&a.0));
+            expected_samples.sort_by_key(|b| cmp::Reverse(b.0));
             assert_eq!(
                 blockstore.get_recent_perf_samples(i + 1).unwrap(),
                 expected_samples
@@ -9828,7 +9825,7 @@ pub mod tests {
 
         for i in 0..num_entries {
             let mut expected_samples = perf_samples[num_entries - 1 - i..].to_vec();
-            expected_samples.sort_by(|a, b| b.0.cmp(&a.0));
+            expected_samples.sort_by_key(|b| cmp::Reverse(b.0));
             assert_eq!(
                 blockstore.get_recent_perf_samples(i + 1).unwrap(),
                 expected_samples
@@ -9858,7 +9855,7 @@ pub mod tests {
 
         for x in 0..num_entries {
             let mut expected_samples = perf_samples[num_entries - 1 - x..].to_vec();
-            expected_samples.sort_by(|a, b| b.0.cmp(&a.0));
+            expected_samples.sort_by_key(|b| cmp::Reverse(b.0));
             assert_eq!(
                 blockstore.get_recent_perf_samples(x + 1).unwrap(),
                 expected_samples

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -470,12 +470,7 @@ pub mod tests {
         test_all_empty_or_min(&blockstore, 100);
         test_all_empty_or_min(&blockstore, 0);
 
-        blockstore
-            .slot_meta_iterator(0)
-            .unwrap()
-            .for_each(|(_, _)| {
-                panic!();
-            });
+        assert_eq!(blockstore.slot_meta_iterator(0).unwrap().next(), None);
     }
 
     #[test]

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -61,6 +61,7 @@ use {
     solana_vote::{vote_account::VoteAccountsHashMap, vote_parser::is_valid_vote_only_transaction},
     std::{
         borrow::Cow,
+        cmp,
         collections::{HashMap, HashSet},
         num::Saturating,
         ops::Index,
@@ -1396,7 +1397,7 @@ impl ReplaySlotStats {
                 .per_program_timings
                 .iter()
                 .collect();
-            per_pubkey_timings.sort_by(|a, b| b.1.accumulated_us.cmp(&a.1.accumulated_us));
+            per_pubkey_timings.sort_by_key(|b| cmp::Reverse(b.1.accumulated_us));
             let (total_us, total_units, total_count, total_errored_units, total_errored_count) =
                 per_pubkey_timings.iter().fold(
                     (0, 0, 0, 0, 0),
@@ -1804,7 +1805,7 @@ fn process_next_slots(
     }
 
     // Reverse sort by slot, so the next slot to be processed can be popped
-    pending_slots.sort_by(|a, b| b.1.slot().cmp(&a.1.slot()));
+    pending_slots.sort_by_key(|b| cmp::Reverse(b.1.slot()));
     Ok(())
 }
 
@@ -2095,7 +2096,7 @@ fn supermajority_root_from_vote_accounts(
         .collect();
 
     // Sort from greatest to smallest slot
-    roots_stakes.sort_unstable_by(|a, b| a.0.cmp(&b.0).reverse());
+    roots_stakes.sort_unstable_by_key(|a| cmp::Reverse(a.0));
 
     // Find latest root
     supermajority_root(&roots_stakes, total_epoch_stake)

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -198,11 +198,9 @@ impl PohService {
     pub fn target_ns_per_tick(ticks_per_slot: u64, target_tick_duration_ns: u64) -> u64 {
         // Account for some extra time outside of PoH generation to account
         // for processing time outside PoH.
-        let adjustment_per_tick = if ticks_per_slot > 0 {
-            TARGET_SLOT_ADJUSTMENT_NS / ticks_per_slot
-        } else {
-            0
-        };
+        let adjustment_per_tick = TARGET_SLOT_ADJUSTMENT_NS
+            .checked_div(ticks_per_slot)
+            .unwrap_or(0);
         target_tick_duration_ns.saturating_sub(adjustment_per_tick)
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3879,7 +3879,7 @@ impl Bank {
             .accounts_db
             .get_pubkey_account_for_slot(self.slot());
         // Sort the accounts by pubkey to make diff deterministic.
-        accounts.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        accounts.sort_unstable_by_key(|a| a.0);
         accounts
     }
 

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -930,7 +930,7 @@ mod tests {
             .iter()
             .map(|entry| (*entry.key(), entry.value().clone()))
             .collect();
-        actual_cache.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        actual_cache.sort_unstable_by_key(|a| a.0);
         assert_eq!(expected_cache, actual_cache.as_slice());
     }
 

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -322,8 +322,7 @@ impl PrioritizationFeeCache {
         // block minimum fee.
         let (slot_prioritization_fee, slot_finalize_us) = measure_us!({
             // remove unfinalized slots
-            *unfinalized =
-                unfinalized.split_off(&slot.checked_sub(MAX_UNFINALIZED_SLOTS).unwrap_or_default());
+            *unfinalized = unfinalized.split_off(&slot.saturating_sub(MAX_UNFINALIZED_SLOTS));
 
             let Some(mut slot_prioritization_fee) = unfinalized.remove(&slot) else {
                 return;

--- a/votor/src/staked_validators_cache.rs
+++ b/votor/src/staked_validators_cache.rs
@@ -124,7 +124,7 @@ impl StakedValidatorsCache {
             .collect();
 
         nodes.dedup_by_key(|node| node.alpenglow_socket);
-        nodes.sort_unstable_by(|a, b| a.stake.cmp(&b.stake));
+        nodes.sort_unstable_by_key(|a| a.stake);
 
         let mut alpenglow_sockets = Vec::with_capacity(nodes.len());
         let override_map = self

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -142,10 +142,7 @@ impl VotingService {
                 );
 
                 info!("AlpenglowVotingService has started");
-                loop {
-                    let Ok(bls_op) = bls_receiver.recv() else {
-                        break;
-                    };
+                while let Ok(bls_op) = bls_receiver.recv() {
                     Self::handle_bls_op(
                         &cluster_info,
                         vote_history_storage.as_ref(),


### PR DESCRIPTION
#### Problem
Most notable is [unnecessary_sort_by](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by) - I couldn't find a comprehensive comparison how it affects performance, but I can imagine for simple access to keys it can be a win if key of one element (e.g. pivot in quicksort) is compared multiple times against keys of several items.

#### Summary of Changes
Fix lints.