### PR TITLE
Uses wincode to handle `VoteHistory`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -456,7 +456,7 @@ solana-genesis-utils = { path = "genesis-utils", version = "=4.0.0-alpha.0", fea
 solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-gossip = { path = "gossip", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-hard-forks = "3.0.0"
-solana-hash = "4.2.0"
+solana-hash = { version = "4.2.0", features = ["wincode"] }
 solana-inflation = "3.0.0"
 solana-instruction = "3.1.0"
 solana-instruction-error = "2.1.0"

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -68,10 +68,10 @@ solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["wincode"] }
 solana-rpc = { workspace = true }
 solana-runtime = { workspace = true }
-solana-signature = { workspace = true }
+solana-signature = { workspace = true, features = ["wincode"] }
 solana-signer = { workspace = true }
 solana-signer-store = { workspace = true }
 solana-streamer = { workspace = true }

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -10,7 +10,7 @@ use {
     solana_pubkey::Pubkey,
     std::collections::{hash_map::Entry, HashMap, HashSet},
     thiserror::Error,
-    wincode::{containers::Pod, SchemaRead, SchemaWrite},
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 pub const VOTE_THRESHOLD_SIZE: f64 = 2f64 / 3f64;
@@ -39,7 +39,6 @@ impl VoteHistoryVersions {
 #[derive(Clone, Debug, Default, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
 pub struct VoteHistory {
     /// The validator identity that cast votes
-    #[wincode(with = "Pod<Pubkey>")]
     pub node_pubkey: Pubkey,
 
     /// The slots which this node has cast either a notarization or skip vote

--- a/votor/src/vote_history_storage.rs
+++ b/votor/src/vote_history_storage.rs
@@ -10,7 +10,7 @@ use {
         io::{self, Read, Write},
         path::PathBuf,
     },
-    wincode::{containers::Pod, SchemaRead, SchemaWrite},
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 pub type Result<T> = std::result::Result<T, VoteHistoryError>;
@@ -74,7 +74,6 @@ impl From<SavedVoteHistory> for SavedVoteHistoryVersions {
 )]
 #[derive(Default, Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
 pub struct SavedVoteHistory {
-    #[wincode(with = "Pod<Signature>")]
     signature: Signature,
     data: Vec<u8>,
     #[wincode(skip)]
@@ -149,7 +148,7 @@ impl VoteHistoryStorage for FileVoteHistoryStorage {
         // New format
         let mut file = File::open(&filename)?;
         let mut buf = vec![];
-        file.read_to_end(&mut buf).unwrap();
+        file.read_to_end(&mut buf)?;
 
         wincode::deserialize(&buf)
             .map_err(|e| e.into())


### PR DESCRIPTION
#### Problem

We want to use `wincode` for as many places as possible.


#### Summary of Changes

- Uses `wincode` for handling `VoteHistory`.  
- We still need to use `Serialize` as it is needed for `frozen_api`.
- `wincode` doesn't seem to have file IO support hence we have to do some additional copying.  Happy to receive feedback from reviewers on if I am missing something in wincode or if I should look into adding support for file IO.