### PR TITLE
runtime: genesis_utils: remove bls key feature override take 2

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -118,8 +118,9 @@ use {
     solana_vote_program::{
         vote_instruction,
         vote_state::{
-            self, create_v4_account_with_authorized, BlockTimestamp, VoteAuthorize, VoteInit,
-            VoteStateV4, VoteStateVersions, MAX_LOCKOUT_HISTORY,
+            self, create_bls_pubkey_and_proof_of_possession, create_v4_account_with_authorized,
+            BlockTimestamp, VoteAuthorize, VoteInit, VoteStateV4, VoteStateVersions,
+            VoterWithBLSArgs, MAX_LOCKOUT_HISTORY,
         },
     },
     spl_generic_token::token,
@@ -10085,12 +10086,17 @@ fn test_rent_state_changes_sysvars() {
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     // Ensure transactions with sysvars succeed, even though sysvars appear RentPaying by balance
+    let (bls_pubkey, bls_proof_of_possession) =
+        create_bls_pubkey_and_proof_of_possession(&validator_vote_account_pubkey);
     let tx = Transaction::new_signed_with_payer(
         &[vote_instruction::authorize(
             &validator_vote_account_pubkey,
             &validator_voting_keypair.pubkey(),
             &Pubkey::new_unique(),
-            VoteAuthorize::Voter,
+            VoteAuthorize::VoterWithBLS(VoterWithBLSArgs {
+                bls_pubkey,
+                bls_proof_of_possession,
+            }),
         )],
         Some(&mint_keypair.pubkey()),
         &[&mint_keypair, &validator_voting_keypair],

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -335,9 +335,6 @@ fn do_activate_all_features<const IS_ALPENGLOW: bool>(genesis_config: &mut Genes
     // Activate all features at genesis in development mode
     for feature_id in FeatureSet::default().inactive() {
         if (IS_ALPENGLOW || *feature_id != agave_feature_set::alpenglow::id())
-            // Skip bls_pubkey_management_in_vote_account feature activation until cli change is in place
-            && *feature_id
-                != agave_feature_set::bls_pubkey_management_in_vote_account::id()
             // TODO: Remove me once SIMD-0464 is no longer hard-coded as `false` in
             // `FeatureSet::runtime_features` and omitted from `FEATURE_NAMES` in
             // agave-feature-set.
@@ -514,10 +511,6 @@ pub fn create_genesis_config_with_leader_ex(
     for feature_id in feature_set.active().keys() {
         // Skip alpenglow (existing behavior)
         if *feature_id == agave_feature_set::alpenglow::id() {
-            continue;
-        }
-        // Skip bls_pubkey_management_in_vote_account feature activation until cli change is in place
-        if *feature_id == agave_feature_set::bls_pubkey_management_in_vote_account::id() {
             continue;
         }
         // TODO: Remove me once SIMD-0464 is no longer hard-coded as `false` in


### PR DESCRIPTION
Same title, same core change as #10003, only this time we can change much less code, since we decided to split SIMD-0387 into two feature gates and *not* disable the legacy `InitializeAccount` instruction.

---

#### Problem
#9310 added support for BLS pubkey management in the Vote program, but it left
a couple of overrides with TODOs in genesis config creation, where the BLS key
feature was temporarily ignored.

#### Summary of Changes
Remove the overrides in `genesis_utils` and update any local-cluster commands and other tests around the monorepo. There are only a few spots now.

Note: Broken off of #9681.