### PR TITLE
tpu-client-next: set initial congestion window to fit 128 transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11359,6 +11359,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
+ "solana-packet 4.0.0",
  "solana-pubkey 4.1.0",
  "solana-pubsub-client",
  "solana-rpc-client",

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -563,6 +563,7 @@ impl TpuClientNextClient {
                 send: 1,
                 connect: 4,
             },
+            override_initial_congestion_window: None,
         }
     }
 }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9450,6 +9450,7 @@ dependencies = [
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
+ "solana-packet 4.0.0",
  "solana-pubkey 4.1.0",
  "solana-rpc-client",
  "solana-rpc-client-api",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10081,6 +10081,7 @@ dependencies = [
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
+ "solana-packet 4.0.0",
  "solana-pubkey 4.1.0",
  "solana-rpc-client",
  "solana-rpc-client-api",

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -182,6 +182,7 @@ impl TpuClientNextClient {
                 connect: leader_forward_count + 1,
                 send: leader_forward_count,
             },
+            override_initial_congestion_window: None,
         }
     }
 

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -32,6 +32,7 @@ solana-epoch-schedule = { workspace = true }
 solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true, optional = true }
+solana-packet = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-pubsub-client = { workspace = true, optional = true }
 solana-rpc-client = { workspace = true }

--- a/tpu-client-next/src/client_builder.rs
+++ b/tpu-client-next/src/client_builder.rs
@@ -89,6 +89,7 @@ pub struct ClientBuilder {
     report_fn: Option<ReportFn>,
     cancel_scheduler: CancellationToken,
     cancel_reporter: CancellationToken,
+    override_initial_congestion_window: Option<u64>,
 }
 
 impl ClientBuilder {
@@ -108,6 +109,7 @@ impl ClientBuilder {
             report_fn: None,
             cancel_scheduler: CancellationToken::new(),
             cancel_reporter: CancellationToken::new(),
+            override_initial_congestion_window: None,
         }
     }
 
@@ -178,6 +180,14 @@ impl ClientBuilder {
         self
     }
 
