### PR TITLE
Refactor - Moves `with_mock` functions in invoke_context.rs behind `cfg(feature = "dev-context-only-utils")`

### DIFF
--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -64,7 +64,7 @@ solana-loader-v3-interface = { workspace = true }
 solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-native-token = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["metrics"] }
+solana-program-runtime = { workspace = true, features = ["dev-context-only-utils", "metrics"] }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1,17 +1,24 @@
+#[cfg(feature = "dev-context-only-utils")]
+use {
+    crate::loaded_programs::ProgramCacheEntry,
+    solana_account::{AccountSharedData, create_account_shared_data_for_test},
+    solana_epoch_schedule::EpochSchedule,
+    solana_instruction::AccountMeta,
+    solana_sdk_ids::sysvar,
+    solana_svm_type_overrides::sync::Arc,
+    solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
+};
 use {
     crate::{
         execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
         loaded_programs::{
-            ProgramCacheEntry, ProgramCacheEntryType, ProgramCacheForTxBatch,
-            ProgramRuntimeEnvironments,
+            ProgramCacheEntryType, ProgramCacheForTxBatch, ProgramRuntimeEnvironments,
         },
         stable_log,
         sysvar_cache::SysvarCache,
     },
-    solana_account::{AccountSharedData, create_account_shared_data_for_test},
-    solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
-    solana_instruction::{AccountMeta, Instruction, error::InstructionError},
+    solana_instruction::{Instruction, error::InstructionError},
     solana_pubkey::Pubkey,
     solana_sbpf::{
         ebpf::MM_HEAP_START,
@@ -22,7 +29,7 @@ use {
         vm::{Config, ContextObject, EbpfVm},
     },
     solana_sdk_ids::{
-        bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4, native_loader, sysvar,
+        bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4, native_loader,
     },
     solana_svm_callback::InvokeContextCallback,
     solana_svm_feature_set::SVMFeatureSet,
@@ -30,11 +37,9 @@ use {
     solana_svm_measure::measure::Measure,
     solana_svm_timings::{ExecuteDetailsTimings, ExecuteTimings},
     solana_svm_transaction::svm_message::SVMMessage,
-    solana_svm_type_overrides::sync::Arc,
     solana_transaction_context::{
         IndexOfAccount, MAX_ACCOUNTS_PER_TRANSACTION, instruction::InstructionContext,
         instruction_accounts::InstructionAccount, transaction::TransactionContext,
-        transaction_accounts::KeyedAccountSharedData,
     },
     std::{
         alloc::Layout,
@@ -785,6 +790,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
     }
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 #[macro_export]
 macro_rules! with_mock_invoke_context_with_feature_set {
     (
@@ -873,6 +879,7 @@ macro_rules! with_mock_invoke_context_with_feature_set {
     };
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 #[macro_export]
 macro_rules! with_mock_invoke_context {
     (
@@ -904,6 +911,7 @@ macro_rules! with_mock_invoke_context {
     };
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 #[expect(clippy::too_many_arguments)]
 pub fn mock_process_instruction_with_feature_set<
     F: FnMut(&mut InvokeContext),
@@ -993,6 +1001,7 @@ pub fn mock_process_instruction_with_feature_set<
     transaction_accounts
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut InvokeContext)>(
     loader_id: &Pubkey,
     program_index: Option<IndexOfAccount>,

--- a/programs/loader-v4/Cargo.toml
+++ b/programs/loader-v4/Cargo.toml
@@ -46,4 +46,5 @@ solana-transaction-context = { workspace = true }
 [dev-dependencies]
 bincode = { workspace = true }
 solana-clock = { workspace = true }
+solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sysvar = { workspace = true }

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -245,7 +245,7 @@ solana-measure = { workspace = true }
 solana-message = "4.0.0"
 solana-program = { workspace = true }
 solana-program-entrypoint = "3.1.1"
-solana-program-runtime = { workspace = true }
+solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = "4.1.0"
 solana-rent = "4.1.0"
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -43,6 +43,7 @@ criterion = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-hash = { workspace = true }
 solana-nonce-account = { workspace = true }
+solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-rent = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-svm-callback = { workspace = true }


### PR DESCRIPTION
#### Problem

Split off from #11080.

#### Summary of Changes

Moves `with_mock_invoke_context_with_feature_set!()`, `with_mock_invoke_context!()`, `mock_process_instruction_with_feature_set()` and `mock_process_instruction_with_feature_set()` behind `cfg(feature = "dev-context-only-utils")`