### PR TITLE
Remove test fee overrides from transaction validation path

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -506,12 +506,16 @@ impl Consumer {
                 .compute_budget_instruction_details()
                 .sanitize_and_convert_to_compute_budget_limits(&bank.feature_set)?,
         );
-        let fee = solana_fee::calculate_fee(
-            transaction,
-            bank.fee_structure().lamports_per_signature,
-            fee_budget_limits.prioritization_fee,
-            FeeFeatures::from(bank.feature_set.as_ref()),
-        );
+        let fee = if bank.get_lamports_per_signature() == 0 {
+            0
+        } else {
+            solana_fee::calculate_fee(
+                transaction,
+                bank.fee_structure().lamports_per_signature,
+                fee_budget_limits.prioritization_fee,
+                FeeFeatures::from(bank.feature_set.as_ref()),
+            )
+        };
         let (mut fee_payer_account, _slot) = bank
             .rc
             .accounts

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -508,7 +508,6 @@ impl Consumer {
         );
         let fee = solana_fee::calculate_fee(
             transaction,
-            bank.get_lamports_per_signature() == 0,
             bank.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             FeeFeatures::from(bank.feature_set.as_ref()),

--- a/fee/src/lib.rs
+++ b/fee/src/lib.rs
@@ -27,14 +27,12 @@ impl From<&FeatureSet> for FeeFeatures {
 /// Calculate fee for `SanitizedMessage`
 pub fn calculate_fee(
     message: &impl SVMStaticMessage,
-    zero_fees_for_test: bool,
     lamports_per_signature: u64,
     prioritization_fee: u64,
     fee_features: FeeFeatures,
 ) -> u64 {
     calculate_fee_details(
         message,
-        zero_fees_for_test,
         lamports_per_signature,
         prioritization_fee,
         fee_features,
@@ -44,15 +42,10 @@ pub fn calculate_fee(
 
 pub fn calculate_fee_details(
     message: &impl SVMStaticMessage,
-    zero_fees_for_test: bool,
     lamports_per_signature: u64,
     prioritization_fee: u64,
     fee_features: FeeFeatures,
 ) -> FeeDetails {
-    if zero_fees_for_test {
-        return FeeDetails::default();
-    }
-
     FeeDetails::new(
         calculate_signature_fee(
             SignatureCounts::from(message),

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4036,12 +4036,16 @@ fn test_program_fees() {
         )
         .unwrap_or_default(),
     );
-    let expected_normal_fee = solana_fee::calculate_fee(
-        &sanitized_message,
-        fee_structure.lamports_per_signature,
-        fee_budget_limits.prioritization_fee,
-        bank.feature_set.as_ref().into(),
-    );
+    let expected_normal_fee = if congestion_multiplier == 0 {
+        0
+    } else {
+        solana_fee::calculate_fee(
+            &sanitized_message,
+            fee_structure.lamports_per_signature,
+            fee_budget_limits.prioritization_fee,
+            bank.feature_set.as_ref().into(),
+        )
+    };
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
         .unwrap();
@@ -4068,12 +4072,16 @@ fn test_program_fees() {
         )
         .unwrap_or_default(),
     );
-    let expected_prioritized_fee = solana_fee::calculate_fee(
-        &sanitized_message,
-        fee_structure.lamports_per_signature,
-        fee_budget_limits.prioritization_fee,
-        bank.feature_set.as_ref().into(),
-    );
+    let expected_prioritized_fee = if congestion_multiplier == 0 {
+        0
+    } else {
+        solana_fee::calculate_fee(
+            &sanitized_message,
+            fee_structure.lamports_per_signature,
+            fee_budget_limits.prioritization_fee,
+            bank.feature_set.as_ref().into(),
+        )
+    };
     assert!(expected_normal_fee < expected_prioritized_fee);
 
     bank_client

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4038,7 +4038,6 @@ fn test_program_fees() {
     );
     let expected_normal_fee = solana_fee::calculate_fee(
         &sanitized_message,
-        congestion_multiplier == 0,
         fee_structure.lamports_per_signature,
         fee_budget_limits.prioritization_fee,
         bank.feature_set.as_ref().into(),
@@ -4071,7 +4070,6 @@ fn test_program_fees() {
     );
     let expected_prioritized_fee = solana_fee::calculate_fee(
         &sanitized_message,
-        congestion_multiplier == 0,
         fee_structure.lamports_per_signature,
         fee_budget_limits.prioritization_fee,
         bank.feature_set.as_ref().into(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1188,14 +1188,6 @@ impl Bank {
         bank.process_genesis_config(genesis_config);
         #[cfg(feature = "dev-context-only-utils")]
         bank.process_genesis_config(genesis_config, leader_id_for_tests, genesis_hash);
-        #[cfg(feature = "dev-context-only-utils")]
-        if genesis_config
-            .fee_rate_governor
-            .target_lamports_per_signature
-            == 0
-        {
-            bank.zero_fee_structure_for_tests();
-        }
 
         bank.compute_and_apply_genesis_features();
 
@@ -1939,14 +1931,6 @@ impl Bank {
             bank_hash_stats: AtomicBankHashStats::new(&fields.bank_hash_stats),
             epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
         };
-        #[cfg(feature = "dev-context-only-utils")]
-        if genesis_config
-            .fee_rate_governor
-            .target_lamports_per_signature
-            == 0
-        {
-            bank.zero_fee_structure_for_tests();
-        }
 
         // Sanity assertions between bank snapshot and genesis config
         // Consider removing from serializable bank state
@@ -2824,8 +2808,11 @@ impl Bank {
     pub fn get_fee_for_message_with_lamports_per_signature(
         &self,
         message: &impl SVMMessage,
-        _lamports_per_signature: u64,
+        lamports_per_signature: u64,
     ) -> u64 {
+        if lamports_per_signature == 0 {
+            return 0;
+        }
         let fee_budget_limits = FeeBudgetLimits::from(
             process_compute_budget_instructions(
                 message.program_instructions_iter(),
@@ -5939,15 +5926,6 @@ impl fmt::Debug for Bank {
 
 #[cfg(feature = "dev-context-only-utils")]
 impl Bank {
-    pub fn zero_fee_structure_for_tests(&mut self) {
-        self.fee_structure.lamports_per_signature = 0;
-        self.fee_structure.lamports_per_write_lock = 0;
-        self.fee_structure
-            .compute_fee_bins
-            .iter_mut()
-            .for_each(|fee_bin| fee_bin.fee = 0);
-    }
-
     pub fn wrap_with_bank_forks_for_tests(self) -> (Arc<Self>, Arc<RwLock<BankForks>>) {
         let bank_forks = BankForks::new_rw_arc(self);
         let bank = bank_forks.read().unwrap().root_bank();

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -4,7 +4,7 @@ use {
     solana_accounts_db::blockhash_queue::BlockhashQueue,
     solana_clock::{Slot, MAX_PROCESSING_AGE, MAX_TRANSACTION_FORWARDING_DELAY},
     solana_fee::{calculate_fee_details, FeeFeatures},
-    solana_fee_structure::FeeBudgetLimits,
+    solana_fee_structure::{FeeBudgetLimits, FeeDetails},
     solana_nonce::state::{Data as NonceData, DurableNonce},
     solana_nonce_account as nonce_account,
     solana_program_runtime::execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
@@ -151,8 +151,13 @@ impl Bank {
 
     fn checked_transactions_details(
         nonce_address: Option<Pubkey>,
-        compute_budget_and_limits: SVMTransactionExecutionAndFeeBudgetLimits,
+        lamports_per_signature: u64,
+        mut compute_budget_and_limits: SVMTransactionExecutionAndFeeBudgetLimits,
     ) -> CheckedTransactionDetails {
+        if lamports_per_signature == 0 {
+            compute_budget_and_limits.fee_details = FeeDetails::default();
+        }
+
         CheckedTransactionDetails::new(nonce_address, compute_budget_and_limits)
     }
 
@@ -166,16 +171,18 @@ impl Bank {
         compute_budget: SVMTransactionExecutionAndFeeBudgetLimits,
     ) -> TransactionCheckResult {
         let recent_blockhash = tx.recent_blockhash();
-        if hash_queue
-            .get_hash_info_if_valid(recent_blockhash, max_age)
-            .is_some()
-        {
-            Ok(Self::checked_transactions_details(None, compute_budget))
-        } else if let Some((nonce_address, _previous_lamports_per_signature)) =
+        if let Some(hash_info) = hash_queue.get_hash_info_if_valid(recent_blockhash, max_age) {
+            Ok(Self::checked_transactions_details(
+                None,
+                hash_info.lamports_per_signature(),
+                compute_budget,
+            ))
+        } else if let Some((nonce_address, previous_lamports_per_signature)) =
             self.check_nonce_transaction_validity(tx, next_durable_nonce)
         {
             Ok(Self::checked_transactions_details(
                 Some(nonce_address),
+                previous_lamports_per_signature,
                 compute_budget,
             ))
         } else {

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -4,7 +4,7 @@ use {
     log::debug,
     solana_account::{ReadableAccount, WritableAccount},
     solana_fee::FeeFeatures,
-    solana_fee_structure::FeeBudgetLimits,
+    solana_fee_structure::{FeeBudgetLimits, FeeDetails},
     solana_pubkey::Pubkey,
     solana_reward_info::RewardType,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -66,14 +66,18 @@ impl Bank {
         transaction: &impl TransactionWithMeta,
         fee_budget_limits: &FeeBudgetLimits,
     ) -> u64 {
-        let (_last_hash, _last_lamports_per_signature) =
+        let (_last_hash, last_lamports_per_signature) =
             self.last_blockhash_and_lamports_per_signature();
-        let fee_details = solana_fee::calculate_fee_details(
-            transaction,
-            self.fee_structure().lamports_per_signature,
-            fee_budget_limits.prioritization_fee,
-            FeeFeatures::from(self.feature_set.as_ref()),
-        );
+        let fee_details = if last_lamports_per_signature == 0 {
+            FeeDetails::default()
+        } else {
+            solana_fee::calculate_fee_details(
+                transaction,
+                self.fee_structure().lamports_per_signature,
+                fee_budget_limits.prioritization_fee,
+                FeeFeatures::from(self.feature_set.as_ref()),
+            )
+        };
         let FeeDistribution {
             deposit: reward,
             burn: _,

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -66,11 +66,10 @@ impl Bank {
         transaction: &impl TransactionWithMeta,
         fee_budget_limits: &FeeBudgetLimits,
     ) -> u64 {
-        let (_last_hash, last_lamports_per_signature) =
+        let (_last_hash, _last_lamports_per_signature) =
             self.last_blockhash_and_lamports_per_signature();
         let fee_details = solana_fee::calculate_fee_details(
             transaction,
-            last_lamports_per_signature == 0,
             self.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             FeeFeatures::from(self.feature_set.as_ref()),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5187,8 +5187,7 @@ fn test_ref_account_key_after_program_id() {
 fn test_fuzz_instructions() {
     agave_logger::setup();
     use rand::{rng, Rng};
-    let mut bank = create_simple_test_bank(1_000_000_000);
-    bank.zero_fee_structure_for_tests();
+    let bank = create_simple_test_bank(1_000_000_000);
 
     let max_programs = 5;
     let program_keys: Vec<_> = (0..max_programs)
@@ -9473,9 +9472,12 @@ fn test_call_precomiled_program() {
 
 fn calculate_test_fee(
     message: &impl SVMMessage,
-    _lamports_per_signature: u64,
+    lamports_per_signature: u64,
     fee_structure: &FeeStructure,
 ) -> u64 {
+    if lamports_per_signature == 0 {
+        return 0;
+    }
     let fee_budget_limits = FeeBudgetLimits::from(
         process_compute_budget_instructions(
             message.program_instructions_iter(),
@@ -12596,7 +12598,6 @@ fn test_temporary_account_execute_and_commit() {
 
     let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
     let mut bank = Bank::new_for_tests(&genesis_config);
-    bank.zero_fee_structure_for_tests();
     bank.activate_feature(&feature_set::relax_intrabatch_account_locks::ID);
     let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
 
@@ -12670,7 +12671,6 @@ fn test_temporary_account_recreated_execute_and_commit() {
 
     let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
     let mut bank = Bank::new_for_tests(&genesis_config);
-    bank.zero_fee_structure_for_tests();
     bank.activate_feature(&feature_set::relax_intrabatch_account_locks::ID);
     let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1845,7 +1845,8 @@ mod tests {
             },
         };
 
-        let bank0 = Bank::new_with_config_for_tests(&genesis_config, bank_test_config);
+        let mut bank0 = Bank::new_with_config_for_tests(&genesis_config, bank_test_config);
+        bank0.zero_fee_structure_for_tests();
 
         let (bank0, bank_forks) = Bank::wrap_with_bank_forks_for_tests(bank0);
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1845,8 +1845,7 @@ mod tests {
             },
         };
 
-        let mut bank0 = Bank::new_with_config_for_tests(&genesis_config, bank_test_config);
-        bank0.zero_fee_structure_for_tests();
+        let bank0 = Bank::new_with_config_for_tests(&genesis_config, bank_test_config);
 
         let (bank0, bank_forks) = Bank::wrap_with_bank_forks_for_tests(bank0);
 


### PR DESCRIPTION
### Problem

`checked_transactions_details_with_test_override()` in `check_transactions.rs` and `calculate_fee()` in `fee/src/lib.rs`
contain overrides that zero out fees when they detect a test environment (`lamports_per_signature == 0`). This test-only logic lives in the production transaction validation path, making it harder to reason about and potentially masking fee-related bugs.

### Proposed Changes

- Remove `zero_fees_for_test` parameter from `calculate_fee()` and `calculate_fee_details()` in `fee/src/lib.rs`, along with the early-return guard that bypassed fee calculation
- Remove `lamports_per_signature` parameter from `checked_transactions_details_with_test_override()` and rename it to `checked_transactions_details()`
- Add `Bank::zero_fee_structure_for_tests()` behind `#[cfg(feature = "dev-context-only-utils")]` that zeroes out `lamports_per_signature`, `lamports_per_write_lock`, and all compute fee bins on the Bank's `FeeStructure`
- Auto-invoke the helper in Bank constructors when genesis config has `target_lamports_per_signature == 0` (covers the majority of tests)
- Explicitly call it in tests that create banks differently (`test_fuzz_instructions`, `test_temporary_account_execute_and_commit`, `test_temporary_account_recreated_execute_and_commit`, snapshot utils)
- Update `test_failed_simulation_load_error` to assert real fee values instead of assuming zero

Previously fees were zero because production code detected a test and skipped calculation. Now fees are zero because the fee structure genuinely has zero fees configured, and the calculation runs normally
(`signatures * 0 = 0`).

Fixes #9875