### PR TITLE
chore: Update feature description to include SIMD number

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1956,7 +1956,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         ),
         (
             add_new_reserved_account_keys::id(),
-            "add new unwritable reserved accounts #34899",
+            "SIMD-0105: Maintain Dynamic Set of Reserved Account Keys",
         ),
         (
             index_erasure_conflict_duplicate_proofs::id(),


### PR DESCRIPTION
#### Problem
Cleaning up feature gate tracker and noticed this one linked the Solana Labs GH issue (https://github.com/solana-labs/solana/issues/34899) whereas the new convention has been to link the SIMD

#### Summary of Changes
Update the message that for consistency; this is what shows in `solana feature status`