### PR TITLE
chore: Reduce Validator threadpool sizes in tests

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -104,7 +104,6 @@ use {
         transaction_recorder::TransactionRecorder,
     },
     solana_pubkey::Pubkey,
-    solana_rayon_threadlimit::get_thread_count,
     solana_rpc::{
         max_slots::MaxSlots,
         optimistically_confirmed_bank_tracker::{
@@ -415,9 +414,6 @@ pub struct ValidatorConfig {
 
 impl ValidatorConfig {
     pub fn default_for_test() -> Self {
-        let max_thread_count =
-            NonZeroUsize::new(num_cpus::get()).expect("thread count is non-zero");
-
         Self {
             logfile: None,
             expected_genesis_hash: None,
@@ -483,12 +479,13 @@ impl ValidatorConfig {
             generator_config: None,
             use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup::default(),
             unified_scheduler_handler_threads: None,
+            // Fix threadpools to small and reasonable sizes; unit tests should
+            // not be creating excessive load and benches can configure more
             ip_echo_server_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
-            rayon_global_threads: max_thread_count,
+            rayon_global_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
             replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
-            replay_transactions_threads: max_thread_count,
-            tvu_shred_sigverify_threads: NonZeroUsize::new(get_thread_count())
-                .expect("thread count is non-zero"),
+            replay_transactions_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
+            tvu_shred_sigverify_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
             delay_leader_block_for_pending_fork: false,
             voting_service_test_override: None,
             repair_handler_type: RepairHandlerType::default(),


### PR DESCRIPTION
#### Problem
ValidatorConfig::default_for_test() currently scales several threadpools to match the number of cores on the machine. Unit tests do not need this many resources and the excessively sized threadpools are probably causing more harm than good when considering that unit tests run in parallel by default.

#### Summary of Changes
Update the helper to use fixed size threadpools instead

The current uses cases are unit tests, LocalCluster tests and TestValidator. I think reducing thread counts on all of these is fine as none of them are measuring/testing perf