### PR TITLE
feat(alpenglow): introduce fast leader handover flag in migration

### DIFF
--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -273,6 +273,11 @@ impl MigrationPhase {
         // Only allow for alpenglow blocks, TowerBFT blocks should not have markers
         self.is_alpenglow_block(slot)
     }
+
+    /// Should this block allow the UpdateParent marker, i.e., support fast leader handover?
+    fn should_allow_fast_leader_handover(&self, slot: Slot) -> bool {
+        self.is_alpenglow_block(slot)
+    }
 }
 
 /// Keeps track of the current migration status
@@ -410,6 +415,7 @@ impl MigrationStatus {
     dispatch!(pub fn should_respond_to_ancestor_hashes_requests(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_have_alpenglow_ticks(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_allow_block_markers(&self, slot: Slot) -> bool);
+    dispatch!(pub fn should_allow_fast_leader_handover(&self, slot: Slot) -> bool);
 
     /// The alpenglow feature flag has been activated in slot `slot`.
     /// This should only be called using the feature account of a *rooted* slot,


### PR DESCRIPTION
#### Problem

There is no migration-aware flag to control whether fast leader handover (the `UpdateParent` block marker) is permitted for a given slot. Without this, there is no way to gate fast leader handover behavior based on the current `MigrationPhase`.

#### Summary of Changes

This PR adds `should_allow_fast_leader_handover` to `MigrationPhase`.