### PR TITLE
runtime: compile programs in a dedicated thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10151,6 +10151,8 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 [[package]]
 name = "solana-sbpf"
 version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b120fcbbc0d8562997183bef32c76a28400ecae7d8c9fff279d33002783a29"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9461,6 +9461,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "cfg-if 1.0.4",
+ "crossbeam-channel",
  "itertools 0.14.0",
  "log",
  "percentage",
@@ -10150,8 +10151,6 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 [[package]]
 name = "solana-sbpf"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b120fcbbc0d8562997183bef32c76a28400ecae7d8c9fff279d33002783a29"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -608,3 +608,4 @@ codegen-units = 1
 [patch.crates-io]
 # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
+solana-sbpf = { path = "../sbpf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -608,4 +608,3 @@ codegen-units = 1
 [patch.crates-io]
 # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
-solana-sbpf = { path = "../sbpf" }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8156,6 +8156,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "cfg-if 1.0.4",
+ "crossbeam-channel",
  "itertools 0.14.0",
  "log",
  "percentage",

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -74,6 +74,7 @@ solana-sysvar = { workspace = true, features = ["bincode"] }
 solana-sysvar-id = { workspace = true }
 solana-transaction-context = { workspace = true }
 thiserror = { workspace = true }
+crossbeam-channel = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -31,6 +31,7 @@ svm-internal = ["dep:qualifier_attr"]
 base64 = { workspace = true }
 bincode = { workspace = true }
 cfg-if = { workspace = true }
+crossbeam-channel = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 percentage = { workspace = true }
@@ -74,7 +75,6 @@ solana-sysvar = { workspace = true, features = ["bincode"] }
 solana-sysvar-id = { workspace = true }
 solana-transaction-context = { workspace = true }
 thiserror = { workspace = true }
-crossbeam-channel = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -18,8 +18,8 @@ pub mod program_metrics;
 pub mod serialization;
 pub mod stable_log;
 pub mod sysvar_cache;
-pub mod vm;
 pub mod threaded_compilation;
+pub mod vm;
 
 // re-exports for macros
 pub mod __private {

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -19,6 +19,7 @@ pub mod serialization;
 pub mod stable_log;
 pub mod sysvar_cache;
 pub mod vm;
+mod threaded_compilation;
 
 // re-exports for macros
 pub mod __private {

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -19,7 +19,7 @@ pub mod serialization;
 pub mod stable_log;
 pub mod sysvar_cache;
 pub mod vm;
-mod threaded_compilation;
+pub mod threaded_compilation;
 
 // re-exports for macros
 pub mod __private {

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -3,7 +3,7 @@ use {
         invoke_context::InvokeContext,
         loading_task::LoadingTaskWaiter,
         program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryType, retention_score},
-        program_metrics::{EMA_SCALE, ProgramCacheStats},
+        program_metrics::{EMA_SCALE, ProgramCacheStats}, threaded_compilation::CompilationWorker,
     },
     log::error,
     percentage::PercentageInteger,
@@ -230,6 +230,9 @@ pub struct ProgramCache<FG: ForkGraph> {
     pub fork_graph: Option<Weak<RwLock<FG>>>,
     /// Coordinates TX batches waiting for others to complete their task during cooperative loading
     pub loading_task_waiter: Arc<LoadingTaskWaiter>,
+    /// As programs are extracted, we'll check if they are a candidate for compilation and send the
+    /// request to compile to a dedicated compilation thread.
+    pub compilation_worker: CompilationWorker,
 }
 
 impl<FG: ForkGraph> std::fmt::Debug for ProgramCache<FG> {
@@ -358,6 +361,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             stats: ProgramCacheStats::default(),
             fork_graph: None,
             loading_task_waiter: Arc::new(LoadingTaskWaiter::default()),
+            compilation_worker: CompilationWorker::new(),
         }
     }
 
@@ -577,6 +581,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         program_runtime_environment_for_execution: &ProgramRuntimeEnvironment,
         increment_usage_counter: bool,
         count_hits_and_misses: bool,
+        on_found_loaded: impl Fn(&Pubkey, &Arc<ProgramCacheEntry>),
     ) -> Option<Pubkey> {
         debug_assert!(self.fork_graph.is_some());
         let fork_graph = self.fork_graph.as_ref().unwrap().upgrade().unwrap();
@@ -651,6 +656,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 };
                                 entry_to_return
                                     .update_access_slot(loaded_programs_for_tx_batch.slot);
+                                on_found_loaded(key, &entry_to_return);
                                 if increment_usage_counter {
                                     entry_to_return.stats.uses.fetch_add(1, Ordering::Relaxed);
                                 }
@@ -797,9 +803,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         let num_to_unload = sorted_candidates
             .len()
             .saturating_sub(shrink_to.apply_to(MAX_LOADED_ENTRY_COUNT));
-        for (program, last_modification_slot, entry) in sorted_candidates.iter().take(num_to_unload)
-        {
-            self.unload_program_entry(*program, *last_modification_slot, entry);
+        for (program, last_modification_slot, entry) in sorted_candidates.drain(..num_to_unload) {
+            self.unload_program_entry(program, last_modification_slot, &entry);
         }
     }
 
@@ -1923,7 +1928,7 @@ pub(crate) mod tests {
         assert!(match_missing(&missing, &program2, false));
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(22);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 20, 22));
         assert!(match_slot(&extracted, &program4, 0, 22));
 
