### PR TITLE
chore: harden xdp program build/verify scripts

### DIFF
--- a/scripts/build-agave-xdp-ebpf.sh
+++ b/scripts/build-agave-xdp-ebpf.sh
@@ -34,4 +34,5 @@ if [ "$BEFORE_HASH" = "$AFTER_HASH" ]; then
     echo "✓ Hash unchanged"
 else
     echo "✗ Hash changed"
+    exit 1
 fi

--- a/scripts/elf-hash-symbol.sh
+++ b/scripts/elf-hash-symbol.sh
@@ -11,7 +11,8 @@ SYMBOL_NAME="$2"
 
 # 1. Get Symbol VA, Size, and Section Index (Ndx)
 # Output fields: [1]Value [2]Size [6]Ndx
-SYMBOL_DETAILS=$(readelf -Ws "$ELF_FILE" | grep -w "$SYMBOL_NAME" | head -n 1)
+SYMBOL_DETAILS=$(readelf --sym-base=16 -CWs "$ELF_FILE" | grep -w "$SYMBOL_NAME" | head -n 1)
+
 
 if [ -z "$SYMBOL_DETAILS" ]; then
     echo "Error: Symbol '$SYMBOL_NAME' not found in '$ELF_FILE'." >&2
@@ -19,6 +20,8 @@ if [ -z "$SYMBOL_DETAILS" ]; then
 fi
 
 read -r _ SYMBOL_VA SYMBOL_SIZE _ _ _ SYMBOL_NDX _ <<< "$SYMBOL_DETAILS"
+
+SYMBOL_SIZE=$(( 16#${SYMBOL_SIZE#0x} ))
 
 # Exit if size is zero or invalid
 if ! [[ "$SYMBOL_SIZE" =~ ^[0-9]+$ ]] || [ "$SYMBOL_SIZE" -eq 0 ]; then


### PR DESCRIPTION
#### Problem
xdp program scripts have some footguns

#### Summary of Changes
- don't exit success on hash mismatch 
- make readelf explicitly demangle symbols (-C)
- make readelf explicitly specify symbol value base 16 (default is mixed :melting_face:)