### PR TITLE
streamer: add quic af_xdp for egress

### DIFF
--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -24,6 +24,7 @@ use {
         validator::{BlockProductionMethod, GeneratorConfig},
     },
     agave_votor::event::VotorEventSender,
+    agave_xdp::transmitter::XdpSender,
     crossbeam_channel::{Receiver, bounded, unbounded},
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
@@ -55,12 +56,12 @@ use {
         streamer::StakedNodes,
     },
     solana_turbine::{
-        XdpSender,
+        XdpSender as TurbineXdpSender,
         broadcast_stage::{BroadcastStage, BroadcastStageType},
     },
     std::{
         collections::{HashMap, HashSet},
-        net::UdpSocket,
+        net::{Ipv4Addr, UdpSocket},
         num::NonZeroUsize,
         path::PathBuf,
         sync::{Arc, RwLock, atomic::AtomicBool},
@@ -116,7 +117,8 @@ impl Tpu {
         entry_notification_sender: Option<EntryNotifierSender>,
         blockstore: Arc<Blockstore>,
         broadcast_type: &BroadcastStageType,
-        turbine_xdp_sender: Option<XdpSender>,
+        turbine_xdp_sender: Option<TurbineXdpSender>,
+        quic_xdp_sender: Option<(XdpSender, Ipv4Addr)>,
         exit: Arc<AtomicBool>,
         shred_version: u16,
         vote_tracker: Arc<VoteTracker>,
@@ -212,11 +214,13 @@ impl Tpu {
         )
         .unwrap();
 
+        // We check on validator startup that XDP is not mixed with multihoming, so by construction
+        // at this moment all the transactions_quic_sockets and transactions_forwards_quic_sockets
+        // have the same bind IP:PORT.
+
         // Streamer for TPU
-        let transactions_quic_sockets: Vec<QuicSocket> = transactions_quic_sockets
-            .into_iter()
-            .map(Into::into)
-            .collect();
+        let transactions_quic_sockets =
+            into_quic_sockets(transactions_quic_sockets, quic_xdp_sender.clone());
         let SpawnServerResult {
             endpoints: _,
             thread: tpu_quic_t,
@@ -235,11 +239,8 @@ impl Tpu {
         .unwrap();
 
         // Streamer for TPU forward
-        let transactions_forwards_quic_sockets: Vec<QuicSocket> =
-            transactions_forwards_quic_sockets
-                .into_iter()
-                .map(Into::into)
-                .collect();
+        let transactions_forwards_quic_sockets =
+            into_quic_sockets(transactions_forwards_quic_sockets, quic_xdp_sender);
         let SpawnServerResult {
             endpoints: _,
             thread: tpu_forwards_quic_t,
@@ -401,4 +402,18 @@ impl Tpu {
         }
         Ok(())
     }
+}
+
+fn into_quic_sockets(
+    sockets: impl IntoIterator<Item = UdpSocket>,
+    quic_xdp_sender: Option<(XdpSender, Ipv4Addr)>,
+) -> impl Iterator<Item = QuicSocket> {
+    sockets
+        .into_iter()
+        .map(move |socket| match &quic_xdp_sender {
+            Some((xdp_sender, fallback_src_ip)) => {
+                QuicSocket::with_xdp(socket, *fallback_src_ip, xdp_sender.clone())
+            }
+            None => QuicSocket::from(socket),
+        })
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1543,12 +1543,16 @@ impl Validator {
         // This channel backing up indicates a serious problem in votor
         let (votor_event_sender, votor_event_receiver) = bounded(1000);
 
-        let (xdp_transmitter, turbine_xdp_sender) =
+        let (xdp_transmitter, turbine_xdp_sender, quic_xdp_sender) =
             if let Some((xdp_transmit_builder, src_addr)) = xdp_builder_with_src_addr {
-                let (rtx, sender) = xdp_transmit_builder.build();
-                (Some(rtx), Some(XdpSender::new(sender, src_addr)))
+                let (transmitter, sender) = xdp_transmit_builder.build();
+                (
+                    Some(transmitter),
+                    Some(XdpSender::new(sender.clone(), src_addr)),
+                    Some((sender, *src_addr.ip())),
+                )
             } else {
-                (None, None)
+                (None, None, None)
             };
 
         // disable all2all tests if not allowed for a given cluster type
@@ -1674,6 +1678,7 @@ impl Validator {
             blockstore.clone(),
             &config.broadcast_stage_type,
             turbine_xdp_sender,
+            quic_xdp_sender,
             exit.clone(),
             node.info.shred_version(),
             vote_tracker,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -5,14 +5,16 @@ use {
             qos::{ConnectionContext, OpaqueStreamerCounter, QosController},
         },
         quic::{QuicServerError, QuicStreamerConfig, StreamerStats, configure_server},
-        quic_socket::QuicSocket,
+        quic_socket::{QuicSocket, QuicXdpSocketParts, QuicXdpTxSocket},
         streamer::StakedNodes,
     },
     bytes::{BufMut, Bytes, BytesMut},
     crossbeam_channel::{Sender, TrySendError},
     futures::{Future, StreamExt as _, stream::FuturesUnordered},
     indexmap::map::{Entry, IndexMap},
-    quinn::{Accept, Connecting, Connection, Endpoint, EndpointConfig, TokioRuntime},
+    quinn::{
+        Accept, AsyncUdpSocket, Connecting, Connection, Endpoint, EndpointConfig, TokioRuntime,
+    },
     rand::{Rng, rng},
     smallvec::SmallVec,
     solana_keypair::Keypair,
@@ -156,14 +158,30 @@ where
     let endpoints = sockets
         .into_iter()
         .map(|sock| match sock {
-            QuicSocket::Kernel(udp_sock) => Endpoint::new(
+            QuicSocket::Kernel(socket) => Endpoint::new(
                 EndpointConfig::default(),
                 Some(config.clone()),
-                udp_sock,
+                socket,
                 Arc::new(TokioRuntime),
             )
             .map_err(QuicServerError::EndpointFailed),
-            QuicSocket::Xdp(_xdp_cfg) => unimplemented!(),
+            QuicSocket::Xdp(QuicXdpSocketParts {
+                socket,
+                fallback_src_ip,
+                xdp_sender,
+            }) => {
+                let socket = Arc::new(
+                    QuicXdpTxSocket::new(socket, fallback_src_ip, xdp_sender)
+                        .map_err(QuicServerError::EndpointFailed)?,
+                ) as Arc<dyn AsyncUdpSocket>;
+                Endpoint::new_with_abstract_socket(
+                    EndpointConfig::default(),
+                    Some(config.clone()),
+                    socket,
+                    Arc::new(TokioRuntime),
+                )
+                .map_err(QuicServerError::EndpointFailed)
+            }
         })
         .collect::<Result<Vec<_>, _>>()?;
 

--- a/streamer/src/quic_socket.rs
+++ b/streamer/src/quic_socket.rs
@@ -1,22 +1,37 @@
-//! This module defines [`QuicSocket`] enum which wraps `std::net::UdpSocket` along with [`QuicXdpSocketBundle`].
-
+//! This module defines [`QuicSocket`], which allows selecting between kernel UDP and AF_XDP-backed
+//! QUIC socket configurations.
 use {
-    agave_xdp::transmitter::XdpSender,
+    agave_xdp::{
+        ecn_codepoint::EcnCodepoint as XdpEcnCodepoint,
+        transmitter::{BytesTxPacket, XdpSender},
+    },
+    bytes::Bytes,
+    crossbeam_channel::TrySendError,
+    nix::ifaddrs::getifaddrs,
+    quinn::{
+        AsyncUdpSocket, Runtime, TokioRuntime, UdpPoller,
+        udp::{EcnCodepoint as QuinnEcnCodepoint, RecvMeta, Transmit},
+    },
     std::{
         fmt::{self, Debug},
-        io::{self},
-        net::SocketAddr,
+        io::{self, IoSliceMut},
+        net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
+        pin::Pin,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{Context, Poll},
     },
 };
 
-/// [`QuicSocket`] is a thin wrapper around `std::net::UdpSocket` that is introduced to simplify the switch
-/// between kernel UDP socket and XDP socket.
+/// [`QuicSocket`] is an enum for selecting between a kernel UDP socket and an AF_XDP-backed
+/// socket for QUIC communication.
 #[derive(Debug)]
 pub enum QuicSocket {
-    /// A QUIC socket that uses XDP for sending and kernel UDP socket for receiving.
-    Xdp(QuicXdpSocketBundle),
-    /// A QUIC socket that uses kernel UDP socket for both sending and receiving. This is used when
-    /// XDP is not available or disabled.
+    /// A QUIC socket that uses AF_XDP for sending and a kernel UDP socket for receiving.
+    Xdp(QuicXdpSocketParts),
+    /// A QUIC socket that uses kernel UDP socket for both sending and receiving.
     Kernel(std::net::UdpSocket),
 }
 
@@ -27,30 +42,257 @@ impl From<std::net::UdpSocket> for QuicSocket {
 }
 
 impl QuicSocket {
+    pub fn with_xdp(
+        socket: std::net::UdpSocket,
+        fallback_src_ip: Ipv4Addr,
+        xdp_sender: XdpSender,
+    ) -> Self {
+        Self::Xdp(QuicXdpSocketParts {
+            socket,
+            fallback_src_ip,
+            xdp_sender,
+        })
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         match self {
-            QuicSocket::Xdp(cfg) => cfg.socket.local_addr(),
+            QuicSocket::Xdp(parts) => parts.socket.local_addr(),
             QuicSocket::Kernel(socket) => socket.local_addr(),
         }
     }
 }
 
-/// [`QuicXdpSocketBundle`] is a configuration struct for creating a QUIC socket.
+/// [`QuicXdpSocketParts`] wraps the resources required to construct an AF_XDP-backed QUIC socket.
 ///
-/// We must create and bundle together both an `XdpSender` and a `std::net::UdpSocket` instead of
-/// directly creating an `AsyncUdpSocket` instance because the underlying sockets can only be
-/// constructed when a Tokio runtime is present. In the case of Streamer and other components, the
-/// runtime is created deep inside the call stack. Therefore, we propagate this bundle up to the
-/// Endpoint creation.
-pub struct QuicXdpSocketBundle {
+/// It carries both an [`XdpSender`] and a [`std::net::UdpSocket`], rather than constructing an
+/// [`QuicXdpTxSocket`] directly, because the underlying sockets can only be created when a Tokio
+/// runtime is present. `fallback_src_ip` is used when the local address of `socket` is a
+/// wildcard address.
+pub struct QuicXdpSocketParts {
     pub socket: std::net::UdpSocket,
+    pub fallback_src_ip: Ipv4Addr,
     pub xdp_sender: XdpSender,
 }
 
-impl Debug for QuicXdpSocketBundle {
+impl Debug for QuicXdpSocketParts {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("QuicXdpSocketBundle")
+        f.debug_struct("QuicXdpSocketParts")
             .field("socket", &self.socket)
             .finish()
+    }
+}
+
+/// [`QuicXdpTxSocket`] uses AF_XDP for egress traffic and `UdpSocket` for ingress traffic.
+///
+/// For egress traffic, it employs an underlying `QuicXdpSender` for non-local destinations. For
+/// destinations owned by the local host (routed via `lo`, including loopback and local interface
+/// IPs), it falls back to a kernel `UdpSocket`.
+pub(crate) struct QuicXdpTxSocket {
+    udp_socket: Arc<dyn AsyncUdpSocket>,
+    xdp_sender: QuicXdpSender,
+    local_ips: Vec<Ipv4Addr>,
+}
+
+impl QuicXdpTxSocket {
+    pub(crate) fn new(
+        socket: std::net::UdpSocket,
+        fallback_src_ip: Ipv4Addr,
+        xdp_sender: XdpSender,
+    ) -> io::Result<Self> {
+        let src_addr = socket.local_addr()?;
+        let SocketAddr::V4(src_addr) = src_addr else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Only IPv4 addresses are supported",
+            ));
+        };
+        // if local address is wildcard, override it with fallback_src_ip.
+        let src_addr = if src_addr.ip().is_unspecified() {
+            SocketAddrV4::new(fallback_src_ip, src_addr.port())
+        } else {
+            src_addr
+        };
+
+        // Collect local interface IPs once at construction time. We do not refresh them if
+        // interface addresses change later. This is a low-risk tradeoff because local-destination
+        // egress is expected to be rare: only RPC sendTransaction traffic or local testing.
+        let local_ips = collect_local_ipv4_ips()?;
+
+        Ok(Self {
+            udp_socket: TokioRuntime.wrap_udp_socket(socket)?,
+            xdp_sender: QuicXdpSender::new(xdp_sender, src_addr),
+            local_ips,
+        })
+    }
+
+    fn should_use_kernel_udp(&self, dst: SocketAddr) -> bool {
+        dst.ip().is_loopback() || matches!(dst.ip(), IpAddr::V4(ip) if self.local_ips.contains(&ip))
+    }
+}
+
+impl fmt::Debug for QuicXdpTxSocket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuicXdpTxSocket")
+            .field("local_addr", &self.udp_socket.local_addr())
+            .finish_non_exhaustive()
+    }
+}
+
+impl AsyncUdpSocket for QuicXdpTxSocket {
+    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>> {
+        // The kernel UDP socket poller is always returned here, ignoring the XDP sender. This
+        // implementation is correct under the following assumptions:
+        // 1. When egress AF_XDP is enabled, the kernel UDP socket is used rarely and only for local
+        //    destinations, so it should almost always be writable.
+        // 2. `QuicXdpSender` can almost always enqueue.
+        //
+        // A rare mismatch is still possible: if the UDP socket is not writable while
+        // `QuicXdpSender` could enqueue, throughput may be temporarily suboptimal until the UDP
+        // socket becomes writable. The reverse mismatch is also possible: the UDP poller is ready
+        // but the selected `QuicXdpSender` channel is full. In this case `try_send` fails with
+        // `WouldBlock`, and the caller invokes `poll_writable` again, which can select another
+        // channel in the next round.
+        self.udp_socket.clone().create_io_poller()
+    }
+
+    /// Attempts to send the given [`Transmit`].
+    ///
+    /// For non-local destinations uses AF_XDP, otherwise kernel UDP.
+    ///
+    /// If enqueueing fails after some datagrams were already enqueued, this method returns
+    /// `Err(WouldBlock)`. The caller may retry the whole transmit, which can cause duplicate
+    /// datagrams to be sent for the already enqueued chunks. QUIC packet numbers make this
+    /// protocol-safe, but duplicates can still degrade throughput and congestion behavior. This
+    /// implementation therefore assumes the AF_XDP channel is rarely (ideally never) full.
+    fn try_send(&self, t: &Transmit<'_>) -> io::Result<()> {
+        if self.should_use_kernel_udp(t.destination) {
+            return self.udp_socket.try_send(t);
+        }
+        if t.destination.is_ipv6() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "IPv6 destination addresses are not supported for AF_XDP sends",
+            ));
+        }
+        let src_ip = match t.src_ip {
+            Some(IpAddr::V4(ip)) => Some(ip),
+            Some(IpAddr::V6(_)) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "IPv6 source addresses are not supported",
+                ));
+            }
+            None => None,
+        };
+
+        debug_assert!(
+            t.segment_size.is_none(),
+            "GSO segmentation is disabled for AF_XDP sends, but segment_size is {:?}",
+            t.segment_size
+        );
+
+        let payload = Bytes::copy_from_slice(t.contents);
+        match self
+            .xdp_sender
+            .try_send(src_ip, t.destination, t.ecn, payload)
+        {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => Err(io::ErrorKind::WouldBlock.into()),
+            Err(TrySendError::Disconnected(_)) => Err(io::ErrorKind::BrokenPipe.into()),
+        }
+    }
+
+    fn poll_recv(
+        &self,
+        cx: &mut Context,
+        bufs: &mut [IoSliceMut<'_>],
+        meta: &mut [RecvMeta],
+    ) -> Poll<io::Result<usize>> {
+        self.udp_socket.poll_recv(cx, bufs, meta)
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.udp_socket.local_addr()
+    }
+
+    fn max_transmit_segments(&self) -> usize {
+        // no GSO batches, so each transmit describes exactly one datagram
+        1
+    }
+
+    fn max_receive_segments(&self) -> usize {
+        self.udp_socket.max_receive_segments()
+    }
+
+    fn may_fragment(&self) -> bool {
+        false
+    }
+}
+
+/// [`QuicXdpSender`] wraps [`XdpSender`] and provides round-robin sender selection.
+///
+/// This wrapper provides a simple round-robin sender index for each packet sent. It is required
+/// because `AsyncUdpSocket::try_send` does not provide a way to specify the sender index. If the
+/// `XdpSender` has only one sender, the index is always 0.
+struct QuicXdpSender {
+    xdp_sender: XdpSender,
+    src_addr: SocketAddrV4,
+    next_sender_index: AtomicUsize,
+}
+
+impl QuicXdpSender {
+    fn new(xdp_sender: XdpSender, src_addr: SocketAddrV4) -> Self {
+        let next_sender_index = AtomicUsize::new(0);
+        Self {
+            xdp_sender,
+            src_addr,
+            next_sender_index,
+        }
+    }
+
+    fn try_send(
+        &self,
+        src_ip: Option<Ipv4Addr>,
+        destination: SocketAddr,
+        ecn: Option<QuinnEcnCodepoint>,
+        payload: Bytes,
+    ) -> Result<(), TrySendError<BytesTxPacket>> {
+        let sender_idx = self.next_sender_index.fetch_add(1, Ordering::Relaxed);
+
+        let src_ip = src_ip.unwrap_or(*self.src_addr.ip());
+        // Respect Quinn's per-packet source IP, used for wildcard-bound sockets, while
+        // keeping the port from `self.src_addr`.
+        let src_addr = SocketAddrV4::new(src_ip, self.src_addr.port());
+        let ecn = ecn.map(quinn_ecn_to_xdp);
+
+        self.xdp_sender.try_send(
+            sender_idx,
+            BytesTxPacket::new(src_addr, destination, ecn, payload),
+        )
+    }
+}
+
+/// Collects IPv4 addresses assigned to local network interfaces.
+fn collect_local_ipv4_ips() -> io::Result<Vec<Ipv4Addr>> {
+    let mut ips = Vec::new();
+    for ifa in getifaddrs().map_err(io::Error::other)? {
+        let Some(addr) = ifa.address else { continue };
+        if let Some(v4) = addr.as_sockaddr_in() {
+            let ip = v4.ip();
+            if !ips.contains(&ip) {
+                ips.push(ip);
+            }
+        }
+    }
+    Ok(ips)
+}
+
+#[inline]
+const fn quinn_ecn_to_xdp(ecn: QuinnEcnCodepoint) -> XdpEcnCodepoint {
+    match ecn {
+        QuinnEcnCodepoint::Ect0 => XdpEcnCodepoint::Ect0,
+        QuinnEcnCodepoint::Ect1 => XdpEcnCodepoint::Ect1,
+        QuinnEcnCodepoint::Ce => XdpEcnCodepoint::Ce,
     }
 }

