### PR TITLE
chore: remove unused solana-define-syscall dep from root workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -424,7 +424,6 @@ solana-core = { path = "core", version = "=4.1.0-alpha.0", features = ["agave-un
 solana-cost-model = { path = "cost-model", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-cpi = "3.1.0"
 solana-curve25519 = "4.0.0"
-solana-define-syscall = "5.0.0"
 solana-derivation-path = "3.0.0"
 solana-download-utils = { path = "download-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-ed25519-program = "3.0.0"


### PR DESCRIPTION
#### Problem

no crates in the root workspace use `solana-define-syscall`.

#### Summary of Changes

remove it from the root workspace.