### PR TITLE
[svm] Remove `ed25519-dalek` dependency on svm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10841,7 +10841,6 @@ dependencies = [
  "ahash 0.8.12",
  "assert_matches",
  "bincode",
- "ed25519-dalek 1.0.1",
  "env_logger",
  "libsecp256k1",
  "log",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -90,7 +90,6 @@ thiserror = { workspace = true }
 agave-syscalls = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
-ed25519-dalek = { workspace = true }
 env_logger = { workspace = true }
 libsecp256k1 = { workspace = true }
 openssl = { workspace = true }

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -81,7 +81,6 @@ pub(crate) fn process_message<'ix_data>(
 mod tests {
     use {
         super::*,
-        ed25519_dalek::ed25519::signature::Signer,
         openssl::{
             ec::{EcGroup, EcKey},
             nid::Nid,
@@ -94,6 +93,7 @@ mod tests {
         solana_ed25519_program::new_ed25519_instruction_with_signature,
         solana_hash::Hash,
         solana_instruction::{AccountMeta, Instruction, error::InstructionError},
+        solana_keypair::Keypair,
         solana_message::{AccountKeys, Message, SanitizedMessage},
         solana_precompile_error::PrecompileError,
         solana_program_runtime::{
@@ -112,6 +112,7 @@ mod tests {
             eth_address_from_pubkey, new_secp256k1_instruction_with_signature,
         },
         solana_secp256r1_program::{new_secp256r1_instruction_with_signature, sign_message},
+        solana_signer::Signer,
         solana_svm_callback::InvokeContextCallback,
         solana_svm_feature_set::SVMFeatureSet,
         solana_transaction_context::transaction::TransactionContext,
@@ -619,10 +620,10 @@ mod tests {
     }
 
     fn ed25519_instruction_for_test() -> Instruction {
-        let secret_key = ed25519_dalek::Keypair::generate(&mut thread_rng());
-        let signature = secret_key.sign(b"hello").to_bytes();
-        let pubkey = secret_key.public.to_bytes();
-        new_ed25519_instruction_with_signature(b"hello", &signature, &pubkey)
+        let keypair = Keypair::new();
+        let signature = keypair.sign_message(b"hello");
+        let pubkey = keypair.pubkey().to_bytes();
+        new_ed25519_instruction_with_signature(b"hello", signature.as_array(), &pubkey)
     }
 
     fn secp256r1_instruction_for_test() -> Instruction {


### PR DESCRIPTION
#### Problem

The svm crate uses ed25519-dalek as a dev-dependency. The dalek crate is only used to generate keypairs in the tests. It would be nice to remove as many direct dependencies on the dalek crate as possible, and just use the solana-keypair crate instead.

#### Summary of Changes

Removed `ed25519-dalek` from the dev-dependencies and updated tests to use `solana-keypair` instead.