### PR TITLE
clippy: remove superfluous clones in votor

### DIFF
--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -118,7 +118,7 @@ impl VoteAccount {
         let vote_state = VoteStateV4::new_with_defaults(&vote_pubkey, &vote_init, &clock);
         let account = AccountSharedData::new_data(
             rng.random(), // lamports
-            &VoteStateVersions::new_v4(vote_state.clone()),
+            &VoteStateVersions::new_v4(vote_state),
             &solana_sdk_ids::vote::id(), // owner
         )
         .unwrap();
@@ -485,7 +485,7 @@ mod tests {
         let vote_state = VoteStateV4::new_with_defaults(&vote_pubkey, &vote_init, &clock);
         AccountSharedData::new_data(
             rng.random(), // lamports
-            &VoteStateVersions::new_v4(vote_state.clone()),
+            &VoteStateVersions::new_v4(vote_state),
             &solana_sdk_ids::vote::id(), // owner
         )
         .unwrap()
@@ -712,7 +712,7 @@ mod tests {
         let ret = vote_accounts.insert(pubkey, vote_account2.clone(), || {
             panic!("should not be called")
         });
-        assert_eq!(ret, Some(vote_account1.clone()));
+        assert_eq!(ret, Some(vote_account1));
         assert_eq!(vote_accounts.get(&pubkey), Some(&vote_account2));
         // stake is unchanged
         assert_eq!(vote_accounts.get_delegated_stake(&pubkey), 42);
@@ -722,10 +722,8 @@ mod tests {
         let new_node_pubkey = Pubkey::new_unique();
         let account3 = new_rand_vote_account(&mut rng, Some(new_node_pubkey));
         let vote_account3 = VoteAccount::try_from(account3).unwrap();
-        let ret = vote_accounts.insert(pubkey, vote_account3.clone(), || {
-            panic!("should not be called")
-        });
-        assert_eq!(ret, Some(vote_account2.clone()));
+        let ret = vote_accounts.insert(pubkey, vote_account3, || panic!("should not be called"));
+        assert_eq!(ret, Some(vote_account2));
         assert_eq!(vote_accounts.staked_nodes().get(&node_pubkey), None);
         assert_eq!(
             vote_accounts.staked_nodes().get(&new_node_pubkey),
@@ -755,9 +753,7 @@ mod tests {
         let new_node_pubkey = Pubkey::new_unique();
         let account2 = new_rand_vote_account(&mut rng, Some(new_node_pubkey));
         let vote_account2 = VoteAccount::try_from(account2).unwrap();
-        let ret = vote_accounts.insert(pubkey, vote_account2.clone(), || {
-            panic!("should not be called")
-        });
+        let ret = vote_accounts.insert(pubkey, vote_account2, || panic!("should not be called"));
         assert_eq!(ret, Some(vote_account1));
         assert_eq!(vote_accounts.get_delegated_stake(&pubkey), 0);
         assert_eq!(vote_accounts.staked_nodes().get(&node_pubkey), None);

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -1875,7 +1875,7 @@ mod tests {
                 root_bank.epoch_stakes_map(),
                 root_bank.slot(),
                 &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_1.clone()),
+                ConsensusMessage::Certificate(cert_1),
                 &mut vec![]
             )
             .is_ok());
@@ -1890,7 +1890,7 @@ mod tests {
                 root_bank.epoch_stakes_map(),
                 root_bank.slot(),
                 &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_2.clone()),
+                ConsensusMessage::Certificate(cert_2),
                 &mut vec![]
             )
             .is_ok());
@@ -1959,7 +1959,7 @@ mod tests {
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_3.clone()),
+                ConsensusMessage::Certificate(cert_3),
                 &mut vec![]
             )
             .is_ok());
@@ -1974,7 +1974,7 @@ mod tests {
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_4.clone()),
+                ConsensusMessage::Certificate(cert_4),
                 &mut vec![]
             )
             .is_ok());
@@ -1998,7 +1998,7 @@ mod tests {
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_5.clone()),
+                ConsensusMessage::Certificate(cert_5),
                 &mut vec![]
             )
             .is_ok());
@@ -2015,7 +2015,7 @@ mod tests {
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_5_finalize.clone()),
+                ConsensusMessage::Certificate(cert_5_finalize),
                 &mut vec![]
             )
             .is_ok());
@@ -2032,7 +2032,7 @@ mod tests {
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_5.clone()),
+                ConsensusMessage::Certificate(cert_5),
                 &mut vec![]
             )
             .is_ok());
