### PR TITLE
feat(alpenglow): alpenglow genesis certificate setter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10407,6 +10407,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
+ "wincode 0.4.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10407,7 +10407,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
- "wincode 0.4.4",
+ "wincode",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8663,6 +8663,7 @@ dependencies = [
  "symlink",
  "tempfile",
  "thiserror 2.0.18",
+ "wincode 0.4.4",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8663,7 +8663,7 @@ dependencies = [
  "symlink",
  "tempfile",
  "thiserror 2.0.18",
- "wincode 0.4.4",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8516,6 +8516,7 @@ dependencies = [
  "symlink",
  "tempfile",
  "thiserror 2.0.18",
+ "wincode 0.4.4",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8516,7 +8516,7 @@ dependencies = [
  "symlink",
  "tempfile",
  "thiserror 2.0.18",
- "wincode 0.4.4",
+ "wincode",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -188,6 +188,7 @@ strum_macros = { workspace = true }
 symlink = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2895,16 +2895,17 @@ impl Bank {
     /// - If `get_alpenglow_genesis_certificate` is called after the marker is processed, we return the certificate
     pub fn get_alpenglow_genesis_certificate(&self) -> Option<Certificate> {
         self.get_account(&GENESIS_CERTIFICATE_ACCOUNT).map(|acct| {
-            acct.deserialize_data()
+            wincode::deserialize(acct.data())
                 .expect("Programmer error deserializing genesis certificate")
         })
     }
 
     /// For use in the first Alpenglow block, set the genesis certificate.
     pub fn set_alpenglow_genesis_certificate(&self, cert: &Certificate) {
-        let cert_size = wincode::serialized_size(cert).unwrap();
-        let lamports = Rent::default().minimum_balance(cert_size as usize);
-        let cert_acct = AccountSharedData::new_data(lamports, cert, &system_program::ID).unwrap();
+        let data = wincode::serialize(cert).unwrap();
+        let lamports = Rent::default().minimum_balance(data.len());
+        let mut cert_acct = AccountSharedData::new(lamports, data.len(), &system_program::ID);
+        cert_acct.set_data_from_slice(&data);
 
         self.store_account_and_update_capitalization(&GENESIS_CERTIFICATE_ACCOUNT, &cert_acct);
     }


### PR DESCRIPTION
#### Problem and Summary of Changes

There is no way to persist the Alpenglow genesis certificate on-chain. The getter (`get_alpenglow_genesis_certificate`) already exists, but there is no corresponding setter to store the certificate into the bank's account state during the first Alpenglow block.

Adds `Bank::set_alpenglow_genesis_certificate`.

For more context: https://github.com/anza-xyz/alpenglow/pull/573