### PR TITLE
Remove slow timeout override for test_bank_forks_new_rw_arc_memory_leak

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -101,10 +101,6 @@ filter = 'package(solana-client-test) & test(/^test_send_and_confirm_transaction
 slow-timeout = { period = "60s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-runtime) & test(/^bank_forks::tests::test_bank_forks_new_rw_arc_memory_leak/)'
-slow-timeout = { period = "60s", terminate-after = 3 }
-
-[[profile.ci.overrides]]
 filter = 'package(solana-runtime) & test(/^test_race_register_tick_freeze/)'
 slow-timeout = { period = "60s", terminate-after = 3 }
 


### PR DESCRIPTION
#### Problem
test_bank_forks_new_rw_arc_memory_leak has a slow test override that it doesn't need

#### Summary of Changes
- Remove it

Test was fixed in https://github.com/anza-xyz/agave/pull/8585

```
running 1 test
test bank_forks::tests::test_bank_forks_new_rw_arc_memory_leak ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 618 filtered out; finished in 0.12s
```
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
