### PR TITLE
delete tests

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1746,7 +1746,7 @@ impl ClusterInfo {
             .add_relaxed(pull_stats.success as u64);
 
         (
-            pull_stats.failed_insert + pull_stats.failed_timeout,
+            pull_stats.failed_insert,
             pull_stats.failed_timeout,
             pull_stats.success,
         )
@@ -2564,8 +2564,6 @@ mod tests {
             let node = Node::new_localhost_with_pubkey(&keypair.pubkey());
             ClusterInfo::new(node.info, keypair, SocketAddrSpace::Unspecified)
         });
-        let entrypoint_pubkey = solana_pubkey::new_rand();
-        let data = test_crds_values(entrypoint_pubkey);
         let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
         let timeouts = CrdsTimeouts::new(
             cluster_info.id(),
@@ -2573,10 +2571,27 @@ mod tests {
             Duration::from_secs(48 * 3600),   // epoch_duration
             &stakes,
         );
+
+        // Generate CRDS value w/ expired timestamp.
+        let entrypoint_pubkey = solana_pubkey::new_rand();
+        let entrypoint_ci = ContactInfo::new_localhost(&entrypoint_pubkey, 0);
+        let entrypoint_crdsvalue = CrdsValue::new_unsigned(CrdsData::from(entrypoint_ci));
+        let data = vec![entrypoint_crdsvalue];
+
+        // Should fail for expired timestamp.
+        assert_eq!(
+            (1, 1, 0),
+            cluster_info.handle_pull_response(data, &timeouts)
+        );
+
+        // Expect pull response to be successfully inserted.
+        let data = test_crds_values(entrypoint_pubkey);
         assert_eq!(
             (0, 0, 1),
             cluster_info.handle_pull_response(data.clone(), &timeouts)
         );
+
+        // Should fail insertion because it was already inserted.
         assert_eq!(
             (1, 0, 0),
             cluster_info.handle_pull_response(data, &timeouts)
@@ -3407,47 +3422,6 @@ mod tests {
         );
         assert!(entrypoints_processed);
         assert_eq!(cluster_info.my_shred_version(), 2); // <--- No change to shred version
-    }
-
-    #[test]
-    #[ignore] // TODO: debug why this is flaky on buildkite!
-    fn test_pull_request_time_pruning() {
-        let node = Node::new_localhost();
-        let cluster_info = Arc::new(ClusterInfo::new(
-            node.info,
-            Arc::new(Keypair::new()),
-            SocketAddrSpace::Unspecified,
-        ));
-        let entrypoint_pubkey = solana_pubkey::new_rand();
-        let entrypoint = ContactInfo::new_localhost(&entrypoint_pubkey, timestamp());
-        cluster_info.set_entrypoint(entrypoint);
-
-        let mut rng = rand::rng();
-        let shred_version = cluster_info.my_shred_version();
-        let mut peers: Vec<Pubkey> = vec![];
-
-        const NO_ENTRIES: usize = CRDS_UNIQUE_PUBKEY_CAPACITY + 128;
-        let data: Vec<_> = repeat_with(|| {
-            let keypair = Keypair::new();
-            peers.push(keypair.pubkey());
-            let mut rand_ci = ContactInfo::new_rand(&mut rng, Some(keypair.pubkey()));
-            rand_ci.set_shred_version(shred_version);
-            rand_ci.set_wallclock(timestamp());
-            CrdsValue::new(CrdsData::from(rand_ci), &keypair)
-        })
-        .take(NO_ENTRIES)
-        .collect();
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
-        let timeouts = CrdsTimeouts::new(
-            cluster_info.id(),
-            CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS * 4, // default_timeout
-            Duration::from_secs(48 * 3600),       // epoch_duration
-            &stakes,
-        );
-        assert_eq!(
-            (0, 0, NO_ENTRIES),
-            cluster_info.handle_pull_response(data, &timeouts)
-        );
     }
 
     #[test]

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -573,11 +573,7 @@ impl CrdsGossipPull {
             now,
             &mut stats,
         );
-        (
-            stats.failed_timeout + stats.failed_insert,
-            stats.failed_timeout,
-            stats.success,
-        )
+        (stats.failed_insert, stats.failed_timeout, stats.success)
     }
 }
 
