### PR TITLE
Remove stale clippy allow

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -523,7 +523,6 @@ impl<O: BucketOccupied> BucketStorage<O> {
             capacity,
             max_search,
             Arc::clone(stats),
-            #[allow(clippy::map_clone)] // https://github.com/rust-lang/rust-clippy/issues/12560
             bucket
                 .map(|bucket| Arc::clone(&bucket.count))
                 .unwrap_or_default(),

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1,6 +1,4 @@
 #![allow(clippy::arithmetic_side_effects)]
-// REMOVE once https://github.com/rust-lang/rust-clippy/issues/11153 is fixed
-#![allow(clippy::items_after_test_module)]
 
 use {
     agave_feature_set::enable_alt_bn128_syscall,

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -90,9 +90,6 @@ pub struct CostTracker {
 
 impl Default for CostTracker {
     fn default() -> Self {
-        // Clippy doesn't like asserts in const contexts, so need to explicitly allow them.  For
-        // more info, see this issue: https://github.com/rust-lang/rust-clippy/issues/8159
-        #![allow(clippy::assertions_on_constants)]
         const _: () = assert!(MAX_WRITABLE_ACCOUNT_UNITS <= MAX_BLOCK_UNITS);
         const _: () = assert!(MAX_VOTE_UNITS <= MAX_BLOCK_UNITS);
 


### PR DESCRIPTION
#### Problem

We have some old clippy allow due to some problems on the clippy side which has been resolved.

#### Summary of Changes



