### PR TITLE
fix(votor): use `get_or_insert_with` to avoid eager allocations

### DIFF
--- a/votor/src/consensus_pool/certificate_builder.rs
+++ b/votor/src/consensus_pool/certificate_builder.rs
@@ -157,8 +157,9 @@ impl BuilderType {
                         try_set_bitmap(bitmap0, msg.rank)?;
                     } else {
                         assert_eq!(vote_type, vote_types[1]);
-                        let (_, bitmap) = sig_and_bitmap1
-                            .get_or_insert((SignatureProjective::identity(), default_bitvec()));
+                        let (_, bitmap) = sig_and_bitmap1.get_or_insert_with(|| {
+                            (SignatureProjective::identity(), default_bitvec())
+                        });
                         try_set_bitmap(bitmap, msg.rank)?;
                     }
                 }
@@ -188,7 +189,7 @@ impl BuilderType {
                         try_set_bitmap(bitmap0, msg.rank)?;
                     } else {
                         assert_eq!(vote_type, vote_types[1]);
-                        let bitmap = bitmap1.get_or_insert(default_bitvec());
+                        let bitmap = bitmap1.get_or_insert_with(default_bitvec);
                         try_set_bitmap(bitmap, msg.rank)?;
                     }
                 }


### PR DESCRIPTION
#### Problem

The `get_or_insert()` method eagerly evaluates its argument, causing [default_bitvec()]https://github.com/anza-xyz/agave/blob/46adba4d0f2800fb3ea4888be960428e6491b832/votor/src/consensus_pool/certificate_builder.rs#L39-L41 (which allocates 4096 bits) to be called on every loop iteration even when the Option already contains a value. This resulted in unnecessary heap allocations when processing fallback vote messages.

#### Summary of Changes

Replace `get_or_insert()` with `get_or_insert_with()` in both Skip and NotarFallback branches of `BuilderType::aggregate()`. The closure is now only invoked when the Option is None, eliminating redundant bitmap allocations during certificate aggregation.
