### PR TITLE
stores `BLSKeypair` in `ValidatorVoteKeypairs`

### DIFF
--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -293,12 +293,11 @@ impl LocalCluster {
                         stake
                     );
                     if *in_genesis {
+                        let node_keypair = node_keypair.insecure_clone();
+                        let vote_keypair = vote_keypair.insecure_clone();
+                        let stake_keypair = Keypair::new();
                         Some((
-                            ValidatorVoteKeypairs {
-                                node_keypair: node_keypair.insecure_clone(),
-                                vote_keypair: vote_keypair.insecure_clone(),
-                                stake_keypair: Keypair::new(),
-                            },
+                            ValidatorVoteKeypairs::new(node_keypair, vote_keypair, stake_keypair),
                             stake,
                         ))
                     } else {


### PR DESCRIPTION
#### Problem

`ValidatorVoteKeypairs` does not store `BLSKeypair` that is associated with the the rest of keys.  Some use cases need it.

Also see: https://discord.com/channels/428295358100013066/1377667311174946816/1473331183973830657.


#### Summary of Changes

Upstreams storing `BLSKeypair` in `ValidatorVoteKeypairs` from the alpenglow repo.
