### PR TITLE
Uses wincode in the `bls-cert-verify` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,6 @@ dependencies = [
  "agave-bls-cert-verify",
  "agave-votor",
  "agave-votor-messages",
- "bincode",
  "bitvec",
  "criterion",
  "qualifier_attr",
@@ -79,6 +78,7 @@ dependencies = [
  "solana-hash 4.1.0",
  "solana-signer-store",
  "thiserror 2.0.18",
+ "wincode 0.4.4",
 ]
 
 [[package]]
@@ -564,6 +564,7 @@ dependencies = [
  "solana-hash 4.1.0",
  "solana-pubkey 4.0.0",
  "tempfile",
+ "wincode 0.4.4",
 ]
 
 [[package]]

--- a/bls-cert-verify/Cargo.toml
+++ b/bls-cert-verify/Cargo.toml
@@ -16,7 +16,6 @@ dev-context-only-utils = []
 
 [dependencies]
 agave-votor-messages = { workspace = true }
-bincode = { workspace = true }
 bitvec = { workspace = true }
 qualifier_attr = { workspace = true }
 rayon = { workspace = true }
@@ -24,6 +23,7 @@ serde = { workspace = true }
 solana-bls-signatures = { workspace = true, features = ["parallel"] }
 solana-signer-store = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 # See order-crates-for-publishing.py for using this unusual `path = "."`

--- a/bls-cert-verify/benches/cert_verify.rs
+++ b/bls-cert-verify/benches/cert_verify.rs
@@ -21,7 +21,7 @@ fn create_bls_keypairs(num_signers: usize) -> Vec<BlsKeypair> {
 
 // Creates vote messages for bench tests
 fn create_signed_vote_message(bls_keypair: &BlsKeypair, vote: Vote, rank: usize) -> VoteMessage {
-    let payload = bincode::serialize(&vote).expect("Failed to serialize vote");
+    let payload = wincode::serialize(&vote).expect("Failed to serialize vote");
     let signature: BlsSignature = bls_keypair.sign(&payload).into();
     VoteMessage {
         vote,

--- a/bls-cert-verify/src/cert_verify.rs
+++ b/bls-cert-verify/src/cert_verify.rs
@@ -120,7 +120,7 @@ fn serialize_vote(vote: &Vote) -> Vec<u8> {
     // `expect` is safe because the `Vote` struct is composed entirely of primitive
     // types (u64, Hash, enums) that are inherently serializable and it is constructed
     // locally within this module.
-    bincode::serialize(vote).expect("Vote serialization should never fail for valid Vote structs")
+    wincode::serialize(vote).expect("Vote serialization should never fail for valid Vote structs")
 }
 
 /// Verifies a signature for a single payload signed by a set of validators.
@@ -238,7 +238,7 @@ mod test {
         rank: usize,
     ) -> VoteMessage {
         let bls_keypair = &bls_keypairs[rank];
-        let payload = bincode::serialize(&vote).expect("Failed to serialize vote");
+        let payload = wincode::serialize(&vote).expect("Failed to serialize vote");
         let signature: BLSSignature = bls_keypair.sign(&payload).into();
         VoteMessage {
             vote,

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-hash 4.1.0",
  "solana-pubkey 4.0.0",
+ "wincode 0.4.4",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-hash 4.1.0",
  "solana-pubkey 4.0.0",
+ "wincode 0.4.4",
 ]
 
 [[package]]

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -41,6 +41,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-hash = { workspace = true, features = ["serde", "copy", "decode"] }
 solana-pubkey = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 agave-votor-messages = { path = ".", features = ["dev-context-only-utils"] }

--- a/votor-messages/src/vote.rs
+++ b/votor-messages/src/vote.rs
@@ -3,6 +3,7 @@ use {
     serde::{Deserialize, Serialize},
     solana_clock::Slot,
     solana_hash::Hash,
+    wincode::{containers::Pod, SchemaRead, SchemaWrite},
 };
 
 /// Enum that clients can use to parse and create the vote
@@ -12,7 +13,9 @@ use {
     derive(AbiExample, AbiEnumVisitor),
     frozen_abi(digest = "AgKoR2cpjUSVCW7Cpihob5nDiPcFt1PXmoPKWJg3zuSB")
 )]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SchemaWrite, SchemaRead,
+)]
 pub enum Vote {
     /// A notarization vote
     Notarize(NotarizationVote),
@@ -188,11 +191,24 @@ impl From<GenesisVote> for Vote {
     derive(AbiExample),
     frozen_abi(digest = "5AdwChAjsj5QUXLdpDnGGK2L2nA8y8EajVXi6jsmTv1m")
 )]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Default,
+    Serialize,
+    Deserialize,
+    SchemaWrite,
+    SchemaRead,
+)]
 pub struct NotarizationVote {
     /// The slot this vote is cast for.
     pub slot: Slot,
     /// The block id this vote is for.
+    #[wincode(with = "Pod<Hash>")]
     pub block_id: Hash,
 }
 
