### PR TITLE
fix(gossip): reduce socket assignment info log from 164 lines to one

### DIFF
--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -441,7 +441,7 @@ impl Node {
             tpu_transaction_forwarding_clients,
             rpc_sts_client,
         };
-        info!("Bound all network sockets as follows: {:#?}", &sockets);
+        info!("Bound all network sockets as follows: {:?}", &sockets);
         Node {
             info,
             sockets,


### PR DESCRIPTION
#### Problem
gossip socket assignment log message emits 164 lines on startup

#### Summary of Changes
don't use pretty print format, reducing the message to one line