### PR TITLE
vote_storage: use the correct epoch to filter authorized voter

### DIFF
--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -83,6 +83,7 @@ impl VoteStorage {
             .map(|pubkey| (*pubkey, (1u64, VoteAccount::new_random())))
             .collect();
         let epoch_stakes = VersionedEpochStakes::new_for_tests(vote_accounts, 0);
+        // Authorized voters don't change in tests so it's fine to use the authorized voters from the "wrong" epoch
         let epoch_authorized_voters = epoch_stakes.epoch_authorized_voters().clone();
 
         Self {
@@ -194,6 +195,8 @@ impl VoteStorage {
             self.cached_epoch_authorized_voters = bank
                 .epoch_stakes(bank.epoch())
                 .map(|stakes| stakes.epoch_authorized_voters().clone())
+                // Should be fine to expect as the current epoch must exist in epoch_stakes,
+                // will cleanup in a follow up
                 .unwrap_or_else(|| current_epoch_stakes.epoch_authorized_voters().clone());
             self.cached_epoch_stakes = current_epoch_stakes;
             self.current_epoch = bank.epoch();

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -9,9 +9,12 @@ use {
     solana_account::from_account,
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
-    solana_runtime::{bank::Bank, epoch_stakes::VersionedEpochStakes},
+    solana_runtime::{
+        bank::Bank,
+        epoch_stakes::{EpochAuthorizedVoters, VersionedEpochStakes},
+    },
     solana_sysvar::{self as sysvar, slot_hashes::SlotHashes},
-    std::cmp,
+    std::{cmp, sync::Arc},
 };
 
 /// Maximum number of votes a single receive call will accept
@@ -42,16 +45,28 @@ pub struct VoteStorage {
     latest_vote_per_vote_pubkey: HashMap<Pubkey, LatestValidatorVote>,
     num_unprocessed_votes: usize,
     cached_epoch_stakes: VersionedEpochStakes,
+    /// Authorized voters for the current epoch. This is separate from
+    /// cached_epoch_stakes because stakes are offset by one epoch (we use
+    /// epoch E + 1 for stake in epoch E), but authorized voters must
+    /// match the epoch of the bank slot
+    cached_epoch_authorized_voters: Arc<EpochAuthorizedVoters>,
     deprecate_legacy_vote_ixs: bool,
     current_epoch: Epoch,
 }
 
 impl VoteStorage {
     pub fn new(bank: &Bank) -> Self {
+        let cached_epoch_stakes = bank.current_epoch_stakes().clone();
+        let cached_epoch_authorized_voters = bank
+            .epoch_stakes(bank.epoch())
+            .expect("Current epoch stakes must exist")
+            .epoch_authorized_voters()
+            .clone();
         Self {
             latest_vote_per_vote_pubkey: HashMap::default(),
             num_unprocessed_votes: 0,
-            cached_epoch_stakes: bank.current_epoch_stakes().clone(),
+            cached_epoch_stakes,
+            cached_epoch_authorized_voters,
             current_epoch: bank.epoch(),
             deprecate_legacy_vote_ixs: bank
                 .feature_set
@@ -68,11 +83,13 @@ impl VoteStorage {
             .map(|pubkey| (*pubkey, (1u64, VoteAccount::new_random())))
             .collect();
         let epoch_stakes = VersionedEpochStakes::new_for_tests(vote_accounts, 0);
+        let epoch_authorized_voters = epoch_stakes.epoch_authorized_voters().clone();
 
         Self {
             latest_vote_per_vote_pubkey: HashMap::default(),
             num_unprocessed_votes: 0,
             cached_epoch_stakes: epoch_stakes,
+            cached_epoch_authorized_voters: epoch_authorized_voters,
             current_epoch: 0,
             deprecate_legacy_vote_ixs: true,
         }
@@ -171,7 +188,14 @@ impl VoteStorage {
             return;
         }
         {
-            self.cached_epoch_stakes = bank.current_epoch_stakes().clone();
+            // Stakes are offset by one epoch
+            let current_epoch_stakes = bank.current_epoch_stakes().clone();
+            // Authorized voters use the same epoch as the leader bank
+            self.cached_epoch_authorized_voters = bank
+                .epoch_stakes(bank.epoch())
+                .map(|stakes| stakes.epoch_authorized_voters().clone())
+                .unwrap_or_else(|| current_epoch_stakes.epoch_authorized_voters().clone());
+            self.cached_epoch_stakes = current_epoch_stakes;
             self.current_epoch = bank.epoch();
             self.deprecate_legacy_vote_ixs = bank
                 .feature_set
@@ -215,8 +239,7 @@ impl VoteStorage {
             }
 
             if self
-                .cached_epoch_stakes
-                .epoch_authorized_voters()
+                .cached_epoch_authorized_voters
                 .get(&vote.vote_pubkey())
                 .is_none_or(|authorized| authorized != &vote.authorized_voter_pubkey())
             {
@@ -350,6 +373,7 @@ pub(crate) mod tests {
         solana_epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
         solana_genesis_config::GenesisConfig,
         solana_hash::Hash,
+        solana_keypair::Keypair,
         solana_perf::packet::{BytesPacket, PacketFlags},
         solana_runtime::genesis_utils::{self, ValidatorVoteKeypairs},
         solana_signer::Signer,
@@ -357,6 +381,41 @@ pub(crate) mod tests {
         solana_vote_program::vote_state::TowerSync,
         std::sync::Arc,
     };
+
+    /// Create a VoteAccount with a specific authorized voter for the given epoch
+    fn vote_account_with_authorized_voter(
+        vote_pubkey: &Pubkey,
+        authorized_voter: &Pubkey,
+        epoch: solana_clock::Epoch,
+    ) -> solana_vote::vote_account::VoteAccount {
+        use {
+            solana_account::AccountSharedData,
+            solana_vote_program::vote_state::{VoteInit, VoteStateV4, VoteStateVersions},
+        };
+
+        let vote_init = VoteInit {
+            node_pubkey: Pubkey::new_unique(),
+            authorized_voter: *authorized_voter,
+            authorized_withdrawer: Pubkey::new_unique(),
+            commission: 0,
+        };
+        let clock = solana_clock::Clock {
+            slot: 0,
+            epoch_start_timestamp: 0,
+            epoch,
+            leader_schedule_epoch: epoch,
+            unix_timestamp: 0,
+        };
+        let vote_state = VoteStateV4::new_with_defaults(vote_pubkey, &vote_init, &clock);
+        let account = AccountSharedData::new_data(
+            1_000_000,
+            &VoteStateVersions::new_v4(vote_state),
+            &solana_sdk_ids::vote::id(),
+        )
+        .unwrap();
+
+        solana_vote::vote_account::VoteAccount::try_from(account).unwrap()
+    }
 
     pub(crate) fn packet_from_slots(
         slots: Vec<(u64, u32)>,
@@ -390,6 +449,32 @@ pub(crate) mod tests {
     ) -> LatestValidatorVote {
         let packet = packet_from_slots(slots, keypairs, timestamp);
         LatestValidatorVote::new(packet.as_ref(), vote_source, true).unwrap()
+    }
+
+    /// Create a vote packet with a custom authorized voter keypair
+    fn packet_from_slots_with_authorized_voter(
+        slots: Vec<(u64, u32)>,
+        keypairs: &ValidatorVoteKeypairs,
+        authorized_voter: &Keypair,
+        timestamp: Option<UnixTimestamp>,
+    ) -> BytesPacket {
+        let mut vote = TowerSync::from(slots);
+        vote.timestamp = timestamp;
+        let vote_tx = new_tower_sync_transaction(
+            vote,
+            Hash::new_unique(),
+            &keypairs.node_keypair,
+            &keypairs.vote_keypair,
+            authorized_voter,
+            None,
+        );
+        let mut packet = BytesPacket::from_data(None, vote_tx).unwrap();
+        packet
+            .meta_mut()
+            .flags
+            .set(PacketFlags::SIMPLE_VOTE_TX, true);
+
+        packet
     }
 
     fn to_sanitized_view(packet: BytesPacket) -> SanitizedTransactionView<SharedBytes> {
@@ -657,6 +742,161 @@ pub(crate) mod tests {
         assert_eq!(
             Some(4),
             vote_storage.get_latest_vote_slot(keypair_d.vote_keypair.pubkey())
+        );
+    }
+
+    #[test]
+    fn test_insert_batch_authorized_voter() {
+        // Test that votes are only accepted when signed by the correct authorized voter.
+        let keypair = ValidatorVoteKeypairs::new_rand();
+        let unauthorized_keypair = solana_keypair::Keypair::new();
+
+        let genesis_config =
+            genesis_utils::create_genesis_config_with_vote_accounts(100, &[&keypair], vec![200])
+                .genesis_config;
+        let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        let mut vote_storage = VoteStorage::new(&bank);
+
+        // Vote signed by the correct authorized voter (vote_keypair) should be accepted
+        let correct_vote = packet_from_slots_with_authorized_voter(
+            vec![(0, 1)],
+            &keypair,
+            &keypair.vote_keypair,
+            None,
+        );
+        vote_storage.insert_batch(
+            VoteSource::Tpu,
+            std::iter::once(to_sanitized_view(correct_vote)),
+        );
+        assert_eq!(1, vote_storage.len());
+        assert_eq!(
+            Some(0),
+            vote_storage.get_latest_vote_slot(keypair.vote_keypair.pubkey())
+        );
+
+        // Vote signed by an unauthorized keypair should be filtered out
+        let unauthorized_vote = packet_from_slots_with_authorized_voter(
+            vec![(1, 1)],
+            &keypair,
+            &unauthorized_keypair,
+            None,
+        );
+        vote_storage.insert_batch(
+            VoteSource::Tpu,
+            std::iter::once(to_sanitized_view(unauthorized_vote)),
+        );
+        // Should still be 1 (unauthorized vote was filtered)
+        assert_eq!(1, vote_storage.len());
+        // Slot should still be 0 (the authorized vote), not 1 (the unauthorized one)
+        assert_eq!(
+            Some(0),
+            vote_storage.get_latest_vote_slot(keypair.vote_keypair.pubkey())
+        );
+
+        // Update with a valid vote for a later slot - should succeed
+        let correct_vote_2 = packet_from_slots_with_authorized_voter(
+            vec![(2, 1)],
+            &keypair,
+            &keypair.vote_keypair,
+            None,
+        );
+        vote_storage.insert_batch(
+            VoteSource::Tpu,
+            std::iter::once(to_sanitized_view(correct_vote_2)),
+        );
+        assert_eq!(1, vote_storage.len());
+        assert_eq!(
+            Some(2),
+            vote_storage.get_latest_vote_slot(keypair.vote_keypair.pubkey())
+        );
+    }
+
+    /// Test that authorized voters are checked against the current epoch, not the next epoch.
+    /// This verifies that cache_epoch_boundary_info uses epoch_stakes(bank.epoch()) for
+    /// authorized voters, not current_epoch_stakes() which returns epoch E+1.
+    #[test]
+    fn test_authorized_voter_uses_current_epoch_not_next() {
+        let keypair = ValidatorVoteKeypairs::new_rand();
+        let vote_pubkey = keypair.vote_keypair.pubkey();
+
+        // Create two different authorized voters: one for epoch 1, one for epoch 2
+        let epoch1_authorized_voter_keypair = keypair.node_keypair.insecure_clone();
+        let epoch1_authorized_voter = epoch1_authorized_voter_keypair.pubkey();
+        let epoch2_authorized_voter_keypair = Keypair::new();
+        let epoch2_authorized_voter = epoch2_authorized_voter_keypair.pubkey();
+
+        // Create vote accounts with different authorized voters for different epochs
+        let vote_account_epoch1 =
+            vote_account_with_authorized_voter(&vote_pubkey, &epoch1_authorized_voter, 1);
+        let vote_account_epoch2 =
+            vote_account_with_authorized_voter(&vote_pubkey, &epoch2_authorized_voter, 2);
+
+        // Create epoch stakes for epochs 1 and 2
+        let epoch1_stakes = VersionedEpochStakes::new_for_tests(
+            [(vote_pubkey, (100, vote_account_epoch1))]
+                .into_iter()
+                .collect(),
+            1, // leader_schedule_epoch
+        );
+        let epoch2_stakes = VersionedEpochStakes::new_for_tests(
+            [(vote_pubkey, (100, vote_account_epoch2))]
+                .into_iter()
+                .collect(),
+            2, // leader_schedule_epoch
+        );
+
+        // Create a bank in epoch 1 with custom epoch stakes
+        let genesis_config =
+            genesis_utils::create_genesis_config_with_vote_accounts(100, &[&keypair], vec![200])
+                .genesis_config;
+        let bank_0 = Bank::new_for_tests(&genesis_config);
+        let mut bank = Bank::new_from_parent(
+            Arc::new(bank_0),
+            &Pubkey::new_unique(),
+            MINIMUM_SLOTS_PER_EPOCH, // This puts us in epoch 1
+        );
+        assert_eq!(bank.epoch(), 1);
+
+        // Set custom epoch stakes: epoch 1 has epoch1_authorized_voter, epoch 2 has epoch2_authorized_voter
+        bank.set_epoch_stakes_for_test(1, epoch1_stakes);
+        bank.set_epoch_stakes_for_test(2, epoch2_stakes);
+
+        let mut vote_storage = VoteStorage::new(&bank);
+
+        // Vote signed by epoch 1's authorized voter (vote_keypair) should be accepted
+        let epoch1_vote = packet_from_slots_with_authorized_voter(
+            vec![(MINIMUM_SLOTS_PER_EPOCH, 1)],
+            &keypair,
+            &epoch1_authorized_voter_keypair,
+            None,
+        );
+        vote_storage.insert_batch(
+            VoteSource::Tpu,
+            std::iter::once(to_sanitized_view(epoch1_vote)),
+        );
+        assert_eq!(
+            1,
+            vote_storage.len(),
+            "Vote with epoch 1 authorized voter should be accepted"
+        );
+
+        // Vote signed by epoch 2's authorized voter should be REJECTED
+        // If we were incorrectly using current_epoch_stakes() (epoch 2), this would be accepted
+        let wrong_epoch_vote = packet_from_slots_with_authorized_voter(
+            vec![(MINIMUM_SLOTS_PER_EPOCH + 1, 1)],
+            &keypair,
+            &epoch2_authorized_voter_keypair, // This won't match epoch 1's authorized voter
+            None,
+        );
+        vote_storage.insert_batch(
+            VoteSource::Tpu,
+            std::iter::once(to_sanitized_view(wrong_epoch_vote)),
+        );
+        // Should still be 1 - the vote with wrong authorized voter was rejected
+        assert_eq!(
+            1,
+            vote_storage.len(),
+            "Vote with wrong authorized voter should be rejected"
         );
     }
 


### PR DESCRIPTION
#### Problem
We use the `current_epoch_stakes` to cache epoch stakes. For a bank in epoch `E` this uses the epoch stakes from `E + 1`.
This is required because of how stake computation is performed.

However we also abuse `epoch_stakes` to check the authorized voter information. This information *should not* be offset by 1 epoch. Instead we need to use the authorized voters from epoch `E`.


#### Summary of Changes
Cache the authorized voters separately for use in the filter. Add tests.
