### PR TITLE
fix(ledger): remove per-message Arc clone in entry notifier service

### DIFF
--- a/ledger/src/entry_notifier_service.rs
+++ b/ledger/src/entry_notifier_service.rs
@@ -40,7 +40,7 @@ impl EntryNotifierService {
                     }
 
                     if let Err(RecvTimeoutError::Disconnected) =
-                        Self::notify_entry(&entry_notification_receiver, entry_notifier.clone())
+                        Self::notify_entry(&entry_notification_receiver, &entry_notifier)
                     {
                         break;
                     }
@@ -55,7 +55,7 @@ impl EntryNotifierService {
 
     fn notify_entry(
         entry_notification_receiver: &EntryNotifierReceiver,
-        entry_notifier: EntryNotifierArc,
+        entry_notifier: &EntryNotifierArc,
     ) -> Result<(), RecvTimeoutError> {
         let EntryNotification {
             slot,


### PR DESCRIPTION
<!-- Why were these changes needed? -->
`EntryNotifierService` cloned `EntryNotifierArc` on every loop iteration before dispatching each entry notification. This added unnecessary atomic refcount work in a hot path without any ownership need.

<!-- What does this PR change? -->
This PR removes per-message `Arc` cloning in ledger/src/entry_notifier_service.rs by passing the notifier as a shared reference into `notify_entry`. 