### PR TITLE
Ignores ancestors in Bank equality

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -544,7 +544,7 @@ impl PartialEq for Bank {
             rc: _,
             status_cache: _,
             blockhash_queue,
-            ancestors,
+            ancestors: _,
             hash,
             parent_hash,
             parent_slot,
@@ -612,7 +612,6 @@ impl PartialEq for Bank {
             // is added to the struct, this PartialEq is accordingly updated.
         } = self;
         *blockhash_queue.read().unwrap() == *other.blockhash_queue.read().unwrap()
-            && ancestors == &other.ancestors
             && *hash.read().unwrap() == *other.hash.read().unwrap()
             && parent_hash == &other.parent_hash
             && parent_slot == &other.parent_slot


### PR DESCRIPTION
#### Problem

Comparing two `Bank`s for equality currently includes their ancestors, but ancestors do not indicate if two banks are equal or not.

Here's an example:

One validator has been running for a while. A second validator boots up.

The first validator will have a reached steady state with its BankForks. Its banks will have their parents and ancestors filled in.

The second validator begins with a single Bank at the snapshot slot. This Bank is a root, and has no parents. It thus has no ancestors.

Assuming the second validator boots successfully, and the snapshot passes verification, the bank for the same slot on the two validators must be identical.

Footnote: We currently include ancestors in the snapshot, so the second validator does have its ancestors field populated, but I'd argue that is erroneous, and I plan to rip it out. Hence this PR first.

Of course the ancestors influence a Bank's view of accounts/state. If there are two banks with different ancestors on different forks, they'll end up with different hashes/account updates. That's the real equality check.


#### Summary of Changes

When comparing banks, ignore their ancestors.