### PR TITLE
chore: Remove frozen-abi from RuntimeConfig

### DIFF
--- a/runtime/src/runtime_config.rs
+++ b/runtime/src/runtime_config.rs
@@ -1,13 +1,5 @@
 use solana_compute_budget::compute_budget::ComputeBudget;
 
-#[cfg(feature = "frozen-abi")]
-impl ::solana_frozen_abi::abi_example::AbiExample for RuntimeConfig {
-    fn example() -> Self {
-        // RuntimeConfig is not Serialize so just rely on Default.
-        RuntimeConfig::default()
-    }
-}
-
 /// Encapsulates flags that can be used to tweak the runtime behavior.
 #[derive(Debug, Default, Clone)]
 pub struct RuntimeConfig {


### PR DESCRIPTION
#### Problem
RuntimeConfig was initially introduced as a field in Bank and thus needed to be stable since Bank's are serialized for snapshots. This struct is no longer a field in Bank so frozen-abi is no longer necessary either.