### PR TITLE
ABIv2: Create `configure_instruction_at_index`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -494,7 +494,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
 
     invoke_context
         .transaction_context
-        .configure_next_instruction_for_tests(
+        .configure_top_level_instruction_for_tests(
             program_index.saturating_add(1),
             instruction_accounts,
             instruction_data,

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -880,7 +880,7 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
         check_aligned,
     )?;
     check_authorized_program(&instruction.program_id, &instruction.data, invoke_context)?;
-    invoke_context.prepare_next_instruction(instruction, &signers)?;
+    invoke_context.prepare_next_cpi_instruction(instruction, &signers)?;
 
     let mut accounts = S::translate_accounts(
         account_infos_addr,
@@ -1454,7 +1454,7 @@ mod tests {
             );
             $invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(
+                .configure_top_level_instruction_for_tests(
                     $program_account,
                     instruction_accounts,
                     instruction_data.to_vec(),
@@ -1968,7 +1968,7 @@ mod tests {
 
         invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(
+            .configure_next_cpi_for_tests(
                 0,
                 vec![
                     InstructionAccount::new(1, false, true),

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -288,7 +288,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         instruction: Instruction,
         signers: &[Pubkey],
     ) -> Result<(), InstructionError> {
-        self.prepare_next_instruction(instruction, signers)?;
+        self.prepare_next_cpi_instruction(instruction, signers)?;
         let mut compute_units_consumed = 0;
         self.process_instruction(&mut compute_units_consumed, &mut ExecuteTimings::default())?;
         Ok(())
@@ -296,7 +296,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
 
     /// Helper to prepare for process_instruction() when the instruction is not a top level one,
     /// and depends on `AccountMeta`s
-    pub fn prepare_next_instruction(
+    pub fn prepare_next_cpi_instruction(
         &mut self,
         instruction: Instruction,
         signers: &[Pubkey],
@@ -431,7 +431,8 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         // This ? operator should not error out because `fn get_current_instruction_index` is also called
         // in `get_current_instruction_context`
         let caller_index = self.transaction_context.get_current_instruction_index()?;
-        self.transaction_context.configure_next_instruction(
+        self.transaction_context.configure_instruction_at_index(
+            self.transaction_context.get_instruction_trace_length(),
             program_account_index,
             instruction_accounts,
             transaction_callee_map,
@@ -474,7 +475,8 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             ));
         }
 
-        self.transaction_context.configure_next_instruction(
+        self.transaction_context.configure_instruction_at_index(
+            self.transaction_context.get_instruction_trace_length(),
             program_account_index,
             instruction_accounts,
             transaction_callee_map,
@@ -936,7 +938,7 @@ pub fn mock_process_instruction_with_feature_set<
     pre_adjustments(&mut invoke_context);
     invoke_context
         .transaction_context
-        .configure_next_instruction_for_tests(
+        .configure_top_level_instruction_for_tests(
             program_index,
             instruction_accounts,
             instruction_data.to_vec(),
@@ -1076,7 +1078,11 @@ mod tests {
                         );
                         invoke_context
                             .transaction_context
-                            .configure_next_instruction_for_tests(3, instruction_accounts, vec![])
+                            .configure_top_level_instruction_for_tests(
+                                3,
+                                instruction_accounts,
+                                vec![],
+                            )
                             .unwrap();
                         let result = invoke_context.push();
                         assert_eq!(result, Err(InstructionError::UnbalancedInstruction));
@@ -1148,7 +1154,7 @@ mod tests {
         for _ in 0..invoke_stack.len() {
             invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(
+                .configure_top_level_instruction_for_tests(
                     one_more_than_max_depth.saturating_add(depth_reached) as IndexOfAccount,
                     instruction_accounts.clone(),
                     vec![],
@@ -1179,7 +1185,7 @@ mod tests {
         for _ in 0..MAX_INSTRUCTIONS {
             transaction_context.push().unwrap();
             transaction_context
-                .configure_next_instruction_for_tests(
+                .configure_top_level_instruction_for_tests(
                     0,
                     vec![InstructionAccount::new(0, false, false)],
                     vec![],
@@ -1243,7 +1249,7 @@ mod tests {
         // Account modification tests
         invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(4, instruction_accounts, vec![])
+            .configure_top_level_instruction_for_tests(4, instruction_accounts, vec![])
             .unwrap();
         invoke_context.push().unwrap();
         let inner_instruction =
@@ -1299,7 +1305,7 @@ mod tests {
         let compute_units_to_consume = 10;
         invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(4, instruction_accounts, vec![])
+            .configure_top_level_instruction_for_tests(4, instruction_accounts, vec![])
             .unwrap();
         invoke_context.push().unwrap();
         let inner_instruction = Instruction::new_with_bincode(
@@ -1311,7 +1317,7 @@ mod tests {
             metas,
         );
         invoke_context
-            .prepare_next_instruction(inner_instruction, &[])
+            .prepare_next_cpi_instruction(inner_instruction, &[])
             .unwrap();
 
         let mut compute_units_consumed = 0;
@@ -1344,7 +1350,7 @@ mod tests {
 
         invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(0, vec![], vec![])
+            .configure_top_level_instruction_for_tests(0, vec![], vec![])
             .unwrap();
         invoke_context.push().unwrap();
         assert_eq!(*invoke_context.get_compute_budget(), execution_budget);
@@ -1384,7 +1390,7 @@ mod tests {
 
         invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(2, instruction_accounts, instruction_data)
+            .configure_top_level_instruction_for_tests(2, instruction_accounts, instruction_data)
             .unwrap();
         let result = invoke_context.process_instruction(&mut 0, &mut ExecuteTimings::default());
 
@@ -1539,13 +1545,13 @@ mod tests {
 
         invoke_context.transaction_context.push().unwrap();
         invoke_context
-            .prepare_next_instruction(instruction_1, &[fee_payer.pubkey()])
+            .prepare_next_cpi_instruction(instruction_1, &[fee_payer.pubkey()])
             .unwrap();
         test_case_1(&invoke_context);
 
         invoke_context.transaction_context.push().unwrap();
         invoke_context
-            .prepare_next_instruction(instruction_2, &[fee_payer.pubkey()])
+            .prepare_next_cpi_instruction(instruction_2, &[fee_payer.pubkey()])
             .unwrap();
         test_case_2(&invoke_context);
     }
@@ -1630,7 +1636,7 @@ mod tests {
         );
 
         invoke_context
-            .prepare_next_instruction(instruction, &[fee_payer.pubkey()])
+            .prepare_next_cpi_instruction(instruction, &[fee_payer.pubkey()])
             .unwrap();
         let instruction_context = invoke_context
             .transaction_context

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -776,18 +776,19 @@ mod tests {
                     let dedup_map = vec![u16::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
                     invoke_context
                         .transaction_context
-                        .configure_next_instruction(
+                        .configure_instruction_at_index(
+                            0,
                             0,
                             instruction_accounts,
                             dedup_map,
                             Cow::Owned(instruction_data.clone()),
-                            None,
+                            Some(0),
                         )
                         .unwrap();
                 } else {
                     invoke_context
                         .transaction_context
-                        .configure_next_instruction_for_tests(
+                        .configure_top_level_instruction_for_tests(
                             0,
                             instruction_accounts,
                             instruction_data.clone(),
@@ -947,7 +948,7 @@ mod tests {
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
             invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(
+                .configure_top_level_instruction_for_tests(
                     0,
                     instruction_accounts.clone(),
                     instruction_data.clone(),
@@ -1046,7 +1047,7 @@ mod tests {
             // check serialize_parameters_unaligned
             invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(
+                .configure_top_level_instruction_for_tests(
                     7,
                     instruction_accounts,
                     instruction_data.clone(),
@@ -1210,7 +1211,7 @@ mod tests {
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
         invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(0, instruction_accounts.clone(), vec![])
+            .configure_top_level_instruction_for_tests(0, instruction_accounts.clone(), vec![])
             .unwrap();
         invoke_context.push().unwrap();
         let instruction_context = invoke_context
@@ -1243,7 +1244,7 @@ mod tests {
         // check serialize_parameters_unaligned
         invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(7, instruction_accounts, vec![])
+            .configure_top_level_instruction_for_tests(7, instruction_accounts, vec![])
             .unwrap();
         invoke_context.push().unwrap();
         let instruction_context = invoke_context
@@ -1451,7 +1452,7 @@ mod tests {
         let instruction_accounts =
             deduplicated_instruction_accounts(&transaction_accounts_indexes, |index| index > 0);
         transaction_context
-            .configure_next_instruction_for_tests(6, instruction_accounts, vec![])
+            .configure_top_level_instruction_for_tests(6, instruction_accounts, vec![])
             .unwrap();
         transaction_context.push().unwrap();
         let instruction_context = transaction_context

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -272,7 +272,7 @@ impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
             .collect::<Vec<_>>();
 
         invoke_context
-            .prepare_next_instruction(instruction.clone(), &signers)
+            .prepare_next_cpi_instruction(instruction.clone(), &signers)
             .unwrap();
 
         // Copy caller's account_info modifications into invoke_context accounts

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -102,7 +102,7 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
         TransactionContext::new(transaction_accounts, Rent::default(), 1, 1, 1);
     let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
     transaction_context
-        .configure_next_instruction_for_tests(0, instruction_accounts, instruction_data)
+        .configure_top_level_instruction_for_tests(0, instruction_accounts, instruction_data)
         .unwrap();
     transaction_context.push().unwrap();
     transaction_context

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -68,7 +68,7 @@ macro_rules! with_mock_invoke_context {
         );
         $invoke_context
             .transaction_context
-            .configure_next_instruction_for_tests(1, instruction_accounts, vec![])
+            .configure_top_level_instruction_for_tests(1, instruction_accounts, vec![])
             .unwrap();
         $invoke_context.push().unwrap();
     };

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -265,7 +265,7 @@ mod test {
         ($invoke_context:expr, $instruction_context:ident, $instruction_accounts:ident) => {
             $invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(2, $instruction_accounts, vec![])
+                .configure_top_level_instruction_for_tests(2, $instruction_accounts, vec![])
                 .unwrap();
             $invoke_context.push().unwrap();
             let transaction_context = &$invoke_context.transaction_context;

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -1161,7 +1161,7 @@ mod tests {
             1,
         );
         transaction_context
-            .configure_next_instruction_for_tests(
+            .configure_top_level_instruction_for_tests(
                 0,
                 vec![InstructionAccount::new(1, false, true)],
                 vec![],

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1602,7 +1602,7 @@ mod tests {
             1,
         );
         transaction_context
-            .configure_next_instruction_for_tests(
+            .configure_top_level_instruction_for_tests(
                 0,
                 vec![InstructionAccount::new(1, false, true)],
                 vec![],
@@ -1774,7 +1774,7 @@ mod tests {
             1,
         );
         transaction_context
-            .configure_next_instruction_for_tests(
+            .configure_top_level_instruction_for_tests(
                 0,
                 vec![InstructionAccount::new(1, false, true)],
                 vec![],
@@ -1947,7 +1947,7 @@ mod tests {
             1,
         );
         transaction_context
-            .configure_next_instruction_for_tests(
+            .configure_top_level_instruction_for_tests(
                 0,
                 vec![InstructionAccount::new(1, false, true)],
                 vec![],
@@ -4275,7 +4275,7 @@ mod tests {
             1,
         );
         transaction_context
-            .configure_next_instruction_for_tests(
+            .configure_top_level_instruction_for_tests(
                 0,
                 vec![InstructionAccount::new(1, false, true)],
                 vec![],
@@ -4367,7 +4367,7 @@ mod tests {
             1,
         );
         transaction_context
-            .configure_next_instruction_for_tests(
+            .configure_top_level_instruction_for_tests(
                 0,
                 vec![InstructionAccount::new(1, false, true)],
                 vec![],
@@ -4470,7 +4470,7 @@ mod tests {
     ) -> TransactionContext<'_> {
         let mut transaction_context = TransactionContext::new(accounts, rent.clone(), 0, 0, 1);
         transaction_context
-            .configure_next_instruction_for_tests(0, instruction_accounts, vec![])
+            .configure_top_level_instruction_for_tests(0, instruction_accounts, vec![])
             .unwrap();
         transaction_context
     }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1369,7 +1369,11 @@ mod tests {
             }
             if stack_height > transaction_context.get_instruction_stack_height() {
                 transaction_context
-                    .configure_next_instruction_for_tests(0, vec![], vec![index_in_trace as u8])
+                    .configure_top_level_instruction_for_tests(
+                        0,
+                        vec![],
+                        vec![index_in_trace as u8],
+                    )
                     .unwrap();
                 transaction_context.push().unwrap();
             }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2751,7 +2751,7 @@ mod tests {
             with_mock_invoke_context!($invoke_context, transaction_context, transaction_accounts);
             $invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(1, vec![], vec![])
+                .configure_top_level_instruction_for_tests(1, vec![], vec![])
                 .unwrap();
             $invoke_context.push().unwrap();
         };
@@ -2778,7 +2778,7 @@ mod tests {
             );
             $invoke_context
                 .transaction_context
-                .configure_next_instruction_for_tests(1, vec![], vec![])
+                .configure_top_level_instruction_for_tests(1, vec![], vec![])
                 .unwrap();
             $invoke_context.push().unwrap();
         };
@@ -5009,7 +5009,7 @@ mod tests {
                 )];
                 invoke_context
                     .transaction_context
-                    .configure_next_instruction_for_tests(
+                    .configure_top_level_instruction_for_tests(
                         0,
                         instruction_accounts,
                         vec![index_in_trace as u8],


### PR DESCRIPTION
#### Problem

For ABIv2, we want the instruction trace to contain top level instructions in indexes [0, N) followed by CPIs at [N, N+number_of_cpis). In order to achieve that, we must change `configure_next_instruction` to work with the new layout.

This PR was split from #10557.

#### Summary of Changes

1. Repurpose `configure_next_instruction` into `configure_instruction_at_index`, which requires an explicit index for the instruction to be configured.
2. Split `confgiure_next_instruction_for_tests` into `configure_top_level_instruction_for_tests` and `configure_next_cpi_for_tests`. These two helper functions for tests look very similar in this PR, but they will acquire different functionality in #10557. (You won't be able to configure a CPI if you had not configured a top level instruction beforehand, so the helper functions do different stuff in tests).
3. Rename `prepare_next_instruction` in `invoke_context.rs` to `prepare_next_cpi_instruction` to make it clear that such a function will ONLY works for CPIs after #10557.
4. I have update the call sites of  `configure_top_level_instruction_for_tests` and `configure_next_cpi_for_tests` to match what is proposed in #10557.

For a clear picture of how each part connects, please check #10557.

I believe I'll still open two or three more PRs (fixing and improving tests) to declutter #10557.
