### PR TITLE
add progress bar to agave-ledger-tool blockstore copy

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "dashmap",
  "futures 0.3.32",
  "histogram",
+ "indicatif 0.18.4",
  "itertools 0.14.0",
  "log",
  "num_cpus",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -61,6 +61,7 @@ csv = "1.4.0"
 dashmap = "5.5.3"
 futures = "0.3.32"
 histogram = "0.6.9"
+indicatif = "0.18.4"
 itertools = "0.14.0"
 jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
     "unprefixed_malloc_on_supported_platforms",

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -33,6 +33,7 @@ csv = { workspace = true }
 dashmap = { workspace = true }
 futures = { workspace = true }
 histogram = { workspace = true }
+indicatif = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 num_cpus = { workspace = true }


### PR DESCRIPTION
# Problem
it is presently hard to tell what the status of `agave-ledger-tool blockstore copy` is rn, as the logs are very noisy

# Solution 
after startup, we set max log level to warn (to mute info) and then a show progress bar instead

example output with 10001 slot range:
```
ubuntu@fra2-solrpc-01:~$ sudo ~/solana/target/release/agave-ledger-tool blockstore copy --starting-slot 401086804 --ending-slot 401096804 --target-ledger ~/ledger-copy-test --ledger ~/ledger
[2026-02-19T06:07:25.708708715Z INFO  agave_ledger_tool] agave-ledger-tool 3.0.6 (src:0c34bdbb; feat:3604001754, client:JitoLabs)
[2026-02-19T06:07:25.710216861Z INFO  solana_ledger::blockstore] Maximum open file descriptors: 1000000
[2026-02-19T06:07:25.710222431Z INFO  solana_ledger::blockstore] Opening blockstore at "/mnt/ledger/ledger/rocksdb"
[2026-02-19T06:07:25.710896454Z INFO  solana_ledger::blockstore_db] Opening Rocks with secondary (read only) access at: "/mnt/ledger/ledger/rocksdb/solana-secondary". This secondary access could temporarily degrade other accesses, such as by agave-validator
[2026-02-19T06:07:54.061242642Z INFO  solana_ledger::blockstore_db] Rocks's automatic compactions are disabled due to Secondary access
[2026-02-19T06:07:54.061402603Z INFO  solana_ledger::blockstore] Opening blockstore done; blockstore open took 28.4s
[2026-02-19T06:07:54.061638444Z INFO  solana_ledger::blockstore] Maximum open file descriptors: 1000000
[2026-02-19T06:07:54.061643784Z INFO  solana_ledger::blockstore] Opening blockstore at "/home/ubuntu/ledger-copy-test/rocksdb"
[2026-02-19T06:07:54.062004705Z WARN  solana_ledger::blockstore_db] Unable to detect Rocks columns: Error { message: "IO error: No such file or directory: While opening a file for sequentially reading: /home/ubuntu/ledger-copy-test/rocksdb/CURRENT: No such file or directory" }
[2026-02-19T06:07:54.070440109Z INFO  solana_ledger::blockstore_db] Rocks's automatic compactions are disabled due to PrimaryForMaintenance access
[2026-02-19T06:07:54.070459249Z INFO  solana_ledger::blockstore] Opening blockstore done; blockstore open took 8ms
⠒ Copying slots 401086804-401096804 (current 401089986)     [============>                           ] 3182/10001 (2m)
```
which ends with 
```
[2026-02-19T06:10:26.371917584Z INFO  agave_ledger_tool] ledger tool took 180.7s
```
after clearing the progress bar

cc: @steviez