### PR TITLE
cleanup(ledger): use native wincode for Signature

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -101,7 +101,7 @@ solana-runtime-transaction = { workspace = true }
 solana-seed-derivable = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-shred-version = { workspace = true }
-solana-signature = { workspace = true }
+solana-signature = { workspace = true, features = ["wincode"] }
 solana-signer = { workspace = true }
 solana-stake-interface = { workspace = true }
 solana-storage-bigtable = { workspace = true }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -238,8 +238,7 @@ pub enum ShredType {
     Code = 0b0101_1010,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
-#[serde(into = "u8", try_from = "u8")]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum ShredVariant {
     // proof_size is the number of Merkle proof entries, and is encoded in the
     // lowest 4 bits of the binary representation. The first 4 bits identify
@@ -253,9 +252,8 @@ enum ShredVariant {
 }
 
 /// A common header that is present in data and code shred headers
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaRead, SchemaWrite)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 struct ShredCommonHeader {
-    #[wincode(with = "Pod<_>")]
     signature: Signature,
     shred_variant: ShredVariant,
     slot: Slot,
@@ -265,7 +263,7 @@ struct ShredCommonHeader {
 }
 
 /// The data shred header has parent offset and flags
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaRead, SchemaWrite)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 struct DataShredHeader {
     parent_offset: u16,
     #[wincode(with = "Pod<_>")]
@@ -274,7 +272,7 @@ struct DataShredHeader {
 }
 
 /// The coding shred header has FEC information
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaRead, SchemaWrite)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 struct CodingShredHeader {
     num_data_shreds: u16,
     num_coding_shreds: u16,
@@ -1021,8 +1019,6 @@ mod tests {
 
     #[test]
     fn test_shred_constants() {
-        use wincode::Serialize as _;
-
         let common_header = ShredCommonHeader {
             signature: Signature::default(),
             shred_variant: ShredVariant::MerkleCode {
@@ -1066,7 +1062,7 @@ mod tests {
         );
         assert_eq!(
             SIZE_OF_SIGNATURE,
-            Pod::<Signature>::serialized_size(&Signature::default()).unwrap() as usize
+            wincode::serialized_size(&Signature::default()).unwrap() as usize
         );
         assert_eq!(
             SIZE_OF_SHRED_VARIANT,


### PR DESCRIPTION
#### Problem
New `solana-signature` version has `wincode` feature, which allows dropping `Pod` from `Signatur`.

#### Summary of Changes
* enable wincode feature on `solana-signature` in `ledger` 
* remove `with = Pod<_>` from signature field
* remove a few serde derives for types that do not need them anymore (serialized with wincode already)
