### PR TITLE
feat: limit serialized snapshot file sizes while writing

### DIFF
--- a/fs/src/buffered_writer.rs
+++ b/fs/src/buffered_writer.rs
@@ -1,7 +1,10 @@
-use std::{
-    fs,
-    io::{self, BufWriter},
-    path::Path,
+use {
+    crate::FileSize,
+    std::{
+        fs,
+        io::{self, BufWriter},
+        path::Path,
+    },
 };
 
 /// Default buffer size for writing large files to disks. Since current implementation does not do
@@ -16,4 +19,91 @@ pub fn large_file_buf_writer(path: impl AsRef<Path>) -> io::Result<impl io::Writ
     let file = fs::File::create(path)?;
 
     Ok(BufWriter::with_capacity(DEFAULT_BUFFER_SIZE, file))
+}
+
+/// A writer that enforces a hard byte-count limit on the wrapped writer.
+///
+/// Each call to [`write`](io::Write::write) checks whether the buffer fits within the remaining
+/// quota. If it does not, the write fails immediately with [`io::ErrorKind::FileTooLarge`]
+/// before any bytes are forwarded to the inner writer.
+pub struct SizeLimitedWriter<W: io::Write> {
+    inner: W,
+    limit: FileSize,
+    bytes_written: FileSize,
+}
+
+impl<W: io::Write> SizeLimitedWriter<W> {
+    pub fn new(inner: W, limit: FileSize) -> Self {
+        Self {
+            inner,
+            limit,
+            bytes_written: 0,
+        }
+    }
+
+    /// Returns the number of bytes successfully written so far.
+    pub fn bytes_written(&self) -> FileSize {
+        self.bytes_written
+    }
+}
+
+impl<W: io::Write> io::Write for SizeLimitedWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let attempted_size = self.bytes_written + buf.len() as FileSize;
+        if attempted_size > self.limit {
+            return Err(io::Error::new(
+                io::ErrorKind::FileTooLarge,
+                format!(
+                    "attempted to write {attempted_size} bytes, which exceeds the limit of {}",
+                    self.limit
+                ),
+            ));
+        }
+        let n = self.inner.write(buf)?;
+        self.bytes_written += n as FileSize;
+        Ok(n)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, io::Write as _, test_case::test_case};
+
+    #[test_case(10, b"hello" ; "within limit")]
+    #[test_case(5,  b"hello" ; "exactly at limit")]
+    fn size_limited_writer_accepts(limit: FileSize, data: &[u8]) {
+        let mut buf = Vec::new();
+        let mut w = SizeLimitedWriter::new(&mut buf, limit);
+        w.write_all(data).unwrap();
+        assert_eq!(w.bytes_written(), data.len() as FileSize);
+        drop(w);
+        assert_eq!(buf, data);
+    }
+
+    #[test_case(4, b"hello" ; "exceeds limit")]
+    #[test_case(0, b"x"     ; "zero limit")]
+    fn size_limited_writer_rejects(limit: FileSize, data: &[u8]) {
+        let mut buf = Vec::new();
+        let mut w = SizeLimitedWriter::new(&mut buf, limit);
+        let err = w.write(data).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::FileTooLarge);
+        assert_eq!(w.bytes_written(), 0);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn size_limited_writer_rejects_on_cumulative_overflow() {
+        let mut buf = Vec::new();
+        let mut w = SizeLimitedWriter::new(&mut buf, 5);
+        w.write_all(b"hi").unwrap();
+        // 3 bytes remain; writing 4 must fail
+        let err = w.write(b"four").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::FileTooLarge);
+        assert_eq!(w.bytes_written(), 2);
+        drop(w);
+        assert_eq!(buf, b"hi");
+    }
 }

--- a/fs/src/buffered_writer.rs
+++ b/fs/src/buffered_writer.rs
@@ -15,7 +15,7 @@ const DEFAULT_BUFFER_SIZE: usize = 2 * 1024 * 1024;
 /// Return a buffered writer for creating a new file at `path`
 ///
 /// The returned writer is using a buffer size tuned for writing large files to disks.
