### PR TITLE
Use assert_not_load in serde_snapshot_test

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6898,7 +6898,7 @@ impl AccountsDb {
     /// Note that this is non-deterministic if clean is running asynchronously.
     /// If a zero lamport account exists in the index, then Some is returned.
     /// Once it is cleaned from the index, None is returned.
-    pub fn load_without_fixed_root(
+    fn load_without_fixed_root(
         &self,
         ancestors: &Ancestors,
         pubkey: &Pubkey,

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -290,11 +290,7 @@ mod serde_snapshot_tests {
         db.assert_load_account(new_root, key2, 1);
 
         // Check purged account stays gone
-        let unrooted_slot_ancestors = vec![(unrooted_slot, 1)].into_iter().collect();
-        assert!(
-            db.load_without_fixed_root(&unrooted_slot_ancestors, &key)
-                .is_none()
-        );
+        db.assert_not_load_account(unrooted_slot, key);
     }
 
     #[test_matrix(


### PR DESCRIPTION
#### Problem
Test is using load_without_fixed_root when assert_not_load_account can do the same thing. This allows for reduced public interface for accounts_db

#### Summary of Changes
- Switch test to use assert_not_load_account
- Make load_without_fixed_root private. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
