### PR TITLE
runtime: expand the per-program statistics we keep track of

### DIFF
--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -15,7 +15,6 @@ use {
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, native_loader},
     solana_stable_layout::stable_instruction::StableInstruction,
     solana_svm_log_collector::ic_msg,
-    solana_svm_measure::measure::Measure,
     solana_svm_timings::ExecuteTimings,
     solana_transaction_context::{
         IndexOfAccount, MAX_ACCOUNTS_PER_INSTRUCTION, MAX_INSTRUCTION_DATA_LEN,
@@ -834,10 +833,6 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
         invoke_context,
         invoke_context.get_execution_cost().invoke_units,
     )?;
-    if let Some(execute_time) = invoke_context.execute_time.as_mut() {
-        execute_time.stop();
-        invoke_context.timings.execute_us += execute_time.as_us();
-    }
     let syscall_parameter_address_restrictions = invoke_context
         .get_feature_set()
         .syscall_parameter_address_restrictions;
@@ -944,7 +939,6 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
         }
     }
 
-    invoke_context.execute_time = Some(Measure::start("execute"));
     Ok(SUCCESS)
 }
 

--- a/program-runtime/src/deploy.rs
+++ b/program-runtime/src/deploy.rs
@@ -19,7 +19,7 @@ use {
         verifier::RequisiteVerifier,
     },
     solana_svm_log_collector::{LogCollector, ic_logger_msg},
-    solana_svm_type_overrides::sync::{Arc, atomic::Ordering},
+    solana_svm_type_overrides::sync::Arc,
     std::{cell::RefCell, rc::Rc},
 };
 
@@ -119,10 +119,7 @@ pub fn deploy_program(
         InstructionError::InvalidAccountData
     })?;
     if let Some(old_entry) = program_cache_for_tx_batch.find(program_id) {
-        executor.tx_usage_counter.store(
-            old_entry.tx_usage_counter.load(Ordering::Relaxed),
-            Ordering::Relaxed,
-        );
+        executor.stats.merge_from(&old_entry.stats);
     }
     #[cfg(feature = "metrics")]
     {

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -49,6 +49,7 @@ use {
         cell::RefCell,
         fmt::{self, Debug},
         rc::Rc,
+        time::Duration,
     },
 };
 
