### PR TITLE
solana gossip: use TPU QUIC not TPU UDP port

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -3094,7 +3094,7 @@ impl CliGossipNode {
             identity_label: labels.get(&info.pubkey).cloned(),
             identity_pubkey: info.pubkey,
             gossip_port: info.gossip.map(|addr| addr.port()),
-            tpu_port: info.tpu.map(|addr| addr.port()),
+            tpu_port: info.tpu_quic.map(|addr| addr.port()),
             rpc_host: info.rpc.map(|addr| addr.to_string()),
             pubsub_host: info.pubsub.map(|addr| addr.to_string()),
             version: info.version,


### PR DESCRIPTION
#### Problem

TPU UDP has not been in use for a while. Would make sense to print TPU QUIC port in output for `solana gossip`

#### Summary of Changes

Update output of solana-gossip to show TPU QUIC.