### PR TITLE
Move long running test to integration tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -105,7 +105,7 @@ filter = 'package(solana-runtime) & test(/^bank_forks::tests::test_bank_forks_ne
 slow-timeout = { period = "60s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-runtime) & test(/^bank::tests::test_race_register_tick_freeze/)'
+filter = 'package(solana-runtime) & test(/^test_race_register_tick_freeze/)'
 slow-timeout = { period = "60s", terminate-after = 3 }
 
 [[profile.ci.overrides]]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -92,7 +92,6 @@ use {
         bpf_loader, bpf_loader_upgradeable, ed25519_program, incinerator, native_loader,
         secp256k1_program,
     },
-    solana_sha256_hasher::hash,
     solana_signature::Signature,
     solana_signer::Signer,
     solana_stake_interface::{
@@ -189,43 +188,6 @@ pub(in crate::bank) fn create_genesis_config(lamports: u64) -> (GenesisConfig, K
 pub(in crate::bank) fn new_sanitized_message(message: Message) -> SanitizedMessage {
     SanitizedMessage::try_from_legacy_message(message, &ReservedAccountKeys::empty_key_set())
         .unwrap()
-}
-
-#[test]
-fn test_race_register_tick_freeze() {
-    agave_logger::setup();
-
-    let (mut genesis_config, _) = create_genesis_config(50);
-    genesis_config.ticks_per_slot = 1;
-    let p = solana_pubkey::new_rand();
-    let hash = hash(p.as_ref());
-
-    for _ in 0..1000 {
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
-        let bank0_ = bank0.clone();
-        let freeze_thread = Builder::new()
-            .name("freeze".to_string())
-            .spawn(move || {
-                loop {
-                    if bank0_.is_complete() {
-                        assert_eq!(bank0_.last_blockhash(), hash);
-                        break;
-                    }
-                }
-            })
-            .unwrap();
-
-        let bank0_ = bank0.clone();
-        let register_tick_thread = Builder::new()
-            .name("register_tick".to_string())
-            .spawn(move || {
-                bank0_.register_tick_for_test(&hash);
-            })
-            .unwrap();
-
-        register_tick_thread.join().unwrap();
-        freeze_thread.join().unwrap();
-    }
 }
 
 fn new_executed_processing_result(

--- a/runtime/tests/bank.rs
+++ b/runtime/tests/bank.rs
@@ -1,0 +1,43 @@
+use {
+    solana_genesis_config::create_genesis_config,
+    solana_runtime::bank::Bank,
+    solana_sha256_hasher::hash,
+    std::{sync::Arc, thread::Builder},
+};
+
+#[test]
+fn test_race_register_tick_freeze() {
+    agave_logger::setup();
+
+    let (mut genesis_config, _) = create_genesis_config(50);
+    genesis_config.ticks_per_slot = 1;
+    let p = solana_pubkey::new_rand();
+    let hash = hash(p.as_ref());
+
+    for _ in 0..1000 {
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let bank0_ = bank0.clone();
+        let freeze_thread = Builder::new()
+            .name("freeze".to_string())
+            .spawn(move || {
+                loop {
+                    if bank0_.is_complete() {
+                        assert_eq!(bank0_.last_blockhash(), hash);
+                        break;
+                    }
+                }
+            })
+            .unwrap();
+
+        let bank0_ = bank0.clone();
+        let register_tick_thread = Builder::new()
+            .name("register_tick".to_string())
+            .spawn(move || {
+                bank0_.register_tick_for_test(&hash);
+            })
+            .unwrap();
+
+        register_tick_thread.join().unwrap();
+        freeze_thread.join().unwrap();
+    }
+}


### PR DESCRIPTION
#### Problem
test_race_register_tick_freeze takes two minutes as it is attempting to exercise a race condition. 

#### Summary of Changes
- Move test_race_register_tick_freeze to integration tests


generic runtime tests now down to 11seconds from 2 minutes. 

Before
```
test result: ok. 628 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 119.33s
```

After
```
test result: ok. 627 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 11.39s
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
