### PR TITLE
chore: use path dependencies in dev-dependencies when possible (part 3)

### DIFF
--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -34,7 +34,7 @@ solana-secp256k1-program = { workspace = true, features = ["serde"] }
 solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 agave-precompiles = { path = ".", features = ["agave-unstable-api"] }
 bytemuck = { workspace = true }
 hex = { workspace = true }

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -83,7 +83,9 @@ solana-program-runtime = { path = ".", features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
-solana-transaction-context = { workspace = true, features = [
+solana-transaction-context = { path = "../transaction-context", features = [
+    "agave-unstable-api",
+    "bincode",
     "dev-context-only-utils",
 ] }
 test-case = { workspace = true }

--- a/programs/bpf-loader-tests/Cargo.toml
+++ b/programs/bpf-loader-tests/Cargo.toml
@@ -21,11 +21,11 @@ agave-unstable-api = []
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 solana-account = { workspace = true }
-solana-bpf-loader-program = { workspace = true }
+solana-bpf-loader-program = { path = "../bpf_loader", default-features = false, features = ["agave-unstable-api"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-loader-v3-interface = { workspace = true }
-solana-program-test = { workspace = true }
+solana-program-test = { path = "../../program-test", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signer = { workspace = true }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -60,12 +60,12 @@ solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-last-restart-slot = { workspace = true }
 solana-program = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-runtime = { path = "../../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-slot-hashes = { workspace = true }
-solana-svm-callback = { workspace = true }
-solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
+solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
+solana-transaction-context = { path = "../../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/programs/ed25519-tests/Cargo.toml
+++ b/programs/ed25519-tests/Cargo.toml
@@ -21,7 +21,7 @@ solana-ed25519-program = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-precompile-error = { workspace = true }
-solana-program-test = { workspace = true }
+solana-program-test = { path = "../../program-test", features = ["agave-unstable-api"] }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -40,15 +40,15 @@ solana-transaction-context = { workspace = true, features = ["bincode"] }
 [dev-dependencies]
 assert_matches = { workspace = true }
 criterion = { workspace = true }
-solana-compute-budget = { workspace = true }
+solana-compute-budget = { path = "../../compute-budget", features = ["agave-unstable-api"] }
 solana-hash = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-rent = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-solana-svm-callback = { workspace = true }
-solana-svm-feature-set = { workspace = true }
+solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
+solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-unstable-api"] }
 solana-system-program = { path = ".", features = ["agave-unstable-api"] }
-solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
+solana-transaction-context = { path = "../../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
 
 [[bench]]
 name = "system"

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -54,7 +54,7 @@ solana-transaction-context = { workspace = true, features = ["bincode"] }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 solana-account = { workspace = true }
@@ -62,13 +62,13 @@ solana-clock = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-hash = { workspace = true, features = ["atomic"] }
 solana-instruction = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-runtime = { path = "../../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-solana-svm-feature-set = { workspace = true }
-solana-system-program = { workspace = true }
+solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-unstable-api"] }
+solana-system-program = { path = "../system", features = ["agave-unstable-api"] }
 solana-vote-program = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 test-case = { workspace = true }
 

--- a/programs/zk-elgamal-proof-tests/Cargo.toml
+++ b/programs/zk-elgamal-proof-tests/Cargo.toml
@@ -13,11 +13,11 @@ agave-unstable-api = []
 [dev-dependencies]
 bytemuck = { workspace = true }
 solana-account = { workspace = true }
-solana-compute-budget = { workspace = true }
+solana-compute-budget = { path = "../../compute-budget", features = ["agave-unstable-api"] }
 solana-compute-budget-interface = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-program-test = { workspace = true }
+solana-program-test = { path = "../../program-test", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -95,19 +95,19 @@ libsecp256k1 = { workspace = true }
 openssl = { workspace = true }
 rand = { workspace = true }
 shuttle = { workspace = true }
-solana-bpf-loader-program = { workspace = true }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api"] }
 solana-clock = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
-solana-compute-budget-program = { workspace = true }
+solana-compute-budget-program = { path = "../programs/compute-budget", features = ["agave-unstable-api"] }
 solana-ed25519-program = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-keypair = { workspace = true }
 solana-native-token = { workspace = true }
 solana-precompile-error = { workspace = true }
-solana-program-binaries = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
+solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-sbpf = { workspace = true, features = ["jit"] }
@@ -121,7 +121,7 @@ solana-system-program = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-sysvar = { workspace = true }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
-solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
+solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
 spl-token-interface = { workspace = true }
 test-case = { workspace = true }
 

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -68,11 +68,11 @@ solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-last-restart-slot = { workspace = true }
 solana-program = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-slot-hashes = { workspace = true }
-solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
+solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 


### PR DESCRIPTION
#### Problem

(split from https://github.com/anza-xyz/agave/pull/10874)

#### Summary of Changes

use path dependencies in dev-dependencies when possible