### PR TITLE
Verifies snapshot capitalization

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -786,6 +786,8 @@ pub(crate) struct ReconstructedBankInfo {
     /// The accounts lt hash calculated during index generation.
     /// Will be used when verifying accounts, after rebuilding a Bank.
     pub(crate) calculated_accounts_lt_hash: AccountsLtHash,
+    /// The capitalization, in lamports, calculated during index generation.
+    pub(crate) calculated_capitalization: u64,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -848,6 +850,7 @@ where
         bank,
         ReconstructedBankInfo {
             calculated_accounts_lt_hash: reconstructed_accounts_db_info.calculated_accounts_lt_hash,
+            calculated_capitalization: reconstructed_accounts_db_info.calculated_capitalization,
         },
     ))
 }
@@ -1003,6 +1006,8 @@ pub struct ReconstructedAccountsDbInfo {
     /// The accounts lt hash calculated during index generation.
     /// Will be used when verifying accounts, after rebuilding a Bank.
     pub calculated_accounts_lt_hash: AccountsLtHash,
+    /// The capitalization, in lamports, calculated during index generation.
+    pub calculated_capitalization: u64,
     pub bank_hash_stats: BankHashStats,
 }
 
@@ -1063,6 +1068,7 @@ where
     let IndexGenerationInfo {
         accounts_data_len,
         calculated_accounts_lt_hash,
+        calculated_capitalization,
     } = accounts_db.generate_index(limit_load_slot_count_from_snapshot, verify_index);
     info!("Building accounts index... Done in {:?}", start.elapsed());
 