@@ -675,10 +671,7 @@ pub(crate) fn get_max_bloom_filter_bytes(caller: &CrdsValue) -> usize {
 pub(crate) mod tests {
     use {
         super::*,
-        crate::{
-            crds_data::{CrdsData, Vote},
-            protocol::Protocol,
-        },
+        crate::{crds_data::CrdsData, protocol::Protocol},
         itertools::Itertools,
         rand::{SeedableRng, prelude::IndexedRandom as _},
         rand_chacha::ChaChaRng,
@@ -686,7 +679,6 @@ pub(crate) mod tests {
         solana_hash::HASH_BYTES,
         solana_keypair::keypair_from_seed,
         solana_packet::PACKET_DATA_SIZE,
-        solana_perf::test_tx::new_test_vote_tx,
         solana_sha256_hasher::hash,
         solana_time_utils::timestamp,
         std::{
@@ -1450,87 +1442,6 @@ pub(crate) mod tests {
                 .count(),
             2u64.pow(mask_bits) as usize
         )
-    }
-
-    #[test]
-    fn test_process_pull_response() {
-        let mut rng = rand::rng();
-        let node_crds = RwLock::<Crds>::default();
-        let node = CrdsGossipPull::default();
-
-        let peer_pubkey = solana_pubkey::new_rand();
-        let peer_entry =
-            CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(&peer_pubkey, 0)));
-        let stakes = HashMap::from([(peer_pubkey, 1u64)]);
-        let timeouts = CrdsTimeouts::new(
-            Pubkey::new_unique(),
-            node.crds_timeout, // default_timeout
-            Duration::from_millis(node.crds_timeout + 1),
-            &stakes,
-        );
-        // inserting a fresh value should be fine.
-        assert_eq!(
-            node.process_pull_response(&node_crds, &timeouts, vec![peer_entry.clone()], 1,)
-                .0,
-            0
-        );
-
-        let node_crds = RwLock::<Crds>::default();
-        let unstaked_peer_entry =
-            CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(&peer_pubkey, 0)));
-        // check that old contact infos fail if they are too old, regardless of "timeouts"
-        assert_eq!(
-            node.process_pull_response(
-                &node_crds,
-                &timeouts,
-                vec![peer_entry.clone(), unstaked_peer_entry],
-                node.crds_timeout + 100,
-            )
-            .0,
-            4
-        );
-
-        let node_crds = RwLock::<Crds>::default();
-        // check that old contact infos can still land as long as they have a "timeouts" entry
-        assert_eq!(
-            node.process_pull_response(
-                &node_crds,
-                &timeouts,
-                vec![peer_entry],
-                node.crds_timeout + 1,
-            )
-            .0,
-            0
-        );
-
-        // construct something that's not a contact info
-        let peer_vote = Vote::new(peer_pubkey, new_test_vote_tx(&mut rng), 0).unwrap();
-        let peer_vote = CrdsValue::new_unsigned(CrdsData::Vote(0, peer_vote));
-        // check that older CrdsValues (non-ContactInfos) infos pass even if are too old,
-        // but a recent contact info (inserted above) exists
-        assert_eq!(
-            node.process_pull_response(
-                &node_crds,
-                &timeouts,
-                vec![peer_vote.clone()],
-                node.crds_timeout + 1,
-            )
-            .0,
-            0
-        );
-
-        let node_crds = RwLock::<Crds>::default();
-        // without a contact info, inserting an old value should fail
-        assert_eq!(
-            node.process_pull_response(
-                &node_crds,
-                &timeouts,
-                vec![peer_vote],
-                node.crds_timeout + 2,
-            )
-            .0,
-            2
-        );
     }
 
     // Asserts that all bincode serialized pull requests fit in a Packet.


### PR DESCRIPTION
#### Problem
One test that's been disabled for 4 years (`test_pull_request_time_pruning`) and another that's fairly worthless, redundant coverage (`test_process_pull_response`).

#### Summary of Changes

- Delete both tests
- Don't double count expired CRDS values in fail count (only used by tests)
- Enhance `test_handle_pull` to check expired value case