### PR TITLE
clippy(clap-v3-utils): remove unnecessary ref binding

### DIFF
--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -1113,7 +1113,7 @@ mod tests {
         assert!(matches!(
             signer_source,
             SignerSource {
-                kind: SignerSourceKind::Base58Keypair(ref s),
+                kind: SignerSourceKind::Base58Keypair(s),
                 derivation_path: None,
                 legacy: false,
             }


### PR DESCRIPTION
#### Problem
`ref` binding is redundant since `signer_source` is already a reference - this becomes a warning in Rust 2024.

#### Summary of Changes
Remove `ref` binding
