### PR TITLE
Revert "Freeze cargo-build-sbf and cargo-test-sbf to the latest version (#10860)"

### DIFF
--- a/scripts/cargo-build-sbf-version.sh
+++ b/scripts/cargo-build-sbf-version.sh
@@ -1,6 +1,6 @@
 # populate this on the stable branch
-cargoBuildSbfVersion=4.0.0
-cargoTestSbfVersion=4.0.0
+cargoBuildSbfVersion=
+cargoTestSbfVersion=
 
 maybeCargoBuildSbfVersionArg=
 if [[ -n "$cargoBuildSbfVersion" ]]; then


### PR DESCRIPTION
#### Problem

Freezing the version should be done in the branch when it is promoted to stable, not when it is just made.

#### Summary of Changes

This reverts commit ed81e7f6e3f3f4253d506ec13e91954c852b8b3d.