### PR TITLE
Splits off accounts-db store_accounts_unfrozen() stats

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -38,9 +38,9 @@ use {
         account_storage_entry::AccountStorageEntry,
         accounts_cache::{AccountsCache, CachedAccount, SlotCache},
         accounts_db::stats::{
-            AccountsStats, CacheAccountStoreStats, CleanAccountsStats, FlushStats,
-            ObsoleteAccountsStats, PurgeStats, ShrinkAncientStats, ShrinkStats, ShrinkStatsSub,
-            StoreAccountsTiming,
+            AccountsStats, CleanAccountsStats, FlushStats, ObsoleteAccountsStats, PurgeStats,
+            ShrinkAncientStats, ShrinkStats, ShrinkStatsSub, StoreAccountsTiming,
+            StoreAccountsUnfrozenStats, WriteAccountsToCacheStats,
         },
         accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
         accounts_hash::{AccountLtHash, AccountsLtHash, ZERO_LAMPORT_ACCOUNT_LT_HASH},
@@ -937,6 +937,9 @@ pub struct AccountsDb {
 
     pub stats: AccountsStats,
 
+    /// Stats from storing accounts unfrozen
+    store_accounts_unfrozen_stats: StoreAccountsUnfrozenStats,
+
     clean_accounts_stats: CleanAccountsStats,
 
     // Stats for purges called outside of clean_accounts()
@@ -1152,6 +1155,7 @@ impl AccountsDb {
             shrink_stats: ShrinkStats::default(),
             shrink_ancient_stats: ShrinkAncientStats::default(),
             stats: AccountsStats::default(),
+            store_accounts_unfrozen_stats: StoreAccountsUnfrozenStats::default(),
             #[cfg(test)]
             load_delay: u64::default(),
             #[cfg(test)]
@@ -5457,49 +5461,46 @@ impl AccountsDb {
             return;
         }
 
-        let mut total_data = 0;
-        (0..accounts.len()).for_each(|index| {
-            total_data += accounts.data_len(index);
-        });
-
-        self.stats
-            .store_total_data
-            .fetch_add(total_data as u64, Ordering::Relaxed);
-
         // Store the accounts in the write cache
-        let mut store_accounts_time = Measure::start("store_accounts");
-        let (store_account, cache_account_store_stats) =
+        let write_accounts_time = Measure::start("write_accounts");
+        let (store_account, write_stats) =
             self.write_accounts_to_cache(accounts.target_slot(), &accounts, ancestors);
-        store_accounts_time.stop();
-        self.stats
-            .store_accounts_to_cache_us
-            .fetch_add(store_accounts_time.as_us(), Ordering::Relaxed);
+        let write_accounts_us = write_accounts_time.end_as_us();
 
         // Update the index
-        let mut update_index_time = Measure::start("update_index");
-
+        let update_index_time = Measure::start("update_index");
         self.update_index_cached_accounts(&accounts, &store_account, update_index_thread_selection);
+        let update_index_us = update_index_time.end_as_us();
 
-        update_index_time.stop();
-        self.stats
-            .store_update_index
-            .fetch_add(update_index_time.as_us(), Ordering::Relaxed);
-        self.stats.num_store_accounts_to_cache.fetch_add(
-            cache_account_store_stats.num_accounts_stored,
+        let stats = &self.store_accounts_unfrozen_stats;
+        stats
+            .write_to_cache_us
+            .fetch_add(write_accounts_us, Ordering::Relaxed);
+        stats
+            .update_index_us
+            .fetch_add(update_index_us, Ordering::Relaxed);
+        stats
+            .num_initial_accounts_to_store
+            .fetch_add(write_stats.num_initial_accounts_to_store, Ordering::Relaxed);
+        stats
+            .num_accounts_stored
+            .fetch_add(write_stats.num_accounts_stored, Ordering::Relaxed);
+        stats.num_duplicate_accounts_skipped.fetch_add(
+            write_stats.num_duplicate_accounts_skipped,
             Ordering::Relaxed,
         );
-        self.stats.num_ephemeral_accounts_skipped.fetch_add(
-            cache_account_store_stats.num_ephemeral_accounts_skipped,
+        stats.num_ephemeral_accounts_skipped.fetch_add(
+            write_stats.num_ephemeral_accounts_skipped,
             Ordering::Relaxed,
         );
-        self.stats.num_duplicate_accounts_skipped.fetch_add(
-            cache_account_store_stats.num_duplicate_accounts_skipped,
+        stats.num_ancestors_zero_lamport_skipped.fetch_add(
+            write_stats.num_ancestors_zero_lamport_skipped,
             Ordering::Relaxed,
         );
-        self.stats.num_ancestors_zero_lamport_skipped.fetch_add(
-            cache_account_store_stats.num_ancestors_zero_lamport_skipped,
-            Ordering::Relaxed,
-        );
+        stats
+            .account_data_bytes_stored
+            .fetch_add(write_stats.account_data_bytes_stored, Ordering::Relaxed);
+        stats.report();
         self.report_store_timings();
     }
 
@@ -5631,10 +5632,13 @@ impl AccountsDb {
         slot: Slot,
         accounts_and_meta_to_store: &impl StorableAccounts<'b>,
         ancestors: Option<&Ancestors>,
-    ) -> (BitVec, CacheAccountStoreStats) {
+    ) -> (BitVec, WriteAccountsToCacheStats) {
         let len = accounts_and_meta_to_store.len();
         let mut pubkey_set = HashSet::with_capacity_and_hasher(len, PubkeyHasherBuilder::default());
-        let mut cache_account_store_stats = CacheAccountStoreStats::default();
+        let mut stats = WriteAccountsToCacheStats {
+            num_initial_accounts_to_store: len as u64,
+            ..Default::default()
+        };
         let mut store_account = BitVec::new_fill(false, len as u64);
 
         (0..len).rev().for_each(|index| {
@@ -5644,7 +5648,7 @@ impl AccountsDb {
                 if is_duplicate_account {
                     // If the same account is written multiple times in the same batch,
                     // only store the latest version
-                    cache_account_store_stats.num_duplicate_accounts_skipped += 1;
+                    stats.num_duplicate_accounts_skipped += 1;
                     return;
                 }
                 if account.is_zero_lamport() {
@@ -5657,29 +5661,32 @@ impl AccountsDb {
                             |(_, account)| account.is_zero_lamport(),
                         ) {
                             if is_zero_lamport {
-                                cache_account_store_stats.num_ancestors_zero_lamport_skipped += 1;
+                                stats.num_ancestors_zero_lamport_skipped += 1;
                                 return;
                             }
                         } else {
-                            cache_account_store_stats.num_ephemeral_accounts_skipped += 1;
+                            stats.num_ephemeral_accounts_skipped += 1;
                             return;
                         }
                     } else if self
                         .accounts_index
                         .get_and_then(pubkey, |account| (true, account.is_none()))
                     {
-                        cache_account_store_stats.num_ephemeral_accounts_skipped += 1;
+                        stats.num_ephemeral_accounts_skipped += 1;
                         return;
                     }
                 }
 
-                self.accounts_cache
-                    .store(slot, pubkey, account.take_account());
+                let account_shared_data = account.take_account();
+                let account_data_len = account_shared_data.data().len();
+                self.accounts_cache.store(slot, pubkey, account_shared_data);
                 store_account.set(index as u64, true);
+                stats.num_accounts_stored += 1;
+                stats.account_data_bytes_stored += account_data_len as u64;
             })
         });
 
-        (store_account, cache_account_store_stats)
+        (store_account, stats)
     }
 
     fn write_accounts_to_storage<'a>(
@@ -5785,13 +5792,6 @@ impl AccountsDb {
             datapoint_info!(
                 "accounts_db_store_timings",
                 (
-                    "store_accounts_to_cache_us",
-                    self.stats
-                        .store_accounts_to_cache_us
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
                     "store_accounts_to_storage_us",
                     self.stats
                         .store_accounts_to_storage_us
@@ -5821,22 +5821,10 @@ impl AccountsDb {
                     i64
                 ),
                 (
-                    "num_store_accounts_to_cache",
-                    self.stats
-                        .num_store_accounts_to_cache
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
                     "num_store_accounts_to_storage",
                     self.stats
                         .num_store_accounts_to_storage
                         .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "total_data",
-                    self.stats.store_total_data.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -5930,27 +5918,6 @@ impl AccountsDb {
                     "num_zero_lamport_accounts_added",
                     self.stats
                         .num_zero_lamport_accounts_added
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "num_ephemeral_accounts_skipped",
-                    self.stats
-                        .num_ephemeral_accounts_skipped
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "num_duplicate_accounts_skipped",
-                    self.stats
-                        .num_duplicate_accounts_skipped
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "num_ancestors_zero_lamport_skipped",
-                    self.stats
-                        .num_ancestors_zero_lamport_skipped
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -5,21 +5,19 @@ use {
         iter::Sum,
         num::Saturating,
         sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+        time::Duration,
     },
 };
 
 #[derive(Debug, Default)]
 pub struct AccountsStats {
     pub last_store_report: AtomicInterval,
-    pub store_accounts_to_cache_us: AtomicU64,
     pub store_accounts_to_storage_us: AtomicU64,
     pub store_update_index: AtomicU64,
     pub store_handle_reclaims: AtomicU64,
     pub store_append_accounts: AtomicU64,
     pub stakes_cache_check_and_store_us: AtomicU64,
-    pub num_store_accounts_to_cache: AtomicU64,
     pub num_store_accounts_to_storage: AtomicU64,
-    pub store_total_data: AtomicU64,
     pub num_reclaims: AtomicU64,
     pub create_store_count: AtomicU64,
     pub dropped_stores: AtomicU64,
@@ -30,9 +28,87 @@ pub struct AccountsStats {
     pub num_obsolete_bytes_removed: AtomicU64,
     pub add_zero_lamport_accounts_us: AtomicU64,
     pub num_zero_lamport_accounts_added: AtomicU64,
-    pub num_ephemeral_accounts_skipped: AtomicU64,
+}
+
+/// Stats from storing accounts unfrozen (i.e. to the write cache)
+#[derive(Debug, Default)]
+pub struct StoreAccountsUnfrozenStats {
+    pub last_report: AtomicInterval,
+    /// time spent writing accounts to the write cache
+    pub write_to_cache_us: AtomicU64,
+    /// time spend updating the accounts index
+    pub update_index_us: AtomicU64,
+    /// initial number of accounts to be stored
+    pub num_initial_accounts_to_store: AtomicU64,
+    /// number of accounts actually stored
+    pub num_accounts_stored: AtomicU64,
+    /// number of accounts *not* stored because they were duplicates
     pub num_duplicate_accounts_skipped: AtomicU64,
+    /// number of accounts *not* stored because they were ephemeral
+    pub num_ephemeral_accounts_skipped: AtomicU64,
+    /// number of accounts *not* stored because they had an ancestor with zero lamports
     pub num_ancestors_zero_lamport_skipped: AtomicU64,
+    /// number of bytes stored, from only account data
+    pub account_data_bytes_stored: AtomicU64,
+}
+
+impl StoreAccountsUnfrozenStats {
+    const REPORT_INTERVAL_MS: u64 = Duration::from_secs(1).as_millis() as u64;
+
+    pub fn report(&self) {
+        let should_report = self.last_report.should_update(Self::REPORT_INTERVAL_MS);
+        if !should_report {
+            return;
+        }
+
+        datapoint_info!(
+            "accounts_db_store_accounts_unfrozen",
+            (
+                "write_to_cache_us",
+                self.write_to_cache_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "update_index_us",
+                self.update_index_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "num_initial_accounts_to_store",
+                self.num_initial_accounts_to_store
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "num_accounts_stored",
+                self.num_accounts_stored.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "num_duplicate_accounts_skipped",
+                self.num_duplicate_accounts_skipped
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "num_ephemeral_accounts_skipped",
+                self.num_ephemeral_accounts_skipped
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "num_ancestors_zero_lamport_skipped",
+                self.num_ancestors_zero_lamport_skipped
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "account_data_bytes_stored",
+                self.account_data_bytes_stored.swap(0, Ordering::Relaxed),
+                i64
+            ),
+        );
+    }
 }
 
 #[derive(Debug, Default)]
@@ -787,10 +863,15 @@ impl Sum<Self> for ObsoleteAccountsStats {
     }
 }
 
+/// Stats from calling write_accounts_to_cache()
+///
+/// Refer to StoreAccountsUnfrozenStats for docs on each field.
 #[derive(Debug, Default)]
-pub struct CacheAccountStoreStats {
+pub struct WriteAccountsToCacheStats {
+    pub num_initial_accounts_to_store: u64,
     pub num_accounts_stored: u64,
-    pub num_ephemeral_accounts_skipped: u64,
     pub num_duplicate_accounts_skipped: u64,
+    pub num_ephemeral_accounts_skipped: u64,
     pub num_ancestors_zero_lamport_skipped: u64,
+    pub account_data_bytes_stored: u64,
 }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -19,7 +19,10 @@ use {
         iter::{self, FromIterator},
         ops::Range,
         str::FromStr,
-        sync::{RwLock, atomic::AtomicBool},
+        sync::{
+            RwLock,
+            atomic::{AtomicBool, Ordering},
+        },
         thread::{self, Builder, JoinHandle, sleep},
     },
     test_case::{test_case, test_matrix},
@@ -6844,27 +6847,27 @@ fn test_write_accounts_to_cache_scenarios(
     }
 
     let ephemeral = db
-        .stats
+        .store_accounts_unfrozen_stats
         .num_ephemeral_accounts_skipped
-        .load(std::sync::atomic::Ordering::Relaxed);
+        .load(Ordering::Relaxed);
     assert_eq!(
         ephemeral, expected_ephemeral_skips,
         "Wrong number of ephemeral skips"
     );
 
     let ancestors_zero_lamport = db
-        .stats
+        .store_accounts_unfrozen_stats
         .num_ancestors_zero_lamport_skipped
-        .load(std::sync::atomic::Ordering::Relaxed);
+        .load(Ordering::Relaxed);
     assert_eq!(
         ancestors_zero_lamport, expected_ancestors_skips,
         "Wrong number of ancestors zero lamport skips"
     );
 
     let duplicates = db
-        .stats
+        .store_accounts_unfrozen_stats
         .num_duplicate_accounts_skipped
-        .load(std::sync::atomic::Ordering::Relaxed);
+        .load(Ordering::Relaxed);
     assert_eq!(
         duplicates, expected_duplicate_skips,
         "Wrong number of duplicate skips"


### PR DESCRIPTION
#### Problem

The accounts db stats for storing accounts are incomplete and confusing -- because it sometimes combines both storing to cache and storing to storages and sometimes doesn't. These are very different code paths, and being able to see their stats individually is very useful. Some of the store stats are split, but some are not, which makes reading the data non obvious.


#### Summary of Changes

Split the stats!

In this PR we move out all the stats for storing to the write cache, `store_accounts_unfrozen()`, to its own datapoint `accounts_db_store_accounts_unfrozen`.

Note: I'd also like to backport this to v4.0 so that it makes comparison simpler/better.