### PR TITLE
chore: bump solana-secp256k1-program from 3.0.0 to 3.0.1 and solana-instruction from 3.1.0 to 3.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8820,15 +8820,15 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1b699a2c1518028a9982e255e0eca10c44d90006542d9d7f9f40dbce3f7c78"
+checksum = "c6a6d22d0a6fdf345be294bb9afdcd40c296cdc095e64e7ceaa3bb3c2f608c1c"
 dependencies = [
  "bincode",
  "borsh",
  "serde",
  "serde_derive",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.0.0",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-instruction-error",
@@ -8837,9 +8837,9 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction-error"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04259e03c05faf38a8c24217b5cfe4c90572ae6184ab49cddb1584fdd756d3f"
+checksum = "7d3d048edaaeef5a3dc8c01853e585539a74417e4c2d43a9e2c161270045b838"
 dependencies = [
  "num-traits",
  "serde",
@@ -10422,9 +10422,9 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-program"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efa767b0188f577edae7080e8bf080e5db9458e2b6ee5beaa73e2e6bb54e99d"
+checksum = "ad4cf8232f7aef9ff2dd95d701f63e3c11909dec2400def5c361be29d24291e7"
 dependencies = [
  "bincode",
  "digest 0.10.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -458,7 +458,7 @@ solana-gossip = { path = "gossip", version = "=4.0.0-alpha.0", features = ["agav
 solana-hard-forks = "3.0.0"
 solana-hash = "4.2.0"
 solana-inflation = "3.0.0"
-solana-instruction = "3.1.0"
+solana-instruction = "3.2.0"
 solana-instruction-error = "2.1.0"
 solana-instructions-sysvar = "3.0.0"
 solana-keccak-hasher = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -517,7 +517,7 @@ solana-runtime-transaction = { path = "runtime-transaction", version = "=4.0.0-a
 solana-sanitize = "3.0.1"
 solana-sbpf = { version = "=0.14.4", default-features = false }
 solana-sdk-ids = "3.1.0"
-solana-secp256k1-program = "3.0.0"
+solana-secp256k1-program = "3.0.1"
 solana-secp256k1-recover = "3.1.0"
 solana-secp256r1-program = "3.0.0"
 solana-seed-derivable = "3.0.0"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7464,24 +7464,24 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1b699a2c1518028a9982e255e0eca10c44d90006542d9d7f9f40dbce3f7c78"
+checksum = "c6a6d22d0a6fdf345be294bb9afdcd40c296cdc095e64e7ceaa3bb3c2f608c1c"
 dependencies = [
  "bincode",
  "borsh",
  "serde",
  "serde_derive",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.0.0",
  "solana-instruction-error",
  "solana-pubkey 4.1.0",
 ]
 
 [[package]]
 name = "solana-instruction-error"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f0d483b8ae387178d9210e0575b666b05cdd4bd0f2f188128249f6e454d39d"
+checksum = "7d3d048edaaeef5a3dc8c01853e585539a74417e4c2d43a9e2c161270045b838"
 dependencies = [
  "num-traits",
  "serde",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8751,9 +8751,9 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-program"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efa767b0188f577edae7080e8bf080e5db9458e2b6ee5beaa73e2e6bb54e99d"
+checksum = "ad4cf8232f7aef9ff2dd95d701f63e3c11909dec2400def5c361be29d24291e7"
 dependencies = [
  "digest 0.10.7",
  "k256",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -105,7 +105,7 @@ solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=
 solana-gossip = { path = "../gossip", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-hash = "4.2.0"
 solana-inflation = "3.0.0"
-solana-instruction = "3.1.0"
+solana-instruction = "3.2.0"
 solana-keypair = "3.0.1"
 solana-ledger = { path = "../ledger", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-loader-v3-interface = "6.1.0"

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -33,7 +33,7 @@ solana-bls-signatures = { workspace = true }
 solana-clap-v3-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-derivation-path = "=3.0.0"
-solana-instruction = { version = "=3.1.0", features = ["bincode"] }
+solana-instruction = { version = "=3.2.0", features = ["bincode"] }
 solana-keypair = "=3.1.0"
 solana-message = { version = "=3.1.0", features = ["bincode"] }
 solana-pubkey = { version = "=4.1.0", default-features = false }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9366,9 +9366,9 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-program"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efa767b0188f577edae7080e8bf080e5db9458e2b6ee5beaa73e2e6bb54e99d"
+checksum = "ad4cf8232f7aef9ff2dd95d701f63e3c11909dec2400def5c361be29d24291e7"
 dependencies = [
  "digest 0.10.7",
  "k256",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7344,24 +7344,24 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1b699a2c1518028a9982e255e0eca10c44d90006542d9d7f9f40dbce3f7c78"
+checksum = "c6a6d22d0a6fdf345be294bb9afdcd40c296cdc095e64e7ceaa3bb3c2f608c1c"
 dependencies = [
  "bincode",
  "borsh",
  "serde",
  "serde_derive",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.0.0",
  "solana-instruction-error",
  "solana-pubkey 4.1.0",
 ]
 
 [[package]]
 name = "solana-instruction-error"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04259e03c05faf38a8c24217b5cfe4c90572ae6184ab49cddb1584fdd756d3f"
+checksum = "7d3d048edaaeef5a3dc8c01853e585539a74417e4c2d43a9e2c161270045b838"
 dependencies = [
  "num-traits",
  "serde",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -130,7 +130,7 @@ solana-curve25519 = "=4.0.0"
 solana-define-syscall = "=3.0.0"
 solana-fee = { path = "../../fee", version = "=4.0.0-alpha.0" }
 solana-hash = { version = "=4.2.0", features = ["bytemuck", "serde", "std"] }
-solana-instruction = "=3.1.0"
+solana-instruction = "=3.2.0"
 solana-instructions-sysvar = "=3.0.0"
 solana-keccak-hasher = { version = "=3.1.0", features = ["sha3"] }
 solana-ledger = { path = "../../ledger", version = "=4.0.0-alpha.0" }


### PR DESCRIPTION
#### Summary of Changes

- bump solana-secp256k1-program from 3.0.0 to 3.0.1
- solana-instruction from 3.1.0 to 3.2.0