### PR TITLE
Remove useless read wrappers

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -159,25 +159,13 @@ impl Accounts {
             Err(AddressLookupError::InvalidAccountOwner)
         }
     }
-    /// Slow because lock is held for 1 operation instead of many
-    /// This always returns None for zero-lamport accounts.
-    fn load_slow(
-        &self,
-        ancestors: &Ancestors,
-        pubkey: &Pubkey,
-        load_hint: LoadHint,
-        populate_read_cache: PopulateReadCache,
-    ) -> Option<(AccountSharedData, Slot)> {
-        self.accounts_db
-            .load(ancestors, pubkey, load_hint, populate_read_cache)
-    }
 
     pub fn load_with_fixed_root(
         &self,
         ancestors: &Ancestors,
         pubkey: &Pubkey,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.load_slow(
+        self.accounts_db.load(
             ancestors,
             pubkey,
             LoadHint::FixedMaxRoot,
@@ -192,7 +180,7 @@ impl Accounts {
         ancestors: &Ancestors,
         pubkey: &Pubkey,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.load_slow(
+        self.accounts_db.load(
             ancestors,
             pubkey,
             LoadHint::FixedMaxRoot,
@@ -205,7 +193,7 @@ impl Accounts {
         ancestors: &Ancestors,
         pubkey: &Pubkey,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.load_slow(
+        self.accounts_db.load(
             ancestors,
             pubkey,
             LoadHint::Unspecified,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3875,16 +3875,6 @@ impl AccountsDb {
         load_hint: LoadHint,
         populate_read_cache: PopulateReadCache,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.do_load_with_populate_read_cache(ancestors, pubkey, load_hint, populate_read_cache)
-    }
-
-    fn do_load_with_populate_read_cache(
-        &self,
-        ancestors: &Ancestors,
-        pubkey: &Pubkey,
-        load_hint: LoadHint,
-        populate_read_cache: PopulateReadCache,
-    ) -> Option<(AccountSharedData, Slot)> {
         let starting_max_root = self.accounts_index.max_root_inclusive();
 
         let (slot, storage_location, _maybe_account_accessor) =


### PR DESCRIPTION
#### Problem
Read path has several wrappers that provide no purpose

#### Summary of Changes
- The last one!
- Remove them

After many PRS:
https://github.com/anza-xyz/agave/pull/10589
https://github.com/anza-xyz/agave/pull/10710
https://github.com/anza-xyz/agave/pull/10737
https://github.com/anza-xyz/agave/pull/10739
https://github.com/anza-xyz/agave/pull/10789
https://github.com/anza-xyz/agave/pull/10804
https://github.com/anza-xyz/agave/pull/10834

The read path has been updated as follows with all striked through functions removed:
~~- accounts_db: do_load_with_populate_read_cache~~
~~-- accounts_db: load_account_into_read_cache~~
~~--- bank: load_account_into_read_cache~~
-- accounts_db: do_load
--- accounts_db: load
~~---- accounts_db: load_with_fixed_root~~ 
~~----- accounts: load_lookup_table_addresses~~
~~---- accounts: load_slow~~
----- accounts: load_with_fixed_root
----- accounts: load_with_fixed_root_do_not_populate_read_cache
----- accounts: load_without_fixed_root
~~- accounts_db: load_account_with~~
~~-- bank: load_account_with~~

In additional multiple parameters removed and many functions had their scopes reduced

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
