### PR TITLE
programs/system: Rename `payer` to `from`

### DIFF
--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -188,7 +188,7 @@ fn create_account(
 fn create_account_allow_prefund(
     to_account_index: IndexOfAccount,
     to_address: &Address,
-    payer_and_lamports: Option<(IndexOfAccount, u64)>,
+    from_and_lamports: Option<(IndexOfAccount, u64)>,
     space: u64,
     owner: &Pubkey,
     signers: &HashSet<Pubkey>,
@@ -199,7 +199,7 @@ fn create_account_allow_prefund(
         let mut to = instruction_context.try_borrow_instruction_account(to_account_index)?;
         allocate_and_assign(&mut to, to_address, space, owner, signers, invoke_context)?;
     }
-    if let Some((from_account_index, lamports)) = payer_and_lamports {
+    if let Some((from_account_index, lamports)) = from_and_lamports {
         if lamports > 0 {
             transfer(
                 from_account_index,
@@ -538,7 +538,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             {
                 return Err(InstructionError::InvalidInstructionData);
             }
-            let payer_and_lamports = if lamports > 0 {
+            let from_and_lamports = if lamports > 0 {
                 instruction_context.check_number_of_instruction_accounts(2)?;
                 Some((1, lamports))
             } else {
@@ -553,7 +553,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             create_account_allow_prefund(
                 0,
                 &to_address,
-                payer_and_lamports,
+                from_and_lamports,
                 space,
                 &owner,
                 &signers,

--- a/transaction-status/src/parse_system.rs
+++ b/transaction-status/src/parse_system.rs
@@ -204,7 +204,7 @@ pub fn parse_system(
             owner,
         } => {
             if lamports == 0 {
-                // No payer case: only need newAccount
+                // No `from` case: only need newAccount
                 check_num_system_accounts(&instruction.accounts, 1)?;
                 Ok(ParsedInstructionEnum {
                     instruction_type: "createAccountAllowPrefund".to_string(),
@@ -215,7 +215,7 @@ pub fn parse_system(
                     }),
                 })
             } else {
-                // With payer: need newAccount and source
+                // With `from`: need newAccount and source
                 check_num_system_accounts(&instruction.accounts, 2)?;
                 Ok(ParsedInstructionEnum {
                     instruction_type: "createAccountAllowPrefund".to_string(),


### PR DESCRIPTION
#### Problem

The `CreateAccountAllowPrefund` currently labels the funding account as `payer`, while `CreateAccount` uses `from`.

#### Summary of Changes

Rename the `payer` label to `from` so both instructions use the same terminology for the funding account.