### PR TITLE
Gossip: deprecate wen-restart values and don't send in PullResponse

### DIFF
--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -63,8 +63,8 @@ pub enum CrdsData {
     DuplicateShred(DuplicateShredIndex, DuplicateShred),
     SnapshotHashes(SnapshotHashes),
     ContactInfo(ContactInfo),
-    RestartLastVotedForkSlots(RestartLastVotedForkSlots),
-    RestartHeaviestFork(RestartHeaviestFork),
+    RestartLastVotedForkSlots(RestartLastVotedForkSlots), // Deprecated
+    RestartHeaviestFork(RestartHeaviestFork),             //Deprecated
 }
 
 impl Sanitize for CrdsData {
@@ -195,8 +195,8 @@ impl CrdsData {
             Self::DuplicateShred(..) => false,
             Self::SnapshotHashes(_) => false,
             Self::ContactInfo(_) => false,
-            Self::RestartLastVotedForkSlots(_) => false,
-            Self::RestartHeaviestFork(_) => false,
+            Self::RestartLastVotedForkSlots(_) => true,
+            Self::RestartHeaviestFork(_) => true,
         }
     }
 }


### PR DESCRIPTION
#### Problem
wen-restart is out of the validator: https://github.com/anza-xyz/agave/pull/10493
start deprecation and removal process of `RestartLastVotedForkSlots` and `RestartHeaviestFork`

#### Summary of Changes
deprecate these message types and do not send them in PullResponses
