### PR TITLE
fix/chore(install): drop v0.8 config file format compatibility logic

### DIFF
--- a/install/src/config.rs
+++ b/install/src/config.rs
@@ -1,6 +1,6 @@
 use {
     crate::update_manifest::UpdateManifest,
-    serde::{Deserialize, Deserializer, Serialize},
+    serde::{Deserialize, Serialize},
     solana_pubkey::Pubkey,
     std::{
         fs::{File, create_dir_all},
@@ -9,44 +9,10 @@ use {
     },
 };
 
-#[derive(Serialize, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub enum ExplicitRelease {
     Semver(String),
     Channel(String),
-}
-
-impl<'de> Deserialize<'de> for ExplicitRelease {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        enum TaggedExplicitRelease {
-            Semver(String),
-            Channel(String),
-        }
-
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum ExplicitReleaseRepr {
-            Tagged(TaggedExplicitRelease),
-            LegacySemver {
-                #[serde(rename = "Semver")]
-                semver: String,
-            },
-            LegacyChannel {
-                #[serde(rename = "Channel")]
-                channel: String,
-            },
-        }
-
-        match ExplicitReleaseRepr::deserialize(deserializer)? {
-            ExplicitReleaseRepr::Tagged(TaggedExplicitRelease::Semver(value))
-            | ExplicitReleaseRepr::LegacySemver { semver: value } => Ok(Self::Semver(value)),
-            ExplicitReleaseRepr::Tagged(TaggedExplicitRelease::Channel(value))
-            | ExplicitReleaseRepr::LegacyChannel { channel: value } => Ok(Self::Channel(value)),
-        }
-    }
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq)]
@@ -190,77 +156,6 @@ releases_dir: {root_dir}/releases
 active_release_dir: {root_dir}/active_release
 "
             ),
-        );
-    }
-
-    #[test]
-    fn test_load_serde_yaml_v_0_8_config() {
-        let file_name = "config.yml";
-        let mut file = File::create(file_name).unwrap();
-        defer! {
-            remove_file(file_name).unwrap();
-        }
-
-        let root_dir = "/home/sol/.local/share/solana/install";
-
-        writeln!(
-            file,
-            "---
-json_rpc_url: \"http://api.devnet.solana.com\"
-update_manifest_pubkey:
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-current_update_manifest: ~
-update_poll_secs: 3600
-explicit_release:
-  Semver: 1.13.6
-releases_dir: {root_dir}/releases
-active_release_dir: {root_dir}/active_release
-"
-        )
-        .unwrap();
-        let config = Config::load(file_name).unwrap();
-        assert_eq!(
-            config,
-            Config {
-                json_rpc_url: String::from("http://api.devnet.solana.com"),
-                update_manifest_pubkey: Pubkey::default(),
-                current_update_manifest: None,
-                update_poll_secs: 3600,
-                explicit_release: Some(ExplicitRelease::Semver(String::from("1.13.6"))),
-                releases_dir: PathBuf::from(format!("{root_dir}/releases")),
-                active_release_dir: PathBuf::from(format!("{root_dir}/active_release")),
-            },
         );
     }
 }


### PR DESCRIPTION
#### Problem
`agave-install` fails to parse modern config files after #10909
```
cargo run --bin agave-install -- update
Error: "Unable to load /home/trent/.config/solana/install/config.yml: Custom { kind: Other, error: \"Error(\\\"explicit_release: untagged and internally tagged enums do not support enum input\\\", line: 38, column: 19)\" }"
```
i could have sworn that we had coverage on both sides of the old v0.8 install config format migration logic, but apparently that is not the case.

#### Summary of Changes
nevermind the time that has passed, we no longer support the binary named `solana-install`. drop support for the v0.8 config format migration altogether
```
cargo run --bin agave-install -- update
Install is up to date. 4.0.0-beta.0 is the latest compatible release
```