-pub fn large_file_buf_writer(path: impl AsRef<Path>) -> io::Result<impl io::Write + io::Seek> {
+pub fn large_file_buf_writer(path: impl AsRef<Path>) -> io::Result<impl io::Write> {
     let file = fs::File::create(path)?;
 
     Ok(BufWriter::with_capacity(DEFAULT_BUFFER_SIZE, file))
@@ -48,6 +48,7 @@ impl<W: io::Write> SizeLimitedWriter<W> {
 }
 
 impl<W: io::Write> io::Write for SizeLimitedWriter<W> {
+    #[allow(clippy::arithmetic_side_effects)]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let attempted_size = self.bytes_written + buf.len() as FileSize;
         if attempted_size > self.limit {
@@ -79,7 +80,6 @@ mod tests {
         let mut w = SizeLimitedWriter::new(&mut buf, limit);
         w.write_all(data).unwrap();
         assert_eq!(w.bytes_written(), data.len() as FileSize);
-        drop(w);
         assert_eq!(buf, data);
     }
 
@@ -103,7 +103,6 @@ mod tests {
         let err = w.write(b"four").unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::FileTooLarge);
         assert_eq!(w.bytes_written(), 2);
-        drop(w);
         assert_eq!(buf, b"hi");
     }
 }

--- a/fs/src/buffered_writer.rs
+++ b/fs/src/buffered_writer.rs
@@ -48,20 +48,22 @@ impl<W: io::Write> SizeLimitedWriter<W> {
 }
 
 impl<W: io::Write> io::Write for SizeLimitedWriter<W> {
-    #[allow(clippy::arithmetic_side_effects)]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let attempted_size = self.bytes_written + buf.len() as FileSize;
-        if attempted_size > self.limit {
+        let attempted_size = self.bytes_written.checked_add(buf.len() as FileSize);
+        if attempted_size.is_none_or(|size| size > self.limit) {
             return Err(io::Error::new(
                 io::ErrorKind::FileTooLarge,
                 format!(
-                    "attempted to write {attempted_size} bytes, which exceeds the limit of {}",
-                    self.limit
+                    "write of {} bytes would exceed limit of {} ({} already written)",
+                    buf.len(),
+                    self.limit,
+                    self.bytes_written,
                 ),
             ));
         }
         let n = self.inner.write(buf)?;
-        self.bytes_written += n as FileSize;
+        // `n` should never be > buf.len() per `write` contract and overflow was already checked above
+        self.bytes_written = self.bytes_written.wrapping_add(n as FileSize);
         Ok(n)
     }
     fn flush(&mut self) -> io::Result<()> {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -709,7 +709,7 @@ fn serialize_obsolete_accounts(
 
     serde_snapshot::serialize_into(&mut file_stream, obsolete_accounts_map).map_err(|err| {
         IoError::other(format!(
-            "unable to serialize obsolete accounts to file ('{}') due to {err}",
+            "unable to serialize obsolete accounts to file '{}': {err}",
             obsolete_accounts_path.display(),
         ))
     })?;
@@ -799,7 +799,7 @@ where
         SizeLimitedWriter::new(large_file_buf_writer(data_file_path)?, maximum_file_size);
     serializer(&mut data_file_stream).map_err(|err| {
         IoError::other(format!(
-            "unable to serialize snapshot data to file ('{}') due to {err}",
+            "unable to serialize snapshot data to file '{}': {err}",
             data_file_path.display(),
         ))
     })?;
@@ -1831,7 +1831,7 @@ mod tests {
                 Ok(())
             },
         );
-        assert_matches!(result, Err(SnapshotError::Io(ref message)) if message.to_string().contains("exceeds the limit of"));
+        assert_matches!(result, Err(SnapshotError::Io(ref message)) if message.to_string().contains("bytes would exceed limit of"));
     }
 
     #[test]
@@ -2656,7 +2656,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "exceeds the limit of 100")]
+    #[should_panic(expected = "bytes would exceed limit of 100")]
     fn test_serialize_obsolete_accounts_too_large_file() {
         let temp_dir = tempfile::tempdir().unwrap();
         let bank_snapshot_dir = temp_dir.path();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -13,7 +13,11 @@ use {
             SnapshotStorageRebuilder, get_slot_and_append_vec_id,
         },
     },
-    agave_fs::{FileInfo, buffered_writer::large_file_buf_writer, io_setup::IoSetupState},
+    agave_fs::{
+        FileInfo,
+        buffered_writer::{SizeLimitedWriter, large_file_buf_writer},
+        io_setup::IoSetupState,
+    },
     agave_snapshots::{
         ArchiveFormat, Result, SnapshotArchiveKind, SnapshotVersion, archive_snapshot,
         error::{
@@ -698,22 +702,20 @@ fn serialize_obsolete_accounts(
     let obsolete_accounts_path = bank_snapshot_dir
         .as_ref()
         .join(snapshot_paths::SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME);
-    let mut file_stream = large_file_buf_writer(&obsolete_accounts_path)?;
+    let mut file_stream = SizeLimitedWriter::new(
+        large_file_buf_writer(&obsolete_accounts_path)?,
+        maximum_obsolete_accounts_file_size,
+    );
 
-    serde_snapshot::serialize_into(&mut file_stream, obsolete_accounts_map)?;
+    serde_snapshot::serialize_into(&mut file_stream, obsolete_accounts_map).map_err(|err| {
+        IoError::other(format!(
+            "unable to serialize obsolete accounts to file ('{}') due to {err}",
+            obsolete_accounts_path.display(),
+        ))
+    })?;
 
     file_stream.flush()?;
-
-    let consumed_size = file_stream.stream_position()?;
-    if consumed_size > maximum_obsolete_accounts_file_size {
-        let error_message = format!(
-            "too large obsolete accounts file to serialize: '{}' has {consumed_size} bytes, max \
-             size is {maximum_obsolete_accounts_file_size}",
-            obsolete_accounts_path.display(),
-        );
-        return Err(IoError::other(error_message).into());
-    }
-    Ok(consumed_size)
+    Ok(file_stream.bytes_written())
 }
 
 fn deserialize_obsolete_accounts(
@@ -793,19 +795,16 @@ fn serialize_snapshot_data_file_capped<F>(
 where
     F: FnOnce(&mut dyn Write) -> Result<()>,
 {
-    let mut data_file_stream = large_file_buf_writer(data_file_path)?;
-    serializer(&mut data_file_stream)?;
-    data_file_stream.flush()?;
-
-    let consumed_size = data_file_stream.stream_position()?;
-    if consumed_size > maximum_file_size {
-        let error_message = format!(
-            "too large snapshot data file to serialize: '{}' has {consumed_size} bytes",
+    let mut data_file_stream =
+        SizeLimitedWriter::new(large_file_buf_writer(data_file_path)?, maximum_file_size);
+    serializer(&mut data_file_stream).map_err(|err| {
+        IoError::other(format!(
+            "unable to serialize snapshot data to file ('{}') due to {err}",
             data_file_path.display(),
-        );
-        return Err(IoError::other(error_message).into());
-    }
-    Ok(consumed_size)
+        ))
+    })?;
+    data_file_stream.flush()?;
+    Ok(data_file_stream.bytes_written())
 }
 
 fn deserialize_snapshot_data_files_capped<T: Sized>(
@@ -1832,7 +1831,7 @@ mod tests {
                 Ok(())
             },
         );
-        assert_matches!(result, Err(SnapshotError::Io(ref message)) if message.to_string().starts_with("too large snapshot data file to serialize"));
+        assert_matches!(result, Err(SnapshotError::Io(ref message)) if message.to_string().contains("exceeds the limit of"));
     }
 
     #[test]
@@ -2657,7 +2656,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "too large obsolete accounts file to serialize")]
+    #[should_panic(expected = "exceeds the limit of 100")]
     fn test_serialize_obsolete_accounts_too_large_file() {
         let temp_dir = tempfile::tempdir().unwrap();
         let bank_snapshot_dir = temp_dir.path();


### PR DESCRIPTION
#### Problem
* `serialize_snapshot_data_file_capped` and `serialize_obsolete_accounts` first serialize the whole content to a file and only then check the size of the generated stream against the provided limit - meaning the amount of data written to disk is effectively unbounded
* checking file size via `stream_position` forces `large_file_buf_writer` to return an impl providing `io::Seek` - something we want to avoid for a more flexible replacement of the buffered writer implementation

#### Summary of Changes
* add `SizeLimitedWriter` that wraps `io::Write`, enforces a byte limit on writes, and exposes a counter of bytes successfully written
* replace the post-write size check with limit-enforced writing in `serialize_snapshot_data_file_capped` and `serialize_obsolete_accounts`
* remove `io::Seek` from the implementation returned by `large_file_buf_writer`

Fixes #10885
