### PR TITLE
Remove feature enable_secp256r1_precompile

### DIFF
--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -125,7 +125,7 @@ impl CostModel {
         data_bytes_cost: u16,
         feature_set: &FeatureSet,
     ) -> TransactionCost<'a, Tx> {
-        let signature_cost = Self::get_signature_cost(transaction, feature_set);
+        let signature_cost = Self::get_signature_cost(transaction);
         let write_lock_cost = Self::get_write_lock_cost(num_write_locks);
 
         let allocated_accounts_data_size =
@@ -145,17 +145,8 @@ impl CostModel {
     }
 
     /// Returns signature details and the total signature cost
-    fn get_signature_cost(transaction: &impl StaticMeta, feature_set: &FeatureSet) -> u64 {
+    fn get_signature_cost(transaction: &impl StaticMeta) -> u64 {
         let signatures_count_detail = transaction.signature_details();
-
-        let ed25519_verify_cost = ED25519_VERIFY_STRICT_COST;
-
-        let secp256r1_verify_cost =
-            if feature_set.is_active(&feature_set::enable_secp256r1_precompile::id()) {
-                SECP256R1_VERIFY_COST
-            } else {
-                0
-            };
 
         signatures_count_detail
             .num_transaction_signatures()
@@ -168,12 +159,12 @@ impl CostModel {
             .saturating_add(
                 signatures_count_detail
                     .num_ed25519_instruction_signatures()
-                    .saturating_mul(ed25519_verify_cost),
+                    .saturating_mul(ED25519_VERIFY_STRICT_COST),
             )
             .saturating_add(
                 signatures_count_detail
                     .num_secp256r1_instruction_signatures()
-                    .saturating_mul(secp256r1_verify_cost),
+                    .saturating_mul(SECP256R1_VERIFY_COST),
             )
     }
 

--- a/fee/src/lib.rs
+++ b/fee/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "agave-unstable-api")]
 use {
-    agave_feature_set::{FeatureSet, enable_secp256r1_precompile},
-    solana_fee_structure::FeeDetails,
+    agave_feature_set::FeatureSet, solana_fee_structure::FeeDetails,
     solana_svm_transaction::svm_message::SVMStaticMessage,
 };
 
@@ -12,15 +11,11 @@ use {
 // instead of removing, since fees will naturally be changed via feature-gates
 // in the future. Keeping this struct will help keep things organized.
 #[derive(Copy, Clone)]
-pub struct FeeFeatures {
-    pub enable_secp256r1_precompile: bool,
-}
+pub struct FeeFeatures {}
 
 impl From<&FeatureSet> for FeeFeatures {
-    fn from(feature_set: &FeatureSet) -> Self {
-        Self {
-            enable_secp256r1_precompile: feature_set.is_active(&enable_secp256r1_precompile::ID),
-        }
+    fn from(_feature_set: &FeatureSet) -> Self {
+        Self {}
     }
 }
 
@@ -47,18 +42,14 @@ pub fn calculate_fee_details(
     zero_fees_for_test: bool,
     lamports_per_signature: u64,
     prioritization_fee: u64,
-    fee_features: FeeFeatures,
+    _fee_features: FeeFeatures,
 ) -> FeeDetails {
     if zero_fees_for_test {
         return FeeDetails::default();
     }
 
     FeeDetails::new(
-        calculate_signature_fee(
-            SignatureCounts::from(message),
-            lamports_per_signature,
-            fee_features.enable_secp256r1_precompile,
-        ),
+        calculate_signature_fee(SignatureCounts::from(message), lamports_per_signature),
         prioritization_fee,
     )
 }
@@ -72,14 +63,11 @@ pub fn calculate_signature_fee(
         num_secp256r1_signatures,
     }: SignatureCounts,
     lamports_per_signature: u64,
-    enable_secp256r1_precompile: bool,
 ) -> u64 {
     let signature_count = num_transaction_signatures
         .saturating_add(num_ed25519_signatures)
         .saturating_add(num_secp256k1_signatures)
-        .saturating_add(
-            u64::from(enable_secp256r1_precompile).wrapping_mul(num_secp256r1_signatures),
-        );
+        .saturating_add(num_secp256r1_signatures);
     signature_count.saturating_mul(lamports_per_signature)
 }
 
@@ -119,7 +107,6 @@ mod tests {
                     num_secp256r1_signatures: 0,
                 },
                 LAMPORTS_PER_SIGNATURE,
-                true,
             ),
             0
         );
@@ -134,7 +121,6 @@ mod tests {
                     num_secp256r1_signatures: 0,
                 },
                 LAMPORTS_PER_SIGNATURE,
