### PR TITLE
remove block vote cost limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11686,6 +11686,7 @@ name = "solana-unified-scheduler-pool"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
+ "agave-feature-set",
  "agave-logger",
  "aquamarine",
  "assert_matches",

--- a/cost-model/benches/cost_tracker.rs
+++ b/cost-model/benches/cost_tracker.rs
@@ -72,7 +72,7 @@ fn bench_cost_tracker_non_contentious_transaction(bencher: &mut Bencher) {
 
     bencher.iter(|| {
         for tx_cost in tx_costs.iter() {
-            if cost_tracker.try_add(tx_cost).is_err() {
+            if cost_tracker.try_add(tx_cost, true).is_err() {
                 break;
             } // stop when hit limits
             cost_tracker.update_execution_cost(tx_cost, 0, 0); // update execution cost down to zero
@@ -90,7 +90,7 @@ fn bench_cost_tracker_contentious_transaction(bencher: &mut Bencher) {
 
     bencher.iter(|| {
         for tx_cost in tx_costs.iter() {
-            if cost_tracker.try_add(tx_cost).is_err() {
+            if cost_tracker.try_add(tx_cost, true).is_err() {
                 break;
             } // stop when hit limits
             cost_tracker.update_execution_cost(tx_cost, 0, 0); // update execution cost down to zero

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -170,8 +170,9 @@ impl CostTracker {
     pub fn try_add(
         &mut self,
         tx_cost: &TransactionCost<impl TransactionWithMeta>,
+        remove_block_vote_cost_limit: bool,
     ) -> Result<UpdatedCosts, CostTrackerError> {
-        self.would_fit(tx_cost)?;
+        self.would_fit(tx_cost, remove_block_vote_cost_limit)?;
         let updated_costliest_account_cost = self.add_transaction_cost(tx_cost);
         Ok(UpdatedCosts {
             updated_block_cost: self.block_cost(),
@@ -312,10 +313,11 @@ impl CostTracker {
     fn would_fit(
         &self,
         tx_cost: &TransactionCost<impl TransactionWithMeta>,
+        remove_block_vote_cost_limit: bool,
     ) -> Result<(), CostTrackerError> {
         let cost: u64 = tx_cost.sum();
 
-        if tx_cost.is_simple_vote() {
+        if !remove_block_vote_cost_limit && tx_cost.is_simple_vote() {
             // if vote transaction, check if it exceeds vote_transaction_limit
             if self.vote_cost.saturating_add(cost) > self.vote_cost_limit {
                 return Err(CostTrackerError::WouldExceedVoteMaxLimit);
@@ -563,7 +565,8 @@ mod tests {
 
         // build testee to have capacity for one simple transaction
         let mut testee = CostTracker::new(cost, cost, cost);
-        assert!(testee.would_fit(&tx_cost).is_ok());
+        assert!(testee.would_fit(&tx_cost, false).is_ok());
+        assert!(testee.would_fit(&tx_cost, true).is_ok());
         testee.add_transaction_cost(&tx_cost);
         assert_eq!(cost, testee.block_cost());
         assert_eq!(0, testee.vote_cost);
@@ -580,7 +583,8 @@ mod tests {
 
         // build testee to have capacity for one simple transaction
         let mut testee = CostTracker::new(cost, cost, cost);
-        assert!(testee.would_fit(&tx_cost).is_ok());
+        assert!(testee.would_fit(&tx_cost, false).is_ok());
+        assert!(testee.would_fit(&tx_cost, true).is_ok());
         testee.add_transaction_cost(&tx_cost);
         assert_eq!(cost, testee.block_cost());
         assert_eq!(cost, testee.vote_cost);
@@ -602,7 +606,8 @@ mod tests {
 
         // build testee to have capacity for one simple transaction
         let mut testee = CostTracker::new(cost, cost, cost);
-        assert!(testee.would_fit(&tx_cost).is_ok());
+        assert!(testee.would_fit(&tx_cost, false).is_ok());
+        assert!(testee.would_fit(&tx_cost, true).is_ok());
         let old = testee.allocated_accounts_data_size;
         testee.add_transaction_cost(&tx_cost);
         assert_eq!(old.0 + 1, testee.allocated_accounts_data_size.0);
@@ -622,11 +627,13 @@ mod tests {
         // build testee to have capacity for two simple transactions, with same accounts
         let mut testee = CostTracker::new(cost1 + cost2, cost1 + cost2, cost1 + cost2);
         {
-            assert!(testee.would_fit(&tx_cost1).is_ok());
+            assert!(testee.would_fit(&tx_cost1, false).is_ok());
+            assert!(testee.would_fit(&tx_cost1, true).is_ok());
             testee.add_transaction_cost(&tx_cost1);
         }
         {
-            assert!(testee.would_fit(&tx_cost2).is_ok());
+            assert!(testee.would_fit(&tx_cost2, false).is_ok());
+            assert!(testee.would_fit(&tx_cost2, true).is_ok());
             testee.add_transaction_cost(&tx_cost2);
         }
         assert_eq!(cost1 + cost2, testee.block_cost());
@@ -651,11 +658,13 @@ mod tests {
         // build testee to have capacity for two simple transactions, with same accounts
         let mut testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2, cost1 + cost2);
         {
-            assert!(testee.would_fit(&tx_cost1).is_ok());
+            assert!(testee.would_fit(&tx_cost1, false).is_ok());
+            assert!(testee.would_fit(&tx_cost1, true).is_ok());
             testee.add_transaction_cost(&tx_cost1);
         }
         {
-            assert!(testee.would_fit(&tx_cost2).is_ok());
+            assert!(testee.would_fit(&tx_cost2, false).is_ok());
+            assert!(testee.would_fit(&tx_cost2, true).is_ok());
             testee.add_transaction_cost(&tx_cost2);
         }
         assert_eq!(cost1 + cost2, testee.block_cost());
@@ -679,12 +688,14 @@ mod tests {
         let mut testee = CostTracker::new(cmp::min(cost1, cost2), cost1 + cost2, cost1 + cost2);
         // should have room for first transaction
         {
-            assert!(testee.would_fit(&tx_cost1).is_ok());
+            assert!(testee.would_fit(&tx_cost1, false).is_ok());
+            assert!(testee.would_fit(&tx_cost1, true).is_ok());
             testee.add_transaction_cost(&tx_cost1);
         }
         // but no more sapce on the same chain (same signer account)
         {
-            assert!(testee.would_fit(&tx_cost2).is_err());
+            assert!(testee.would_fit(&tx_cost2, false).is_err());
+            assert!(testee.would_fit(&tx_cost2, true).is_err());
         }
     }
 
@@ -705,12 +716,14 @@ mod tests {
             CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2 - 1, cost1 + cost2 - 1);
         // should have room for first transaction
         {
-            assert!(testee.would_fit(&tx_cost1).is_ok());
+            assert!(testee.would_fit(&tx_cost1, false).is_ok());
+            assert!(testee.would_fit(&tx_cost1, true).is_ok());
             testee.add_transaction_cost(&tx_cost1);
         }
         // but no more room for package as whole
         {
-            assert!(testee.would_fit(&tx_cost2).is_err());
+            assert!(testee.would_fit(&tx_cost2, false).is_err());
+            assert!(testee.would_fit(&tx_cost2, true).is_err());
         }
     }
 
@@ -730,19 +743,24 @@ mod tests {
         let mut testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2, cost1 + cost2 - 1);
         // should have room for first vote
         {
-            assert!(testee.would_fit(&tx_cost1).is_ok());
+            assert!(testee.would_fit(&tx_cost1, false).is_ok());
+            assert!(testee.would_fit(&tx_cost1, true).is_ok());
             testee.add_transaction_cost(&tx_cost1);
         }
         // but no more room for package as whole
         {
-            assert!(testee.would_fit(&tx_cost2).is_err());
+            assert!(testee.would_fit(&tx_cost2, false).is_err());
+
+            // with vote limit removed, it fits
+            assert!(testee.would_fit(&tx_cost2, true).is_ok());
         }
         // however there is room for none-vote tx3
         {
             let third_account = Keypair::new();
             let tx3 = build_simple_transaction(&third_account);
             let tx_cost3 = simple_transaction_cost(&tx3, 5);
-            assert!(testee.would_fit(&tx_cost3).is_ok());
+            assert!(testee.would_fit(&tx_cost3, false).is_ok());
+            assert!(testee.would_fit(&tx_cost3, true).is_ok());
         }
     }
 
@@ -770,10 +788,15 @@ mod tests {
 
         // build testee that passes
         let testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2 - 1, cost1 + cost2 - 1);
-        assert!(testee.would_fit(&tx_cost1).is_ok());
+        assert!(testee.would_fit(&tx_cost1, false).is_ok());
+        assert!(testee.would_fit(&tx_cost1, true).is_ok());
         // data is too big
         assert_eq!(
-            testee.would_fit(&tx_cost2),
+            testee.would_fit(&tx_cost2, false),
+            Err(CostTrackerError::WouldExceedAccountDataBlockLimit),
+        );
+        assert_eq!(
+            testee.would_fit(&tx_cost2, true),
             Err(CostTrackerError::WouldExceedAccountDataBlockLimit),
         );
     }
@@ -793,8 +816,8 @@ mod tests {
         // build testee
         let mut testee = CostTracker::new(cost1 + cost2, cost1 + cost2, cost1 + cost2);
 
-        assert!(testee.try_add(&tx_cost1).is_ok());
-        assert!(testee.try_add(&tx_cost2).is_ok());
+        assert!(testee.try_add(&tx_cost1, true).is_ok());
+        assert!(testee.try_add(&tx_cost2, true).is_ok());
         assert_eq!(cost1 + cost2, testee.block_cost());
 
         // removing a tx_cost affects block_cost
@@ -802,11 +825,11 @@ mod tests {
         assert_eq!(cost2, testee.block_cost());
 
         // add back tx1
-        assert!(testee.try_add(&tx_cost1).is_ok());
+        assert!(testee.try_add(&tx_cost1, true).is_ok());
         assert_eq!(cost1 + cost2, testee.block_cost());
 
         // cannot add tx1 again, cost limit would be exceeded
-        assert!(testee.try_add(&tx_cost1).is_err());
+        assert!(testee.try_add(&tx_cost1, true).is_err());
     }
 
     #[test]
@@ -828,7 +851,7 @@ mod tests {
         {
             let transaction = WritableKeysTransaction::new(vec![acct1, acct2, acct3]);
             let tx_cost = simple_transaction_cost(&transaction, cost);
-            assert!(testee.try_add(&tx_cost).is_ok());
+            assert!(testee.try_add(&tx_cost, true).is_ok());
             let (_costliest_account, costliest_account_cost) = testee.find_costliest_account();
             assert_eq!(cost, testee.block_cost());
             assert_eq!(3, testee.cost_by_writable_accounts.len());
@@ -843,7 +866,7 @@ mod tests {
         {
             let transaction = WritableKeysTransaction::new(vec![acct2]);
             let tx_cost = simple_transaction_cost(&transaction, cost);
-            assert!(testee.try_add(&tx_cost).is_ok());
+            assert!(testee.try_add(&tx_cost, true).is_ok());
             let (costliest_account, costliest_account_cost) = testee.find_costliest_account();
             assert_eq!(cost * 2, testee.block_cost());
             assert_eq!(3, testee.cost_by_writable_accounts.len());
@@ -860,7 +883,7 @@ mod tests {
         {
             let transaction = WritableKeysTransaction::new(vec![acct1, acct2]);
             let tx_cost = simple_transaction_cost(&transaction, cost);
-            assert!(testee.try_add(&tx_cost).is_err());
+            assert!(testee.try_add(&tx_cost, true).is_err());
             let (costliest_account, costliest_account_cost) = testee.find_costliest_account();
             assert_eq!(cost * 2, testee.block_cost());
             assert_eq!(3, testee.cost_by_writable_accounts.len());
@@ -883,7 +906,7 @@ mod tests {
         let tx_cost = simple_transaction_cost(&transaction, cost);
         let mut expected_block_cost = tx_cost.sum();
         let expected_tx_count = 1;
-        assert!(testee.try_add(&tx_cost).is_ok());
+        assert!(testee.try_add(&tx_cost, true).is_ok());
         assert_eq!(expected_block_cost, testee.block_cost());
         assert_eq!(expected_tx_count, testee.transaction_count());
         testee
@@ -950,7 +973,7 @@ mod tests {
         let test_update_cost_tracker =
             |execution_cost_adjust: i64, loaded_accounts_data_size_cost_adjust: i64| {
                 let mut cost_tracker = CostTracker::default();
-                assert!(cost_tracker.try_add(&tx_cost).is_ok());
+                assert!(cost_tracker.try_add(&tx_cost, true).is_ok());
 
                 let actual_programs_execution_cost =
                     (estimated_programs_execution_cost as i64 + execution_cost_adjust) as u64;

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9768,6 +9768,7 @@ name = "solana-unified-scheduler-pool"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
+ "agave-feature-set",
  "aquamarine",
  "assert_matches",
  "crossbeam-channel",

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1296,6 +1296,10 @@ pub mod block_revenue_sharing {
     solana_pubkey::declare_id!("HqUXZzYaxpbjHRCZHn8GLDCSecyCe2A7JD3An6asGdw4");
 }
 
+pub mod remove_block_vote_cost_limit {
+    solana_pubkey::declare_id!("VoTEDQfcnyYSQQHmX8fGRN19KaEJG5mSgSMYwvW6fXY");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2306,6 +2310,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             limit_instruction_accounts::id(),
             "SIMD-406: Maximum instruction accounts",
+        ),
+        (
+            remove_block_vote_cost_limit::id(),
+            "remove block vote cost limit",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -455,6 +455,8 @@ fn compute_slot_cost(
     let feature_set = FeatureSet::all_enabled();
     let reserved_account_keys = ReservedAccountKeys::new_all_activated();
 
+    let remove_block_vote_cost_limit =
+        feature_set.is_active(&agave_feature_set::remove_block_vote_cost_limit::ID);
     for entry in entries {
         num_transactions += entry.transactions.len();
         entry
@@ -479,7 +481,7 @@ fn compute_slot_cost(
                 num_programs += transaction.message().instructions().len();
 
                 let tx_cost = CostModel::calculate_cost(&transaction, &feature_set);
-                let result = cost_tracker.try_add(&tx_cost);
+                let result = cost_tracker.try_add(&tx_cost, remove_block_vote_cost_limit);
                 if result.is_err() {
                     println!(
                         "Slot: {slot}, CostModel rejected transaction {transaction:?}, reason \

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -338,10 +338,13 @@ fn check_block_cost_limits<Tx: TransactionWithMeta>(
     bank: &Bank,
     tx_costs: &[Option<TransactionCost<'_, Tx>>],
 ) -> Result<()> {
+    let remove_block_vote_cost_limit = bank
+        .feature_set
+        .is_active(&agave_feature_set::remove_block_vote_cost_limit::ID);
     let mut cost_tracker = bank.write_cost_tracker().unwrap();
     for tx_cost in tx_costs.iter().flatten() {
         cost_tracker
-            .try_add(tx_cost)
+            .try_add(tx_cost, remove_block_vote_cost_limit)
             .map_err(TransactionError::from)?;
     }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10280,6 +10280,7 @@ name = "solana-unified-scheduler-pool"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
+ "agave-feature-set",
  "aquamarine",
  "assert_matches",
  "crossbeam-channel",

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -15,6 +15,7 @@ dev-context-only-utils = []
 
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
+agave-feature-set = { workspace = true }
 aquamarine = { workspace = true }
 assert_matches = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -1262,7 +1262,11 @@ impl TaskHandler for DefaultTaskHandler {
                 );
                 // Note that we're about to partially commit side effects to bank in _pre commit_
                 // callback. Extra care must be taken in the case of poh failure just below;
-                bank.write_cost_tracker().unwrap().try_add(&cost)?;
+                bank.write_cost_tracker().unwrap().try_add(
+                    &cost,
+                    bank.feature_set
+                        .is_active(&agave_feature_set::remove_block_vote_cost_limit::ID),
+                )?;
 
                 let RecordTransactionsSummary {
                     result,


### PR DESCRIPTION
#### Problem
- Once #10226 is activated the only consensus use of simple-vote classification (excluding vote-only mode for alpenglow transition) is the block vote cost limit  

#### Summary of Changes
- Remove block vote cost limit behind a new feature flag

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
