### PR TITLE
Tidies unused snapshot fields

### DIFF
--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -122,8 +122,8 @@ mod tests {
                 &bank2.get_snapshot_storages(None),
                 ExtraFieldsToSerialize {
                     lamports_per_signature: bank2.fee_rate_governor.lamports_per_signature,
-                    obsolete_incremental_snapshot_persistence: None,
-                    obsolete_epoch_accounts_hash: None,
+                    unused_incremental_snapshot_persistence: None,
+                    unused_epoch_accounts_hash: None,
                     versioned_epoch_stakes,
                     accounts_lt_hash,
                 },
@@ -316,7 +316,7 @@ mod tests {
     mod test_bank_serialize {
         use {
             super::*,
-            crate::{bank::BankHashStats, serde_snapshot::ObsoleteIncrementalSnapshotPersistence},
+            crate::{bank::BankHashStats, serde_snapshot::UnusedIncrementalSnapshotPersistence},
             solana_accounts_db::accounts_hash::AccountsLtHash,
             solana_frozen_abi::abi_example::AbiExample,
             solana_hash::Hash,
@@ -345,7 +345,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "EEwojKqUDSpYNeutW56K9bsJmsjCMZn8i4n3qgvJYRxf")
+            frozen_abi(digest = "FCDuswxZnGvvJURSkrQPshX45a25CR6UAmPgzGeUfMFv")
         )]
         #[derive(serde::Serialize)]
         pub struct BankAbiTestWrapper {
@@ -362,7 +362,7 @@ mod tests {
             // ensure there is at least one snapshot storage example for ABI digesting
             assert!(!snapshot_storages.is_empty());
 
-            let incremental_snapshot_persistence = ObsoleteIncrementalSnapshotPersistence {
+            let incremental_snapshot_persistence = UnusedIncrementalSnapshotPersistence {
                 full_slot: u64::default(),
                 full_hash: [1; 32],
                 full_capitalization: u64::default(),
@@ -379,10 +379,8 @@ mod tests {
                 &snapshot_storages,
                 ExtraFieldsToSerialize {
                     lamports_per_signature: bank.fee_rate_governor.lamports_per_signature,
-                    obsolete_incremental_snapshot_persistence: Some(
-                        incremental_snapshot_persistence,
-                    ),
-                    obsolete_epoch_accounts_hash: Some(Hash::new_unique()),
+                    unused_incremental_snapshot_persistence: Some(incremental_snapshot_persistence),
+                    unused_epoch_accounts_hash: Some(Hash::new_unique()),
                     versioned_epoch_stakes,
                     accounts_lt_hash: Some(AccountsLtHash(LtHash::identity()).into()),
                 },

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -79,7 +79,7 @@ const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;
 #[derive(Debug, Deserialize)]
 pub(crate) struct AccountsDbFields<T>(
     Vec<(Slot, SmallVec<[T; 1]>)>,
-    u64, // obsolete, formerly write_version
+    u64, // unused, formerly write_version
     Slot,
     BankHashInfo,
     /// all slots that were roots within the last epoch
@@ -125,7 +125,7 @@ impl<T: SerializableStorage> AccountsDbFields<T> {
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Default, PartialEq))]
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct ObsoleteIncrementalSnapshotPersistence {
+pub struct UnusedIncrementalSnapshotPersistence {
     pub full_slot: u64,
     pub full_hash: [u8; 32],
     pub full_capitalization: u64,
@@ -136,8 +136,8 @@ pub struct ObsoleteIncrementalSnapshotPersistence {
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct BankHashInfo {
-    obsolete_accounts_delta_hash: [u8; 32],
-    obsolete_accounts_hash: [u8; 32],
+    unused_accounts_delta_hash: [u8; 32],
+    unused_accounts_hash: [u8; 32],
     stats: BankHashStats,
 }
 
@@ -178,13 +178,12 @@ struct DeserializableVersionedBank {
     _unused_collector_fees: u64,
     _unused_fee_calculator: u64,
     fee_rate_governor: FeeRateGovernor,
-    _collected_rent: u64,
+    _unused_collected_rent: u64,
     rent_collector: RentCollector,
     epoch_schedule: EpochSchedule,
     inflation: Inflation,
     stakes: DeserializableStakes<Delegation>,
-    #[allow(dead_code)]
-    unused_accounts: UnusedAccounts,
+    _unused_accounts: UnusedAccounts,
     unused_epoch_stakes: HashMap<Epoch, ()>,
     is_delta: bool,
 }
@@ -257,7 +256,7 @@ struct SerializableVersionedBank {
     unused_collector_fees: u64,
     unused_fee_calculator: u64,
     fee_rate_governor: FeeRateGovernor,
-    collected_rent: u64,
+    unused_collected_rent: u64,
     rent_collector: RentCollector,
     epoch_schedule: EpochSchedule,
     inflation: Inflation,
@@ -295,7 +294,7 @@ impl From<BankFieldsToSerialize> for SerializableVersionedBank {
             unused_collector_fees: 0,
             unused_fee_calculator: 0,
             fee_rate_governor: rhs.fee_rate_governor,
-            collected_rent: u64::default(),
+            unused_collected_rent: u64::default(),
             rent_collector: rhs.rent_collector,
             epoch_schedule: rhs.epoch_schedule,
             inflation: rhs.inflation,
@@ -421,9 +420,9 @@ struct ExtraFieldsToDeserialize {
     #[serde(deserialize_with = "default_on_eof")]
     lamports_per_signature: u64,
     #[serde(deserialize_with = "default_on_eof")]
-    _obsolete_incremental_snapshot_persistence: Option<ObsoleteIncrementalSnapshotPersistence>,
+    _unused_incremental_snapshot_persistence: Option<UnusedIncrementalSnapshotPersistence>,
     #[serde(deserialize_with = "default_on_eof")]
-    _obsolete_epoch_accounts_hash: Option<Hash>,
+    _unused_epoch_accounts_hash: Option<Hash>,
     #[serde(deserialize_with = "default_on_eof")]
     versioned_epoch_stakes: Vec<(u64, DeserializableVersionedEpochStakes)>,
     #[serde(deserialize_with = "default_on_eof")]
@@ -451,8 +450,8 @@ struct ExtraFieldsToDeserialize {
 #[derive(Debug, Serialize)]
 pub struct ExtraFieldsToSerialize {
     pub lamports_per_signature: u64,
-    pub obsolete_incremental_snapshot_persistence: Option<ObsoleteIncrementalSnapshotPersistence>,
-    pub obsolete_epoch_accounts_hash: Option<Hash>,
+    pub unused_incremental_snapshot_persistence: Option<UnusedIncrementalSnapshotPersistence>,
+    pub unused_epoch_accounts_hash: Option<Hash>,
     pub versioned_epoch_stakes: HashMap<u64, VersionedEpochStakes>,
     pub accounts_lt_hash: Option<SerdeAccountsLtHash>,
 }
@@ -482,8 +481,8 @@ where
     // Process extra fields
     let ExtraFieldsToDeserialize {
         lamports_per_signature,
-        _obsolete_incremental_snapshot_persistence,
-        _obsolete_epoch_accounts_hash,
+        _unused_incremental_snapshot_persistence,
+        _unused_epoch_accounts_hash,
         versioned_epoch_stakes,
         accounts_lt_hash,
         block_id: _,
@@ -679,8 +678,8 @@ impl Serialize for SerializableBankAndStorage<'_> {
             },
             ExtraFieldsToSerialize {
                 lamports_per_signature,
-                obsolete_incremental_snapshot_persistence: None,
-                obsolete_epoch_accounts_hash: None,
+                unused_incremental_snapshot_persistence: None,
+                unused_epoch_accounts_hash: None,
                 versioned_epoch_stakes,
                 accounts_lt_hash,
             },
@@ -752,8 +751,8 @@ impl Serialize for SerializableAccountsDb<'_> {
             )
         }));
         let bank_hash_info = BankHashInfo {
-            obsolete_accounts_delta_hash: [0; 32],
-            obsolete_accounts_hash: [0; 32],
+            unused_accounts_delta_hash: [0; 32],
+            unused_accounts_hash: [0; 32],
             stats: self.bank_hash_stats.clone(),
         };
 
@@ -763,7 +762,7 @@ impl Serialize for SerializableAccountsDb<'_> {
         let mut serialize_account_storage_timer = Measure::start("serialize_account_storage_ms");
         let result = (
             entries,
-            0u64, // obsolete, formerly write_version
+            0u64, // unused, formerly write_version
             self.slot,
             bank_hash_info,
             historical_roots,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -525,8 +525,8 @@ pub fn serialize_snapshot(
             let versioned_epoch_stakes = mem::take(&mut bank_fields.versioned_epoch_stakes);
             let extra_fields = ExtraFieldsToSerialize {
                 lamports_per_signature: bank_fields.fee_rate_governor.lamports_per_signature,
-                obsolete_incremental_snapshot_persistence: None,
-                obsolete_epoch_accounts_hash: None,
+                unused_incremental_snapshot_persistence: None,
+                unused_epoch_accounts_hash: None,
                 versioned_epoch_stakes,
                 accounts_lt_hash: Some(bank_fields.accounts_lt_hash.clone().into()),
             };


### PR DESCRIPTION
#### Problem

There are unused fields in the snapshot. Some are prepended with "unused". Some are prepended with "obsolete". One, this is inconsistent. Two, there is now a concept of *obsolete accounts*, which are fully *used* in the snapshot. So now the term "obsolete" is ambiguous.

Additionally:
* `collected_rent` is unused, but isn't prepended with 'unused'
* `unused_accounts` is annotated with `[allow(dead_code)]`, whereas all the other unused fields have a leading underscore. IMO the field is not dead, as we very much need it for binary compatibility. We just never read it.


#### Summary of Changes

Standardize on "unused" as the name for the snapshot when a field is no longer used.