@@ -1932,7 +1937,7 @@ pub(crate) mod tests {
             get_entries_to_load(&cache, 15, &[program1, program2, program3, program4]);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(15);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 15));
         assert!(match_slot(&extracted, &program2, 11, 15));
         // The effective slot of program4 deployed in slot 15 is 19. So it should not be usable in slot 16.
@@ -1948,7 +1953,7 @@ pub(crate) mod tests {
             get_entries_to_load(&cache, 18, &[program1, program2, program3, program4]);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(18);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 18));
         assert!(match_slot(&extracted, &program2, 11, 18));
         // The effective slot of program4 deployed in slot 15 is 18. So it should be usable in slot 18.
@@ -1959,7 +1964,7 @@ pub(crate) mod tests {
             get_entries_to_load(&cache, 23, &[program1, program2, program3, program4]);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(23);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 23));
         assert!(match_slot(&extracted, &program2, 11, 23));
         // The effective slot of program4 deployed in slot 15 is 19. So it should be usable in slot 23.
@@ -1970,7 +1975,7 @@ pub(crate) mod tests {
             get_entries_to_load(&cache, 11, &[program1, program2, program3, program4]);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(11);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 11));
         // program2 was updated at slot 11, but is not effective till slot 12. The result should contain a tombstone.
         let tombstone = extracted
@@ -2002,7 +2007,7 @@ pub(crate) mod tests {
             get_entries_to_load(&cache, 21, &[program1, program2, program3, program4]);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(21);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         // Since the fork was pruned, we should not find the entry deployed at slot 20.
         assert!(match_slot(&extracted, &program1, 0, 21));
         assert!(match_slot(&extracted, &program2, 11, 21));
@@ -2012,7 +2017,7 @@ pub(crate) mod tests {
         let mut missing =
             get_entries_to_load(&cache, 27, &[program1, program2, program3, program4]);
         let mut extracted = ProgramCacheForTxBatch::new(27);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 27));
         assert!(match_slot(&extracted, &program2, 11, 27));
         assert!(match_slot(&extracted, &program3, 25, 27));
@@ -2040,7 +2045,7 @@ pub(crate) mod tests {
             get_entries_to_load(&cache, 23, &[program1, program2, program3, program4]);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(23);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 23));
         assert!(match_slot(&extracted, &program2, 11, 23));
         assert!(match_slot(&extracted, &program4, 15, 23));
@@ -2089,7 +2094,7 @@ pub(crate) mod tests {
         let mut missing = get_entries_to_load(&cache, 12, &[program1, program2, program3]);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(12);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 12));
         assert!(match_slot(&extracted, &program2, 11, 12));
 
@@ -2099,7 +2104,7 @@ pub(crate) mod tests {
         missing.get_mut(1).unwrap().1 = ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(5);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(12);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_missing(&missing, &program1, true));
         assert!(match_slot(&extracted, &program2, 11, 12));
     }
@@ -2162,14 +2167,14 @@ pub(crate) mod tests {
         let mut missing = get_entries_to_load(&cache, 19, &[program1, program2, program3]);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(19);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 19));
         assert!(match_slot(&extracted, &program2, 11, 19));
 
         // Testing fork 0 - 5 - 11 - 25 - 27 with current slot at 27
         let mut missing = get_entries_to_load(&cache, 27, &[program1, program2, program3]);
         let mut extracted = ProgramCacheForTxBatch::new(27);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 27));
         assert!(match_slot(&extracted, &program2, 11, 27));
         assert!(match_missing(&missing, &program3, true));
