### PR TITLE
runtime: add test coverage for SIMD-0185 and SIMD-0291

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10173,6 +10173,7 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "percentage",
+ "proptest",
  "qualifier_attr",
  "rand 0.9.2",
  "rayon",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -199,6 +199,7 @@ agave-transaction-view = { workspace = true }
 bitvec = { workspace = true }
 libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }
+proptest = { workspace = true }
 solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
 solana-builtins = { workspace = true, features = ["dev-context-only-utils"] }
 solana-instruction-error = { workspace = true }

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -276,6 +276,7 @@ mod tests {
     use {
         self::points::null_tracer,
         super::*,
+        proptest::prelude::*,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_pubkey::Pubkey,
         solana_stake_interface::state::Delegation,
@@ -845,5 +846,67 @@ mod tests {
                 true
             )
         ); // 1-lamport truncation
+    }
+
+    proptest! {
+        #[test]
+        fn test_commission_split_properties(
+            commission_bps in 0..=u16::MAX,
+            rewards in 0..=u64::MAX,
+        ) {
+            let (voter, staker, was_split) = commission_split(commission_bps, rewards);
+
+            // Invariant 1: No overflow — voter + staker never exceeds rewards.
+            prop_assert!(voter + staker <= rewards);
+
+            // Invariant 2: At most 1 lamport lost to truncation.
+            prop_assert!(rewards - voter - staker <= 1);
+
+            // Invariant 3: was_split is false only at the 0% and 100% boundaries.
+            let effective_bps = commission_bps.min(10_000);
+            if effective_bps == 0 || effective_bps == 10_000 {
+                prop_assert!(!was_split);
+            } else {
+                prop_assert!(was_split);
+            }
+
+            // Invariant 4: Boundary — 0% commission gives everything to staker.
+            if effective_bps == 0 {
+                prop_assert_eq!(voter, 0);
+                prop_assert_eq!(staker, rewards);
+            }
+
+            // Invariant 5: Boundary — 100% commission gives everything to voter.
+            if effective_bps == 10_000 {
+                prop_assert_eq!(voter, rewards);
+                prop_assert_eq!(staker, 0);
+            }
+
+            // Invariant 6: Clamping — values above 10,000 bps behave as 10,000.
+            if commission_bps > 10_000 {
+                let (clamped_voter, clamped_staker, clamped_ws) =
+                    commission_split(10_000, rewards);
+                prop_assert_eq!(voter, clamped_voter);
+                prop_assert_eq!(staker, clamped_staker);
+                prop_assert_eq!(was_split, clamped_ws);
+            }
+
+            // Invariant 7: Monotonicity — higher commission means voter >= what
+            // they'd get with a lower commission (for the same rewards).
+            if commission_bps > 0 {
+                let lower_bps = commission_bps - 1;
+                let (lower_voter, _, _) = commission_split(lower_bps, rewards);
+                prop_assert!(voter >= lower_voter);
+            }
+
+            // Invariant 8: Exact split when bps divides evenly.
+            // voter == rewards * effective_bps / 10_000 (using u128 math).
+            let expected_voter =
+                (u128::from(rewards) * u128::from(effective_bps) / 10_000) as u64;
+            let expected_staker =
+                (u128::from(rewards) * u128::from(10_000 - effective_bps) / 10_000) as u64;
+            prop_assert_eq!(voter, expected_voter);
+            prop_assert_eq!(staker, expected_staker);
+        }
     }
 }

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -743,36 +743,107 @@ mod tests {
     fn test_commission_split_bps() {
         // 0% commission
         assert_eq!(commission_split(0, 1), (0, 1, false));
+        assert_eq!(commission_split(0, 10), (0, 10, false));
+        assert_eq!(commission_split(0, 100), (0, 100, false));
+        assert_eq!(commission_split(0, 1_000), (0, 1_000, false));
+        assert_eq!(commission_split(0, u64::MAX), (0, u64::MAX, false));
 
         // 100% commission (10,000 bps)
         assert_eq!(commission_split(10_000, 1), (1, 0, false));
+        assert_eq!(commission_split(10_000, 10), (10, 0, false));
+        assert_eq!(commission_split(10_000, 100), (100, 0, false));
+        assert_eq!(commission_split(10_000, 1_000), (1_000, 0, false));
+        assert_eq!(commission_split(10_000, u64::MAX), (u64::MAX, 0, false));
 
         // Values > 10,000 bps are capped at 100%
         assert_eq!(commission_split(u16::MAX, 1), (1, 0, false));
+        assert_eq!(commission_split(u16::MAX, 10), (10, 0, false));
+        assert_eq!(commission_split(u16::MAX, 100), (100, 0, false));
+        assert_eq!(commission_split(u16::MAX, 1_000), (1_000, 0, false));
+        assert_eq!(commission_split(u16::MAX, u64::MAX), (u64::MAX, 0, false));
 
-        // 99% commission (9,900 bps) - voter gets floored 99% of 10 = 9
-        assert_eq!(commission_split(9_900, 10), (9, 0, true));
+        // 99% commission (9,900 bps)
+        assert_eq!(commission_split(9_900, 1), (0, 0, true)); // 1-lamport truncation
+        assert_eq!(commission_split(9_900, 10), (9, 0, true)); // 1-lamport truncation
+        assert_eq!(commission_split(9_900, 100), (99, 1, true));
+        assert_eq!(commission_split(9_900, 1_000), (990, 10, true));
+        assert_eq!(
+            commission_split(9_900, u64::MAX),
+            (
+                (u64::MAX as u128 * 9_900 / 10_000) as u64,
+                (u64::MAX as u128 * 100 / 10_000) as u64,
+                true
+            )
+        ); // 1-lamport truncation
 
-        // 1% commission (100 bps) - voter gets floored 1% of 10 = 0
-        assert_eq!(commission_split(100, 10), (0, 9, true));
+        // 99.99% commission (9,999 bps)
+        assert_eq!(commission_split(9_999, 1), (0, 0, true)); // 1-lamport truncation
+        assert_eq!(commission_split(9_999, 10), (9, 0, true)); // 1-lamport truncation
+        assert_eq!(commission_split(9_999, 100), (99, 0, true)); // 1-lamport truncation
+        assert_eq!(commission_split(9_999, 1_000), (999, 0, true)); // 1-lamport truncation
+        assert_eq!(
+            commission_split(9_999, u64::MAX),
+            (
+                (u64::MAX as u128 * 9_999 / 10_000) as u64,
+                (u64::MAX as u128 / 10_000) as u64,
+                true
+            )
+        ); // 1-lamport truncation
+
+        // 1% commission (100 bps)
+        assert_eq!(commission_split(100, 1), (0, 0, true)); // 1-lamport truncation
+        assert_eq!(commission_split(100, 10), (0, 9, true)); // 1-lamport truncation
+        assert_eq!(commission_split(100, 100), (1, 99, true));
+        assert_eq!(commission_split(100, 1_000), (10, 990, true));
+        assert_eq!(
+            commission_split(100, u64::MAX),
+            (
+                (u64::MAX as u128 * 100 / 10_000) as u64,
+                (u64::MAX as u128 * 9_900 / 10_000) as u64,
+                true
+            )
+        ); // 1-lamport truncation
 
         // 50% commission (5,000 bps)
-        let (voter_portion, staker_portion, was_split) = commission_split(5_000, 10);
-        assert_eq!((voter_portion, staker_portion, was_split), (5, 5, true));
-
-        // Test fractional bps: 12.34% = 1,234 bps
-        // voter gets 1234/10000 * 1000 = 123.4 -> 123
-        // staker gets 8766/10000 * 1000 = 876.6 -> 876
-        let (voter_portion, staker_portion, was_split) = commission_split(1_234, 1_000);
-        assert_eq!((voter_portion, staker_portion, was_split), (123, 876, true));
-
-        // Test another fractional: 33.33% = 3,333 bps on 10,000 rewards
-        // voter gets 3333/10000 * 10000 = 3333
-        // staker gets 6667/10000 * 10000 = 6667
-        let (voter_portion, staker_portion, was_split) = commission_split(3_333, 10_000);
+        assert_eq!(commission_split(5_000, 1), (0, 0, true)); // 1-lamport truncation
+        assert_eq!(commission_split(5_000, 10), (5, 5, true));
+        assert_eq!(commission_split(5_000, 100), (50, 50, true));
+        assert_eq!(commission_split(5_000, 1_000), (500, 500, true));
         assert_eq!(
-            (voter_portion, staker_portion, was_split),
-            (3_333, 6_667, true)
-        );
+            commission_split(5_000, u64::MAX),
+            (
+                (u64::MAX as u128 * 5_000 / 10_000) as u64,
+                (u64::MAX as u128 * 5_000 / 10_000) as u64,
+                true
+            )
+        ); // 1-lamport truncation
+
+        // 12.34% commission (1,234 bps)
+        assert_eq!(commission_split(1_234, 1), (0, 0, true)); // 1-lamport truncation
+        assert_eq!(commission_split(1_234, 10), (1, 8, true)); // 1-lamport truncation
+        assert_eq!(commission_split(1_234, 1_000), (123, 876, true)); // 1-lamport truncation
+        assert_eq!(commission_split(1_234, 10_000), (1_234, 8_766, true));
+        assert_eq!(
+            commission_split(1_234, u64::MAX),
+            (
+                (u64::MAX as u128 * 1_234 / 10_000) as u64,
+                (u64::MAX as u128 * 8_766 / 10_000) as u64,
+                true
+            )
+        ); // 1-lamport truncation
+
+        // 33.33% commission (3,333 bps)
+        assert_eq!(commission_split(3_333, 1), (0, 0, true)); // 1-lamport truncation
+        assert_eq!(commission_split(3_333, 10), (3, 6, true)); // 1-lamport truncation
+        assert_eq!(commission_split(3_333, 1_000), (333, 666, true)); // 1-lamport truncation
+        assert_eq!(commission_split(3_333, 10_000), (3_333, 6_667, true));
+        assert_eq!(
+            commission_split(3_333, u64::MAX),
+            (
+                (u64::MAX as u128 * 3_333 / 10_000) as u64,
+                (u64::MAX as u128 * 6_667 / 10_000) as u64,
+                true
+            )
+        ); // 1-lamport truncation
     }
 }