@@ -205,8 +206,8 @@ pub struct InvokeContext<'a, 'ix_data> {
     /// the designated compute budget during program execution.
     compute_meter: RefCell<u64>,
     log_collector: Option<Rc<RefCell<LogCollector>>>,
-    /// Latest measurement not yet accumulated in [ExecuteDetailsTimings::execute_us]
-    pub execute_time: Option<Measure>,
+    /// Time spent so far executing nested program calls.
+    pub total_nested_exec_time: Duration,
     pub timings: ExecuteDetailsTimings,
     pub syscall_context: Vec<Option<SyscallContext>>,
     /// Pairs of index in TX instruction trace and VM register trace
@@ -233,7 +234,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             compute_budget,
             execution_cost,
             compute_meter: RefCell::new(compute_budget.compute_unit_limit),
-            execute_time: None,
+            total_nested_exec_time: Duration::ZERO,
             timings: ExecuteDetailsTimings::default(),
             syscall_context: Vec::new(),
             register_traces: Vec::new(),

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "metrics")]
+use solana_svm_timings::ExecuteDetailsTimings;
 use {
     crate::invoke_context::{BuiltinFunctionRegisterer, InvokeContext},
     log::{debug, error, log_enabled, trace},
@@ -8,6 +10,7 @@ use {
     solana_sdk_ids::{
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4, native_loader,
     },
+    solana_svm_measure::measure::Measure,
     solana_svm_type_overrides::{
         rand::{Rng, rng},
         sync::{
@@ -18,12 +21,10 @@ use {
     },
     std::{
         collections::{HashMap, hash_map::Entry},
-        fmt::{Debug, Formatter},
+        fmt::{Debug, Formatter, Write},
         sync::Weak,
     },
 };
-#[cfg(feature = "metrics")]
-use {solana_svm_measure::measure::Measure, solana_svm_timings::ExecuteDetailsTimings};
 
 #[repr(transparent)]
 #[derive(Clone, Debug)]
@@ -182,7 +183,9 @@ pub enum ProgramCacheEntryType {
     ///
     /// It continues to track usage statistics even when the compiled executable of the program is evicted from memory.
     Unloaded(ProgramRuntimeEnvironment),
-    /// Verified and compiled program
+    /// Verified program.
+    ///
+    /// It may or may not be JIT compiled.
     Loaded(Executable<InvokeContext<'static, 'static>>),
     /// A built-in program which is not stored on-chain but backed into and distributed with the validator
     Builtin(BuiltinProgram<InvokeContext<'static, 'static>>),
@@ -190,18 +193,17 @@ pub enum ProgramCacheEntryType {
 
 impl Debug for ProgramCacheEntryType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
+        f.debug_struct(match self {
             ProgramCacheEntryType::FailedVerification(_) => {
-                write!(f, "ProgramCacheEntryType::FailedVerification")
+                "ProgramCacheEntryType::FailedVerification"
             }
-            ProgramCacheEntryType::Closed => write!(f, "ProgramCacheEntryType::Closed"),
-            ProgramCacheEntryType::DelayVisibility => {
-                write!(f, "ProgramCacheEntryType::DelayVisibility")
-            }
-            ProgramCacheEntryType::Unloaded(_) => write!(f, "ProgramCacheEntryType::Unloaded"),
-            ProgramCacheEntryType::Loaded(_) => write!(f, "ProgramCacheEntryType::Loaded"),
-            ProgramCacheEntryType::Builtin(_) => write!(f, "ProgramCacheEntryType::Builtin"),
-        }
+            ProgramCacheEntryType::Closed => "ProgramCacheEntryType::Closed",
+            ProgramCacheEntryType::DelayVisibility => "ProgramCacheEntryType::DelayVisibility",
+            ProgramCacheEntryType::Unloaded(_) => "ProgramCacheEntryType::Unloaded",
+            ProgramCacheEntryType::Loaded(_) => "ProgramCacheEntryType::Loaded",
+            ProgramCacheEntryType::Builtin(_) => "ProgramCacheEntryType::Builtin",
+        })
+        .finish()
     }
 }
 
@@ -215,6 +217,145 @@ impl ProgramCacheEntryType {
             ProgramCacheEntryType::FailedVerification(env)
             | ProgramCacheEntryType::Unloaded(env) => Some(env),
             _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ProgramStatistics {
+    pub uses: AtomicU64,
+
+    pub compilations: AtomicU64,
+    pub total_compilation_time_us: AtomicU64,
+    /// Exponential moving average of the compilation time.
+    pub compilation_time_ema: AtomicU64,
+
+    pub jit_invocations: AtomicU64,
+    pub total_jit_execution_time_us: AtomicU64,
+    /// Exponential moving average of the JIT execution time.
+    pub jit_execution_time_ema: AtomicU64,
+
+    pub interpreted_invocations: AtomicU64,
+    pub total_interpretation_time_us: AtomicU64,
+    /// Exponential moving average of the interpreted execution time.
+    pub interpretation_time_ema: AtomicU64,
+}
+
+/// Number of compilation observations contributing to the the [`Self::compilation_time_ema`].
+const COMPILATION_EMA_WINDOW_SIZE: u64 = 10;
+/// Number of execution observations contributing to the execution EMA stats.
+const EXECUTION_EMA_WINDOW_SIZE: u64 = 500;
+/// Track exponential moving average in scaled-up units.
+///
+/// Doing so allows to mitigate error from rounding-towards-zero we get when using integer math.
+const EMA_SCALE: u64 = 1_000;
+
+impl ProgramStatistics {
+    fn observe_ema<const WINDOW_SIZE: u64>(counter: &AtomicU64, duration_us: u64) {
+        let duration_ema = duration_us.saturating_mul(EMA_SCALE);
+        counter
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |ema| {
+                // Exponential moving average iteratively is computed as $ema' = alpha *
+                // observation + (1 - alpha) * ema$. This works great for floating point, but we
+                // want integers. For purposes of convenience we also want to really think in terms
+                // of simple moving average window sizes as that is easier to reason about.
+                //
+                // Exponential moving average and simple moving average of window N has a rough
+                // equivalence of `alpha ≈ 2 / (N + 1)`. Slotting this into our original iterative
+                // formula:
+                //
+                // $$ ema' = 2 / (N+1) * observation + (1 - 2/(N+1)) * ema $$
+                //
+                // we get
+                //
+                // $$ ema' = (2*observation)/(N+1) + (N+1-2)*ema/(N+1) $$
+                let (numer, denom) = const { (2, 1 + WINDOW_SIZE) };
+                Some(if ema == 0 {
+                    duration_ema
+                } else {
+                    let weighted_observation = duration_ema.saturating_mul(numer);
+                    let previous_observations = ema.saturating_mul(denom.saturating_sub(numer));
+                    weighted_observation
+                        .saturating_add(previous_observations)
+                        .checked_div(denom)
+                        .expect("unreachable: denom is >= 1")
+                })
+            })
+            .expect("unreachable: closure always returns a Some");
+    }
+
+    /// JIT compilation happened. Record information about this event.
+    pub fn jit_compiled(&self, duration_us: u64) {
+        let ord = Ordering::Relaxed;
+        self.compilations.fetch_add(1, ord);
+        self.total_compilation_time_us.fetch_add(duration_us, ord);
+        Self::observe_ema::<COMPILATION_EMA_WINDOW_SIZE>(&self.compilation_time_ema, duration_us);
+    }
+
+    /// JIT compilation happened. Record information about this event.
+    pub fn jit_executed(&self, duration_us: u64) {
+        let ord = Ordering::Relaxed;
+        self.jit_invocations.fetch_add(1, ord);
+        self.total_jit_execution_time_us.fetch_add(duration_us, ord);
+        Self::observe_ema::<EXECUTION_EMA_WINDOW_SIZE>(&self.jit_execution_time_ema, duration_us);
+    }
+
+    /// JIT compilation happened. Record information about this event.
+    pub fn interpreter_executed(&self, duration_us: u64) {
+        let ord = Ordering::Relaxed;
+        self.interpreted_invocations.fetch_add(1, ord);
+        self.total_interpretation_time_us
+            .fetch_add(duration_us, ord);
+        Self::observe_ema::<EXECUTION_EMA_WINDOW_SIZE>(&self.interpretation_time_ema, duration_us);
+    }
+
+    pub fn merge_from(&self, other: &ProgramStatistics) {
+        let ord = Ordering::Relaxed;
+        self.uses.fetch_add(other.uses.load(ord), ord);
+        let other_compilations = other.compilations.load(ord);
+        let this_compilations = self.compilations.fetch_add(other_compilations, ord);
+        self.total_compilation_time_us
+            .fetch_add(other.total_compilation_time_us.load(ord), ord);
+        let other_jit_invocations = other.jit_invocations.load(ord);
+        let this_jit_invocations = self.jit_invocations.fetch_add(other_jit_invocations, ord);
+        self.total_jit_execution_time_us
+            .fetch_add(other.total_jit_execution_time_us.load(ord), ord);
+        let other_interpretations = other.interpreted_invocations.load(ord);
+        let this_interpretations = self
+            .interpreted_invocations
+            .fetch_add(other.interpreted_invocations.load(ord), ord);
+        self.total_interpretation_time_us
+            .fetch_add(other.total_interpretation_time_us.load(ord), ord);
+        if let Some(comp_ema) = ProgramCacheStats::combined_ema::<
+            COMPILATION_EMA_WINDOW_SIZE,
+            COMPILATION_EMA_WINDOW_SIZE,
+        >(
+            &self.compilation_time_ema,
+            &other.compilation_time_ema,
+            this_compilations,
+            other_compilations,
+        ) {
+            self.compilation_time_ema.store(comp_ema, ord);
+        }
+        if let Some(exec_ema) =
+            ProgramCacheStats::combined_ema::<EXECUTION_EMA_WINDOW_SIZE, EXECUTION_EMA_WINDOW_SIZE>(
+                &self.jit_execution_time_ema,
+                &other.jit_execution_time_ema,
+                this_jit_invocations,
+                other_jit_invocations,
+            )
+        {
+            self.jit_execution_time_ema.store(exec_ema, ord);
+        }
+        if let Some(interp_ema) =
+            ProgramCacheStats::combined_ema::<EXECUTION_EMA_WINDOW_SIZE, EXECUTION_EMA_WINDOW_SIZE>(
+                &self.interpretation_time_ema,
+                &other.interpretation_time_ema,
+                this_interpretations,
+                other_interpretations,
+            )
+        {
+            self.interpretation_time_ema.store(interp_ema, ord);
         }
     }
 }
@@ -235,7 +376,7 @@ pub struct ProgramCacheEntry {
     /// Slot in which this entry will become active (can be in the future)
     pub effective_slot: Slot,
     /// How often this entry was used by a transaction
-    pub tx_usage_counter: Arc<AtomicU64>,
+    pub stats: Arc<ProgramStatistics>,
     /// Latest slot in which the entry was used
     pub latest_access_slot: AtomicU64,
 }
@@ -293,6 +434,7 @@ impl ProgramCacheStats {
              Prunes-Orphan: {prunes_orphan}, Prunes-Environment: {prunes_environment}, Empty: \
              {empty_entries}, Water-Level: {water_level}"
         );
+
         if log_enabled!(log::Level::Trace) && !self.evictions.is_empty() {
             let mut evictions = self.evictions.iter().collect::<Vec<_>>();
             evictions.sort_by_key(|e| e.1);
@@ -309,6 +451,25 @@ impl ProgramCacheStats {
                 "Program", "Count", evictions
             );
         }
+    }
+
+    fn combined_ema<const WINDOW1: u64, const WINDOW2: u64>(
+        into_ema: &AtomicU64,
+        from_ema: &AtomicU64,
+        into_observations: u64,
+        from_observations: u64,
+    ) -> Option<u64> {
+        // This is a mild non-sense, but there is no good mathematically rigorous way to merge
+        // two independent EMA trackers AFAICT and this is the best I (nagisa) could come up
+        // with…
+        let other_ema_val = from_ema.load(Ordering::Relaxed);
+        let other_ema_weight = std::cmp::max(WINDOW1, from_observations);
+        let this_ema_val = into_ema.load(Ordering::Relaxed);
+        let this_ema_weight = std::cmp::max(WINDOW2, into_observations);
+        other_ema_val
+            .wrapping_mul(other_ema_weight)
+            .wrapping_add(this_ema_val.wrapping_mul(this_ema_weight))
+            .checked_div(other_ema_weight.wrapping_add(this_ema_weight))
     }
 }
 
