### PR TITLE
fix: only update last_tick_height after carryover entry check

### DIFF
--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -141,7 +141,6 @@ pub(super) fn recv_slot_entries(
             bank = try_bank.clone();
             coalesce_start = Instant::now();
         }
-        last_tick_height = tick_height;
 
         let entry_bytes = serialized_size(&entry)?;
         if serialized_batch_byte_count + entry_bytes > max_batch_byte_count {
@@ -151,6 +150,10 @@ pub(super) fn recv_slot_entries(
             process_stats.coalesce_exited_hit_max += 1;
             break;
         }
+
+        // only update the last tick height after confirming we did
+        // not carry over the entry to the next batch.
+        last_tick_height = tick_height;
 
         // Add the entry to the batch.
         serialized_batch_byte_count += entry_bytes;


### PR DESCRIPTION
#### Problem
`last_tick_height` is unconditionally updated even when we carry over the entry to the next batch.

#### Summary of Changes
only update last_tick_height after carryover entry check
