### PR TITLE
banking_stage: fix receive_time_us accumulating total elapsed instead of delta

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -178,9 +178,10 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
 
         if !timed_out {
             while start.elapsed() < TIMEOUT && stats.num_received < PACKET_BURST_LIMIT {
+                let receive_start = Instant::now();
                 match self.receiver.try_recv() {
                     Ok(packet_batch_message) => {
-                        stats.receive_time_us += start.elapsed().as_micros() as u64;
+                        stats.receive_time_us += receive_start.elapsed().as_micros() as u64;
                         received_message = true;
                         let batch_stats = self.handle_packet_batch_message(
                             container,


### PR DESCRIPTION
#### Problem

`receive_time_us` in the banking stage scheduler uses `start.elapsed()` inside the receive loop, which returns the total time since `start` was created. Each iteration accumulates the total elapsed time rather than the delta for that individual receive, causing the metric to grow quadratically with the number of receives.

Fixes #10427

#### Summary of Changes

Use a per-iteration `Instant::now()` before `try_recv` so that only the time for each individual receive is accumulated.