### PR TITLE
streamer: introduce QuicSocket enum wrapping UdpSocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10786,6 +10786,7 @@ name = "solana-streamer"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-logger",
+ "agave-xdp",
  "anyhow",
  "arc-swap",
  "assert_matches",

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -53,6 +53,7 @@ use {
             SimpleQosQuicStreamerConfig, SpawnServerResult, SwQosQuicStreamerConfig,
             spawn_simple_qos_server, spawn_stake_wighted_qos_server,
         },
+        quic_socket::QuicSocket,
         streamer::StakedNodes,
     },
     solana_turbine::broadcast_stage::{BroadcastStage, BroadcastStageType},
@@ -188,6 +189,8 @@ impl Tpu {
         } = banking_tracer_channels;
 
         // Streamer for Votes:
+        let quic_vote_sockets: Vec<QuicSocket> =
+            tpu_vote_quic_sockets.into_iter().map(Into::into).collect();
         let SpawnServerResult {
             endpoints: _,
             thread: tpu_vote_quic_t,
@@ -195,7 +198,7 @@ impl Tpu {
         } = spawn_simple_qos_server(
             "solQuicTVo",
             "quic_streamer_tpu_vote",
-            tpu_vote_quic_sockets,
+            quic_vote_sockets,
             keypair,
             vote_packet_sender,
             staked_nodes.clone(),
@@ -206,6 +209,10 @@ impl Tpu {
         .unwrap();
 
         // Streamer for TPU
+        let transactions_quic_sockets: Vec<QuicSocket> = transactions_quic_sockets
+            .into_iter()
+            .map(Into::into)
+            .collect();
         let SpawnServerResult {
             endpoints: _,
             thread: tpu_quic_t,
@@ -224,6 +231,11 @@ impl Tpu {
         .unwrap();
 
         // Streamer for TPU forward
+        let transactions_forwards_quic_sockets: Vec<QuicSocket> =
+            transactions_forwards_quic_sockets
+                .into_iter()
+                .map(Into::into)
+                .collect();
         let SpawnServerResult {
             endpoints: _,
             thread: tpu_forwards_quic_t,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -283,7 +283,7 @@ impl Tvu {
                 spawn_simple_qos_server(
                     "solQuicBLS",
                     "quic_streamer_bls",
-                    vec![bls_socket],
+                    vec![bls_socket.into()],
                     &cluster_info.keypair(),
                     bls_packet_sender,
                     staked_nodes,

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9055,6 +9055,7 @@ dependencies = [
 name = "solana-streamer"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "agave-xdp",
  "arc-swap",
  "bytes",
  "crossbeam-channel",

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -479,7 +479,7 @@ pub fn start_quic_streamer_to_listen_for_votes_and_certs(
     let result = spawn_simple_qos_server(
         "solAlpenglowTest",
         "alpenglow_local_cluster_test",
-        [vote_listener_socket],
+        [vote_listener_socket.into()],
         &Keypair::new(),
         sender,
         staked_nodes,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9670,6 +9670,7 @@ dependencies = [
 name = "solana-streamer"
 version = "4.0.0-alpha.0"
 dependencies = [
+ "agave-xdp",
  "arc-swap",
  "bytes",
  "crossbeam-channel",

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -77,7 +77,7 @@ mod tests {
         } = solana_streamer::quic::spawn_stake_wighted_qos_server(
             "solQuicTest",
             "quic_streamer_test",
-            vec![s.try_clone().unwrap()],
+            vec![s.try_clone().unwrap().into()],
             &keypair,
             sender,
             staked_nodes,
@@ -158,7 +158,7 @@ mod tests {
             max_concurrent_connections: _,
         } = solana_streamer::nonblocking::testing_utilities::spawn_stake_weighted_qos_server(
             "quic_streamer_test",
-            vec![s.try_clone().unwrap()],
+            vec![s.try_clone().unwrap().into()],
             &keypair,
             sender,
             staked_nodes,
@@ -217,7 +217,7 @@ mod tests {
         } = solana_streamer::quic::spawn_stake_wighted_qos_server(
             "solQuicTest",
             "quic_streamer_test",
-            [request_recv_socket.try_clone().unwrap()],
+            [request_recv_socket.try_clone().unwrap().into()],
             &keypair,
             sender,
             staked_nodes.clone(),
@@ -242,7 +242,7 @@ mod tests {
         } = solana_streamer::quic::spawn_stake_wighted_qos_server(
             "solQuicTest",
             "quic_streamer_test",
-            [response_recv_socket],
+            [response_recv_socket.into()],
             &keypair2,
             sender2,
             staked_nodes,
@@ -329,7 +329,7 @@ mod tests {
             max_concurrent_connections: _,
         } = solana_streamer::nonblocking::testing_utilities::spawn_stake_weighted_qos_server(
             "quic_streamer_test",
-            vec![s.try_clone().unwrap()],
+            vec![s.try_clone().unwrap().into()],
             &keypair,
             sender,
             staked_nodes,

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -21,6 +21,7 @@ agave-unstable-api = []
 dev-context-only-utils = []
 
 [dependencies]
+agave-xdp = { workspace = true }
 arc-swap = { workspace = true }
 bytes = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/streamer/examples/swqos.rs
+++ b/streamer/examples/swqos.rs
@@ -117,7 +117,7 @@ async fn main() -> anyhow::Result<()> {
         max_concurrent_connections: _,
     } = solana_streamer::nonblocking::testing_utilities::spawn_stake_weighted_qos_server(
         "quic_streamer_test",
-        [socket.try_clone()?],
+        [socket.try_clone()?.into()],
         &keypair,
         sender,
         staked_nodes,

--- a/streamer/src/lib.rs
+++ b/streamer/src/lib.rs
@@ -5,6 +5,7 @@ pub mod msghdr;
 pub mod nonblocking;
 pub mod packet;
 pub mod quic;
+pub mod quic_socket;
 pub mod recvmmsg;
 pub mod sendmmsg;
 pub mod streamer;

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -6,6 +6,7 @@ use {
             simple_qos::{SimpleQos, SimpleQosConfig},
             swqos::{SwQos, SwQosConfig},
         },
+        quic_socket::QuicSocket,
         streamer::StakedNodes,
     },
     crossbeam_channel::Sender,
@@ -20,7 +21,6 @@ use {
     solana_perf::packet::PacketBatch,
     solana_tls_utils::{NotifyKeyUpdate, new_dummy_x509_certificate, tls_server_config_builder},
     std::{
-        net::UdpSocket,
         num::NonZeroUsize,
         sync::{
             Arc, Mutex, RwLock,
@@ -610,7 +610,7 @@ fn spawn_runtime_and_server<Q, C>(
     thread_name: &'static str,
     metrics_name: &'static str,
     stats: Arc<StreamerStats>,
-    sockets: impl IntoIterator<Item = UdpSocket>,
+    sockets: impl IntoIterator<Item = QuicSocket>,
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
     quic_server_params: QuicStreamerConfig,
@@ -658,7 +658,7 @@ where
 pub fn spawn_stake_wighted_qos_server(
     thread_name: &'static str,
     metrics_name: &'static str,
-    sockets: impl IntoIterator<Item = UdpSocket>,
+    sockets: impl IntoIterator<Item = QuicSocket>,
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
     staked_nodes: Arc<RwLock<StakedNodes>>,
@@ -690,7 +690,7 @@ pub fn spawn_stake_wighted_qos_server(
 pub fn spawn_simple_qos_server(
     thread_name: &'static str,
     metrics_name: &'static str,
-    sockets: impl IntoIterator<Item = UdpSocket>,
+    sockets: impl IntoIterator<Item = QuicSocket>,
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
     staked_nodes: Arc<RwLock<StakedNodes>>,
@@ -763,7 +763,7 @@ mod test {
         } = spawn_simple_qos_server(
             "solQuicTest",
             "quic_streamer_test",
-            [s],
+            [s.into()],
             &keypair,
             sender,
             staked_nodes,
@@ -796,7 +796,7 @@ mod test {
         } = spawn_stake_wighted_qos_server(
             "solQuicTest",
             "quic_streamer_test",
-            [s],
+            [s.into()],
             &keypair,
             sender,
             staked_nodes,
@@ -852,7 +852,7 @@ mod test {
         } = spawn_stake_wighted_qos_server(
             "solQuicTest",
             "quic_streamer_test",
-            [s],
+            [s.into()],
             &keypair,
             sender,
             staked_nodes,
@@ -944,7 +944,7 @@ mod test {
         } = spawn_stake_wighted_qos_server(
             "solQuicTest",
             "quic_streamer_test",
-            [s],
+            [s.into()],
             &keypair,
             sender,
             staked_nodes,

--- a/streamer/src/quic_socket.rs
+++ b/streamer/src/quic_socket.rs
@@ -1,0 +1,56 @@
+//! This module defines [`QuicSocket`] enum which wraps `std::net::UdpSocket` along with [`QuicXdpSocketBundle`].
+
+use {
+    agave_xdp::xdp_retransmitter::XdpSender,
+    std::{
+        fmt::{self, Debug},
+        io::{self},
+        net::SocketAddr,
+    },
+};
+
+/// [`QuicSocket`] is a thin wrapper around `std::net::UdpSocket` that is introduced to simplify the switch
+/// between kernel UDP socket and XDP socket.
+#[derive(Debug)]
+pub enum QuicSocket {
+    /// A QUIC socket that uses XDP for sending and kernel UDP socket for receiving.
+    Xdp(QuicXdpSocketBundle),
+    /// A QUIC socket that uses kernel UDP socket for both sending and receiving. This is used when
+    /// XDP is not available or disabled.
+    Kernel(std::net::UdpSocket),
+}
+
+impl From<std::net::UdpSocket> for QuicSocket {
+    fn from(socket: std::net::UdpSocket) -> Self {
+        QuicSocket::Kernel(socket)
+    }
+}
+
+impl QuicSocket {
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        match self {
+            QuicSocket::Xdp(cfg) => cfg.socket.local_addr(),
+            QuicSocket::Kernel(socket) => socket.local_addr(),
+        }
+    }
+}
+
+/// [`QuicXdpSocketBundle`] is a configuration struct for creating a QUIC socket.
+///
+/// We must create and bundle together both an `XdpSender` and a `std::net::UdpSocket` instead of
+/// directly creating an `AsyncUdpSocket` instance because the underlying sockets can only be
+/// constructed when a Tokio runtime is present. In the case of Streamer and other components, the
+/// runtime is created deep inside the call stack. Therefore, we propagate this bundle up to the
+/// Endpoint creation.
+pub struct QuicXdpSocketBundle {
+    pub socket: std::net::UdpSocket,
+    pub xdp_sender: XdpSender,
+}
+
+impl Debug for QuicXdpSocketBundle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuicXdpSocketBundle")
+            .field("socket", &self.socket)
+            .finish()
+    }
+}

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -375,7 +375,7 @@ mod tests {
         } = spawn_stake_wighted_qos_server(
             "AlpenglowLocalClusterTest",
             "voting_service_test",
-            [socket],
+            [socket.into()],
             &Keypair::new(),
             sender,
             staked_nodes,


### PR DESCRIPTION
#### Problem

In order to add AF_XDP egress for quic, we need to introduce a new socket type. At the same time we want to be able to select between kernel-mode `UpdSocket` and new XDP socket. 

#### Summary of Changes

For that we introduce a new new enum `QuicSocket` which encapsulates these options.
In this PR we introduce the enum but without introducing the logic to use AF_XDP to keep changes minimal.

This PR is prerequisite for https://github.com/anza-xyz/agave/pull/10820 