+    /// Set the initial congestion window size in bytes.
+    ///
+    /// If not set, defaults to INITIAL_CONGESTION_WINDOW.
+    pub fn override_initial_congestion_window(mut self, bytes: u64) -> Self {
+        self.override_initial_congestion_window = Some(bytes);
+        self
+    }
+
     /// Set the broadcaster used by the scheduler.
     pub fn broadcaster(mut self, broadcaster: impl WorkersBroadcaster + 'static) -> Self {
         self.broadcaster = Box::new(broadcaster);
@@ -213,6 +223,7 @@ impl ClientBuilder {
                 connect: self.leader_send_fanout.saturating_add(1),
                 send: self.leader_send_fanout,
             },
+            override_initial_congestion_window: self.override_initial_congestion_window,
         };
 
         let scheduler = ConnectionWorkersScheduler::new(

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -100,6 +100,10 @@ pub struct ConnectionWorkersSchedulerConfig {
 
     /// Configures the number of leaders to connect to and send transactions to.
     pub leaders_fanout: Fanout,
+
+    /// Override the initial congestion window size in bytes. If `None`, uses
+    /// INITIAL_CONGESTION_WINDOW as the default.
+    pub override_initial_congestion_window: Option<u64>,
 }
 
 /// The [`BindTarget`] enum defines how the UDP socket should be bound:
@@ -214,6 +218,7 @@ impl ConnectionWorkersScheduler {
             worker_channel_size,
             max_reconnect_attempts,
             leaders_fanout,
+            override_initial_congestion_window: initial_congestion_window,
         }: ConnectionWorkersSchedulerConfig,
         broadcaster: Box<dyn WorkersBroadcaster>,
     ) -> Result<Arc<SendTransactionStats>, ConnectionWorkersSchedulerError> {
@@ -224,7 +229,7 @@ impl ConnectionWorkersScheduler {
             cancel,
             stats,
         } = self;
-        let mut endpoint = setup_endpoint(bind, stake_identity)?;
+        let mut endpoint = setup_endpoint(bind, stake_identity, initial_congestion_window)?;
 
         debug!("Client endpoint bind address: {:?}", endpoint.local_addr());
         let mut workers = WorkersCache::new(num_connections, cancel.clone());
@@ -252,7 +257,7 @@ impl ConnectionWorkersScheduler {
                         continue;
                     };
 
-                    let client_config = build_client_config(update_identity_receiver.borrow_and_update().as_ref());
+                    let client_config = build_client_config(update_identity_receiver.borrow_and_update().as_ref(), initial_congestion_window);
                     endpoint.set_default_client_config(client_config);
                     // Flush workers since they are handling connections created
                     // with outdated certificate.
@@ -309,18 +314,22 @@ impl ConnectionWorkersScheduler {
 pub fn setup_endpoint(
     bind: BindTarget,
     stake_identity: Option<StakeIdentity>,
+    initial_congestion_window: Option<u64>,
 ) -> Result<Endpoint, ConnectionWorkersSchedulerError> {
-    let client_config = build_client_config(stake_identity.as_ref());
+    let client_config = build_client_config(stake_identity.as_ref(), initial_congestion_window);
     let endpoint = create_client_endpoint(bind, client_config)?;
     Ok(endpoint)
 }
 
-fn build_client_config(stake_identity: Option<&StakeIdentity>) -> ClientConfig {
+fn build_client_config(
+    stake_identity: Option<&StakeIdentity>,
+    initial_congestion_window: Option<u64>,
+) -> ClientConfig {
     let client_certificate = match stake_identity {
         Some(identity) => identity.as_certificate(),
         None => &QuicClientCertificate::new(None),
     };
-    create_client_config(client_certificate)
+    create_client_config(client_certificate, initial_congestion_window)
 }
 
 /// [`NonblockingBroadcaster`] attempts to immediately send transactions to all

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -388,7 +388,7 @@ mod tests {
 
     fn create_test_endpoint() -> Endpoint {
         let socket = bind_to_localhost_unique().unwrap();
-        let client_config = create_client_config(&QuicClientCertificate::new(None));
+        let client_config = create_client_config(&QuicClientCertificate::new(None), None);
         create_client_endpoint(BindTarget::Socket(socket), client_config).unwrap()
     }
 

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -68,6 +68,7 @@ fn test_config(stake_identity: Option<Keypair>) -> ConnectionWorkersSchedulerCon
             send: 1,
             connect: 1,
         },
+        override_initial_congestion_window: None,
     }
 }
 


### PR DESCRIPTION
#### Problem
Default initial congestion window in Quinn's Cubic (10 segmanets) is arguably overly conservative for short-lived, latency-sensitive flows. Modern CDNs routinely use much larger initial congestion windows to avoid slow start dominating transfer time.

#### Summary of Changes
Increase the QUIC initial congestion window from quinn's default 10 segments to 128 * PACKET_DATA_SIZE bytes, allowing clients to burst 128 transaction at connection start without waiting for slow-start ramp-up.

128 was chosen to match the lowest MAX_STREAMS value for staked connections (flow control restriction) in v3.1.

This large initial_cwnd may be overkill (and even suboptimal) for short-RTT connections. But note that there is **an interplay with the MAX_STREAMS changes** in https://github.com/anza-xyz/agave/pull/10666, which scales MAX_STREAMS based on RTT down to RTT=1ms. Say, a connection with RTT=1ms will have MAX_STREAMS=20, in which case flow control will be the limiting factor, i.e., the client will send at most ~20KB per RTT, not a complete cwnd window. However, this will change with the introduction of 4K transactions.

Future: evaluate alternative CC algorithms better suited for bursty, latency-sensitive traffic
 
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
