### PR TITLE
cleanup(blockstore): remove migration fallback for Index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@ prerelease version. The new interpretation is as follows:
     * { min: 0x4002, patch: 0x0002 } -> X.2.0-rc.2
     * { min: 0x8003, patch: 0x0001 } -> X.3.0-beta.1
     * { min: 0xC004, patch: 0x0000 } -> X.4.0-alpha.0
+* Blockstore `SlotMeta` and `Index` columns legacy format removed.
+  * The `Index` column was updated in v2.2 to write `IndexV2`.
+  * The `SlotMeta` column format was updated in v3.1 to write `SlotMetaV2`.
+  * The old formats, `SlotMetaV1` and `IndexV1`, will no longer be supported for fallback reads as of v4.0
 
 #### Deprecations
 * Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.

--- a/ledger/src/bit_vec.rs
+++ b/ledger/src/bit_vec.rs
@@ -24,7 +24,7 @@ const BITS_PER_WORD: usize = std::mem::size_of::<Word>() * 8;
 /// assert_eq!(bit_vec.range(..2).iter_ones().collect::<Vec<_>>(), [0, 1]);
 /// assert_eq!(bit_vec.range(1..).count_ones(), 1);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct BitVec<const NUM_BITS: usize> {
     #[serde(with = "serde_bytes")]
@@ -36,6 +36,31 @@ impl<const NUM_BITS: usize> Default for BitVec<NUM_BITS> {
         Self {
             words: vec![0; Self::NUM_WORDS].into_boxed_slice(),
         }
+    }
+}
+
+// Note: serde_bytes' default `Deserialize` would construct a variable-length buffer,
+// which violates `BitVec`'s invariant that its backing vector length (in words)
+// is exactly `NUM_WORDS`. Bounds checks and performance rely on this fixed size.
+//
+// `BitVec` is normally constructed via `Default`, which initializes with
+// `vec![0; Self::NUM_WORDS]`. This custom `Deserialize` preserves the invariant by
+// allocating exactly `NUM_WORDS` and populating from the serialized data, zero-filling
+// any missing words. This is required for the `SlotMetaV1` -> `SlotMetaV2` migration,
+// where `completed_data_indexes` was encoded as a variable-length `BTreeSet<u32>`.
+impl<'de, const NUM_BITS: usize> Deserialize<'de> for BitVec<NUM_BITS> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bytes = <&serde_bytes::Bytes as Deserialize>::deserialize(deserializer)?;
+        let mut words = Vec::with_capacity(Self::NUM_WORDS);
+        words.extend_from_slice(bytes);
+        words.resize(Self::NUM_WORDS, 0);
+
+        Ok(Self {
+            words: words.into_boxed_slice(),
+        })
     }
 }
 
@@ -568,6 +593,25 @@ mod tests {
                 prop_assert_eq!(iter.next(), range_iter.next());
                 prop_assert_eq!(iter.next_back(), range_iter.next_back());
             }
+        }
+
+        #[test]
+        fn test_deserialize_from_smaller_length(data in prop::collection::vec(any::<u8>(), 0..BitVec::<1024>::NUM_WORDS)) {
+            const NUM_BITS: usize = 1024;
+            let mut expected = BitVec::<NUM_BITS>::default();
+            expected.words[..data.len()].copy_from_slice(&data);
+
+            #[derive(Serialize)]
+            #[serde(transparent)]
+            struct Source {
+                #[serde(with = "serde_bytes")]
+                data: Vec<u8>,
+            }
+            let serialized = bincode::serialize(&Source { data }).unwrap();
+            // Deserializing should always result in a BitVec with exactly NUM_WORDS words,
+            // adding zeroed bits that are not present in the serialized data.
+            let deserialized: BitVec<NUM_BITS> = bincode::deserialize(&serialized).unwrap();
+            prop_assert_eq!(deserialized, expected);
         }
 
         #[test]

--- a/ledger/src/bit_vec.rs
+++ b/ledger/src/bit_vec.rs
@@ -24,7 +24,7 @@ const BITS_PER_WORD: usize = std::mem::size_of::<Word>() * 8;
 /// assert_eq!(bit_vec.range(..2).iter_ones().collect::<Vec<_>>(), [0, 1]);
 /// assert_eq!(bit_vec.range(1..).count_ones(), 1);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct BitVec<const NUM_BITS: usize> {
     #[serde(with = "serde_bytes")]
