### PR TITLE
clippy: fix manual_checked_ops lint

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -466,19 +466,11 @@ fn run_rpc_bench_loop(
             "t({}) rpc({:?}) iters: {} success: {} errors: {}",
             thread, rpc_bench, iters, stats.success, stats.errors
         );
-        if stats.success > 0 {
-            info!(
-                " t({}) rpc({:?} average success_time: {} us",
-                thread,
-                rpc_bench,
-                stats.total_success_time_us / stats.success
-            );
+        if let Some(avg_success) = stats.total_success_time_us.checked_div(stats.success) {
+            info!(" t({thread}) rpc({rpc_bench:?} average success_time: {avg_success} us",);
         }
-        if stats.errors > 0 {
-            info!(
-                " rpc average average errors time: {} us",
-                stats.total_errors_time_us / stats.errors
-            );
+        if let Some(avg_errors) = stats.total_errors_time_us.checked_div(stats.errors) {
+            info!(" rpc average average errors time: {avg_errors} us");
         }
         *last_print = Instant::now();
         *stats = RpcBenchStats::default();

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -135,13 +135,13 @@ impl Stats {
             age_now += Age::MAX as u64 + 1;
         }
         let age_delta = age_now.saturating_sub(last_age);
-        if age_delta > 0 {
-            return elapsed_ms / age_delta;
+        if let Some(v) = elapsed_ms.checked_div(age_delta) {
+            return v;
         } else {
             // did not advance an age, but probably did partial work, so report that
             let bin_delta = ages_flushed.saturating_sub(last_ages_flushed);
-            if bin_delta > 0 {
-                return elapsed_ms * self.bins / bin_delta;
+            if let Some(v) = (elapsed_ms * self.bins).checked_div(bin_delta) {
+                return v;
             }
         }
         0 // avoid crazy numbers


### PR DESCRIPTION
#### Problem
Newer rust toolchain warns against using "if x > 0 { y / x }" pattern

#### Summary of Changes
Fixes cases in accounts-db and accounts-cluter-bench
