### PR TITLE
chore: add Zed local dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ log-*/
 .idea/
 /solana.iml
 /.vscode/
+/.zed/
 
 # fetch-core-bpf.sh artifacts
 /core-bpf-genesis-args.sh


### PR DESCRIPTION
#### Problem
There are some project level settings that are useful to keep for Zed (in particular after https://github.com/anza-xyz/agave/pull/8935 running tests inside crates requires specifying `features=agave-unstable-api` and after https://github.com/anza-xyz/agave/pull/10669 enabling debug profile).

#### Summary of Changes
Adding `/.zed/` to git ignores similar to `/.vscode/`
