### PR TITLE
Skip storing zero lamport accounts if ancestor is zero lamport account

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -85,7 +85,7 @@ where
     )
     .collect();
     let storable_accounts: Vec<_> = pubkeys.iter().zip(accounts_data.iter()).collect();
-    accounts.store_accounts_par((slot, storable_accounts.as_slice()), None);
+    accounts.store_accounts_par((slot, storable_accounts.as_slice()), None, None);
     accounts.accounts_db.add_root_and_flush_write_cache(slot);
 
     let pubkeys = Arc::new(pubkeys);
@@ -109,7 +109,7 @@ where
         // Write to a different slot than the one being read from. Because
         // there's a new account pubkey being written to every time, will
         // compete for the accounts index lock on every store
-        accounts.store_accounts_par((slot + 1, new_storable_accounts.as_slice()), None);
+        accounts.store_accounts_par((slot + 1, new_storable_accounts.as_slice()), None, None);
     });
 }
 

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -554,8 +554,14 @@ impl Accounts {
         &self,
         accounts: impl StorableAccounts<'a>,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
+        ancestors: Option<&Ancestors>,
     ) {
-        self._store_accounts(accounts, transactions, UpdateIndexThreadSelection::Inline);
+        self._store_accounts(
+            accounts,
+            transactions,
+            UpdateIndexThreadSelection::Inline,
+            ancestors,
+        );
     }
 
     /// Store `accounts` into the DB
@@ -566,11 +572,13 @@ impl Accounts {
         &self,
         accounts: impl StorableAccounts<'a>,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
+        ancestors: Option<&Ancestors>,
     ) {
         self._store_accounts(
             accounts,
             transactions,
             UpdateIndexThreadSelection::PoolWithThreshold,
+            ancestors,
         );
     }
 
@@ -584,6 +592,7 @@ impl Accounts {
         accounts: impl StorableAccounts<'a>,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
         update_index_thread_selection: UpdateIndexThreadSelection,
+        ancestors: Option<&Ancestors>,
     ) {
         let accounts_db = &self.accounts_db;
         if accounts_db.has_accounts_update_notifier() {
@@ -607,7 +616,7 @@ impl Accounts {
             }
         }
 
-        accounts_db.store_accounts_unfrozen(accounts, update_index_thread_selection);
+        accounts_db.store_accounts_unfrozen(accounts, update_index_thread_selection, ancestors);
     }
 
     /// Add a slot to root.  Root slots cannot be purged

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5618,8 +5618,8 @@ impl AccountsDb {
             cache_account_store_stats.num_duplicate_accounts_skipped,
             Ordering::Relaxed,
         );
