### PR TITLE
xdp: introduce new xdp sender API to allow custom source address in xdp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11188,6 +11188,7 @@ dependencies = [
  "assert_matches",
  "bencher",
  "bs58",
+ "bytes",
  "crossbeam-channel",
  "itertools 0.14.0",
  "lazy-lru",

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -25,7 +25,6 @@ use {
         validator::{BlockProductionMethod, GeneratorConfig},
     },
     agave_votor::event::VotorEventSender,
-    agave_xdp::xdp_retransmitter::XdpSender,
     crossbeam_channel::{Receiver, bounded, unbounded},
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
@@ -56,7 +55,10 @@ use {
         quic_socket::QuicSocket,
         streamer::StakedNodes,
     },
-    solana_turbine::broadcast_stage::{BroadcastStage, BroadcastStageType},
+    solana_turbine::{
+        XdpSender,
+        broadcast_stage::{BroadcastStage, BroadcastStageType},
+    },
     std::{
         collections::HashMap,
         net::UdpSocket,
@@ -116,7 +118,7 @@ impl Tpu {
         entry_notification_sender: Option<EntryNotifierSender>,
         blockstore: Arc<Blockstore>,
         broadcast_type: &BroadcastStageType,
-        xdp_sender: Option<XdpSender>,
+        turbine_xdp_sender: Option<XdpSender>,
         exit: Arc<AtomicBool>,
         shred_version: u16,
         vote_tracker: Arc<VoteTracker>,
@@ -363,7 +365,7 @@ impl Tpu {
             blockstore,
             bank_forks,
             shred_version,
-            xdp_sender,
+            turbine_xdp_sender,
             votor_event_sender,
         );
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -33,7 +33,6 @@ use {
         votor::{Votor, VotorConfig},
     },
     agave_votor_messages::reward_certificate::{BuildRewardCertsRequest, BuildRewardCertsResponse},
-    agave_xdp::xdp_retransmitter::XdpSender,
     bytes::Bytes,
     crossbeam_channel::{Receiver, Sender, bounded, unbounded},
     solana_client::connection_cache::ConnectionCache,
@@ -67,7 +66,7 @@ use {
         quic::{QuicStreamerConfig, SpawnServerResult, spawn_simple_qos_server},
         streamer::StakedNodes,
     },
-    solana_turbine::retransmit_stage::RetransmitStage,
+    solana_turbine::{XdpSender, retransmit_stage::RetransmitStage},
     std::{
         collections::HashSet,
         net::{SocketAddr, UdpSocket},
@@ -139,7 +138,7 @@ pub struct TvuConfig {
     pub replay_transactions_threads: NonZeroUsize,
     pub shred_sigverify_threads: NonZeroUsize,
     pub bls_sigverify_threads: NonZeroUsize,
-    pub xdp_sender: Option<XdpSender>,
+    pub turbine_xdp_sender: Option<XdpSender>,
 }
 
 impl Default for TvuConfig {
@@ -154,7 +153,7 @@ impl Default for TvuConfig {
             replay_transactions_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             shred_sigverify_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             bls_sigverify_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
-            xdp_sender: None,
+            turbine_xdp_sender: None,
         }
     }
 }
@@ -375,7 +374,7 @@ impl Tvu {
             max_slots.clone(),
             rpc_subscriptions.clone(),
             slot_status_notifier.clone(),
-            tvu_config.xdp_sender,
+            tvu_config.turbine_xdp_sender,
             votor_event_sender.clone(),
         );
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -143,7 +143,7 @@ use {
     },
     solana_time_utils::timestamp,
     solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC},
-    solana_turbine::{self, broadcast_stage::BroadcastStageType},
+    solana_turbine::{self, XdpSender, broadcast_stage::BroadcastStageType},
     solana_unified_scheduler_logic::SchedulingMode,
     solana_unified_scheduler_pool::{DefaultSchedulerPool, SupportedSchedulingMode},
     solana_validator_exit::Exit,
@@ -152,7 +152,7 @@ use {
         borrow::Cow,
         cmp,
         collections::{HashMap, HashSet},
-        net::SocketAddr,
+        net::{SocketAddr, SocketAddrV4},
         num::{NonZeroU64, NonZeroUsize},
         path::{Path, PathBuf},
         str::FromStr,
@@ -675,7 +675,7 @@ impl Validator {
         socket_addr_space: SocketAddrSpace,
         tpu_config: ValidatorTpuConfig,
         admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
-        maybe_xdp_retransmit_builder: Option<XdpRetransmitBuilder>,
+        xdp_builder_with_src_addr: Option<(XdpRetransmitBuilder, SocketAddrV4)>,
     ) -> Result<Self> {
         let exit = Arc::new(AtomicBool::new(false));
         Self::new_with_exit(
@@ -692,7 +692,7 @@ impl Validator {
             socket_addr_space,
             tpu_config,
             admin_rpc_service_post_init,
-            maybe_xdp_retransmit_builder,
+            xdp_builder_with_src_addr,
             exit,
         )
     }
@@ -712,7 +712,7 @@ impl Validator {
         socket_addr_space: SocketAddrSpace,
         tpu_config: ValidatorTpuConfig,
         admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
-        maybe_xdp_retransmit_builder: Option<XdpRetransmitBuilder>,
+        xdp_builder_with_src_addr: Option<(XdpRetransmitBuilder, SocketAddrV4)>,
         exit: Arc<AtomicBool>,
     ) -> Result<Self> {
         #[cfg(debug_assertions)]
@@ -1583,10 +1583,10 @@ impl Validator {
         // This channel backing up indicates a serious problem in votor
         let (votor_event_sender, votor_event_receiver) = bounded(1000);
 
-        let (xdp_retransmitter, xdp_sender) =
-            if let Some(xdp_retransmit_builder) = maybe_xdp_retransmit_builder {
+        let (xdp_retransmitter, turbine_xdp_sender) =
+            if let Some((xdp_retransmit_builder, src_addr)) = xdp_builder_with_src_addr {
                 let (rtx, sender) = xdp_retransmit_builder.build();
-                (Some(rtx), Some(sender))
+                (Some(rtx), Some(XdpSender::new(sender, src_addr)))
             } else {
                 (None, None)
             };
@@ -1646,7 +1646,7 @@ impl Validator {
                 replay_transactions_threads: config.replay_transactions_threads,
                 shred_sigverify_threads: config.tvu_shred_sigverify_threads,
                 bls_sigverify_threads: config.tvu_bls_sigverify_threads,
-                xdp_sender: xdp_sender.clone(),
+                turbine_xdp_sender: turbine_xdp_sender.clone(),
             },
             &max_slots,
             block_metadata_notifier,
@@ -1711,7 +1711,7 @@ impl Validator {
             entry_notification_sender,
             blockstore.clone(),
             &config.broadcast_stage_type,
-            xdp_sender,
+            turbine_xdp_sender,
             exit.clone(),
             node.info.shred_version(),
             vote_tracker,

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9577,6 +9577,7 @@ dependencies = [
  "agave-votor",
  "agave-votor-messages",
  "agave-xdp",
+ "bytes",
  "crossbeam-channel",
  "itertools 0.14.0",
  "lazy-lru",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9880,6 +9880,7 @@ dependencies = [
  "agave-votor",
  "agave-votor-messages",
  "agave-xdp",
+ "bytes",
  "crossbeam-channel",
  "itertools 0.14.0",
  "lazy-lru",

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -17,6 +17,7 @@ agave-feature-set = { workspace = true }
 agave-votor = { workspace = true }
 agave-votor-messages = { workspace = true }
 agave-xdp = { workspace = true }
+bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
 itertools = { workspace = true }
 lazy-lru = { workspace = true }

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -8,9 +8,11 @@ use {
         fail_entry_verification_broadcast_run::FailEntryVerificationBroadcastRun,
         standard_broadcast_run::StandardBroadcastRun,
     },
-    crate::cluster_nodes::{ClusterNodes, ClusterNodesCache},
+    crate::{
+        XdpSender,
+        cluster_nodes::{ClusterNodes, ClusterNodesCache},
+    },
     agave_votor::event::VotorEventSender,
-    agave_xdp::xdp_retransmitter::XdpSender,
     crossbeam_channel::{Receiver, RecvError, RecvTimeoutError, Sender, unbounded},
     itertools::Itertools,
     solana_clock::Slot,

--- a/turbine/src/lib.rs
+++ b/turbine/src/lib.rs
@@ -11,6 +11,10 @@ pub mod retransmit_stage;
 
 pub mod sigverify_shreds;
 
+pub mod xdp_sender;
+
+pub use crate::xdp_sender::XdpSender;
+
 #[macro_use]
 extern crate log;
 

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -2,6 +2,7 @@
 
 use {
     crate::{
+        XdpSender,
         addr_cache::AddrCache,
         cluster_nodes::{
             ClusterNodes, ClusterNodesCache, DATA_PLANE_FANOUT, Error, MAX_NUM_TURBINE_HOPS,
@@ -9,7 +10,6 @@ use {
     },
     agave_votor::event::VotorEvent,
     agave_votor_messages::migration::MigrationStatus,
-    agave_xdp::xdp_retransmitter::XdpSender,
     crossbeam_channel::{Receiver, Sender, TryRecvError, TrySendError},
     lru::LruCache,
     rand::Rng,
@@ -240,8 +240,8 @@ impl<'a> RetransmitSocket<'a> {
         xdp_sender: Option<&'a XdpSender>,
         cluster_info: &'a ClusterInfo,
     ) -> Self {
-        if let Some(xdp_sender) = xdp_sender {
-            RetransmitSocket::Xdp(xdp_sender)
+        if let Some(sender) = xdp_sender {
+            RetransmitSocket::Xdp(sender)
         } else if cluster_info.bind_ip_addrs().multihoming_enabled() {
             let sockets_per_interface =
                 retransmit_sockets.len() / cluster_info.bind_ip_addrs().len();

--- a/turbine/src/xdp_sender.rs
+++ b/turbine/src/xdp_sender.rs
@@ -1,0 +1,34 @@
+//! This module defines [`XdpSender`] which is a convenience wrapper around
+//! [`agave_xdp::xdp_retransmitter::XdpSender`] for the case when source address is fixed for all
+//! items like it is in turbine.
+use {
+    agave_xdp::xdp_retransmitter as tx, bytes::Bytes, crossbeam_channel::TrySendError,
+    std::net::SocketAddrV4,
+};
+
+/// [`XdpSender`] is a structure that simplifies sending packets over XDP with `XdpSender`
+/// when source address is fixed for all items.
+#[derive(Clone)]
+pub struct XdpSender {
+    sender: tx::XdpSender,
+    src_addr: SocketAddrV4,
+}
+
+impl XdpSender {
+    pub fn new(sender: tx::XdpSender, src_addr: SocketAddrV4) -> Self {
+        Self { sender, src_addr }
+    }
+
+    #[inline]
+    pub fn try_send(
+        &self,
+        sender_index: usize,
+        addr: impl Into<tx::XdpAddrs>,
+        payload: Bytes,
+    ) -> Result<(), TrySendError<tx::XdpTransmitItem>> {
+        self.sender.try_send(
+            sender_index,
+            tx::XdpTransmitItem::new(self.src_addr, addr, payload),
+        )
+    }
+}

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -263,9 +263,9 @@ pub fn execute(
     let exit = Arc::new(AtomicBool::new(false));
 
     #[cfg(target_os = "linux")]
-    let maybe_xdp_retransmit_builder = {
+    let xdp_builder_with_src_addr = {
         use {
-            agave_xdp::xdp_retransmitter::{XdpRetransmitBuilder, master_ip_if_bonded},
+            agave_xdp::xdp_retransmitter::XdpRetransmitBuilder,
             caps::{
                 CapSet,
                 Capability::{CAP_BPF, CAP_NET_ADMIN, CAP_NET_RAW, CAP_PERFMON, CAP_SYS_NICE},
@@ -335,32 +335,47 @@ pub fn execute(
         // XDP _MUST_ be setup _BEFORE_ the app spawns any threads to ensure linux
         // capabilities do not leak, leaving the process in a state where it could
         // potentially be used as a privilege escalation gadget
-        let maybe_xdp_retransmit_builder = retransmit_xdp.clone().map(|xdp_config| {
+        let xdp_builder_with_src_addr = retransmit_xdp.clone().map(|xdp_config| {
+            use {
+                agave_xdp::{default_device_ipv4, interface_ipv4},
+                std::net::SocketAddrV4,
+            };
+
             let src_port = node.sockets.retransmit_sockets[0]
                 .local_addr()
                 .expect("failed to get local address")
                 .port();
             let src_ip = match node.bind_ip_addrs.active() {
-                IpAddr::V4(ip) if !ip.is_unspecified() => Some(ip),
-                IpAddr::V4(_unspecified) => xdp_config
-                    .interface
-                    .as_ref()
-                    .and_then(|iface| master_ip_if_bonded(iface)),
+                IpAddr::V4(ip) if !ip.is_unspecified() => ip,
+                IpAddr::V4(_unspecified) => {
+                    if let Some(interface) = xdp_config.interface.as_ref() {
+                        interface_ipv4(interface).expect(
+                            "configured interface should exist and have an IPv4 address assigned",
+                        )
+                    } else {
+                        default_device_ipv4().expect(
+                            "default route device should exist and have an IPv4 address assigned",
+                        )
+                    }
+                }
                 _ => panic!("IPv6 not supported"),
             };
-            XdpRetransmitBuilder::new(xdp_config, src_port, src_ip, exit.clone())
-                .expect("failed to create xdp retransmitter")
+            (
+                XdpRetransmitBuilder::new(xdp_config, exit.clone())
+                    .expect("failed to create xdp retransmitter"),
+                SocketAddrV4::new(src_ip, src_port),
+            )
         });
 
         // we're done with caps needed to init xdp now. remove them from our process
         caps::set(None, CapSet::Permitted, &retained_caps)
             .expect("linux allows permitted capset to be set");
 
-        maybe_xdp_retransmit_builder
+        xdp_builder_with_src_addr
     };
 
     #[cfg(not(target_os = "linux"))]
-    let maybe_xdp_retransmit_builder = None;
+    let xdp_builder_with_src_addr = None;
 
     let reserved = retransmit_xdp
         .map(|xdp| xdp.cpus.clone())
@@ -1114,7 +1129,7 @@ pub fn execute(
             sigverify_threads: tpu_sigverify_threads,
         },
         admin_service_post_init,
-        maybe_xdp_retransmit_builder,
+        xdp_builder_with_src_addr,
         exit,
     )
     .map_err(|err| format!("{err:?}"))?;

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -32,7 +32,7 @@ pub mod xdp_retransmitter;
 
 #[cfg(target_os = "linux")]
 pub use program::load_xdp_program;
-use std::io;
+use std::{io, net::Ipv4Addr};
 
 #[cfg(target_os = "linux")]
 pub fn set_cpu_affinity(cpus: impl IntoIterator<Item = usize>) -> Result<(), io::Error> {
@@ -76,5 +76,33 @@ pub fn get_cpu() -> Result<usize, io::Error> {
 
 #[cfg(not(target_os = "linux"))]
 pub fn get_cpu() -> Result<usize, io::Error> {
+    unimplemented!()
+}
+
+/// Returns the IPv4 address of the specified network interface.
+///
+/// If the interface is part of a bonded interface, returns the master's IPv4 address.
+#[cfg(target_os = "linux")]
+pub fn interface_ipv4(interface: &str) -> Result<Ipv4Addr, io::Error> {
+    if let Some(ip) = crate::xdp_retransmitter::master_ip_if_bonded(interface) {
+        Ok(ip)
+    } else {
+        crate::device::NetworkDevice::new(interface)?.ipv4_addr()
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn interface_ipv4(_interface: &str) -> Result<Ipv4Addr, io::Error> {
+    unimplemented!()
+}
+
+/// Returns the IPv4 address of the device associated with the default route.
+#[cfg(target_os = "linux")]
+pub fn default_device_ipv4() -> Result<Ipv4Addr, io::Error> {
+    crate::device::NetworkDevice::new_from_default_route()?.ipv4_addr()
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn default_device_ipv4() -> Result<Ipv4Addr, io::Error> {
     unimplemented!()
 }

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -17,7 +17,7 @@ use {
     crossbeam_channel::{Receiver, Sender, TryRecvError},
     libc::{_SC_PAGESIZE, sysconf},
     std::{
-        net::{IpAddr, Ipv4Addr, SocketAddr},
+        net::{IpAddr, SocketAddr, SocketAddrV4},
         thread,
         time::Duration,
     },
@@ -26,17 +26,13 @@ use {
 pub struct TxLoopConfigBuilder {
     zero_copy: bool,
     maybe_src_mac: Option<MacAddress>,
-    maybe_src_ip: Option<Ipv4Addr>,
-    src_port: u16,
 }
 
 impl TxLoopConfigBuilder {
-    pub fn new(src_port: u16) -> Self {
+    pub fn new() -> Self {
         Self {
             zero_copy: false,
             maybe_src_mac: None,
-            maybe_src_ip: None,
-            src_port,
         }
     }
 
@@ -50,17 +46,10 @@ impl TxLoopConfigBuilder {
         self
     }
 
-    pub fn override_src_ip(&mut self, ip: Ipv4Addr) -> &mut Self {
-        self.maybe_src_ip = Some(ip);
-        self
-    }
-
     pub fn build_with_src_device(self, src_device: &NetworkDevice) -> TxLoopConfig {
         let Self {
             zero_copy,
             maybe_src_mac,
-            maybe_src_ip,
-            src_port,
         } = self;
 
         let src_mac = maybe_src_mac.unwrap_or_else(|| {
@@ -70,19 +59,13 @@ impl TxLoopConfigBuilder {
                 .expect("no src_mac provided, device must have a MAC address")
         });
 
-        let src_ip = maybe_src_ip.unwrap_or_else(|| {
-            // if no source IP is provided, use the device's IPv4 address
-            src_device
-                .ipv4_addr()
-                .expect("no src_ip provided, device must have an IPv4 address")
-        });
+        TxLoopConfig { zero_copy, src_mac }
+    }
+}
 
-        TxLoopConfig {
-            zero_copy,
-            src_mac,
-            src_ip,
-            src_port,
-        }
+impl Default for TxLoopConfigBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -90,8 +73,6 @@ impl TxLoopConfigBuilder {
 pub struct TxLoopConfig {
     zero_copy: bool,
     src_mac: MacAddress,
-    src_ip: Ipv4Addr,
-    src_port: u16,
 }
 
 pub struct TxLoopBuilder<U: Umem> {
@@ -99,8 +80,6 @@ pub struct TxLoopBuilder<U: Umem> {
     queue_id: QueueId,
     zero_copy: bool,
     src_mac: MacAddress,
-    src_ip: Ipv4Addr,
-    src_port: u16,
     queue: DeviceQueue,
     tx_size: usize,
     umem: U,
@@ -113,12 +92,7 @@ impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
         config: TxLoopConfig,
         dev: &NetworkDevice,
     ) -> TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
-        let TxLoopConfig {
-            zero_copy,
-            src_mac,
-            src_ip,
-            src_port,
-        } = config;
+        let TxLoopConfig { zero_copy, src_mac } = config;
 
         log::info!(
             "starting xdp loop on {} queue {queue_id:?} cpu {cpu_id}",
@@ -160,8 +134,6 @@ impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
             queue_id,
             zero_copy,
             src_mac,
-            src_ip,
-            src_port,
             queue,
             tx_size,
             umem,
@@ -174,8 +146,6 @@ impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
             queue_id,
             zero_copy,
             src_mac,
-            src_ip,
-            src_port,
             queue,
             tx_size,
             umem,
@@ -196,8 +166,6 @@ impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
         TxLoop {
             cpu_id,
             src_mac,
-            src_ip,
-            src_port,
             socket,
             ring,
             completion,
@@ -208,18 +176,32 @@ impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
 pub struct TxLoop<U: Umem> {
     cpu_id: usize,
     src_mac: MacAddress,
-    src_ip: Ipv4Addr,
-    src_port: u16,
     socket: Socket<U>,
     ring: TxRing<U::Frame>,
     completion: TxCompletionRing,
 }
 
+/// [`TransmitItem`] represents an item to transmit a packet via XDP to a list of addresses with the
+/// provided `payload` and source address.
+pub trait TransmitItem {
+    type Addrs: AsRef<[SocketAddr]>;
+    type Payload: AsRef<[u8]>;
+
+    /// List of destination addresses to which the packet should be sent.
+    fn dst_addrs(&self) -> &Self::Addrs;
+
+    /// Payload of the packet to be sent.
+    fn payload(&self) -> &Self::Payload;
+
+    /// Source address used when sending the packet.
+    fn src_addr(&self) -> SocketAddrV4;
+}
+
 impl<U: Umem> TxLoop<U> {
-    pub fn run<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>, R: Fn(&IpAddr) -> Option<NextHop>>(
+    pub fn run<T: TransmitItem, R: Fn(&IpAddr) -> Option<NextHop>>(
         self,
-        receiver: Receiver<(A, T)>,
-        drop_sender: Sender<(A, T)>,
+        receiver: Receiver<T>,
+        drop_sender: Sender<T>,
         route_fn: R,
     ) {
         // How long we sleep waiting to receive shreds from the channel.
@@ -235,8 +217,6 @@ impl<U: Umem> TxLoop<U> {
         let TxLoop {
             cpu_id,
             src_mac,
-            src_ip,
-            src_port,
             mut socket,
             mut ring,
             mut completion,
@@ -259,9 +239,9 @@ impl<U: Umem> TxLoop<U> {
         let mut timeouts = 0;
         loop {
             match receiver.try_recv() {
-                Ok((addrs, payload)) => {
-                    batched_packets += addrs.as_ref().len();
-                    batched_items.push((addrs, payload));
+                Ok(item) => {
+                    batched_packets += item.dst_addrs().as_ref().len();
+                    batched_items.push(item);
                     timeouts = 0;
                     if batched_packets < BATCH_SIZE {
                         continue;
@@ -290,8 +270,11 @@ impl<U: Umem> TxLoop<U> {
             // necessary
             let mut chunk_remaining = BATCH_SIZE.min(batched_packets);
 
-            for (addrs, payload) in batched_items.drain(..) {
-                for addr in addrs.as_ref() {
+            for item in batched_items.drain(..) {
+                let src_addr = item.src_addr();
+                let src_ip = src_addr.ip();
+                let src_port = src_addr.port();
+                for addr in item.dst_addrs().as_ref() {
                     if ring.available() == 0 || umem.available() == 0 {
                         // loop until we have space for the next packet
                         loop {
@@ -322,7 +305,8 @@ impl<U: Umem> TxLoop<U> {
                         panic!("IPv6 not supported");
                     };
 
-                    let len = payload.as_ref().len();
+                    let payload = item.payload().as_ref();
+                    let len = payload.len();
 
                     let dst = addr.ip();
                     let Some(next_hop) = route_fn(&dst) else {
@@ -335,16 +319,16 @@ impl<U: Umem> TxLoop<U> {
                     if let Some(gre) = &next_hop.gre {
                         frame.set_len(gre_packet_size(len));
                         let packet = umem.map_frame_mut(&frame);
-                        let inner_src_ip = next_hop.preferred_src_ip.unwrap_or(src_ip);
+                        let inner_src_ip = next_hop.preferred_src_ip.as_ref().unwrap_or(src_ip);
                         if let Err(err) = construct_gre_packet(
                             packet,
                             &src_mac,
                             &gre.mac_addr,
-                            &inner_src_ip,
+                            inner_src_ip,
                             &dst_ip,
                             src_port,
                             addr.port(),
-                            payload.as_ref(),
+                            payload,
                             &gre.tunnel_info,
                         ) {
                             log::warn!("dropping packet: {err}");
@@ -371,20 +355,20 @@ impl<U: Umem> TxLoop<U> {
                         let packet = umem.map_frame_mut(&frame);
 
                         // write the payload first as it's needed for checksum calculation (if enabled)
-                        packet[PACKET_HEADER_SIZE..][..len].copy_from_slice(payload.as_ref());
+                        packet[PACKET_HEADER_SIZE..][..len].copy_from_slice(payload);
 
                         write_eth_header(packet, &src_mac.0, &dest_mac.0);
 
                         write_ip_header_for_udp(
                             &mut packet[ETH_HEADER_SIZE..],
-                            &src_ip,
+                            src_ip,
                             &dst_ip,
                             (UDP_HEADER_SIZE + len) as u16,
                         );
 
                         write_udp_header(
                             &mut packet[ETH_HEADER_SIZE + IP_HEADER_SIZE..],
-                            &src_ip,
+                            src_ip,
                             src_port,
                             &dst_ip,
                             addr.port(),
@@ -411,7 +395,7 @@ impl<U: Umem> TxLoop<U> {
                         kick(&ring);
                     }
                 }
-                let _ = drop_sender.try_send((addrs, payload));
+                let _ = drop_sender.try_send(item);
             }
             debug_assert_eq!(batched_packets, 0);
         }

--- a/xdp/src/xdp_retransmitter.rs
+++ b/xdp/src/xdp_retransmitter.rs
@@ -6,6 +6,7 @@ use {
         route::Router,
         route_monitor::RouteMonitor,
         set_cpu_affinity,
+        tx_loop::TransmitItem,
         tx_loop::{TxLoop, TxLoopBuilder, TxLoopConfigBuilder},
         umem::{OwnedUmem, PageAlignedMemory},
     },
@@ -13,14 +14,14 @@ use {
     aya::Ebpf,
     crossbeam_channel::TryRecvError,
     log::info,
-    std::{thread::Builder, time::Duration},
+    std::{net::Ipv4Addr, thread::Builder, time::Duration},
 };
 use {
     bytes::Bytes,
     crossbeam_channel::{Sender, TrySendError},
     std::{
         error::Error,
-        net::{Ipv4Addr, SocketAddr},
+        net::{SocketAddr, SocketAddrV4},
         sync::{Arc, atomic::AtomicBool},
         thread,
     },
@@ -66,9 +67,57 @@ impl XdpConfig {
     }
 }
 
+/// [`XdpTransmitItem`] encapsulates the information needed to transmit a packet via XDP. Besides
+/// the payload and destination addresses, it includes the source address of the packet.
+#[cfg(target_os = "linux")]
+pub struct XdpTransmitItem {
+    src_addr: SocketAddrV4,
+    dst_addrs: XdpAddrs,
+    payload: Bytes,
+}
+
+#[cfg(not(target_os = "linux"))]
+pub struct XdpTransmitItem;
+
+#[cfg(target_os = "linux")]
+impl XdpTransmitItem {
+    pub fn new(src_addr: SocketAddrV4, dst_addrs: impl Into<XdpAddrs>, payload: Bytes) -> Self {
+        Self {
+            src_addr,
+            dst_addrs: dst_addrs.into(),
+            payload,
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+impl XdpTransmitItem {
+    pub fn new(_src_addr: SocketAddrV4, _dst_addrs: impl Into<XdpAddrs>, _payload: Bytes) -> Self {
+        Self
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl TransmitItem for XdpTransmitItem {
+    type Addrs = XdpAddrs;
+    type Payload = Bytes;
+
+    fn dst_addrs(&self) -> &Self::Addrs {
+        &self.dst_addrs
+    }
+
+    fn payload(&self) -> &Self::Payload {
+        &self.payload
+    }
+
+    fn src_addr(&self) -> SocketAddrV4 {
+        self.src_addr
+    }
+}
+
 #[derive(Clone)]
 pub struct XdpSender {
-    senders: Vec<Sender<(XdpAddrs, Bytes)>>,
+    senders: Vec<Sender<XdpTransmitItem>>,
 }
 
 pub enum XdpAddrs {
@@ -105,13 +154,12 @@ impl XdpSender {
     pub fn try_send(
         &self,
         sender_index: usize,
-        addr: impl Into<XdpAddrs>,
-        payload: Bytes,
-    ) -> Result<(), TrySendError<(XdpAddrs, Bytes)>> {
+        item: XdpTransmitItem,
+    ) -> Result<(), TrySendError<XdpTransmitItem>> {
         let idx = sender_index
             .checked_rem(self.senders.len())
             .expect("XdpSender::senders should not be empty");
-        self.senders[idx].try_send((addr.into(), payload))
+        self.senders[idx].try_send(item)
     }
 }
 
@@ -133,22 +181,12 @@ pub struct XdpRetransmitBuilder {
 
 impl XdpRetransmitBuilder {
     #[cfg(not(target_os = "linux"))]
-    pub fn new(
-        _config: XdpConfig,
-        _src_port: u16,
-        _src_ip: Option<Ipv4Addr>,
-        _exit: Arc<AtomicBool>,
-    ) -> Result<Self, Box<dyn Error>> {
+    pub fn new(_config: XdpConfig, _exit: Arc<AtomicBool>) -> Result<Self, Box<dyn Error>> {
         Err("XDP is only supported on Linux".into())
     }
 
     #[cfg(target_os = "linux")]
-    pub fn new(
-        config: XdpConfig,
-        src_port: u16,
-        src_ip: Option<Ipv4Addr>,
-        exit: Arc<AtomicBool>,
-    ) -> Result<Self, Box<dyn Error>> {
+    pub fn new(config: XdpConfig, exit: Arc<AtomicBool>) -> Result<Self, Box<dyn Error>> {
         use {
             caps::{
                 CapSet,
@@ -169,11 +207,8 @@ impl XdpRetransmitBuilder {
             NetworkDevice::new_from_default_route().unwrap()
         });
 
-        let mut tx_loop_config_builder = TxLoopConfigBuilder::new(src_port);
+        let mut tx_loop_config_builder = TxLoopConfigBuilder::new();
         tx_loop_config_builder.zero_copy(zero_copy);
-        if let Some(src_ip) = src_ip {
-            tx_loop_config_builder.override_src_ip(src_ip);
-        }
         let tx_loop_config = tx_loop_config_builder.build_with_src_device(&dev);
 
         let reserved_cores = cpus.iter().cloned().collect::<HashSet<_>>();
@@ -344,7 +379,7 @@ impl XdpRetransmitter {
 
 /// Returns the IPv4 address of the master interface if the given interface is part of a bond.
 #[cfg(target_os = "linux")]
-pub fn master_ip_if_bonded(interface: &str) -> Option<Ipv4Addr> {
+pub(crate) fn master_ip_if_bonded(interface: &str) -> Option<Ipv4Addr> {
     let master_ifindex_path = format!("/sys/class/net/{interface}/master/ifindex");
     if let Ok(contents) = std::fs::read_to_string(&master_ifindex_path) {
         let idx = contents.trim().parse().unwrap();
@@ -359,10 +394,5 @@ pub fn master_ip_if_bonded(interface: &str) -> Option<Ipv4Addr> {
                 }),
         );
     }
-    None
-}
-
-#[cfg(not(target_os = "linux"))]
-pub fn master_ip_if_bonded(_interface: &str) -> Option<Ipv4Addr> {
     None
 }


### PR DESCRIPTION
#### Problem

In order to implement quic egress over `AF_XDP` we need to be able to use custom source address rather that one we use for turbine. 

For context, https://github.com/anza-xyz/agave/pull/10820

#### Summary of Changes

* change implementation of `XdpSender` to be more generic and support `src_addr`
* introduce a convenience wrapper `XdpSender`in turbine crate that encapsulates source address and more general-purpose sender from xdp crate
* move logic related to `src_ip` to one place and call it in execute

