### PR TITLE
Adds an Index to the write cache 

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -1,5 +1,6 @@
 use {
-    dashmap::DashMap,
+    crate::ancestors::Ancestors,
+    dashmap::{DashMap, mapref::entry::Entry},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::Slot,
     solana_nohash_hasher::BuildNoHashHasher,
@@ -33,6 +34,23 @@ impl MaxFlushedRoot {
     fn fetch_max(&self, slot: Slot) {
         self.0.fetch_max(slot + 1, Ordering::Release);
     }
+}
+
+/// Indicates whether a slot is an ancestor, an unflushed root, or a root being flushed
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotStatus {
+    /// Slot is in the ancestors list and not a root being flushed root. Slot is guaranteed to be
+    /// the newest version of the account so the cached copy can be used without checking storage
+    /// NOTE: A slot in this state may also be an Unflushedroot
+    Ancestor,
+    /// Slot is a root that has not yet been claimed for flushing. Slot is guaranteed to be the
+    /// newest version of the account so the cached copy can be used without checking storage
+    UnflushedRoot,
+    /// Slot is a root that is currently being flushed. The version found in the accounts cache
+    /// may not be the newest version of the account, and the storage should be checked for newer
+    /// versions
+    /// NOTE: A slot in this state may also be an Ancestor
+    RootBeingFlushed,
 }
 
 #[derive(Debug)]
@@ -90,13 +108,16 @@ impl SlotCache {
         );
     }
 