-        self.stats.num_ancestors_zero_skipped.fetch_add(
-            cache_account_store_stats.num_ancestors_zero_skipped,
+        self.stats.num_ancestors_zero_lamport_skipped.fetch_add(
+            cache_account_store_stats.num_ancestors_zero_lamport_skipped,
             Ordering::Relaxed,
         );
         self.report_store_timings();
@@ -5771,15 +5771,15 @@ impl AccountsDb {
                 }
                 if account.is_zero_lamport() {
                     if ancestors.is_some() {
-                        if let Some(zero_lamport) = self.accounts_index.get_with_and_then(
+                        if let Some(is_zero_lamport) = self.accounts_index.get_with_and_then(
                             pubkey,
                             ancestors,
                             None,
                             true,
                             |(_, account)| account.is_zero_lamport(),
                         ) {
-                            if zero_lamport {
-                                cache_account_store_stats.num_ancestors_zero_skipped += 1;
+                            if is_zero_lamport {
+                                cache_account_store_stats.num_ancestors_zero_lamport_skipped += 1;
                                 return;
                             }
                         } else {
@@ -6070,9 +6070,9 @@ impl AccountsDb {
                     i64
                 ),
                 (
-                    "num_ancestors_zero_skipped",
+                    "num_ancestors_zero_lamport_skipped",
                     self.stats
-                        .num_ancestors_zero_skipped
+                        .num_ancestors_zero_lamport_skipped
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -189,24 +189,24 @@ mod tests {
         let account1 =
             AccountSharedData::new(account1_lamports1, 1, AccountSharedData::default().owner());
         let slot0 = 0;
-        accounts.store_accounts_seq((slot0, &[(&key1, &account1)][..]), None);
+        accounts.store_accounts_seq((slot0, &[(&key1, &account1)][..]), None, None);
 
         let key2 = solana_pubkey::new_rand();
         let account2_lamports: u64 = 200;
         let account2 =
             AccountSharedData::new(account2_lamports, 1, AccountSharedData::default().owner());
-        accounts.store_accounts_seq((slot0, &[(&key2, &account2)][..]), None);
+        accounts.store_accounts_seq((slot0, &[(&key2, &account2)][..]), None, None);
 
         let account1_lamports2 = 2;
         let slot1 = 1;
         let account1 = AccountSharedData::new(account1_lamports2, 1, account1.owner());
-        accounts.store_accounts_seq((slot1, &[(&key1, &account1)][..]), None);
+        accounts.store_accounts_seq((slot1, &[(&key1, &account1)][..]), None, None);
 
         let key3 = solana_pubkey::new_rand();
         let account3_lamports: u64 = 300;
         let account3 =
             AccountSharedData::new(account3_lamports, 1, AccountSharedData::default().owner());
-        accounts.store_accounts_seq((slot1, &[(&key3, &account3)][..]), None);
+        accounts.store_accounts_seq((slot1, &[(&key3, &account3)][..]), None, None);
 
         assert_eq!(notifier.accounts_notified.get(&key1).unwrap().len(), 2);
         assert_eq!(
@@ -258,8 +258,16 @@ mod tests {
 
         let slot_open = 6;
         let slot_close = slot_open + 1;
-        accounts.store_accounts_seq((slot_open, [(&address, &account_open)].as_slice()), None);
-        accounts.store_accounts_seq((slot_close, [(&address, &account_close)].as_slice()), None);
+        accounts.store_accounts_seq(
+            (slot_open, [(&address, &account_open)].as_slice()),
+            None,
+            None,
+        );
+        accounts.store_accounts_seq(
+            (slot_close, [(&address, &account_close)].as_slice()),
+            None,
+            None,
+        );
 
         let notifications = notifier.accounts_notified.get(&address).unwrap().clone();
         assert_eq!(notifications.len(), 2);

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -32,6 +32,7 @@ pub struct AccountsStats {
     pub num_zero_lamport_accounts_added: AtomicU64,
     pub num_ephemeral_accounts_skipped: AtomicU64,
     pub num_duplicate_accounts_skipped: AtomicU64,
+    pub num_ancestors_zero_skipped: AtomicU64,
 }
 
 #[derive(Debug, Default)]
@@ -791,4 +792,5 @@ pub struct CacheAccountStoreStats {
     pub num_accounts_stored: u64,
     pub num_ephemeral_accounts_skipped: u64,
     pub num_duplicate_accounts_skipped: u64,
+    pub num_ancestors_zero_skipped: u64,
 }

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -32,7 +32,7 @@ pub struct AccountsStats {
     pub num_zero_lamport_accounts_added: AtomicU64,
     pub num_ephemeral_accounts_skipped: AtomicU64,
     pub num_duplicate_accounts_skipped: AtomicU64,
-    pub num_ancestors_zero_skipped: AtomicU64,
+    pub num_ancestors_zero_lamport_skipped: AtomicU64,
 }
 
 #[derive(Debug, Default)]
@@ -792,5 +792,5 @@ pub struct CacheAccountStoreStats {
     pub num_accounts_stored: u64,
     pub num_ephemeral_accounts_skipped: u64,
     pub num_duplicate_accounts_skipped: u64,
-    pub num_ancestors_zero_skipped: u64,
+    pub num_ancestors_zero_lamport_skipped: u64,
 }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6738,7 +6738,7 @@ fn test_write_accounts_to_cache_scenarios(
     batch_accounts: Vec<u64>,
     expected_lamports: Option<u64>,
     expected_ephemeral_skips: u64,
-    expected_ancestors_skipped: u64,
+    expected_ancestors_skips: u64,
     expected_duplicate_skips: u64,
 ) {
     let db = AccountsDb::new_single_for_tests();
@@ -6815,10 +6815,10 @@ fn test_write_accounts_to_cache_scenarios(
 
     let ancestors_zero_lamport = db
         .stats
-        .num_ancestors_zero_skipped
+        .num_ancestors_zero_lamport_skipped
         .load(std::sync::atomic::Ordering::Relaxed);
     assert_eq!(
-        ancestors_zero_lamport, expected_ancestors_skipped,
+        ancestors_zero_lamport, expected_ancestors_skips,
         "Wrong number of ancestors zero lamport skips"
     );
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6605,6 +6605,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     accounts_db.store_accounts_unfrozen(
         (slot, [(&pubkey1, &zero_account)].as_slice()),
         UpdateIndexThreadSelection::Inline,
+        None,
     );
     assert!(!accounts_db.accounts_index.contains(&pubkey1));
     assert!(accounts_db.accounts_cache.slot_cache(slot).is_none());
@@ -6623,6 +6624,7 @@ fn test_new_zero_lamport_accounts_skipped() {
             .as_slice(),
         ),
         UpdateIndexThreadSelection::Inline,
+        None,
     );
     assert!(!accounts_db.accounts_index.contains(&pubkey1));
     assert!(!accounts_db
@@ -6648,6 +6650,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     accounts_db.store_accounts_unfrozen(
         (slot, [(&pubkey2, &zero_account)].as_slice()),
         UpdateIndexThreadSelection::Inline,
+        None,
     );
     assert!(accounts_db.accounts_index.contains(&pubkey2));
     assert!(accounts_db
@@ -6675,6 +6678,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     accounts_db.store_accounts_unfrozen(
         (slot, [(&pubkey1, &account)].as_slice()),
         UpdateIndexThreadSelection::Inline,
+        None,
     );
     assert!(accounts_db.accounts_index.contains(&pubkey1));
 
@@ -6683,6 +6687,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     accounts_db.store_accounts_unfrozen(
         (slot, [(&pubkey3, &zero_account)].as_slice()),
         UpdateIndexThreadSelection::Inline,
+        None,
     );
     accounts_db.add_root_and_flush_write_cache(slot);
 
@@ -6704,35 +6709,36 @@ enum InitialState {
     WithoutLamports,
 }
 
-#[test_case(InitialState::None, vec![0], None, 1, 0;
+#[test_case(InitialState::None, vec![0], None, 1, 0, 0;
     "store_single_zero_lamport")]
-#[test_case(InitialState::None, vec![100, 200, 300], Some(300), 0, 2;
+#[test_case(InitialState::None, vec![100, 200, 300], Some(300), 0, 0, 2;
 "store_multiple_duplicates_some_lamports")]
-#[test_case(InitialState::None, vec![11, 0, 12, 0], None, 1, 3;
+#[test_case(InitialState::None, vec![11, 0, 12, 0], None, 1, 0, 3;
     "store_mixed_accounts_ending_with_zero_lamports")]
-#[test_case(InitialState::None, vec![0, 5, 0, 10], Some(10), 0, 3;
+#[test_case(InitialState::None, vec![0, 5, 0, 10], Some(10), 0, 0, 3;
 "store_mixed_accounts_ending_with_nonzero_lamports")]
-#[test_case(InitialState::WithLamports(10), vec![0], Some(0), 0, 0;
+#[test_case(InitialState::WithLamports(10), vec![0], Some(0), 0, 0, 0;
 "overwrite_existing_account_with_zero_lamports")]
-#[test_case(InitialState::WithLamports(50), vec![101, 102, 103], Some(103), 0, 2;
+#[test_case(InitialState::WithLamports(50), vec![101, 102, 103], Some(103), 0, 0, 2;
 "overwrite_existing_account_with_duplicate_some_lamports")]
-#[test_case(InitialState::WithLamports(50), vec![0, 5, 0, 10], Some(10), 0, 3;
+#[test_case(InitialState::WithLamports(50), vec![0, 5, 0, 10], Some(10), 0, 0, 3;
 "overwrite_existing_account_mixed_ending_some_lamports")]