@@ -410,6 +571,7 @@ impl ProgramCacheEntry {
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
         reloading: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        let entry_stats = ProgramStatistics::default();
         #[cfg(feature = "metrics")]
         let load_elf_time = Measure::start("load_elf_time");
         let executable = Executable::load(elf_bytes, Arc::clone(&*program_runtime_environment))?;
@@ -431,12 +593,13 @@ impl ProgramCacheEntry {
 
         #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
         {
-            #[cfg(feature = "metrics")]
             let jit_compile_time = Measure::start("jit_compile_time");
             executable.jit_compile()?;
+            let jit_compile_time = jit_compile_time.end_as_us();
+            entry_stats.jit_compiled(jit_compile_time);
             #[cfg(feature = "metrics")]
             {
-                metrics.jit_compile_us = jit_compile_time.end_as_us();
+                metrics.jit_compile_us = jit_compile_time;
             }
         }
 
@@ -445,8 +608,8 @@ impl ProgramCacheEntry {
             account_owner: ProgramCacheEntryOwner::try_from(loader_key).unwrap(),
             account_size,
             effective_slot,
-            tx_usage_counter: Arc::<AtomicU64>::default(),
             program: ProgramCacheEntryType::Loaded(executable),
+            stats: entry_stats.into(),
             latest_access_slot: AtomicU64::new(0),
         })
     }
@@ -468,7 +631,7 @@ impl ProgramCacheEntry {
             account_size: self.account_size,
             deployment_slot: self.deployment_slot,
             effective_slot: self.effective_slot,
-            tx_usage_counter: self.tx_usage_counter.clone(),
+            stats: Arc::clone(&self.stats),
             latest_access_slot: AtomicU64::new(self.latest_access_slot.load(Ordering::Relaxed)),
         })
     }
@@ -486,8 +649,8 @@ impl ProgramCacheEntry {
             account_owner: ProgramCacheEntryOwner::NativeLoader,
             account_size,
             effective_slot: deployment_slot,
-            tx_usage_counter: Arc::<AtomicU64>::default(),
             program: ProgramCacheEntryType::Builtin(program),
+            stats: Arc::default(),
             latest_access_slot: AtomicU64::new(0),
         }
     }
@@ -497,19 +660,14 @@ impl ProgramCacheEntry {
         account_owner: ProgramCacheEntryOwner,
         reason: ProgramCacheEntryType,
     ) -> Self {
-        Self::new_tombstone_with_usage_counter(
-            slot,
-            account_owner,
-            reason,
-            Arc::<AtomicU64>::default(),
-        )
+        Self::new_tombstone_with_stats(slot, account_owner, reason, Arc::default())
     }
 
