### PR TITLE
clippy(programs/sbf): mark no_mangle attributes with unsafe

### DIFF
--- a/programs/sbf/rust/128bit/src/lib.rs
+++ b/programs/sbf/rust/128bit/src/lib.rs
@@ -4,7 +4,7 @@
 
 use solana_program_entrypoint::{SUCCESS, custom_heap_default, custom_panic_default};
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     let x: u128 = 1;
     let y = x.rotate_right(1);

--- a/programs/sbf/rust/alloc/src/lib.rs
+++ b/programs/sbf/rust/alloc/src/lib.rs
@@ -11,7 +11,7 @@ use {
     std::{alloc::Layout, mem},
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     unsafe {
         // Test modest allocation and de-allocation

--- a/programs/sbf/rust/alt_bn128/src/lib.rs
+++ b/programs/sbf/rust/alt_bn128/src/lib.rs
@@ -906,7 +906,7 @@ fn alt_bn128_pairing_le_test() {
     );
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     msg!("alt_bn128");
 

--- a/programs/sbf/rust/alt_bn128_compression/src/lib.rs
+++ b/programs/sbf/rust/alt_bn128_compression/src/lib.rs
@@ -114,7 +114,7 @@ fn alt_bn128_compression_g2_le() {
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     msg!("alt_bn128_compression");
 

--- a/programs/sbf/rust/big_mod_exp/src/lib.rs
+++ b/programs/sbf/rust/big_mod_exp/src/lib.rs
@@ -83,7 +83,7 @@ fn big_mod_exp_test() {
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     msg!("big_mod_exp");
 

--- a/programs/sbf/rust/call_depth/src/lib.rs
+++ b/programs/sbf/rust/call_depth/src/lib.rs
@@ -17,10 +17,10 @@ pub fn recurse(data: &mut [u8]) {
 
 /// # Safety
 #[inline(never)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
     msg!("Call depth");
-    let depth = *input.add(16);
+    let depth = unsafe { *input.add(16) };
     sol_log_64(line!() as u64, 0, 0, 0, depth as u64);
     let mut data = Vec::with_capacity(depth as usize);
     for i in 0_u8..depth {

--- a/programs/sbf/rust/curve25519/src/lib.rs
+++ b/programs/sbf/rust/curve25519/src/lib.rs
@@ -6,7 +6,7 @@ use {
     solana_program_entrypoint::{custom_heap_default, custom_panic_default},
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     let scalar_one = scalar::PodScalar([
         1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/programs/sbf/rust/custom_heap/src/lib.rs
+++ b/programs/sbf/rust/custom_heap/src/lib.rs
@@ -35,7 +35,7 @@ unsafe impl std::alloc::GlobalAlloc for BumpAllocator {
             const TOP_ADDRESS: usize = HEAP_START_ADDRESS as usize + HEAP_LENGTH;
             const BOTTOM_ADDRESS: usize = HEAP_START_ADDRESS as usize + size_of::<*mut u8>();
 
-            let mut pos = *POS_PTR;
+            let mut pos = unsafe { *POS_PTR };
             if pos == 0 {
                 // First time, set starting position
                 pos = TOP_ADDRESS;
@@ -45,7 +45,7 @@ unsafe impl std::alloc::GlobalAlloc for BumpAllocator {
             if pos < BOTTOM_ADDRESS {
                 return null_mut();
             }
-            *POS_PTR = pos;
+            unsafe { *POS_PTR = pos };
             pos as *mut u8
         }
     }

--- a/programs/sbf/rust/dep_crate/src/lib.rs
+++ b/programs/sbf/rust/dep_crate/src/lib.rs
@@ -5,7 +5,7 @@ use {
     solana_program_entrypoint::SUCCESS,
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     let mut buf = [0; 4];
     LittleEndian::write_u32(&mut buf, 1_000_000);

--- a/programs/sbf/rust/deprecated_loader/src/lib.rs
+++ b/programs/sbf/rust/deprecated_loader/src/lib.rs
@@ -27,7 +27,7 @@ fn return_sstruct() -> SStruct {
     SStruct { x: 1, y: 2, z: 3 }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 fn custom_panic(info: &core::panic::PanicInfo<'_>) {
     // Full panic reporting
     msg!(&format!("{info}"));

--- a/programs/sbf/rust/inner_instruction_alignment_check/src/lib.rs
+++ b/programs/sbf/rust/inner_instruction_alignment_check/src/lib.rs
@@ -36,7 +36,7 @@ fn process_instruction(
 
 custom_heap_default!();
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 fn custom_panic(info: &core::panic::PanicInfo<'_>) {
     // Full panic reporting
     msg!(&format!("{info}"));

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -1660,8 +1660,10 @@ struct RcBox<T> {
 
 #[allow(invalid_reference_casting)]
 unsafe fn overwrite_account_data(account: &AccountInfo, data: Rc<RefCell<&mut [u8]>>) {
-    std::ptr::write_volatile(
-        &account.data as *const _ as usize as *mut Rc<RefCell<&mut [u8]>>,
-        data,
-    );
+    unsafe {
+        std::ptr::write_volatile(
+            &account.data as *const _ as usize as *mut Rc<RefCell<&mut [u8]>>,
+            data,
+        );
+    }
 }

--- a/programs/sbf/rust/iter/src/lib.rs
+++ b/programs/sbf/rust/iter/src/lib.rs
@@ -7,7 +7,7 @@ use {
     solana_program_entrypoint::{SUCCESS, custom_heap_default, custom_panic_default},
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     const ITERS: usize = 100;
     let ones = [1_u64; ITERS];

--- a/programs/sbf/rust/many_args/src/lib.rs
+++ b/programs/sbf/rust/many_args/src/lib.rs
@@ -6,7 +6,7 @@ use {
     solana_program_entrypoint::{SUCCESS, custom_heap_default, custom_panic_default},
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     msg!("Call same package");
     assert_eq!(crate::helper::many_args(1, 2, 3, 4, 5, 6, 7, 8, 9), 45);

--- a/programs/sbf/rust/mem/src/lib.rs
+++ b/programs/sbf/rust/mem/src/lib.rs
@@ -19,16 +19,16 @@ pub fn process_instruction(
     struct MemOpSyscalls();
     impl MemOps for MemOpSyscalls {
         unsafe fn memcpy(&self, dst: &mut [u8], src: &[u8], n: usize) {
-            sol_memcpy(dst, src, n)
+            unsafe { sol_memcpy(dst, src, n) }
         }
         unsafe fn memmove(&self, dst: *mut u8, src: *mut u8, n: usize) {
-            sol_memmove(dst, src, n)
+            unsafe { sol_memmove(dst, src, n) }
         }
         unsafe fn memset(&self, s: &mut [u8], c: u8, n: usize) {
-            sol_memset(s, c, n)
+            unsafe { sol_memset(s, c, n) }
         }
         unsafe fn memcmp(&self, s1: &[u8], s2: &[u8], n: usize) -> i32 {
-            sol_memcmp(s1, s2, n)
+            unsafe { sol_memcmp(s1, s2, n) }
         }
     }
     run_mem_tests(MemOpSyscalls::default());

--- a/programs/sbf/rust/membuiltins/src/lib.rs
+++ b/programs/sbf/rust/membuiltins/src/lib.rs
@@ -9,7 +9,7 @@ use {
     solana_sbf_rust_mem_dep::{MemOps, run_mem_tests},
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     #[derive(Default)]
     struct MemOpSyscalls();
@@ -20,7 +20,9 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
             }
         }
         unsafe fn memmove(&self, dst: *mut u8, src: *mut u8, n: usize) {
-            compiler_builtins::mem::memmove(dst, src, n);
+            unsafe {
+                compiler_builtins::mem::memmove(dst, src, n);
+            }
         }
         unsafe fn memset(&self, s: &mut [u8], c: u8, n: usize) {
             unsafe {

--- a/programs/sbf/rust/panic/src/lib.rs
+++ b/programs/sbf/rust/panic/src/lib.rs
@@ -1,7 +1,7 @@
 //! Example Rust-based SBF program that panics
 
 #[cfg(all(feature = "custom-panic", target_os = "solana"))]
-#[no_mangle]
+#[unsafe(no_mangle)]
 fn custom_panic(info: &core::panic::PanicInfo<'_>) {
     // Note: Full panic reporting is included here for testing purposes
     solana_msg::msg!("program custom panic enabled");

--- a/programs/sbf/rust/param_passing/src/lib.rs
+++ b/programs/sbf/rust/param_passing/src/lib.rs
@@ -6,7 +6,7 @@ use {
     solana_sbf_rust_param_passing_dep::{Data, TestDep},
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     let array = [0xA, 0xB, 0xC, 0xD, 0xE, 0xF];
     let data = Data {

--- a/programs/sbf/rust/poseidon/src/lib.rs
+++ b/programs/sbf/rust/poseidon/src/lib.rs
@@ -213,7 +213,7 @@ fn test_poseidon_input_one() -> Result<(), PoseidonSyscallError> {
     Ok(())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     msg!("poseidon_hash");
 

--- a/programs/sbf/rust/r2_instruction_data_pointer/src/lib.rs
+++ b/programs/sbf/rust/r2_instruction_data_pointer/src/lib.rs
@@ -3,11 +3,12 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![allow(clippy::missing_safety_doc)]
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn entrypoint(_input: *mut u8, instruction_data_addr: *const u8) -> u64 {
-    let instruction_data_len = *((instruction_data_addr as u64 - 8) as *const u64);
-    let instruction_data =
-        core::slice::from_raw_parts(instruction_data_addr, instruction_data_len as usize);
+    let instruction_data_len = unsafe { *((instruction_data_addr as u64 - 8) as *const u64) };
+    let instruction_data = unsafe {
+        core::slice::from_raw_parts(instruction_data_addr, instruction_data_len as usize)
+    };
 
     solana_cpi::set_return_data(instruction_data);
 

--- a/programs/sbf/rust/r2_instruction_data_pointer/src/lib.rs
+++ b/programs/sbf/rust/r2_instruction_data_pointer/src/lib.rs
@@ -5,8 +5,8 @@
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn entrypoint(_input: *mut u8, instruction_data_addr: *const u8) -> u64 {
-    let instruction_data_len = unsafe { *((instruction_data_addr as u64 - 8) as *const u64) };
     let instruction_data = unsafe {
+        let instruction_data_len = *((instruction_data_addr as u64 - 8) as *const u64);
         core::slice::from_raw_parts(instruction_data_addr, instruction_data_len as usize)
     };
 

--- a/programs/sbf/rust/ro_modify/src/lib.rs
+++ b/programs/sbf/rust/ro_modify/src/lib.rs
@@ -197,5 +197,5 @@ macro_rules! check {
 /// # Safety
 #[inline(never)]
 pub unsafe fn read_val<T: Copy>(ptr: *mut T) -> T {
-    *ptr
+    unsafe { *ptr }
 }

--- a/programs/sbf/rust/secp256k1_recover/src/lib.rs
+++ b/programs/sbf/rust/secp256k1_recover/src/lib.rs
@@ -90,7 +90,7 @@ fn test_secp256k1_recover_malleability() {
     assert_eq!(alt_recovered_pubkey.to_bytes(), pubkey_bytes);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     msg!("secp256k1_recover");
 

--- a/programs/sbf/rust/sha/src/lib.rs
+++ b/programs/sbf/rust/sha/src/lib.rs
@@ -56,7 +56,7 @@ fn test_blake3_hasher() {
     assert_eq!(hashv(vals).as_bytes(), hash.as_bytes());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     msg!("sha");
 


### PR DESCRIPTION
#### Problem
Rust edition 2024 changes [no_mandle](https://doc.rust-lang.org/reference/abi.html#r-abi.no_mangle.edition2024) to require `unsafe` marker

#### Summary of Changes
Update annotation. Fix calls to those and other unsafe operations wrapping with `unsafe { }` blocks.
