### PR TITLE
cli: Print error during `program close`

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2432,7 +2432,7 @@ async fn process_close(
 
         let mut closed = vec![];
         for buffer in buffers.buffers.iter() {
-            if close(
+            match close(
                 rpc_client,
                 config,
                 &Pubkey::from_str(&buffer.address)?,
@@ -2441,11 +2441,16 @@ async fn process_close(
                 None,
             )
             .await
-            .is_ok()
             {
-                closed.push(buffer.clone());
+                Ok(()) => {
+                    closed.push(buffer.clone());
+                }
+                Err(err) => {
+                    eprintln!("Failed to close buffer {}: {}", buffer.address, err);
+                }
             }
         }
+
         Ok(config
             .output_format
             .formatted_string(&CliUpgradeableBuffers {


### PR DESCRIPTION
#### Problem

If user has no realistic (very small) sol balance and unclosed buffers

solana program close --buffers

will fail silently and just convey to the user that there's no buffers to close

#### Summary of Changes

Instead of printing nothing print the unclosed buffers with their corresponding error message.

Fixes [solana program close --buffers -> fails silently if there's no valid amount of solana in the wallet #10638](https://github.com/anza-xyz/agave/issues/10638)