### PR TITLE
clippy: clean up redundant clones in runtime/svm

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1247,7 +1247,7 @@ mod tests {
             .unwrap();
         invoke_context.push().unwrap();
         let inner_instruction =
-            Instruction::new_with_bincode(callee_program_id, &instruction, metas.clone());
+            Instruction::new_with_bincode(callee_program_id, &instruction, metas);
         let result = invoke_context
             .native_invoke(inner_instruction, &[])
             .and(invoke_context.pop());
@@ -1308,7 +1308,7 @@ mod tests {
                 compute_units_to_consume,
                 desired_result: expected_result.clone(),
             },
-            metas.clone(),
+            metas,
         );
         invoke_context
             .prepare_next_instruction(inner_instruction, &[])

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -1508,7 +1508,10 @@ mod tests {
             .store::<u32>(0, account_start_offsets[0])
             .unwrap_err();
 
-        // Writing to shared writable account makes it unique (CoW logic)
+        // Writing to shared writable account makes it unique (CoW logic.)
+        // It has been previously been made non-unique at the beginning of
+        // the test through a clone.
+        let _shared_account_ref = shared_account;
         assert!(
             transaction_context
                 .accounts()

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -546,7 +546,7 @@ mod tests {
             .collect();
 
         let mut expected_delta_lt_hash = LtHash::identity();
-        let mut expected_accounts_lt_hash = prev_accounts_lt_hash.clone();
+        let mut expected_accounts_lt_hash = prev_accounts_lt_hash;
         let mut updater =
             |address: &Pubkey, prev: Option<AccountSharedData>, post: Option<AccountSharedData>| {
                 // if there was an alive account, mix out

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -589,7 +589,7 @@ mod tests {
         } = create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, stakes);
         genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
 
-        let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING.clone();
+        let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING;
         accounts_db_config.partitioned_epoch_rewards_config =
             PartitionedEpochRewardsConfig::new_for_test(stake_account_stores_per_block);
 
@@ -704,7 +704,7 @@ mod tests {
         genesis_config.epoch_schedule = EpochSchedule::custom(32, 32, false);
 
         // Config stake reward distribution to be 10 per block
-        let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING.clone();
+        let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING;
         accounts_db_config.partitioned_epoch_rewards_config =
             PartitionedEpochRewardsConfig::new_for_test(10);
 

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -607,9 +607,9 @@ mod tests {
             &Pubkey::new_unique(),
             &Pubkey::new_unique(),
         )];
-        sync_update(&prioritization_fee_cache, bank2.clone(), txs.iter());
+        sync_update(&prioritization_fee_cache, bank2, txs.iter());
 
-        let bank3 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 3));
+        let bank3 = Arc::new(Bank::new_from_parent(bank, &collector, 3));
         sync_update(
             &prioritization_fee_cache,
             bank3.clone(),
@@ -919,7 +919,7 @@ mod tests {
                     &Pubkey::new_unique(),
                 ),
             ];
-            sync_update(&prioritization_fee_cache, bank2.clone(), txs.iter());
+            sync_update(&prioritization_fee_cache, bank2, txs.iter());
         }
 
         // Assert after finalize with bank1 of slot 1,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -904,7 +904,7 @@ pub(crate) fn remap_append_vec_file(
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
     let append_vec_path_cstr = cstring_from_path(&append_vec_file_info.path)?;
 
-    let mut remapped_append_vec_path = append_vec_file_info.path.to_path_buf();
+    let mut remapped_append_vec_path = append_vec_file_info.path.clone();
 
     // Break out of the loop in the following situations:
     // 1. The new ID is the same as the original ID.  This means we do not need to

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -272,7 +272,7 @@ impl Stakes<StakeAccount> {
             stake_delegations,
             unused: stakes.unused,
             epoch: stakes.epoch,
-            stake_history: stakes.stake_history.clone(),
+            stake_history: stakes.stake_history,
         })
     }
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1886,7 +1886,7 @@ mod tests {
         let mut error_metrics = TransactionErrorMetrics::default();
         let load_result = load_transaction(
             &mut account_loader,
-            &sanitized_tx.clone(),
+            &sanitized_tx,
             Ok(ValidatedTransactionDetails::default()),
             &mut error_metrics,
             &Rent::default(),
@@ -2048,7 +2048,7 @@ mod tests {
         let load_result = load_transaction(
             &mut account_loader,
             &sanitized_transaction,
-            validation_result.clone(),
+            validation_result,
             &mut TransactionErrorMetrics::default(),
             &rent,
         );

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -253,7 +253,7 @@ mod tests {
         let rollback_accounts = RollbackAccounts::new(
             Some(nonce),
             fee_payer_address,
-            rent_epoch_updated_fee_payer_account.clone(),
+            rent_epoch_updated_fee_payer_account,
             u64::MAX, // ignored
         );
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -2126,7 +2126,7 @@ mod tests {
         let fee_payer_address = message.fee_payer();
         let fee_payer_account = AccountSharedData::new(1, 0, &Pubkey::default());
         let mut mock_accounts = HashMap::new();
-        mock_accounts.insert(*fee_payer_address, fee_payer_account.clone());
+        mock_accounts.insert(*fee_payer_address, fee_payer_account);
         let mock_bank = MockBankCallback {
             account_shared_data: Arc::new(RwLock::new(mock_accounts)),
             ..Default::default()
@@ -2170,7 +2170,7 @@ mod tests {
         let starting_balance = min_balance + transaction_fee - 1;
         let fee_payer_account = AccountSharedData::new(starting_balance, 0, &Pubkey::default());
         let mut mock_accounts = HashMap::new();
-        mock_accounts.insert(*fee_payer_address, fee_payer_account.clone());
+        mock_accounts.insert(*fee_payer_address, fee_payer_account);
         let mock_bank = MockBankCallback {
             account_shared_data: Arc::new(RwLock::new(mock_accounts)),
             ..Default::default()
@@ -2212,7 +2212,7 @@ mod tests {
         let fee_payer_address = message.fee_payer();
         let fee_payer_account = AccountSharedData::new(1_000_000, 0, &Pubkey::new_unique());
         let mut mock_accounts = HashMap::new();
-        mock_accounts.insert(*fee_payer_address, fee_payer_account.clone());
+        mock_accounts.insert(*fee_payer_address, fee_payer_account);
         let mock_bank = MockBankCallback {
             account_shared_data: Arc::new(RwLock::new(mock_accounts)),
             ..Default::default()
@@ -2464,7 +2464,7 @@ mod tests {
             .unwrap();
 
             let mut mock_accounts = HashMap::new();
-            mock_accounts.insert(*fee_payer_address, fee_payer_account.clone());
+            mock_accounts.insert(*fee_payer_address, fee_payer_account);
             let mock_bank = MockBankCallback {
                 account_shared_data: Arc::new(RwLock::new(mock_accounts)),
                 ..Default::default()

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -4107,7 +4107,8 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
+    #[expect(deprecated)]
+    #[expect(clippy::redundant_clone)]
     fn test_syscall_get_sysvar() {
         let config = Config::default();
 


### PR DESCRIPTION
These are detected by the `clippy::redundant_clone` lint which I hope to deny by default in near future.

ref. https://github.com/anza-xyz/agave/pull/10121