@@ -36,31 +36,6 @@ impl<const NUM_BITS: usize> Default for BitVec<NUM_BITS> {
         Self {
             words: vec![0; Self::NUM_WORDS].into_boxed_slice(),
         }
-    }
-}
-
-// Note: serde_bytes' default `Deserialize` would construct a variable-length buffer,
-// which violates `BitVec`'s invariant that its backing vector length (in words)
-// is exactly `NUM_WORDS`. Bounds checks and performance rely on this fixed size.
-//
-// `BitVec` is normally constructed via `Default`, which initializes with
-// `vec![0; Self::NUM_WORDS]`. This custom `Deserialize` preserves the invariant by
-// allocating exactly `NUM_WORDS` and populating from the serialized data, zero-filling
-// any missing words. This is required for the `SlotMetaV1` -> `SlotMetaV2` migration,
-// where `completed_data_indexes` was encoded as a variable-length `BTreeSet<u32>`.
-impl<'de, const NUM_BITS: usize> Deserialize<'de> for BitVec<NUM_BITS> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let bytes = <&serde_bytes::Bytes as Deserialize>::deserialize(deserializer)?;
-        let mut words = Vec::with_capacity(Self::NUM_WORDS);
-        words.extend_from_slice(bytes);
-        words.resize(Self::NUM_WORDS, 0);
-
-        Ok(Self {
-            words: words.into_boxed_slice(),
-        })
     }
 }
 
@@ -593,25 +568,6 @@ mod tests {
                 prop_assert_eq!(iter.next(), range_iter.next());
                 prop_assert_eq!(iter.next_back(), range_iter.next_back());
             }
