### PR TITLE
Optimises channel to send vec of ConsensusMessage instead one at a time

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -304,7 +304,7 @@ pub struct ReplaySenders {
     pub block_metadata_notifier: Option<BlockMetadataNotifierArc>,
     pub dumped_slots_sender: Sender<Vec<(u64, Hash)>>,
     pub votor_event_sender: VotorEventSender,
-    pub own_vote_sender: Sender<ConsensusMessage>,
+    pub own_vote_sender: Sender<Vec<ConsensusMessage>>,
     pub lockouts_sender: Sender<TowerCommitmentAggregationData>,
 }
 
@@ -1435,7 +1435,7 @@ impl ReplayStage {
         vote_account: Pubkey,
         identity_keypair: &Arc<Keypair>,
         authorized_voter_keypairs: &Arc<std::sync::RwLock<Vec<Arc<Keypair>>>>,
-        own_vote_sender: &Sender<ConsensusMessage>,
+        own_vote_sender: &Sender<Vec<ConsensusMessage>>,
         bls_sender: &Sender<BLSOp>,
     ) -> bool {
         let Some((slot, block_id)) = migration_status.eligible_genesis_block() else {
@@ -1460,7 +1460,7 @@ impl ReplayStage {
                     identity_keypair.pubkey()
                 );
                 // If sending fails that means the channel is disconnected and we are shutting down
-                let _ = own_vote_sender.send(message.clone());
+                let _ = own_vote_sender.send(vec![message.clone()]);
                 let _ = bls_sender.send(BLSOp::PushVote {
                     message: Arc::new(message),
                     slot,

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -840,7 +840,7 @@ mod tests {
     struct EventHandlerTestContext {
         bls_receiver: Receiver<BLSOp>,
         commitment_receiver: Receiver<CommitmentAggregationData>,
-        own_vote_receiver: Receiver<ConsensusMessage>,
+        own_vote_receiver: Receiver<Vec<ConsensusMessage>>,
         bank_forks: Arc<RwLock<BankForks>>,
         my_bls_keypair: BLSKeypair,
         timer_manager: Arc<PlRwLock<TimerManager>>,
@@ -1195,7 +1195,7 @@ mod tests {
             );
             // Also check own_vote_receiver
             let own_vote = self.own_vote_receiver.try_recv().unwrap();
-            assert_eq!(own_vote, expected_message);
+            assert_eq!(own_vote, vec![expected_message]);
         }
 
         fn check_for_commitment(&mut self, expected_type: CommitmentType, expected_slot: Slot) {

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -118,7 +118,7 @@ pub struct VotingContext {
     // The BLS keypair should always change with authorized_voter_keypairs.
     pub derived_bls_keypairs: HashMap<Pubkey, Arc<BLSKeypair>>,
     pub has_new_vote_been_rooted: bool,
-    pub own_vote_sender: Sender<ConsensusMessage>,
+    pub own_vote_sender: Sender<Vec<ConsensusMessage>>,
     pub bls_sender: Sender<BLSOp>,
     pub commitment_sender: Sender<CommitmentAggregationData>,
     pub wait_to_vote_slot: Option<u64>,
@@ -286,7 +286,7 @@ fn insert_vote_and_create_bls_message(
     };
     context
         .own_vote_sender
-        .send(message.clone())
+        .send(vec![message.clone()])
         .map_err(|_| SendError(()))?;
 
     // TODO: for refresh votes use a different BLSOp so we don't have to rewrite the same vote history to file
@@ -355,7 +355,7 @@ mod tests {
     }
 
     fn setup_voting_context_and_bank_forks(
-        own_vote_sender: Sender<ConsensusMessage>,
+        own_vote_sender: Sender<Vec<ConsensusMessage>>,
         validator_keypairs: &[ValidatorVoteKeypairs],
         my_index: usize,
     ) -> VotingContext {
@@ -441,7 +441,7 @@ mod tests {
 
         // Check that own vote sender receives the vote
         let received_message = own_vote_receiver.recv().unwrap();
-        assert_eq!(received_message, expected_message);
+        assert_eq!(received_message, vec![expected_message]);
     }
 
     #[test]

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -110,11 +110,11 @@ pub struct VotorConfig {
     pub leader_window_info_sender: Sender<LeaderWindowInfo>,
     pub highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
     pub event_sender: VotorEventSender,
-    pub own_vote_sender: Sender<ConsensusMessage>,
+    pub own_vote_sender: Sender<Vec<ConsensusMessage>>,
 
     // Receivers
     pub event_receiver: VotorEventReceiver,
-    pub consensus_message_receiver: Receiver<ConsensusMessage>,
+    pub consensus_message_receiver: Receiver<Vec<ConsensusMessage>>,
     pub consensus_metrics_receiver: ConsensusMetricsEventReceiver,
 }
 
@@ -161,7 +161,7 @@ impl Votor {
             event_sender,
             own_vote_sender,
             event_receiver,
-            consensus_message_receiver: bls_receiver,
+            consensus_message_receiver,
             consensus_metrics_sender,
             consensus_metrics_receiver,
         } = config;
@@ -231,7 +231,7 @@ impl Votor {
             blockstore,
             sharable_banks,
             leader_schedule_cache,
-            consensus_message_receiver: bls_receiver,
+            consensus_message_receiver,
             bls_sender,
             event_sender,
             commitment_sender,


### PR DESCRIPTION
#### Problem

Generally, the sender and the receiver need to send and receive a batch of msgs so sending them one at a time is not efficient.

#### Summary of Changes

This change changes the channel to handle sending and receiving of a `Vec<ConsensusMessage>` instead of just a `ConsensusMessage`.

This is an upstream of https://github.com/anza-xyz/alpenglow/pull/737.  This is in preparation of upstreaming the bls sigverifier.
