### PR TITLE
ABIv2: Reorder instruction trace

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -29,7 +29,7 @@ use {
     solana_svm_log_collector::{LogCollector, ic_msg},
     solana_svm_measure::measure::Measure,
     solana_svm_timings::{ExecuteDetailsTimings, ExecuteTimings},
-    solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMMessage},
+    solana_svm_transaction::svm_message::SVMMessage,
     solana_svm_type_overrides::sync::Arc,
     solana_transaction_context::{
         IndexOfAccount, MAX_ACCOUNTS_PER_TRANSACTION, instruction::InstructionContext,
@@ -454,47 +454,51 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         Ok(())
     }
 
-    /// Helper to prepare for process_instruction()/process_precompile() when the instruction is
-    /// a top level one
-    pub fn prepare_next_top_level_instruction(
+    /// Prepare the instruction trace with all the top level instructions
+    pub fn prepare_top_level_instructions(
         &mut self,
-        message: &impl SVMMessage,
-        instruction: &SVMInstruction,
-        program_account_index: IndexOfAccount,
-        data: &'ix_data [u8],
-    ) -> Result<(), InstructionError> {
-        // We reference accounts by an u8 index, so we have a total of 256 accounts.
-        let mut transaction_callee_map: Vec<u16> = vec![u16::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
+        message: &'ix_data impl SVMMessage,
+        program_indices: &[IndexOfAccount],
+    ) -> Result<(), (u8, InstructionError)> {
+        for (top_level_instruction_index, ((_, instruction), program_account_index)) in message
+            .program_instructions_iter()
+            .zip(program_indices.iter())
+            .enumerate()
+        {
+            let mut transaction_callee_map: Vec<u16> = vec![u16::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
 
-        let mut instruction_accounts: Vec<InstructionAccount> =
-            Vec::with_capacity(instruction.accounts.len());
-        for index_in_transaction in instruction.accounts.iter() {
-            debug_assert!((*index_in_transaction as usize) < transaction_callee_map.len());
+            let mut instruction_accounts: Vec<InstructionAccount> =
+                Vec::with_capacity(instruction.accounts.len());
+            for index_in_transaction in instruction.accounts.iter() {
+                debug_assert!((*index_in_transaction as usize) < transaction_callee_map.len());
 
-            let index_in_callee = transaction_callee_map
-                .get_mut(*index_in_transaction as usize)
-                .unwrap();
+                let index_in_callee = transaction_callee_map
+                    .get_mut(*index_in_transaction as usize)
+                    .unwrap();
 
-            if (*index_in_callee as usize) > instruction_accounts.len() {
-                *index_in_callee = instruction_accounts.len() as u16;
+                if (*index_in_callee as usize) > instruction_accounts.len() {
+                    *index_in_callee = instruction_accounts.len() as u16;
+                }
+
+                let index_in_transaction = *index_in_transaction as usize;
+                instruction_accounts.push(InstructionAccount::new(
+                    index_in_transaction as IndexOfAccount,
+                    message.is_signer(index_in_transaction),
+                    message.is_writable(index_in_transaction),
+                ));
             }
 
-            let index_in_transaction = *index_in_transaction as usize;
-            instruction_accounts.push(InstructionAccount::new(
-                index_in_transaction as IndexOfAccount,
-                message.is_signer(index_in_transaction),
-                message.is_writable(index_in_transaction),
-            ));
+            self.transaction_context
+                .configure_instruction_at_index(
+                    top_level_instruction_index,
+                    *program_account_index,
+                    instruction_accounts,
+                    transaction_callee_map,
+                    Cow::Borrowed(instruction.data),
+                    None,
+                )
+                .map_err(|err| (top_level_instruction_index as u8, err))?;
         }
-
-        self.transaction_context.configure_instruction_at_index(
-            self.transaction_context.get_instruction_trace_length(),
-            program_account_index,
-            instruction_accounts,
-            transaction_callee_map,
-            Cow::Borrowed(data),
-            None,
-        )?;
         Ok(())
     }
 
@@ -1257,27 +1261,27 @@ mod tests {
         );
 
         // To be uncommented when we reorder the trace
-        // transaction_context
-        //     .configure_instruction_at_index(
-        //         0,
-        //         0,
-        //         vec![InstructionAccount::new(0, false, false)],
-        //         vec![u16::MAX; 256],
-        //         Cow::Owned(Vec::new()),
-        //         None,
-        //     )
-        //     .unwrap();
-        //
-        // transaction_context
-        //     .configure_instruction_at_index(
-        //         1,
-        //         0,
-        //         vec![InstructionAccount::new(0, false, false)],
-        //         vec![u16::MAX; 256],
-        //         Cow::Owned(Vec::new()),
-        //         None,
-        //     )
-        //     .unwrap();
+        transaction_context
+            .configure_instruction_at_index(
+                0,
+                0,
+                vec![InstructionAccount::new(0, false, false)],
+                vec![u16::MAX; 256],
+                Cow::Owned(Vec::new()),
+                None,
+            )
+            .unwrap();
+
+        transaction_context
+            .configure_instruction_at_index(
+                1,
+                0,
+                vec![InstructionAccount::new(0, false, false)],
+                vec![u16::MAX; 256],
+                Cow::Owned(Vec::new()),
+                None,
+            )
+            .unwrap();
 
         for _ in 0..MAX_INSTRUCTIONS {
             transaction_context.push().unwrap();
@@ -1613,30 +1617,14 @@ mod tests {
             }
         }
 
-        let svm_instruction =
-            SVMInstruction::from(sanitized.message().instructions().first().unwrap());
         invoke_context
-            .prepare_next_top_level_instruction(
-                &sanitized,
-                &svm_instruction,
-                90,
-                svm_instruction.data,
-            )
+            .prepare_top_level_instructions(&sanitized, &[90, 90])
             .unwrap();
 
         test_case_1(&invoke_context);
 
         invoke_context.transaction_context.push().unwrap();
-        let svm_instruction =
-            SVMInstruction::from(sanitized.message().instructions().get(1).unwrap());
-        invoke_context
-            .prepare_next_top_level_instruction(
-                &sanitized,
-                &svm_instruction,
-                90,
-                svm_instruction.data,
-            )
-            .unwrap();
+        invoke_context.transaction_context.pop().unwrap();
 
         test_case_2(&invoke_context);
 
@@ -1695,16 +1683,9 @@ mod tests {
         let sanitized =
             SanitizedTransaction::try_from_legacy_transaction(transaction, &HashSet::new())
                 .unwrap();
-        let svm_instruction =
-            SVMInstruction::from(sanitized.message().instructions().first().unwrap());
 
         invoke_context
-            .prepare_next_top_level_instruction(
-                &sanitized,
-                &svm_instruction,
-                90,
-                svm_instruction.data,
-            )
+            .prepare_top_level_instructions(&sanitized, &[90, 90])
             .unwrap();
 
         {

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1260,7 +1260,6 @@ mod tests {
             2,
         );
 
-        // To be uncommented when we reorder the trace
         transaction_context
             .configure_instruction_at_index(
                 0,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -470,11 +470,9 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             let mut instruction_accounts: Vec<InstructionAccount> =
                 Vec::with_capacity(instruction.accounts.len());
             for index_in_transaction in instruction.accounts.iter() {
-                debug_assert!((*index_in_transaction as usize) < transaction_callee_map.len());
-
                 let index_in_callee = transaction_callee_map
                     .get_mut(*index_in_transaction as usize)
-                    .unwrap();
+                    .expect("Invalid index in transaction");
 
                 if (*index_in_callee as usize) > instruction_accounts.len() {
                     *index_in_callee = instruction_accounts.len() as u16;

--- a/svm-test-harness/instr/src/harness.rs
+++ b/svm-test-harness/instr/src/harness.rs
@@ -17,7 +17,7 @@ use {
     solana_svm_callback::InvokeContextCallback,
     solana_svm_log_collector::LogCollector,
     solana_svm_timings::ExecuteTimings,
-    solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMStaticMessage},
+    solana_svm_transaction::svm_message::SVMStaticMessage,
     solana_transaction_context::transaction::TransactionContext,
     std::{collections::HashSet, rc::Rc, sync::Arc},
 };
@@ -148,16 +148,10 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
         );
 
         let compiled_ix = sanitized_message.instructions().first()?;
-        let svm_instruction = SVMInstruction::from(compiled_ix);
         let program_account_index = compiled_ix.program_id_index as u16;
 
         invoke_context
-            .prepare_next_top_level_instruction(
-                &sanitized_message,
-                &svm_instruction,
-                program_account_index,
-                svm_instruction.data,
-            )
+            .prepare_top_level_instructions(&sanitized_message, &[program_account_index])
             .ok()?;
 
         if invoke_context.is_precompile(&input.instruction.program_id) {

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -733,7 +733,7 @@ mod tests {
             ))
         );
         assert_eq!(
-            transaction_context.number_of_active_instructions_in_trace(),
+            transaction_context.number_of_called_instructions_in_trace(),
             4
         );
     }

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -20,22 +20,14 @@ pub(crate) fn process_message<'ix_data>(
     accumulated_consumed_units: &mut u64,
 ) -> Result<(), TransactionError> {
     debug_assert_eq!(program_indices.len(), message.num_instructions());
-    for (top_level_instruction_index, ((program_id, instruction), program_account_index)) in message
-        .program_instructions_iter()
-        .zip(program_indices.iter())
-        .enumerate()
-    {
-        invoke_context
-            .prepare_next_top_level_instruction(
-                message,
-                &instruction,
-                *program_account_index,
-                instruction.data,
-            )
-            .map_err(|err| {
-                TransactionError::InstructionError(top_level_instruction_index as u8, err)
-            })?;
 
+    invoke_context
+        .prepare_top_level_instructions(message, program_indices)
+        .map_err(|(ix_idx, err)| TransactionError::InstructionError(ix_idx, err))?;
+
+    for (top_level_instruction_index, (program_id, instruction)) in
+        message.program_instructions_iter().enumerate()
+    {
         let mut compute_units_consumed = 0;
         let (result, process_instruction_us) = measure_us!({
             if invoke_context.is_precompile(program_id) {
@@ -740,6 +732,9 @@ mod tests {
                 InstructionError::Custom(0xbabb1e)
             ))
         );
-        assert_eq!(transaction_context.get_instruction_trace_length(), 4);
+        assert_eq!(
+            transaction_context.number_of_active_instructions_in_trace(),
+            4
+        );
     }
 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1100,17 +1100,51 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     .unwrap_or(true)
             );
 
+            let top_level_ixs_num = transaction_context
+                .get_instruction_trace_length()
+                .saturating_sub(transaction_context.number_of_cpis_in_trace());
+            // This vector is a map between CPI number in trace (not counting top level
+            // instructions) and the top level caller index.
+            // This mapping assumes that the caller instruction is always placed before the callee
+            // instruction in the trace.
+            let mut parent_positions: Vec<usize> =
+                vec![usize::MAX; transaction_context.number_of_cpis_in_trace()];
             let (ix_trace, accounts, ix_data_trace) = transaction_context.take_instruction_trace();
-            let mut outer_instructions = Vec::new();
-            for ((ix_in_trace, ix_data), ix_accounts) in ix_trace
+            let mut outer_instructions: Vec<Vec<InnerInstruction>> =
+                vec![Vec::new(); top_level_ixs_num];
+            for (cpi_num, ((ix_in_trace, ix_data), ix_accounts)) in ix_trace
                 .into_iter()
                 .zip(ix_data_trace.into_iter())
                 .zip(accounts)
+                .skip(top_level_ixs_num)
+                .enumerate()
             {
-                let stack_height = ix_in_trace.nesting_level.saturating_add(1) as usize;
-                if stack_height == TRANSACTION_LEVEL_STACK_HEIGHT {
-                    outer_instructions.push(Vec::new());
-                } else if let Some(inner_instructions) = outer_instructions.last_mut() {
+                let caller_ix = ix_in_trace.index_of_caller_instruction;
+                debug_assert_ne!(caller_ix, u16::MAX, "Instruction is not a CPI");
+
+                // If the caller index is less than the number of top level instructions,
+                // it directly represents a top level instruction index.
+                let outer_index = if (caller_ix as usize) < top_level_ixs_num {
+                    *parent_positions.get_mut(cpi_num).unwrap() = caller_ix as usize;
+                    caller_ix as usize
+                // If the above condition was false, we are dealing with a nested CPI.
+                // The caller_ix represents the CPI index in the instruction trace.
+                // To calculate its cpi_number (i.e. the index in `parent_positions)`
+                // we subtract is from the number of top level instructions.
+                } else if let Some(caller_index) = parent_positions
+                    .get((caller_ix as usize).saturating_sub(top_level_ixs_num))
+                    .copied()
+                    && caller_index != usize::MAX
+                {
+                    *parent_positions.get_mut(cpi_num).unwrap() = caller_index;
+                    caller_index
+                } else {
+                    debug_assert!(false);
+                    usize::MAX
+                };
+
+                if let Some(inner_instructions) = outer_instructions.get_mut(outer_index) {
+                    let stack_height = ix_in_trace.nesting_level.saturating_add(1);
                     let stack_height = u8::try_from(stack_height).unwrap_or(u8::MAX);
                     inner_instructions.push(InnerInstruction {
                         instruction: CompiledInstruction::new_from_raw_parts(
@@ -1216,7 +1250,7 @@ mod tests {
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         solana_transaction_context::transaction::TransactionContext,
         solana_transaction_error::TransactionError,
-        std::collections::HashMap,
+        std::{borrow::Cow, collections::HashMap},
         test_case::test_case,
     };
 
@@ -1366,25 +1400,21 @@ mod tests {
             4,
         );
 
-        // To be uncommented when we reorder the instruction trace
         // Four top level instructions
-        // for i in 0..4 {
-        //     transaction_context
-        //         .configure_instruction_at_index(
-        //             i,
-        //             0,
-        //             vec![],
-        //             vec![u16::MAX; 256],
-        //             Cow::Owned(vec![i as u8]),
-        //             None,
-        //         )
-        //         .unwrap();
-        // }
+        for i in 0..4 {
+            transaction_context
+                .configure_instruction_at_index(
+                    i,
+                    0,
+                    vec![],
+                    vec![u16::MAX; 256],
+                    Cow::Owned(vec![i as u8]),
+                    None,
+                )
+                .unwrap();
+        }
 
         // Execute ix #0
-        transaction_context
-            .configure_top_level_instruction_for_tests(0, vec![], vec![0])
-            .unwrap();
         transaction_context.push().unwrap();
         // ix #0 does a CPI
         transaction_context
@@ -1395,15 +1425,9 @@ mod tests {
         transaction_context.pop().unwrap();
         transaction_context.pop().unwrap();
         // Execute ix #1
-        transaction_context
-            .configure_top_level_instruction_for_tests(0, vec![], vec![1])
-            .unwrap();
         transaction_context.push().unwrap();
         transaction_context.pop().unwrap();
         // Execute ix #2
-        transaction_context
-            .configure_top_level_instruction_for_tests(0, vec![], vec![2])
-            .unwrap();
         transaction_context.push().unwrap();
         // ix #2 does a CPI
         transaction_context
@@ -1428,9 +1452,6 @@ mod tests {
         transaction_context.pop().unwrap();
         transaction_context.pop().unwrap();
         // Execute ix #3
-        transaction_context
-            .configure_top_level_instruction_for_tests(0, vec![], vec![3])
-            .unwrap();
         transaction_context.push().unwrap();
         // ix #3 does a CPI
         transaction_context

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1105,8 +1105,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 .saturating_sub(transaction_context.number_of_cpis_in_trace());
             // This vector is a map between CPI number in trace (not counting top level
             // instructions) and the top level caller index.
-            // This mapping assumes that the caller instruction is always placed before the callee
-            // instruction in the trace.
+            // In TransactionContext, caller instructions always precede callee instructions, so
+            // we can use it to avoid backtracking on instructions callers to
+            // find the top level instruction that started the call chain.
             let mut parent_positions: Vec<usize> =
                 vec![usize::MAX; transaction_context.number_of_cpis_in_trace()];
             let (ix_trace, accounts, ix_data_trace) = transaction_context.take_instruction_trace();
@@ -1124,6 +1125,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
                 // If the caller index is less than the number of top level instructions,
                 // it directly represents a top level instruction index.
+                // Top level instructions precede all CPIs in the instruction trace.
                 let outer_index = if (caller_ix as usize) < top_level_ixs_num {
                     *parent_positions.get_mut(cpi_num).unwrap() = caller_ix as usize;
                     caller_ix as usize
@@ -1139,6 +1141,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     *parent_positions.get_mut(cpi_num).unwrap() = caller_index;
                     caller_index
                 } else {
+                    // This case shall never happen. Program runtime always executes caller before
+                    // callees, so the if-statement can only be broken into two different cases:
+                    // 1. Top-level instructions doing a CPI
+                    // 2. A nested CPI.
                     debug_assert!(false);
                     usize::MAX
                 };

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1987,18 +1987,30 @@ declare_builtin_function!(
 
         consume_compute_meter(invoke_context, execution_cost.syscall_base_cost)?;
 
-        // Reverse iterate through the instruction trace,
-        // ignoring anything except instructions on the same level
         let stack_height = invoke_context.get_stack_height();
-        let instruction_trace_length = invoke_context
-            .transaction_context
-            .get_instruction_trace_length();
         let mut reverse_index_at_stack_height = 0;
         let mut found_instruction_context = None;
-        for index_in_trace in (0..instruction_trace_length).rev() {
+        let current_ix_caller = invoke_context.transaction_context.get_current_instruction_context()?.get_index_of_caller();
+
+        // Either we only search for top level instructions or CPIs, depending on the stack height.
+        let range = if stack_height == 1 {
+            0..invoke_context.transaction_context.next_top_level_instruction_index()
+        } else {
+            let end = invoke_context.transaction_context.get_instruction_trace_length();
+            let start = end.saturating_sub(invoke_context.transaction_context.number_of_cpis_in_trace());
+            start..end
+        };
+
+        for index_in_trace in range.rev() {
             let instruction_context = invoke_context
                 .transaction_context
                 .get_instruction_context_at_index_in_trace(index_in_trace)?;
+            // If we are searching through CPIs, sibling instructions must have the same caller
+            // but instructions from different callers are interspaced in the frame.
+            if instruction_context.get_index_of_caller() != current_ix_caller {
+                continue;
+            }
+
             if instruction_context.get_stack_height() < stack_height {
                 break;
             }
@@ -5250,17 +5262,16 @@ mod tests {
         */
 
         let top_level = [b'A', b'B', b'C'];
-        // To be uncommented when we reoder the instruction trace
-        // for (idx, ix) in top_level.iter().enumerate() {
-        //     invoke_context
-        //         .transaction_context
-        //         .configure_top_level_instruction_for_tests(
-        //             0,
-        //             vec![InstructionAccount::new(idx as u16, false, false)],
-        //             vec![*ix],
-        //         )
-        //         .unwrap();
-        // }
+        for (idx, ix) in top_level.iter().enumerate() {
+            invoke_context
+                .transaction_context
+                .configure_top_level_instruction_for_tests(
+                    0,
+                    vec![InstructionAccount::new(idx as u16, false, false)],
+                    vec![*ix],
+                )
+                .unwrap();
+        }
 
         /*
         The trace looks like this:
@@ -5269,25 +5280,9 @@ mod tests {
          */
 
         // Execute Instr A
-        invoke_context
-            .transaction_context
-            .configure_top_level_instruction_for_tests(
-                0,
-                vec![InstructionAccount::new(0, false, false)],
-                vec![*top_level.first().unwrap()],
-            )
-            .unwrap();
         invoke_context.transaction_context.push().unwrap();
         invoke_context.transaction_context.pop().unwrap();
         // Execute Instr B
-        invoke_context
-            .transaction_context
-            .configure_top_level_instruction_for_tests(
-                0,
-                vec![InstructionAccount::new(1, false, false)],
-                vec![*top_level.get(1).unwrap()],
-            )
-            .unwrap();
         invoke_context.transaction_context.push().unwrap();
         // CPI into B1
         invoke_context
@@ -5587,14 +5582,6 @@ mod tests {
         invoke_context.transaction_context.pop().unwrap();
 
         // Execute C
-        invoke_context
-            .transaction_context
-            .configure_top_level_instruction_for_tests(
-                0,
-                vec![InstructionAccount::new(2, false, false)],
-                vec![*top_level.get(2).unwrap()],
-            )
-            .unwrap();
         invoke_context.transaction_context.push().unwrap();
 
         // Invoking the syscall from B with index zero should return ix C

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -95,12 +95,20 @@ impl<'ix_data> TransactionContext<'ix_data> {
             number_of_transaction_accounts: transaction_accounts.len() as u16,
         };
 
+        // We need an extra space for the placeholder, so we avoid relocations.
+        let mut instruction_trace =
+            Vec::with_capacity(instruction_trace_capacity.saturating_add(1));
+        instruction_trace.resize_with(
+            number_of_top_level_instructions.saturating_add(1),
+            InstructionFrame::default,
+        );
+
         Self {
             accounts: Rc::new(TransactionAccounts::new(transaction_accounts)),
             instruction_stack_capacity,
             instruction_trace_capacity,
             instruction_stack: Vec::with_capacity(instruction_stack_capacity),
-            instruction_trace: vec![InstructionFrame::default()],
+            instruction_trace,
             return_data_bytes: Vec::new(),
             transaction_frame,
             next_top_level_instruction_index: 0,
@@ -249,11 +257,14 @@ impl<'ix_data> TransactionContext<'ix_data> {
     pub fn get_next_instruction_context(
         &self,
     ) -> Result<InstructionContext<'_, '_>, InstructionError> {
-        let index_in_trace = self
-            .instruction_trace
-            .len()
-            .checked_sub(1)
-            .ok_or(InstructionError::CallDepth)?;
+        let index_in_trace = if self.instruction_stack.is_empty() {
+            self.next_top_level_instruction_index
+        } else {
+            self.instruction_trace
+                .len()
+                .checked_sub(1)
+                .ok_or(InstructionError::CallDepth)?
+        };
         self.get_instruction_context_at_index_in_trace(index_in_trace)
     }
 
@@ -329,7 +340,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
         let dedup_map = Self::deduplicate_accounts_for_tests(&instruction_accounts);
 
         self.configure_instruction_at_index(
-            self.get_instruction_trace_length(),
+            self.next_top_level_instruction_index,
             program_index,
             instruction_accounts,
             dedup_map,
@@ -374,25 +385,29 @@ impl<'ix_data> TransactionContext<'ix_data> {
                 .ok_or(InstructionError::CallDepth)?;
             instruction.nesting_level = nesting_level as u16;
         }
-        let index_in_trace = self.get_instruction_trace_length();
-        if index_in_trace >= self.instruction_trace_capacity {
+
+        if self.number_of_active_instructions_in_trace() >= self.instruction_trace_capacity {
             return Err(InstructionError::MaxInstructionTraceLengthExceeded);
         }
 
-        let current_top_level_instruction = if self.instruction_stack.is_empty() {
+        let (index_in_trace, current_top_level_instruction) = if self.instruction_stack.is_empty() {
             let index = self.next_top_level_instruction_index;
             self.next_top_level_instruction_index =
                 self.next_top_level_instruction_index.saturating_add(1);
-            index
+            (index, index)
         } else {
+            let index = self.get_instruction_trace_length();
             self.transaction_frame.number_of_cpis_in_trace = self
                 .transaction_frame
                 .number_of_cpis_in_trace
                 .saturating_add(1);
-            self.next_top_level_instruction_index.saturating_sub(1)
+            self.instruction_trace.push(InstructionFrame::default());
+            (
+                index,
+                self.next_top_level_instruction_index.saturating_sub(1),
+            )
         };
 
-        self.instruction_trace.push(InstructionFrame::default());
         if nesting_level >= self.instruction_stack_capacity {
             return Err(InstructionError::CallDepth);
         }
@@ -559,7 +574,6 @@ impl<'ix_data> TransactionContext<'ix_data> {
 
     /// An active instruction is either one that has already finished execution or that is
     /// under execution (e.g. all nested CPIs are active).
-    /// For ABIv2 only.
     pub fn number_of_active_instructions_in_trace(&self) -> usize {
         self.next_top_level_instruction_index
             .saturating_add(self.transaction_frame.number_of_cpis_in_trace as usize)
@@ -847,6 +861,18 @@ mod tests {
             )
             .unwrap();
 
+        // Instruction #1
+        transaction_context
+            .configure_instruction_at_index(
+                1,
+                0,
+                vec![InstructionAccount::new(1, false, false)],
+                vec![0; MAX_ACCOUNTS_PER_TRANSACTION],
+                Vec::new().into(),
+                None,
+            )
+            .unwrap();
+
         // Executing instruction #0
         transaction_context.push().unwrap();
         assert_eq!(
@@ -854,6 +880,10 @@ mod tests {
                 .transaction_frame
                 .current_executing_instruction,
             0
+        );
+        assert_eq!(
+            transaction_context.number_of_active_instructions_in_trace(),
+            1
         );
 
         assert_eq!(
@@ -897,7 +927,7 @@ mod tests {
             transaction_context
                 .transaction_frame
                 .current_executing_instruction,
-            1,
+            2
         );
 
         assert_eq!(
@@ -936,7 +966,7 @@ mod tests {
             transaction_context
                 .transaction_frame
                 .current_executing_instruction,
-            2
+            3
         );
 
         assert_eq!(
@@ -985,7 +1015,7 @@ mod tests {
             transaction_context
                 .transaction_frame
                 .current_executing_instruction,
-            1
+            2
         );
 
         // A second nested CPI
@@ -1002,7 +1032,7 @@ mod tests {
             transaction_context
                 .transaction_frame
                 .current_executing_instruction,
-            3
+            4
         );
 
         assert_eq!(
@@ -1034,7 +1064,7 @@ mod tests {
             transaction_context
                 .transaction_frame
                 .current_executing_instruction,
-            1
+            2
         );
 
         assert_eq!(
@@ -1091,21 +1121,12 @@ mod tests {
 
         // Let's go to Instruction #1 (top level)
         transaction_context.pop().unwrap();
-
-        // Instruction #1
-        transaction_context
-            .configure_top_level_instruction_for_tests(
-                0,
-                vec![InstructionAccount::new(1, false, false)],
-                Vec::new(),
-            )
-            .unwrap();
         transaction_context.push().unwrap();
         assert_eq!(
             transaction_context
                 .transaction_frame
                 .current_executing_instruction,
-            4,
+            1,
         );
         assert_eq!(
             transaction_context
@@ -1166,7 +1187,7 @@ mod tests {
             transaction_context
                 .transaction_frame
                 .current_executing_instruction,
-            4,
+            1,
         );
 
         transaction_context.pop().unwrap();
@@ -1192,12 +1213,6 @@ mod tests {
                 None,
             )
             .unwrap();
-        transaction_context.push().unwrap();
-        assert_eq!(
-            transaction_context.get_current_instruction_index().unwrap(),
-            0
-        );
-        transaction_context.pop().unwrap();
 
         // Second top-level instruction
         transaction_context
@@ -1213,6 +1228,15 @@ mod tests {
                 None,
             )
             .unwrap();
+
+        transaction_context.push().unwrap();
+        assert_eq!(
+            transaction_context.get_current_instruction_index().unwrap(),
+            0
+        );
+
+        transaction_context.pop().unwrap();
+
         transaction_context.push().unwrap();
         assert_eq!(
             transaction_context.get_current_instruction_index().unwrap(),


### PR DESCRIPTION
#### Problem

For ABIv2, we want to share the instruction trace with programs, so that instructions can see the entire trace since the beginning. This design is incompatible with the current implementation whereby we push a new instruction to the trace before executing it.

This PR reorders the instruction trace so that we pre-fill it with top level instructions before executing the first one, and only pushes CPIs after the last top level one.

#### Summary of Changes

In `transaction-context/src/transaction.rs`:
1. Initialize `instruction_trace` with placeholders for all top level instructions.
2. Update `fn get_next_instruction_context` to always fetch the correct next instruction.
3. `TransactionContext::push` has a new logic to determine the next instruction to execute, and when the instruction trace length was exceeded.
4. Fix tests.


In `syscalls/src/lib.rs`:
1. The algorithm in `SyscallGetProcessedSiblingInstruction` was revisited to accommodate the changes in the trace order.
2. Fix tests.

In `transaction_processor.rs`:
1. The algorithm in `deconstruct_transaction` was redesign to accommodate the changes in the trace order.
2. Fix tests.

In `invoke_context.rs`:
1. Rename `prepare_top_level_instruction` to `prepare_top_level_instructions`, since it now prepares ALL top level instructions.
2. Modify `fn push` to use the next instruction context.
3. Fix tests.

In `message_processor.rs`:
1. `fn process_message` must now prepare all top level instructions before executing them.

