### PR TITLE
ABIv2: Improve test coverage

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1226,7 +1226,7 @@ mod tests {
     }
 
     #[test]
-    fn test_max_instruction_trace_length() {
+    fn test_max_instruction_trace_length_top_level() {
         const MAX_INSTRUCTIONS: usize = 8;
         let mut transaction_context = TransactionContext::new(
             vec![(
@@ -1253,8 +1253,12 @@ mod tests {
             transaction_context.push(),
             Err(InstructionError::MaxInstructionTraceLengthExceeded)
         );
+    }
 
+    #[test]
+    fn test_max_instruction_trace_length_cpi() {
         // Hitting the limit with CPIs
+        const MAX_INSTRUCTIONS: usize = 8;
         let mut transaction_context = TransactionContext::new(
             vec![(
                 Pubkey::new_unique(),

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -64,6 +64,7 @@ macro_rules! with_mock_invoke_context {
         solana_program_runtime::with_mock_invoke_context!(
             $invoke_context,
             transaction_context,
+            1,
             transaction_accounts
         );
         $invoke_context

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -191,7 +191,8 @@ mod tests {
                 create_loadable_account_for_test("mock_system_program"),
             ),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3, 2);
+        let mut transaction_context =
+            TransactionContext::new(accounts.clone(), Rent::default(), 1, 3, 1);
         let program_indices = vec![2];
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
@@ -293,6 +294,8 @@ mod tests {
             &program_runtime_environments,
             &sysvar_cache,
         );
+        let mut transaction_context =
+            TransactionContext::new(accounts.clone(), Rent::default(), 1, 3, 1);
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &mut program_cache_for_tx_batch,
@@ -340,6 +343,7 @@ mod tests {
             &program_runtime_environments,
             &sysvar_cache,
         );
+        let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3, 1);
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &mut program_cache_for_tx_batch,
@@ -433,7 +437,8 @@ mod tests {
                 create_loadable_account_for_test("mock_system_program"),
             ),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3, 2);
+        let mut transaction_context =
+            TransactionContext::new(accounts.clone(), Rent::default(), 1, 3, 1);
         let program_indices = vec![2];
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
@@ -518,6 +523,8 @@ mod tests {
             &program_runtime_environments,
             &sysvar_cache,
         );
+        let mut transaction_context =
+            TransactionContext::new(accounts.clone(), Rent::default(), 1, 3, 1);
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &mut program_cache_for_tx_batch,
@@ -557,6 +564,7 @@ mod tests {
             &program_runtime_environments,
             &sysvar_cache,
         );
+        let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3, 1);
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &mut program_cache_for_tx_batch,

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2699,7 +2699,8 @@ mod tests {
             execution_budget::MAX_HEAP_FRAME_BYTES,
             invoke_context::{BpfAllocator, InvokeContext, SyscallContext},
             memory::address_is_aligned,
-            with_mock_invoke_context, with_mock_invoke_context_with_feature_set,
+            mock_invoke_context_with_top_level_ixs, with_mock_invoke_context,
+            with_mock_invoke_context_with_feature_set,
         },
         solana_sbpf::{
             aligned_memory::AlignedMemory,
@@ -2717,7 +2718,7 @@ mod tests {
         solana_stable_layout::stable_instruction::StableInstruction,
         solana_stake_interface::stake_history::{self, StakeHistory, StakeHistoryEntry},
         solana_sysvar_id::SysvarId,
-        solana_transaction_context::{instruction_accounts::InstructionAccount, IndexOfAccount},
+        solana_transaction_context::instruction_accounts::InstructionAccount,
         std::{
             hash::{DefaultHasher, Hash, Hasher},
             mem,
@@ -4978,7 +4979,7 @@ mod tests {
     }
 
     #[test]
-    fn test_syscall_sol_get_processed_sibling_instruction() {
+    fn test_syscall_sol_get_processed_sibling_instruction_top_level() {
         let transaction_accounts = (0..9)
             .map(|_| {
                 (
@@ -4987,39 +4988,64 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        let instruction_trace = [1, 2, 3, 2, 2, 3, 4, 3];
-        with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
-        for (index_in_trace, stack_height) in instruction_trace.into_iter().enumerate() {
-            while stack_height
-                <= invoke_context
-                    .transaction_context
-                    .get_instruction_stack_height()
-            {
-                invoke_context.transaction_context.pop().unwrap();
-            }
-            if stack_height
-                > invoke_context
-                    .transaction_context
-                    .get_instruction_stack_height()
-            {
-                let instruction_accounts = vec![InstructionAccount::new(
-                    index_in_trace.saturating_add(1) as IndexOfAccount,
-                    false,
-                    false,
-                )];
-                invoke_context
-                    .transaction_context
-                    .configure_top_level_instruction_for_tests(
-                        0,
-                        instruction_accounts,
-                        vec![index_in_trace as u8],
-                    )
-                    .unwrap();
-                invoke_context.transaction_context.push().unwrap();
-            }
+        mock_invoke_context_with_top_level_ixs!(
+            invoke_context,
+            transaction_context,
+            4,
+            transaction_accounts
+        );
+
+        /*
+        We are testing GetProcessedSiblingInstruction for top level instructions.
+
+        We are simulating this scenario:
+        Top level:   A | B  | C | D
+        CPI level I:   | B1 |   |
+
+        We are invoking the syscall from C.
+
+         */
+
+        // Prepare four top level instructions: A, B, C and D
+        let ixs = [b'A', b'B', b'C', b'D'];
+        for (idx, ix) in ixs.iter().enumerate() {
+            invoke_context
+                .transaction_context
+                .configure_top_level_instruction_for_tests(
+                    0,
+                    vec![InstructionAccount::new(idx as u16, false, false)],
+                    vec![*ix],
+                )
+                .unwrap();
         }
 
-        let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
+        /*
+        The trace looks like this:
+        IX:    |A|B|C|D|B1|
+        INDEX: |0|1|2|3|4 |
+         */
+
+        // Execute A
+        invoke_context.transaction_context.push().unwrap();
+        invoke_context.transaction_context.pop().unwrap();
+
+        // Execute B
+        invoke_context.transaction_context.push().unwrap();
+        // B does a CPI into B1
+        invoke_context
+            .transaction_context
+            .configure_next_cpi_for_tests(
+                1,
+                vec![InstructionAccount::new(4, false, false)],
+                vec![b'B', 1],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+        invoke_context.transaction_context.pop().unwrap();
+        invoke_context.transaction_context.pop().unwrap();
+
+        // Start instruction C
+        invoke_context.transaction_context.push().unwrap();
 
         const VM_BASE_ADDRESS: u64 = 0x100000000;
         const META_OFFSET: usize = 0;
@@ -5041,6 +5067,7 @@ mod tests {
         processed_sibling_instruction.data_len = 1;
         processed_sibling_instruction.accounts_len = 1;
 
+        let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
         invoke_context.mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
@@ -5080,17 +5107,18 @@ mod tests {
                 program_id,
                 transaction_context.get_key_of_account_at_index(0).unwrap(),
             );
-            assert_eq!(data, &[5]);
+            assert_eq!(data, b"B");
             assert_eq!(
                 accounts,
                 &[AccountMeta {
-                    pubkey: *transaction_context.get_key_of_account_at_index(6).unwrap(),
+                    pubkey: *transaction_context.get_key_of_account_at_index(1).unwrap(),
                     is_signer: false,
                     is_writable: false
                 }]
             );
         }
 
+        let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
         invoke_context.mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
@@ -5101,6 +5129,59 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
             &mut memory_mapping,
         );
+
+        assert_eq!(result.unwrap(), 1);
+        {
+            let program_id = translate_type::<Pubkey>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+                true,
+            )
+            .unwrap();
+            let data = translate_slice::<u8>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+                processed_sibling_instruction.data_len,
+                true,
+            )
+            .unwrap();
+            let accounts = translate_slice::<AccountMeta>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+                processed_sibling_instruction.accounts_len,
+                true,
+            )
+            .unwrap();
+            let transaction_context = &invoke_context.transaction_context;
+            assert_eq!(processed_sibling_instruction.data_len, 1);
+            assert_eq!(processed_sibling_instruction.accounts_len, 1);
+            assert_eq!(
+                program_id,
+                transaction_context.get_key_of_account_at_index(0).unwrap(),
+            );
+            assert_eq!(data, b"A");
+            assert_eq!(
+                accounts,
+                &[AccountMeta {
+                    pubkey: *transaction_context.get_key_of_account_at_index(0).unwrap(),
+                    is_signer: false,
+                    is_writable: false
+                }]
+            );
+        }
+
+        let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            2,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+
         assert_eq!(result.unwrap(), 0);
 
         invoke_context.mock_set_remaining(syscall_base_cost);
@@ -5117,6 +5198,571 @@ mod tests {
             result,
             Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::CopyOverlapping
         );
+    }
+
+    #[test]
+    fn test_syscall_sol_get_processed_sibling_instruction_cpi() {
+        let transaction_accounts = (0..9)
+            .map(|_| {
+                (
+                    Pubkey::new_unique(),
+                    AccountSharedData::new(0, 0, &bpf_loader::id()),
+                )
+            })
+            .collect::<Vec<_>>();
+        mock_invoke_context_with_top_level_ixs!(
+            invoke_context,
+            transaction_context,
+            3,
+            transaction_accounts
+        );
+
+        const VM_BASE_ADDRESS: u64 = 0x100000000;
+        const META_OFFSET: usize = 0;
+        const PROGRAM_ID_OFFSET: usize =
+            META_OFFSET + std::mem::size_of::<ProcessedSiblingInstruction>();
+        const DATA_OFFSET: usize = PROGRAM_ID_OFFSET + std::mem::size_of::<Pubkey>();
+        const ACCOUNTS_OFFSET: usize = DATA_OFFSET + 0x100;
+        const END_OFFSET: usize = ACCOUNTS_OFFSET + std::mem::size_of::<AccountInfo>() * 4;
+        let mut memory = [0u8; END_OFFSET];
+        let config = Config::default();
+        let mut memory_mapping = MemoryMapping::new(
+            vec![MemoryRegion::new_writable(&mut memory, VM_BASE_ADDRESS)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap();
+        let processed_sibling_instruction =
+            unsafe { &mut *memory.as_mut_ptr().cast::<ProcessedSiblingInstruction>() };
+        processed_sibling_instruction.data_len = 2;
+        processed_sibling_instruction.accounts_len = 1;
+        let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
+
+        /*
+        We are testing GetProcessedSiblingInstruction for CPIs
+        We are simulating this scenario:
+        Top level:   A | B | C
+
+        CPIs from B:
+        Level 1:         B
+                    /    |      \
+        Level 2:   B1    B3      B4
+                   |           /  |  \
+        Level 3:   B2         B5  B6 B8
+                              |
+        Level 4:              B7
+
+        CPIs from C:
+        Level 1: C
+                 | \
+        Level 2: C1 C2
+
+        We are invoking the syscall from B5, B6, B8, C, C1 and C2 for comprehensive testing.
+        */
+
+        let top_level = [b'A', b'B', b'C'];
+        // To be uncommented when we reoder the instruction trace
+        // for (idx, ix) in top_level.iter().enumerate() {
+        //     invoke_context
+        //         .transaction_context
+        //         .configure_top_level_instruction_for_tests(
+        //             0,
+        //             vec![InstructionAccount::new(idx as u16, false, false)],
+        //             vec![*ix],
+        //         )
+        //         .unwrap();
+        // }
+
+        /*
+        The trace looks like this:
+        IX:    |A|B|C|B1|B2|B3|B4|B5|B6|B7|B8|C1|C2|
+        Index: |0|1|2|3 |4 |5 |6 |7 |8 |9 |10|11|12|
+         */
+
+        // Execute Instr A
+        invoke_context
+            .transaction_context
+            .configure_top_level_instruction_for_tests(
+                0,
+                vec![InstructionAccount::new(0, false, false)],
+                vec![*top_level.first().unwrap()],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+        invoke_context.transaction_context.pop().unwrap();
+        // Execute Instr B
+        invoke_context
+            .transaction_context
+            .configure_top_level_instruction_for_tests(
+                0,
+                vec![InstructionAccount::new(1, false, false)],
+                vec![*top_level.get(1).unwrap()],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+        // CPI into B1
+        invoke_context
+            .transaction_context
+            .configure_next_cpi_for_tests(
+                1,
+                vec![InstructionAccount::new(1, false, false)],
+                vec![b'B', 1],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+        // CPI into B2
+        invoke_context
+            .transaction_context
+            .configure_next_cpi_for_tests(
+                1,
+                vec![InstructionAccount::new(2, false, false)],
+                vec![b'B', 2],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+        // Return from B2 and B1
+        invoke_context.transaction_context.pop().unwrap();
+        invoke_context.transaction_context.pop().unwrap();
+        // CPI into B3
+        invoke_context
+            .transaction_context
+            .configure_next_cpi_for_tests(
+                1,
+                vec![InstructionAccount::new(3, false, false)],
+                vec![b'B', 3],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+        // Return from B3
+        invoke_context.transaction_context.pop().unwrap();
+        // CPI into B4
+        invoke_context
+            .transaction_context
+            .configure_next_cpi_for_tests(
+                1,
+                vec![InstructionAccount::new(4, false, false)],
+                vec![b'B', 4],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+        // CPI into B5
+        invoke_context
+            .transaction_context
+            .configure_next_cpi_for_tests(
+                1,
+                vec![InstructionAccount::new(5, false, false)],
+                vec![b'B', 5],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+
+        // Invoking the syscall from B5 should return false
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            0,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+        assert_eq!(result.unwrap(), 0);
+
+        // Return from B5
+        invoke_context.transaction_context.pop().unwrap();
+        // CPI into B6
+        invoke_context
+            .transaction_context
+            .configure_next_cpi_for_tests(
+                2,
+                vec![InstructionAccount::new(6, false, false)],
+                vec![b'B', 6],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+        // CPI into B7
+        invoke_context
+            .transaction_context
+            .configure_next_cpi_for_tests(
+                1,
+                vec![InstructionAccount::new(6, false, false)],
+                vec![b'B', 7],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+        // Return from B7
+        invoke_context.transaction_context.pop().unwrap();
+
+        // Invoking the syscall from B6 with index zero should return ix B5
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            0,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+
+        assert_eq!(result.unwrap(), 1);
+        {
+            let program_id = translate_type::<Pubkey>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+                true,
+            )
+            .unwrap();
+            let data = translate_slice::<u8>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+                processed_sibling_instruction.data_len,
+                true,
+            )
+            .unwrap();
+            let accounts = translate_slice::<AccountMeta>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+                processed_sibling_instruction.accounts_len,
+                true,
+            )
+            .unwrap();
+            let transaction_context = &invoke_context.transaction_context;
+            assert_eq!(processed_sibling_instruction.data_len, 2);
+            assert_eq!(processed_sibling_instruction.accounts_len, 1);
+            assert_eq!(
+                program_id,
+                transaction_context.get_key_of_account_at_index(1).unwrap(),
+            );
+            assert_eq!(data, &[b'B', 5]);
+            assert_eq!(
+                accounts,
+                &[AccountMeta {
+                    pubkey: *transaction_context.get_key_of_account_at_index(5).unwrap(),
+                    is_signer: false,
+                    is_writable: false
+                }]
+            );
+        }
+
+        // Invoking the syscall from B6 with index one should return false
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            1,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+        assert_eq!(result.unwrap(), 0);
+
+        // Return from B6
+        invoke_context.transaction_context.pop().unwrap();
+
+        // CPI into B8
+        invoke_context
+            .transaction_context
+            .configure_next_cpi_for_tests(
+                3,
+                vec![InstructionAccount::new(8, false, false)],
+                vec![b'B', 8],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+
+        // Invoking the syscall from B8 with index zero should return ix B6
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            0,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+
+        assert_eq!(result.unwrap(), 1);
+        {
+            let program_id = translate_type::<Pubkey>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+                true,
+            )
+            .unwrap();
+            let data = translate_slice::<u8>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+                processed_sibling_instruction.data_len,
+                true,
+            )
+            .unwrap();
+            let accounts = translate_slice::<AccountMeta>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+                processed_sibling_instruction.accounts_len,
+                true,
+            )
+            .unwrap();
+            let transaction_context = &invoke_context.transaction_context;
+            assert_eq!(processed_sibling_instruction.data_len, 2);
+            assert_eq!(processed_sibling_instruction.accounts_len, 1);
+            assert_eq!(
+                program_id,
+                transaction_context.get_key_of_account_at_index(2).unwrap(),
+            );
+            assert_eq!(data, &[b'B', 6]);
+            assert_eq!(
+                accounts,
+                &[AccountMeta {
+                    pubkey: *transaction_context.get_key_of_account_at_index(6).unwrap(),
+                    is_signer: false,
+                    is_writable: false
+                }]
+            );
+        }
+
+        // Invoking the syscall from B6 with index one should return ix B5
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            1,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+
+        assert_eq!(result.unwrap(), 1);
+        {
+            let program_id = translate_type::<Pubkey>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+                true,
+            )
+            .unwrap();
+            let data = translate_slice::<u8>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+                processed_sibling_instruction.data_len,
+                true,
+            )
+            .unwrap();
+            let accounts = translate_slice::<AccountMeta>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+                processed_sibling_instruction.accounts_len,
+                true,
+            )
+            .unwrap();
+            let transaction_context = &invoke_context.transaction_context;
+            assert_eq!(processed_sibling_instruction.data_len, 2);
+            assert_eq!(processed_sibling_instruction.accounts_len, 1);
+            assert_eq!(
+                program_id,
+                transaction_context.get_key_of_account_at_index(1).unwrap(),
+            );
+            assert_eq!(data, &[b'B', 5]);
+            assert_eq!(
+                accounts,
+                &[AccountMeta {
+                    pubkey: *transaction_context.get_key_of_account_at_index(5).unwrap(),
+                    is_signer: false,
+                    is_writable: false
+                }]
+            );
+        }
+
+        // Invoking the syscall from B8 with index two should return false
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            2,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+        assert_eq!(result.unwrap(), 0);
+
+        // Return from B8
+        invoke_context.transaction_context.pop().unwrap();
+        // Return from B4
+        invoke_context.transaction_context.pop().unwrap();
+        // Return from B
+        invoke_context.transaction_context.pop().unwrap();
+
+        // Execute C
+        invoke_context
+            .transaction_context
+            .configure_top_level_instruction_for_tests(
+                0,
+                vec![InstructionAccount::new(2, false, false)],
+                vec![*top_level.get(2).unwrap()],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+
+        // Invoking the syscall from B with index zero should return ix C
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        processed_sibling_instruction.data_len = 1;
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            0,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+
+        assert_eq!(result.unwrap(), 1);
+        {
+            let program_id = translate_type::<Pubkey>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+                true,
+            )
+            .unwrap();
+            let data = translate_slice::<u8>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+                processed_sibling_instruction.data_len,
+                true,
+            )
+            .unwrap();
+            let accounts = translate_slice::<AccountMeta>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+                processed_sibling_instruction.accounts_len,
+                true,
+            )
+            .unwrap();
+            let transaction_context = &invoke_context.transaction_context;
+            assert_eq!(processed_sibling_instruction.data_len, 1);
+            assert_eq!(processed_sibling_instruction.accounts_len, 1);
+            assert_eq!(
+                program_id,
+                transaction_context.get_key_of_account_at_index(0).unwrap(),
+            );
+            assert_eq!(data, b"B");
+            assert_eq!(
+                accounts,
+                &[AccountMeta {
+                    pubkey: *transaction_context.get_key_of_account_at_index(1).unwrap(),
+                    is_signer: false,
+                    is_writable: false
+                }]
+            );
+        }
+
+        // CPI into C1
+        invoke_context
+            .transaction_context
+            .configure_next_cpi_for_tests(
+                2,
+                vec![InstructionAccount::new(7, false, false)],
+                vec![b'C', 1],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+
+        // Invoking the CPI from C1 with index zero should return false.
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            0,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+        assert_eq!(result.unwrap(), 0);
+
+        // Return from C1
+        invoke_context.transaction_context.pop().unwrap();
+        // CPI into C2
+        invoke_context
+            .transaction_context
+            .configure_next_cpi_for_tests(
+                2,
+                vec![InstructionAccount::new(7, false, false)],
+                vec![b'C', 2],
+            )
+            .unwrap();
+        invoke_context.transaction_context.push().unwrap();
+
+        // Invoking the syscall from C2 with index zero should return ix C1
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        processed_sibling_instruction.data_len = 2;
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            0,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+
+        assert_eq!(result.unwrap(), 1);
+        {
+            let program_id = translate_type::<Pubkey>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+                true,
+            )
+            .unwrap();
+            let data = translate_slice::<u8>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+                processed_sibling_instruction.data_len,
+                true,
+            )
+            .unwrap();
+            let accounts = translate_slice::<AccountMeta>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+                processed_sibling_instruction.accounts_len,
+                true,
+            )
+            .unwrap();
+            let transaction_context = &invoke_context.transaction_context;
+            assert_eq!(processed_sibling_instruction.data_len, 2);
+            assert_eq!(processed_sibling_instruction.accounts_len, 1);
+            assert_eq!(
+                program_id,
+                transaction_context.get_key_of_account_at_index(2).unwrap(),
+            );
+            assert_eq!(data, &[b'C', 1]);
+            assert_eq!(
+                accounts,
+                &[AccountMeta {
+                    pubkey: *transaction_context.get_key_of_account_at_index(7).unwrap(),
+                    is_signer: false,
+                    is_writable: false
+                }]
+            );
+        }
+
+        // Invoking the CPI from C2 with index one should return false.
+        invoke_context.mock_set_remaining(syscall_base_cost);
+        let result = SyscallGetProcessedSiblingInstruction::rust(
+            &mut invoke_context,
+            1,
+            VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+            &mut memory_mapping,
+        );
+        assert_eq!(result.unwrap(), 0);
     }
 
     #[test]

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2699,8 +2699,7 @@ mod tests {
             execution_budget::MAX_HEAP_FRAME_BYTES,
             invoke_context::{BpfAllocator, InvokeContext, SyscallContext},
             memory::address_is_aligned,
-            mock_invoke_context_with_top_level_ixs, with_mock_invoke_context,
-            with_mock_invoke_context_with_feature_set,
+            with_mock_invoke_context, with_mock_invoke_context_with_feature_set,
         },
         solana_sbpf::{
             aligned_memory::AlignedMemory,
@@ -4988,12 +4987,7 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        mock_invoke_context_with_top_level_ixs!(
-            invoke_context,
-            transaction_context,
-            4,
-            transaction_accounts
-        );
+        with_mock_invoke_context!(invoke_context, transaction_context, 4, transaction_accounts);
 
         /*
         We are testing GetProcessedSiblingInstruction for top level instructions.
@@ -5210,12 +5204,7 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        mock_invoke_context_with_top_level_ixs!(
-            invoke_context,
-            transaction_context,
-            3,
-            transaction_accounts
-        );
+        with_mock_invoke_context!(invoke_context, transaction_context, 3, transaction_accounts);
 
         const VM_BASE_ADDRESS: u64 = 0x100000000;
         const META_OFFSET: usize = 0;


### PR DESCRIPTION
#### Problem

After we reorder the instruction trace for ABIv2 (see #10557), we'll need some additional methods to a couple of tests, given the differences in trace management.

Furthermore, some tests were missing coverage for the changes in #10557.

#### Summary of Changes

1. After #10557, `TransactionContext::new` will need the correct number of top level instructions to work, so I created the macro `mock_invoke_context_with_top_level_ixs` to be used in tests.
2. Improve coverage of `test_max_instruction_trace_length`.
3. In `test_process_message_readonly_handling`, we were reusing the same `TransactionContext` with multiple `InvokeContext` instances. That won't work after #10557, so I already fixed it here.
4. Improve coverage of `test_inner_instructions_list_from_instruction_trace`. This test will need slight adjustments for #10557.
5. Improve coverage of `test_syscall_sol_get_processed_sibling_instruction_top_level`. This test will need slight adjustments after #10557.
6. Create `test_syscall_sol_get_processed_sibling_instruction_cpi`. Again, this one will need slight adjustments.


PS: This PR was split from #10557, so take a look there to see how everything connects.