-    pub fn new_tombstone_with_usage_counter(
+    pub fn new_tombstone_with_stats(
         slot: Slot,
         account_owner: ProgramCacheEntryOwner,
         reason: ProgramCacheEntryType,
-        tx_usage_counter: Arc<AtomicU64>,
+        stats: Arc<ProgramStatistics>,
     ) -> Self {
         let tombstone = Self {
             program: reason,
@@ -517,7 +675,7 @@ impl ProgramCacheEntry {
             account_size: 0,
             deployment_slot: slot,
             effective_slot: slot,
-            tx_usage_counter,
+            stats,
             latest_access_slot: AtomicU64::new(0),
         };
         debug_assert!(tombstone.is_tombstone());
@@ -549,7 +707,7 @@ impl ProgramCacheEntry {
         let last_access = self.latest_access_slot.load(Ordering::Relaxed);
         // Shifting the u64 value for more than 63 will cause an overflow.
         let decaying_for = std::cmp::min(63, now.saturating_sub(last_access));
-        self.tx_usage_counter.load(Ordering::Relaxed) >> decaying_for
+        self.stats.uses.load(Ordering::Relaxed) >> decaying_for
     }
 
     pub fn account_owner(&self) -> Pubkey {
@@ -779,11 +937,11 @@ impl ProgramCacheForTxBatch {
                     // Found a program entry on the current fork, but it's not effective
                     // yet. It indicates that the program has delayed visibility. Return
                     // the tombstone to reflect that.
-                    Arc::new(ProgramCacheEntry::new_tombstone_with_usage_counter(
+                    Arc::new(ProgramCacheEntry::new_tombstone_with_stats(
                         entry.deployment_slot,
                         entry.account_owner,
                         ProgramCacheEntryType::DelayVisibility,
-                        entry.tx_usage_counter.clone(),
+                        Arc::clone(&entry.stats),
                     ))
                 } else {
                     entry.clone()
@@ -905,11 +1063,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 return true;
                             }
                         }
-                        // Copy over the usage counter to the new entry
-                        entry.tx_usage_counter.fetch_add(
-                            existing.tx_usage_counter.load(Ordering::Relaxed),
-                            Ordering::Relaxed,
-                        );
+                        entry.stats.merge_from(&existing.stats);
                         *existing = Arc::clone(&entry);
                         self.stats.reloads.fetch_add(1, Ordering::Relaxed);
                     }
@@ -1122,11 +1276,11 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                     // Found a program entry on the current fork, but it's not effective
                                     // yet. It indicates that the program has delayed visibility. Return
                                     // the tombstone to reflect that.
-                                    Arc::new(ProgramCacheEntry::new_tombstone_with_usage_counter(
+                                    Arc::new(ProgramCacheEntry::new_tombstone_with_stats(
                                         entry.deployment_slot,
                                         entry.account_owner,
                                         ProgramCacheEntryType::DelayVisibility,
-                                        entry.tx_usage_counter.clone(),
+                                        Arc::clone(&entry.stats),
                                     ))
                                 } else {
                                     continue;
@@ -1134,9 +1288,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 entry_to_return
                                     .update_access_slot(loaded_programs_for_tx_batch.slot);
                                 if increment_usage_counter {
-                                    entry_to_return
-                                        .tx_usage_counter
-                                        .fetch_add(1, Ordering::Relaxed);
+                                    entry_to_return.stats.uses.fetch_add(1, Ordering::Relaxed);
                                 }
                                 loaded_programs_for_tx_batch
                                     .entries
@@ -1275,7 +1427,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     pub fn sort_and_unload(&mut self, shrink_to: PercentageInteger) {
         let mut sorted_candidates = self.get_flattened_entries();
         sorted_candidates.sort_by_cached_key(|(_id, _last_modification_slot, program)| {
-            program.tx_usage_counter.load(Ordering::Relaxed)
+            program.stats.uses.load(Ordering::Relaxed)
         });
         let num_to_unload = sorted_candidates
             .len()
@@ -1359,7 +1511,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                 // For such entries, `to_unloaded()` will return None.
                 // These entry types do not occupy much memory.
                 if let Some(unloaded) = candidate.to_unloaded() {
-                    if candidate.tx_usage_counter.load(Ordering::Relaxed) == 1 {
+                    if candidate.stats.uses.load(Ordering::Relaxed) == 1 {
                         self.stats.one_hit_wonders.fetch_add(1, Ordering::Relaxed);
                     }
                     self.stats
@@ -1387,6 +1539,68 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             }
         }
     }
+
+    /// Log per-entry statistics for each entry in the global cache.
+    pub fn output_entry_stats(&self) {
+        // The entry stats can become very verbose after some runtime. Rather than dumping them
+        // to the log, we'd rather maintain a continuously updated file instead...
+        static ENTRY_STAT_PATH: std::sync::LazyLock<Option<std::ffi::OsString>> =
+            std::sync::LazyLock::new(|| std::env::var_os("AGAVE_PROGRAM_CACHE_ENTRY_STATS_PATH"));
+        let Some(stat_path) = &*ENTRY_STAT_PATH else {
+            log::trace!("Set AGAVE_PROGRAM_CACHE_ENTRY_STATS_PATH to write per-entry stats");
+            return;
+        };
+        let mut output = String::new();
+        match &self.index {
+            IndexImplementation::V1 { entries, .. } => {
+                for (addr, entry_versions) in entries {
+                    for (idx, entry) in entry_versions.iter().enumerate() {
+                        let entry_ty = match &entry.program {
+                            ProgramCacheEntryType::FailedVerification(_) => "FailedVerification",
+                            ProgramCacheEntryType::Closed => "Closed",
+                            ProgramCacheEntryType::DelayVisibility => "DelayVisibility",
+                            ProgramCacheEntryType::Unloaded(_) => "Unloaded",
+                            ProgramCacheEntryType::Builtin(_) => "Builtin",
+                            #[cfg(not(all(not(target_os = "windows"), target_arch = "x86_64")))]
+                            ProgramCacheEntryType::Loaded(_) => "Loaded",
+                            #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
+                            ProgramCacheEntryType::Loaded(executable) => {
+                                if executable.get_compiled_program().is_some() {
+                                    "JitCompiled"
+                                } else {
+                                    "Loaded"
+                                }
+                            }
+                        };
+                        let stats = &entry.stats;
+                        let uses = stats.uses.load(Ordering::Relaxed);
+                        let compiles = stats.compilations.load(Ordering::Relaxed);
+                        let comptime = stats.total_compilation_time_us.load(Ordering::Relaxed);
+                        let comptime_ema =
+                            stats.compilation_time_ema.load(Ordering::Relaxed) / EMA_SCALE;
+                        let invokes = stats.jit_invocations.load(Ordering::Relaxed);
+                        let jittime = stats.total_jit_execution_time_us.load(Ordering::Relaxed);
+                        let jittime_ema =
+                            stats.jit_execution_time_ema.load(Ordering::Relaxed) / EMA_SCALE;
+                        let interps = stats.interpreted_invocations.load(Ordering::Relaxed);
+                        let interptime = stats.total_interpretation_time_us.load(Ordering::Relaxed);
+                        let interpema =
+                            stats.interpretation_time_ema.load(Ordering::Relaxed) / EMA_SCALE;
+                        let _ = writeln!(
+                            &mut output,
+                            "{addr},{idx},{entry_ty},{uses},{compiles},{comptime},{comptime_ema},\
+                             {invokes},{jittime},{jittime_ema},{interps},{interptime},{interpema}"
+                        );
+                    }
+                }
+            }
+        }
+        if let Err(e) = std::fs::write(stat_path, output) {
+            log::info!("Writing entry stats to {stat_path:?} failed: {e:?}");
+        } else {
+            log::debug!("Entry stats written to {stat_path:?}");
+        }
+    }
 }
 
 #[cfg(feature = "frozen-abi")]
@@ -1412,7 +1626,7 @@ mod tests {
             BlockRelation, DELAY_VISIBILITY_SLOT_OFFSET, ForkGraph, ProgramCache,
             ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
             ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
-            get_mock_program_runtime_environment,
+            ProgramStatistics, get_mock_program_runtime_environment,
         },
         assert_matches::assert_matches,
         percentage::Percentage,
@@ -1432,7 +1646,11 @@ mod tests {
     };
 
     fn new_test_entry(deployment_slot: Slot, effective_slot: Slot) -> Arc<ProgramCacheEntry> {
-        new_test_entry_with_usage(deployment_slot, effective_slot, AtomicU64::default())
+        new_test_entry_with_usage(
+            deployment_slot,
+            effective_slot,
+            ProgramStatistics::default(),
+        )
     }
 
     fn new_loaded_entry(env: ProgramRuntimeEnvironment) -> ProgramCacheEntryType {
@@ -1448,7 +1666,7 @@ mod tests {
     fn new_test_entry_with_usage(
         deployment_slot: Slot,
         effective_slot: Slot,
-        usage_counter: AtomicU64,
+        stats: ProgramStatistics,
     ) -> Arc<ProgramCacheEntry> {
         Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(get_mock_program_runtime_environment()),
@@ -1456,7 +1674,7 @@ mod tests {
             account_size: 0,
             deployment_slot,
             effective_slot,
-            tx_usage_counter: Arc::new(usage_counter),
+            stats: Arc::new(stats),
             latest_access_slot: AtomicU64::new(deployment_slot),
         })
     }
@@ -1471,7 +1689,7 @@ mod tests {
             account_size: 0,
             deployment_slot,
             effective_slot,
-            tx_usage_counter: Arc::default(),
+            stats: Arc::default(),
             latest_access_slot: AtomicU64::default(),
         })
     }
@@ -1501,7 +1719,7 @@ mod tests {
         let loaded = new_test_entry_with_usage(
             current_slot,
             current_slot.saturating_add(1),
-            AtomicU64::default(),
+            ProgramStatistics::default(),
         );
         let unloaded = Arc::new(loaded.to_unloaded().expect("Failed to unload the program"));
         cache.assign_program(&env, key, current_slot, unloaded.clone());
@@ -1522,7 +1740,11 @@ mod tests {
 
     #[test]
     fn test_usage_counter_decay() {
-        let program = new_test_entry_with_usage(10, 11, AtomicU64::new(32));
+        let stats = ProgramStatistics {
+            uses: AtomicU64::new(32),
+            ..Default::default()
+        };
+        let program = new_test_entry_with_usage(10, 11, stats);
         program.update_access_slot(15);
         assert_eq!(program.decayed_usage_counter(15), 32);
         assert_eq!(program.decayed_usage_counter(16), 16);
@@ -1562,6 +1784,10 @@ mod tests {
             .enumerate()
             .for_each(|(i, deployment_slot)| {
                 let usage_counter = *usage_counters.get(i).unwrap_or(&0);
+                let stats = ProgramStatistics {
+                    uses: usage_counter.into(),
+                    ..Default::default()
+                };
                 cache.assign_program(
                     &env,
                     program,
@@ -1569,7 +1795,7 @@ mod tests {
                     new_test_entry_with_usage(
                         *deployment_slot,
                         (*deployment_slot).saturating_add(2),
-                        AtomicU64::new(usage_counter),
+                        stats,
                     ),
                 );
                 programs.push((program, *deployment_slot, usage_counter));
@@ -1759,7 +1985,7 @@ mod tests {
             .iter()
             .filter_map(|(key, program)| {
                 matches!(program.program, ProgramCacheEntryType::Unloaded(_))
-                    .then_some((*key, program.tx_usage_counter.load(Ordering::Relaxed)))
+                    .then_some((*key, program.stats.uses.load(Ordering::Relaxed)))
             })
             .collect::<Vec<(Pubkey, u64)>>();
 
@@ -1804,12 +2030,12 @@ mod tests {
         // Add enough programs to the cache to trigger 1 eviction after shrinking.
         let num_total_programs = (cache_capacity_after_shrink + 1) as u64;
         (0..num_total_programs).for_each(|i| {
-            cache.assign_program(
-                &env,
-                program,
-                i,
-                new_test_entry_with_usage(i, i + 2, AtomicU64::new(i + 10)),
-            );
+            let stats = ProgramStatistics {
+                uses: (i + 10).into(),
+                ..Default::default()
+            };
+            let entry = new_test_entry_with_usage(i, i + 2, stats);
+            cache.assign_program(&env, program, i, entry);
         });
 
         cache.sort_and_unload(Percentage::from(evict_to_pct));
@@ -1825,7 +2051,7 @@ mod tests {
             .for_each(|(_key, program)| {
                 if matches!(program.program, ProgramCacheEntryType::Unloaded(_)) {
                     // Test that the usage counter is retained for the unloaded program
-                    assert_eq!(program.tx_usage_counter.load(Ordering::Relaxed), 10);
+                    assert_eq!(program.stats.uses.load(Ordering::Relaxed), 10);
                     assert_eq!(program.deployment_slot, 0);
                     assert_eq!(program.effective_slot, 2);
                 }
@@ -1837,7 +2063,7 @@ mod tests {
             &env,
             program,
             0,
-            new_test_entry_with_usage(0, 2, AtomicU64::new(0)),
+            new_test_entry_with_usage(0, 2, ProgramStatistics::default()),
         );
 
         cache
@@ -1849,7 +2075,7 @@ mod tests {
                     && program.effective_slot == 2
                 {
                     // Test that the usage counter was correctly updated.
-                    assert_eq!(program.tx_usage_counter.load(Ordering::Relaxed), 10);
+                    assert_eq!(program.stats.uses.load(Ordering::Relaxed), 10);
                 }
             });
     }
@@ -1875,7 +2101,7 @@ mod tests {
                     account_size: 0,
                     deployment_slot,
                     effective_slot,
-                    tx_usage_counter: Arc::new(AtomicU64::default()),
+                    stats: Arc::default(),
                     latest_access_slot: AtomicU64::new(deployment_slot),
                 });
                 assert!(!cache.assign_program(&env, program_id, deployment_slot, entry));
@@ -1939,7 +2165,7 @@ mod tests {
                 account_size: 0,
                 deployment_slot: 10,
                 effective_slot: 11,
-                tx_usage_counter: Arc::default(),
+                stats: Arc::default(),
                 latest_access_slot: AtomicU64::default(),
             }),
         ));
@@ -1953,7 +2179,7 @@ mod tests {
                 account_size: 0,
                 deployment_slot: 10,
                 effective_slot: 11,
-                tx_usage_counter: Arc::default(),
+                stats: Arc::default(),
                 latest_access_slot: AtomicU64::default(),
             }),
         );
@@ -1983,7 +2209,7 @@ mod tests {
                 account_size: 0,
                 deployment_slot: 10,
                 effective_slot: 11,
-                tx_usage_counter: Arc::default(),
+                stats: Arc::default(),
                 latest_access_slot: AtomicU64::default(),
             }),
         ));
@@ -1997,7 +2223,7 @@ mod tests {
                 account_size: 0,
                 deployment_slot: 10,
                 effective_slot: 11,
-                tx_usage_counter: Arc::default(),
+                stats: Arc::default(),
                 latest_access_slot: AtomicU64::default(),
             }),
         ));
@@ -2014,7 +2240,7 @@ mod tests {
             account_size: 0,
             deployment_slot: 9,
             effective_slot: 9,
-            tx_usage_counter: Arc::default(),
+            stats: Arc::default(),
             latest_access_slot: AtomicU64::default(),
         });
         let closed_current_slot = Arc::new(ProgramCacheEntry {
@@ -2023,7 +2249,7 @@ mod tests {
             account_size: 0,
             deployment_slot: 10,
             effective_slot: 10,
-            tx_usage_counter: Arc::default(),
+            stats: Arc::default(),
             latest_access_slot: AtomicU64::default(),
         });
         let loaded_entry_current_env = Arc::new(ProgramCacheEntry {
@@ -2032,7 +2258,7 @@ mod tests {
             account_size: 0,
             deployment_slot: 10,
             effective_slot: 11,
-            tx_usage_counter: Arc::default(),
+            stats: Arc::default(),
             latest_access_slot: AtomicU64::default(),
         });
         let loaded_entry_upcoming_env = Arc::new(ProgramCacheEntry {
@@ -2043,7 +2269,7 @@ mod tests {
             account_size: 0,
             deployment_slot: 10,
             effective_slot: 11,
-            tx_usage_counter: Arc::default(),
+            stats: Arc::default(),
             latest_access_slot: AtomicU64::default(),
         });
         assert!(!cache.assign_program(&env, program_id, 9, closed_other_slot.clone()));
@@ -2203,12 +2429,9 @@ mod tests {
         let upcoming_environment = Some(new_env.clone());
         let updated_program = Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(new_env.clone()),
-            account_owner: ProgramCacheEntryOwner::LoaderV2,
-            account_size: 0,
             deployment_slot: 20,
             effective_slot: 20,
-            tx_usage_counter: Arc::default(),
-            latest_access_slot: AtomicU64::default(),
+            ..Default::default()
         });
         cache.assign_program(
             &env,
@@ -2748,7 +2971,7 @@ mod tests {
                 account_size: 0,
                 deployment_slot: 0,
                 effective_slot: 0,
-                tx_usage_counter: Arc::default(),
+                stats: Arc::default(),
                 latest_access_slot: AtomicU64::default(),
             });
             assert!(entry.to_unloaded().is_none());
@@ -2761,12 +2984,16 @@ mod tests {
             assert!(cache.stats.evictions.is_empty());
         }
 
-        let entry = new_test_entry_with_usage(1, 2, AtomicU64::new(3));
+        let stats = ProgramStatistics {
+            uses: 3.into(),
+            ..Default::default()
+        };
+        let entry = new_test_entry_with_usage(1, 2, stats);
         let unloaded_entry = entry.to_unloaded().unwrap();
         assert_eq!(unloaded_entry.deployment_slot, 1);
         assert_eq!(unloaded_entry.effective_slot, 2);
         assert_eq!(unloaded_entry.latest_access_slot.load(Ordering::Relaxed), 1);
-        assert_eq!(unloaded_entry.tx_usage_counter.load(Ordering::Relaxed), 3);
+        assert_eq!(unloaded_entry.stats.uses.load(Ordering::Relaxed), 3);
 
         // Check that unload_program_entry() does its work
         let program_id = Pubkey::new_unique();
@@ -2934,7 +3161,11 @@ mod tests {
             &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(1)
         ));
 
-        let program = Arc::new(new_test_entry_with_usage(0, 1, AtomicU64::default()));
+        let program = Arc::new(new_test_entry_with_usage(
+            0,
+            1,
+            ProgramStatistics::default(),
+        ));
 
         assert!(ProgramCache::<TestForkGraph>::matches_criteria(
             &program,

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -6,6 +6,7 @@ use {
     crate::{
         execution_budget::MAX_INSTRUCTION_STACK_DEPTH,
         invoke_context::{BpfAllocator, InvokeContext, SerializedAccountMetadata, SyscallContext},
+        loaded_programs::ProgramCacheEntry,
         mem_pool::VmMemoryPool,
         serialization, stable_log,
     },
@@ -22,7 +23,7 @@ use {
     solana_svm_log_collector::ic_logger_msg,
     solana_svm_measure::measure::Measure,
     solana_transaction_context::{IndexOfAccount, transaction::TransactionContext},
-    std::{cell::RefCell, mem},
+    std::{cell::RefCell, mem, time::Duration},
 };
 
 thread_local! {
@@ -155,6 +156,7 @@ macro_rules! create_vm {
 pub fn execute<'a, 'b: 'a>(
     executable: &'a Executable<InvokeContext<'static, 'static>>,
     invoke_context: &'a mut InvokeContext<'b, 'b>,
+    cache_entry: &ProgramCacheEntry,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // We dropped the lifetime tracking in the Executor by setting it to 'static,
     // thus we need to reintroduce the correct lifetime of InvokeContext here again.
@@ -251,9 +253,11 @@ pub fn execute<'a, 'b: 'a>(
             vm.debug_port = debug_port;
             vm.debug_metadata = Some(debug_metadata);
         }
-        vm.context_object_pointer.execute_time = Some(Measure::start("execute"));
-        vm.registers[1] = ebpf::MM_INPUT_START;
 
+        let execute_time = Measure::start("execute");
+        let prev_nested_exec_time = vm.context_object_pointer.total_nested_exec_time;
+
+        vm.registers[1] = ebpf::MM_INPUT_START;
         // SIMD-0321: Provide offset to instruction data in VM register 2.
         if provide_instruction_data_offset_in_vm_r2 {
             vm.registers[2] = instruction_data_offset as u64;
@@ -268,9 +272,23 @@ pub fn execute<'a, 'b: 'a>(
         });
         drop(vm);
         invoke_context.insert_register_trace(register_trace);
-        if let Some(execute_time) = invoke_context.execute_time.as_mut() {
-            execute_time.stop();
-            invoke_context.timings.execute_us += execute_time.as_us();
+
+        // This section is a little convoluted due to the nested and sibling (CPI) invocations.
+        let total_execute_ns = execute_time.end_as_ns();
+        let nested_execution_time_delta = invoke_context
+            .total_nested_exec_time
+            .saturating_sub(prev_nested_exec_time);
+        let this_call_ns =
+            total_execute_ns.saturating_sub(nested_execution_time_delta.as_nanos() as u64);
+        invoke_context.total_nested_exec_time = invoke_context
+            .total_nested_exec_time
+            .saturating_add(Duration::from_nanos(this_call_ns));
+        let this_call_us = this_call_ns / 1000;
+        invoke_context.timings.execute_us += this_call_us;
+        match execution_mode {
+            ExecutionMode::Interpreted => cache_entry.stats.interpreter_executed(this_call_us),
+            ExecutionMode::Jit => cache_entry.stats.jit_executed(this_call_us),
+            ExecutionMode::PreferJit => { /* not actually executed? */ }
         }
 
         ic_logger_msg!(

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -135,17 +135,7 @@ pub(crate) fn process_instruction_inner<'a>(
             ic_logger_msg!(log_collector, "Program is not deployed");
             Err(Box::new(InstructionError::UnsupportedProgramId) as Box<dyn std::error::Error>)
         }
-        ProgramCacheEntryType::Loaded(executable) => {
-            let mut timer = Measure::start("execute");
-            let result = execute(executable, invoke_context);
-            timer.stop();
-            if executable.get_compiled_program().is_some() {
-                executor.stats.jit_executed(timer.as_us());
-            } else {
-                executor.stats.interpreter_executed(timer.as_us());
-            }
-            result
-        }
+        ProgramCacheEntryType::Loaded(executable) => execute(executable, invoke_context, &executor),
         _ => Err(Box::new(InstructionError::UnsupportedProgramId) as Box<dyn std::error::Error>),
     }
     .map(|_| 0)
@@ -1242,9 +1232,10 @@ mod tests {
         solana_epoch_schedule::EpochSchedule,
         solana_instruction::{AccountMeta, error::InstructionError},
         solana_program_runtime::{
-            invoke_context::mock_process_instruction, loaded_programs::ProgramRuntimeEnvironment,
-            loaded_programs::ProgramStatistics,
-            vm::calculate_heap_cost, with_mock_invoke_context,
+            invoke_context::mock_process_instruction,
+            loaded_programs::{ProgramRuntimeEnvironment, ProgramStatistics},
+            vm::calculate_heap_cost,
+            with_mock_invoke_context,
         },
         solana_pubkey::Pubkey,
         solana_rent::Rent,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -135,7 +135,17 @@ pub(crate) fn process_instruction_inner<'a>(
             ic_logger_msg!(log_collector, "Program is not deployed");
             Err(Box::new(InstructionError::UnsupportedProgramId) as Box<dyn std::error::Error>)
         }
-        ProgramCacheEntryType::Loaded(executable) => execute(executable, invoke_context),
+        ProgramCacheEntryType::Loaded(executable) => {
+            let mut timer = Measure::start("execute");
+            let result = execute(executable, invoke_context);
+            timer.stop();
+            if executable.get_compiled_program().is_some() {
+                executor.stats.jit_executed(timer.as_us());
+            } else {
+                executor.stats.interpreter_executed(timer.as_us());
+            }
+            result
+        }
         _ => Err(Box::new(InstructionError::UnsupportedProgramId) as Box<dyn std::error::Error>),
     }
     .map(|_| 0)
@@ -1233,6 +1243,7 @@ mod tests {
         solana_instruction::{AccountMeta, error::InstructionError},
         solana_program_runtime::{
             invoke_context::mock_process_instruction, loaded_programs::ProgramRuntimeEnvironment,
+            loaded_programs::ProgramStatistics,
             vm::calculate_heap_cost, with_mock_invoke_context,
         },
         solana_pubkey::Pubkey,
@@ -3375,13 +3386,17 @@ mod tests {
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
         let program_id = Pubkey::new_unique();
         let env = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
+        let stats = ProgramStatistics {
+            uses: 100.into(),
+            ..Default::default()
+        };
         let program = ProgramCacheEntry {
             program: ProgramCacheEntryType::Unloaded(env),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
             account_size: 0,
             deployment_slot: 0,
             effective_slot: 0,
-            tx_usage_counter: Arc::new(AtomicU64::new(100)),
+            stats: stats.into(),
             latest_access_slot: AtomicU64::new(0),
         };
         invoke_context
@@ -3402,10 +3417,7 @@ mod tests {
             .expect("Didn't find upgraded program in the cache");
 
         assert_eq!(updated_program.deployment_slot, 2);
-        assert_eq!(
-            updated_program.tx_usage_counter.load(Ordering::Relaxed),
-            100
-        );
+        assert_eq!(updated_program.stats.uses.load(Ordering::Relaxed), 100);
     }
 
     #[test]
@@ -3417,13 +3429,17 @@ mod tests {
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
         let program_id = Pubkey::new_unique();
         let env = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
+        let stats = ProgramStatistics {
+            uses: 100.into(),
+            ..Default::default()
+        };
         let program = ProgramCacheEntry {
             program: ProgramCacheEntryType::Unloaded(env),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
             account_size: 0,
             deployment_slot: 0,
             effective_slot: 0,
-            tx_usage_counter: Arc::new(AtomicU64::new(100)),
+            stats: stats.into(),
             latest_access_slot: AtomicU64::new(0),
         };
         invoke_context
@@ -3445,6 +3461,6 @@ mod tests {
             .expect("Didn't find upgraded program in the cache");
 
         assert_eq!(program2.deployment_slot, 2);
-        assert_eq!(program2.tx_usage_counter.load(Ordering::Relaxed), 0);
+        assert_eq!(program2.stats.uses.load(Ordering::Relaxed), 0);
     }
 }

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -485,7 +485,9 @@ fn process_instruction_inner<'a>(
                 ic_logger_msg!(log_collector, "Program is not deployed");
                 Err(Box::new(InstructionError::UnsupportedProgramId) as Box<dyn std::error::Error>)
             }
-            ProgramCacheEntryType::Loaded(executable) => execute(executable, invoke_context),
+            ProgramCacheEntryType::Loaded(executable) => {
+                execute(executable, invoke_context, &loaded_program)
+            }
             _ => {
                 Err(Box::new(InstructionError::UnsupportedProgramId) as Box<dyn std::error::Error>)
             }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -193,7 +193,7 @@ use {
             Arc, LazyLock, LockResult, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak,
             atomic::{
                 AtomicBool, AtomicI64, AtomicU64,
-                Ordering::{self, AcqRel, Acquire, Relaxed},
+                Ordering::{AcqRel, Acquire, Relaxed},
             },
         },
         time::{Duration, Instant},
@@ -1512,8 +1512,7 @@ impl Bank {
                 .transaction_processor
                 .global_program_cache
                 .read()
-                .unwrap()
-                .stats,
+                .unwrap(),
             parent.slot(),
         );
 
@@ -1573,12 +1572,7 @@ impl Bank {
                     self.slot,
                     &mut ExecuteTimings::default(),
                 ) {
-                    recompiled.tx_usage_counter.fetch_add(
-                        program_to_recompile
-                            .tx_usage_counter
-                            .load(Ordering::Relaxed),
-                        Ordering::Relaxed,
-                    );
+                    recompiled.stats.merge_from(&program_to_recompile.stats);
                     let mut program_cache = self
                         .transaction_processor
                         .global_program_cache

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -1,7 +1,7 @@
 use {
     crate::bank::Bank,
     solana_clock::{Epoch, Slot},
-    solana_program_runtime::loaded_programs::ProgramCacheStats,
+    solana_program_runtime::loaded_programs::{ForkGraph, ProgramCache},
     std::sync::atomic::{
         AtomicU64,
         Ordering::{self, Relaxed},
@@ -205,7 +205,8 @@ pub(crate) fn report_partitioned_reward_metrics(bank: &Bank, timings: RewardsSto
 }
 
 /// Logs the measurement values
-pub(crate) fn report_loaded_programs_stats(stats: &ProgramCacheStats, slot: Slot) {
+pub(crate) fn report_loaded_programs_stats<T: ForkGraph>(cache: &ProgramCache<T>, slot: Slot) {
+    let stats = &cache.stats;
     let hits = stats.hits.load(Ordering::Relaxed);
     let misses = stats.misses.load(Ordering::Relaxed);
     let evictions: u64 = stats.evictions.values().sum();
@@ -235,4 +236,5 @@ pub(crate) fn report_loaded_programs_stats(stats: &ProgramCacheStats, slot: Slot
         ("water_level", water_level, i64),
     );
     stats.log();
+    cache.output_entry_stats();
 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -805,7 +805,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let mut program_accounts_set = HashMap::default();
         for account_key in tx.account_keys().iter() {
             if let Some(cache_entry) = program_cache_for_tx_batch.find(account_key) {
-                cache_entry.tx_usage_counter.fetch_add(1, Ordering::Relaxed);
+                cache_entry.stats.uses.fetch_add(1, Ordering::Relaxed);
             } else if let Some((account, last_modification_slot)) =
                 account_loader.get_account_shared_data(account_key)
                 && PROGRAM_OWNERS.contains(account.owner())

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -3019,7 +3019,7 @@ fn program_cache_stats() {
         .unwrap();
 
     assert_eq!(
-        noop_entry.tx_usage_counter.load(Ordering::Relaxed),
+        noop_entry.stats.uses.load(Ordering::Relaxed),
         noop_tx_usage,
         "noop_tx_usage matches"
     );
@@ -3030,7 +3030,7 @@ fn program_cache_stats() {
         .unwrap();
 
     assert_eq!(
-        system_entry.tx_usage_counter.load(Ordering::Relaxed),
+        system_entry.stats.uses.load(Ordering::Relaxed),
         system_tx_usage,
         "system_tx_usage matches"
     );
@@ -3092,7 +3092,7 @@ fn program_cache_stats() {
         .unwrap();
 
     assert_eq!(
-        noop_entry.tx_usage_counter.load(Ordering::Relaxed),
+        noop_entry.stats.uses.load(Ordering::Relaxed),
         noop_tx_usage,
         "noop_tx_usage matches"
     );
@@ -3127,7 +3127,7 @@ fn program_cache_stats() {
         .unwrap();
 
     assert_eq!(
-        noop_entry.tx_usage_counter.load(Ordering::Relaxed),
+        noop_entry.stats.uses.load(Ordering::Relaxed),
         noop_tx_usage,
         "noop_tx_usage matches"
     );


### PR DESCRIPTION
In particular track types of execution and the total time taken for each. In addition to the totals that could be useful to report as metrics we'll also track a decaying mean of each execution type to inform JIT tiering decisions, or just as a convenient "here's how much time things take" look.

This PR does not actually report these metrics out to influx for the simple reason that the cardinality of these metrics is relatively high. For each program (1000s) there are 11 metrics each available every slot (600ms.) This means 18333 datapoints per second per node. Way too much!

Instead I opted to make it possible to optionally write out these stats into a csv-like file which can then be analyzed in whatever way that's convenient. E.g. a `top`-like view of the entry cache can be had with a simple command like:

```
watch -n0.6 "bash -c 'sort -t, -k4 -h -r entry-stats.csv | column -s, -t'"
```

Which looks sorta like this:

https://github.com/user-attachments/assets/fcdbb9ec-df9e-4139-919b-2adfc2d5cc24

Note that this PR somewhat intentionally avoids the `ExecuteDetailsTimings::per_program_timings` in part because threading the data into them is pretty onerous, in part because submitting them to Influx is not desired at least in the current iteration. The execution counts and totals aren't actually needed for JIT scoring so I could remove them altogether, they're just nice to have and were cheap to add...

I also ended up replacing uses of `Measure` with a new `Stopwatch` type based on the understanding that the affected crate(s) are migrating to a different repository shortly and want to avoid dependencies on `agave` stuff anyway. For the most part this is motivated by needing to access execution timings and the way they were implemented previously made doing so difficult.