### PR TITLE
Alpenglow: upstream VAT (SIMD-0357)

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1305,6 +1305,10 @@ pub mod validate_chained_block_id {
     solana_pubkey::declare_id!("vbiddkDHTSHSvL8B21AetWvTBLxxUZ1FmU6DFjztyRn");
 }
 
+pub mod validator_admission_ticket {
+    solana_pubkey::declare_id!("VATtb1DepUwdPh5bFVasdtkbeDNsftZSRzr2aKpKWJA");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2323,6 +2327,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             validate_chained_block_id::id(),
             "SIMD-0340: Validate chained block ID",
+        ),
+        (
+            validator_admission_ticket::id(),
+            "SIMD-0357: Alpenglow VAT implementation",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -181,6 +181,7 @@ use {
         vote_account::{VoteAccount, VoteAccounts, VoteAccountsHashMap},
         vote_parser,
     },
+    solana_vote_interface::state::VoteStateV4,
     std::{
         collections::{HashMap, HashSet},
         fmt,
@@ -1218,7 +1219,7 @@ impl Bank {
         // genesis needs stakes for all epochs up to the epoch implied by
         //  slot = 0 and genesis configuration
         {
-            let stakes = bank.stakes_cache.stakes().clone();
+            let stakes = bank.get_top_epoch_stakes();
             let stakes = SerdeStakesToStakeFormat::from(stakes);
             for epoch in 0..=bank.get_leader_schedule_epoch(bank.slot) {
                 bank.epoch_stakes
@@ -2326,7 +2327,7 @@ impl Bank {
                 // to ensure we retain the oldest epoch, if that epoch is 0.
                 epoch >= leader_schedule_epoch.saturating_sub(MAX_LEADER_SCHEDULE_STAKES - 1)
             });
-            let stakes = self.stakes_cache.stakes().clone();
+            let stakes = self.get_top_epoch_stakes();
             let stakes = SerdeStakesToStakeFormat::from(stakes);
             let new_epoch_stakes = VersionedEpochStakes::new(stakes, leader_schedule_epoch);
             info!(
@@ -2334,6 +2335,16 @@ impl Bank {
                 leader_schedule_epoch,
                 new_epoch_stakes.total_stake(),
             );
+            // Only deduct and burn the VAT if both the VAT and alpenglow features are active.
+            if self
+                .feature_set
+                .is_active(&agave_feature_set::alpenglow::id())
+                && self
+                    .feature_set
+                    .is_active(&agave_feature_set::validator_admission_ticket::id())
+            {
+                self.burn_vat_from_staked_accounts(&new_epoch_stakes);
+            }
 
             // It is expensive to log the details of epoch stakes. Only log them at "trace"
             // level for debugging purpose.
@@ -2350,6 +2361,51 @@ impl Bank {
             self.epoch_stakes
                 .insert(leader_schedule_epoch, new_epoch_stakes);
         }
+    }
+
+    /// Burn the Validator Admission ticket from each vote account.
+    ///
+    /// Note: This must ONLY be called after the vote accounts have been filtered (`clone_and_filter_for_vat`)
+    /// to the top `MAX_ALPENGLOW_VOTE_ACCOUNTS` that contain enough balance for admission.
+    fn burn_vat_from_staked_accounts(&mut self, epoch_stakes: &VersionedEpochStakes) {
+        let vote_accounts = epoch_stakes.stakes().vote_accounts();
+        // +1 for the incinerator account
+        let mut accounts_to_store: Vec<(Pubkey, AccountSharedData)> =
+            Vec::with_capacity(vote_accounts.len() + 1);
+        let mut total_vat = 0u64;
+
+        // Vote accounts have already been filtered by clone_and_filter_for_vat to only include
+        // accounts with non-zero stake and sufficient balance.
+        for (vote_pubkey, _stake) in vote_accounts.delegated_stakes() {
+            let mut account = self.get_account(vote_pubkey).unwrap();
+            total_vat += VAT_TO_BURN_PER_EPOCH;
+            account.set_lamports(
+                account
+                    .lamports()
+                    .checked_sub(VAT_TO_BURN_PER_EPOCH)
+                    .expect(
+                        "Vote accounts should have already been filtered to contain enough \
+                         balance for the VAT",
+                    ),
+            );
+            accounts_to_store.push((*vote_pubkey, account));
+        }
+
+        // Per SIMD-0357, transfer collected VAT to the incinerator account.
+        let mut incinerator_account = self.get_account(&incinerator::id()).unwrap_or_default();
+        incinerator_account.set_lamports(
+            incinerator_account
+                .lamports()
+                .checked_add(total_vat)
+                .unwrap(),
+        );
+        accounts_to_store.push((incinerator::id(), incinerator_account));
+
+        self.store_accounts((self.slot, accounts_to_store.as_slice()));
+        info!(
+            "Transferred total VAT of {total_vat} lamports to incinerator from staked vote \
+             accounts"
+        );
     }
 
     #[cfg(feature = "dev-context-only-utils")]
@@ -6025,6 +6081,37 @@ impl Bank {
     /// Return total transaction fee collected
     pub fn get_collector_fee_details(&self) -> CollectorFeeDetails {
         self.collector_fee_details.read().unwrap().clone()
+    }
+
+    /// If the VAT feature is active, returns the `Stakes` as filtered by SIMD-0357
+    /// See `VoteAccounts::cloneand_filter_for_vat` for the full criteria
+    ///
+    /// If the VAT feature is not active, return all stakes
+    pub fn get_top_epoch_stakes(&self) -> Stakes<StakeAccount<Delegation>> {
+        let vote_account_rent_exempt_minimum = self
+            .rent_collector
+            .rent
+            .minimum_balance(VoteStateV4::size_of());
+        let minimum_vote_account_balance =
+            if self.feature_set.is_active(&feature_set::alpenglow::id()) {
+                // When alpenglow is active the minimum required balance is
+                // VAT + rent-exempt minimum for vote account.
+                vote_account_rent_exempt_minimum + VAT_TO_BURN_PER_EPOCH
+            } else {
+                // If alpenglow is not active, the minimum required balance is rent-exempt-minimum
+                vote_account_rent_exempt_minimum
+            };
+
+        if self
+            .feature_set
+            .is_active(&feature_set::validator_admission_ticket::id())
+        {
+            self.stakes_cache
+                .stakes()
+                .clone_and_filter_for_vat(MAX_ALPENGLOW_VOTE_ACCOUNTS, minimum_vote_account_balance)
+        } else {
+            self.stakes_cache.stakes().clone()
+        }
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2369,6 +2369,7 @@ impl Bank {
     /// to the top `MAX_ALPENGLOW_VOTE_ACCOUNTS` that contain enough balance for admission.
     fn burn_vat_from_staked_accounts(&mut self, epoch_stakes: &VersionedEpochStakes) {
         let vote_accounts = epoch_stakes.stakes().vote_accounts();
+        debug_assert!(vote_accounts.len() <= 2000);
         // +1 for the incinerator account
         let mut accounts_to_store: Vec<(Pubkey, AccountSharedData)> =
             Vec::with_capacity(vote_accounts.len() + 1);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6085,7 +6085,7 @@ impl Bank {
     }
 
     /// If the VAT feature is active, returns the `Stakes` as filtered by SIMD-0357
-    /// See `VoteAccounts::cloneand_filter_for_vat` for the full criteria
+    /// See `VoteAccounts::clone_and_filter_for_vat` for the full criteria
     ///
     /// If the VAT feature is not active, return all stakes
     pub fn get_top_epoch_stakes(&self) -> Stakes<StakeAccount<Delegation>> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2335,16 +2335,8 @@ impl Bank {
                 leader_schedule_epoch,
                 new_epoch_stakes.total_stake(),
             );
-            // Only deduct and burn the VAT if both the VAT and alpenglow features are active.
-            if self
-                .feature_set
-                .is_active(&agave_feature_set::alpenglow::id())
-                && self
-                    .feature_set
-                    .is_active(&agave_feature_set::validator_admission_ticket::id())
-            {
-                self.burn_vat_from_staked_accounts(&new_epoch_stakes);
-            }
+
+            self.maybe_burn_vat_from_staked_accounts(&new_epoch_stakes);
 
             // It is expensive to log the details of epoch stakes. Only log them at "trace"
             // level for debugging purpose.
@@ -2363,11 +2355,23 @@ impl Bank {
         }
     }
 
-    /// Burn the Validator Admission ticket from each vote account.
+    /// Burn the Validator Admission ticket from each vote account if both the VAT and Alpenglow feature flags
+    /// are enabled
     ///
     /// Note: This must ONLY be called after the vote accounts have been filtered (`clone_and_filter_for_vat`)
     /// to the top `MAX_ALPENGLOW_VOTE_ACCOUNTS` that contain enough balance for admission.
-    fn burn_vat_from_staked_accounts(&mut self, epoch_stakes: &VersionedEpochStakes) {
+    fn maybe_burn_vat_from_staked_accounts(&mut self, epoch_stakes: &VersionedEpochStakes) {
+        // Only deduct and burn the VAT if both the VAT and alpenglow features are active.
+        if !self
+            .feature_set
+            .is_active(&agave_feature_set::alpenglow::id())
+            || !self
+                .feature_set
+                .is_active(&agave_feature_set::validator_admission_ticket::id())
+        {
+            return;
+        }
+
         let vote_accounts = epoch_stakes.stakes().vote_accounts();
         debug_assert!(vote_accounts.len() <= 2000);
         // +1 for the incinerator account

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -181,6 +181,23 @@ pub struct Stakes<T: Clone> {
 }
 
 impl<T: Clone> Stakes<T> {
+    pub fn clone_and_filter_for_vat(
+        &self,
+        max_vote_accounts: usize,
+        minimum_vote_account_balance: u64,
+    ) -> Stakes<T> {
+        Stakes {
+            vote_accounts: self
+                .vote_accounts
+                .clone_and_filter_for_vat(max_vote_accounts, minimum_vote_account_balance),
+            epoch: self.epoch,
+            // Do not need anything else for EpochStakes
+            stake_delegations: ImHashMap::new(),
+            unused: 0,
+            stake_history: StakeHistory::default(),
+        }
+    }
+
     pub fn vote_accounts(&self) -> &VoteAccounts {
         &self.vote_accounts
     }

--- a/runtime/tests/vote_account.rs
+++ b/runtime/tests/vote_account.rs
@@ -73,6 +73,8 @@ fn new_rand_vote_accounts<R: Rng>(
 
 /// Creates `num_nodes` random vote accounts with the specified stake.
 /// The first `num_nodes_with_bls_pubkeys` have the bls_pubkeys set while the rest are unset.
+/// If `stake_per_node` is specified, then each node will have that stake, otherwise a random amount
+/// between `MIN_STAKE_FOR_STAKED_ACCOUNT` and `MAX_STAKE_FOR_STAKED_ACCOUNT` is chosen.
 fn new_staked_vote_accounts<R: Rng, F>(
     rng: &mut R,
     num_nodes: usize,

--- a/runtime/tests/vote_account.rs
+++ b/runtime/tests/vote_account.rs
@@ -18,6 +18,7 @@ use {
     std::{collections::HashMap, iter::repeat_with, sync::Arc},
 };
 
+const MIN_STAKE_FOR_STAKED_ACCOUNT: u64 = 1;
 const MAX_STAKE_FOR_STAKED_ACCOUNT: u64 = 997;
 
 /// Creates a vote account
@@ -68,6 +69,33 @@ fn new_rand_vote_accounts<R: Rng>(
         let vote_account = VoteAccount::try_from(account).unwrap();
         (Pubkey::new_unique(), (stake, vote_account))
     })
+}
+
+/// Creates `num_nodes` random vote accounts with the specified stake.
+/// The first `num_nodes_with_bls_pubkeys` have the bls_pubkeys set while the rest are unset.
+fn new_staked_vote_accounts<R: Rng, F>(
+    rng: &mut R,
+    num_nodes: usize,
+    num_nodes_with_bls_pubkeys: usize,
+    stake_per_node: Option<u64>,
+    lamports_per_node: F,
+) -> VoteAccounts
+where
+    F: Fn(usize) -> u64,
+{
+    let mut vote_accounts = VoteAccounts::default();
+    for index in 0..num_nodes {
+        let pubkey = Pubkey::new_unique();
+        let stake = stake_per_node.unwrap_or_else(|| {
+            rng.random_range(MIN_STAKE_FOR_STAKED_ACCOUNT..MAX_STAKE_FOR_STAKED_ACCOUNT)
+        });
+        let node_pubkey = Pubkey::new_unique();
+        let set_bls_pubkey = index < num_nodes_with_bls_pubkeys;
+        let mut account = new_rand_vote_account(rng, Some(node_pubkey), set_bls_pubkey);
+        account.set_lamports(lamports_per_node(index));
+        vote_accounts.insert(pubkey, VoteAccount::try_from(account).unwrap(), || stake);
+    }
+    vote_accounts
 }
 
 fn staked_nodes<'a, I>(vote_accounts: I) -> HashMap<Pubkey, u64>
@@ -376,4 +404,149 @@ fn test_vote_accounts_cow() {
             assert_eq!(value, &other);
         }
     }
+}
+
+#[test]
+fn test_clone_and_filter_for_vat_truncates() {
+    let mut rng = rand::rng();
+    let current_limit = 3000;
+    let vote_accounts =
+        new_staked_vote_accounts(&mut rng, current_limit, current_limit, None, |_| {
+            10_000_000_000
+        });
+    // All vote accounts should be returned if the limit is high enough.
+    let filtered =
+        vote_accounts.clone_and_filter_for_vat(current_limit + 500, MIN_STAKE_FOR_STAKED_ACCOUNT);
+    assert_eq!(filtered.len(), vote_accounts.len());
+
+    // If the limit is smaller than number of accounts, truncate it.
+    let lower_limit = current_limit - 1000;
+    let filtered =
+        vote_accounts.clone_and_filter_for_vat(lower_limit, MIN_STAKE_FOR_STAKED_ACCOUNT);
+    assert!(filtered.len() <= lower_limit);
+    // Check that the filtered accounts are the same as the original accounts.
+    for (pubkey, (_, vote_account)) in filtered.as_ref().iter() {
+        assert_eq!(vote_accounts.get(pubkey), Some(vote_account));
+    }
+    // Check that the stake in any filtered account is higher than truncated accounts.
+    let min_stake = filtered
+        .as_ref()
+        .iter()
+        .map(|(_, (stake, _))| *stake)
+        .min()
+        .unwrap();
+    for (pubkey, (stake, _vote_account)) in vote_accounts.as_ref().iter() {
+        if *stake < min_stake {
+            assert!(filtered.get(pubkey).is_none());
+        }
+    }
+}
+
+#[test]
+fn test_clone_and_filter_for_vat_filters_non_alpenglow() {
+    let mut rng = rand::rng();
+    let num_alpenglow_nodes = 2000;
+    // Check that non-alpenglow accounts are kicked out, 2000 accounts with bls pubkey, 1000
+    // accounts without.
+    let num_nodes = num_alpenglow_nodes + 1000;
+    let vote_accounts =
+        new_staked_vote_accounts(&mut rng, num_nodes, num_alpenglow_nodes, None, |_| {
+            10_000_000_000
+        });
+    let new_limit = num_alpenglow_nodes + 500;
+    let filtered = vote_accounts.clone_and_filter_for_vat(new_limit, MIN_STAKE_FOR_STAKED_ACCOUNT);
+    assert_eq!(filtered.len(), num_alpenglow_nodes);
+    // Check that all filtered accounts have bls pubkey.
+    for (_pubkey, (_stake, vote_account)) in filtered.as_ref().iter() {
+        assert!(
+            vote_account
+                .vote_state_view()
+                .bls_pubkey_compressed()
+                .is_some()
+        );
+    }
+    // Now get only 1500 accounts, even some alpenglow accounts are kicked out.
+    let new_limit = num_alpenglow_nodes - 500;
+    let filtered = vote_accounts.clone_and_filter_for_vat(new_limit, MIN_STAKE_FOR_STAKED_ACCOUNT);
+    assert!(filtered.len() <= new_limit);
+    for (_pubkey, (_stake, vote_account)) in filtered.as_ref().iter() {
+        assert!(
+            vote_account
+                .vote_state_view()
+                .bls_pubkey_compressed()
+                .is_some()
+        );
+    }
+}
+
+#[test]
+fn test_clone_and_filter_for_vat_same_stake_at_border() {
+    let mut rng = rand::rng();
+    let num_alpenglow_nodes = 2000;
+    // Create exactly num_alpenglow_nodes + 2 accounts with the same stake.
+    let num_accounts = num_alpenglow_nodes + 2;
+    let accounts = (0..num_accounts).map(|index| {
+        let mut account = new_rand_vote_account(&mut rng, None, true);
+        account.set_lamports(10_000_000_000);
+        let vote_account = VoteAccount::try_from(account).unwrap();
+        let stake = if index < num_alpenglow_nodes - 10 {
+            100 + index as u64
+        } else {
+            10 // Same stake for the last 12 accounts.
+        };
+        (Pubkey::new_unique(), (stake, vote_account))
+    });
+    let mut vote_accounts = VoteAccounts::default();
+    for (pubkey, (stake, vote_account)) in accounts {
+        vote_accounts.insert(pubkey, vote_account, || stake);
+    }
+    let filtered =
+        vote_accounts.clone_and_filter_for_vat(num_accounts, MIN_STAKE_FOR_STAKED_ACCOUNT);
+    assert_eq!(filtered.len(), num_accounts);
+    let filtered =
+        vote_accounts.clone_and_filter_for_vat(num_alpenglow_nodes, MIN_STAKE_FOR_STAKED_ACCOUNT);
+    assert_eq!(filtered.len(), num_alpenglow_nodes - 10);
+}
+
+#[test]
+fn test_clone_and_filter_for_vat_not_enough_lamports() {
+    let mut rng = rand::rng();
+    let num_alpenglow_nodes = 2000;
+    let minimum_vote_account_balance = 1_600_000_000;
+    // For 10% of vote accounts, set the balance below the minimum.
+    let entries_to_modify = num_alpenglow_nodes / 10;
+    let vote_accounts = new_staked_vote_accounts(
+        &mut rng,
+        num_alpenglow_nodes,
+        num_alpenglow_nodes,
+        None,
+        |index| {
+            if index < entries_to_modify {
+                minimum_vote_account_balance - 1
+            } else {
+                10_000_000_000
+            }
+        },
+    );
+    let filtered =
+        vote_accounts.clone_and_filter_for_vat(num_alpenglow_nodes, minimum_vote_account_balance);
+    assert!(filtered.len() <= num_alpenglow_nodes - entries_to_modify);
+}
+
+#[test]
+fn test_clone_and_filter_for_vat_empty_accounts() {
+    let mut rng = rand::rng();
+    let current_limit = 3000;
+    let vote_accounts = new_staked_vote_accounts(
+        &mut rng,
+        current_limit,
+        current_limit,
+        Some(100), // Set all vote accounts to equal stake of 100.
+        |_| 10_000_000_000,
+    );
+    // Since everyone has the same stake and the limit is 500 less than number of accounts,
+    // all border stake peers are removed and we end up with no valid accounts.
+    let filtered =
+        vote_accounts.clone_and_filter_for_vat(current_limit - 500, MIN_STAKE_FOR_STAKED_ACCOUNT);
+    assert_eq!(filtered.len(), 0);
 }

--- a/runtime/tests/vote_account.rs
+++ b/runtime/tests/vote_account.rs
@@ -10,7 +10,7 @@ use {
         keypair::Keypair as BLSKeypair, pubkey::PubkeyCompressed as BLSPubkeyCompressed,
     },
     solana_pubkey::Pubkey,
-    solana_runtime::bank::MAX_ALPENGLOW_VOTE_ACCOUNTS,
+    solana_runtime::bank::{MAX_ALPENGLOW_VOTE_ACCOUNTS, VAT_TO_BURN_PER_EPOCH},
     solana_vote::vote_account::{VoteAccount, VoteAccounts, VoteAccountsHashMap},
     solana_vote_interface::{
         authorized_voters::AuthorizedVoters,
@@ -515,7 +515,6 @@ fn test_clone_and_filter_for_vat_same_stake_at_border() {
 #[test]
 fn test_clone_and_filter_for_vat_not_enough_lamports() {
     let mut rng = rand::rng();
-    let minimum_vote_account_balance = 1_600_000_000;
     // For 10% of vote accounts, set the balance below the minimum.
     let entries_to_modify = MAX_ALPENGLOW_VOTE_ACCOUNTS / 10;
     let vote_accounts = new_staked_vote_accounts(
@@ -525,14 +524,14 @@ fn test_clone_and_filter_for_vat_not_enough_lamports() {
         None,
         |index| {
             if index < entries_to_modify {
-                minimum_vote_account_balance - 1
+                VAT_TO_BURN_PER_EPOCH - 1
             } else {
                 10_000_000_000
             }
         },
     );
-    let filtered = vote_accounts
-        .clone_and_filter_for_vat(MAX_ALPENGLOW_VOTE_ACCOUNTS, minimum_vote_account_balance);
+    let filtered =
+        vote_accounts.clone_and_filter_for_vat(MAX_ALPENGLOW_VOTE_ACCOUNTS, VAT_TO_BURN_PER_EPOCH);
     assert!(filtered.len() <= MAX_ALPENGLOW_VOTE_ACCOUNTS - entries_to_modify);
 }
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1549,6 +1549,7 @@ mod test {
             alpenglow::id(),
             agave_feature_set::bls_pubkey_management_in_vote_account::id(),
             agave_feature_set::vote_account_initialize_v2::id(),
+            agave_feature_set::validator_admission_ticket::id(),
         ]
         .into_iter()
         .for_each(|feature| {

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -1,5 +1,6 @@
 use {
     crate::vote_state_view::VoteStateView,
+    log::*,
     serde::{
         Deserialize, Serialize,
         de::{MapAccess, Visitor},
@@ -157,6 +158,72 @@ impl VoteAccounts {
                 Arc::new(staked_nodes)
             })
             .clone()
+    }
+
+    // This implements the filtering logic described in SIMD-357.
+    // 1. Filter out any vote accounts without BLS pubkey
+    // 2. Given minimum_vote_account_balance, filter out any vote account
+    //    without required balance
+    // 3. If we have more than max_vote_accounts vote accounts after above
+    //    filtering, sort by stake and truncate
+    // 4. If any vote account in the resulting list has the same stake as any
+    //    truncated vote account, just remove this vote account as well (A and
+    //    B have the same stake amount, it's unfair to keep A in and kick B out
+    //    just because of Pubkey difference, because that can be grinded)
+    // 5. If we end up with an empty list (can happen if everyone in the world
+    //    has the same stake, happens in tests, doesn't happen in real world),
+    //    log a warning
+    pub fn clone_and_filter_for_vat(
+        &self,
+        max_vote_accounts: usize,
+        minimum_vote_account_balance: u64,
+    ) -> VoteAccounts {
+        assert!(max_vote_accounts > 0, "max_vote_accounts must be > 0");
+        let mut entries_to_sort: Vec<(&Pubkey, &VoteAccount, u64)> =
+            Vec::with_capacity(max_vote_accounts);
+        for (pubkey, (stake, vote_account)) in self.vote_accounts.iter() {
+            let has_bls = vote_account
+                .vote_state_view()
+                .bls_pubkey_compressed()
+                .is_some();
+            let has_stake = *stake != 0u64;
+            let has_balance = vote_account.lamports() >= minimum_vote_account_balance;
+
+            if !has_bls || !has_stake || !has_balance {
+                continue;
+            }
+            entries_to_sort.push((pubkey, vote_account, *stake));
+        }
+        if entries_to_sort.len() > max_vote_accounts {
+            // Find the cutoff stake using partial sort (more efficient than full sort).
+            let (_, cutoff_entry, _) =
+                entries_to_sort.select_nth_unstable_by(max_vote_accounts, |a, b| b.2.cmp(&a.2));
+            let floor_stake = cutoff_entry.2;
+
+            // Per SIMD 357, we remove all vote accounts with stake smaller or equal to
+            // the first truncated one.
+            entries_to_sort.retain(|(_, _, stake)| *stake > floor_stake);
+        }
+
+        let mut valid_entries: HashMap<Pubkey, (u64, VoteAccount)> =
+            HashMap::with_capacity(entries_to_sort.len());
+        valid_entries.extend(
+            entries_to_sort
+                .into_iter()
+                .map(|(pubkey, vote_account, stake)| (*pubkey, (stake, vote_account.clone()))),
+        );
+        if valid_entries.is_empty() {
+            error!("no valid vote accounts found");
+        }
+        info!(
+            "Out of {} vote accounts, {} are valid vote accounts after filtering",
+            self.vote_accounts.len(),
+            valid_entries.len()
+        );
+        VoteAccounts {
+            vote_accounts: Arc::new(valid_entries),
+            staked_nodes: OnceLock::new(),
+        }
     }
 
     pub fn get(&self, pubkey: &Pubkey) -> Option<&VoteAccount> {

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -179,8 +179,8 @@ impl VoteAccounts {
         minimum_vote_account_balance: u64,
     ) -> VoteAccounts {
         assert!(max_vote_accounts > 0, "max_vote_accounts must be > 0");
-        let mut entries_to_sort: Vec<(&Pubkey, &VoteAccount, u64)> =
-            Vec::with_capacity(max_vote_accounts);
+        let capacity = max_vote_accounts.min(self.vote_accounts.len());
+        let mut entries_to_sort: Vec<(&Pubkey, &VoteAccount, u64)> = Vec::with_capacity(capacity);
         for (pubkey, (stake, vote_account)) in self.vote_accounts.iter() {
             let has_bls = vote_account
                 .vote_state_view()

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -205,23 +205,23 @@ impl VoteAccounts {
             entries_to_sort.retain(|(_, _, stake)| *stake > floor_stake);
         }
 
-        let mut valid_entries: HashMap<Pubkey, (u64, VoteAccount)> =
+        let mut top_entries: HashMap<Pubkey, (u64, VoteAccount)> =
             HashMap::with_capacity(entries_to_sort.len());
-        valid_entries.extend(
+        top_entries.extend(
             entries_to_sort
                 .into_iter()
                 .map(|(pubkey, vote_account, stake)| (*pubkey, (stake, vote_account.clone()))),
         );
-        if valid_entries.is_empty() {
+        if top_entries.is_empty() {
             error!("no valid vote accounts found");
         }
         info!(
             "Out of {} vote accounts, {} are valid vote accounts after filtering",
             self.vote_accounts.len(),
-            valid_entries.len()
+            top_entries.len()
         );
         VoteAccounts {
-            vote_accounts: Arc::new(valid_entries),
+            vote_accounts: Arc::new(top_entries),
             staked_nodes: OnceLock::new(),
         }
     }

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -194,6 +194,8 @@ impl VoteAccounts {
             }
             entries_to_sort.push((pubkey, vote_account, *stake));
         }
+
+        let valid_len = entries_to_sort.len();
         if entries_to_sort.len() > max_vote_accounts {
             // Find the cutoff stake using partial sort (more efficient than full sort).
             let (_, cutoff_entry, _) =
@@ -216,8 +218,10 @@ impl VoteAccounts {
             error!("no valid vote accounts found");
         }
         info!(
-            "Out of {} vote accounts, {} are valid vote accounts after filtering",
+            "Out of {} vote accounts, {} are valid vote accounts after filtering, {} remain after \
+             truncation",
             self.vote_accounts.len(),
+            valid_len,
             top_entries.len()
         );
         VoteAccounts {


### PR DESCRIPTION
#### Problem
Need some way of constraining validator set and charging admission https://github.com/solana-foundation/solana-improvement-documents/pull/357/changes

#### Summary of Changes
When feature is active, constrain to 2k validators. If alpenglow feature is also active, charge 1.6 sol.

This also filters the vote accounts for v4 w/ a valid bls pubkey.

Upstream of wen's original PRs:
https://github.com/anza-xyz/alpenglow/pull/516
https://github.com/anza-xyz/alpenglow/pull/509