--- a/turbine/src/xdp_sender.rs
+++ b/turbine/src/xdp_sender.rs
@@ -28,7 +28,7 @@ impl XdpSender {
     ) -> Result<(), TrySendError<tx::BytesTxPacket>> {
         self.sender.try_send(
             sender_index,
-            tx::BytesTxPacket::new(self.src_addr, addr, payload),
+            tx::BytesTxPacket::new(self.src_addr, addr, None, payload),
         )
     }
 }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -182,6 +182,11 @@ pub fn execute(
                 xdp_zero_copy,
             )
         });
+    if bind_addresses.len() > 1 && retransmit_xdp.is_some() {
+        Err(String::from(
+            "--xdp-cpu-cores cannot be used in a multihoming context",
+        ))?;
+    }
 
     let dynamic_port_range =
         solana_net_utils::parse_port_range(matches.value_of("dynamic_port_range").unwrap())

--- a/xdp/src/ecn_codepoint.rs
+++ b/xdp/src/ecn_codepoint.rs
@@ -1,0 +1,15 @@
+/// Explicit congestion notification codepoint carried in the IP header.
+///
+/// These values correspond to the two-bit ECN field defined by RFC 3168. They occupy the low two
+/// bits of the IPv4 DS field or IPv6 Traffic Class field. To indicate non-ECT codepoint, use `None`
+/// for `Option<EcnCodepoint>`.
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum EcnCodepoint {
+    /// ECN Capable Transport, codepoint 0.
+    Ect0 = 0b10,
+    /// ECN Capable Transport, codepoint 1.
+    Ect1 = 0b01,
+    /// Indicates congestion to the end nodes, set by router.
+    Ce = 0b11,
+}

