### PR TITLE
stakes_accounts_load_duration should not include rent param loading time

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1880,6 +1880,7 @@ impl Bank {
             !epoch_stakes.is_empty(),
             "should be populated (from fields.versioned_epoch_stakes)"
         );
+        let stakes_accounts_load_duration = now.elapsed();
         // The serialized rent collector is deprecated. Instead, reconstruct from fields plus
         // the rent sysvar account state.
         let rent = {
@@ -1891,7 +1892,6 @@ impl Bank {
             from_account::<sysvar::rent::Rent, _>(&rent_sysvar)
                 .expect("snapshot must contain well-formed rent sysvar account")
         };
-        let stakes_accounts_load_duration = now.elapsed();
         let mut bank = Self {
             rc: bank_rc,
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),


### PR DESCRIPTION
#### Problem

Recent change moved `stakes_accounts_load_duration` calculation after rent param loading in `new_from_snapshot()`.

#### Summary of Changes

- move the duration calculation to before the rent param loading.

#### Why backport

The previous change that caused this issue was backported so the fix needs to be as well.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
