### PR TITLE
remove shred version filtering on pull response

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1624,7 +1624,6 @@ impl ClusterInfo {
                         GossipFilterDirection::EgressPullResponse,
                     )
                 },
-                self.my_shred_version(),
                 &self.stats,
             )
         };

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -453,24 +453,16 @@ impl Crds {
 
     /// Returns all crds values which the first 'mask_bits'
     /// of their hash value is equal to 'mask'.
-    /// Excludes deprecated values and ContactInfo with invalid shred version
+    /// Excludes deprecated values.
     pub(crate) fn filter_bitmask(
         &self,
         mask: u64,
         mask_bits: u32,
-        self_shred_version: u16,
     ) -> impl Iterator<Item = &VersionedCrdsValue> {
         self.shards
             .find(mask, mask_bits)
             .map(move |i| self.table.index(i))
-            .filter(move |VersionedCrdsValue { value, .. }| {
-                let data = value.data();
-                !value.data().is_deprecated()
-                    && match data {
-                        CrdsData::ContactInfo(info) => info.shred_version() == self_shred_version,
-                        _ => true,
-                    }
-            })
+            .filter(move |VersionedCrdsValue { value, .. }| !value.data().is_deprecated())
     }
 
     /// Update the timestamp's of all the labels that are associated with Pubkey

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -237,7 +237,6 @@ impl CrdsGossip {
         output_size_limit: usize, // Limit number of crds values returned.
         now: u64,
         should_retain_crds_value: impl Fn(&CrdsValue) -> bool + Sync,
-        self_shred_version: u16,
         stats: &GossipStats,
     ) -> Vec<Vec<CrdsValue>> {
         CrdsGossipPull::generate_pull_responses(
@@ -247,7 +246,6 @@ impl CrdsGossip {
             output_size_limit,
             now,
             should_retain_crds_value,
-            self_shred_version,
             stats,
         )
     }

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -316,7 +316,6 @@ impl CrdsGossipPull {
         output_size_limit: usize, // Limit number of crds values returned.
         now: u64,
         should_retain_crds_value: impl Fn(&CrdsValue) -> bool + Sync,
-        self_shred_version: u16,
         stats: &GossipStats,
     ) -> Vec<Vec<CrdsValue>> {
         Self::filter_crds_values(
@@ -326,7 +325,6 @@ impl CrdsGossipPull {
             output_size_limit,
             now,
             should_retain_crds_value,
-            self_shred_version,
             stats,
         )
     }
@@ -475,7 +473,6 @@ impl CrdsGossipPull {
         now: u64,
         // Predicate returning false if the CRDS value should be discarded.
         should_retain_crds_value: impl Fn(&CrdsValue) -> bool + Sync,
-        self_shred_version: u16,
         stats: &GossipStats,
     ) -> Vec<Vec<CrdsValue>> {
         let msg_timeout = CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS;
@@ -511,7 +508,7 @@ impl CrdsGossipPull {
                 }
             };
             let out: Vec<_> = crds
-                .filter_bitmask(filter.mask, filter.mask_bits, self_shred_version)
+                .filter_bitmask(filter.mask, filter.mask_bits)
                 .filter(pred)
                 .map(|entry| entry.value.clone())
                 .take(output_size_limit.load(Ordering::Relaxed).max(0) as usize)
@@ -1126,7 +1123,6 @@ pub(crate) mod tests {
             usize::MAX, // output_size_limit
             now,
             |_| true, // should_retain_crds_value
-            0,        // self_shred_version
             &GossipStats::default(),
         );
 
@@ -1151,7 +1147,6 @@ pub(crate) mod tests {
             usize::MAX, // output_size_limit
             now,
             |_| true, // should_retain_crds_value
-            0,        // self_shred_version
             &GossipStats::default(),
         );
         assert_eq!(rsp[0].len(), 0);
@@ -1178,7 +1173,6 @@ pub(crate) mod tests {
             usize::MAX, // output_size_limit
             now,
             |_| true, // should_retain_crds_value
-            0,        // self_shred_version
             &GossipStats::default(),
         );
         assert_eq!(rsp.len(), 2 * MIN_NUM_BLOOM_FILTERS);
@@ -1272,7 +1266,6 @@ pub(crate) mod tests {
                 usize::MAX, // output_size_limit
                 0,          // now
                 |_| true,   // should_retain_crds_value
-                0,          // self_shred_version
                 &GossipStats::default(),
             );
             // if there is a false positive this is empty

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -592,7 +592,6 @@ fn network_run_pull(
                                 usize::MAX, // output_size_limit
                                 now,
                                 |_| true, // should_retain_crds_value
-                                0,        // network shred version
                                 &GossipStats::default(),
                             )
                             .into_iter()


### PR DESCRIPTION
#### Problem
we do not send back contactinfo with different shred versions in pull responses. but we no longer accept any contactinfo with the wrong shred version via push or pull. So this is no longer needed

#### Summary of Changes
Remove dead code.