-    pub fn insert(&self, pubkey: &Pubkey, account: AccountSharedData) -> Arc<CachedAccount> {
+    /// Insert an account into this slot's cache
+    ///
+    /// Returns the cached account and whether this was a new unique key for this slot
+    fn insert(&self, pubkey: &Pubkey, account: AccountSharedData) -> (Arc<CachedAccount>, bool) {
         let data_len = account.data().len() as u64;
         let item = Arc::new(CachedAccount {
             account,
             pubkey: *pubkey,
         });
-        if let Some(old) = self.cache.insert(*pubkey, item.clone()) {
+        let is_new_key = if let Some(old) = self.cache.insert(*pubkey, item.clone()) {
             self.same_account_writes.fetch_add(1, Ordering::Relaxed);
             self.same_account_writes_size
                 .fetch_add(data_len, Ordering::Relaxed);
@@ -113,6 +134,7 @@ impl SlotCache {
                     self.total_size.fetch_sub(shrink, Ordering::Relaxed);
                 }
             }
+            false
         } else {
             self.size.fetch_add(data_len, Ordering::Relaxed);
             self.total_size.fetch_add(data_len, Ordering::Relaxed);
@@ -120,11 +142,12 @@ impl SlotCache {
                 .fetch_add(data_len, Ordering::Relaxed);
             self.accounts_count.fetch_add(1, Ordering::Relaxed);
             self.total_accounts_count.fetch_add(1, Ordering::Relaxed);
-        }
-        item
+            true
+        };
+        (item, is_new_key)
     }
 
-    pub fn get_cloned(&self, pubkey: &Pubkey) -> Option<Arc<CachedAccount>> {
+    fn get_cloned(&self, pubkey: &Pubkey) -> Option<Arc<CachedAccount>> {
         self.cache
             .get(pubkey)
             // 1) Maybe can eventually use a Cow to avoid a clone on every read
@@ -166,12 +189,71 @@ impl CachedAccount {
     }
 }
 
+/// Maps each pubkey to (max_slot, count) where max_slot is the highest slot at which the pubkey
+/// has been written into the cache, and count is the number of SlotCache entries that currently
+/// hold the pubkey. max_slot may be stale after a removal; callers must handle a
+/// look-up miss on max_slot by falling back to scanning all slots in the cache (see load_latest)
+#[derive(Debug, Default)]
+pub struct AccountsCacheIndex {
+    entries: DashMap<Pubkey, (Slot, u64), PubkeyHasherBuilder>,
+    // The number of unique pubkeys in the index, for reporting purposes. This is to avoid having to
+    // lock each shard of the entries dashmap to count unique keys on demand
+    num_unique_pubkeys: AtomicU64,
+}
+
+impl AccountsCacheIndex {
+    /// Inserts an entry into the index. If the entry is already present, increase the ref count
+    fn insert(&self, pubkey: &Pubkey, slot: Slot) {
+        self.entries
+            .entry(*pubkey)
+            .and_modify(|(stored_slot, count)| {
+                *stored_slot = slot.max(*stored_slot);
+                *count += 1;
+            })
+            .or_insert_with(|| {
+                self.num_unique_pubkeys.fetch_add(1, Ordering::Relaxed);
+                (slot, 1)
+            });
+    }
+
+    /// Decrement the reference count for each pubkey in `pubkeys`. Removes an entry entirely if
+    /// the count reaches zero. `max_slot` is not updated; it will become stale if the removed slot
+    /// is the highest slot
+    fn remove(&self, pubkeys: impl IntoIterator<Item = Pubkey>) {
+        for pubkey in pubkeys {
+            if let Entry::Occupied(mut occupied_entry) = self.entries.entry(pubkey) {
+                let (_, count) = occupied_entry.get_mut();
+                *count -= 1;
+                if *count == 0 {
+                    occupied_entry.remove_entry();
+                    self.num_unique_pubkeys.fetch_sub(1, Ordering::Relaxed);
+                }
+            } else {
+                // If this has happened the index is corrupted
+                panic!("pubkey {pubkey} not found in cache index during remove");
+            }
+        }
+    }
+
+    /// Returns the recorded max slot for `pubkey`, or `None` if the pubkey is not present in the
+    /// cache. Note: the account is not necessarily in this slot if it was removed during flush
+    /// This is just the maximum slot that it could be found in during search
+    fn max_slot_for_pubkey(&self, pubkey: &Pubkey) -> Option<Slot> {
+        self.entries.get(pubkey).map(|entry| entry.0)
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct AccountsCache {
     cache: DashMap<Slot, Arc<SlotCache>, BuildNoHashHasher<Slot>>,
+    // Index to find which slots a pubkey is stored in, to speed up lookups in load_latest
+    index: AccountsCacheIndex,
     // Queue of potentially unflushed roots. Random eviction + cache too large
     // could have triggered a flush of this slot already
     maybe_unflushed_roots: RwLock<BTreeSet<Slot>>,
+    // Roots that have been claimed for flushing by `begin_flush_roots` but not yet
+    // cleared by `end_flush_roots`
+    roots_being_flushed: RwLock<BTreeSet<Slot>>,
     max_flushed_root: MaxFlushedRoot,
     /// The size of account data stored in the whole AccountsCache, in bytes
     total_size: Arc<AtomicU64>,
@@ -211,6 +293,11 @@ impl AccountsCache {
                 self.total_accounts_counts.load(Ordering::Relaxed),
                 i64
             ),
+            (
+                "num_unique_pubkeys",
+                self.index.num_unique_pubkeys.load(Ordering::Relaxed),
+                i64
+            ),
         );
     }
 
@@ -231,7 +318,14 @@ impl AccountsCache {
                 .or_insert_with(|| self.new_inner())
                 .clone());
 
-        slot_cache.insert(pubkey, account)
+        let (item, is_new_key) = slot_cache.insert(pubkey, account);
+        if is_new_key {
+            // Only update the index when the pubkey is new to this slot. Overwrites within the
+            // same slot (is_new_key = false) cannot update the index because the ref count was
+            // already incremented when the pubkey was first stored in this slot
+            self.index.insert(pubkey, slot);
+        }
+        item
     }
 
     pub fn load(&self, slot: Slot, pubkey: &Pubkey) -> Option<Arc<CachedAccount>> {
@@ -240,7 +334,78 @@ impl AccountsCache {
     }
 
     pub fn remove_slot(&self, slot: Slot) -> Option<Arc<SlotCache>> {
-        self.cache.remove(&slot).map(|(_, slot_cache)| slot_cache)
+        let result = self.cache.remove(&slot).map(|(_, slot_cache)| slot_cache);
+        if let Some(slot_cache) = &result {
+            self.index.remove(slot_cache.iter().map(|item| *item.key()));
+        }
+        result
+    }
+
+    /// Returns the minimum visible slot across ancestors, unflushed roots, and roots
+    /// being flushed. Returns `None` if all three sources are empty
+    fn min_visible_slot(&self, ancestors: &Ancestors) -> Option<Slot> {
+        let unflushed_first = self.maybe_unflushed_roots.read().unwrap().first().copied();
+        let flushing_first = self.roots_being_flushed.read().unwrap().first().copied();
+
+        [ancestors.min_slot(), unflushed_first, flushing_first]
+            .into_iter()
+            .flatten()
+            .min()
+    }
+
+    /// Finds the newest write-cache entry for `pubkey` by scanning visible slots in descending
+    /// order. The scan range is bounded by the index's max_slot for the pubkey and the min
+    /// of all visibility sets (ancestors, unflushed roots, roots being flushed)
+    /// Returns the account, the slot it was found in, and where the slot was found
+    pub fn load_latest(
+        &self,
+        pubkey: &Pubkey,
+        ancestors: &Ancestors,
+    ) -> Option<(Arc<CachedAccount>, Slot, SlotStatus)> {
+        // Exit early if the pubkey isn't in the cache
+        let index_max_slot = self.index.max_slot_for_pubkey(pubkey)?;
+        let min_visible = self.min_visible_slot(ancestors)?;
+
+        // Iterate from max_slot down to min_visible. Check slot_status first before hitting the
+        // per-slot DashMap. The common case — newest slot is valid — returns on the first iteration
+        for slot in (min_visible..=index_max_slot).rev() {
+            if let Some(status) = self.slot_status(ancestors, slot) {
+                if let Some(account) = self.load(slot, pubkey) {
+                    return Some((account, slot, status));
+                }
+            }
+        }
+        None
+    }
+
+    /// Returns the status of `slot` if it is visible (as an unflushed root, a root being
+    /// flushed, or an ancestor)
+    ///
+    /// Only `RootBeingFlushed` requires the caller to also check storage, since the cached entry
+    /// may be stale. All other visible statuses guarantee the cached entry is the newest version
+    ///
+    /// Checks ancestors first (cheap HashMap lookup, no lock) since the common case is an
+    /// ancestor that is not a root. When the slot is an ancestor we only need to check
+    /// `roots_being_flushed` — distinguishing unrooted from unflushed-root
+    /// is unnecessary because both guarantee the cached entry is newest
+    pub(crate) fn slot_status(&self, ancestors: &Ancestors, slot: Slot) -> Option<SlotStatus> {
+        if ancestors.contains_key(&slot) {
+            // Ancestor: check if root being flushed, which may require checking storage
+            return if self.roots_being_flushed.read().unwrap().contains(&slot) {
+                Some(SlotStatus::RootBeingFlushed)
+            } else {
+                Some(SlotStatus::Ancestor)
+            };
+        }
+
+        // Not an ancestor — check root sets for visibility
+        if self.maybe_unflushed_roots.read().unwrap().contains(&slot) {
+            return Some(SlotStatus::UnflushedRoot);
+        }
+        if self.roots_being_flushed.read().unwrap().contains(&slot) {
+            return Some(SlotStatus::RootBeingFlushed);
+        }
+        None
     }
 
     pub fn slot_cache(&self, slot: Slot) -> Option<Arc<SlotCache>> {
@@ -255,19 +420,35 @@ impl AccountsCache {
         self.maybe_unflushed_roots.read().unwrap().len()
     }
 
-    pub fn clear_roots(&self, max_root: Option<Slot>) -> BTreeSet<Slot> {
+    /// Atomically moves roots up to and including `max_root` (or all roots if `None`) out of
+    /// `maybe_unflushed_roots` and into `roots_being_flushed`, then returns them
+    ///
+    /// Panics if there are already roots being flushed (i.e. `end_flush_roots` was not called after
+    /// a previous `begin_flush_roots`)
+    pub fn begin_flush_roots(&self, max_root: Option<Slot>) -> BTreeSet<Slot> {
         let mut w_maybe_unflushed_roots = self.maybe_unflushed_roots.write().unwrap();
-        if let Some(max_root) = max_root {
-            // `greater_than_max_root` contains all slots >= `max_root + 1`, or alternatively,
-            // all slots > `max_root`. Meanwhile, `w_maybe_unflushed_roots` is left with all slots
-            // <= `max_root`.
-            let greater_than_max_root = w_maybe_unflushed_roots.split_off(&(max_root + 1));
-            // After the replace, `w_maybe_unflushed_roots` contains slots > `max_root`, and
-            // we return all slots <= `max_root`
-            std::mem::replace(&mut w_maybe_unflushed_roots, greater_than_max_root)
+        let mut w_being_flushed = self.roots_being_flushed.write().unwrap();
+
+        assert!(
+            w_being_flushed.is_empty(),
+            "begin_flush_roots called while roots are already being flushed; end_flush_roots must \
+             be called first"
+        );
+
+        let roots_to_flush = if let Some(max_root) = max_root {
+            let remaining = w_maybe_unflushed_roots.split_off(&(max_root + 1));
+            std::mem::replace(&mut *w_maybe_unflushed_roots, remaining)
         } else {
             std::mem::take(&mut *w_maybe_unflushed_roots)
-        }
+        };
+
+        *w_being_flushed = roots_to_flush.clone();
+        roots_to_flush
+    }
+
+    /// Signals that flushing is complete. Clears the roots that were staged by `begin_flush_roots`
+    pub fn end_flush_roots(&self) {
+        self.roots_being_flushed.write().unwrap().clear();
     }
 
     pub fn cached_frozen_slots(&self) -> Vec<Slot> {
@@ -299,7 +480,7 @@ impl AccountsCache {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {super::*, test_case::test_case};
 
     impl AccountsCache {
         // Removes slots less than or equal to `max_root`. Only safe to pass in a rooted slot,
@@ -375,5 +556,281 @@ mod tests {
         assert_eq!(root.get(), Some(20));
         root.fetch_max(20);
         assert_eq!(root.get(), Some(20));
+    }
+
+    #[test]
+    fn test_cache_index_insert_and_max_slot() {
+        let index = AccountsCacheIndex::default();
+        let pubkey = Pubkey::new_unique();
+
+        // Initially empty
+        assert!(index.max_slot_for_pubkey(&pubkey).is_none());
+
+        // Insert at slot 5
+        index.insert(&pubkey, 5);
+        assert_eq!(index.max_slot_for_pubkey(&pubkey), Some(5));
+
+        // Insert same pubkey at a higher slot updates max_slot
+        index.insert(&pubkey, 10);
+        assert_eq!(index.max_slot_for_pubkey(&pubkey), Some(10));
+
+        // Insert same pubkey at a lower slot does not decrease max_slot
+        index.insert(&pubkey, 3);
+        assert_eq!(index.max_slot_for_pubkey(&pubkey), Some(10));
+    }
+
+    #[test]
+    fn test_cache_index_remove_decrements_count() {
+        let cache = AccountsCache::default();
+        let pk = Pubkey::new_unique();
+
+        assert_eq!(cache.index.num_unique_pubkeys.load(Ordering::Relaxed), 0);
+
+        // Store pubkey into 3 different slots
+        cache.store(1, &pk, AccountSharedData::new(1, 0, &Pubkey::default()));
+        assert_eq!(cache.index.num_unique_pubkeys.load(Ordering::Relaxed), 1);
+        cache.store(5, &pk, AccountSharedData::new(5, 0, &Pubkey::default()));
+        cache.store(3, &pk, AccountSharedData::new(3, 0, &Pubkey::default()));
+        // Same pubkey across 3 slots — still only 1 unique pubkey
+        assert_eq!(cache.index.num_unique_pubkeys.load(Ordering::Relaxed), 1);
+
+        // Remove and drop slot 1 — entry should still exist (count goes from 3 to 2)
+        let removed = cache.remove_slot(1);
+        assert!(removed.is_some());
+        drop(removed);
+        assert_eq!(cache.index.max_slot_for_pubkey(&pk), Some(5));
+        assert_eq!(cache.index.num_unique_pubkeys.load(Ordering::Relaxed), 1);
+
+        // Remove and drop slot 5 — entry should still exist (count goes from 2 to 1)
+        // max_slot stays stale at 5 because the index doesn't scan for a new max on removal
+        let removed = cache.remove_slot(5);
+        assert!(removed.is_some());
+        drop(removed);
+        assert!(cache.index.max_slot_for_pubkey(&pk).is_some());
+        assert_eq!(cache.index.num_unique_pubkeys.load(Ordering::Relaxed), 1);
+
+        // Remove and drop slot 3 — last reference gone, entry removed
+        let removed = cache.remove_slot(3);
+        assert!(removed.is_some());
+        drop(removed);
+        assert!(cache.index.max_slot_for_pubkey(&pk).is_none());
+        assert_eq!(cache.index.num_unique_pubkeys.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_remove_slot_cleans_up_index() {
+        let cache = AccountsCache::default();
+        let pk1 = Pubkey::new_unique();
+        let pk2 = Pubkey::new_unique();
+
+        // pk1 in slots 1 and 3; pk2 only in slot 1
+        cache.store(1, &pk1, AccountSharedData::new(1, 0, &Pubkey::default()));
+        cache.store(1, &pk2, AccountSharedData::new(1, 0, &Pubkey::default()));
+        cache.store(3, &pk1, AccountSharedData::new(1, 0, &Pubkey::default()));
+
+        // Before removal: both pubkeys are in the index
+        assert!(cache.index.max_slot_for_pubkey(&pk1).is_some());
+        assert!(cache.index.max_slot_for_pubkey(&pk2).is_some());
+
+        // Remove slot 1 — pk2 should disappear, pk1 still present (in slot 3)
+        cache.remove_slot(1);
+        assert!(cache.index.max_slot_for_pubkey(&pk1).is_some());
+        assert!(cache.index.max_slot_for_pubkey(&pk2).is_none());
+
+        // Remove slot 3 — pk1 should also disappear
+        cache.remove_slot(3);
+        assert!(cache.index.max_slot_for_pubkey(&pk1).is_none());
+    }
+
+    #[test_case(true, false, false, Some(SlotStatus::Ancestor); "ancestor unrooted slot")]
+    #[test_case(true, true, false, Some(SlotStatus::Ancestor); "ancestor rooted unflushed slot")]
+    #[test_case(true, true, true, Some(SlotStatus::RootBeingFlushed); "ancestor rooted slot being flushed")]
+    #[test_case(false, true, false, Some(SlotStatus::UnflushedRoot); "rooted unflushed slot")]
+    #[test_case(false, true, true, Some(SlotStatus::RootBeingFlushed); "rooted slot being flushed")]
+    #[test_case(false, false, false, None; "not ancestor not root")]
+    fn test_slot_status(
+        in_ancestors: bool,
+        is_root: bool,
+        is_flushing: bool,
+        expected_status: Option<SlotStatus>,
+    ) {
+        let cache = AccountsCache::default();
+        let pk = Pubkey::new_unique();
+        let slot = 10;
+
+        cache.store(
+            slot,
+            &pk,
+            AccountSharedData::new(100, 0, &Pubkey::default()),
+        );
+
+        if is_root {
+            cache.add_root(slot);
+        }
+        if is_flushing {
+            cache.begin_flush_roots(None);
+        }
+
+        let ancestors = if in_ancestors {
+            Ancestors::from(vec![(slot, 1)])
+        } else {
+            Ancestors::default()
+        };
+
+        // Invalid configuration: a slot must never be in both unflushed roots and roots being
+        // flushed — begin_flush_roots drains unflushed into flushing, so overlap is impossible
+        // If this is hit, it is likely a test setup issue
+        let in_unflushed = cache.maybe_unflushed_roots.read().unwrap().contains(&slot);
+        let in_flushing = cache.roots_being_flushed.read().unwrap().contains(&slot);
+        assert!(!(in_unflushed && in_flushing));
+
+        // Verify slot_status returns the expected status
+        assert_eq!(cache.slot_status(&ancestors, slot), expected_status);
+
+        // Verify load_latest is consistent with slot_status
+        if let Some(expected) = expected_status {
+            let (account, loaded_slot, status) = cache.load_latest(&pk, &ancestors).unwrap();
+            assert_eq!(loaded_slot, slot);
+            assert_eq!(status, expected);
+            assert_eq!(account.account.lamports(), 100);
+        } else {
+            assert!(cache.load_latest(&pk, &ancestors).is_none());
+        }
+    }
+
+    #[test]
+    fn test_slot_status_visibility_after_flush() {
+        let cache = AccountsCache::default();
+        let pk = Pubkey::new_unique();
+
+        cache.store(10, &pk, AccountSharedData::new(100, 0, &Pubkey::default()));
+        cache.add_root(10);
+        cache.begin_flush_roots(None);
+        cache.end_flush_roots();
+
+        // After clearing flushed roots, slot is no longer visible
+        let empty = Ancestors::default();
+        assert_eq!(cache.slot_status(&empty, 10), None);
+        assert!(cache.load_latest(&pk, &empty).is_none());
+    }
+
+    #[test]
+    fn test_begin_flush_roots_with_max_root() {
+        let cache = AccountsCache::default();
+        cache.add_root(1);
+        cache.add_root(3);
+        cache.add_root(5);
+        cache.add_root(7);
+
+        // begin_flush_roots(Some(5)) should return {1, 3, 5} and leave {7}
+        let taken = cache.begin_flush_roots(Some(5));
+        assert_eq!(taken, BTreeSet::from([1, 3, 5]));
+
+        // Remaining unflushed roots should only contain 7
+        assert!(!cache.maybe_unflushed_roots.read().unwrap().contains(&3));
+        assert!(cache.maybe_unflushed_roots.read().unwrap().contains(&7));
+
+        // Taken roots should now be in roots_being_flushed
+        assert!(cache.roots_being_flushed.read().unwrap().contains(&1));
+        assert!(cache.roots_being_flushed.read().unwrap().contains(&3));
+        assert!(cache.roots_being_flushed.read().unwrap().contains(&5));
+        assert!(!cache.roots_being_flushed.read().unwrap().contains(&7));
+
+        // slot_status should reflect the transition
+        let empty = Ancestors::default();
+        assert_eq!(
+            cache.slot_status(&empty, 3),
+            Some(SlotStatus::RootBeingFlushed)
+        );
+        assert_eq!(
+            cache.slot_status(&empty, 7),
+            Some(SlotStatus::UnflushedRoot)
+        );
+
+        cache.end_flush_roots();
+    }
+
+    #[test]
+    fn test_begin_flush_roots_none_takes_all() {
+        let cache = AccountsCache::default();
+        cache.add_root(2);
+        cache.add_root(4);
+        cache.add_root(6);
+
+        let taken = cache.begin_flush_roots(None);
+        assert_eq!(taken, BTreeSet::from([2, 4, 6]));
+
+        // All unflushed roots should be drained
+        assert!(cache.maybe_unflushed_roots.read().unwrap().is_empty());
+
+        // All should be in roots_being_flushed
+        assert_eq!(
+            *cache.roots_being_flushed.read().unwrap(),
+            BTreeSet::from([2, 4, 6])
+        );
+
+        cache.end_flush_roots();
+    }
+
+    #[test]
+    #[should_panic(expected = "begin_flush_roots called while roots are already being flushed")]
+    fn test_begin_flush_roots_panics_if_already_flushing() {
+        let cache = AccountsCache::default();
+        cache.add_root(1);
+        cache.begin_flush_roots(None);
+        // Calling again without end_flush_roots should panic
+        cache.add_root(2);
+        cache.begin_flush_roots(None);
+    }
+
+    #[test]
+    fn test_end_flush_roots_allows_next_flush() {
+        let cache = AccountsCache::default();
+        cache.add_root(1);
+        cache.add_root(2);
+
+        // First cycle
+        let taken = cache.begin_flush_roots(None);
+        assert_eq!(taken, BTreeSet::from([1, 2]));
+
+        let empty = Ancestors::default();
+        assert_eq!(
+            cache.slot_status(&empty, 1),
+            Some(SlotStatus::RootBeingFlushed)
+        );
+
+        cache.end_flush_roots();
+
+        // After clear, roots_being_flushed is empty
+        assert!(cache.roots_being_flushed.read().unwrap().is_empty());
+        // Slots are no longer visible
+        assert_eq!(cache.slot_status(&empty, 1), None);
+
+        // Second cycle works without panic
+        cache.add_root(3);
+        let taken = cache.begin_flush_roots(None);
+        assert_eq!(taken, BTreeSet::from([3]));
+        cache.end_flush_roots();
+    }
+
+    #[test]
+    fn test_load_latest_root_being_flushed() {
+        let cache = AccountsCache::default();
+        let pk = Pubkey::new_unique();
+
+        cache.store(10, &pk, AccountSharedData::new(500, 0, &Pubkey::default()));
+        cache.add_root(10);
+        cache.begin_flush_roots(None);
+
+        // Account should still be loadable with RootBeingFlushed status
+        let empty = Ancestors::default();
+        let (account, slot, status) = cache.load_latest(&pk, &empty).unwrap();
+        assert_eq!(slot, 10);
+        assert_eq!(status, SlotStatus::RootBeingFlushed);
+        assert_eq!(account.account.lamports(), 500);
+
+        // After end_flush_roots, the slot is no longer visible
+        cache.end_flush_roots();
+        assert!(cache.load_latest(&pk, &empty).is_none());
     }
 }

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -40,16 +40,19 @@ impl MaxFlushedRoot {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SlotStatus {
     /// Slot is in the ancestors list and not a root being flushed root. Slot is guaranteed to be
-    /// the newest version of the account so the cached copy can be used without checking storage
-    /// NOTE: A slot in this state may also be an Unflushedroot
+    /// the newest version of the account on this fork so the cached copy can be used without
+    /// checking storage
     Ancestor,
+    /// Slot is in the ancestors list but is also a root being flushed. The version found in the
+    /// accounts cache may not be the newest version of the account, and the storage should be
+    /// checked for newer versions
+    AncestorBeingFlushed,
     /// Slot is a root that has not yet been claimed for flushing. Slot is guaranteed to be the
     /// newest version of the account so the cached copy can be used without checking storage
     UnflushedRoot,
     /// Slot is a root that is currently being flushed. The version found in the accounts cache
     /// may not be the newest version of the account, and the storage should be checked for newer
     /// versions
-    /// NOTE: A slot in this state may also be an Ancestor
     RootBeingFlushed,
 }
 
@@ -341,22 +344,10 @@ impl AccountsCache {
         result
     }
 
-    /// Returns the minimum visible slot across ancestors, unflushed roots, and roots
-    /// being flushed. Returns `None` if all three sources are empty
-    fn min_visible_slot(&self, ancestors: &Ancestors) -> Option<Slot> {
-        let unflushed_first = self.maybe_unflushed_roots.read().unwrap().first().copied();
-        let flushing_first = self.roots_being_flushed.read().unwrap().first().copied();
-
-        [ancestors.min_slot(), unflushed_first, flushing_first]
-            .into_iter()
-            .flatten()
-            .min()
-    }
-
-    /// Finds the newest write-cache entry for `pubkey` by scanning visible slots in descending
-    /// order. The scan range is bounded by the index's max_slot for the pubkey and the min
-    /// of all visibility sets (ancestors, unflushed roots, roots being flushed)
-    /// Returns the account, the slot it was found in, and where the slot was found
+    /// Finds the best write-cache entry for `pubkey` visible from `ancestors`. Searches
+    /// ancestors first (highest to lowest), then unflushed roots, then roots being flushed.
+    /// Ancestors are checked exhaustively before roots, so a lower-slot ancestor wins over a
+    /// higher-slot root. Returns the account, slot, and status, or `None` if not found.
     pub fn load_latest(
         &self,
         pubkey: &Pubkey,
@@ -364,47 +355,44 @@ impl AccountsCache {
     ) -> Option<(Arc<CachedAccount>, Slot, SlotStatus)> {
         // Exit early if the pubkey isn't in the cache
         let index_max_slot = self.index.max_slot_for_pubkey(pubkey)?;
-        let min_visible = self.min_visible_slot(ancestors)?;
 
-        // Iterate from max_slot down to min_visible. Check slot_status first before hitting the
-        // per-slot DashMap. The common case — newest slot is valid — returns on the first iteration
-        for slot in (min_visible..=index_max_slot).rev() {
-            if let Some(status) = self.slot_status(ancestors, slot) {
-                if let Some(account) = self.load(slot, pubkey) {
-                    return Some((account, slot, status));
+        if let Some(ancestors_min_slot) = ancestors.min_slot() {
+            // Iterate every slot in the range in descending order. Check ancestors first as it
+            // requires no RwLocks
+            for slot in (ancestors_min_slot..=index_max_slot).rev() {
+                if ancestors.contains_key(&slot) {
+                    if let Some(account) = self.load(slot, pubkey) {
+                        // Need to check flush status of the slot even for ancestors, because
+                        // there could be newer version of the account that has already been
+                        // flushed
+                        if self.roots_being_flushed.read().unwrap().contains(&slot) {
+                            return Some((account, slot, SlotStatus::AncestorBeingFlushed));
+                        } else {
+                            return Some((account, slot, SlotStatus::Ancestor));
+                        };
+                    }
                 }
             }
         }
-        None
-    }
 
-    /// Returns the status of `slot` if it is visible (as an unflushed root, a root being
-    /// flushed, or an ancestor)
-    ///
-    /// Only `RootBeingFlushed` requires the caller to also check storage, since the cached entry
-    /// may be stale. All other visible statuses guarantee the cached entry is the newest version
-    ///
-    /// Checks ancestors first (cheap HashMap lookup, no lock) since the common case is an
-    /// ancestor that is not a root. When the slot is an ancestor we only need to check
-    /// `roots_being_flushed` — distinguishing unrooted from unflushed-root
-    /// is unnecessary because both guarantee the cached entry is newest
-    pub(crate) fn slot_status(&self, ancestors: &Ancestors, slot: Slot) -> Option<SlotStatus> {
-        if ancestors.contains_key(&slot) {
-            // Ancestor: check if root being flushed, which may require checking storage
-            return if self.roots_being_flushed.read().unwrap().contains(&slot) {
-                Some(SlotStatus::RootBeingFlushed)
-            } else {
-                Some(SlotStatus::Ancestor)
-            };
+        // If the slot is not found in the ancestors fall back to searching roots
+        let unflushed_roots = self.maybe_unflushed_roots.read().unwrap();
+        for &slot in unflushed_roots.range(..=index_max_slot).rev() {
+            if let Some(account) = self.load(slot, pubkey) {
+                return Some((account, slot, SlotStatus::UnflushedRoot));
+            }
         }
+        drop(unflushed_roots);
 
-        // Not an ancestor — check root sets for visibility
-        if self.maybe_unflushed_roots.read().unwrap().contains(&slot) {
-            return Some(SlotStatus::UnflushedRoot);
+        let flushing_roots = self.roots_being_flushed.read().unwrap();
+        for &slot in flushing_roots.range(..=index_max_slot).rev() {
+            if let Some(account) = self.load(slot, pubkey) {
+                return Some((account, slot, SlotStatus::RootBeingFlushed));
+            }
         }
-        if self.roots_being_flushed.read().unwrap().contains(&slot) {
-            return Some(SlotStatus::RootBeingFlushed);
-        }
+        drop(flushing_roots);
+
+        // Found nothing, the version of the account in the cache must be on a different fork
         None
     }
 
@@ -642,64 +630,73 @@ mod tests {
         assert!(cache.index.max_slot_for_pubkey(&pk1).is_none());
     }
 
-    #[test_case(true, false, false, Some(SlotStatus::Ancestor); "ancestor unrooted slot")]
-    #[test_case(true, true, false, Some(SlotStatus::Ancestor); "ancestor rooted unflushed slot")]
-    #[test_case(true, true, true, Some(SlotStatus::RootBeingFlushed); "ancestor rooted slot being flushed")]
-    #[test_case(false, true, false, Some(SlotStatus::UnflushedRoot); "rooted unflushed slot")]
-    #[test_case(false, true, true, Some(SlotStatus::RootBeingFlushed); "rooted slot being flushed")]
-    #[test_case(false, false, false, None; "not ancestor not root")]
-    fn test_slot_status(
-        in_ancestors: bool,
-        is_root: bool,
-        is_flushing: bool,
-        expected_status: Option<SlotStatus>,
+    /// Tests that `load_latest` returns the correct slot, status, and account value
+    /// given various combinations of ancestor slots, root slots, and flushing state.
+    ///
+    /// Ancestors always take priority over roots regardless of slot
+    // None case
+    #[test_case(&[], &[], &[], None; "not ancestor not root")]
+    #[test_case(&[10], &[], &[], Some((10, SlotStatus::Ancestor)); "ancestor only")]
+    #[test_case(&[5, 10, 15], &[], &[], Some((15, SlotStatus::Ancestor)); "highest ancestor returned")]
+    #[test_case(&[], &[10, 20], &[], Some((20, SlotStatus::UnflushedRoot)); "rooted, with no ancestors")]
+    #[test_case(&[], &[], &[10], Some((10, SlotStatus::RootBeingFlushed)); "root being flushed")]
+    #[test_case(&[10], &[], &[10], Some((10, SlotStatus::AncestorBeingFlushed)); "ancestor being flushed")]
+    #[test_case(&[5], &[20], &[], Some((5, SlotStatus::Ancestor)); "ancestor wins over higher root")]
+    #[test_case(&[], &[20], &[10], Some((20, SlotStatus::UnflushedRoot));"unflushed root over flushing root")]
+    #[test_case(&[5], &[20], &[10], Some((5, SlotStatus::Ancestor));"ancestor over unflushed and flushing roots")]
+    fn test_load_latest_slot_priority(
+        ancestor_slots: &[Slot],
+        unflushed_root_slots: &[Slot],
+        flushing_root_slots: &[Slot],
+        expected: Option<(Slot, SlotStatus)>,
     ) {
         let cache = AccountsCache::default();
         let pk = Pubkey::new_unique();
-        let slot = 10;
 
-        cache.store(
-            slot,
-            &pk,
-            AccountSharedData::new(100, 0, &Pubkey::default()),
-        );
-
-        if is_root {
+        for &slot in ancestor_slots {
+            cache.store(
+                slot,
+                &pk,
+                AccountSharedData::new(slot, 0, &Pubkey::default()),
+            );
+        }
+        for &slot in unflushed_root_slots.iter().chain(flushing_root_slots) {
+            cache.store(
+                slot,
+                &pk,
+                AccountSharedData::new(slot, 0, &Pubkey::default()),
+            );
             cache.add_root(slot);
         }
-        if is_flushing {
-            cache.begin_flush_roots(None);
+        if let Some(&max) = flushing_root_slots.iter().max() {
+            cache.begin_flush_roots(Some(max));
         }
 
-        let ancestors = if in_ancestors {
-            Ancestors::from(vec![(slot, 1)])
-        } else {
-            Ancestors::default()
-        };
-
-        // Invalid configuration: a slot must never be in both unflushed roots and roots being
-        // flushed — begin_flush_roots drains unflushed into flushing, so overlap is impossible
-        // If this is hit, it is likely a test setup issue
-        let in_unflushed = cache.maybe_unflushed_roots.read().unwrap().contains(&slot);
-        let in_flushing = cache.roots_being_flushed.read().unwrap().contains(&slot);
-        assert!(!(in_unflushed && in_flushing));
-
-        // Verify slot_status returns the expected status
-        assert_eq!(cache.slot_status(&ancestors, slot), expected_status);
-
-        // Verify load_latest is consistent with slot_status
-        if let Some(expected) = expected_status {
-            let (account, loaded_slot, status) = cache.load_latest(&pk, &ancestors).unwrap();
-            assert_eq!(loaded_slot, slot);
-            assert_eq!(status, expected);
-            assert_eq!(account.account.lamports(), 100);
-        } else {
-            assert!(cache.load_latest(&pk, &ancestors).is_none());
-        }
+        let ancestors = Ancestors::from(ancestor_slots.to_vec());
+        let result = cache
+            .load_latest(&pk, &ancestors)
+            .map(|(account, slot, status)| {
+                assert_eq!(account.account.lamports(), slot);
+                (slot, status)
+            });
+        assert_eq!(result, expected);
     }
 
     #[test]
-    fn test_slot_status_visibility_after_flush() {
+    fn test_load_latest_ignores_non_ancestor_non_root_slot() {
+        let cache = AccountsCache::default();
+        let pk = Pubkey::new_unique();
+
+        // Store an account at slot 10, but don't add it as an ancestor or root.
+        cache.store(10, &pk, AccountSharedData::new(10, 0, &Pubkey::default()));
+
+        let ancestors = Ancestors::from(vec![5, 15]);
+        let result = cache.load_latest(&pk, &ancestors);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_visibility_after_flush() {
         let cache = AccountsCache::default();
         let pk = Pubkey::new_unique();
 
@@ -710,7 +707,6 @@ mod tests {
 
         // After clearing flushed roots, slot is no longer visible
         let empty = Ancestors::default();
-        assert_eq!(cache.slot_status(&empty, 10), None);
         assert!(cache.load_latest(&pk, &empty).is_none());
     }
 
@@ -735,17 +731,6 @@ mod tests {
         assert!(cache.roots_being_flushed.read().unwrap().contains(&3));
         assert!(cache.roots_being_flushed.read().unwrap().contains(&5));
         assert!(!cache.roots_being_flushed.read().unwrap().contains(&7));
-
-        // slot_status should reflect the transition
-        let empty = Ancestors::default();
-        assert_eq!(
-            cache.slot_status(&empty, 3),
-            Some(SlotStatus::RootBeingFlushed)
-        );
-        assert_eq!(
-            cache.slot_status(&empty, 7),
-            Some(SlotStatus::UnflushedRoot)
-        );
 
         cache.end_flush_roots();
     }
@@ -793,18 +778,10 @@ mod tests {
         let taken = cache.begin_flush_roots(None);
         assert_eq!(taken, BTreeSet::from([1, 2]));
 
-        let empty = Ancestors::default();
-        assert_eq!(
-            cache.slot_status(&empty, 1),
-            Some(SlotStatus::RootBeingFlushed)
-        );
-
         cache.end_flush_roots();
 
         // After clear, roots_being_flushed is empty
         assert!(cache.roots_being_flushed.read().unwrap().is_empty());
-        // Slots are no longer visible
-        assert_eq!(cache.slot_status(&empty, 1), None);
 
         // Second cycle works without panic
         cache.add_root(3);
@@ -814,23 +791,26 @@ mod tests {
     }
 
     #[test]
-    fn test_load_latest_root_being_flushed() {
+    fn test_load_latest_multiple_ancestors_one_being_flushed() {
         let cache = AccountsCache::default();
         let pk = Pubkey::new_unique();
 
-        cache.store(10, &pk, AccountSharedData::new(500, 0, &Pubkey::default()));
+        // Store at slots 5 and 10, both will be ancestors
+        cache.store(5, &pk, AccountSharedData::new(5, 0, &Pubkey::default()));
+        cache.store(10, &pk, AccountSharedData::new(10, 0, &Pubkey::default()));
+
+        // Slot 10 is also a root that gets claimed for flushing
         cache.add_root(10);
         cache.begin_flush_roots(None);
 
-        // Account should still be loadable with RootBeingFlushed status
-        let empty = Ancestors::default();
-        let (account, slot, status) = cache.load_latest(&pk, &empty).unwrap();
-        assert_eq!(slot, 10);
-        assert_eq!(status, SlotStatus::RootBeingFlushed);
-        assert_eq!(account.account.lamports(), 500);
+        let ancestors = Ancestors::from(vec![5, 10]);
+        let (account, slot, status) = cache.load_latest(&pk, &ancestors).unwrap();
 
-        // After end_flush_roots, the slot is no longer visible
+        // Slot 10 is highest ancestor but is being flushed, so should return AncestorBeingFlushed
+        assert_eq!(slot, 10);
+        assert_eq!(status, SlotStatus::AncestorBeingFlushed);
+        assert_eq!(account.account.lamports(), 10);
+
         cache.end_flush_roots();
-        assert!(cache.load_latest(&pk, &empty).is_none());
     }
 }

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -380,7 +380,7 @@ impl AccountsCache {
         }
 
         // If the slot is not found in the ancestors fall back to searching roots
-        let r_maybe_unflushed_roots = self.r_maybe_unflushed_roots.read().unwrap();
+        let r_maybe_unflushed_roots = self.maybe_unflushed_roots.read().unwrap();
         for &slot in r_maybe_unflushed_roots.range(..=index_max_slot).rev() {
             if let Some(account) = self.load(slot, pubkey) {
                 return Some((account, slot, SlotStatus::UnflushedRoot));
@@ -388,7 +388,7 @@ impl AccountsCache {
         }
         drop(r_maybe_unflushed_roots);
 
-        let r_roots_being_flushed = self.r_roots_being_flushed.read().unwrap();
+        let r_roots_being_flushed = self.roots_being_flushed.read().unwrap();
         for &slot in r_roots_being_flushed.range(..=index_max_slot).rev() {
             if let Some(account) = self.load(slot, pubkey) {
                 return Some((account, slot, SlotStatus::RootBeingFlushed));

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -39,7 +39,7 @@ impl MaxFlushedRoot {
 /// Indicates whether a slot is an ancestor, an unflushed root, or a root being flushed
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SlotStatus {
-    /// Slot is in the ancestors list and not a root being flushed root. Slot is guaranteed to be
+    /// Slot is in the ancestors list and not a root being flushed. Slot is guaranteed to be
     /// the newest version of the account on this fork so the cached copy can be used without
     /// checking storage
     Ancestor,
@@ -357,40 +357,44 @@ impl AccountsCache {
         let index_max_slot = self.index.max_slot_for_pubkey(pubkey)?;
 
         if let Some(ancestors_min_slot) = ancestors.min_slot() {
-            // Iterate every slot in the range in descending order. Check ancestors first as it
-            // requires no RwLocks
+            // Iterate every slot in the range in descending order
+            // Grab a read lock on flushing roots once before the loop to avoid locking/unlocking
+            // on every iteration
+            let r_roots_being_flushed = self.roots_being_flushed.read().unwrap();
             for slot in (ancestors_min_slot..=index_max_slot).rev() {
                 if ancestors.contains_key(&slot) {
                     if let Some(account) = self.load(slot, pubkey) {
                         // Need to check flush status of the slot even for ancestors, because
                         // there could be newer version of the account that has already been
                         // flushed
-                        if self.roots_being_flushed.read().unwrap().contains(&slot) {
-                            return Some((account, slot, SlotStatus::AncestorBeingFlushed));
+                        let slot_status = if r_roots_being_flushed.contains(&slot) {
+                            SlotStatus::AncestorBeingFlushed
                         } else {
-                            return Some((account, slot, SlotStatus::Ancestor));
+                            SlotStatus::Ancestor
                         };
+                        return Some((account, slot, slot_status));
                     }
                 }
             }
+            drop(r_roots_being_flushed);
         }
 
         // If the slot is not found in the ancestors fall back to searching roots
-        let unflushed_roots = self.maybe_unflushed_roots.read().unwrap();
-        for &slot in unflushed_roots.range(..=index_max_slot).rev() {
+        let r_maybe_unflushed_roots = self.r_maybe_unflushed_roots.read().unwrap();
+        for &slot in r_maybe_unflushed_roots.range(..=index_max_slot).rev() {
             if let Some(account) = self.load(slot, pubkey) {
                 return Some((account, slot, SlotStatus::UnflushedRoot));
             }
         }
-        drop(unflushed_roots);
+        drop(r_maybe_unflushed_roots);
 
-        let flushing_roots = self.roots_being_flushed.read().unwrap();
-        for &slot in flushing_roots.range(..=index_max_slot).rev() {
+        let r_roots_being_flushed = self.r_roots_being_flushed.read().unwrap();
+        for &slot in r_roots_being_flushed.range(..=index_max_slot).rev() {
             if let Some(account) = self.load(slot, pubkey) {
                 return Some((account, slot, SlotStatus::RootBeingFlushed));
             }
         }
-        drop(flushing_roots);
+        drop(r_roots_being_flushed);
 
         // Found nothing, the version of the account in the cache must be on a different fork
         None
@@ -415,10 +419,10 @@ impl AccountsCache {
     /// a previous `begin_flush_roots`)
     pub fn begin_flush_roots(&self, max_root: Option<Slot>) -> BTreeSet<Slot> {
         let mut w_maybe_unflushed_roots = self.maybe_unflushed_roots.write().unwrap();
-        let mut w_being_flushed = self.roots_being_flushed.write().unwrap();
+        let mut w_roots_being_flushed = self.roots_being_flushed.write().unwrap();
 
         assert!(
-            w_being_flushed.is_empty(),
+            w_roots_being_flushed.is_empty(),
             "begin_flush_roots called while roots are already being flushed; end_flush_roots must \
              be called first"
         );
@@ -430,7 +434,7 @@ impl AccountsCache {
             std::mem::take(&mut *w_maybe_unflushed_roots)
         };
 
-        *w_being_flushed = roots_to_flush.clone();
+        *w_roots_being_flushed = roots_to_flush.clone();
         roots_to_flush
     }
 

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -192,13 +192,13 @@ impl CachedAccount {
     }
 }
 
-/// Maps each pubkey to (max_slot, count) where max_slot is the highest slot at which the pubkey
-/// has been written into the cache, and count is the number of SlotCache entries that currently
-/// hold the pubkey. max_slot may be stale after a removal; callers must handle a
+/// Maps each pubkey to (max_slot, ref_count) where max_slot is the highest slot at which the
+/// pubkey has been written into the cache, and ref_count is the number of SlotCache entries that
+/// currently hold the pubkey. max_slot may be stale after a removal; callers must handle a
 /// look-up miss on max_slot by falling back to scanning all slots in the cache (see load_latest)
 #[derive(Debug, Default)]
-pub struct AccountsCacheIndex {
-    entries: DashMap<Pubkey, (Slot, u64), PubkeyHasherBuilder>,
+struct AccountsCacheIndex {
+    entries: DashMap<Pubkey, (Slot, u32), PubkeyHasherBuilder>,
     // The number of unique pubkeys in the index, for reporting purposes. This is to avoid having to
     // lock each shard of the entries dashmap to count unique keys on demand
     num_unique_pubkeys: AtomicU64,
@@ -209,9 +209,9 @@ impl AccountsCacheIndex {
     fn insert(&self, pubkey: &Pubkey, slot: Slot) {
         self.entries
             .entry(*pubkey)
-            .and_modify(|(stored_slot, count)| {
+            .and_modify(|(stored_slot, ref_count)| {
                 *stored_slot = slot.max(*stored_slot);
-                *count += 1;
+                *ref_count += 1;
             })
             .or_insert_with(|| {
                 self.num_unique_pubkeys.fetch_add(1, Ordering::Relaxed);
@@ -224,16 +224,15 @@ impl AccountsCacheIndex {
     /// is the highest slot
     fn remove(&self, pubkeys: impl IntoIterator<Item = Pubkey>) {
         for pubkey in pubkeys {
-            if let Entry::Occupied(mut occupied_entry) = self.entries.entry(pubkey) {
-                let (_, count) = occupied_entry.get_mut();
-                *count -= 1;
-                if *count == 0 {
-                    occupied_entry.remove_entry();
-                    self.num_unique_pubkeys.fetch_sub(1, Ordering::Relaxed);
-                }
-            } else {
+            let Entry::Occupied(mut occupied_entry) = self.entries.entry(pubkey) else {
                 // If this has happened the index is corrupted
                 panic!("pubkey {pubkey} not found in cache index during remove");
+            };
+            let (_, ref_count) = occupied_entry.get_mut();
+            *ref_count -= 1;
+            if *ref_count == 0 {
+                occupied_entry.remove_entry();
+                self.num_unique_pubkeys.fetch_sub(1, Ordering::Relaxed);
             }
         }
     }
@@ -728,7 +727,7 @@ mod tests {
         assert_eq!(taken, BTreeSet::from([1, 3, 5]));
 
         // Remaining unflushed roots should only contain 7
-        assert!(!cache.maybe_unflushed_roots.read().unwrap().contains(&3));
+        assert_eq!(cache.maybe_unflushed_roots.read().unwrap().len(), 1);
         assert!(cache.maybe_unflushed_roots.read().unwrap().contains(&7));
 
         // Taken roots should now be in roots_being_flushed

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -359,7 +359,8 @@ impl AccountsCache {
         if let Some(ancestors_min_slot) = ancestors.min_slot() {
             // Iterate every slot in the range in descending order
             // Grab a read lock on flushing roots once before the loop to avoid locking/unlocking
-            // on every iteration
+            // on every iteration. This lock ensures that the load call in the loop correctly
+            // identifies slots with status AncestorBeingFlushed.
             let r_roots_being_flushed = self.roots_being_flushed.read().unwrap();
             for slot in (ancestors_min_slot..=index_max_slot).rev() {
                 if ancestors.contains_key(&slot) {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -36,10 +36,10 @@ use {
             stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
         },
         account_storage_entry::AccountStorageEntry,
-        accounts_cache::{AccountsCache, CachedAccount, SlotCache},
+        accounts_cache::{AccountsCache, CachedAccount, SlotCache, SlotStatus},
         accounts_db::stats::{
-            AccountsStats, CleanAccountsStats, FlushStats, ObsoleteAccountsStats, PurgeStats,
-            ShrinkAncientStats, ShrinkStats, ShrinkStatsSub, StoreAccountsFrozenStats,
+            AccountsStats, CleanAccountsStats, FlushStats, LoadStats, ObsoleteAccountsStats,
+            PurgeStats, ShrinkAncientStats, ShrinkStats, ShrinkStatsSub, StoreAccountsFrozenStats,
             StoreAccountsTiming, StoreAccountsUnfrozenStats, WriteAccountsToCacheStats,
         },
         accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
@@ -913,6 +913,9 @@ pub struct AccountsDb {
 
     pub stats: AccountsStats,
 
+    /// Stats for loading accounts during replay
+    load_stats: LoadStats,
+
     /// Stats from storing accounts unfrozen
     store_accounts_unfrozen_stats: StoreAccountsUnfrozenStats,
 
@@ -1125,6 +1128,7 @@ impl AccountsDb {
             shrink_candidate_slots: Mutex::new(ShrinkCandidates::default()),
             write_version: AtomicU64::new(0),
             external_purge_slots_stats: PurgeStats::default(),
+            load_stats: LoadStats::default(),
             clean_accounts_stats: CleanAccountsStats::default(),
             shrink_stats: ShrinkStats::default(),
             shrink_ancient_stats: ShrinkAncientStats::default(),
@@ -3912,6 +3916,23 @@ impl AccountsDb {
     ) -> Option<(AccountSharedData, Slot)> {
         let starting_max_root = self.accounts_index.max_root_inclusive();
 
+        // First check the write cache
+        let cache_result = self.accounts_cache.load_latest(pubkey, ancestors);
+
+        if let Some((cached_account, cached_slot, slot_status)) = &cache_result {
+            // If the slot is an ancestor or an unflushed root, it hasn't been flushed to
+            // storage yet, so the write cache is authoritative — return it directly.
+            if matches!(
+                slot_status,
+                SlotStatus::Ancestor | SlotStatus::UnflushedRoot
+            ) {
+                self.load_stats
+                    .loaded_from_write_cache
+                    .fetch_add(1, Ordering::Relaxed);
+                return Some((cached_account.account.clone(), *cached_slot));
+            }
+        }
+
         let (slot, storage_location, _maybe_account_accessor) =
             self.read_index_for_accessor_or_load_slow(ancestors, pubkey, false)?;
         // Notice the subtle `?` at previous line, we bail out pretty early if missing.
@@ -3920,6 +3941,9 @@ impl AccountsDb {
         if !in_write_cache {
             let result = self.read_only_accounts_cache.load(*pubkey, slot);
             if let Some(account) = result {
+                self.load_stats
+                    .loaded_from_read_cache
+                    .fetch_add(1, Ordering::Relaxed);
                 return Some((account, slot));
             }
         }
@@ -3934,6 +3958,23 @@ impl AccountsDb {
         // note that the account being in the cache could be different now than it was previously
         // since the cache could be flushed in between the 2 calls.
         let in_write_cache = matches!(account_accessor, LoadedAccountAccessor::Cached(_));
+        if in_write_cache {
+            // While the account wasn't loaded directly from the write cache, the write cache
+            // provided the correct slot, so count this as a load from the write cache
+            if cache_result.is_some_and(|(_, cached_slot, _)| cached_slot == slot) {
+                self.load_stats
+                    .loaded_from_write_cache
+                    .fetch_add(1, Ordering::Relaxed);
+            } else {
+                self.load_stats
+                    .loaded_from_index_cache
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        } else {
+            self.load_stats
+                .loaded_from_index_storage
+                .fetch_add(1, Ordering::Relaxed);
+        }
         let account = account_accessor.check_and_get_loaded_account_shared_data();
 
         if !in_write_cache && populate_read_cache == PopulateReadCache::True {
@@ -4522,7 +4563,8 @@ impl AccountsDb {
         mut should_flush_f: Option<&mut impl FnMut(&Pubkey) -> bool>,
     ) -> (usize, usize, FlushStats) {
         // Always flush up to `requested_flush_root`, which is necessary for things like snapshotting.
-        let flushed_roots: BTreeSet<Slot> = self.accounts_cache.clear_roots(requested_flush_root);
+        let flushed_roots: BTreeSet<Slot> =
+            self.accounts_cache.begin_flush_roots(requested_flush_root);
         let max_flush_root = flushed_roots.last().copied();
         let num_new_roots = flushed_roots.len();
 
@@ -4540,6 +4582,9 @@ impl AccountsDb {
         }
 
         max_flush_root.inspect(|&root| self.accounts_cache.set_max_flush_root(root));
+
+        // Now that all the rooted slots are flushed, we can clear the roots from the cache
+        self.accounts_cache.end_flush_roots();
 
         (num_new_roots, num_roots_flushed, flush_stats)
     }
@@ -5750,6 +5795,8 @@ impl AccountsDb {
                     i64
                 ),
             );
+
+            self.load_stats.report();
         }
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -38,9 +38,10 @@ use {
         account_storage_entry::AccountStorageEntry,
         accounts_cache::{AccountsCache, CachedAccount, SlotCache, SlotStatus},
         accounts_db::stats::{
-            AccountsStats, CleanAccountsStats, FlushStats, LoadStats, ObsoleteAccountsStats,
-            PurgeStats, ShrinkAncientStats, ShrinkStats, ShrinkStatsSub, StoreAccountsFrozenStats,
-            StoreAccountsTiming, StoreAccountsUnfrozenStats, WriteAccountsToCacheStats,
+            AccountsStats, CleanAccountsStats, FlushStats, LoadAccountsStats,
+            ObsoleteAccountsStats, PurgeStats, ShrinkAncientStats, ShrinkStats, ShrinkStatsSub,
+            StoreAccountsFrozenStats, StoreAccountsTiming, StoreAccountsUnfrozenStats,
+            WriteAccountsToCacheStats,
         },
         accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
         accounts_hash::{AccountLtHash, AccountsLtHash, ZERO_LAMPORT_ACCOUNT_LT_HASH},
@@ -913,8 +914,8 @@ pub struct AccountsDb {
 
     pub stats: AccountsStats,
 
-    /// Stats for loading accounts during replay
-    load_stats: LoadStats,
+    /// Stats for loading accounts during transaction processing
+    load_account_stats: LoadAccountsStats,
 
     /// Stats from storing accounts unfrozen
     store_accounts_unfrozen_stats: StoreAccountsUnfrozenStats,
@@ -1128,11 +1129,11 @@ impl AccountsDb {
             shrink_candidate_slots: Mutex::new(ShrinkCandidates::default()),
             write_version: AtomicU64::new(0),
             external_purge_slots_stats: PurgeStats::default(),
-            load_stats: LoadStats::default(),
             clean_accounts_stats: CleanAccountsStats::default(),
             shrink_stats: ShrinkStats::default(),
             shrink_ancient_stats: ShrinkAncientStats::default(),
             stats: AccountsStats::default(),
+            load_account_stats: LoadAccountsStats::default(),
             store_accounts_unfrozen_stats: StoreAccountsUnfrozenStats::default(),
             store_accounts_frozen_stats: StoreAccountsFrozenStats::default(),
             #[cfg(test)]
@@ -3926,8 +3927,8 @@ impl AccountsDb {
                 slot_status,
                 SlotStatus::Ancestor | SlotStatus::UnflushedRoot
             ) {
-                self.load_stats
-                    .loaded_from_write_cache
+                self.load_account_stats
+                    .num_loaded_from_write_cache
                     .fetch_add(1, Ordering::Relaxed);
                 return Some((cached_account.account.clone(), *cached_slot));
             }
@@ -3941,8 +3942,8 @@ impl AccountsDb {
         if !in_write_cache {
             let result = self.read_only_accounts_cache.load(*pubkey, slot);
             if let Some(account) = result {
-                self.load_stats
-                    .loaded_from_read_cache
+                self.load_account_stats
+                    .num_loaded_from_read_cache
                     .fetch_add(1, Ordering::Relaxed);
                 return Some((account, slot));
             }
@@ -3962,17 +3963,17 @@ impl AccountsDb {
             // While the account wasn't loaded directly from the write cache, the write cache
             // provided the correct slot, so count this as a load from the write cache
             if cache_result.is_some_and(|(_, cached_slot, _)| cached_slot == slot) {
-                self.load_stats
-                    .loaded_from_write_cache
+                self.load_account_stats
+                    .num_loaded_from_write_cache
                     .fetch_add(1, Ordering::Relaxed);
             } else {
-                self.load_stats
-                    .loaded_from_index_cache
+                self.load_account_stats
+                    .num_loaded_from_index_cache
                     .fetch_add(1, Ordering::Relaxed);
             }
         } else {
-            self.load_stats
-                .loaded_from_index_storage
+            self.load_account_stats
+                .num_loaded_from_index_storage
                 .fetch_add(1, Ordering::Relaxed);
         }
         let account = account_accessor.check_and_get_loaded_account_shared_data();
@@ -5796,7 +5797,7 @@ impl AccountsDb {
                 ),
             );
 
-            self.load_stats.report();
+            self.load_account_stats.report();
         }
     }
 

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -948,3 +948,39 @@ pub struct WriteAccountsToCacheStats {
     pub num_ancestors_zero_lamport_skipped: u64,
     pub account_data_bytes_stored: u64,
 }
+
+#[derive(Debug, Default)]
+pub struct LoadStats {
+    pub loaded_from_write_cache: AtomicU64,
+    pub loaded_from_read_cache: AtomicU64,
+    pub loaded_from_index_cache: AtomicU64,
+    pub loaded_from_index_storage: AtomicU64,
+}
+
+impl LoadStats {
+    pub fn report(&self) {
+        datapoint_info!(
+            "accounts_db_load",
+            (
+                "loaded_from_write_cache",
+                self.loaded_from_write_cache.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "loaded_from_read_cache",
+                self.loaded_from_read_cache.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "loaded_from_index_cache",
+                self.loaded_from_index_cache.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "loaded_from_index_storage",
+                self.loaded_from_index_storage.swap(0, Ordering::Relaxed),
+                i64
+            ),
+        );
+    }
+}

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -950,35 +950,36 @@ pub struct WriteAccountsToCacheStats {
 }
 
 #[derive(Debug, Default)]
-pub struct LoadStats {
-    pub loaded_from_write_cache: AtomicU64,
-    pub loaded_from_read_cache: AtomicU64,
-    pub loaded_from_index_cache: AtomicU64,
-    pub loaded_from_index_storage: AtomicU64,
+pub struct LoadAccountsStats {
+    pub num_loaded_from_write_cache: AtomicU64,
+    pub num_loaded_from_read_cache: AtomicU64,
+    pub num_loaded_from_index_cache: AtomicU64,
+    pub num_loaded_from_index_storage: AtomicU64,
 }
 
-impl LoadStats {
+impl LoadAccountsStats {
     pub fn report(&self) {
         datapoint_info!(
-            "accounts_db_load",
+            "accounts_db_load_accounts",
             (
-                "loaded_from_write_cache",
-                self.loaded_from_write_cache.swap(0, Ordering::Relaxed),
+                "num_loaded_from_write_cache",
+                self.num_loaded_from_write_cache.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
-                "loaded_from_read_cache",
-                self.loaded_from_read_cache.swap(0, Ordering::Relaxed),
+                "num_loaded_from_read_cache",
+                self.num_loaded_from_read_cache.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
-                "loaded_from_index_cache",
-                self.loaded_from_index_cache.swap(0, Ordering::Relaxed),
+                "num_loaded_from_index_cache",
+                self.num_loaded_from_index_cache.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
-                "loaded_from_index_storage",
-                self.loaded_from_index_storage.swap(0, Ordering::Relaxed),
+                "num_loaded_from_index_storage",
+                self.num_loaded_from_index_storage
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
         );

--- a/accounts-db/src/ancestors.rs
+++ b/accounts-db/src/ancestors.rs
@@ -62,8 +62,8 @@ impl Ancestors {
         self.len() == 0
     }
 
-    pub fn min_slot(&self) -> Slot {
-        self.ancestors.min().unwrap_or_default()
+    pub fn min_slot(&self) -> Option<Slot> {
+        self.ancestors.min()
     }
 
     pub fn max_slot(&self) -> Slot {


### PR DESCRIPTION
#### Problem
- When reading the accessor looks up the accounts index first to find the entry, then the write cache. Items are likely to be in the write cache, and it would be faster to look them up first

#### Summary of Changes
- Add counters to determine where do_load is finding data
- Add an index to the write cache
- do_read now looks a the write cache index to find pubkeys first

#### Perf data:
Purplish: Load time for edge validator
Red: Store time for edge validator
Blue: load time with this change
Orange: Store time with this change


Median:
Overall, load time drops by 25% while store time almost doubles. This leads to a 5-10% reduction in overall median load+store time
Store time is doubling for two reasons: an extra store is done during load (to update the accounts_index_cache) and some of the cache misses moved from load to store. 
<img width="1651" height="441" alt="image" src="https://github.com/user-attachments/assets/06bf1eaa-4fd2-4ab3-9cf3-555777bf6a78" />
Max:
Similar data to median
<img width="1651" height="441" alt="image" src="https://github.com/user-attachments/assets/e3798c02-981e-43a3-8a2f-cb6ed6e2d494" />

Cache Flush: 
Cache flush now has extra work to, but no meaningful change in timing:
<img width="1848" height="503" alt="image" src="https://github.com/user-attachments/assets/c3b98ca1-0624-4d67-aee0-1885db225b7f" />


#### Non performance data
Sizing: 
Dashmap contains about 50k entires. so total memory addition is in the order of 2MB
<img width="1848" height="503" alt="image" src="https://github.com/user-attachments/assets/d3f2e62d-084d-4f2c-8b20-9476ebe448d7" />

Slot range (Maximum scan size) varies between 50 and 100 slots during normal operation, with spikes during snapshots
<img width="1848" height="503" alt="image" src="https://github.com/user-attachments/assets/57e58a53-ce40-4054-877c-ab5e63ff592c" />

Hit Rate: 
~ 65% of accounts are loaded directly from the write cache
~ 33% of accounts are loaded from the read cache
~ 1% of accounts are loaded from storage after looking up the index
Critically for the next after this: 0 accounts are loaded from the cache after looking up the index. 
<img width="1848" height="503" alt="image" src="https://github.com/user-attachments/assets/cd7a258e-983c-44ea-9e70-e195303437f0" />

Note: I didn't see an easy way to split up this PR so it's a little large. 
The most obvious is the read stats, but they didn't seem valuable separately. 

Other than that: 
- Adding the index without lookups would be large perf degradation
- Making the change to use begin_flush_roots doesn't make a lot of sense without the rest of the change. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
