### PR TITLE
fix: align xdp ebpf program bytes as required by the kernel ebpf parser

### DIFF
--- a/scripts/elf-hash-symbol.sh
+++ b/scripts/elf-hash-symbol.sh
@@ -55,6 +55,17 @@ echo "Size: $SYMBOL_SIZE bytes"
 echo "File Offset (Dec): $FILE_OFFSET_DEC"
 echo "----------------------"
 
+# 5. The program data is embedded in a struct with 4-byte alignment and a leading
+#    u8, to enforce ebpf alignment requirements. We need to skip past the leading
+#    byte initial value and remove the padding
+FILE_OFFSET_DEC=$((FILE_OFFSET_DEC + 1))
+SYMBOL_SIZE=$((SYMBOL_SIZE - 4))
+
+echo "--- Elf Details ---"
+echo "Start Offset: ${FILE_OFFSET_DEC}"
+echo "Size: ${SYMBOL_SIZE}"
+echo "-------------------"
+
 # dd command to extract and hash the content
 echo -n "Hash (SHA256): "
 dd if="$ELF_FILE" bs=1 skip="$FILE_OFFSET_DEC" count="$SYMBOL_SIZE" status=none 2>/dev/null | sha256sum | awk '{print $1}'

--- a/xdp-ebpf/src/lib.rs
+++ b/xdp-ebpf/src/lib.rs
@@ -8,16 +8,22 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 #![no_std]
 
+#[repr(C, align(4))]
+pub struct Aligned<Bytes: ?Sized> {
+    pub _align: u8,
+    pub bytes: Bytes,
+}
+
+#[cfg(all(target_os = "linux", not(target_arch = "bpf")))]
+macro_rules! program {
+    () => {
+        include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/agave-xdp-prog"))
+    };
+}
+
 #[cfg(all(target_os = "linux", not(target_arch = "bpf")))]
 #[unsafe(no_mangle)]
-pub static AGAVE_XDP_EBPF_PROGRAM: [u8; aya::include_bytes_aligned!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/agave-xdp-prog"
-))
-.len()] = unsafe {
-    core::ptr::read(
-        aya::include_bytes_aligned!(concat!(env!("CARGO_MANIFEST_DIR"), "/agave-xdp-prog"))
-            .as_ptr()
-            .cast(),
-    )
+pub static AGAVE_XDP_EBPF_PROGRAM: &Aligned<[u8; program!().len()]> = &Aligned {
+    _align: 0,
+    bytes: *program!(),
 };

--- a/xdp/src/program.rs
+++ b/xdp/src/program.rs
@@ -45,7 +45,7 @@ pub fn load_xdp_program(dev: &NetworkDevice) -> Result<Ebpf, Box<dyn std::error:
     let broken_frags = dev.driver()? == "i40e";
     let mut ebpf = if broken_frags {
         loader.set_global("AGAVE_XDP_DROP_MULTI_FRAGS", &1u8, true);
-        loader.load(&agave_xdp_ebpf::AGAVE_XDP_EBPF_PROGRAM)
+        loader.load(&agave_xdp_ebpf::AGAVE_XDP_EBPF_PROGRAM.bytes)
     } else {
         loader.load(&generate_xdp_elf())
     }?;


### PR DESCRIPTION
#### Problem
the kernel ebpf parser strictly require that the program bytes start on a 4-byte boundary. we currently subvert aya's attempts to align them for us by copying the bytes away from the aligned address :melting_face: 

#### Summary of Changes
- replicode the aya alignment wrapper struct
- use it directly instead of copying
- fix up the symbol check script accordingly

closes: #10742 