### PR TITLE
chore(deps): bump wincode to 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8405,7 +8405,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "thiserror 2.0.18",
- "wincode 0.4.0",
+ "wincode 0.4.3",
 ]
 
 [[package]]
@@ -9141,7 +9141,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "trees",
- "wincode 0.4.0",
+ "wincode 0.4.3",
 ]
 
 [[package]]
@@ -11630,7 +11630,7 @@ dependencies = [
  "static_assertions",
  "test-case",
  "thiserror 2.0.18",
- "wincode 0.4.0",
+ "wincode 0.4.3",
 ]
 
 [[package]]
@@ -13517,16 +13517,16 @@ dependencies = [
 
 [[package]]
 name = "wincode"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70404f69984d4a07b1fd1baeec55f577c9fecdea55a9c7196fb32fd84f84955a"
+checksum = "6d1068d2b3145b56f47cd84e5eb99d3371bf03605bb4ee1b1efb519ff23d92f7"
 dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
  "solana-short-vec",
  "thiserror 2.0.18",
- "wincode-derive 0.4.0",
+ "wincode-derive 0.4.1",
 ]
 
 [[package]]
@@ -13543,9 +13543,9 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505f603ab2302ff300837c3c96e5b1c6e4b65a66b756e3eb07376c935ff1907"
+checksum = "0cfae870aaafeb47dd6eed6b48a945c3da75cc03ae6cbddc651bc3808526eadf"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -626,7 +626,7 @@ url = "2.5.8"
 vec_extract_if_polyfill = "0.1.0"
 wasm-bindgen = "0.2"
 winapi = "0.3.8"
-wincode = { version = "0.4.0", features = ["derive", "solana-short-vec"] }
+wincode = { version = "0.4.3", features = ["derive", "solana-short-vec"] }
 winreg = "0.55"
 x509-parser = "0.18.1"
 zstd = "0.13.3"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7155,7 +7155,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "thiserror 2.0.18",
- "wincode 0.4.0",
+ "wincode 0.4.3",
 ]
 
 [[package]]
@@ -7731,7 +7731,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "trees",
- "wincode 0.4.0",
+ "wincode 0.4.3",
 ]
 
 [[package]]
@@ -9690,7 +9690,7 @@ dependencies = [
  "solana-transaction-error",
  "static_assertions",
  "thiserror 2.0.18",
- "wincode 0.4.0",
+ "wincode 0.4.3",
 ]
 
 [[package]]
@@ -11481,16 +11481,16 @@ dependencies = [
 
 [[package]]
 name = "wincode"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70404f69984d4a07b1fd1baeec55f577c9fecdea55a9c7196fb32fd84f84955a"
+checksum = "6d1068d2b3145b56f47cd84e5eb99d3371bf03605bb4ee1b1efb519ff23d92f7"
 dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
  "solana-short-vec",
  "thiserror 2.0.18",
- "wincode-derive 0.4.0",
+ "wincode-derive 0.4.1",
 ]
 
 [[package]]
@@ -11507,9 +11507,9 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505f603ab2302ff300837c3c96e5b1c6e4b65a66b756e3eb07376c935ff1907"
+checksum = "0cfae870aaafeb47dd6eed6b48a945c3da75cc03ae6cbddc651bc3808526eadf"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/entry/src/wincode.rs
+++ b/entry/src/wincode.rs
@@ -14,12 +14,12 @@ use {
         error::invalid_tag_encoding,
         io::{Reader, Writer},
         len::ShortU16,
-        ReadResult, SchemaRead, SchemaWrite, WriteResult,
+        ReadResult, SchemaRead, SchemaWrite, UninitBuilder, WriteResult,
     },
 };
 
-#[derive(SchemaWrite, SchemaRead)]
-#[wincode(from = "solana_message::MessageHeader", struct_extensions)]
+#[derive(SchemaWrite, SchemaRead, UninitBuilder)]
+#[wincode(from = "solana_message::MessageHeader")]
 struct MessageHeader {
     num_required_signatures: u8,
     num_readonly_signed_accounts: u8,
@@ -34,8 +34,8 @@ struct CompiledInstruction {
     data: containers::Vec<u8, ShortU16>,
 }
 
-#[derive(SchemaWrite, SchemaRead)]
-#[wincode(from = "legacy::Message", struct_extensions)]
+#[derive(SchemaWrite, SchemaRead, UninitBuilder)]
+#[wincode(from = "legacy::Message")]
 struct LegacyMessage {
     header: MessageHeader,
     account_keys: containers::Vec<Pod<Address>, ShortU16>,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6973,7 +6973,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "thiserror 2.0.18",
- "wincode 0.4.0",
+ "wincode 0.4.3",
 ]
 
 [[package]]
@@ -7535,7 +7535,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "trees",
- "wincode 0.4.0",
+ "wincode 0.4.3",
 ]
 
 [[package]]
@@ -10245,7 +10245,7 @@ dependencies = [
  "solana-transaction-error",
  "static_assertions",
  "thiserror 2.0.18",
- "wincode 0.4.0",
+ "wincode 0.4.3",
 ]
 
 [[package]]
@@ -12015,16 +12015,16 @@ dependencies = [
 
 [[package]]
 name = "wincode"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70404f69984d4a07b1fd1baeec55f577c9fecdea55a9c7196fb32fd84f84955a"
+checksum = "6d1068d2b3145b56f47cd84e5eb99d3371bf03605bb4ee1b1efb519ff23d92f7"
 dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
  "solana-short-vec",
  "thiserror 2.0.18",
- "wincode-derive 0.4.0",
+ "wincode-derive 0.4.1",
 ]
 
 [[package]]
@@ -12041,9 +12041,9 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505f603ab2302ff300837c3c96e5b1c6e4b65a66b756e3eb07376c935ff1907"
+checksum = "0cfae870aaafeb47dd6eed6b48a945c3da75cc03ae6cbddc651bc3808526eadf"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
#### Problem
New wincode release deprecated `struct_extensions` in favor of dedicated derive macro.

#### Summary of Changes
Bump version and update code
