### PR TITLE
Remove function load_account_with

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3917,25 +3917,6 @@ impl AccountsDb {
         )
     }
 
-    /// Load account with `pubkey` and maybe put into read cache.
-    ///
-    /// Return the account and the slot when the account was last stored.
-    /// Return None for ZeroLamport accounts.
-    pub fn load_account_with(
-        &self,
-        ancestors: &Ancestors,
-        pubkey: &Pubkey,
-        should_put_in_read_cache: PopulateReadCache,
-    ) -> Option<(AccountSharedData, Slot)> {
-        self.do_load_with_populate_read_cache(
-            ancestors,
-            pubkey,
-            LoadHint::Unspecified,
-            LoadZeroLamports::None,
-            should_put_in_read_cache,
-        )
-    }
-
     fn do_load_with_populate_read_cache(
         &self,
         ancestors: &Ancestors,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3220,9 +3220,11 @@ fn test_load_with_read_only_accounts_cache() {
 
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
     let (account, slot) = db
-        .load_account_with(
+        .do_load(
             &Ancestors::default(),
             &account_key,
+            LoadHint::Unspecified,
+            LoadZeroLamports::None,
             PopulateReadCache::False,
         )
         .unwrap();
@@ -3231,16 +3233,24 @@ fn test_load_with_read_only_accounts_cache() {
     assert_eq!(slot, 1);
 
     let (account, slot) = db
-        .load_account_with(&Ancestors::default(), &account_key, PopulateReadCache::True)
+        .do_load(
+            &Ancestors::default(),
+            &account_key,
+            LoadHint::Unspecified,
+            LoadZeroLamports::None,
+            PopulateReadCache::True,
+        )
         .unwrap();
     assert_eq!(account.lamports(), 1);
     assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
     assert_eq!(slot, 1);
 
     db.store_for_tests((2, &[(&account_key, &zero_lamport_account)][..]));
-    let account = db.load_account_with(
+    let account = db.do_load(
         &Ancestors::default(),
         &account_key,
+        LoadHint::Unspecified,
+        LoadZeroLamports::None,
         PopulateReadCache::False,
     );
     assert!(account.is_none());
@@ -3248,17 +3258,24 @@ fn test_load_with_read_only_accounts_cache() {
 
     db.read_only_accounts_cache.reset_for_tests();
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
-    let account =
-        db.load_account_with(&Ancestors::default(), &account_key, PopulateReadCache::True);
+    let account = db.do_load(
+        &Ancestors::default(),
+        &account_key,
+        LoadHint::Unspecified,
+        LoadZeroLamports::None,
+        PopulateReadCache::True,
+    );
     assert!(account.is_none());
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
 
     let slot2_account = AccountSharedData::new(2, 1, AccountSharedData::default().owner());
     db.store_for_tests((2, &[(&account_key, &slot2_account)][..]));
     let (account, slot) = db
-        .load_account_with(
+        .do_load(
             &Ancestors::default(),
             &account_key,
+            LoadHint::Unspecified,
+            LoadZeroLamports::None,
             PopulateReadCache::False,
         )
         .unwrap();
@@ -3269,7 +3286,13 @@ fn test_load_with_read_only_accounts_cache() {
     let slot2_account = AccountSharedData::new(2, 1, AccountSharedData::default().owner());
     db.store_for_tests((2, &[(&account_key, &slot2_account)][..]));
     let (account, slot) = db
-        .load_account_with(&Ancestors::default(), &account_key, PopulateReadCache::True)
+        .do_load(
+            &Ancestors::default(),
+            &account_key,
+            LoadHint::Unspecified,
+            LoadZeroLamports::None,
+            PopulateReadCache::True,
+        )
         .unwrap();
     assert_eq!(account.lamports(), 2);
     // The account shouldn't be added to read_only_cache because it is in write_cache.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -91,7 +91,7 @@ use {
         account_locks::validate_account_locks,
         account_storage_entry::AccountStorageEntry,
         accounts::{AccountAddressFilter, Accounts, PubkeyAccountSlot},
-        accounts_db::{AccountsDb, AccountsDbConfig, PopulateReadCache},
+        accounts_db::{AccountsDb, AccountsDbConfig},
         accounts_hash::AccountsLtHash,
         accounts_index::{IndexKey, ScanConfig, ScanResult},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
@@ -4486,20 +4486,10 @@ impl Bank {
         &self,
         pubkey: &Pubkey,
     ) -> Option<AccountSharedData> {
-        self.load_account_with(pubkey, PopulateReadCache::False)
+        self.rc
+            .accounts
+            .load_with_fixed_root_do_not_populate_read_cache(&self.ancestors, pubkey)
             .map(|(acc, _slot)| acc)
-    }
-
-    fn load_account_with(
-        &self,
-        pubkey: &Pubkey,
-        should_put_in_read_cache: PopulateReadCache,
-    ) -> Option<(AccountSharedData, Slot)> {
-        self.rc.accounts.accounts_db.load_account_with(
-            &self.ancestors,
-            pubkey,
-            should_put_in_read_cache,
-        )
     }
 
     // Hi! leaky abstraction here....


### PR DESCRIPTION
#### Problem
Function is only used in one place (outside of test) and is used improperly. The calling function load_with_fixed_root_do_not_populate_read_cache specifically says fixed_root, while load_account_with specifies the LoadHint as Unspecified instead of FixedMaxRoot. 

#### Summary of Changes
- Remove the function
- Modify tests that call the function to use do_load with the same paramaters

Note: unlike [the other one](https://github.com/anza-xyz/agave/pull/10788), this broken functionality was prior to any changes made in the recent factorings.

Note: Only a few more to go! 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
