### PR TITLE
Call accounts read wrappers for accounts_db functions

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -110,7 +110,6 @@ impl Accounts {
         loaded_addresses: &mut LoadedAddresses,
     ) -> std::result::Result<Slot, AddressLookupError> {
         let table_account = self
-            .accounts_db
             .load_with_fixed_root(ancestors, address_table_lookup.account_key)
             .map(|(account, _rent)| account)
             .ok_or(AddressLookupError::LookupTableAccountNotFound)?;

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3594,20 +3594,6 @@ impl AccountsDb {
         )
     }
 
-    /// note this returns None for accounts with zero lamports
-    pub fn load_with_fixed_root(
-        &self,
-        ancestors: &Ancestors,
-        pubkey: &Pubkey,
-    ) -> Option<(AccountSharedData, Slot)> {
-        self.load(
-            ancestors,
-            pubkey,
-            LoadHint::FixedMaxRoot,
-            PopulateReadCache::True,
-        )
-    }
-
     fn read_index_for_accessor_or_load_slow<'a>(
         &'a self,
         ancestors: &Ancestors,
@@ -6959,6 +6945,23 @@ impl AccountsDb {
         self.flush_root_write_cache(slot);
     }
 
+    /// note this returns None for accounts with zero lamports
+    #[cfg(test)]
+    fn load_with_fixed_root(
+        &self,
+        ancestors: &Ancestors,
+        pubkey: &Pubkey,
+    ) -> Option<(AccountSharedData, Slot)> {
+        self.do_load(
+            ancestors,
+            pubkey,
+            LoadHint::FixedMaxRoot,
+            LoadZeroLamports::None,
+            PopulateReadCache::True,
+        )
+    }
+
+    /// note this returns Some for accounts with zero lamports
     pub fn load_without_fixed_root(
         &self,
         ancestors: &Ancestors,

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -893,7 +893,6 @@ pub(crate) mod external {
                 let fee_payer_balance = working_bank
                     .rc
                     .accounts
-                    .accounts_db
                     .load_with_fixed_root(
                         &working_bank.ancestors,
                         &transaction.static_account_keys()[0],

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -526,7 +526,6 @@ impl Consumer {
         let (mut fee_payer_account, _slot) = bank
             .rc
             .accounts
-            .accounts_db
             .load_with_fixed_root(&bank.ancestors, fee_payer)
             .ok_or(TransactionError::AccountNotFound)?;
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6066,7 +6066,6 @@ impl TransactionProcessingCallback for Bank {
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
         self.rc
             .accounts
-            .accounts_db
             .load_with_fixed_root(&self.ancestors, pubkey)
     }
 


### PR DESCRIPTION
#### Problem
Wrappers are available to avoid calling into the accounts_db directly from outside the create for read functions

#### Summary of Changes
- Switch callers to use the wrappers 
- Moved function no longer used outside of test to the dcou section

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
