### PR TITLE
runtime: use direct `get_prioritization_fee()` instead of `FeeBudgetLimits` conversion

### DIFF
--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -248,10 +248,8 @@ impl PrioritizationFeeCache {
                     .map(|(_, key)| *key)
                     .collect();
 
-                let (prioritization_fee, calculate_prioritization_fee_us) = measure_us!({
-                    solana_fee_structure::FeeBudgetLimits::from(compute_budget_limits)
-                        .prioritization_fee
-                });
+                let (prioritization_fee, calculate_prioritization_fee_us) =
+                    measure_us!(compute_budget_limits.get_prioritization_fee());
                 self.metrics
                     .accumulate_total_calculate_prioritization_fee_elapsed_us(
                         calculate_prioritization_fee_us,


### PR DESCRIPTION
<!-- в чем причина правок? -->
The code was creating a full FeeBudgetLimits struct via From<ComputeBudgetLimits> just to extract the prioritization_fee field. This unnecessarily copied 3 unused fields (loaded_accounts_data_size_limit, heap_cost, compute_unit_limit) and performed 
redundant work.

<!-- Четкое и лаконичное общее описание изменений, вносимых этим PR -->
Replace FeeBudgetLimits::from(compute_budget_limits).prioritization_fee with compute_budget_limits.get_prioritization_fee() for cleaner, more efficient code.