### PR TITLE
halve slot times

### DIFF
--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -148,12 +148,7 @@ impl BlockhashQueue {
         })
     }
 
-    #[deprecated(
-        since = "2.0.0",
-        note = "Please use `solana_clock::MAX_PROCESSING_AGE`"
-    )]
     pub fn get_max_age(&self) -> usize {
-        #[allow(deprecated)]
         self.max_age
     }
 }

--- a/accounts-db/src/partitioned_rewards.rs
+++ b/accounts-db/src/partitioned_rewards.rs
@@ -4,7 +4,9 @@
 /// Target to store 64 rewards per entry/tick in a block. A block has a minimum of 64
 /// entries/tick. This gives 4096 total rewards to store in one block.
 /// This constant affects consensus.
-const MAX_PARTITIONED_REWARDS_PER_BLOCK: u64 = 4096;
+pub const MAX_PARTITIONED_REWARDS_PER_BLOCK: u64 = 4096;
+pub const MAX_PARTITIONED_REWARDS_PER_BLOCK_HALVE_SLOTS: u64 =
+    MAX_PARTITIONED_REWARDS_PER_BLOCK / 2;
 
 #[derive(Debug, Clone, Copy)]
 /// Configuration options for partitioned epoch rewards.

--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -22,7 +22,7 @@ rm -rf config/run/init-completed config/ledger
 # Also the banking_tracer thread needs some extra time to flush due to
 # unsynchronized and buffered IO.
 validator_timeout="${SOLANA_VALIDATOR_EXIT_TIMEOUT:-120}"
