### PR TITLE
Revert "Pin spl-token-cli version to v5.5.0 for agave v4.0 (#10859)"

### DIFF
--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,5 +1,5 @@
 # populate this on the stable branch
-splTokenCliVersion=5.5.0
+splTokenCliVersion=
 
 maybeSplTokenCliVersionArg=
 if [[ -n "$splTokenCliVersion" ]]; then


### PR DESCRIPTION
#### Problem

Pinning has to be done in the branch that becomes stable on creation of a new stabilisation branch - so the previous one, which is v3.1 currently.

#### Summary of Changes

This reverts commit 4f9c45322b47728af141cf95a169d45ac84cf4d9.