### PR TITLE
enforce AGAVE_XDP_EBPF_PROGRAM 32b alignment

### DIFF
--- a/xdp-ebpf/src/lib.rs
+++ b/xdp-ebpf/src/lib.rs
@@ -10,14 +10,5 @@
 
 #[cfg(all(target_os = "linux", not(target_arch = "bpf")))]
 #[unsafe(no_mangle)]
-pub static AGAVE_XDP_EBPF_PROGRAM: [u8; aya::include_bytes_aligned!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/agave-xdp-prog"
-))
-.len()] = unsafe {
-    core::ptr::read(
-        aya::include_bytes_aligned!(concat!(env!("CARGO_MANIFEST_DIR"), "/agave-xdp-prog"))
-            .as_ptr()
-            .cast(),
-    )
-};
+pub static AGAVE_XDP_EBPF_PROGRAM: &[u8] =
+    aya::include_bytes_aligned!(concat!(env!("CARGO_MANIFEST_DIR"), "/agave-xdp-prog"));

--- a/xdp/src/program.rs
+++ b/xdp/src/program.rs
@@ -45,7 +45,7 @@ pub fn load_xdp_program(dev: &NetworkDevice) -> Result<Ebpf, Box<dyn std::error:
     let broken_frags = dev.driver()? == "i40e";
     let mut ebpf = if broken_frags {
         loader.set_global("AGAVE_XDP_DROP_MULTI_FRAGS", &1u8, true);
-        loader.load(&agave_xdp_ebpf::AGAVE_XDP_EBPF_PROGRAM)
+        loader.load(agave_xdp_ebpf::AGAVE_XDP_EBPF_PROGRAM)
     } else {
         loader.load(&generate_xdp_elf())
     }?;


### PR DESCRIPTION
#### Problem

I experience error:
```
thread 'main' (1264829) panicked at validator/src/commands/run/execute.rs:349:18:
failed to create xdp retransmitter: "failed to attach xdp program: error parsing BPF object: error parsing ELF data"
```

I'm using driver: `i40e` which is means that the the branch for `broken_frags` in `load_xdp_program` is touched:
```
> readlink -f /sys/class/net/enp5s0f0/device/driver
/sys/bus/pci/drivers/i40e
```

#### Summary of Changes

This happens due to broken alignment of the ebpf program bytes (1 by default). Fixed by enforcing `32` bytes alignment.


