### PR TITLE
chore: Update feature description to include SIMD number

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1881,7 +1881,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         ),
         (
             last_restart_slot_sysvar::id(),
-            "enable new sysvar last_restart_slot",
+            "SIMD-0047: Enable new sysvar last_restart_slot",
         ),
         (
             reduce_stake_warmup_cooldown::id(),


### PR DESCRIPTION
#### Problem
This feature corresponds to below SIMD but text does not mention it:
https://github.com/solana-foundation/solana-improvement-documents/pull/47

#### Summary of Changes
Make the text that shows up in `solana feature status` (need `--display-all` since this was activated so long ago) to make it uniform with others. Output below for MNB:
```
HooKD5NC9QNxk25QuzCssB8ecrEzGt6eXEPBUxWp1LaR | active since epoch 653  | 282096004       | SIMD-0047: Enable new sysvar last_restart_slot
```