### PR TITLE
vote-program: Remove unused dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11701,7 +11701,6 @@ dependencies = [
  "solana-svm-feature-set",
  "solana-system-interface 3.1.0",
  "solana-system-program",
- "solana-transaction",
  "solana-transaction-context",
  "solana-vote-interface",
  "solana-vote-program",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9751,7 +9751,6 @@ dependencies = [
  "solana-sdk-ids",
  "solana-slot-hashes",
  "solana-system-interface 3.1.0",
- "solana-transaction",
  "solana-transaction-context",
  "solana-vote-interface",
 ]

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -43,7 +43,7 @@ solana-runtime-transaction = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-short-vec = { workspace = true }
 solana-signature = { workspace = true }
-solana-transaction = { workspace = true }
+solana-transaction = { workspace = true, features = ["wincode"] }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 wincode = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10374,7 +10374,6 @@ dependencies = [
  "solana-sdk-ids",
  "solana-slot-hashes",
  "solana-system-interface 3.1.0",
- "solana-transaction",
  "solana-transaction-context",
  "solana-vote-interface",
 ]

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -50,7 +50,6 @@ solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-slot-hashes = { workspace = true }
 solana-system-interface = { workspace = true }
-solana-transaction = { workspace = true, features = ["wincode"] }
 solana-transaction-context = { workspace = true, features = ["bincode"] }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -26,7 +26,7 @@ log = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-instruction = { workspace = true }
 solana-hash = { workspace = true }
-solana-message = { workspace = true, features = ["blake3"] }
+solana-message = { workspace = true, features = ["blake3", "wincode"] }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true }

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -17,7 +17,7 @@ assert_matches = { workspace = true }
 solana-clock = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-runtime-transaction = { workspace = true }
-solana-transaction = { workspace = true }
+solana-transaction = { workspace = true, features = ["wincode"] }
 static_assertions = { workspace = true }
 unwrap_none = { workspace = true }
 


### PR DESCRIPTION
#### Problem
`solana-transaction` is not used in `solana-vote-program` but implicitly enables `wincode` feature to some crates that depend on `solana-vote-program`.

#### Summary of Changes
Remove the dependency and explicitly enable `wincode` feature where necessary.
