### PR TITLE
clippy: fix unsafe annotations for Rust 2024 in programs/sbf direct account pointers

### DIFF
--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -82,6 +82,22 @@ homepage = "https://anza.xyz"
 license = "Apache-2.0"
 edition = "2021"
 
+[workspace.lints.rust]
+# List of rust-2024-compatibility lints that are already satisfied
+# See https://doc.rust-lang.org/rustc/lints/groups.html
+boxed_slice_into_iter = "deny"
+dependency_on_unit_never_type_fallback = "deny"
+deprecated_safe_2024 = "deny"
+impl_trait_overcaptures = "deny"
+missing_unsafe_on_extern = "deny"
+never_type_fallback_flowing_into_unsafe = "deny"
+rust_2024_guarded_string_incompatible_syntax = "deny"
+rust_2024_incompatible_pat = "deny"
+rust_2024_prelude_collisions = "deny"
+static_mut_refs = "deny"
+unsafe_attr_outside_unsafe = "deny"
+unsafe_op_in_unsafe_fn = "deny"
+
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [

--- a/programs/sbf/rust/direct_account_pointers_in_program_input/src/lib.rs
+++ b/programs/sbf/rust/direct_account_pointers_in_program_input/src/lib.rs
@@ -23,28 +23,31 @@ macro_rules! align_pointer {
     };
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn entrypoint(program_input: *mut u8, instruction_data: *mut u8) -> u64 {
     // First 8-bytes of program_input contains the number of accounts.
     let accounts = program_input as *mut u64;
 
-    // The 8-bytes before the instruction data contains the length of
-    // the instruction data, even if the instruction data is empty.
-    let ix_data_len = *(instruction_data.sub(size_of::<u64>()) as *mut u64) as usize;
+    let (program_id, accounts, instruction_data) = unsafe {
+        // The 8-bytes before the instruction data contains the length of
+        // the instruction data, even if the instruction data is empty.
+        let ix_data_len = *(instruction_data.sub(size_of::<u64>()) as *mut u64) as usize;
 
-    // The program_id is located right after the instruction data.
-    let program_id = &*(instruction_data.add(ix_data_len) as *const Address);
+        // The program_id is located right after the instruction data.
+        let program_id = &*(instruction_data.add(ix_data_len) as *const Address);
 
-    // The slice of account pointers is located right after the program_id.
-    let slice_ptr = instruction_data.add(ix_data_len + size_of::<Address>());
-    let accounts = from_raw_parts(
-        align_pointer!(slice_ptr) as *const AccountView,
-        *accounts as usize,
-    );
+        // The slice of account pointers is located right after the program_id.
+        let slice_ptr = instruction_data.add(ix_data_len + size_of::<Address>());
+        let accounts = from_raw_parts(
+            align_pointer!(slice_ptr) as *const AccountView,
+            *accounts as usize,
+        );
 
-    // The instruction data slice.
-    let instruction_data = from_raw_parts(instruction_data, ix_data_len);
+        // The instruction data slice.
+        let instruction_data = from_raw_parts(instruction_data, ix_data_len);
 
+        (program_id, accounts, instruction_data)
+    };
     match process_instruction(program_id, accounts, instruction_data) {
         Ok(_) => solana_program_entrypoint::SUCCESS,
         Err(e) => e.into(),


### PR DESCRIPTION
#### Problem
Recent changes added code that lacks unsafe annotations required by Rust 2024 edition

#### Summary of Changes
* add forward compatibility warnings to avoid breakages until https://github.com/anza-xyz/agave/pull/9663 (which will remove them)
* annotate `no_mangle` attribute with `unsafe`
* wrap some unsafe code with `unsafe` block
