### PR TITLE
program-test: Add `sol_get_sysvar` stub

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -257,11 +257,10 @@ impl SyscallStubs {
         }
         let sysvar = unsafe { sysvar.assume_init() };
 
-        // Check that the requested legth is not greater than
+        // Check that the requested length is not greater than
         // the actual serialized length of the sysvar data.
-        let expected_length = match bincode::serialized_size(&sysvar) {
-            Ok(n) => n,
-            Err(_) => return UNSUPPORTED_SYSVAR,
+        let Ok(expected_length) = bincode::serialized_size(&sysvar) else {
+            return UNSUPPORTED_SYSVAR;
         };
 
         if offset.saturating_add(length) > expected_length {

--- a/program-test/tests/sysvar.rs
+++ b/program-test/tests/sysvar.rs
@@ -1,4 +1,5 @@
 use {
+    core::{mem::size_of, slice::from_raw_parts_mut},
     solana_account_info::AccountInfo,
     solana_clock::Clock,
     solana_epoch_rewards::EpochRewards,
@@ -11,6 +12,7 @@ use {
     solana_rent::Rent,
     solana_signer::Signer,
     solana_sysvar::Sysvar,
+    solana_sysvar_id::SysvarId,
     solana_transaction::Transaction,
 };
 
@@ -122,6 +124,56 @@ async fn get_epoch_rewards_sysvar() {
 
     // inside of reward interval, set input[0] == 1, so that the program assert that epoch_rewards sysvar exist.
     let instructions = vec![Instruction::new_with_bincode(program_id, &[1u8], vec![])];
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}
+
+// Process instruction to get the clock sysvar
+fn clock_sol_get_sysvar_process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _input: &[u8],
+) -> ProgramResult {
+    msg!("clock_sol_get_sysvar");
+
+    let clock_get = Clock::get()?;
+
+    let mut buffer = [0u64; size_of::<Clock>() / size_of::<u64>()];
+    let length = size_of::<Clock>();
+    let bytes = unsafe { from_raw_parts_mut(buffer.as_mut_ptr() as *mut u8, length) };
+
+    solana_sysvar::get_sysvar(bytes, &Clock::id(), 0, length as u64)?;
+
+    let clock_get_sysvar = unsafe { &*(buffer.as_ptr() as *const Clock) };
+
+    assert_eq!(clock_get, *clock_get_sysvar);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn clock_sol_get_sysvar() {
+    let program_id = Pubkey::new_unique();
+    let program_test = ProgramTest::new(
+        "clock_sol_get_sysvar",
+        program_id,
+        processor!(clock_sol_get_sysvar_process_instruction),
+    );
+
+    let mut context = program_test.start_with_context().await;
+    context.warp_to_slot(42).unwrap();
+    let instructions = vec![Instruction::new_with_bincode(program_id, &(), vec![])];
+
     let transaction = Transaction::new_signed_with_payer(
         &instructions,
         Some(&context.payer.pubkey()),


### PR DESCRIPTION
#### Problem

The new `solana-sysvar` crate changed the implementation of `Sysvar::get` to use the generic `sol_get_sysvar` syscall, but the current syscall stubs in program-test do not provide an implementation for it. This will generate `UnsupportedSysvar` errors when the `solana-sysvar` crate version is updated.

#### Summary of Changes

Implement the `sol_get_sysvar` syscall stub in program-test.