### PR TITLE
blockstore: propagate errors in shred insertion

### DIFF
--- a/core/src/repair/repair_weighted_traversal.rs
+++ b/core/src/repair/repair_weighted_traversal.rs
@@ -285,10 +285,10 @@ pub mod test {
         let keypair = Keypair::new();
         let reed_solomon_cache = ReedSolomonCache::default();
 
-        let completed_shreds: Vec<Shred> = [0, 2, 4, 6]
+        let completed_shreds: Vec<Shred> = [(0, 0), (2, 1), (4, 2), (6, best_overall_slot)]
             .iter()
-            .flat_map(|slot| {
-                let shredder = Shredder::new(*slot, slot.saturating_sub(1), 0, 42).unwrap();
+            .flat_map(|(slot, parent_slot)| {
+                let shredder = Shredder::new(*slot, *parent_slot, 0, 42).unwrap();
                 let (shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
                     &keypair,
                     &[],

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1477,7 +1477,13 @@ impl Blockstore {
         } = shred_insertion_tracker;
 
         let index_meta_working_set_entry =
-            self.get_index_meta_entry(slot, index_working_set, index_meta_time_us);
+            match self.get_index_meta_entry(slot, index_working_set, index_meta_time_us) {
+                Ok(entry) => entry,
+                Err(err) => {
+                    error!("blockstore error during coding shred insertion: {err}");
+                    return false;
+                }
+            };
 
         let index_meta = &mut index_meta_working_set_entry.index;
         let erasure_set = shred.erasure_set();
@@ -1687,7 +1693,7 @@ impl Blockstore {
         } = shred_insertion_tracker;
 
         let index_meta_working_set_entry =
-            self.get_index_meta_entry(slot, index_working_set, index_meta_time_us);
+            self.get_index_meta_entry(slot, index_working_set, index_meta_time_us)?;
         let index_meta = &mut index_meta_working_set_entry.index;
         let slot_meta_entry = self.get_slot_meta_entry(
             slot_meta_working_set,
@@ -1695,7 +1701,7 @@ impl Blockstore {
             shred
                 .parent()
                 .map_err(|_| InsertDataShredError::InvalidShred)?,
-        );
+        )?;
 
         let slot_meta = &mut slot_meta_entry.new_slot_meta.borrow_mut();
         let erasure_set = shred.erasure_set();
@@ -2214,12 +2220,42 @@ impl Blockstore {
             return false;
         }
 
-        // TODO Shouldn't this use shred.parent() instead and update
-        // slot_meta.parent_slot accordingly?
-        slot_meta
-            .parent_slot
-            .map(|parent_slot| verify_shred_slots(slot, parent_slot, max_root))
-            .unwrap_or_default()
+        let Some(meta_parent_slot) = slot_meta.parent_slot else {
+            return false;
+        };
+
+        let Ok(shred_parent) = shred.parent() else {
+            warn!(
+                "Invalid data shred could not get parent slot shred_id {:?}",
+                shred.id()
+            );
+            return false;
+        };
+
+        if meta_parent_slot != shred_parent {
+            let leader_pubkey = leader_schedule
+                .and_then(|leader_schedule| leader_schedule.slot_leader_at(slot, None));
+
+            datapoint_error!(
+                "blockstore_error",
+                (
+                    "error",
+                    format!(
+                        "Leader {:?}, shred_id {:?}: received shred with parent {} but slot_meta \
+                         has parent {}",
+                        leader_pubkey,
+                        shred.id(),
+                        shred_parent,
+                        meta_parent_slot
+                    ),
+                    String
+                )
+            );
+
+            return false;
+        }
+
+        verify_shred_slots(slot, meta_parent_slot, max_root)
     }
 
     fn insert_data_shred<'a>(
@@ -4637,32 +4673,29 @@ impl Blockstore {
         slot_meta_working_set: &'a mut HashMap<u64, SlotMetaWorkingSetEntry>,
         slot: Slot,
         parent_slot: Slot,
-    ) -> &'a mut SlotMetaWorkingSetEntry {
+    ) -> Result<&'a mut SlotMetaWorkingSetEntry> {
         // Check if we've already inserted the slot metadata for this shred's slot
-        slot_meta_working_set.entry(slot).or_insert_with(|| {
-            // Store a 2-tuple of the metadata (working copy, backup copy)
-            if let Some(mut meta) = self
-                .meta_cf
-                .get(slot)
-                .expect("Expect database get to succeed")
-            {
-                let backup = Some(meta.clone());
-                // If parent_slot == None, then this is one of the orphans inserted
-                // during the chaining process, see the function find_slot_meta_in_cached_state()
-                // for details. Slots that are orphans are missing a parent_slot, so we should
-                // fill in the parent now that we know it.
-                if meta.is_orphan() {
-                    meta.parent_slot = Some(parent_slot);
-                }
-
-                SlotMetaWorkingSetEntry::new(Rc::new(RefCell::new(meta)), backup)
-            } else {
-                SlotMetaWorkingSetEntry::new(
-                    Rc::new(RefCell::new(SlotMeta::new(slot, Some(parent_slot)))),
-                    None,
-                )
+        let entry = match slot_meta_working_set.entry(slot) {
+            HashMapEntry::Occupied(occupied_entry) => occupied_entry.into_mut(),
+            HashMapEntry::Vacant(vacant_entry) => {
+                let meta = self.meta_cf.get(slot)?;
+                // Insert a new 2-tuple of the metadata (working copy, backup copy)
+                let slot_meta_entry = if let Some(mut meta) = meta {
+                    let backup = Some(meta.clone());
+                    if meta.is_orphan() {
+                        meta.parent_slot = Some(parent_slot);
+                    }
+                    SlotMetaWorkingSetEntry::new(Rc::new(RefCell::new(meta)), backup)
+                } else {
+                    SlotMetaWorkingSetEntry::new(
+                        Rc::new(RefCell::new(SlotMeta::new(slot, Some(parent_slot)))),
+                        None,
+                    )
+                };
+                vacant_entry.insert(slot_meta_entry)
             }
-        })
+        };
+        Ok(entry)
     }
 
     /// Returns the `SlotMeta` with the specified `slot_index`.  The resulting
@@ -4715,22 +4748,25 @@ impl Blockstore {
         slot: Slot,
         index_working_set: &'a mut HashMap<u64, IndexMetaWorkingSetEntry>,
         index_meta_time_us: &mut u64,
-    ) -> &'a mut IndexMetaWorkingSetEntry {
+    ) -> Result<&'a mut IndexMetaWorkingSetEntry> {
         let mut total_start = Measure::start("Total elapsed");
-        let res = index_working_set.entry(slot).or_insert_with(|| {
-            let newly_inserted_meta = self
-                .index_cf
-                .get(slot)
-                .unwrap()
-                .unwrap_or_else(|| Index::new(slot));
-            IndexMetaWorkingSetEntry {
-                index: newly_inserted_meta,
-                did_insert_occur: false,
+
+        let index_meta_entry = match index_working_set.entry(slot) {
+            HashMapEntry::Occupied(occupied_entry) => occupied_entry.into_mut(),
+            HashMapEntry::Vacant(vacant_entry) => {
+                let index = self.index_cf.get(slot)?.unwrap_or_else(|| Index::new(slot));
+                let index_entry = IndexMetaWorkingSetEntry {
+                    index,
+                    did_insert_occur: false,
+                };
+                vacant_entry.insert(index_entry)
             }
-        });
+        };
+
         total_start.stop();
         *index_meta_time_us += total_start.as_us();
-        res
+
+        Ok(index_meta_entry)
     }
 
     pub fn get_write_batch(&self) -> Result<WriteBatch> {


### PR DESCRIPTION
#### Problem
We hard unwrap blockstore errors rather than passing them up. Additionally there is poor error logging / metrics in shred insertion.

#### Summary of Changes
Propagate underlying blockstore errors up during shred insertion instead of panicking. These errors show in metrics and with ERROR logs and will give insertion a chance to recover instead of dying immediately