### PR TITLE
remove simple vote from cost model

### DIFF
--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -36,9 +36,9 @@ impl CostModel {
         transaction: &'a Tx,
         feature_set: &FeatureSet,
     ) -> TransactionCost<'a, Tx> {
-        let stop_use_static_simple_vote_tx_cost =
-            feature_set.is_active(&feature_set::stop_use_static_simple_vote_tx_cost::id());
-        if transaction.is_simple_vote_transaction() && !stop_use_static_simple_vote_tx_cost {
+        let remove_simple_vote_from_cost_model =
+            feature_set.is_active(&feature_set::remove_simple_vote_from_cost_model::id());
+        if transaction.is_simple_vote_transaction() && !remove_simple_vote_from_cost_model {
             TransactionCost::SimpleVote { transaction }
         } else {
             let (programs_execution_cost, loaded_accounts_data_size_cost) =
@@ -64,9 +64,9 @@ impl CostModel {
         actual_loaded_accounts_data_size_bytes: u32,
         feature_set: &FeatureSet,
     ) -> TransactionCost<'a, Tx> {
-        let stop_use_static_simple_vote_tx_cost =
-            feature_set.is_active(&feature_set::stop_use_static_simple_vote_tx_cost::id());
-        if transaction.is_simple_vote_transaction() && !stop_use_static_simple_vote_tx_cost {
+        let remove_simple_vote_from_cost_model =
+            feature_set.is_active(&feature_set::remove_simple_vote_from_cost_model::id());
+        if transaction.is_simple_vote_transaction() && !remove_simple_vote_from_cost_model {
             TransactionCost::SimpleVote { transaction }
         } else {
             let loaded_accounts_data_size_cost = Self::calculate_loaded_accounts_data_size_cost(
@@ -97,9 +97,9 @@ impl CostModel {
         num_write_locks: u64,
         feature_set: &FeatureSet,
     ) -> TransactionCost<'a, Tx> {
-        let stop_use_static_simple_vote_tx_cost =
-            feature_set.is_active(&feature_set::stop_use_static_simple_vote_tx_cost::id());
-        if transaction.is_simple_vote_transaction() && !stop_use_static_simple_vote_tx_cost {
+        let remove_simple_vote_from_cost_model =
+            feature_set.is_active(&feature_set::remove_simple_vote_from_cost_model::id());
+        if transaction.is_simple_vote_transaction() && !remove_simple_vote_from_cost_model {
             return TransactionCost::SimpleVote { transaction };
         }
         let (programs_execution_cost, loaded_accounts_data_size_cost) =

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -312,7 +312,7 @@ impl CostTracker {
     ) -> Result<(), CostTrackerError> {
         let cost: u64 = tx_cost.sum();
 
-        if tx_cost.is_simple_vote() {
+        if tx_cost.should_track_as_simple_vote() {
             // if vote transaction, check if it exceeds vote_transaction_limit
             if self.vote_cost.saturating_add(cost) > self.vote_cost_limit {
                 return Err(CostTrackerError::WouldExceedVoteMaxLimit);
@@ -396,7 +396,7 @@ impl CostTracker {
             costliest_account_cost = costliest_account_cost.max(*account_cost);
         }
         self.block_cost.fetch_add(adjustment);
-        if tx_cost.is_simple_vote() {
+        if tx_cost.should_track_as_simple_vote() {
             self.vote_cost = self.vote_cost.saturating_add(adjustment);
         }
 
@@ -417,7 +417,7 @@ impl CostTracker {
             *account_cost = account_cost.saturating_sub(adjustment);
         }
         self.block_cost.fetch_sub(adjustment);
-        if tx_cost.is_simple_vote() {
+        if tx_cost.should_track_as_simple_vote() {
             self.vote_cost = self.vote_cost.saturating_sub(adjustment);
         }
     }

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -471,6 +471,7 @@ mod tests {
         solana_keypair::Keypair,
         solana_signer::Signer,
         std::cmp,
+        test_case::test_case,
     };
 
     impl CostTracker {
@@ -529,16 +530,21 @@ mod tests {
 
     fn simple_vote_transaction_cost(
         transaction: &WritableKeysTransaction,
+        remove_simple_vote_from_cost_model: bool,
     ) -> TransactionCost<'_, WritableKeysTransaction> {
-        TransactionCost::Transaction(UsageCostDetails {
-            transaction,
-            signature_cost: 1,
-            write_lock_cost: 2,
-            data_bytes_cost: 0,
-            programs_execution_cost: solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS,
-            loaded_accounts_data_size_cost: 8,
-            allocated_accounts_data_size: 0,
-        })
+        if !remove_simple_vote_from_cost_model {
+            TransactionCost::SimpleVote { transaction }
+        } else {
+            TransactionCost::Transaction(UsageCostDetails {
+                transaction,
+                signature_cost: 1,
+                write_lock_cost: 2,
+                data_bytes_cost: 0,
+                programs_execution_cost: solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS,
+                loaded_accounts_data_size_cost: 8,
+                allocated_accounts_data_size: 0,
+            })
+        }
     }
 
     #[test]
@@ -568,11 +574,12 @@ mod tests {
         assert_eq!(cost, costliest_account_cost);
     }
 
-    #[test]
-    fn test_cost_tracker_ok_add_one_vote() {
+    #[test_case(false; "remove_simple_vote_from_cost_model not activated")]
+    #[test_case(true; "remove_simple_vote_from_cost_model activated")]
+    fn test_cost_tracker_ok_add_one_vote(remove_simple_vote_from_cost_model: bool) {
         let mint_keypair = test_setup();
         let tx = build_simple_vote_transaction(&mint_keypair);
-        let tx_cost = simple_vote_transaction_cost(&tx);
+        let tx_cost = simple_vote_transaction_cost(&tx, remove_simple_vote_from_cost_model);
         let cost = tx_cost.sum();
 
         // build testee to have capacity for one simple transaction
@@ -580,7 +587,12 @@ mod tests {
         assert!(testee.would_fit(&tx_cost).is_ok());
         testee.add_transaction_cost(&tx_cost);
         assert_eq!(cost, testee.block_cost());
-        assert_eq!(cost, testee.vote_cost);
+        if !remove_simple_vote_from_cost_model {
+            assert_eq!(cost, testee.vote_cost);
+        } else {
+            // not trackijng vote cu after feature activation
+            assert_eq!(0, testee.vote_cost);
+        }
         let (_costliest_account, costliest_account_cost) = testee.find_costliest_account();
         assert_eq!(cost, costliest_account_cost);
     }
@@ -711,16 +723,17 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_cost_tracker_reach_vote_limit() {
+    #[test_case(false; "remove_simple_vote_from_cost_model not activated")]
+    #[test_case(true; "remove_simple_vote_from_cost_model activated")]
+    fn test_cost_tracker_reach_vote_limit(remove_simple_vote_from_cost_model: bool) {
         let mint_keypair = test_setup();
         // build two mocking vote transactions with diff accounts
         let second_account = Keypair::new();
         let tx1 = build_simple_vote_transaction(&mint_keypair);
-        let tx_cost1 = simple_vote_transaction_cost(&tx1);
+        let tx_cost1 = simple_vote_transaction_cost(&tx1, remove_simple_vote_from_cost_model);
         let cost1 = tx_cost1.sum();
         let tx2 = build_simple_vote_transaction(&second_account);
-        let tx_cost2 = simple_vote_transaction_cost(&tx2);
+        let tx_cost2 = simple_vote_transaction_cost(&tx2, remove_simple_vote_from_cost_model);
         let cost2 = tx_cost2.sum();
 
         // build testee to have capacity for each chain, but not enough room for both votes
@@ -730,9 +743,12 @@ mod tests {
             assert!(testee.would_fit(&tx_cost1).is_ok());
             testee.add_transaction_cost(&tx_cost1);
         }
-        // but no more room for package as whole
-        {
+        if !remove_simple_vote_from_cost_model {
+            // but no more room for package as whole
             assert!(testee.would_fit(&tx_cost2).is_err());
+        } else {
+            // no more vote cu limit if feature activated
+            assert!(testee.would_fit(&tx_cost2).is_ok());
         }
         // however there is room for none-vote tx3
         {

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -360,11 +360,11 @@ mod tests {
         [false, true]
     )]
     fn test_vote_transaction_cost(
-        stop_use_static_simple_vote_tx_cost: bool,
+        remove_simple_vote_from_cost_model: bool,
         simd_0387_enabled: bool,
     ) {
-        // SIMD-0387 requires `stop_use_static_simple_vote_tx_cost`.
-        if simd_0387_enabled && !stop_use_static_simple_vote_tx_cost {
+        // SIMD-0387 requires `remove_simple_vote_from_cost_model`.
+        if simd_0387_enabled && !remove_simple_vote_from_cost_model {
             return;
         }
 
@@ -391,15 +391,15 @@ mod tests {
         .unwrap();
 
         let mut feature_set = FeatureSet::all_enabled();
-        if !stop_use_static_simple_vote_tx_cost {
-            feature_set.deactivate(&agave_feature_set::stop_use_static_simple_vote_tx_cost::id());
+        if !remove_simple_vote_from_cost_model {
+            feature_set.deactivate(&agave_feature_set::remove_simple_vote_from_cost_model::id());
         }
         if !simd_0387_enabled {
             feature_set.deactivate(&bls_pubkey_management_in_vote_account::id());
         }
 
         // Verify actual cost matches expected.
-        let expected_cost = if !stop_use_static_simple_vote_tx_cost {
+        let expected_cost = if !remove_simple_vote_from_cost_model {
             SIMPLE_VOTE_USAGE_COST
         } else {
             // when feature `stop-use-static-simple-vote-tx-cost` is enabled, vote transaction

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -52,7 +52,7 @@ impl<Tx: StaticMeta> TransactionCost<'_, Tx> {
         }
     }
 
-    pub fn is_simple_vote(&self) -> bool {
+    pub fn should_track_as_simple_vote(&self) -> bool {
         match self {
             Self::SimpleVote { .. } => true,
             Self::Transaction(_) => false,

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -55,9 +55,7 @@ impl<Tx: StaticMeta> TransactionCost<'_, Tx> {
     pub fn is_simple_vote(&self) -> bool {
         match self {
             Self::SimpleVote { .. } => true,
-            Self::Transaction(usage_details) => {
-                usage_details.transaction.is_simple_vote_transaction()
-            }
+            Self::Transaction(_) => false,
         }
     }
 

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1285,7 +1285,7 @@ pub mod set_lamports_per_byte_to_696 {
     pub const LAMPORTS_PER_BYTE: u64 = 696;
 }
 
-pub mod stop_use_static_simple_vote_tx_cost {
+pub mod remove_simple_vote_from_cost_model {
     solana_pubkey::declare_id!("2GCrNXbzmt4xrwdcKS2RdsLzsgu4V5zHAemW57pcHT6a");
 }
 
@@ -2314,7 +2314,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
             "SIMD-0437-5: Set lamports per byte to 696",
         ),
         (
-            stop_use_static_simple_vote_tx_cost::id(),
+            remove_simple_vote_from_cost_model::id(),
             "stop use static SimpleVote transaction cost, issue #10227",
         ),
         (

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1286,7 +1286,7 @@ pub mod set_lamports_per_byte_to_696 {
 }
 
 pub mod stop_use_static_simple_vote_tx_cost {
-    solana_pubkey::declare_id!("NSVt1s8oP1A9NjEc6UNcj2voeCcfzHaq4jZTiUL2Mf5");
+    solana_pubkey::declare_id!("2GCrNXbzmt4xrwdcKS2RdsLzsgu4V5zHAemW57pcHT6a");
 }
 
 pub mod limit_instruction_accounts {


### PR DESCRIPTION
#### Problem

SIMD-0458 [is amended](https://github.com/solana-foundation/solana-improvement-documents/pull/471/changes) to include removing vote CU limit. 

Need to update feature gate, so once it's activated, simple vote will not be tracked against vote cu limit.

#### Summary of Changes
- commit 1: rekey feature gate
- commit 2: rename feature gate
- commit 3: update is_simple_vote() function, since TransactionCost::Transaction can never be simple-vote.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
