### PR TITLE
upstreams introducing `CertificateType::limits_and_vote_types()`

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -20,7 +20,7 @@ use {
         tower_vote_state::TowerVoteState,
     },
     crate::{consensus::progress_map::LockoutInterval, replay_stage::DUPLICATE_THRESHOLD},
-    agave_votor_messages::migration::GENESIS_VOTE_THRESHOLD,
+    agave_votor_messages::{fraction::Fraction, migration::GENESIS_VOTE_THRESHOLD},
     chrono::prelude::*,
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
@@ -42,6 +42,7 @@ use {
     std::{
         cmp::Ordering,
         collections::{HashMap, HashSet},
+        num::NonZeroU64,
         ops::Deref,
     },
     thiserror::Error,
@@ -542,7 +543,8 @@ impl Tower {
 
         debug_assert!(total_stake > 0);
         let parent_is_super_oc = bank_slot == parent_slot + 1
-            && super_oc_stake as f64 / total_stake as f64 > GENESIS_VOTE_THRESHOLD;
+            && Fraction::new(super_oc_stake, NonZeroU64::new(total_stake).unwrap())
+                > GENESIS_VOTE_THRESHOLD;
 
         // TODO: populate_ancestor_voted_stakes only adds zeros. Comment why
         // that is necessary (if so).

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -43,7 +43,10 @@
 //!   TowerBFT slots pre alpenglow genesis in order to help other cluster participants catchup.
 //! - When in `FullAlpenglowEpoch` we completely shutdown these TowerBFT threads (AncestorHashesService and ClusterSlotsService)
 use {
-    crate::consensus_message::{Block, Certificate, CertificateType},
+    crate::{
+        consensus_message::{Block, Certificate, CertificateType},
+        fraction::Fraction,
+    },
     log::*,
     solana_address::Address,
     solana_clock::{Epoch, Slot},
@@ -77,7 +80,7 @@ pub const MIGRATION_MALICIOUS_THRESHOLD: f64 = 20.0 / 100.0;
 /// `SWITCH_FORK_THRESHOLD` - (1 - `GENESIS_VOTE_THRESHOLD`) = `MIGRATION_MALICIOUS_THRESHOLD` malicious stake.
 ///
 /// Using 38% as the `SWITCH_FORK_THRESHOLD` gives us 82% for `GENESIS_VOTE_THRESHOLD`.
-pub const GENESIS_VOTE_THRESHOLD: f64 = 82.0 / 100.0;
+pub const GENESIS_VOTE_THRESHOLD: Fraction = Fraction::from_percentage(82);
 
 /// The interval at which we refresh our genesis vote
 pub const GENESIS_VOTE_REFRESH: Duration = Duration::from_millis(400);

--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -1,7 +1,6 @@
 use {
     agave_votor_messages::{
         consensus_message::CertificateType,
-        migration::GENESIS_VOTE_THRESHOLD,
         vote::{Vote, VoteType},
     },
     std::time::Duration,
@@ -28,25 +27,6 @@ pub const fn conflicting_types(vote_type: VoteType) -> &'static [VoteType] {
             VoteType::Skip,
             VoteType::SkipFallback,
         ],
-    }
-}
-
-/// Lookup from `CertificateId` to the `VoteType`s that contribute,
-/// as well as the stake fraction required for certificate completion.
-///
-/// Must be in sync with `vote_to_cert_types`
-pub(crate) const fn certificate_limits_and_vote_types(
-    cert_type: &CertificateType,
-) -> (f64, &'static [VoteType]) {
-    match cert_type {
-        CertificateType::Notarize(_, _) => (0.6, &[VoteType::Notarize]),
-        CertificateType::NotarizeFallback(_, _) => {
-            (0.6, &[VoteType::Notarize, VoteType::NotarizeFallback])
-        }
-        CertificateType::FinalizeFast(_, _) => (0.8, &[VoteType::Notarize]),
-        CertificateType::Finalize(_) => (0.6, &[VoteType::Finalize]),
-        CertificateType::Skip(_) => (0.6, &[VoteType::Skip, VoteType::SkipFallback]),
-        CertificateType::Genesis(_, _) => (GENESIS_VOTE_THRESHOLD, &[VoteType::Genesis]),
     }
 }
 

--- a/votor/src/consensus_pool/certificate_builder.rs
+++ b/votor/src/consensus_pool/certificate_builder.rs
@@ -1,5 +1,4 @@
 use {
-    crate::common::certificate_limits_and_vote_types,
     agave_votor_messages::consensus_message::{Certificate, CertificateType, VoteMessage},
     bitvec::prelude::*,
     solana_bls_signatures::{BlsError, SignatureProjective},
@@ -143,7 +142,7 @@ impl BuilderType {
         cert_type: &CertificateType,
         msgs: &[VoteMessage],
     ) -> Result<(), AggregateError> {
-        let vote_types = certificate_limits_and_vote_types(cert_type).1;
+        let vote_types = cert_type.limits_and_vote_types().1;
         match self {
             Self::Skip {
                 signature0,


### PR DESCRIPTION
#### Problem

Upstreams some more code to set the stage for upstreaming of bls sigverifier.

Given a `CertificateType`, we need to be able to look up the limits and vote types in crates that cannot depend upon the `votor` crate.


#### Summary of Changes

Moves the code into into the `votor-messages` crate.