### PR TITLE
Async transaction verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8219,6 +8219,8 @@ dependencies = [
  "proptest",
  "rand 0.9.2",
  "rayon",
+ "smallvec",
+ "solana-address 2.2.0",
  "solana-bls-signatures",
  "solana-clock",
  "solana-entry",

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -12,7 +12,7 @@ use {
         bank_utils,
         prioritization_fee_cache::PrioritizationFeeCache,
         transaction_batch::TransactionBatch,
-        vote_sender_types::ReplayVoteSender,
+        vote_sender_types::{ReplayVoteSendType, ReplayVoteSender},
     },
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_svm::{
@@ -100,6 +100,7 @@ impl Committer {
                 batch.sanitized_transactions(),
                 &commit_results,
                 Some(&self.replay_vote_sender),
+                ReplayVoteSendType::VerifiedExecuted,
             );
 
             if let Some(prioritization_fee_cache) = self.prioritization_fee_cache.as_ref() {

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -12,7 +12,7 @@ use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Select, Sender, unbounded},
     log::*,
     rayon::ThreadPool,
-    solana_clock::{DEFAULT_MS_PER_SLOT, Slot},
+    solana_clock::{BankId, DEFAULT_MS_PER_SLOT, Slot},
     solana_gossip::{
         cluster_info::{ClusterInfo, GOSSIP_SLEEP_MILLIS},
         crds::Cursor,
@@ -32,7 +32,7 @@ use {
         bank_forks::{BankForks, SharableBanks},
         commitment::VOTE_THRESHOLD_SIZE,
         epoch_stakes::VersionedEpochStakes,
-        vote_sender_types::ReplayVoteReceiver,
+        vote_sender_types::{ReplayVoteMessage, ReplayVoteReceiver},
     },
     solana_signature::Signature,
     solana_time_utils::AtomicInterval,
@@ -43,7 +43,7 @@ use {
     },
     std::{
         cmp::max,
-        collections::HashMap,
+        collections::{HashMap, hash_map::Entry},
         iter::repeat,
         sync::{
             Arc, RwLock,
@@ -194,6 +194,225 @@ impl VoteProcessingTiming {
             );
             self.reset();
         }
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+enum BufferedVote {
+    Executed(ParsedVote),
+    Verified,
+}
+
+#[allow(clippy::large_enum_variant)]
+enum ReplayVoteAction {
+    Executed(ParsedVote),
+    Verified,
+}
+
+impl From<ReplayVoteAction> for BufferedVote {
+    fn from(action: ReplayVoteAction) -> Self {
+        match action {
+            ReplayVoteAction::Executed(parsed_vote) => Self::Executed(parsed_vote),
+            ReplayVoteAction::Verified => Self::Verified,
+        }
+    }
+}
+
+impl BufferedVote {
+    fn apply(
+        self,
+        action: ReplayVoteAction,
+        ready_votes: &mut Vec<ParsedVote>,
+        replay_bank_id: BankId,
+        signature: Signature,
+    ) -> Option<Self> {
+        match (self, action) {
+            (Self::Executed(parsed_vote), ReplayVoteAction::Verified)
+            | (Self::Verified, ReplayVoteAction::Executed(parsed_vote)) => {
+                ready_votes.push(parsed_vote);
+                None
+            }
+            (Self::Verified, ReplayVoteAction::Verified) => Some(Self::Verified),
+            (Self::Executed(parsed_vote), ReplayVoteAction::Executed(_)) => {
+                debug_assert!(
+                    false,
+                    "duplicate Executed replay vote for same bank {replay_bank_id} signature \
+                     {signature}"
+                );
+                Some(Self::Executed(parsed_vote))
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum BankVoteBuffer {
+    /// The bank is active and we are buffering votes for it.
+    Active {
+        slot: Slot,
+        votes: HashMap<Signature, BufferedVote>,
+    },
+    /// The bank is invalid and we are discarding votes.
+    Invalid { slot: Slot },
+}
+
+impl BankVoteBuffer {
+    fn slot(&self) -> Slot {
+        match self {
+            BankVoteBuffer::Active { slot, .. } => *slot,
+            BankVoteBuffer::Invalid { slot } => *slot,
+        }
+    }
+}
+
+struct VoteBuffer {
+    bank_votes: HashMap<BankId, BankVoteBuffer>,
+}
+
+impl VoteBuffer {
+    fn new() -> Self {
+        Self {
+            bank_votes: HashMap::new(),
+        }
+    }
+
+    fn receive_and_collect_ready_votes(
+        &mut self,
+        replay_votes: impl Iterator<Item = ReplayVoteMessage>,
+    ) -> Vec<ParsedVote> {
+        let mut ready_votes = Vec::new();
+        for replay_vote in replay_votes {
+            match replay_vote {
+                ReplayVoteMessage::VerifiedExecuted(parsed_vote) => ready_votes.push(parsed_vote),
+                ReplayVoteMessage::Executed {
+                    replay_bank_id,
+                    replay_slot,
+                    parsed_vote,
+                } => {
+                    let signature = parsed_vote.3;
+                    match self.bank_votes.entry(replay_bank_id) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(BankVoteBuffer::Active {
+                                slot: replay_slot,
+                                votes: HashMap::from([(
+                                    signature,
+                                    BufferedVote::Executed(parsed_vote),
+                                )]),
+                            });
+                        }
+                        Entry::Occupied(mut entry) => {
+                            let BankVoteBuffer::Active {
+                                slot: stored_replay_slot,
+                                votes,
+                            } = entry.get_mut()
+                            else {
+                                // Skip votes for invalid banks
+                                continue;
+                            };
+                            debug_assert_eq!(*stored_replay_slot, replay_slot);
+                            Self::apply_action_for_signature(
+                                votes,
+                                signature,
+                                ReplayVoteAction::Executed(parsed_vote),
+                                &mut ready_votes,
+                                replay_bank_id,
+                            );
+                            if votes.is_empty() {
+                                entry.remove();
+                            }
+                        }
+                    }
+                }
+
+                ReplayVoteMessage::Verified {
+                    replay_bank_id,
+                    replay_slot,
+                    verified_signatures,
+                } => {
+                    debug_assert!(
+                        !verified_signatures.is_empty(),
+                        "empty replay Verified message for bank {replay_bank_id}, slot \
+                         {replay_slot}"
+                    );
+                    match self.bank_votes.entry(replay_bank_id) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(BankVoteBuffer::Active {
+                                slot: replay_slot,
+                                votes: verified_signatures
+                                    .into_iter()
+                                    .map(|signature| (signature, BufferedVote::Verified))
+                                    .collect(),
+                            });
+                        }
+                        Entry::Occupied(mut entry) => {
+                            let BankVoteBuffer::Active {
+                                slot: stored_replay_slot,
+                                votes,
+                            } = entry.get_mut()
+                            else {
+                                // Skip votes for invalid banks
+                                continue;
+                            };
+                            debug_assert_eq!(*stored_replay_slot, replay_slot);
+                            for signature in verified_signatures.into_iter() {
+                                Self::apply_action_for_signature(
+                                    votes,
+                                    signature,
+                                    ReplayVoteAction::Verified,
+                                    &mut ready_votes,
+                                    replay_bank_id,
+                                );
+                            }
+                            if votes.is_empty() {
+                                entry.remove();
+                            }
+                        }
+                    }
+                }
+                ReplayVoteMessage::InvalidBank {
+                    replay_bank_id,
+                    replay_slot,
+                } => {
+                    self.bank_votes.insert(
+                        replay_bank_id,
+                        BankVoteBuffer::Invalid { slot: replay_slot },
+                    );
+                }
+                ReplayVoteMessage::BankComplete { replay_bank_id, .. } => {
+                    self.bank_votes.remove(&replay_bank_id);
+                }
+            }
+        }
+
+        ready_votes
+    }
+
+    #[inline]
+    fn apply_action_for_signature(
+        votes: &mut HashMap<Signature, BufferedVote>,
+        signature: Signature,
+        action: ReplayVoteAction,
+        ready_votes: &mut Vec<ParsedVote>,
+        replay_bank_id: BankId,
+    ) {
+        match votes.entry(signature) {
+            Entry::Vacant(entry) => {
+                entry.insert(action.into());
+            }
+            Entry::Occupied(entry) => {
+                let (_signature, current_state) = entry.remove_entry();
+                if let Some(next_state) =
+                    current_state.apply(action, ready_votes, replay_bank_id, signature)
+                {
+                    votes.insert(signature, next_state);
+                }
+            }
+        }
+    }
+
+    fn prune_stale_slots(&mut self, root_slot: Slot) {
+        self.bank_votes.retain(|_, state| state.slot() > root_slot);
     }
 }
 
@@ -350,6 +569,7 @@ impl ClusterInfoVoteListener {
         let mut latest_vote_slot_per_validator = HashMap::new();
         let mut last_process_root = Instant::now();
         let mut vote_processing_time = Some(VoteProcessingTiming::default());
+        let mut replay_vote_buffer = VoteBuffer::new();
         loop {
             if exit.load(Ordering::Relaxed) {
                 return Ok(());
@@ -368,6 +588,7 @@ impl ClusterInfoVoteListener {
                     &unrooted_optimistic_slots,
                 );
                 vote_tracker.progress_with_new_root_bank(&root_bank);
+                replay_vote_buffer.prune_stale_slots(root_bank.slot());
                 last_process_root = Instant::now();
             }
             let confirmed_slots = Self::listen_and_confirm_votes(
@@ -375,6 +596,7 @@ impl ClusterInfoVoteListener {
                 &vote_tracker,
                 &root_bank,
                 &replay_votes_receiver,
+                &mut replay_vote_buffer,
                 &notifiers,
                 &mut vote_processing_time,
                 &mut latest_vote_slot_per_validator,
@@ -410,6 +632,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: &VoteTracker,
         root_bank: &Bank,
         replay_votes_receiver: &ReplayVoteReceiver,
+        replay_vote_buffer: &mut VoteBuffer,
         notifiers: &ConfirmationNotifiers,
         vote_processing_time: &mut Option<VoteProcessingTiming>,
         latest_vote_slot_per_validator: &mut HashMap<Pubkey, Slot>,
@@ -429,7 +652,8 @@ impl ClusterInfoVoteListener {
             // Should not early return from this point onwards until `process_votes()`
             // returns below to avoid missing any potential `optimistic_confirmed_slots`
             let gossip_vote_txs: Vec<_> = gossip_vote_txs_receiver.try_iter().flatten().collect();
-            let replay_votes: Vec<_> = replay_votes_receiver.try_iter().collect();
+            let replay_votes = replay_vote_buffer
+                .receive_and_collect_ready_votes(replay_votes_receiver.try_iter());
             if !gossip_vote_txs.is_empty() || !replay_votes.is_empty() {
                 return Ok(Self::filter_and_confirm_with_new_votes(
                     vote_tracker,
@@ -750,7 +974,7 @@ mod tests {
             genesis_utils::{
                 self, GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config,
             },
-            vote_sender_types::ReplayVoteSender,
+            vote_sender_types::{ReplayVoteMessage, ReplayVoteSender},
         },
         solana_signature::Signature,
         solana_signer::Signer,
@@ -903,11 +1127,13 @@ mod tests {
             duplicate_confirmed_slot_sender: None,
             migration_status: Arc::new(MigrationStatus::default()),
         };
+        let mut replay_vote_buffer = VoteBuffer::new();
         ClusterInfoVoteListener::listen_and_confirm_votes(
             &votes_receiver,
             &vote_tracker,
             &bank3,
             &replay_votes_receiver,
+            &mut replay_vote_buffer,
             &notifiers,
             &mut None,
             &mut latest_vote_slot_per_validator,
@@ -937,6 +1163,7 @@ mod tests {
             &vote_tracker,
             &bank3,
             &replay_votes_receiver,
+            &mut replay_vote_buffer,
             &notifiers,
             &mut None,
             &mut latest_vote_slot_per_validator,
@@ -972,12 +1199,12 @@ mod tests {
             // Send same vote twice, but should only notify once
             for _ in 0..2 {
                 replay_votes_sender
-                    .send((
+                    .send(ReplayVoteMessage::VerifiedExecuted((
                         vote_keypair.pubkey(),
                         VoteTransaction::from(replay_vote.clone()),
                         switch_proof_hash,
                         Signature::default(),
-                    ))
+                    )))
                     .unwrap();
             }
         });
@@ -1026,11 +1253,13 @@ mod tests {
             duplicate_confirmed_slot_sender: None,
             migration_status: Arc::new(MigrationStatus::default()),
         };
+        let mut replay_vote_buffer = VoteBuffer::new();
         ClusterInfoVoteListener::listen_and_confirm_votes(
             &votes_txs_receiver,
             &vote_tracker,
             &bank0,
             &replay_votes_receiver,
+            &mut replay_vote_buffer,
             &notifiers,
             &mut None,
             &mut latest_vote_slot_per_validator,
@@ -1198,11 +1427,13 @@ mod tests {
             duplicate_confirmed_slot_sender: None,
             migration_status: Arc::new(MigrationStatus::default()),
         };
+        let mut replay_vote_buffer = VoteBuffer::new();
         ClusterInfoVoteListener::listen_and_confirm_votes(
             &votes_txs_receiver,
             &vote_tracker,
             &bank0,
             &replay_votes_receiver,
+            &mut replay_vote_buffer,
             &notifiers,
             &mut None,
             &mut latest_vote_slot_per_validator,
@@ -1287,6 +1518,7 @@ mod tests {
                 duplicate_confirmed_slot_sender: None,
                 migration_status: Arc::new(MigrationStatus::default()),
             };
+            let mut replay_vote_buffer = VoteBuffer::new();
             for &e in &events {
                 if e == 0 || e == 2 {
                     // Create vote transaction
@@ -1304,12 +1536,12 @@ mod tests {
                 }
                 if e == 1 || e == 2 {
                     replay_votes_sender
-                        .send((
+                        .send(ReplayVoteMessage::VerifiedExecuted((
                             vote_keypair.pubkey(),
                             VoteTransaction::from(Vote::new(vec![vote_slot], Hash::default())),
                             switch_proof_hash,
                             Signature::default(),
-                        ))
+                        )))
                         .unwrap();
                 }
                 let _ = ClusterInfoVoteListener::listen_and_confirm_votes(
@@ -1317,6 +1549,7 @@ mod tests {
                     &vote_tracker,
                     &bank,
                     &replay_votes_receiver,
+                    &mut replay_vote_buffer,
                     &notifiers,
                     &mut None,
                     &mut latest_vote_slot_per_validator,
@@ -1347,6 +1580,210 @@ mod tests {
     fn test_run_test_process_votes3() {
         run_test_process_votes3(None);
         run_test_process_votes3(Some(Hash::default()));
+    }
+
+    fn sample_parsed_vote(slot: Slot) -> ParsedVote {
+        (
+            Pubkey::new_unique(),
+            VoteTransaction::from(Vote::new(vec![slot], Hash::default())),
+            None,
+            Signature::default(),
+        )
+    }
+
+    #[test]
+    fn test_replay_vote_buffer_gates_unverified_votes() {
+        let replay_bank_id = 1;
+        let replay_slot = 42;
+        let parsed_vote = sample_parsed_vote(replay_slot);
+        let signature = parsed_vote.3;
+        let mut replay_vote_buffer = VoteBuffer::new();
+
+        let ready_votes = replay_vote_buffer.receive_and_collect_ready_votes(
+            vec![ReplayVoteMessage::Executed {
+                replay_bank_id,
+                replay_slot,
+                parsed_vote: parsed_vote.clone(),
+            }]
+            .into_iter(),
+        );
+        assert!(ready_votes.is_empty());
+        assert_eq!(replay_vote_buffer.bank_votes.len(), 1);
+        assert!(matches!(
+            replay_vote_buffer.bank_votes.get(&replay_bank_id),
+            Some(BankVoteBuffer::Active { .. })
+        ));
+
+        let ready_votes = replay_vote_buffer.receive_and_collect_ready_votes(
+            vec![ReplayVoteMessage::Verified {
+                replay_bank_id,
+                replay_slot,
+                verified_signatures: vec![signature],
+            }]
+            .into_iter(),
+        );
+        assert_eq!(ready_votes, vec![parsed_vote]);
+        assert!(replay_vote_buffer.bank_votes.is_empty());
+    }
+
+    #[test]
+    fn test_replay_vote_buffer_gates_unexecuted_votes() {
+        let replay_bank_id = 3;
+        let replay_slot = 77;
+        let parsed_vote = sample_parsed_vote(replay_slot);
+        let signature = parsed_vote.3;
+        let mut replay_vote_buffer = VoteBuffer::new();
+
+        let ready_votes = replay_vote_buffer.receive_and_collect_ready_votes(
+            vec![ReplayVoteMessage::Verified {
+                replay_bank_id,
+                replay_slot,
+                verified_signatures: vec![signature],
+            }]
+            .into_iter(),
+        );
+        assert!(ready_votes.is_empty());
+        assert_eq!(replay_vote_buffer.bank_votes.len(), 1);
+        assert!(matches!(
+            replay_vote_buffer.bank_votes.get(&replay_bank_id),
+            Some(BankVoteBuffer::Active { .. })
+        ));
+
+        let ready_votes = replay_vote_buffer.receive_and_collect_ready_votes(
+            vec![ReplayVoteMessage::Executed {
+                replay_bank_id,
+                replay_slot,
+                parsed_vote: parsed_vote.clone(),
+            }]
+            .into_iter(),
+        );
+        assert_eq!(ready_votes, vec![parsed_vote]);
+        assert!(replay_vote_buffer.bank_votes.is_empty());
+    }
+
+    #[test]
+    fn test_replay_vote_buffer_invalid_bank_drops_late_messages() {
+        let replay_bank_id = 2;
+        let replay_slot = 100;
+        let parsed_vote = sample_parsed_vote(replay_slot);
+        let signature = parsed_vote.3;
+        let mut replay_vote_buffer = VoteBuffer::new();
+
+        let ready_votes = replay_vote_buffer.receive_and_collect_ready_votes(
+            vec![ReplayVoteMessage::Verified {
+                replay_bank_id,
+                replay_slot,
+                verified_signatures: vec![signature],
+            }]
+            .into_iter(),
+        );
+        assert!(ready_votes.is_empty());
+        assert_eq!(replay_vote_buffer.bank_votes.len(), 1);
+        assert!(matches!(
+            replay_vote_buffer.bank_votes.get(&replay_bank_id),
+            Some(BankVoteBuffer::Active { .. })
+        ));
+
+        let ready_votes = replay_vote_buffer.receive_and_collect_ready_votes(
+            vec![ReplayVoteMessage::InvalidBank {
+                replay_bank_id,
+                replay_slot,
+            }]
+            .into_iter(),
+        );
+        assert!(ready_votes.is_empty());
+        assert_eq!(replay_vote_buffer.bank_votes.len(), 1);
+        assert!(matches!(
+            replay_vote_buffer.bank_votes.get(&replay_bank_id),
+            Some(BankVoteBuffer::Invalid {
+                slot: invalid_slot
+            }) if *invalid_slot == replay_slot
+        ));
+
+        let ready_votes = replay_vote_buffer.receive_and_collect_ready_votes(
+            vec![ReplayVoteMessage::Executed {
+                replay_bank_id,
+                replay_slot,
+                parsed_vote: parsed_vote.clone(),
+            }]
+            .into_iter(),
+        );
+        assert!(ready_votes.is_empty());
+        assert_eq!(replay_vote_buffer.bank_votes.len(), 1);
+        assert!(matches!(
+            replay_vote_buffer.bank_votes.get(&replay_bank_id),
+            Some(BankVoteBuffer::Invalid {
+                slot: invalid_slot
+            }) if *invalid_slot == replay_slot
+        ));
+    }
+
+    #[test]
+    fn test_replay_vote_buffer_bank_complete_clears_pending_state() {
+        let replay_bank_id = 5;
+        let replay_slot = 123;
+        let parsed_vote = sample_parsed_vote(replay_slot);
+        let mut replay_vote_buffer = VoteBuffer::new();
+
+        let ready_votes = replay_vote_buffer.receive_and_collect_ready_votes(
+            vec![ReplayVoteMessage::Executed {
+                replay_bank_id,
+                replay_slot,
+                parsed_vote,
+            }]
+            .into_iter(),
+        );
+        assert!(ready_votes.is_empty());
+        assert_eq!(replay_vote_buffer.bank_votes.len(), 1);
+        assert_matches!(
+            replay_vote_buffer.bank_votes.get(&replay_bank_id),
+            Some(BankVoteBuffer::Active { .. })
+        );
+
+        let ready_votes = replay_vote_buffer.receive_and_collect_ready_votes(
+            vec![ReplayVoteMessage::BankComplete {
+                replay_bank_id,
+                replay_slot,
+            }]
+            .into_iter(),
+        );
+        assert!(ready_votes.is_empty());
+        assert!(replay_vote_buffer.bank_votes.is_empty());
+    }
+
+    #[test]
+    fn test_replay_vote_buffer_processes_verified_signature() {
+        let replay_bank_id = 6;
+        let replay_slot = 124;
+        let parsed_vote = sample_parsed_vote(replay_slot);
+        let signature = parsed_vote.3;
+        let mut replay_vote_buffer = VoteBuffer::new();
+
+        let ready_votes = replay_vote_buffer.receive_and_collect_ready_votes(
+            vec![ReplayVoteMessage::Executed {
+                replay_bank_id,
+                replay_slot,
+                parsed_vote: parsed_vote.clone(),
+            }]
+            .into_iter(),
+        );
+        assert!(ready_votes.is_empty());
+        assert_eq!(replay_vote_buffer.bank_votes.len(), 1);
+        assert_matches!(
+            replay_vote_buffer.bank_votes.get(&replay_bank_id),
+            Some(BankVoteBuffer::Active { .. })
+        );
+
+        let ready_votes = replay_vote_buffer.receive_and_collect_ready_votes(
+            vec![ReplayVoteMessage::Verified {
+                replay_bank_id,
+                replay_slot,
+                verified_signatures: vec![signature],
+            }]
+            .into_iter(),
+        );
+        assert_eq!(ready_votes, vec![parsed_vote]);
+        assert!(replay_vote_buffer.bank_votes.is_empty());
     }
 
     #[test]

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -87,7 +87,7 @@ use {
         leader_schedule_utils::first_of_consecutive_leader_slots,
         prioritization_fee_cache::PrioritizationFeeCache,
         snapshot_controller::SnapshotController,
-        vote_sender_types::ReplayVoteSender,
+        vote_sender_types::{ReplayVoteMessage, ReplayVoteSender},
     },
     solana_signer::Signer,
     solana_svm_timings::ExecuteTimings,
@@ -2479,6 +2479,7 @@ impl ReplayStage {
         ancestor_hashes_replay_update_sender: &AncestorHashesReplayUpdateSender,
         purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
         tbft_structs: &mut Option<&mut TowerBFTStructures>,
+        replay_vote_sender: &ReplayVoteSender,
     ) {
         // Do not remove from progress map when marking dead! Needed by
         // `process_duplicate_confirmed_slots()`
@@ -2509,6 +2510,12 @@ impl ReplayStage {
         blockstore
             .set_dead_slot(slot)
             .expect("Failed to mark slot as dead in blockstore");
+        replay_vote_sender
+            .send(ReplayVoteMessage::InvalidBank {
+                replay_bank_id: bank.bank_id(),
+                replay_slot: slot,
+            })
+            .expect("Failed to send InvalidBank message to replay vote sender");
 
         blockstore.slots_stats.mark_dead(slot);
 
@@ -3307,6 +3314,7 @@ impl ReplayStage {
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
         transaction_status_sender: Option<&TransactionStatusSender>,
+        replay_vote_sender: &ReplayVoteSender,
         bank_notification_sender: &Option<BankNotificationSenderConfig>,
         rpc_subscriptions: Option<&RpcSubscriptions>,
         slot_status_notifier: &Option<SlotStatusNotifier>,
@@ -3354,6 +3362,7 @@ impl ReplayStage {
                             ancestor_hashes_replay_update_sender,
                             purge_repair_slot_counter,
                             &mut tbft_structs,
+                            replay_vote_sender,
                         );
                         // don't try to run the below logic to check if the bank is completed
                         continue;
@@ -3408,6 +3417,12 @@ impl ReplayStage {
                     }
                     res
                 };
+                // we send this whether the block was valid or not. It's only
+                // used to release buffered votes if any.
+                let _ = replay_vote_sender.send(ReplayVoteMessage::BankComplete {
+                    replay_bank_id: bank.bank_id(),
+                    replay_slot: bank.slot(),
+                });
                 if let Err(err) = replay_err.or(verify_err) {
                     let root = bank_forks.read().unwrap().root();
                     Self::mark_dead_slot(
@@ -3422,11 +3437,11 @@ impl ReplayStage {
                         ancestor_hashes_replay_update_sender,
                         purge_repair_slot_counter,
                         &mut tbft_structs,
+                        replay_vote_sender,
                     );
                     // don't try to run the remaining normal processing for the completed bank
                     continue;
                 }
-
                 let is_leader_block = bank.leader_id() == my_pubkey;
                 let block_id = if !is_leader_block {
                     // If the block does not have at least DATA_SHREDS_PER_FEC_BLOCK correctly retransmitted
@@ -3451,6 +3466,7 @@ impl ReplayStage {
                                 ancestor_hashes_replay_update_sender,
                                 purge_repair_slot_counter,
                                 &mut tbft_structs,
+                                replay_vote_sender,
                             );
                             continue;
                         }
@@ -3735,6 +3751,7 @@ impl ReplayStage {
             bank_forks,
             progress,
             transaction_status_sender,
+            replay_vote_sender,
             bank_notification_sender,
             rpc_subscriptions,
             slot_status_notifier,
@@ -5460,6 +5477,7 @@ pub(crate) mod tests {
             ));
             let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
                 unbounded();
+            let (replay_vote_sender, replay_vote_receiver) = unbounded();
             let dead_slots = Arc::new(Mutex::new(HashSet::default()));
 
             let slot_status_notifier: Option<SlotStatusNotifier> = Some(Arc::new(RwLock::new(
@@ -5481,8 +5499,16 @@ pub(crate) mod tests {
                     &ancestor_hashes_replay_update_sender,
                     &mut PurgeRepairSlotCounter::default(),
                     &mut Some(&mut tbft_structs),
+                    &replay_vote_sender,
                 );
             }
+            assert_eq!(
+                replay_vote_receiver.try_recv(),
+                Ok(ReplayVoteMessage::InvalidBank {
+                    replay_bank_id: bank1.bank_id(),
+                    replay_slot: bank1.slot(),
+                })
+            );
             assert!(dead_slots.lock().unwrap().contains(&bank1.slot()));
             // Check that the erroring bank was marked as dead in the progress map
             assert!(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3391,13 +3391,21 @@ impl ReplayStage {
                     Ok(())
                 };
                 let verify_err = {
-                    let mut elapsed = 0;
+                    let mut poh_verify_elapsed = 0;
+                    let mut tx_verify_elapsed = 0;
                     let res = bank_progress
                         .replay_progress
                         .write()
                         .unwrap()
-                        .wait_for_all_verification_results(&mut elapsed);
-                    replay_stats.write().unwrap().poh_verify_elapsed += elapsed;
+                        .wait_for_all_verification_results(
+                            &mut poh_verify_elapsed,
+                            &mut tx_verify_elapsed,
+                        );
+                    {
+                        let mut stats = replay_stats.write().unwrap();
+                        stats.poh_verify_elapsed += poh_verify_elapsed;
+                        stats.transaction_verify_elapsed += tx_verify_elapsed;
+                    }
                     res
                 };
                 if let Err(err) = replay_err.or(verify_err) {
@@ -5425,17 +5433,21 @@ pub(crate) mod tests {
                 &MigrationStatus::default(),
             )
             .and_then(|replay_tx_count| {
-                let mut elapsed = 0;
+                let mut poh_verify_elapsed = 0;
+                let mut tx_verify_elapsed = 0;
                 bank1_progress
                     .replay_progress
                     .write()
                     .unwrap()
-                    .wait_for_all_verification_results(&mut elapsed)?;
-                bank1_progress
-                    .replay_stats
-                    .write()
-                    .unwrap()
-                    .poh_verify_elapsed += elapsed;
+                    .wait_for_all_verification_results(
+                        &mut poh_verify_elapsed,
+                        &mut tx_verify_elapsed,
+                    )?;
+                {
+                    let mut stats = bank1_progress.replay_stats.write().unwrap();
+                    stats.poh_verify_elapsed += poh_verify_elapsed;
+                    stats.transaction_verify_elapsed += tx_verify_elapsed;
+                }
                 Ok(replay_tx_count)
             });
             let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6836,6 +6836,8 @@ dependencies = [
  "log",
  "num_cpus",
  "rayon",
+ "smallvec",
+ "solana-address 2.2.0",
  "solana-bls-signatures",
  "solana-clock",
  "solana-hash 4.2.0",

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -27,6 +27,8 @@ dlopen2 = { workspace = true }
 log = { workspace = true }
 num_cpus = { workspace = true }
 rayon = { workspace = true }
+smallvec = { workspace = true }
+solana-address = { workspace = true }
 solana-bls-signatures = { workspace = true }
 solana-clock = { workspace = true }
 solana-hash = { workspace = true, features = ["wincode"] }

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -195,6 +195,7 @@ pub enum EntryType<Tx: TransactionWithMeta> {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct TxVerificationData {
+    is_simple_vote: bool,
     signatures: SmallVec<[Signature; 2]>,
     signer_pubkeys: SmallVec<[Address; 2]>,
     serialized_message: Vec<u8>,
@@ -226,6 +227,14 @@ impl UnverifiedSignatures {
                 Err(TransactionError::SignatureFailure)
             }
         })
+    }
+
+    pub fn vote_transaction_signatures(&self) -> Vec<Signature> {
+        self.signatures
+            .iter()
+            .filter(|tx_signatures| tx_signatures.is_simple_vote)
+            .filter_map(|tx_signatures| tx_signatures.signatures.first().copied())
+            .collect()
     }
 }
 
@@ -377,6 +386,7 @@ where
             let serialized_message = versioned_tx.message.serialize();
             let verified_transaction = verify(versioned_tx, &serialized_message)?;
             unverified_signatures.signatures.push(TxVerificationData {
+                is_simple_vote: verified_transaction.is_simple_vote_transaction(),
                 signatures,
                 serialized_message,
                 signer_pubkeys,

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -8,18 +8,18 @@ use {
     dlopen2::symbor::{Container, SymBorApi, Symbol},
     log::*,
     rayon::{ThreadPool, prelude::*},
+    smallvec::SmallVec,
+    solana_address::Address,
     solana_hash::Hash,
     solana_merkle_tree::MerkleTree,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_signature::Signature,
-    solana_transaction::{
-        Transaction, TransactionVerificationMode, versioned::VersionedTransaction,
-    },
-    solana_transaction_error::TransactionResult as Result,
+    solana_transaction::{Transaction, versioned::VersionedTransaction},
+    solana_transaction_error::{TransactionError, TransactionResult as Result},
     std::{
         ffi::OsStr,
         iter::repeat_with,
-        sync::{Arc, Once, OnceLock},
+        sync::{Once, OnceLock},
         time::Instant,
     },
     wincode::{SchemaRead, SchemaWrite, containers::Vec as WincodeVec, len::BincodeLen},
@@ -193,6 +193,47 @@ pub enum EntryType<Tx: TransactionWithMeta> {
     Tick(Hash),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TxVerificationData {
+    signatures: SmallVec<[Signature; 2]>,
+    signer_pubkeys: SmallVec<[Address; 2]>,
+    serialized_message: Vec<u8>,
+}
+
+pub struct UnverifiedSignatures {
+    signatures: Vec<TxVerificationData>,
+}
+
+impl UnverifiedSignatures {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            signatures: Vec::with_capacity(capacity),
+        }
+    }
+
+    pub fn verify(&self) -> Result<()> {
+        self.signatures.par_iter().try_for_each(|tx_signatures| {
+            if tx_signatures
+                .signatures
+                .iter()
+                .zip(tx_signatures.signer_pubkeys.iter())
+                .all(|(signature, pubkey)| {
+                    signature.verify(pubkey.as_ref(), &tx_signatures.serialized_message)
+                })
+            {
+                Ok(())
+            } else {
+                Err(TransactionError::SignatureFailure)
+            }
+        })
+    }
+}
+
+pub struct ValidatedHashedTransactions<Tx: TransactionWithMeta> {
+    pub entries: Vec<EntryType<Tx>>,
+    pub unverified_signatures: UnverifiedSignatures,
+}
+
 impl Entry {
     /// Creates the next Entry `num_hashes` after `start_hash`.
     pub fn new(prev_hash: &Hash, mut num_hashes: u64, transactions: Vec<Transaction>) -> Self {
@@ -300,20 +341,6 @@ pub struct EntryVerificationState {
     poh_duration_us: u64,
 }
 
-pub struct EntrySigVerificationState<Tx: TransactionWithMeta> {
-    verification_status: bool,
-    entries: Option<Vec<EntryType<Tx>>>,
-}
-
-impl<Tx: TransactionWithMeta> EntrySigVerificationState<Tx> {
-    pub fn entries(&mut self) -> Option<Vec<EntryType<Tx>>> {
-        self.entries.take()
-    }
-    pub fn status(&self) -> bool {
-        self.verification_status
-    }
-}
-
 impl EntryVerificationState {
     pub fn status(&self) -> bool {
         self.verification_status
@@ -324,65 +351,98 @@ impl EntryVerificationState {
     }
 }
 
-pub fn verify_transactions<Tx: TransactionWithMeta + Send + Sync>(
+fn validate_and_hash_entry_transactions<Tx: TransactionWithMeta, F>(
+    entry: Entry,
+    verify: &F,
+    unverified_signatures: &mut UnverifiedSignatures,
+) -> Result<EntryType<Tx>>
+where
+    F: Fn(VersionedTransaction, &[u8]) -> Result<Tx>,
+{
+    if entry.transactions.is_empty() {
+        return Ok(EntryType::Tick(entry.hash));
+    }
+
+    let verified_transactions = entry
+        .transactions
+        .into_iter()
+        .map(|versioned_tx| {
+            let num_signers = usize::from(versioned_tx.message.header().num_required_signatures);
+            let static_account_keys = versioned_tx.message.static_account_keys();
+            if static_account_keys.len() < num_signers {
+                return Err(TransactionError::SanitizeFailure);
+            }
+            let signatures = versioned_tx.signatures.iter().copied().collect();
+            let signer_pubkeys = static_account_keys[..num_signers].iter().copied().collect();
+            let serialized_message = versioned_tx.message.serialize();
+            let verified_transaction = verify(versioned_tx, &serialized_message)?;
+            unverified_signatures.signatures.push(TxVerificationData {
+                signatures,
+                serialized_message,
+                signer_pubkeys,
+            });
+
+            Ok(verified_transaction)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(EntryType::Transactions(verified_transactions))
+}
+
+/// Validates and hashes the transactions included in the given entries.
+///
+/// The function does NOT verify transaction signatures. The caller is expected to call
+/// `UnverifiedSignatures::verify()` on the returned `unverified_signatures`.
+pub fn validate_and_hash_transactions<Tx: TransactionWithMeta + Send + Sync, F>(
     entries: Vec<Entry>,
+    num_txs: usize,
     thread_pool: &ThreadPool,
-    verify: Arc<dyn Fn(VersionedTransaction) -> Result<Tx> + Send + Sync>,
-) -> Result<Vec<EntryType<Tx>>> {
-    thread_pool.install(|| {
+    verify: F,
+) -> Result<ValidatedHashedTransactions<Tx>>
+where
+    F: Fn(VersionedTransaction, &[u8]) -> Result<Tx> + Send + Sync,
+{
+    const PARALLEL_VERIFY_THRESHOLD: usize = 200;
+    if num_txs < PARALLEL_VERIFY_THRESHOLD {
+        let mut unverified_signatures = UnverifiedSignatures::with_capacity(num_txs);
+        let entries = entries
+            .into_iter()
+            .map(|entry| {
+                validate_and_hash_entry_transactions(entry, &verify, &mut unverified_signatures)
+            })
+            .collect::<Result<_>>()?;
+        return Ok(ValidatedHashedTransactions {
+            entries,
+            unverified_signatures,
+        });
+    }
+
+    let verified = thread_pool.install(|| {
         entries
             .into_par_iter()
             .map(|entry| {
-                if entry.transactions.is_empty() {
-                    Ok(EntryType::Tick(entry.hash))
-                } else {
-                    Ok(EntryType::Transactions(
-                        entry
-                            .transactions
-                            .into_par_iter()
-                            .map(verify.as_ref())
-                            .collect::<Result<Vec<_>>>()?,
-                    ))
-                }
+                let mut unverified_signatures =
+                    UnverifiedSignatures::with_capacity(entry.transactions.len());
+                let verified_entry = validate_and_hash_entry_transactions(
+                    entry,
+                    &verify,
+                    &mut unverified_signatures,
+                )?;
+                Ok((verified_entry, unverified_signatures))
             })
-            .collect()
-    })
-}
+            .collect::<Result<Vec<_>>>()
+    })?;
 
-pub fn start_verify_transactions<Tx: TransactionWithMeta + Send + Sync + 'static>(
-    entries: Vec<Entry>,
-    skip_verification: bool,
-    thread_pool: &ThreadPool,
-    verify: Arc<
-        dyn Fn(VersionedTransaction, TransactionVerificationMode) -> Result<Tx> + Send + Sync,
-    >,
-) -> Result<EntrySigVerificationState<Tx>> {
-    start_verify_transactions_cpu(entries, skip_verification, thread_pool, verify)
-}
-
-fn start_verify_transactions_cpu<Tx: TransactionWithMeta + Send + Sync + 'static>(
-    entries: Vec<Entry>,
-    skip_verification: bool,
-    thread_pool: &ThreadPool,
-    verify: Arc<
-        dyn Fn(VersionedTransaction, TransactionVerificationMode) -> Result<Tx> + Send + Sync,
-    >,
-) -> Result<EntrySigVerificationState<Tx>> {
-    let verify_func = {
-        let mode = if skip_verification {
-            TransactionVerificationMode::HashOnly
-        } else {
-            TransactionVerificationMode::FullVerification
-        };
-
-        move |versioned_tx| verify(versioned_tx, mode)
-    };
-
-    let entries = verify_transactions(entries, thread_pool, Arc::new(verify_func))?;
-
-    Ok(EntrySigVerificationState {
-        verification_status: true,
-        entries: Some(entries),
+    let mut entries = Vec::with_capacity(verified.len());
+    let mut unverified_signatures = UnverifiedSignatures::with_capacity(num_txs);
+    for (entry, mut tx_unverified_signatures) in verified {
+        entries.push(entry);
+        unverified_signatures
+            .signatures
+            .append(&mut tx_unverified_signatures.signatures);
+    }
+    Ok(ValidatedHashedTransactions {
+        entries,
+        unverified_signatures,
     })
 }
 
@@ -417,7 +477,7 @@ fn verify_entries_cpu_generic(
         num_hashes: 0,
         hash: *start_hash,
         num_transactions: 0,
-        signatures: vec![],
+        signatures: Vec::new(),
     }];
     let entry_pairs = genesis.par_iter().chain(entries).zip(entries);
     let res = entry_pairs.all(|(x0, x1)| {
@@ -448,7 +508,7 @@ fn verify_entries_cpu_x86_simd(
         num_hashes: 0,
         hash: *start_hash,
         num_transactions: 0,
-        signatures: vec![],
+        signatures: Vec::new(),
     }];
 
     let aligned_len = entries.len().div_ceil(simd_len) * simd_len;
@@ -706,26 +766,14 @@ mod tests {
         entries: Vec<Entry>,
         skip_verification: bool,
         thread_pool: &ThreadPool,
-        verify: Arc<
-            dyn Fn(VersionedTransaction, TransactionVerificationMode) -> Result<Tx> + Send + Sync,
-        >,
+        verify: impl Fn(VersionedTransaction, &[u8]) -> Result<Tx> + Send + Sync,
     ) -> bool {
-        let verify_func = {
-            let verify = verify.clone();
-            let verification_mode = if skip_verification {
-                TransactionVerificationMode::HashOnly
-            } else {
-                TransactionVerificationMode::FullVerification
-            };
-            move |versioned_tx: VersionedTransaction| -> Result<Tx> {
-                verify(versioned_tx, verification_mode)
-            }
+        let num_txs = entries.iter().map(|entry| entry.transactions.len()).sum();
+        let txs = validate_and_hash_transactions(entries, num_txs, thread_pool, verify);
+        let Ok(txs) = txs else {
+            return false;
         };
-
-        let cpu_verify_result =
-            verify_transactions(entries.clone(), thread_pool, Arc::new(verify_func));
-
-        cpu_verify_result.is_ok()
+        skip_verification || txs.unverified_signatures.verify().is_ok()
     }
 
     #[test]
@@ -749,23 +797,18 @@ mod tests {
         // Next, verify entry slice
         let verify_transaction = {
             move |versioned_tx: VersionedTransaction,
-                  _mode: TransactionVerificationMode|
+                  message_bytes: &[u8]|
                   -> Result<RuntimeTransaction<SanitizedTransaction>> {
-                let sanitized_tx = {
-                    let message_hash = versioned_tx.verify_and_hash_message()?;
-                    RuntimeTransaction::try_create(
-                        versioned_tx,
-                        MessageHash::Precomputed(message_hash),
-                        None,
-                        SimpleAddressLoader::Disabled,
-                        &ReservedAccountKeys::empty_key_set(),
-                        true,
-                    )
-                }?;
-
-                sanitized_tx.verify()?;
-
-                Ok(sanitized_tx)
+                RuntimeTransaction::try_create(
+                    versioned_tx,
+                    MessageHash::Precomputed(solana_message::VersionedMessage::hash_raw_message(
+                        message_bytes,
+                    )),
+                    None,
+                    SimpleAddressLoader::Disabled,
+                    &ReservedAccountKeys::empty_key_set(),
+                    true,
+                )
             }
         };
 
@@ -773,7 +816,49 @@ mod tests {
             es,
             false,
             &thread_pool,
-            Arc::new(verify_transaction)
+            verify_transaction
+        ));
+    }
+
+    #[test]
+    fn test_validate_and_hash_transactions_and_signatures() {
+        let thread_pool = ThreadPoolBuilder::new().build().unwrap();
+        let zero = Hash::default();
+        let keypair = Keypair::new();
+        let tx = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, zero);
+        let entries = vec![Entry::new(&zero, 0, vec![tx])];
+
+        let validate_and_hash_transaction =
+            move |versioned_tx: VersionedTransaction,
+                  message_bytes: &[u8]|
+                  -> Result<RuntimeTransaction<SanitizedTransaction>> {
+                RuntimeTransaction::try_create(
+                    versioned_tx,
+                    MessageHash::Precomputed(solana_message::VersionedMessage::hash_raw_message(
+                        message_bytes,
+                    )),
+                    None,
+                    SimpleAddressLoader::Disabled,
+                    &ReservedAccountKeys::empty_key_set(),
+                    true,
+                )
+            };
+        let txs =
+            validate_and_hash_transactions(entries, 1, &thread_pool, validate_and_hash_transaction)
+                .expect("transaction validation and hashing must not verify signatures");
+        assert_eq!(txs.entries.len(), 1);
+        assert!(txs.unverified_signatures.verify().is_ok());
+
+        let mut tx = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, zero);
+        tx.signatures[0] = solana_signature::Signature::default();
+        let entries = vec![Entry::new(&zero, 0, vec![tx])];
+        let txs =
+            validate_and_hash_transactions(entries, 1, &thread_pool, validate_and_hash_transaction)
+                .expect("transaction validation and hashing must not verify signatures");
+        assert_eq!(txs.entries.len(), 1);
+        assert!(matches!(
+            txs.unverified_signatures.verify(),
+            Err(solana_transaction_error::TransactionError::SignatureFailure)
         ));
     }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -67,7 +67,7 @@ use {
         ops::Index,
         path::PathBuf,
         result,
-        sync::{Arc, Mutex, RwLock, atomic::AtomicBool},
+        sync::{Arc, Mutex, OnceLock, RwLock, atomic::AtomicBool},
         time::{Duration, Instant},
         vec::Drain,
     },
@@ -155,6 +155,18 @@ fn create_thread_pool(num_threads: usize) -> ThreadPool {
         .thread_name(|i| format!("solReplayTx{i:02}"))
         .build()
         .expect("new rayon threadpool")
+}
+
+fn transaction_hash_verify_thread_pool() -> &'static ThreadPool {
+    const TX_HASH_VERIFY_THREAD_POOL_SIZE: usize = 4;
+    static TX_HASH_VERIFY_THREAD_POOL: OnceLock<ThreadPool> = OnceLock::new();
+    TX_HASH_VERIFY_THREAD_POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(TX_HASH_VERIFY_THREAD_POOL_SIZE)
+            .thread_name(|i| format!("solReplayHash{i:02}"))
+            .build()
+            .expect("new transaction hash verify rayon threadpool")
+    })
 }
 
 pub fn execute_batch<'a>(
@@ -611,32 +623,46 @@ pub fn process_entries_for_tests(
     replay_vote_sender: Option<&ReplayVoteSender>,
 ) -> Result<()> {
     let replay_tx_thread_pool = create_thread_pool(1);
-    let verify_transaction = {
+    let validate_and_hash_transaction = {
         let bank = bank.clone_with_scheduler();
-        move |versioned_tx: VersionedTransaction| -> Result<RuntimeTransaction<SanitizedTransaction>> {
-            bank.verify_transaction(versioned_tx, TransactionVerificationMode::FullVerification)
+        move |versioned_tx: VersionedTransaction,
+              serialized_message: &[u8]|
+              -> Result<RuntimeTransaction<SanitizedTransaction>> {
+            bank.verify_transaction_with_serialized_message(
+                versioned_tx,
+                serialized_message,
+                TransactionVerificationMode::HashOnly,
+            )
         }
     };
 
+    let num_txs = entries.iter().map(|entry| entry.transactions.len()).sum();
+    let entry::ValidatedHashedTransactions {
+        entries,
+        unverified_signatures,
+    } = entry::validate_and_hash_transactions(
+        entries,
+        num_txs,
+        &replay_tx_thread_pool,
+        validate_and_hash_transaction,
+    )?;
+    unverified_signatures.verify()?;
+
     let mut entry_starting_index: usize = bank.transaction_count().try_into().unwrap();
     let mut batch_timing = BatchExecutionTiming::default();
-    let replay_entries: Vec<_> = entry::verify_transactions(
-        entries,
-        &replay_tx_thread_pool,
-        Arc::new(verify_transaction),
-    )?
-    .into_iter()
-    .map(|entry| {
-        let starting_index = entry_starting_index;
-        if let EntryType::Transactions(ref transactions) = entry {
-            entry_starting_index = entry_starting_index.saturating_add(transactions.len());
-        }
-        ReplayEntry {
-            entry,
-            starting_index,
-        }
-    })
-    .collect();
+    let replay_entries: Vec<_> = entries
+        .into_iter()
+        .map(|entry| {
+            let starting_index = entry_starting_index;
+            if let EntryType::Transactions(ref transactions) = entry {
+                entry_starting_index = entry_starting_index.saturating_add(transactions.len());
+            }
+            ReplayEntry {
+                entry,
+                starting_index,
+            }
+        })
+        .collect();
 
     let result = process_entries(
         bank,
@@ -1115,7 +1141,7 @@ fn confirm_full_slot(
         result?;
     }
 
-    progress.wait_for_all_verification_results(&mut 0)
+    progress.wait_for_all_verification_results(&mut 0, &mut 0)
 }
 
 /// Measures different parts of the slot confirmation processing pipeline.
@@ -1432,22 +1458,25 @@ impl ConfirmationProgress {
     fn collect_available_verification_results(
         &mut self,
         poh_verify_elapsed: &mut u64,
+        transaction_verify_elapsed: &mut u64,
     ) -> result::Result<(), BlockstoreProcessorError> {
         self.async_verification
-            .collect_available_results(poh_verify_elapsed)
+            .collect_available_results(poh_verify_elapsed, transaction_verify_elapsed)
     }
 
     pub fn wait_for_all_verification_results(
         &mut self,
         poh_verify_elapsed: &mut u64,
+        transaction_verify_elapsed: &mut u64,
     ) -> result::Result<(), BlockstoreProcessorError> {
         self.async_verification
-            .wait_for_all_results(poh_verify_elapsed)
+            .wait_for_all_results(poh_verify_elapsed, transaction_verify_elapsed)
     }
 }
 
 struct AsyncVerificationResult {
     poh_verify_elapsed: u64,
+    transaction_verify_elapsed: u64,
     error: Option<BlockstoreProcessorError>,
 }
 
@@ -1487,6 +1516,7 @@ impl AsyncVerificationProgress {
         &mut self,
         replay_tx_thread_pool: &ThreadPool,
         poh_verify_elapsed: &mut u64,
+        transaction_verify_elapsed: &mut u64,
         work: impl FnOnce() -> AsyncVerificationResult + Send + 'static,
     ) -> result::Result<(), BlockstoreProcessorError> {
         while self.sender.is_full() {
@@ -1496,7 +1526,7 @@ impl AsyncVerificationProgress {
             //
             // We also really don't want sender.send(result) below to sleep, because that would
             // block rayon threads slowing down progress even more.
-            self.collect_available_results(poh_verify_elapsed)?;
+            self.collect_available_results(poh_verify_elapsed, transaction_verify_elapsed)?;
         }
         self.pending_jobs = self.pending_jobs.saturating_add(1);
         let sender = self.sender.clone();
@@ -1512,9 +1542,10 @@ impl AsyncVerificationProgress {
     fn collect_available_results(
         &mut self,
         poh_verify_elapsed: &mut u64,
+        transaction_verify_elapsed: &mut u64,
     ) -> result::Result<(), BlockstoreProcessorError> {
         while let Ok(result) = self.receiver.try_recv() {
-            self.apply_result(result, poh_verify_elapsed);
+            self.apply_result(result, poh_verify_elapsed, transaction_verify_elapsed);
         }
         if let Some(error) = self.first_error.take() {
             return Err(error);
@@ -1528,12 +1559,13 @@ impl AsyncVerificationProgress {
     fn wait_for_all_results(
         &mut self,
         poh_verify_elapsed: &mut u64,
+        transaction_verify_elapsed: &mut u64,
     ) -> result::Result<(), BlockstoreProcessorError> {
         while self.pending_jobs > 0 {
             let result = self.receiver.recv().map_err(|_| {
                 BlockstoreProcessorError::InvalidBlock(BlockError::InvalidEntryHash)
             })?;
-            self.apply_result(result, poh_verify_elapsed);
+            self.apply_result(result, poh_verify_elapsed, transaction_verify_elapsed);
         }
         if let Some(error) = self.first_error.take() {
             return Err(error);
@@ -1545,12 +1577,15 @@ impl AsyncVerificationProgress {
         &mut self,
         AsyncVerificationResult {
             poh_verify_elapsed: poh_us,
+            transaction_verify_elapsed: tx_verify_us,
             error,
         }: AsyncVerificationResult,
         poh_verify_elapsed: &mut u64,
+        transaction_verify_elapsed: &mut u64,
     ) {
         self.pending_jobs = self.pending_jobs.saturating_sub(1);
         *poh_verify_elapsed = poh_verify_elapsed.saturating_add(poh_us);
+        *transaction_verify_elapsed = transaction_verify_elapsed.saturating_add(tx_verify_us);
         if self.first_error.is_none() {
             self.first_error = error;
         }
@@ -1698,6 +1733,7 @@ fn confirm_slot_entries(
         progress.async_verification.spawn(
             replay_tx_thread_pool,
             poh_verify_elapsed,
+            transaction_verify_elapsed,
             move || {
                 datapoint_debug!(
                     "verify-batch-size",
@@ -1714,44 +1750,64 @@ fn confirm_slot_entries(
                 };
                 AsyncVerificationResult {
                     poh_verify_elapsed: state.poh_duration_us(),
+                    transaction_verify_elapsed: 0,
                     error,
                 }
             },
         )?;
     }
 
-    let verify_transaction = {
+    let validate_and_hash_transaction = {
         let bank = bank.clone_with_scheduler();
-        move |versioned_tx: VersionedTransaction,
-              verification_mode: TransactionVerificationMode|
-              -> Result<RuntimeTransaction<SanitizedTransaction>> {
-            bank.verify_transaction(versioned_tx, verification_mode)
+        move |versioned_tx: VersionedTransaction, serialized_message: &[u8]| {
+            bank.verify_transaction_with_serialized_message(
+                versioned_tx,
+                serialized_message,
+                TransactionVerificationMode::HashOnly,
+            )
         }
     };
 
-    let transaction_verification_start = Instant::now();
-    let transaction_verification_result = entry::start_verify_transactions(
+    let entry::ValidatedHashedTransactions {
         entries,
-        skip_verification,
-        replay_tx_thread_pool,
-        Arc::new(verify_transaction),
-    );
-    let transaction_cpu_duration_us = transaction_verification_start.elapsed().as_micros() as u64;
-
-    let mut transaction_verification_result = match transaction_verification_result {
-        Ok(transaction_verification_result) => transaction_verification_result,
+        unverified_signatures,
+    } = match entry::validate_and_hash_transactions(
+        entries,
+        num_txs,
+        transaction_hash_verify_thread_pool(),
+        validate_and_hash_transaction,
+    ) {
+        Ok(txs) => txs,
         Err(err) => {
             warn!(
-                "Ledger transaction signature verification failed at slot: {}",
+                "Ledger transaction hash verification failed at slot: {}",
                 bank.slot()
             );
             return Err(err.into());
         }
     };
-
-    let entries = transaction_verification_result
-        .entries()
-        .expect("Transaction verification generates entries");
+    if !skip_verification {
+        progress.async_verification.spawn(
+            replay_tx_thread_pool,
+            poh_verify_elapsed,
+            transaction_verify_elapsed,
+            move || {
+                let verification_start = Instant::now();
+                let error = unverified_signatures
+                    .verify()
+                    .map_err(BlockstoreProcessorError::from)
+                    .err();
+                if let Some(err) = &error {
+                    warn!("Ledger transaction signature verification failed at slot {slot}: {err}");
+                }
+                AsyncVerificationResult {
+                    poh_verify_elapsed: 0,
+                    transaction_verify_elapsed: verification_start.elapsed().as_micros() as u64,
+                    error,
+                }
+            },
+        )?;
+    }
 
     let mut replay_timer = Measure::start("replay_elapsed");
     let is_vote_only_bank = bank.vote_only_bank();
@@ -1798,21 +1854,9 @@ fn confirm_slot_entries(
     replay_timer.stop();
     *replay_elapsed += replay_timer.as_us();
 
-    {
-        let valid = transaction_verification_result.status();
-        *transaction_verify_elapsed += transaction_cpu_duration_us;
-
-        if !valid {
-            warn!(
-                "Ledger transaction signature verification failed at slot: {}",
-                bank.slot()
-            );
-            return Err(TransactionError::SignatureFailure.into());
-        }
-    }
-
     process_result?;
-    progress.collect_available_verification_results(poh_verify_elapsed)?;
+    progress
+        .collect_available_verification_results(poh_verify_elapsed, transaction_verify_elapsed)?;
 
     progress.num_shreds += num_shreds;
     progress.num_entries += num_entries;
@@ -4996,7 +5040,7 @@ pub mod tests {
             None,
             &MigrationStatus::default(),
         )?;
-        progress.wait_for_all_verification_results(&mut 0)
+        progress.wait_for_all_verification_results(&mut 0, &mut 0)
     }
 
     fn create_test_transactions(
@@ -5092,7 +5136,9 @@ pub mod tests {
             &MigrationStatus::default(),
         )
         .unwrap();
-        progress.wait_for_all_verification_results(&mut 0).unwrap();
+        progress
+            .wait_for_all_verification_results(&mut 0, &mut 0)
+            .unwrap();
         assert_eq!(progress.num_txs, 2);
         let batch = transaction_status_receiver.recv().unwrap();
         if let TransactionStatusMessage::Batch((batch, _sequence)) = batch {
@@ -5138,7 +5184,9 @@ pub mod tests {
             &MigrationStatus::default(),
         )
         .unwrap();
-        progress.wait_for_all_verification_results(&mut 0).unwrap();
+        progress
+            .wait_for_all_verification_results(&mut 0, &mut 0)
+            .unwrap();
         assert_eq!(progress.num_txs, 5);
         let batch = transaction_status_receiver.recv().unwrap();
         if let TransactionStatusMessage::Batch((batch, _sequnce)) = batch {
@@ -5148,6 +5196,29 @@ pub mod tests {
         } else {
             panic!("batch should have been sent");
         }
+    }
+
+    #[test]
+    fn test_confirm_slot_entries_async_sigverify_fail() {
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(100 * LAMPORTS_PER_SOL);
+        let genesis_hash = genesis_config.hash();
+        let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+
+        let mut tx =
+            system_transaction::transfer(&mint_keypair, &Pubkey::new_unique(), 1, genesis_hash);
+        tx.signatures[0] = solana_signature::Signature::default();
+        let entry = Entry::new(&genesis_hash, 1, vec![tx]);
+
+        assert_matches!(
+            confirm_slot_entries_for_tests(&bank, vec![entry], false, genesis_hash),
+            Err(BlockstoreProcessorError::InvalidTransaction(
+                TransactionError::SignatureFailure
+            ))
+        );
     }
 
     fn do_test_schedule_batches_for_execution(should_succeed: bool) {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -39,7 +39,7 @@ use {
         runtime_config::RuntimeConfig,
         snapshot_controller::SnapshotController,
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
-        vote_sender_types::ReplayVoteSender,
+        vote_sender_types::{ReplayVoteMessage, ReplayVoteSendType, ReplayVoteSender},
     },
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
@@ -174,6 +174,7 @@ pub fn execute_batch<'a>(
     bank: &'a Arc<Bank>,
     transaction_status_sender: Option<&'a TransactionStatusSender>,
     replay_vote_sender: Option<&'a ReplayVoteSender>,
+    replay_vote_send_type: ReplayVoteSendType,
     timings: &'a mut ExecuteTimings,
     log_messages_bytes_limit: Option<usize>,
     prioritization_fee_cache: Option<&'a PrioritizationFeeCache>,
@@ -283,6 +284,7 @@ pub fn execute_batch<'a>(
         batch.sanitized_transactions(),
         &commit_results,
         replay_vote_sender,
+        replay_vote_send_type,
     );
 
     if let Some(prioritization_fee_cache) = prioritization_fee_cache {
@@ -420,6 +422,10 @@ fn execute_batches_internal(
                     bank,
                     transaction_status_sender,
                     replay_vote_sender,
+                    ReplayVoteSendType::Executed {
+                        replay_bank_id: bank.bank_id(),
+                        replay_slot: bank.slot(),
+                    },
                     &mut timings,
                     log_messages_bytes_limit,
                     prioritization_fee_cache,
@@ -1111,6 +1117,16 @@ fn confirm_full_slot(
 ) -> result::Result<(), BlockstoreProcessorError> {
     let mut confirmation_timing = ConfirmationTiming::default();
     let skip_verification = !opts.run_verification;
+    let slot = bank.slot();
+    let bank_id = bank.bank_id();
+    defer! {
+        if let Some(replay_vote_sender) = replay_vote_sender {
+            let _ = replay_vote_sender.send(ReplayVoteMessage::BankComplete {
+                replay_bank_id: bank_id,
+                replay_slot: slot,
+            });
+        }
+    }
 
     confirm_slot(
         blockstore,
@@ -1786,7 +1802,20 @@ fn confirm_slot_entries(
             return Err(err.into());
         }
     };
-    if !skip_verification {
+    let bank_id = bank.bank_id();
+    if skip_verification {
+        if let Some(replay_vote_sender) = replay_vote_sender {
+            let verified_vote_signatures = unverified_signatures.vote_transaction_signatures();
+            if !verified_vote_signatures.is_empty() {
+                let _ = replay_vote_sender.send(ReplayVoteMessage::Verified {
+                    replay_bank_id: bank_id,
+                    replay_slot: slot,
+                    verified_signatures: verified_vote_signatures,
+                });
+            }
+        }
+    } else {
+        let replay_vote_sender = replay_vote_sender.cloned();
         progress.async_verification.spawn(
             replay_tx_thread_pool,
             poh_verify_elapsed,
@@ -1799,6 +1828,22 @@ fn confirm_slot_entries(
                     .err();
                 if let Some(err) = &error {
                     warn!("Ledger transaction signature verification failed at slot {slot}: {err}");
+                    if let Some(replay_vote_sender) = &replay_vote_sender {
+                        let _ = replay_vote_sender.send(ReplayVoteMessage::InvalidBank {
+                            replay_bank_id: bank_id,
+                            replay_slot: slot,
+                        });
+                    }
+                } else if let Some(replay_vote_sender) = &replay_vote_sender {
+                    let verified_vote_signatures =
+                        unverified_signatures.vote_transaction_signatures();
+                    if !verified_vote_signatures.is_empty() {
+                        let _ = replay_vote_sender.send(ReplayVoteMessage::Verified {
+                            replay_bank_id: bank_id,
+                            replay_slot: slot,
+                            verified_signatures: verified_vote_signatures,
+                        });
+                    }
                 }
                 AsyncVerificationResult {
                     poh_verify_elapsed: 0,
@@ -4743,7 +4788,16 @@ pub mod tests {
         );
         let successes: BTreeSet<Pubkey> = replay_vote_receiver
             .try_iter()
-            .map(|(vote_pubkey, ..)| vote_pubkey)
+            .filter_map(|replay_vote| match replay_vote {
+                ReplayVoteMessage::VerifiedExecuted((vote_pubkey, ..))
+                | ReplayVoteMessage::Executed {
+                    parsed_vote: (vote_pubkey, ..),
+                    ..
+                } => Some(vote_pubkey),
+                ReplayVoteMessage::Verified { .. }
+                | ReplayVoteMessage::InvalidBank { .. }
+                | ReplayVoteMessage::BankComplete { .. } => None,
+            })
             .collect();
         assert_eq!(successes, expected_successful_voter_pubkeys);
     }
@@ -5393,6 +5447,7 @@ pub mod tests {
                 dependency_tracker: None,
             }),
             None,
+            ReplayVoteSendType::VerifiedExecuted,
             &mut timing,
             None,
             None,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6764,6 +6764,8 @@ dependencies = [
  "log",
  "num_cpus",
  "rayon",
+ "smallvec",
+ "solana-address 2.2.0",
  "solana-bls-signatures",
  "solana-clock",
  "solana-hash 4.2.0",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -122,7 +122,9 @@ use {
     solana_keypair::Keypair,
     solana_lattice_hash::lt_hash::LtHash,
     solana_measure::{measure::Measure, measure_time, measure_us},
-    solana_message::{AccountKeys, SanitizedMessage, inner_instruction::InnerInstructions},
+    solana_message::{
+        AccountKeys, SanitizedMessage, VersionedMessage, inner_instruction::InnerInstructions,
+    },
     solana_packet::PACKET_DATA_SIZE,
     solana_precompile_error::PrecompileError,
     solana_program_runtime::{
@@ -4961,37 +4963,61 @@ impl Bank {
         }
     }
 
+    /// Verify the transaction signatures, hash and other metadata.
     pub fn verify_transaction(
         &self,
         tx: VersionedTransaction,
         verification_mode: TransactionVerificationMode,
     ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
-        let enable_instruction_account_limit = self
-            .feature_set
-            .is_active(&agave_feature_set::limit_instruction_accounts::id());
-
         // Discard v1 transactions until support is added.
         if tx.version() == TransactionVersion::Number(1) {
             return Err(TransactionError::UnsupportedVersion);
         }
 
+        let serialized_message = tx.message.serialize();
+        self.verify_transaction_with_serialized_message(tx, &serialized_message, verification_mode)
+    }
+
+    /// Verify the transaction signatures, hash and other metadata, using the provided serialized
+    /// message.
+    ///
+    /// Verifying a transaction requires the serialized message to calculate the message hash. Use
+    /// this function if the message is already available. Note that the serialized message MUST
+    /// correspond to the transaction's message.
+    pub fn verify_transaction_with_serialized_message(
+        &self,
+        tx: VersionedTransaction,
+        serialized_message: &[u8],
+        verification_mode: TransactionVerificationMode,
+    ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
+        // Discard v1 transactions until support is added.
+        if tx.version() == TransactionVersion::Number(1) {
+            return Err(TransactionError::UnsupportedVersion);
+        }
+
+        let enable_instruction_account_limit = self
+            .feature_set
+            .is_active(&agave_feature_set::limit_instruction_accounts::id());
+
         let sanitized_tx = {
             let size =
-                bincode::serialized_size(&tx).map_err(|_| TransactionError::SanitizeFailure)?;
+                wincode::serialized_size(&tx).map_err(|_| TransactionError::SanitizeFailure)?;
             if size > PACKET_DATA_SIZE as u64 {
                 return Err(TransactionError::SanitizeFailure);
             }
+
+            // SIMD-0160, check instruction limit before signature verification
+            if tx.message.instructions().len()
+                > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
+            {
+                return Err(solana_transaction_error::TransactionError::SanitizeFailure);
+            }
+
             let message_hash = if verification_mode == TransactionVerificationMode::FullVerification
             {
-                // SIMD-0160, check instruction limit before signature verificaton
-                if tx.message.instructions().len()
-                    > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
-                {
-                    return Err(solana_transaction_error::TransactionError::SanitizeFailure);
-                }
                 tx.verify_and_hash_message()?
             } else {
-                tx.message.hash()
+                VersionedMessage::hash_raw_message(serialized_message)
             };
 
             RuntimeTransaction::try_create(

--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -1,5 +1,5 @@
 use {
-    crate::vote_sender_types::ReplayVoteSender,
+    crate::vote_sender_types::{ReplayVoteMessage, ReplayVoteSendType, ReplayVoteSender},
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_svm::transaction_commit_result::{
         TransactionCommitResult, TransactionCommitResultExtensions,
@@ -44,6 +44,7 @@ pub fn find_and_send_votes(
     sanitized_txs: &[impl TransactionWithMeta],
     commit_results: &[TransactionCommitResult],
     vote_sender: Option<&ReplayVoteSender>,
+    send_type: ReplayVoteSendType,
 ) {
     if let Some(vote_sender) = vote_sender {
         sanitized_txs
@@ -53,7 +54,20 @@ pub fn find_and_send_votes(
                 if tx.is_simple_vote_transaction() && commit_result.was_executed_successfully() {
                     if let Some(parsed_vote) = vote_parser::parse_sanitized_vote_transaction(tx) {
                         if parsed_vote.1.last_voted_slot().is_some() {
-                            let _ = vote_sender.send(parsed_vote);
+                            let vote = match send_type {
+                                ReplayVoteSendType::VerifiedExecuted => {
+                                    ReplayVoteMessage::VerifiedExecuted(parsed_vote)
+                                }
+                                ReplayVoteSendType::Executed {
+                                    replay_bank_id,
+                                    replay_slot,
+                                } => ReplayVoteMessage::Executed {
+                                    replay_bank_id,
+                                    replay_slot,
+                                    parsed_vote,
+                                },
+                            };
+                            let _ = vote_sender.send(vote);
                         }
                     }
                 }

--- a/runtime/src/vote_sender_types.rs
+++ b/runtime/src/vote_sender_types.rs
@@ -1,7 +1,59 @@
 use {
     crossbeam_channel::{Receiver, Sender},
+    solana_clock::{BankId, Slot},
+    solana_signature::Signature,
     solana_vote::vote_parser::ParsedVote,
 };
 
-pub type ReplayVoteSender = Sender<ParsedVote>;
-pub type ReplayVoteReceiver = Receiver<ParsedVote>;
+/// Message sent by banking and replay to the solCiProcVotes thread to update its state machine.
+///
+/// Banking sends VerifiedExecuted(vote) as it builds a block, and solCiProcVotes processes those
+/// votes immediately.
+///
+/// Replay runs sigverify and execution in parallel, and sends Verified and Executed respectively as
+/// those stages complete. solCiProcVotes waits until it has received both messages for a given vote
+/// before processing it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ReplayVoteMessage {
+    /// The vote was sigverified and executed
+    VerifiedExecuted(ParsedVote),
+    /// The vote was executed, but sigverify might not have finished yet
+    Executed {
+        replay_bank_id: BankId,
+        replay_slot: Slot,
+        parsed_vote: ParsedVote,
+    },
+    /// The vote was sigverified.
+    Verified {
+        replay_bank_id: BankId,
+        replay_slot: Slot,
+        verified_signatures: Vec<Signature>,
+    },
+    /// The bank is invalid no more votes should be processed.
+    ///
+    /// This is informative and used to release memory early. If not sent (like
+    /// in some replay error paths), memory will be released as slots are rooted.
+    InvalidBank {
+        replay_bank_id: BankId,
+        replay_slot: Slot,
+    },
+    /// The bank is complete.
+    ///
+    /// Like InvalidBank this is informative and used to release memory early.
+    BankComplete {
+        replay_bank_id: BankId,
+        replay_slot: Slot,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReplayVoteSendType {
+    VerifiedExecuted,
+    Executed {
+        replay_bank_id: BankId,
+        replay_slot: Slot,
+    },
+}
+
+pub type ReplayVoteSender = Sender<ReplayVoteMessage>;
+pub type ReplayVoteReceiver = Receiver<ReplayVoteMessage>;

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -39,7 +39,7 @@ use {
             UninstalledScheduler, UninstalledSchedulerBox, initialized_result_with_timings,
         },
         prioritization_fee_cache::PrioritizationFeeCache,
-        vote_sender_types::ReplayVoteSender,
+        vote_sender_types::{ReplayVoteSendType, ReplayVoteSender},
     },
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_svm::transaction_processing_result::ProcessedTransaction,
@@ -1283,6 +1283,13 @@ impl TaskHandler for DefaultTaskHandler {
             bank,
             handler_context.transaction_status_sender.as_ref(),
             handler_context.replay_vote_sender.as_ref(),
+            match scheduling_context.mode() {
+                BlockVerification => ReplayVoteSendType::Executed {
+                    replay_bank_id: bank.bank_id(),
+                    replay_slot: bank.slot(),
+                },
+                BlockProduction => ReplayVoteSendType::VerifiedExecuted,
+            },
             timings,
             handler_context.log_messages_bytes_limit,
             handler_context.prioritization_fee_cache.as_deref(),


### PR DESCRIPTION
Similar to #10723 but for transactions.

This splits hash verification from signature verification for transactions. Runs the latter in background while txs are executed. At the end of a block if any signature verification failed the block is considered invalid. 

The top commit adjusts solCiProcVotes to wait until both sigverify and exec are complete before doing state transitions based on votes. 