### PR TITLE
`ConsensusReward`: improves naming of the channel to receive verified votes on

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -256,7 +256,8 @@ impl Tvu {
         let (consensus_metrics_sender, consensus_metrics_receiver) =
             bounded(MAX_IN_FLIGHT_CONSENSUS_EVENTS);
         // TODO: once the bls sigverifier is upstreamed, it will need the sender side.
-        let (_reward_votes_sender, reward_votes_receiver) = bounded(MAX_ALPENGLOW_PACKET_NUM);
+        let (_reward_add_vote_msg_sender, reward_add_vote_msg_receiver) =
+            bounded(MAX_ALPENGLOW_PACKET_NUM);
 
         // The BLS socket is currently only available on Testnet and Development clusters.
         // Closer to release we will enable this for all clusters.
@@ -462,7 +463,7 @@ impl Tvu {
             consensus_message_receiver,
             consensus_metrics_sender,
             consensus_metrics_receiver,
-            reward_votes_receiver,
+            reward_add_vote_msg_receiver,
             reward_certs_sender,
             build_reward_certs_receiver,
         };

--- a/votor-messages/src/reward_certificate.rs
+++ b/votor-messages/src/reward_certificate.rs
@@ -116,7 +116,7 @@ impl NotarRewardCertificate {
 
 /// Message to add votes to the rewards container.
 #[derive(Debug)]
-pub struct AddVoteMessage {
+pub struct AddVoteMsg {
     /// List of [`VoteMessage`]s.
     pub votes: Vec<VoteMessage>,
 }

--- a/votor/src/consensus_rewards.rs
+++ b/votor/src/consensus_rewards.rs
@@ -2,7 +2,7 @@ use {
     agave_votor_messages::{
         consensus_message::VoteMessage,
         reward_certificate::{
-            AddVoteMessage, BuildRewardCertsRequest, BuildRewardCertsRespError,
+            AddVoteMsg, BuildRewardCertsRequest, BuildRewardCertsRespError,
             BuildRewardCertsRespSucc, BuildRewardCertsResponse, NUM_SLOTS_FOR_REWARD,
         },
         vote::Vote,
@@ -72,8 +72,8 @@ struct ConsensusRewards {
     build_reward_certs_receiver: Receiver<BuildRewardCertsRequest>,
     /// Channel send the built reward certificates.
     reward_certs_sender: Sender<BuildRewardCertsResponse>,
-    /// Channel to receive verified votes.
-    votes_receiver: Receiver<AddVoteMessage>,
+    /// Channel to receive `AddVoteMsg` containing sig verified votes.
+    add_vote_msg_receiver: Receiver<AddVoteMsg>,
 }
 
 impl ConsensusRewards {
@@ -85,7 +85,7 @@ impl ConsensusRewards {
         exit: Arc<AtomicBool>,
         build_reward_certs_receiver: Receiver<BuildRewardCertsRequest>,
         reward_certs_sender: Sender<BuildRewardCertsResponse>,
-        votes_receiver: Receiver<AddVoteMessage>,
+        add_vote_msg_receiver: Receiver<AddVoteMsg>,
     ) -> Self {
         Self {
             votes: BTreeMap::default(),
@@ -95,7 +95,7 @@ impl ConsensusRewards {
             exit,
             build_reward_certs_receiver,
             reward_certs_sender,
-            votes_receiver,
+            add_vote_msg_receiver,
         }
     }
 
@@ -119,7 +119,7 @@ impl ConsensusRewards {
                         }
                     }
                 }
-                recv(self.votes_receiver) -> msg => {
+                recv(self.add_vote_msg_receiver) -> msg => {
                     match msg {
                         Ok(msg) => {
                             let bank = self.sharable_banks.root();
@@ -215,7 +215,7 @@ impl ConsensusRewardsService {
         leader_schedule: Arc<LeaderScheduleCache>,
         sharable_banks: SharableBanks,
         exit: Arc<AtomicBool>,
-        votes_receiver: Receiver<AddVoteMessage>,
+        add_vote_msg_receiver: Receiver<AddVoteMsg>,
         build_reward_certs_receiver: Receiver<BuildRewardCertsRequest>,
         reward_certs_sender: Sender<BuildRewardCertsResponse>,
     ) -> Self {
@@ -229,7 +229,7 @@ impl ConsensusRewardsService {
                     exit,
                     build_reward_certs_receiver,
                     reward_certs_sender,
-                    votes_receiver,
+                    add_vote_msg_receiver,
                 )
                 .run();
             })

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -60,7 +60,7 @@ use {
     },
     agave_votor_messages::{
         consensus_message::ConsensusMessage,
-        reward_certificate::{AddVoteMessage, BuildRewardCertsRequest, BuildRewardCertsResponse},
+        reward_certificate::{AddVoteMsg, BuildRewardCertsRequest, BuildRewardCertsResponse},
     },
     crossbeam_channel::{Receiver, Sender},
     parking_lot::RwLock as PlRwLock,
@@ -121,7 +121,7 @@ pub struct VotorConfig {
     pub event_receiver: VotorEventReceiver,
     pub consensus_message_receiver: Receiver<Vec<ConsensusMessage>>,
     pub consensus_metrics_receiver: ConsensusMetricsEventReceiver,
-    pub reward_votes_receiver: Receiver<AddVoteMessage>,
+    pub reward_add_vote_msg_receiver: Receiver<AddVoteMsg>,
     pub build_reward_certs_receiver: Receiver<BuildRewardCertsRequest>,
 }
 
@@ -172,7 +172,7 @@ impl Votor {
             consensus_message_receiver,
             consensus_metrics_sender,
             consensus_metrics_receiver,
-            reward_votes_receiver,
+            reward_add_vote_msg_receiver,
             build_reward_certs_receiver,
             reward_certs_sender,
         } = config;
@@ -260,7 +260,7 @@ impl Votor {
             leader_schedule_cache,
             sharable_banks,
             exit,
-            reward_votes_receiver,
+            reward_add_vote_msg_receiver,
             build_reward_certs_receiver,
             reward_certs_sender,
         );


### PR DESCRIPTION
#### Problem

The name of the channel is a bit outdated.  Also see https://github.com/anza-xyz/agave/pull/10707/changes#r2869701475.


#### Summary of Changes

Improves the naming.