### PR TITLE
refactor: remove unnecessary `Arc::clone` in `repair_shred_from_peer`

### DIFF
--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -646,7 +646,7 @@ impl AdminRpc for AdminRpcImpl {
                 pubkey,
                 slot,
                 shred_index,
-                &post_init.repair_socket.clone(),
+                &post_init.repair_socket,
                 post_init.outstanding_repair_requests.clone(),
             );
             Ok(())


### PR DESCRIPTION
#### Problem

[request_repair_for_shred_from_peer]https://github.com/anza-xyz/agave/blob/bf9c84df59c8469ae9fd311436c20e72c29f0e1d/core/src/repair/repair_service.rs#L962-L1004 takes `repair_socket: &UdpSocket`, but the call site was doing `&post_init.repair_socket.clone()` - cloning the `Arc<UdpSocket>` just to immediately borrow it. This is redundant because `&Arc<UdpSocket>` auto-derefs to `&UdpSocket` via the Deref trait.

#### Summary of Changes

Remove the unnecessary `.clone()` to avoid a needless atomic refcount increment/decrement.
