### PR TITLE
Set-identity-and-vote-account

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -78,7 +78,7 @@ impl<'a> IntoIterator for &'a KeyUpdaters {
 pub struct AdminRpcRequestMetadataPostInit {
     pub cluster_info: Arc<ClusterInfo>,
     pub bank_forks: Arc<RwLock<BankForks>>,
-    pub vote_account: Pubkey,
+    pub vote_account: Arc<RwLock<Pubkey>>,
     pub repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
     pub notifies: Arc<RwLock<KeyUpdaters>>,
     pub repair_socket: Arc<UdpSocket>,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -179,7 +179,7 @@ impl Tvu {
     /// * `blockstore` - the ledger itself
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        vote_account: &Pubkey,
+        vote_account: Arc<RwLock<Pubkey>>,
         authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
         bank_forks: &Arc<RwLock<BankForks>>,
         cluster_info: &Arc<ClusterInfo>,
@@ -430,7 +430,7 @@ impl Tvu {
 
         let votor_config = VotorConfig {
             exit: exit.clone(),
-            vote_account: *vote_account,
+            vote_account: vote_account.clone(),
             wait_to_vote_slot,
             wait_for_vote_to_start_leader: tvu_config.wait_for_vote_to_start_leader,
             vote_history,
@@ -488,7 +488,7 @@ impl Tvu {
         };
 
         let replay_stage_config = ReplayStageConfig {
-            vote_account: *vote_account,
+            vote_account: vote_account.clone(),
             authorized_voter_keypairs,
             exit: exit.clone(),
             leader_schedule_cache: leader_schedule_cache.clone(),
@@ -754,7 +754,7 @@ pub mod tests {
         });
 
         let tvu = Tvu::new(
-            &vote_keypair.pubkey(),
+            Arc::new(RwLock::new(vote_keypair.pubkey())),
             Arc::new(RwLock::new(vec![Arc::new(vote_keypair)])),
             &bank_forks,
             &cref1,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -784,6 +784,8 @@ impl Validator {
         info!("identity pubkey: {id}");
         info!("vote account pubkey: {vote_account}");
 
+        let vote_account = Arc::new(RwLock::new(*vote_account));
+
         if !config.no_os_network_stats_reporting {
             verify_net_stats_access().map_err(|e| {
                 ValidatorError::Other(format!("Failed to access network stats: {e:?}"))
@@ -1142,9 +1144,10 @@ impl Validator {
         let entry_notification_sender = entry_notifier_service
             .as_ref()
             .map(|service| service.sender());
+        let vote_account_pubkey = *vote_account.read().unwrap();
         let mut process_blockstore = ProcessBlockStore::new(
             &id,
-            vote_account,
+            &vote_account_pubkey,
             &start_progress,
             &blockstore,
             original_blockstore_root,
@@ -1637,7 +1640,7 @@ impl Validator {
         };
 
         let tvu = Tvu::new(
-            vote_account,
+            vote_account.clone(),
             authorized_voter_keypairs,
             &bank_forks,
             &cluster_info,
@@ -1807,7 +1810,7 @@ impl Validator {
         *admin_rpc_service_post_init.write().unwrap() = Some(AdminRpcRequestMetadataPostInit {
             bank_forks: bank_forks.clone(),
             cluster_info: cluster_info.clone(),
-            vote_account: *vote_account,
+            vote_account: vote_account.clone(),
             repair_whitelist: config.repair_whitelist.clone(),
             notifies: key_notifiers,
             repair_socket: Arc::new(node.sockets.repair),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -72,6 +72,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .subcommand(SubCommand::with_name("run").about("Run the validator"))
         .subcommand(commands::plugin::command())
         .subcommand(commands::set_identity::command())
+        .subcommand(commands::set_identity_and_vote_account::command())
         .subcommand(commands::set_log_filter::command())
         .subcommand(commands::staked_nodes_overrides::command())
         .subcommand(commands::wait_for_restart_window::command())

--- a/validator/src/commands/mod.rs
+++ b/validator/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod repair_shred_from_peer;
 pub mod repair_whitelist;
 pub mod run;
 pub mod set_identity;
+pub mod set_identity_and_vote_account;
 pub mod set_log_filter;
 pub mod set_public_address;
 pub mod staked_nodes_overrides;

--- a/validator/src/commands/set_identity_and_vote_account/mod.rs
+++ b/validator/src/commands/set_identity_and_vote_account/mod.rs
@@ -1,0 +1,290 @@
+use {
+    crate::{
+        admin_rpc_service,
+        commands::{FromClapArgMatches, Result},
+    },
+    clap::{value_t, App, Arg, ArgMatches, SubCommand},
+    solana_clap_utils::input_validators::is_keypair,
+    solana_keypair::{read_keypair, read_keypair_file},
+    solana_pubkey::Pubkey,
+    solana_signer::Signer,
+    std::{fs, path::Path},
+};
+
+const COMMAND: &str = "set-identity-and-vote-account";
+
+#[derive(Debug, PartialEq)]
+#[cfg_attr(test, derive(Default))]
+pub struct SetIdentityAndVoteAccountArgs {
+    pub identity: Option<String>,
+    pub vote_account: String,
+    pub require_tower: bool,
+}
+
+impl FromClapArgMatches for SetIdentityAndVoteAccountArgs {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        Ok(SetIdentityAndVoteAccountArgs {
+            identity: value_t!(matches, "identity", String).ok(),
+            vote_account: value_t!(matches, "vote_account", String).map_err(|e| {
+                clap::Error::with_description(&e.to_string(), clap::ErrorKind::ValueValidation)
+            })?,
+            require_tower: matches.is_present("require_tower"),
+        })
+    }
+}
+
+/// Resolve a vote account argument to a Pubkey.
+///
+/// Accepts:
+/// - A bs58-encoded pubkey string
+/// - A path to a keypair file (the pubkey is extracted)
+/// - A path to a file containing a bs58-encoded pubkey
+fn resolve_vote_account_pubkey(value: &str) -> std::result::Result<Pubkey, String> {
+    // Try parsing as a bs58 pubkey directly
+    if let Ok(pubkey) = value.parse::<Pubkey>() {
+        return Ok(pubkey);
+    }
+
+    // Try reading as a keypair file
+    if let Ok(keypair) = read_keypair_file(value) {
+        return Ok(keypair.pubkey());
+    }
+
+    // Try reading as a file containing a bs58 pubkey
+    if let Ok(contents) = fs::read_to_string(value) {
+        if let Ok(pubkey) = contents.trim().parse::<Pubkey>() {
+            return Ok(pubkey);
+        }
+    }
+
+    Err(format!(
+        "Could not parse '{value}' as a pubkey, keypair file, or pubkey file"
+    ))
+}
+
+/// Clap validator that accepts a pubkey string, keypair file, or pubkey file
+fn is_pubkey_or_keypair_or_pubkey_file<T: AsRef<str> + std::fmt::Display>(
+    string: T,
+) -> std::result::Result<(), String> {
+    resolve_vote_account_pubkey(string.as_ref()).map(|_| ())
+}
+
+pub fn command<'a>() -> App<'a, 'a> {
+    SubCommand::with_name(COMMAND)
+        .about("Set the validator identity and vote account")
+        .arg(
+            Arg::with_name("identity")
+                .index(1)
+                .value_name("KEYPAIR")
+                .required(false)
+                .takes_value(true)
+                .validator(is_keypair)
+                .help("Path to validator identity keypair [default: read JSON keypair from stdin]"),
+        )
+        .arg(
+            Arg::with_name("vote_account")
+                .long("vote-account")
+                .value_name("ADDRESS")
+                .required(true)
+                .takes_value(true)
+                .validator(is_pubkey_or_keypair_or_pubkey_file)
+                .help(
+                    "Vote account public key. Accepts a base58 pubkey, a path to a keypair file, \
+                     or a path to a file containing a base58 pubkey",
+                ),
+        )
+        .arg(
+            clap::Arg::with_name("require_tower")
+                .long("require-tower")
+                .takes_value(false)
+                .help("Refuse to set the validator identity if saved tower state is not found"),
+        )
+        .after_help(
+            "Note: the new identity and vote account only apply to the currently running \
+             validator instance",
+        )
+}
+
+pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
+    let SetIdentityAndVoteAccountArgs {
+        identity,
+        vote_account,
+        require_tower,
+    } = SetIdentityAndVoteAccountArgs::from_clap_arg_match(matches)?;
+
+    let vote_account_pubkey = resolve_vote_account_pubkey(&vote_account)
+        .map_err(|e| clap::Error::with_description(&e, clap::ErrorKind::ValueValidation))?;
+    let vote_account_str = vote_account_pubkey.to_string();
+
+    if let Some(identity_keypair) = identity {
+        let identity_keypair = fs::canonicalize(&identity_keypair)?;
+
+        println!(
+            "New validator identity path: {}",
+            identity_keypair.display()
+        );
+        println!("New vote account: {vote_account_str}");
+
+        let admin_client = admin_rpc_service::connect(ledger_path);
+        admin_rpc_service::runtime().block_on(async move {
+            admin_client
+                .await?
+                .set_identity_and_vote_account(
+                    identity_keypair.display().to_string(),
+                    vote_account_str,
+                    require_tower,
+                )
+                .await
+        })?;
+    } else {
+        let mut stdin = std::io::stdin();
+        let identity_keypair = read_keypair(&mut stdin)?;
+
+        println!("New validator identity: {}", identity_keypair.pubkey());
+        println!("New vote account: {vote_account_str}");
+
+        let admin_client = admin_rpc_service::connect(ledger_path);
+        admin_rpc_service::runtime().block_on(async move {
+            admin_client
+                .await?
+                .set_identity_and_vote_account_from_bytes(
+                    Vec::from(identity_keypair.to_bytes()),
+                    vote_account_str,
+                    require_tower,
+                )
+                .await
+        })?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::commands::tests::verify_args_struct_by_command,
+        solana_keypair::Keypair,
+        solana_signer::Signer,
+    };
+
+    #[test]
+    fn verify_args_struct_by_command_with_pubkey_string() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let file = tmp_dir.path().join("id.json");
+        let keypair = Keypair::new();
+        solana_keypair::write_keypair_file(&keypair, &file).unwrap();
+
+        let vote_account = Keypair::new();
+        let vote_account_str = vote_account.pubkey().to_string();
+
+        verify_args_struct_by_command(
+            command(),
+            vec![
+                COMMAND,
+                file.to_str().unwrap(),
+                "--vote-account",
+                &vote_account_str,
+            ],
+            SetIdentityAndVoteAccountArgs {
+                identity: Some(file.to_str().unwrap().to_string()),
+                vote_account: vote_account_str.clone(),
+                require_tower: false,
+            },
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_with_keypair_file() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let id_file = tmp_dir.path().join("id.json");
+        let keypair = Keypair::new();
+        solana_keypair::write_keypair_file(&keypair, &id_file).unwrap();
+
+        let vote_keypair = Keypair::new();
+        let vote_file = tmp_dir.path().join("vote.json");
+        solana_keypair::write_keypair_file(&vote_keypair, &vote_file).unwrap();
+
+        verify_args_struct_by_command(
+            command(),
+            vec![
+                COMMAND,
+                id_file.to_str().unwrap(),
+                "--vote-account",
+                vote_file.to_str().unwrap(),
+            ],
+            SetIdentityAndVoteAccountArgs {
+                identity: Some(id_file.to_str().unwrap().to_string()),
+                vote_account: vote_file.to_str().unwrap().to_string(),
+                require_tower: false,
+            },
+        );
+
+        // Verify resolution extracts the correct pubkey
+        let resolved = resolve_vote_account_pubkey(vote_file.to_str().unwrap()).unwrap();
+        assert_eq!(resolved, vote_keypair.pubkey());
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_with_pubkey_file() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let id_file = tmp_dir.path().join("id.json");
+        let keypair = Keypair::new();
+        solana_keypair::write_keypair_file(&keypair, &id_file).unwrap();
+
+        let vote_pubkey = Keypair::new().pubkey();
+        let pubkey_file = tmp_dir.path().join("vote_pubkey.txt");
+        fs::write(&pubkey_file, vote_pubkey.to_string()).unwrap();
+
+        verify_args_struct_by_command(
+            command(),
+            vec![
+                COMMAND,
+                id_file.to_str().unwrap(),
+                "--vote-account",
+                pubkey_file.to_str().unwrap(),
+            ],
+            SetIdentityAndVoteAccountArgs {
+                identity: Some(id_file.to_str().unwrap().to_string()),
+                vote_account: pubkey_file.to_str().unwrap().to_string(),
+                require_tower: false,
+            },
+        );
+
+        // Verify resolution extracts the correct pubkey
+        let resolved = resolve_vote_account_pubkey(pubkey_file.to_str().unwrap()).unwrap();
+        assert_eq!(resolved, vote_pubkey);
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_with_require_tower() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let file = tmp_dir.path().join("id.json");
+        let keypair = Keypair::new();
+        solana_keypair::write_keypair_file(&keypair, &file).unwrap();
+
+        let vote_account = Keypair::new();
+        let vote_account_str = vote_account.pubkey().to_string();
+
+        verify_args_struct_by_command(
+            command(),
+            vec![
+                COMMAND,
+                file.to_str().unwrap(),
+                "--vote-account",
+                &vote_account_str,
+                "--require-tower",
+            ],
+            SetIdentityAndVoteAccountArgs {
+                identity: Some(file.to_str().unwrap().to_string()),
+                vote_account: vote_account_str.clone(),
+                require_tower: true,
+            },
+        );
+    }
+
+    #[test]
+    fn test_resolve_vote_account_pubkey_invalid() {
+        assert!(resolve_vote_account_pubkey("not-a-pubkey-or-file").is_err());
+    }
+}

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -80,6 +80,9 @@ pub fn main() {
         ("set-identity", Some(subcommand_matches)) => {
             commands::set_identity::execute(subcommand_matches, &ledger_path)
         }
+        ("set-identity-and-vote-account", Some(subcommand_matches)) => {
+            commands::set_identity_and_vote_account::execute(subcommand_matches, &ledger_path)
+        }
         ("set-log-filter", Some(subcommand_matches)) => {
             commands::set_log_filter::execute(subcommand_matches, &ledger_path)
         }

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -113,6 +113,7 @@ pub enum VoteError {
 pub struct VotingContext {
     pub vote_history: VoteHistory,
     pub vote_account_pubkey: Pubkey,
+    pub shared_vote_account: Arc<std::sync::RwLock<Pubkey>>,
     pub identity_keypair: Arc<Keypair>,
     pub authorized_voter_keypairs: Arc<std::sync::RwLock<Vec<Arc<Keypair>>>>,
     // The BLS keypair should always change with authorized_voter_keypairs.
@@ -374,9 +375,11 @@ mod tests {
         let bls_sender = unbounded().0;
         let commitment_sender = unbounded().0;
         let consensus_metrics_sender = unbounded().0;
+        let vote_account_pubkey = my_keys.vote_keypair.pubkey();
         VotingContext {
             vote_history: VoteHistory::new(my_keys.node_keypair.pubkey(), 0),
-            vote_account_pubkey: my_keys.vote_keypair.pubkey(),
+            vote_account_pubkey,
+            shared_vote_account: Arc::new(RwLock::new(vote_account_pubkey)),
             identity_keypair: Arc::new(my_keys.node_keypair.insecure_clone()),
             authorized_voter_keypairs: Arc::new(RwLock::new(vec![Arc::new(
                 my_keys.vote_keypair.insecure_clone(),

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -86,7 +86,7 @@ use {
 pub struct VotorConfig {
     pub exit: Arc<AtomicBool>,
     // Validator config
-    pub vote_account: Pubkey,
+    pub vote_account: Arc<RwLock<Pubkey>>,
     pub wait_to_vote_slot: Option<Slot>,
     pub wait_for_vote_to_start_leader: bool,
     pub vote_history: VoteHistory,
@@ -140,7 +140,7 @@ impl Votor {
     pub fn new(config: VotorConfig) -> Self {
         let VotorConfig {
             exit,
-            vote_account,
+            vote_account: shared_vote_account,
             wait_to_vote_slot,
             wait_for_vote_to_start_leader,
             vote_history,
@@ -183,9 +183,11 @@ impl Votor {
             vote_history_storage,
         };
 
+        let vote_account = *shared_vote_account.read().unwrap();
         let voting_context = VotingContext {
             vote_history,
             vote_account_pubkey: vote_account,
+            shared_vote_account: shared_vote_account.clone(),
             identity_keypair,
             authorized_voter_keypairs,
             derived_bls_keypairs: HashMap::new(),
@@ -228,6 +230,7 @@ impl Votor {
             migration_status,
             cluster_info,
             my_vote_pubkey: vote_account,
+            shared_vote_account,
             blockstore,
             sharable_banks,
             leader_schedule_cache,


### PR DESCRIPTION
#### Problem
Presently there is only a `set-identity` command to change the identity of a node. This makes it necessary to have a dedicated failover node for every validator that an organization may run (or to restart the validator every time for the target id/vote account).


#### Summary of Changes
Add a `set-identity-and-vote-account` command, enabling a single failover node to be used for any given identity/vote account without needing to restart the validator.
