### PR TITLE
chore: use path dependencies in dev-dependencies when possible (part 5)

### DIFF
--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -50,11 +50,11 @@ spl-token-interface = { workspace = true }
 jemallocator = { workspace = true }
 
 [dev-dependencies]
-solana-accounts-db = { workspace = true }
-solana-core = { workspace = true, features = ["dev-context-only-utils"] }
-solana-faucet = { workspace = true, features = ["dev-context-only-utils"] }
-solana-local-cluster = { workspace = true, features = ["dev-context-only-utils"] }
+solana-accounts-db = { path = "../accounts-db", features = ["agave-unstable-api"] }
+solana-core = { path = "../core", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-faucet = { path = "../faucet", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-local-cluster = { path = "../local-cluster", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-native-token = { workspace = true }
 solana-poh-config = { workspace = true }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-test-validator = { workspace = true }
+solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-test-validator = { path = "../test-validator" }

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -98,8 +98,8 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
-agave-reserved-account-keys = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 libsecp256k1 = { workspace = true }
@@ -108,12 +108,12 @@ rand_chacha = { workspace = true }
 serde_bytes = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-accounts-db = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-compute-budget = { workspace = true }
+solana-compute-budget = { path = "../compute-budget", features = ["agave-unstable-api"] }
 solana-instruction = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-slot-history = { workspace = true }
-solana-svm = { workspace = true }
+solana-svm = { path = "../svm", features = ["agave-unstable-api"] }
 static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -32,7 +32,7 @@ solana-pubkey = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 fs_extra = { workspace = true }
 rayon = { workspace = true }
 solana-bucket-map = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -28,4 +28,4 @@ solana-genesis-config = { workspace = true }
 solana-runtime = { workspace = true }
 
 [dev-dependencies]
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/snapshots/Cargo.toml
+++ b/snapshots/Cargo.toml
@@ -44,5 +44,5 @@ thiserror = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }


### PR DESCRIPTION
#### Problem

(split from https://github.com/anza-xyz/agave/pull/10874)

#### Summary of Changes

use path dependencies in dev-dependencies when possible