### PR TITLE
accounts-db: Reduce read-only cache lock contention

### DIFF
--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -30,6 +30,13 @@ use {
 const CACHE_ENTRY_SIZE: usize =
     size_of::<ReadOnlyAccountCacheEntry>() + size_of::<ReadOnlyCacheKey>();
 
+/// Number of cache shards. Using 2^16 (65 536) shards keeps the count a power
+/// of two and roughly matches the number of cached accounts we observe on
+/// mainnet-beta. The average load is still ~1 account per shard (collisions are
+/// common), but compared with the default `num_cpus * 4` shards - where we saw
+/// hot shards carrying ~200 accounts - this dramatically lowers contention.
+const NUM_SHARDS: usize = 65536;
+
 type ReadOnlyCacheKey = Pubkey;
 
 #[derive(Debug)]
@@ -105,7 +112,10 @@ impl ReadOnlyAccountsCache {
     ) -> Self {
         assert!(max_data_size_lo <= max_data_size_hi);
         assert!(evict_sample_size > 0);
-        let cache = Arc::new(DashMap::with_hasher(AHashRandomState::default()));
+        let cache = Arc::new(DashMap::with_hasher_and_shard_amount(
+            AHashRandomState::default(),
+            NUM_SHARDS,
+        ));
         let data_size = Arc::new(AtomicUsize::default());
         let stats = Arc::new(AtomicReadOnlyCacheStats::default());
         let timer = Instant::now();


### PR DESCRIPTION
This PR builds on #10640. It can be merged independently, but the issue was identified after applying that change, and the profiles below were captured with #10640 applied.

---

#### Problem

`DashMap` defaults to `num_cpus * 4` shards (~256 on 64-core validators), so each shard holds ~200 of the ~45-55k cached accounts and locking one shard blocks many unrelated keys.

<img width="3798" height="366" alt="eviction_small_rng" src="https://github.com/user-attachments/assets/091d605a-a59a-409c-99d3-ffcc9a608212" />
<img width="1237" height="271" alt="eviction_small_rng_2" src="https://github.com/user-attachments/assets/0ef316b8-1eb9-4996-b40c-e1e0dc46d7e4" />

The current load/store times on master are:

```
read_only_accounts_cache_load_us=5474i read_only_accounts_cache_store_us=293i
read_only_accounts_cache_load_us=4659i read_only_accounts_cache_store_us=227i
read_only_accounts_cache_load_us=5042i read_only_accounts_cache_store_us=220i
read_only_accounts_cache_load_us=3286i read_only_accounts_cache_store_us=92i
read_only_accounts_cache_load_us=7615i read_only_accounts_cache_store_us=599i
read_only_accounts_cache_load_us=2819i read_only_accounts_cache_store_us=82i
read_only_accounts_cache_load_us=3240i read_only_accounts_cache_store_us=204i
read_only_accounts_cache_load_us=3832i read_only_accounts_cache_store_us=240i
read_only_accounts_cache_load_us=8635i read_only_accounts_cache_store_us=378i
read_only_accounts_cache_load_us=9273i read_only_accounts_cache_store_us=260i
```

#### Summary of Changes

Increase the shard count to 2^16 (65 536) that keeps a power of two and roughly matches the number of cached accounts we observe on mainnet-beta. The average load is still ~1 account per shard (collisions are common), but compared with the default `num_cpus * 4` shards - where we saw hot shards carrying ~200 accounts - this dramatically lowers contention.

After the change, the only visible sleeps are the ones taking ~100ms intervals, so it's the sleep we trigger on each iteration of evictor, rather than sleep coming from the lock contention. In between these sleep intervals, the only visible work is dropping the cache memory (the actual eviction).

<img width="1798" height="624" alt="eviction_moar_shards" src="https://github.com/user-attachments/assets/f652caad-5a92-4c70-ac4b-e23f844346c1" />
<img width="1797" height="491" alt="eviction_moar_shards_2" src="https://github.com/user-attachments/assets/d931071a-05ca-4316-9489-ccda893d73f4" />
<img width="1432" height="316" alt="eviction_moar_shards_3" src="https://github.com/user-attachments/assets/3affcce1-06b4-4a1e-9434-0617a3d3894f" />
<img width="1798" height="491" alt="eviction_moar_shards_4" src="https://github.com/user-attachments/assets/e398e337-9ccf-45b9-86ba-6f15a326e012" />

The new load/store times are:

```
read_only_accounts_cache_load_us=4103i read_only_accounts_cache_store_us=10i
read_only_accounts_cache_load_us=4577i read_only_accounts_cache_store_us=72i
read_only_accounts_cache_load_us=5233i read_only_accounts_cache_store_us=19i
read_only_accounts_cache_load_us=4928i read_only_accounts_cache_store_us=12i
read_only_accounts_cache_load_us=2270i read_only_accounts_cache_store_us=5i
read_only_accounts_cache_load_us=3722i read_only_accounts_cache_store_us=48i
read_only_accounts_cache_load_us=5225i read_only_accounts_cache_store_us=28i
read_only_accounts_cache_load_us=5243i read_only_accounts_cache_store_us=9i
read_only_accounts_cache_load_us=4631i read_only_accounts_cache_store_us=14i
read_only_accounts_cache_load_us=4564i read_only_accounts_cache_store_us=18i
```