### PR TITLE
ledger-tool: remove rent-exempt reserve inflation trace

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2889,7 +2889,7 @@ fn main() {
                             voter_owner: Pubkey,
                             current_effective_stake: u64,
                             total_stake: u64,
-                            rent_exempt_reserve: u64,
+                            prior_total_lamports: u64,
                             points: Vec<PointDetail>,
                             base_rewards: u64,
                             commission_bps: u16,
@@ -2960,8 +2960,8 @@ fn main() {
                                 InflationPointCalculationEvent::CommissionBps(commission_bps) => {
                                     detail.commission_bps = *commission_bps;
                                 }
-                                InflationPointCalculationEvent::RentExemptReserve(reserve) => {
-                                    detail.rent_exempt_reserve = *reserve;
+                                InflationPointCalculationEvent::PriorTotalLamports(lamports) => {
+                                    detail.prior_total_lamports = *lamports;
                                 }
                                 InflationPointCalculationEvent::CreditsObserved(
                                     old_credits_observed,
@@ -3118,7 +3118,7 @@ fn main() {
                                         delegation_owner: String,
                                         effective_stake: String,
                                         delegated_stake: String,
-                                        rent_exempt_reserve: String,
+                                        prior_total_lamports: String,
                                         activation_epoch: String,
                                         deactivation_epoch: String,
                                         earned_epochs: String,
@@ -3178,8 +3178,8 @@ fn main() {
                                             delegated_stake: format_or_na(
                                                 detail.map(|d| d.total_stake),
                                             ),
-                                            rent_exempt_reserve: format_or_na(
-                                                detail.map(|d| d.rent_exempt_reserve),
+                                            prior_total_lamports: format_or_na(
+                                                detail.map(|d| d.prior_total_lamports),
                                             ),
                                             activation_epoch: format_or_na(detail.map(|d| {
                                                 if d.activation_epoch < Epoch::MAX {

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -497,6 +497,7 @@ impl Bank {
             reward_calc_tracer,
             new_rate_activation_epoch,
             commission_rate_in_basis_points,
+            stake_account.lamports(),
         ) {
             Ok((stake_reward, commission_lamports, stake)) => {
                 let stake_reward = PartitionedStakeReward {

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -28,6 +28,7 @@ struct CalculatedStakeRewards {
 /// * Stakers reward
 /// * Voters reward
 /// * Updated stake information
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn redeem_rewards(
     rewarded_epoch: Epoch,
     stake_state: &StakeStateV2,
@@ -38,8 +39,9 @@ pub(crate) fn redeem_rewards(
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
     commission_rate_in_basis_points: bool,
+    stake_account_lamports_for_trace: u64,
 ) -> Result<(u64, u64, Stake), InstructionError> {
-    if let StakeStateV2::Stake(meta, stake, _stake_flags) = stake_state {
+    if let StakeStateV2::Stake(_meta, stake, _stake_flags) = stake_state {
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
             inflation_point_calc_tracer(
                 &InflationPointCalculationEvent::EffectiveStakeAtRewardedEpoch(stake.stake(
@@ -48,8 +50,8 @@ pub(crate) fn redeem_rewards(
                     new_rate_activation_epoch,
                 )),
             );
-            inflation_point_calc_tracer(&InflationPointCalculationEvent::RentExemptReserve(
-                meta.rent_exempt_reserve,
+            inflation_point_calc_tracer(&InflationPointCalculationEvent::PriorTotalLamports(
+                stake_account_lamports_for_trace,
             ));
             // Choose which trace to emit based on the `commission_rate_in_basis_points` feature.
             if commission_rate_in_basis_points {

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -34,7 +34,7 @@ pub enum InflationPointCalculationEvent {
     CalculatedPoints(u64, u128, u128, u128),
     SplitRewards(u64, u64, u64, PointValue),
     EffectiveStakeAtRewardedEpoch(u64),
-    RentExemptReserve(u64),
+    PriorTotalLamports(u64),
     Delegation(Delegation, Pubkey),
     /// Commission as a percentage (0-100).
     Commission(u8),


### PR DESCRIPTION
#### Problem
when rent is allowed to fluctuate, `Meta.rent_exempt_reserve` will be meaningless, and possibly even dangerous depending how it is used. however, hooks inside inflation calculations report this value upstream to ledger-tool

#### Summary of Changes
replace it with total account lamports prior to calculation/distribution. this is likely at least no less helpful than before. if rent is _really_ required for someones flow, we could calculate it in runtime, but it doesnt seem necessary