### PR TITLE
bls cert verify: publish crate

### DIFF
--- a/bls-cert-verify/Cargo.toml
+++ b/bls-cert-verify/Cargo.toml
@@ -8,7 +8,6 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-publish = false
 
 [features]
 agave-unstable-api = []


### PR DESCRIPTION
#### Problem
This crate was erroneously upstreamed with "publish = false"

This causes issues as it is depended on by `solana-runtime` which has publish = true.
More context here https://github.com/anza-xyz/agave/issues/10854

#### Summary of Changes
Remove it
