### PR TITLE
remove sub function

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2596,10 +2596,6 @@ fn test_restart_tower_rollback() {
 #[test]
 #[serial]
 fn test_run_test_load_program_accounts_partition_root() {
-    run_test_load_program_accounts_partition(CommitmentConfig::finalized());
-}
-
-fn run_test_load_program_accounts_partition(scan_commitment: CommitmentConfig) {
     let num_slots_per_validator = 8;
     let partitions: [usize; 2] = [1, 1];
     let (leader_schedule, validator_keys) = create_custom_leader_schedule_with_random_keys(&[
@@ -2614,7 +2610,7 @@ fn run_test_load_program_accounts_partition(scan_commitment: CommitmentConfig) {
     let (t_update, t_scan, additional_accounts) = setup_transfer_scan_threads(
         100,
         exit.clone(),
-        scan_commitment,
+        CommitmentConfig::finalized(),
         update_client_receiver,
         scan_client_receiver,
     );


### PR DESCRIPTION
#### Problem
`test_run_test_load_program_accounts_partition_root` has 1 line and it is calling `run_test_load_program_accounts_partition`, which is only called by `test_run_test_load_program_accounts_partition_root`

#### Summary of Changes
inline `run_test_load_program_accounts_partition`
