### PR TITLE
Remove PerfSampleV1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Release channels have their own copy of this changelog:
 ### RPC
 #### Breaking
 * `--public-tpu-address` and `--public-tpu-forwards-address` CLI arguments and `setPublicTpuForwardsAddress`, `setPublicTpuAddress` RPC methods now specify QUIC ports, not UDP.
+* Blockstore `PerfSamples` column legacy format removed.
+  * The `PerfSamples` column format was updated in agave v1.15 to write `PerfSampleV2`. The old format, `PerfSampleV1`, will no longer be supported for fallback reads as of v4.0.
 #### Changes
 * Added `--enable-scheduler-bindings` which binds an IPC server at `<ledger-path>/scheduler_bindings.ipc` for external schedulers to connect to.
 * Added `clientId` field to each node in `getClusterNodes` response

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -1,5 +1,5 @@
 use {
-    solana_ledger::{blockstore::Blockstore, blockstore_meta::PerfSampleV2},
+    solana_ledger::{blockstore::Blockstore, blockstore_meta::PerfSample},
     solana_runtime::bank_forks::BankForks,
     std::{
         sync::{
@@ -54,7 +54,7 @@ impl SamplePerformanceService {
                 // Store the new snapshot to compare against in the next iteration of the loop.
                 snapshot = new_snapshot;
 
-                let perf_sample = PerfSampleV2 {
+                let perf_sample = PerfSample {
                     // Note: since num_slots is computed from the highest slot and not the bank
                     // slot, this value should not be used in conjunction with num_transactions or
                     // num_non_vote_transactions to draw any conclusions about number of

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -74,7 +74,7 @@ use {
         convert::TryInto,
         fmt::Write,
         fs::{self, File},
-        io::{Error as IoError, ErrorKind},
+        io::Error as IoError,
         ops::{Bound, Range},
         path::{Path, PathBuf},
         rc::Rc,
@@ -3539,30 +3539,17 @@ impl Blockstore {
                 .iter(IteratorMode::End)?
                 .take(num)
                 .map(|(slot, data)| {
-                    deserialize::<PerfSampleV2>(&data)
-                        .map(|sample| (slot, sample.into()))
-                        .or_else(|err| {
-                            match &*err {
-                                bincode::ErrorKind::Io(io_err)
-                                    if matches!(io_err.kind(), ErrorKind::UnexpectedEof) =>
-                                {
-                                    // Not enough bytes to deserialize as `PerfSampleV2`.
-                                }
-                                _ => return Err(err),
-                            }
-
-                            deserialize::<PerfSampleV1>(&data).map(|sample| (slot, sample.into()))
-                        })
+                    deserialize::<PerfSample>(&data)
+                        .map(|sample| (slot, sample))
                         .map_err(Into::into)
                 });
 
         samples.collect()
     }
 
-    pub fn write_perf_sample(&self, index: Slot, perf_sample: &PerfSampleV2) -> Result<()> {
+    pub fn write_perf_sample(&self, index: Slot, perf_sample: &PerfSample) -> Result<()> {
         // Always write as the current version.
-        let bytes =
-            serialize(&perf_sample).expect("`PerfSampleV2` can be serialized with `bincode`");
+        let bytes = serialize(&perf_sample).expect("`PerfSample` can be serialized with `bincode`");
         self.perf_samples_cf.put_bytes(index, &bytes)
     }
 
@@ -9861,120 +9848,6 @@ pub mod tests {
     }
 
     #[test]
-    fn test_get_recent_perf_samples_v1_only() {
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-
-        let num_entries: usize = 10;
-
-        let slot_sample = |i: u64| PerfSampleV1 {
-            num_transactions: 1406 + i,
-            num_slots: 34 + i / 2,
-            sample_period_secs: (40 + i / 5) as u16,
-        };
-
-        let mut perf_samples: Vec<(Slot, PerfSample)> = vec![];
-        for i in 0..num_entries {
-            let slot = (i + 1) as u64 * 50;
-            let sample = slot_sample(i as u64);
-
-            let bytes = serialize(&sample).unwrap();
-            blockstore.perf_samples_cf.put_bytes(slot, &bytes).unwrap();
-            perf_samples.push((slot, sample.into()));
-        }
-
-        for i in 0..num_entries {
-            let mut expected_samples = perf_samples[num_entries - 1 - i..].to_vec();
-            expected_samples.sort_by_key(|b| cmp::Reverse(b.0));
-            assert_eq!(
-                blockstore.get_recent_perf_samples(i + 1).unwrap(),
-                expected_samples
-            );
-        }
-    }
-
-    #[test]
-    fn test_get_recent_perf_samples_v2_only() {
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-
-        let num_entries: usize = 10;
-
-        let slot_sample = |i: u64| PerfSampleV2 {
-            num_transactions: 2495 + i,
-            num_slots: 167 + i / 2,
-            sample_period_secs: (37 + i / 5) as u16,
-            num_non_vote_transactions: 1672 + i,
-        };
-
-        let mut perf_samples: Vec<(Slot, PerfSample)> = vec![];
-        for i in 0..num_entries {
-            let slot = (i + 1) as u64 * 50;
-            let sample = slot_sample(i as u64);
-
-            let bytes = serialize(&sample).unwrap();
-            blockstore.perf_samples_cf.put_bytes(slot, &bytes).unwrap();
-            perf_samples.push((slot, sample.into()));
-        }
-
-        for i in 0..num_entries {
-            let mut expected_samples = perf_samples[num_entries - 1 - i..].to_vec();
-            expected_samples.sort_by_key(|b| cmp::Reverse(b.0));
-            assert_eq!(
-                blockstore.get_recent_perf_samples(i + 1).unwrap(),
-                expected_samples
-            );
-        }
-    }
-
-    #[test]
-    fn test_get_recent_perf_samples_v1_and_v2() {
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-
-        let num_entries: usize = 10;
-
-        let slot_sample_v1 = |i: u64| PerfSampleV1 {
-            num_transactions: 1599 + i,
-            num_slots: 123 + i / 2,
-            sample_period_secs: (42 + i / 5) as u16,
-        };
-
-        let slot_sample_v2 = |i: u64| PerfSampleV2 {
-            num_transactions: 5809 + i,
-            num_slots: 81 + i / 2,
-            sample_period_secs: (35 + i / 5) as u16,
-            num_non_vote_transactions: 2209 + i,
-        };
-
-        let mut perf_samples: Vec<(Slot, PerfSample)> = vec![];
-        for i in 0..num_entries {
-            let slot = (i + 1) as u64 * 50;
-
-            if i % 3 == 0 {
-                let sample = slot_sample_v1(i as u64);
-                let bytes = serialize(&sample).unwrap();
-                blockstore.perf_samples_cf.put_bytes(slot, &bytes).unwrap();
-                perf_samples.push((slot, sample.into()));
-            } else {
-                let sample = slot_sample_v2(i as u64);
-                let bytes = serialize(&sample).unwrap();
-                blockstore.perf_samples_cf.put_bytes(slot, &bytes).unwrap();
-                perf_samples.push((slot, sample.into()));
-            }
-        }
-
-        for i in 0..num_entries {
-            let mut expected_samples = perf_samples[num_entries - 1 - i..].to_vec();
-            expected_samples.sort_by_key(|b| cmp::Reverse(b.0));
-            assert_eq!(
-                blockstore.get_recent_perf_samples(i + 1).unwrap(),
-                expected_samples
-            );
-        }
-    }
-
-    #[test]
     fn test_write_perf_samples() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
@@ -9983,7 +9856,7 @@ pub mod tests {
         let mut perf_samples: Vec<(Slot, PerfSample)> = vec![];
         for x in 1..num_entries + 1 {
             let slot = x as u64 * 50;
-            let sample = PerfSampleV2 {
+            let sample = PerfSample {
                 num_transactions: 1000 + x as u64,
                 num_slots: 50,
                 sample_period_secs: 20,
@@ -9991,7 +9864,7 @@ pub mod tests {
             };
 
             blockstore.write_perf_sample(slot, &sample).unwrap();
-            perf_samples.push((slot, PerfSample::V2(sample)));
+            perf_samples.push((slot, sample));
         }
 
         for x in 0..num_entries {

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -814,37 +814,9 @@ pub struct AddressSignatureMeta {
 
 /// Performance information about validator execution during a time slice.
 ///
-/// Older versions should only arise as a result of deserialization of entries stored by a previous
-/// version of the validator.  Current version should only produce [`PerfSampleV2`].
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum PerfSample {
-    V1(PerfSampleV1),
-    V2(PerfSampleV2),
-}
-
-impl From<PerfSampleV1> for PerfSample {
-    fn from(value: PerfSampleV1) -> PerfSample {
-        PerfSample::V1(value)
-    }
-}
-
-impl From<PerfSampleV2> for PerfSample {
-    fn from(value: PerfSampleV2) -> PerfSample {
-        PerfSample::V2(value)
-    }
-}
-
-/// Version of [`PerfSample`] used before 1.15.x.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct PerfSampleV1 {
-    pub num_transactions: u64,
-    pub num_slots: u64,
-    pub sample_period_secs: u16,
-}
-
 /// Version of the [`PerfSample`] introduced in 1.15.x.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct PerfSampleV2 {
+pub struct PerfSample {
     // `PerfSampleV1` part
     pub num_transactions: u64,
     pub num_slots: u64,
@@ -1237,30 +1209,6 @@ mod test {
         let mut expected = SlotMeta::new_orphan(5);
         expected.next_slots = vec![6, 7];
         assert_eq!(slot_meta, expected);
-    }
-
-    // `PerfSampleV2` should contain `PerfSampleV1` as a prefix, in order for the column to be
-    // backward and forward compatible.
-    #[test]
-    fn perf_sample_v1_is_prefix_of_perf_sample_v2() {
-        let v2 = PerfSampleV2 {
-            num_transactions: 4190143848,
-            num_slots: 3607325588,
-            sample_period_secs: 31263,
-            num_non_vote_transactions: 4056116066,
-        };
-
-        let v2_bytes = bincode::serialize(&v2).expect("`PerfSampleV2` can be serialized");
-
-        let actual: PerfSampleV1 = bincode::deserialize(&v2_bytes)
-            .expect("Bytes encoded as `PerfSampleV2` can be decoded as `PerfSampleV1`");
-        let expected = PerfSampleV1 {
-            num_transactions: v2.num_transactions,
-            num_slots: v2.num_slots,
-            sample_period_secs: v2.sample_period_secs,
-        };
-
-        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -42,7 +42,7 @@ use {
     solana_keypair::Keypair,
     solana_ledger::{
         blockstore::{Blockstore, BlockstoreError, SignatureInfosForAddress},
-        blockstore_meta::{PerfSample, PerfSampleV1, PerfSampleV2},
+        blockstore_meta::PerfSample,
         leader_schedule_cache::LeaderScheduleCache,
     },
     solana_message::{AddressLoader, SanitizedMessage},
@@ -4321,30 +4321,12 @@ pub mod rpc_full {
 }
 
 fn rpc_perf_sample_from_perf_sample(slot: u64, sample: PerfSample) -> RpcPerfSample {
-    match sample {
-        PerfSample::V1(PerfSampleV1 {
-            num_transactions,
-            num_slots,
-            sample_period_secs,
-        }) => RpcPerfSample {
-            slot,
-            num_transactions,
-            num_non_vote_transactions: None,
-            num_slots,
-            sample_period_secs,
-        },
-        PerfSample::V2(PerfSampleV2 {
-            num_transactions,
-            num_non_vote_transactions,
-            num_slots,
-            sample_period_secs,
-        }) => RpcPerfSample {
-            slot,
-            num_transactions,
-            num_non_vote_transactions: Some(num_non_vote_transactions),
-            num_slots,
-            sample_period_secs,
-        },
+    RpcPerfSample {
+        slot,
+        num_transactions: sample.num_transactions,
+        num_non_vote_transactions: Some(sample.num_non_vote_transactions),
+        num_slots: sample.num_slots,
+        sample_period_secs: sample.sample_period_secs,
     }
 }
 
@@ -4551,7 +4533,7 @@ pub mod tests {
         solana_instruction::{AccountMeta, Instruction, error::InstructionError},
         solana_keypair::Keypair,
         solana_ledger::{
-            blockstore_meta::PerfSampleV2,
+            blockstore_meta::PerfSample,
             blockstore_processor::fill_blockstore_slot_with_ticks,
             genesis_utils::{GenesisConfigInfo, create_genesis_config},
             get_tmp_ledger_path,
@@ -5221,7 +5203,7 @@ pub mod tests {
         rpc.blockstore
             .write_perf_sample(
                 slot,
-                &PerfSampleV2 {
+                &PerfSample {
                     num_slots,
                     num_transactions,
                     num_non_vote_transactions,


### PR DESCRIPTION
#### Problem

`PerfSampleV2` was introduced in 1.15.x. We're now on 4.x, so seems reasonable to delete.

#### Summary of Changes

Deletes all usage and references to `PerfSampleV1`, renames `PerfSampleV2` to `PerfSample`, and deletes the enum.