### PR TITLE
Remove zero lamport flag from do_load_with_populate_read_cache

### DIFF
--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -795,7 +795,7 @@ mod serde_snapshot_tests {
         // 2nd clean needed to clean-up pubkey1
         accounts.clean_accounts_for_tests();
 
-        // Ensure pubkey2 is cleaned from the index finally
+        // Ensure pubkey1 is cleaned from the index finally
         assert!(!accounts.accounts_index.contains(&pubkey1));
         accounts.assert_not_load_account(current_slot, pubkey1);
         accounts.assert_load_account(current_slot, pubkey2, old_lamport);


### PR DESCRIPTION
#### Problem
Zero lamport flag in do_load_with_populate_read_cache is for testing only, but adds complexity to the production path. The information can be accessed in other ways. 

#### Summary of Changes
- Remove ZeroLamport flag from do_load
- Modify tests as required. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
