### PR TITLE
cli: update create-vote-account to key on SIMD-0464 not SIMD-0387

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -328,7 +328,7 @@ pub enum CliCommand {
         authorized_withdrawer: Pubkey,
         // VoteInit (v1) args.
         commission: Option<u8>,
-        // VoteInitV2 args (SIMD-0387).
+        // VoteInitV2 args (SIMD-0464).
         use_v2_instruction: bool,
         inflation_rewards_commission_bps: Option<u16>,
         inflation_rewards_collector: Option<Pubkey>,
@@ -2308,7 +2308,7 @@ mod tests {
             }),
         });
         // Use MocksMap to queue multiple GetAccountInfo responses:
-        // 1. SIMD-0387 feature account (returns null = feature inactive)
+        // 1. SIMD-0464 feature account (returns null = feature inactive)
         // 2. Vote account
         let mut mocks = MocksMap::default();
         mocks.insert(RpcRequest::GetAccountInfo, feature_check_response);

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -338,6 +338,10 @@ fn do_activate_all_features<const IS_ALPENGLOW: bool>(genesis_config: &mut Genes
             // Skip bls_pubkey_management_in_vote_account feature activation until cli change is in place
             && *feature_id
                 != agave_feature_set::bls_pubkey_management_in_vote_account::id()
+            // TODO: Remove me once SIMD-0464 is no longer hard-coded as `false` in
+            // `FeatureSet::runtime_features` and omitted from `FEATURE_NAMES` in
+            // agave-feature-set.
+            && *feature_id != agave_feature_set::vote_account_initialize_v2::id()
         {
             activate_feature(genesis_config, *feature_id);
         }
@@ -514,6 +518,12 @@ pub fn create_genesis_config_with_leader_ex(
         }
         // Skip bls_pubkey_management_in_vote_account feature activation until cli change is in place
         if *feature_id == agave_feature_set::bls_pubkey_management_in_vote_account::id() {
+            continue;
+        }
+        // TODO: Remove me once SIMD-0464 is no longer hard-coded as `false` in
+        // `FeatureSet::runtime_features` and omitted from `FEATURE_NAMES` in
+        // agave-feature-set.
+        if *feature_id == agave_feature_set::vote_account_initialize_v2::id() {
             continue;
         }
         activate_feature(&mut genesis_config, *feature_id);

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1544,6 +1544,7 @@ mod test {
             agave_feature_set::disable_fees_sysvar::id(),
             alpenglow::id(),
             agave_feature_set::bls_pubkey_management_in_vote_account::id(),
+            agave_feature_set::vote_account_initialize_v2::id(),
         ]
         .into_iter()
         .for_each(|feature| {


### PR DESCRIPTION
#### Problem
Before SIMD-0387 was split and `InitializeAccountV2` was moved into a new SIMD ([SIMD-0464](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0464-vote-account-initialize-v2.md)), the CLI command `create-vote-account` keyed on SIMD-0387's activation status to determine which initialize instruction to use.

#### Summary of Changes
Key on SIMD-0464 instead of SIMD-0387.
