### PR TITLE
Revert "fix: align xdp ebpf program bytes as required by the kernel ebpf parser (#10823)"

### DIFF
--- a/scripts/elf-hash-symbol.sh
+++ b/scripts/elf-hash-symbol.sh
@@ -58,17 +58,6 @@ echo "Size: $SYMBOL_SIZE bytes"
 echo "File Offset (Dec): $FILE_OFFSET_DEC"
 echo "----------------------"
 
-# 5. The program data is embedded in a struct with 4-byte alignment and a leading
-#    u8, to enforce ebpf alignment requirements. We need to skip past the leading
-#    byte initial value and remove the padding
-FILE_OFFSET_DEC=$((FILE_OFFSET_DEC + 1))
-SYMBOL_SIZE=$((SYMBOL_SIZE - 4))
-
-echo "--- Elf Details ---"
-echo "Start Offset: ${FILE_OFFSET_DEC}"
-echo "Size: ${SYMBOL_SIZE}"
-echo "-------------------"
-
 # dd command to extract and hash the content
 echo -n "Hash (SHA256): "
 dd if="$ELF_FILE" bs=1 skip="$FILE_OFFSET_DEC" count="$SYMBOL_SIZE" status=none 2>/dev/null | sha256sum | awk '{print $1}'

--- a/xdp-ebpf/src/lib.rs
+++ b/xdp-ebpf/src/lib.rs
@@ -8,22 +8,16 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 #![no_std]
 
-#[repr(C, align(4))]
-pub struct Aligned<Bytes: ?Sized> {
-    pub _align: u8,
-    pub bytes: Bytes,
-}
-
-#[cfg(all(target_os = "linux", not(target_arch = "bpf")))]
-macro_rules! program {
-    () => {
-        include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/agave-xdp-prog"))
-    };
-}
-
 #[cfg(all(target_os = "linux", not(target_arch = "bpf")))]
 #[unsafe(no_mangle)]
-pub static AGAVE_XDP_EBPF_PROGRAM: &Aligned<[u8; program!().len()]> = &Aligned {
-    _align: 0,
-    bytes: *program!(),
+pub static AGAVE_XDP_EBPF_PROGRAM: [u8; aya::include_bytes_aligned!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/agave-xdp-prog"
+))
+.len()] = unsafe {
+    core::ptr::read(
+        aya::include_bytes_aligned!(concat!(env!("CARGO_MANIFEST_DIR"), "/agave-xdp-prog"))
+            .as_ptr()
+            .cast(),
+    )
 };

--- a/xdp/src/program.rs
+++ b/xdp/src/program.rs
@@ -45,7 +45,7 @@ pub fn load_xdp_program(dev: &NetworkDevice) -> Result<Ebpf, Box<dyn std::error:
     let broken_frags = dev.driver()? == "i40e";
     let mut ebpf = if broken_frags {
         loader.set_global("AGAVE_XDP_DROP_MULTI_FRAGS", &1u8, true);
-        loader.load(&agave_xdp_ebpf::AGAVE_XDP_EBPF_PROGRAM.bytes)
+        loader.load(&agave_xdp_ebpf::AGAVE_XDP_EBPF_PROGRAM)
     } else {
         loader.load(&generate_xdp_elf())
     }?;


### PR DESCRIPTION
#### Problem
[concerns in original](https://github.com/anza-xyz/agave/pull/10823#discussion_r2851569897) pr were justified. i have a fix, but want a backportable change set

#### Summary of Changes
This reverts commit 424fac54cd8f835a6afbdc646909311c1251514f.