### PR TITLE
fix test: race condition w/ data budget

### DIFF
--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -906,7 +906,7 @@ impl ServeRepair {
             .spawn(move || {
                 let mut last_print = Instant::now();
                 let mut stats = ServeRepairStats::default();
-                let data_budget = DataBudget::default();
+                let data_budget = DataBudget::new(MAX_BYTES_PER_INTERVAL);
                 while !exit.load(Ordering::Relaxed) {
                     let result = self.run_listen(
                         &mut ping_cache,

--- a/perf/src/data_budget.rs
+++ b/perf/src/data_budget.rs
@@ -10,6 +10,13 @@ pub struct DataBudget {
 }
 
 impl DataBudget {
+    pub fn new(bytes: usize) -> Self {
+        Self {
+            bytes: AtomicUsize::new(bytes),
+            asof: AtomicU64::new(solana_time_utils::timestamp()),
+        }
+    }
+
     /// Create a data budget with max bytes, used for tests
     pub fn restricted() -> Self {
         Self {


### PR DESCRIPTION
#### Problem
`test_ancestor_hashes_service_initiate_ancestor_hashes_requests_for_duplicate_slot` has a race condition and can fail with:
```
thread 'repair::ancestor_hashes_service::test::test_ancestor_hashes_service_initiate_ancestor_hashes_requests_for_duplicate_slot' (939335) panicked at core/src/repair/ancestor_hashes_service.rs:1560:14:
called `Result::unwrap()` on an `Err` value: Timeout
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test repair::ancestor_hashes_service::test::test_ancestor_hashes_service_initiate_ancestor_hashes_requests_for_duplicate_slot ... FAILED
```
because there is a race in resetting the data budget.

`DataBudget::default()` initializes the budget to 0 here:
https://github.com/anza-xyz/agave/blob/master/core/src/repair/serve_repair.rs#L909

the budget will not get bumped above 0 until here (1 second later):
https://github.com/anza-xyz/agave/blob/master/core/src/repair/serve_repair.rs#L931

with build optimizations on, we seem to consistently send the packet in time that it shows up while the data budget is 0 and gets discarded, which leads to waiting for a response for 1 second and then panicking.

#### Summary of Changes
Initialize the budget to `MAX_BYTES_PER_INTERVAL`