### PR TITLE
Add async io support to blockstore db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8893,6 +8893,7 @@ name = "solana-ledger"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-io-uring",
  "agave-logger",
  "agave-reserved-account-keys",
  "agave-snapshots",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -30,6 +30,7 @@ agave-unstable-api = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-io-uring = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor-messages = { workspace = true }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -22,7 +22,7 @@ use {
     rocksdb::{
         self, ColumnFamily, ColumnFamilyDescriptor, CompactionDecision, DB, DBCompressionType,
         DBIterator, DBPinnableSlice, DBRawIterator, IteratorMode as RocksIteratorMode, LiveFile,
-        Options, WriteBatch as RWriteBatch,
+        Options, ReadOptions, WriteBatch as RWriteBatch,
         compaction_filter::CompactionFilter,
         compaction_filter_factory::{CompactionFilterContext, CompactionFilterFactory},
         properties as RocksProperties,
@@ -363,8 +363,13 @@ impl Rocks {
         K: AsRef<[u8]> + 'a + ?Sized,
         I: IntoIterator<Item = &'a K>,
     {
+        let mut read_options = ReadOptions::default();
+        #[cfg(target_os = "linux")]
+        {
+            read_options.set_async_io(true);
+        }
         self.db
-            .batched_multi_get_cf(cf, keys, /*sorted_input:*/ false)
+            .batched_multi_get_cf_opt(cf, keys, false, &read_options)
             .into_iter()
             .map(|out| out.map_err(BlockstoreError::RocksDb))
     }
@@ -390,11 +395,21 @@ impl Rocks {
         cf: &ColumnFamily,
         iterator_mode: RocksIteratorMode,
     ) -> DBIterator<'_> {
-        self.db.iterator_cf(cf, iterator_mode)
+        let mut read_options = ReadOptions::default();
+        #[cfg(target_os = "linux")]
+        {
+            read_options.set_async_io(true);
+        }
+        self.db.iterator_cf_opt(cf, read_options, iterator_mode)
     }
 
     pub(crate) fn raw_iterator_cf(&self, cf: &ColumnFamily) -> Result<DBRawIterator<'_>> {
-        Ok(self.db.raw_iterator_cf(cf))
+        let mut read_options = ReadOptions::default();
+        #[cfg(target_os = "linux")]
+        {
+            read_options.set_async_io(true);
+        }
+        Ok(self.db.raw_iterator_cf_opt(cf, read_options))
     }
 
     pub(crate) fn batch(&self) -> Result<WriteBatch> {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -366,6 +366,7 @@ impl Rocks {
         let mut read_options = ReadOptions::default();
         #[cfg(target_os = "linux")]
         {
+            assert!(agave_io_uring::io_uring_supported());
             read_options.set_async_io(true);
         }
         self.db
@@ -398,6 +399,7 @@ impl Rocks {
         let mut read_options = ReadOptions::default();
         #[cfg(target_os = "linux")]
         {
+            assert!(agave_io_uring::io_uring_supported());
             read_options.set_async_io(true);
         }
         self.db.iterator_cf_opt(cf, read_options, iterator_mode)
@@ -407,6 +409,7 @@ impl Rocks {
         let mut read_options = ReadOptions::default();
         #[cfg(target_os = "linux")]
         {
+            assert!(agave_io_uring::io_uring_supported());
             read_options.set_async_io(true);
         }
         Ok(self.db.raw_iterator_cf_opt(cf, read_options))


### PR DESCRIPTION
#### Problem
n/a

#### Summary of Changes
Adds async io support to blockstore db.

Rocksdb asyncio docs page: https://github.com/facebook/rocksdb/wiki/Asynchronous-IO

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
n/a
