### PR TITLE
Improve error message when keypair file is not found

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -174,11 +174,11 @@ impl DefaultSigner {
                         Ok(())
                     }
                 })
-                .map_err(|_| {
+                .map_err(|err| {
                     std::io::Error::other(format!(
-                        "No default signer found, run \"solana-keygen new -o {}\" to create a new \
-                         one",
-                        self.path
+                        "could not read keypair file \"{}\". \
+                         Run \"solana-keygen new -o {}\" to create a new one: {err}",
+                        self.path, self.path
                     ))
                 })?;
             *self.is_path_checked.borrow_mut() = true;
@@ -1289,6 +1289,22 @@ mod tests {
                 derivation_path: None,
                 legacy: false,
             } if p == relative_path_str)
+        );
+    }
+
+    #[test]
+    fn test_default_signer_path_with_nonexistent_file() {
+        let default_signer =
+            DefaultSigner::new("keypair", "/tmp/nonexistent-keypair-file-123456.json");
+        let err = default_signer.path().unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("could not read keypair file"),
+            "Error should mention keypair file, got: {err_msg}"
+        );
+        assert!(
+            err_msg.contains("nonexistent-keypair-file-123456.json"),
+            "Error should include the file path, got: {err_msg}"
         );
     }
 

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -170,11 +170,11 @@ impl DefaultSigner {
                         Ok(())
                     }
                 })
-                .map_err(|_| {
+                .map_err(|err| {
                     std::io::Error::other(format!(
-                        "No default signer found, run \"solana-keygen new -o {}\" to create a new \
-                         one",
-                        self.path
+                        "could not read keypair file \"{}\". \
+                         Run \"solana-keygen new -o {}\" to create a new one: {err}",
+                        self.path, self.path
                     ))
                 })?;
             *self.is_path_checked.borrow_mut() = true;


### PR DESCRIPTION
## Problem

When a non-existent keypair path is provided via `--keypair`, the error message is misleading:

```
$ solana program deploy foo.so --keypair nonexistent.json
Error: No default signer found, run "solana-keygen new -o nonexistent.json" to create a new one
```

This is confusing because:
- The user explicitly passed `--keypair` but the error says "No default signer found"
- It doesn't mention the file wasn't found or what went wrong
- The underlying OS error is discarded

Resolves #2266

## Proposed Changes

- Update `DefaultSigner::path()` in both `clap-utils` and `clap-v3-utils` to preserve the underlying error instead of discarding it
- The new error message matches the style already used in `signer_from_path_with_config()`:

```
Error: could not read keypair file "nonexistent.json". Run "solana-keygen new -o nonexistent.json" to create a new one: No such file or directory (os error 2)
```

- Add a unit test for the improved error message

## Test Plan

- [x] `cargo clippy -p solana-clap-utils -p solana-clap-v3-utils` -- no warnings
- [x] `cargo test -p solana-clap-utils --features agave-unstable-api` -- 14 passed, 1 pre-existing failure (hidapi disabled)
- [x] New test `test_default_signer_path_with_nonexistent_file` passes