### PR TITLE
cli: remove inaccurate APR from stake rewards display

### DIFF
--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -113,14 +113,9 @@ async fn process_rewards(
                 format!("Rewards not available {err}")
             }
         })?;
-    let epoch_schedule = rpc_client.get_epoch_schedule().await?;
-
     let mut epoch_rewards: Vec<CliKeyedEpochReward> = vec![];
     let mut block_times: HashMap<Slot, UnixTimestamp> = HashMap::new();
     let epoch_metadata = if let Some(Some(first_reward)) = rewards.iter().find(|&v| v.is_some()) {
-        let (epoch_start_time, epoch_end_time) =
-            crate::stake::get_epoch_boundary_timestamps(rpc_client, first_reward, &epoch_schedule)
-                .await?;
         for (reward, address) in rewards.iter().zip(addresses) {
             let cli_reward = if let Some(reward) = reward {
                 let block_time = if let Some(block_time) = block_times.get(&reward.effective_slot) {
@@ -130,7 +125,7 @@ async fn process_rewards(
                     block_times.insert(reward.effective_slot, block_time);
                     block_time
                 };
-                crate::stake::make_cli_reward(reward, block_time, epoch_start_time, epoch_end_time)
+                crate::stake::make_cli_reward(reward, block_time)
             } else {
                 None
             };


### PR DESCRIPTION
## Summary

Resolves #5498

The APR calculation in the CLI relied on wallclock epoch duration (`epoch_end_time - epoch_start_time`) which produced unreliable results due to variable block times, skipped slots, and other timing inconsistencies. As noted in the issue, there are better external tools for tracking APR.

This PR:
- Removes the `apr` field from `CliEpochReward`
- Removes the APR column from all reward display contexts (`stake-account --with-rewards`, `inflation rewards`, vote account epoch rewards)
- Removes `get_epoch_boundary_timestamps()` which was only used for APR computation
- Eliminates unnecessary RPC calls to fetch epoch boundary block times

## Test Plan

- [x] `cargo clippy -p solana-cli -p solana-cli-output` -- no warnings
- [x] `cargo test -p solana-cli-output --features agave-unstable-api` -- all 8 tests pass
- [x] Updated `test_format_vote_account` to reflect removed APR column