### PR TITLE
[runtime] Remove `ed25519-dalek` from runtime dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10240,7 +10240,6 @@ dependencies = [
  "percentage",
  "qualifier_attr",
  "rand 0.9.2",
- "rand_chacha 0.9.0",
  "rayon",
  "regex",
  "semver 1.0.27",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10223,7 +10223,6 @@ dependencies = [
  "bytemuck",
  "crossbeam-channel",
  "dashmap",
- "ed25519-dalek 1.0.1",
  "im",
  "itertools 0.14.0",
  "libc",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -196,7 +196,6 @@ wincode = { workspace = true }
 agave-logger = { workspace = true }
 agave-transaction-view = { workspace = true }
 bitvec = { workspace = true }
-ed25519-dalek = { workspace = true }
 libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }
 rand_chacha = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -198,7 +198,6 @@ agave-transaction-view = { workspace = true }
 bitvec = { workspace = true }
 libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }
-rand_chacha = { workspace = true }
 solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
 solana-builtins = { workspace = true, features = ["dev-context-only-utils"] }
 solana-instruction-error = { workspace = true }


### PR DESCRIPTION
#### Problem

The runtime uses ed25519-dalek as a dev-dependency. The dalek crate is only used to generate keypairs in the tests. It would be nice to remove as many direct dependencies on the dalek crate as possible, and just use the solana-keypair crate instead.

#### Summary of Changes

Removed ed25519-dalek from the dev-dependencies and updated tests to use solana-keypair instead.

I saw that the `rand_chacha` crate that is listed as a dev-dependency is also not used anywhere, so I removed this too.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
