### PR TITLE
fix(version): correct version!() macro for v4::Version

### DIFF
--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -27,7 +27,7 @@ macro_rules! semver {
 #[macro_export]
 macro_rules! version {
     () => {
-        &*format!("{:?}", $crate::Version::default())
+        &*format!("{}", $crate::Version::default().as_detailed_string())
     };
 }
 


### PR DESCRIPTION
#### Problem
v4.0.0.alpha.0 bins emit the `Debug` string when passed the `--version` flag

#### Summary of Changes
fix the stupid, superfluous version!() macro for how v4::Version behaves