### PR TITLE
runtime: swap im for imbl in StakesCache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9982,7 +9982,7 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "dashmap",
- "im",
+ "imbl",
  "itertools 0.14.0",
  "libc",
  "libsecp256k1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,7 @@ histogram = "0.6.9"
 http = "1.4.0"
 humantime = "2.3.0"
 hyper-util = "0.1.20"
-im = "15.1.0"
+imbl = "7.0.0"
 indexmap = "2.13.1"
 indicatif = "0.18.4"
 io-uring = { version = "0.7.11", features = ["io_safety"] }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -568,6 +568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
+
+[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,12 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "bitmaps"
-version = "2.1.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitvec"
@@ -3370,19 +3373,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
-name = "im"
-version = "15.1.0"
+name = "imbl"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
 dependencies = [
+ "archery",
  "bitmaps",
- "rand_core 0.6.4",
+ "imbl-sized-chunks",
+ "rand_core 0.9.5",
  "rand_xoshiro",
  "rayon",
- "serde",
- "sized-chunks",
- "typenum",
+ "serde_core",
  "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
 ]
 
 [[package]]
@@ -5173,11 +5186,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5608,6 +5621,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5978,16 +6000,6 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"
@@ -8563,7 +8575,7 @@ dependencies = [
  "bytemuck",
  "crossbeam-channel",
  "dashmap",
- "im",
+ "imbl",
  "itertools 0.14.0",
  "libc",
  "log",
@@ -11330,6 +11342,16 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -565,6 +565,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
+
+[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,12 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "bitmaps"
-version = "2.1.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitvec"
@@ -3235,19 +3238,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
-name = "im"
-version = "15.1.0"
+name = "imbl"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
 dependencies = [
+ "archery",
  "bitmaps",
- "rand_core 0.6.4",
+ "imbl-sized-chunks",
+ "rand_core 0.9.3",
  "rand_xoshiro",
  "rayon",
- "serde",
- "sized-chunks",
- "typenum",
+ "serde_core",
  "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
 ]
 
 [[package]]
@@ -4934,11 +4947,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5365,6 +5378,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5702,16 +5724,6 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"
@@ -8204,7 +8216,7 @@ dependencies = [
  "bytemuck",
  "crossbeam-channel",
  "dashmap",
- "im",
+ "imbl",
  "itertools 0.14.0",
  "libc",
  "log",
@@ -11618,6 +11630,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -68,7 +68,7 @@ bincode = { workspace = true }
 bytemuck = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api", "serde"] }
-im = { workspace = true, features = ["rayon", "serde"] }
+imbl = { workspace = true, features = ["rayon", "serde"] }
 itertools = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -190,7 +190,7 @@ impl Bank {
     }
 
     fn build_updated_stake_reward(
-        stakes_cache_accounts: &im::HashMap<Pubkey, StakeAccount<Delegation>>,
+        stakes_cache_accounts: &imbl::HashMap<Pubkey, StakeAccount<Delegation>>,
         partitioned_stake_reward: &PartitionedStakeReward,
     ) -> Result<StakeReward, DistributionError> {
         let stake_account = stakes_cache_accounts

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -205,7 +205,7 @@ impl VersionedEpochStakes {
             SerdeStakesToStakeFormat::Account(crate::stakes::Stakes::new_for_tests(
                 0,
                 solana_vote::vote_account::VoteAccounts::from(Arc::new(vote_accounts_hash_map)),
-                im::HashMap::default(),
+                imbl::HashMap::default(),
             )),
             leader_schedule_epoch,
         )
@@ -410,7 +410,7 @@ impl From<DeserializableEpochStakes> for EpochStakes {
 
 /// Snapshot epoch stakes contain delegations, but the main EpochStakes no longer uses them.
 /// This fn does custom deserialization to visit-and-ignore the delegations,
-/// avoiding the need to construct an expensive im::HashMap.
+/// avoiding the need to construct an expensive imbl::HashMap.
 fn deserialize_and_ignore_stake_delegations<'de, D>(deserializer: D) -> Result<(), D::Error>
 where
     D: Deserializer<'de>,
@@ -698,7 +698,7 @@ pub(crate) mod tests {
         let stakes = Stakes::new_for_tests(
             epoch,
             vote_accounts,
-            im::HashMap::from_iter([(stake_pubkey, stake_account)]),
+            imbl::HashMap::from_iter([(stake_pubkey, stake_account)]),
         );
 
         // ensure stake delegations start off *not* empty

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -4,7 +4,7 @@
 use solana_stake_interface::state::Stake;
 use {
     crate::{stake_account, stake_history::StakeHistory},
-    im::HashMap as ImHashMap,
+    imbl::HashMap as ImblHashMap,
     log::error,
     num_derive::ToPrimitive,
     rayon::{ThreadPool, prelude::*},
@@ -169,7 +169,7 @@ pub struct Stakes<T: Clone> {
     vote_accounts: VoteAccounts,
 
     /// stake_delegations
-    stake_delegations: ImHashMap<Pubkey, T>,
+    stake_delegations: ImblHashMap<Pubkey, T>,
 
     /// unused
     unused: u64,
@@ -193,7 +193,7 @@ impl<T: Clone> Stakes<T> {
                 .clone_and_filter_for_vat(max_vote_accounts, minimum_vote_account_balance),
             epoch: self.epoch,
             // Do not need anything else for EpochStakes
-            stake_delegations: ImHashMap::new(),
+            stake_delegations: ImblHashMap::new(),
             unused: 0,
             stake_history: StakeHistory::default(),
         }
@@ -236,9 +236,9 @@ impl Stakes<StakeAccount> {
             .stake_delegations
             .into_par_iter()
             // We use fold/reduce to aggregate the results, which does a bit more work than calling
-            // collect()/collect_vec_list() and then im::HashMap::from_iter(collected.into_iter()),
+            // collect()/collect_vec_list() and then imbl::HashMap::from_iter(collected.into_iter()),
             // but it does it in background threads, so effectively it's faster.
-            .try_fold(ImHashMap::new, |mut map, (pubkey, delegation)| {
+            .try_fold(ImblHashMap::new, |mut map, (pubkey, delegation)| {
                 let Some(stake_account) = get_account(&pubkey) else {
                     return Err(Error::StakeAccountNotFound(pubkey));
                 };
@@ -267,7 +267,7 @@ impl Stakes<StakeAccount> {
                     Err(Error::InvalidDelegation(pubkey))
                 }
             })
-            .try_reduce(ImHashMap::new, |a, b| Ok(a.union(b)))?;
+            .try_reduce(ImblHashMap::new, |a, b| Ok(a.union(b)))?;
 
         // Assert that cached vote accounts are consistent with accounts-db.
         //
@@ -297,7 +297,7 @@ impl Stakes<StakeAccount> {
     pub fn new_for_tests(
         epoch: Epoch,
         vote_accounts: VoteAccounts,
-        stake_delegations: ImHashMap<Pubkey, StakeAccount>,
+        stake_delegations: ImblHashMap<Pubkey, StakeAccount>,
     ) -> Self {
         Self {
             vote_accounts,
@@ -365,7 +365,7 @@ impl Stakes<StakeAccount> {
 
     /// Sum the stakes that point to the given voter_pubkey
     fn calculate_stake(
-        stake_delegations: &ImHashMap<Pubkey, StakeAccount>,
+        stake_delegations: &ImblHashMap<Pubkey, StakeAccount>,
         voter_pubkey: &Pubkey,
         epoch: Epoch,
         stake_history: &StakeHistory,
@@ -452,14 +452,14 @@ impl Stakes<StakeAccount> {
     ///
     /// # Performance
     ///
-    /// `[im::HashMap]` is a [hash array mapped trie (HAMT)][hamt], which means
+    /// `[imbl::HashMap]` is a [hash array mapped trie (HAMT)][hamt], which means
     /// that inserts, deletions and lookups are average-case O(1) and
     /// worst-case O(log n). However, the performance of iterations is poor due
     /// to depth-first traversal and jumps. Currently it's also impossible to
     /// iterate over it with [`rayon`].
     ///
     /// [hamt]: https://en.wikipedia.org/wiki/Hash_array_mapped_trie
-    pub(crate) fn stake_delegations(&self) -> &ImHashMap<Pubkey, StakeAccount> {
+    pub(crate) fn stake_delegations(&self) -> &ImblHashMap<Pubkey, StakeAccount> {
         &self.stake_delegations
     }
 
@@ -469,7 +469,7 @@ impl Stakes<StakeAccount> {
     /// # Performance
     ///
     /// The execution of this method takes ~200ms and it collects elements of
-    /// the [`im::HashMap`], which is a [hash array mapped trie (HAMT)][hamt],
+    /// the [`imbl::HashMap`], which is a [hash array mapped trie (HAMT)][hamt],
     /// so that operation involves a depth-first traversal with jumps. However,
     /// it's still a reasonable tradeoff if the caller iterates over these
     /// elements.
@@ -611,7 +611,7 @@ pub(crate) mod tests {
         pub(crate) fn from_deserialized(stakes: DeserializableStakes<T>) -> Self {
             Self {
                 vote_accounts: stakes.vote_accounts,
-                stake_delegations: ImHashMap::from_iter(stakes.stake_delegations),
+                stake_delegations: ImblHashMap::from_iter(stakes.stake_delegations),
                 unused: stakes.unused,
                 epoch: stakes.epoch,
                 stake_history: stakes.stake_history,

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -1,7 +1,7 @@
 use {
     super::{StakeAccount, Stakes},
     crate::stake_history::StakeHistory,
-    im::HashMap as ImHashMap,
+    imbl::HashMap as ImblHashMap,
     serde::{Deserialize, Serialize, Serializer, ser::SerializeMap},
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
@@ -145,7 +145,7 @@ struct SerdeStakeAccountsToStakeFormat {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-struct SerdeStakeAccountMapToDelegationFormat(ImHashMap<Pubkey, StakeAccount>);
+struct SerdeStakeAccountMapToDelegationFormat(ImblHashMap<Pubkey, StakeAccount>);
 impl Serialize for SerdeStakeAccountMapToDelegationFormat {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -160,7 +160,7 @@ impl Serialize for SerdeStakeAccountMapToDelegationFormat {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-struct SerdeStakeAccountMapToStakeFormat(ImHashMap<Pubkey, StakeAccount>);
+struct SerdeStakeAccountMapToStakeFormat(ImblHashMap<Pubkey, StakeAccount>);
 impl Serialize for SerdeStakeAccountMapToStakeFormat {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -177,7 +177,7 @@ impl Serialize for SerdeStakeAccountMapToStakeFormat {
 /// Simplified, intermediate representation of [`Stakes<T>`]
 ///
 /// Its bincode serializaiton format is identical as Stakes<T>, but allows faster
-/// deserialization without creating im::HashMap (such conversion is deferred until
+/// deserialization without creating imbl::HashMap (such conversion is deferred until
 /// data is actually needed).
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct DeserializableStakes<T> {
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_serde_stakes_to_stake_format() {
-        let mut stake_delegations = ImHashMap::new();
+        let mut stake_delegations = ImblHashMap::new();
         let vote_pubkey = Pubkey::new_unique();
         let node_pubkey = Pubkey::new_unique();
         stake_delegations.insert(


### PR DESCRIPTION
#### Problem
stakes cache is a bottleneck

#### Summary of Changes
replace `im` with `imbl`. the former has not been updated for years, the latter is a backwards-compat fork that is presently maintained and more optimized

in #10760 i add some very simple benches for epoch rewards and advancing the epoch. if they are to be believed, this speeds rewards up by 10% and epoch advance by 30%

before:
```
test bench_epoch_rewards_period ... bench: 352,109,145.90 ns/iter (+/- 56,468,574.76)
test bench_epoch_turnover       ... bench:  15,555,461.00 ns/iter (+/- 2,037,170.53
```

after:
```
test bench_epoch_rewards_period ... bench: 310,888,743.00 ns/iter (+/- 53,842,063.38)
test bench_epoch_turnover       ... bench:  10,845,295.30 ns/iter (+/- 1,171,299.93)
```