@@ -2178,7 +2183,7 @@ pub(crate) mod tests {
         let mut missing = get_entries_to_load(&cache, 22, &[program1, program2, program3]);
         assert!(match_missing(&missing, &program2, false));
         let mut extracted = ProgramCacheForTxBatch::new(22);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 20, 22));
         assert!(match_missing(&missing, &program3, true));
     }
@@ -2220,13 +2225,20 @@ pub(crate) mod tests {
         // Testing fork 0 - 10 - 20 - 22 with current slot at 22
         let mut missing = get_entries_to_load(&cache, 22, &[program1]);
         let mut extracted = ProgramCacheForTxBatch::new(22);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 20, 22));
 
         // Looking for a different environment
         let mut missing = get_entries_to_load(&cache, 22, &[program1]);
         let mut extracted = ProgramCacheForTxBatch::new(22);
-        cache.extract(&mut missing, &mut extracted, &other_env, true, true);
+        cache.extract(
+            &mut missing,
+            &mut extracted,
+            &other_env,
+            true,
+            true,
+            |_, _| {},
+        );
         assert!(match_missing(&missing, &program1, true));
     }
 
@@ -2241,7 +2253,7 @@ pub(crate) mod tests {
         let program1 = Pubkey::new_unique();
         let mut missing = vec![(program1, ProgramCacheMatchCriteria::NoCriteria, 0)];
         let mut extracted = ProgramCacheForTxBatch::new(0);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_missing(&missing, &program1, true));
     }
 
@@ -2321,7 +2333,7 @@ pub(crate) mod tests {
 
         let mut missing = get_entries_to_load(&cache, 20, &[program1]);
         let mut extracted = ProgramCacheForTxBatch::new(20);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
 
         // The cache should have the program deployed at slot 0
         assert_eq!(
@@ -2363,14 +2375,14 @@ pub(crate) mod tests {
 
         let mut missing = get_entries_to_load(&cache, 20, &[program1, program2]);
         let mut extracted = ProgramCacheForTxBatch::new(20);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 20));
         assert!(match_slot(&extracted, &program2, 10, 20));
 
         let mut missing = get_entries_to_load(&cache, 6, &[program1, program2]);
         assert!(match_missing(&missing, &program2, false));
         let mut extracted = ProgramCacheForTxBatch::new(6);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 5, 6));
 
         // Pruning slot 5 will remove program1 entry deployed at slot 5.
@@ -2379,14 +2391,14 @@ pub(crate) mod tests {
 
         let mut missing = get_entries_to_load(&cache, 20, &[program1, program2]);
         let mut extracted = ProgramCacheForTxBatch::new(20);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 20));
         assert!(match_slot(&extracted, &program2, 10, 20));
 
         let mut missing = get_entries_to_load(&cache, 6, &[program1, program2]);
         assert!(match_missing(&missing, &program2, false));
         let mut extracted = ProgramCacheForTxBatch::new(6);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 6));
 
         // Pruning slot 10 will remove program2 entry deployed at slot 10.
@@ -2396,7 +2408,7 @@ pub(crate) mod tests {
         let mut missing = get_entries_to_load(&cache, 20, &[program1, program2]);
         assert!(match_missing(&missing, &program2, false));
         let mut extracted = ProgramCacheForTxBatch::new(20);
-        cache.extract(&mut missing, &mut extracted, &env, true, true);
+        cache.extract(&mut missing, &mut extracted, &env, true, true, |_, _| {});
         assert!(match_slot(&extracted, &program1, 0, 20));
     }
 

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -230,9 +230,6 @@ pub struct ProgramCache<FG: ForkGraph> {
     pub fork_graph: Option<Weak<RwLock<FG>>>,
     /// Coordinates TX batches waiting for others to complete their task during cooperative loading
     pub loading_task_waiter: Arc<LoadingTaskWaiter>,
-    /// As programs are extracted, we'll check if they are a candidate for compilation and send the
-    /// request to compile to a dedicated compilation thread.
-    pub compilation_worker: CompilationWorker,
 }
 
 impl<FG: ForkGraph> std::fmt::Debug for ProgramCache<FG> {
@@ -361,7 +358,6 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             stats: ProgramCacheStats::default(),
             fork_graph: None,
             loading_task_waiter: Arc::new(LoadingTaskWaiter::default()),
-            compilation_worker: CompilationWorker::new(),
         }
     }
 

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -3,7 +3,7 @@ use {
         invoke_context::InvokeContext,
         loading_task::LoadingTaskWaiter,
         program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryType, retention_score},