-#[test_case(InitialState::WithLamports(50), vec![11, 0, 12, 0], Some(0), 0, 3;
+#[test_case(InitialState::WithLamports(50), vec![11, 0, 12, 0], Some(0), 0, 0, 3;
 "overwrite_existing_account_mixed_ending_zero_lamports")]
-#[test_case(InitialState::WithoutLamports, vec![0], Some(0), 0, 0;
+#[test_case(InitialState::WithoutLamports, vec![0], Some(0), 0, 1, 0;
 "overwrite_zero_lamport_account_with_zero_lamports")]
-#[test_case(InitialState::WithoutLamports, vec![5], Some(5), 0, 0;
+#[test_case(InitialState::WithoutLamports, vec![5], Some(5), 0, 0, 0;
 "overwrite_zero_lamport_account_with_some_lamports")]
-#[test_case(InitialState::WithoutLamports, vec![0, 10, 0, 15], Some(15), 0, 3;
+#[test_case(InitialState::WithoutLamports, vec![0, 10, 0, 15], Some(15), 0, 0, 3;
 "overwrite_zero_lamport_account_mixed_ending_some_lamports")]
-#[test_case(InitialState::WithoutLamports, vec![12, 0, 25, 0], Some(0),0, 3;
-"overwrite_zero_lamport_account__mixed_ending_zero_lamports")]
+#[test_case(InitialState::WithoutLamports, vec![12, 0, 25, 0], Some(0), 0, 1, 3;
+"overwrite_zero_lamport_account_mixed_ending_zero_lamports")]
 fn test_write_accounts_to_cache_scenarios(
     initial_state: InitialState,
     batch_accounts: Vec<u64>,
     expected_lamports: Option<u64>,
     expected_ephemeral_skips: u64,
+    expected_ancestors_skipped: u64,
     expected_duplicate_skips: u64,
 ) {
     let db = AccountsDb::new_single_for_tests();
@@ -6750,6 +6756,7 @@ fn test_write_accounts_to_cache_scenarios(
             db.store_accounts_unfrozen(
                 (slot, [(&key, &account)].as_slice()),
                 UpdateIndexThreadSelection::Inline,
+                None,
             );
         }
         InitialState::WithoutLamports => {
@@ -6759,11 +6766,13 @@ fn test_write_accounts_to_cache_scenarios(
             db.store_accounts_unfrozen(
                 (slot, [(&key, &account)].as_slice()),
                 UpdateIndexThreadSelection::Inline,
+                None,
             );
             // Overwrite with a zero-lamport account to simulate ephemeral setup
             db.store_accounts_unfrozen(
                 (slot, [(&key, &account_zero)].as_slice()),
                 UpdateIndexThreadSelection::Inline,
+                None,
             );
         }
     }
@@ -6776,7 +6785,11 @@ fn test_write_accounts_to_cache_scenarios(
         .collect();
     let batch: Vec<_> = accounts.iter().map(|account| (&key, account)).collect();
 
-    db.store_accounts_unfrozen((slot, batch.as_slice()), UpdateIndexThreadSelection::Inline);
+    db.store_accounts_unfrozen(
+        (slot, batch.as_slice()),
+        UpdateIndexThreadSelection::Inline,
+        Some(&ancestors),
+    );
 
     // Verify results
     let loaded = db.load_without_fixed_root(&ancestors, &key);
@@ -6798,6 +6811,15 @@ fn test_write_accounts_to_cache_scenarios(
     assert_eq!(
         ephemeral, expected_ephemeral_skips,
         "Wrong number of ephemeral skips"
+    );
+
+    let ancestors_zero_lamport = db
+        .stats
+        .num_ancestors_zero_skipped
+        .load(std::sync::atomic::Ordering::Relaxed);
+    assert_eq!(
+        ancestors_zero_lamport, expected_ancestors_skipped,
+        "Wrong number of ancestors zero lamport skips"
     );
 
     let duplicates = db

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3730,9 +3730,11 @@ impl Bank {
             self.update_bank_hash_stats(&to_store);
             // See https://github.com/solana-labs/solana/pull/31455 for discussion
             // on *not* updating the index within a threadpool.
-            self.rc
-                .accounts
-                .store_accounts_seq(to_store, transactions.as_deref());
+            self.rc.accounts.store_accounts_seq(
+                to_store,
+                transactions.as_deref(),
+                Some(&self.ancestors),
+            );
         });
 
         // Cached vote and stake accounts are synchronized with accounts-db
@@ -4112,7 +4114,9 @@ impl Bank {
             })
         });
         self.update_bank_hash_stats(&accounts);
