### PR TITLE
delete bench

### DIFF
--- a/ledger/benches/blockstore.rs
+++ b/ledger/benches/blockstore.rs
@@ -6,7 +6,7 @@ extern crate test;
 use {
     rand::Rng,
     solana_clock::Slot,
-    solana_entry::entry::{Entry, create_ticks},
+    solana_entry::entry::create_ticks,
     solana_hash::Hash,
     solana_ledger::{
         blockstore::{Blockstore, entries_to_test_shreds},
@@ -15,19 +15,8 @@ use {
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_transaction_status::TransactionStatusMeta,
-    std::path::Path,
     test::Bencher,
 };
-
-// Given some shreds and a ledger at ledger_path, benchmark writing the shreds to the ledger
-fn bench_write_shreds(bench: &mut Bencher, entries: Vec<Entry>, ledger_path: &Path) {
-    let blockstore =
-        Blockstore::open(ledger_path).expect("Expected to be able to open database ledger");
-    bench.iter(move || {
-        let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
-    });
-}
 
 // Insert some shreds into the ledger in preparation for read benchmarks
 fn setup_read_bench(
@@ -56,24 +45,19 @@ fn setup_read_bench(
         .expect("Expected successful insertion of shreds into ledger");
 }
 
-// Write small shreds to the ledger
+// Write shreds to the ledger
 #[bench]
 #[ignore]
-fn bench_write_small(bench: &mut Bencher) {
+fn bench_write_shreds(bench: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let num_entries = 32 * 1024;
     let entries = create_ticks(num_entries, 0, Hash::default());
-    bench_write_shreds(bench, entries, ledger_path.path());
-}
-
-// Write big shreds to the ledger
-#[bench]
-#[ignore]
-fn bench_write_big(bench: &mut Bencher) {
-    let ledger_path = get_tmp_ledger_path_auto_delete!();
-    let num_entries = 32 * 1024;
-    let entries = create_ticks(num_entries, 0, Hash::default());
-    bench_write_shreds(bench, entries, ledger_path.path());
+    let blockstore =
+        Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");
+    bench.iter(move || {
+        let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0);
+        blockstore.insert_shreds(shreds, None, false).unwrap();
+    });
 }
 
 #[bench]
@@ -132,21 +116,7 @@ fn bench_read_random(bench: &mut Bencher) {
 
 #[bench]
 #[ignore]
-fn bench_insert_data_shred_small(bench: &mut Bencher) {
-    let ledger_path = get_tmp_ledger_path_auto_delete!();
-    let blockstore =
-        Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");
-    let num_entries = 32 * 1024;
-    let entries = create_ticks(num_entries, 0, Hash::default());
-    bench.iter(move || {
-        let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
-    });
-}
-
-#[bench]
-#[ignore]
-fn bench_insert_data_shred_big(bench: &mut Bencher) {
+fn bench_insert_data_shred(bench: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore =
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");


### PR DESCRIPTION
#### Problem
`bench_write_small` and `bench_write_large` are identical because there is no shred size difference.
same story w/ `bench_insert_data_shred_small` and `bench_insert_data_shred_large`

All of these benches are currently ignored, but still...

#### Summary of Changes

1. drop the postfix and smash these into just: `bench_write_shreds` and `bench_insert_data_shred`
2. Delete the helper (just inline into `bench_write_shreds`)