### PR TITLE
chore(sec-pol): exclude alpenglow from security reports

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -147,6 +147,11 @@ The following components are out of scope for the bounty program
 to, any and all web properties not explicitly listed on this page)
 * Programs in the Solana Program Library, such as SPL Token. Please refer to the
 [SPL security policy](https://github.com/solana-labs/solana-program-library/security/policy).
+* Alpenglow crates (votor, votor-messages, etc) and plumbing. Migration of the
+Alpenglow logic from a feature fork to agave master is currently underway. As
+such there are many paritially migrated changes isolated to a few areas. These
+are disqualified from reports and bounties. Bugs in integration logic that impact
+the no-Alpenglow code path remain in scope
 
 ### Eligibility:
 * Submissions _MUST_ include an exploit proof-of-concept to be considered eligible


### PR DESCRIPTION
#### Problem
ag logic is partially migrated and unaudited, attracting clanker bug reports for bounty

#### Summary of Changes
explicitly disqualify ag components from bug reports/bounties until migration is complete