@@ -2056,7 +2056,7 @@ mod tests {
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_6.clone()),
+                ConsensusMessage::Certificate(cert_6),
                 &mut vec![]
             )
             .is_ok());
@@ -2080,7 +2080,7 @@ mod tests {
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_6_finalize.clone()),
+                ConsensusMessage::Certificate(cert_6_finalize),
                 &mut vec![]
             )
             .is_ok());
@@ -2096,7 +2096,7 @@ mod tests {
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_6_notarize_fallback.clone()),
+                ConsensusMessage::Certificate(cert_6_notarize_fallback),
                 &mut vec![]
             )
             .is_ok());
@@ -2121,7 +2121,7 @@ mod tests {
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                ConsensusMessage::Certificate(cert_7.clone()),
+                ConsensusMessage::Certificate(cert_7),
                 &mut vec![]
             )
             .is_ok());

--- a/votor/src/staked_validators_cache.rs
+++ b/votor/src/staked_validators_cache.rs
@@ -547,7 +547,7 @@ mod tests {
 
         // Create our staked validators cache - set include_self to false
         let mut svc =
-            StakedValidatorsCache::new(bank_forks.clone(), Duration::from_secs(5), 5, false, None);
+            StakedValidatorsCache::new(bank_forks, Duration::from_secs(5), 5, false, None);
 
         let (sockets, _) =
             svc.get_staked_validators_by_slot(slot_num, &cluster_info, Instant::now());
@@ -567,7 +567,7 @@ mod tests {
 
         // Create our staked validators cache - set include_self to false
         let mut svc = StakedValidatorsCache::new(
-            bank_forks.clone(),
+            bank_forks,
             Duration::from_secs(5),
             5,
             false,

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -309,7 +309,7 @@ mod tests {
                     "TestAlpenglowConnectionCache",
                     10,
                 )),
-                bank_forks.clone(),
+                bank_forks,
                 Some(VotingServiceOverride {
                     additional_listeners: vec![listener],
                     alpenglow_port_override: AlpenglowPortOverride::default(),

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -167,7 +167,7 @@ impl Votor {
         } = config;
 
         let migration_status = bank_forks.read().unwrap().migration_status();
-        let identity_keypair = cluster_info.keypair().clone();
+        let identity_keypair = cluster_info.keypair();
         let has_new_vote_been_rooted = !wait_for_vote_to_start_leader;
 
         // Get the sharable root bank
@@ -175,7 +175,7 @@ impl Votor {
 
         let shared_context = SharedContext {
             blockstore: blockstore.clone(),
-            bank_forks: bank_forks.clone(),
+            bank_forks,
             cluster_info: cluster_info.clone(),
             rpc_subscriptions,
             highest_parent_ready,
@@ -186,7 +186,7 @@ impl Votor {
         let voting_context = VotingContext {
             vote_history,
             vote_account_pubkey: vote_account,
-            identity_keypair: identity_keypair.clone(),
+            identity_keypair,
             authorized_voter_keypairs,
             derived_bls_keypairs: HashMap::new(),
             has_new_vote_been_rooted,
@@ -195,7 +195,7 @@ impl Votor {
             commitment_sender: commitment_sender.clone(),
             wait_to_vote_slot,
             sharable_banks: sharable_banks.clone(),
-            consensus_metrics_sender: consensus_metrics_sender.clone(),
+            consensus_metrics_sender,
         };
 
         let root_context = RootContext {
@@ -226,7 +226,7 @@ impl Votor {
         let consensus_pool_context = ConsensusPoolContext {
             exit: exit.clone(),
             migration_status,
-            cluster_info: cluster_info.clone(),
+            cluster_info,
             my_vote_pubkey: vote_account,
             blockstore,
             sharable_banks,
@@ -237,11 +237,8 @@ impl Votor {
             commitment_sender,
         };
 
-        let metrics = ConsensusMetrics::start_metrics_loop(
-            epoch_schedule,
-            consensus_metrics_receiver,
-            exit.clone(),
-        );
+        let metrics =
+            ConsensusMetrics::start_metrics_loop(epoch_schedule, consensus_metrics_receiver, exit);
         let event_handler = EventHandler::new(event_handler_context);
         let consensus_pool_service = ConsensusPoolService::new(consensus_pool_context);
 


### PR DESCRIPTION
These are detected by the `clippy::redundant_clone` lint which I hope to deny by default in near future.

ref. https://github.com/anza-xyz/agave/pull/10121