### PR TITLE
chore: update dev config to reduce debug info (and add full-dev profile for original behaviour)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -629,9 +629,23 @@ winreg = "0.55"
 x509-parser = "0.18.1"
 zstd = "0.13.3"
 
-[profile.fast-dev]
+[profile.dev]
+debug = "line-tables-only"
+
+# curve25519-dalek uses the simd backend by default in v4 if possible,
+# which has very slow performance on some platforms with opt-level 0,
+# which is the default for dev and test builds.
+# This slowdown causes certain interactions in the solana-test-validator,
+# such as verifying ZK proofs in transactions, to take much more than 400ms,
+# creating problems in the testing environment.
+# To enable better performance in solana-test-validator during tests and dev builds,
+# we override the opt-level to 3 for the crate.
+[profile.dev.package.curve25519-dalek]
+opt-level = 3
+
+[profile.full-dev]
 inherits = "dev"
-debug = false
+debug = "full"
 
 [profile.release-with-debug]
 inherits = "release"
@@ -647,17 +661,6 @@ lto = "thin"
 inherits = "release"
 lto = "fat"
 codegen-units = 1
-
-# curve25519-dalek uses the simd backend by default in v4 if possible,
-# which has very slow performance on some platforms with opt-level 0,
-# which is the default for dev and test builds.
-# This slowdown causes certain interactions in the solana-test-validator,
-# such as verifying ZK proofs in transactions, to take much more than 400ms,
-# creating problems in the testing environment.
-# To enable better performance in solana-test-validator during tests and dev builds,
-# we override the opt-level to 3 for the crate.
-[profile.dev.package.curve25519-dalek]
-opt-level = 3
 
 [patch.crates-io]
 # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -629,6 +629,10 @@ winreg = "0.55"
 x509-parser = "0.18.1"
 zstd = "0.13.3"
 
+[profile.fast-dev]
+inherits = "dev"
+debug = false
+
 [profile.release-with-debug]
 inherits = "release"
 debug = true

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -24,3 +24,10 @@ env_logger = "0.11.9"
 log = "0.4.28"
 tokio = { version = "1.48.0", features = ["full"] }
 xtask_shared = { package = "xtask", git = "https://github.com/anza-xyz/xtask", rev = "d189441" }
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.full-dev]
+inherits = "dev"
+debug = "full"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -157,6 +157,24 @@ tempfile = "3.23.0"
 thiserror = "2.0.17"
 tokio = "1.48.0"
 
+[profile.dev]
+debug = "line-tables-only"
+
+# curve25519-dalek uses the simd backend by default in v4 if possible,
+# which has very slow performance on some platforms with opt-level 0,
+# which is the default for dev and test builds.
+# This slowdown causes certain interactions in the solana-test-validator,
+# such as verifying ZK proofs in transactions, to take much more than 400ms,
+# creating problems in the testing environment.
+# To enable better performance in solana-test-validator during tests and dev builds,
+# we override the opt-level to 3 for the crate.
+[profile.dev.package.curve25519-dalek]
+opt-level = 3
+
+[profile.full-dev]
+inherits = "dev"
+debug = "full"
+
 [profile.release-with-debug]
 inherits = "release"
 debug = true
@@ -171,14 +189,3 @@ lto = "thin"
 inherits = "release"
 lto = "fat"
 codegen-units = 1
-
-# curve25519-dalek uses the simd backend by default in v4 if possible,
-# which has very slow performance on some platforms with opt-level 0,
-# which is the default for dev and test builds.
-# This slowdown causes certain interactions in the solana-test-validator,
-# such as verifying ZK proofs in transactions, to take much more than 400ms,
-# creating problems in the testing environment.
-# To enable better performance in solana-test-validator during tests and dev builds,
-# we override the opt-level to 3 for the crate.
-[profile.dev.package.curve25519-dalek]
-opt-level = 3

--- a/platform-tools-sdk/Cargo.toml
+++ b/platform-tools-sdk/Cargo.toml
@@ -49,3 +49,10 @@ semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serial_test = "3.4.0"
 tar = "0.4.44"
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.full-dev]
+inherits = "dev"
+debug = "full"

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -263,6 +263,13 @@ solana-vote-interface = { workspace = true }
 solana-vote-program = { workspace = true }
 test-case = { workspace = true }
 
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.full-dev]
+inherits = "dev"
+debug = "full"
+
 [profile.release]
 # The test programs are build in release mode
 # Minimize their file size so that they fit into the account size limit

--- a/scripts/cargo-clippy-nightly.sh
+++ b/scripts/cargo-clippy-nightly.sh
@@ -24,6 +24,7 @@ source "$here/../ci/rust-version.sh" nightly
 #   ref: https://github.com/rust-lang/rust/issues/66287
 "$here/cargo-for-all-lock-files.sh" -- \
   "+${rust_nightly}" clippy \
+  --profile=fast-dev \
   --workspace --all-targets --features dummy-for-ci-check,frozen-abi -- \
   --deny=warnings \
   --deny=clippy::default_trait_access \

--- a/scripts/cargo-clippy-nightly.sh
+++ b/scripts/cargo-clippy-nightly.sh
@@ -24,7 +24,6 @@ source "$here/../ci/rust-version.sh" nightly
 #   ref: https://github.com/rust-lang/rust/issues/66287
 "$here/cargo-for-all-lock-files.sh" -- \
   "+${rust_nightly}" clippy \
-  --profile=fast-dev \
   --workspace --all-targets --features dummy-for-ci-check,frozen-abi -- \
   --deny=warnings \
   --deny=clippy::default_trait_access \


### PR DESCRIPTION
Building agave with debug info enabled is resource intensive in both memory (need roughly 64G of memory with -j8) and disk (produces around 64G target/ directory.)

In this economy where one has been made 5x the
price compared to half a year ago and the other costs >2x per unit of storage, running the debug enabled build can be an exercise in frustration.

With debug info disabled the memory consumption is much, much better even at `-j32`, not exceeding a single digit GBs. The produced target directory is half as large as well.

This new configuration is largely meant for users running their edit-compile-test cycle locally: the speed of compiled code is not particularly important (you are usually running a subset of tests, right?), and the debug info is only rarely needed (use of a profiler/debugger is only occasional.)