### PR TITLE
feature-set: Rekey create-account-allow-prefund

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1175,7 +1175,7 @@ pub mod provide_instruction_data_offset_in_vm_r2 {
 }
 
 pub mod create_account_allow_prefund {
-    solana_pubkey::declare_id!("caapcFpbcsJTMQMEMcpyx1m27DcXVp4MH6faHM5h5Z5");
+    solana_pubkey::declare_id!("6sPDzwyARRExKH52LECxcGoqziH8G7SZofwuxi8Ja331");
 }
 
 pub mod static_instruction_limit {


### PR DESCRIPTION
#### Problem

`create_account_allow_prefund` needs to be rekeyed.

#### Summary of changes

Use a new key.