### PR TITLE
test-validator: Avoid AccountsDbConfig::default()

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -14,7 +14,8 @@ use {
     log::*,
     solana_account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
     solana_accounts_db::{
-        accounts_db::AccountsDbConfig, accounts_index::AccountsIndexConfig,
+        accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
+        accounts_index::{AccountsIndexConfig, ScanFilter},
         utils::create_accounts_run_and_snapshot_dirs,
     },
     solana_cli_output::CliAccount,
@@ -1165,7 +1166,10 @@ impl TestValidator {
         let accounts_db_config = AccountsDbConfig {
             index: Some(AccountsIndexConfig::default()),
             account_indexes: Some(config.rpc_config.account_indexes.clone()),
-            ..AccountsDbConfig::default()
+            scan_filter_for_shrinking: ScanFilter::All,
+            use_registered_io_uring_buffers: false,
+            snapshots_use_direct_io: false,
+            ..ACCOUNTS_DB_CONFIG_FOR_TESTING
         };
 
         let runtime_config = RuntimeConfig {


### PR DESCRIPTION
#### Summary of Changes
Use the ACCOUNTS_DB_CONFIG_FOR_TESTING constant instead which is a suitable substitute given that test-validator is a test tool.

Additionally, as shown below, this PR as-is does not introduce any configuration changes. I have gone through the fields in `ACCOUNTS_DB_CONFIG_FOR_TESTING` and added commentary:
```rust
pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
    // test-validator specifies this field
    index: Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
    // test-validator specifies this field
    account_indexes: None,
    // PathBuf::new() == PathBuf::default()
    bank_hash_details_dir: PathBuf::new(), // tests don't use bank hash details
    // None is default
    shrink_paths: None,
    // DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION == AccountShrinkThreshold::default()
    shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
    // None is default
    read_cache_limit_bytes: None,
    // None is default
    read_cache_evict_sample_size: None,
    // None is default
    write_cache_limit_bytes: None,
    // None is default
    ancient_append_vec_offset: None,
    // None is default
    ancient_storage_ideal_size: None,
    // None is default
    max_ancient_storages: None,
    // false is default
    skip_initial_hash_calc: false,
    // false is default
    exhaustively_verify_refcounts: false,
    // DEFAULT_PARTITIONED_EPOCH_REWARDS_CONFIG == PartitionedEpochRewardsConfig::default()
    partitioned_epoch_rewards_config: DEFAULT_PARTITIONED_EPOCH_REWARDS_CONFIG,
    // StorageAccess::File == StorageAccess::default()
    storage_access: StorageAccess::File,
    // test-validator specifies this field to the default value of ScanFilter::All (as of this PR)
    scan_filter_for_shrinking: ScanFilter::OnlyAbnormalTest,
    // MarkObsoleteAccounts::Enabled == MarkObsoleteAccounts::default()
    mark_obsolete_accounts: MarkObsoleteAccounts::Enabled,
    // None is default
    num_background_threads: None,
    // None is default
    num_foreground_threads: None,
    // test-validator specifies this field to default value of false (as of this PR)
    use_registered_io_uring_buffers: true,
    // test-validator specifies this field to default value of false (as of this PR)
    snapshots_use_direct_io: true,
};
```