@@ -1071,6 +1077,7 @@ where
         ReconstructedAccountsDbInfo {
             accounts_data_len,
             calculated_accounts_lt_hash,
+            calculated_capitalization,
             bank_hash_stats: snapshot_bank_hash_info.stats,
         },
     ))

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -209,6 +209,18 @@ pub fn bank_from_snapshot_archives(
     measure_rebuild.stop();
     info!("{measure_rebuild}");
 
+    if bank.capitalization() != info.calculated_capitalization {
+        // When limit_load_slot_count is set, ignore capitalization mismatches.
+        // Because skipped slots may have changed the calculated capitalization,
+        // causing a mismatch with the bank's capitalization.
+        if limit_load_slot_count_from_snapshot.is_none() {
+            return Err(SnapshotError::MismatchedCapitalization(
+                bank.capitalization(),
+                info.calculated_capitalization,
+            ));
+        }
+    }
+
     verify_epoch_stakes(&bank)?;
 
     // The status cache is rebuilt from the latest snapshot.  So, if there's an incremental
@@ -393,6 +405,18 @@ pub fn bank_from_snapshot_dir(
         "rebuild bank from snapshot"
     );
     info!("{measure_rebuild_bank}");
+
+    if bank.capitalization() != info.calculated_capitalization {
+        // When limit_load_slot_count is set, ignore capitalization mismatches.
+        // Because skipped slots may have changed the calculated capitalization,
+        // causing a mismatch with the bank's capitalization.
+        if limit_load_slot_count_from_snapshot.is_none() {
+            return Err(SnapshotError::MismatchedCapitalization(
+                bank.capitalization(),
+                info.calculated_capitalization,
+            ));
+        }
+    }
 
     verify_epoch_stakes(&bank)?;
 
@@ -1334,6 +1358,63 @@ mod tests {
         assert_eq!(deserialized_bank, *bank4);
     }
 
+    /// Ensure bank_from_snapshot_archives() catches a snapshot with incorrect capitalization.
+    #[test]
+    fn test_bank_from_snapshot_archives_bad_capitalization() {
+        let genesis_config = GenesisConfig::default();
+        let bank = Bank::new_for_tests(&genesis_config);
+        bank.fill_bank_with_ticks_for_tests();
+
+        // freeze the bank before mucking with capitalization, since
+        // freezing also changes capitalization (fees, incinerator, etc).
+        bank.freeze();
+
+        let good_capitalization = bank.capitalization();
+        let bad_capitalization = good_capitalization + 1;
+        bank.set_capitalization_for_tests(bad_capitalization);
+
+        let snapshot_dir = tempfile::TempDir::new().unwrap();
+        let full_snapshot_archive_info = bank_to_full_snapshot_archive(
+            &snapshot_dir,
+            &bank,
+            None,
+            &snapshot_dir,
+            &snapshot_dir,
+            SnapshotConfig::default().archive_format,
+        )
+        .unwrap();
+
+        let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let error = bank_from_snapshot_archives(
+            &[accounts_dir],
+            &bank_snapshots_dir,
+            &full_snapshot_archive_info,
+            None,
+            &genesis_config,
+            &RuntimeConfig::default(),
+            None,
+            None,
+            false,
+            false,
+            false,
+            ACCOUNTS_DB_CONFIG_FOR_TESTING,
+            None,
+            Arc::default(),
+        )
+        .unwrap_err();
+
+        match error {
+            SnapshotError::MismatchedCapitalization(expected, calculated) => {
+                assert_eq!(expected, bad_capitalization);
+                assert_eq!(calculated, good_capitalization);
+            }
+            _ => {
+                panic!("wrong error");
+            }
+        }
+    }
+
     /// Test that cleaning works well in the edge cases of zero-lamport accounts and snapshots.
     /// Here's the scenario:
     ///
@@ -2086,7 +2167,7 @@ mod tests {
 
     #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
-    fn test_bank_from_snapshot_dir(storage_access: StorageAccess) {
+    fn test_bank_from_snapshot_dir_good(storage_access: StorageAccess) {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let bank = Bank::new_for_tests(&genesis_config);
@@ -2137,6 +2218,57 @@ mod tests {
         }
         let next_id = bank.accounts().accounts_db.next_id.load(Ordering::Relaxed) as usize;
         assert_eq!(max_id, next_id - 1);
+    }
+
+    /// Ensure bank_from_snapshot_dir() catches a snapshot with incorrect capitalization.
+    #[test]
+    fn test_bank_from_snapshot_dir_bad_capitalization() {
+        let genesis_config = GenesisConfig::default();
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let bank = Bank::new_for_tests(&genesis_config);
+        bank.fill_bank_with_ticks_for_tests();
+
+        // freeze the bank before mucking with capitalization, since
+        // freezing also changes capitalization (fees, incinerator, etc).
+        bank.freeze();
+
+        let good_capitalization = bank.capitalization();
+        let bad_capitalization = good_capitalization + 1;
+        bank.set_capitalization_for_tests(bad_capitalization);
+
+        create_bank_snapshot_from_bank(
+            &bank_snapshots_dir,
+            &bank,
+            SnapshotVersion::default(),
+            true,
+        )
+        .unwrap();
+
+        let bank_snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
+        let account_paths = &bank.rc.accounts.accounts_db.paths;
+        let error = bank_from_snapshot_dir(
+            account_paths,
+            &bank_snapshot,
+            &genesis_config,
+            &RuntimeConfig::default(),
+            None,
+            None,
+            false,
+            ACCOUNTS_DB_CONFIG_FOR_TESTING,
+            None,
+            Arc::default(),
+        )
+        .unwrap_err();
+
+        match error {
+            SnapshotError::MismatchedCapitalization(expected, calculated) => {
+                assert_eq!(expected, bad_capitalization);
+                assert_eq!(calculated, good_capitalization);
+            }
+            _ => {
+                panic!("wrong error");
+            }
+        }
     }
 
     #[test_case(false)]

--- a/snapshots/src/error.rs
+++ b/snapshots/src/error.rs
@@ -98,6 +98,9 @@ pub enum SnapshotError {
 
     #[error("failed to rebuild snapshot storages: {0}")]
     RebuildStorages(String),
+
+    #[error("capitalization mismatch: expected: {0}, calculated: {1}")]
+    MismatchedCapitalization(u64, u64),
 }
 
 impl From<SendError<FileInfo>> for SnapshotError {


### PR DESCRIPTION
#### Problem

The snapshot's capitalization is implicitly verified by the accounts verification. But if just the bank field is wrong, snapshot verification will pass and then the validator will diverge as soon as the bank field is used/checked.


#### Summary of Changes

Verify snapshot capitalization explicitly.