### PR TITLE
Split changes to be done in the stable and the new beta branch

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -110,8 +110,13 @@ Create a PR that makes the following updates to [CHANGELOG.md](https://github.co
 
 ### Miscellaneous Clean up
 
+#### Newly Promoted Stable (Former Beta) Branch
+
 1. Pin the spl-token-cli version in the newly promoted stable branch by setting `splTokenCliVersion` in scripts/spl-token-cli-version.sh to the latest release that depends on the stable branch (usually this will be the latest spl-token-cli release).
 1. Pin the cargo-build-sbf and cargo-test-sbf versions in the newly promoted stable branch by setting `cargoBuildSbfVersion` and `cargoTestSbfVersion` in scripts/cargo-build-sbf-version.sh to the latest release that depends on the stable branch (usually this will be the latest releases).
+
+#### Newly Created Beta Branch
+
 1. Update [CHANGELOG.md](https://github.com/anza-xyz/agave/blob/master/CHANGELOG.md) to remove the channel links on the new branch. Additionally, remove any wording about the new branch being unreleased.
 1. Update [CODEOWNERS](https://github.com/anza-xyz/agave/blob/master/.github/CODEOWNERS) to `* @anza-xyz/backport-reviewers` on the new branch.
 1. Update [mergify.yml](https://github.com/anza-xyz/agave/blob/master/.mergify.yml) to add backport actions for the new branch and remove actions for the obsolete branch.


### PR DESCRIPTION
#### Problem

The way it instructions currently written makes it too easy to misinterpret them and pin versions in the newly created branch, when it has to be done in the stable channel branch.

#### Summary of Changes

Split changes that have to be done in the stable and the new beta branch into two separate lists.