### PR TITLE
refactor: bump lru to 0.17.0 and initialize caches with non-zero capacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,6 +3008,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3368,7 +3374,7 @@ checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -3376,6 +3382,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -4429,6 +4440,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lru"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
+dependencies = [
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -5820,7 +5840,7 @@ dependencies = [
  "cc",
  "libc",
  "libm",
- "lru",
+ "lru 0.7.8",
  "parking_lot 0.11.2",
  "smallvec",
  "spin",
@@ -8773,7 +8793,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy-lru",
  "log",
- "lru",
+ "lru 0.17.0",
  "mockall",
  "num_cpus",
  "num_enum",
@@ -11066,7 +11086,7 @@ dependencies = [
  "futures 0.3.32",
  "futures-util",
  "log",
- "lru",
+ "lru 0.17.0",
  "quinn",
  "rustls",
  "serde_json",
@@ -11238,7 +11258,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy-lru",
  "log",
- "lru",
+ "lru 0.17.0",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,7 +296,7 @@ libsecp256k1 = { version = "0.7.2", default-features = false, features = [
     "static-context",
 ] }
 log = "0.4.29"
-lru = "0.7.7"
+lru = "0.17.0"
 lz4 = "1.28.1"
 memmap2 = "0.9.10"
 memoffset = "0.9.1"

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -36,6 +36,7 @@ use {
     solana_transaction_error::TransportError,
     std::{
         net::{SocketAddr, UdpSocket},
+        num::NonZeroUsize,
         sync::{Arc, RwLock},
         thread::{Builder, JoinHandle},
         time::{Duration, Instant},
@@ -540,7 +541,7 @@ impl TpuClientNextClient {
             stake_identity: stake_identity.map(StakeIdentity::new),
             // Cache size of 128 covers all nodes above the P90 slot count threshold,
             // which together account for ~75% of total slots in the epoch.
-            num_connections: 128,
+            num_connections: NonZeroUsize::new(128).unwrap(),
             skip_check_transaction_age: true,
             worker_channel_size: 2,
             max_reconnect_attempts: 4,

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -2612,6 +2612,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,7 +2950,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2952,6 +2958,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -3949,6 +3960,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lru"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
+dependencies = [
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -5262,7 +5282,7 @@ dependencies = [
  "cc",
  "libc",
  "libm",
- "lru",
+ "lru 0.7.8",
  "parking_lot 0.11.2",
  "smallvec",
  "spin",
@@ -7630,7 +7650,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy-lru",
  "log",
- "lru",
+ "lru 0.17.0",
  "mockall",
  "num_cpus",
  "num_enum",
@@ -9535,7 +9555,7 @@ dependencies = [
  "futures 0.3.32",
  "futures-util",
  "log",
- "lru",
+ "lru 0.17.0",
  "quinn",
  "rustls",
  "solana-clock",
@@ -9681,7 +9701,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy-lru",
  "log",
- "lru",
+ "lru 0.17.0",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rayon",

--- a/ledger/src/slot_stats.rs
+++ b/ledger/src/slot_stats.rs
@@ -3,10 +3,10 @@ use {
     bitflags::bitflags,
     lru::LruCache,
     solana_clock::Slot,
-    std::{collections::HashMap, sync::Mutex},
+    std::{collections::HashMap, num::NonZeroUsize, sync::Mutex},
 };
 
-const SLOTS_STATS_CACHE_CAPACITY: usize = 300;
+const SLOTS_STATS_CACHE_CAPACITY: NonZeroUsize = NonZeroUsize::new(300).unwrap();
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum ShredSource {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2493,6 +2493,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,7 +2808,7 @@ checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2810,6 +2816,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -3811,6 +3822,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lru"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
+dependencies = [
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -5018,7 +5038,7 @@ dependencies = [
  "cc",
  "libc",
  "libm",
- "lru",
+ "lru 0.7.8",
  "parking_lot 0.11.2",
  "smallvec",
  "spin",
@@ -7288,7 +7308,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy-lru",
  "log",
- "lru",
+ "lru 0.17.0",
  "mockall",
  "num_cpus",
  "num_enum",
@@ -9846,7 +9866,7 @@ dependencies = [
  "futures 0.3.32",
  "futures-util",
  "log",
- "lru",
+ "lru 0.17.0",
  "quinn",
  "rustls",
  "solana-clock",
@@ -9992,7 +10012,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy-lru",
  "log",
- "lru",
+ "lru 0.17.0",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rayon",

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -15,6 +15,7 @@ use {
     },
     std::{
         net::{SocketAddr, UdpSocket},
+        num::NonZeroUsize,
         sync::atomic::Ordering,
         time::{Duration, Instant},
     },
@@ -30,7 +31,7 @@ use {
 
 /// How many connections to maintain the tpu-client-next cache. The value is
 /// chosen to match MAX_CONNECTIONS from ConnectionCache
-const MAX_CONNECTIONS: usize = 1024;
+const MAX_CONNECTIONS: NonZeroUsize = NonZeroUsize::new(1024).unwrap();
 
 // Alias trait to shorten function definitions.
 pub trait TpuInfoWithSendStatic: TpuInfo + std::marker::Send + 'static {}

--- a/tpu-client-next/src/client_builder.rs
+++ b/tpu-client-next/src/client_builder.rs
@@ -18,7 +18,7 @@
 //!        ))
 //!        .leader_send_fanout(1)
 //!        .identity(&identity_keypair)
-//!        .max_cache_size(128);
+//!        .max_cache_size(NonZeroUsize::new(128).unwrap())
 //!        .metric_reporter({
 //!            let successfully_sent = successfully_sent.clone();
 //!            |stats: Arc<SendTransactionStats>, cancel: CancellationToken| async move {
@@ -50,7 +50,7 @@ use {
         transaction_batch::TransactionBatch,
     },
     solana_keypair::Keypair,
-    std::{future::Future, net::UdpSocket, pin::Pin, sync::Arc},
+    std::{future::Future, net::UdpSocket, num::NonZeroUsize, pin::Pin, sync::Arc},
     thiserror::Error,
     tokio::{
         runtime,
@@ -79,7 +79,7 @@ pub struct ClientBuilder {
     leader_updater: Box<dyn LeaderUpdater>,
     bind_target: Option<BindTarget>,
     identity: Option<StakeIdentity>,
-    num_connections: usize,
+    num_connections: NonZeroUsize,
     leader_send_fanout: usize,
     skip_check_transaction_age: bool,
     sender_channel_size: usize,
@@ -99,7 +99,7 @@ impl ClientBuilder {
             leader_updater,
             bind_target: None,
             identity: None,
-            num_connections: 64,
+            num_connections: NonZeroUsize::new(64).unwrap(),
             leader_send_fanout: 2,
             skip_check_transaction_age: true,
             worker_channel_size: 2,
@@ -141,7 +141,7 @@ impl ClientBuilder {
     }
 
     /// Set the maximum number of cached connections.
-    pub fn max_cache_size(mut self, num_connections: usize) -> Self {
+    pub fn max_cache_size(mut self, num_connections: NonZeroUsize) -> Self {
         self.num_connections = num_connections;
         self
     }

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -18,6 +18,7 @@ use {
     solana_keypair::Keypair,
     std::{
         net::{SocketAddr, UdpSocket},
+        num::NonZeroUsize,
         sync::Arc,
     },
     thiserror::Error,
@@ -85,7 +86,7 @@ pub struct ConnectionWorkersSchedulerConfig {
     pub stake_identity: Option<StakeIdentity>,
 
     /// The number of connections to be maintained by the scheduler.
-    pub num_connections: usize,
+    pub num_connections: NonZeroUsize,
 
     /// Whether to skip checking the transaction blockhash expiration.
     pub skip_check_transaction_age: bool,

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -11,7 +11,7 @@ use {
     },
     lru::LruCache,
     quinn::Endpoint,
-    std::{net::SocketAddr, sync::Arc, time::Duration},
+    std::{net::SocketAddr, num::NonZeroUsize, sync::Arc, time::Duration},
     thiserror::Error,
     tokio::{
         sync::mpsc::{self, error::TrySendError},
@@ -138,7 +138,7 @@ pub enum WorkersCacheError {
 }
 
 impl WorkersCache {
-    pub fn new(capacity: usize, cancel: CancellationToken) -> Self {
+    pub fn new(capacity: NonZeroUsize, cancel: CancellationToken) -> Self {
         Self {
             workers: LruCache::new(capacity),
             cancel,
@@ -376,6 +376,7 @@ mod tests {
         solana_tls_utils::QuicClientCertificate,
         std::{
             net::{Ipv4Addr, SocketAddr},
+            num::NonZeroUsize,
             sync::Arc,
             time::Duration,
         },
@@ -461,7 +462,7 @@ mod tests {
         let endpoint = create_test_endpoint();
 
         let cancel = CancellationToken::new();
-        let mut cache = WorkersCache::new(10, cancel.clone());
+        let mut cache = WorkersCache::new(NonZeroUsize::new(10).unwrap(), cancel.clone());
 
         let port_range = unique_port_range_for_tests(2);
         let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.start);

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -29,7 +29,7 @@ use {
     std::{
         collections::HashMap,
         net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
-        num::Saturating,
+        num::{NonZeroUsize, Saturating},
         sync::{
             Arc,
             atomic::{AtomicU64, Ordering},
@@ -55,7 +55,7 @@ fn test_config(stake_identity: Option<Keypair>) -> ConnectionWorkersSchedulerCon
     ConnectionWorkersSchedulerConfig {
         bind: BindTarget::Address(address),
         stake_identity: stake_identity.map(|identity| StakeIdentity::new(&identity)),
-        num_connections: 1,
+        num_connections: NonZeroUsize::new(1).unwrap(),
         skip_check_transaction_age: false,
         // At the moment we have only one strategy to send transactions: we try
         // to put to worker channel transaction batch and in case of failure
@@ -882,7 +882,7 @@ async fn test_client_builder() {
         .bind_socket(socket)
         .leader_send_fanout(1)
         .identity(None)
-        .max_cache_size(1)
+        .max_cache_size(NonZeroUsize::new(1).unwrap())
         .worker_channel_size(100)
         .metric_reporter({
             let successfully_sent = successfully_sent.clone();


### PR DESCRIPTION
#### Problem
Many new version of `lru` crate were released.

#### Summary of Changes
Based on change log (https://github.com/jeromefroe/lru-rs/blob/master/CHANGELOG.md) there are 3 categories of changes
* underlying hashbrown version bumps, likely allowing us to get better performance
* cache size now needs to be non-zero (initialized with `NonZeroUsize` that was a breaking change, which stopped us bumping this dependency
* API additions that do not affect us directly

