### PR TITLE
ci: fetch codecov env only in coverage steps

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -282,16 +282,22 @@ EOF
       - command: "ci/docker-run-default-image.sh ci/coverage/part-1.sh"
         name: "coverage-1"
         timeout_in_minutes: 60
+        env:
+          FETCH_CODECOV_ENVS: true
         agents:
           queue: "default"
       - command: "ci/docker-run-default-image.sh ci/coverage/part-2.sh"
         name: "coverage-2"
         timeout_in_minutes: 60
+        env:
+          FETCH_CODECOV_ENVS: true
         agents:
           queue: "default"
       - command: "ci/docker-run-default-image.sh ci/coverage/part-3.sh"
         name: "coverage-3"
         timeout_in_minutes: 60
+        env:
+          FETCH_CODECOV_ENVS: true
         agents:
           queue: "default"
 EOF

--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -129,12 +129,16 @@ ARGS+=(
   --env CRATES_IO_TOKEN
 )
 
-# Also propagate environment variables needed for codecov
-# https://docs.codecov.io/docs/testing-with-docker#section-codecov-inside-docker
-# We normalize CI to `1`; but codecov expects it to be `true` to detect Buildkite...
-# Unfortunately, codecov.io fails sometimes:
-#   curl: (7) Failed to connect to codecov.io port 443: Connection timed out
-CODECOV_ENVS=$(CI=true bash <(while ! curl -sS --retry 5 --retry-delay 2 --retry-connrefused --fail https://codecov.io/env; do sleep 10; done))
+CODECOV_ENVS=
+if [[ ${FETCH_CODECOV_ENVS:-false} == true ]]; then
+	echo "FETCH_CODECOV_ENVS=true, fetching codecov environment variables"
+	# ref: https://docs.codecov.io/docs/testing-with-docker#section-codecov-inside-docker
+	# Unfortunately, codecov.io fails sometimes:
+	#   curl: (7) Failed to connect to codecov.io port 443: Connection timed out
+	CODECOV_ENVS=$(CI=true bash <(while ! curl -sS --retry 5 --retry-delay 2 --retry-connrefused --fail https://codecov.io/env; do sleep 10; done))
+else
+	echo "skipping fetching codecov environment variables. (set FETCH_CODECOV_ENVS to true to enable)"
+fi
 
 if $INTERACTIVE; then
   if [[ -n $1 ]]; then


### PR DESCRIPTION
#### Problem

context:
- https://discord.com/channels/428295358100013066/560503042458517505/1478431744221905007
- https://buildkite.com/anza/agave/builds/42293#019cb489-d27a-4c53-be4d-40468b8b0b4e/L88-L111

it happens sometimes:
```
2026-03-03 16:34:42 UTC | curl: (22) The requested URL returned error: 502
2026-03-03 16:34:53 UTC | curl: (22) The requested URL returned error: 502
2026-03-03 16:35:04 UTC | curl: (22) The requested URL returned error: 502
2026-03-03 16:35:24 UTC | curl: (22) The requested URL returned error: 502
2026-03-03 16:35:35 UTC | curl: (22) The requested URL returned error: 502
2026-03-03 16:35:46 UTC | curl: (22) The requested URL returned error: 502
2026-03-03 16:35:57 UTC | curl: (22) The requested URL returned error: 502
2026-03-03 16:36:08 UTC | curl: (22) The requested URL returned error: 502
2026-03-03 16:36:20 UTC | curl: (22) The requested URL returned error: 502
```

looks like it's generated by the codecov env setup. let's try only fetch it when needed

#### Summary of Changes

- fetch codecov env only in coverage steps

  - fetching in coverage steps: https://buildkite.com/anza/agave/builds/42346#019cb721-097f-41cb-a33b-f3f42336b249/L71
  - skipping in other steps: https://buildkite.com/anza/agave/builds/42346#019cb721-0947-437f-9714-4bcc1fbac179/L71