### PR TITLE
Remove unused enum

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -250,13 +250,6 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
     }
 }
 
-pub enum StoreReclaims {
-    /// normal reclaim mode
-    Default,
-    /// do not return reclaims from accounts index upsert
-    Ignore,
-}
-
 #[derive(Debug)]
 pub(crate) struct ShrinkCollect<'a, T: ShrinkCollectRefs<'a>> {
     pub(crate) slot: Slot,


### PR DESCRIPTION
#### Problem
Enum is unused. Anywhere. Public so rust doesn't pick it up.

#### Summary of Changes
- Remove it. 

Notes
- It was added at least 4 years ago. unclear when it stopped being used (or if it was ever use) but clearly no plans to use it. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
