### PR TITLE
quic server: when adding to banlist also close any existing connections

### DIFF
--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -52,6 +52,9 @@ pub(crate) trait QosController<C: ConnectionContext> {
         connection: Connection,
     ) -> impl Future<Output = usize> + Send;
 
+    /// Optionally spawn QoS-specific background tasks onto the server runtime.
+    fn spawn_background_tasks(&mut self) {}
+
     /// How many concurrent
     fn max_concurrent_connections(&self) -> usize;
 }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -279,6 +279,8 @@ where
             })
         })
         .collect::<FuturesUnordered<_>>();
+    let mut qos = qos;
+    qos.spawn_background_tasks();
     let qos = Arc::new(qos);
     let tasks = TaskTracker::new();
     loop {
@@ -1063,6 +1065,27 @@ impl<S: OpaqueStreamerCounter> ConnectionTable<S> {
             0
         }
     }
+
+    /// Removes all connections associated with `key`.
+    ///
+    /// Returns the number of removed connections.
+    pub(crate) fn remove_connections_by_key(&mut self, key: ConnectionTableKey) -> usize {
+        self.table
+            .swap_remove(&key)
+            .map(|connections| {
+                let num_removed = connections.len();
+                debug_assert!(
+                    self.total_size >= num_removed,
+                    "connection table size underflow while removing by key; total_size={}, \
+                     removed={}",
+                    self.total_size,
+                    num_removed
+                );
+                self.total_size = self.total_size.saturating_sub(num_removed);
+                num_removed
+            })
+            .unwrap_or_default()
+    }
 }
 
 struct EndpointAccept<'a> {
@@ -1713,6 +1736,55 @@ pub mod test {
         }
         assert_eq!(table.total_size, 0);
         assert_eq!(stats.open_connections.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_remove_connections_by_key() {
+        agave_logger::setup();
+        let cancel = CancellationToken::new();
+        let mut table = ConnectionTable::new(ConnectionTableType::Unstaked, cancel);
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+        let max_connections_per_peer = 10;
+        let stats = Arc::new(StreamerStats::default());
+
+        (0..2).for_each(|i| {
+            table
+                .try_add_connection(
+                    ConnectionTableKey::Pubkey(pubkey1),
+                    0,
+                    ClientConnectionTracker::new(stats.clone(), 1000).unwrap(),
+                    None,
+                    ConnectionPeerType::Unstaked,
+                    Arc::new(AtomicU64::new(i)),
+                    max_connections_per_peer,
+                    || Arc::new(NullStreamerCounter {}),
+                )
+                .unwrap();
+        });
+        table
+            .try_add_connection(
+                ConnectionTableKey::Pubkey(pubkey2),
+                0,
+                ClientConnectionTracker::new(stats.clone(), 1000).unwrap(),
+                None,
+                ConnectionPeerType::Unstaked,
+                Arc::new(AtomicU64::new(2)),
+                max_connections_per_peer,
+                || Arc::new(NullStreamerCounter {}),
+            )
+            .unwrap();
+
+        assert_eq!(table.total_size, 3);
+        let removed = table.remove_connections_by_key(ConnectionTableKey::Pubkey(pubkey1));
+        assert_eq!(removed, 2);
+        assert_eq!(table.total_size, 1);
+        assert_eq!(table.table.len(), 1);
+        assert!(
+            table
+                .table
+                .contains_key(&ConnectionTableKey::Pubkey(pubkey2))
+        );
     }
 
     #[test]

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -28,8 +28,11 @@ use {
         time::Duration,
     },
     tokio::{
-        sync::{Mutex, MutexGuard},
-        time::sleep,
+        sync::{
+            Mutex, MutexGuard,
+            mpsc::{Receiver, Sender, channel, error::TrySendError},
+        },
+        time::{MissedTickBehavior, interval, sleep},
     },
     tokio_util::sync::CancellationToken,
 };
