### PR TITLE
[ed25519-tests] Remove `ed25519-dalek` from ed25519 tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8281,10 +8281,10 @@ name = "solana-ed25519-program-tests"
 version = "4.0.0-alpha.0"
 dependencies = [
  "assert_matches",
- "ed25519-dalek 1.0.1",
  "rand 0.9.2",
  "solana-ed25519-program",
  "solana-instruction",
+ "solana-keypair",
  "solana-precompile-error",
  "solana-program-test",
  "solana-signer",

--- a/programs/ed25519-tests/Cargo.toml
+++ b/programs/ed25519-tests/Cargo.toml
@@ -16,10 +16,10 @@ agave-unstable-api = []
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-ed25519-dalek = { workspace = true }
 rand = { workspace = true }
 solana-ed25519-program = { workspace = true }
 solana-instruction = { workspace = true }
+solana-keypair = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-program-test = { workspace = true }
 solana-signer = { workspace = true }


### PR DESCRIPTION
#### Problem

The ed25519-tests crate uses ed25519-dalek as a dev-dependency. The dalek crate is only used to generate keypairs in the tests. It would be nice to remove as many direct dependencies on the dalek crate as possible, and just use the solana-keypair crate instead.

#### Summary of Changes

Removed ed25519-dalek from the dev-dependencies and updated tests to use solana-keypair instead.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
