### PR TITLE
build: internal scheduler bindings on windows

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -77,9 +77,11 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
 rolling-file = { workspace = true }
+rts-alloc = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
+shaq = { workspace = true }
 signal-hook = { workspace = true }
 slab = { workspace = true }
 solana-account = { workspace = true }
@@ -171,8 +173,6 @@ trees = { workspace = true }
 wincode = { workspace = true }
 
 [target."cfg(unix)".dependencies]
-rts-alloc = { workspace = true }
-shaq = { workspace = true }
 sysctl = { workspace = true }
 
 [dev-dependencies]

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -92,9 +92,7 @@ pub mod unified_scheduler;
 #[cfg(not(feature = "dev-context-only-utils"))]
 pub(crate) mod unified_scheduler;
 
-#[cfg(unix)]
 mod progress_tracker;
-#[cfg(unix)]
 mod tpu_to_pack;
 
 /// The maximum number of worker threads that can be spawned by banking stage.
@@ -720,7 +718,7 @@ mod external {
     use {
         super::*,
         crate::banking_stage::consume_worker::external::ExternalWorker,
-        agave_scheduling_utils::handshake::server::{AgaveSession, AgaveWorkerSession},
+        agave_scheduling_utils::handshake::{AgaveSession, AgaveWorkerSession},
         tpu_to_pack::BankingPacketReceivers,
     };
 
@@ -838,7 +836,7 @@ pub enum BankingControlMsg {
     },
     #[cfg(unix)]
     External {
-        session: agave_scheduling_utils::handshake::server::AgaveSession,
+        session: agave_scheduling_utils::handshake::AgaveSession,
     },
 }
 

--- a/core/src/banking_stage/tpu_to_pack.rs
+++ b/core/src/banking_stage/tpu_to_pack.rs
@@ -4,7 +4,7 @@
 use {
     agave_banking_stage_ingress_types::BankingPacketReceiver,
     agave_scheduler_bindings::{SharableTransactionRegion, TpuToPackMessage, tpu_message_flags},
-    agave_scheduling_utils::handshake::server::AgaveTpuToPackSession,
+    agave_scheduling_utils::handshake::AgaveTpuToPackSession,
     rts_alloc::Allocator,
     solana_packet::PacketFlags,
     solana_perf::packet::PacketBatch,

--- a/scheduling-utils/Cargo.toml
+++ b/scheduling-utils/Cargo.toml
@@ -25,15 +25,12 @@ solana-fee = { workspace = true, features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
 solana-transaction = { workspace = true, optional = true, features = ["serde"] }
 solana-transaction-error = { workspace = true }
+thiserror = { workspace = true }
 wincode = { workspace = true, optional = true }
 
 [target."cfg(unix)".dependencies]
-agave-transaction-view = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true, features = ["socket", "uio"] }
-rts-alloc = { workspace = true }
-shaq = { workspace = true }
-thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/scheduling-utils/src/bridge/bindings.rs
+++ b/scheduling-utils/src/bridge/bindings.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        handshake::client::{ClientSession, ClientWorkerSession},
+        handshake::{ClientSession, ClientWorkerSession},
         pubkeys_ptr::PubkeysPtr,
         transaction_ptr::{TransactionPtr, TransactionPtrBatch},
     },