--- a/xdp/src/gre/packet.rs
+++ b/xdp/src/gre/packet.rs
@@ -2,6 +2,7 @@
 
 use {
     crate::{
+        ecn_codepoint::EcnCodepoint,
         netlink::{GreTunnelInfo, MacAddress},
         packet::{
             ETH_HEADER_SIZE, IP_HEADER_SIZE, UDP_HEADER_SIZE, write_eth_header, write_ip_header,
@@ -74,6 +75,7 @@ fn write_gre_outer_headers(
     gre_dst_mac: &MacAddress,
     inner_packet_len: usize,
     gre_header: &GreHeader,
+    ecn: Option<EcnCodepoint>,
     info: &GreTunnelInfo,
 ) -> Result<(), PacketError> {
     write_eth_header(packet, &gre_src_mac.0, &gre_dst_mac.0);
@@ -84,6 +86,10 @@ fn write_gre_outer_headers(
     let (IpAddr::V4(outer_local), IpAddr::V4(outer_remote)) = (info.local, info.remote) else {
         return Err(PacketError::InvalidTunnelEndpoints);
     };
+    // We must construct the outer encapsulating IP header by copying the two-bit ECN field of the
+    // incoming IP header, see RFC 6040 Section 4.1.
+    let outer_tos = update_tos_with_ecn(info.tos, ecn);
+
     write_ip_header(
         &mut packet[ETH_HEADER_SIZE..],
         &outer_local,
@@ -94,7 +100,7 @@ fn write_gre_outer_headers(
         // Fragment (DF) flag set.
         true,
         outer_ttl,
-        Some(info.tos),
+        Some(outer_tos),
     );
 
     // Write GRE header
@@ -119,6 +125,7 @@ pub fn construct_gre_packet(
     src_port: u16,
     dst_port: u16,
     payload: &[u8],
+    ecn: Option<EcnCodepoint>,
     info: &GreTunnelInfo,
 ) -> Result<(), PacketError> {
     let payload_len = payload.len();
@@ -142,6 +149,7 @@ pub fn construct_gre_packet(
         dst_mac,
         inner_packet_len,
         &gre_header,
+        ecn,
         info,
     )?;
 
@@ -151,6 +159,7 @@ pub fn construct_gre_packet(
         &mut packet[inner_start..inner_start + IP_HEADER_SIZE],
         src_ip,
         dst_ip,
+        ecn,
         (UDP_HEADER_SIZE + payload_len) as u16,
     );
 
@@ -169,4 +178,9 @@ pub fn construct_gre_packet(
         ..inner_start + INNER_PACKET_HEADER_SIZE + payload_len]
         .copy_from_slice(payload);
     Ok(())
+}
+
+/// Returns `tos` with ECN (low 2 bits) replaced; DSCP (high 6 bits) is preserved.
+fn update_tos_with_ecn(tos: u8, ecn: Option<EcnCodepoint>) -> u8 {
+    tos & 0b1111_1100 | ecn.map_or(0, |ecn| ecn as u8 & 0b0000_0011)
 }

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -30,6 +30,8 @@ pub mod tx_loop;
 #[cfg(target_os = "linux")]
 pub mod umem;
 
+pub mod ecn_codepoint;
+
 pub mod transmitter;
 
 #[cfg(target_os = "linux")]

--- a/xdp/src/packet.rs
+++ b/xdp/src/packet.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
+    crate::ecn_codepoint::EcnCodepoint,
     libc::{ETH_P_IP, IPPROTO_UDP},
     std::net::Ipv4Addr,
 };
@@ -55,6 +56,7 @@ pub fn write_ip_header_for_udp(
     packet: &mut [u8],
     src_ip: &Ipv4Addr,
     dst_ip: &Ipv4Addr,
+    ecn: Option<EcnCodepoint>,
     payload_len: u16,
 ) {
     write_ip_header(
@@ -65,7 +67,9 @@ pub fn write_ip_header_for_udp(
         IPPROTO_UDP as u8,
         true,
         None,
-        None,
+        // tos is composed of DSCP (high 6 bits) and ECN (low 2 bits). We don't set DSCP bits, so
+        // just set the ECN bits.
+        ecn.map(|ecn| ecn as u8),
     );
 }
 

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -1,3 +1,14 @@
+use {
+    crate::ecn_codepoint::EcnCodepoint,
+    bytes::Bytes,
+    crossbeam_channel::{Sender, TrySendError},
+    std::{
+        error::Error,
+        net::{SocketAddr, SocketAddrV4},
+        sync::{Arc, atomic::AtomicBool},
+        thread,
+    },
+};
 #[cfg(target_os = "linux")]
 use {
     crate::{
@@ -6,8 +17,7 @@ use {
         route::{RouteTable, Router, RoutingTables},
         route_monitor::RouteMonitor,
         set_cpu_affinity,
-        tx_loop::TxPacket,
-        tx_loop::{TxLoop, TxLoopBuilder, TxLoopConfigBuilder},
+        tx_loop::{TxLoop, TxLoopBuilder, TxLoopConfigBuilder, TxPacket},
         umem::{OwnedUmem, PageAlignedMemory},
     },
     arc_swap::ArcSwap,
@@ -18,16 +28,6 @@ use {
         net::{IpAddr, Ipv4Addr},
         thread::Builder,
         time::Duration,
-    },
-};
-use {
-    bytes::Bytes,
-    crossbeam_channel::{Sender, TrySendError},
-    std::{
-        error::Error,
-        net::{SocketAddr, SocketAddrV4},
-        sync::{Arc, atomic::AtomicBool},
-        thread,
     },
 };
 
@@ -77,6 +77,7 @@ impl XdpConfig {
 pub struct BytesTxPacket {
     src_addr: SocketAddrV4,
     dst_addrs: XdpAddrs,
+    ecn: Option<EcnCodepoint>,
     payload: Bytes,
 }
 
@@ -85,10 +86,16 @@ pub struct BytesTxPacket;
 
 #[cfg(target_os = "linux")]
 impl BytesTxPacket {
-    pub fn new(src_addr: SocketAddrV4, dst_addrs: impl Into<XdpAddrs>, payload: Bytes) -> Self {
+    pub fn new(
+        src_addr: SocketAddrV4,
+        dst_addrs: impl Into<XdpAddrs>,
+        ecn: Option<EcnCodepoint>,
+        payload: Bytes,
+    ) -> Self {
         Self {
             src_addr,
             dst_addrs: dst_addrs.into(),
+            ecn,
             payload,
         }
     }
@@ -96,7 +103,12 @@ impl BytesTxPacket {
 
 #[cfg(not(target_os = "linux"))]
 impl BytesTxPacket {
-    pub fn new(_src_addr: SocketAddrV4, _dst_addrs: impl Into<XdpAddrs>, _payload: Bytes) -> Self {
+    pub fn new(
+        _src_addr: SocketAddrV4,
+        _dst_addrs: impl Into<XdpAddrs>,
+        _ecn: Option<EcnCodepoint>,
+        _payload: Bytes,
+    ) -> Self {
         Self
     }
 }
@@ -116,6 +128,10 @@ impl TxPacket for BytesTxPacket {
 
     fn src_addr(&self) -> SocketAddrV4 {
         self.src_addr
+    }
+
+    fn ecn(&self) -> Option<EcnCodepoint> {
+        self.ecn
     }
 }
 
@@ -164,6 +180,14 @@ impl XdpSender {
             .checked_rem(self.senders.len())
             .expect("XdpSender::senders should not be empty");
         self.senders[idx].try_send(packet)
+    }
+
+    pub fn len(&self) -> usize {
+        self.senders.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.senders.is_empty()
     }
 }
 

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -3,6 +3,7 @@
 use {
     crate::{
         device::{DeviceQueue, NetworkDevice, QueueId, RingSizes, TxCompletionRing},
+        ecn_codepoint::EcnCodepoint,
         gre::{
             construct_gre_packet, gre_packet_size,
             packet::{GRE_HEADER_BASE_SIZE, INNER_PACKET_HEADER_SIZE},
@@ -201,6 +202,9 @@ pub trait TxPacket {
 
     /// Source address used when sending the packet.
     fn src_addr(&self) -> SocketAddrV4;
+
+    /// Explicit congestion notification bits to set on the packet.
+    fn ecn(&self) -> Option<EcnCodepoint>;
 }
 
 impl<U: Umem> TxLoop<U> {
@@ -279,6 +283,7 @@ impl<U: Umem> TxLoop<U> {
                 let src_addr = item.src_addr();
                 let src_ip = src_addr.ip();
                 let src_port = src_addr.port();
+                let ecn = item.ecn();
                 for addr in item.dst_addrs().as_ref() {
                     if ring.available() == 0 || umem.available() == 0 {
                         commit_pending(&mut ring, &mut written_uncommitted);
@@ -368,6 +373,7 @@ impl<U: Umem> TxLoop<U> {
                             src_port,
                             addr.port(),
                             payload,
+                            ecn,
                             &gre.tunnel_info,
                         ) {
                             log::warn!("dropping packet: {err}");
@@ -425,6 +431,7 @@ impl<U: Umem> TxLoop<U> {
                             &mut packet[ETH_HEADER_SIZE..],
                             src_ip,
                             &dst_ip,
+                            ecn,
                             (UDP_HEADER_SIZE + len) as u16,
                         );
 


### PR DESCRIPTION
#### Short description

This PR adds QUIC transmit support over AF_XDP and optionally enables it in streamer for TPU transactions, excluding votes.

It introduces `QuicXdpTxSocket`, which implements Quinn's `AsyncUdpSocket`.
The socket uses Quinn's default `UdpSocket` implementation for receive, while
routing transmit packets through the AF_XDP socket path when selected by the
user.

This implementation explicitly disables GSO batching and fragmentation.

#### Profiling

Setup:
1. one validator and 4 transaction-bench on two different machines
2. Generated load: 216k TPS of valid transfer txs.
3. Each run is for 60s.

This change drastically reduces net stack syscalls: 

event | without AF_XDP | with AF_XDP | Relative change
-- | -- | -- | -- 
syscalls:sys_enter_recvmmsg | 597023 | 439885 | (597023-439885)/597023=-26%
syscalls:sys_enter_sendmsg | 459758 | 76 | (459758-76)/459758=-99.9%

If we look into flamegraphs (without/with):

<img width="1182" height="847" alt="Screenshot 2026-02-24 at 16 38 20" src="https://github.com/user-attachments/assets/468eef79-0784-4284-863b-230dda0ae68b" />

<img width="1195" height="411" alt="Screenshot 2026-02-24 at 17 07 44" src="https://github.com/user-attachments/assets/173a14d3-97e9-405e-9973-5f45128be176" />

#### Why less recvmmsg

Because batches in recvmmsg are bigger:

<img width="1200" height="500" alt="Figure_1" src="https://github.com/user-attachments/assets/22177bef-b7b1-435b-9d74-bf9cb392cec0" />

```shell
sudo bpftrace -e 'tracepoint:syscalls:sys_exit_recvmmsg /args->ret > 0/ { printf("%d %s %d batch=%d\n", nsecs/1000000, comm, pid, args->ret); }'
```

#### Why draft

From this PR I've extracted two smaller PRs to minimize the changes:
- [x] https://github.com/anza-xyz/agave/pull/10846
- [x] https://github.com/anza-xyz/agave/pull/11200
- [x] https://github.com/anza-xyz/agave/pull/10830
- [x] https://github.com/anza-xyz/agave/pull/11378


