### PR TITLE
fix(2): align xdp ebpf program bytes as required by the kernel ebpf parser

### DIFF
--- a/scripts/elf-hash-symbol.sh
+++ b/scripts/elf-hash-symbol.sh
@@ -58,6 +58,11 @@ echo "Size: $SYMBOL_SIZE bytes"
 echo "File Offset (Dec): $FILE_OFFSET_DEC"
 echo "----------------------"
 
+if [ $((FILE_OFFSET_DEC % 4)) -ne 0 ]; then
+  echo "Error: ELF not aligned to 4-byte boundary, which is required be eBPF" >&2
+  exit 5
+fi
+
 # dd command to extract and hash the content
 echo -n "Hash (SHA256): "
 dd if="$ELF_FILE" bs=1 skip="$FILE_OFFSET_DEC" count="$SYMBOL_SIZE" status=none 2>/dev/null | sha256sum | awk '{print $1}'

--- a/xdp-ebpf/src/lib.rs
+++ b/xdp-ebpf/src/lib.rs
@@ -8,16 +8,19 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 #![no_std]
 
+#[repr(C, align(4))]
+pub struct Aligned<Bytes: ?Sized>(Bytes);
+
+impl<Bytes: ?Sized> core::ops::Deref for Aligned<Bytes> {
+    type Target = Bytes;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[cfg(all(target_os = "linux", not(target_arch = "bpf")))]
 #[unsafe(no_mangle)]
-pub static AGAVE_XDP_EBPF_PROGRAM: [u8; aya::include_bytes_aligned!(concat!(
+pub static AGAVE_XDP_EBPF_PROGRAM: &Aligned<[u8]> = &Aligned(*include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/agave-xdp-prog"
-))
-.len()] = unsafe {
-    core::ptr::read(
-        aya::include_bytes_aligned!(concat!(env!("CARGO_MANIFEST_DIR"), "/agave-xdp-prog"))
-            .as_ptr()
-            .cast(),
-    )
-};
+)));

--- a/xdp/src/program.rs
+++ b/xdp/src/program.rs
@@ -45,7 +45,7 @@ pub fn load_xdp_program(dev: &NetworkDevice) -> Result<Ebpf, Box<dyn std::error:
     let broken_frags = dev.driver()? == "i40e";
     let mut ebpf = if broken_frags {
         loader.set_global("AGAVE_XDP_DROP_MULTI_FRAGS", &1u8, true);
-        loader.load(&agave_xdp_ebpf::AGAVE_XDP_EBPF_PROGRAM)
+        loader.load(agave_xdp_ebpf::AGAVE_XDP_EBPF_PROGRAM)
     } else {
         loader.load(&generate_xdp_elf())
     }?;


### PR DESCRIPTION
#### Problem
xdp ebpf program is required to load from a 4-byte aligned address, but we copy it out of aya's alignment helper to a destination with no alignment constraints

#### Summary of Changes
* add an aligned wrapper similar to aya's (will upstream a similar thing)
* compile-time embed the xdp ebpf elf bytes directly into our wrapper
* add an alignment check to the embedded elf verifier script

technically we could use aya's macro directly. however we desire verifiablity of the embedded elf and the macro discards size information, causing the symbol to be omitted from the validator binary. this makes locating the xdp ebpf elf bytes unreliable. replicoding the wrapper directly preserves the symbol allowing trivial location via readelf+grep

---

~change will just be the second commit. rebase after https://github.com/anza-xyz/agave/pull/10949~