### PR TITLE
Increases IndexGenerationAccumulator's slot capacity

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6295,7 +6295,7 @@ impl AccountsDb {
                         .name(format!("solGenIndex{i:02}"))
                         .spawn_scoped(s, || {
                             let mut thread_accum = IndexGenerationAccumulator::with_slots_capacity(
-                                num_storages / num_threads,
+                                num_storages.div_ceil(num_threads),
                             );
                             let mut reader = append_vec::new_scan_accounts_reader();
                             for next_item in storages_orderer.iter() {


### PR DESCRIPTION
#### Problem

In index generation, we preallocate some per-thread data structures to handle accumulating info from the slots each thread visits. We compute the capacity with `num slots / num threads`, which truncates. Thus we'll need an additional allocation for some of the threads.


#### Summary of Changes

Use `div_ceil` instead. Avoid the extra allocation.