### PR TITLE
svm: add metrics feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -471,7 +471,7 @@ solana-ledger = { path = "ledger", version = "=4.0.0-alpha.0", features = ["agav
 solana-loader-v2-interface = "3.0.0"
 solana-loader-v3-interface = "6.1.0"
 solana-loader-v4-interface = "3.1.0"
-solana-loader-v4-program = { path = "programs/loader-v4", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
+solana-loader-v4-program = { path = "programs/loader-v4", version = "=4.0.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-local-cluster = { path = "local-cluster", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-measure = { path = "measure", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-merkle-tree = { path = "merkle-tree", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -152,7 +152,7 @@ solana-signer = { workspace = true }
 solana-slot-hashes = { workspace = true }
 solana-slot-history = { workspace = true }
 solana-streamer = { workspace = true }
-solana-svm = { workspace = true }
+solana-svm = { workspace = true, features = ["metrics"] }
 solana-svm-timings = { workspace = true }
 solana-svm-transaction = { workspace = true }
 solana-system-interface = { workspace = true }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -107,7 +107,7 @@ solana-stake-interface = { workspace = true }
 solana-storage-bigtable = { workspace = true }
 solana-storage-proto = { workspace = true }
 solana-streamer = { workspace = true }
-solana-svm = { workspace = true }
+solana-svm = { workspace = true, features = ["metrics"] }
 solana-svm-timings = { workspace = true }
 solana-svm-transaction = { workspace = true }
 solana-system-interface = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -162,7 +162,7 @@ solana-signer = { workspace = true }
 solana-slot-hashes = { workspace = true }
 solana-slot-history = { workspace = true }
 solana-stake-interface = { workspace = true }
-solana-svm = { workspace = true }
+solana-svm = { workspace = true, features = ["metrics"] }
 solana-svm-callback = { workspace = true }
 solana-svm-timings = { workspace = true }
 solana-svm-transaction = { workspace = true }

--- a/svm-test-harness/instr/Cargo.toml
+++ b/svm-test-harness/instr/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 [features]
 agave-unstable-api = []
 dummy-for-ci-check = ["fuzz"]
+metrics = ["solana-program-runtime/metrics", "solana-svm/metrics"]
 fuzz = [
     "dep:agave-feature-set",
     "dep:agave-precompiles",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -17,7 +17,9 @@ crate-type = ["lib"]
 name = "solana_svm"
 
 [features]
+default = ["metrics"]
 agave-unstable-api = []
+dummy-for-ci-check = ["metrics"]
 dev-context-only-utils = [
     "dep:qualifier_attr",
     "solana-program-runtime/dev-context-only-utils",
@@ -26,6 +28,11 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-program-runtime/frozen-abi",
+]
+metrics = [
+    "solana-bpf-loader-program/metrics",
+    "solana-loader-v4-program/metrics",
+    "solana-program-runtime/metrics",
 ]
 shuttle-test = [
     "solana-bpf-loader-program/shuttle-test",
@@ -61,7 +68,7 @@ solana-nonce = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-pack = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["metrics"] }
+solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "metrics")]
+use solana_program_runtime::loaded_programs::LoadProgramMetrics;
 use {
     solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMut},
     solana_clock::Slot,
@@ -5,9 +7,8 @@ use {
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_loader_v4_interface::state::{LoaderV4State, LoaderV4Status},
     solana_program_runtime::loaded_programs::{
-        DELAY_VISIBILITY_SLOT_OFFSET, LoadProgramMetrics, ProgramCacheEntry,
-        ProgramCacheEntryOwner, ProgramCacheEntryType, ProgramRuntimeEnvironment,
-        ProgramRuntimeEnvironments,
+        DELAY_VISIBILITY_SLOT_OFFSET, ProgramCacheEntry, ProgramCacheEntryOwner,
+        ProgramCacheEntryType, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
     },
     solana_pubkey::Pubkey,
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4},
@@ -27,7 +28,7 @@ pub(crate) enum ProgramAccountLoadResult {
 }
 
 pub(crate) fn load_program_from_bytes(
-    load_program_metrics: &mut LoadProgramMetrics,
+    #[cfg(feature = "metrics")] load_program_metrics: &mut LoadProgramMetrics,
     programdata: &[u8],
     loader_key: &Pubkey,
     account_size: usize,
@@ -41,6 +42,7 @@ pub(crate) fn load_program_from_bytes(
         deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
         programdata,
         account_size,
+        #[cfg(feature = "metrics")]
         load_program_metrics,
     )
 }
@@ -104,6 +106,7 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
 /// If the account doesn't exist it returns `None`. If the account does exist, it must be a program
 /// account (belong to one of the program loaders). Returns `Some(InvalidAccountData)` if the program
 /// account is `Closed`, contains invalid data or any of the programdata accounts are invalid.
+#[cfg_attr(not(feature = "metrics"), allow(unused_variables))]
 pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     callbacks: &CB,
     environments: &ProgramRuntimeEnvironments,
@@ -111,6 +114,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     current_slot: Slot,
     execute_timings: &mut ExecuteTimings,
 ) -> Option<(Arc<ProgramCacheEntry>, Slot)> {
+    #[cfg(feature = "metrics")]
     let mut load_program_metrics = LoadProgramMetrics {
         program_id: pubkey.to_string(),
         ..LoadProgramMetrics::default()
@@ -123,6 +127,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
         ),
 
         ProgramAccountLoadResult::ProgramOfLoaderV1(program_account) => load_program_from_bytes(
+            #[cfg(feature = "metrics")]
             &mut load_program_metrics,
             program_account.data(),
             program_account.owner(),
@@ -133,6 +138,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
         .map_err(|_| (0, ProgramCacheEntryOwner::LoaderV1)),
 
         ProgramAccountLoadResult::ProgramOfLoaderV2(program_account) => load_program_from_bytes(
+            #[cfg(feature = "metrics")]
             &mut load_program_metrics,
             program_account.data(),
             program_account.owner(),
@@ -152,6 +158,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
             .ok_or(Box::new(InstructionError::InvalidAccountData).into())
             .and_then(|programdata| {
                 load_program_from_bytes(
+                    #[cfg(feature = "metrics")]
                     &mut load_program_metrics,
                     programdata,
                     program_account.owner(),
@@ -172,6 +179,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
                 .ok_or(Box::new(InstructionError::InvalidAccountData).into())
                 .and_then(|elf_bytes| {
                     load_program_from_bytes(
+                        #[cfg(feature = "metrics")]
                         &mut load_program_metrics,
                         elf_bytes,
                         &loader_v4::id(),
@@ -192,6 +200,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
         )
     });
 
+    #[cfg(feature = "metrics")]
     load_program_metrics.submit_datapoint(&mut execute_timings.details);
     loaded_program.update_access_slot(current_slot);
     Some((Arc::new(loaded_program), last_modification_slot))
@@ -460,6 +469,7 @@ mod tests {
     fn test_load_program_from_bytes() {
         let buffer = load_test_program();
 
+        #[cfg(feature = "metrics")]
         let mut metrics = LoadProgramMetrics::default();
         let loader = bpf_loader_upgradeable::id();
         let size = buffer.len();
@@ -467,6 +477,7 @@ mod tests {
         let environment = ProgramRuntimeEnvironment::new(BuiltinProgram::new_mock());
 
         let result = load_program_from_bytes(
+            #[cfg(feature = "metrics")]
             &mut metrics,
             &buffer,
             &loader,
@@ -575,6 +586,7 @@ mod tests {
 
         let environments = ProgramRuntimeEnvironments::default();
         let expected = load_program_from_bytes(
+            #[cfg(feature = "metrics")]
             &mut LoadProgramMetrics::default(),
             account_data.data(),
             account_data.owner(),
@@ -667,6 +679,7 @@ mod tests {
 
         let environments = ProgramRuntimeEnvironments::default();
         let expected = load_program_from_bytes(
+            #[cfg(feature = "metrics")]
             &mut LoadProgramMetrics::default(),
             account_data.data(),
             account_data.owner(),
@@ -750,6 +763,7 @@ mod tests {
 
         let environments = ProgramRuntimeEnvironments::default();
         let expected = load_program_from_bytes(
+            #[cfg(feature = "metrics")]
             &mut LoadProgramMetrics::default(),
             account_data.data(),
             account_data.owner(),

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -106,7 +106,6 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
 /// If the account doesn't exist it returns `None`. If the account does exist, it must be a program
 /// account (belong to one of the program loaders). Returns `Some(InvalidAccountData)` if the program
 /// account is `Closed`, contains invalid data or any of the programdata accounts are invalid.
-#[cfg_attr(not(feature = "metrics"), allow(unused_variables))]
 pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     callbacks: &CB,
     environments: &ProgramRuntimeEnvironments,
@@ -119,6 +118,8 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
         program_id: pubkey.to_string(),
         ..LoadProgramMetrics::default()
     };
+    #[cfg(not(feature = "metrics"))]
+    let _ = execute_timings;
 
     let (load_result, last_modification_slot) = load_program_accounts(callbacks, pubkey)?;
     let loaded_program = match load_result {


### PR DESCRIPTION
#### Problem
`solana-svm` doesn't offer an optional `metrics` feature, which somewhat defeats the purpose of offering execution-layer consumers the ability to opt out of metrics dependencies in program-runtime and the loader programs.

#### Summary of Changes
Offer a `metrics` feature on `solana-svm` to opt-out of metrics dependencies and telemetry.
