### PR TITLE
clippy(svm): fix sort_by lint

### DIFF
--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -2189,7 +2189,7 @@ mod tests {
             .iter()
             .map(|(k, v)| (*k, v.clone()))
             .collect();
-        actual_inspected_accounts.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        actual_inspected_accounts.sort_unstable_by_key(|a| a.0);
 
         let mut expected_inspected_accounts = vec![
             // *not* key0, since it is loaded during fee payer validation
@@ -2197,7 +2197,7 @@ mod tests {
             (address2, vec![(None, true)]),
             (address3, vec![(Some(account3), false)]),
         ];
-        expected_inspected_accounts.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        expected_inspected_accounts.sort_unstable_by_key(|a| a.0);
 
         assert_eq!(actual_inspected_accounts, expected_inspected_accounts,);
     }


### PR DESCRIPTION
#### Problem
Newer Rust toolchains signal [unnecessary_sort_by](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by) patten for tuples.

#### Summary of Changes
Use `sort_by_key`
