### PR TITLE
chore: Refactor to avoid extra ArcSwap load

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -79,20 +79,13 @@ impl ShredFetchStage {
         const STATS_SUBMIT_CADENCE: Duration = Duration::from_secs(1);
         let mut last_updated = Instant::now();
         let mut keypair = repair_context.as_ref().copied().map(RepairContext::keypair);
-        let (
-            mut last_root,
-            mut slots_per_epoch,
-            mut feature_set,
-            mut epoch_schedule,
-            mut last_slot,
-        ) = {
+        let (mut last_root, mut slots_per_epoch, mut feature_set, mut epoch_schedule) = {
             let root_bank = sharable_banks.root();
             (
                 root_bank.slot(),
                 root_bank.get_slots_in_epoch(root_bank.epoch()),
                 root_bank.feature_set.clone(),
                 root_bank.epoch_schedule().clone(),
-                sharable_banks.working().slot(),
             )
         };
         let mut stats = ShredFetchStats::default();
@@ -100,7 +93,6 @@ impl ShredFetchStage {
         for mut packet_batch in recvr {
             if last_updated.elapsed().as_millis() as u64 > DEFAULT_MS_PER_SLOT {
                 last_updated = Instant::now();
-                last_slot = sharable_banks.working().slot();
                 let root_bank = sharable_banks.root();
                 feature_set = root_bank.feature_set.clone();
                 epoch_schedule = root_bank.epoch_schedule().clone();
@@ -144,7 +136,7 @@ impl ShredFetchStage {
 
             // Filter out shreds that are way too far in the future to avoid the
             // overhead of having to hold onto them.
-            let max_slot = last_slot + MAX_SHRED_DISTANCE_MINIMUM.max(2 * slots_per_epoch);
+            let max_slot = last_root + MAX_SHRED_DISTANCE_MINIMUM.max(2 * slots_per_epoch);
             let discard_unexpected_data_complete_shreds = |shred_slot| {
                 check_feature_activation(
                     &agave_feature_set::discard_unexpected_data_complete_shreds::id(),


### PR DESCRIPTION
#### Summary of Changes
ShredFetchStage has a range of allowable shreds that can be inserted. Update the range to derive the lower and upper bound from the root which will avoid us having to get SharableBanks::working() altogether