### PR TITLE
feat(alpenglow): introduce `ParentMeta` in blockstore

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -37,7 +37,9 @@ use {
     solana_address_lookup_table_interface::state::AddressLookupTable,
     solana_clock::{DEFAULT_TICKS_PER_SECOND, Slot, UnixTimestamp},
     solana_entry::{
-        block_component::BlockComponent,
+        block_component::{
+            BlockComponent, BlockMarkerV1, VersionedBlockHeader, VersionedBlockMarker,
+        },
         entry::{Entry, MaxDataShredsLen, create_ticks},
     },
     solana_genesis_config::{DEFAULT_GENESIS_ARCHIVE, DEFAULT_GENESIS_FILE, GenesisConfig},
@@ -268,6 +270,7 @@ pub struct Blockstore {
     transaction_memos_cf: LedgerColumn<cf::TransactionMemos>,
     transaction_status_cf: LedgerColumn<cf::TransactionStatus>,
     transaction_status_index_cf: LedgerColumn<cf::TransactionStatusIndex>,
+    parent_meta_cf: LedgerColumn<cf::ParentMeta>,
 
     highest_primary_index_slot: RwLock<Option<Slot>>,
     max_root: AtomicU64,
@@ -315,6 +318,9 @@ struct ShredInsertionTracker<'a> {
     // In-memory map that maintains the dirty copy of the index meta.  It will
     // later be written to `cf::Index`
     index_working_set: HashMap<u64, IndexMetaWorkingSetEntry>,
+    // In-memory map that maintains the dirty copy of the parent meta.  It will
+    // later be written to `cf::ParentMeta`
+    parent_metas: HashMap<(BlockLocation, u64), WorkingEntry<ParentMeta>>,
     duplicate_shreds: Vec<PossibleDuplicateShred>,
     // Collection of the current blockstore writes which will be committed
     // atomically.
@@ -333,6 +339,7 @@ impl ShredInsertionTracker<'_> {
             merkle_root_metas: HashMap::new(),
             slot_meta_working_set: HashMap::new(),
             index_working_set: HashMap::new(),
+            parent_metas: HashMap::new(),
             duplicate_shreds: vec![],
             write_batch,
             index_meta_time_us: 0,
@@ -412,6 +419,7 @@ impl Blockstore {
         let transaction_memos_cf = db.column();
         let transaction_status_cf = db.column();
         let transaction_status_index_cf = db.column();
+        let parent_meta_cf = db.column();
 
         // Get max root or 0 if it doesn't exist
         let max_root = roots_cf
@@ -446,6 +454,7 @@ impl Blockstore {
             transaction_memos_cf,
             transaction_status_cf,
             transaction_status_index_cf,
+            parent_meta_cf,
             highest_primary_index_slot: RwLock::<Option<Slot>>::default(),
             new_shreds_signals: Mutex::default(),
             completed_slots_senders: Mutex::default(),
@@ -651,6 +660,39 @@ impl Blockstore {
 
     fn merkle_root_meta(&self, erasure_set: ErasureSetId) -> Result<Option<MerkleRootMeta>> {
         self.merkle_root_meta_cf.get(erasure_set.store_key())
+    }
+
+    /// Returns the ParentMeta for the specified slot and location.
+    pub fn get_parent_meta(
+        &self,
+        slot: Slot,
+        location: Option<BlockLocation>,
+    ) -> Result<Option<ParentMeta>> {
+        self.parent_meta_cf
+            .get((slot, location.unwrap_or(BlockLocation::Original)))
+    }
+
+    /// Parse BlockHeader from data shred payload
+    #[allow(dead_code)]
+    fn parse_block_header_from_data_payload(data: &[u8]) -> Option<(Slot, Hash)> {
+        // Try to deserialize as BlockComponent
+        let component: BlockComponent = wincode::deserialize(data).ok()?;
+
+        // If we were able to parse the component, it must be a block marker
+        let marker = component.as_marker()?;
+
+        // Check whether it's a BlockMarker with BlockHeader
+        match marker {
+            VersionedBlockMarker::V1(BlockMarkerV1::BlockHeader(header)) => {
+                // Extract the BlockHeader from the versioned wrapper
+                match header.inner() {
+                    VersionedBlockHeader::V1(update) => {
+                        Some((update.parent_slot, update.parent_block_id))
+                    }
+                }
+            }
+            _ => None,
+        }
     }
 
     /// Check whether the specified slot is an orphan slot which does not
@@ -1157,6 +1199,19 @@ impl Blockstore {
                 &mut shred_insertion_tracker.write_batch,
                 erasure_set.store_key(),
                 working_merkle_root_meta.as_ref(),
+            )?;
+        }
+
+        for (&(location, slot), working_parent_meta) in &shred_insertion_tracker.parent_metas {
+            if !working_parent_meta.should_write() {
+                // No need to rewrite the column
+                continue;
+            }
+
+            self.parent_meta_cf.put_in_batch(
+                &mut shred_insertion_tracker.write_batch,
+                (slot, location),
+                working_parent_meta.as_ref(),
             )?;
         }
 
@@ -1684,6 +1739,7 @@ impl Blockstore {
             slot_meta_working_set,
             just_inserted_shreds,
             merkle_root_metas,
+            parent_metas: _,
             duplicate_shreds,
             index_meta_time_us,
             erasure_metas,

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -274,6 +274,8 @@ impl Blockstore {
             .delete_range_in_batch(write_batch, from_slot, to_slot)?;
         self.merkle_root_meta_cf
             .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+        self.parent_meta_cf
+            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
 
         match purge_type {
             PurgeType::Exact => self.purge_special_columns_exact(write_batch, from_slot, to_slot),
@@ -312,7 +314,8 @@ impl Blockstore {
         self.optimistic_slots_cf
             .delete_file_in_range(from_slot, to_slot)?;
         self.merkle_root_meta_cf
-            .delete_file_in_range(from_slot, to_slot)
+            .delete_file_in_range(from_slot, to_slot)?;
+        self.parent_meta_cf.delete_file_in_range(from_slot, to_slot)
     }
 
     /// Returns true if the special columns, TransactionStatus and

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -2,11 +2,12 @@
 use {
     crate::{
         blockstore::error::Result,
-        blockstore_meta::{self, PerfSample},
+        blockstore_meta::{self, BlockLocation, PerfSample},
     },
     bincode::Options as BincodeOptions,
     serde::{Serialize, de::DeserializeOwned},
     solana_clock::{Slot, UnixTimestamp},
+    solana_hash::{HASH_BYTES, Hash},
     solana_pubkey::{PUBKEY_BYTES, Pubkey},
     solana_signature::{SIGNATURE_BYTES, Signature},
     solana_storage_proto::convert::generated,
@@ -208,6 +209,16 @@ pub mod columns {
     /// * index type: `crate::shred::ErasureSetId` `(Slot, fec_set_index: u32)`
     /// * value type: [`blockstore_meta::MerkleRootMeta`]`
     pub struct MerkleRootMeta;
+
+    #[derive(Debug)]
+    /// The parent metadata column
+    ///
+    /// This column stores metadata about parent blocks for each slot and block location. We update
+    /// this column on receiving BlockHeader and UpdateParent BlockComponents.
+    ///
+    /// * index type: `(Slot, BlockLocation)`
+    /// * value type: [`blockstore_meta::ParentMeta`]
+    pub struct ParentMeta;
 }
 
 macro_rules! convert_column_index_to_key_bytes {
@@ -815,4 +826,53 @@ impl ColumnName for columns::MerkleRootMeta {
 }
 impl TypedColumn for columns::MerkleRootMeta {
     type Type = blockstore_meta::MerkleRootMeta;
+}
+
+impl Column for columns::ParentMeta {
+    type Index = (Slot, BlockLocation);
+    // Key size: Slot (8 bytes) + Hash (32 bytes)
+    // When BlockLocation::Original, the hash is Hash::default().
+    type Key = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+
+    #[inline]
+    fn key((slot, location): &Self::Index) -> Self::Key {
+        let mut key = [0u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+        key[..8].copy_from_slice(&slot.to_le_bytes());
+
+        let hash_bytes = match location {
+            BlockLocation::Original => &Hash::default().to_bytes(),
+            BlockLocation::Alternate { block_id } => &block_id.to_bytes(),
+        };
+
+        key[8..40].copy_from_slice(hash_bytes);
+
+        key
+    }
+
+    fn index(key: &[u8]) -> Self::Index {
+        let slot = Slot::from_le_bytes(key[0..8].try_into().unwrap());
+        let hash = Hash::new_from_array(key[8..40].try_into().unwrap());
+        let location = match hash == Hash::default() {
+            true => BlockLocation::Original,
+            false => BlockLocation::Alternate { block_id: hash },
+        };
+
+        (slot, location)
+    }
+
+    fn as_index(slot: Slot) -> Self::Index {
+        (slot, BlockLocation::Original)
+    }
+
+    fn slot((slot, _location): Self::Index) -> Slot {
+        slot
+    }
+}
+
+impl ColumnName for columns::ParentMeta {
+    const NAME: &'static str = "parent_meta";
+}
+
+impl TypedColumn for columns::ParentMeta {
+    type Type = blockstore_meta::ParentMeta;
 }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -193,6 +193,7 @@ impl Rocks {
             new_cf_descriptor::<columns::BlockHeight>(options, oldest_slot),
             new_cf_descriptor::<columns::OptimisticSlots>(options, oldest_slot),
             new_cf_descriptor::<columns::MerkleRootMeta>(options, oldest_slot),
+            new_cf_descriptor::<columns::ParentMeta>(options, oldest_slot),
         ];
 
         // When remaining columns are optional we can just return immediately here.
@@ -237,7 +238,7 @@ impl Rocks {
         cf_descriptors
     }
 
-    const fn columns() -> [&'static str; 20] {
+    const fn columns() -> [&'static str; 21] {
         [
             columns::ErasureMeta::NAME,
             columns::DeadSlots::NAME,
@@ -259,6 +260,7 @@ impl Rocks {
             columns::BlockHeight::NAME,
             columns::OptimisticSlots::NAME,
             columns::MerkleRootMeta::NAME,
+            columns::ParentMeta::NAME,
         ]
     }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -7,7 +7,10 @@ use {
     serde::{Deserialize, Deserializer, Serialize, Serializer},
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
-    std::ops::{Range, RangeBounds},
+    std::{
+        fmt::Display,
+        ops::{Range, RangeBounds},
+    },
 };
 
 bitflags! {
@@ -631,6 +634,29 @@ impl OptimisticSlotMetaVersioned {
             OptimisticSlotMetaVersioned::V0(meta) => meta.timestamp,
         }
     }
+}
+
+/// Which column an associated block currently resides
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BlockLocation {
+    Original,
+    Alternate { block_id: Hash },
+}
+
+impl Display for BlockLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BlockLocation::Original => write!(f, "Original"),
+            BlockLocation::Alternate { block_id } => write!(f, "Alternate({block_id})"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ParentMeta {
+    pub parent_slot: Slot,
+    pub parent_block_id: Hash,
+    pub replay_fec_set_index: u32,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is a partial upstream of https://github.com/anza-xyz/alpenglow/pull/590.

#### Problem and Summary of Changes
Introduces a new `ParentMeta` column family in blockstore to track parent-related metadata during shred ingestion. This is crucial to Alpenglow's fast leader handover, where validators need to know a block's parent slot, parent block ID, and replay FEC set index at shred ingest time rather than during replay.

In Alpenglow, fast leader handover requires validators to begin preparing for their leader slot before the parent block is finalized. To support this, blockstore needs to persist parent metadata extracted from block headers as shreds arrive.

Note: a future PR will extend this to also handle `UpdateParent` markers, which act as a "second header" during leader transitions.