### PR TITLE
v3.0: ignore RUSTSEC-2026-0009

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -78,6 +78,16 @@ cargo_audit_ignores=(
 	# URL:       https://github.com/advisories/GHSA-434x-w66g-qw3r
 	# Solution:  Upgrade to >=1.11.1
 	--ignore RUSTSEC-2026-0007
+
+	# Crate:     time
+	# Version:   0.3.9
+	# Title:     Denial of Service via Stack Exhaustion
+	# Date:      2026-02-05
+	# ID:        RUSTSEC-2026-0009
+	# URL:       https://rustsec.org/advisories/RUSTSEC-2026-0009
+	# Severity:  6.8 (medium)
+	# Solution:  Upgrade to >=0.3.47
+	--ignore RUSTSEC-2026-0009
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s

--- a/clippy.toml
+++ b/clippy.toml
@@ -8,6 +8,12 @@ disallowed-methods = [
     { path = "bytes::BytesMut::reserve", reason = "Branch is ignoring https://rustsec.org/advisories/RUSTSEC-2026-0007.html" },
     { path = "bytes::BytesMut::put_bytes", reason = "Branch is ignoring https://rustsec.org/advisories/RUSTSEC-2026-0007.html" },
     { path = "bytes::BytesMut::resize", reason = "Branch is ignoring https://rustsec.org/advisories/RUSTSEC-2026-0007.html" },
+    { path = "time::Date::parse", reason = "Branch is ignoring https://rustsec.org/advisories/RUSTSEC-2026-0009" },
+    { path = "time::OffsetDateTime::parse", reason = "Branch is ignoring https://rustsec.org/advisories/RUSTSEC-2026-0009" },
+    { path = "time::PrimitiveDateTime::parse", reason = "Branch is ignoring https://rustsec.org/advisories/RUSTSEC-2026-0009" },
+    { path = "time::Time::parse", reason = "Branch is ignoring https://rustsec.org/advisories/RUSTSEC-2026-0009" },
+    { path = "time::UtcOffset::parse", reason = "Branch is ignoring https://rustsec.org/advisories/RUSTSEC-2026-0009" },
+    { path = "time::parsing::Parsed::parse_item", reason = "Branch is ignoring https://rustsec.org/advisories/RUSTSEC-2026-0009" },
 ]
 
 disallowed-macros = [


### PR DESCRIPTION
#### Problem
[RUSTSEC-2026-0009](https://rustsec.org/advisories/RUSTSEC-2026-0009)

#### Summary of Changes
we don't use the `time` crate directly. any datetime string parsing we _do_ do is iso8601/rfc3339. i checked the five transitive deps that use it and none of them appear to expect rfc2822 timestamps, nor use this crate for parsing