### PR TITLE
accounts-db: Use `SmallRng` for LRU eviction sampling

### DIFF
--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -7,9 +7,9 @@ use {
     dashmap::{mapref::entry::Entry, DashMap},
     log::*,
     rand::{
-        rng,
+        rngs::SmallRng,
         seq::{IndexedRandom as _, IteratorRandom},
-        Rng,
+        Rng, SeedableRng,
     },
     solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::Slot,
@@ -288,7 +288,7 @@ impl ReadOnlyAccountsCache {
             .name("solAcctReadCache".to_string())
             .spawn(move || {
                 info!("AccountsReadCacheEvictor has started");
-                let mut rng = rng();
+                let mut rng = SmallRng::from_os_rng();
                 loop {
                     if exit.load(Ordering::Relaxed) {
                         break;


### PR DESCRIPTION
#### Problem

Sampling is the biggest bottleneck in the eviction mechanism, which with the default `Rng` takes 82% of the whole eviction process and causes the overall eviction process to take over 20s.

<img width="1908" height="535" alt="eviction_before_2" src="https://github.com/user-attachments/assets/38a09782-a1d2-4a0e-8061-e14215a86e51" />
<img width="1907" height="398" alt="eviction_before" src="https://github.com/user-attachments/assets/0b6bf318-6fe2-4964-aaf2-0d045936e3e9" />

#### Summary of Changes

Optimize it by using `SmallRng`.

<img width="3798" height="366" alt="eviction_small_rng" src="https://github.com/user-attachments/assets/8b6410ea-393f-4f48-8ad0-d8337c5bbc30" />
<img width="1237" height="271" alt="eviction_small_rng_2" src="https://github.com/user-attachments/assets/391ed572-779c-4981-8c59-15fad5e87f07" />

---

:point_up: The new profiles are still not ideal - the lock contention, previously taking 11% of time, now is the biggest bottleneck taking 91%. But that's going away in #10641.