### PR TITLE
test bench tps

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -1232,11 +1232,6 @@ mod tests {
         solana_runtime::{bank::Bank, bank_client::BankClient, bank_forks::BankForks},
     };
 
-    // Just a handful of txs to make sure the general flow works.
-    const BENCH_TPS_TX_COUNT: usize = 10;
-    // Just a short amount of runtime to make sure things don't crash.
-    const BENCH_TPS_DURATION: Duration = Duration::from_secs(5);
-
     fn bank_with_all_features(
         genesis_config: &GenesisConfig,
     ) -> (Arc<Bank>, Arc<RwLock<BankForks>>) {
@@ -1245,73 +1240,51 @@ mod tests {
         bank.wrap_with_bank_forks_for_tests()
     }
 
-    #[test]
-    fn test_bench_tps_bank_client() {
+    fn run_bench_tps_bank_client(mut config: Config) {
         let (genesis_config, id) = create_genesis_config(10_000 * LAMPORTS_PER_SOL);
+        config.id = id;
+        config.tx_count = 10;
+        config.duration = Duration::from_secs(5);
         let (bank, _bank_forks) = bank_with_all_features(&genesis_config);
         let client = Arc::new(BankClient::new_shared(bank));
-
-        let config = Config {
-            id,
-            tx_count: BENCH_TPS_TX_COUNT,
-            duration: BENCH_TPS_DURATION,
-            ..Config::default()
-        };
-
-        let keypair_count = config.tx_count * config.keypair_multiplier;
-        let keypairs =
-            generate_and_fund_keypairs(client.clone(), &config.id, keypair_count, 20, false, false)
-                .unwrap();
-
-        do_bench_tps(client, config, keypairs, None);
-    }
-
-    #[test]
-    fn test_bench_tps_bank_client_nonce() {
-        let (genesis_config, id) = create_genesis_config(10_000 * LAMPORTS_PER_SOL);
-        let (bank, _bank_forks) = bank_with_all_features(&genesis_config);
-        let client = Arc::new(BankClient::new_shared(bank));
-
-        let config = Config {
-            id,
-            tx_count: BENCH_TPS_TX_COUNT,
-            duration: BENCH_TPS_DURATION,
-            use_durable_nonce: true,
-            ..Config::default()
-        };
 
         let keypair_count = config.tx_count * config.keypair_multiplier;
         let keypairs =
             generate_and_fund_keypairs(client.clone(), &config.id, keypair_count, 1_000_000_000, false, false)
                 .unwrap();
-        let nonce_keypairs = Some(generate_durable_nonce_accounts(client.clone(), &keypairs));
+        let nonce_keypairs = if config.use_durable_nonce {
+            Some(generate_durable_nonce_accounts(client.clone(), &keypairs))
+        } else {
+            None
+        };
 
         do_bench_tps(client, config, keypairs, nonce_keypairs);
     }
 
     #[test]
-    fn test_bench_tps_bank_client_with_padding() {
-        let (genesis_config, id) = create_genesis_config(10_000 * LAMPORTS_PER_SOL);
-        let (bank, _bank_forks) = bank_with_all_features(&genesis_config);
-        let client = Arc::new(BankClient::new_shared(bank));
+    fn test_bench_tps_bank_client() {
+        run_bench_tps_bank_client(Config::default());
+    }
 
+    #[test]
+    fn test_bench_tps_bank_client_nonce() {
         let config = Config {
-            id,
-            tx_count: BENCH_TPS_TX_COUNT,
-            duration: BENCH_TPS_DURATION,
+            use_durable_nonce: true,
+            ..Config::default()
+        };
+        run_bench_tps_bank_client(config);
+    }
+
+    #[test]
+    fn test_bench_tps_bank_client_with_padding() {
+        let config = Config {
             instruction_padding_config: Some(InstructionPaddingConfig {
                 program_id: spl_instruction_padding_interface::ID,
                 data_size: 0,
             }),
             ..Config::default()
         };
-
-        let keypair_count = config.tx_count * config.keypair_multiplier;
-        let keypairs =
-            generate_and_fund_keypairs(client.clone(), &config.id, keypair_count, 20, false, false)
-                .unwrap();
-
-        do_bench_tps(client, config, keypairs, None);
+        run_bench_tps_bank_client(config);
     }
 
     #[test]

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -1249,9 +1249,15 @@ mod tests {
         let client = Arc::new(BankClient::new_shared(bank));
 
         let keypair_count = config.tx_count * config.keypair_multiplier;
-        let keypairs =
-            generate_and_fund_keypairs(client.clone(), &config.id, keypair_count, 1_000_000_000, false, false)
-                .unwrap();
+        let keypairs = generate_and_fund_keypairs(
+            client.clone(),
+            &config.id,
+            keypair_count,
+            1_000_000_000,
+            false,
+            false,
+        )
+        .unwrap();
         let nonce_keypairs = if config.use_durable_nonce {
             Some(generate_durable_nonce_accounts(client.clone(), &keypairs))
         } else {

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -1232,6 +1232,11 @@ mod tests {
         solana_runtime::{bank::Bank, bank_client::BankClient, bank_forks::BankForks},
     };
 
+    // Just a handful of txs to make sure the general flow works.
+    const BENCH_TPS_TX_COUNT: usize = 10;
+    // Just a short amount of runtime to make sure things don't crash.
+    const BENCH_TPS_DURATION: Duration = Duration::from_secs(5);
+
     fn bank_with_all_features(
         genesis_config: &GenesisConfig,
     ) -> (Arc<Bank>, Arc<RwLock<BankForks>>) {
@@ -1248,8 +1253,56 @@ mod tests {
 
         let config = Config {
             id,
-            tx_count: 10,
-            duration: Duration::from_secs(5),
+            tx_count: BENCH_TPS_TX_COUNT,
+            duration: BENCH_TPS_DURATION,
+            ..Config::default()
+        };
+
+        let keypair_count = config.tx_count * config.keypair_multiplier;
+        let keypairs =
+            generate_and_fund_keypairs(client.clone(), &config.id, keypair_count, 20, false, false)
+                .unwrap();
+
+        do_bench_tps(client, config, keypairs, None);
+    }
+
+    #[test]
+    fn test_bench_tps_bank_client_nonce() {
+        let (genesis_config, id) = create_genesis_config(10_000 * LAMPORTS_PER_SOL);
+        let (bank, _bank_forks) = bank_with_all_features(&genesis_config);
+        let client = Arc::new(BankClient::new_shared(bank));
+
+        let config = Config {
+            id,
+            tx_count: BENCH_TPS_TX_COUNT,
+            duration: BENCH_TPS_DURATION,
+            use_durable_nonce: true,
+            ..Config::default()
+        };
+
+        let keypair_count = config.tx_count * config.keypair_multiplier;
+        let keypairs =
+            generate_and_fund_keypairs(client.clone(), &config.id, keypair_count, 1_000_000_000, false, false)
+                .unwrap();
+        let nonce_keypairs = Some(generate_durable_nonce_accounts(client.clone(), &keypairs));
+
+        do_bench_tps(client, config, keypairs, nonce_keypairs);
+    }
+
+    #[test]
+    fn test_bench_tps_bank_client_with_padding() {
+        let (genesis_config, id) = create_genesis_config(10_000 * LAMPORTS_PER_SOL);
+        let (bank, _bank_forks) = bank_with_all_features(&genesis_config);
+        let client = Arc::new(BankClient::new_shared(bank));
+
+        let config = Config {
+            id,
+            tx_count: BENCH_TPS_TX_COUNT,
+            duration: BENCH_TPS_DURATION,
+            instruction_padding_config: Some(InstructionPaddingConfig {
+                program_id: spl_instruction_padding_interface::ID,
+                data_size: 0,
+            }),
             ..Config::default()
         };
 

--- a/bench-tps/src/send_batch.rs
+++ b/bench-tps/src/send_batch.rs
@@ -104,19 +104,16 @@ pub fn generate_durable_nonce_accounts<T: 'static + TpsClient + Send + Sync + ?S
     let nonce_rent = client
         .get_minimum_balance_for_rent_exemption(State::size())
         .unwrap();
-
     let seed_keypair = &authority_keypairs[0];
     let count = authority_keypairs.len();
     let (mut nonce_keypairs, _extra) = generate_keypairs(seed_keypair, count as u64);
     nonce_keypairs.truncate(count);
-
     info!("Creating {count} nonce accounts...");
     let to_fund: Vec<NonceCreateSigners> = authority_keypairs
         .iter()
         .zip(nonce_keypairs.iter())
         .map(|x| NonceCreateSigners(x.0, x.1))
         .collect();
-
     to_fund.chunks(FUND_CHUNK_LEN).for_each(|chunk| {
         NonceCreateContainer::with_capacity(chunk.len())
             .create_accounts(&client, chunk, nonce_rent);

--- a/bench-tps/src/send_batch.rs
+++ b/bench-tps/src/send_batch.rs
@@ -104,16 +104,19 @@ pub fn generate_durable_nonce_accounts<T: 'static + TpsClient + Send + Sync + ?S
     let nonce_rent = client
         .get_minimum_balance_for_rent_exemption(State::size())
         .unwrap();
+
     let seed_keypair = &authority_keypairs[0];
     let count = authority_keypairs.len();
     let (mut nonce_keypairs, _extra) = generate_keypairs(seed_keypair, count as u64);
     nonce_keypairs.truncate(count);
+
     info!("Creating {count} nonce accounts...");
     let to_fund: Vec<NonceCreateSigners> = authority_keypairs
         .iter()
         .zip(nonce_keypairs.iter())
         .map(|x| NonceCreateSigners(x.0, x.1))
         .collect();
+
     to_fund.chunks(FUND_CHUNK_LEN).for_each(|chunk| {
         NonceCreateContainer::with_capacity(chunk.len())
             .create_accounts(&client, chunk, nonce_rent);

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -2,10 +2,9 @@
 
 use {
     serial_test::serial,
-    solana_account::{Account, AccountSharedData},
     solana_bench_tps::{
         bench::{do_bench_tps, generate_and_fund_keypairs},
-        cli::{Config, InstructionPaddingConfig},
+        cli::Config,
         send_batch::generate_durable_nonce_accounts,
     },
     solana_commitment_config::CommitmentConfig,
@@ -20,34 +19,20 @@ use {
         validator_configs::make_identical_validator_configs,
     },
     solana_net_utils::SocketAddrSpace,
-    solana_quic_client::{QuicConfig, QuicConnectionManager},
+    solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
     solana_rent::Rent,
     solana_rpc::rpc::JsonRpcConfig,
     solana_rpc_client::rpc_client::RpcClient,
     solana_signer::Signer,
-    solana_test_validator::TestValidatorGenesis,
+    solana_test_validator::{TestValidator, TestValidatorGenesis},
     solana_tpu_client::tpu_client::{TpuClient, TpuClientConfig},
     std::{sync::Arc, time::Duration},
 };
 
-fn program_account(program_data: &[u8]) -> AccountSharedData {
-    AccountSharedData::from(Account {
-        lamports: Rent::default().minimum_balance(program_data.len()).min(1),
-        data: program_data.to_vec(),
-        owner: solana_sdk_ids::bpf_loader::id(),
-        executable: true,
-        rent_epoch: 0,
-    })
-}
-
-fn test_bench_tps_local_cluster(config: Config) {
-    let additional_accounts = vec![(
-        spl_instruction_padding_interface::ID,
-        program_account(include_bytes!("fixtures/spl_instruction_padding.so")),
-    )];
-
-    agave_logger::setup();
-
+fn create_local_cluster_and_client() -> (
+    LocalCluster,
+    Arc<TpuClient<QuicPool, QuicConnectionManager, QuicConfig>>,
+) {
     let faucet_keypair = Keypair::new();
     let faucet_pubkey = faucet_keypair.pubkey();
     let faucet_addr = run_local_faucet_for_tests(
@@ -71,7 +56,6 @@ fn test_bench_tps_local_cluster(config: Config) {
                 },
                 NUM_NODES,
             ),
-            additional_accounts,
             ..ClusterConfig::default()
         },
         SocketAddrSpace::Unspecified,
@@ -84,31 +68,15 @@ fn test_bench_tps_local_cluster(config: Config) {
             .build_validator_tpu_quic_client(cluster.entry_point_info.pubkey())
             .unwrap_or_else(|err| {
                 panic!("Could not create TpuClient with Quic Cache {err:?}");
-            }),
-    );
+            }));
 
-    let lamports_per_account = 100;
-
-    let keypair_count = config.tx_count * config.keypair_multiplier;
-    let keypairs = generate_and_fund_keypairs(
-        client.clone(),
-        &config.id,
-        keypair_count,
-        lamports_per_account,
-        false,
-        false,
-    )
-    .unwrap();
-
-    let _total = do_bench_tps(client, config, keypairs, None);
-
-    #[cfg(not(debug_assertions))]
-    assert!(_total > 100);
+    (cluster, client)
 }
 
-fn test_bench_tps_test_validator(config: Config) {
-    agave_logger::setup();
-
+fn create_test_validator_and_client() -> (
+    TestValidator,
+    Arc<TpuClient<QuicPool, QuicConnectionManager, QuicConfig>>,
+) {
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet_for_tests(
@@ -137,20 +105,31 @@ fn test_bench_tps_test_validator(config: Config) {
     ));
     let websocket_url = test_validator.rpc_pubsub_url();
 
-    let client = Arc::new(
-        TpuClient::new(
-            "tpu_client_quic_bench_tps",
-            rpc_client,
-            &websocket_url,
-            TpuClientConfig::default(),
-            QuicConnectionManager::new_with_connection_config(QuicConfig::new().unwrap()),
-        )
-        .expect("Should build Quic Tpu Client."),
-    );
+    (
+        test_validator,
+        Arc::new(
+            TpuClient::new(
+                "tpu_client_quic_bench_tps",
+                rpc_client,
+                &websocket_url,
+                TpuClientConfig::default(),
+                QuicConnectionManager::new_with_connection_config(QuicConfig::new().unwrap()),
+            )
+            .expect("Should build Quic Tpu Client."),
+        ),
+    )
+}
 
-    let lamports_per_account = 1000;
-
+fn run_bench_tps(
+    client: Arc<TpuClient<QuicPool, QuicConnectionManager, QuicConfig>>,
+) {
+    let config = Config {
+        tx_count: 100,
+        duration: Duration::from_secs(5),
+        ..Config::default()
+    };
     let keypair_count = config.tx_count * config.keypair_multiplier;
+    let lamports_per_account = 1000;
     let keypairs = generate_and_fund_keypairs(
         client.clone(),
         &config.id,
@@ -166,67 +145,24 @@ fn test_bench_tps_test_validator(config: Config) {
         None
     };
 
-    let _total = do_bench_tps(client, config, keypairs, nonce_keypairs);
-
-    #[cfg(not(debug_assertions))]
-    assert!(_total > 100);
+    let tps = do_bench_tps(client, config, keypairs, nonce_keypairs);
+    assert!(tps > 100, "TPS less than expected {tps}");
 }
 
 #[test]
 #[serial]
-fn test_bench_tps_local_cluster_solana() {
-    test_bench_tps_local_cluster(Config {
-        tx_count: 100,
-        duration: Duration::from_secs(10),
-        ..Config::default()
-    });
+fn test_bench_tps_local_cluster() {
+    agave_logger::setup();
+    let (local_cluster, client) = create_local_cluster_and_client();
+    run_bench_tps(client);
+    drop(local_cluster);
 }
 
 #[test]
 #[serial]
-fn test_bench_tps_tpu_client() {
-    test_bench_tps_test_validator(Config {
-        tx_count: 100,
-        duration: Duration::from_secs(10),
-        ..Config::default()
-    });
-}
-
-#[test]
-#[serial]
-fn test_bench_tps_tpu_client_nonce() {
-    test_bench_tps_test_validator(Config {
-        tx_count: 100,
-        duration: Duration::from_secs(10),
-        use_durable_nonce: true,
-        ..Config::default()
-    });
-}
-
-#[test]
-#[serial]
-fn test_bench_tps_local_cluster_with_padding() {
-    test_bench_tps_local_cluster(Config {
-        tx_count: 100,
-        duration: Duration::from_secs(10),
-        instruction_padding_config: Some(InstructionPaddingConfig {
-            program_id: spl_instruction_padding_interface::ID,
-            data_size: 0,
-        }),
-        ..Config::default()
-    });
-}
-
-#[test]
-#[serial]
-fn test_bench_tps_tpu_client_with_padding() {
-    test_bench_tps_test_validator(Config {
-        tx_count: 100,
-        duration: Duration::from_secs(10),
-        instruction_padding_config: Some(InstructionPaddingConfig {
-            program_id: spl_instruction_padding_interface::ID,
-            data_size: 0,
-        }),
-        ..Config::default()
-    });
+fn test_bench_tps_test_validator() {
+    agave_logger::setup();
+    let (test_validator, client) = create_test_validator_and_client();
+    run_bench_tps(client);
+    drop(test_validator)
 }

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -68,7 +68,8 @@ fn create_local_cluster_and_client() -> (
             .build_validator_tpu_quic_client(cluster.entry_point_info.pubkey())
             .unwrap_or_else(|err| {
                 panic!("Could not create TpuClient with Quic Cache {err:?}");
-            }));
+            }),
+    );
 
     (cluster, client)
 }
@@ -120,9 +121,7 @@ fn create_test_validator_and_client() -> (
     )
 }
 
-fn run_bench_tps(
-    client: Arc<TpuClient<QuicPool, QuicConnectionManager, QuicConfig>>,
-) {
+fn run_bench_tps(client: Arc<TpuClient<QuicPool, QuicConnectionManager, QuicConfig>>) {
     let config = Config {
         tx_count: 100,
         duration: Duration::from_secs(5),

--- a/tps-client/src/bank_client.rs
+++ b/tps-client/src/bank_client.rs
@@ -113,8 +113,19 @@ impl TpsClient for BankClient {
             })
     }
 
-    fn get_multiple_accounts(&self, _pubkeys: &[Pubkey]) -> TpsClientResult<Vec<Option<Account>>> {
-        unimplemented!("BankClient doesn't support get_multiple_accounts");
+    fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> TpsClientResult<Vec<Option<Account>>> {
+        let mut accounts = Vec::with_capacity(pubkeys.len());
+        for pubkey in pubkeys {
+            let account = SyncClient::get_account(self, pubkey)
+                .map_err(|err| TpsClientError::Custom(format!("{err:?}")))?;
+            if account.is_none() {
+                return Err(TpsClientError::Custom(format!(
+                    "AccountNotFound: pubkey={pubkey}"
+                )));
+            }
+            accounts.push(account);
+        }
+        Ok(accounts)
     }
 
     fn get_slot_with_commitment(


### PR DESCRIPTION
#### Problem
Handful of issues discovered while looking at bench-tps testing:

1. 2 tests spinning up a local cluster and 3 spinning up test validator to test integration and different `bench-tps` configs. These tests are very expensive in terms of time.
2. `get_multiple_accounts` unimplemented for `bank_client`, which is necessary if we want to run `bench-tps` w/ nonces using `bank_client` (which is much faster).
3. Quite a bit of duplicated code across the tests.

#### Summary of Changes

1. Only keep 1 instance of testing bench-tps w/ local cluster and 1 with test validator for integration purposes. Move all different config (nonce and padding) testing to test against BanksClient (executes much faster).
2. Implement `get_multiple_accounts` for `bank_client`
3. Reorganize some of the setup code into helpers that can be reused