### PR TITLE
 program-runtime: Fix a warning

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1304,8 +1304,10 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             let mut rng = rng();
             // gen_range is deprecated in favor of random_range in rand>=0.9, but we also get
             // rnd() from shuttle, which doesn't yet support rand 0.9 APIs
-            #[expect(deprecated)]
+            #[cfg(feature = "shuttle-test")]
             let index = rng.gen_range(0..candidates.len());
+            #[cfg(not(feature = "shuttle-test"))]
+            let index = rng.random_range(0..candidates.len());
             let usage_counter = candidates
                 .get(index)
                 .expect("Failed to get cached entry")


### PR DESCRIPTION
#### Problem
There is a warning when running `./ci/feature-check/test-feature.sh` after #10798, where `allow(deprecated)` was replaced with `expect(deprecated)`. This is because, when `shuttle-test` is activated, the old version of `rand` is used, where `gen_range` is not deprecated.

#### Summary of Changes
Configure to use `gen_range` if feature `shuttle-test` is active, and `random_range` if not.