### PR TITLE
remove feature code

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -179,8 +179,6 @@ fn simulate_transaction(
         bank,
         bank.get_reserved_account_keys(),
         bank.feature_set
-            .is_active(&agave_feature_set::static_instruction_limit::id()),
-        bank.feature_set
             .is_active(&agave_feature_set::limit_instruction_accounts::id()),
     ) {
         Err(err) => {

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -156,10 +156,10 @@ impl Default for ComputeBudget {
 }
 
 impl ComputeBudget {
-    pub fn new_with_defaults(simd_0268_active: bool, simd_0339_active: bool) -> Self {
+    pub fn new_with_defaults(simd_0268_active: bool) -> Self {
         Self::from_budget_and_cost(
             &SVMTransactionExecutionBudget::new_with_defaults(simd_0268_active),
-            &SVMTransactionExecutionCost::new_with_defaults(simd_0339_active),
+            &SVMTransactionExecutionCost::new_with_defaults(),
         )
     }
 

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -769,9 +769,6 @@ pub(crate) mod external {
             Vec<TxView>,
             &'a mut [CheckResponse],
         ) {
-            let enable_static_instruction_limit = bank
-                .feature_set
-                .is_active(&agave_feature_set::static_instruction_limit::ID);
             let enable_instruction_accounts_limit = bank
                 .feature_set
                 .is_active(&agave_feature_set::limit_instruction_accounts::ID);
@@ -781,7 +778,6 @@ pub(crate) mod external {
                 // Parsing and basic sanitization checks
                 match SanitizedTransactionView::try_new_sanitized(
                     tx_ptr,
-                    enable_static_instruction_limit,
                     enable_instruction_accounts_limit,
                 ) {
                     Ok(view) => {
@@ -962,9 +958,6 @@ pub(crate) mod external {
             batch: &TransactionPtrBatch,
             bank: &Bank,
         ) -> (Vec<Result<(), PacketHandlingError>>, Vec<Tx>, Vec<MaxAge>) {
-            let enable_static_instruction_limit = bank
-                .feature_set
-                .is_active(&agave_feature_set::static_instruction_limit::ID);
             let enable_instruction_accounts_limit = bank
                 .feature_set
                 .is_active(&agave_feature_set::limit_instruction_accounts::ID);
@@ -977,7 +970,6 @@ pub(crate) mod external {
                 match Self::translate_transaction(
                     transaction_ptr,
                     bank,
-                    enable_static_instruction_limit,
                     transaction_account_lock_limit,
                     enable_instruction_accounts_limit,
                 ) {
@@ -996,14 +988,12 @@ pub(crate) mod external {
         fn translate_transaction(
             transaction_ptr: TransactionPtr,
             bank: &Bank,
-            enable_static_instruction_limit: bool,
             transaction_account_lock_limit: usize,
             enable_instruction_accounts_limit: bool,
         ) -> Result<(Tx, MaxAge), PacketHandlingError> {
             translate_to_runtime_view(
                 transaction_ptr,
                 bank,
-                enable_static_instruction_limit,
                 transaction_account_lock_limit,
                 enable_instruction_accounts_limit,
             )
@@ -1187,7 +1177,6 @@ pub(crate) mod external {
                     translate_to_runtime_view(
                         &simple_tx[..],
                         &bank,
-                        true,
                         bank.get_transaction_account_lock_limit(),
                         true,
                     )
@@ -1377,8 +1366,8 @@ pub(crate) mod external {
 
             let parsing_results = [Ok(()), Err(TransactionViewError::ParseError), Ok(())];
             let parsed_transactions = [
-                SanitizedTransactionView::try_new_sanitized(&tx1[..], true, true).unwrap(),
-                SanitizedTransactionView::try_new_sanitized(&tx2[..], true, true).unwrap(),
+                SanitizedTransactionView::try_new_sanitized(&tx1[..], true).unwrap(),
+                SanitizedTransactionView::try_new_sanitized(&tx2[..], true).unwrap(),
             ];
             bank.store_account(
                 &parsed_transactions[1].static_account_keys()[0],
@@ -1428,7 +1417,7 @@ pub(crate) mod external {
             ) -> RuntimeTransaction<ResolvedTransactionView<&'_ [u8]>> {
                 RuntimeTransaction::<ResolvedTransactionView<_>>::try_new(
                     RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
-                        SanitizedTransactionView::try_new_sanitized(tx, true, true).unwrap(),
+                        SanitizedTransactionView::try_new_sanitized(tx, true).unwrap(),
                         solana_transaction::sanitized::MessageHash::Compute,
                         Some(false),
                     )
@@ -2576,8 +2565,6 @@ mod tests {
                 None,
                 loader,
                 &HashSet::default(),
-                bank.feature_set
-                    .is_active(&agave_feature_set::static_instruction_limit::id()),
                 bank.feature_set
                     .is_active(&agave_feature_set::limit_instruction_accounts::id()),
             )

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1446,8 +1446,6 @@ mod tests {
             bank.as_ref(),
             &ReservedAccountKeys::empty_key_set(),
             bank.feature_set
-                .is_active(&agave_feature_set::static_instruction_limit::id()),
-            bank.feature_set
                 .is_active(&agave_feature_set::limit_instruction_accounts::id()),
         )
         .unwrap();

--- a/core/src/banking_stage/latest_validator_vote_packet.rs
+++ b/core/src/banking_stage/latest_validator_vote_packet.rs
@@ -108,7 +108,6 @@ impl LatestValidatorVote {
 
         let vote = SanitizedTransactionView::try_new_sanitized(
             std::sync::Arc::new(packet.data(..).unwrap().to_vec()),
-            false,
             true,
         )
         .unwrap();

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -242,9 +242,6 @@ impl TransactionViewReceiveAndBuffer {
         // If outside holding window, do not parse.
         let should_parse = !matches!(decision, BufferedPacketsDecision::Forward);
 
-        let enable_static_instruction_limit = root_bank
-            .feature_set
-            .is_active(&agave_feature_set::static_instruction_limit::ID);
         let enable_instruction_accounts_limit = root_bank
             .feature_set
             .is_active(&agave_feature_set::limit_instruction_accounts::ID);
@@ -349,7 +346,6 @@ impl TransactionViewReceiveAndBuffer {
                             bytes,
                             root_bank,
                             working_bank,
-                            enable_static_instruction_limit,
                             transaction_account_lock_limit,
                             enable_instruction_accounts_limit,
                         ) {
@@ -410,14 +406,12 @@ impl TransactionViewReceiveAndBuffer {
         bytes: SharedBytes,
         root_bank: &Bank,
         working_bank: &Bank,
-        enable_static_instruction_limit: bool,
         transaction_account_lock_limit: usize,
         enable_instruction_accounts_limit: bool,
     ) -> Result<TransactionViewState, PacketHandlingError> {
         let (view, deactivation_slot) = translate_to_runtime_view(
             bytes,
             root_bank,
-            enable_static_instruction_limit,
             transaction_account_lock_limit,
             enable_instruction_accounts_limit,
         )?;
@@ -443,16 +437,13 @@ impl TransactionViewReceiveAndBuffer {
 pub(crate) fn translate_to_runtime_view<D: TransactionData>(
     data: D,
     bank: &Bank,
-    enable_static_instruction_limit: bool,
     transaction_account_lock_limit: usize,
     enable_instruction_accounts_limit: bool,
 ) -> Result<(RuntimeTransaction<ResolvedTransactionView<D>>, u64), PacketHandlingError> {
     // Parsing and basic sanitization checks
-    let Ok(view) = SanitizedTransactionView::try_new_sanitized(
-        data,
-        enable_static_instruction_limit,
-        enable_instruction_accounts_limit,
-    ) else {
+    let Ok(view) =
+        SanitizedTransactionView::try_new_sanitized(data, enable_instruction_accounts_limit)
+    else {
         return Err(PacketHandlingError::Sanitization);
     };
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -503,7 +503,7 @@ mod tests {
 
         let reserved_addresses = HashSet::default();
         let packet_parser = |data, priority, cost| {
-            let view = SanitizedTransactionView::try_new_sanitized(data, true, true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(data, true).unwrap();
             let view = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 view,
                 MessageHash::Compute,

--- a/core/src/banking_stage/vote_packet_receiver.rs
+++ b/core/src/banking_stage/vote_packet_receiver.rs
@@ -107,9 +107,6 @@ impl VotePacketReceiver {
             .filter_map(|pkt| {
                 match SanitizedTransactionView::try_new_sanitized(
                     Arc::new(pkt.data(..)?.to_vec()),
-                    // NB: It's safe to always pass false in here as simple vote
-                    // transactions are guaranteed to be a single instruction.
-                    false,
                     // Vote instructions are created in the validator code, and they are not
                     // referencing more than 255 accounts, so it is safe to set this to true.
                     true,

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -479,7 +479,7 @@ pub(crate) mod tests {
     }
 
     fn to_sanitized_view(packet: BytesPacket) -> SanitizedTransactionView<SharedBytes> {
-        SanitizedTransactionView::try_new_sanitized(Arc::new(packet.buffer().to_vec()), false, true)
+        SanitizedTransactionView::try_new_sanitized(Arc::new(packet.buffer().to_vec()), true)
             .unwrap()
     }
 

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -590,12 +590,9 @@ mod tests {
     };
 
     fn to_runtime_transaction_view(packet: BytesPacket) -> RuntimeTransactionView {
-        let tx = SanitizedTransactionView::try_new_sanitized(
-            Arc::new(packet.buffer().to_vec()),
-            false,
-            true,
-        )
-        .unwrap();
+        let tx =
+            SanitizedTransactionView::try_new_sanitized(Arc::new(packet.buffer().to_vec()), true)
+                .unwrap();
         let tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
             tx,
             MessageHash::Compute,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -680,37 +680,18 @@ impl Tower {
             // here that this is our leader bank.
             Hash::default()
         });
-        self.record_bank_vote_and_update_lockouts(
-            bank.slot(),
-            bank.hash(),
-            bank.feature_set
-                .is_active(&agave_feature_set::enable_tower_sync_ix::id()),
-            block_id,
-        )
+        self.record_bank_vote_and_update_lockouts(bank.slot(), bank.hash(), block_id)
     }
 
     /// If we've recently updated the vote state by applying a new vote
     /// or syncing from a bank, generate the proper last_vote.
-    pub(crate) fn update_last_vote_from_vote_state(
-        &mut self,
-        vote_hash: Hash,
-        enable_tower_sync_ix: bool,
-        block_id: Hash,
-    ) {
-        let mut new_vote = if enable_tower_sync_ix {
-            VoteTransaction::from(TowerSync::new(
-                self.vote_state.votes.clone(),
-                self.vote_state.root_slot,
-                vote_hash,
-                block_id,
-            ))
-        } else {
-            VoteTransaction::from(VoteStateUpdate::new(
-                self.vote_state.votes.clone(),
-                self.vote_state.root_slot,
-                vote_hash,
-            ))
-        };
+    pub(crate) fn update_last_vote_from_vote_state(&mut self, vote_hash: Hash, block_id: Hash) {
+        let mut new_vote = VoteTransaction::from(TowerSync::new(
+            self.vote_state.votes.clone(),
+            self.vote_state.root_slot,
+            vote_hash,
+            block_id,
+        ));
 
         new_vote.set_timestamp(self.maybe_timestamp(self.last_voted_slot().unwrap_or_default()));
         self.last_vote = new_vote;
@@ -720,7 +701,6 @@ impl Tower {
         &mut self,
         vote_slot: Slot,
         vote_hash: Hash,
-        enable_tower_sync_ix: bool,
         block_id: Hash,
     ) -> Option<Slot> {
         if let Some(last_voted_slot) = self.vote_state.last_voted_slot() {
@@ -738,7 +718,7 @@ impl Tower {
         let old_root = self.root();
 
         self.vote_state.process_next_vote_slot(vote_slot);
-        self.update_last_vote_from_vote_state(vote_hash, enable_tower_sync_ix, block_id);
+        self.update_last_vote_from_vote_state(vote_hash, block_id);
 
         let new_root = self.root();
 
@@ -756,7 +736,7 @@ impl Tower {
 
     #[cfg(feature = "dev-context-only-utils")]
     pub fn record_vote(&mut self, slot: Slot, hash: Hash) -> Option<Slot> {
-        self.record_bank_vote_and_update_lockouts(slot, hash, true, Hash::default())
+        self.record_bank_vote_and_update_lockouts(slot, hash, Hash::default())
     }
 
     #[cfg(feature = "dev-context-only-utils")]

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -264,9 +264,6 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
         is_tpu_vote_batch: bool,
         bank: &Bank,
     ) {
-        let enable_static_instruction_limit = bank
-            .feature_set
-            .is_active(&agave_feature_set::static_instruction_limit::id());
         let enable_instruction_accounts_limit = bank
             .feature_set
             .is_active(&agave_feature_set::limit_instruction_accounts::id());
@@ -292,7 +289,6 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
                 // If any steps fail, drop the packet.
                 let Some(priority) = SanitizedTransactionView::try_new_sanitized(
                     packet_data,
-                    enable_static_instruction_limit,
                     enable_instruction_accounts_limit,
                 )
                 .map_err(|_| ())

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4000,8 +4000,6 @@ impl ReplayStage {
             progress
                 .get_hash(last_voted_slot)
                 .expect("Must exist for us to have frozen descendant"),
-            bank.feature_set
-                .is_active(&agave_feature_set::enable_tower_sync_ix::id()),
             block_id,
         );
         // Since we are updating our tower we need to update associated caches for previously computed

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -125,7 +125,7 @@ impl CostModel {
         data_bytes_cost: u16,
         feature_set: &FeatureSet,
     ) -> TransactionCost<'a, Tx> {
-        let signature_cost = Self::get_signature_cost(transaction, feature_set);
+        let signature_cost = Self::get_signature_cost(transaction);
         let write_lock_cost = Self::get_write_lock_cost(num_write_locks);
 
         let allocated_accounts_data_size =
@@ -145,17 +145,8 @@ impl CostModel {
     }
 
     /// Returns signature details and the total signature cost
-    fn get_signature_cost(transaction: &impl StaticMeta, feature_set: &FeatureSet) -> u64 {
+    fn get_signature_cost(transaction: &impl StaticMeta) -> u64 {
         let signatures_count_detail = transaction.signature_details();
-
-        let ed25519_verify_cost = ED25519_VERIFY_STRICT_COST;
-
-        let secp256r1_verify_cost =
-            if feature_set.is_active(&feature_set::enable_secp256r1_precompile::id()) {
-                SECP256R1_VERIFY_COST
-            } else {
-                0
-            };
 
         signatures_count_detail
             .num_transaction_signatures()
@@ -168,12 +159,12 @@ impl CostModel {
             .saturating_add(
                 signatures_count_detail
                     .num_ed25519_instruction_signatures()
-                    .saturating_mul(ed25519_verify_cost),
+                    .saturating_mul(ED25519_VERIFY_STRICT_COST),
             )
             .saturating_add(
                 signatures_count_detail
                     .num_secp256r1_instruction_signatures()
-                    .saturating_mul(secp256r1_verify_cost),
+                    .saturating_mul(SECP256R1_VERIFY_COST),
             )
     }
 

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -384,7 +384,6 @@ mod tests {
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
             true,
-            true,
         )
         .unwrap();
 
@@ -450,7 +449,6 @@ mod tests {
             Some(false),
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
-            true,
             true,
         )
         .unwrap();

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -760,7 +760,6 @@ mod tests {
                         SimpleAddressLoader::Disabled,
                         &ReservedAccountKeys::empty_key_set(),
                         true,
-                        true,
                     )
                 }?;
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -467,7 +467,6 @@ fn compute_slot_cost(
                     None,
                     SimpleAddressLoader::Disabled,
                     &reserved_account_keys.active,
-                    feature_set.is_active(&agave_feature_set::static_instruction_limit::id()),
                     feature_set.is_active(&agave_feature_set::limit_instruction_accounts::id()),
                 )
                 .map_err(|err| {

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -1,11 +1,8 @@
 #![cfg(feature = "agave-unstable-api")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {
-    agave_feature_set::{FeatureSet, enable_secp256r1_precompile},
-    solana_message::compiled_instruction::CompiledInstruction,
-    solana_precompile_error::PrecompileError,
-    solana_pubkey::Pubkey,
-    std::sync::LazyLock,
+    agave_feature_set::FeatureSet, solana_message::compiled_instruction::CompiledInstruction,
+    solana_precompile_error::PrecompileError, solana_pubkey::Pubkey, std::sync::LazyLock,
 };
 
 pub mod ed25519;
@@ -68,7 +65,7 @@ static PRECOMPILES: LazyLock<Vec<Precompile>> = LazyLock::new(|| {
         ),
         Precompile::new(
             solana_sdk_ids::secp256r1_program::id(),
-            Some(enable_secp256r1_precompile::id()),
+            None, // always enabled
             secp256r1::verify,
         ),
     ]

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -119,9 +119,7 @@ struct SolSignerSeedsC {
 }
 
 /// Maximum number of account info structs that can be used in a single CPI invocation
-const MAX_CPI_ACCOUNT_INFOS: usize = 128;
-/// Maximum number of account info structs that can be used in a single CPI invocation with SIMD-0339 active
-const MAX_CPI_ACCOUNT_INFOS_SIMD_0339: usize = 255;
+const MAX_CPI_ACCOUNT_INFOS: usize = 255;
 
 /// Check that an account info pointer field points to the expected address
 fn check_account_info_pointer(
@@ -161,25 +159,9 @@ fn check_instruction_size(num_accounts: usize, data_len: usize) -> Result<(), Er
 }
 
 /// Check that the number of account infos is within the CPI limit
-fn check_account_infos(
-    num_account_infos: usize,
-    invoke_context: &mut InvokeContext,
-) -> Result<(), Error> {
-    let max_cpi_account_infos = if invoke_context
-        .get_feature_set()
-        .increase_cpi_account_info_limit
-    {
-        MAX_CPI_ACCOUNT_INFOS_SIMD_0339
-    } else if invoke_context
-        .get_feature_set()
-        .increase_tx_account_lock_limit
-    {
-        MAX_CPI_ACCOUNT_INFOS
-    } else {
-        64
-    };
+fn check_account_infos(num_account_infos: usize) -> Result<(), Error> {
     let num_account_infos = num_account_infos as u64;
-    let max_account_infos = max_cpi_account_infos as u64;
+    let max_account_infos = MAX_CPI_ACCOUNT_INFOS as u64;
     if num_account_infos > max_account_infos {
         return Err(Box::new(CpiError::MaxInstructionAccountInfosExceeded {
             num_account_infos,
@@ -598,19 +580,14 @@ pub fn translate_instruction_rust(
         .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
         .unwrap_or(u64::MAX);
 
-    if invoke_context
-        .get_feature_set()
-        .increase_cpi_account_info_limit
-    {
-        // Each account meta is 34 bytes (32 for pubkey, 1 for is_signer, 1 for is_writable)
-        let account_meta_translation_cost =
-            (account_metas.len().saturating_mul(size_of::<AccountMeta>()) as u64)
-                .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
-                .unwrap_or(u64::MAX);
+    // Each account meta is 34 bytes (32 for pubkey, 1 for is_signer, 1 for is_writable)
+    let account_meta_translation_cost =
+        (account_metas.len().saturating_mul(size_of::<AccountMeta>()) as u64)
+            .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
+            .unwrap_or(u64::MAX);
 
-        total_cu_translation_cost =
-            total_cu_translation_cost.saturating_add(account_meta_translation_cost);
-    }
+    total_cu_translation_cost =
+        total_cu_translation_cost.saturating_add(account_meta_translation_cost);
 
     consume_compute_meter(invoke_context, total_cu_translation_cost)?;
 
@@ -729,20 +706,15 @@ pub fn translate_instruction_c(
         .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
         .unwrap_or(u64::MAX);
 
-    if invoke_context
-        .get_feature_set()
-        .increase_cpi_account_info_limit
-    {
-        // Each account meta is 34 bytes (32 for pubkey, 1 for is_signer, 1 for is_writable)
-        let account_meta_translation_cost = (ix_c
-            .accounts_len
-            .saturating_mul(size_of::<AccountMeta>() as u64))
-        .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
-        .unwrap_or(u64::MAX);
+    // Each account meta is 34 bytes (32 for pubkey, 1 for is_signer, 1 for is_writable)
+    let account_meta_translation_cost = (ix_c
+        .accounts_len
+        .saturating_mul(size_of::<AccountMeta>() as u64))
+    .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
+    .unwrap_or(u64::MAX);
 
-        total_cu_translation_cost =
-            total_cu_translation_cost.saturating_add(account_meta_translation_cost);
-    }
+    total_cu_translation_cost =
+        total_cu_translation_cost.saturating_add(account_meta_translation_cost);
 
     consume_compute_meter(invoke_context, total_cu_translation_cost)?;
 
@@ -1016,21 +988,16 @@ where
         account_infos_len,
         check_aligned,
     )?;
-    check_account_infos(account_infos.len(), invoke_context)?;
+    check_account_infos(account_infos.len())?;
 
-    if invoke_context
-        .get_feature_set()
-        .increase_cpi_account_info_limit
-    {
-        let account_infos_bytes = account_infos.len().saturating_mul(ACCOUNT_INFO_BYTE_SIZE);
+    let account_infos_bytes = account_infos.len().saturating_mul(ACCOUNT_INFO_BYTE_SIZE);
 
-        consume_compute_meter(
-            invoke_context,
-            (account_infos_bytes as u64)
-                .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
-                .unwrap_or(u64::MAX),
-        )?;
-    }
+    consume_compute_meter(
+        invoke_context,
+        (account_infos_bytes as u64)
+            .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
+            .unwrap_or(u64::MAX),
+    )?;
 
     let mut account_info_keys = Vec::with_capacity(account_infos_len as usize);
     #[expect(clippy::needless_range_loop)]

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -18,17 +18,7 @@ fn get_max_instruction_stack_depth(simd_0268_active: bool) -> usize {
 }
 
 //Default CPI invocation cost
-pub const DEFAULT_INVOCATION_COST: u64 = 1000;
-//CPI Invocation cost with SIMD-0339 active
-pub const INVOKE_UNITS_COST_SIMD_0339: u64 = 946;
-
-fn get_invoke_unit_cost(simd_0339_active: bool) -> u64 {
-    if simd_0339_active {
-        INVOKE_UNITS_COST_SIMD_0339
-    } else {
-        DEFAULT_INVOCATION_COST
-    }
-}
+pub const DEFAULT_INVOCATION_COST: u64 = 946;
 
 /// Max call depth. This is the maximum nesting of SBF to SBF call that can happen within a program.
 pub const MAX_CALL_DEPTH: usize = 64;
@@ -217,16 +207,16 @@ pub struct SVMTransactionExecutionCost {
 
 impl Default for SVMTransactionExecutionCost {
     fn default() -> Self {
-        Self::new_with_defaults(/* simd_0339_active */ false)
+        Self::new_with_defaults()
     }
 }
 
 impl SVMTransactionExecutionCost {
-    pub fn new_with_defaults(simd_0339_active: bool) -> Self {
+    pub fn new_with_defaults() -> Self {
         SVMTransactionExecutionCost {
             log_64_units: 100,
             create_program_address_units: 1500,
-            invoke_units: get_invoke_unit_cost(simd_0339_active),
+            invoke_units: DEFAULT_INVOCATION_COST,
             sha256_base_cost: 85,
             sha256_byte_cost: 1,
             log_pubkey_units: 100,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -856,9 +856,7 @@ macro_rules! with_mock_invoke_context_with_feature_set {
             environment_config,
             Some(LogCollector::new_ref()),
             compute_budget,
-            SVMTransactionExecutionCost::new_with_defaults(
-                $feature_set.increase_cpi_account_info_limit,
-            ),
+            SVMTransactionExecutionCost::new_with_defaults(),
         );
     };
     (

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -5,9 +5,7 @@
 // Export tokio for test clients
 pub use tokio;
 use {
-    agave_feature_set::{
-        FEATURE_NAMES, FeatureSet, increase_cpi_account_info_limit, raise_cpi_nesting_limit_to_8,
-    },
+    agave_feature_set::{FEATURE_NAMES, FeatureSet, raise_cpi_nesting_limit_to_8},
     async_trait::async_trait,
     base64::{Engine, prelude::BASE64_STANDARD},
     chrono_humanize::{Accuracy, HumanTime, Tense},
@@ -955,9 +953,6 @@ impl ProgramTest {
                         genesis_config
                             .accounts
                             .contains_key(&raise_cpi_nesting_limit_to_8::id()),
-                        genesis_config
-                            .accounts
-                            .contains_key(&increase_cpi_account_info_limit::id()),
                     )
                 }),
                 transaction_account_lock_limit: self.transaction_account_lock_limit,

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1235,25 +1235,6 @@ fn test_program_sbf_invoke_sanity() {
         );
 
         do_invoke_failure_test_local(
-            TEST_MAX_ACCOUNT_INFOS_EXCEEDED_BEFORE_INCREASE_TX_ACCOUNT_LOCK_BEFORE_SIMD_0339,
-            TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete),
-            &[],
-            Some(vec![
-                format!("Program {invoke_program_id} invoke [1]"),
-                format!("Program log: invoke {program_lang} program"),
-                "Program log: Test max account infos exceeded before SIMD-0339 and before \
-                 increase cpi info"
-                    .into(),
-                "skip".into(), // don't compare compute consumption logs
-                format!(
-                    "Program {invoke_program_id} failed: Invoked an instruction with too many \
-                     account info's (65 > 64)"
-                ),
-            ]),
-            &bank,
-        );
-
-        do_invoke_failure_test_local(
             TEST_RETURN_ERROR,
             TransactionError::InstructionError(0, InstructionError::Custom(42)),
             std::slice::from_ref(&invoked_program_id),

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -291,7 +291,7 @@ fn test_program_sbf_sanity() {
 
         let accounts = vec![(pubkey1, Account::default()), (pubkey2, Account::default())];
 
-        let compute_budget = ComputeBudget::new_with_defaults(false, false);
+        let compute_budget = ComputeBudget::new_with_defaults(false);
         let mut program_cache = default_program_cache_with_program(
             &program_id,
             &program_elf,
@@ -349,7 +349,7 @@ fn test_program_sbf_loader_deprecated() {
             ..SVMFeatureSet::all_enabled()
         };
 
-        let compute_budget = ComputeBudget::new_with_defaults(false, false);
+        let compute_budget = ComputeBudget::new_with_defaults(false);
 
         let pubkey = Pubkey::new_unique();
         let accounts = vec![
@@ -405,7 +405,7 @@ fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
     let authority_pubkey = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false, false);
+    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     // Create a retracted program account with LoaderV4State header + ELF bytes.
     let loader_state = LoaderV4State {
@@ -480,7 +480,7 @@ fn test_program_sbf_duplicate_accounts() {
         let program_elf = harness::file::load_program_elf(program);
         let program_id = Pubkey::new_unique();
         let feature_set = SVMFeatureSet::all_enabled();
-        let compute_budget = ComputeBudget::new_with_defaults(false, false);
+        let compute_budget = ComputeBudget::new_with_defaults(false);
         let mut program_cache = default_program_cache_with_program(
             &program_id,
             &program_elf,
@@ -600,7 +600,7 @@ fn test_program_sbf_error_handling() {
 
         let accounts = vec![(pubkey1, Account::default())];
 
-        let compute_budget = ComputeBudget::new_with_defaults(false, false);
+        let compute_budget = ComputeBudget::new_with_defaults(false);
         let mut program_cache = default_program_cache_with_program(
             &program_id,
             &program_elf,
@@ -690,7 +690,7 @@ fn test_return_data_and_log_data_syscall() {
         let program_id = Pubkey::new_unique();
 
         let feature_set = SVMFeatureSet::all_enabled();
-        let compute_budget = ComputeBudget::new_with_defaults(false, false);
+        let compute_budget = ComputeBudget::new_with_defaults(false);
 
         let pubkey = Pubkey::new_unique();
         let accounts = vec![(pubkey, Account::default())];
@@ -1426,7 +1426,7 @@ fn test_program_sbf_program_id_spoofing() {
     let malicious_system_pubkey = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false, false);
+    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let from_pubkey = Pubkey::new_unique();
     let to_pubkey = Pubkey::new_unique();
@@ -1501,7 +1501,7 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
     let caller2_pubkey = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false, false);
+    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let accounts = vec![
         (caller_pubkey, Account::new(0, 0, &loader_v4::id())),
@@ -1555,7 +1555,7 @@ fn test_program_sbf_ro_modify() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false, false);
+    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let test_pubkey = Pubkey::new_unique();
     let accounts = vec![
@@ -1606,7 +1606,7 @@ fn test_program_sbf_call_depth() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false, false);
+    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let mut program_cache = default_program_cache_with_program(
         &program_id,
@@ -1644,7 +1644,7 @@ fn test_program_sbf_compute_budget() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let mut compute_budget = ComputeBudget::new_with_defaults(false, false);
+    let mut compute_budget = ComputeBudget::new_with_defaults(false);
     compute_budget.compute_unit_limit = 0;
 
     let accounts = vec![(program_id, Account::new(0, 0, &loader_v4::id()))];
@@ -1719,7 +1719,7 @@ fn assert_instruction_count() {
     }
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false, false);
+    let compute_budget = ComputeBudget::new_with_defaults(false);
     let sysvar_cache = default_sysvar_cache();
 
     println!("\n  {:36} expected actual  diff", "SBF program");
@@ -1844,7 +1844,7 @@ fn test_program_sbf_r2_instruction_data_pointer(num_accounts: usize, input_data_
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false, false);
+    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let mut program_cache = default_program_cache_with_program(
         &program_id,
@@ -2395,7 +2395,7 @@ fn test_program_sbf_disguised_as_sbf_loader() {
             remove_bpf_loader_incorrect_program_id: false,
             ..SVMFeatureSet::all_enabled()
         };
-        let compute_budget = ComputeBudget::new_with_defaults(false, false);
+        let compute_budget = ComputeBudget::new_with_defaults(false);
 
         let mut program_cache = default_program_cache();
         harness::program_cache::add_program(
@@ -2434,7 +2434,7 @@ fn test_program_reads_from_program_account() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false, false);
+    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let mut program_cache = harness::program_cache::new_with_builtins(0);
     harness::program_cache::add_program(
@@ -2494,7 +2494,7 @@ fn test_program_sbf_c_dup() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false, false);
+    let compute_budget = ComputeBudget::new_with_defaults(false);
     let mut program_cache = harness::program_cache::new_with_builtins(0);
     harness::program_cache::add_program(
         &mut program_cache,
@@ -2738,7 +2738,7 @@ fn test_program_sbf_ro_account_modify() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false, false);
+    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let mut program_cache = default_program_cache_with_program(
         &program_id,
@@ -4705,7 +4705,7 @@ fn test_program_sbf_deplete_cost_meter_with_divide_by_zero() {
 
     let feature_set = SVMFeatureSet::all_enabled();
     let compute_budget = {
-        let mut budget = ComputeBudget::new_with_defaults(false, false);
+        let mut budget = ComputeBudget::new_with_defaults(false);
         budget.compute_unit_limit = 10_000u64;
         budget
     };
@@ -5786,7 +5786,7 @@ fn test_program_sbf_rust_direct_account_pointers(num_accounts: usize, input_data
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false, false);
+    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let mut program_cache = default_program_cache_with_program(
         &program_id,

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1029,25 +1029,6 @@ fn test_program_sbf_invoke_sanity() {
         let bank = bank_with_feature_deactivated(
             &bank_forks,
             bank,
-            &feature_set::increase_cpi_account_info_limit::id(),
-        );
-
-        assert!(
-            !bank
-                .feature_set
-                .is_active(&feature_set::increase_cpi_account_info_limit::id())
-        );
-
-        do_invoke_success(
-            TEST_MAX_ACCOUNT_INFOS_OK_BEFORE_SIMD_0339,
-            &[],
-            std::slice::from_ref(&invoked_program_id),
-            &bank,
-        );
-
-        let bank = bank_with_feature_deactivated(
-            &bank_forks,
-            bank,
             &feature_set::increase_tx_account_lock_limit::id(),
         );
         assert!(
@@ -1073,16 +1054,6 @@ fn test_program_sbf_invoke_sanity() {
                 .is_active(&feature_set::increase_tx_account_lock_limit::id())
         );
 
-        let bank = bank_with_feature_activated(
-            &bank_forks,
-            bank,
-            &feature_set::increase_cpi_account_info_limit::id(),
-        );
-
-        assert!(
-            bank.feature_set
-                .is_active(&feature_set::increase_cpi_account_info_limit::id())
-        );
         // failure cases
 
         let do_invoke_failure_test_local_with_compute_check =
@@ -1246,35 +1217,6 @@ fn test_program_sbf_invoke_sanity() {
                 format!(
                     "Program {invoke_program_id} failed: Invoked an instruction with too many \
                      account info's (256 > 255)"
-                ),
-            ]),
-            &bank,
-        );
-
-        let bank = bank_with_feature_deactivated(
-            &bank_forks,
-            bank,
-            &feature_set::increase_cpi_account_info_limit::id(),
-        );
-
-        assert!(
-            !bank
-                .feature_set
-                .is_active(&feature_set::increase_cpi_account_info_limit::id())
-        );
-
-        do_invoke_failure_test_local(
-            TEST_MAX_ACCOUNT_INFOS_EXCEEDED_BEFORE_SIMD_0339,
-            TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete),
-            &[],
-            Some(vec![
-                format!("Program {invoke_program_id} invoke [1]"),
-                format!("Program log: invoke {program_lang} program"),
-                "Program log: Test max account infos exceeded before SIMD-0339".into(),
-                "skip".into(), // don't compare compute consumption logs
-                format!(
-                    "Program {invoke_program_id} failed: Invoked an instruction with too many \
-                     account info's (129 > 128)"
                 ),
             ]),
             &bank,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3837,9 +3837,6 @@ pub mod rpc_full {
                 preflight_bank.get_reserved_account_keys(),
                 preflight_bank
                     .feature_set
-                    .is_active(&agave_feature_set::static_instruction_limit::id()),
-                preflight_bank
-                    .feature_set
                     .is_active(&agave_feature_set::limit_instruction_accounts::id()),
             )?;
             let blockhash = *transaction.message().recent_blockhash();
@@ -4001,8 +3998,6 @@ pub mod rpc_full {
                 unsanitized_tx,
                 bank,
                 bank.get_reserved_account_keys(),
-                bank.feature_set
-                    .is_active(&agave_feature_set::static_instruction_limit::id()),
                 bank.feature_set
                     .is_active(&agave_feature_set::limit_instruction_accounts::id()),
             )?;
@@ -4416,7 +4411,6 @@ fn sanitize_transaction(
     transaction: VersionedTransaction,
     address_loader: impl AddressLoader,
     reserved_account_keys: &HashSet<Pubkey>,
-    enable_static_instruction_limit: bool,
     enable_instruction_accounts_limit: bool,
 ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
     RuntimeTransaction::try_create(
@@ -4425,7 +4419,6 @@ fn sanitize_transaction(
         None,
         address_loader,
         reserved_account_keys,
-        enable_static_instruction_limit,
         enable_instruction_accounts_limit,
     )
     .map_err(|err| Error::invalid_params(format!("invalid transaction: {err}")))
@@ -9217,7 +9210,6 @@ pub mod tests {
                 SimpleAddressLoader::Disabled,
                 &ReservedAccountKeys::empty_key_set(),
                 true,
-                true,
             )
             .unwrap_err(),
             expect58
@@ -9243,7 +9235,6 @@ pub mod tests {
                 versioned_tx,
                 SimpleAddressLoader::Disabled,
                 &ReservedAccountKeys::empty_key_set(),
-                true,
                 true,
             )
             .unwrap_err(),

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -80,12 +80,10 @@ impl RuntimeTransaction<SanitizedTransaction> {
         is_simple_vote_tx: Option<bool>,
         address_loader: impl AddressLoader,
         reserved_account_keys: &HashSet<Pubkey>,
-        enable_static_instruction_limit: bool,
         enable_instruction_accounts_limit: bool,
     ) -> Result<Self> {
-        if enable_static_instruction_limit
-            && tx.message.instructions().len()
-                > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
+        if tx.message.instructions().len()
+            > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
         {
             return Err(solana_transaction_error::TransactionError::SanitizeFailure);
         }
@@ -159,7 +157,6 @@ impl TransactionWithMeta for RuntimeTransaction<SanitizedTransaction> {
 impl RuntimeTransaction<SanitizedTransaction> {
     pub fn from_transaction_for_tests(transaction: solana_transaction::Transaction) -> Self {
         let versioned_transaction = VersionedTransaction::from(transaction);
-        let enable_static_instruction_limit = true;
         let enable_instruction_accounts_limit = true;
         Self::try_create(
             versioned_transaction,
@@ -167,7 +164,6 @@ impl RuntimeTransaction<SanitizedTransaction> {
             None,
             solana_message::SimpleAddressLoader::Disabled,
             &HashSet::new(),
-            enable_static_instruction_limit,
             enable_instruction_accounts_limit,
         )
         .expect("failed to create RuntimeTransaction from Transaction")
@@ -397,7 +393,6 @@ mod tests {
             solana_message::SimpleAddressLoader::Disabled,
             &HashSet::new(),
             true,
-            true,
         );
         assert!(result.is_ok());
 
@@ -419,7 +414,6 @@ mod tests {
             None,
             solana_message::SimpleAddressLoader::Disabled,
             &HashSet::new(),
-            true,
             true,
         );
         assert_eq!(

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -245,8 +245,7 @@ mod tests {
 
         let hash = Hash::new_unique();
         let transaction =
-            SanitizedTransactionView::try_new_sanitized(&serialized_transaction[..], true, true)
-                .unwrap();
+            SanitizedTransactionView::try_new_sanitized(&serialized_transaction[..], true).unwrap();
         let static_runtime_transaction =
             RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 transaction,
@@ -279,7 +278,7 @@ mod tests {
         ) {
             let bytes = bincode::serialize(&original_transaction).unwrap();
             let transaction_view =
-                SanitizedTransactionView::try_new_sanitized(&bytes[..], true, true).unwrap();
+                SanitizedTransactionView::try_new_sanitized(&bytes[..], true).unwrap();
             let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 transaction_view,
                 MessageHash::Compute,
@@ -346,7 +345,7 @@ mod tests {
             let bytes =
                 bincode::serialize(&original_transaction.to_versioned_transaction()).unwrap();
             let transaction_view =
-                SanitizedTransactionView::try_new_sanitized(&bytes[..], true, true).unwrap();
+                SanitizedTransactionView::try_new_sanitized(&bytes[..], true).unwrap();
             let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 transaction_view,
                 MessageHash::Compute,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -65,8 +65,8 @@ use {
     accounts_lt_hash::{CacheValue as AccountsLtHashCacheValue, Stats as AccountsLtHashStats},
     agave_bls_cert_verify::cert_verify::{self, Error as CertVerifyError},
     agave_feature_set::{
-        self as feature_set, FeatureSet, increase_cpi_account_info_limit,
-        raise_cpi_nesting_limit_to_8, relax_programdata_account_check_migration,
+        self as feature_set, FeatureSet, raise_cpi_nesting_limit_to_8,
+        relax_programdata_account_check_migration,
     },
     agave_precompiles::{get_precompile, get_precompiles, is_precompile},
     agave_reserved_account_keys::ReservedAccountKeys,
@@ -2230,44 +2230,37 @@ impl Bank {
     }
 
     pub fn update_last_restart_slot(&self) {
-        let feature_flag = self
-            .feature_set
-            .is_active(&feature_set::last_restart_slot_sysvar::id());
+        // First, see what the currently stored last restart slot is.
+        let current_last_restart_slot = self
+            .get_account(&sysvar::last_restart_slot::id())
+            .and_then(|account| {
+                let lrs: Option<LastRestartSlot> = from_account(&account);
+                lrs
+            })
+            .map(|account| account.last_restart_slot);
 
-        if feature_flag {
-            // First, see what the currently stored last restart slot is. This
-            // account may not exist yet if the feature was just activated.
-            let current_last_restart_slot = self
-                .get_account(&sysvar::last_restart_slot::id())
-                .and_then(|account| {
-                    let lrs: Option<LastRestartSlot> = from_account(&account);
-                    lrs
-                })
-                .map(|account| account.last_restart_slot);
+        let last_restart_slot = {
+            let slot = self.slot;
+            let hard_forks_r = self.hard_forks.read().unwrap();
 
-            let last_restart_slot = {
-                let slot = self.slot;
-                let hard_forks_r = self.hard_forks.read().unwrap();
+            // Only consider hard forks <= this bank's slot to avoid prematurely applying
+            // a hard fork that is set to occur in the future.
+            hard_forks_r
+                .iter()
+                .rev()
+                .find(|(hard_fork, _)| *hard_fork <= slot)
+                .map(|(slot, _)| *slot)
+                .unwrap_or(0)
+        };
 
-                // Only consider hard forks <= this bank's slot to avoid prematurely applying
-                // a hard fork that is set to occur in the future.
-                hard_forks_r
-                    .iter()
-                    .rev()
-                    .find(|(hard_fork, _)| *hard_fork <= slot)
-                    .map(|(slot, _)| *slot)
-                    .unwrap_or(0)
-            };
-
-            // Only need to write if the last restart has changed
-            if current_last_restart_slot != Some(last_restart_slot) {
-                self.update_sysvar_account(&sysvar::last_restart_slot::id(), |account| {
-                    create_account(
-                        &LastRestartSlot { last_restart_slot },
-                        self.inherit_specially_retained_account_fields(account),
-                    )
-                });
-            }
+        // Only need to write if the last restart has changed
+        if current_last_restart_slot != Some(last_restart_slot) {
+            self.update_sysvar_account(&sysvar::last_restart_slot::id(), |account| {
+                create_account(
+                    &LastRestartSlot { last_restart_slot },
+                    self.inherit_specially_retained_account_fields(account),
+                )
+            });
         }
     }
 
@@ -2618,8 +2611,7 @@ impl Bank {
             slot_duration,
             epoch_start_timestamp,
             max_allowable_drift,
-            self.feature_set
-                .is_active(&feature_set::warp_timestamp_again::id()),
+            true,
         );
         get_timestamp_estimate_time.stop();
         datapoint_info!(
@@ -3226,9 +3218,6 @@ impl Bank {
         &self,
         txs: Vec<VersionedTransaction>,
     ) -> Result<TransactionBatch<'_, '_, RuntimeTransaction<SanitizedTransaction>>> {
-        let enable_static_instruction_limit = self
-            .feature_set
-            .is_active(&agave_feature_set::static_instruction_limit::id());
         let enable_instruction_account_limit = self
             .feature_set
             .is_active(&agave_feature_set::limit_instruction_accounts::id());
@@ -3241,7 +3230,6 @@ impl Bank {
                     None,
                     self,
                     self.get_reserved_account_keys(),
-                    enable_static_instruction_limit,
                     enable_instruction_account_limit,
                 )
             })
@@ -4400,16 +4388,10 @@ impl Bank {
         let simd_0268_active = self
             .feature_set
             .is_active(&raise_cpi_nesting_limit_to_8::id());
-        let simd_0339_active = self
-            .feature_set
-            .is_active(&increase_cpi_account_info_limit::id());
         let compute_budget = self
             .compute_budget()
             .as_ref()
-            .unwrap_or(&ComputeBudget::new_with_defaults(
-                simd_0268_active,
-                simd_0339_active,
-            ))
+            .unwrap_or(&ComputeBudget::new_with_defaults(simd_0268_active))
             .to_cost();
 
         self.transaction_processor
@@ -4443,19 +4425,8 @@ impl Bank {
             cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
         }
 
-        if self
-            .feature_set
-            .is_active(&feature_set::raise_account_cu_limit::id())
-        {
-            self.apply_simd_0306_cost_tracker_changes();
-        }
-
-        if self
-            .feature_set
-            .is_active(&feature_set::increase_cpi_account_info_limit::id())
-        {
-            self.apply_simd_0339_invoke_cost_changes();
-        }
+        self.apply_simd_0306_cost_tracker_changes();
+        self.apply_simd_0339_invoke_cost_changes();
 
         let environments = self.create_program_runtime_environments(&self.feature_set);
         self.transaction_processor
@@ -4476,14 +4447,10 @@ impl Bank {
         feature_set: &FeatureSet,
     ) -> ProgramRuntimeEnvironments {
         let simd_0268_active = feature_set.is_active(&raise_cpi_nesting_limit_to_8::id());
-        let simd_0339_active = feature_set.is_active(&increase_cpi_account_info_limit::id());
         let compute_budget = self
             .compute_budget()
             .as_ref()
-            .unwrap_or(&ComputeBudget::new_with_defaults(
-                simd_0268_active,
-                simd_0339_active,
-            ))
+            .unwrap_or(&ComputeBudget::new_with_defaults(simd_0268_active))
             .to_budget();
         ProgramRuntimeEnvironments {
             program_runtime_v1: Arc::new(
@@ -5010,9 +4977,6 @@ impl Bank {
         tx: VersionedTransaction,
         verification_mode: TransactionVerificationMode,
     ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
-        let enable_static_instruction_limit = self
-            .feature_set
-            .is_active(&agave_feature_set::static_instruction_limit::id());
         let enable_instruction_account_limit = self
             .feature_set
             .is_active(&agave_feature_set::limit_instruction_accounts::id());
@@ -5031,9 +4995,8 @@ impl Bank {
             let message_hash = if verification_mode == TransactionVerificationMode::FullVerification
             {
                 // SIMD-0160, check instruction limit before signature verificaton
-                if enable_static_instruction_limit
-                    && tx.message.instructions().len()
-                        > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
+                if tx.message.instructions().len()
+                    > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
                 {
                     return Err(solana_transaction_error::TransactionError::SanitizeFailure);
                 }
@@ -5048,7 +5011,6 @@ impl Bank {
                 None,
                 self,
                 self.get_reserved_account_keys(),
-                enable_static_instruction_limit,
                 enable_instruction_account_limit,
             )
         }?;
@@ -5677,16 +5639,6 @@ impl Bank {
             let vote_cost_limit = cost_tracker.get_vote_limit();
             cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
             drop(cost_tracker);
-
-            if self
-                .feature_set
-                .is_active(&feature_set::raise_account_cu_limit::id())
-            {
-                self.apply_simd_0306_cost_tracker_changes();
-            }
-        }
-
-        if new_feature_activations.contains(&feature_set::raise_account_cu_limit::id()) {
             self.apply_simd_0306_cost_tracker_changes();
         }
 
@@ -5699,10 +5651,6 @@ impl Bank {
                 error!("Failed to upgrade Core BPF Stake program: {e}");
             }
         }
-        if new_feature_activations.contains(&feature_set::increase_cpi_account_info_limit::id()) {
-            self.apply_simd_0339_invoke_cost_changes();
-        }
-
         if new_feature_activations.contains(&feature_set::replace_spl_token_with_p_token::id()) {
             if let Err(e) = self.upgrade_loader_v2_program_with_loader_v3_program(
                 &feature_set::replace_spl_token_with_p_token::SPL_TOKEN_PROGRAM_ID,

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -148,7 +148,7 @@ impl Bank {
             let compute_budget = self
                 .compute_budget()
                 .unwrap_or(ComputeBudget::new_with_defaults(
-                    /* simd_0268_active */ false, /* simd_0339_active */ false,
+                    /* simd_0268_active */ false,
                 ));
             let mut sysvar_cache = SysvarCache::default();
             sysvar_cache.fill_missing_entries(|pubkey, set_sysvar| {

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -214,10 +214,7 @@ impl Bank {
         &self,
         message: &impl SVMMessage,
     ) -> Option<(Pubkey, NonceData)> {
-        let require_static_nonce_account = self
-            .feature_set
-            .is_active(&agave_feature_set::require_static_nonce_account::id());
-        let nonce_address = message.get_durable_nonce(require_static_nonce_account)?;
+        let nonce_address = message.get_durable_nonce(true)?;
         let nonce_account = self.get_account_with_fixed_root(nonce_address)?;
         let nonce_data =
             nonce_account::verify_nonce_account(&nonce_account, message.recent_blockhash())?;
@@ -301,7 +298,6 @@ mod tests {
             program as system_program,
         },
         std::collections::HashSet,
-        test_case::test_case,
     };
 
     #[test]
@@ -468,14 +464,8 @@ mod tests {
         );
     }
 
-    #[test_case(true; "test_check_nonce_transaction_validity_nonce_is_alt_disallowed")]
-    #[test_case(false; "test_check_nonce_transaction_validity_nonce_is_alt_allowed")]
-    fn test_check_nonce_transaction_validity_nonce_is_alt(require_static_nonce_account: bool) {
-        let feature_set = if require_static_nonce_account {
-            FeatureSet::all_enabled()
-        } else {
-            FeatureSet::default()
-        };
+    #[test]
+    fn test_check_nonce_transaction_validity_nonce_is_alt() {
         let nonce_authority = Pubkey::new_unique();
         let (bank, _mint_keypair, _custodian_keypair, nonce_keypair, _) = setup_nonce_with_bank(
             10_000_000,
@@ -483,7 +473,7 @@ mod tests {
             5_000_000,
             250_000,
             Some(nonce_authority),
-            feature_set,
+            FeatureSet::default(),
         )
         .unwrap();
 
@@ -528,9 +518,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce())
-                .is_none(),
-            require_static_nonce_account,
+            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce()),
+            None,
         );
     }
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -56,9 +56,7 @@ use {
         compute_budget::ComputeBudget, compute_budget_limits::ComputeBudgetLimits,
     },
     solana_compute_budget_interface::ComputeBudgetInstruction,
-    solana_cost_model::block_cost_limits::{
-        MAX_BLOCK_UNITS, MAX_BLOCK_UNITS_SIMD_0286, MAX_WRITABLE_ACCOUNT_UNITS,
-    },
+    solana_cost_model::block_cost_limits::{MAX_BLOCK_UNITS, MAX_BLOCK_UNITS_SIMD_0286},
     solana_cpi::MAX_RETURN_DATA,
     solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     solana_feature_gate_interface::{self as feature, Feature},
@@ -5546,7 +5544,7 @@ fn test_shrink_candidate_slots_cached() {
     // No more slots should be shrunk
     assert_eq!(bank2.shrink_candidate_slots(), 0);
     // alive_counts represents the count of alive accounts in the three slots 0,1,2
-    assert_eq!(alive_counts, vec![12, 1, 6]);
+    assert_eq!(alive_counts, vec![14, 1, 6]);
 }
 
 #[test]
@@ -6880,14 +6878,9 @@ fn test_block_limits() {
         MAX_BLOCK_UNITS,
         "before activating the feature, bank should have old/default limit"
     );
-    assert!(
-        !bank
-            .feature_set
-            .is_active(&feature_set::raise_account_cu_limit::id())
-    );
     assert_eq!(
         bank.read_cost_tracker().unwrap().get_account_limit(),
-        MAX_WRITABLE_ACCOUNT_UNITS,
+        MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_FIRST,
         "before activating the feature, bank should have old/default limit"
     );
 
@@ -6911,91 +6904,18 @@ fn test_block_limits() {
         MAX_BLOCK_UNITS_SIMD_0286,
         "after activating the feature, bank should have new limit"
     );
-    assert_eq!(
-        bank.read_cost_tracker().unwrap().get_account_limit(),
-        MAX_WRITABLE_ACCOUNT_UNITS,
-        "after activating the feature, bank should have new limit"
-    );
-
-    // Make sure the limits propagate to the child-bank.
-    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), 2);
-    assert_eq!(
-        bank.read_cost_tracker().unwrap().get_block_limit(),
-        MAX_BLOCK_UNITS_SIMD_0286,
-        "child bank should have new limit"
-    );
-
-    // Activate `raise_account_cu_limit` feature
-    bank.store_account(
-        &feature_set::raise_account_cu_limit::id(),
-        &feature::create_account(&Feature::default(), 42),
-    );
-
-    // compute_and_apply_features_after_snapshot_restore will not cause the block limit to be updated
-    bank.compute_and_apply_features_after_snapshot_restore();
-    assert_eq!(
-        bank.read_cost_tracker().unwrap().get_account_limit(),
-        MAX_WRITABLE_ACCOUNT_UNITS,
-        "before activating the feature, bank should have old/default limit"
-    );
-
-    // compute_and_apply_new_feature_activations will cause feature to be activated
-    bank.compute_and_apply_new_feature_activations();
     assert_eq!(
         bank.read_cost_tracker().unwrap().get_account_limit(),
         MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_SECOND,
         "after activating the feature, bank should have new limit"
     );
 
-    // Test SIMD-0306 getting activated first
-    let (bank0, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
-
-    // Activate `raise_account_cu_limit` feature
-    bank.store_account(
-        &feature_set::raise_account_cu_limit::id(),
-        &feature::create_account(&Feature::default(), 42),
-    );
-    // compute_and_apply_features_after_snapshot_restore will not cause the block limit to be updated
-    bank.compute_and_apply_features_after_snapshot_restore();
-    assert_eq!(
-        bank.read_cost_tracker().unwrap().get_account_limit(),
-        MAX_WRITABLE_ACCOUNT_UNITS,
-        "before activating the feature, bank should have old/default limit"
-    );
-
-    // compute_and_apply_new_feature_activations will cause feature to be activated
-    bank.compute_and_apply_new_feature_activations();
-    assert_eq!(
-        bank.read_cost_tracker().unwrap().get_block_limit(),
-        MAX_BLOCK_UNITS,
-        "after activating the feature, bank should have new limit"
-    );
-    assert_eq!(
-        bank.read_cost_tracker().unwrap().get_account_limit(),
-        MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_FIRST,
-        "after activating the feature, bank should have new limit"
-    );
-
-    // Activate `raise_block_limits_to_100m` feature
-    bank.store_account(
-        &feature_set::raise_block_limits_to_100m::id(),
-        &feature::create_account(&Feature::default(), 42),
-    );
-    // compute_and_apply_features_after_snapshot_restore will not cause the block limit to be updated
-    bank.compute_and_apply_features_after_snapshot_restore();
-    assert_eq!(
-        bank.read_cost_tracker().unwrap().get_block_limit(),
-        MAX_BLOCK_UNITS,
-        "before activating the feature, bank should have old/default limit"
-    );
-
-    // compute_and_apply_new_feature_activations will cause feature to be activated
-    bank.compute_and_apply_new_feature_activations();
+    // Make sure the limits propagate to the child-bank.
+    let bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), 2);
     assert_eq!(
         bank.read_cost_tracker().unwrap().get_block_limit(),
         MAX_BLOCK_UNITS_SIMD_0286,
-        "after activating the feature, bank should have new limit"
+        "child bank should have new limit"
     );
     assert_eq!(
         bank.read_cost_tracker().unwrap().get_account_limit(),
@@ -7014,7 +6934,7 @@ fn test_block_limits() {
     );
     assert_eq!(
         bank.read_cost_tracker().unwrap().get_account_limit(),
-        MAX_WRITABLE_ACCOUNT_UNITS,
+        MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_FIRST,
         "before activating the feature, bank should have old/default limit"
     );
 
@@ -7033,15 +6953,7 @@ fn test_block_limits() {
         "bank created from genesis config should have new limit"
     );
 
-    activate_feature(
-        &mut genesis_config,
-        feature_set::raise_account_cu_limit::id(),
-    );
     let bank = Bank::new_for_tests(&genesis_config);
-    assert!(
-        bank.feature_set
-            .is_active(&feature_set::raise_account_cu_limit::id())
-    );
     assert_eq!(
         bank.read_cost_tracker().unwrap().get_account_limit(),
         MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_SECOND,
@@ -8964,9 +8876,6 @@ fn test_compute_budget_program_noop() {
                     invoke_context
                         .get_feature_set()
                         .raise_cpi_nesting_limit_to_8,
-                    invoke_context
-                        .get_feature_set()
-                        .increase_cpi_account_info_limit
                 )
             }
         );
@@ -9019,9 +8928,6 @@ fn test_compute_request_instruction() {
                     invoke_context
                         .get_feature_set()
                         .raise_cpi_nesting_limit_to_8,
-                    invoke_context
-                        .get_feature_set()
-                        .increase_cpi_account_info_limit
                 )
             }
         );
@@ -9081,9 +8987,6 @@ fn test_failed_compute_request_instruction() {
                     invoke_context
                         .get_feature_set()
                         .raise_cpi_nesting_limit_to_8,
-                    invoke_context
-                        .get_feature_set()
-                        .increase_cpi_account_info_limit
                 )
             }
         );
@@ -9231,15 +9134,11 @@ fn test_verify_transactions_packet_data_size() {
     }
 }
 
-#[test_case(false; "pre_simd160_static_instruction_limit")]
-#[test_case(true; "simd160_static_instruction_limit")]
-fn test_verify_transactions_instruction_limit(simd_0160_enabled: bool) {
+#[test]
+fn test_verify_transactions_instruction_limit() {
     let GenesisConfigInfo { genesis_config, .. } =
         create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
-    let mut bank = Bank::new_for_tests(&genesis_config);
-    if !simd_0160_enabled {
-        bank.deactivate_feature(&feature_set::static_instruction_limit::id());
-    }
+    let bank = Bank::new_for_tests(&genesis_config);
 
     let recent_blockhash = Hash::new_unique();
     let keypair = Keypair::new();
@@ -9264,17 +9163,10 @@ fn test_verify_transactions_instruction_limit(simd_0160_enabled: bool) {
 
     assert!(bincode::serialized_size(&tx).unwrap() <= PACKET_DATA_SIZE as u64);
 
-    if simd_0160_enabled {
-        assert_matches!(
-            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
-            Err(TransactionError::SanitizeFailure)
-        );
-    } else {
-        assert!(
-            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
-                .is_ok()
-        );
-    }
+    assert_matches!(
+        bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
+        Err(TransactionError::SanitizeFailure)
+    );
 }
 
 #[test_case(false; "pre_simd406_limit_instruction_accounts")]
@@ -11469,54 +11361,33 @@ fn test_last_restart_slot() {
     let mint_lamports = 100;
     let validator_stake_lamports = 10;
     let leader_pubkey = Pubkey::default();
-    let GenesisConfigInfo {
-        mut genesis_config, ..
-    } = create_genesis_config_with_leader(mint_lamports, &leader_pubkey, validator_stake_lamports);
-    // Remove last restart slot account so we can simluate its' activation
-    genesis_config
-        .accounts
-        .remove(&feature_set::last_restart_slot_sysvar::id())
-        .unwrap();
+    let GenesisConfigInfo { genesis_config, .. } =
+        create_genesis_config_with_leader(mint_lamports, &leader_pubkey, validator_stake_lamports);
 
     let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
     // Register a hard fork in the future so last restart slot will update
-    bank0.register_hard_fork(6);
-    assert!(!last_restart_slot_dirty(&bank0));
-    assert_eq!(get_last_restart_slot(&bank0), None);
-
-    let mut bank1 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 1));
-    assert!(!last_restart_slot_dirty(&bank1));
-    assert_eq!(get_last_restart_slot(&bank1), None);
-
-    // Activate the feature in slot 1, it will get initialized in slot 1's children
-    Arc::get_mut(&mut bank1)
-        .unwrap()
-        .activate_feature(&feature_set::last_restart_slot_sysvar::id());
-    let bank2 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 2));
-    assert!(last_restart_slot_dirty(&bank2));
-    assert_eq!(get_last_restart_slot(&bank2), Some(0));
-    let bank3 = Arc::new(Bank::new_from_parent(bank1, &Pubkey::default(), 3));
-    assert!(last_restart_slot_dirty(&bank3));
-    assert_eq!(get_last_restart_slot(&bank3), Some(0));
+    bank0.register_hard_fork(3);
+    assert!(last_restart_slot_dirty(&bank0));
+    assert_eq!(get_last_restart_slot(&bank0), Some(0));
 
     // Not dirty in children where the last restart slot has not changed
-    let bank4 = Arc::new(Bank::new_from_parent(bank2, &Pubkey::default(), 4));
-    assert!(!last_restart_slot_dirty(&bank4));
-    assert_eq!(get_last_restart_slot(&bank4), Some(0));
-    let bank5 = Arc::new(Bank::new_from_parent(bank3, &Pubkey::default(), 5));
-    assert!(!last_restart_slot_dirty(&bank5));
-    assert_eq!(get_last_restart_slot(&bank5), Some(0));
+    let bank1 = Arc::new(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1));
+    assert!(!last_restart_slot_dirty(&bank1));
+    assert_eq!(get_last_restart_slot(&bank1), Some(0));
+    let bank2 = Arc::new(Bank::new_from_parent(bank0, &Pubkey::default(), 2));
+    assert!(!last_restart_slot_dirty(&bank2));
+    assert_eq!(get_last_restart_slot(&bank2), Some(0));
 
     // Last restart slot has now changed so it will be dirty again
-    let bank6 = Arc::new(Bank::new_from_parent(bank4, &Pubkey::default(), 6));
-    assert!(last_restart_slot_dirty(&bank6));
-    assert_eq!(get_last_restart_slot(&bank6), Some(6));
+    let bank3 = Arc::new(Bank::new_from_parent(bank2, &Pubkey::default(), 3));
+    assert!(last_restart_slot_dirty(&bank3));
+    assert_eq!(get_last_restart_slot(&bank3), Some(3));
 
     // Last restart will not change for a hard fork that has not occurred yet
-    bank6.register_hard_fork(10);
-    let bank7 = Arc::new(Bank::new_from_parent(bank6, &Pubkey::default(), 7));
-    assert!(!last_restart_slot_dirty(&bank7));
-    assert_eq!(get_last_restart_slot(&bank7), Some(6));
+    bank3.register_hard_fork(6);
+    let bank4 = Arc::new(Bank::new_from_parent(bank3, &Pubkey::default(), 4));
+    assert!(!last_restart_slot_dirty(&bank4));
+    assert_eq!(get_last_restart_slot(&bank4), Some(3));
 }
 
 /// Test that simulations report the compute units of failed transactions

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -62,18 +62,20 @@ pub fn bootstrap_validator_stake_lamports() -> u64 {
 // Number of lamports automatically used for genesis accounts
 pub const fn genesis_sysvar_and_builtin_program_lamports() -> u64 {
     const NUM_BUILTIN_PROGRAMS: u64 = 6;
-    const NUM_PRECOMPILES: u64 = 2;
+    const NUM_PRECOMPILES: u64 = 3;
     const STAKE_HISTORY_MIN_BALANCE: u64 = 114_979_200;
     const CLOCK_SYSVAR_MIN_BALANCE: u64 = 1_169_280;
     const RENT_SYSVAR_MIN_BALANCE: u64 = 1_009_200;
     const EPOCH_SCHEDULE_SYSVAR_MIN_BALANCE: u64 = 1_120_560;
     const RECENT_BLOCKHASHES_SYSVAR_MIN_BALANCE: u64 = 42_706_560;
+    const LAST_RESTART_SLOT_SYSVAR_MIN_BALANCE: u64 = 946_560;
 
     STAKE_HISTORY_MIN_BALANCE
         + CLOCK_SYSVAR_MIN_BALANCE
         + RENT_SYSVAR_MIN_BALANCE
         + EPOCH_SCHEDULE_SYSVAR_MIN_BALANCE
         + RECENT_BLOCKHASHES_SYSVAR_MIN_BALANCE
+        + LAST_RESTART_SLOT_SYSVAR_MIN_BALANCE
         + NUM_BUILTIN_PROGRAMS
         + NUM_PRECOMPILES
 }

--- a/svm-test-harness/instr/src/fuzz.rs
+++ b/svm-test-harness/instr/src/fuzz.rs
@@ -72,10 +72,9 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects
 
     let feature_set = &instr_context.feature_set;
     let simd_0268_active = feature_set.raise_cpi_nesting_limit_to_8;
-    let simd_0339_active = feature_set.increase_cpi_account_info_limit;
 
     let compute_budget = {
-        let mut budget = ComputeBudget::new_with_defaults(simd_0268_active, simd_0339_active);
+        let mut budget = ComputeBudget::new_with_defaults(simd_0268_active);
         budget.compute_unit_limit = cu_avail;
         budget
     };

--- a/svm-test-harness/instr/src/harness.rs
+++ b/svm-test-harness/instr/src/harness.rs
@@ -346,7 +346,7 @@ mod tests {
 
         // Set up the Compute Budget.
         let compute_budget = {
-            let mut budget = ComputeBudget::new_with_defaults(false, false);
+            let mut budget = ComputeBudget::new_with_defaults(false);
             budget.compute_unit_limit = cu_avail;
             budget
         };

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1,9 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
-    agave_feature_set::{
-        FEATURE_NAMES, FeatureSet, alpenglow, increase_cpi_account_info_limit,
-        raise_cpi_nesting_limit_to_8,
-    },
+    agave_feature_set::{FEATURE_NAMES, FeatureSet, alpenglow, raise_cpi_nesting_limit_to_8},
     agave_snapshots::{
         SnapshotInterval, paths::BANK_SNAPSHOTS_DIR, snapshot_config::SnapshotConfig,
     },
@@ -1181,9 +1178,6 @@ impl TestValidator {
                         !config
                             .deactivate_feature_set
                             .contains(&raise_cpi_nesting_limit_to_8::id()),
-                        !config
-                            .deactivate_feature_set
-                            .contains(&increase_cpi_account_info_limit::id()),
                     )
                 }),
             log_messages_bytes_limit: config.log_messages_bytes_limit,

--- a/transaction-view/benches/transaction_view.rs
+++ b/transaction-view/benches/transaction_view.rs
@@ -65,8 +65,8 @@ fn bench_transactions_parsing(
     group.bench_function("TransactionView (Sanitized)", |c| {
         c.iter(|| {
             for bytes in serialized_transactions.iter() {
-                let _ = TransactionView::try_new_sanitized(black_box(bytes.as_ref()), true, true)
-                    .unwrap();
+                let _ =
+                    TransactionView::try_new_sanitized(black_box(bytes.as_ref()), true).unwrap();
             }
         });
     });

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -290,7 +290,7 @@ mod tests {
             }),
         };
         let bytes = bincode::serialize(&transaction).unwrap();
-        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
+        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
         let result = ResolvedTransactionView::try_new(view, None, &HashSet::default());
         assert!(matches!(
             result,
@@ -321,7 +321,7 @@ mod tests {
             }),
         };
         let bytes = bincode::serialize(&transaction).unwrap();
-        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
+        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
         let result =
             ResolvedTransactionView::try_new(view, Some(loaded_addresses), &HashSet::default());
         assert!(matches!(
@@ -358,7 +358,7 @@ mod tests {
             }),
         };
         let bytes = bincode::serialize(&transaction).unwrap();
-        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
+        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
         let result =
             ResolvedTransactionView::try_new(view, Some(loaded_addresses), &HashSet::default());
         assert!(matches!(
@@ -408,8 +408,7 @@ mod tests {
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view =
-                SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses),
@@ -432,8 +431,7 @@ mod tests {
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view =
-                SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses),
@@ -456,8 +454,7 @@ mod tests {
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view =
-                SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses),
@@ -518,8 +515,7 @@ mod tests {
             let static_keys = vec![key0, key1, key2];
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view =
-                SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses.clone()),
@@ -538,8 +534,7 @@ mod tests {
             let static_keys = vec![key0, key1, bpf_loader_upgradeable::ID];
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view =
-                SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses.clone()),
@@ -562,8 +557,7 @@ mod tests {
             };
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
             let bytes = bincode::serialize(&transaction).unwrap();
-            let view =
-                SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true, true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
 
             let resolved_view = ResolvedTransactionView::try_new(
                 view,

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -6,16 +6,11 @@ use crate::{
 
 pub(crate) fn sanitize(
     view: &UnsanitizedTransactionView<impl TransactionData>,
-    enable_static_instruction_limit: bool,
     enable_instruction_accounts_limit: bool,
 ) -> Result<()> {
     sanitize_signatures(view)?;
     sanitize_account_access(view)?;
-    sanitize_instructions(
-        view,
-        enable_static_instruction_limit,
-        enable_instruction_accounts_limit,
-    )?;
+    sanitize_instructions(view, enable_instruction_accounts_limit)?;
     sanitize_address_table_lookups(view)
 }
 
@@ -61,13 +56,11 @@ fn sanitize_account_access(view: &UnsanitizedTransactionView<impl TransactionDat
 
 fn sanitize_instructions(
     view: &UnsanitizedTransactionView<impl TransactionData>,
-    enable_static_instruction_limit: bool,
     enable_instruction_accounts_limit: bool,
 ) -> Result<()> {
     // SIMD-160: transaction can not have more than 64 top level instructions
-    if enable_static_instruction_limit
-        && usize::from(view.num_instructions())
-            > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
+    if usize::from(view.num_instructions())
+        > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
     {
         return Err(TransactionViewError::SanitizeError);
     }
@@ -198,7 +191,7 @@ mod tests {
         let transaction = multiple_transfers();
         let data = bincode::serialize(&transaction).unwrap();
         let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-        assert!(view.sanitize(true, true).is_ok());
+        assert!(view.sanitize(true).is_ok());
     }
 
     #[test]
@@ -405,7 +398,7 @@ mod tests {
             );
             let data = bincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-            assert!(sanitize_instructions(&view, true, true).is_ok());
+            assert!(sanitize_instructions(&view, true).is_ok());
 
             let transaction = create_v0_transaction(
                 num_signatures,
@@ -416,7 +409,7 @@ mod tests {
             );
             let data = bincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-            assert!(sanitize_instructions(&view, true, true).is_ok());
+            assert!(sanitize_instructions(&view, true).is_ok());
         }
 
         for instruction_index in 0..valid_instructions.len() {
@@ -433,7 +426,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true, true),
+                    sanitize_instructions(&view, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -452,7 +445,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true, true),
+                    sanitize_instructions(&view, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -470,7 +463,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true, true),
+                    sanitize_instructions(&view, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -490,7 +483,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true, true),
+                    sanitize_instructions(&view, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -514,7 +507,7 @@ mod tests {
                 let data = bincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true, true),
+                    sanitize_instructions(&view, true),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -537,10 +530,9 @@ mod tests {
             let data = bincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
-                sanitize_instructions(&view, true, true),
+                sanitize_instructions(&view, true),
                 Err(TransactionViewError::SanitizeError)
             );
-            assert!(sanitize_instructions(&view, false, true).is_ok());
 
             let transaction = create_v0_transaction(
                 num_signatures,
@@ -552,10 +544,9 @@ mod tests {
             let data = bincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
-                sanitize_instructions(&view, true, true),
+                sanitize_instructions(&view, true),
                 Err(TransactionViewError::SanitizeError)
             );
-            assert!(sanitize_instructions(&view, false, true).is_ok());
         }
 
         // SIMD-406: Limit instruction accounts to 255
@@ -573,7 +564,7 @@ mod tests {
             let data = bincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
-                sanitize_instructions(&view, false, true),
+                sanitize_instructions(&view, true),
                 Err(TransactionViewError::SanitizeError)
             );
         }
@@ -592,7 +583,7 @@ mod tests {
             let data = bincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             // Exactly 255 accounts must pass sanitization.
-            assert!(sanitize_instructions(&view, false, true).is_ok());
+            assert!(sanitize_instructions(&view, true).is_ok());
         }
     }
 

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -41,14 +41,9 @@ impl<D: TransactionData> TransactionView<false, D> {
     /// Sanitizes the transaction view, returning a sanitized view on success.
     pub fn sanitize(
         self,
-        enable_static_instruction_limit: bool,
         enable_instruction_accounts_limit: bool,
     ) -> Result<SanitizedTransactionView<D>> {
-        sanitize(
-            &self,
-            enable_static_instruction_limit,
-            enable_instruction_accounts_limit,
-        )?;
+        sanitize(&self, enable_instruction_accounts_limit)?;
         Ok(SanitizedTransactionView {
             data: self.data,
             frame: self.frame,
@@ -58,16 +53,9 @@ impl<D: TransactionData> TransactionView<false, D> {
 
 impl<D: TransactionData> TransactionView<true, D> {
     /// Creates a new `TransactionView`, running sanitization checks.
-    pub fn try_new_sanitized(
-        data: D,
-        enable_static_instruction_limit: bool,
-        enable_instruction_accounts_limit: bool,
-    ) -> Result<Self> {
+    pub fn try_new_sanitized(data: D, enable_instruction_accounts_limit: bool) -> Result<Self> {
         let unsanitized_view = TransactionView::try_new_unsanitized(data)?;
-        unsanitized_view.sanitize(
-            enable_static_instruction_limit,
-            enable_instruction_accounts_limit,
-        )
+        unsanitized_view.sanitize(enable_instruction_accounts_limit)
     }
 }
 


### PR DESCRIPTION
#### Problem
Following features are active on all clusters and could have the feature activation conditional code removed:
```
static_instruction_limit
enable_tower_sync_ix
enable_secp256r1_precompile
require_static_nonce_account
last_restart_slot_sysvar
warp_timestamp_again
increase_cpi_account_info_limit
raise_account_cu_limit
```

#### Summary of Changes

- Flatten logic
- Remove unnecessary params
- Fixup tests