### PR TITLE
streamer: refactor QoS module spawn logic to not require Arc early

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -142,7 +142,7 @@ pub(crate) fn spawn_server<Q, C>(
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
     quic_server_params: QuicStreamerConfig,
-    qos: Arc<Q>,
+    qos: Q,
     cancel: CancellationToken,
 ) -> Result<SpawnNonBlockingServerResult, QuicServerError>
 where
@@ -169,22 +169,15 @@ where
 
     let max_concurrent_connections = qos.max_concurrent_connections();
     let handle = tokio::spawn({
-        let endpoints = endpoints.clone();
-        let stats = stats.clone();
-        async move {
-            let tasks = run_server(
-                name,
-                endpoints.clone(),
-                packet_sender,
-                stats.clone(),
-                quic_server_params,
-                cancel,
-                qos,
-            )
-            .await;
-            tasks.close();
-            tasks.wait().await;
-        }
+        run_server(
+            name,
+            endpoints.clone(),
+            packet_sender,
+            stats.clone(),
+            quic_server_params,
+            cancel,
+            qos,
+        )
     });
 
     Ok(SpawnNonBlockingServerResult {
@@ -248,8 +241,8 @@ async fn run_server<Q, C>(
     stats: Arc<StreamerStats>,
     quic_server_params: QuicStreamerConfig,
     cancel: CancellationToken,
-    qos: Arc<Q>,
-) -> TaskTracker
+    qos: Q,
+) -> ()
 where
     Q: QosController<C> + Send + Sync + 'static,
     C: ConnectionContext + Send + Sync + 'static,
@@ -286,7 +279,7 @@ where
             })
         })
         .collect::<FuturesUnordered<_>>();
-
+    let qos = Arc::new(qos);
     let tasks = TaskTracker::new();
     loop {
         let timeout_connection = select! {
@@ -386,7 +379,8 @@ where
             debug!("accept(): Timed out waiting for connection");
         }
     }
-    tasks
+    tasks.close();
+    tasks.wait().await;
 }
 
 pub fn get_remote_pubkey(connection: &Connection) -> Option<Pubkey> {

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -51,12 +51,7 @@ where
 {
     let stats = Arc::<StreamerStats>::default();
 
-    let swqos = Arc::new(SwQos::new(
-        qos_config,
-        stats.clone(),
-        staked_nodes,
-        cancel.clone(),
-    ));
+    let swqos = SwQos::new(qos_config, stats.clone(), staked_nodes, cancel.clone());
 
     spawn_server(
         name,

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -594,7 +594,7 @@ fn spawn_runtime_and_server<Q, C>(
     keypair: &Keypair,
     packet_sender: Sender<PacketBatch>,
     quic_server_params: QuicStreamerConfig,
-    qos: Arc<Q>,
+    qos: Q,
     cancel: CancellationToken,
 ) -> Result<SpawnServerResult, QuicServerError>
 where
@@ -647,12 +647,7 @@ pub fn spawn_stake_weighted_qos_server(
     cancel: CancellationToken,
 ) -> Result<SpawnServerResult, QuicServerError> {
     let stats = Arc::<StreamerStats>::default();
-    let swqos = Arc::new(SwQos::new(
-        qos_config,
-        stats.clone(),
-        staked_nodes,
-        cancel.clone(),
-    ));
+    let swqos = SwQos::new(qos_config, stats.clone(), staked_nodes, cancel.clone());
     spawn_runtime_and_server(
         thread_name,
         metrics_name,
@@ -685,12 +680,12 @@ pub fn spawn_simple_qos_server(
         qos_config,
     };
     let stats = Arc::<StreamerStats>::default();
-    let simple_qos = Arc::new(SimpleQos::new(
+    let simple_qos = SimpleQos::new(
         server_params.qos_config,
         stats.clone(),
         staked_nodes,
         cancel.clone(),
-    ));
+    );
     let banlist = simple_qos.banlist.clone();
 
     spawn_runtime_and_server(


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/pull/10993 could benefit from an owned Qos instance inside fn spawn_server, but we currently wrap Qos into Arc too early for that to be viable.

#### Summary of Changes

- Move the Arc creation later in the code.
- No functional changes.