### PR TITLE
rpc: Change `clientId` field to string representation

### DIFF
--- a/cli-output/src/cli_clientid.rs
+++ b/cli-output/src/cli_clientid.rs
@@ -1,16 +1,12 @@
 use {
-    serde::{Deserialize, Deserializer, Serialize, Serializer},
-    std::{fmt, str::FromStr},
+    serde::{Deserialize, Serialize},
+    std::fmt,
 };
 
-#[derive(Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
-pub struct CliClientId(Option<u16>);
+#[derive(Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Serialize, Deserialize)]
+pub struct CliClientId(Option<String>);
 
 impl CliClientId {
-    pub fn new(id: Option<u16>) -> Self {
-        Self(id)
-    }
-
     pub fn unknown() -> Self {
         Self(None)
     }
@@ -18,46 +14,15 @@ impl CliClientId {
 
 impl fmt::Display for CliClientId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
+        match &self.0 {
             Some(id) => write!(f, "{id}"),
-            None => write!(f, "unknown"),
+            None => write!(f, "Unknown"),
         }
     }
 }
 
-impl From<Option<u16>> for CliClientId {
-    fn from(id: Option<u16>) -> Self {
+impl From<Option<String>> for CliClientId {
+    fn from(id: Option<String>) -> Self {
         Self(id)
-    }
-}
-
-impl FromStr for CliClientId {
-    type Err = std::num::ParseIntError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "unknown" {
-            Ok(CliClientId(None))
-        } else {
-            Ok(CliClientId(Some(s.parse()?)))
-        }
-    }
-}
-
-impl Serialize for CliClientId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&self.to_string())
-    }
-}
-
-impl<'de> Deserialize<'de> for CliClientId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s: &str = Deserialize::deserialize(deserializer)?;
-        CliClientId::from_str(s).map_err(serde::de::Error::custom)
     }
 }

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -521,7 +521,7 @@ impl fmt::Display for CliValidators {
 
             writeln!(
                 f,
-                "{} {:<44}  {:<44}  {:>3}%  {:>14}  {:>14} {:>7} {:>8}  {:>7} {:>9} {:>22} \
+                "{} {:<44}  {:<44}  {:>3}%  {:>14}  {:>14} {:>7} {:>8}  {:>7} {:<14} {:>22} \
                  ({:.2}%)",
                 if validator.delinquent {
                     WARNING.to_string()
@@ -560,7 +560,7 @@ impl fmt::Display for CliValidators {
             0
         };
         let header = style(format!(
-            "{:padding$} {:<44}  {:<38}  {}  {}  {} {}  {}  {} {:>9} {:>22}",
+            "{:padding$} {:<44}  {:<38}  {}  {}  {} {}  {}  {} {:<14} {:>22}",
             " ",
             "Identity",
             "Vote Account",
@@ -735,8 +735,8 @@ impl fmt::Display for CliValidators {
         for (client_id, info) in self.stake_by_client_id.iter() {
             writeln!(
                 f,
-                "{:>7} - {:4} current validators ({:>5.2}%){}",
-                client_id.to_string(),
+                "{:<14} - {:4} current validators ({:>5.2}%){}",
+                client_id,
                 info.current_validators,
                 100. * info.current_active_stake as f64 / self.total_active_stake as f64,
                 if info.delinquent_validators > 0 {

--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -318,7 +318,7 @@ pub struct RpcContactInfo {
     /// Software version
     pub version: Option<String>,
     /// Client ID
-    pub client_id: Option<u16>,
+    pub client_id: Option<String>,
     /// First 4 bytes of the FeatureSet identifier
     pub feature_set: Option<u32>,
     /// Shred version

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -397,7 +397,7 @@ impl RpcSender for MockSender {
                 rpc: Some(SocketAddr::from(([10, 239, 6, 48], 8899))),
                 pubsub: Some(SocketAddr::from(([10, 239, 6, 48], 8900))),
                 version: Some("1.0.0 c375ce1f".to_string()),
-                client_id: Some(0),
+                client_id: Some("Agave".to_string()),
                 feature_set: None,
                 shred_version: None,
             }])?,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3660,7 +3660,7 @@ pub mod rpc_full {
                             (
                                 Some(version.to_string()),
                                 Some(version.feature_set),
-                                Some(version.client),
+                                Some(version.client()),
                             )
                         } else {
                             (None, None, None)
@@ -3692,7 +3692,7 @@ pub mod rpc_full {
                                 .rpc_pubsub()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             version,
-                            client_id,
+                            client_id: client_id.map(|id| format!("{id}")),
                             feature_set,
                             shred_version: Some(my_shred_version),
                         })
@@ -5192,7 +5192,7 @@ pub mod tests {
             "pubsub": format!("127.0.0.1:8900"),
             "version": format!("{version}"),
             "featureSet": version.feature_set,
-            "clientId": 3u16,
+            "clientId": "Agave",
         }, {
             "pubkey": rpc.leader_pubkey().to_string(),
             "gossip": "127.0.0.1:1235",
@@ -5208,7 +5208,7 @@ pub mod tests {
             "pubsub": format!("127.0.0.1:8900"),
             "version": format!("{version}"),
             "featureSet": version.feature_set,
-            "clientId": 3u16,
+            "clientId": "Agave",
         }]);
         assert_eq!(result, expected);
     }

--- a/version/src/client_ids.rs
+++ b/version/src/client_ids.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[derive(Debug, Eq, PartialEq)]
 pub enum ClientId {
     SolanaLabs,
@@ -10,6 +12,22 @@ pub enum ClientId {
     Sig,
     // If new variants are added, update From<u16> and TryFrom<ClientId>.
     Unknown(u16),
+}
+
+impl fmt::Display for ClientId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::SolanaLabs => write!(f, "SolanaLabs"),
+            Self::JitoLabs => write!(f, "JitoLabs"),
+            Self::Frankendancer => write!(f, "Frankendancer"),
+            Self::Agave => write!(f, "Agave"),
+            Self::AgavePaladin => write!(f, "AgavePaladin"),
+            Self::Firedancer => write!(f, "Firedancer"),
+            Self::AgaveBam => write!(f, "AgaveBam"),
+            Self::Sig => write!(f, "Sig"),
+            Self::Unknown(id) => write!(f, "Unknown({id})"),
+        }
+    }
 }
 
 impl From<u16> for ClientId {
@@ -81,5 +99,19 @@ mod test {
         for client in 8u16..=u16::MAX {
             assert_eq!(u16::try_from(ClientId::Unknown(client)), Ok(client));
         }
+    }
+
+    #[test]
+    fn test_fmt() {
+        assert_eq!(format!("{}", ClientId::SolanaLabs), "SolanaLabs");
+        assert_eq!(format!("{}", ClientId::JitoLabs), "JitoLabs");
+        assert_eq!(format!("{}", ClientId::Frankendancer), "Frankendancer");
+        assert_eq!(format!("{}", ClientId::Agave), "Agave");
+        assert_eq!(format!("{}", ClientId::AgavePaladin), "AgavePaladin");
+        assert_eq!(format!("{}", ClientId::Firedancer), "Firedancer");
+        assert_eq!(format!("{}", ClientId::AgaveBam), "AgaveBam");
+        assert_eq!(format!("{}", ClientId::Sig), "Sig");
+        assert_eq!(format!("{}", ClientId::Unknown(0)), "Unknown(0)");
+        assert_eq!(format!("{}", ClientId::Unknown(u16::MAX)), "Unknown(65535)");
     }
 }


### PR DESCRIPTION
#### Problem

The client id was added in #7817, but the returned field is a u16, which requires clients to maintain the mapping from number to string. They shouldn't need to do that work.

#### Summary of changes

Change the reported field to be a string instead. The spacing for printing the field needs to be widened to 14 characters, to accommodate `Unknown(u16::MAX)`, and the CLI field can just become a string.

I was worried about abusing `Debug` on `ClientId`, so I did the idiomatic thing and implemented `Display` on it, but let me know if you prefer to revert that.