### PR TITLE
ibrl: txn dispatch overhead. cache builtins

### DIFF
--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -278,11 +278,8 @@ mod test {
 
         // Add a new bank 7 that descends from 6
         let bank6 = vote_simulator.bank_forks.read().unwrap().get(6).unwrap();
-        vote_simulator
-            .bank_forks
-            .write()
-            .unwrap()
-            .insert(Bank::new_from_parent(bank6, SlotLeader::default(), 7));
+        let bank7_new = Bank::new_from_parent(bank6, SlotLeader::default(), 7);
+        vote_simulator.bank_forks.write().unwrap().insert(bank7_new);
         let bank7 = vote_simulator.bank_forks.read().unwrap().get(7).unwrap();
         assert!(!bank7.ancestors.contains_key(&3));
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5481,11 +5481,8 @@ pub(crate) mod tests {
             DefaultSchedulerPool::new_for_verification(None, None, None, None, None),
         );
 
-        let bank = bank_forks.write().unwrap().insert(Bank::new_from_parent(
-            bank,
-            SlotLeader::default(),
-            1,
-        ));
+        let child_bank = Bank::new_from_parent(bank, SlotLeader::default(), 1);
+        let bank = bank_forks.write().unwrap().insert(child_bank);
 
         let slot = bank.slot();
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
@@ -5878,10 +5875,11 @@ pub(crate) mod tests {
                 )
                 .unwrap();
 
+            let child_bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
             let bank1 = bank_forks
                 .write()
                 .unwrap()
-                .insert(Bank::new_from_parent(bank0, SlotLeader::default(), 1))
+                .insert(child_bank)
                 .clone_without_scheduler();
             let slot = bank1.slot();
 
@@ -6751,10 +6749,11 @@ pub(crate) mod tests {
 
         // If the root is now set to `parent_slot`, this filters out `previous_leader_slot` from the progress map,
         // which implies confirmation
-        let bank0 = Bank::new_for_tests(&genesis_config::create_genesis_config(10000).0);
+        let genesis_config = genesis_config::create_genesis_config(10000).0;
+        let (bank0, bank_forks_arc) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         let parent_slot_bank =
-            Bank::new_from_parent(Arc::new(bank0), SlotLeader::default(), parent_slot);
-        let bank_forks_arc = BankForks::new_rw_arc(parent_slot_bank);
+            Bank::new_from_parent(Arc::clone(&bank0), SlotLeader::default(), parent_slot);
+        bank_forks_arc.write().unwrap().insert(parent_slot_bank);
         let parent_bank = bank_forks_arc.read().unwrap().get(parent_slot).unwrap();
         let bank5 = Bank::new_from_parent(parent_bank, SlotLeader::default(), 5);
         bank_forks_arc.write().unwrap().insert(bank5);
@@ -9807,11 +9806,9 @@ pub(crate) mod tests {
         blockstore.store_duplicate_slot(4, vec![], vec![]).unwrap();
         blockstore.store_duplicate_slot(5, vec![], vec![]).unwrap();
 
-        let bank1 = bank_forks.write().unwrap().insert(Bank::new_from_parent(
-            bank0.clone_without_scheduler(),
-            SlotLeader::default(),
-            1,
-        ));
+        let bank1_child =
+            Bank::new_from_parent(bank0.clone_without_scheduler(), SlotLeader::default(), 1);
+        let bank1 = bank_forks.write().unwrap().insert(bank1_child);
         confirm_full_slot(
             &blockstore,
             &bank1,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2460,20 +2460,20 @@ fn maybe_warp_slot(
     snapshot_controller: &SnapshotController,
 ) -> Result<(), String> {
     if let Some(warp_slot) = config.warp_slot {
-        let mut bank_forks = bank_forks.write().unwrap();
+        let root_bank = {
+            let bank_forks_r = bank_forks.read().unwrap();
+            let working_bank = bank_forks_r.working_bank();
+            if warp_slot <= working_bank.slot() {
+                return Err(format!(
+                    "warp slot ({}) cannot be less than the working bank slot ({})",
+                    warp_slot,
+                    working_bank.slot()
+                ));
+            }
+            bank_forks_r.root_bank()
+        };
 
-        let working_bank = bank_forks.working_bank();
-
-        if warp_slot <= working_bank.slot() {
-            return Err(format!(
-                "warp slot ({}) cannot be less than the working bank slot ({})",
-                warp_slot,
-                working_bank.slot()
-            ));
-        }
         info!("warping to slot {warp_slot}");
-
-        let root_bank = bank_forks.root_bank();
 
         // An accounts hash calculation from storages will occur in warp_from_parent() below.  This
         // requires that the accounts cache has been flushed, which requires the parent slot to be
@@ -2481,11 +2481,13 @@ fn maybe_warp_slot(
         root_bank.squash();
         root_bank.force_flush_accounts_cache();
 
-        bank_forks.insert(Bank::warp_from_parent(
-            root_bank,
-            SlotLeader::default(),
-            warp_slot,
-        ));
+        // Do not call `Bank::warp_from_parent` while holding `bank_forks.write()`: child bank
+        // construction runs `ProgramCache::extract`, which takes `fork_graph.read()` on this same
+        // `RwLock<BankForks>` (deadlock with an exclusive lock).
+        let warp_bank = Bank::warp_from_parent(root_bank, SlotLeader::default(), warp_slot);
+
+        let mut bank_forks = bank_forks.write().unwrap();
+        bank_forks.insert(warp_bank);
         // The bank must have a block id set to take a snapshot.
         // Also must be set before calling set_root() just incase the warp slot triggers a
         // snapshot request based on the snapshot config inside snapshot_controller.

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -830,14 +830,11 @@ fn test_fastboot_snapshots_teardown(exit_backpressure: bool) {
     for slot in 1..=LAST_SLOT {
         // Make a new bank and process some transactions
         let parent_bank = bank_forks.read().unwrap().get(slot - 1).unwrap();
+        let child_bank = Bank::new_from_parent(parent_bank.clone(), *parent_bank.leader(), slot);
         let bank = bank_forks
             .write()
             .unwrap()
-            .insert(Bank::new_from_parent(
-                parent_bank.clone(),
-                *parent_bank.leader(),
-                slot,
-            ))
+            .insert(child_bank)
             .clone_without_scheduler();
 
         let key = solana_pubkey::new_rand();

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -301,9 +301,10 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks_arc = BankForks::new_rw_arc(bank);
         {
+            let bank0 = bank_forks_arc.read().unwrap().get(0).unwrap();
+            let bank9 = Bank::new_from_parent(bank0, SlotLeader::default(), 9);
             let mut bank_forks = bank_forks_arc.write().unwrap();
-            let bank0 = bank_forks.get(0).unwrap();
-            bank_forks.insert(Bank::new_from_parent(bank0, SlotLeader::default(), 9));
+            bank_forks.insert(bank9);
             bank_forks.set_root(9, None, None);
         }
         assert!(blockstore.set_roots([0, 9].iter()).is_ok());
@@ -393,9 +394,10 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks_arc = BankForks::new_rw_arc(bank);
         {
+            let bank0 = bank_forks_arc.read().unwrap().get(0).unwrap();
+            let bank9 = Bank::new_from_parent(bank0, SlotLeader::default(), 9);
             let mut bank_forks = bank_forks_arc.write().unwrap();
-            let bank0 = bank_forks.get(0).unwrap();
-            bank_forks.insert(Bank::new_from_parent(bank0, SlotLeader::default(), 9));
+            bank_forks.insert(bank9);
             bank_forks.set_root(9, None, None);
         }
         blockstore.set_roots([0, 9].iter()).unwrap();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -4522,11 +4522,9 @@ pub mod tests {
         )
         .unwrap();
         let bank0_last_blockhash = bank0.last_blockhash();
-        let bank1 = bank_forks.write().unwrap().insert(Bank::new_from_parent(
-            bank0.clone_without_scheduler(),
-            SlotLeader::default(),
-            1,
-        ));
+        let bank1_child =
+            Bank::new_from_parent(bank0.clone_without_scheduler(), SlotLeader::default(), 1);
+        let bank1 = bank_forks.write().unwrap().insert(bank1_child);
         confirm_full_slot(
             &blockstore,
             &bank1,
@@ -4773,14 +4771,11 @@ pub mod tests {
         let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         bank0.freeze();
 
+        let bank1_child = Bank::new_from_parent(bank0.clone(), SlotLeader::new_unique(), 1);
         let bank1 = bank_forks
             .write()
             .unwrap()
-            .insert(Bank::new_from_parent(
-                bank0.clone(),
-                SlotLeader::new_unique(),
-                1,
-            ))
+            .insert(bank1_child)
             .clone_without_scheduler();
 
         // The new blockhash is going to be the hash of the last tick in the block

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -539,14 +539,11 @@ mod tests {
             target_slot += 1;
         }
 
+        let child_bank = Bank::new_from_parent(bank.clone(), SlotLeader::default(), target_slot);
         let bank = bank_forks
             .write()
             .unwrap()
-            .insert(Bank::new_from_parent(
-                bank.clone(),
-                SlotLeader::default(),
-                target_slot,
-            ))
+            .insert(child_bank)
             .clone_without_scheduler();
         let mut expected_slot = 0;
         let epoch = bank.get_leader_schedule_epoch(target_slot);

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5017,15 +5017,12 @@ pub mod tests {
 
         fn advance_bank_to_confirmed_slot(&self, slot: Slot) -> Arc<Bank> {
             let parent_bank = self.working_bank();
+            let child_bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), slot);
             let bank = self
                 .bank_forks
                 .write()
                 .unwrap()
-                .insert(Bank::new_from_parent(
-                    parent_bank,
-                    SlotLeader::default(),
-                    slot,
-                ))
+                .insert(child_bank)
                 .clone_without_scheduler();
 
             let new_block_commitment = BlockCommitmentCache::new(

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -1091,11 +1091,8 @@ mod tests {
     fn extend_bank_forks(bank_forks: Arc<RwLock<BankForks>>, parent_child_pairs: &[(Slot, Slot)]) {
         for (parent, child) in parent_child_pairs.iter() {
             let parent: Arc<Bank> = bank_forks.read().unwrap().banks[parent].clone();
-            bank_forks.write().unwrap().insert(Bank::new_from_parent(
-                parent,
-                SlotLeader::default(),
-                *child,
-            ));
+            let child_bank = Bank::new_from_parent(parent, SlotLeader::default(), *child);
+            bank_forks.write().unwrap().insert(child_bank);
         }
     }
 

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -655,14 +655,11 @@ mod test {
             (transaction, signature)
         };
 
+        let working_child = Bank::new_from_parent(root_bank.clone(), SlotLeader::default(), 2);
         let working_bank = bank_forks
             .write()
             .unwrap()
-            .insert(Bank::new_from_parent(
-                root_bank.clone(),
-                SlotLeader::default(),
-                2,
-            ))
+            .insert(working_child)
             .clone_without_scheduler();
 
         let (non_rooted_transaction, non_rooted_signature) = {
@@ -946,14 +943,11 @@ mod test {
             AccountSharedData::new_data(43, &nonce_state, &system_program::id()).unwrap();
         root_bank.store_account(&nonce_address, &nonce_account);
 
+        let working_child = Bank::new_from_parent(root_bank.clone(), SlotLeader::default(), 2);
         let working_bank = bank_forks
             .write()
             .unwrap()
-            .insert(Bank::new_from_parent(
-                root_bank.clone(),
-                SlotLeader::default(),
-                2,
-            ))
+            .insert(working_child)
             .clone_without_scheduler();
 
         let (non_rooted_transaction, non_rooted_signature) = {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -202,6 +202,11 @@ pub struct TransactionBatchProcessor<FG: ForkGraph> {
     /// Builtin program ids
     pub builtin_program_ids: RwLock<HashSet<Pubkey>>,
 
+    /// Cached ProgramCacheForTxBatch pre-populated with builtin entries.
+    /// Populated once per block in `new_from()` from the global program cache,
+    /// avoiding re-acquiring the lock and re-running extract() on every batch.
+    builtin_program_cache: RwLock<ProgramCacheForTxBatch>,
+
     execution_cost: SVMTransactionExecutionCost,
 }
 
@@ -228,6 +233,7 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
                 BuiltinProgram::new_loader(VmConfig::default()),
             ),
             builtin_program_ids: RwLock::new(HashSet::new()),
+            builtin_program_cache: RwLock::new(ProgramCacheForTxBatch::new(Slot::default())),
             execution_cost: SVMTransactionExecutionCost::default(),
         }
     }
@@ -251,6 +257,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             epoch,
             epoch_boundary_preparation,
             global_program_cache: Arc::new(RwLock::new(ProgramCache::new(slot))),
+            builtin_program_cache: RwLock::new(ProgramCacheForTxBatch::new(slot)),
             ..Self::default()
         }
     }
@@ -299,16 +306,33 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     ///   instance.
     /// * Resets the sysvar cache.
     pub fn new_from(&self, slot: Slot, epoch: Epoch) -> Self {
+        let builtin_program_ids = self.builtin_program_ids.read().unwrap().clone();
+        let environments = self.program_runtime_environment.clone();
+
+        // Pre-populate the builtin program cache from the global cache.
+        // This is done once per block rather than once per batch.
+        let mut builtin_program_cache = ProgramCacheForTxBatch::new(slot);
+        let mut search_for: Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)> = builtin_program_ids
+            .iter()
+            .map(|key| (*key, ProgramCacheMatchCriteria::NoCriteria, 0))
+            .collect();
+        self.global_program_cache.read().unwrap().extract(
+            &mut search_for,
+            &mut builtin_program_cache,
+            &environments,
+            false,
+            false,
+        );
+
         Self {
             slot,
             epoch,
             sysvar_cache: RwLock::<SysvarCache>::default(),
             epoch_boundary_preparation: self.epoch_boundary_preparation.clone(),
             global_program_cache: self.global_program_cache.clone(),
-            program_runtime_environment: ProgramRuntimeEnvironment::clone(
-                &self.program_runtime_environment,
-            ),
-            builtin_program_ids: RwLock::new(self.builtin_program_ids.read().unwrap().clone()),
+            program_runtime_environment: environments,
+            builtin_program_ids: RwLock::new(builtin_program_ids),
+            builtin_program_cache: RwLock::new(builtin_program_cache),
             execution_cost: self.execution_cost,
         }
     }
@@ -395,31 +419,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .enable_transaction_balance_recording
             .then(|| BalanceCollector::new_with_transaction_count(sanitized_txs.len()));
 
-        // Create the batch-local program cache.
-        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(self.slot);
-        let builtins = self
-            .builtin_program_ids
-            .read()
-            .unwrap()
-            .iter()
-            .map(|key| (*key, 0))
-            .collect::<HashMap<Pubkey, Slot>>();
-        let ((), program_cache_us) = measure_us!({
-            self.replenish_program_cache(
-                &account_loader,
-                &builtins,
-                environment
-                    .program_runtime_environments
-                    .get_env_for_execution(),
-                &mut program_cache_for_tx_batch,
-                &mut execute_timings,
-                config.check_program_deployment_slot,
-                config.limit_to_load_programs,
-                false, // increment_usage_counter
-            );
-        });
-        execute_timings
-            .saturating_add_in_place(ExecuteTimingType::ProgramCacheUs, program_cache_us);
+        // Clone the batch-local program cache (builtins already populated in new_from()).
+        // User-deployed programs are loaded per-transaction via replenish_program_cache
+        // in the transaction loop below.
+        let mut program_cache_for_tx_batch = self.builtin_program_cache.read().unwrap().clone();
 
         if program_cache_for_tx_batch.hit_max_limit {
             return LoadAndExecuteSanitizedTransactionsOutput {
@@ -1196,12 +1199,17 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     /// Add a built-in program
     pub fn add_builtin(&self, program_id: Pubkey, builtin: ProgramCacheEntry) {
         self.builtin_program_ids.write().unwrap().insert(program_id);
+        let entry = Arc::new(builtin);
         self.global_program_cache.write().unwrap().assign_program(
             &self.program_runtime_environment,
             program_id,
             0,
-            Arc::new(builtin),
+            Arc::clone(&entry),
         );
+        self.builtin_program_cache
+            .write()
+            .unwrap()
+            .replenish(program_id, entry);
     }
 
     #[cfg(feature = "dev-context-only-utils")]


### PR DESCRIPTION
# Problem
every transaction batch dispatch recomputes two values that are actually constant for the entire epoch:

1. **builtin program cache**: each txn dispatch acquires a read lock on `global_program_cache` and runs `extract()` to populate a `ProgramCacheForTxBatch` with builtin entries. this is expensive and not ibrl. we deal with this in the current PR

2. **runtime feature set**: each txn dispatch performs >50 `FeatureSet::is_active()` lookups to build an `SVMFeatureSet`, even though the active feature set is fixed for the epoch. this is also expensive and also not ibrl.
this is dealt with in https://github.com/anza-xyz/agave/pull/11220

# Solution 
- `TransactionBatchProcessor` now stores a `cached_builtin_program_cache` that is populated once on first dispatch and then cloned into same-epoch child banks via `copy_builtin_program_cache_from()`, avoiding the global cache lock and extract on every subsequent dispatch. note again this is ONLY for builtins; user-deployed programs continue to be loaded per-transaction as before.

with this + feature set optimizations, as measured by the (previously) included `bench_tx_dispatch` benchmark (16 simple transfers dispatched as 16 individual batches vs. 1 batch of 16), the overhead ratio drops from 1.82x to 1.23x -- a 48% reduction in per-batch dispatch overhead.

benchmark done on `AMD EPYC 9275F 24-Core Processor`
before:
```
=== Top-level (16 txs, 200 iters) ===

Batch of 16:     mean    43.76µs
16 x individual: mean    79.84µs
Overhead ratio:  1.82x
```

after:
```
=== Top-level (16 txs, 200 iters) ===

Batch of 16:     mean    42.03µs
16 x individual: mean    53.42µs
Overhead ratio:  1.23x
```

the cached builtins optimization is responsible for 75% of this speedup.

# Why do we care?
speeds up replay and block production!

1. in mainnet traffic we often see long dependency chains and often see small batches executed serially. in the current world, oracle updates are very cheap and so many sequential oracle updates actually mimic this benchmark and can be sped up with this PR. in the future when ppl actually care about performace and use p-token and p-anchor, this dispatch overhead will also matter. 
2. in banking, large batches are used rn (max=64 for nonvotes, max=16 for votes) to amortize this overhead. this is kind of fine except it isn't because if a valuable lock (a hot market) is held alongside 63 other txns, the valuable lock is not released until the whole batch is done. this is no bueno. this PR enables us to reduce batching without having to overpay on this overhead.
3. also related to block production ibrl: smaller batches = smaller entries = higher probability of less padding when serializing entries into a fec set. this is technically possible with large batch execution if recording is changed to record len=1 batches, but we leave this issue for another time.
