### PR TITLE
feature-set: add real feature key for commission_rate_in_basis_points

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1249,7 +1249,7 @@ pub mod enable_alt_bn128_g2_syscalls {
 }
 
 pub mod commission_rate_in_basis_points {
-    solana_pubkey::declare_id!("CommissionRate1nBasisPoints1111111111111111");
+    solana_pubkey::declare_id!("Eg7tXEwMZzS98xaZ1YHUbdRHsaYZiCsSaR6sKgxreoaj");
 }
 
 pub mod custom_commission_collector {


### PR DESCRIPTION
#### Problem
The feature gate for SIMD-0291: Commission Rate in Basis Points was not yet keyed.

#### Summary of Changes
Key it up.