### PR TITLE
clippy(repair): fix sort_by lints

### DIFF
--- a/core/src/repair/repair_generic_traversal.rs
+++ b/core/src/repair/repair_generic_traversal.rs
@@ -176,7 +176,7 @@ pub fn get_closest_completion(
             }
         }
     }
-    slot_dists.sort_by(|(_, d1), (_, d2)| d1.cmp(d2));
+    slot_dists.sort_by_key(|(_, d)| *d);
 
     let mut visited = HashSet::from([root_slot]);
     let mut repairs = Vec::new();


### PR DESCRIPTION
#### Problem
Newer Rust toolchains signal [unnecessary_sort_by](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by) patten for tuples.

#### Summary of Changes
Use `sort_by_key`
