### PR TITLE
remove test

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -4357,27 +4357,7 @@ fn find_latest_replayed_slot_from_ledger(
 
 #[test]
 #[serial]
-fn test_cluster_partition_1_1() {
-    let empty = |_: &mut LocalCluster, _: &mut ()| {};
-    let on_partition_resolved = |cluster: &mut LocalCluster, _: &mut ()| {
-        cluster.check_for_new_roots(16, "PARTITION_TEST", SocketAddrSpace::Unspecified);
-    };
-    run_cluster_partition(
-        &[1, 1],
-        None,
-        (),
-        empty,
-        empty,
-        on_partition_resolved,
-        None,
-        false,
-        vec![],
-    )
-}
-
-#[test]
-#[serial]
-fn test_cluster_partition_1_1_1() {
+fn test_cluster_partition() {
     let empty = |_: &mut LocalCluster, _: &mut ()| {};
     let on_partition_resolved = |cluster: &mut LocalCluster, _: &mut ()| {
         cluster.check_for_new_roots(16, "PARTITION_TEST", SocketAddrSpace::Unspecified);


### PR DESCRIPTION
#### Problem
LocalCluster tests are very expensive. Currently have 2 variants of test_cluster_partition_*, which exercise mostly the same thing.

#### Summary of Changes
Only keep the 3 node variant of this test and drop the 2 node variant