### PR TITLE
ABIv2: Rename variables and add new method

### DIFF
--- a/transaction-context/src/instruction.rs
+++ b/transaction-context/src/instruction.rs
@@ -75,6 +75,7 @@ pub struct InstructionContext<'a, 'ix_data> {
     // The rest of the fields are redundant shortcuts
     pub(crate) index_in_trace: usize,
     pub(crate) nesting_level: usize,
+    pub(crate) index_of_caller_instruction: usize,
     pub(crate) program_account_index_in_tx: IndexOfAccount,
     pub(crate) instruction_accounts: &'a [InstructionAccount],
     pub(crate) dedup_map: &'a [u16],
@@ -85,6 +86,11 @@ impl<'a> InstructionContext<'a, '_> {
     /// How many Instructions were on the trace before this one was pushed
     pub fn get_index_in_trace(&self) -> usize {
         self.index_in_trace
+    }
+
+    /// Returns the index of the instruction that called into this one.
+    pub fn get_index_of_caller(&self) -> usize {
+        self.index_of_caller_instruction
     }
 
     /// How many Instructions were on the stack after this one was pushed


### PR DESCRIPTION
#### Problem

For ABIv2, we want to reorder the instruction trace (see https://github.com/anza-xyz/agave/pull/10557). For that to happen, we need to expose more information through new methods, rename and repurpose some variables.

This PR was split from https://github.com/anza-xyz/agave/pull/10557.

#### Summary of Changes

1. Add `index_of_caller_instruction` to `InstructionContext` and expose it via `get_index_of_caller`. The variable was previously only available in `InstructionFrame`.
2. Rename `number_of_instructions` to `total_number_of_instructions_in_trace` and update the comment above it.
3. Repurpose `number_of_executed_cpis` into `number_of_cpis_in_trace`. The number of executed CPIs isn't helpful either for runtime or programs, since there could be CPI instructions in trace whose execution had not finished yet. As a consequence, they wouldn't be represented in the variables we track.
4. Repurpose `top_level_instruction_index` into `next_top_level_instruction_index`. For a reordered trace, when the next instruction to execute is not necessarily the next one, knowing the next top level one comes in handy.
5. Do not initialize `cpi_scratchpad` in the `TransactionContext` constructor. The initialization there is not necessary and always happens in `configure_next_instruction`.
6. Delete `set_top_level_instruction_index` because it was unused.
7. Update both `next_top_level_instruction_index` and `number_of_cpis_in_trace` in `fn push`.
8. Create getters `fn number_of_active_instructions_in_trace`, `fn next_top_level_instruction_index` and `fn number_of_cpis_in_trace`.


For a broader view of how everything connects, please check https://github.com/anza-xyz/agave/pull/10557.
