### PR TITLE
bcl: change shutdown log from error -> info

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -166,7 +166,7 @@ fn start_loop(config: BlockCreationLoopConfig) {
     let record_receiver = match record_receiver_receiver.recv() {
         Ok(receiver) => receiver,
         Err(e) => {
-            error!("{my_pubkey}: Failed to receive RecordReceiver from PohService. Exiting: {e:?}",);
+            info!("{my_pubkey}: Failed to receive RecordReceiver from PohService. Exiting: {e:?}",);
             return;
         }
     };


### PR DESCRIPTION
#### Problem
This error is logged when PohService shutsdown without passing the `record_receiver` to bcl.
This should have never been an error log in the first place as pre Alpenglow this is expected during the shutdown path.

#### Summary of Changes
Change to info log