### PR TITLE
feat(scheduler-bindings): don't dev gate useful impls

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -192,7 +192,7 @@ sysctl = { workspace = true }
 
 [dev-dependencies]
 agave-reserved-account-keys = { workspace = true }
-agave-scheduler-bindings = { workspace = true, features = ["dev-context-only-utils"] }
+agave-scheduler-bindings = { workspace = true }
 bencher = { workspace = true }
 criterion = { workspace = true }
 fs_extra = { workspace = true }

--- a/scheduler-bindings/Cargo.toml
+++ b/scheduler-bindings/Cargo.toml
@@ -11,7 +11,6 @@ edition = { workspace = true }
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = []
 
 [dependencies]
 

--- a/scheduler-bindings/src/lib.rs
+++ b/scheduler-bindings/src/lib.rs
@@ -49,10 +49,7 @@
 //!
 
 /// Reference to a transaction that can shared safely across processes.
-#[cfg_attr(
-    feature = "dev-context-only-utils",
-    derive(Debug, Clone, Copy, PartialEq, Eq)
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub struct SharableTransactionRegion {
     /// Offset within the shared memory allocator.
@@ -62,10 +59,7 @@ pub struct SharableTransactionRegion {
 }
 
 /// Reference to an array of Pubkeys that can be shared safely across processes.
-#[cfg_attr(
-    feature = "dev-context-only-utils",
-    derive(Debug, Clone, Copy, PartialEq, Eq)
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub struct SharablePubkeys {
     /// Offset within the shared memory allocator.
@@ -86,8 +80,7 @@ pub struct SharablePubkeys {
 /// 4. External pack process frees all transaction memory pointed to by the
 ///    [`SharableTransactionRegion`] in the batch, then frees the memory for
 ///    the array of [`SharableTransactionRegion`].
-#[cfg_attr(feature = "dev-context-only-utils", derive(Debug, PartialEq, Eq))]
-#[derive(Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(C)]
 pub struct SharableTransactionBatchRegion {
     /// Number of transactions in the batch.
@@ -103,10 +96,7 @@ pub struct SharableTransactionBatchRegion {
 /// 2. agave sends a [`WorkerToPackMessage`] with `responses`.
 /// 3. External pack process processes the inner messages. Potentially freeing
 ///    any memory within each inner message (see [`worker_message_types`] for details).
-#[cfg_attr(
-    feature = "dev-context-only-utils",
-    derive(Debug, Clone, Copy, PartialEq, Eq)
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub struct TransactionResponseRegion {
     /// Tag indicating the type of message.
@@ -131,10 +121,7 @@ pub struct TransactionResponseRegion {
 /// TPU passes transactions to the external pack process.
 /// This is also a transfer of ownership of the transaction:
 ///   the external pack process is responsible for freeing the memory.
-#[cfg_attr(
-    feature = "dev-context-only-utils",
-    derive(Debug, Clone, Copy, PartialEq, Eq)
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub struct TpuToPackMessage {
     pub transaction: SharableTransactionRegion,
@@ -172,10 +159,7 @@ pub const LEADER_READY: u8 = 2;
 
 /// Message: [Agave -> Pack]
 /// Agave passes leader status to the external pack process.
-#[cfg_attr(
-    feature = "dev-context-only-utils",
-    derive(Debug, Clone, Copy, PartialEq, Eq)
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub struct ProgressMessage {
     /// Indicates the current leader status of the node.
@@ -223,10 +207,7 @@ pub const MAX_TRANSACTIONS_PER_MESSAGE: usize = 64;
 ///
 /// These messages do not transfer ownership of the transactions.
 /// The external pack process is still responsible for freeing the memory.
-#[cfg_attr(
-    feature = "dev-context-only-utils",
-    derive(Debug, Clone, Copy, PartialEq, Eq)
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub struct PackToWorkerMessage {
     /// Flags on how to handle this message.
@@ -299,10 +280,7 @@ pub mod processed_codes {
 
 /// Message: [Worker -> Pack]
 /// Message from worker threads in response to a [`PackToWorkerMessage`].
-#[cfg_attr(
-    feature = "dev-context-only-utils",
-    derive(Debug, Clone, Copy, PartialEq, Eq)
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub struct WorkerToPackMessage {
     /// Offset and number of transactions in the batch.
@@ -329,10 +307,7 @@ pub mod worker_message_types {
     /// Response to pack for a transaction that attempted execution.
     /// This response will only be sent if the original message flags
     /// requested execution i.e. not [`super::pack_message_flags::RESOLVE`].
-    #[cfg_attr(
-        feature = "dev-context-only-utils",
-        derive(Debug, Clone, Copy, PartialEq, Eq)
-    )]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[repr(C)]
     pub struct ExecutionResponse {
         /// The slot this transaction was executed.
@@ -496,10 +471,7 @@ pub mod worker_message_types {
         pub const FAILED: u8 = 1 << 2;
     }
 
-    #[cfg_attr(
-        feature = "dev-context-only-utils",
-        derive(Debug, Clone, Copy, PartialEq, Eq)
-    )]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[repr(C)]
     pub struct CheckResponse {
         /// See [`parsing_and_sanitization_flags`] for details.

--- a/scheduling-utils/Cargo.toml
+++ b/scheduling-utils/Cargo.toml
@@ -11,7 +11,6 @@ edition = { workspace = true }
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = []
 
 [dependencies]
 agave-scheduler-bindings = { workspace = true }
@@ -31,7 +30,7 @@ thiserror = { workspace = true }
 tempfile = { workspace = true }
 
 [target."cfg(unix)".dev-dependencies]
-agave-scheduler-bindings = { workspace = true, features = ["dev-context-only-utils"] }
+agave-scheduler-bindings = { workspace = true }
 
 [lints]
 workspace = true

--- a/scheduling-utils/src/pubkeys_ptr.rs
+++ b/scheduling-utils/src/pubkeys_ptr.rs
@@ -21,7 +21,6 @@ impl PubkeysPtr {
     ///
     /// If you are trying to construct a pointer for use by Agave, you almost certainly want to use
     /// [`Self::from_sharable_pubkeys`].
-    #[cfg(feature = "dev-context-only-utils")]
     pub unsafe fn from_raw_parts(ptr: NonNull<Pubkey>, count: usize) -> Self {
         Self { ptr, count }
     }

--- a/scheduling-utils/src/responses_region.rs
+++ b/scheduling-utils/src/responses_region.rs
@@ -113,7 +113,6 @@ impl CheckResponsesPtr {
     ///
     /// If you are trying to construct a pointer for use by Agave, you almost certainly want to use
     /// [`Self::from_transaction_response_region`].
-    #[cfg(feature = "dev-context-only-utils")]
     pub unsafe fn from_raw_parts(ptr: NonNull<CheckResponse>, count: usize) -> Self {
         Self { ptr, count }
     }
@@ -184,7 +183,6 @@ impl ExecutionResponsesPtr {
     ///
     /// If you are trying to construct a pointer for use by Agave, you almost certainly want to use
     /// [`Self::from_transaction_response_region`].
-    #[cfg(feature = "dev-context-only-utils")]
     pub unsafe fn from_raw_parts(ptr: NonNull<ExecutionResponse>, count: usize) -> Self {
         Self { ptr, count }
     }

--- a/scheduling-utils/src/transaction_ptr.rs
+++ b/scheduling-utils/src/transaction_ptr.rs
@@ -38,7 +38,6 @@ impl TransactionPtr {
     ///
     /// If you are trying to construct a pointer for use by Agave, you almost certainly want to use
     /// [`Self::from_sharable_transaction_region`].
-    #[cfg(feature = "dev-context-only-utils")]
     pub unsafe fn from_raw_parts(ptr: NonNull<u8>, count: usize) -> Self {
         Self { ptr, count }
     }


### PR DESCRIPTION
#### Problem

- Constructing the pointer helpers from a raw `Allactor` pointers is not easily achievable without enabling `dev-context-only-utils`.

#### Summary of Changes

- Expose `from_raw_parts` by removing the `dev-context-only-utils` feature flag.