### PR TITLE
replay: validate chained block id SIMD-340

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3256,31 +3256,25 @@ impl ReplayStage {
                 )
             });
 
-            let validate_chained_block_id = bank
-                .feature_set
-                .is_active(&agave_feature_set::validate_chained_block_id::id());
-
-            if validate_chained_block_id {
-                // Check if the child block's chained merkle root chains the to parent's block id
-                // It's important that we do this here (after we have a bank) rather than failing
-                // in generate_new_bank_forks, as we need a bank to mark as dead in order to kick off
-                // ancestor hashes service / duplicate block repair
-                match check_chained_block_id(blockstore, bank.slot(), bank.parent_slot()) {
-                    ChainedBlockIdCheck::Pass => (),
-                    ChainedBlockIdCheck::Unavailable => {
-                        // Missing shred 0, can't replay anyway
-                        return replay_result;
-                    }
-                    ChainedBlockIdCheck::Mismatch => {
-                        // Mismatch, mark dead and don't replay
-                        replay_result.is_slot_dead = true;
-                        replay_result.replay_result =
-                            Some(Err(BlockstoreProcessorError::ChainedBlockIdFailure(
-                                bank.slot(),
-                                bank.parent_slot(),
-                            )));
-                        return replay_result;
-                    }
+            // Check if the child block's chained merkle root chains to the parent's block id.
+            // It's important that we do this here (after we have a bank) rather than failing
+            // in generate_new_bank_forks, as we need a bank to mark as dead in order to kick off
+            // ancestor hashes service / duplicate block repair.
+            match check_chained_block_id(blockstore, &bank) {
+                ChainedBlockIdCheck::Inactive | ChainedBlockIdCheck::Pass => (),
+                ChainedBlockIdCheck::Unavailable => {
+                    // Missing shred 0, can't replay anyway
+                    return replay_result;
+                }
+                ChainedBlockIdCheck::Mismatch => {
+                    // Mismatch, mark dead and don't replay
+                    replay_result.is_slot_dead = true;
+                    replay_result.replay_result =
+                        Some(Err(BlockstoreProcessorError::ChainedBlockIdFailure(
+                            bank.slot(),
+                            bank.parent_slot(),
+                        )));
+                    return replay_result;
                 }
             }
 

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1301,6 +1301,10 @@ pub mod vote_account_initialize_v2 {
     solana_pubkey::declare_id!("9PtjteCDs5yLKwseLKVWgKwTBMfLBxZmTDBgmmws8vRt");
 }
 
+pub mod validate_chained_block_id {
+    solana_pubkey::declare_id!("vbiddkDHTSHSvL8B21AetWvTBLxxUZ1FmU6DFjztyRn");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2315,6 +2319,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             vote_account_initialize_v2::id(),
             "SIMD-0464: Vote Account Initialize V2",
+        ),
+        (
+            validate_chained_block_id::id(),
+            "SIMD-0340: Validate chained block ID",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -520,7 +520,7 @@ impl Blockstore {
                     .and_then(|p| merkle_roots.get(&p).copied())
                     .or_else(|| self.get_final_merkle_root(parent_slot).unwrap())
                     .unwrap_or_else(|| Hash::new_from_array(rand::rng().random()));
-                let shreds: Vec<shred::Shred> = shred::Shredder::new(slot, parent_slot, 0, 0)
+                let shreds: Vec<Shred> = Shredder::new(slot, parent_slot, 0, 0)
                     .unwrap()
                     .make_merkle_shreds_from_entries(
                         &Keypair::new(),
@@ -530,9 +530,9 @@ impl Blockstore {
                         0,
                         0,
                         &reed_solomon_cache,
-                        &mut shred::ProcessShredsStats::default(),
+                        &mut ProcessShredsStats::default(),
                     )
-                    .filter(shred::Shred::is_data)
+                    .filter(Shred::is_data)
                     .collect();
                 if let Some(last_shred) = shreds.last() {
                     merkle_roots.insert(slot, last_shred.merkle_root().unwrap());

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -490,6 +490,8 @@ impl Blockstore {
     ) {
         let mut walk = TreeWalk::from(forks);
         let mut blockhashes = HashMap::new();
+        let mut merkle_roots: HashMap<Slot, Hash> = HashMap::new();
+        let reed_solomon_cache = shred::ReedSolomonCache::default();
         while let Some(visit) = walk.get() {
             let slot = *visit.node().data();
             if self.meta(slot).unwrap().is_some() && self.orphan(slot).unwrap().is_none() {
@@ -504,8 +506,9 @@ impl Blockstore {
                     // `is_orphan == true`
                     .and_then(|parent| blockhashes.get(&parent))
                     .unwrap_or(&starting_hash);
+                let parent_slot = parent.unwrap_or(slot);
                 let mut entries = create_ticks(
-                    num_ticks * (std::cmp::max(1, slot - parent.unwrap_or(slot))),
+                    num_ticks * (std::cmp::max(1, slot - parent_slot)),
                     0,
                     *parent_hash,
                 );
@@ -513,13 +516,27 @@ impl Blockstore {
                 if !is_slot_complete {
                     entries.pop().unwrap();
                 }
-                let shreds = entries_to_test_shreds(
-                    &entries,
-                    slot,
-                    parent.unwrap_or(slot),
-                    is_slot_complete,
-                    0,
-                );
+                let chained_merkle_root = parent
+                    .and_then(|p| merkle_roots.get(&p).copied())
+                    .or_else(|| self.get_final_merkle_root(parent_slot).unwrap())
+                    .unwrap_or_else(|| Hash::new_from_array(rand::rng().random()));
+                let shreds: Vec<shred::Shred> = shred::Shredder::new(slot, parent_slot, 0, 0)
+                    .unwrap()
+                    .make_merkle_shreds_from_entries(
+                        &Keypair::new(),
+                        &entries,
+                        is_slot_complete,
+                        chained_merkle_root,
+                        0,
+                        0,
+                        &reed_solomon_cache,
+                        &mut shred::ProcessShredsStats::default(),
+                    )
+                    .filter(shred::Shred::is_data)
+                    .collect();
+                if let Some(last_shred) = shreds.last() {
+                    merkle_roots.insert(slot, last_shred.merkle_root().unwrap());
+                }
                 self.insert_shreds(shreds, None, false).unwrap();
             }
             walk.forward();
@@ -2275,6 +2292,29 @@ impl Blockstore {
         self.data_shred_cf.get_bytes((slot, index))
     }
 
+    pub fn get_parent_chained_block_id(&self, slot: Slot) -> Result<Option<Hash>> {
+        let Some(shred_bytes) = self.get_data_shred(slot, 0)? else {
+            return Ok(None);
+        };
+        Ok(shred::layout::get_chained_merkle_root(&shred_bytes))
+    }
+
+    pub fn get_final_merkle_root(&self, slot: Slot) -> Result<Option<Hash>> {
+        let Some(meta) = self.meta(slot)? else {
+            return Ok(None);
+        };
+
+        let Some(final_shred_index) = meta.last_index else {
+            return Ok(None);
+        };
+
+        let Some(shred_bytes) = self.get_data_shred(slot, final_shred_index)? else {
+            return Ok(None);
+        };
+
+        Ok(shred::layout::get_merkle_root(&shred_bytes))
+    }
+
     pub fn get_data_shreds_for_slot(&self, slot: Slot, start_index: u64) -> Result<Vec<Shred>> {
         self.slot_data_iterator(slot, start_index)
             .expect("blockstore couldn't fetch iterator")
@@ -2367,7 +2407,10 @@ impl Blockstore {
         let mut all_shreds = vec![];
         let mut slot_entries = vec![];
         let reed_solomon_cache = ReedSolomonCache::default();
-        let mut chained_merkle_root = Hash::new_from_array(rand::rng().random());
+        let mut chained_merkle_root = self
+            .get_final_merkle_root(parent_slot)
+            .unwrap()
+            .unwrap_or_else(|| Hash::new_from_array(rand::rng().random()));
         // Find all the entries for start_slot
         for entry in entries.into_iter() {
             if remaining_ticks_in_slot == 0 {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -501,9 +501,9 @@ impl Blockstore {
             }
             let parent = walk.get_parent().map(|n| *n.data());
             if parent.is_some() || !is_orphan {
+                // parent won't exist for first node in a tree where
+                // `is_orphan == true`
                 let parent_hash = parent
-                    // parent won't exist for first node in a tree where
-                    // `is_orphan == true`
                     .and_then(|parent| blockhashes.get(&parent))
                     .unwrap_or(&starting_hash);
                 let parent_slot = parent.unwrap_or(slot);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2125,7 +2125,7 @@ pub fn check_chained_block_id(blockstore: &Blockstore, bank: &Bank) -> ChainedBl
         return ChainedBlockIdCheck::Unavailable;
     };
 
-    match blockstore.get_block_merkle_root(parent_slot) {
+    match blockstore.get_last_shred_merkle_root(parent_slot) {
         Ok(parent_block_id) => {
             if expected_parent_block_id != parent_block_id {
                 warn!(

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -172,7 +172,12 @@ impl BroadcastStageType {
                 exit_sender,
                 blockstore,
                 bank_forks,
-                BroadcastDuplicatesRun::new(shred_version, config.clone()),
+                BroadcastDuplicatesRun::new(
+                    shred_version,
+                    config.clone(),
+                    migration_status,
+                    votor_event_sender,
+                ),
                 xdp_sender,
             ),
         }


### PR DESCRIPTION
#### Problem
Currently it is not required to verify that a FEC set merkle root chains
correctly across slot boundaries. Consensus can converge on a block even
if the first FEC set's chained merkle root is invalid ie. does not chain
off the parent block's last FEC set merkle root (the block id).

This is critical for FD see https://github.com/solana-foundation/solana-improvement-documents/pull/340 for full details.

#### Summary of Changes
Validate the CMR of shred 0 matches the block id of the parent when the feature flag is active
Mark the block as dead during replay if it doesn't match

NOTE: this validation is ignored if the parent is our snapshot slot when we first restart
