### PR TITLE
tpu-client-next: fix flaky test_client_builder #10596

### DIFF
--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -868,7 +868,6 @@ async fn test_client_builder() {
     );
 
     let _drop_guard = cancel.clone().drop_guard();
-
     let successfully_sent = Arc::new(AtomicU64::new(0));
 
     let port_range = localhost_port_range_for_tests();
@@ -897,6 +896,9 @@ async fn test_client_builder() {
                         }
                     })
                     .await;
+                // update right after the cancel
+                let view = stats.read_and_reset();
+                successfully_sent.fetch_add(view.successfully_sent, Ordering::Relaxed);
             }
         });
 


### PR DESCRIPTION
#### Problem

There was a problem with flaky test_client_builder due to a lack of synchronization between stats collection and the assertion.

ref: https://github.com/anza-xyz/agave/issues/10596

#### Summary of Changes

Fixes:  https://github.com/anza-xyz/agave/issues/10596

