### PR TITLE
alpenglow: upstream alternate shred blockstore columns

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1233,21 +1233,25 @@ impl Blockstore {
         location: BlockLocation,
         erasure_set: ErasureSetId,
         merkle_root_metas: &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
-    ) -> Option<Hash> {
+    ) -> Result<Option<Hash>> {
+        let err = || {
+            BlockstoreError::MissingMerkleRoot(
+                erasure_set.slot(),
+                erasure_set.fec_set_index() as u64,
+            )
+        };
         // First check the tracker
         if let Some(working_entry) = merkle_root_metas.get(&(location, erasure_set)) {
-            return Some(
-                working_entry
-                    .as_ref()
-                    .merkle_root()
-                    .expect("No more legacy shreds"),
-            );
+            return Ok(Some(working_entry.as_ref().merkle_root().ok_or_else(err)?));
         }
 
         // Fall back to the db
         self.merkle_root_meta_from_location(erasure_set, location)
-            .expect("Blockstore operations must succeed")
-            .map(|meta| meta.merkle_root().expect("No more legacy shreds"))
+            .and_then(|maybe_meta| {
+                maybe_meta
+                    .map(|meta| meta.merkle_root().ok_or_else(err))
+                    .transpose()
+            })
     }
 
     fn commit_updates_to_write_batch(
@@ -2569,7 +2573,7 @@ impl Blockstore {
         let Some(index) = self.get_index_from_location(slot, location)? else {
             return Ok(Vec::new());
         };
-        let num_shreds = index.data().num_shreds();
+        let num_shreds = index.data().range(start_index..).count();
         let mut shreds = Vec::with_capacity(num_shreds);
 
         let shred_bytes_iter: Box<dyn Iterator<Item = Box<[u8]>>> = match location {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -268,6 +268,10 @@ pub struct Blockstore {
     transaction_memos_cf: LedgerColumn<cf::TransactionMemos>,
     transaction_status_cf: LedgerColumn<cf::TransactionStatus>,
     transaction_status_index_cf: LedgerColumn<cf::TransactionStatusIndex>,
+    alt_meta_cf: LedgerColumn<cf::AlternateSlotMeta>,
+    alt_index_cf: LedgerColumn<cf::AlternateIndex>,
+    alt_data_shred_cf: LedgerColumn<cf::AlternateShredData>,
+    alt_merkle_root_meta_cf: LedgerColumn<cf::AlternateMerkleRootMeta>,
 
     highest_primary_index_slot: RwLock<Option<Slot>>,
     max_root: AtomicU64,
@@ -412,6 +416,10 @@ impl Blockstore {
         let transaction_memos_cf = db.column();
         let transaction_status_cf = db.column();
         let transaction_status_index_cf = db.column();
+        let alt_meta_cf = db.column();
+        let alt_index_cf = db.column();
+        let alt_data_shred_cf = db.column();
+        let alt_merkle_root_meta_cf = db.column();
 
         // Get max root or 0 if it doesn't exist
         let max_root = roots_cf
@@ -446,6 +454,11 @@ impl Blockstore {
             transaction_memos_cf,
             transaction_status_cf,
             transaction_status_index_cf,
+            alt_meta_cf,
+            alt_index_cf,
+            alt_data_shred_cf,
+            alt_merkle_root_meta_cf,
+
             highest_primary_index_slot: RwLock::<Option<Slot>>::default(),
             new_shreds_signals: Mutex::default(),
             completed_slots_senders: Mutex::default(),
@@ -558,6 +571,54 @@ impl Blockstore {
         self.meta_cf.get(slot)
     }
 
+    /// Returns the SlotMeta of the specified slot from the specified location
+    pub fn meta_from_location(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+    ) -> Result<Option<SlotMeta>> {
+        match location {
+            BlockLocation::Original => self.meta_cf.get(slot),
+            BlockLocation::Alternate { block_id } => self.alt_meta_cf.get((slot, block_id)),
+        }
+    }
+
+    /// Puts the SlotMeta of the specified slot in the column for the specified location
+    #[allow(dead_code)]
+    fn put_meta_in_batch(
+        &self,
+        write_batch: &mut WriteBatch,
+        slot: Slot,
+        location: BlockLocation,
+        meta: &SlotMeta,
+    ) -> Result<()> {
+        match location {
+            BlockLocation::Original => self.meta_cf.put_in_batch(write_batch, slot, meta),
+            BlockLocation::Alternate { block_id } => {
+                self.alt_meta_cf
+                    .put_in_batch(write_batch, (slot, block_id), meta)
+            }
+        }
+    }
+
+    /// Inserts a shred index into the alternate index for testing purposes.
+    /// This simulates receiving a data shred for an alternate block.
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn insert_shred_index_for_alternate_block(
+        &self,
+        slot: Slot,
+        block_id: Hash,
+        shred_index: u32,
+    ) -> Result<()> {
+        use crate::blockstore_meta::Index;
+        let mut index = self
+            .alt_index_cf
+            .get((slot, block_id))?
+            .unwrap_or_else(|| Index::new(slot));
+        index.data_mut().insert(shred_index as u64);
+        self.alt_index_cf.put((slot, block_id), &index)
+    }
+
     /// Returns true if the specified slot is full.
     pub fn is_full(&self, slot: Slot) -> bool {
         if let Ok(Some(meta)) = self.meta_cf.get(slot) {
@@ -651,6 +712,46 @@ impl Blockstore {
 
     fn merkle_root_meta(&self, erasure_set: ErasureSetId) -> Result<Option<MerkleRootMeta>> {
         self.merkle_root_meta_cf.get(erasure_set.store_key())
+    }
+
+    #[allow(dead_code)]
+    fn merkle_root_meta_from_location(
+        &self,
+        erasure_set: ErasureSetId,
+        location: BlockLocation,
+    ) -> Result<Option<MerkleRootMeta>> {
+        match location {
+            BlockLocation::Original => self.merkle_root_meta_cf.get(erasure_set.store_key()),
+            BlockLocation::Alternate { block_id } => {
+                let (slot, fec_set_index) = erasure_set.store_key();
+                self.alt_merkle_root_meta_cf
+                    .get((slot, fec_set_index, block_id))
+            }
+        }
+    }
+
+    /// Puts the MerkleRootMeta of the specified erasure set in the column for the specified location
+    #[allow(dead_code)]
+    fn put_merkle_root_meta_in_batch(
+        &self,
+        write_batch: &mut WriteBatch,
+        erasure_set: ErasureSetId,
+        location: BlockLocation,
+        merkle_root_meta: &MerkleRootMeta,
+    ) -> Result<()> {
+        let (slot, fec_set_index) = erasure_set.store_key();
+        match location {
+            BlockLocation::Original => self.merkle_root_meta_cf.put_in_batch(
+                write_batch,
+                (slot, fec_set_index),
+                merkle_root_meta,
+            ),
+            BlockLocation::Alternate { block_id } => self.alt_merkle_root_meta_cf.put_in_batch(
+                write_batch,
+                (slot, fec_set_index, block_id),
+                merkle_root_meta,
+            ),
+        }
     }
 
     /// Check whether the specified slot is an orphan slot which does not
@@ -880,6 +981,10 @@ impl Blockstore {
         self.bank_hash_cf.submit_rocksdb_cf_metrics();
         self.optimistic_slots_cf.submit_rocksdb_cf_metrics();
         self.merkle_root_meta_cf.submit_rocksdb_cf_metrics();
+        self.alt_meta_cf.submit_rocksdb_cf_metrics();
+        self.alt_index_cf.submit_rocksdb_cf_metrics();
+        self.alt_data_shred_cf.submit_rocksdb_cf_metrics();
+        self.alt_merkle_root_meta_cf.submit_rocksdb_cf_metrics();
     }
 
     /// Attempts to insert shreds into blockstore and updates relevant metrics
@@ -1119,6 +1224,30 @@ impl Blockstore {
                 &mut shred_insertion_tracker.duplicate_shreds,
             );
         }
+    }
+
+    /// Gets the merkle root from the tracker if available, otherwise from the db.
+    #[allow(dead_code)]
+    fn get_merkle_root_from_tracker_or_db(
+        &self,
+        location: BlockLocation,
+        erasure_set: ErasureSetId,
+        merkle_root_metas: &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
+    ) -> Option<Hash> {
+        // First check the tracker
+        if let Some(working_entry) = merkle_root_metas.get(&(location, erasure_set)) {
+            return Some(
+                working_entry
+                    .as_ref()
+                    .merkle_root()
+                    .expect("No more legacy shreds"),
+            );
+        }
+
+        // Fall back to the db
+        self.merkle_root_meta_from_location(erasure_set, location)
+            .expect("Blockstore operations must succeed")
+            .map(|meta| meta.merkle_root().expect("No more legacy shreds"))
     }
 
     fn commit_updates_to_write_batch(
@@ -2356,16 +2485,7 @@ impl Blockstore {
     }
 
     pub fn get_data_shreds_for_slot(&self, slot: Slot, start_index: u64) -> Result<Vec<Shred>> {
-        self.slot_data_iterator(slot, start_index)
-            .expect("blockstore couldn't fetch iterator")
-            .map(|(_, bytes)| {
-                Shred::new_from_serialized_shred(Vec::from(bytes)).map_err(|err| {
-                    BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
-                        format!("Could not reconstruct shred from shred payload: {err:?}"),
-                    )))
-                })
-            })
-            .collect()
+        self.get_data_shreds_for_slot_from_location(slot, start_index, BlockLocation::Original)
     }
 
     #[cfg(test)]
@@ -2421,6 +2541,97 @@ impl Blockstore {
             .expect("blockstore couldn't fetch iterator")
             .map(|(_, bytes)| Shred::new_from_serialized_shred(Vec::from(bytes)))
             .collect()
+    }
+
+    pub fn get_data_shred_from_location(
+        &self,
+        slot: Slot,
+        index: u64,
+        location: BlockLocation,
+    ) -> Result<Option<Vec<u8>>> {
+        match location {
+            BlockLocation::Original => self.get_data_shred(slot, index),
+            BlockLocation::Alternate { block_id } => {
+                self.alt_data_shred_cf.get_bytes((slot, index, block_id))
+            }
+        }
+    }
+
+    /// Gets all data shreds for a slot from the specified location.
+    /// Returns shreds in index order starting from `start_index`.
+    pub fn get_data_shreds_for_slot_from_location(
+        &self,
+        slot: Slot,
+        start_index: u64,
+        location: BlockLocation,
+    ) -> Result<Vec<Shred>> {
+        // Get the index to determine capacity for pre-allocation
+        let Some(index) = self.get_index_from_location(slot, location)? else {
+            return Ok(Vec::new());
+        };
+        let num_shreds = index.data().num_shreds();
+        let mut shreds = Vec::with_capacity(num_shreds);
+
+        let shred_bytes_iter: Box<dyn Iterator<Item = Box<[u8]>>> = match location {
+            BlockLocation::Original => {
+                let iter = self
+                    .data_shred_cf
+                    .iter(IteratorMode::From(
+                        (slot, start_index),
+                        IteratorDirection::Forward,
+                    ))?
+                    .take_while(move |((shred_slot, _), _)| *shred_slot == slot)
+                    .map(|(_, bytes)| bytes);
+                Box::new(iter)
+            }
+            BlockLocation::Alternate { block_id } => {
+                let iter = self
+                    .alt_data_shred_cf
+                    .iter(IteratorMode::From(
+                        (slot, start_index, block_id),
+                        IteratorDirection::Forward,
+                    ))?
+                    .take_while(move |((shred_slot, _, shred_block_id), _)| {
+                        *shred_slot == slot && *shred_block_id == block_id
+                    })
+                    .map(|(_, bytes)| bytes);
+                Box::new(iter)
+            }
+        };
+
+        for bytes in shred_bytes_iter {
+            let shred = Shred::new_from_serialized_shred(Vec::from(bytes)).map_err(|err| {
+                BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(format!(
+                    "Could not reconstruct shred from shred payload: {err:?}"
+                ))))
+            })?;
+            shreds.push(shred);
+        }
+
+        Ok(shreds)
+    }
+
+    /// Puts the shred of the specified slot-index in the column for the specified location
+    #[allow(dead_code)]
+    fn put_data_shred_in_batch(
+        &self,
+        write_batch: &mut WriteBatch,
+        slot: Slot,
+        index: u64,
+        location: BlockLocation,
+        shred: &[u8],
+    ) -> Result<()> {
+        match location {
+            BlockLocation::Original => {
+                self.data_shred_cf
+                    .put_bytes_in_batch(write_batch, (slot, index), shred)
+            }
+            BlockLocation::Alternate { block_id } => self.alt_data_shred_cf.put_bytes_in_batch(
+                write_batch,
+                (slot, index, block_id),
+                shred,
+            ),
+        }
     }
 
     // Only used by tests
@@ -2512,6 +2723,35 @@ impl Blockstore {
 
     pub fn get_index(&self, slot: Slot) -> Result<Option<Index>> {
         self.index_cf.get(slot)
+    }
+
+    pub fn get_index_from_location(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+    ) -> Result<Option<Index>> {
+        match location {
+            BlockLocation::Original => self.get_index(slot),
+            BlockLocation::Alternate { block_id } => self.alt_index_cf.get((slot, block_id)),
+        }
+    }
+
+    /// Puts the Index of the specified erasure set in the column for the specified location
+    #[allow(dead_code)]
+    fn put_index_in_batch(
+        &self,
+        write_batch: &mut WriteBatch,
+        slot: Slot,
+        location: BlockLocation,
+        index: &Index,
+    ) -> Result<()> {
+        match location {
+            BlockLocation::Original => self.index_cf.put_in_batch(write_batch, slot, index),
+            BlockLocation::Alternate { block_id } => {
+                self.alt_index_cf
+                    .put_in_batch(write_batch, (slot, block_id), index)
+            }
+        }
     }
 
     /// Manually update the meta for a slot.

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2573,7 +2573,7 @@ impl Blockstore {
         let Some(index) = self.get_index_from_location(slot, location)? else {
             return Ok(Vec::new());
         };
-        let num_shreds = index.data().range(start_index..).count();
+        let num_shreds = index.data().count_range(start_index..);
         let mut shreds = Vec::with_capacity(num_shreds);
 
         let shred_bytes_iter: Box<dyn Iterator<Item = Box<[u8]>>> = match location {
@@ -2624,17 +2624,19 @@ impl Blockstore {
         index: u64,
         location: BlockLocation,
         shred: &[u8],
-    ) -> Result<()> {
+    ) {
         match location {
             BlockLocation::Original => {
                 self.data_shred_cf
-                    .put_bytes_in_batch(write_batch, (slot, index), shred)
+                    .put_bytes_in_batch(write_batch, (slot, index), shred);
             }
-            BlockLocation::Alternate { block_id } => self.alt_data_shred_cf.put_bytes_in_batch(
-                write_batch,
-                (slot, index, block_id),
-                shred,
-            ),
+            BlockLocation::Alternate { block_id } => {
+                self.alt_data_shred_cf.put_bytes_in_batch(
+                    write_batch,
+                    (slot, index, block_id),
+                    shred,
+                );
+            }
         }
     }
 

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -302,13 +302,13 @@ impl Blockstore {
         if purge_alt_columns {
             // Purge all alternate columns
             self.alt_meta_cf
-                .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+                .delete_range_in_batch(write_batch, from_slot, to_slot);
             self.alt_index_cf
-                .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+                .delete_range_in_batch(write_batch, from_slot, to_slot);
             self.alt_data_shred_cf
-                .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+                .delete_range_in_batch(write_batch, from_slot, to_slot);
             self.alt_merkle_root_meta_cf
-                .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+                .delete_range_in_batch(write_batch, from_slot, to_slot);
         }
 
         match purge_type {

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -143,12 +143,29 @@ impl Blockstore {
     /// that preserves `slot`'s `next_slots`. This ensures that `slot`'s fork is
     /// replayable upon repair of `slot`.
     pub(crate) fn purge_slot_cleanup_chaining(&self, slot: Slot) -> Result<()> {
+        self.do_purge_slot_cleanup_chaining(slot, /* purge_alt_columns */ true)
+    }
+
+    /// Like `purge_slot_cleanup_chaining` but preserves alternate block columns.
+    /// Used when switching from an alternate block to allow repair data to be retained.
+    #[allow(dead_code)]
+    pub(crate) fn purge_slot_cleanup_chaining_keep_alt(&self, slot: Slot) -> Result<()> {
+        self.do_purge_slot_cleanup_chaining(slot, /* purge_alt_columns */ false)
+    }
+
+    fn do_purge_slot_cleanup_chaining(&self, slot: Slot, purge_alt_columns: bool) -> Result<()> {
         let Some(mut slot_meta) = self.meta(slot)? else {
             return Err(BlockstoreError::SlotUnavailable);
         };
         let mut write_batch = self.get_write_batch()?;
 
-        self.purge_range(&mut write_batch, slot, slot, PurgeType::Exact)?;
+        self.purge_range(
+            &mut write_batch,
+            slot,
+            slot,
+            PurgeType::Exact,
+            purge_alt_columns,
+        )?;
 
         if let Some(parent_slot) = slot_meta.parent_slot {
             let parent_slot_meta = self.meta(parent_slot)?;
@@ -199,7 +216,13 @@ impl Blockstore {
         let mut write_batch = self.get_write_batch()?;
 
         let mut delete_range_timer = Measure::start("delete_range");
-        self.purge_range(&mut write_batch, from_slot, to_slot, purge_type)?;
+        self.purge_range(
+            &mut write_batch,
+            from_slot,
+            to_slot,
+            purge_type,
+            /* purge_alt_columns */ true,
+        )?;
         delete_range_timer.stop();
 
         let mut write_timer = Measure::start("write_batch");
@@ -241,6 +264,7 @@ impl Blockstore {
         from_slot: Slot,
         to_slot: Slot,
         purge_type: PurgeType,
+        purge_alt_columns: bool,
     ) -> Result<()> {
         self.meta_cf
             .delete_range_in_batch(write_batch, from_slot, to_slot);
@@ -274,6 +298,18 @@ impl Blockstore {
             .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.merkle_root_meta_cf
             .delete_range_in_batch(write_batch, from_slot, to_slot);
+
+        if purge_alt_columns {
+            // Purge all alternate columns
+            self.alt_meta_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            self.alt_index_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            self.alt_data_shred_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            self.alt_merkle_root_meta_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+        }
 
         match purge_type {
             PurgeType::Exact => self.purge_special_columns_exact(write_batch, from_slot, to_slot),
@@ -312,6 +348,12 @@ impl Blockstore {
         self.optimistic_slots_cf
             .delete_file_in_range(from_slot, to_slot)?;
         self.merkle_root_meta_cf
+            .delete_file_in_range(from_slot, to_slot)?;
+        self.alt_meta_cf.delete_file_in_range(from_slot, to_slot)?;
+        self.alt_index_cf.delete_file_in_range(from_slot, to_slot)?;
+        self.alt_data_shred_cf
+            .delete_file_in_range(from_slot, to_slot)?;
+        self.alt_merkle_root_meta_cf
             .delete_file_in_range(from_slot, to_slot)
     }
 

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -266,6 +266,31 @@ macro_rules! convert_column_key_bytes_to_index {
     }};
 }
 
+fn deserialize_fixint_reject_trailing<T: DeserializeOwned>(data: &[u8]) -> Result<T> {
+    let config = bincode::DefaultOptions::new()
+        // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
+        .with_fixint_encoding()
+        .reject_trailing_bytes();
+    Ok(config.deserialize(data)?)
+}
+
+type SlotAndHashKey = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+
+#[inline]
+fn slot_and_hash_key((slot, block_id): &(Slot, Hash)) -> SlotAndHashKey {
+    let mut key = [0u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+    key[..8].copy_from_slice(&slot.to_be_bytes());
+    key[8..].copy_from_slice(&block_id.to_bytes());
+    key
+}
+
+fn slot_and_hash_index(key: &[u8]) -> (Slot, Hash) {
+    let slot = Slot::from_be_bytes(<[u8; 8]>::try_from(&key[..8]).unwrap());
+    let block_id =
+        Hash::new_from_array(<[u8; HASH_BYTES]>::try_from(&key[8..8 + HASH_BYTES]).unwrap());
+    (slot, block_id)
+}
+
 pub trait Column {
     // The logical key for how data will be accessed in this column
     type Index;
@@ -745,32 +770,21 @@ impl TypedColumn for columns::Index {
     type Type = blockstore_meta::Index;
 
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
-        let config = bincode::DefaultOptions::new()
-            // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
-            .with_fixint_encoding()
-            .reject_trailing_bytes();
-
-        Ok(config.deserialize(data)?)
+        deserialize_fixint_reject_trailing(data)
     }
 }
 
 impl Column for columns::AlternateIndex {
     type Index = (Slot, /* block_id */ Hash);
-    type Key = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+    type Key = SlotAndHashKey;
 
     #[inline]
-    fn key((slot, block_id): &Self::Index) -> Self::Key {
-        convert_column_index_to_key_bytes!(Key,
-            ..8 => &slot.to_be_bytes(),
-            8.. => &block_id.to_bytes(),
-        )
+    fn key(index: &Self::Index) -> Self::Key {
+        slot_and_hash_key(index)
     }
 
     fn index(key: &[u8]) -> Self::Index {
-        convert_column_key_bytes_to_index!(key,
-            0..8  => Slot::from_be_bytes,
-            8..40 => Hash::new_from_array, // block_id
-        )
+        slot_and_hash_index(key)
     }
 
     fn slot(index: Self::Index) -> Slot {
@@ -785,15 +799,10 @@ impl ColumnName for columns::AlternateIndex {
     const NAME: &'static str = "alt_index";
 }
 impl TypedColumn for columns::AlternateIndex {
-    type Type = blockstore_meta::Index;
+    type Type = <columns::Index as TypedColumn>::Type;
 
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
-        let config = bincode::DefaultOptions::new()
-            // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
-            .with_fixint_encoding()
-            .reject_trailing_bytes();
-
-        Ok(config.deserialize(data)?)
+        <columns::Index as TypedColumn>::deserialize(data)
     }
 }
 
@@ -845,35 +854,21 @@ impl TypedColumn for columns::SlotMeta {
     type Type = blockstore_meta::SlotMeta;
 
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
-        // SlotMeta is being migrated to a new `completed_data_indexes` format.
-        //
-        // Ensure that reject trailing bytes is enabled to prevent false postivies in deserialization.
-        let config = bincode::DefaultOptions::new()
-            // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
-            .with_fixint_encoding()
-            .reject_trailing_bytes();
-
-        Ok(config.deserialize(data)?)
+        deserialize_fixint_reject_trailing(data)
     }
 }
 
 impl Column for columns::AlternateSlotMeta {
     type Index = (Slot, /* block_id */ Hash);
-    type Key = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+    type Key = SlotAndHashKey;
 
     #[inline]
-    fn key((slot, block_id): &Self::Index) -> Self::Key {
-        convert_column_index_to_key_bytes!(Key,
-            ..8 => &slot.to_be_bytes(),
-            8.. => &block_id.to_bytes(),
-        )
+    fn key(index: &Self::Index) -> Self::Key {
+        slot_and_hash_key(index)
     }
 
     fn index(key: &[u8]) -> Self::Index {
-        convert_column_key_bytes_to_index!(key,
-            0..8  => Slot::from_be_bytes,
-            8..40 => Hash::new_from_array, // block_id
-        )
+        slot_and_hash_index(key)
     }
 
     fn slot(index: Self::Index) -> Slot {
@@ -888,16 +883,10 @@ impl ColumnName for columns::AlternateSlotMeta {
     const NAME: &'static str = "alt_meta";
 }
 impl TypedColumn for columns::AlternateSlotMeta {
-    type Type = blockstore_meta::SlotMeta;
+    type Type = <columns::SlotMeta as TypedColumn>::Type;
 
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
-        // Ensure that reject trailing bytes is enabled to prevent false postivies in deserialization.
-        let config = bincode::DefaultOptions::new()
-            // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
-            .with_fixint_encoding()
-            .reject_trailing_bytes();
-
-        Ok(config.deserialize(data)?)
+        <columns::SlotMeta as TypedColumn>::deserialize(data)
     }
 }
 

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -7,6 +7,7 @@ use {
     bincode::Options as BincodeOptions,
     serde::{Serialize, de::DeserializeOwned},
     solana_clock::{Slot, UnixTimestamp},
+    solana_hash::{HASH_BYTES, Hash},
     solana_pubkey::{PUBKEY_BYTES, Pubkey},
     solana_signature::{SIGNATURE_BYTES, Signature},
     solana_storage_proto::convert::generated,
@@ -37,6 +38,16 @@ pub mod columns {
     /// * index type: `u64` (see [`SlotColumn`])
     /// * value type: [`blockstore_meta::SlotMeta`]
     pub struct SlotMeta;
+
+    #[derive(Debug)]
+    /// The alternate slot metadata column.
+    ///
+    /// Similar to [`SlotMeta`], however this column is only populated for alternate
+    /// versions fetched via block_id based repair.
+    ///
+    /// * index type: `(slot: u64, block_id: Hash)`
+    /// * value type: [`blockstore_meta::SlotMeta`]
+    pub struct AlternateSlotMeta;
 
     #[derive(Debug)]
     /// The orphans column.
@@ -120,6 +131,16 @@ pub mod columns {
     pub struct Index;
 
     #[derive(Debug)]
+    /// The alternate index column.
+    ///
+    /// Similar to [`Index`], however this column is only populated for alternate
+    /// versions fetched via block_id based repair.
+    ///
+    /// * index type: `(slot: u64, block_id: Hash)`
+    /// * value type: [`blockstore_meta::Index`]
+    pub struct AlternateIndex;
+
+    #[derive(Debug)]
     /// The shred data column
     ///
     /// * index type: `(u64, u64)`
@@ -132,6 +153,16 @@ pub mod columns {
     /// * index type: `(u64, u64)`
     /// * value type: [`Vec<u8>`]
     pub struct ShredCode;
+
+    #[derive(Debug)]
+    /// The alternate shred data column
+    ///
+    /// Similar to [`ShredData`], however this column is only populated for alternate
+    /// versions fetched via block_id based repair.
+    ///
+    /// * index type: `(slot: u64, shred_index: u64, block_id: Hash)`
+    /// * value type: [`Vec<u8>`]
+    pub struct AlternateShredData;
 
     #[derive(Debug)]
     /// The transaction status column
@@ -206,8 +237,18 @@ pub mod columns {
     /// Its index type is (Slot, fec_set_index).
     ///
     /// * index type: `crate::shred::ErasureSetId` `(Slot, fec_set_index: u32)`
-    /// * value type: [`blockstore_meta::MerkleRootMeta`]`
+    /// * value type: [`blockstore_meta::MerkleRootMeta`]
     pub struct MerkleRootMeta;
+
+    #[derive(Debug)]
+    /// The alternate merkle root meta column
+    ///
+    /// Similar to [`MerkleRootMeta`], however this column is only populated for alternate
+    /// versions fetched via block_id based repair.
+    ///
+    /// * index type: `(slot: u64, fec_set_index: u32, block_id: Hash)`
+    /// * value type: [`blockstore_meta::MerkleRootMeta`]
+    pub struct AlternateMerkleRootMeta;
 }
 
 macro_rules! convert_column_index_to_key_bytes {
@@ -663,11 +704,87 @@ impl ColumnName for columns::ShredData {
     const NAME: &'static str = "data_shred";
 }
 
+impl Column for columns::AlternateShredData {
+    type Index = (Slot, /*shred index:*/ u64, /* block id*/ Hash);
+    type Key = [u8; std::mem::size_of::<Slot>() + std::mem::size_of::<u64>() + HASH_BYTES];
+
+    #[inline]
+    fn key((slot, index, hash): &Self::Index) -> Self::Key {
+        convert_column_index_to_key_bytes!(Key,
+            ..8 => &slot.to_be_bytes(),
+            8..16 => &index.to_be_bytes(),
+            16.. => &hash.to_bytes(),
+        )
+    }
+
+    fn index(key: &[u8]) -> Self::Index {
+        convert_column_key_bytes_to_index!(key,
+            0..8  => Slot::from_be_bytes,
+            8..16 => u64::from_be_bytes,  // shred index
+            16..48 => Hash::new_from_array,
+        )
+    }
+
+    fn slot(index: Self::Index) -> Slot {
+        index.0
+    }
+
+    fn as_index(slot: Slot) -> Self::Index {
+        (slot, 0, Hash::default())
+    }
+}
+impl ColumnName for columns::AlternateShredData {
+    const NAME: &'static str = "alt_data_shred";
+}
+
 impl SlotColumn for columns::Index {}
 impl ColumnName for columns::Index {
     const NAME: &'static str = "index";
 }
 impl TypedColumn for columns::Index {
+    type Type = blockstore_meta::Index;
+
+    fn deserialize(data: &[u8]) -> Result<Self::Type> {
+        let config = bincode::DefaultOptions::new()
+            // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
+            .with_fixint_encoding()
+            .reject_trailing_bytes();
+
+        Ok(config.deserialize(data)?)
+    }
+}
+
+impl Column for columns::AlternateIndex {
+    type Index = (Slot, /* block_id */ Hash);
+    type Key = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+
+    #[inline]
+    fn key((slot, block_id): &Self::Index) -> Self::Key {
+        convert_column_index_to_key_bytes!(Key,
+            ..8 => &slot.to_be_bytes(),
+            8.. => &block_id.to_bytes(),
+        )
+    }
+
+    fn index(key: &[u8]) -> Self::Index {
+        convert_column_key_bytes_to_index!(key,
+            0..8  => Slot::from_be_bytes,
+            8..40 => Hash::new_from_array, // block_id
+        )
+    }
+
+    fn slot(index: Self::Index) -> Slot {
+        index.0
+    }
+
+    fn as_index(slot: Slot) -> Self::Index {
+        (slot, Hash::default())
+    }
+}
+impl ColumnName for columns::AlternateIndex {
+    const NAME: &'static str = "alt_index";
+}
+impl TypedColumn for columns::AlternateIndex {
     type Type = blockstore_meta::Index;
 
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
@@ -730,6 +847,50 @@ impl TypedColumn for columns::SlotMeta {
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
         // SlotMeta is being migrated to a new `completed_data_indexes` format.
         //
+        // Ensure that reject trailing bytes is enabled to prevent false postivies in deserialization.
+        let config = bincode::DefaultOptions::new()
+            // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
+            .with_fixint_encoding()
+            .reject_trailing_bytes();
+
+        Ok(config.deserialize(data)?)
+    }
+}
+
+impl Column for columns::AlternateSlotMeta {
+    type Index = (Slot, /* block_id */ Hash);
+    type Key = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+
+    #[inline]
+    fn key((slot, block_id): &Self::Index) -> Self::Key {
+        convert_column_index_to_key_bytes!(Key,
+            ..8 => &slot.to_be_bytes(),
+            8.. => &block_id.to_bytes(),
+        )
+    }
+
+    fn index(key: &[u8]) -> Self::Index {
+        convert_column_key_bytes_to_index!(key,
+            0..8  => Slot::from_be_bytes,
+            8..40 => Hash::new_from_array, // block_id
+        )
+    }
+
+    fn slot(index: Self::Index) -> Slot {
+        index.0
+    }
+
+    fn as_index(slot: Slot) -> Self::Index {
+        (slot, Hash::default())
+    }
+}
+impl ColumnName for columns::AlternateSlotMeta {
+    const NAME: &'static str = "alt_meta";
+}
+impl TypedColumn for columns::AlternateSlotMeta {
+    type Type = blockstore_meta::SlotMeta;
+
+    fn deserialize(data: &[u8]) -> Result<Self::Type> {
         // Ensure that reject trailing bytes is enabled to prevent false postivies in deserialization.
         let config = bincode::DefaultOptions::new()
             // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
@@ -814,5 +975,42 @@ impl ColumnName for columns::MerkleRootMeta {
     const NAME: &'static str = "merkle_root_meta";
 }
 impl TypedColumn for columns::MerkleRootMeta {
+    type Type = blockstore_meta::MerkleRootMeta;
+}
+
+impl Column for columns::AlternateMerkleRootMeta {
+    type Index = (Slot, /*fec_set_index:*/ u32, /* block_id */ Hash);
+    type Key = [u8; std::mem::size_of::<Slot>() + std::mem::size_of::<u32>() + HASH_BYTES];
+
+    #[inline]
+    fn key((slot, fec_set_index, block_id): &Self::Index) -> Self::Key {
+        convert_column_index_to_key_bytes!(Key,
+            ..8 => &slot.to_be_bytes(),
+            8..12 => &fec_set_index.to_be_bytes(),
+            12.. => &block_id.to_bytes(),
+        )
+    }
+
+    fn index(key: &[u8]) -> Self::Index {
+        convert_column_key_bytes_to_index!(key,
+            0..8  => Slot::from_be_bytes,
+            8..12 => u32::from_be_bytes,  // fec_set_index
+            12..44 => Hash::new_from_array, // block_id
+        )
+    }
+
+    fn slot((slot, _fec_set_index, _block_id): Self::Index) -> Slot {
+        slot
+    }
+
+    fn as_index(slot: Slot) -> Self::Index {
+        (slot, 0, Hash::default())
+    }
+}
+
+impl ColumnName for columns::AlternateMerkleRootMeta {
+    const NAME: &'static str = "alt_merkle_root_meta";
+}
+impl TypedColumn for columns::AlternateMerkleRootMeta {
     type Type = blockstore_meta::MerkleRootMeta;
 }

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -274,23 +274,6 @@ fn deserialize_fixint_reject_trailing<T: DeserializeOwned>(data: &[u8]) -> Resul
     Ok(config.deserialize(data)?)
 }
 
-type SlotAndHashKey = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
-
-#[inline]
-fn slot_and_hash_key((slot, block_id): &(Slot, Hash)) -> SlotAndHashKey {
-    let mut key = [0u8; std::mem::size_of::<Slot>() + HASH_BYTES];
-    key[..8].copy_from_slice(&slot.to_be_bytes());
-    key[8..].copy_from_slice(&block_id.to_bytes());
-    key
-}
-
-fn slot_and_hash_index(key: &[u8]) -> (Slot, Hash) {
-    let slot = Slot::from_be_bytes(<[u8; 8]>::try_from(&key[..8]).unwrap());
-    let block_id =
-        Hash::new_from_array(<[u8; HASH_BYTES]>::try_from(&key[8..8 + HASH_BYTES]).unwrap());
-    (slot, block_id)
-}
-
 pub trait Column {
     // The logical key for how data will be accessed in this column
     type Index;
@@ -775,24 +758,24 @@ impl TypedColumn for columns::Index {
 }
 
 impl Column for columns::AlternateIndex {
-    type Index = (Slot, /* block_id */ Hash);
-    type Key = SlotAndHashKey;
+    type Index = <columns::AlternateSlotMeta as Column>::Index;
+    type Key = <columns::AlternateSlotMeta as Column>::Key;
 
     #[inline]
     fn key(index: &Self::Index) -> Self::Key {
-        slot_and_hash_key(index)
+        <columns::AlternateSlotMeta as Column>::key(index)
     }
 
     fn index(key: &[u8]) -> Self::Index {
-        slot_and_hash_index(key)
+        <columns::AlternateSlotMeta as Column>::index(key)
     }
 
     fn slot(index: Self::Index) -> Slot {
-        index.0
+        <columns::AlternateSlotMeta as Column>::slot(index)
     }
 
     fn as_index(slot: Slot) -> Self::Index {
-        (slot, Hash::default())
+        <columns::AlternateSlotMeta as Column>::as_index(slot)
     }
 }
 impl ColumnName for columns::AlternateIndex {
@@ -860,15 +843,21 @@ impl TypedColumn for columns::SlotMeta {
 
 impl Column for columns::AlternateSlotMeta {
     type Index = (Slot, /* block_id */ Hash);
-    type Key = SlotAndHashKey;
+    type Key = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
 
     #[inline]
-    fn key(index: &Self::Index) -> Self::Key {
-        slot_and_hash_key(index)
+    fn key((slot, block_id): &Self::Index) -> Self::Key {
+        convert_column_index_to_key_bytes!(Key,
+            ..8 => &slot.to_be_bytes(),
+            8.. => &block_id.to_bytes(),
+        )
     }
 
     fn index(key: &[u8]) -> Self::Index {
-        slot_and_hash_index(key)
+        convert_column_key_bytes_to_index!(key,
+            0..8  => Slot::from_be_bytes,
+            8..40 => Hash::new_from_array,
+        )
     }
 
     fn slot(index: Self::Index) -> Slot {

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -758,6 +758,7 @@ impl TypedColumn for columns::Index {
 }
 
 impl Column for columns::AlternateIndex {
+    // AlternateIndex and AlternateSlotMeta share the same key type so reuse code here
     type Index = <columns::AlternateSlotMeta as Column>::Index;
     type Key = <columns::AlternateSlotMeta as Column>::Key;
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -193,6 +193,10 @@ impl Rocks {
             new_cf_descriptor::<columns::BlockHeight>(options, oldest_slot),
             new_cf_descriptor::<columns::OptimisticSlots>(options, oldest_slot),
             new_cf_descriptor::<columns::MerkleRootMeta>(options, oldest_slot),
+            new_cf_descriptor::<columns::AlternateSlotMeta>(options, oldest_slot),
+            new_cf_descriptor::<columns::AlternateIndex>(options, oldest_slot),
+            new_cf_descriptor::<columns::AlternateShredData>(options, oldest_slot),
+            new_cf_descriptor::<columns::AlternateMerkleRootMeta>(options, oldest_slot),
         ];
 
         // When remaining columns are optional we can just return immediately here.
@@ -237,7 +241,7 @@ impl Rocks {
         cf_descriptors
     }
 
-    const fn columns() -> [&'static str; 20] {
+    const fn columns() -> [&'static str; 24] {
         [
             columns::ErasureMeta::NAME,
             columns::DeadSlots::NAME,
@@ -259,6 +263,10 @@ impl Rocks {
             columns::BlockHeight::NAME,
             columns::OptimisticSlots::NAME,
             columns::MerkleRootMeta::NAME,
+            columns::AlternateSlotMeta::NAME,
+            columns::AlternateIndex::NAME,
+            columns::AlternateShredData::NAME,
+            columns::AlternateMerkleRootMeta::NAME,
         ]
     }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -7,7 +7,10 @@ use {
     serde::{Deserialize, Deserializer, Serialize, Serializer},
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
-    std::ops::{Range, RangeBounds},
+    std::{
+        fmt::Display,
+        ops::{Range, RangeBounds},
+    },
 };
 
 bitflags! {
@@ -237,6 +240,22 @@ pub struct DuplicateSlotProof {
     pub shred2: shred::Payload,
 }
 
+/// Which column an associated block currently resides
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BlockLocation {
+    Original,
+    Alternate { block_id: Hash },
+}
+
+impl Display for BlockLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BlockLocation::Original => write!(f, "Original"),
+            BlockLocation::Alternate { block_id } => write!(f, "Alternate({block_id})"),
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub enum FrozenHashVersioned {
     Current(FrozenHashStatus),
@@ -315,8 +334,7 @@ impl ShredIndex {
         }
     }
 
-    #[allow(unused)]
-    pub(crate) fn contains(&self, idx: u64) -> bool {
+    pub fn contains(&self, idx: u64) -> bool {
         self.index.contains(idx as usize)
     }
 
@@ -554,7 +572,7 @@ impl MerkleRootMeta {
         }
     }
 
-    pub(crate) fn merkle_root(&self) -> Option<Hash> {
+    pub fn merkle_root(&self) -> Option<Hash> {
         self.merkle_root
     }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -334,7 +334,7 @@ impl ShredIndex {
         }
     }
 
-    pub fn contains(&self, idx: u64) -> bool {
+    pub(crate) fn contains(&self, idx: u64) -> bool {
         self.index.contains(idx as usize)
     }
 
@@ -572,7 +572,7 @@ impl MerkleRootMeta {
         }
     }
 
-    pub fn merkle_root(&self) -> Option<Hash> {
+    pub(crate) fn merkle_root(&self) -> Option<Hash> {
         self.merkle_root
     }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -344,6 +344,15 @@ impl ShredIndex {
         }
     }
 
+    pub(crate) fn count_range<R>(&self, bounds: R) -> usize
+    where
+        R: RangeBounds<u64>,
+    {
+        let start = bounds.start_bound().map(|&b| b as usize);
+        let end = bounds.end_bound().map(|&b| b as usize);
+        self.index.range((start, end)).count_ones()
+    }
+
     pub(crate) fn range<R>(&self, bounds: R) -> impl Iterator<Item = u64> + '_
     where
         R: RangeBounds<u64>,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -344,6 +344,10 @@ impl ErasureSetId {
         self.0
     }
 
+    pub(crate) fn fec_set_index(&self) -> u32 {
+        self.1
+    }
+
     // Storage key for ErasureMeta and MerkleRootMeta in blockstore db.
     // Note: ErasureMeta column uses u64 so this will need to be typecast
     pub(crate) fn store_key(&self) -> (Slot, /*fec_set_index:*/ u32) {


### PR DESCRIPTION
Upstream of https://github.com/anza-xyz/alpenglow/pull/355

#### Problem
In Alpenglow we need to store multiple versions of a block during duplicate block events.
There is a hard cap on the number of alternate blocks per slot that will need to be stored, and these will only be fetched via a special repair when certain vote thresholds are met.

#### Summary of Changes
Add alternate columns to store the minimum set of state necessary for these alternate blocks.
In a future PR we will upstream the insertion logic, which generalizes `do_insert_shreds` to insert data shreds into these other columns. 
