### PR TITLE
rpc-client: return error instead of panicking on non-object JSON responses

### DIFF
--- a/rpc-client/src/http_sender.rs
+++ b/rpc-client/src/http_sender.rs
@@ -185,6 +185,12 @@ impl RpcSender for HttpSender {
             }
 
             let mut json = response.json::<serde_json::Value>().await?;
+            if !json.is_object() {
+                return Err(RpcError::RpcRequestError(format!(
+                    "RPC response is not a JSON object: {json}",
+                ))
+                .into());
+            }
             if json["error"].is_object() {
                 return match serde_json::from_value::<RpcErrorObject>(json["error"].clone()) {
                     Ok(rpc_error_object) => {
@@ -251,5 +257,42 @@ mod tests {
         let _ = http_sender
             .send(RpcRequest::GetVersion, serde_json::Value::Null)
             .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn http_sender_returns_error_for_non_object_json_response() {
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Spawn a server that returns a JSON string instead of a JSON object,
+        // simulating a misbehaving RPC proxy or load balancer.
+        tokio::task::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 4096];
+            stream.readable().await.unwrap();
+            let _ = stream.try_read(&mut buf);
+            let body = r#""Service Unavailable""#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body,
+            );
+            stream.writable().await.unwrap();
+            stream.try_write(response.as_bytes()).unwrap();
+        });
+
+        let http_sender = HttpSender::new(format!("http://{addr}"));
+        let result = http_sender
+            .send(RpcRequest::GetVersion, serde_json::Value::Null)
+            .await;
+
+        let err = result.unwrap_err();
+        let err_string = err.to_string();
+        assert!(
+            err_string.contains("not a JSON object"),
+            "Expected 'not a JSON object' error, got: {err_string}"
+        );
     }
 }


### PR DESCRIPTION
#### Problem

`HttpSender::send()` panics when an RPC endpoint returns valid JSON that is not a JSON object. This can happen when a load balancer or reverse proxy in front of an RPC node returns a plain string like `"Service Unavailable"` with an HTTP 200 status.

The panic occurs at `http_sender.rs:227`:
```rust
return Ok(json["result"].take());
```

`Value::take()` requires `&mut self`, which invokes serde_json's `IndexMut` trait. Unlike the read-only `Index` trait (used on the preceding line `json["error"].is_object()`, which safely returns `Null`), `IndexMut` panics for non-Object values:
```
thread 'tokio-runtime-worker' panicked at serde_json/src/value/index.rs:102:
cannot access key "result" in JSON string
```

This was observed in production when a public RPC endpoint returned a malformed response after hours of stable operation, crashing the process.

#### Summary of Changes

* Add an early guard after JSON deserialization that validates the response is a JSON object, returning a descriptive `RpcRequestError` instead of panicking
* Add a test that serves a JSON string response via a local HTTP server and verifies the error path