### PR TITLE
ci: add crate publish test

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -14,7 +14,7 @@ source ci/env.sh
   while read -r line; do
     read -r id image _ <<<"$line"
 
-    if [[ $image =~ "anzaxyz/ci" ]]; then
+    if [[ $image =~ "anzaxyz/ci" || $image =~ "kellnr" ]]; then
       if docker kill "$id" >/dev/null; then
         echo "kill $id $image"
       fi

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -51,11 +51,11 @@ spl-token-interface = { workspace = true }
 jemallocator = { workspace = true }
 
 [dev-dependencies]
-solana-accounts-db = { workspace = true }
-solana-core = { workspace = true, features = ["dev-context-only-utils"] }
-solana-faucet = { workspace = true, features = ["dev-context-only-utils"] }
-solana-local-cluster = { workspace = true, features = ["dev-context-only-utils"] }
+solana-accounts-db = { path = "../accounts-db", features = ["agave-unstable-api"] }
+solana-core = { path = "../core", features = ["dev-context-only-utils"] }
+solana-faucet = { path = "../faucet", features = ["dev-context-only-utils"] }
+solana-local-cluster = { path = "../local-cluster", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-native-token = { workspace = true }
 solana-poh-config = { workspace = true }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-test-validator = { workspace = true }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
+solana-test-validator = { path = "../test-validator" }

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -105,8 +105,8 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
-agave-reserved-account-keys = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 libsecp256k1 = { workspace = true }
@@ -115,12 +115,12 @@ rand_chacha = { workspace = true }
 serde_bytes = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-accounts-db = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-compute-budget = { workspace = true }
+solana-compute-budget = { path = "../compute-budget", features = ["agave-unstable-api"] }
 solana-instruction = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-slot-history = { workspace = true }
-solana-svm = { workspace = true }
+solana-svm = { path = "../svm", features = ["agave-unstable-api"] }
 static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -42,8 +42,8 @@ tokio = { workspace = true, features = ["full"] }
 tokio-serde = { workspace = true, features = ["bincode"] }
 
 [dev-dependencies]
-solana-banks-server = { workspace = true }
+solana-banks-server = { path = "../banks-server", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -77,13 +77,13 @@ thiserror = { workspace = true }
 jemallocator = { workspace = true }
 
 [dev-dependencies]
-agave-feature-set = { workspace = true }
+agave-feature-set = { path = "../feature-set", features = ["agave-unstable-api"] }
 serial_test = { workspace = true }
-solana-faucet = { workspace = true, features = ["dev-context-only-utils"] }
-solana-local-cluster = { workspace = true }
+solana-faucet = { path = "../faucet", features = ["dev-context-only-utils"] }
+solana-local-cluster = { path = "../local-cluster", features = ["agave-unstable-api"] }
 solana-rent = { workspace = true }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
 solana-sdk-ids = { workspace = true }
-solana-test-validator = { workspace = true }
-solana-tps-client = { workspace = true, features = ["bank-client"] }
+solana-test-validator = { path = "../test-validator" }
+solana-tps-client = { path = "../tps-client", features = ["bank-client"] }
 tempfile = { workspace = true }

--- a/bls-cert-verify/Cargo.toml
+++ b/bls-cert-verify/Cargo.toml
@@ -28,7 +28,7 @@ wincode = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 agave-bls-cert-verify = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 # See order-crates-for-publishing.py for using this unusual `path`
-agave-votor = { path = "../votor" }
+agave-votor = { path = "../votor", features = ["agave-unstable-api"] }
 criterion = { workspace = true }
 solana-hash = { workspace = true }
 

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -32,7 +32,7 @@ solana-pubkey = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 fs_extra = { workspace = true }
 rayon = { workspace = true }
 solana-bucket-map = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -299,6 +299,11 @@ EOF
     annotate --style info --context test-coverage \
       "Coverage skipped as no .rs files were modified"
   fi
+
+  # crate publish test
+  if [[ -z $CI_PULL_REQUEST ]]; then
+    command_step crate-publish-test "cargo xtask publish test" 30 default
+  fi
 }
 
 pull_or_push_steps() {

--- a/ci/xtask/Cargo.lock
+++ b/ci/xtask/Cargo.lock
@@ -808,13 +808,13 @@ dependencies = [
  "env_logger",
  "log",
  "tokio",
- "xtask 0.1.0 (git+https://github.com/anza-xyz/xtask?rev=d189441)",
+ "xtask 0.1.0 (git+https://github.com/anza-xyz/xtask?rev=79448195157b565a99d1ea3f948bac011f36da1d)",
 ]
 
 [[package]]
 name = "xtask"
 version = "0.1.0"
-source = "git+https://github.com/anza-xyz/xtask?rev=d189441#d189441c1bc86aa1741e1a079572fea00ea9b007"
+source = "git+https://github.com/anza-xyz/xtask?rev=79448195157b565a99d1ea3f948bac011f36da1d#79448195157b565a99d1ea3f948bac011f36da1d"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "4.5.59", features = ["derive"] }
 env_logger = "0.11.9"
 log = "0.4.28"
 tokio = { version = "1.48.0", features = ["full"] }
-xtask_shared = { package = "xtask", git = "https://github.com/anza-xyz/xtask", rev = "d189441" }
+xtask_shared = { package = "xtask", git = "https://github.com/anza-xyz/xtask", rev = "79448195157b565a99d1ea3f948bac011f36da1d" }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -55,4 +55,4 @@ spl-memo-interface = { workspace = true }
 solana-keypair = { workspace = true }
 solana-seed-derivable = { workspace = true }
 solana-signer = { workspace = true }
-solana-transaction-context = { workspace = true }
+solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -111,14 +111,14 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-solana-client = { workspace = true, features = ["dev-context-only-utils"] }
-solana-faucet = { workspace = true, features = ["dev-context-only-utils"] }
-solana-net-utils = { workspace = true }
+solana-client = { path = "../client", features = ["dev-context-only-utils"] }
+solana-faucet = { path = "../faucet", features = ["dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-nonce-account = { workspace = true }
 solana-presigner = { workspace = true }
-solana-rpc = { workspace = true }
+solana-rpc = { path = "../rpc", features = ["agave-unstable-api"] }
 solana-sha256-hasher = { workspace = true }
-solana-test-validator = { workspace = true }
-solana-tps-client = { workspace = true, features = ["dev-context-only-utils"] }
+solana-test-validator = { path = "../test-validator" }
+solana-tps-client = { path = "../tps-client", features = ["dev-context-only-utils"] }
 tempfile = { workspace = true }
 test-case = { workspace = true }

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -47,7 +47,7 @@ tokio = { workspace = true, features = ["full"] }
 tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
-solana-net-utils = { workspace = true }
-solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
+solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
+solana-rpc = { path = "../rpc", features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }

--- a/compute-budget-instruction/Cargo.toml
+++ b/compute-budget-instruction/Cargo.toml
@@ -39,7 +39,7 @@ thiserror = { workspace = true }
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-builtins-default-costs = { workspace = true, features = ["dev-context-only-utils"] }
+solana-builtins-default-costs = { path = "../builtins-default-costs", features = ["dev-context-only-utils"] }
 solana-compute-budget-instruction = { path = ".", features = ["agave-unstable-api"] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }

--- a/connection-cache/Cargo.toml
+++ b/connection-cache/Cargo.toml
@@ -31,6 +31,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 rand_chacha = { workspace = true }
-solana-net-utils = { workspace = true }
+solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -192,33 +192,33 @@ shaq = { workspace = true }
 sysctl = { workspace = true }
 
 [dev-dependencies]
-agave-reserved-account-keys = { workspace = true }
-agave-scheduler-bindings = { workspace = true }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-scheduler-bindings = { path = "../scheduler-bindings", features = ["agave-unstable-api"] }
 bencher = { workspace = true }
 criterion = { workspace = true }
 fs_extra = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
 solana-account = { workspace = true, features = ["dev-context-only-utils"] }
-solana-bpf-loader-program = { workspace = true }
-solana-client = { workspace = true, features = ["dev-context-only-utils"] }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", features = ["agave-unstable-api"], default-features = false }
+solana-client = { path = "../client", features = ["dev-context-only-utils"] }
 solana-compute-budget-interface = { workspace = true }
-solana-compute-budget-program = { workspace = true }
+solana-compute-budget-program = { path = "../programs/compute-budget", features = ["agave-unstable-api"] }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-core = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-cost-model = { workspace = true, features = ["dev-context-only-utils"] }
+solana-cost-model = { path = "../cost-model", features = ["dev-context-only-utils"] }
 solana-keypair = { workspace = true }
-solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
-solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
-solana-poh = { workspace = true, features = ["dev-context-only-utils"] }
-solana-program-binaries = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["metrics"] }
-solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
-solana-system-program = { workspace = true }
-solana-unified-scheduler-pool = { workspace = true, features = [
+solana-ledger = { path = "../ledger", features = ["dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = ["dev-context-only-utils"] }
+solana-poh = { path = "../poh", features = ["dev-context-only-utils"] }
+solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
+solana-program-runtime = { path = "../program-runtime", features = ["metrics"] }
+solana-rpc = { path = "../rpc", features = ["dev-context-only-utils"] }
+solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
+solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", features = [
     "dev-context-only-utils",
 ] }
-solana-vote = { workspace = true, features = ["dev-context-only-utils"] }
+solana-vote = { path = "../vote", features = ["dev-context-only-utils"] }
 spl-memo-interface = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -66,27 +66,27 @@ solana-transaction-error = { workspace = true }
 solana-vote-program = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
-agave-reserved-account-keys = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
 itertools = { workspace = true }
 rand = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
-solana-compute-budget-instruction = { workspace = true, features = [
+solana-compute-budget-instruction = { path = "../compute-budget-instruction", features = [
     "dev-context-only-utils",
 ] }
 solana-compute-budget-interface = { workspace = true }
-solana-compute-budget-program = { workspace = true }
+solana-compute-budget-program = { path = "../programs/compute-budget", features = ["agave-unstable-api"] }
 solana-cost-model = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-runtime-transaction = { workspace = true, features = [
+solana-runtime-transaction = { path = "../runtime-transaction", features = [
     "dev-context-only-utils",
 ] }
 solana-signer = { workspace = true }
-solana-system-program = { workspace = true }
+solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
 solana-system-transaction = { workspace = true }
-solana-vote = { workspace = true }
+solana-vote = { path = "../vote", features = ["agave-unstable-api"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -28,4 +28,4 @@ solana-genesis-config = { workspace = true }
 solana-runtime = { workspace = true }
 
 [dev-dependencies]
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -49,15 +49,15 @@ thiserror = { workspace = true }
 wincode = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
-agave-reserved-account-keys = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 solana-entry = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-keypair = { workspace = true }
 solana-message = { workspace = true }
-solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
+solana-perf = { path = "../perf", features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -71,6 +71,6 @@ tempfile = { workspace = true }
 solana-borsh = { workspace = true }
 solana-genesis = { path = ".", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-vote = { workspace = true }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
+solana-vote = { path = "../vote", features = ["agave-unstable-api"] }
 test-case = { workspace = true }

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -101,9 +101,9 @@ criterion = { workspace = true }
 num_cpus = { workspace = true }
 serial_test = { workspace = true }
 solana-gossip = { path = ".", features = ["agave-unstable-api"] }
-solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
-solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = ["dev-context-only-utils"] }
+solana-perf = { path = "../perf", features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
 solana-vote-interface = { workspace = true }

--- a/leader-schedule/Cargo.toml
+++ b/leader-schedule/Cargo.toml
@@ -32,7 +32,7 @@ bs58 = { workspace = true, features = ["alloc"] }
 rand = { workspace = true }
 sha2 = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-vote = { workspace = true, features = ["dev-context-only-utils"] }
+solana-vote = { path = "../vote", features = ["dev-context-only-utils"] }
 test-case = { workspace = true }
 
 [lints]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -138,21 +138,21 @@ default-features = false
 features = ["lz4"]
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 bs58 = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }
-solana-account-decoder = { workspace = true }
+solana-account-decoder = { path = "../account-decoder", features = ["agave-unstable-api"] }
 solana-bls-signatures = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-ledger = { path = ".", features = ["dev-context-only-utils", "agave-unstable-api"] }
-solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
-solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = ["dev-context-only-utils"] }
+solana-perf = { path = "../perf", features = ["dev-context-only-utils"] }
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
 solana-signature = { workspace = true, features = ["rand"] }
-solana-vote = { workspace = true, features = ["dev-context-only-utils"] }
+solana-vote = { path = "../vote", features = ["dev-context-only-utils"] }
 spl-generic-token = { workspace = true }
 spl-pod = { workspace = true }
 test-case = { workspace = true }

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -90,9 +90,9 @@ assert_matches = { workspace = true }
 fs_extra = { workspace = true }
 gag = { workspace = true }
 serial_test = { workspace = true }
-solana-core = { workspace = true, features = ["dev-context-only-utils"] }
-solana-download-utils = { workspace = true }
-solana-genesis-utils = { workspace = true }
-solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
+solana-core = { path = "../core", features = ["dev-context-only-utils"] }
+solana-download-utils = { path = "../download-utils", features = ["agave-unstable-api"] }
+solana-genesis-utils = { path = "../genesis-utils", features = ["agave-unstable-api"] }
+solana-ledger = { path = "../ledger", features = ["dev-context-only-utils"] }
 solana-local-cluster = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 solana-net-utils = { path = ".", features = ["agave-unstable-api"] }
 
 [lints]

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -78,8 +78,8 @@ libc = { workspace = true }
 nix = { workspace = true, features = ["user"] }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
-agave-random = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
+agave-random = { path = "../random", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 bencher = { workspace = true }
 rand_chacha = { workspace = true }

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -44,16 +44,16 @@ solana-transaction = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-entry = { workspace = true, features = ["dev-context-only-utils"] }
+solana-entry = { path = "../entry", features = ["dev-context-only-utils"] }
 solana-keypair = { workspace = true }
-solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
+solana-perf = { path = "../perf", features = ["dev-context-only-utils"] }
 solana-poh = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
 solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }

--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -34,7 +34,7 @@ solana-secp256k1-program = { workspace = true, features = ["serde"] }
 solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 agave-precompiles = { path = ".", features = ["agave-unstable-api"] }
 bytemuck = { workspace = true }
 hex = { workspace = true }

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -83,7 +83,7 @@ solana-program-runtime = { path = ".", features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
-solana-transaction-context = { workspace = true, features = [
+solana-transaction-context = { path = "../transaction-context", features = [
     "dev-context-only-utils",
 ] }
 test-case = { workspace = true }

--- a/programs/bpf-loader-tests/Cargo.toml
+++ b/programs/bpf-loader-tests/Cargo.toml
@@ -21,11 +21,11 @@ agave-unstable-api = []
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 solana-account = { workspace = true }
-solana-bpf-loader-program = { workspace = true }
+solana-bpf-loader-program = { path = "../bpf_loader", features = ["agave-unstable-api"], default-features = false }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-loader-v3-interface = { workspace = true }
-solana-program-test = { workspace = true }
+solana-program-test = { path = "../../program-test", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signer = { workspace = true }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -54,18 +54,18 @@ solana-transaction-context = { workspace = true, features = ["bincode"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-bpf-loader-program = { path = ".", features = ["agave-unstable-api", "svm-internal"] }
+solana-bpf-loader-program = { path = ".", features = ["agave-unstable-api", "svm-internal"], default-features = false }
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-last-restart-slot = { workspace = true }
 solana-program = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-runtime = { path = "../../program-runtime", features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-slot-hashes = { workspace = true }
-solana-svm-callback = { workspace = true }
-solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
+solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
+solana-transaction-context = { path = "../../transaction-context", features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/programs/ed25519-tests/Cargo.toml
+++ b/programs/ed25519-tests/Cargo.toml
@@ -21,7 +21,7 @@ solana-ed25519-program = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-precompile-error = { workspace = true }
-solana-program-test = { workspace = true }
+solana-program-test = { path = "../../program-test", features = ["agave-unstable-api"] }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -185,11 +185,11 @@ dummy-for-ci-check = ["sbf_c", "sbf_rust", "sbf_sanity_list", "sbpf-v3"]
 frozen-abi = []
 
 [dev-dependencies]
-agave-feature-set = { workspace = true }
-agave-logger = { workspace = true }
-agave-reserved-account-keys = { workspace = true }
-agave-syscalls = { workspace = true }
-agave-validator = { workspace = true }
+agave-feature-set = { path = "../../feature-set", features = ["agave-unstable-api"] }
+agave-logger = { path = "../../logger", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-syscalls = { path = "../../syscalls", features = ["agave-unstable-api"], default-features = false }
+agave-validator = { path = "../../validator" }
 bincode = { workspace = true }
 borsh = { workspace = true }
 byteorder = { workspace = true }
@@ -199,38 +199,38 @@ log = { workspace = true }
 miow = { workspace = true }
 net2 = { workspace = true }
 solana-account = "4.0.0"
-solana-account-decoder = { workspace = true }
+solana-account-decoder = { path = "../../account-decoder", features = ["agave-unstable-api"] }
 solana-account-info = "3.1.0"
-solana-accounts-db = { workspace = true }
-solana-bpf-loader-program = { workspace = true }
-solana-cli-output = { workspace = true }
+solana-accounts-db = { path = "../../accounts-db", features = ["agave-unstable-api"] }
+solana-bpf-loader-program = { path = "../bpf_loader", features = ["agave-unstable-api"], default-features = false }
+solana-cli-output = { path = "../../cli-output", features = ["agave-unstable-api"] }
 solana-client-traits = "4.0.0"
 solana-clock = "3.0.0"
 solana-cluster-type = "3.0.0"
-solana-compute-budget = { workspace = true }
-solana-compute-budget-instruction = { workspace = true, features = [
+solana-compute-budget = { path = "../../compute-budget", features = ["agave-unstable-api"] }
+solana-compute-budget-instruction = { path = "../../compute-budget-instruction", features = [
     "dev-context-only-utils",
 ] }
 solana-compute-budget-interface = "3.0.0"
-solana-fee = { workspace = true }
+solana-fee = { path = "../../fee", features = ["agave-unstable-api"] }
 solana-fee-calculator = "3.0.0"
 solana-fee-structure = "3.0.0"
 solana-genesis-config = "4.0.0"
 solana-hash = "4.2.0"
 solana-instruction = { workspace = true }
 solana-keypair = "3.0.0"
-solana-ledger = { workspace = true }
+solana-ledger = { path = "../../ledger", features = ["agave-unstable-api"] }
 solana-loader-v3-interface = "6.1.0"
 solana-loader-v4-interface = "3.1.0"
-solana-measure = { workspace = true }
+solana-measure = { path = "../../measure", features = ["agave-unstable-api"] }
 solana-message = "4.0.0"
 solana-program = { workspace = true }
 solana-program-entrypoint = "3.1.1"
-solana-program-runtime = { workspace = true }
+solana-program-runtime = { path = "../../program-runtime", features = ["agave-unstable-api"] }
 solana-pubkey = "4.1.0"
 solana-rent = "4.1.0"
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-runtime-transaction = { workspace = true, features = [
+solana-runtime = { path = "../../runtime", features = ["dev-context-only-utils"] }
+solana-runtime-transaction = { path = "../../runtime-transaction", features = [
     "dev-context-only-utils",
 ] }
 solana-sbf-rust-invoke-dep = { workspace = true }
@@ -240,25 +240,25 @@ solana-sbpf = { workspace = true, features = ["jit"] }
 solana-sdk-ids = "3.1.0"
 solana-signer = "3.0.0"
 solana-stake-interface = "3.0.0"
-solana-svm = { workspace = true }
-solana-svm-callback = { workspace = true }
-solana-svm-feature-set = { workspace = true }
-solana-svm-log-collector = { workspace = true }
-solana-svm-test-harness-instr = { workspace = true }
-solana-svm-timings = { workspace = true }
-solana-svm-transaction = { workspace = true }
-solana-svm-type-overrides = { workspace = true }
+solana-svm = { path = "../../svm", features = ["agave-unstable-api"] }
+solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
+solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-unstable-api"] }
+solana-svm-log-collector = { path = "../../svm-log-collector", features = ["agave-unstable-api"] }
+solana-svm-test-harness-instr = { path = "../../svm-test-harness/instr" }
+solana-svm-timings = { path = "../../svm-timings", features = ["agave-unstable-api"] }
+solana-svm-transaction = { path = "../../svm-transaction", features = ["agave-unstable-api"] }
+solana-svm-type-overrides = { path = "../../svm-type-overrides", features = ["agave-unstable-api"] }
 solana-system-interface = { workspace = true }
 solana-sysvar = "4.0.0"
 solana-transaction = "4.0.0"
-solana-transaction-context = { workspace = true, features = [
+solana-transaction-context = { path = "../../transaction-context", features = [
     "dev-context-only-utils",
 ] }
 solana-transaction-error = "3.0.0"
-solana-transaction-status = { workspace = true }
-solana-vote = { workspace = true }
+solana-transaction-status = { path = "../../transaction-status", features = ["agave-unstable-api"] }
+solana-vote = { path = "../../vote", features = ["agave-unstable-api"] }
 solana-vote-interface = { workspace = true }
-solana-vote-program = { workspace = true }
+solana-vote-program = { path = "../vote", features = ["agave-unstable-api"], default-features = false }
 test-case = { workspace = true }
 
 [profile.dev]

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -40,15 +40,15 @@ solana-transaction-context = { workspace = true, features = ["bincode"] }
 [dev-dependencies]
 assert_matches = { workspace = true }
 criterion = { workspace = true }
-solana-compute-budget = { workspace = true }
+solana-compute-budget = { path = "../../compute-budget", features = ["agave-unstable-api"] }
 solana-hash = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-rent = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-solana-svm-callback = { workspace = true }
-solana-svm-feature-set = { workspace = true }
+solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
+solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-unstable-api"] }
 solana-system-program = { path = ".", features = ["agave-unstable-api"] }
-solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
+solana-transaction-context = { path = "../../transaction-context", features = ["dev-context-only-utils"] }
 
 [[bench]]
 name = "system"

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -55,21 +55,21 @@ solana-transaction-context = { workspace = true, features = ["bincode"] }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 solana-account = { workspace = true }
 solana-clock = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-instruction = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-runtime = { path = "../../program-runtime", features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-solana-svm-feature-set = { workspace = true }
-solana-system-program = { workspace = true }
-solana-vote-program = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-unstable-api"] }
+solana-system-program = { path = "../system", features = ["agave-unstable-api"] }
+solana-vote-program = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"], default-features = false }
 test-case = { workspace = true }
 
 [[bench]]

--- a/programs/zk-elgamal-proof-tests/Cargo.toml
+++ b/programs/zk-elgamal-proof-tests/Cargo.toml
@@ -13,11 +13,11 @@ agave-unstable-api = []
 [dev-dependencies]
 bytemuck = { workspace = true }
 solana-account = { workspace = true }
-solana-compute-budget = { workspace = true }
+solana-compute-budget = { path = "../../compute-budget", features = ["agave-unstable-api"] }
 solana-compute-budget-interface = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-program-test = { workspace = true }
+solana-program-test = { path = "../../program-test", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }

--- a/quic-client/Cargo.toml
+++ b/quic-client/Cargo.toml
@@ -36,11 +36,11 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 crossbeam-channel = { workspace = true }
-solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = ["dev-context-only-utils"] }
 solana-packet = { workspace = true }
-solana-perf = { workspace = true }
+solana-perf = { path = "../perf", features = ["agave-unstable-api"] }
 solana-quic-client = { path = ".", features = ["agave-unstable-api"] }
-solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
+solana-streamer = { path = "../streamer", features = ["dev-context-only-utils"] }
 tokio-util = { workspace = true }

--- a/rpc-client-nonce-utils/Cargo.toml
+++ b/rpc-client-nonce-utils/Cargo.toml
@@ -34,10 +34,10 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 futures = { workspace = true }
 serde_json = { workspace = true }
-solana-account-decoder = { workspace = true }
+solana-account-decoder = { path = "../account-decoder", features = ["agave-unstable-api"] }
 solana-fee-calculator = { workspace = true }
 solana-keypair = { workspace = true }
-solana-rpc-client-api = { workspace = true }
+solana-rpc-client-api = { path = "../rpc-client-api" }
 solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -59,7 +59,7 @@ crossbeam-channel = { workspace = true }
 futures = { workspace = true }
 jsonrpc-core = { workspace = true }
 jsonrpc-http-server = { workspace = true }
-solana-account-decoder = { workspace = true }
+solana-account-decoder = { path = "../account-decoder", features = ["agave-unstable-api"] }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -40,11 +40,11 @@ solana-transaction-status = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
-solana-client = { workspace = true, features = ["dev-context-only-utils"] }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
+solana-client = { path = "../client", features = ["dev-context-only-utils"] }
 solana-clock = { workspace = true }
 solana-commitment-config = { workspace = true }
-solana-connection-cache = { workspace = true }
+solana-connection-cache = { path = "../connection-cache", features = ["agave-unstable-api"], default-features = false }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -103,7 +103,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, features = ["codec", "compat"] }
 
 [dev-dependencies]
-agave-reserved-account-keys = { workspace = true }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
 serial_test = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }
 solana-cluster-type = { workspace = true }
@@ -111,22 +111,22 @@ solana-compute-budget-interface = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-instruction = { workspace = true }
-solana-net-utils = { workspace = true }
+solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-nonce = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-program-option = { workspace = true }
-solana-program-runtime = { workspace = true }
+solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api"] }
 solana-rent = { workspace = true }
 solana-rpc = { path = ".", features = ["dev-context-only-utils"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-runtime-transaction = { workspace = true, features = [
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
+solana-runtime-transaction = { path = "../runtime-transaction", features = [
     "dev-context-only-utils",
 ] }
 solana-sdk-ids = { workspace = true }
-solana-send-transaction-service = { workspace = true, features = ["dev-context-only-utils"] }
+solana-send-transaction-service = { path = "../send-transaction-service", features = ["dev-context-only-utils"] }
 solana-sha256-hasher = { workspace = true }
 solana-stake-interface = { workspace = true }
-solana-svm-log-collector = { workspace = true }
+solana-svm-log-collector = { path = "../svm-log-collector", features = ["agave-unstable-api"] }
 solana-vote-interface = { workspace = true }
 spl-pod = { workspace = true }
 symlink = { workspace = true }

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -37,12 +37,12 @@ solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-agave-feature-set = { workspace = true }
-agave-reserved-account-keys = { workspace = true }
+agave-feature-set = { path = "../feature-set", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-compute-budget-instruction = { workspace = true, features = ["dev-context-only-utils"] }
+solana-compute-budget-instruction = { path = "../compute-budget-instruction", features = ["dev-context-only-utils"] }
 solana-compute-budget-interface = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -194,19 +194,19 @@ thiserror = { workspace = true }
 wincode = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
-agave-transaction-view = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
+agave-transaction-view = { path = "../transaction-view", features = ["agave-unstable-api"] }
 bitvec = { workspace = true }
 libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }
 proptest = { workspace = true }
-solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
-solana-builtins = { workspace = true, features = ["dev-context-only-utils"] }
+solana-accounts-db = { path = "../accounts-db", features = ["dev-context-only-utils"] }
+solana-builtins = { path = "../builtins", features = ["dev-context-only-utils"] }
 solana-instruction-error = { workspace = true }
-solana-program-binaries = { workspace = true }
+solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-runtime = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime-transaction = { workspace = true, features = [
+solana-runtime-transaction = { path = "../runtime-transaction", features = [
     "dev-context-only-utils",
 ] }
 solana-sdk-ids = { workspace = true }
@@ -214,11 +214,11 @@ solana-secp256k1-program = { workspace = true, features = ["bincode"] }
 solana-signature = { workspace = true, features = ["std"] }
 solana-signer-store = { workspace = true }
 solana-stake-interface = { workspace = true, features = ["sysvar"] }
-solana-svm = { workspace = true, features = ["dev-context-only-utils"] }
-solana-transaction-context = { workspace = true, features = [
+solana-svm = { path = "../svm", features = ["dev-context-only-utils"] }
+solana-transaction-context = { path = "../transaction-context", features = [
     "dev-context-only-utils",
 ] }
-solana-vote-program = { workspace = true, features = ["dev-context-only-utils"] }
+solana-vote-program = { path = "../programs/vote", features = ["dev-context-only-utils"], default-features = false }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/scheduling-utils/Cargo.toml
+++ b/scheduling-utils/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = { workspace = true }
 tempfile = { workspace = true }
 
 [target."cfg(unix)".dev-dependencies]
-agave-scheduler-bindings = { workspace = true }
+agave-scheduler-bindings = { path = "../scheduler-bindings", features = ["agave-unstable-api"] }
 
 [lints]
 workspace = true

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -39,13 +39,13 @@ tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 solana-account = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-genesis-config = { workspace = true }
-solana-net-utils = { workspace = true }
+solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-nonce = { workspace = true }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-system-transaction = { workspace = true }

--- a/snapshots/Cargo.toml
+++ b/snapshots/Cargo.toml
@@ -44,5 +44,5 @@ thiserror = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -45,5 +45,5 @@ solana-version = { workspace = true }
 
 [dev-dependencies]
 solana-client-traits = { workspace = true }
-solana-program-binaries = { workspace = true }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -60,4 +60,4 @@ solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
-solana-transaction-context = { workspace = true }
+solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode"] }

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -61,10 +61,10 @@ tokio-util = { workspace = true, features = ["rt"] }
 x509-parser = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 anyhow = { workspace = true }
 assert_matches = { workspace = true }
 chrono = { workspace = true, features = ["now"] }
 clap = { version = "4.5.31", features = ["cargo", "derive", "error-context"] }
-solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = ["dev-context-only-utils"] }
 solana-streamer = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -87,7 +87,7 @@ spl-generic-token = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-agave-syscalls = { workspace = true }
+agave-syscalls = { path = "../syscalls", features = ["agave-unstable-api"], default-features = false }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 env_logger = { workspace = true }
@@ -95,19 +95,19 @@ libsecp256k1 = { workspace = true }
 openssl = { workspace = true }
 rand = { workspace = true }
 shuttle = { workspace = true }
-solana-bpf-loader-program = { workspace = true }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", features = ["agave-unstable-api"], default-features = false }
 solana-clock = { workspace = true }
-solana-compute-budget = { workspace = true }
+solana-compute-budget = { path = "../compute-budget", features = ["agave-unstable-api"] }
 solana-compute-budget-interface = { workspace = true }
-solana-compute-budget-program = { workspace = true }
+solana-compute-budget-program = { path = "../programs/compute-budget", features = ["agave-unstable-api"] }
 solana-ed25519-program = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-keypair = { workspace = true }
 solana-native-token = { workspace = true }
 solana-precompile-error = { workspace = true }
-solana-program-binaries = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
+solana-program-runtime = { path = "../program-runtime", features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-sbpf = { workspace = true, features = ["jit"] }
@@ -117,11 +117,11 @@ solana-signature = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-svm = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils", "svm-internal"] }
-solana-system-program = { workspace = true }
+solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
 solana-system-transaction = { workspace = true }
 solana-sysvar = { workspace = true }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
-solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
+solana-transaction-context = { path = "../transaction-context", features = ["dev-context-only-utils"] }
 spl-token-interface = { workspace = true }
 test-case = { workspace = true }
 

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -68,11 +68,11 @@ solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-last-restart-slot = { workspace = true }
 solana-program = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-runtime = { path = "../program-runtime", features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-slot-hashes = { workspace = true }
-solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
+solana-transaction-context = { path = "../transaction-context", features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -58,8 +58,8 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
-solana-test-validator = { workspace = true }
+solana-test-validator = { path = "../test-validator" }
 solana-transaction-error = { workspace = true }

--- a/tps-client/Cargo.toml
+++ b/tps-client/Cargo.toml
@@ -46,5 +46,5 @@ solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
 tempfile = { workspace = true }

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -50,10 +50,10 @@ tracing = { workspace = true, optional = true }
 crossbeam-channel = { workspace = true }
 futures = { workspace = true }
 serde_json = { workspace = true }
-solana-cli-config = { workspace = true }
+solana-cli-config = { path = "../cli-config" }
 solana-commitment-config = { workspace = true }
-solana-net-utils = { workspace = true }
+solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
-solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
+solana-streamer = { path = "../streamer", features = ["dev-context-only-utils"] }
 solana-tpu-client-next = { path = ".", features = ["agave-unstable-api", "websocket-node-address-service", "dev-context-only-utils"] }

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -57,13 +57,13 @@ thiserror = { workspace = true }
 wincode = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 bencher = { workspace = true }
 bs58 = { workspace = true }
 solana-genesis-config = { workspace = true }
-solana-ledger = { workspace = true, features = ["agave-unstable-api","dev-context-only-utils"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-ledger = { path = "../ledger", features = ["agave-unstable-api","dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-transaction = { workspace = true }
 solana-turbine = { path = ".", features = ["agave-unstable-api"] }

--- a/udp-client/Cargo.toml
+++ b/udp-client/Cargo.toml
@@ -24,6 +24,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
-solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = ["dev-context-only-utils"] }
 solana-packet = { workspace = true }
-solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
+solana-streamer = { path = "../streamer", features = ["dev-context-only-utils"] }

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -24,7 +24,7 @@ unwrap_none = { workspace = true }
 [dev-dependencies]
 solana-instruction = { workspace = true }
 solana-message = { workspace = true }
-solana-runtime-transaction = { workspace = true, features = [
+solana-runtime-transaction = { path = "../runtime-transaction", features = [
     "dev-context-only-utils",
 ] }
 test-case = { workspace = true }

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -43,13 +43,13 @@ unwrap_none = { workspace = true }
 vec_extract_if_polyfill = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 solana-clock = { workspace = true }
-solana-entry = { workspace = true }
+solana-entry = { path = "../entry", features = ["agave-unstable-api"] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
 solana-system-transaction = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-unified-scheduler-pool = { path = ".", features = ["dev-context-only-utils"] }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -108,11 +108,11 @@ assert_cmd = { workspace = true }
 predicates = { workspace = true }
 pretty_assertions = { workspace = true }
 scopeguard = { workspace = true }
-solana-account-decoder = { workspace = true }
-solana-core = { workspace = true, features = ["dev-context-only-utils"] }
+solana-account-decoder = { path = "../account-decoder", features = ["agave-unstable-api"] }
+solana-core = { path = "../core", features = ["dev-context-only-utils"] }
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
 solana-time-utils = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -55,7 +55,7 @@ solana-vote-interface = { workspace = true, features = ["bincode"] }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 arbitrary = { workspace = true }
 bencher = { workspace = true }
 bincode = { workspace = true }

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -86,11 +86,11 @@ wincode = { workspace = true, features = ["alloc"] }
 [dev-dependencies]
 agave-votor = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 rand = { workspace = true }
-solana-net-utils = { workspace = true }
-solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
+solana-perf = { path = "../perf", features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["dev-context-only-utils"] }
 solana-sdk-ids = { workspace = true }
-solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
+solana-streamer = { path = "../streamer", features = ["dev-context-only-utils"] }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 tokio-util = { workspace = true }


### PR DESCRIPTION
#### Problem

context: https://github.com/anza-xyz/agave/issues/10854

the new ci step looks like: https://buildkite.com/anza/agave/builds/41983#019c9f1d-845b-488a-8022-8cf2e24d5811.  

since this is a ~18m build and usually trivial unless new crates are introduced or existing publish status changes, let's have it in push-only for now as a starting point and see how it goes.

(the issue usually happens when cutting new branches, so this should be sufficient to catch it)

#### Summary of Changes

- use `path = ...` instead of `workspace = true` for skipping publish validation (https://github.com/anza-xyz/xtask/issues/22#issuecomment-3972484715)
<details>

<summary>solana-connection-cache error message (it uses solana-net-utils in [dev-dependencies])</summary>

```
[2026-03-04T11:58:13Z ERROR xtask] Error: Failed to publish 1 package(s) in level 2:
      - Failed to publish package solana-connection-cache: Failed to publish package: + exec docker run --workdir /solana --volume /home/sol/syncbuild/yihau/solana:/solana --rm --user 1001:1001 --network container:kellnr --env BUILDKITE --env BUILDKITE_AGENT_ACCESS_TOKEN --env BUILDKITE_JOB_ID --env BUILDKITE_PARALLEL_JOB --env BUILDKITE_PARALLEL_JOB_COUNT --env CI --env CI_BRANCH --env CI_BASE_BRANCH --env CI_TAG --env CI_BUILD_ID --env CI_COMMIT --env CI_JOB_ID --env CI_PULL_REQUEST --env CI_REPO_SLUG --env CRATES_IO_TOKEN -e CODECOV_ENV -e CODECOV_TOKEN -e CODECOV_URL -e CODECOV_SLUG -e VCS_COMMIT_ID -e VCS_BRANCH_NAME -e VCS_PULL_REQUEST -e VCS_SLUG -e VCS_TAG -e CI_BUILD_URL -e CI_BUILD_ID -e CI_JOB_ID -t anzaxyz/ci:ubuntu-22.04_rust-1.93.1_nightly-2025-12-05_9c95af75 cargo publish --manifest-path connection-cache/Cargo.toml --registry kellnr --allow-dirty

    ubuntu-22.04_rust-1.93.1_nightly-2025-12-05_9c95af75: Pulling from anzaxyz/ci
    Digest: sha256:c513111dd62104f1c62de4b112d57683f89e206ed0c2a545a8170438a7e0c83c
    Status: Image is up to date for anzaxyz/ci:ubuntu-22.04_rust-1.93.1_nightly-2025-12-05_9c95af75
    docker.io/anzaxyz/ci:ubuntu-22.04_rust-1.93.1_nightly-2025-12-05_9c95af75
        Updating `kellnr` index
        Updating git repository `https://github.com/anza-xyz/crossbeam`
        Updating crates.io index
        Blocking waiting for file lock on temporary registry
       Packaging solana-connection-cache v4.1.0-alpha.0 (/solana/connection-cache)
        Updating `kellnr` index
        Updating crates.io index
    error: failed to prepare local package for uploading

    Caused by:
      failed to select a version for the requirement `solana-net-utils = "=4.1.0-alpha.0"`
      candidate versions found which didn't match: 4.0.0-alpha.0, 3.1.9, 3.1.8, ...
      location searched: crates.io index
      required by package `solana-connection-cache v4.1.0-alpha.0 (/solana/connection-cache)`
      if you are looking for the prerelease package it needs to be specified explicitly
          solana-net-utils = { version = "4.0.0-alpha.0" }
```

</details>

- update shared xtask (blocked by: https://github.com/anza-xyz/xtask/pull/23)
- add crate publish test step to push only pipeline