### PR TITLE
Enable direct io for blockstore_db reads and writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8893,6 +8893,7 @@ name = "solana-ledger"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-fs",
  "agave-logger",
  "agave-reserved-account-keys",
  "agave-snapshots",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -30,6 +30,7 @@ agave-unstable-api = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-fs = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor-messages = { workspace = true }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1151,6 +1151,13 @@ fn get_db_options(blockstore_options: &BlockstoreOptions) -> Options {
     options.create_if_missing(true);
     options.create_missing_column_families(true);
 
+    // Direct io
+    #[cfg(target_os = "linux")]
+    {
+        options.set_use_direct_io_for_flush_and_compaction(true);
+        options.set_use_direct_reads(true);
+    }
+
     // rocksdb builds two threadpools: low and high priority. The low priority
     // pool is used for compactions whereas the high priority pool is used for
     // memtable flushes. Separate pools are created so that compactions are

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -111,7 +111,7 @@ impl Rocks {
         fs::create_dir_all(&path)?;
 
         // Use default database options
-        let mut db_options = get_db_options(&options);
+        let mut db_options = get_db_options(&options, &path)?;
         if let Some(recovery_mode) = recovery_mode {
             db_options.set_wal_recovery_mode(recovery_mode.into());
         }
@@ -1144,7 +1144,10 @@ fn process_cf_options_advanced<C: 'static + Column + ColumnName>(
     }
 }
 
-fn get_db_options(blockstore_options: &BlockstoreOptions) -> Options {
+fn get_db_options(
+    blockstore_options: &BlockstoreOptions,
+    path: &PathBuf,
+) -> std::io::Result<Options> {
     let mut options = Options::default();
 
     // Create missing items to support a clean start
@@ -1154,8 +1157,12 @@ fn get_db_options(blockstore_options: &BlockstoreOptions) -> Options {
     // Direct io
     #[cfg(target_os = "linux")]
     {
-        options.set_use_direct_io_for_flush_and_compaction(true);
-        options.set_use_direct_reads(true);
+        use agave_fs::metadata::DirectIoSupport;
+
+        if agave_fs::metadata::check_direct_io_capability(path)? == DirectIoSupport::Supported {
+            options.set_use_direct_io_for_flush_and_compaction(true);
+            options.set_use_direct_reads(true);
+        }
     }
 
     // rocksdb builds two threadpools: low and high priority. The low priority
@@ -1190,7 +1197,7 @@ fn get_db_options(blockstore_options: &BlockstoreOptions) -> Options {
     // it is not required for read-only access, but should be fine with our high ulimit.
     options.set_max_open_files(-1);
 
-    options
+    Ok(options)
 }
 
 /// The default number of threads to use for rocksdb compaction in the rocksdb


### PR DESCRIPTION
#### Problem
n/a

#### Summary of Changes
Add direct io support to blockstore_db reads and writes.

This uses `check_direct_io_capability` added by #10957 to check for dio support and then sets

```rs

options.set_use_direct_io_for_flush_and_compaction(true);
options.set_use_direct_reads(true);
```

if dio is supported on the blockstore path.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
