### PR TITLE
Reduces visibility of accounts_db::stats to pub(crate)

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -20,7 +20,7 @@
 
 mod accounts_db_config;
 mod geyser_plugin_utils;
-pub mod stats;
+pub(crate) mod stats;
 pub(crate) mod tests;
 
 pub use accounts_db_config::{
@@ -4047,7 +4047,7 @@ impl AccountsDb {
 
     /// Purges every slot in `removed_slots` from both the cache and storage. This includes
     /// entries in the accounts index, cache entries, and any backing storage entries.
-    pub fn purge_slots_from_cache_and_store<'a>(
+    fn purge_slots_from_cache_and_store<'a>(
         &self,
         removed_slots: impl Iterator<Item = &'a Slot> + Clone,
         purge_stats: &PurgeStats,
@@ -4090,6 +4090,18 @@ impl AccountsDb {
         purge_stats
             .total_removed_cached_bytes
             .fetch_add(total_removed_cached_bytes, Ordering::Relaxed);
+    }
+
+    /// Purges every slot in `removed_slots` from both the cache and storage. This includes
+    /// entries in the accounts index, cache entries, and any backing storage entries.
+    ///
+    /// This fn is to only be called by snapshot minimizer
+    pub fn purge_slots_for_snapshot_minimizer<'a>(
+        &self,
+        removed_slots: impl Iterator<Item = &'a Slot> + Clone,
+    ) {
+        let stats = PurgeStats::default();
+        self.purge_slots_from_cache_and_store(removed_slots, &stats);
     }
 
     /// Purge the backing storage entries for the given slot, does not purge from

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -13,9 +13,7 @@ use {
     solana_account::{ReadableAccount, state_traits::StateMut},
     solana_accounts_db::{
         account_storage_entry::AccountStorageEntry,
-        accounts_db::{
-            AccountsDb, GetUniqueAccountsResult, UpdateIndexThreadSelection, stats::PurgeStats,
-        },
+        accounts_db::{AccountsDb, GetUniqueAccountsResult, UpdateIndexThreadSelection},
         storable_accounts::StorableAccountsBySlot,
     },
     solana_clock::Slot,
@@ -344,9 +342,8 @@ impl<'a> SnapshotMinimizer<'a> {
 
     /// Purge dead slots from storage and cache
     fn purge_dead_slots(&self, dead_slots: Vec<Slot>) {
-        let stats = PurgeStats::default();
         self.accounts_db()
-            .purge_slots_from_cache_and_store(dead_slots.iter(), &stats);
+            .purge_slots_for_snapshot_minimizer(dead_slots.iter());
     }
 
     /// Convenience function for getting accounts_db


### PR DESCRIPTION
#### Problem

The accounts-db `stats` module is annoyingly public to the world. There's no real reason why non-accounts-db code should have access to the stats.

The _current_ reason is that snapshot-minimizer needs to purge slots, and the fn it uses is from accounts-db, which needs to take in a `PurgeStats` parameter... Snapshot minimizer doesn't care about the purge stats though.


#### Summary of Changes

* Make the `stats` module only crate-public.
* Make a wrapper function for snapshot-minimizer to call when purging slots.
* Return the original purge slots fn to `private`.