-        }
-
-        #[test]
-        fn test_deserialize_from_smaller_length(data in prop::collection::vec(any::<u8>(), 0..BitVec::<1024>::NUM_WORDS)) {
-            const NUM_BITS: usize = 1024;
-            let mut expected = BitVec::<NUM_BITS>::default();
-            expected.words[..data.len()].copy_from_slice(&data);
-
-            #[derive(Serialize)]
-            #[serde(transparent)]
-            struct Source {
-                #[serde(with = "serde_bytes")]
-                data: Vec<u8>,
-            }
-            let serialized = bincode::serialize(&Source { data }).unwrap();
-            // Deserializing should always result in a BitVec with exactly NUM_WORDS words,
-            // adding zeroed bits that are not present in the serialized data.
-            let deserialized: BitVec<NUM_BITS> = bincode::deserialize(&serialized).unwrap();
-            prop_assert_eq!(deserialized, expected);
         }
 
         #[test]

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5373,10 +5373,10 @@ pub mod tests {
         super::*,
         crate::{
             genesis_utils::{GenesisConfigInfo, create_genesis_config},
-            shred::{MAX_DATA_SHREDS_PER_SLOT, max_ticks_per_n_shreds},
+            shred::max_ticks_per_n_shreds,
         },
         assert_matches::assert_matches,
-        bincode::{Options, serialize},
+        bincode::serialize,
         crossbeam_channel::unbounded,
         rand::{rng, seq::SliceRandom},
         solana_account_decoder::parse_token::UiTokenAmount,
@@ -5837,36 +5837,6 @@ pub mod tests {
     fn test_insert_slots() {
         test_insert_data_shreds_slots(false);
         test_insert_data_shreds_slots(true);
-    }
-
-    #[test]
-    fn test_index_fallback_deserialize() {
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-        let mut rng = rand::rng();
-        let slot = rng.random_range(0..100);
-        let bincode = bincode::DefaultOptions::new()
-            .reject_trailing_bytes()
-            .with_fixint_encoding();
-
-        let data = 0..rng.random_range(100..MAX_DATA_SHREDS_PER_SLOT as u64);
-        let coding = 0..rng.random_range(100..MAX_DATA_SHREDS_PER_SLOT as u64);
-        let mut fallback = IndexFallback::new(slot);
-        for (d, c) in data.clone().zip(coding.clone()) {
-            fallback.data_mut().insert(d);
-            fallback.coding_mut().insert(c);
-        }
-
-        blockstore
-            .index_cf
-            .put_bytes(slot, &bincode.serialize(&fallback).unwrap())
-            .unwrap();
-
-        let current = blockstore.index_cf.get(slot).unwrap().unwrap();
-        for (d, c) in data.zip(coding) {
-            assert!(current.data().contains(d));
-            assert!(current.coding().contains(c));
-        }
     }
 
     #[test]
@@ -7898,7 +7868,7 @@ pub mod tests {
         // range:
         // [start_index, completed_data_end_indexes[j]] ==
         // [completed_data_end_indexes[i], completed_data_end_indexes[j]],
-        let completed_data_end_indexes: Vec<_> = completed_data_end_indexes.into_iter().collect();
+        let completed_data_end_indexes: Vec<_> = completed_data_end_indexes.iter().collect();
         for i in 0..completed_data_end_indexes.len() {
             for j in i..completed_data_end_indexes.len() {
                 let start_index = completed_data_end_indexes[i];
@@ -10400,7 +10370,7 @@ pub mod tests {
                 update_completed_data_indexes(true, i, &shred_index, &mut completed_data_indexes)
                     .eq(std::iter::once(i..i + 1))
             );
-            assert!(completed_data_indexes.clone().into_iter().eq(0..=i));
+            assert!(completed_data_indexes.iter().eq(0..=i));
         }
     }
 
@@ -10428,7 +10398,7 @@ pub mod tests {
             update_completed_data_indexes(true, 3, &shred_index, &mut completed_data_indexes)
                 .eq([])
         );
-        assert!(completed_data_indexes.clone().into_iter().eq([3]));
+        assert!(completed_data_indexes.clone().iter().eq([3]));
 
         // Inserting data complete shred 1 now confirms the range of shreds [2, 3]
         // is part of the same data set
@@ -10437,7 +10407,7 @@ pub mod tests {
             update_completed_data_indexes(true, 1, &shred_index, &mut completed_data_indexes)
                 .eq(std::iter::once(2..4))
         );
-        assert!(completed_data_indexes.clone().into_iter().eq([1, 3]));
+        assert!(completed_data_indexes.clone().iter().eq([1, 3]));
 
         // Inserting data complete shred 0 now confirms the range of shreds [0]
         // is part of the same data set
@@ -10446,7 +10416,7 @@ pub mod tests {
             update_completed_data_indexes(true, 0, &shred_index, &mut completed_data_indexes)
                 .eq([0..1, 1..2])
         );
-        assert!(completed_data_indexes.clone().into_iter().eq([0, 1, 3]));
+        assert!(completed_data_indexes.clone().iter().eq([0, 1, 3]));
     }
 
     #[test]

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -672,20 +672,7 @@ impl TypedColumn for columns::Index {
             .with_fixint_encoding()
             .reject_trailing_bytes();
 
-        // Migration strategy for new column format:
-        // 1. Release 1: Add ability to read new format as fallback, keep writing old format
-        // 2. Release 2: Switch to writing new format, keep reading old format as fallback
-        // 3. Release 3: Remove old format support once stable
-        // This allows safe downgrade to Release 1 since it can read both formats
-        // https://github.com/anza-xyz/agave/issues/3570
-        let index: bincode::Result<blockstore_meta::Index> = config.deserialize(data);
-        match index {
-            Ok(index) => Ok(index),
-            Err(_) => {
-                let index: blockstore_meta::IndexFallback = config.deserialize(data)?;
-                Ok(index.into())
-            }
-        }
+        Ok(config.deserialize(data)?)
     }
 }
 
@@ -745,19 +732,7 @@ impl TypedColumn for columns::SlotMeta {
             .with_fixint_encoding()
             .reject_trailing_bytes();
 
-        // Migration strategy for new column format:
-        // 1. Release 1: Add ability to read new format as fallback, keep writing old format
-        // 2. Release 2: Switch to writing new format, keep reading old format as fallback
-        // 3. Release 3: Remove old format support once stable
-        // This allows safe downgrade to Release 1 since it can read both formats
-        let index: bincode::Result<blockstore_meta::SlotMeta> = config.deserialize(data);
-        match index {
-            Ok(index) => Ok(index),
-            Err(_) => {
-                let index: blockstore_meta::SlotMetaFallback = config.deserialize(data)?;
-                Ok(index.into())
-            }
-        }
+        Ok(config.deserialize(data)?)
     }
 }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -7,10 +7,7 @@ use {
     serde::{Deserialize, Deserializer, Serialize, Serializer},
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
-    std::{
-        collections::BTreeSet,
-        ops::{Range, RangeBounds},
-    },
+    std::ops::{Range, RangeBounds},
 };
 
 bitflags! {
@@ -49,34 +46,18 @@ impl Default for ConnectedFlags {
     }
 }
 
