### PR TITLE
vote-program: add signer check to deposit_delegator_rewards

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -982,6 +982,12 @@ pub fn deposit_delegator_rewards(
 
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
+
+    // Source account must be a transaction-level signer.
+    if !instruction_context.is_instruction_account_signer(SENDER_ACCOUNT_INDEX)? {
+        return Err(InstructionError::MissingRequiredSignature);
+    }
+
     let vote_address = *instruction_context.get_key_of_instruction_account(VOTE_ACCOUNT_INDEX)?;
     let source_address =
         *instruction_context.get_key_of_instruction_account(SENDER_ACCOUNT_INDEX)?;
@@ -1010,7 +1016,7 @@ pub fn deposit_delegator_rewards(
     // CPI to System: Transfer from sender to vote account.
     invoke_context.native_invoke(
         system_instruction::transfer(&source_address, &vote_address, deposit),
-        &[source_address],
+        &[],
     )?;
 
     // Update `pending_delegator_rewards`.


### PR DESCRIPTION
#### Problem

In `deposit_delegator_rewards` (SIMD-0123), the Vote program itself doesn't verify that the source account is a transaction-level signer before invoking CPI. It calls into `native_invoke` with `&[source_address]`, as the `signers` parameter.

Unfortunately, what the `signers` parameter actually means is that those keys are "vouched for" by the caller program, thus they are expected to have been checked in the caller program. That being said, the Vote program should instead verify the source account is a signer before invoking CPI.

Introduced in #10183.

#### Summary of Changes

* Add an explicit `is_instruction_account_signer` check on the source account before any other logic, returning `MissingRequiredSignature` if false.
* Change the `native_invoke` signers from `&[source_address]` to `&[]`.
* Add a negative test for `DepositDelegatorRewards` with a non-signing source.