### PR TITLE
feat(alpenglow): introducing the alpenclock account to the bank

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10387,6 +10387,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
+ "wincode 0.4.4",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8661,6 +8661,7 @@ dependencies = [
  "symlink",
  "tempfile",
  "thiserror 2.0.18",
+ "wincode 0.4.4",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8514,6 +8514,7 @@ dependencies = [
  "symlink",
  "tempfile",
  "thiserror 2.0.18",
+ "wincode 0.4.4",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -188,6 +188,7 @@ strum_macros = { workspace = true }
 symlink = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -195,6 +195,7 @@ use {
         },
         time::{Duration, Instant},
     },
+    wincode,
 };
 #[cfg(feature = "dev-context-only-utils")]
 use {


### PR DESCRIPTION
#### Problem
The clock sysvar (`Clock`) has second-level resolution for its `unix_timestamp` field. Alpenglow block footers carry UNIX timestamps at nanosecond resolution, but there is currently no on-chain account to store and expose this higher-precision timestamp.

#### Summary of Changes

- Introduce a new off-curve PDA account (`NANOSECOND_CLOCK_ACCOUNT`) derived from the seed `"alpenclock"` under the `alpenglow` feature gate program address.

- Add `Bank::update_clock_from_footer(unix_timestamp_nanos)`

- Add `Bank::get_nanosecond_clock()` to deserialize the nanosecond timestamp from the `alpenclock` account.

This PR addresses https://github.com/solana-foundation/solana-improvement-documents/pull/363.