### PR TITLE
Refactor - Rename serialization functions according to ABI versions

### DIFF
--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -270,7 +270,7 @@ pub fn serialize_parameters(
             account_data_direct_mapping,
         )
     } else {
-        serialize_parameters_aligned(
+        serialize_parameters_for_abiv1(
             accounts,
             instruction_context.get_instruction_data(),
             &program_id,
@@ -299,7 +299,7 @@ pub fn deserialize_parameters(
             account_lengths,
         )
     } else {
-        deserialize_parameters_aligned(
+        deserialize_parameters_for_abiv1(
             instruction_context,
             stricter_abi_and_runtime_constraints,
             account_data_direct_mapping,
@@ -463,7 +463,7 @@ fn deserialize_parameters_for_abiv0<I: IntoIterator<Item = usize>>(
     Ok(())
 }
 
-fn serialize_parameters_aligned(
+fn serialize_parameters_for_abiv1(
     accounts: Vec<SerializeAccount>,
     instruction_data: &[u8],
     program_id: &Pubkey,
@@ -564,7 +564,7 @@ fn serialize_parameters_aligned(
     ))
 }
 
-fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
+fn deserialize_parameters_for_abiv1<I: IntoIterator<Item = usize>>(
     instruction_context: &InstructionContext,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
@@ -960,7 +960,7 @@ mod tests {
                 .get_current_instruction_context()
                 .unwrap();
 
-            // check serialize_parameters_aligned
+            // check serialize_parameters_for_abiv1
             let (mut serialized, regions, accounts_metadata, _instruction_data_offset) =
                 serialize_parameters(
                     &instruction_context,
@@ -1219,7 +1219,7 @@ mod tests {
             .get_current_instruction_context()
             .unwrap();
 
-        // check serialize_parameters_aligned
+        // check serialize_parameters_for_abiv1
         let (_serialized, regions, _accounts_metadata, _instruction_data_offset) =
             serialize_parameters(
                 &instruction_context,

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -262,6 +262,7 @@ pub fn serialize_parameters(
         .collect::<Vec<_>>();
 
     if is_loader_deprecated {
+        // Used by loader-v1 (bpf_loader_deprecated)
         serialize_parameters_for_abiv0(
             accounts,
             instruction_context.get_instruction_data(),
@@ -270,6 +271,7 @@ pub fn serialize_parameters(
             account_data_direct_mapping,
         )
     } else {
+        // Used by loader-v2 (bpf_loader) and loader-v3 (bpf_loader_upgradeable)
         serialize_parameters_for_abiv1(
             accounts,
             instruction_context.get_instruction_data(),
@@ -291,6 +293,7 @@ pub fn deserialize_parameters(
         instruction_context.get_program_owner()? == bpf_loader_deprecated::id();
     let account_lengths = accounts_metadata.iter().map(|a| a.original_data_len);
     if is_loader_deprecated {
+        // Used by loader-v1 (bpf_loader_deprecated)
         deserialize_parameters_for_abiv0(
             instruction_context,
             stricter_abi_and_runtime_constraints,
@@ -299,6 +302,7 @@ pub fn deserialize_parameters(
             account_lengths,
         )
     } else {
+        // Used by loader-v2 (bpf_loader) and loader-v3 (bpf_loader_upgradeable)
         deserialize_parameters_for_abiv1(
             instruction_context,
             stricter_abi_and_runtime_constraints,

--- a/programs/sbf/rust/deprecated_loader/src/lib.rs
+++ b/programs/sbf/rust/deprecated_loader/src/lib.rs
@@ -167,7 +167,7 @@ fn process_instruction(
             )
             .unwrap();
 
-            // deserialize_parameters_unaligned predates realloc support, and
+            // deserialize_parameters_for_abiv0 predates realloc support, and
             // hardcodes the account data length to the original length.
             if !solana_program::bpf_loader_deprecated::check_id(realloc_program_owner)
                 && stricter_abi_and_runtime_constraints == 0

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -1088,7 +1088,7 @@ fn process_instruction<'a>(
             )
             .unwrap();
 
-            // deserialize_parameters_unaligned predates realloc support, and
+            // deserialize_parameters_for_abiv0 predates realloc support, and
             // hardcodes the account data length to the original length.
             if !bpf_loader_deprecated::check_id(realloc_program_owner)
                 && stricter_abi_and_runtime_constraints == 0


### PR DESCRIPTION
#### Problem

The current naming scheme `unaligned` and `aligned` is confusing and questions about the mapping between serialization functions, ABI versions and loaders pop up frequently.

#### Summary of Changes

- Renames `serialize_parameters_unaligned` => `serialize_parameters_for_abiv0`.
- Renames `deserialize_parameters_unaligned` => `deserialize_parameters_for_abiv0`.
- Renames `serialize_parameters_aligned` => `serialize_parameters_for_abiv1`.
- Renames `deserialize_parameters_aligned` => `deserialize_parameters_for_abiv1`.
- Adds more comments about the mapping of serialization functions, ABI versions and loaders.