### PR TITLE
xdp: use bytes instead of shred::Payload in xdp_retransmitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,12 +599,12 @@ dependencies = [
  "agave-xdp-ebpf",
  "arc-swap",
  "aya",
+ "bytes",
  "caps",
  "core_affinity",
  "crossbeam-channel",
  "libc",
  "log",
- "solana-ledger",
  "thiserror 2.0.18",
 ]
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -469,12 +469,12 @@ dependencies = [
  "agave-xdp-ebpf",
  "arc-swap",
  "aya",
+ "bytes",
  "caps",
  "core_affinity",
  "crossbeam-channel",
  "libc",
  "log",
- "solana-ledger",
  "thiserror 2.0.18",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -455,12 +455,12 @@ dependencies = [
  "agave-xdp-ebpf",
  "arc-swap",
  "aya",
+ "bytes",
  "caps",
  "core_affinity",
  "crossbeam-channel",
  "libc",
  "log",
- "solana-ledger",
  "thiserror 2.0.18",
 ]
 

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -542,7 +542,7 @@ pub fn broadcast_shreds(
         BroadcastSocket::Xdp(s) => {
             let mut send_xdp_time = Measure::start("send_xdp");
             for (idx, (payload, addr)) in packets.into_iter().enumerate() {
-                if let Err(e) = s.try_send(idx, addr, payload.clone()) {
+                if let Err(e) = s.try_send(idx, addr, payload.bytes.clone()) {
                     log::warn!("xdp channel full: {e:?}");
                     transmit_stats.dropped_packets_xdp += 1;
                     result = Err(Error::XdpChannelFull);

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -485,7 +485,7 @@ fn retransmit_shred(
         RetransmitSocket::Xdp(sender) => {
             let mut sent = num_addrs;
             if num_addrs > 0
-                && let Err(e) = sender.try_send(key.index() as usize, addrs.to_vec(), shred)
+                && let Err(e) = sender.try_send(key.index() as usize, addrs.to_vec(), shred.bytes)
             {
                 log::warn!("xdp channel full: {e:?}");
                 stats

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -13,10 +13,10 @@ agave-unstable-api = []
 
 [dependencies]
 arc-swap = { workspace = true }
+bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
-solana-ledger = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/xdp/src/xdp_retransmitter.rs
+++ b/xdp/src/xdp_retransmitter.rs
@@ -16,8 +16,8 @@ use {
     std::{thread::Builder, time::Duration},
 };
 use {
+    bytes::Bytes,
     crossbeam_channel::{Sender, TrySendError},
-    solana_ledger::shred,
     std::{
         error::Error,
         net::{Ipv4Addr, SocketAddr},
@@ -68,7 +68,7 @@ impl XdpConfig {
 
 #[derive(Clone)]
 pub struct XdpSender {
-    senders: Vec<Sender<(XdpAddrs, shred::Payload)>>,
+    senders: Vec<Sender<(XdpAddrs, Bytes)>>,
 }
 
 pub enum XdpAddrs {
@@ -106,8 +106,8 @@ impl XdpSender {
         &self,
         sender_index: usize,
         addr: impl Into<XdpAddrs>,
-        payload: shred::Payload,
-    ) -> Result<(), TrySendError<(XdpAddrs, shred::Payload)>> {
+        payload: Bytes,
+    ) -> Result<(), TrySendError<(XdpAddrs, Bytes)>> {
         let idx = sender_index
             .checked_rem(self.senders.len())
             .expect("XdpSender::senders should not be empty");


### PR DESCRIPTION
#### Problem

We want to use `XdpRetransmitter` not only for shreds but also for quic packets.
The problem is that currently it is using `shred::Payload` which is thin wrapper of `Bytes` from crate `solana_ledger`.  

#### Summary of Changes

Use `Bytes` instead of `shred::Payload` in xdp crate, remove dependency on `solana_legger` crate.
