### PR TITLE
fix(fs): handle reads for file with zero size / limit

### DIFF
--- a/fs/src/io_uring/sequential_file_reader.rs
+++ b/fs/src/io_uring/sequential_file_reader.rs
@@ -290,28 +290,33 @@ impl<'a> SequentialFileReader<'a> {
         state.current_buf_len = 0;
         state.left_to_consume = 0;
 
-        // Reclaim current and all subsequent unread buffers of removed file as uninitialized.
-        let sentinel_buf_index = state
-            .files
-            .front()
-            .and_then(|f| f.start_buf_index)
-            .unwrap_or(state.current_buf_index);
-        let num_bufs = self.ring.context().len();
-        loop {
-            self.ring.process_completions()?;
-            let current_buf = self.ring.context_mut().get_mut(state.current_buf_index);
-            if current_buf.is_reading() {
-                // Still no data, wait for more completions, but submit in case there are queued
-                // entries in the submission queue.
-                self.ring.submit()?;
-                continue;
-            }
-            current_buf.transition_to_uninit();
+        if removed_file.had_scheduled_reads() {
+            // Reclaim current and all subsequent unread buffers of removed file as uninitialized.
+            // This includes all buffers until sentinel index, which is:
+            // * an index used for next scheduled read (if any file has some scheduled)
+            // * otherwise `state.next_read_buf_index` (default buffer index to start read from)
+            let sentinel_buf_index = state
+                .files
+                .iter()
+                .find_map(|f| f.start_buf_index)
+                .unwrap_or(state.next_read_buf_index);
+            let num_bufs = self.ring.context().len();
+            loop {
+                self.ring.process_completions()?;
+                let current_buf = self.ring.context_mut().get_mut(state.current_buf_index);
+                if current_buf.is_reading() {
+                    // Still no data, wait for more completions, but submit in case there are queued
+                    // entries in the submission queue.
+                    self.ring.submit()?;
+                    continue;
+                }
+                current_buf.transition_to_uninit();
 
-            let next_buf_index = (state.current_buf_index + 1) % num_bufs;
-            state.current_buf_index = next_buf_index;
-            if sentinel_buf_index == next_buf_index {
-                break;
+                let next_buf_index = (state.current_buf_index + 1) % num_bufs;
+                state.current_buf_index = next_buf_index;
+                if sentinel_buf_index == next_buf_index {
+                    break;
+                }
             }
         }
 
@@ -351,7 +356,12 @@ impl<'a> SequentialFileReader<'a> {
     }
 
     fn wait_current_buf_full(&mut self) -> io::Result<bool> {
-        if self.state.files.is_empty() {
+        if self
+            .state
+            .files
+            .front()
+            .is_none_or(|file| !file.had_scheduled_reads())
+        {
             return Ok(false);
         }
         let num_bufs = self.ring.context().len();
@@ -612,6 +622,10 @@ impl FileState {
 
     fn is_same_file(&self, file: &File) -> bool {
         self.raw_fd == file.as_raw_fd()
+    }
+
+    fn had_scheduled_reads(&self) -> bool {
+        self.start_buf_index.is_some()
     }
 
     /// Create a new read operation into the `bufs[index]` buffer and update file state.
@@ -884,6 +898,11 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_reading_empty_file() {
+        check_reading_file(0, 4096, 1024, false);
+    }
+
     /// Test with buffer larger than the whole file
     #[test]
     fn test_reading_small_file() {
@@ -951,6 +970,7 @@ mod tests {
 
     #[test]
     fn test_direct_io_read() {
+        check_reading_file(0, 4096, 4096, true);
         check_reading_file(2_500, 4096, 4096, true);
         check_reading_file(2_500, 16384, 4096, true);
         check_reading_file(25_000, 4096, 4096, true);
@@ -1092,6 +1112,39 @@ mod tests {
         assert_eq!(read_as_vec(&mut reader), vec![0xa, 0xb, 0xc]);
 
         reader.set_file(temp2.as_file(), 4).unwrap();
+        assert_eq!(read_as_vec(&mut reader), vec![0xd, 0xe, 0xf, 0x10]);
+    }
+
+    #[test]
+    fn test_multiple_files_including_zero_limit() {
+        let mut temp1 = NamedTempFile::new().unwrap();
+        io::Write::write_all(&mut temp1, &[0xa, 0xb, 0xc]).unwrap();
+        let mut temp2 = NamedTempFile::new().unwrap();
+        io::Write::write_all(&mut temp2, &[0xd, 0xe, 0xf, 0x10]).unwrap();
+
+        let mut reader = SequentialFileReaderBuilder::new()
+            .read_capacity(512)
+            .build(1024)
+            .unwrap();
+
+        reader.add_file_to_prefetch(temp1.as_file(), 3).unwrap();
+        reader.add_file_to_prefetch(temp2.as_file(), 0).unwrap();
+        reader.add_file_to_prefetch(temp1.as_file(), 10).unwrap();
+
+        assert_eq!(read_as_vec(&mut reader), vec![0xa, 0xb, 0xc]);
+
+        reader.move_to_next_file().unwrap();
+        assert_eq!(read_as_vec(&mut reader), vec![]);
+
+        reader.move_to_next_file().unwrap();
+        assert_eq!(read_as_vec(&mut reader), vec![0xa, 0xb, 0xc]);
+
+        reader.add_file_to_prefetch(temp1.as_file(), 0).unwrap();
+        reader.move_to_next_file().unwrap();
+        assert_eq!(read_as_vec(&mut reader), vec![]);
+
+        reader.add_file_to_prefetch(temp2.as_file(), 4).unwrap();
+        reader.move_to_next_file().unwrap();
         assert_eq!(read_as_vec(&mut reader), vec![0xd, 0xe, 0xf, 0x10]);
     }
 }


### PR DESCRIPTION
#### Problem
Files with 0 size or set to be read with limit 0 are not handled properly by `SequentialFileReader`.

This bug was introduced by https://github.com/anza-xyz/agave/pull/9701, which:
* added limits for read file length (obviously not handling 0 properly)
* added concept of reading a sequence of multiple files (causes a bit more complexity when handling switch between current and next file if current or next files have read limit 0)

#### Summary of Changes
The fix covers two areas:
* skip obtaining full buffer if the current file state indicates no scheduled reads - this only happens for current file when `read_limit == 0` (read ops are skipped and `start_buf_index` is never set)
* when moving to read next file (i.e. discarding current file as finished reading from) we should:
  * only reclaim buffers if that file did any reads
  * make sure we look through all queued files to search for buffer index that was used for next scheduled read (some queued files might be zero limited) or fallback properly to the index to be used as such