### PR TITLE
ABIv2: Improve and fix tests

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -237,11 +237,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
 
     /// Push a stack frame onto the invocation stack
     pub fn push(&mut self) -> Result<(), InstructionError> {
-        let instruction_context = self
-            .transaction_context
-            .get_instruction_context_at_index_in_trace(
-                self.transaction_context.get_instruction_trace_length(),
-            )?;
+        let instruction_context = self.transaction_context.get_next_instruction_context()?;
         let program_id = instruction_context
             .get_program_key()
             .map_err(|_| InstructionError::UnsupportedProgramId)?;
@@ -271,7 +267,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
     }
 
     /// Pop a stack frame from the invocation stack
-    fn pop(&mut self) -> Result<(), InstructionError> {
+    pub(crate) fn pop(&mut self) -> Result<(), InstructionError> {
         self.syscall_context.pop();
         self.transaction_context.pop()
     }

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -1048,6 +1048,7 @@ mod tests {
                 assert_eq!(&*account, original_account);
             }
 
+            invoke_context.pop().unwrap();
             // check serialize_parameters_for_abiv0
             invoke_context
                 .transaction_context


### PR DESCRIPTION
#### Problem

This PR was split from #10557, in an attempt to further shrink it. It pre-fixes two tests and replaces a function.

#### Summary of Changes

1. Replace a function in `invoke_context.rs` by one that has the same effect.
2. Make `fn pop` `pub(crate)` so that it can be used in a test in `serialization.rs`.
3. In `transaction.rs`, I improve the coverage of one test.

