### PR TITLE
remove deprecated cla

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -20,9 +20,7 @@ use {
         },
     },
     solana_clock::Slot,
-    solana_core::{
-        banking_trace::BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT, validator::TransactionStructure,
-    },
+    solana_core::banking_trace::BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT,
     solana_epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
     solana_faucet::faucet::{self, FAUCET_PORT},
     solana_hash::Hash,
@@ -162,16 +160,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .validator(is_parsable::<usize>)
             .help("Controls the TPU connection pool size per remote address"),
          usage_warning:"This parameter is misleading, avoid setting it",
-    );
-    add_arg!(
-        // deprecated in v3.1.0
-        Arg::with_name("transaction_struct")
-            .long("transaction-structure")
-            .value_name("STRUCT")
-            .takes_value(true)
-            .possible_values(TransactionStructure::cli_names())
-            .help(TransactionStructure::cli_message()),
-        usage_warning: "Transaction structure is no longer configurable"
     );
     res
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -143,16 +143,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         replaced_by: "accounts-index-limit",
     );
     add_arg!(
-        // deprecated in v3.1.0
-        Arg::with_name("tpu_coalesce_ms")
-            .long("tpu-coalesce-ms")
-            .value_name("MILLISECS")
-            .takes_value(true)
-            .validator(is_parsable::<u64>)
-            .help("Milliseconds to wait in the TPU receiver for packet coalescing."),
-            usage_warning:"tpu_coalesce will be dropped (currently ignored)",
-    );
-    add_arg!(
         // deprecated in v4.0.0
         Arg::with_name("tpu_connection_pool_size")
             .long("tpu-connection-pool-size")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -127,14 +127,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
     }
 
     add_arg!(
-        // deprecated in v3.1.1
-        Arg::with_name("cuda")
-            .long("cuda")
-            .takes_value(false)
-            .help("Use CUDA"),
-        usage_warning: "CUDA support will be dropped"
-    );
-    add_arg!(
         // deprecated in v4.0.0
         Arg::with_name("enable_accounts_disk_index")
             .long("enable-accounts-disk-index")


### PR DESCRIPTION
#### Problem

There are 3 command line arguments which are marked deprecated in v3.1.

#### Summary of Changes

We remove them in this PR.
