### PR TITLE
clippy: redundant clones in networking code

### DIFF
--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -714,7 +714,7 @@ mod tests {
             ],
             Some(&keypair.pubkey()),
         ));
-        let transfer_tx = RuntimeTransaction::from_transaction_for_tests(transaction.clone());
+        let transfer_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
         let txs: Vec<_> = (0..transaction_count)
             .map(|_| transfer_tx.clone())
             .collect();

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -789,7 +789,7 @@ mod tests {
         let (sender, receiver) = unbounded();
         let (bank_forks, _mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
-            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks);
 
         let packet_batches = Arc::new(vec![PacketBatch::from(RecycledPacketBatch::new(vec![
             Packet::new([1u8; PACKET_DATA_SIZE], Meta::default()),
@@ -832,7 +832,7 @@ mod tests {
         let (sender, receiver) = unbounded();
         let (bank_forks, mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
-            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks);
 
         let transaction = transfer(&mint_keypair, &Pubkey::new_unique(), 1, Hash::new_unique());
         let packet_batches = Arc::new(to_packet_batches(&[transaction], 1));

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -521,7 +521,7 @@ impl TpuClientNextClient {
     ) -> Self {
         // For now use large channel, the more suitable size to be found later.
         let (sender, receiver) = mpsc::channel(128);
-        let leader_updater = forward_address_getter.clone();
+        let leader_updater = forward_address_getter;
 
         let config = Self::create_config(bind_socket, stake_identity);
         let (update_certificate_sender, update_certificate_receiver) = watch::channel(None);
@@ -535,7 +535,7 @@ impl TpuClientNextClient {
         runtime_handle.spawn(scheduler.get_stats().report_to_influxdb(
             "forwarding-stage-tpu-client",
             METRICS_REPORTING_INTERVAL,
-            cancel.clone(),
+            cancel,
         ));
         let _handle = runtime_handle.spawn(scheduler.run(config));
         Self {

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1285,7 +1285,7 @@ mod test {
 
         // Send a repair request
         RepairService::request_repair_for_shred_from_address(
-            cluster_info.clone(),
+            cluster_info,
             pubkey,
             address,
             slot,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -630,7 +630,7 @@ impl ReplayStage {
 
         trace!("replay stage");
 
-        let mut identity_keypair = cluster_info.keypair().clone();
+        let mut identity_keypair = cluster_info.keypair();
         let mut my_pubkey = identity_keypair.pubkey();
 
         let mut highest_frozen_slot = bank_forks
@@ -8250,7 +8250,7 @@ pub(crate) mod tests {
         // 2) The blockheight is still eligible for a refresh
         // This will still not refresh because `MAX_VOTE_REFRESH_INTERVAL_MILLIS` has not expired yet
         let expired_bank_sibling = {
-            let mut parent_bank = bank2.clone();
+            let mut parent_bank = bank2;
             for i in 0..expired_bank_child_slot {
                 let slot = expired_bank_child.slot() + i + 1;
                 parent_bank = Bank::new_from_parent_with_bank_forks(

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -293,7 +293,7 @@ impl ShredFetchStage {
             vec![repair_socket],
             exit.clone(),
             sender.clone(),
-            recycler.clone(),
+            recycler,
             bank_forks.clone(),
             shred_version,
             "shred_fetch_repair",
@@ -309,10 +309,6 @@ impl ShredFetchStage {
         // Repair shreds fetched over QUIC protocol.
         {
             let (packet_sender, packet_receiver) = unbounded();
-            let bank_forks = bank_forks.clone();
-            let exit = exit.clone();
-            let sender = sender.clone();
-            let turbine_disabled = turbine_disabled.clone();
             tvu_threads.extend([
                 Builder::new()
                     .name("solTvuRecvRpr".to_string())

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -199,7 +199,7 @@ impl Tpu {
             "quic_streamer_tpu_vote",
             tpu_vote_quic_sockets,
             keypair,
-            vote_packet_sender.clone(),
+            vote_packet_sender,
             staked_nodes.clone(),
             vote_quic_server_config.quic_streamer_config,
             vote_quic_server_config.qos_config,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -283,7 +283,7 @@ impl Tvu {
                     vec![bls_socket],
                     &cluster_info.keypair(),
                     bls_packet_sender,
-                    staked_nodes.clone(),
+                    staked_nodes,
                     quic_server_params,
                     qos_config,
                     cancel,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1006,7 +1006,7 @@ impl Validator {
 
         let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
         let snapshot_controller = Arc::new(SnapshotController::new(
-            snapshot_request_sender.clone(),
+            snapshot_request_sender,
             config.snapshot_config.clone(),
             bank_forks.read().unwrap().root(),
         ));
@@ -1734,7 +1734,7 @@ impl Validator {
                 vote_quic: node.sockets.tpu_vote_quic,
                 vote_forwarding_client: node.sockets.tpu_vote_forwarding_client,
             },
-            rpc_subscriptions.clone(),
+            rpc_subscriptions,
             transaction_status_sender,
             entry_notification_sender,
             blockstore.clone(),
@@ -2697,10 +2697,10 @@ fn initialize_rpc_transaction_history_services(
         max_complete_transaction_status_slot.clone(),
         enable_rpc_transaction_history,
         transaction_notifier,
-        blockstore.clone(),
+        blockstore,
         enable_extended_tx_metadata_storage,
         dependency_tracker,
-        exit.clone(),
+        exit,
     ));
 
     TransactionHistoryServices {

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -294,7 +294,7 @@ impl WindowService {
             repair_socket,
             ancestor_hashes_socket,
             repair_info,
-            outstanding_repair_requests.clone(),
+            outstanding_repair_requests,
             repair_service_channels,
         );
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -634,11 +634,11 @@ fn test_snapshots_with_background_services() {
 
     let exit = Arc::new(AtomicBool::new(false));
     let snapshot_packager_service = SnapshotPackagerService::new(
-        pending_snapshot_packages.clone(),
+        pending_snapshot_packages,
         None,
         exit.clone(),
         None,
-        cluster_info.clone(),
+        cluster_info,
         snapshot_controller.clone(),
         false,
         0,
@@ -789,7 +789,7 @@ fn test_fastboot_snapshots_teardown(exit_backpressure: bool) {
     let bank_forks = snapshot_test_config.bank_forks.clone();
 
     let snapshot_controller = Arc::new(SnapshotController::new(
-        snapshot_request_sender.clone(),
+        snapshot_request_sender,
         snapshot_test_config.snapshot_config.clone(),
         bank_forks.read().unwrap().root(),
     ));

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2941,7 +2941,7 @@ mod tests {
         let refresh_ix = vote_instruction::vote(
             &Pubkey::new_unique(), // vote_pubkey
             &Pubkey::new_unique(), // authorized_voter_pubkey
-            refresh_vote.clone(),
+            refresh_vote,
         );
         let refresh_tx = Transaction::new_with_payer(
             &[refresh_ix], // instructions
@@ -2958,7 +2958,7 @@ mod tests {
         let refresh_ix = vote_instruction::vote(
             &Pubkey::new_unique(), // vote_pubkey
             &Pubkey::new_unique(), // authorized_voter_pubkey
-            refresh_vote.clone(),
+            refresh_vote,
         );
         let refresh_tx = Transaction::new_with_payer(
             &[refresh_ix], // instructions
@@ -3000,7 +3000,7 @@ mod tests {
         // Now construct vote for the slot to be refreshed later.
         let refresh_slot = unrefresh_slot + 1;
         let refresh_tower = vec![1, 3, unrefresh_slot, refresh_slot];
-        let refresh_vote = Vote::new(refresh_tower.clone(), Hash::new_unique());
+        let refresh_vote = Vote::new(refresh_tower, Hash::new_unique());
         let refresh_ix = vote_instruction::vote(
             &Pubkey::new_unique(), // vote_pubkey
             &Pubkey::new_unique(), // authorized_voter_pubkey

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -303,7 +303,7 @@ mod tests {
         {
             let mut bank_forks = bank_forks_arc.write().unwrap();
             let bank0 = bank_forks.get(0).unwrap();
-            bank_forks.insert(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 9));
+            bank_forks.insert(Bank::new_from_parent(bank0, &Pubkey::default(), 9));
             bank_forks.set_root(9, None, None);
         }
         assert!(blockstore.set_roots([0, 9].iter()).is_ok());
@@ -395,7 +395,7 @@ mod tests {
         {
             let mut bank_forks = bank_forks_arc.write().unwrap();
             let bank0 = bank_forks.get(0).unwrap();
-            bank_forks.insert(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 9));
+            bank_forks.insert(Bank::new_from_parent(bank0, &Pubkey::default(), 9));
             bank_forks.set_root(9, None, None);
         }
         blockstore.set_roots([0, 9].iter()).unwrap();

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -98,7 +98,7 @@ impl GossipService {
         );
         let t_responder = streamer::responder_atomic(
             "Gossip",
-            gossip_sockets.clone(),
+            gossip_sockets,
             cluster_info.bind_ip_addrs(),
             response_receiver,
             socket_addr_space,


### PR DESCRIPTION
These are detected by the `clippy::redundant_clone` lint which I hope to deny by default in near future.

ref. https://github.com/anza-xyz/agave/pull/10121