### PR TITLE
chore: bump solana-file-download from 3.1.0 to 3.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
  "crossbeam-channel",
  "ctrlc",
  "dirs-next",
- "indicatif 0.18.4",
+ "indicatif",
  "nix",
  "reqwest 0.12.28",
  "scopeguard",
@@ -404,7 +404,7 @@ dependencies = [
  "core_affinity",
  "crossbeam-channel",
  "fd-lock",
- "indicatif 0.18.4",
+ "indicatif",
  "itertools 0.14.0",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3983,19 +3983,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
  "rayon",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
-dependencies = [
- "console 0.16.2",
- "portable-atomic",
- "unicode-width 0.2.0",
- "unit-prefix",
- "web-time",
 ]
 
 [[package]]
@@ -7688,7 +7675,7 @@ dependencies = [
  "clap 2.33.3",
  "console 0.16.2",
  "humantime",
- "indicatif 0.18.4",
+ "indicatif",
  "pretty-hex",
  "semver 1.0.27",
  "serde",
@@ -7732,7 +7719,7 @@ dependencies = [
  "futures 0.3.32",
  "futures-util",
  "indexmap 2.13.0",
- "indicatif 0.18.4",
+ "indicatif",
  "log",
  "quinn",
  "rayon",
@@ -7959,7 +7946,7 @@ dependencies = [
  "crossbeam-channel",
  "futures-util",
  "indexmap 2.13.0",
- "indicatif 0.18.4",
+ "indicatif",
  "log",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -8514,12 +8501,12 @@ dependencies = [
 
 [[package]]
 name = "solana-file-download"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6884e13cc98f58e609a9b73e3d53f728f0f743b8c15c6768cad6f6382c336c1"
+checksum = "a1022ee4c7fa77446a735aec66aaed1d1a946b27d00fd27684305519c281c1e2"
 dependencies = [
  "console 0.15.11",
- "indicatif 0.17.12",
+ "indicatif",
  "log",
  "reqwest 0.11.27",
 ]
@@ -10044,7 +10031,7 @@ dependencies = [
  "bs58",
  "crossbeam-channel",
  "futures 0.3.32",
- "indicatif 0.18.4",
+ "indicatif",
  "jsonrpc-core",
  "jsonrpc-http-server",
  "log",
@@ -11236,7 +11223,7 @@ dependencies = [
  "csv",
  "ctrlc",
  "indexmap 2.13.0",
- "indicatif 0.18.4",
+ "indicatif",
  "pickledb",
  "serde",
  "solana-account-decoder",
@@ -11312,7 +11299,7 @@ dependencies = [
  "bincode",
  "futures-util",
  "indexmap 2.13.0",
- "indicatif 0.18.4",
+ "indicatif",
  "log",
  "rayon",
  "solana-client-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -444,7 +444,7 @@ solana-feature-gate-interface = "3.1.0"
 solana-fee = { path = "fee", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-fee-calculator = "3.1.0"
 solana-fee-structure = "3.0.0"
-solana-file-download = "3.1.0"
+solana-file-download = "3.1.2"
 solana-frozen-abi = "3.1.2"
 solana-frozen-abi-macro = "3.2.1"
 solana-genesis = { path = "genesis", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -3433,19 +3433,6 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console 0.15.11",
- "number_prefix",
- "portable-atomic",
- "unicode-width 0.2.2",
- "web-time",
-]
-
-[[package]]
-name = "indicatif"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
@@ -4321,12 +4308,6 @@ dependencies = [
  "quote",
  "syn 2.0.116",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -6587,7 +6568,7 @@ dependencies = [
  "clap",
  "console 0.16.2",
  "humantime",
- "indicatif 0.18.4",
+ "indicatif",
  "pretty-hex",
  "semver",
  "serde",
@@ -6626,7 +6607,7 @@ dependencies = [
  "futures 0.3.32",
  "futures-util",
  "indexmap 2.13.0",
- "indicatif 0.18.4",
+ "indicatif",
  "log",
  "quinn",
  "rayon",
@@ -7229,12 +7210,12 @@ dependencies = [
 
 [[package]]
 name = "solana-file-download"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6884e13cc98f58e609a9b73e3d53f728f0f743b8c15c6768cad6f6382c336c1"
+checksum = "a1022ee4c7fa77446a735aec66aaed1d1a946b27d00fd27684305519c281c1e2"
 dependencies = [
  "console 0.15.11",
- "indicatif 0.17.11",
+ "indicatif",
  "log",
  "reqwest 0.11.27",
 ]
@@ -8462,7 +8443,7 @@ dependencies = [
  "bincode",
  "bs58",
  "futures 0.3.32",
- "indicatif 0.18.4",
+ "indicatif",
  "log",
  "reqwest 0.12.28",
  "reqwest-middleware",
@@ -9410,7 +9391,7 @@ dependencies = [
  "bincode",
  "futures-util",
  "indexmap 2.13.0",
- "indicatif 0.18.4",
+ "indicatif",
  "log",
  "rayon",
  "solana-client-traits",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
  "core_affinity",
  "crossbeam-channel",
  "fd-lock",
- "indicatif 0.18.4",
+ "indicatif",
  "itertools 0.14.0",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3377,19 +3377,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
  "rayon",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
-dependencies = [
- "console 0.16.2",
- "portable-atomic",
- "unicode-width 0.2.0",
- "unit-prefix",
- "web-time",
 ]
 
 [[package]]
@@ -6483,7 +6470,7 @@ dependencies = [
  "clap",
  "console 0.16.2",
  "humantime",
- "indicatif 0.18.4",
+ "indicatif",
  "pretty-hex",
  "semver",
  "serde",
@@ -6522,7 +6509,7 @@ dependencies = [
  "futures 0.3.32",
  "futures-util",
  "indexmap 2.13.0",
- "indicatif 0.18.4",
+ "indicatif",
  "log",
  "quinn",
  "rayon",
@@ -7156,12 +7143,12 @@ dependencies = [
 
 [[package]]
 name = "solana-file-download"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6884e13cc98f58e609a9b73e3d53f728f0f743b8c15c6768cad6f6382c336c1"
+checksum = "a1022ee4c7fa77446a735aec66aaed1d1a946b27d00fd27684305519c281c1e2"
 dependencies = [
  "console 0.15.11",
- "indicatif 0.17.12",
+ "indicatif",
  "log",
  "reqwest 0.11.27",
 ]
@@ -8315,7 +8302,7 @@ dependencies = [
  "bincode",
  "bs58",
  "futures 0.3.32",
- "indicatif 0.18.4",
+ "indicatif",
  "log",
  "reqwest 0.12.28",
  "reqwest-middleware",
@@ -10041,7 +10028,7 @@ dependencies = [
  "bincode",
  "futures-util",
  "indexmap 2.13.0",
- "indicatif 0.18.4",
+ "indicatif",
  "log",
  "rayon",
  "solana-client-traits",


### PR DESCRIPTION
#### Problem
```
Crate:     indicatif
Version:   0.17.12
Warning:   yanked
Dependency tree:
indicatif 0.17.12
```

#### Summary of Changes
bump `solana-file-download` from 3.1.0 to 3.1.2 which brings indicatif up to 0.18.4, like the rest of the monorepo