### PR TITLE
Remove `pbkdf2`, `rand_chacha0-2` as they are not used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,7 +334,6 @@ num_enum = "0.7.4"
 openssl = "0.10"
 pairing = "0.23.0"
 parking_lot = "0.12"
-pbkdf2 = { version = "0.12.2", default-features = false }
 pem = "1.1.1"
 percentage = "0.1.0"
 pickledb = { version = "0.5.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -356,7 +356,6 @@ quote = "1.0"
 rand = "0.9.2"
 rand0-7 = { package = "rand", version = "0.7" }
 rand_chacha = "0.9.0"
-rand_chacha0-2 = { package = "rand_chacha", version = "0.2.2" }
 rayon = "1.11.0"
 reed-solomon-erasure = "6.0.0"
 regex = "1.12.3"


### PR DESCRIPTION
#### Problem

The `pbkdf2` and `rand_chacha0-2` crates are not used by any crates in the repo.

#### Summary of Changes

Clean up unused crates.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
