### PR TITLE
chore: Replacing MakeExtractIf with std equivalent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11582,7 +11582,6 @@ dependencies = [
  "test-case",
  "trait-set",
  "unwrap_none",
- "vec_extract_if_polyfill",
 ]
 
 [[package]]
@@ -13120,12 +13119,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_extract_if_polyfill"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c9cb5fb67c2692310b6eb3fce7dd4b6e4c9a75be4f2f46b27f0b2b7799759c"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -613,7 +613,6 @@ tungstenite = "0.28.0"
 unwrap_none = "0.1.2"
 uriparse = "0.6.4"
 url = "2.5.8"
-vec_extract_if_polyfill = "0.1.0"
 wasm-bindgen = "0.2"
 winapi = "0.3.8"
 wincode = { version = "0.4.5", features = ["derive", "solana-short-vec"] }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9657,7 +9657,6 @@ dependencies = [
  "static_assertions",
  "trait-set",
  "unwrap_none",
- "vec_extract_if_polyfill",
 ]
 
 [[package]]
@@ -11075,12 +11074,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_extract_if_polyfill"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c9cb5fb67c2692310b6eb3fce7dd4b6e4c9a75be4f2f46b27f0b2b7799759c"
 
 [[package]]
 name = "vec_map"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10280,7 +10280,6 @@ dependencies = [
  "static_assertions",
  "trait-set",
  "unwrap_none",
- "vec_extract_if_polyfill",
 ]
 
 [[package]]
@@ -11716,12 +11715,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_extract_if_polyfill"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c9cb5fb67c2692310b6eb3fce7dd4b6e4c9a75be4f2f46b27f0b2b7799759c"
 
 [[package]]
 name = "vec_map"

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -40,7 +40,6 @@ solana-unified-scheduler-logic = { workspace = true }
 static_assertions = { workspace = true }
 trait-set = { workspace = true }
 unwrap_none = { workspace = true }
-vec_extract_if_polyfill = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { workspace = true }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -56,7 +56,6 @@ use {
         fmt::Debug,
         marker::PhantomData,
         mem,
-        ops::DerefMut,
         sync::{
             Arc, Mutex, MutexGuard, OnceLock, Weak,
             atomic::{AtomicU64, AtomicUsize, Ordering::Relaxed},
@@ -66,7 +65,6 @@ use {
     },
     trait_set::trait_set,
     unwrap_none::UnwrapNone,
-    vec_extract_if_polyfill::MakeExtractIf,
 };
 
 // For now, cap bandwidth use to just half of 1 Gbps link, which should be pretty conservative
@@ -586,17 +584,11 @@ where
                     let Ok(mut scheduler_inners) = scheduler_pool.scheduler_inners.lock() else {
                         break;
                     };
-                    // Use the still-unstable Vec::extract_if() even on stable rust toolchain by
-                    // using a polyfill and allowing unstable_name_collisions, because it's
-                    // simplest to code and fastest to run (= O(n); single linear pass and no
-                    // reallocation).
-                    //
                     // Note that this critical section could block the latency-sensitive replay
                     // code-path via ::take_scheduler().
-                    idle_inners.extend(MakeExtractIf::extract_if(
-                        scheduler_inners.deref_mut(),
-                        |(_inner, pooled_at)| now.duration_since(*pooled_at) > max_pooling_duration,
-                    ));
+                    idle_inners.extend(scheduler_inners.extract_if(.., |(_inner, pooled_at)| {
+                        now.duration_since(*pooled_at) > max_pooling_duration
+                    }));
                     drop(scheduler_inners);
 
                     let idle_inner_count = idle_inners.len();
@@ -686,8 +678,8 @@ where
                     let Ok(mut timeout_listeners) = scheduler_pool.timeout_listeners.lock() else {
                         break;
                     };
-                    expired_listeners.extend(MakeExtractIf::extract_if(
-                        timeout_listeners.deref_mut(),
+                    expired_listeners.extend(timeout_listeners.extract_if(
+                        ..,
                         |(_callback, registered_at)| {
                             now.duration_since(*registered_at) > timeout_duration
                         },


### PR DESCRIPTION
#### Problem

`Vec::extract_if` was stabilized in Rust 1.87. Removing the `vec_extract_if_polyfill` dependency from `solana-unified-scheduler-pool` and replacing the two `MakeExtractIf::extract_if call` sites with the equivalent `Vec::extract_if`. The dep was a polyfill for `Vec::extract_if`.

#### Summary of Changes

The only difference between polyfill and the underlying std function is that it takes a range, so setting it to equivalent of the whole vector to match `vec_extract_if_polyfill` behaviour with `..`