@@ -37,8 +40,90 @@ use {
 /// Allow for extra streams "in flight" on top of the nominal
 /// send rate in case of bursty traffic from the sender side.
 const STREAMS_IN_FLIGHT_MARGIN: u32 = 2;
+const BANLIST_PRUNE_INTERVAL: Duration = Duration::from_hours(1);
 
-pub type SimpleQosBanlist = Banlist<Pubkey>;
+/// For simple QoS we only ban staked connections.
+/// Overprovision at 2000 which assumes we ban every validator
+const MAX_IN_FLIGHT_EVICTIONS: usize = 2_000;
+
+pub struct SimpleQosBanlist {
+    banlist: Arc<Banlist<Pubkey>>,
+    eviction_sender: Sender<Pubkey>,
+}
+
+impl SimpleQosBanlist {
+    fn new() -> (Self, Receiver<Pubkey>) {
+        let (eviction_sender, eviction_receiver) = channel(MAX_IN_FLIGHT_EVICTIONS);
+        (
+            Self {
+                banlist: Arc::new(Banlist::default()),
+                eviction_sender,
+            },
+            eviction_receiver,
+        )
+    }
+
+    pub fn ban(&self, pubkey: Pubkey, timeout: Duration) {
+        self.banlist.ban(pubkey, timeout);
+        match self.eviction_sender.try_send(pubkey) {
+            Ok(()) => {}
+            Err(TrySendError::Full(pubkey)) => {
+                error!(
+                    "Simple QoS banlist eviction queue full, dropping eviction request for \
+                     {pubkey}"
+                );
+            }
+            Err(TrySendError::Closed(pubkey)) => {
+                info!(
+                    "Simple QoS banlist eviction queue closed, dropping eviction request for \
+                     {pubkey}"
+                );
+            }
+        }
+    }
+
+    pub fn is_banned(&self, pubkey: &Pubkey) -> bool {
+        self.banlist.is_banned(pubkey)
+    }
+
+    fn spawn_connection_evictor(
+        &self,
+        mut eviction_receiver: Receiver<Pubkey>,
+        staked_connection_table: Arc<Mutex<ConnectionTable<TokenBucket>>>,
+        stats: Arc<StreamerStats>,
+    ) {
+        let banlist = self.banlist.clone();
+        let _eviction_task = tokio::spawn(async move {
+            let mut prune_interval = interval(BANLIST_PRUNE_INTERVAL);
+            prune_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            prune_interval.tick().await;
+            loop {
+                tokio::select! {
+                    maybe_pubkey = eviction_receiver.recv() => {
+                        let Some(pubkey) = maybe_pubkey else {
+                            break;
+                        };
+                        let mut connection_table = staked_connection_table.lock().await;
+                        let removed_connection_count = connection_table
+                            .remove_connections_by_key(ConnectionTableKey::Pubkey(pubkey));
+                        if removed_connection_count > 0 {
+                            update_open_connections_stat(&stats, &connection_table);
+                            stats
+                                .connection_removed
+                                .fetch_add(removed_connection_count, Ordering::Relaxed);
+                            stats
+                                .connection_removed_banned
+                                .fetch_add(removed_connection_count, Ordering::Relaxed);
+                        }
+                    }
+                    _ = prune_interval.tick() => {
+                        banlist.prune();
+                    }
+                }
+            }
+        });
+    }
+}
 
 #[derive(Clone)]
 pub struct SimpleQosConfig {
@@ -65,6 +150,7 @@ pub struct SimpleQos {
     staked_connection_table: Arc<Mutex<ConnectionTable<TokenBucket>>>,
     staked_nodes: Arc<RwLock<StakedNodes>>,
     pub(crate) banlist: Arc<SimpleQosBanlist>,
+    banlist_eviction_receiver: Option<Receiver<Pubkey>>,
 }
 
 impl SimpleQos {
@@ -74,12 +160,14 @@ impl SimpleQos {
         staked_nodes: Arc<RwLock<StakedNodes>>,
         cancel: CancellationToken,
     ) -> Self {
-        let banlist = Arc::new(SimpleQosBanlist::default());
+        let (banlist, banlist_eviction_receiver) = SimpleQosBanlist::new();
+        let banlist = Arc::new(banlist);
         Self {
             config,
             stats,
             staked_nodes,
             banlist,
+            banlist_eviction_receiver: Some(banlist_eviction_receiver),
             staked_connection_table: Arc::new(Mutex::new(ConnectionTable::new(
                 ConnectionTableType::Staked,
                 cancel,
@@ -178,6 +266,18 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
             last_update: Arc::new(AtomicU64::new(timing::timestamp())),
             stream_counter: None,
         }
+    }
+
+    fn spawn_background_tasks(&mut self) {
+        let eviction_receiver = self
+            .banlist_eviction_receiver
+            .take()
+            .expect("Simple QoS banlist eviction task already spawned");
+        self.banlist.spawn_connection_evictor(
+            eviction_receiver,
+            self.staked_connection_table.clone(),
+            self.stats.clone(),
+        );
     }
 
     #[allow(clippy::manual_async_fn)]

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -203,6 +203,7 @@ pub struct StreamerStats {
     pub(crate) connection_setup_error_reset: AtomicUsize,
     pub(crate) connection_setup_error_locally_closed: AtomicUsize,
     pub(crate) connection_removed: AtomicUsize,
+    pub(crate) connection_removed_banned: AtomicUsize,
     pub(crate) connection_remove_failed: AtomicUsize,
     // Number of connections to the endpoint exceeding the allowed limit
     // regardless of the source IP address.
@@ -311,6 +312,11 @@ impl StreamerStats {
             (
                 "connection_removed",
                 self.connection_removed.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "connection_removed_banned",
+                self.connection_removed_banned.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
@@ -956,26 +962,26 @@ mod test {
             };
 
             // Pre-ban: same pubkey is accepted from different source IP addresses.
-            let connection = make_client_endpoint_with_bind_ip(
+            let connection1 = make_client_endpoint_with_bind_ip(
                 &server_address,
                 IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                 Some(&client_keypair),
             )
             .await
             .expect("connection should succeed for staked client");
-            let mut stream = connection.open_uni().await.unwrap();
+            let mut stream = connection1.open_uni().await.unwrap();
             stream.write_all(&[9u8]).await.unwrap();
             stream.finish().unwrap();
             assert!(wait_for_packet().await.is_some());
 
-            let connection = make_client_endpoint_with_bind_ip(
+            let connection2 = make_client_endpoint_with_bind_ip(
                 &server_address,
                 IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
                 Some(&client_keypair),
             )
             .await
             .expect("connection should succeed for staked client");
-            let mut stream = connection.open_uni().await.unwrap();
+            let mut stream = connection2.open_uni().await.unwrap();
             stream.write_all(&[9u8]).await.unwrap();
             stream.finish().unwrap();
             let packet_batch = wait_for_packet().await.unwrap();
@@ -983,6 +989,19 @@ mod test {
 
             // Ban the pubkey and ensure new connections are rejected.
             banlist.ban(remote_pubkey, Duration::from_secs(30));
+
+            // Existing connections from this pubkey should be actively evicted.
+            let start = Instant::now();
+            let mut existing_connection_closed = false;
+            while start.elapsed().as_secs() < 3 {
+                if connection1.close_reason().is_some() {
+                    existing_connection_closed = true;
+                    break;
+                }
+                sleep(Duration::from_millis(25)).await;
+            }
+            assert!(existing_connection_closed);
+
             let post_ban = make_client_endpoint_with_bind_ip(
                 &server_address,
                 IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)),


### PR DESCRIPTION
#### Problem
#10948 allows the ability to ban a peer and stop them from opening new connections. However they can still send packets on existing connections.

#### Summary of Changes
When adding to the banlist additionally close any existing connections.

For performance I made this channel based to avoid having the user of the banlist (e.g. bls sigverifier) do a `blocking_lock` on the `staked_connection_table`