### PR TITLE
Revert "chore: Reduce Validator threadpool sizes in tests (#10735)"

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -104,6 +104,7 @@ use {
         transaction_recorder::TransactionRecorder,
     },
     solana_pubkey::Pubkey,
+    solana_rayon_threadlimit::get_thread_count,
     solana_rpc::{
         max_slots::MaxSlots,
         optimistically_confirmed_bank_tracker::{
@@ -410,6 +411,9 @@ pub struct ValidatorConfig {
 
 impl ValidatorConfig {
     pub fn default_for_test() -> Self {
+        let max_thread_count =
+            NonZeroUsize::new(num_cpus::get()).expect("thread count is non-zero");
+
         Self {
             logfile: None,
             expected_genesis_hash: None,
@@ -475,13 +479,12 @@ impl ValidatorConfig {
             generator_config: None,
             use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup::default(),
             unified_scheduler_handler_threads: None,
-            // Fix threadpools to small and reasonable sizes; unit tests should
-            // not be creating excessive load and benches can configure more
             ip_echo_server_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
-            rayon_global_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
+            rayon_global_threads: max_thread_count,
             replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
-            replay_transactions_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
-            tvu_shred_sigverify_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
+            replay_transactions_threads: max_thread_count,
+            tvu_shred_sigverify_threads: NonZeroUsize::new(get_thread_count())
+                .expect("thread count is non-zero"),
             delay_leader_block_for_pending_fork: false,
             voting_service_test_override: None,
             repair_handler_type: RepairHandlerType::default(),


### PR DESCRIPTION

#### Problem

1c4daaeb509f0c71b83cef29a2162cbb0af9de9b appears to be causing sporadic test failures in https://github.com/anza-xyz/agave/pull/10707.  See https://github.com/anza-xyz/agave/pull/10707#issuecomment-3946866867 and https://github.com/anza-xyz/agave/pull/10707#issuecomment-3951832116.


#### Summary of Changes

This reverts commit 1c4daaeb509f0c71b83cef29a2162cbb0af9de9b.