--- a/scheduling-utils/src/bridge/test.rs
+++ b/scheduling-utils/src/bridge/test.rs
@@ -1,10 +1,7 @@
 use {
     crate::{
         bridge::{KeyedTransactionMeta, ScheduleBatch, SchedulerBindingsBridge, TransactionKey},
-        handshake::{
-            ClientLogon, client,
-            server::{AgaveSession, Server},
-        },
+        handshake::{AgaveSession, ClientLogon, client, server::Server},
         responses_region::{execution_responses_from_iter, resolve_responses_from_iter},
         transaction_ptr::TransactionPtrBatch,
     },

--- a/scheduling-utils/src/handshake/client.rs
+++ b/scheduling-utils/src/handshake/client.rs
@@ -1,10 +1,7 @@
 use {
     crate::handshake::{
-        ClientLogon,
+        ClientHandshakeError, ClientLogon, ClientSession, ClientWorkerSession,
         shared::{LOGON_FAILURE, MAX_WORKERS, VERSION},
-    },
-    agave_scheduler_bindings::{
-        PackToWorkerMessage, ProgressMessage, TpuToPackMessage, WorkerToPackMessage,
     },
     libc::CMSG_LEN,
     nix::sys::socket::{self, ControlMessageOwned, MsgFlags, UnixAddr},
@@ -19,11 +16,7 @@ use {
         path::Path,
         time::Duration,
     },
-    thiserror::Error,
 };
-
-type RtsError = rts_alloc::error::Error;
-type ShaqError = shaq::error::Error;
 
 /// Number of global shared memory objects (in addition to per worker objects).
 const GLOBAL_SHMEM: usize = 3;
@@ -187,37 +180,6 @@ pub fn setup_session(
     drop(files);
 
     Ok(session)
-}
-
-/// The complete initialized scheduling session.
-pub struct ClientSession {
-    pub allocators: Vec<Allocator>,
-    pub tpu_to_pack: shaq::spsc::Consumer<TpuToPackMessage>,
-    pub progress_tracker: shaq::spsc::Consumer<ProgressMessage>,
-    pub workers: Vec<ClientWorkerSession>,
-}
-
-/// An per worker scheduling session.
-pub struct ClientWorkerSession {
-    pub pack_to_worker: shaq::spsc::Producer<PackToWorkerMessage>,
-    pub worker_to_pack: shaq::spsc::Consumer<WorkerToPackMessage>,
-}
-
-/// Potential errors that can occur during the client's side of the handshake.
-#[derive(Debug, Error)]
-pub enum ClientHandshakeError {
-    #[error("Io; err={0}")]
-    Io(#[from] std::io::Error),
-    #[error("Timed out")]
-    TimedOut,
-    #[error("Protocol violation")]
-    ProtocolViolation,
-    #[error("Rejected; reason={0}")]
-    Rejected(String),
-    #[error("Rts alloc; err={0}")]
-    RtsAlloc(#[from] RtsError),
-    #[error("Shaq; err={0}")]
-    Shaq(#[from] ShaqError),
 }
 
 impl From<nix::Error> for ClientHandshakeError {

--- a/scheduling-utils/src/handshake/mod.rs
+++ b/scheduling-utils/src/handshake/mod.rs
@@ -1,7 +1,9 @@
+#[cfg(unix)]
 pub mod client;
+#[cfg(unix)]
 pub mod server;
 mod shared;
 #[cfg(test)]
 mod tests;
 
-pub use shared::{ClientLogon, MAX_WORKERS, logon_flags};
+pub use shared::*;

--- a/scheduling-utils/src/handshake/server.rs
+++ b/scheduling-utils/src/handshake/server.rs
@@ -1,14 +1,12 @@
 use {
     crate::handshake::{
-        ClientLogon,
+        AgaveHandshakeError, AgaveTpuToPackSession, AgaveWorkerSession, ClientLogon,
         shared::{
-            GLOBAL_ALLOCATORS, LOGON_FAILURE, LOGON_SUCCESS, MAX_ALLOCATOR_HANDLES, MAX_WORKERS,
-            VERSION,
+            AgaveSession, GLOBAL_ALLOCATORS, LOGON_FAILURE, LOGON_SUCCESS, MAX_ALLOCATOR_HANDLES,
+            MAX_WORKERS, VERSION,
         },
     },
-    agave_scheduler_bindings::{
-        PackToWorkerMessage, ProgressMessage, TpuToPackMessage, WorkerToPackMessage,
-    },
+    agave_scheduler_bindings::PackToWorkerMessage,
     nix::sys::socket::{self, ControlMessage, MsgFlags, UnixAddr},
     rts_alloc::Allocator,
     std::{
@@ -22,7 +20,6 @@ use {
         path::Path,
         time::{Duration, Instant},
     },
-    thiserror::Error,
 };
 
 type ShaqError = shaq::error::Error;
@@ -339,50 +336,4 @@ impl Server {
             false => size.next_multiple_of(4096),
         }
     }
-}
-
-/// An initialized scheduling session.
-pub struct AgaveSession {
-    pub flags: u16,
-    pub tpu_to_pack: AgaveTpuToPackSession,
-    pub progress_tracker: shaq::spsc::Producer<ProgressMessage>,
-    pub workers: Vec<AgaveWorkerSession>,
-}
-
-/// Shared memory objects for the tpu to pack worker.
-pub struct AgaveTpuToPackSession {
-    pub allocator: Allocator,
-    pub producer: shaq::spsc::Producer<TpuToPackMessage>,
-}
-
-/// Shared memory objects for a single banking worker.
-pub struct AgaveWorkerSession {
-    pub allocator: Allocator,
-    pub pack_to_worker: shaq::spsc::Consumer<PackToWorkerMessage>,
-    pub worker_to_pack: shaq::spsc::Producer<WorkerToPackMessage>,
-}
-
-/// Potential errors that can occur during the Agave side of the handshake.
-///
-/// # Note
-///
-/// These errors are stringified (up to 256 bytes then truncated) and sent to the client.
-#[derive(Debug, Error)]
-pub enum AgaveHandshakeError {
-    #[error("Io; err={0}")]
-    Io(#[from] std::io::Error),
-    #[error("Timeout")]
-    Timeout,
-    #[error("Close during handshake")]
-    EofDuringHandshake,
-    #[error("Version; server={server}; client={client}")]
-    Version { server: u64, client: u64 },
-    #[error("Worker count; count={0}")]
-    WorkerCount(usize),
-    #[error("Allocator handles; count={0}")]
-    AllocatorHandles(usize),
-    #[error("Rts alloc; err={0:?}")]
-    RtsAlloc(#[from] RtsAllocError),
-    #[error("Shaq; err={0:?}")]
-    Shaq(#[from] ShaqError),
 }

--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -1,3 +1,14 @@
+use {
+    agave_scheduler_bindings::{
+        PackToWorkerMessage, ProgressMessage, TpuToPackMessage, WorkerToPackMessage,
+    },
+    rts_alloc::Allocator,
+    thiserror::Error,
+};
+
+pub(crate) type RtsAllocError = rts_alloc::error::Error;
+pub(crate) type ShaqError = shaq::error::Error;
+
 pub const MAX_WORKERS: usize = 64;
 
 /// Protocol version.
@@ -49,3 +60,80 @@ impl ClientLogon {
 }
 
 pub mod logon_flags {}
+
+/// The complete initialized scheduling session.
+pub struct ClientSession {
+    pub allocators: Vec<Allocator>,
+    pub tpu_to_pack: shaq::spsc::Consumer<TpuToPackMessage>,
+    pub progress_tracker: shaq::spsc::Consumer<ProgressMessage>,
+    pub workers: Vec<ClientWorkerSession>,
+}
+
+/// An per worker scheduling session.
+pub struct ClientWorkerSession {
+    pub pack_to_worker: shaq::spsc::Producer<PackToWorkerMessage>,
+    pub worker_to_pack: shaq::spsc::Consumer<WorkerToPackMessage>,
+}
+
+/// Potential errors that can occur during the client's side of the handshake.
+#[derive(Debug, Error)]
+pub enum ClientHandshakeError {
+    #[error("Io; err={0}")]
+    Io(#[from] std::io::Error),
+    #[error("Timed out")]
+    TimedOut,
+    #[error("Protocol violation")]
+    ProtocolViolation,
+    #[error("Rejected; reason={0}")]
+    Rejected(String),
+    #[error("Rts alloc; err={0}")]
+    RtsAlloc(#[from] RtsAllocError),
+    #[error("Shaq; err={0}")]
+    Shaq(#[from] ShaqError),
+}
+
+/// An initialized scheduling session.
+pub struct AgaveSession {
+    pub flags: u16,
+    pub tpu_to_pack: AgaveTpuToPackSession,
+    pub progress_tracker: shaq::spsc::Producer<ProgressMessage>,
+    pub workers: Vec<AgaveWorkerSession>,
+}
+
+/// Shared memory objects for the tpu to pack worker.
+pub struct AgaveTpuToPackSession {
+    pub allocator: Allocator,
+    pub producer: shaq::spsc::Producer<TpuToPackMessage>,
+}
+
+/// Shared memory objects for a single banking worker.
+pub struct AgaveWorkerSession {
+    pub allocator: Allocator,
+    pub pack_to_worker: shaq::spsc::Consumer<PackToWorkerMessage>,
+    pub worker_to_pack: shaq::spsc::Producer<WorkerToPackMessage>,
+}
+
+/// Potential errors that can occur during the Agave side of the handshake.
+///
+/// # Note
+///
+/// These errors are stringified (up to 256 bytes then truncated) and sent to the client.
+#[derive(Debug, Error)]
+pub enum AgaveHandshakeError {
+    #[error("Io; err={0}")]
+    Io(#[from] std::io::Error),
+    #[error("Timeout")]
+    Timeout,
+    #[error("Close during handshake")]
+    EofDuringHandshake,
+    #[error("Version; server={server}; client={client}")]
+    Version { server: u64, client: u64 },
+    #[error("Worker count; count={0}")]
+    WorkerCount(usize),
+    #[error("Allocator handles; count={0}")]
+    AllocatorHandles(usize),
+    #[error("Rts alloc; err={0:?}")]
+    RtsAlloc(#[from] RtsAllocError),
+    #[error("Shaq; err={0:?}")]
+    Shaq(#[from] ShaqError),
+}

--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -69,7 +69,7 @@ pub struct ClientSession {
     pub workers: Vec<ClientWorkerSession>,
 }
 
-/// An per worker scheduling session.
+/// A per worker scheduling session.
 pub struct ClientWorkerSession {
     pub pack_to_worker: shaq::spsc::Producer<PackToWorkerMessage>,
     pub worker_to_pack: shaq::spsc::Consumer<WorkerToPackMessage>,

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -1,8 +1,6 @@
 use {
     crate::handshake::{
-        ClientLogon,
-        client::{ClientHandshakeError, connect},
-        server::{AgaveHandshakeError, Server},
+        AgaveHandshakeError, ClientHandshakeError, ClientLogon, client::connect, server::Server,
         shared::MAX_WORKERS,
     },
     agave_scheduler_bindings::{

--- a/scheduling-utils/src/lib.rs
+++ b/scheduling-utils/src/lib.rs
@@ -3,13 +3,8 @@
 pub mod error;
 pub mod thread_aware_account_locks;
 
-#[cfg(unix)]
 pub mod bridge;
-#[cfg(unix)]
 pub mod handshake;
-#[cfg(unix)]
 pub mod pubkeys_ptr;
-#[cfg(unix)]
 pub mod responses_region;
-#[cfg(unix)]
 pub mod transaction_ptr;


### PR DESCRIPTION
#### Problem

- Maintaining the legacy internal scheduler just for windows is going to be painful.

#### Summary of Changes

- Let's enable shmem on windows so we can run the `GreedyThroughputScheduler` internally.
