### PR TITLE
[bls12-381] Reject affine points if the compressed or parity flag is set

### DIFF
--- a/bls12-381/src/encoding.rs
+++ b/bls12-381/src/encoding.rs
@@ -48,15 +48,19 @@ impl PodG1Point {
     /// Checks: Field validity, Curve equation (`y^2 = x^3 + 4`).
     /// Skips: Subgroup membership
     pub fn to_affine_subgroup_unchecked(&self, endianness: Endianness) -> Option<G1Affine> {
-        match endianness {
-            // `G1Affine::from_uncompressed_unchecked` already performs field and on-curve checks
-            Endianness::BE => G1Affine::from_uncompressed_unchecked(&self.0).into_option(),
-            Endianness::LE => {
-                let mut bytes = self.0;
-                swap_fq_endianness(&mut bytes);
-                G1Affine::from_uncompressed_unchecked(&bytes).into_option()
-            }
+        let mut bytes = self.0;
+
+        if matches!(endianness, Endianness::LE) {
+            swap_fq_endianness(&mut bytes);
         }
+
+        // reject point if the compressed or parity flag is set
+        if bytes[0] & 0xa0 != 0 {
+            return None;
+        }
+
+        // `G1Affine::from_uncompressed_unchecked` already performs field and on-curve checks
+        G1Affine::from_uncompressed_unchecked(&bytes).into_option()
     }
 
     /// Deserializes to an affine point with full validation.
@@ -89,16 +93,20 @@ impl PodG2Point {
     /// Checks: Field validity, Curve equation (`y^2 = x^3 + 4(1+u)^{-1}`).
     /// Skips: Subgroup membership
     pub fn to_affine_subgroup_unchecked(&self, endianness: Endianness) -> Option<G2Affine> {
-        match endianness {
-            // `G2Affine::from_uncompressed_unchecked` already performs field and on-curve checks
-            Endianness::BE => G2Affine::from_uncompressed_unchecked(&self.0).into_option(),
-            Endianness::LE => {
-                let mut bytes = self.0;
-                swap_fq_endianness(&mut bytes);
-                swap_g2_c0_c1(&mut bytes);
-                G2Affine::from_uncompressed_unchecked(&bytes).into_option()
-            }
+        let mut bytes = self.0;
+
+        if matches!(endianness, Endianness::LE) {
+            swap_fq_endianness(&mut bytes);
+            swap_g2_c0_c1(&mut bytes);
         }
+
+        // reject point if the compressed or parity flag is set
+        if bytes[0] & 0xa0 != 0 {
+            return None;
+        }
+
+        // `G2Affine::from_uncompressed_unchecked` already performs field and on-curve checks
+        G2Affine::from_uncompressed_unchecked(&bytes).into_option()
     }
 
     /// Deserializes to an affine point with full validation.


### PR DESCRIPTION
#### Problem

The `sol_curve_validate_point` syscall expects strictly uncompressed BLS12-381 points, but the underlying `blst` library auto-detects formats based on flag bits. This introduces a representation malleability vulnerability:
- If the compression flag (`0x80`) is set on a 96-byte G1 or 192-byte G2 input, `blst` treats it as a compressed point and reads only the first half of the buffer.
- The trailing bytes are completely ignored, allowing an attacker to append arbitrary garbage data to the second half of a valid compressed point.
- As a result, numerous distinct byte arrays can successfully validate and decode as the exact same logical curve point.
- Additionally, the sort/parity flag (`0x20`) must be explicitly rejected for uncompressed points to prevent a similar 1-bit malleability vector.

#### Summary of Changes

Added a strict `0xa0` bitmask check prior to uncompressed point deserialization for both `PodG1Point` and `PodG2Point` to explicitly reject the compression (`0x80`) and sort (`0x20`) flags. This enforces the correct uncompressed format and eliminates representation malleability while safely preserving the infinity flag (`0x40`) needed for valid points at infinity.