### PR TITLE
Pin spl-token-cli version to v5.5.0 for agave v4.0

### DIFF
--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,5 +1,5 @@
 # populate this on the stable branch
-splTokenCliVersion=
+splTokenCliVersion=5.5.0
 
 maybeSplTokenCliVersionArg=
 if [[ -n "$splTokenCliVersion" ]]; then


### PR DESCRIPTION
This this the current version that matches Agave stable release (v3.1): https://github.com/solana-program/token-2022/blob/bf0abe3ada87269fbb41bb6200b3b5f901ecbe58/clients/cli/Cargo.toml#L2