### PR TITLE
uses the `wincode` feature from the `solana-hash` crate

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7433,6 +7433,7 @@ dependencies = [
  "serde_derive",
  "solana-atomic-u64",
  "solana-sanitize",
+ "wincode",
 ]
 
 [[package]]

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -32,7 +32,7 @@ serde = { workspace = true }
 solana-address = { workspace = true }
 solana-bls-signatures = { workspace = true }
 solana-clock = { workspace = true }
-solana-hash = { workspace = true }
+solana-hash = { workspace = true, features = ["wincode"] }
 solana-measure = { workspace = true }
 solana-merkle-tree = { workspace = true }
 solana-message = { workspace = true }

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -204,7 +204,6 @@ pub enum BlockComponentError {
 /// Block production metadata. User agent is capped at 255 bytes.
 #[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
 pub struct BlockFooterV1 {
-    #[wincode(with = "Pod<Hash>")]
     pub bank_hash: Hash,
     pub block_producer_time_nanos: u64,
     #[wincode(with = "WincodeVec<u8, FixIntLen<u8>>")]
@@ -217,14 +216,12 @@ pub struct BlockFooterV1 {
 #[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
 pub struct BlockHeaderV1 {
     pub parent_slot: Slot,
-    #[wincode(with = "Pod<Hash>")]
     pub parent_block_id: Hash,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
 pub struct UpdateParentV1 {
     pub new_parent_slot: Slot,
-    #[wincode(with = "Pod<Hash>")]
     pub new_parent_block_id: Hash,
 }
 
@@ -232,7 +229,6 @@ pub struct UpdateParentV1 {
 #[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
 pub struct GenesisCertificate {
     pub slot: Slot,
-    #[wincode(with = "Pod<Hash>")]
     pub block_id: Hash,
     #[wincode(with = "Pod<BLSSignature>")]
     pub bls_signature: BLSSignature,
@@ -281,7 +277,6 @@ impl From<GenesisCertificate> for Certificate {
 #[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
 pub struct FinalCertificate {
     pub slot: Slot,
-    #[wincode(with = "Pod<Hash>")]
     pub block_id: Hash,
     pub final_aggregate: VotesAggregate,
     pub notar_aggregate: Option<VotesAggregate>,

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -22,11 +22,7 @@ use {
         sync::{Arc, Once, OnceLock},
         time::Instant,
     },
-    wincode::{
-        containers::{Pod, Vec as WincodeVec},
-        len::BincodeLen,
-        SchemaRead, SchemaWrite,
-    },
+    wincode::{containers::Vec as WincodeVec, len::BincodeLen, SchemaRead, SchemaWrite},
 };
 
 pub type EntrySender = Sender<Vec<Entry>>;
@@ -119,7 +115,6 @@ pub struct Entry {
     pub num_hashes: u64,
 
     /// The SHA-256 hash `num_hashes` after the previous Entry ID.
-    #[wincode(with = "Pod<Hash>")]
     pub hash: Hash,
 
     /// An unordered list of transactions that were observed before the Entry ID was

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -39,7 +39,7 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-hash = { workspace = true, features = ["serde", "copy", "decode"] }
+solana-hash = { workspace = true, features = ["serde", "copy", "decode", "wincode"] }
 solana-pubkey = { workspace = true }
 solana-signer-store = { workspace = true }
 thiserror = { workspace = true }

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -54,15 +54,15 @@ pub enum CertificateType {
     /// Finalize certificate
     Finalize(Slot),
     /// Fast finalize certificate
-    FinalizeFast(Slot, #[wincode(with = "Pod<Hash>")] Hash),
+    FinalizeFast(Slot, Hash),
     /// Notarize certificate
-    Notarize(Slot, #[wincode(with = "Pod<Hash>")] Hash),
+    Notarize(Slot, Hash),
     /// Notarize fallback certificate
-    NotarizeFallback(Slot, #[wincode(with = "Pod<Hash>")] Hash),
+    NotarizeFallback(Slot, Hash),
     /// Skip certificate
     Skip(Slot),
     /// Genesis certificate
-    Genesis(Slot, #[wincode(with = "Pod<Hash>")] Hash),
+    Genesis(Slot, Hash),
 }
 
 impl CertificateType {

--- a/votor-messages/src/reward_certificate.rs
+++ b/votor-messages/src/reward_certificate.rs
@@ -75,7 +75,6 @@ pub struct NotarRewardCertificate {
     /// The slot the certificate is for.
     pub slot: Slot,
     /// The block id the certificate is for.
-    #[wincode(with = "Pod<Hash>")]
     pub block_id: Hash,
     /// The signature.
     #[wincode(with = "Pod<BLSSignatureCompressed>")]

--- a/votor-messages/src/vote.rs
+++ b/votor-messages/src/vote.rs
@@ -3,7 +3,7 @@ use {
     serde::{Deserialize, Serialize},
     solana_clock::Slot,
     solana_hash::Hash,
-    wincode::{containers::Pod, SchemaRead, SchemaWrite},
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 /// Enum that clients can use to parse and create the vote
@@ -208,7 +208,6 @@ pub struct NotarizationVote {
     /// The slot this vote is cast for.
     pub slot: Slot,
     /// The block id this vote is for.
-    #[wincode(with = "Pod<Hash>")]
     pub block_id: Hash,
 }
 
@@ -285,7 +284,6 @@ pub struct NotarizationFallbackVote {
     /// The slot this vote is cast for.
     pub slot: Slot,
     /// The block id this vote is for.
-    #[wincode(with = "Pod<Hash>")]
     pub block_id: Hash,
 }
 
@@ -336,6 +334,5 @@ pub struct GenesisVote {
     /// The slot this vote is cast for.
     pub slot: Slot,
     /// The block id this vote is for.
-    #[wincode(with = "Pod<Hash>")]
     pub block_id: Hash,
 }


### PR DESCRIPTION
#### Problem

Various users of `solana-hash` crate are also using `wincode`.  And `solana-hash` recently introduced the `wincode` feature.


#### Summary of Changes

Updates the various users of `solana-hash` crate to use the `wincode` feature as appropriate.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
