### PR TITLE
Max Flush root updated to differentiate between Slot0 flushed and not

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -9,10 +9,49 @@ use {
         ops::Deref,
         sync::{
             Arc, RwLock,
-            atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
+            atomic::{AtomicBool, AtomicU64, Ordering},
         },
     },
 };
+
+/// Tracks the maximum flushed root slot.
+#[derive(Debug)]
+struct MaxFlushedRoot(AtomicU64);
+
+impl MaxFlushedRoot {
+    // Sentinel value indicating no flushed roots. Any real slot will replace this value.
+    const NO_FLUSHED_ROOTS: u64 = u64::MAX;
+
+    fn new() -> Self {
+        Self(AtomicU64::new(Self::NO_FLUSHED_ROOTS))
+    }
+
+    fn get(&self) -> Option<Slot> {
+        match self.0.load(Ordering::Acquire) {
+            u64::MAX => None,
+            slot => Some(slot),
+        }
+    }
+
+    /// Atomically update to the maximum of the current value and `slot`.
+    /// Any real slot replaces the sentinel; between two real slots, the max wins.
+    fn fetch_max(&self, slot: Slot) {
+        assert_ne!(slot, Self::NO_FLUSHED_ROOTS);
+        loop {
+            let current = self.0.load(Ordering::Acquire);
+            if current != Self::NO_FLUSHED_ROOTS && current >= slot {
+                return;
+            }
+            if self
+                .0
+                .compare_exchange_weak(current, slot, Ordering::Release, Ordering::Relaxed)
+                .is_ok()
+            {
+                return;
+            }
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct SlotCache {
@@ -151,20 +190,19 @@ pub struct AccountsCache {
     // Queue of potentially unflushed roots. Random eviction + cache too large
     // could have triggered a flush of this slot already
     maybe_unflushed_roots: RwLock<BTreeSet<Slot>>,
-    max_flushed_root: AtomicI64,
+    max_flushed_root: MaxFlushedRoot,
     /// The size of account data stored in the whole AccountsCache, in bytes
     total_size: Arc<AtomicU64>,
     /// The number of accounts stored in the whole AccountsCache
     total_accounts_counts: Arc<AtomicU64>,
 }
 
-const NO_FLUSHED_ROOTS: i64 = -1;
 impl Default for AccountsCache {
     fn default() -> Self {
         Self {
             cache: DashMap::with_capacity_and_hasher(1024, BuildNoHashHasher::default()),
             maybe_unflushed_roots: RwLock::new(BTreeSet::new()),
-            max_flushed_root: AtomicI64::new(NO_FLUSHED_ROOTS),
+            max_flushed_root: MaxFlushedRoot::new(),
             total_size: Arc::new(AtomicU64::new(0)),
             total_accounts_counts: Arc::new(AtomicU64::new(0)),
         }
@@ -280,12 +318,12 @@ impl AccountsCache {
         self.cache.len()
     }
 
-    pub fn fetch_max_flush_root(&self) -> i64 {
-        self.max_flushed_root.load(Ordering::Acquire)
+    pub fn fetch_max_flush_root(&self) -> Option<u64> {
+        self.max_flushed_root.get()
     }
 
-    pub fn set_max_flush_root(&self, root: i64) {
-        self.max_flushed_root.fetch_max(root, Ordering::Release);
+    pub fn set_max_flush_root(&self, root: u64) {
+        self.max_flushed_root.fetch_max(root);
     }
 }
 
@@ -344,5 +382,38 @@ mod tests {
         cache.slot_cache(inserted_slot).unwrap().mark_slot_frozen();
         // If the cache is told the size limit is 0, it should return the one frozen slot
         assert_eq!(cache.cached_frozen_slots(), vec![inserted_slot]);
+    }
+
+    #[test]
+    fn test_max_flushed_root_fetch_max() {
+        let root = MaxFlushedRoot::new();
+        assert_eq!(root.get(), None);
+
+        // first real slot replaces sentinel
+        root.fetch_max(10);
+        assert_eq!(root.get(), Some(10));
+
+        // larger slot wins
+        root.fetch_max(20);
+        assert_eq!(root.get(), Some(20));
+
+        // smaller and equal slots are ignored
+        root.fetch_max(5);
+        assert_eq!(root.get(), Some(20));
+        root.fetch_max(20);
+        assert_eq!(root.get(), Some(20));
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion")]
+    fn test_max_flushed_root_rejects_sentinel() {
+        MaxFlushedRoot::new().fetch_max(u64::MAX);
+    }
+
+    #[test]
+    fn test_max_flushed_root_slot_zero() {
+        let root = MaxFlushedRoot::new();
+        root.fetch_max(0);
+        assert_eq!(root.get(), Some(0));
     }
 }

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -15,41 +15,22 @@ use {
 };
 
 /// Tracks the maximum flushed root slot.
-#[derive(Debug)]
+///
+/// Internally stores `slot + 1` so that the default value of `0` naturally
+/// represents "no flushed roots".
+#[derive(Debug, Default)]
 struct MaxFlushedRoot(AtomicU64);
 
 impl MaxFlushedRoot {
-    // Sentinel value indicating no flushed roots. Any real slot will replace this value.
-    const NO_FLUSHED_ROOTS: u64 = u64::MAX;
-
-    fn new() -> Self {
-        Self(AtomicU64::new(Self::NO_FLUSHED_ROOTS))
-    }
-
+    /// Returns the current max flushed root, or `None` if no root has been flushed.
     fn get(&self) -> Option<Slot> {
-        match self.0.load(Ordering::Acquire) {
-            u64::MAX => None,
-            slot => Some(slot),
-        }
+        self.0.load(Ordering::Acquire).checked_sub(1)
     }
 
     /// Atomically update to the maximum of the current value and `slot`.
-    /// Any real slot replaces the sentinel; between two real slots, the max wins.
+    /// Stores `slot + 1` internally so 0 can represent no slots flushed
     fn fetch_max(&self, slot: Slot) {
-        assert_ne!(slot, Self::NO_FLUSHED_ROOTS);
-        loop {
-            let current = self.0.load(Ordering::Acquire);
-            if current != Self::NO_FLUSHED_ROOTS && current >= slot {
-                return;
-            }
-            if self
-                .0
-                .compare_exchange_weak(current, slot, Ordering::Release, Ordering::Relaxed)
-                .is_ok()
-            {
-                return;
-            }
-        }
+        self.0.fetch_max(slot + 1, Ordering::Release);
     }
 }
 
@@ -184,7 +165,7 @@ impl CachedAccount {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct AccountsCache {
     cache: DashMap<Slot, Arc<SlotCache>, BuildNoHashHasher<Slot>>,
     // Queue of potentially unflushed roots. Random eviction + cache too large
@@ -195,18 +176,6 @@ pub struct AccountsCache {
     total_size: Arc<AtomicU64>,
     /// The number of accounts stored in the whole AccountsCache
     total_accounts_counts: Arc<AtomicU64>,
-}
-
-impl Default for AccountsCache {
-    fn default() -> Self {
-        Self {
-            cache: DashMap::with_capacity_and_hasher(1024, BuildNoHashHasher::default()),
-            maybe_unflushed_roots: RwLock::new(BTreeSet::new()),
-            max_flushed_root: MaxFlushedRoot::new(),
-            total_size: Arc::new(AtomicU64::new(0)),
-            total_accounts_counts: Arc::new(AtomicU64::new(0)),
-        }
-    }
 }
 
 impl AccountsCache {
@@ -386,8 +355,11 @@ mod tests {
 
     #[test]
     fn test_max_flushed_root_fetch_max() {
-        let root = MaxFlushedRoot::new();
+        let root = MaxFlushedRoot::default();
         assert_eq!(root.get(), None);
+
+        root.fetch_max(0);
+        assert_eq!(root.get(), Some(0));
 
         // first real slot replaces sentinel
         root.fetch_max(10);
@@ -402,18 +374,5 @@ mod tests {
         assert_eq!(root.get(), Some(20));
         root.fetch_max(20);
         assert_eq!(root.get(), Some(20));
-    }
-
-    #[test]
-    #[should_panic(expected = "assertion")]
-    fn test_max_flushed_root_rejects_sentinel() {
-        MaxFlushedRoot::new().fetch_max(u64::MAX);
-    }
-
-    #[test]
-    fn test_max_flushed_root_slot_zero() {
-        let root = MaxFlushedRoot::new();
-        root.fetch_max(0);
-        assert_eq!(root.get(), Some(0));
     }
 }

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -29,6 +29,7 @@ impl MaxFlushedRoot {
 
     /// Atomically update to the maximum of the current value and `slot`.
     /// Stores `slot + 1` internally so 0 can represent no slots flushed
+    /// Note: Will overflow at u64::MAX - 1, but realistically should never get that high
     fn fetch_max(&self, slot: Slot) {
         self.0.fetch_max(slot + 1, Ordering::Release);
     }
@@ -287,11 +288,11 @@ impl AccountsCache {
         self.cache.len()
     }
 
-    pub fn fetch_max_flush_root(&self) -> Option<u64> {
+    pub fn fetch_max_flush_root(&self) -> Option<Slot> {
         self.max_flushed_root.get()
     }
 
-    pub fn set_max_flush_root(&self, root: u64) {
+    pub fn set_max_flush_root(&self, root: Slot) {
         self.max_flushed_root.fetch_max(root);
     }
 }

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -9,7 +9,7 @@ use {
         ops::Deref,
         sync::{
             Arc, RwLock,
-            atomic::{AtomicBool, AtomicU64, Ordering},
+            atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
         },
     },
 };
@@ -145,17 +145,30 @@ impl CachedAccount {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct AccountsCache {
     cache: DashMap<Slot, Arc<SlotCache>, BuildNoHashHasher<Slot>>,
     // Queue of potentially unflushed roots. Random eviction + cache too large
     // could have triggered a flush of this slot already
     maybe_unflushed_roots: RwLock<BTreeSet<Slot>>,
-    max_flushed_root: AtomicU64,
+    max_flushed_root: AtomicI64,
     /// The size of account data stored in the whole AccountsCache, in bytes
     total_size: Arc<AtomicU64>,
     /// The number of accounts stored in the whole AccountsCache
     total_accounts_counts: Arc<AtomicU64>,
+}
+
+const NO_FLUSHED_ROOTS: i64 = -1;
+impl Default for AccountsCache {
+    fn default() -> Self {
+        Self {
+            cache: DashMap::with_capacity_and_hasher(1024, BuildNoHashHasher::default()),
+            maybe_unflushed_roots: RwLock::new(BTreeSet::new()),
+            max_flushed_root: AtomicI64::new(NO_FLUSHED_ROOTS),
+            total_size: Arc::new(AtomicU64::new(0)),
+            total_accounts_counts: Arc::new(AtomicU64::new(0)),
+        }
+    }
 }
 
 impl AccountsCache {
@@ -267,11 +280,11 @@ impl AccountsCache {
         self.cache.len()
     }
 
-    pub fn fetch_max_flush_root(&self) -> Slot {
+    pub fn fetch_max_flush_root(&self) -> i64 {
         self.max_flushed_root.load(Ordering::Acquire)
     }
 
-    pub fn set_max_flush_root(&self, root: Slot) {
+    pub fn set_max_flush_root(&self, root: i64) {
         self.max_flushed_root.fetch_max(root, Ordering::Release);
     }
 }

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -29,7 +29,7 @@ impl MaxFlushedRoot {
 
     /// Atomically update to the maximum of the current value and `slot`.
     /// Stores `slot + 1` internally so 0 can represent no slots flushed
-    /// Note: Will overflow at u64::MAX - 1, but realistically should never get that high
+    /// Note: Will overflow at u64::MAX, but realistically should never get that high
     fn fetch_max(&self, slot: Slot) {
         self.0.fetch_max(slot + 1, Ordering::Release);
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4497,7 +4497,7 @@ impl AccountsDb {
             }
         }
 
-        max_flush_root.inspect(|&root| self.accounts_cache.set_max_flush_root(root as i64));
+        max_flush_root.inspect(|&root| self.accounts_cache.set_max_flush_root(root));
 
         (num_new_roots, num_roots_flushed, flush_stats)
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4497,7 +4497,7 @@ impl AccountsDb {
             }
         }
 
-        max_flush_root.inspect(|&root| self.accounts_cache.set_max_flush_root(root));
+        max_flush_root.inspect(|&root| self.accounts_cache.set_max_flush_root(root as i64));
 
         (num_new_roots, num_roots_flushed, flush_stats)
     }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3822,8 +3822,11 @@ fn test_accounts_db_cache_clean_dead_slots() {
     accounts_db.flush_accounts_cache(true, None);
     assert_eq!(accounts_db.accounts_cache.num_slots(), 0);
     assert_eq!(
-        accounts_db.accounts_cache.fetch_max_flush_root(),
-        alive_slot as i64,
+        accounts_db
+            .accounts_cache
+            .fetch_max_flush_root()
+            .expect("Roots have been flushed"),
+        alive_slot,
     );
 
     // Specifying a max_root < alive_slot, should not return any more entries,
@@ -3866,8 +3869,11 @@ fn test_accounts_db_cache_clean() {
     accounts_db.flush_accounts_cache(true, None);
     assert_eq!(accounts_db.accounts_cache.num_slots(), 0);
     assert_eq!(
-        accounts_db.accounts_cache.fetch_max_flush_root(),
-        *slots.last().unwrap() as i64
+        accounts_db
+            .accounts_cache
+            .fetch_max_flush_root()
+            .expect("Roots have been flushed"),
+        *slots.last().unwrap()
     );
 
     // Each slot should only have one entry in the storage, since all other accounts were
@@ -3924,8 +3930,11 @@ fn run_test_accounts_db_cache_clean_max_root(
     };
 
     assert_eq!(
-        accounts_db.accounts_cache.fetch_max_flush_root(),
-        expected_max_flushed_root as i64,
+        accounts_db
+            .accounts_cache
+            .fetch_max_flush_root()
+            .expect("Roots have been flushed"),
+        expected_max_flushed_root,
     );
 
     for slot in &slots {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3823,7 +3823,7 @@ fn test_accounts_db_cache_clean_dead_slots() {
     assert_eq!(accounts_db.accounts_cache.num_slots(), 0);
     assert_eq!(
         accounts_db.accounts_cache.fetch_max_flush_root(),
-        alive_slot,
+        alive_slot as i64,
     );
 
     // Specifying a max_root < alive_slot, should not return any more entries,
@@ -3867,7 +3867,7 @@ fn test_accounts_db_cache_clean() {
     assert_eq!(accounts_db.accounts_cache.num_slots(), 0);
     assert_eq!(
         accounts_db.accounts_cache.fetch_max_flush_root(),
-        *slots.last().unwrap()
+        *slots.last().unwrap() as i64
     );
 
     // Each slot should only have one entry in the storage, since all other accounts were
@@ -3925,7 +3925,7 @@ fn run_test_accounts_db_cache_clean_max_root(
 
     assert_eq!(
         accounts_db.accounts_cache.fetch_max_flush_root(),
-        expected_max_flushed_root,
+        expected_max_flushed_root as i64,
     );
 
     for slot in &slots {

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -251,13 +251,14 @@ impl SnapshotRequestHandler {
         // Note `max_flush_root` could be larger than self.slot() if there are
         // `> MAX_CACHE_SLOT` cached and rooted slots which triggered earlier flushes.
         assert!(
-            snapshot_root_bank.slot() as i64
+            snapshot_root_bank.slot()
                 <= snapshot_root_bank
                     .rc
                     .accounts
                     .accounts_db
                     .accounts_cache
                     .fetch_max_flush_root()
+                    .expect("Roots have been flushed")
         );
         flush_accounts_cache_time.stop();
 

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -251,7 +251,7 @@ impl SnapshotRequestHandler {
         // Note `max_flush_root` could be larger than self.slot() if there are
         // `> MAX_CACHE_SLOT` cached and rooted slots which triggered earlier flushes.
         assert!(
-            snapshot_root_bank.slot()
+            snapshot_root_bank.slot() as i64
                 <= snapshot_root_bank
                     .rc
                     .accounts


### PR DESCRIPTION
#### Problem
Max Flush Root cannot differentiate between slot0 being in the cache, and slot0 being flushed. While currently not causing any issues, accurate tracking is required when the accounts cache index is added.

#### Summary of Changes
- Change max_flush_root to a type MaxFlushRoot
- Store Slot+1 and return None if stored value is 0

Note: I tried a bunch of different options. This seemed like the cleanest. 
1. Using an Option -> This required RwLock<Option<u64>> which was not great for perf on the fast path
2. Adding a variable to determine if it's initialized. Seemed very not rusty. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
