### PR TITLE
Remove max root from read path

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4005,6 +4005,7 @@ impl AccountsDb {
         Some((account, slot))
     }
 
+    #[cfg_attr(test, qualifiers(pub(crate)))]
     fn get_account_accessor<'a>(
         &'a self,
         slot: Slot,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3587,7 +3587,6 @@ impl AccountsDb {
         self.do_load(
             ancestors,
             pubkey,
-            None,
             load_hint,
             LoadZeroLamports::None,
             populate_read_cache,
@@ -3612,13 +3611,12 @@ impl AccountsDb {
         &'a self,
         ancestors: &Ancestors,
         pubkey: &'a Pubkey,
-        max_root: Option<Slot>,
         clone_in_lock: bool,
     ) -> Option<(Slot, StorageLocation, Option<LoadedAccountAccessor<'a>>)> {
         self.accounts_index.get_with_and_then(
             pubkey,
             Some(ancestors),
-            max_root,
+            None,
             true,
             |(slot, account_info)| {
                 let storage_location = account_info.storage_location();
@@ -3635,7 +3633,6 @@ impl AccountsDb {
         mut storage_location: StorageLocation,
         ancestors: &'a Ancestors,
         pubkey: &'a Pubkey,
-        max_root: Option<Slot>,
         load_hint: LoadHint,
     ) -> Option<(LoadedAccountAccessor<'a>, Slot)> {
         // Happy drawing time! :)
@@ -3848,12 +3845,7 @@ impl AccountsDb {
 
             // Because reading from the cache/storage failed, retry from the index read
             let (new_slot, new_storage_location, maybe_account_accessor) = self
-                .read_index_for_accessor_or_load_slow(
-                    ancestors,
-                    pubkey,
-                    max_root,
-                    fallback_to_slow_path,
-                )?;
+                .read_index_for_accessor_or_load_slow(ancestors, pubkey, fallback_to_slow_path)?;
             // Notice the subtle `?` at previous line, we bail out pretty early if missing.
 
             if new_slot == slot && new_storage_location.is_store_id_equal(&storage_location) {
@@ -3911,7 +3903,6 @@ impl AccountsDb {
         &self,
         ancestors: &Ancestors,
         pubkey: &Pubkey,
-        max_root: Option<Slot>,
         load_hint: LoadHint,
         load_zero_lamports: LoadZeroLamports,
         populate_read_cache: PopulateReadCache,
@@ -3919,7 +3910,6 @@ impl AccountsDb {
         self.do_load_with_populate_read_cache(
             ancestors,
             pubkey,
-            max_root,
             load_hint,
             load_zero_lamports,
             populate_read_cache,
@@ -3939,7 +3929,6 @@ impl AccountsDb {
         self.do_load_with_populate_read_cache(
             ancestors,
             pubkey,
-            None,
             LoadHint::Unspecified,
             LoadZeroLamports::None,
             should_put_in_read_cache,
@@ -3950,18 +3939,14 @@ impl AccountsDb {
         &self,
         ancestors: &Ancestors,
         pubkey: &Pubkey,
-        max_root: Option<Slot>,
         load_hint: LoadHint,
         load_zero_lamports: LoadZeroLamports,
         populate_read_cache: PopulateReadCache,
     ) -> Option<(AccountSharedData, Slot)> {
-        #[cfg(not(test))]
-        assert!(max_root.is_none());
-
         let starting_max_root = self.accounts_index.max_root_inclusive();
 
         let (slot, storage_location, _maybe_account_accessor) =
-            self.read_index_for_accessor_or_load_slow(ancestors, pubkey, max_root, false)?;
+            self.read_index_for_accessor_or_load_slow(ancestors, pubkey, false)?;
         // Notice the subtle `?` at previous line, we bail out pretty early if missing.
 
         let in_write_cache = storage_location.is_cached();
@@ -3980,7 +3965,6 @@ impl AccountsDb {
             storage_location,
             ancestors,
             pubkey,
-            max_root,
             load_hint,
         )?;
         // note that the account being in the cache could be different now than it was previously
@@ -6979,7 +6963,6 @@ impl AccountsDb {
         self.do_load(
             ancestors,
             pubkey,
-            None,
             LoadHint::Unspecified,
             // callers of this expect zero lamport accounts that exist in the index to be returned as Some(empty)
             LoadZeroLamports::SomeWithZeroLamportAccountForTests,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3554,7 +3554,7 @@ impl AccountsDb {
         let mut ancestors = Ancestors::default();
         ancestors.insert(slot, 1);
 
-        // Limit the max root to the slot being queried to returning newer rooted slots
+        // Limit the max root to the slot being queried to avoid returning newer rooted slots
         let max_root = Some(slot);
 
         self.accounts_index.get_with_and_then(

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3292,17 +3292,20 @@ fn test_flush_cache_clean() {
 
     // Clean should not remove anything yet as nothing has been flushed
     db.clean_accounts_for_tests();
-    let account = db
-        .do_load(
-            &Ancestors::default(),
-            &account_key,
-            Some(0),
-            LoadHint::Unspecified,
-            LoadZeroLamports::SomeWithZeroLamportAccountForTests,
-            PopulateReadCache::True,
-        )
-        .unwrap();
-    assert_eq!(account.0.lamports(), 1);
+    assert!(
+        db.accounts_index
+            .get_with_and_then(
+                &account_key,
+                None,
+                Some(0),
+                false,
+                |(slot, account_info)| {
+                    assert_eq!(slot, 0);
+                    assert!(!account_info.is_zero_lamport());
+                },
+            )
+            .is_some()
+    );
     // since this item is in the cache, it should not be in the read only cache
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
 
@@ -3311,15 +3314,9 @@ fn test_flush_cache_clean() {
     db.flush_accounts_cache(true, None);
     db.clean_accounts_for_tests();
     assert!(
-        db.do_load(
-            &Ancestors::default(),
-            &account_key,
-            Some(0),
-            LoadHint::Unspecified,
-            LOAD_ZERO_LAMPORTS_ANY_TESTS,
-            PopulateReadCache::True,
-        )
-        .is_none()
+        db.accounts_index
+            .get_with_and_then(&account_key, None, Some(0), false, |_| {},)
+            .is_none()
     );
 }
 
@@ -3389,7 +3386,6 @@ fn test_flush_cache_dont_clean_zero_lamport_account(mark_obsolete_accounts: Mark
     // entry in slot 0 is blocking cleanup of the zero-lamport account.
     // With obsolete accounts enabled, the zero lamport account being newer
     // than the latest full snapshot blocks cleanup
-    let max_root = None;
     // Fine to simulate a transaction load since we are not doing any out of band
     // removals, only using clean_accounts
     let load_hint = LoadHint::FixedMaxRoot;
@@ -3397,7 +3393,6 @@ fn test_flush_cache_dont_clean_zero_lamport_account(mark_obsolete_accounts: Mark
         db.do_load(
             &Ancestors::default(),
             &zero_lamport_account_key,
-            max_root,
             load_hint,
             LoadZeroLamports::SomeWithZeroLamportAccountForTests,
             PopulateReadCache::True,
@@ -3535,62 +3530,65 @@ fn test_scan_flush_accounts_cache_then_clean_drop() {
 
     // Intra cache cleaning should not clean the entry for `account_key` from slot 0,
     // even though it was updated in slot `2` because of the ongoing scan
-    let account = db
-        .do_load(
-            &Ancestors::default(),
-            &account_key,
-            Some(0),
-            LoadHint::Unspecified,
-            LoadZeroLamports::SomeWithZeroLamportAccountForTests,
-            PopulateReadCache::True,
-        )
-        .unwrap();
-    assert_eq!(account.0.lamports(), slot0_account.lamports());
+    assert!(
+        db.accounts_index
+            .get_with_and_then(
+                &account_key,
+                None,
+                Some(0),
+                false,
+                |(slot, account_info)| {
+                    assert_eq!(slot, 0);
+                    assert!(!account_info.is_zero_lamport());
+                },
+            )
+            .is_some()
+    );
 
     // Run clean, unrooted slot 1 should not be purged, and still readable from the cache,
     // because we're still doing a scan on it.
     db.clean_accounts_for_tests();
-    let account = db
-        .do_load(
-            &scan_ancestors,
-            &account_key,
-            Some(max_scan_root),
-            LoadHint::Unspecified,
-            LOAD_ZERO_LAMPORTS_ANY_TESTS,
-            PopulateReadCache::True,
-        )
-        .unwrap();
-    assert_eq!(account.0.lamports(), slot1_account.lamports());
+    assert!(
+        db.accounts_index
+            .get_with_and_then(
+                &account_key,
+                Some(&scan_ancestors),
+                Some(max_scan_root),
+                false,
+                |(slot, _)| assert_eq!(slot, 1),
+            )
+            .is_some()
+    );
 
     // When the scan is over, clean should not panic and should not purge something
     // still in the cache.
     scan_tracker.exit().unwrap();
     db.clean_accounts_for_tests();
-    let account = db
-        .do_load(
-            &scan_ancestors,
-            &account_key,
-            Some(max_scan_root),
-            LoadHint::Unspecified,
-            LOAD_ZERO_LAMPORTS_ANY_TESTS,
-            PopulateReadCache::True,
-        )
-        .unwrap();
-    assert_eq!(account.0.lamports(), slot1_account.lamports());
+    assert!(
+        db.accounts_index
+            .get_with_and_then(
+                &account_key,
+                Some(&scan_ancestors),
+                Some(max_scan_root),
+                false,
+                |(slot, _)| assert_eq!(slot, 1),
+            )
+            .is_some()
+    );
 
     // Simulate dropping the bank, which finally removes the slot from the cache
     let bank_id = 1;
     db.purge_slot(1, bank_id, false);
     assert!(
-        db.do_load(
-            &scan_ancestors,
-            &account_key,
-            Some(max_scan_root),
-            LoadHint::Unspecified,
-            LOAD_ZERO_LAMPORTS_ANY_TESTS,
-            PopulateReadCache::True
-        )
-        .is_none()
+        db.accounts_index
+            .get_with_and_then(
+                &account_key,
+                Some(&scan_ancestors),
+                Some(max_scan_root),
+                false,
+                |_| {},
+            )
+            .is_none()
     );
 }
 
@@ -3805,14 +3803,8 @@ fn test_accounts_db_cache_clean_dead_slots() {
     for key in &keys {
         assert!(
             accounts_db
-                .do_load(
-                    &Ancestors::default(),
-                    key,
-                    Some(last_dead_slot),
-                    LoadHint::Unspecified,
-                    LOAD_ZERO_LAMPORTS_ANY_TESTS,
-                    PopulateReadCache::True
-                )
+                .accounts_index
+                .get_with_and_then(key, None, Some(last_dead_slot), false, |_| {})
                 .is_some()
         );
     }
@@ -3830,14 +3822,8 @@ fn test_accounts_db_cache_clean_dead_slots() {
     for key in &keys {
         assert!(
             accounts_db
-                .do_load(
-                    &Ancestors::default(),
-                    key,
-                    Some(last_dead_slot),
-                    LoadHint::Unspecified,
-                    LOAD_ZERO_LAMPORTS_ANY_TESTS,
-                    PopulateReadCache::True
-                )
+                .accounts_index
+                .get_with_and_then(key, None, Some(last_dead_slot), false, |_| {})
                 .is_none()
         );
     }
@@ -4379,7 +4365,6 @@ fn start_load_thread(
                     .do_load(
                         &ancestors,
                         &pubkey,
-                        None,
                         load_hint,
                         LOAD_ZERO_LAMPORTS_ANY_TESTS,
                         PopulateReadCache::True,


### PR DESCRIPTION
#### Problem
do_load_with_populate_read_cache has additional parameters for test purposes only

#### Summary of Changes
Move tests to use get_with_and_then which is required to support max_root

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
