### PR TITLE
genesis: Check faucet_lamports supplied is in valid range

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -472,11 +472,17 @@ where
 
 pub fn is_non_zero(value: impl AsRef<str>) -> Result<(), String> {
     let value = value.as_ref();
-    if value.eq("0") {
-        Err(String::from("cannot be zero"))
-    } else {
-        Ok(())
+
+    // Try parsing as f64 to catch "0.00" or "0e2"
+    if let Ok(float_val) = value.parse::<f64>() {
+        if float_val == 0.0 {
+            return Err(String::from("cannot be zero"));
+        }
+        return Ok(());
     }
+
+    // Other validators should catch parse errors.
+    Ok(())
 }
 
 #[cfg(test)]

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -414,6 +414,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .long("faucet-lamports")
                 .value_name("LAMPORTS")
                 .takes_value(true)
+                .requires("faucet_pubkey")
                 .validator(is_non_zero)
                 .help("Number of lamports to assign to the faucet"),
         )

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -735,7 +735,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let bootstrap_stake_authorized_pubkey =
         pubkey_of(&matches, "bootstrap_stake_authorized_pubkey");
-    let faucet_lamports = u64::from(value_t_or_exit!(matches, "faucet_lamports", NonZeroU64));
     let faucet_pubkey = pubkey_of(&matches, "faucet_pubkey");
 
     let ticks_per_slot = value_t_or_exit!(matches, "ticks_per_slot", u64);
@@ -829,6 +828,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     }
 
     if let Some(faucet_pubkey) = faucet_pubkey {
+        let faucet_lamports = u64::from(value_t_or_exit!(matches, "faucet_lamports", NonZeroU64));
         genesis_config.add_account(
             faucet_pubkey,
             AccountSharedData::new(faucet_lamports, 0, &system_program::id()),

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -14,8 +14,8 @@ use {
             unix_timestamp_from_rfc3339_datetime,
         },
         input_validators::{
-            is_pubkey, is_pubkey_or_keypair, is_rfc3339_datetime, is_slot, is_url_or_moniker,
-            is_valid_percentage, normalize_to_url_if_moniker,
+            is_non_zero, is_pubkey, is_pubkey_or_keypair, is_rfc3339_datetime, is_slot,
+            is_url_or_moniker, is_valid_percentage, normalize_to_url_if_moniker,
         },
     },
     solana_clock as clock,
@@ -55,6 +55,7 @@ use {
         error,
         fs::File,
         io::{self, Read},
+        num::NonZeroU64,
         path::PathBuf,
         process,
         slice::Iter,
@@ -413,6 +414,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .long("faucet-lamports")
                 .value_name("LAMPORTS")
                 .takes_value(true)
+                .validator(is_non_zero)
                 .help("Number of lamports to assign to the faucet"),
         )
         .arg(
@@ -733,7 +735,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let bootstrap_stake_authorized_pubkey =
         pubkey_of(&matches, "bootstrap_stake_authorized_pubkey");
-    let faucet_lamports = value_t!(matches, "faucet_lamports", u64).unwrap_or(0);
+    let faucet_lamports = u64::from(value_t_or_exit!(matches, "faucet_lamports", NonZeroU64));
     let faucet_pubkey = pubkey_of(&matches, "faucet_pubkey");
 
     let ticks_per_slot = value_t_or_exit!(matches, "ticks_per_slot", u64);

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -828,13 +828,17 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         genesis_config.creation_time = creation_time;
     }
 
-    if let Some(faucet_pubkey) = faucet_pubkey {
-        let faucet_lamports = u64::from(value_t_or_exit!(matches, "faucet_lamports", NonZeroU64));
-        genesis_config.add_account(
-            faucet_pubkey,
-            AccountSharedData::new(faucet_lamports, 0, &system_program::id()),
-        );
-    }
+    let faucet_account_lamports = faucet_pubkey
+        .map(|faucet_pubkey| {
+            let faucet_lamports =
+                u64::from(value_t_or_exit!(matches, "faucet_lamports", NonZeroU64));
+            genesis_config.add_account(
+                faucet_pubkey,
+                AccountSharedData::new(faucet_lamports, 0, &system_program::id()),
+            );
+            faucet_lamports
+        })
+        .unwrap_or(0);
 
     add_genesis_stake_config_account(&mut genesis_config);
     add_genesis_epoch_rewards_account(&mut genesis_config);
@@ -884,7 +888,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         .map(|account| account.lamports)
         .sum::<u64>();
 
-    add_genesis_stake_accounts(&mut genesis_config, issued_lamports - faucet_lamports);
+    add_genesis_stake_accounts(
+        &mut genesis_config,
+        issued_lamports - faucet_account_lamports,
+    );
 
     let parse_address = |address: &str, input_type: &str| {
         address.parse::<Pubkey>().unwrap_or_else(|err| {


### PR DESCRIPTION
#### Problem

When `solana-genesis` is run with `--faucet-lamports 0` or with `--faucet-lamports 50000000000000000000` (not a valid u64), the command will panic due to an assertion in `GenesisConfig::fmt`. `solana_genesis_config` asserts that all accounts generated have `lamports > 0`:

```rust
self.accounts
                .iter()
                .map(|(pubkey, account)| {
                    assert!(account.lamports > 0, "{:?}", (pubkey, account));
                    account.lamports
                })
                .sum::<u64>(),
``` 
https://github.com/anza-xyz/solana-sdk/blob/1cf4c970e5dedbbf5cb6c2081d8f40e73f053c74/genesis-config/src/lib.rs#L257C1-L263C31

#### Summary of Changes

- Use value_t_or_exit! instead of value_t! to parse faucet_lamports to prevent setting it to 0 when invalid value is supplied
- Print error and exit if faucet_lamports is 0


Fixes panic in `solana-genesis`
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
