### PR TITLE
fix: remove double-counting of num_duplicated_accounts in shrink stats

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2563,9 +2563,6 @@ impl AccountsDb {
         stats
             .storage_read_elapsed
             .fetch_add(storage_read_elapsed_us, Ordering::Relaxed);
-        stats
-            .num_duplicated_accounts
-            .fetch_add(result.num_duplicated_accounts as u64, Ordering::Relaxed);
         result
     }
 


### PR DESCRIPTION
Problem:
`num_duplicated_accounts` was added to `ShrinkStats` twice — first in
`get_unique_accounts_from_storage_for_shrink`https://github.com/anza-xyz/agave/blob/4aa6e60cb55e541c1ee0b9b120ade14512740d72/accounts-db/src/accounts_db.rs#L2556-L2566 and then again in
`shrink_collect`https://github.com/anza-xyz/agave/blob/4aa6e60cb55e541c1ee0b9b120ade14512740d72/accounts-db/src/accounts_db.rs#L2568-L2570 with the same value and the same stats instance. This caused the reported metric to always be 2x the actual number.
