### PR TITLE
validator: Emit the deprecated arg warning to logger

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -209,7 +209,6 @@ pub fn warn_for_deprecated_arguments(matches: &ArgMatches) {
                     msg.push('.');
                 }
             }
-            eprintln!("{msg}");
             warn!("{msg}");
         }
     }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -10,6 +10,7 @@ use {
         },
     },
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand, crate_description, crate_name},
+    log::warn,
     solana_accounts_db::accounts_db::{
         DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO,
     },
@@ -208,8 +209,8 @@ pub fn warn_for_deprecated_arguments(matches: &ArgMatches) {
                     msg.push('.');
                 }
             }
-            // this can not rely on logger since it is not initialized at the time of call
             eprintln!("{msg}");
+            warn!("{msg}");
         }
     }
 }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -130,6 +130,7 @@ pub fn execute(
     }
     let use_progress_bar = logfile.is_none();
     agave_logger::initialize_logging(logfile.clone());
+    cli::warn_for_deprecated_arguments(matches);
 
     info!("{} {}", crate_name!(), solana_version);
     info!("Starting validator with: {:#?}", std::env::args_os());

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -3,7 +3,7 @@
 use jemallocator::Jemalloc;
 use {
     agave_validator::{
-        cli::{DefaultArgs, app, warn_for_deprecated_arguments},
+        cli::{DefaultArgs, app},
         commands,
     },
     log::error,
@@ -19,7 +19,6 @@ pub fn main() {
     let solana_version = solana_version::version!();
     let cli_app = app(solana_version, &default_args);
     let matches = cli_app.get_matches();
-    warn_for_deprecated_arguments(&matches);
 
     let ledger_path = PathBuf::from(matches.value_of("ledger_path").unwrap());
 


### PR DESCRIPTION
## Problem

`warn_for_deprecated_arguments` is called before the logger is initialized, so deprecation warnings are only printed to stderr via `eprintln!` and never appear in the validator log file. Operators running with `systemd` may never see these warnings since stderr output doesn't reach the validator logs.

Fixes #7504

Previous attempt: #7564, closed in favor of #8634 which reorganized signal handling but didn't address the logging issue. The approach here follows the consensus from [that discussion](https://github.com/anza-xyz/agave/pull/7564#issuecomment-3204482321): write to both `eprintln!` and `warn!`.

## Summary of Changes

- Move the `warn_for_deprecated_arguments` call from `main()` to `execute()`, after `agave_logger::initialize_logging` is called
- Add `warn!` alongside the existing `eprintln!` so deprecation warnings are written to both stderr and the log file
- All deprecated arguments are validator `run`/`init` args, so calling the function inside `execute()` is sufficient