### PR TITLE
fix(storage-proto): also regen when build.rs itself changes

### DIFF
--- a/storage-proto/build.rs
+++ b/storage-proto/build.rs
@@ -18,6 +18,7 @@ fn main() -> Result<(), std::io::Error> {
     for proto_file in &proto_files {
         let proto = proto_base_path.join(proto_file);
         println!("cargo:rerun-if-changed={}", proto.display());
+        println!("cargo:rerun-if-changed=build.rs");
         protos.push(proto);
     }
 


### PR DESCRIPTION
#### Problem
the build script in `solana-storage-proto` doesn't not rerun when build.rs itself is modified

#### Summary of Changes
emit the appropriate build script directive