### PR TITLE
replace lru with lazy_lru for ReceviedCache (prune path)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8684,6 +8684,7 @@ dependencies = [
  "flate2",
  "indexmap 2.13.0",
  "itertools 0.14.0",
+ "lazy-lru",
  "log",
  "lru",
  "num-traits",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7323,6 +7323,7 @@ dependencies = [
  "flate2",
  "indexmap 2.13.0",
  "itertools 0.14.0",
+ "lazy-lru",
  "log",
  "lru",
  "num-traits",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -44,6 +44,7 @@ crossbeam-channel = { workspace = true }
 flate2 = { workspace = true }
 indexmap = { workspace = true, features = ["rayon"] }
 itertools = { workspace = true }
+lazy-lru = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
 num-traits = { workspace = true }

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -72,7 +72,7 @@ impl Default for CrdsGossipPush {
         Self {
             active_set: RwLock::default(),
             crds_cursor: Mutex::default(),
-            received_cache: Mutex::new(ReceivedCache::new(2 * CRDS_UNIQUE_PUBKEY_CAPACITY)),
+            received_cache: Mutex::new(ReceivedCache::new(CRDS_UNIQUE_PUBKEY_CAPACITY)),
             push_fanout: CRDS_GOSSIP_PUSH_FANOUT,
             msg_timeout: CRDS_GOSSIP_PUSH_MSG_TIMEOUT_MS,
             prune_timeout: CRDS_GOSSIP_PRUNE_MSG_TIMEOUT_MS,

--- a/gossip/src/received_cache.rs
+++ b/gossip/src/received_cache.rs
@@ -1,6 +1,6 @@
 use {
     itertools::Itertools,
-    lru::LruCache,
+    lazy_lru::LruCache,
     solana_pubkey::Pubkey,
     std::{cmp::Reverse, collections::HashMap},
 };
@@ -42,7 +42,7 @@ impl ReceivedCache {
         min_ingress_nodes: usize,
         stakes: &HashMap<Pubkey, u64>,
     ) -> impl Iterator<Item = Pubkey> + use<> {
-        match self.0.peek_mut(&origin) {
+        match self.0.get_mut(&origin) {
             None => None,
             Some(entry) if entry.num_upserts < Self::MIN_NUM_UPSERTS => None,
             Some(entry) => Some(
@@ -56,12 +56,8 @@ impl ReceivedCache {
     }
 
     #[cfg(test)]
-    fn mock_clone(&self) -> Self {
-        let mut cache = LruCache::new(self.0.cap());
-        for (&origin, entry) in self.0.iter().rev() {
-            cache.put(origin, entry.clone());
-        }
-        Self(cache)
+    fn mock_clone(&mut self) -> Self {
+        Self(self.0.clone())
     }
 }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7229,6 +7229,7 @@ dependencies = [
  "flate2",
  "indexmap 2.13.0",
  "itertools 0.14.0",
+ "lazy-lru",
  "log",
  "lru",
  "num-traits",


### PR DESCRIPTION
#### Problem

- Gossip uses lru crate to handle prunes. It is wildly inefficient due to internal linked list. 
- Context: https://github.com/anza-xyz/agave/pull/11107

#### Summary of Changes

- Replace with lazy_lru
- Drop target capacity by 2x (to CRDS_UNIQUE_PUBKEY_CAPACITY) as lazy_lru internally grows to up to 2x allowed size.