### PR TITLE
entry: introduce EntryVerificationData

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1728,7 +1728,7 @@ fn confirm_slot_entries(
     let last_entry_hash = entries.last().map(|e| e.hash);
     if !skip_verification {
         let start_hash = progress.last_entry;
-        let verify_entries = entries.clone();
+        let verify_entries = entry::entries_to_verification_data(&entries);
         progress.async_verification.spawn(
             replay_tx_thread_pool,
             poh_verify_elapsed,
@@ -1737,7 +1737,7 @@ fn confirm_slot_entries(
                     "verify-batch-size",
                     ("size", verify_entries.len() as i64, i64)
                 );
-                let state = verify_entries.verify_cpu(&start_hash);
+                let state = entry::verify_entries_cpu(&verify_entries, &start_hash);
                 let error = if state.status() {
                     None
                 } else {


### PR DESCRIPTION
718dddd86b2266bda28159efa209131bbe8e2ddb introduced async poh verification. Since entries are needed to verify both poh and transactions, that commit introduced a clone of all entries in confirm_slot_entries().

When verifying poh we only need transaction signatures from entries tho, not whole transactions. This commit introduces `EntryVerificationData` which allows collecting hashes and signatures from `&[Entry]` before sending all for async verification, avoiding a more expensive clone of all transactions.

Note that this change doesn't remove `EntrySlice` yet to keep the diff manageable. `EntrySlice` is used in a bunch of tests and benches of dubious quality and I plan to unleash codex on those after I'm done landing the whole patch set.