-SOLANA_RUN_SH_VALIDATOR_ARGS="${SOLANA_RUN_SH_VALIDATOR_ARGS} --full-snapshot-interval-slots 200" \
+SOLANA_RUN_SH_VALIDATOR_ARGS="${SOLANA_RUN_SH_VALIDATOR_ARGS} --full-snapshot-interval-slots 400 --incremental-snapshot-interval-slots 200" \
   SOLANA_VALIDATOR_EXIT_TIMEOUT="$validator_timeout" \
   timeout "$validator_timeout" ./scripts/run.sh &
 

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -7,7 +7,9 @@ use {
     solana_epoch_schedule::EpochSchedule,
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
-    solana_ledger::shred::{self, ShredFetchStats, should_discard_shred},
+    solana_ledger::shred::{
+        self, ShredFetchStats, max_shred_index, should_discard_shred_with_custom_shred_limits,
+    },
     solana_perf::packet::{PacketBatch, PacketBatchRecycler, PacketFlags, PacketRef},
     solana_pubkey::Pubkey,
     solana_runtime::{
@@ -156,15 +158,26 @@ impl ShredFetchStage {
                     &shred_filter_ctx.epoch_schedule,
                 )
             };
+            let max_shred_index = |shred_slot| {
+                let halve_slot_times_active = check_feature_activation(
+                    &agave_feature_set::halve_slot_times::id(),
+                    shred_slot,
+                    &shred_filter_ctx.feature_set,
+                    &shred_filter_ctx.epoch_schedule,
+                );
+                max_shred_index(halve_slot_times_active)
+            };
             let turbine_disabled = turbine_disabled.load(Ordering::Relaxed);
             for mut packet in packet_batch.iter_mut().filter(|p| !p.meta().discard()) {
                 if turbine_disabled
-                    || should_discard_shred(
+                    || should_discard_shred_with_custom_shred_limits(
                         packet.as_ref(),
                         shred_filter_ctx.last_root,
                         max_slot,
                         shred_version,
                         discard_unexpected_data_complete_shreds,
+                        max_shred_index,
+                        max_shred_index,
                         &mut stats,
                     )
                 {

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1352,6 +1352,10 @@ pub mod raise_account_cu_limit {
     solana_pubkey::declare_id!("htsptAwi2yRoZH83SKaUXykeZGtZHgxkS2QwW1pssR8");
 }
 
+pub mod halve_slot_times {
+    solana_pubkey::declare_id!("shortoK7FR1q2FtTS83NAFEERpibyAGSEFHvNj1mJW7");
+}
+
 pub mod delay_commission_updates {
     solana_pubkey::declare_id!("76dHtohc2s5dR3ahJyBxs7eJJVipFkaPdih9CLgTTb4B");
 }
@@ -2429,6 +2433,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
             raise_account_cu_limit::id(),
             "SIMD-0306: Raise account CU limit to 40% max",
         ),
+        (halve_slot_times::id(), "Halve slot time to 200ms"),
         (
             raise_cpi_nesting_limit_to_8::id(),
             "SIMD-0268: Raise CPI nesting limit from 4 to 8",

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -23,6 +23,7 @@ use {
         slot_stats::{ShredSource, SlotsStats},
         transaction_address_lookup_table_scanner::scan_transaction,
     },
+    agave_feature_set as feature_set,
     agave_snapshots::unpack_genesis_archive,
     agave_votor_messages::migration::MigrationStatus,
     assert_matches::{assert_matches, debug_assert_matches},
@@ -356,11 +357,22 @@ impl SlotMetaWorkingSetEntry {
     }
 }
 
+fn is_feature_active_at_genesis(genesis_config: &GenesisConfig, feature_id: &Pubkey) -> bool {
+    genesis_config.accounts.contains_key(feature_id)
+}
+
 pub(crate) fn hashes_per_tick_for_ledger(genesis_config: &GenesisConfig) -> u64 {
     let Some(hashes_per_tick) = genesis_config.poh_config.hashes_per_tick else {
         return 0;
     };
-    hashes_per_tick
+
+    if is_feature_active_at_genesis(genesis_config, &feature_set::halve_slot_times::id())
+        && !is_feature_active_at_genesis(genesis_config, &feature_set::alpenglow::id())
+    {
+        hashes_per_tick.saturating_div(2).max(1)
+    } else {
+        hashes_per_tick
+    }
 }
 
 pub fn banking_trace_path(path: &Path) -> PathBuf {
@@ -5836,13 +5848,17 @@ pub mod tests {
         rand::{rng, seq::SliceRandom},
         solana_account_decoder::parse_token::UiTokenAmount,
         solana_entry::entry::{next_entry, next_entry_mut},
+        solana_genesis_config::GenesisConfig,
         solana_genesis_utils::{MAX_GENESIS_ARCHIVE_UNPACKED_SIZE, open_genesis_config},
         solana_hash::Hash,
         solana_leader_schedule::{FixedSchedule, LeaderSchedule, SlotLeader},
         solana_message::{compiled_instruction::CompiledInstruction, v0::LoadedAddresses},
         solana_packet::PACKET_DATA_SIZE,
         solana_pubkey::Pubkey,
-        solana_runtime::bank::{Bank, RewardType},
+        solana_runtime::{
+            bank::{Bank, RewardType},
+            genesis_utils::activate_feature,
+        },
         solana_sha256_hasher::hash,
         solana_shred_version::version_from_hash,
         solana_signature::Signature,
@@ -5895,6 +5911,16 @@ pub mod tests {
         assert_eq!(hashes_per_tick_for_ledger(&genesis_config), 0);
 
         genesis_config.poh_config.hashes_per_tick = Some(2);
+        assert_eq!(hashes_per_tick_for_ledger(&genesis_config), 2);
+
+        activate_feature(&mut genesis_config, feature_set::halve_slot_times::id());
+        assert_eq!(hashes_per_tick_for_ledger(&genesis_config), 1);
+
+        genesis_config.poh_config.hashes_per_tick = Some(1);
+        assert_eq!(hashes_per_tick_for_ledger(&genesis_config), 1);
+
+        genesis_config.poh_config.hashes_per_tick = Some(2);
+        activate_feature(&mut genesis_config, feature_set::alpenglow::id());
         assert_eq!(hashes_per_tick_for_ledger(&genesis_config), 2);
     }
 

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -124,6 +124,17 @@ pub const SHREDS_PER_FEC_BLOCK: usize = DATA_SHREDS_PER_FEC_BLOCK + CODING_SHRED
 /// (32K shreds per slot * 4 TX per shred * 2.5 slots per sec)
 pub const MAX_DATA_SHREDS_PER_SLOT: usize = 32_768;
 pub const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT;
+// `fn max_shred_index` breaks if this assumption doesn't hold and would need to
+// be split out into separate data/coding functions.
+const_assert_eq!(MAX_DATA_SHREDS_PER_SLOT, MAX_CODE_SHREDS_PER_SLOT);
+
+pub const fn max_shred_index(halve_slot_times_active: bool) -> u32 {
+    if halve_slot_times_active {
+        (MAX_DATA_SHREDS_PER_SLOT as u32) / 2
+    } else {
+        MAX_DATA_SHREDS_PER_SLOT as u32
+    }
+}
 
 pub const MAX_FEC_SETS_PER_SLOT: u32 =
     MAX_DATA_SHREDS_PER_SLOT as u32 / DATA_SHREDS_PER_FEC_BLOCK as u32;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -103,13 +103,19 @@ use {
     },
     solana_builtins::{BUILTINS, STATELESS_BUILTINS},
     solana_clock::{
-        BankId, Epoch, INITIAL_RENT_EPOCH, MAX_PROCESSING_AGE, MAX_TRANSACTION_FORWARDING_DELAY,
-        Slot, SlotIndex, UnixTimestamp,
+        BankId, Epoch, INITIAL_RENT_EPOCH, MAX_PROCESSING_AGE, MAX_RECENT_BLOCKHASHES,
+        MAX_TRANSACTION_FORWARDING_DELAY, Slot, SlotIndex, UnixTimestamp,
     },
     solana_cluster_type::ClusterType,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
-    solana_cost_model::{block_cost_limits::simd_0286_block_limit, cost_tracker::CostTracker},
+    solana_cost_model::{
+        block_cost_limits::{
+            MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA, MAX_BLOCK_UNITS, MAX_VOTE_UNITS,
+            simd_0286_block_limit,
+        },
+        cost_tracker::CostTracker,
+    },
     solana_epoch_info::EpochInfo,
     solana_epoch_schedule::EpochSchedule,
     solana_feature_gate_interface as feature,
@@ -172,7 +178,6 @@ use {
     solana_system_transaction as system_transaction,
     solana_sysvar::{self as sysvar, SysvarSerialize, last_restart_slot::LastRestartSlot},
     solana_sysvar_id::SysvarId,
-    solana_time_utils::years_as_slots,
     solana_transaction::{
         Transaction, TransactionVerificationMode,
         sanitized::{MAX_TX_ACCOUNT_LOCKS, MessageHash, SanitizedTransaction},
@@ -190,6 +195,7 @@ use {
     std::{
         collections::{HashMap, HashSet},
         fmt,
+        num::NonZeroUsize,
         ops::AddAssign,
         path::PathBuf,
         slice,
@@ -239,6 +245,7 @@ mod sysvar_cache;
 pub(crate) mod tests;
 
 pub const SECONDS_PER_YEAR: f64 = 365.25 * 24.0 * 60.0 * 60.0;
+pub(crate) const HALVE_SLOT_TIMES_FACTOR: u64 = 2;
 
 pub const MAX_LEADER_SCHEDULE_STAKES: Epoch = 5;
 
@@ -548,6 +555,7 @@ impl PartialEq for Bank {
             status_cache: _,
             blockhash_queue,
             max_processing_age,
+            partitioned_rewards_stake_account_stores_per_block,
             ancestors: _,
             hash,
             parent_hash,
@@ -618,6 +626,8 @@ impl PartialEq for Bank {
         } = self;
         *blockhash_queue.read().unwrap() == *other.blockhash_queue.read().unwrap()
             && *max_processing_age == other.max_processing_age
+            && *partitioned_rewards_stake_account_stores_per_block
+                == other.partitioned_rewards_stake_account_stores_per_block
             && *hash.read().unwrap() == *other.hash.read().unwrap()
             && parent_hash == &other.parent_hash
             && parent_slot == &other.parent_slot
@@ -771,6 +781,10 @@ pub struct Bank {
 
     /// Maximum age in slots a blockhash can be for a tx to be processed.
     max_processing_age: usize,
+
+    /// Effective number of stake accounts to store in each block during
+    /// partitioned rewards distribution for this bank.
+    partitioned_rewards_stake_account_stores_per_block: u64,
 
     /// The set of parents including this bank
     pub ancestors: Ancestors,
@@ -1098,11 +1112,16 @@ struct NewEpochBundle {
 
 impl Bank {
     fn default_with_accounts(accounts: Accounts) -> Self {
+        let partitioned_rewards_stake_account_stores_per_block = accounts
+            .accounts_db
+            .partitioned_epoch_rewards_config
+            .stake_account_stores_per_block;
         let mut bank = Self {
             rc: BankRc::new(accounts),
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
             blockhash_queue: RwLock::<BlockhashQueue>::default(),
             max_processing_age: MAX_PROCESSING_AGE,
+            partitioned_rewards_stake_account_stores_per_block,
             ancestors: Ancestors::default(),
             hash: RwLock::<Hash>::default(),
             parent_hash: Hash::default(),
@@ -1342,6 +1361,8 @@ impl Bank {
             epoch,
             blockhash_queue,
             max_processing_age: parent.max_processing_age,
+            partitioned_rewards_stake_account_stores_per_block: parent
+                .partitioned_rewards_stake_account_stores_per_block,
             // TODO: clean this up, so much special-case copying...
             hashes_per_tick: parent.hashes_per_tick,
             ticks_per_slot: parent.ticks_per_slot,
@@ -1950,11 +1971,17 @@ impl Bank {
             from_account::<sysvar::rent::Rent, _>(&rent_sysvar)
                 .expect("snapshot must contain well-formed rent sysvar account")
         };
+        let partitioned_rewards_stake_account_stores_per_block = bank_rc
+            .accounts
+            .accounts_db
+            .partitioned_epoch_rewards_config
+            .stake_account_stores_per_block;
         let mut bank = Self {
             rc: bank_rc,
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
             blockhash_queue: RwLock::new(fields.blockhash_queue),
             max_processing_age: MAX_PROCESSING_AGE,
+            partitioned_rewards_stake_account_stores_per_block,
             ancestors,
             hash: RwLock::new(fields.hash),
             parent_hash: fields.parent_hash,
@@ -2037,20 +2064,7 @@ impl Bank {
              snapshot and genesis.bin might pertain to different clusters"
         );
         assert_eq!(bank.ticks_per_slot, genesis_config.ticks_per_slot);
-        assert_eq!(
-            bank.ns_per_slot,
-            genesis_config.poh_config.target_tick_duration.as_nanos()
-                * genesis_config.ticks_per_slot as u128
-        );
         assert_eq!(bank.max_tick_height, (bank.slot + 1) * bank.ticks_per_slot);
-        assert_eq!(
-            bank.slots_per_year,
-            years_as_slots(
-                1.0,
-                &genesis_config.poh_config.target_tick_duration,
-                bank.ticks_per_slot,
-            )
-        );
         assert_eq!(bank.epoch_schedule, genesis_config.epoch_schedule);
 
         bank.initialize_after_snapshot_restore(|| {
@@ -2521,15 +2535,48 @@ impl Bank {
         });
     }
 
+    // Get number of slots per year when slots were 400ms.
+    fn pre_halve_slot_times_slots_per_year(&self) -> f64 {
+        debug_assert!(
+            self.halve_slot_times_slot().is_some(),
+            "pre_halve_slot_times_slots_per_year should only be called when the feature is active"
+        );
+        self.slots_per_year / HALVE_SLOT_TIMES_FACTOR as f64
+    }
+
+    // Get slots per year given slot times during this epoch.
+    fn slots_per_year_for_epoch(&self, epoch: Epoch) -> f64 {
+        let Some(activation_slot) = self.halve_slot_times_slot() else {
+            return self.slots_per_year;
+        };
+        let activation_epoch = self.epoch_schedule().get_epoch(activation_slot);
+        if epoch < activation_epoch {
+            self.pre_halve_slot_times_slots_per_year()
+        } else {
+            self.slots_per_year
+        }
+    }
+
+    // Get epoch duration in years given slot times during this epoch.
     pub fn epoch_duration_in_years(&self, epoch: Epoch) -> f64 {
-        // period: time that has passed as a fraction of a year, basically the length of
-        //  an epoch as a fraction of a year
-        //  calculated as: slots_elapsed / (slots / year)
-        self.epoch_schedule().get_slots_in_epoch(epoch) as f64 / self.slots_per_year
+        self.epoch_schedule().get_slots_in_epoch(epoch) as f64
+            / self.slots_per_year_for_epoch(epoch)
     }
 
     pub fn max_processing_age(&self) -> usize {
         self.max_processing_age
+    }
+
+    fn max_recent_blockhashes_for_active_features(&self) -> usize {
+        if self.halve_slot_times_active() {
+            MAX_RECENT_BLOCKHASHES.saturating_mul(HALVE_SLOT_TIMES_FACTOR as usize)
+        } else {
+            MAX_RECENT_BLOCKHASHES
+        }
+    }
+
+    fn max_status_cache_entries_for_active_features(&self) -> usize {
+        self.max_recent_blockhashes_for_active_features()
     }
 
     // Calculates the starting-slot for inflation from the activation slot.
@@ -2552,19 +2599,40 @@ impl Bank {
         })
     }
 
+    // Number of slots since inflation started, aligned to the first slot of the
+    // epoch for rewards calculation.
     fn get_inflation_num_slots(&self) -> u64 {
-        let inflation_activation_slot = self.get_inflation_start_slot();
-        // Normalize inflation_start to align with the start of rewards accrual.
-        let inflation_start_slot = self.epoch_schedule().get_first_slot_in_epoch(
-            self.epoch_schedule()
-                .get_epoch(inflation_activation_slot)
-                .saturating_sub(1),
-        );
+        let inflation_start_slot = self.inflation_start_slot_aligned_to_rewards();
         self.epoch_schedule().get_first_slot_in_epoch(self.epoch()) - inflation_start_slot
     }
 
+    // The starting slot for inflation rewards calculation, aligned to the first
+    // slot of the epoch.
+    fn inflation_start_slot_aligned_to_rewards(&self) -> Slot {
+        let inflation_activation_slot = self.get_inflation_start_slot();
+        self.epoch_schedule().get_first_slot_in_epoch(
+            self.epoch_schedule()
+                .get_epoch(inflation_activation_slot)
+                .saturating_sub(1),
+        )
+    }
+
+    // Since the time inflation started, translate number of slots --> years.
     pub fn slot_in_year_for_inflation(&self) -> f64 {
         let num_slots = self.get_inflation_num_slots();
+
+        if let Some(activation_slot) = self.halve_slot_times_slot() {
+            // Need to understand how many slots were ~400ms vs ~200ms to
+            // translate the slot range properly to number of years.
+            let inflation_start_slot = self.inflation_start_slot_aligned_to_rewards();
+            if activation_slot > inflation_start_slot {
+                let slots_before_feature = activation_slot - inflation_start_slot;
+                let slots_after_feature = num_slots.saturating_sub(slots_before_feature);
+                let pre_halve_slots_per_year = self.pre_halve_slot_times_slots_per_year();
+                return slots_before_feature as f64 / pre_halve_slots_per_year
+                    + slots_after_feature as f64 / self.slots_per_year;
+            }
+        }
 
         // calculated as: num_slots / (slots / year)
         num_slots as f64 / self.slots_per_year
@@ -4437,22 +4505,103 @@ impl Bank {
         self.rc.accounts.clone()
     }
 
+    pub fn halve_slot_times_active(&self) -> bool {
+        self.feature_set
+            .is_active(&feature_set::halve_slot_times::id())
+    }
+
+    fn halve_slot_times_slot(&self) -> Option<u64> {
+        self.feature_set
+            .activated_slot(&feature_set::halve_slot_times::id())
+    }
+
     fn apply_cost_tracker_limits_for_active_features(&mut self) {
-        let mut cost_tracker = self.write_cost_tracker().unwrap();
-        let block_cost_limit = if self.feature_set.snapshot().raise_block_limits_to_100m {
+        let mut block_cost_limit = if self
+            .feature_set
+            .is_active(&feature_set::raise_block_limits_to_100m::id())
+        {
             simd_0286_block_limit()
         } else {
-            cost_tracker.get_block_limit()
+            MAX_BLOCK_UNITS
         };
-        let account_cost_limit = block_cost_limit.saturating_mul(40).saturating_div(100);
-        let vote_cost_limit = cost_tracker.get_vote_limit();
-        let allocated_data_size_limit = cost_tracker.get_allocated_data_size_limit();
+        let mut account_cost_limit = block_cost_limit.saturating_mul(40).saturating_div(100);
+        let mut vote_cost_limit = MAX_VOTE_UNITS;
+        let mut allocated_data_size_limit = MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA;
+
+        if self.halve_slot_times_active() {
+            block_cost_limit = block_cost_limit.saturating_div(HALVE_SLOT_TIMES_FACTOR);
+            account_cost_limit = account_cost_limit.saturating_div(HALVE_SLOT_TIMES_FACTOR);
+            vote_cost_limit = vote_cost_limit.saturating_div(HALVE_SLOT_TIMES_FACTOR);
+            allocated_data_size_limit =
+                allocated_data_size_limit.saturating_div(HALVE_SLOT_TIMES_FACTOR);
+        }
+
+        let mut cost_tracker = self.write_cost_tracker().unwrap();
         cost_tracker.set_limits(
             account_cost_limit,
             block_cost_limit,
             vote_cost_limit,
             allocated_data_size_limit,
         );
+    }
+
+    fn apply_status_cache_limits_for_active_features(&self) {
+        self.status_cache.write().unwrap().set_max_root_entries(
+            NonZeroUsize::new(self.max_status_cache_entries_for_active_features())
+                .expect("status-cache limit must be non-zero"),
+        );
+    }
+
+    fn apply_partitioned_epoch_rewards_config_for_active_features(&mut self) {
+        if self.halve_slot_times_active() {
+            self.partitioned_rewards_stake_account_stores_per_block = self
+                .rc
+                .accounts
+                .accounts_db
+                .partitioned_epoch_rewards_config
+                .stake_account_stores_per_block
+                .saturating_div(HALVE_SLOT_TIMES_FACTOR)
+                .max(1)
+        }
+    }
+
+    // These fields are persisted across restarts.
+    fn apply_halve_slot_times_persistent_changes(&mut self) {
+        self.ns_per_slot = self
+            .ns_per_slot
+            .saturating_div(u128::from(HALVE_SLOT_TIMES_FACTOR));
+        self.slots_per_year *= HALVE_SLOT_TIMES_FACTOR as f64;
+        self.rent_collector.slots_per_year *= HALVE_SLOT_TIMES_FACTOR as f64;
+        if !self.feature_set.is_active(&feature_set::alpenglow::id()) {
+            if let Some(hashes_per_tick) = self.hashes_per_tick {
+                self.hashes_per_tick = Some(
+                    hashes_per_tick
+                        .saturating_div(HALVE_SLOT_TIMES_FACTOR)
+                        .max(1),
+                );
+            }
+        }
+        if self.fee_rate_governor.target_signatures_per_slot > 0 {
+            self.fee_rate_governor.target_signatures_per_slot = self
+                .fee_rate_governor
+                .target_signatures_per_slot
+                .saturating_div(HALVE_SLOT_TIMES_FACTOR)
+                .max(1);
+        }
+    }
+
+    // These fields are not persisted across restarts and must be reactivated.
+    // This function is idempotent.
+    fn apply_halve_slot_times_runtime_changes(&mut self) {
+        self.max_processing_age =
+            MAX_PROCESSING_AGE.saturating_mul(HALVE_SLOT_TIMES_FACTOR as usize);
+        self.blockhash_queue
+            .write()
+            .unwrap()
+            .set_max_age(self.max_recent_blockhashes_for_active_features());
+        self.apply_cost_tracker_limits_for_active_features();
+        self.apply_status_cache_limits_for_active_features();
+        self.apply_partitioned_epoch_rewards_config_for_active_features();
     }
 
     fn apply_simd_0339_invoke_cost_changes(&mut self) {
@@ -4479,11 +4628,17 @@ impl Bank {
         // Update the transaction processor with all active built-in programs
         self.add_active_builtin_programs();
 
-        // Cost-Tracker is not serialized in snapshot or any configs.
-        // We must apply previously activated features related to limits here
+        // Many fields are not serialized in snapshot or any configs.
+        // We must apply previously activated features related to values here
         // so that the initial bank state is consistent with the feature set.
-        // Cost-tracker limits are propagated through children banks.
-        self.apply_cost_tracker_limits_for_active_features();
+        if self.halve_slot_times_active() {
+            // Cost tracker and status cache limits are updated as part of halve
+            // slot times updates.
+            self.apply_halve_slot_times_runtime_changes();
+        } else {
+            self.apply_cost_tracker_limits_for_active_features();
+            self.apply_status_cache_limits_for_active_features();
+        }
         self.apply_simd_0339_invoke_cost_changes();
 
         let program_runtime_environment =
@@ -5612,6 +5767,10 @@ impl Bank {
             self.rent_collector.deprecate_rent_exemption_threshold();
         }
 
+        if self.halve_slot_times_active() {
+            self.apply_halve_slot_times_persistent_changes();
+        }
+
         // Add built-in program accounts to the bank if they don't already exist
         self.add_builtin_program_accounts();
 
@@ -5706,10 +5865,13 @@ impl Bank {
             self.fee_rate_governor.burn_percent = solana_fee_calculator::DEFAULT_BURN_PERCENT;
         }
 
-        self.apply_new_builtin_program_feature_transitions(&new_feature_activations);
-        if new_feature_activations.contains(&feature_set::raise_block_limits_to_100m::id()) {
+        if new_feature_activations.contains(&feature_set::halve_slot_times::id()) {
+            self.apply_halve_slot_times_persistent_changes();
+            self.apply_halve_slot_times_runtime_changes();
+        } else if new_feature_activations.contains(&feature_set::raise_block_limits_to_100m::id()) {
             self.apply_cost_tracker_limits_for_active_features();
         }
+        self.apply_new_builtin_program_feature_transitions(&new_feature_activations);
 
         if new_feature_activations.contains(&feature_set::replace_spl_token_with_p_token::id()) {
             if let Err(e) = self.upgrade_loader_v2_program_with_loader_v3_program(

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -2316,8 +2316,8 @@ mod tests {
             &voters,               // expected_voters
             &stakers,              // expected_stakers
             0,                     // expected_reward_commissions
-            499500,                // expected_stake_rewards
-            499542,                // expected_rewards
+            249700,                // expected_stake_rewards
+            249771,                // expected_rewards
             8_400_000_000_000u128, // expected_points
             None,                  // parent_capitalization
         );
@@ -2336,9 +2336,9 @@ mod tests {
             2,                           // expected_cache_len
             &voters,                     // expected_voters
             &stakers,                    // expected_stakers
-            5555,                        // expected_reward_commissions
-            494730,                      // expected_stake_rewards
-            500313,                      // expected_rewards
+            2775,                        // expected_reward_commissions
+            247315,                      // expected_stake_rewards
+            250156,                      // expected_rewards
             9_450_000_000_000u128,       // expected_points
             Some(parent_capitalization), // parent_capitalization
         );
@@ -2357,9 +2357,9 @@ mod tests {
             3,                           // expected_cache_len
             &voters,                     // expected_voters
             &stakers,                    // expected_stakers
-            17300,                       // expected_reward_commissions
-            485365,                      // expected_stake_rewards
-            502779,                      // expected_rewards
+            8650,                        // expected_reward_commissions
+            242670,                      // expected_stake_rewards
+            251389,                      // expected_rewards
             12_810_000_000_000u128,      // expected_points
             Some(parent_capitalization), // parent_capitalization
         );

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -375,11 +375,7 @@ impl Bank {
 
     /// # stake accounts to store in one block during partitioned reward interval
     pub(super) fn partitioned_rewards_stake_account_stores_per_block(&self) -> u64 {
-        self.rc
-            .accounts
-            .accounts_db
-            .partitioned_epoch_rewards_config
-            .stake_account_stores_per_block
+        self.partitioned_rewards_stake_account_stores_per_block
     }
 
     /// Calculate the number of blocks required to distribute rewards to all stake accounts.

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13,8 +13,8 @@ use {
             self, GenesisConfigInfo, ValidatorVoteKeypairs, activate_all_features,
             activate_feature, bootstrap_validator_stake_lamports,
             create_genesis_config_with_leader, create_genesis_config_with_vote_accounts,
-            create_lockup_stake_account, genesis_sysvar_and_builtin_program_lamports,
-            minimum_vote_account_balance_for_vat,
+            create_lockup_stake_account, deactivate_features,
+            genesis_sysvar_and_builtin_program_lamports, minimum_vote_account_balance_for_vat,
         },
         runtime_config::RuntimeConfig,
         serde_snapshot::fields_from_stream,
@@ -43,6 +43,7 @@ use {
         accounts_index::{AccountIndex, AccountSecondaryIndexes, IndexKey},
         accounts_scan::ScanError,
         ancestors::Ancestors,
+        partitioned_rewards::MAX_PARTITIONED_REWARDS_PER_BLOCK_HALVE_SLOTS,
     },
     solana_client_traits::SyncClient,
     solana_clock::{
@@ -5172,9 +5173,10 @@ fn test_fuzz_instructions() {
 // test matrix that tests the bank hash calculation with and without your
 // added feature.
 #[allow(deprecated)]
-#[test_case(false ; "legacy")]
-#[test_case(true ; "deprecate rent exemption threshold")]
-fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
+#[test_case(false, false ; "legacy")]
+#[test_case(true, false ; "deprecate rent exemption threshold")]
+#[test_case(false, true ; "halve slots")]
+fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool, halve_slots: bool) {
     let mut genesis_config = GenesisConfig {
         // Override the creation time to ensure bank hash consistency
         creation_time: 0,
@@ -5195,6 +5197,10 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
 
     if !deprecate_rent_exemption_threshold {
         feature_set.deactivate(&feature_set::deprecate_rent_exemption_threshold::id());
+    }
+
+    if !halve_slots {
+        feature_set.deactivate(&feature_set::halve_slot_times::id());
     }
 
     let (mut bank, _bank_forks) = Bank::new_from_genesis(
@@ -5233,6 +5239,8 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
                     "Gqd3QevNuGLvzL91YbUa86FCcPFCi3GsSDqrhbq2gjX7"
+                } else if halve_slots {
+                    "5CVXp9MBMzrKjfyyFr1iEtBzKeq3RkBHifTbzrzj7Xsm"
                 } else {
                     "HV9Wr7XVke8YYYxMnsQWYf8GnBC5PPKJyGX52raDvev8"
                 },
@@ -5244,6 +5252,8 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
                     "Gdes9UEi7nxJyytpnAPM8wRMpZ39W8G3tqJSHUj49GQk"
+                } else if halve_slots {
+                    "4oBqKQxAwfDy8wcDhKZUfVvLSE98sAR8QpSwKGAvkKKY"
                 } else {
                     "5Gp1HpKChMPo1t34WHCFM2mhWxy5s8QYFkf3FnxEAmku"
                 },
@@ -6791,6 +6801,179 @@ fn test_block_limits() {
         bank.read_cost_tracker().unwrap().get_account_limit(),
         MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_ENABLED,
         "bank created from genesis config should have new limit"
+    );
+}
+
+fn verify_bank_values(
+    bank: Bank,
+    expected_ns_per_slot: u128,
+    expected_hashes_per_tick: u64,
+    expected_ticks_per_slot: u64,
+    expected_slots_per_year: f64,
+    expected_signatures_per_slot: u64,
+    base_cost_tracker: Option<&CostTracker>,
+) {
+    assert_eq!(bank.ns_per_slot, expected_ns_per_slot);
+    assert_eq!(bank.hashes_per_tick().unwrap(), expected_hashes_per_tick,);
+    assert_eq!(bank.ticks_per_slot(), expected_ticks_per_slot,);
+    assert_eq!(bank.slots_per_year(), expected_slots_per_year,);
+    assert_eq!(
+        bank.rent_collector().slots_per_year,
+        expected_slots_per_year,
+    );
+    assert_eq!(
+        bank.fee_rate_governor.target_signatures_per_slot,
+        expected_signatures_per_slot,
+    );
+    assert_eq!(bank.max_processing_age(), MAX_PROCESSING_AGE * 2,);
+    assert_eq!(
+        bank.blockhash_queue.read().unwrap().get_max_age(),
+        MAX_RECENT_BLOCKHASHES * 2,
+    );
+    assert_eq!(
+        bank.status_cache.read().unwrap().max_root_entries(),
+        MAX_RECENT_BLOCKHASHES * 2,
+    );
+    assert_eq!(
+        bank.partitioned_rewards_stake_account_stores_per_block(),
+        MAX_PARTITIONED_REWARDS_PER_BLOCK_HALVE_SLOTS,
+    );
+    let Some(base_cost_tracker) = base_cost_tracker else {
+        return;
+    };
+    let cost_tracker = bank.read_cost_tracker().unwrap();
+    assert_eq!(
+        cost_tracker.get_block_limit(),
+        base_cost_tracker.get_block_limit() / 2
+    );
+    assert_eq!(
+        cost_tracker.get_account_limit(),
+        base_cost_tracker.get_account_limit() / 2,
+    );
+    assert_eq!(
+        cost_tracker.get_vote_limit(),
+        base_cost_tracker.get_vote_limit() / 2,
+    );
+    assert_eq!(
+        cost_tracker.get_allocated_data_size_limit(),
+        base_cost_tracker.get_allocated_data_size_limit() / 2,
+    );
+}
+
+#[test]
+fn test_halve_slot_times_feature_activate() {
+    // Setup the parent bank with some non-default values to ensure the feature
+    // properly updates them.
+    let (bank0, bank_forks) = {
+        let (mut genesis_config, _mint_keypair) = create_genesis_config(100_000);
+        let features_to_deactivate = vec![feature_set::halve_slot_times::id()];
+        deactivate_features(&mut genesis_config, &features_to_deactivate);
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        bank.set_hashes_per_tick(Some(1000));
+        bank.wrap_with_bank_forks_for_tests()
+    };
+    let mut bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
+    bank1.set_fork_graph_in_program_cache(Arc::downgrade(&bank_forks));
+
+    // Activate and apply the `halve_slot_times` feature.
+    bank1.store_account(
+        &feature_set::halve_slot_times::id(),
+        &feature::create_account(&Feature::default(), 42),
+    );
+    bank1.compute_and_apply_new_feature_activations();
+
+    // Verify expectations.
+    assert!(bank1.halve_slot_times_active());
+    assert_eq!(bank1.halve_slot_times_slot(), Some(1));
+    verify_bank_values(
+        bank1,
+        bank0.ns_per_slot / 2,
+        bank0.hashes_per_tick().unwrap() / 2,
+        bank0.ticks_per_slot(),
+        bank0.slots_per_year() * 2.0,
+        bank0.fee_rate_governor.target_signatures_per_slot / 2,
+        Some(&bank0.read_cost_tracker().unwrap()),
+    );
+}
+
+#[test]
+fn test_halve_slot_times_feature_active_at_genesis() {
+    let GenesisConfigInfo {
+        mut genesis_config, ..
+    } = genesis_utils::create_genesis_config(1_000_000);
+    assert_eq!(
+        genesis_config.hashes_per_tick(),
+        None,
+        "genesis hashes-per-tick should remain unset when no explicit value is configured",
+    );
+    genesis_config.poh_config.hashes_per_tick = Some(2);
+
+    let bank = Bank::new_for_tests(&genesis_config);
+    assert!(bank.halve_slot_times_active());
+    assert_eq!(bank.halve_slot_times_slot(), Some(0));
+    verify_bank_values(
+        bank,
+        genesis_config.ns_per_slot() / 2,
+        genesis_config.hashes_per_tick().unwrap() / 2,
+        genesis_config.ticks_per_slot(),
+        genesis_config.slots_per_year() * 2.0,
+        genesis_config.fee_rate_governor.target_signatures_per_slot,
+        None,
+    )
+}
+
+#[test]
+fn test_halve_slot_times_feature_preserves_inflation_real_time() {
+    // Setup.
+    let (mut genesis_config, _mint_keypair) = create_genesis_config(1_000_000);
+    let slots_per_epoch = MINIMUM_SLOTS_PER_EPOCH;
+    genesis_config.epoch_schedule = EpochSchedule::custom(slots_per_epoch, slots_per_epoch, false);
+    let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    let mut bank = Bank::new_from_parent(bank0, SlotLeader::default(), slots_per_epoch);
+    bank.set_fork_graph_in_program_cache(Arc::downgrade(&bank_forks));
+
+    // Snapshot pre-activation values.
+    let pre_feature_slots_per_year = bank.slots_per_year();
+    let slot_in_years_before_activation = bank.slot_in_year_for_inflation();
+    let expected_epoch_duration_before_activation =
+        slots_per_epoch as f64 / pre_feature_slots_per_year;
+    let pre_activation_epoch = bank.epoch().saturating_sub(1);
+
+    // Activate halve slots feature.
+    bank.store_account(
+        &feature_set::halve_slot_times::id(),
+        &feature::create_account(&Feature::default(), 42),
+    );
+    bank.compute_and_apply_new_feature_activations();
+
+    // Snapshot post-activation values.
+    let slot_in_years_after_activation = bank.slot_in_year_for_inflation();
+    let expected_epoch_duration_after_activation = expected_epoch_duration_before_activation / 2.0;
+
+    // Verify expectations.
+    assert_eq!(
+        slot_in_years_after_activation,
+        slot_in_years_before_activation
+    );
+    assert_eq!(
+        bank.epoch_duration_in_years(pre_activation_epoch),
+        expected_epoch_duration_before_activation
+    );
+    assert_eq!(
+        bank.epoch_duration_in_years(bank.epoch()),
+        expected_epoch_duration_after_activation
+    );
+    let child_slot = bank.slot();
+    let bank_next_epoch = Bank::new_from_parent(
+        Arc::new(bank),
+        SlotLeader::default(),
+        child_slot + slots_per_epoch,
+    );
+    let inflation_years_advanced =
+        bank_next_epoch.slot_in_year_for_inflation() - slot_in_years_after_activation;
+    assert_eq!(
+        inflation_years_advanced,
+        expected_epoch_duration_after_activation
     );
 }
 
@@ -11570,8 +11753,9 @@ fn test_blockhash_last_valid_block_height() {
         assert!(bank.is_blockhash_valid(&last_blockhash));
     }
 
-    // Make sure it stays in the queue until `MAX_RECENT_BLOCKHASHES`
-    for i in max_processing_age + 1..=MAX_RECENT_BLOCKHASHES {
+    // Make sure it stays in the queue until `max_recent_blockhashes`
+    let max_recent_blockhashes = bank.max_status_cache_entries_for_active_features();
+    for i in max_processing_age + 1..=max_recent_blockhashes {
         goto_end_of_slot(bank.clone());
         bank = Arc::new(new_from_parent(bank));
         assert_eq!(bank.block_height, i as u64);
@@ -11587,7 +11771,7 @@ fn test_blockhash_last_valid_block_height() {
         assert!(!bank.is_blockhash_valid(&last_blockhash));
     }
 
-    // one past MAX_RECENT_BLOCKHASHES is no longer present at all
+    // one past `max_recent_blockhashes` is no longer present at all
     goto_end_of_slot(bank.clone());
     bank = Arc::new(new_from_parent(bank));
     assert_eq!(

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -1014,9 +1014,9 @@ mod tests {
 
     #[test]
     fn test_clock_bounds_multi_slot_gap() {
-        // For 5 slots: upper_bound = parent_time + 2 * 5 * 400ms = parent_time + 4000ms
-        // Use 2 seconds which is within bounds
-        test_clock_bounds_helper(5, |_, lower, _| lower + 2_000_000_000, true);
+        // For 5 slots: upper_bound = parent_time + 2 * 5 * 200ms = parent_time + 2000ms
+        // Use 1 second which is within bounds
+        test_clock_bounds_helper(5, |_, lower, _| lower + 1_000_000_000, true);
     }
 
     #[test]

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -402,7 +402,7 @@ mod tests {
     #[test]
     fn calculate_and_pay_works() {
         let num_validators = 100;
-        let per_validator_stake = LAMPORTS_PER_SOL * 100;
+        let per_validator_stake = LAMPORTS_PER_SOL * 200;
         let num_validators_to_reward = 10;
 
         let validator_keypairs = (0..num_validators)

--- a/snapshots/src/snapshot_config.rs
+++ b/snapshots/src/snapshot_config.rs
@@ -7,9 +7,9 @@ use {
 };
 
 pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
-    NonZeroU64::new(100_000).unwrap();
+    NonZeroU64::new(200_000).unwrap();
 pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
-    NonZeroU64::new(100).unwrap();
+    NonZeroU64::new(200).unwrap();
 pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
     NonZeroUsize::new(2).unwrap();
 pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -13,7 +13,7 @@ use {
     solana_keypair::Keypair,
     solana_ledger::shred::{
         MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT, ProcessShredsStats, ReedSolomonCache,
-        Shred, ShredType, Shredder, merkle_tree::MerkleTree,
+        Shred, ShredType, Shredder, max_shred_index, merkle_tree::MerkleTree,
     },
     solana_runtime::bank::Bank,
     solana_sha256_hasher::hashv,
@@ -268,6 +268,9 @@ impl StandardBroadcastRun {
         } = receive_results;
 
         let mut to_shreds_time = Measure::start("broadcast_to_shreds");
+        let halve_slot_times_active = bank.halve_slot_times_active();
+        self.max_data_shreds_per_slot = max_shred_index(halve_slot_times_active);
+        self.max_code_shreds_per_slot = max_shred_index(halve_slot_times_active);
 
         let maybe_send_header = if self.slot != bank.slot() {
             // Finish previous slot if it was interrupted.


### PR DESCRIPTION
#### Problem
Exploratory PR to investigate what all needs to change to accommodate halving slot times.

This is to help inform the SIMD discussion: https://github.com/solana-foundation/solana-improvement-documents/discussions/469

#### Summary of Changes

- Feature gate `halve_slot_times`
- Halve all of the following when feature is activated
  - Persisted changes (persisted, e.g. in Bank/snapshot)
    - nanos per slot
    - hashes per tick (if Alpenglow is not enabled)
    - target signatures per slot
  - Runtime changes (re-applied after restart)
    - Block limits
      - overall CUs
      - single accounts CUs
      - vote cost limit
      - allocated data
      - shred limit
    - PER stake accounts written per slot
- Double the following when feature is activated
  - Persisted changes (persisted, e.g. in Bank/snapshot)
    - slots_per_year
  - Runtime changes (re-applied after restart)
    - max processing age
    - blockhash queue max age (controls tx expiry)
    - status cache max entries
- Double default snapshot intervals (full and incremental)
- Change the slot range --> wall clock time translation to comprehend 200ms vs. 400ms slot times (for inflation)
- Repair dynamic understanding of tick --> wall clock time
- Add a few tests
- Fix a few tests
- Some black magic to make sure tick count matches expectations based on feature set active at genesis

#### Notable non-changes
- Leader span is still 4 slots
- Ticks per slot is still 64
- Epoch is still 432k slots
- `solana-clock` type constant values (these are dynamically doubled or halved in Agave but unchanged in `solana-sdk` for now
- Grace ticks
- TVC Grace
- Repair delay (250ms)
- Vote costs

#### Things I think we can avoid changing
- AG Genesis vote refresh `GENESIS_VOTE_REFRESH` - just keep at 400ms for how often we retry spamming our vote. Doesn't need to match slot time perfectly.
- `sleep_shred_deferment_period` - it's fine if we sleep a little extra here. There's also nothing dynamic to grab on to and derive a different slot time in these blockstore/shred paths

#### TODOs
Need to switch the following away from hard coded slot time understanding:
- Client heuristics/backoff/age conversions in
  - `tpu-client`
  - `tpu-client-next`
  - `rpc-client`