-/// Legacy completed data indexes type; de/serialization is inefficient for a BTreeSet.
-///
-/// Replaced by [`CompletedDataIndexesV2`].
-pub type CompletedDataIndexesV1 = BTreeSet<u32>;
 /// A fixed size BitVec offers fast lookup and fast de/serialization.
-///
-/// Supersedes [`CompletedDataIndexesV1`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(transparent)]
 pub struct CompletedDataIndexesV2 {
     index: BitVec<MAX_DATA_SHREDS_PER_SLOT>,
 }
 
-// API for CompletedDataIndexesV2 that mirrors BTreeSet<u32> to make migration easier.
-// This allows CompletedDataIndexesV2 to be a drop-in replacement for CompletedDataIndexesV1.
+// API for CompletedDataIndexesV2 that mirrors BTreeSet<u32>.
 impl CompletedDataIndexesV2 {
     #[inline]
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = u32> + '_ {
         self.index.iter_ones().map(|i| i as u32)
-    }
-
-    /// Only needed for V1 / V2 test compatibility.
-    ///
-    /// TODO: Remove once the migration is complete.
-    #[cfg(test)]
-    #[inline]
-    pub fn into_iter(&self) -> impl DoubleEndedIterator<Item = u32> + '_ {
-        self.iter()
     }
 
     #[inline]
@@ -109,18 +90,6 @@ impl FromIterator<u32> for CompletedDataIndexesV2 {
     fn from_iter<T: IntoIterator<Item = u32>>(iter: T) -> Self {
         let index = iter.into_iter().map(|i| i as usize).collect();
         CompletedDataIndexesV2 { index }
-    }
-}
-
-impl From<CompletedDataIndexesV2> for CompletedDataIndexesV1 {
-    fn from(value: CompletedDataIndexesV2) -> Self {
-        value.iter().collect()
-    }
-}
-
-impl From<CompletedDataIndexesV1> for CompletedDataIndexesV2 {
-    fn from(value: CompletedDataIndexesV1) -> Self {
-        value.into_iter().collect()
     }
 }
 
@@ -158,65 +127,10 @@ pub struct SlotMetaBase<T> {
     pub completed_data_indexes: T,
 }
 
-pub type SlotMetaV1 = SlotMetaBase<CompletedDataIndexesV1>;
 pub type SlotMetaV2 = SlotMetaBase<CompletedDataIndexesV2>;
 
-impl From<SlotMetaV1> for SlotMetaV2 {
-    fn from(value: SlotMetaV1) -> Self {
-        SlotMetaV2 {
-            slot: value.slot,
-            consumed: value.consumed,
-            received: value.received,
-            first_shred_timestamp: value.first_shred_timestamp,
-            last_index: value.last_index,
-            parent_slot: value.parent_slot,
-            next_slots: value.next_slots,
-            connected_flags: value.connected_flags,
-            completed_data_indexes: value.completed_data_indexes.into(),
-        }
-    }
-}
-
-impl From<SlotMetaV2> for SlotMetaV1 {
-    fn from(value: SlotMetaV2) -> Self {
-        SlotMetaV1 {
-            slot: value.slot,
-            consumed: value.consumed,
-            received: value.received,
-            first_shred_timestamp: value.first_shred_timestamp,
-            last_index: value.last_index,
-            parent_slot: value.parent_slot,
-            next_slots: value.next_slots,
-            connected_flags: value.connected_flags,
-            completed_data_indexes: value.completed_data_indexes.into(),
-        }
-    }
-}
-
-// We need to maintain both formats during migration,
-// as both formats will need to be supported when reading
-// from rocksdb until the migration is complete.
-//
-// Swap these types to migrate to the new format.
-//
-// For example, to enable the new format,
-//
-// ```
-// pub type SlotMeta = SlotMetaV2;
-// pub type CompletedDataIndexes = CompletedDataIndexesV2;
-// pub type SlotMetaFallback = SlotMetaV1;
-// ```
-//
-// To enable the old format,
-//
-// ```
-// pub type SlotMeta = SlotMetaV1;
-// pub type CompletedDataIndexes = CompletedDataIndexesV1;
-// pub type SlotMetaFallback = SlotMetaV2;
-// ```
 pub type SlotMeta = SlotMetaV2;
 pub type CompletedDataIndexes = CompletedDataIndexesV2;
