### PR TITLE
compute-budget: Remove unused dependencies and features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7786,9 +7786,7 @@ dependencies = [
 name = "solana-compute-budget"
 version = "4.1.0-alpha.0"
 dependencies = [
- "qualifier_attr",
  "solana-fee-structure",
- "solana-frozen-abi",
  "solana-program-runtime",
 ]
 
@@ -8403,7 +8401,6 @@ checksum = "5e2abdb1223eea8ec64136f39cb1ffcf257e00f915c957c35c0dd9e3f4e700b0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-frozen-abi",
 ]
 
 [[package]]

--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -11,18 +11,10 @@ edition = { workspace = true }
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = [
-    "dep:qualifier_attr",
-    "solana-program-runtime/dev-context-only-utils",
-]
-frozen-abi = ["dep:solana-frozen-abi", "solana-fee-structure/frozen-abi"]
+dev-context-only-utils = []
 
 [dependencies]
-qualifier_attr = { workspace = true, optional = true }
 solana-fee-structure = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
-] }
 solana-program-runtime = { workspace = true }
 
 [lints]

--- a/compute-budget/src/lib.rs
+++ b/compute-budget/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "agave-unstable-api")]
 //! Solana compute budget types and default configurations.
-#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 pub mod compute_budget;
 pub mod compute_budget_limits;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,6 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "solana-accounts-db/frozen-abi",
     "solana-bloom/frozen-abi",
-    "solana-compute-budget/frozen-abi",
     "solana-cost-model/frozen-abi",
     "solana-frozen-abi/frozen-abi",
     "solana-gossip/frozen-abi",

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -28,7 +28,6 @@ dev-context-only-utils = [
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
-    "solana-compute-budget/frozen-abi",
     "solana-pubkey/frozen-abi",
     "solana-vote-program/frozen-abi",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -31,7 +31,6 @@ frozen-abi = [
     "solana-account/frozen-abi",
     "solana-accounts-db/frozen-abi",
     "solana-bls-signatures/frozen-abi",
-    "solana-compute-budget/frozen-abi",
     "solana-cost-model/frozen-abi",
     "solana-epoch-schedule/frozen-abi",
     "solana-hard-forks/frozen-abi",


### PR DESCRIPTION
#### Problem
`compute-budget` was refactored in #5127, but unused dependencies and features were not removed.

#### Summary of Changes
Remove them.