### PR TITLE
Remove unused load_into_read_cache_only flag

### DIFF
--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -133,15 +133,6 @@ impl ReadOnlyAccountsCache {
         }
     }
 
-    /// true if pubkey is in cache at slot
-    pub(crate) fn in_cache(&self, pubkey: &Pubkey, slot: Slot) -> bool {
-        if let Some(entry) = self.cache.get(pubkey) {
-            entry.slot == slot
-        } else {
-            false
-        }
-    }
-
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn load(&self, pubkey: Pubkey, slot: Slot) -> Option<AccountSharedData> {
         let (account, load_us) = measure_us!({

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4920,13 +4920,6 @@ impl Bank {
         SnapshotHash::new(self.accounts_lt_hash.lock().unwrap().0.checksum())
     }
 
-    pub fn load_account_into_read_cache(&self, key: &Pubkey) {
-        self.rc
-            .accounts
-            .accounts_db
-            .load_account_into_read_cache(&self.ancestors, key);
-    }
-
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash
     /// calculation and could shield other real accounts.
     pub fn verify_snapshot_bank(


### PR DESCRIPTION
#### Problem
load_into_read_cache_only flag is present in do_load_with_populate_read_cache API, but never used by any callers, including tests. 

#### Summary of Changes
Remove it. 

This is a step towards merging do_load_with_populate_read_cache and load_account_with into one function.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