--- a/runtime/tests/vote_account.rs
+++ b/runtime/tests/vote_account.rs
@@ -552,3 +552,100 @@ fn test_clone_and_filter_for_vat_empty_accounts() {
         vote_accounts.clone_and_filter_for_vat(current_limit - 500, MIN_STAKE_FOR_STAKED_ACCOUNT);
     assert_eq!(filtered.len(), 0);
 }
+
+#[test]
+fn test_vote_account_trailing_bytes_ignored() {
+    // Trailing bytes (zero and garbage) must not affect VoteAccount
+    // accessor results.
+    let mut rng = rand::rng();
+    let base_account = new_rand_vote_account(&mut rng, None, true);
+    let base_data = base_account.data().to_vec();
+
+    // With trailing zeros.
+    let mut data_zero = base_data.clone();
+    data_zero.extend_from_slice(&[0x00; 42]);
+    let mut acct_zero = AccountSharedData::new(
+        base_account.lamports(),
+        data_zero.len(),
+        base_account.owner(),
+    );
+    acct_zero.set_data_from_slice(&data_zero);
+    let va_zero = VoteAccount::try_from(acct_zero).unwrap();
+
+    // With trailing garbage.
+    let mut data_garbage = base_data.clone();
+    data_garbage.extend_from_slice(&[0xFF; 42]);
+    let mut acct_garbage = AccountSharedData::new(
+        base_account.lamports(),
+        data_garbage.len(),
+        base_account.owner(),
+    );
+    acct_garbage.set_data_from_slice(&data_garbage);
+    let va_garbage = VoteAccount::try_from(acct_garbage).unwrap();
+
+    // Both should return identical accessor values.
+    assert_eq!(va_zero.node_pubkey(), va_garbage.node_pubkey());
+}
+
+#[test]
+fn test_vote_account_v3_vs_v4_accessor_parity() {
+    // Same logical vote state in V3 and V4 should produce equivalent
+    // VoteAccount accessor results.
+    let node_pubkey = Pubkey::new_unique();
+    let authorized_voter = Pubkey::new_unique();
+    let authorized_withdrawer = Pubkey::new_unique();
+    let commission = 42u8;
+
+    // V3
+    let v3_state = solana_vote_interface::state::VoteStateV3::new(
+        &VoteInit {
+            node_pubkey,
+            authorized_voter,
+            authorized_withdrawer,
+            commission,
+        },
+        &solana_clock::Clock::default(),
+    );
+    let v3_versioned = VoteStateVersions::V3(Box::new(v3_state));
+    let v3_bytes = bincode::serialize(&v3_versioned).unwrap();
+    let mut v3_account = AccountSharedData::new(
+        10_000_000,
+        v3_bytes.len(),
+        &solana_vote_interface::program::id(),
+    );
+    v3_account.set_data_from_slice(&v3_bytes);
+    let va_v3 = VoteAccount::try_from(v3_account).unwrap();
+
+    // V4 (equivalent state via migration defaults).
+    let v4_state = VoteStateV4 {
+        node_pubkey,
+        authorized_voters: AuthorizedVoters::new(0, authorized_voter),
+        authorized_withdrawer,
+        inflation_rewards_commission_bps: commission as u16 * 100,
+        ..VoteStateV4::default()
+    };
+    let v4_versioned = VoteStateVersions::new_v4(v4_state);
+    let v4_bytes = bincode::serialize(&v4_versioned).unwrap();
+    let mut v4_account = AccountSharedData::new(
+        10_000_000,
+        v4_bytes.len(),
+        &solana_vote_interface::program::id(),
+    );
+    v4_account.set_data_from_slice(&v4_bytes);
+    let va_v4 = VoteAccount::try_from(v4_account).unwrap();
+
+    // Accessors should return equivalent values.
+    assert_eq!(va_v3.node_pubkey(), va_v4.node_pubkey());
+
+    let view_v3 = va_v3.vote_state_view();
+    let view_v4 = va_v4.vote_state_view();
+    assert_eq!(view_v3.commission(), view_v4.commission());
+    assert_eq!(view_v3.root_slot(), view_v4.root_slot());
+    assert_eq!(view_v3.last_voted_slot(), view_v4.last_voted_slot());
+    assert_eq!(view_v3.last_timestamp(), view_v4.last_timestamp());
+    assert_eq!(view_v3.num_epoch_credits(), view_v4.num_epoch_credits());
+    assert_eq!(
+        view_v3.get_authorized_voter(0),
+        view_v4.get_authorized_voter(0)
+    );
+}


### PR DESCRIPTION
#### Problem
The inflation rewards calculation as well as the runtime's use of the `vote` crate to deserialize vote state (v3 or v4) is a bit under-tested.

#### Summary of Changes
Test the code. Also adds a prop test for commission_split!