@@ -202,7 +218,19 @@ pub struct NotarizationVote {
     derive(AbiExample),
     frozen_abi(digest = "2XQ5N6YLJjF28w7cMFFUQ9SDgKuf9JpJNtAiXSPA8vR2")
 )]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Default,
+    Serialize,
+    Deserialize,
+    SchemaWrite,
+    SchemaRead,
+)]
 pub struct FinalizationVote {
     /// The slot this vote is cast for.
     pub slot: Slot,
@@ -216,7 +244,19 @@ pub struct FinalizationVote {
     derive(AbiExample),
     frozen_abi(digest = "G8Nrx3sMYdnLpHsCNark3BGA58BmW2sqNnqjkYhQHtN")
 )]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Default,
+    Serialize,
+    Deserialize,
+    SchemaWrite,
+    SchemaRead,
+)]
 pub struct SkipVote {
     /// The slot this vote is cast for.
     pub slot: Slot,
@@ -228,11 +268,24 @@ pub struct SkipVote {
     derive(AbiExample),
     frozen_abi(digest = "7j5ZPwwyz1FaG3fpyQv5PVnQXicdSmqSk8NvqzkG1Eqz")
 )]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Default,
+    Serialize,
+    Deserialize,
+    SchemaWrite,
+    SchemaRead,
+)]
 pub struct NotarizationFallbackVote {
     /// The slot this vote is cast for.
     pub slot: Slot,
     /// The block id this vote is for.
+    #[wincode(with = "Pod<Hash>")]
     pub block_id: Hash,
 }
 
@@ -242,7 +295,19 @@ pub struct NotarizationFallbackVote {
     derive(AbiExample),
     frozen_abi(digest = "WsUNum8V62gjRU1yAnPuBMAQui4YvMwD1RwrzHeYkeF")
 )]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Default,
+    Serialize,
+    Deserialize,
+    SchemaWrite,
+    SchemaRead,
+)]
 pub struct SkipFallbackVote {
     /// The slot this vote is cast for.
     pub slot: Slot,
@@ -254,10 +319,23 @@ pub struct SkipFallbackVote {
     derive(AbiExample),
     frozen_abi(digest = "2JAiHmnnKHCzhkyCY3Bej6rAaVkMHsXgRcz1TPCNqAJ9")
 )]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Default,
+    Serialize,
+    Deserialize,
+    SchemaWrite,
+    SchemaRead,
+)]
 pub struct GenesisVote {
     /// The slot this vote is cast for.
     pub slot: Slot,
     /// The block id this vote is for.
+    #[wincode(with = "Pod<Hash>")]
     pub block_id: Hash,
 }


### PR DESCRIPTION
#### Problem

We want to use `wincode` instead of `bincode` in as many places as possible.  Picking a relatively simple crate to start with.

#### Summary of Changes

This PR updates `bls-cert-verify` crate to use `wincode` instead of `bincode`.  This also means having to update derives on the various votes data structs.