### PR TITLE
Fix target build directory when --release is passed with debug config

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
@@ -141,7 +141,7 @@ pub(crate) fn post_process(
 
     create_folders(config, &sbf_out_dir, &sbf_debug_dir);
 
-    let target_build_directory = if config.debug {
+    let target_build_directory = if config.debug && !config.cargo_args.contains(&"--release") {
         target_directory.join(&target_triple).join("debug")
     } else {
         target_directory.join(&target_triple).join("release")


### PR DESCRIPTION
#### Problem

Can't build a binary that's production-like optimized and still keep the debug sections.

#### Summary of Changes

The change allows building binaries like so (mind the `-- --release`):
```
RUST_LOG=debug RUSTFLAGS="-C strip=none -C debuginfo=2" cargo-build-sbf --tools-version v1.53 --debug -- --release
```
As a result, the artifacts remain in `target/deploy/debug` as they should and yet it's an optimized --release build accompanied by a `.so.debug` that's useful for trace disassembly. Lacking `--release` forms a gap between production code because its counterpart debug mode is different in the following sense:
* Optimization level: opt-level=3 vs opt-level=0
* Debug assertions: off vs on (debug_assert!() macros are compiled in)
* Overflow checks: off vs on (integer overflow panics instead of wrapping)
* Debug info: debuginfo=0 vs debuginfo=2
* Codegen units: 1 vs 256 (fewer = better optimization across modules)
* LTO: eligible (if configured in [profile.release]) vs off
* Incremental compilation: off vs on (incremental produces less optimized code)
* cfg(debug_assertions): false vs true (conditional compilation changes)
* etc..