### PR TITLE
chore: Update feature description to state SIMD with 4 digits

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -2278,7 +2278,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         ),
         (
             enable_alt_bn128_g2_syscalls::id(),
-            "SIMD-302: Add alt_bn128 G2 syscalls",
+            "SIMD-0302: Add alt_bn128 G2 syscalls",
         ),
         (
             commission_rate_in_basis_points::id(),
@@ -2314,7 +2314,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         ),
         (
             limit_instruction_accounts::id(),
-            "SIMD-406: Maximum instruction accounts",
+            "SIMD-0406: Maximum instruction accounts",
         ),
         (
             vote_account_initialize_v2::id(),


### PR DESCRIPTION
#### Problem
SIMD's are commonly stated with four digits which includes a leading zero. Update several feature descriptions to follow this convention as the rest of the file does