### PR TITLE
ci: deny warnings when checking feature combinations

### DIFF
--- a/ci/feature-check/test-feature.sh
+++ b/ci/feature-check/test-feature.sh
@@ -26,4 +26,5 @@ cargo +"$rust_nightly" hack check \
 	--each-feature \
 	--exclude-features "$(IFS=,; echo "${exclude_features[*]}")" \
 	--exclude-all-features \
-	--partition "$partition"
+	--partition "$partition" \
+	--config build.rustflags='"--deny=warnings"'


### PR DESCRIPTION
#### Problem

The `test-feature.sh` script doesn't actually fail the CI if there are warnings or similar issues that we would otherwise fail the CI for.

#### Summary of Changes

Deny the warnings in this script.


Inspired by #11097