-pub type SlotMetaFallback = SlotMetaV1;
 
 // Serde implementation of serialize and deserialize for Option<u64>
 // where None is represented as u64::MAX; for backward compatibility.
@@ -241,51 +155,12 @@ mod serde_compat {
 
 pub type Index = IndexV2;
 pub type ShredIndex = ShredIndexV2;
-/// We currently support falling back to the previous format for migration purposes.
-///
-/// See https://github.com/anza-xyz/agave/issues/3570.
-pub type IndexFallback = IndexV1;
-pub type ShredIndexFallback = ShredIndexV1;
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-/// Index recording presence/absence of shreds
-pub struct IndexV1 {
-    pub slot: Slot,
-    data: ShredIndexV1,
-    coding: ShredIndexV1,
-}
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct IndexV2 {
     pub slot: Slot,
     data: ShredIndexV2,
     coding: ShredIndexV2,
-}
-
-impl From<IndexV2> for IndexV1 {
-    fn from(index: IndexV2) -> Self {
-        IndexV1 {
-            slot: index.slot,
-            data: index.data.into(),
-            coding: index.coding.into(),
-        }
-    }
-}
-
-impl From<IndexV1> for IndexV2 {
-    fn from(index: IndexV1) -> Self {
-        IndexV2 {
-            slot: index.slot,
-            data: index.data.into(),
-            coding: index.coding.into(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-pub struct ShredIndexV1 {
-    /// Map representing presence/absence of shreds
-    index: BTreeSet<u64>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
@@ -419,75 +294,10 @@ impl Index {
     }
 }
 
-#[cfg(test)]
-#[allow(unused)]
-impl IndexFallback {
-    pub(crate) fn new(slot: Slot) -> Self {
-        Self {
-            slot,
-            data: ShredIndexFallback::default(),
-            coding: ShredIndexFallback::default(),
-        }
-    }
-
-    pub fn data(&self) -> &ShredIndexFallback {
-        &self.data
-    }
-    pub fn coding(&self) -> &ShredIndexFallback {
-        &self.coding
-    }
-
-    pub(crate) fn data_mut(&mut self) -> &mut ShredIndexFallback {
-        &mut self.data
-    }
-    pub(crate) fn coding_mut(&mut self) -> &mut ShredIndexFallback {
-        &mut self.coding
-    }
-}
-
-/// Superseded by [`ShredIndexV2`].
+/// A bitvec (`Box<[u8]>`) of shred indices, where each u8 represents 8 shred indices.
 ///
-/// TODO: Remove this once new [`ShredIndexV2`] is fully rolled out
-/// and no longer relies on it for fallback.
-#[cfg(test)]
-#[allow(unused)]
-impl ShredIndexV1 {
-    pub fn num_shreds(&self) -> usize {
-        self.index.len()
-    }
-
-    pub(crate) fn range<R>(&self, bounds: R) -> impl Iterator<Item = &u64>
-    where
-        R: RangeBounds<u64>,
-    {
-        self.index.range(bounds)
-    }
-
-    pub(crate) fn contains(&self, index: u64) -> bool {
-        self.index.contains(&index)
-    }
-
-    pub(crate) fn insert(&mut self, index: u64) {
-        self.index.insert(index);
-    }
-
-    fn remove(&mut self, index: u64) {
-        self.index.remove(&index);
-    }
-}
-
-/// A bitvec (`Vec<u8>`) of shred indices, where each u8 represents 8 shred indices.
-///
-/// The current implementation of [`ShredIndex`] utilizes a [`BTreeSet`] to store
-/// shred indices. While [`BTreeSet`] remains efficient as operations are amortized
-/// over time, the overhead of the B-tree structure becomes significant when frequently
-/// serialized and deserialized. In particular:
-/// - **Tree Traversal**: Serialization requires walking the non-contiguous tree structure.
-/// - **Reconstruction**: Deserialization involves rebuilding the tree in bulk,
-///   including dynamic memory allocations and re-balancing nodes.
-///
-/// In contrast, our bit vec implementation provides:
-/// - **Contiguous Memory**: All bits are stored in a contiguous array of u64 words,
+/// Bit vec implementation provides:
+/// - **Contiguous Memory**: All bits are stored in a contiguous array of words,
 ///   allowing direct indexing and efficient memory access patterns.
 /// - **Direct Range Access**: Can load only the specific words that overlap with a
 ///   requested range, avoiding unnecessary traversal.
@@ -533,10 +343,6 @@ impl ShredIndexV2 {
             .iter_ones()
             .map(|idx| idx as u64)
     }
-
-    fn iter(&self) -> impl Iterator<Item = u64> + '_ {
-        self.range(0..MAX_DATA_SHREDS_PER_SLOT as u64)
-    }
 }
 
 impl FromIterator<u64> for ShredIndexV2 {
@@ -546,28 +352,6 @@ impl FromIterator<u64> for ShredIndexV2 {
             index.insert(idx);
         }
         index
-    }
-}
-
-impl FromIterator<u64> for ShredIndexV1 {
-    fn from_iter<T: IntoIterator<Item = u64>>(iter: T) -> Self {
-        ShredIndexV1 {
-            index: iter.into_iter().collect(),
-        }
-    }
-}
-
-impl From<ShredIndexV1> for ShredIndexV2 {
-    fn from(value: ShredIndexV1) -> Self {
-        value.index.into_iter().collect()
-    }
-}
-
-impl From<ShredIndexV2> for ShredIndexV1 {
-    fn from(value: ShredIndexV2) -> Self {
-        ShredIndexV1 {
-            index: value.iter().collect(),
-        }
     }
 }
 
@@ -859,7 +643,6 @@ impl OptimisticSlotMetaVersioned {
 mod test {
     use {
         super::*,
-        bincode::Options,
         proptest::prelude::*,
         rand::{prelude::IndexedRandom as _, rng},
     };
@@ -937,84 +720,6 @@ mod test {
     }
 
     proptest! {
-        #[test]
-        fn shred_index_legacy_compat(
-            shreds in rand_range(0..MAX_DATA_SHREDS_PER_SLOT as u64),
-            range in rand_range(0..MAX_DATA_SHREDS_PER_SLOT as u64)
-        ) {
-            let mut legacy = ShredIndexV1::default();
-            let mut v2 = ShredIndexV2::default();
-
-            for i in shreds {
-                v2.insert(i);
-                legacy.insert(i);
-            }
-
-            for &i in legacy.index.iter() {
-                assert!(v2.contains(i));
-            }
-
-            assert_eq!(v2.num_shreds(), legacy.num_shreds());
-
-            assert_eq!(
-                v2.range(range.clone()).sum::<u64>(),
-                legacy.range(range).sum::<u64>()
-            );
-
-            assert_eq!(ShredIndexV2::from(legacy.clone()), v2.clone());
-            assert_eq!(ShredIndexV1::from(v2), legacy);
-        }
-
-        /// Property: [`Index`] cannot be deserialized from [`IndexV2`].
-        ///
-        /// # Failure cases
-        /// 1. Empty [`IndexV2`]
-        ///     - [`ShredIndex`] deserialization should fail due to trailing bytes of `num_shreds`.
-        /// 2. Non-empty [`IndexV2`]
-        ///     - Encoded length of [`ShredIndexV2::index`] (`Vec<u8>`) will be relative to a sequence of `u8`,
-        ///       resulting in not enough bytes when deserialized into sequence of `u64`.
-        #[test]
-        fn test_legacy_collision(
-            coding_indices in rand_range(0..MAX_DATA_SHREDS_PER_SLOT as u64),
-            data_indices in rand_range(0..MAX_DATA_SHREDS_PER_SLOT as u64),
-            slot in 0..u64::MAX
-        ) {
-            let index = IndexV2 {
-                coding: coding_indices.into_iter().collect(),
-                data: data_indices.into_iter().collect(),
-                slot,
-            };
-            let config = bincode::DefaultOptions::new().with_fixint_encoding().reject_trailing_bytes();
-            let legacy = config.deserialize::<IndexV1>(&config.serialize(&index).unwrap());
-            prop_assert!(legacy.is_err());
-        }
-
-        /// Property: [`IndexV2`] cannot be deserialized from [`Index`].
-        ///
-        /// # Failure cases
-        /// 1. Empty [`Index`]
-        ///     - [`ShredIndexV2`] deserialization should fail due to missing `num_shreds` (not enough bytes).
-        /// 2. Non-empty [`Index`]
-        ///     - Encoded length of [`ShredIndex::index`] (`BTreeSet<u64>`) will be relative to a sequence of `u64`,
-        ///       resulting in trailing bytes when deserialized into sequence of `u8`.
-        #[test]
-        fn test_legacy_collision_inverse(
-            coding_indices in rand_range(0..MAX_DATA_SHREDS_PER_SLOT as u64),
-            data_indices in rand_range(0..MAX_DATA_SHREDS_PER_SLOT as u64),
-            slot in 0..u64::MAX
-        ) {
-            let index = IndexV1 {
-                coding: coding_indices.into_iter().collect(),
-                data: data_indices.into_iter().collect(),
-                slot,
-            };
-            let config = bincode::DefaultOptions::new()
-                .with_fixint_encoding()
-                .reject_trailing_bytes();
-            let v2 = config.deserialize::<IndexV2>(&config.serialize(&index).unwrap());
-            prop_assert!(v2.is_err());
-        }
-
         // Property: range queries should return correct indices
         #[test]
         fn range_query_correctness(

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -150,14 +150,11 @@ mod serde_compat {
     }
 }
 
-pub type Index = IndexV2;
-pub type ShredIndex = ShredIndexV2;
-
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-pub struct IndexV2 {
+pub struct Index {
     pub slot: Slot,
-    data: ShredIndexV2,
-    coding: ShredIndexV2,
+    data: ShredIndex,
+    coding: ShredIndex,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
@@ -301,12 +298,12 @@ impl Index {
 /// - **Simplified Serialization**: The contiguous memory layout allows for efficient
 ///   serialization/deserialization without tree reconstruction.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct ShredIndexV2 {
+pub struct ShredIndex {
     index: BitVec<MAX_DATA_SHREDS_PER_SLOT>,
     num_shreds: usize,
 }
 
-impl ShredIndexV2 {
+impl ShredIndex {
     pub fn num_shreds(&self) -> usize {
         self.num_shreds
     }
@@ -342,9 +339,9 @@ impl ShredIndexV2 {
     }
 }
 
-impl FromIterator<u64> for ShredIndexV2 {
+impl FromIterator<u64> for ShredIndex {
     fn from_iter<T: IntoIterator<Item = u64>>(iter: T) -> Self {
-        let mut index = ShredIndexV2::default();
+        let mut index = ShredIndex::default();
         for idx in iter {
             index.insert(idx);
         }
@@ -722,7 +719,7 @@ mod test {
         fn range_query_correctness(
             indices in rand_range(0..MAX_DATA_SHREDS_PER_SLOT as u64),
         ) {
-            let mut index = ShredIndexV2::default();
+            let mut index = ShredIndex::default();
 
             for idx in indices.clone() {
                 index.insert(idx);
@@ -737,7 +734,7 @@ mod test {
 
     #[test]
     fn test_shred_index_v2_range_bounds() {
-        let mut index = ShredIndexV2::default();
+        let mut index = ShredIndex::default();
 
         index.insert(10);
         index.insert(20);
@@ -774,7 +771,7 @@ mod test {
 
     #[test]
     fn test_shred_index_v2_boundary_conditions() {
-        let mut index = ShredIndexV2::default();
+        let mut index = ShredIndex::default();
 
         // First possible index
         index.insert(0);

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -49,12 +49,12 @@ impl Default for ConnectedFlags {
 /// A fixed size BitVec offers fast lookup and fast de/serialization.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(transparent)]
-pub struct CompletedDataIndexesV2 {
+pub struct CompletedDataIndexes {
     index: BitVec<MAX_DATA_SHREDS_PER_SLOT>,
 }
 
 // API for CompletedDataIndexesV2 that mirrors BTreeSet<u32>.
-impl CompletedDataIndexesV2 {
+impl CompletedDataIndexes {
     #[inline]
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = u32> + '_ {
         self.index.iter_ones().map(|i| i as u32)
@@ -86,10 +86,10 @@ impl CompletedDataIndexesV2 {
     }
 }
 
-impl FromIterator<u32> for CompletedDataIndexesV2 {
+impl FromIterator<u32> for CompletedDataIndexes {
     fn from_iter<T: IntoIterator<Item = u32>>(iter: T) -> Self {
         let index = iter.into_iter().map(|i| i as usize).collect();
-        CompletedDataIndexesV2 { index }
+        CompletedDataIndexes { index }
     }
 }
 
@@ -127,10 +127,7 @@ pub struct SlotMetaBase<T> {
     pub completed_data_indexes: T,
 }
 
-pub type SlotMetaV2 = SlotMetaBase<CompletedDataIndexesV2>;
-
-pub type SlotMeta = SlotMetaV2;
-pub type CompletedDataIndexes = CompletedDataIndexesV2;
+pub type SlotMeta = SlotMetaBase<CompletedDataIndexes>;
 
 // Serde implementation of serialize and deserialize for Option<u64>
 // where None is represented as u64::MAX; for backward compatibility.

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -53,7 +53,7 @@ pub struct CompletedDataIndexes {
     index: BitVec<MAX_DATA_SHREDS_PER_SLOT>,
 }
 
-// API for CompletedDataIndexesV2 that mirrors BTreeSet<u32>.
+// API of CompletedDataIndexes that semantically mirrors BTreeSet<u32>.
 impl CompletedDataIndexes {
     #[inline]
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = u32> + '_ {
@@ -733,7 +733,7 @@ mod test {
     }
 
     #[test]
-    fn test_shred_index_v2_range_bounds() {
+    fn test_shred_index_range_bounds() {
         let mut index = ShredIndex::default();
 
         index.insert(10);
@@ -770,7 +770,7 @@ mod test {
     }
 
     #[test]
-    fn test_shred_index_v2_boundary_conditions() {
+    fn test_shred_index_boundary_conditions() {
         let mut index = ShredIndex::default();
 
         // First possible index


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/8459 enabled migration to `CompletedDataIndexesV2` (contained in `SlotMetaV2`) and `ShredIndexV2` (contained in `IndexV2`) which switched to serializing indices as fixed size bit-vec instead of using btree-set (which on the wire generates shorter integer lists).
Post 3.1 we don't need the old btree-set code that generates old format, it's enough that current bit-vec can understand it (that part could also be removed post 4.0).

This means `CompletedDataIndexesV1`, `ShredIndexV2` and related structs can be removed.

This PR also removes the fallback deserialization code for supporting migrations of `blockstore_meta::Index` and `blockstore_meta::SlotMeta` columns - we could potentially keep it, but I think it's uncertain if any future migration could re-use it as-is, so for the sake of simplification it's better to cut it and re-create if we ever need it.

#### Summary of Changes
* remove `IndexV1`, `ShredIndexV1`, `CompletedDataIndexesV1`, `SlotMetaV1`
* rename `CompletedDataIndexesV2` to `CompletedDataIndexes`, `SlotMetaV2` to `SlotMeta`, `ShredIndexV2` to `ShredIndex`, `IndexV2` to `Index`
* still keep custom `BitVec` deserialization that supports data emitted by `CompletedDataIndexesV1`
* remove fallback deserialization that checked two formats