### PR TITLE
Bump alpine to 3.23.3

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -45,6 +45,7 @@ jobs:
       image: ${{ matrix.os.container }}
     env:
       RUSTFLAGS: ${{ matrix.os.rustflags }}
+      RUST_LIBC_UNSTABLE_MUSL_V1_2_3: true
     steps:
       # Alpine container needs:
       # * `bash`, to run the scripts.

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -37,7 +37,7 @@ jobs:
           - os: macos-15
           # musl with dynamic linking
           - os: ubuntu-24.04
-            container: docker.io/rust:1-alpine3.22
+            container: docker.io/rust:1-alpine3.23
             rustflags: -C target-feature=-crt-static
           - os: windows-2025
     runs-on: ${{ matrix.os.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,9 +4315,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libloading"
@@ -4707,9 +4707,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,7 +309,7 @@ jsonrpc-http-server = "18.0.0"
 jsonrpc-ipc-server = "18.0.0"
 jsonrpc-pubsub = "18.0.0"
 lazy-lru = "0.1.3"
-libc = "0.2.180"
+libc = "0.2.182"
 libloading = "0.9.0"
 libsecp256k1 = { version = "0.6.0", default-features = false, features = [
     "std",

--- a/accounts-db/src/utils.rs
+++ b/accounts-db/src/utils.rs
@@ -1,4 +1,5 @@
 use {
+    crate::accounts_db::AccountsDbConfig,
     agave_fs::dirs,
     log::*,
     solana_account::{AccountSharedData, ReadableAccount},
@@ -161,6 +162,36 @@ pub fn create_account_shared_data(account: &impl ReadableAccount) -> AccountShar
         account.executable(),
         account.rent_epoch(),
     )
+}
+
+/// Check that given paths conform to requirements defined by `config`.
+///
+/// Return `Err` if paths are impossible to access or do not support required features.
+///
+/// This functions validates that paths reside on filesystem supporting configured operations
+/// like direct-io. This allows providing meaningful error messages to user during startup
+/// instead of generating hard to diagnose errors during runtime.
+pub fn validate_account_paths_for_direct_io(
+    config: &AccountsDbConfig,
+    accounts_paths: &[PathBuf],
+    account_snapshot_paths: &[PathBuf],
+) -> io::Result<()> {
+    if config.snapshots_use_direct_io {
+        for path in accounts_paths.iter().chain(account_snapshot_paths.iter()) {
+            if agave_fs::metadata::check_direct_io_capability(path)? == Some(false) {
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    format!(
+                        "direct-io (O_DIRECT) is not supported for path `{}`. Ensure the \
+                         filesystem hosting that path supports direct-io, or disable direct-io \
+                         with --no-accounts-db-snapshots-direct-io flag.",
+                        path.display()
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -51,7 +51,7 @@ use {
     solana_accounts_db::{
         accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
-        utils::move_and_async_delete_path_contents,
+        utils::{move_and_async_delete_path_contents, validate_account_paths_for_direct_io},
     },
     solana_client::connection_cache::{ConnectionCache, Protocol},
     solana_clock::Slot,
@@ -831,12 +831,13 @@ impl Validator {
         let genesis_config = load_genesis(config, ledger_path)?;
         metrics_config_sanity_check(genesis_config.cluster_type)?;
 
-        info!("Cleaning accounts paths..");
+        info!("Validating and cleaning accounts paths..");
         *start_progress.write().unwrap() = ValidatorStartProgress::CleaningAccounts;
-        let mut timer = Measure::start("clean_accounts_paths");
+        let mut timer = Measure::start("validate_and_clean_accounts_paths");
+        validate_account_paths(config)?;
         cleanup_accounts_paths(config);
         timer.stop();
-        info!("Cleaning accounts paths done. {timer}");
+        info!("Validating and cleaning accounts paths done. {timer}");
 
         snapshot_utils::purge_incomplete_bank_snapshots(&config.snapshot_config.bank_snapshots_dir);
         snapshot_utils::purge_old_bank_snapshots_at_startup(
@@ -2918,6 +2919,14 @@ fn cleanup_accounts_paths(config: &ValidatorConfig) {
             move_and_async_delete_path_contents(shrink_path);
         }
     }
+}
+
+fn validate_account_paths(config: &ValidatorConfig) -> std::io::Result<()> {
+    validate_account_paths_for_direct_io(
+        &config.accounts_db_config,
+        &config.account_paths,
+        &config.account_snapshot_paths,
+    )
 }
 
 pub fn is_snapshot_config_valid(snapshot_config: &SnapshotConfig) -> bool {

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -3747,9 +3747,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libloading"
@@ -4139,9 +4139,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.4",

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -14,6 +14,7 @@ mod file_info;
 pub mod file_io;
 pub mod io_setup;
 mod io_uring;
+pub mod metadata;
 
 pub use file_info::FileInfo;
 

--- a/fs/src/metadata.rs
+++ b/fs/src/metadata.rs
@@ -1,8 +1,6 @@
 /// Utilities for querying filesystem metadata, including direct I/O support.
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-use std::{ffi::CString, mem};
 #[cfg(target_os = "linux")]
-use std::{fs, path::PathBuf};
+use std::{ffi::CString, fs, mem, path::PathBuf};
 use std::{io, path::Path};
 
 /// Returns whether `path` (a file or directory) resides on a filesystem that supports
@@ -20,14 +18,10 @@ pub fn check_direct_io_capability(path: impl AsRef<Path>) -> io::Result<Option<b
     let Some(file) = find_any_file_under_path(path.as_ref())? else {
         return Ok(None);
     };
-    // statx with STATX_DIOALIGN is the preferred check, but libc does not expose
-    // statx on musl (requires musl >= 1.2.3), so skip it there.
-    #[cfg(not(target_env = "musl"))]
-    {
-        let statx_result = check_direct_io_via_statx(&file);
-        if !matches!(&statx_result, Ok(None)) {
-            return statx_result;
-        }
+    // statx with STATX_DIOALIGN is the preferred check.
+    let statx_result = check_direct_io_via_statx(&file);
+    if !matches!(&statx_result, Ok(None)) {
+        return statx_result;
     }
     Ok(check_direct_io_via_open_probe(&file))
 }
@@ -43,7 +37,7 @@ pub fn check_direct_io_capability(_path: impl AsRef<Path>) -> io::Result<Option<
 /// Returns `Ok(Some(true))` when `stx_dio_mem_align != 0` (DIO supported),
 /// `Ok(Some(false))` when `STATX_DIOALIGN` is set but DIO is not supported, or
 /// `Ok(None)` when the kernel did not populate `STATX_DIOALIGN` fields (kernel < 6.1).
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+#[cfg(target_os = "linux")]
 fn check_direct_io_via_statx(path: &Path) -> io::Result<Option<bool>> {
     let path_cstr = CString::new(path.as_os_str().as_encoded_bytes())
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a null byte"))?;

--- a/fs/src/metadata.rs
+++ b/fs/src/metadata.rs
@@ -1,0 +1,181 @@
+/// Utilities for querying filesystem metadata, including direct I/O support.
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+use std::{ffi::CString, mem};
+#[cfg(target_os = "linux")]
+use std::{fs, path::PathBuf};
+use std::{io, path::Path};
+
+/// Returns whether `path` (a file or directory) resides on a filesystem that supports
+/// direct I/O (`O_DIRECT`).
+///
+/// Returns `Ok(Some(true))` if direct I/O is supported, `Ok(Some(false))` if it is not,
+/// or `Ok(None)` if no conclusion can be drawn (e.g. an empty directory or a path that
+/// does not exist).
+///
+/// On Linux: resolves a concrete file under `path` first, then attempts a `statx(2)`-based
+/// check; if the kernel does not support it (< 6.1), falls back to an open-probe check.
+/// On non-Linux platforms: always returns `Ok(None)`.
+#[cfg(target_os = "linux")]
+pub fn check_direct_io_capability(path: impl AsRef<Path>) -> io::Result<Option<bool>> {
+    let Some(file) = find_any_file_under_path(path.as_ref())? else {
+        return Ok(None);
+    };
+    // statx with STATX_DIOALIGN is the preferred check, but libc does not expose
+    // statx on musl (requires musl >= 1.2.3), so skip it there.
+    #[cfg(not(target_env = "musl"))]
+    {
+        let statx_result = check_direct_io_via_statx(&file);
+        if !matches!(&statx_result, Ok(None)) {
+            return statx_result;
+        }
+    }
+    Ok(check_direct_io_via_open_probe(&file))
+}
+
+/// Always return `Ok(None)`, since direct I/O functionality is not used on non-linux
+#[cfg(not(target_os = "linux"))]
+pub fn check_direct_io_capability(_path: impl AsRef<Path>) -> io::Result<Option<bool>> {
+    Ok(None)
+}
+
+/// Check direct I/O capability via `statx(2)` with `STATX_DIOALIGN`.
+///
+/// Returns `Ok(Some(true))` when `stx_dio_mem_align != 0` (DIO supported),
+/// `Ok(Some(false))` when `STATX_DIOALIGN` is set but DIO is not supported, or
+/// `Ok(None)` when the kernel did not populate `STATX_DIOALIGN` fields (kernel < 6.1).
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+fn check_direct_io_via_statx(path: &Path) -> io::Result<Option<bool>> {
+    let path_cstr = CString::new(path.as_os_str().as_encoded_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a null byte"))?;
+
+    let mut statx_info: libc::statx = unsafe { mem::zeroed() };
+    let ret = unsafe {
+        libc::statx(
+            libc::AT_FDCWD,
+            path_cstr.as_ptr(),
+            // Follow symlinks; don't trigger automounts.
+            libc::AT_NO_AUTOMOUNT,
+            libc::STATX_DIOALIGN,
+            &mut statx_info,
+        )
+    };
+
+    if ret != 0 {
+        // statx is available since 4.11, fail completely if it doesn't properly execute
+        return Err(io::Error::last_os_error());
+    }
+
+    // Kernel did not populate DIOALIGN fields - kernels < 6.1 silently ignore unknown mask bits
+    // and file systems without proper implementation of the check will also ignore it.
+    let supported = if statx_info.stx_mask & libc::STATX_DIOALIGN == 0 {
+        None
+    } else {
+        // stx_dio_mem_align == 0 means the filesystem does not support DIO.
+        Some(statx_info.stx_dio_mem_align != 0)
+    };
+    Ok(supported)
+}
+
+/// Check direct I/O capability by attempting to open `file` with `O_DIRECT`.
+///
+/// Confirms the file is readable, then tries to reopen it with `O_DIRECT`.
+/// Returns `None` if the file is not readable and no conclusion can be drawn.
+#[cfg(target_os = "linux")]
+fn check_direct_io_via_open_probe(file: &Path) -> Option<bool> {
+    use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt as _};
+
+    // Confirm the file is readable at all; if not, we cannot conclude anything.
+    if OpenOptions::new().read(true).open(file).is_err() {
+        return None;
+    }
+    Some(
+        OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECT)
+            .open(file)
+            .is_ok(),
+    )
+}
+
+/// Returns a path to any regular file at or under `path`, recursively traversing
+/// directories and returning as soon as one file is found. Returns `Ok(None)` if
+/// no file exists under `path`.
+#[cfg(target_os = "linux")]
+fn find_any_file_under_path(path: &Path) -> io::Result<Option<PathBuf>> {
+    if path.is_file() {
+        return Ok(Some(path.to_path_buf()));
+    }
+    if path.is_dir() {
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            if let Some(path) = find_any_file_under_path(&entry.path())? {
+                return Ok(Some(path));
+            }
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use {super::*, tempfile::TempDir};
+
+    fn make_temp_file(dir: &TempDir, name: &str, content: &[u8]) -> std::path::PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_find_any_file_under_path_file() {
+        let dir = TempDir::new().unwrap();
+        let file = make_temp_file(&dir, "f.bin", b"hello");
+        assert_eq!(find_any_file_under_path(&file).unwrap(), Some(file));
+    }
+
+    #[test]
+    fn test_find_any_file_under_path_dir() {
+        let dir = TempDir::new().unwrap();
+        make_temp_file(&dir, "a.bin", b"data");
+        let candidate = find_any_file_under_path(dir.path()).unwrap();
+        assert!(candidate.is_some());
+        assert!(candidate.unwrap().is_file());
+    }
+
+    #[test]
+    fn test_find_any_file_under_path_empty_dir() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(find_any_file_under_path(dir.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn test_path_supports_direct_io_file() {
+        let dir = TempDir::new().unwrap();
+        let file = make_temp_file(&dir, "probe.bin", &[0u8; 4096]);
+        let result = check_direct_io_capability(&file).expect("check must not fail");
+        assert_eq!(result, Some(true), "dev filesystem must support direct I/O");
+    }
+
+    #[test]
+    fn test_path_supports_direct_io_dir() {
+        let dir = TempDir::new().unwrap();
+        make_temp_file(&dir, "probe.bin", &[0u8; 4096]);
+        let result = check_direct_io_capability(dir.path()).expect("check must not fail");
+        assert_eq!(result, Some(true), "dev filesystem must support direct I/O");
+    }
+
+    #[test]
+    fn test_path_supports_direct_io_empty_dir() {
+        let dir = TempDir::new().unwrap();
+        let result = check_direct_io_capability(dir.path()).expect("check must not fail");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_path_supports_direct_io_nonexistent_path() {
+        let dir = TempDir::new().unwrap();
+        let result = check_direct_io_capability(dir.path().join("does-not-exist"))
+            .expect("check must not fail");
+        assert_eq!(result, None);
+    }
+}

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -10,6 +10,7 @@ use {
     log::*,
     solana_accounts_db::utils::{
         create_all_accounts_run_and_snapshot_dirs, move_and_async_delete_path_contents,
+        validate_account_paths_for_direct_io,
     },
     solana_clock::Slot,
     solana_core::validator::{
@@ -106,6 +107,9 @@ pub(crate) enum LoadAndProcessLedgerError {
 
     #[error("failed to process blockstore from root: {0}")]
     ProcessBlockstoreFromRoot(#[source] BlockstoreProcessorError),
+
+    #[error("failed to validate account paths: {0}")]
+    ValidateAccountPaths(#[source] std::io::Error),
 }
 
 pub fn load_and_process_ledger_or_exit(
@@ -252,6 +256,13 @@ pub fn load_and_process_ledger(
             .map_err(LoadAndProcessLedgerError::CreateAllAccountsRunAndSnapshotDirectories)?;
     // From now on, use run/ paths in the same way as the previous account_paths.
     let account_paths = account_run_paths;
+
+    validate_account_paths_for_direct_io(
+        &process_options.accounts_db_config,
+        &account_paths,
+        &account_snapshot_paths,
+    )
+    .map_err(LoadAndProcessLedgerError::ValidateAccountPaths)?;
 
     let (_, measure_clean_account_paths) = measure_time!(
         account_paths.iter().for_each(|path| {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -3712,9 +3712,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libloading"
@@ -4151,9 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.4",


### PR DESCRIPTION
#### Problem
I need musl at version 1.2.5, seems like our existing alpine uses older version even though rust 1.93 already uses / requires 1.2.5

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
