### PR TITLE
chore: relax version constraints for solana-cli, solana-faucet, and solana-genesis

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -48,63 +48,63 @@ reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-solana-account = "=3.4.0"
+solana-account = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }
 solana-bls-signatures = { workspace = true }
-solana-borsh = "=3.0.0"
+solana-borsh = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-cli-output = { workspace = true }
 solana-client = { workspace = true }
-solana-clock = "=3.0.0"
-solana-cluster-type = "=3.0.0"
-solana-commitment-config = "=3.1.0"
-solana-compute-budget-interface = { version = "=3.0.0", features = ["borsh"] }
-solana-config-interface = "=2.0.0"
+solana-clock = { workspace = true }
+solana-cluster-type = { workspace = true }
+solana-commitment-config = { workspace = true }
+solana-compute-budget-interface = { workspace = true, features = ["borsh"] }
+solana-config-interface = { workspace = true }
 solana-connection-cache = { workspace = true }
-solana-epoch-schedule = "=3.0.0"
-solana-feature-gate-interface = { version = "=3.1.0", features = ["bincode"] }
-solana-fee-calculator = "=3.0.0"
-solana-fee-structure = "=3.0.0"
-solana-hash = "=4.1.0"
-solana-instruction = "=3.1.0"
-solana-keypair = "=3.1.0"
-solana-loader-v3-interface = { version = "=6.1.0", features = ["bincode"] }
-solana-loader-v4-interface = "=3.1.0"
+solana-epoch-schedule = { workspace = true }
+solana-feature-gate-interface = { workspace = true, features = ["bincode"] }
+solana-fee-calculator = { workspace = true }
+solana-fee-structure = { workspace = true }
+solana-hash = { workspace = true }
+solana-instruction = { workspace = true }
+solana-keypair = { workspace = true }
+solana-loader-v3-interface = { workspace = true, features = ["bincode"] }
+solana-loader-v4-interface = { workspace = true }
 solana-loader-v4-program = { workspace = true }
-solana-message = "=3.1.0"
-solana-native-token = "=3.0.0"
-solana-nonce = "=3.0.0"
-solana-offchain-message = { version = "=3.0.0", features = ["verify"] }
-solana-packet = "=4.0.0"
+solana-message = { workspace = true }
+solana-native-token = { workspace = true }
+solana-nonce = { workspace = true }
+solana-offchain-message = { workspace = true, features = ["verify"] }
+solana-packet = { workspace = true }
 solana-program-runtime = { workspace = true }
-solana-pubkey = { version = "=4.0.0", default-features = false }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-pubsub-client = { workspace = true }
 solana-quic-client = { workspace = true }
 solana-remote-wallet = { workspace = true }
-solana-rent = "=3.0.0"
+solana-rent = { workspace = true }
 solana-rpc-client = { workspace = true, features = ["default"] }
 solana-rpc-client-api = { workspace = true }
 solana-rpc-client-nonce-utils = { workspace = true, features = ["clap"] }
 solana-sbpf = { workspace = true, features = ["jit"] }
-solana-sdk-ids = "=3.1.0"
-solana-signature = { version = "=3.2.0", default-features = false }
-solana-signer = "=3.0.0"
-solana-slot-history = "=3.0.0"
-solana-stake-interface = "=2.0.2"
-solana-system-interface = { version = "=3.0", features = ["bincode"] }
-solana-sysvar = "=3.1.1"
+solana-sdk-ids = { workspace = true }
+solana-signature = { workspace = true }
+solana-signer = { workspace = true }
+solana-slot-history = { workspace = true }
+solana-stake-interface = { workspace = true }
+solana-system-interface = { workspace = true, features = ["bincode"] }
+solana-sysvar = { workspace = true }
 solana-tps-client = { workspace = true }
 solana-tpu-client = { workspace = true, features = ["default"] }
