### PR TITLE
feat(alpenglow): enable blockstore `BlockComponent` parsing

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3591,9 +3591,7 @@ impl Blockstore {
 
         let components =
             self.get_slot_components_in_block(slot, &completed_ranges, Some(&slot_meta))?;
-
         debug_assert_eq!(completed_ranges.len(), components.len());
-
         Ok((components, completed_ranges, slot_meta.is_full()))
     }
 


### PR DESCRIPTION
#### Problem and Summary of Changes
Today, blockstore purely interprets sequences of shreds as as `Vec<Entry>`. Alpenglow requires blocks to store `BlockComponent` instead:

```
#[derive(Debug, Clone, PartialEq, Eq)]
#[allow(clippy::large_enum_variant)]
pub enum BlockComponent {
    EntryBatch(Vec<Entry>),
    BlockMarker(VersionedBlockMarker),
}
```

Described in https://github.com/anza-xyz/agave/pull/10090, we take careful measures to ensure that the serialization scheme for `BlockComponent::EntryBatch` is identical to how we currently serialize `Vec<Entry>`.

#### Summary of Changes
This PR introduces functions which allow us to reason about shreds as `BlockComponent`s.

Note: we do not introduce any logical changes to blockstore in this PR. In the near future, we'll modify blockstore processor to (1) detect whether migration has occurred, and if so, (2) interpret sequences of shreds as block components and replay accordingly.