### PR TITLE
refactor: non-functional program-runtime changes for clarity

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1061,16 +1061,16 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     if let Some(second_level) = entries.get(key) {
                         let mut filter_by_deployment_slot = None;
                         for entry in second_level.iter().rev() {
-                            let deployment_slot = entry.deployment_slot;
                             let required_deployment_slot =
-                                filter_by_deployment_slot.unwrap_or(deployment_slot);
-                            if required_deployment_slot != deployment_slot {
+                                filter_by_deployment_slot.unwrap_or(entry.deployment_slot);
+                            if required_deployment_slot != entry.deployment_slot {
                                 continue;
                             }
-                            let entry_in_same_branch = deployment_slot <= self.latest_root_slot
+                            let entry_in_same_branch = entry.deployment_slot
+                                <= self.latest_root_slot
                                 || matches!(
                                     locked_fork_graph.relationship(
-                                        deployment_slot,
+                                        entry.deployment_slot,
                                         loaded_programs_for_tx_batch.slot
                                     ),
                                     BlockRelation::Equal | BlockRelation::Ancestor
@@ -1091,8 +1091,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                         // program we're looking at in this iteration. We just have to find
                                         // one with the correct environment and can skip entries for any
                                         // other deployment slot while searching further.
-                                        filter_by_deployment_slot =
-                                            filter_by_deployment_slot.or(Some(deployment_slot));
+                                        filter_by_deployment_slot = filter_by_deployment_slot
+                                            .or(Some(entry.deployment_slot));
                                         continue;
                                     }
                                     if !Self::matches_criteria(entry, match_criteria) {
@@ -1111,7 +1111,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                     // yet. It indicates that the program has delayed visibility. Return
                                     // the tombstone to reflect that.
                                     Arc::new(ProgramCacheEntry::new_tombstone_with_usage_counter(
-                                        deployment_slot,
+                                        entry.deployment_slot,
                                         entry.account_owner,
                                         ProgramCacheEntryType::DelayVisibility,
                                         entry.tx_usage_counter.clone(),

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -849,7 +849,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         match &mut self.index {
             IndexImplementation::V1 { entries, .. } => {
                 let slot_versions = &mut entries.entry(key).or_default();
-                match slot_versions.binary_search_by(|at| {
+                let insertion_point = slot_versions.binary_search_by(|at| {
                     at.effective_slot
                         .cmp(&entry.effective_slot)
                         .then(at.deployment_slot.cmp(&entry.deployment_slot))
@@ -866,7 +866,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 entry.program.get_environment(),
                             )),
                         )
-                }) {
+                });
+                match insertion_point {
                     Ok(index) => {
                         let existing = slot_versions.get_mut(index).unwrap();
                         match (&existing.program, &entry.program) {
@@ -904,7 +905,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                         slot_versions.insert(index, Arc::clone(&entry));
                     }
                 }
-                // Remove existing entries in the same deployment slot unless they are for a different environment.
+                // Remove existing entries in the same deployment slot unless they are for a different
+                // environment.
                 // This overwrites the current status of a program in program management instructions.
                 slot_versions.retain(|existing| {
                     existing.deployment_slot != entry.deployment_slot
@@ -969,12 +971,13 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                     first_ancestor_env = entry.program.get_environment();
                                     return true;
                                 }
-                                // Do not prune the entry if the runtime environment of the entry is different
-                                // than the entry that was previously found (stored in first_ancestor_env).
-                                // Different environment indicates that this entry might belong to an older
-                                // epoch that had a different environment (e.g. different feature set).
-                                // Once the root moves to the new/current epoch, the entry will get pruned.
-                                // But, until then the entry might still be getting used by an older slot.
+                                // Do not prune the entry if the runtime environment of the entry is
+                                // different than the entry that was previously found (stored in
+                                // first_ancestor_env). Different environment indicates that this entry
+                                // might belong to an older epoch that had a different environment (e.g.
+                                // different feature set). Once the root moves to the new/current epoch,
+                                // the entry will get pruned. But, until then the entry might still be
+                                // getting used by an older slot.
                                 if let Some(entry_env) = entry.program.get_environment()
                                     && let Some(env) = first_ancestor_env
                                     && !Arc::ptr_eq(entry_env, env)
@@ -1058,30 +1061,38 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     if let Some(second_level) = entries.get(key) {
                         let mut filter_by_deployment_slot = None;
                         for entry in second_level.iter().rev() {
-                            if filter_by_deployment_slot
-                                .map(|slot| slot != entry.deployment_slot)
-                                .unwrap_or(false)
-                            {
+                            let deployment_slot = entry.deployment_slot;
+                            let required_deployment_slot =
+                                filter_by_deployment_slot.unwrap_or(deployment_slot);
+                            if required_deployment_slot != deployment_slot {
                                 continue;
                             }
-                            if entry.deployment_slot <= self.latest_root_slot
+                            let entry_in_same_branch = deployment_slot <= self.latest_root_slot
                                 || matches!(
                                     locked_fork_graph.relationship(
-                                        entry.deployment_slot,
+                                        deployment_slot,
                                         loaded_programs_for_tx_batch.slot
                                     ),
                                     BlockRelation::Equal | BlockRelation::Ancestor
-                                )
-                            {
-                                let entry_to_return = if loaded_programs_for_tx_batch.slot
-                                    >= entry.effective_slot
-                                {
+                                );
+                            if entry_in_same_branch {
+                                let entry_is_effective =
+                                    loaded_programs_for_tx_batch.slot >= entry.effective_slot;
+                                let entry_to_return = if entry_is_effective {
                                     if !Self::matches_environment(
                                         entry,
                                         program_runtime_environments_for_execution,
                                     ) {
-                                        filter_by_deployment_slot = filter_by_deployment_slot
-                                            .or(Some(entry.deployment_slot));
+                                        // We found an entry that would work, had its environment matched
+                                        // the one we're planning to use for this slot.
+                                        //
+                                        // At this point we know that whatever the "current version" of
+                                        // program is, it must have had a deployment slot equal to the
+                                        // program we're looking at in this iteration. We just have to find
+                                        // one with the correct environment and can skip entries for any
+                                        // other deployment slot while searching further.
+                                        filter_by_deployment_slot =
+                                            filter_by_deployment_slot.or(Some(deployment_slot));
                                         continue;
                                     }
                                     if !Self::matches_criteria(entry, match_criteria) {
@@ -1100,7 +1111,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                     // yet. It indicates that the program has delayed visibility. Return
                                     // the tombstone to reflect that.
                                     Arc::new(ProgramCacheEntry::new_tombstone_with_usage_counter(
-                                        entry.deployment_slot,
+                                        deployment_slot,
                                         entry.account_owner,
                                         ProgramCacheEntryType::DelayVisibility,
                                         entry.tx_usage_counter.clone(),

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -8,7 +8,7 @@ use {
     solana_loader_v4_interface::state::{LoaderV4State, LoaderV4Status},
     solana_program_runtime::loaded_programs::{
         DELAY_VISIBILITY_SLOT_OFFSET, ProgramCacheEntry, ProgramCacheEntryOwner,
-        ProgramCacheEntryType, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
+        ProgramCacheEntryType, ProgramRuntimeEnvironments,
     },
     solana_pubkey::Pubkey,
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4},
@@ -25,26 +25,6 @@ pub(crate) enum ProgramAccountLoadResult {
     ProgramOfLoaderV2(AccountSharedData),
     ProgramOfLoaderV3(AccountSharedData, AccountSharedData, Slot),
     ProgramOfLoaderV4(AccountSharedData, Slot),
-}
-
-pub(crate) fn load_program_from_bytes(
-    #[cfg(feature = "metrics")] load_program_metrics: &mut LoadProgramMetrics,
-    programdata: &[u8],
-    loader_key: &Pubkey,
-    account_size: usize,
-    deployment_slot: Slot,
-    program_runtime_environment: ProgramRuntimeEnvironment,
-) -> std::result::Result<ProgramCacheEntry, Box<dyn std::error::Error>> {
-    ProgramCacheEntry::new(
-        loader_key,
-        program_runtime_environment,
-        deployment_slot,
-        deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
-        programdata,
-        account_size,
-        #[cfg(feature = "metrics")]
-        load_program_metrics,
-    )
 }
 
 pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
@@ -127,25 +107,27 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
             ProgramCacheEntry::new_tombstone(current_slot, owner, ProgramCacheEntryType::Closed),
         ),
 
-        ProgramAccountLoadResult::ProgramOfLoaderV1(program_account) => load_program_from_bytes(
+        ProgramAccountLoadResult::ProgramOfLoaderV1(program_account) => ProgramCacheEntry::new(
+            program_account.owner(),
+            environments.program_runtime_v1.clone(),
+            0,
+            DELAY_VISIBILITY_SLOT_OFFSET,
+            program_account.data(),
+            program_account.data().len(),
             #[cfg(feature = "metrics")]
             &mut load_program_metrics,
-            program_account.data(),
-            program_account.owner(),
-            program_account.data().len(),
-            0,
-            environments.program_runtime_v1.clone(),
         )
         .map_err(|_| (0, ProgramCacheEntryOwner::LoaderV1)),
 
-        ProgramAccountLoadResult::ProgramOfLoaderV2(program_account) => load_program_from_bytes(
+        ProgramAccountLoadResult::ProgramOfLoaderV2(program_account) => ProgramCacheEntry::new(
+            program_account.owner(),
+            environments.program_runtime_v1.clone(),
+            0,
+            DELAY_VISIBILITY_SLOT_OFFSET,
+            program_account.data(),
+            program_account.data().len(),
             #[cfg(feature = "metrics")]
             &mut load_program_metrics,
-            program_account.data(),
-            program_account.owner(),
-            program_account.data().len(),
-            0,
-            environments.program_runtime_v1.clone(),
         )
         .map_err(|_| (0, ProgramCacheEntryOwner::LoaderV2)),
 
@@ -158,17 +140,18 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
             .get(UpgradeableLoaderState::size_of_programdata_metadata()..)
             .ok_or(Box::new(InstructionError::InvalidAccountData).into())
             .and_then(|programdata| {
-                load_program_from_bytes(
-                    #[cfg(feature = "metrics")]
-                    &mut load_program_metrics,
-                    programdata,
+                ProgramCacheEntry::new(
                     program_account.owner(),
+                    environments.program_runtime_v1.clone(),
+                    deployment_slot,
+                    deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
+                    programdata,
                     program_account
                         .data()
                         .len()
                         .saturating_add(programdata_account.data().len()),
-                    deployment_slot,
-                    environments.program_runtime_v1.clone(),
+                    #[cfg(feature = "metrics")]
+                    &mut load_program_metrics,
                 )
             })
             .map_err(|_| (deployment_slot, ProgramCacheEntryOwner::LoaderV3)),
@@ -179,14 +162,15 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
                 .get(LoaderV4State::program_data_offset()..)
                 .ok_or(Box::new(InstructionError::InvalidAccountData).into())
                 .and_then(|elf_bytes| {
-                    load_program_from_bytes(
+                    ProgramCacheEntry::new(
+                        &loader_v4::id(),
+                        environments.program_runtime_v1.clone(),
+                        deployment_slot,
+                        deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
+                        elf_bytes,
+                        program_account.data().len(),
                         #[cfg(feature = "metrics")]
                         &mut load_program_metrics,
-                        elf_bytes,
-                        &loader_v4::id(),
-                        program_account.data().len(),
-                        deployment_slot,
-                        environments.program_runtime_v1.clone(),
                     )
                 })
                 .map_err(|_| (deployment_slot, ProgramCacheEntryOwner::LoaderV4))
@@ -251,7 +235,9 @@ mod tests {
         crate::transaction_processor::TransactionBatchProcessor,
         solana_account::WritableAccount,
         solana_program_runtime::{
-            loaded_programs::{BlockRelation, ForkGraph, ProgramRuntimeEnvironments},
+            loaded_programs::{
+                BlockRelation, ForkGraph, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
+            },
             solana_sbpf::program::BuiltinProgram,
         },
         solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable},
@@ -477,14 +463,15 @@ mod tests {
         let slot = 2;
         let environment = ProgramRuntimeEnvironment::new(BuiltinProgram::new_mock());
 
-        let result = load_program_from_bytes(
+        let result = ProgramCacheEntry::new(
+            &loader,
+            environment.clone(),
+            slot,
+            slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
+            &buffer,
+            size,
             #[cfg(feature = "metrics")]
             &mut metrics,
-            &buffer,
-            &loader,
-            size,
-            slot,
-            environment.clone(),
         );
 
         assert!(result.is_ok());
@@ -586,14 +573,15 @@ mod tests {
         );
 
         let environments = ProgramRuntimeEnvironments::default();
-        let expected = load_program_from_bytes(
+        let expected = ProgramCacheEntry::new(
+            account_data.owner(),
+            environments.program_runtime_v1.clone(),
+            0,
+            DELAY_VISIBILITY_SLOT_OFFSET,
+            account_data.data(),
+            account_data.data().len(),
             #[cfg(feature = "metrics")]
             &mut LoadProgramMetrics::default(),
-            account_data.data(),
-            account_data.owner(),
-            account_data.data().len(),
-            0,
-            environments.program_runtime_v1.clone(),
         );
 
         assert_eq!(result.unwrap(), (Arc::new(expected.unwrap()), 0));
@@ -679,14 +667,15 @@ mod tests {
             .set_data(data[UpgradeableLoaderState::size_of_programdata_metadata()..].to_vec());
 
         let environments = ProgramRuntimeEnvironments::default();
-        let expected = load_program_from_bytes(
+        let expected = ProgramCacheEntry::new(
+            account_data.owner(),
+            environments.program_runtime_v1.clone(),
+            0,
+            DELAY_VISIBILITY_SLOT_OFFSET,
+            account_data.data(),
+            account_data.data().len(),
             #[cfg(feature = "metrics")]
             &mut LoadProgramMetrics::default(),
-            account_data.data(),
-            account_data.owner(),
-            account_data.data().len(),
-            0,
-            environments.program_runtime_v1.clone(),
         );
         assert_eq!(result.unwrap(), (Arc::new(expected.unwrap()), 0));
     }
@@ -763,14 +752,15 @@ mod tests {
             .insert(key, (account_data.clone(), 0));
 
         let environments = ProgramRuntimeEnvironments::default();
-        let expected = load_program_from_bytes(
+        let expected = ProgramCacheEntry::new(
+            account_data.owner(),
+            environments.program_runtime_v1.clone(),
+            0,
+            DELAY_VISIBILITY_SLOT_OFFSET,
+            account_data.data(),
+            account_data.data().len(),
             #[cfg(feature = "metrics")]
             &mut LoadProgramMetrics::default(),
-            account_data.data(),
-            account_data.owner(),
-            account_data.data().len(),
-            0,
-            environments.program_runtime_v1.clone(),
         );
         assert_eq!(result.unwrap(), (Arc::new(expected.unwrap()), 0));
     }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -904,8 +904,11 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             } else if missing_programs.is_empty() {
                 break;
             } else {
-                // Sleep until the next finish_cooperative_loading_task() call.
-                // Once a task completes we'll wake up and try to load the
+                // Remember: there are multiple transaction processor threads running concurrently
+                // and those other threads may be loading this or other programs.
+                //
+                // So, sleep until some other thread submits a program with their
+                // `finish_cooperative_loading_task` call. We'll then wake up and try to load the
                 // missing programs inside the tx batch again.
                 let _new_cookie = task_waiter.wait(task_cookie);
             }


### PR DESCRIPTION
I've been working on measuring the JIT-interpreter tradeoff and in doing so I had to get intimately familiar with how the loaded program cache works. I made some stylistic changes (mostly in order to reduce excessive nesting) and added some comments in parts that took more time to grok.

This PR also bundles the inlining of `load_program_from_bytes` from https://github.com/anza-xyz/agave/pull/10447#discussion_r2779122238.

Best reviewed with [whitespace changes filtered out](https://github.com/anza-xyz/agave/pull/10510/changes?w=1).