-        program_metrics::{EMA_SCALE, ProgramCacheStats}, threaded_compilation::CompilationWorker,
+        program_metrics::{EMA_SCALE, ProgramCacheStats},
     },
     log::error,
     percentage::PercentageInteger,

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -261,18 +261,6 @@ impl ProgramCacheEntry {
             }
         }
 
-        #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
-        {
-            let jit_compile_time = solana_svm_measure::measure::Measure::start("jit_compile_time");
-            executable.jit_compile()?;
-            let jit_compile_time = jit_compile_time.end_as_us();
-            entry_stats.jit_compiled(jit_compile_time);
-            #[cfg(feature = "metrics")]
-            {
-                metrics.jit_compile_us = jit_compile_time;
-            }
-        }
-
         Ok(Self {
             deployment_slot,
             account_owner: ProgramCacheEntryOwner::try_from(loader_key).unwrap(),

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -377,6 +377,35 @@ impl ProgramCacheEntry {
     pub fn account_owner(&self) -> Pubkey {
         self.account_owner.into()
     }
+
+    /// JIT compile a program entry if possible.
+    ///
+    /// Returns the number of microseconds it took for the compilation.
+    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
+    pub fn try_compile_loaded(&self) -> u64 {
+        use solana_svm_measure::measure::Measure;
+        let executable = match &self.program {
+            ProgramCacheEntryType::FailedVerification(_)
+            | ProgramCacheEntryType::Closed
+            | ProgramCacheEntryType::DelayVisibility
+            | ProgramCacheEntryType::Unloaded(_)
+            | ProgramCacheEntryType::Builtin(_) => return 0,
+            ProgramCacheEntryType::Loaded(executable) => executable,
+        };
+        if executable.get_compiled_program().is_some() {
+            return 0;
+        }
+        let jit_compile_time = Measure::start("jit_compile_time");
+        if let Err(e) = executable.jit_compile() {
+            log::warn!("compiling failed even though program is valid: {e:?}");
+        }
+        jit_compile_time.end_as_us()
+    }
+
+    #[cfg(not(all(not(target_os = "windows"), target_arch = "x86_64")))]
+    pub fn try_compile_loaded(&self) -> u64 {
+        0
+    }
 }
 
 /// See [`ProgramCacheEntry::retention_score`].

--- a/program-runtime/src/program_metrics.rs
+++ b/program-runtime/src/program_metrics.rs
@@ -253,8 +253,6 @@ pub struct LoadProgramMetrics {
     pub load_elf_us: u64,
     /// Microseconds it took to `executable.verify::<RequisiteVerifier>`
     pub verify_code_us: u64,
-    /// Microseconds it took to `executable.jit_compile`
-    pub jit_compile_us: u64,
 }
 
 #[cfg(feature = "metrics")]
@@ -263,7 +261,6 @@ impl LoadProgramMetrics {
         timings.create_executor_register_syscalls_us += self.register_syscalls_us;
         timings.create_executor_load_elf_us += self.load_elf_us;
         timings.create_executor_verify_code_us += self.verify_code_us;
-        timings.create_executor_jit_compile_us += self.jit_compile_us;
     }
 }
 

--- a/program-runtime/src/threaded_compilation.rs
+++ b/program-runtime/src/threaded_compilation.rs
@@ -1,5 +1,7 @@
-use crate::program_cache_entry::ProgramCacheEntry;
-use std::sync::{Arc, atomic::AtomicU64};
+use {
+    crate::program_cache_entry::ProgramCacheEntry,
+    std::sync::{Arc, atomic::AtomicU64},
+};
 
 // There are ~600ms per slot. Making an assumption that each compile takes on average 1ms, that
 // would mean we'd fit about 600 compiles per slot. Given that slot also involves sending and

--- a/program-runtime/src/threaded_compilation.rs
+++ b/program-runtime/src/threaded_compilation.rs
@@ -18,8 +18,8 @@ pub struct CompilationWorker {
     sender: crossbeam_channel::Sender<CompilationRequest>,
 }
 
-impl CompilationWorker {
-    pub fn new() -> Self {
+impl Default for CompilationWorker {
+    fn default() -> Self {
         let (compile_send, compile_recv) =
             crossbeam_channel::bounded::<CompilationRequest>(COMPILE_REQUEST_CHANNEL_SIZE);
         std::thread::Builder::new()
@@ -37,7 +37,9 @@ impl CompilationWorker {
             sender: compile_send,
         }
     }
+}
 
+impl CompilationWorker {
     pub fn request_compilation(
         &self,
         entry: Arc<ProgramCacheEntry>,

--- a/program-runtime/src/threaded_compilation.rs
+++ b/program-runtime/src/threaded_compilation.rs
@@ -19,7 +19,7 @@ pub struct CompilationWorker {
 }
 
 impl CompilationWorker {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         let (compile_send, compile_recv) =
             crossbeam_channel::bounded::<CompilationRequest>(COMPILE_REQUEST_CHANNEL_SIZE);
         std::thread::Builder::new()

--- a/program-runtime/src/threaded_compilation.rs
+++ b/program-runtime/src/threaded_compilation.rs
@@ -1,0 +1,73 @@
+use crate::program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryType};
+use std::sync::{Arc, atomic::AtomicU64};
+
+// There are ~600ms per slot. Making an assumption that each compile takes on average 1ms, that
+// would mean we'd fit about 600 compiles per slot. Given that slot also involves sending and
+// receiving data, executing programs, etc. giving about 1/10th of the slot time for compilation
+// seems quite appropriate. Otherwise we might end up spending a lot of time compiling programs
+// that have already been executed in interpreted mode.
+const COMPILE_REQUEST_CHANNEL_SIZE: usize = 64;
+
+struct CompilationRequest {
+    entry: Arc<ProgramCacheEntry>,
+    compile_time_us: Arc<AtomicU64>,
+}
+
+#[derive(Clone)]
+pub struct CompilationWorker {
+    sender: crossbeam_channel::Sender<CompilationRequest>,
+}
+
+impl CompilationWorker {
+    pub(crate) fn new() -> Self {
+        let (compile_send, compile_recv) =
+            crossbeam_channel::bounded::<CompilationRequest>(COMPILE_REQUEST_CHANNEL_SIZE);
+        std::thread::Builder::new()
+            .name("solCompile".into())
+            .spawn(move || {
+                for request in compile_recv {
+                    let executable = match &request.entry.program {
+                        ProgramCacheEntryType::FailedVerification(_)
+                        | ProgramCacheEntryType::Closed
+                        | ProgramCacheEntryType::DelayVisibility
+                        | ProgramCacheEntryType::Unloaded(_)
+                        | ProgramCacheEntryType::Builtin(_) => continue,
+                        ProgramCacheEntryType::Loaded(executable) => executable,
+                    };
+                    if executable.get_compiled_program().is_some() {
+                        continue;
+                    }
+
+                    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
+                    {
+                        use solana_svm_measure::measure::Measure;
+                        use std::sync::atomic::Ordering;
+
+                        let jit_compile_time = Measure::start("jit_compile_time");
+                        if let Err(e) = executable.jit_compile() {
+                            log::warn!("compiling failed even though program is valid: {e:?}");
+                        }
+                        let jit_compile_time = jit_compile_time.end_as_us();
+                        request
+                            .compile_time_us
+                            .fetch_add(jit_compile_time, Ordering::Relaxed);
+                    }
+                }
+            })
+            .expect("thread spawns should succeed");
+        Self {
+            sender: compile_send,
+        }
+    }
+
+    pub fn request_compilation(
+        &self,
+        entry: Arc<ProgramCacheEntry>,
+        compile_time_us: Arc<AtomicU64>,
+    ) {
+        let _ = self.sender.try_send(CompilationRequest {
+            entry,
+            compile_time_us,
+        });
+    }
+}

--- a/program-runtime/src/threaded_compilation.rs
+++ b/program-runtime/src/threaded_compilation.rs
@@ -1,4 +1,4 @@
-use crate::program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryType};
+use crate::program_cache_entry::ProgramCacheEntry;
 use std::sync::{Arc, atomic::AtomicU64};
 
 // There are ~600ms per slot. Making an assumption that each compile takes on average 1ms, that
@@ -26,32 +26,10 @@ impl CompilationWorker {
             .name("solCompile".into())
             .spawn(move || {
                 for request in compile_recv {
-                    let executable = match &request.entry.program {
-                        ProgramCacheEntryType::FailedVerification(_)
-                        | ProgramCacheEntryType::Closed
-                        | ProgramCacheEntryType::DelayVisibility
-                        | ProgramCacheEntryType::Unloaded(_)
-                        | ProgramCacheEntryType::Builtin(_) => continue,
-                        ProgramCacheEntryType::Loaded(executable) => executable,
-                    };
-                    if executable.get_compiled_program().is_some() {
-                        continue;
-                    }
-
-                    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
-                    {
-                        use solana_svm_measure::measure::Measure;
-                        use std::sync::atomic::Ordering;
-
-                        let jit_compile_time = Measure::start("jit_compile_time");
-                        if let Err(e) = executable.jit_compile() {
-                            log::warn!("compiling failed even though program is valid: {e:?}");
-                        }
-                        let jit_compile_time = jit_compile_time.end_as_us();
-                        request
-                            .compile_time_us
-                            .fetch_add(jit_compile_time, Ordering::Relaxed);
-                    }
+                    request.compile_time_us.fetch_add(
+                        request.entry.try_compile_loaded(),
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
                 }
             })
             .expect("thread spawns should succeed");
@@ -69,5 +47,30 @@ impl CompilationWorker {
             entry,
             compile_time_us,
         });
+    }
+}
+
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+pub enum CompilationMode {
+    #[default]
+    ThreadedJit,
+    AlwaysJit,
+    Never,
+}
+
+impl CompilationMode {
+    pub fn get() -> Self {
+        static COMPILE_MODE: std::sync::LazyLock<CompilationMode> =
+            std::sync::LazyLock::new(|| {
+                std::env::var("AGAVE_COMPILE_PROGRAMS")
+                    .map(|v| match &*v {
+                        "always" => CompilationMode::AlwaysJit,
+                        "never" => CompilationMode::Never,
+                        "threaded" => CompilationMode::ThreadedJit,
+                        _ => CompilationMode::ThreadedJit,
+                    })
+                    .unwrap_or_default()
+            });
+        *COMPILE_MODE
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7788,6 +7788,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "cfg-if 1.0.4",
+ "crossbeam-channel",
  "itertools 0.14.0",
  "log",
  "percentage",

--- a/svm-timings/src/lib.rs
+++ b/svm-timings/src/lib.rs
@@ -525,13 +525,35 @@ mod tests {
         assert_eq!(timings1.create_vm_us, timings2.create_vm_us);
         assert_eq!(timings1.execute_us, timings2.execute_us);
         assert_eq!(timings1.deserialize_us, timings2.deserialize_us);
-        assert_eq!(timings1.get_or_create_executor_us, timings2.get_or_create_executor_us);
-        assert_eq!(timings1.changed_account_count, timings2.changed_account_count);
+        assert_eq!(
+            timings1.get_or_create_executor_us,
+            timings2.get_or_create_executor_us
+        );
+        assert_eq!(
+            timings1.changed_account_count,
+            timings2.changed_account_count
+        );
         assert_eq!(timings1.total_account_count, timings2.total_account_count);
-        assert_eq!(timings1.create_executor_register_syscalls_us, timings2.create_executor_register_syscalls_us);
-        assert_eq!(timings1.create_executor_load_elf_us, timings2.create_executor_load_elf_us);
-        assert_eq!(timings1.create_executor_verify_code_us, timings2.create_executor_verify_code_us);
-        assert_eq!(timings1.create_executor_jit_compile_us.load(Ordering::Relaxed), timings2.create_executor_jit_compile_us.load(Ordering::Relaxed));
+        assert_eq!(
+            timings1.create_executor_register_syscalls_us,
+            timings2.create_executor_register_syscalls_us
+        );
+        assert_eq!(
+            timings1.create_executor_load_elf_us,
+            timings2.create_executor_load_elf_us
+        );
+        assert_eq!(
+            timings1.create_executor_verify_code_us,
+            timings2.create_executor_verify_code_us
+        );
+        assert_eq!(
+            timings1
+                .create_executor_jit_compile_us
+                .load(Ordering::Relaxed),
+            timings2
+                .create_executor_jit_compile_us
+                .load(Ordering::Relaxed)
+        );
         assert_eq!(timings1.per_program_timings, timings2.per_program_timings);
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -48,6 +48,7 @@ use {
         program_cache_entry::ProgramCacheEntry,
         solana_sbpf::{program::BuiltinProgram, vm::Config as VmConfig},
         sysvar_cache::SysvarCache,
+        threaded_compilation::CompilationMode,
     },
     solana_pubkey::Pubkey,
     solana_rent::Rent,
@@ -864,12 +865,25 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 .collect();
 
         let mut count_hits_and_misses = true;
-        let compilation_worker = self
-            .global_program_cache
-            .read()
-            .unwrap()
-            .compilation_worker
-            .clone();
+
+        let compilation_mode = CompilationMode::get();
+        let extracted_callback: &dyn Fn(&_, &_) = if let CompilationMode::ThreadedJit =
+            compilation_mode
+        {
+            let compilation_worker = self
+                .global_program_cache
+                .read()
+                .unwrap()
+                .compilation_worker
+                .clone();
+            let jit_timer = Arc::clone(&execute_timings.details.create_executor_jit_compile_us);
+            &move |_, program| {
+                compilation_worker.request_compilation(Arc::clone(program), Arc::clone(&jit_timer));
+            }
+        } else {
+            &|_, _| {}
+        };
+
         loop {
             // Lock the global cache.
             let global_program_cache = self.global_program_cache.read().unwrap();
@@ -880,12 +894,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 program_runtime_environment_for_execution,
                 increment_usage_counter,
                 count_hits_and_misses,
-                |_key, program| {
-                    compilation_worker.request_compilation(
-                        Arc::clone(program),
-                        Arc::clone(&execute_timings.details.create_executor_jit_compile_us),
-                    );
-                },
+                extracted_callback,
             );
 
             count_hits_and_misses = false;
@@ -895,7 +904,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             drop(global_program_cache);
 
             let program_to_store = program_to_load.map(|key| {
-                // Load, verify and potentially compile one program.
+                // Load and verify one program.
                 let (program, last_modification_slot) = load_program_with_pubkey(
                     account_loader,
                     program_runtime_environment_for_execution,
@@ -904,6 +913,17 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     execute_timings,
                 )
                 .expect("called load_program_with_pubkey() with nonexistent account");
+                match compilation_mode {
+                    CompilationMode::Never => {}
+                    CompilationMode::ThreadedJit => extracted_callback(&key, &program),
+                    CompilationMode::AlwaysJit => {
+                        let compile_duration = program.try_compile_loaded();
+                        execute_timings
+                            .details
+                            .create_executor_jit_compile_us
+                            .fetch_add(compile_duration, Ordering::Relaxed);
+                    }
+                }
                 (key, program, last_modification_slot)
             });
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -244,7 +244,7 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
             builtin_program_ids: RwLock::new(HashSet::new()),
             builtin_program_cache: RwLock::new(ProgramCacheForTxBatch::new(Slot::default())),
             execution_cost: SVMTransactionExecutionCost::default(),
-            compilation_worker: CompilationWorker::new(),
+            compilation_worker: CompilationWorker::default(),
         }
     }
 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -326,6 +326,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             &environments,
             false,
             false,
+            |_, _| {},
         );
 
         Self {
@@ -863,6 +864,12 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 .collect();
 
         let mut count_hits_and_misses = true;
+        let compilation_worker = self
+            .global_program_cache
+            .read()
+            .unwrap()
+            .compilation_worker
+            .clone();
         loop {
             // Lock the global cache.
             let global_program_cache = self.global_program_cache.read().unwrap();
@@ -873,7 +880,14 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 program_runtime_environment_for_execution,
                 increment_usage_counter,
                 count_hits_and_misses,
+                |_key, program| {
+                    compilation_worker.request_compilation(
+                        Arc::clone(program),
+                        Arc::clone(&execute_timings.details.create_executor_jit_compile_us),
+                    );
+                },
             );
+
             count_hits_and_misses = false;
             let task_waiter = Arc::clone(&global_program_cache.loading_task_waiter);
             let task_cookie = task_waiter.cookie();
@@ -881,7 +895,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             drop(global_program_cache);
 
             let program_to_store = program_to_load.map(|key| {
-                // Load, verify and compile one program.
+                // Load, verify and potentially compile one program.
                 let (program, last_modification_slot) = load_program_with_pubkey(
                     account_loader,
                     program_runtime_environment_for_execution,
@@ -2159,6 +2173,7 @@ mod tests {
                 &program_runtime_environment,
                 true,
                 true,
+                |_, _| {},
             );
         let entry = loaded_programs_for_tx_batch.find(&key).unwrap();
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -48,7 +48,7 @@ use {
         program_cache_entry::ProgramCacheEntry,
         solana_sbpf::{program::BuiltinProgram, vm::Config as VmConfig},
         sysvar_cache::SysvarCache,
-        threaded_compilation::CompilationMode,
+        threaded_compilation::{CompilationMode, CompilationWorker},
     },
     solana_pubkey::Pubkey,
     solana_rent::Rent,
@@ -213,6 +213,10 @@ pub struct TransactionBatchProcessor<FG: ForkGraph> {
     builtin_program_cache: RwLock<ProgramCacheForTxBatch>,
 
     execution_cost: SVMTransactionExecutionCost,
+
+    /// As programs are collected, we'll check if they are a candidate for compilation and send the
+    /// request to compile to a dedicated compilation thread.
+    pub compilation_worker: CompilationWorker,
 }
 
 impl<FG: ForkGraph> Debug for TransactionBatchProcessor<FG> {
@@ -240,6 +244,7 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
             builtin_program_ids: RwLock::new(HashSet::new()),
             builtin_program_cache: RwLock::new(ProgramCacheForTxBatch::new(Slot::default())),
             execution_cost: SVMTransactionExecutionCost::default(),
+            compilation_worker: CompilationWorker::new(),
         }
     }
 }
@@ -340,6 +345,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             builtin_program_ids: RwLock::new(builtin_program_ids),
             builtin_program_cache: RwLock::new(builtin_program_cache),
             execution_cost: self.execution_cost,
+            compilation_worker: self.compilation_worker.clone(),
         }
     }
 
@@ -870,12 +876,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let extracted_callback: &dyn Fn(&_, &_) = if let CompilationMode::ThreadedJit =
             compilation_mode
         {
-            let compilation_worker = self
-                .global_program_cache
-                .read()
-                .unwrap()
-                .compilation_worker
-                .clone();
+            let compilation_worker = self.compilation_worker.clone();
             let jit_timer = Arc::clone(&execute_timings.details.create_executor_jit_compile_us);
             &move |_, program| {
                 compilation_worker.request_compilation(Arc::clone(program), Arc::clone(&jit_timer));

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -3742,14 +3742,19 @@ fn svm_metrics_accumulation() {
         // jit compilation only happens on non-windows && x86_64
         #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
         {
-            assert_ne!(
-                result
-                    .execute_timings
-                    .details
-                    .create_executor_jit_compile_us
-                    .0,
-                0
-            );
+            let jit_time = result
+                .execute_timings
+                .details
+                .create_executor_jit_compile_us
+                .load(Ordering::Relaxed);
+            // JIT compilation happens in a separate thread and might not
+            // complete in time before execution finishes. Give it some more
+            // time.
+            for _ in 0..1000 {
+                if jit_time != 0 { break; }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            assert_ne!(jit_time, 0);
         }
         assert_ne!(
             result.execute_timings.details.create_executor_load_elf_us.0,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -3751,7 +3751,9 @@ fn svm_metrics_accumulation() {
             // complete in time before execution finishes. Give it some more
             // time.
             for _ in 0..1000 {
-                if jit_time != 0 { break; }
+                if jit_time != 0 {
+                    break;
+                }
                 std::thread::sleep(std::time::Duration::from_millis(1));
             }
             assert_ne!(jit_time, 0);


### PR DESCRIPTION
#### Problem

Currently before program execution begins, all the programs have to be compiled which increases the time before any program execution begins, thus increasing the overall slot time.

#### Summary of Changes

Instead of compiling in the critical path of program loading loop the, JIT compile them in a dedicated thread. At the execution time we won't wait around for the compiled programs to be ready either. If one isn't yet ready, we interpret it.

I experimentally determined that in most instances just one thread is more than enough. There are occasional interpreted executions of programs, but they are rare enough to not be a cause for concern.

That said I acknowledge that it makes selection between JIT and interpreted execution non-deterministic, which can make differences, if any come up, very difficult to track down. This has been derisked by running a month-long mainnet validator test with `AGAVE_COMPILE_PROGRAMS=never` and `AGAVE_COMPILE_PROGRAMS=threaded`. This way we have gained a fair bit of confidence that any interpreted execution will work correctly. If needed or desired, the original behaviour can be recovered with `AGAVE_COMPILE_PROGRAMS=always`.