### PR TITLE
Switch from `UnsafeCell<Box<[ITEM]>>` to `Box<[UnsafeCell<ITEM>]>` in transaction context

### DIFF
--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -249,8 +249,8 @@ pub(crate) type DeconstructedTransactionAccounts =
 #[derive(Debug)]
 #[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
 pub struct TransactionAccounts {
-    shared_account_fields: UnsafeCell<Box<[AccountSharedFields]>>,
-    private_account_fields: UnsafeCell<Box<[AccountPrivateFields]>>,
+    shared_account_fields: Box<[UnsafeCell<AccountSharedFields>]>,
+    private_account_fields: Box<[UnsafeCell<AccountPrivateFields>]>,
     borrow_counters: Box<[BorrowCounter]>,
     touched_flags: Box<[Cell<bool>]>,
     resize_delta: Cell<i64>,
@@ -267,7 +267,7 @@ impl TransactionAccounts {
             .enumerate()
             .map(|(idx, item)| {
                 (
-                    AccountSharedFields {
+                    UnsafeCell::new(AccountSharedFields {
                         key: item.0,
                         owner: *item.1.owner(),
                         lamports: item.1.lamports(),
@@ -276,19 +276,22 @@ impl TransactionAccounts {
                                 .saturating_add(GUEST_REGION_SIZE.saturating_mul(idx as u64)),
                             item.1.data().len() as u64,
                         ),
-                    },
-                    AccountPrivateFields {
+                    }),
+                    UnsafeCell::new(AccountPrivateFields {
                         rent_epoch: item.1.rent_epoch(),
                         executable: item.1.executable(),
                         payload: item.1.data_clone(),
-                    },
+                    }),
                 )
             })
-            .collect::<(Vec<AccountSharedFields>, Vec<AccountPrivateFields>)>();
+            .collect::<(
+                Vec<UnsafeCell<AccountSharedFields>>,
+                Vec<UnsafeCell<AccountPrivateFields>>,
+            )>();
 
         TransactionAccounts {
-            shared_account_fields: UnsafeCell::new(shared_accounts.into_boxed_slice()),
-            private_account_fields: UnsafeCell::new(private_fields.into_boxed_slice()),
+            shared_account_fields: shared_accounts.into_boxed_slice(),
+            private_account_fields: private_fields.into_boxed_slice(),
             borrow_counters,
             touched_flags,
             resize_delta: Cell::new(0),
@@ -297,21 +300,7 @@ impl TransactionAccounts {
     }
 
     pub(crate) fn len(&self) -> usize {
-        // RUST UPGRADE NOTE
-        //
-        // Rust 1.87.0 reports a `needless_borrow` warning
-        // Rust 1.88.0 reports a `dangerous_implicit_autorefs` warning if the
-        // recommendation given from Rust 1.87.0 is applied
-        //
-        // In order to facilitate upgrading to Rust >= 1.88.0, use the 1.88.0
-        // suggestion and ignore the warning given by 1.87.0. This comment and
-        // the `#[allow(clippy::needless_borrow)]` will be removed after the
-        // Rust version has advanced
-        #[allow(clippy::needless_borrow)]
-        // SAFETY: The borrow is local to this function and is only reading length.
-        unsafe {
-            (&(*self.shared_account_fields.get())).len()
-        }
+        self.shared_account_fields.len()
     }
 
     pub fn touch(&self, index: IndexOfAccount) -> Result<(), InstructionError> {
@@ -364,22 +353,23 @@ impl TransactionAccounts {
             .ok_or(InstructionError::MissingAccount)?;
         borrow_counter.try_borrow_mut()?;
 
-        // See previous RUST UPGRADE NOTE in this file
-        #[allow(clippy::needless_borrow)]
         // SAFETY: The borrow counter guarantees this is the only mutable borrow of this account.
         // The unwrap is safe because accounts.len() == borrow_counters.len(), so the missing
         // account error should have been returned above.
         let svm_account = unsafe {
-            (&mut (*self.shared_account_fields.get()))
-                .get_mut(index as usize)
+            &mut *self
+                .shared_account_fields
+                .get(index as usize)
                 .unwrap()
+                .get()
         };
-        // See previous RUST UPGRADE NOTE in this file
-        #[allow(clippy::needless_borrow)]
+
         let private_fields = unsafe {
-            (&mut (*self.private_account_fields.get()))
-                .get_mut(index as usize)
+            &mut *self
+                .private_account_fields
+                .get(index as usize)
                 .unwrap()
+                .get()
         };
 
         let account = TransactionAccountViewMut {
@@ -400,22 +390,23 @@ impl TransactionAccounts {
             .ok_or(InstructionError::MissingAccount)?;
         borrow_counter.try_borrow()?;
 
-        // See previous RUST UPGRADE NOTE in this file
-        #[allow(clippy::needless_borrow)]
         // SAFETY: The borrow counter guarantees there are no mutable borrow of this account.
         // The unwrap is safe because accounts.len() == borrow_counters.len(), so the missing
         // account error should have been returned above.
         let svm_account = unsafe {
-            (&(*self.shared_account_fields.get()))
+            &*self
+                .shared_account_fields
                 .get(index as usize)
                 .unwrap()
+                .get()
         };
-        // See previous RUST UPGRADE NOTE in this file
-        #[allow(clippy::needless_borrow)]
+
         let private_fields = unsafe {
-            (&(*self.private_account_fields.get()))
+            &*self
+                .private_account_fields
                 .get(index as usize)
                 .unwrap()
+                .get()
         };
 
         let account = TransactionAccountView {
@@ -445,10 +436,11 @@ impl TransactionAccounts {
 
     fn deconstruct_into_keyed_account_shared_data(&mut self) -> Vec<KeyedAccountSharedData> {
         self.shared_account_fields
-            .get_mut()
-            .into_iter()
-            .zip(&mut *self.private_account_fields.get_mut())
-            .map(|(shared_fields, private_fields)| {
+            .iter_mut()
+            .zip(self.private_account_fields.iter_mut())
+            .map(|(shared_fields_cell, private_fields_cell)| {
+                let shared_fields = shared_fields_cell.get_mut();
+                let private_fields = private_fields_cell.get_mut();
                 (
                     shared_fields.key,
                     AccountSharedData::create_from_existing_shared_data(
@@ -465,10 +457,11 @@ impl TransactionAccounts {
 
     pub(crate) fn deconstruct_into_account_shared_data(&mut self) -> Vec<AccountSharedData> {
         self.shared_account_fields
-            .get_mut()
-            .into_iter()
-            .zip(&mut *self.private_account_fields.get_mut())
-            .map(|(shared_fields, private_fields)| {
+            .iter_mut()
+            .zip(self.private_account_fields.iter_mut())
+            .map(|(shared_fields_cell, private_fields_cell)| {
+                let shared_fields = shared_fields_cell.get_mut();
+                let private_fields = private_fields_cell.get_mut();
                 AccountSharedData::create_from_existing_shared_data(
                     shared_fields.lamports,
                     private_fields.payload.clone(),
@@ -490,22 +483,20 @@ impl TransactionAccounts {
     }
 
     pub(crate) fn account_key(&self, index: IndexOfAccount) -> Option<&Pubkey> {
-        // See previous RUST UPGRADE NOTE in this file
-        #[allow(clippy::needless_borrow)]
         // SAFETY: We never modify an account key, so returning a reference to it is safe.
         unsafe {
-            (&(*self.shared_account_fields.get()))
+            self.shared_account_fields
                 .get(index as usize)
-                .map(|acc| &acc.key)
+                .map(|acc| &(*acc.get()).key)
         }
     }
 
     pub(crate) fn account_keys_iter(&self) -> impl Iterator<Item = &Pubkey> {
         // SAFETY: We never modify account keys, so returning an immutable reference to them is safe.
         unsafe {
-            (*self.shared_account_fields.get())
+            self.shared_account_fields
                 .iter()
-                .map(|item| &item.key)
+                .map(|item| &(*item.get()).key)
         }
     }
 }

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -435,12 +435,14 @@ impl TransactionAccounts {
     }
 
     fn deconstruct_into_keyed_account_shared_data(&mut self) -> Vec<KeyedAccountSharedData> {
-        self.shared_account_fields
-            .iter_mut()
-            .zip(self.private_account_fields.iter_mut())
+        let shared_account_fields = std::mem::take(&mut self.shared_account_fields);
+        let private_account_fields = std::mem::take(&mut self.private_account_fields);
+        shared_account_fields
+            .into_iter()
+            .zip(private_account_fields)
             .map(|(shared_fields_cell, private_fields_cell)| {
-                let shared_fields = shared_fields_cell.get_mut();
-                let private_fields = private_fields_cell.get_mut();
+                let shared_fields = shared_fields_cell.into_inner();
+                let private_fields = private_fields_cell.into_inner();
                 (
                     shared_fields.key,
                     AccountSharedData::create_from_existing_shared_data(
@@ -456,12 +458,14 @@ impl TransactionAccounts {
     }
 
     pub(crate) fn deconstruct_into_account_shared_data(&mut self) -> Vec<AccountSharedData> {
-        self.shared_account_fields
-            .iter_mut()
-            .zip(self.private_account_fields.iter_mut())
+        let shared_account_fields = std::mem::take(&mut self.shared_account_fields);
+        let private_account_fields = std::mem::take(&mut self.private_account_fields);
+        shared_account_fields
+            .into_iter()
+            .zip(private_account_fields)
             .map(|(shared_fields_cell, private_fields_cell)| {
-                let shared_fields = shared_fields_cell.get_mut();
-                let private_fields = private_fields_cell.get_mut();
+                let shared_fields = shared_fields_cell.into_inner();
+                let private_fields = private_fields_cell.into_inner();
                 AccountSharedData::create_from_existing_shared_data(
                     shared_fields.lamports,
                     private_fields.payload.clone(),


### PR DESCRIPTION
#### Problem

Borrowing `shared_account_fields` and `private_account_fields` multiple time is undefined behavior, since we call `.get` for the same data structure.

Cargo miri points the usage as undefined behavior.

This problem was found by @jamie-osec from OtterSec.

#### Summary of Changes

Switch from `UnsafeCell<Box<[ITEM]>>` to `Box<[UnsafeCell<ITEM>]>` 
