### PR TITLE
process_entries: break loop on block boundary

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -4333,33 +4333,6 @@ pub mod tests {
         }
     }
 
-    #[test]
-    fn test_process_ledger_ticks_ordering() {
-        let GenesisConfigInfo {
-            genesis_config,
-            mint_keypair,
-            ..
-        } = create_genesis_config(100);
-        let (bank0, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-        let genesis_hash = genesis_config.hash();
-        let keypair = Keypair::new();
-
-        // Simulate a slot of virtual ticks, creates a new blockhash
-        let mut entries = create_ticks(genesis_config.ticks_per_slot, 1, genesis_hash);
-
-        // The new blockhash is going to be the hash of the last tick in the block
-        let new_blockhash = entries.last().unwrap().hash;
-        // Create an transaction that references the new blockhash, should still
-        // be able to find the blockhash if we process transactions all in the same
-        // batch
-        let tx = system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 1, new_blockhash);
-        let entry = next_entry(&new_blockhash, 1, vec![tx]);
-        entries.push(entry);
-
-        process_entries_for_tests_without_scheduler(&bank0, entries).unwrap();
-        assert_eq!(bank0.get_balance(&keypair.pubkey()), 1)
-    }
-
     fn get_epoch_schedule(genesis_config: &GenesisConfig) -> EpochSchedule {
         let bank = Bank::new_for_tests(genesis_config);
         bank.epoch_schedule().clone()

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -665,21 +665,7 @@ fn process_entries(
                 // If it's a tick, save it for later
                 tick_hashes.push(hash);
                 if bank.is_block_boundary(bank.tick_height() + tick_hashes.len() as u64) {
-                    // If it's a tick that will cause a new blockhash to be created,
-                    // execute the group and register the tick
-                    process_batches(
-                        bank,
-                        replay_tx_thread_pool,
-                        batches.drain(..),
-                        transaction_status_sender,
-                        replay_vote_sender,
-                        batch_timing,
-                        log_messages_bytes_limit,
-                        prioritization_fee_cache,
-                    )?;
-                    for hash in tick_hashes.drain(..) {
-                        bank.register_tick(&hash);
-                    }
+                    break;
                 }
             }
             EntryType::Transactions(transactions) => {


### PR DESCRIPTION
#### Problem
- We call this exact code after the loop breaks

#### Summary of Changes
- Just break loop on block boundary
- Remove `test_process_ledger_ticks_ordering`:
	- This test was testing ordering of something that is not permitted - transactions after the last tick in a block 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