-                true,
             ),
             LAMPORTS_PER_SIGNATURE
         );
@@ -149,24 +135,8 @@ mod tests {
                     num_secp256r1_signatures: 4,
                 },
                 LAMPORTS_PER_SIGNATURE,
-                true,
             ),
             10 * LAMPORTS_PER_SIGNATURE
-        );
-
-        // Pre-compile signatures (no secp256r1)
-        assert_eq!(
-            calculate_signature_fee(
-                SignatureCounts {
-                    num_transaction_signatures: 1,
-                    num_ed25519_signatures: 2,
-                    num_secp256k1_signatures: 3,
-                    num_secp256r1_signatures: 4,
-                },
-                LAMPORTS_PER_SIGNATURE,
-                false,
-            ),
-            6 * LAMPORTS_PER_SIGNATURE
         );
     }
 }

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -1,11 +1,8 @@
 #![cfg(feature = "agave-unstable-api")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {
-    agave_feature_set::{FeatureSet, enable_secp256r1_precompile},
-    solana_message::compiled_instruction::CompiledInstruction,
-    solana_precompile_error::PrecompileError,
-    solana_pubkey::Pubkey,
-    std::sync::LazyLock,
+    agave_feature_set::FeatureSet, solana_message::compiled_instruction::CompiledInstruction,
+    solana_precompile_error::PrecompileError, solana_pubkey::Pubkey, std::sync::LazyLock,
 };
 
 pub mod ed25519;
@@ -68,7 +65,7 @@ static PRECOMPILES: LazyLock<Vec<Precompile>> = LazyLock::new(|| {
         ),
         Precompile::new(
             solana_sdk_ids::secp256r1_program::id(),
-            Some(enable_secp256r1_precompile::id()),
+            None, // always enabled
             secp256r1::verify,
         ),
     ]

--- a/reserved-account-keys/src/lib.rs
+++ b/reserved-account-keys/src/lib.rs
@@ -5,7 +5,7 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {
-    agave_feature_set::{self as feature_set, FeatureSet},
+    agave_feature_set::FeatureSet,
     solana_pubkey::Pubkey,
     solana_sdk_ids::{
         address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,

--- a/reserved-account-keys/src/lib.rs
+++ b/reserved-account-keys/src/lib.rs
@@ -152,10 +152,7 @@ static RESERVED_ACCOUNTS: std::sync::LazyLock<Vec<ReservedAccount>> =
             ReservedAccount::new_active(feature::id()),
             ReservedAccount::new_active(loader_v4::id()),
             ReservedAccount::new_active(secp256k1_program::id()),
-            ReservedAccount::new_pending(
-                secp256r1_program::id(),
-                feature_set::enable_secp256r1_precompile::id(),
-            ),
+            ReservedAccount::new_active(secp256r1_program::id()),
             #[allow(deprecated)]
             ReservedAccount::new_active(stake::config::id()),
             ReservedAccount::new_active(stake::id()),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5546,7 +5546,7 @@ fn test_shrink_candidate_slots_cached() {
     // No more slots should be shrunk
     assert_eq!(bank2.shrink_candidate_slots(), 0);
     // alive_counts represents the count of alive accounts in the three slots 0,1,2
-    assert_eq!(alive_counts, vec![12, 1, 6]);
+    assert_eq!(alive_counts, vec![13, 1, 6]);
 }
 
 #[test]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9435,9 +9435,7 @@ fn calculate_test_fee(
         lamports_per_signature == 0,
         fee_structure.lamports_per_signature,
         fee_budget_limits.prioritization_fee,
-        FeeFeatures {
-            enable_secp256r1_precompile: true,
-        },
+        FeeFeatures {},
     )
 }
 

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -62,7 +62,7 @@ pub fn bootstrap_validator_stake_lamports() -> u64 {
 // Number of lamports automatically used for genesis accounts
 pub const fn genesis_sysvar_and_builtin_program_lamports() -> u64 {
     const NUM_BUILTIN_PROGRAMS: u64 = 6;
-    const NUM_PRECOMPILES: u64 = 2;
+    const NUM_PRECOMPILES: u64 = 3;
     const STAKE_HISTORY_MIN_BALANCE: u64 = 114_979_200;
     const CLOCK_SYSVAR_MIN_BALANCE: u64 = 1_169_280;
     const RENT_SYSVAR_MIN_BALANCE: u64 = 1_009_200;


### PR DESCRIPTION
#### Problem
feature `enable_secp256r1_precompile` has been enabled on all clusters and feature conditional code can be removed.

#### Summary of Changes
remove it