-        self.rc.accounts.store_accounts_par(accounts, None);
+        self.rc
+            .accounts
+            .store_accounts_par(accounts, None, Some(&self.ancestors));
         m.stop();
         self.rc
             .accounts

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8937,6 +8937,10 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
     bank2
         .transfer(amount, &mint_keypair, &key3.pubkey())
         .unwrap();
+    // Store accounts with lamports to populate the index
+    bank2.store_account(&key5.pubkey(), &AccountSharedData::new(1, 0, &owner));
+
+    // Then set the accounts to zero lamports
     bank2.store_account(&key5.pubkey(), &AccountSharedData::new(0, 0, &owner));
 
     bank2.freeze(); // the freeze here is not strictly necessary, but more for illustration

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -213,7 +213,7 @@ mod serde_snapshot_tests {
             .collect();
         for (i, pubkey) in pubkeys.iter().enumerate() {
             let account = AccountSharedData::new(i as u64 + 1, 0, &Pubkey::default());
-            accounts.store_accounts_seq((slot, [(pubkey, &account)].as_slice()), None);
+            accounts.store_accounts_seq((slot, [(pubkey, &account)].as_slice()), None, None);
         }
         check_accounts_local(&accounts, &pubkeys, 100);
         accounts.accounts_db.add_root_and_flush_write_cache(slot);


### PR DESCRIPTION
#### Problem
Many zero lamports accounts are present in the snapshot already, which will cause the recently added ephemeral check to fail, resulting in storage of the account. If the most recent ancestor is zero lamports, then account saves can be skipped.

The other option is cleaning them during snapshot save/restore but that solution is more complex. 

#### Summary of Changes
- Add in ancestors when saving to cache
- If most recent ancestor is zero lamport, and this store is zero lamport then the store is not needed. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