-solana-transaction = "=3.1.0"
-solana-transaction-error = "=3.0.0"
+solana-transaction = { workspace = true }
+solana-transaction-error = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
 solana-udp-client = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
-spl-memo-interface = { version = "=2.0.0" }
+spl-memo-interface = { workspace = true }
 thiserror = { workspace = true }
 tiny-bip39 = { workspace = true }
 tokio = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -79,7 +79,7 @@ solana-nonce = { workspace = true }
 solana-offchain-message = { workspace = true, features = ["verify"] }
 solana-packet = { workspace = true }
 solana-program-runtime = { workspace = true }
-solana-pubkey = { workspace = true, features = ["rand"] }
+solana-pubkey = { workspace = true }
 solana-pubsub-client = { workspace = true }
 solana-quic-client = { workspace = true }
 solana-remote-wallet = { workspace = true }

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -35,20 +35,20 @@ serde = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-cli-output = { workspace = true }
-solana-hash = "=4.1.0"
-solana-instruction = "=3.1.0"
-solana-keypair = "=3.1.0"
-solana-message = "=3.1.0"
+solana-hash = { workspace = true }
+solana-instruction = { workspace = true }
+solana-keypair = { workspace = true }
+solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true }
-solana-packet = "=4.0.0"
-solana-pubkey = { version = "=4.0.0", features = ["rand"] }
-solana-signer = "=3.0.0"
-solana-system-interface = "=3.0"
-solana-system-transaction = "=3.0.0"
-solana-transaction = "=3.1.0"
+solana-packet = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
+solana-signer = { workspace = true }
+solana-system-interface = { workspace = true }
+solana-system-transaction = { workspace = true }
+solana-transaction = { workspace = true }
 solana-version = { workspace = true }
-spl-memo-interface = { version = "=2.0.0" }
+spl-memo-interface = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -35,34 +35,34 @@ itertools = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-solana-account = "=3.4.0"
+solana-account = { workspace = true }
 solana-bls-signatures = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
-solana-clock = "=3.0.0"
-solana-cluster-type = "=3.0.0"
-solana-commitment-config = "=3.1.0"
+solana-clock = { workspace = true }
+solana-cluster-type = { workspace = true }
+solana-commitment-config = { workspace = true }
 solana-entry = { workspace = true }
-solana-epoch-schedule = "=3.0.0"
-solana-feature-gate-interface = "=3.1.0"
-solana-fee-calculator = "=3.0.0"
-solana-genesis-config = "=3.0.0"
+solana-epoch-schedule = { workspace = true }
+solana-feature-gate-interface = { workspace = true }
+solana-fee-calculator = { workspace = true }
+solana-genesis-config = { workspace = true }
 solana-genesis-utils = { workspace = true }
-solana-inflation = "=3.0.0"
-solana-keypair = "=3.1.0"
+solana-inflation = { workspace = true }
+solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
-solana-loader-v3-interface = "6.1.0"
-solana-native-token = "=3.0.0"
-solana-poh-config = "=3.0.0"
-solana-pubkey = { version = "=4.0.0", default-features = false }
-solana-rent = "=3.0.0"
+solana-loader-v3-interface = { workspace = true }
+solana-native-token = { workspace = true }
+solana-poh-config = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-rent = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
-solana-sdk-ids = "=3.1.0"
-solana-signer = "=3.0.0"
-solana-stake-interface = { version = "=2.0.2", features = ["borsh"] }
-solana-time-utils = "3.0.0"
+solana-sdk-ids = { workspace = true }
+solana-signer = { workspace = true }
+solana-stake-interface = { workspace = true, features = ["borsh"] }
+solana-time-utils = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
#### Problem

solana-cli, solana-faucet, and solana-genesis are lib + bin crates. we pinned version for bins will also affect libs. I'm not entirely sure why we need to pin. I guess most of issues can be solved by `--locked` arg when we build or install.

#### Summary of Changes

relax