### PR TITLE
add --block-producer CLI flag

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -735,7 +735,7 @@ impl ReplayStage {
             if !migration_status.is_alpenglow_enabled() {
                 // This reset is handled in block creation loop for alpenglow
                 Self::reset_poh_recorder(
-                    &my_pubkey,
+                    &cluster_info.turbine_id(),
                     &blockstore,
                     working_bank,
                     &mut poh_controller,
@@ -750,6 +750,11 @@ impl ReplayStage {
                 if exit.load(Ordering::Relaxed) {
                     break;
                 }
+
+                // Read block-producer identity once per iteration so it's
+                // consistent across all leader-schedule checks in this loop.
+                // Updated dynamically via ClusterInfo::set_block_producer_keypair.
+                let block_producer_id = cluster_info.turbine_id();
 
                 let mut generate_new_bank_forks_time =
                     Measure::start("generate_new_bank_forks_time");
@@ -778,7 +783,7 @@ impl ReplayStage {
                 let new_frozen_slots = Self::replay_active_banks(
                     &blockstore,
                     &bank_forks,
-                    &my_pubkey,
+                    &block_producer_id,
                     &vote_account,
                     &mut progress,
                     transaction_status_sender.as_ref(),
@@ -1175,7 +1180,7 @@ impl ReplayStage {
 
                             if !poh_controller.has_pending_message() {
                                 Self::reset_poh_recorder(
-                                    &my_pubkey,
+                                    &block_producer_id,
                                     &blockstore,
                                     reset_bank.clone(),
                                     &mut poh_controller,
@@ -1247,7 +1252,7 @@ impl ReplayStage {
                     drop(descendants);
                     if !tpu_has_bank && !poh_controller.has_pending_message() {
                         if let Some(poh_slot) = Self::maybe_start_leader(
-                            &my_pubkey,
+                            &block_producer_id,
                             &bank_forks,
                             &poh_recorder,
                             &mut poh_controller,
@@ -1265,7 +1270,7 @@ impl ReplayStage {
                                 &my_pubkey,
                                 poh_slot,
                                 &mut current_leader,
-                                &my_pubkey,
+                                &block_producer_id,
                             );
                         }
                     }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -690,6 +690,7 @@ impl Validator {
     pub fn new(
         node: Node,
         identity_keypair: Arc<Keypair>,
+        block_producer_keypair: Option<Arc<Keypair>>,
         ledger_path: &Path,
         vote_account: &Pubkey,
         authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
@@ -707,6 +708,7 @@ impl Validator {
         Self::new_with_exit(
             node,
             identity_keypair,
+            block_producer_keypair,
             ledger_path,
             vote_account,
             authorized_voter_keypairs,
@@ -727,6 +729,7 @@ impl Validator {
     pub fn new_with_exit(
         mut node: Node,
         identity_keypair: Arc<Keypair>,
+        block_producer_keypair: Option<Arc<Keypair>>,
         ledger_path: &Path,
         vote_account: &Pubkey,
         authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
@@ -775,6 +778,12 @@ impl Validator {
         assert_eq!(&id, node.info.pubkey());
 
         info!("identity pubkey: {id}");
+        if let Some(ref bp_keypair) = block_producer_keypair {
+            info!(
+                "block producer pubkey: {} (overrides identity for leader schedule)",
+                bp_keypair.pubkey()
+            );
+        }
         info!("vote account pubkey: {vote_account}");
 
         if !config.no_os_network_stats_reporting {
@@ -998,6 +1007,9 @@ impl Validator {
         cluster_info.set_entrypoints(cluster_entrypoints);
         cluster_info.restore_contact_info(ledger_path, config.contact_save_interval);
         cluster_info.set_bind_ip_addrs(node.bind_ip_addrs.clone());
+        if let Some(ref bp_keypair) = block_producer_keypair {
+            cluster_info.set_block_producer_keypair(bp_keypair.clone());
+        }
         let cluster_info = Arc::new(cluster_info);
         let node_multihoming = Arc::new(NodeMultihoming::from(&node));
         migration_status.set_pubkey(cluster_info.id());
@@ -2978,6 +2990,7 @@ mod tests {
         let validator = Validator::new(
             validator_node,
             Arc::new(validator_keypair),
+            None, // block_producer_keypair
             &validator_ledger_path,
             &voting_keypair.pubkey(),
             Arc::new(RwLock::new(vec![voting_keypair])),
@@ -3195,6 +3208,7 @@ mod tests {
                 Validator::new(
                     validator_node,
                     Arc::new(validator_keypair),
+                    None, // block_producer_keypair
                     &validator_ledger_path,
                     &vote_account_keypair.pubkey(),
                     Arc::new(RwLock::new(vec![Arc::new(vote_account_keypair)])),

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -152,6 +152,14 @@ pub struct ClusterInfo {
     pub gossip: CrdsGossip,
     /// set the keypair that will be used to sign crds values generated. It is unset only in tests.
     keypair: ArcSwap<Keypair>,
+    /// Optional keypair for block production under a different identity (e.g. during identity
+    /// transitions). When set, this keypair is used for shred signing and a second ContactInfo
+    /// entry is published in gossip so the network can route transactions to this validator
+    /// for the block-producer's leader slots.
+    block_producer_keypair: ArcSwap<Option<Arc<Keypair>>>,
+    /// ContactInfo published under the block_producer identity, mirrors the node's socket
+    /// addresses so the network can reach this validator for the block-producer's leader slots.
+    block_producer_contact_info: RwLock<Option<ContactInfo>>,
     /// Network entrypoints
     entrypoints: RwLock<Vec<ContactInfo>>,
     outbound_budget: DataBudget,
@@ -176,6 +184,8 @@ impl ClusterInfo {
         let me = Self {
             gossip: CrdsGossip::default(),
             keypair: ArcSwap::from(keypair),
+            block_producer_keypair: ArcSwap::from(Arc::new(None)),
+            block_producer_contact_info: RwLock::new(None),
             entrypoints: RwLock::default(),
             outbound_budget: DataBudget::default(),
             my_contact_info: RwLock::new(contact_info),
@@ -414,6 +424,7 @@ impl ClusterInfo {
             .unwrap()
             .set_tpu(contact_info::Protocol::QUIC, tpu_addr)?;
         self.refresh_my_gossip_contact_info();
+        self.refresh_block_producer_contact_info();
         Ok(())
     }
 
@@ -426,7 +437,77 @@ impl ClusterInfo {
             .unwrap()
             .set_tpu_forwards(contact_info::Protocol::QUIC, tpu_forwards_addr)?;
         self.refresh_my_gossip_contact_info();
+        self.refresh_block_producer_contact_info();
         Ok(())
+    }
+
+    /// Set the block-producer keypair. This publishes a second ContactInfo in gossip under the
+    /// block-producer's pubkey, pointing to the same TPU/TVU sockets as this node's identity.
+    /// This allows the network to route transactions to this validator for the block-producer's
+    /// leader slots during an identity transition.
+    pub fn set_block_producer_keypair(&self, keypair: Arc<Keypair>) {
+        info!("Setting block producer keypair: {}", keypair.pubkey());
+        self.block_producer_keypair.store(Arc::new(Some(keypair)));
+        self.refresh_block_producer_contact_info();
+    }
+
+    /// Returns the block-producer keypair if set, otherwise the identity keypair.
+    /// Use this for shred signing and relayer/block-engine authentication.
+    pub fn block_producer_keypair(&self) -> Arc<Keypair> {
+        if let Some(bp_keypair) = self.block_producer_keypair.load().as_ref() {
+            bp_keypair.clone()
+        } else {
+            self.keypair()
+        }
+    }
+
+    /// Returns the pubkey to use for the turbine tree.
+    /// If a block-producer is configured, returns the block-producer's pubkey
+    /// (the identity on the leader schedule). Otherwise returns id().
+    pub fn turbine_id(&self) -> Pubkey {
+        if let Some(bp_keypair) = self.block_producer_keypair.load().as_ref() {
+            bp_keypair.pubkey()
+        } else {
+            self.id()
+        }
+    }
+
+    /// Returns the ContactInfo to use for the local node in the turbine tree.
+    /// If a block-producer is configured, returns its ContactInfo (with block-producer
+    /// pubkey and same TVU addresses). Otherwise returns the primary identity's ContactInfo.
+    pub fn turbine_contact_info(&self) -> ContactInfo {
+        if let Some(bp_ci) = self.block_producer_contact_info.read().unwrap().as_ref() {
+            bp_ci.clone()
+        } else {
+            self.my_contact_info.read().unwrap().clone()
+        }
+    }
+
+    /// Re-publishes the block-producer's ContactInfo in CRDS, mirroring any socket
+    /// changes from the identity's ContactInfo (e.g. TPU address updates).
+    fn refresh_block_producer_contact_info(&self) {
+        let bp_keypair_opt = self.block_producer_keypair.load();
+        let Some(bp_keypair) = bp_keypair_opt.as_ref() else {
+            return;
+        };
+
+        // Clone the primary identity's ContactInfo to pick up any socket changes,
+        // then hot_swap_pubkey to the block-producer identity. This gives a fresh
+        // outset each refresh, enabling duplicate-instance detection if another
+        // validator starts with the same block-producer pubkey.
+        let mut bp_info = self.my_contact_info.read().unwrap().clone();
+        bp_info.hot_swap_pubkey(bp_keypair.pubkey());
+        bp_info.set_wallclock(timestamp());
+
+        let entry = CrdsValue::new(CrdsData::ContactInfo(bp_info.clone()), bp_keypair);
+        if let Err(err) = {
+            let mut gossip_crds = self.gossip.crds.write().unwrap();
+            gossip_crds.insert(entry, timestamp(), GossipRoute::LocalMessage)
+        } {
+            error!("refresh_block_producer_contact_info: {err:?}");
+        }
+
+        *self.block_producer_contact_info.write().unwrap() = Some(bp_info);
     }
 
     pub fn set_tpu_vote(
@@ -1455,6 +1536,7 @@ impl ClusterInfo {
                     //we saw a deadlock passing an self.read().unwrap().timeout into sleep
                     if start - last_push > CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS / 2 {
                         self.refresh_my_gossip_contact_info();
+                        self.refresh_block_producer_contact_info();
                         self.refresh_push_active_set(
                             &recycler,
                             &stakes,
@@ -1920,15 +2002,23 @@ impl ClusterInfo {
         }
         // Check if there is a duplicate instance of
         // this node with more recent timestamp.
+        // Also checks the block-producer identity if one is configured.
         let check_duplicate_instance = {
             let my_contact_info = self.my_contact_info();
+            let bp_contact_info = self.block_producer_contact_info.read().unwrap().clone();
             move |values: &[CrdsValue]| {
-                let mut nodes = values.iter().filter_map(CrdsValue::contact_info);
-                if nodes.any(|other| my_contact_info.check_duplicate(other)) {
-                    Err(GossipError::DuplicateNodeInstance)
-                } else {
-                    Ok(())
+                for other in values.iter().filter_map(CrdsValue::contact_info) {
+                    if my_contact_info.check_duplicate(other) {
+                        return Err(GossipError::DuplicateNodeInstance);
+                    }
+                    if let Some(ref bp_ci) = bp_contact_info {
+                        if bp_ci.check_duplicate(other) {
+                            log::warn!("Duplicate block-producer instance: {other:?}");
+                            return Err(GossipError::DuplicateNodeInstance);
+                        }
+                    }
                 }
+                Ok(())
             }
         };
         let mut pings = Vec::new();

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -438,6 +438,7 @@ impl LocalCluster {
             let leader_server = Validator::new(
                 leader_node,
                 leader_keypair.clone(),
+                None, // block_producer_keypair
                 &leader_ledger_path,
                 &leader_vote_keypair.pubkey(),
                 Arc::new(RwLock::new(vec![leader_vote_keypair.clone()])),
@@ -649,6 +650,7 @@ impl LocalCluster {
         let validator_server = Validator::new(
             validator_node,
             validator_keypair.clone(),
+            None, // block_producer_keypair
             &ledger_path,
             &voting_keypair.pubkey(),
             Arc::new(RwLock::new(vec![voting_keypair.clone()])),
@@ -715,6 +717,7 @@ impl LocalCluster {
             let leader_server = Validator::new(
                 leader_node,
                 leader_keypair.clone(),
+                None, // block_producer_keypair
                 &leader_ledger_path,
                 &leader_vote_keypair.pubkey(),
                 Arc::new(RwLock::new(vec![leader_vote_keypair.clone()])),
@@ -779,6 +782,7 @@ impl LocalCluster {
                 let validator_server = Validator::new(
                     validator_node,
                     validator_keypair.clone(),
+                    None, // block_producer_keypair
                     &ledger_path,
                     &voting_keypair.pubkey(),
                     Arc::new(RwLock::new(vec![voting_keypair.clone()])),
@@ -1408,6 +1412,7 @@ impl Cluster for LocalCluster {
         let restarted_node = Validator::new(
             node,
             validator_info.keypair.clone(),
+            None, // block_producer_keypair
             &validator_info.ledger_path,
             &validator_info.voting_keypair.pubkey(),
             Arc::new(RwLock::new(vec![validator_info.voting_keypair.clone()])),

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1234,6 +1234,7 @@ impl TestValidator {
         let validator = Some(Validator::new(
             node,
             Arc::new(validator_identity),
+            None, // block_producer_keypair
             &ledger_path,
             &vote_account_address,
             config.authorized_voter_keypairs.clone(),

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -232,7 +232,7 @@ impl BroadcastStage {
     ) -> BroadcastStageReturnType {
         loop {
             let res = broadcast_stage_run.run(
-                &cluster_info.keypair(),
+                &cluster_info.block_producer_keypair(),
                 blockstore,
                 receiver,
                 socket_sender,

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -345,7 +345,7 @@ pub fn new_cluster_nodes<T: 'static>(
     stakes: &HashMap<Pubkey, u64>,
     use_cha_cha_8: bool,
 ) -> ClusterNodes<T> {
-    let self_pubkey = cluster_info.id();
+    let self_pubkey = cluster_info.turbine_id();
     let nodes = get_nodes(cluster_info, cluster_type, stakes);
     let index: HashMap<_, _> = nodes
         .iter()
@@ -375,15 +375,16 @@ fn get_nodes(
     cluster_type: ClusterType,
     stakes: &HashMap<Pubkey, u64>,
 ) -> Vec<Node> {
-    let self_pubkey = cluster_info.id();
+    let turbine_ci = cluster_info.turbine_contact_info();
+    let self_pubkey = *turbine_ci.pubkey();
     let should_dedup_tvu_addrs = match cluster_type {
         ClusterType::Development => false,
         ClusterType::Devnet | ClusterType::Testnet | ClusterType::MainnetBeta => true,
     };
     let mut nodes: Vec<Node> = std::iter::once({
-        // The local node itself.
+        // The local node itself (uses block-producer identity if configured).
         let stake = stakes.get(&self_pubkey).copied().unwrap_or_default();
-        let node = ContactInfo::from(&cluster_info.my_contact_info());
+        let node = ContactInfo::from(&turbine_ci);
         let node = NodeId::from(node);
         Node { node, stake }
     })

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1616,6 +1616,7 @@ mod tests {
             let _validator = Validator::new(
                 validator_node,
                 Arc::new(validator_keypair),
+                None, // block_producer_keypair
                 &validator_ledger_path,
                 &voting_pubkey,
                 authorized_voter_keypairs,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -47,6 +47,7 @@ pub mod send_transaction_config;
 #[derive(Debug, PartialEq)]
 pub struct RunArgs {
     pub identity_keypair: Keypair,
+    pub block_producer_keypair: Option<Keypair>,
     pub ledger_path: PathBuf,
     pub logfile: Option<PathBuf>,
     pub entrypoints: Vec<SocketAddr>,
@@ -66,6 +67,8 @@ impl FromClapArgMatches for RunArgs {
                 "The --identity <KEYPAIR> argument is required",
                 clap::ErrorKind::ArgumentNotFound,
             ))?;
+
+        let block_producer_keypair = keypair_of(matches, "block_producer");
 
         let ledger_path = PathBuf::from(matches.value_of("ledger_path").ok_or(
             clap::Error::with_description(
@@ -118,6 +121,7 @@ impl FromClapArgMatches for RunArgs {
 
         Ok(RunArgs {
             identity_keypair,
+            block_producer_keypair,
             ledger_path,
             logfile,
             entrypoints,
@@ -148,6 +152,19 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .validator(is_keypair_or_ask_keyword)
             .help("Validator identity keypair"),
+    )
+    .arg(
+        Arg::with_name("block_producer")
+            .long("block-producer")
+            .value_name("KEYPAIR")
+            .takes_value(true)
+            .validator(is_keypair_or_ask_keyword)
+            .help(
+                "Optional keypair whose identity is checked against the leader schedule for block \
+                 production. Use this to produce blocks under a previous identity during an \
+                 identity transition, while the new identity propagates through the epoch stakes \
+                 snapshot. [default: the --identity keypair]",
+            ),
     )
     .arg(
         Arg::with_name("authorized_voter_keypairs")
@@ -1304,6 +1321,7 @@ mod tests {
 
             RunArgs {
                 identity_keypair,
+                block_producer_keypair: None,
                 ledger_path,
                 logfile: Some(logfile),
                 entrypoints,
@@ -1328,6 +1346,10 @@ mod tests {
         fn clone(&self) -> Self {
             RunArgs {
                 identity_keypair: self.identity_keypair.insecure_clone(),
+                block_producer_keypair: self
+                    .block_producer_keypair
+                    .as_ref()
+                    .map(|kp| kp.insecure_clone()),
                 logfile: self.logfile.clone(),
                 entrypoints: self.entrypoints.clone(),
                 known_validators: self.known_validators.clone(),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -123,6 +123,7 @@ pub fn execute(
     } = cli::thread_args::parse_num_threads_args(matches);
 
     let identity_keypair = Arc::new(run_args.identity_keypair);
+    let block_producer_keypair = run_args.block_producer_keypair.map(Arc::new);
 
     let logfile = run_args.logfile;
     if let Some(logfile) = logfile.as_ref() {
@@ -1124,6 +1125,7 @@ pub fn execute(
     let validator = Validator::new_with_exit(
         node,
         identity_keypair,
+        block_producer_keypair,
         &ledger_path,
         &vote_account,
         authorized_voter_keypairs,


### PR DESCRIPTION
# Problem:
Currently, if a validator operators switches their validator identity after using `vote-update-validator`, they will be required to vote using the new identity, but block production is broken because the leader schedule still has the old identity in the cached EpochStakes.

# Solution:
Adds a `--block-producer` CLI flag that accepts an optional keypair whose identity is used for leader schedule checks, shred signing, and turbine tree construction instead of the --identity keypair. This enables block production under a previous identity during an identity transition (i.e. after using `vote-update-validator`), while the new identity propagates through the epoch stakes snapshot. The block-producer keypair is stored on ClusterInfo behind an ArcSwap, allowing dynamic updates and reusing the existing gossip infrastructure (hot_swap_pubkey, duplicate-instance detection) to publish a second ContactInfo under the block-producer's pubkey. When no `--block-producer` is specified, behavior is unchanged (the identity keypair is used everywhere).

So, when undergoing id change, operators can use

```
    --identity new_identity.json \
    --vote-account vote.json \
    --authorized-voter auth_voter.json \
    --block-producer old_identity.json
```
(if authorized_voter==new_identity, then operator should obv use same keypair)

This is a workaround until we write a SIMD to update the vote program to queue up the change.