### PR TITLE
nix integration: use python3 instead of python310

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
@@ -596,7 +596,7 @@ fn nix_patch_bin_or_dylib(out: &Path, fname: &Path) {
             name = \"solana-sbf-dependencies\";
             paths = [
                 libedit
-                python310
+                python3
                 ncurses
                 zlib
                 xz.out


### PR DESCRIPTION
#### Problem

python310 was dropped upstream in https://github.com/NixOS/nixpkgs/pull/490538

#### Summary of Changes

use plain `python3` which should mostly work until python releases a 4.0.