### PR TITLE
quic server: add banlist functionality

### DIFF
--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -191,11 +191,14 @@ impl Tpu {
         // Streamer for Votes:
         let quic_vote_sockets: Vec<QuicSocket> =
             tpu_vote_quic_sockets.into_iter().map(Into::into).collect();
-        let SpawnServerResult {
-            endpoints: _,
-            thread: tpu_vote_quic_t,
-            key_updater: vote_streamer_key_updater,
-        } = spawn_simple_qos_server(
+        let (
+            SpawnServerResult {
+                endpoints: _,
+                thread: tpu_vote_quic_t,
+                key_updater: vote_streamer_key_updater,
+            },
+            _banlist,
+        ) = spawn_simple_qos_server(
             "solQuicTVo",
             "quic_streamer_tpu_vote",
             quic_vote_sockets,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -263,12 +263,14 @@ impl Tvu {
         let bls_sigverify_threads = if let Some(bls_socket) = bls_socket {
             let (bls_packet_sender, bls_packet_receiver) = bounded(MAX_ALPENGLOW_PACKET_NUM);
 
-            // streamer
-            let SpawnServerResult {
-                endpoints: _,
-                thread: bls_streamer_t,
-                key_updater: bls_key_updater,
-            } = {
+            let (
+                SpawnServerResult {
+                    endpoints: _,
+                    thread: bls_streamer_t,
+                    key_updater: bls_key_updater,
+                },
+                _banlist,
+            ) = {
                 let quic_server_params = QuicStreamerConfig {
                     num_threads: NonZeroUsize::new(4.min(num_cpus::get())).unwrap(),
                     ..Default::default()

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -476,7 +476,7 @@ pub fn start_quic_streamer_to_listen_for_votes_and_certs(
         Arc::new(stakes),
         HashMap::<Pubkey, u64>::default(), // overrides
     )));
-    let result = spawn_simple_qos_server(
+    let (result, _banlist) = spawn_simple_qos_server(
         "solAlpenglowTest",
         "alpenglow_local_cluster_test",
         [vote_listener_socket.into()],

--- a/net-utils/src/banlist.rs
+++ b/net-utils/src/banlist.rs
@@ -1,0 +1,99 @@
+use std::{
+    borrow::Borrow,
+    collections::HashMap,
+    hash::Hash,
+    sync::RwLock,
+    time::{Duration, Instant},
+};
+
+/// Tracks temporary bans based on e.g. address or pubkey
+#[derive(Default)]
+pub struct Banlist<T> {
+    banned: RwLock<HashMap<T, Instant>>,
+}
+
+impl<T: Eq + Hash> Banlist<T> {
+    /// Ban the `id` for the specified `timeout`
+    pub fn ban(&self, id: T, timeout: Duration) {
+        debug_assert!(!timeout.is_zero());
+        let Some(expires_at) = Instant::now().checked_add(timeout) else {
+            return;
+        };
+        let prev = self.banned.write().unwrap().insert(id, expires_at);
+        debug_assert!(prev < Some(expires_at));
+    }
+
+    /// Check if `id` is banned using the current time.
+    pub fn is_banned<Q>(&self, id: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let now = Instant::now();
+        let Some(expires_at) = self.banned.read().unwrap().get(id).copied() else {
+            return false;
+        };
+
+        if expires_at > now {
+            return true;
+        }
+
+        let mut banned = self.banned.write().unwrap();
+        // Check again in case another thread modified  the banlist
+        let Some(expires_at) = banned.get(id).copied() else {
+            return false;
+        };
+
+        if expires_at > now {
+            return true;
+        }
+
+        banned.remove(id);
+        false
+    }
+
+    /// Prune the banlist for any expired bans
+    pub fn prune(&self) {
+        let now = Instant::now();
+        let mut banned = self.banned.write().unwrap();
+
+        banned.retain(|_, expires_at| *expires_at > now)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::Banlist,
+        std::time::{Duration, Instant},
+    };
+
+    #[test]
+    fn test_is_banned() {
+        let banlist = Banlist::<String>::default();
+        banlist.ban("malicious-peer".to_string(), Duration::from_secs(60));
+
+        assert!(banlist.is_banned("malicious-peer"));
+        assert!(!banlist.is_banned("benign-peer"));
+    }
+
+    #[test]
+    fn test_prune_removes_expired_entries() {
+        let banlist = Banlist::<String>::default();
+        let expired_id = "expired-peer".to_string();
+        let active_id = "active-peer".to_string();
+
+        {
+            let mut banned = banlist.banned.write().unwrap();
+            banned.insert(expired_id.clone(), Instant::now() - Duration::from_secs(1));
+            banned.insert(active_id.clone(), Instant::now() + Duration::from_secs(60));
+        }
+
+        banlist.prune();
+
+        let banned = banlist.banned.read().unwrap();
+        assert!(!banned.contains_key("expired-peer"));
+        assert!(banned.contains_key("active-peer"));
+        assert_eq!(banned.len(), 1);
+    }
+}

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -9,6 +9,7 @@
 #![warn(unsafe_attr_outside_unsafe)]
 #![warn(unsafe_op_in_unsafe_fn)]
 
+pub mod banlist;
 mod ip_echo_client;
 mod ip_echo_server;
 pub mod multihomed_sockets;

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -3,6 +3,7 @@ use {
         nonblocking::{
             qos::{ConnectionContext, OpaqueStreamerCounter, QosController},
             quic::{
+                CONNECTION_CLOSE_CODE_DISALLOWED, CONNECTION_CLOSE_REASON_DISALLOWED,
                 ClientConnectionTracker, ConnectionHandlerError, ConnectionPeerType,
                 ConnectionTable, ConnectionTableKey, ConnectionTableType, MAX_RTT, MIN_RTT,
                 get_connection_stake, update_open_connections_stat,
@@ -15,7 +16,8 @@ use {
         streamer::StakedNodes,
     },
     quinn::{Connection, VarInt},
-    solana_net_utils::token_bucket::TokenBucket,
+    solana_net_utils::{banlist::Banlist, token_bucket::TokenBucket},
+    solana_pubkey::Pubkey,
     solana_time_utils as timing,
     std::{
         future::Future,
@@ -35,6 +37,8 @@ use {
 /// Allow for extra streams "in flight" on top of the nominal
 /// send rate in case of bursty traffic from the sender side.
 const STREAMS_IN_FLIGHT_MARGIN: u32 = 2;
+
+pub type SimpleQosBanlist = Banlist<Pubkey>;
 
 #[derive(Clone)]
 pub struct SimpleQosConfig {
@@ -60,6 +64,7 @@ pub struct SimpleQos {
     stats: Arc<StreamerStats>,
     staked_connection_table: Arc<Mutex<ConnectionTable<TokenBucket>>>,
     staked_nodes: Arc<RwLock<StakedNodes>>,
+    pub(crate) banlist: Arc<SimpleQosBanlist>,
 }
 
 impl SimpleQos {
@@ -69,10 +74,12 @@ impl SimpleQos {
         staked_nodes: Arc<RwLock<StakedNodes>>,
         cancel: CancellationToken,
     ) -> Self {
+        let banlist = Arc::new(SimpleQosBanlist::default());
         Self {
             config,
             stats,
             staked_nodes,
+            banlist,
             staked_connection_table: Arc::new(Mutex::new(ConnectionTable::new(
                 ConnectionTableType::Staked,
                 cancel,
@@ -138,7 +145,7 @@ impl SimpleQos {
 #[derive(Clone)]
 pub struct SimpleQosConnectionContext {
     peer_type: ConnectionPeerType,
-    remote_pubkey: Option<solana_pubkey::Pubkey>,
+    remote_pubkey: Option<Pubkey>,
     remote_address: std::net::SocketAddr,
     last_update: Arc<AtomicU64>,
     stream_counter: Option<Arc<TokenBucket>>,
@@ -149,7 +156,7 @@ impl ConnectionContext for SimpleQosConnectionContext {
         self.peer_type
     }
 
-    fn remote_pubkey(&self) -> Option<solana_pubkey::Pubkey> {
+    fn remote_pubkey(&self) -> Option<Pubkey> {
         self.remote_pubkey
     }
 }
@@ -182,6 +189,20 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
     ) -> impl Future<Output = Option<CancellationToken>> + Send {
         async move {
             const PRUNE_RANDOM_SAMPLE_SIZE: usize = 2;
+            let remote_pubkey = conn_context.remote_pubkey()?;
+            if self.banlist.is_banned(&remote_pubkey) {
+                let remote_address = connection.remote_address();
+                info!("Rejecting banned pubkey {remote_pubkey} from {remote_address:?}");
+                self.stats
+                    .connection_add_failed_banned
+                    .fetch_add(1, Ordering::Relaxed);
+                connection.close(
+                    CONNECTION_CLOSE_CODE_DISALLOWED.into(),
+                    CONNECTION_CLOSE_REASON_DISALLOWED,
+                );
+                return None;
+            }
+
             match conn_context.peer_type() {
                 ConnectionPeerType::Staked(stake) => {
                     let mut connection_table_l = self.staked_connection_table.lock().await;
@@ -389,7 +410,7 @@ mod tests {
         stakes.insert(server_keypair.pubkey(), stake_amount);
         stakes.insert(client_keypair.pubkey(), stake_amount);
 
-        let overrides: HashMap<solana_pubkey::Pubkey, u64> = HashMap::new();
+        let overrides: HashMap<Pubkey, u64> = HashMap::new();
 
         Arc::new(RwLock::new(StakedNodes::new(Arc::new(stakes), overrides)))
     }
@@ -424,7 +445,7 @@ mod tests {
         let remote_addr = server_connection.remote_address();
         let conn_context = SimpleQosConnectionContext {
             peer_type: ConnectionPeerType::Staked(1000),
-            remote_pubkey: Some(solana_pubkey::Pubkey::new_unique()),
+            remote_pubkey: Some(Pubkey::new_unique()),
             remote_address: remote_addr,
             last_update: Arc::new(AtomicU64::new(0)),
             stream_counter: None,
@@ -548,7 +569,7 @@ mod tests {
 
         let conn_context = SimpleQosConnectionContext {
             peer_type: ConnectionPeerType::Staked(1000),
-            remote_pubkey: Some(solana_pubkey::Pubkey::new_unique()),
+            remote_pubkey: Some(Pubkey::new_unique()),
             remote_address: remote_addr,
             last_update: Arc::new(AtomicU64::new(0)),
             stream_counter: None,
@@ -743,6 +764,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_try_add_connection_banned_pubkey_rejected() {
+        let cancel = CancellationToken::new();
+        let stats = Arc::new(StreamerStats::default());
+        let server_keypair = Keypair::new();
+        let client_keypair = Keypair::new();
+        let staked_nodes =
+            create_staked_nodes_with_keypairs(&server_keypair, &client_keypair, 50_000_000);
+
+        let simple_qos = SimpleQos::new(
+            SimpleQosConfig::default(),
+            stats.clone(),
+            staked_nodes,
+            cancel,
+        );
+
+        simple_qos
+            .banlist
+            .ban(client_keypair.pubkey(), Duration::from_secs(30));
+
+        let client_tracker = ClientConnectionTracker {
+            stats: stats.clone(),
+        };
+        let (server_connection, _client_endpoint, _server_endpoint) =
+            create_connection_with_keypairs(&server_keypair, &client_keypair).await;
+        let mut conn_context = simple_qos.build_connection_context(&server_connection);
+        let result = simple_qos
+            .try_add_connection(client_tracker, &server_connection, &mut conn_context)
+            .await;
+
+        assert!(result.is_none());
+        assert_eq!(
+            stats.connection_add_failed_banned.load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[tokio::test]
     async fn test_try_add_connection_max_staked_connections_with_pruning() {
         // Setup with very low max connections to trigger pruning
         let cancel = CancellationToken::new();
@@ -762,7 +820,7 @@ mod tests {
         // client 2 has higher stake so that it can prune client 1
         stakes.insert(client_keypair2.pubkey(), stake_amount * 2);
 
-        let overrides: HashMap<solana_pubkey::Pubkey, u64> = HashMap::new();
+        let overrides: HashMap<Pubkey, u64> = HashMap::new();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(Arc::new(stakes), overrides)));
 
         let simple_qos = SimpleQos::new(
@@ -832,7 +890,7 @@ mod tests {
         stakes.insert(server_keypair2.pubkey(), low_stake);
         stakes.insert(client_keypair2.pubkey(), low_stake);
 
-        let overrides: HashMap<solana_pubkey::Pubkey, u64> = HashMap::new();
+        let overrides: HashMap<Pubkey, u64> = HashMap::new();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(Arc::new(stakes), overrides)));
 
         let simple_qos = SimpleQos::new(

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -17,8 +17,8 @@ use {
     },
     solana_keypair::Keypair,
     solana_net_utils::sockets::{
-        SocketConfiguration as SocketConfig, bind_to_localhost_unique,
-        localhost_port_range_for_tests, multi_bind_in_range_with_config,
+        SocketConfiguration as SocketConfig, bind_to_with_config, localhost_port_range_for_tests,
+        multi_bind_in_range_with_config, unique_port_range_for_tests,
     },
     solana_perf::packet::PacketBatch,
     solana_tls_utils::{new_dummy_x509_certificate, tls_client_config_builder},
@@ -161,7 +161,42 @@ pub async fn make_client_endpoint(
     addr: &SocketAddr,
     client_keypair: Option<&Keypair>,
 ) -> Connection {
-    let client_socket = bind_to_localhost_unique().expect("should bind - client");
+    make_client_endpoint_with_local_addr(
+        addr,
+        SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            unique_port_range_for_tests(1).start,
+        ),
+        client_keypair,
+    )
+    .await
+    .expect("Test server should be already listening on '{addr}'")
+}
+
+pub async fn make_client_endpoint_with_bind_ip(
+    addr: &SocketAddr,
+    bind_ip: IpAddr,
+    client_keypair: Option<&Keypair>,
+) -> Result<Connection, quinn::ConnectionError> {
+    make_client_endpoint_with_local_addr(
+        addr,
+        SocketAddr::new(bind_ip, unique_port_range_for_tests(1).start),
+        client_keypair,
+    )
+    .await
+}
+
+pub async fn make_client_endpoint_with_local_addr(
+    addr: &SocketAddr,
+    local_addr: SocketAddr,
+    client_keypair: Option<&Keypair>,
+) -> Result<Connection, quinn::ConnectionError> {
+    let client_socket = bind_to_with_config(
+        local_addr.ip(),
+        local_addr.port(),
+        SocketConfig::default().set_non_blocking(true),
+    )
+    .expect("should bind client socket with local addr");
     let mut endpoint = quinn::Endpoint::new(
         EndpointConfig::default(),
         None,
@@ -177,7 +212,6 @@ pub async fn make_client_endpoint(
         .connect(*addr, "localhost")
         .expect("Endpoint configuration should be correct")
         .await
-        .expect("Test server should be already listening on 'localhost'")
 }
 
 pub async fn check_multiple_streams(

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -3,7 +3,7 @@ use {
         nonblocking::{
             qos::{ConnectionContext, QosController},
             quic::{ALPN_TPU_PROTOCOL_ID, DEFAULT_WAIT_FOR_CHUNK_TIMEOUT},
-            simple_qos::{SimpleQos, SimpleQosConfig},
+            simple_qos::{SimpleQos, SimpleQosBanlist, SimpleQosConfig},
             swqos::{SwQos, SwQosConfig},
         },
         quic_socket::QuicSocket,
@@ -193,6 +193,7 @@ pub struct StreamerStats {
     pub(crate) connection_add_failed_staked_node: AtomicUsize,
     pub(crate) connection_add_failed_unstaked_node: AtomicUsize,
     pub(crate) connection_add_failed_on_pruning: AtomicUsize,
+    pub(crate) connection_add_failed_banned: AtomicUsize,
     pub(crate) connection_setup_timeout: AtomicUsize,
     pub(crate) connection_setup_error: AtomicUsize,
     pub(crate) connection_setup_error_closed: AtomicUsize,
@@ -300,6 +301,11 @@ impl StreamerStats {
                 "connection_add_failed_on_pruning",
                 self.connection_add_failed_on_pruning
                     .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "connection_add_failed_banned",
+                self.connection_add_failed_banned.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
@@ -661,6 +667,8 @@ pub fn spawn_stake_weighted_qos_server(
 }
 
 /// Spawns a tokio runtime and a streamer instance inside it.
+///
+/// Additionally returns a banlist for control over connection admission
 pub fn spawn_simple_qos_server(
     thread_name: &'static str,
     metrics_name: &'static str,
@@ -671,14 +679,19 @@ pub fn spawn_simple_qos_server(
     quic_server_params: QuicStreamerConfig,
     qos_config: SimpleQosConfig,
     cancel: CancellationToken,
-) -> Result<SpawnServerResult, QuicServerError> {
+) -> Result<(SpawnServerResult, Arc<SimpleQosBanlist>), QuicServerError> {
+    let server_params = SimpleQosQuicStreamerConfig {
+        quic_streamer_config: quic_server_params,
+        qos_config,
+    };
     let stats = Arc::<StreamerStats>::default();
     let simple_qos = Arc::new(SimpleQos::new(
-        qos_config,
+        server_params.qos_config,
         stats.clone(),
         staked_nodes,
         cancel.clone(),
     ));
+    let banlist = simple_qos.banlist.clone();
 
     spawn_runtime_and_server(
         thread_name,
@@ -687,10 +700,11 @@ pub fn spawn_simple_qos_server(
         sockets,
         keypair,
         packet_sender,
-        quic_server_params,
+        server_params.quic_streamer_config,
         simple_qos,
         cancel,
     )
+    .map(|ssr| (ssr, banlist))
 }
 
 #[cfg(test)]
@@ -699,13 +713,20 @@ mod test {
         super::*,
         crate::nonblocking::{
             quic::test::*,
-            testing_utilities::{check_multiple_streams, make_client_endpoint},
+            testing_utilities::{
+                check_multiple_streams, make_client_endpoint, make_client_endpoint_with_bind_ip,
+            },
         },
         crossbeam_channel::{Receiver, unbounded},
         solana_net_utils::sockets::bind_to_localhost_unique,
         solana_pubkey::Pubkey,
         solana_signer::Signer,
-        std::{collections::HashMap, net::SocketAddr, time::Instant},
+        std::{
+            collections::HashMap,
+            net::{IpAddr, Ipv4Addr, SocketAddr},
+            sync::Arc,
+            time::Instant,
+        },
         tokio::time::sleep,
     };
 
@@ -724,17 +745,21 @@ mod test {
         crossbeam_channel::Receiver<PacketBatch>,
         SocketAddr,
         CancellationToken,
+        Arc<SimpleQosBanlist>,
     ) {
         let s = bind_to_localhost_unique().expect("should bind");
         let (sender, receiver) = unbounded();
         let keypair = Keypair::new();
         let server_address = s.local_addr().unwrap();
         let cancel = CancellationToken::new();
-        let SpawnServerResult {
-            endpoints: _,
-            thread: t,
-            key_updater: _,
-        } = spawn_simple_qos_server(
+        let (
+            SpawnServerResult {
+                endpoints: _,
+                thread: t,
+                key_updater: _,
+            },
+            banlist,
+        ) = spawn_simple_qos_server(
             "solQuicTest",
             "quic_streamer_test",
             [s.into()],
@@ -746,7 +771,7 @@ mod test {
             cancel.clone(),
         )
         .unwrap();
-        (t, receiver, server_address, cancel)
+        (t, receiver, server_address, cancel, banlist)
     }
 
     fn setup_swqos_quic_server() -> (
@@ -885,7 +910,7 @@ mod test {
             quic_streamer_config: server_params,
             qos_config,
         };
-        let (t, receiver, server_address, cancel) =
+        let (t, receiver, server_address, cancel, _banlist) =
             setup_simple_qos_quic_server(server_params, Arc::new(RwLock::new(staked_nodes)));
 
         let runtime = rt_for_test();
@@ -898,6 +923,93 @@ mod test {
             Some(&rich_node_keypair),
             num_expected_packets,
         ));
+        cancel.cancel();
+        t.join().unwrap();
+    }
+
+    #[test]
+    fn test_simple_qos_banned_pubkey_rejected_across_source_ip() {
+        agave_logger::setup();
+        let client_keypair = Keypair::new();
+        let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(
+            Arc::new(HashMap::from([(client_keypair.pubkey(), 1_000)])),
+            HashMap::<Pubkey, u64>::default(),
+        )));
+
+        let server_params = SimpleQosQuicStreamerConfig {
+            quic_streamer_config: QuicStreamerConfig::default_for_tests(),
+            qos_config: SimpleQosConfig {
+                max_connections_per_peer: 2,
+                max_streams_per_second: 20,
+                ..Default::default()
+            },
+        };
+        let (t, receiver, server_address, cancel, banlist) =
+            setup_simple_qos_quic_server(server_params, staked_nodes);
+
+        let runtime = rt_for_test();
+        runtime.block_on(async move {
+            let wait_for_packet = || async {
+                let start = Instant::now();
+                while start.elapsed().as_secs() < 3 {
+                    if let Ok(packet_batch) = receiver.try_recv() {
+                        return Some(packet_batch);
+                    }
+                    sleep(Duration::from_millis(25)).await;
+                }
+                None
+            };
+
+            // Pre-ban: same pubkey is accepted from different source IP addresses.
+            let connection = make_client_endpoint_with_bind_ip(
+                &server_address,
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                Some(&client_keypair),
+            )
+            .await
+            .expect("connection should succeed for staked client");
+            let mut stream = connection.open_uni().await.unwrap();
+            stream.write_all(&[9u8]).await.unwrap();
+            stream.finish().unwrap();
+            assert!(wait_for_packet().await.is_some());
+
+            let connection = make_client_endpoint_with_bind_ip(
+                &server_address,
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                Some(&client_keypair),
+            )
+            .await
+            .expect("connection should succeed for staked client");
+            let mut stream = connection.open_uni().await.unwrap();
+            stream.write_all(&[9u8]).await.unwrap();
+            stream.finish().unwrap();
+            let packet_batch = wait_for_packet().await.unwrap();
+            let remote_pubkey = packet_batch.get(0).unwrap().meta().remote_pubkey().unwrap();
+
+            // Ban the pubkey and ensure new connections are rejected.
+            banlist.ban(remote_pubkey, Duration::from_secs(30));
+            let post_ban = make_client_endpoint_with_bind_ip(
+                &server_address,
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)),
+                Some(&client_keypair),
+            )
+            .await;
+
+            // Rejection can happen at handshake or when opening streams.
+            if let Ok(connection) = post_ban {
+                if let Ok(mut stream) = connection.open_uni().await {
+                    let _ = stream.write_all(&[7u8]).await;
+                    let _ = stream.finish();
+                }
+            }
+
+            // Ensure nothing from the post-ban attempt made it through.
+            let start = Instant::now();
+            while start.elapsed().as_secs() < 1 {
+                assert!(receiver.try_recv().is_err());
+                sleep(Duration::from_millis(25)).await;
+            }
+        });
         cancel.cancel();
         t.join().unwrap();
     }


### PR DESCRIPTION
#### Problem
In alpenglow we leverage BLS to batch verify votes. This allows us to significantly speedup signature verification.
If any individual vote in the batch fails to verify, we must resort to verifying votes individually.

BLS verification is slow compared to ED25519, verifying individually loses the advantage of the BLS aggregation properties.

Any vote that fails to verify is malicious. In order to stop attackers from forcing us to verify serially, we need the ability to ban senders that send us malicious votes. 

https://github.com/anza-xyz/solana-sdk/pull/436 and the related changes gives us the ability to tie a packet to the `remote_pubkey` of the connection. We now need to add the ability to ban malicious pubkeys.

#### Summary of Changes
Add a banlist to the simple qos server and expose it for the BLS sigverifier to use in a future PR