### PR TITLE
chore: use path dependencies in dev-dependencies when possible (part 6)

### DIFF
--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -54,4 +54,4 @@ spl-memo-interface = { workspace = true }
 solana-keypair = { workspace = true }
 solana-seed-derivable = { workspace = true }
 solana-signer = { workspace = true }
-solana-transaction-context = { workspace = true }
+solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -106,13 +106,13 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-solana-client = { workspace = true, features = ["dev-context-only-utils"] }
-solana-faucet = { workspace = true, features = ["dev-context-only-utils"] }
-solana-net-utils = { workspace = true }
+solana-client = { path = "../client", features = ["dev-context-only-utils"] }
+solana-faucet = { path = "../faucet", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-nonce-account = { workspace = true }
 solana-presigner = { workspace = true }
-solana-rpc = { workspace = true }
+solana-rpc = { path = "../rpc", features = ["agave-unstable-api"] }
 solana-sha256-hasher = { workspace = true }
-solana-test-validator = { workspace = true }
+solana-test-validator = { path = "../test-validator" }
 tempfile = { workspace = true }
 test-case = { workspace = true }

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -43,7 +43,7 @@ tokio = { workspace = true, features = ["full"] }
 tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
-solana-net-utils = { workspace = true }
-solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
+solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
+solana-rpc = { path = "../rpc", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -71,6 +71,6 @@ tempfile = { workspace = true }
 solana-borsh = { workspace = true }
 solana-genesis = { path = ".", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-vote = { workspace = true }
+solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-vote = { path = "../vote", features = ["agave-unstable-api"] }
 test-case = { workspace = true }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -133,21 +133,21 @@ default-features = false
 features = ["lz4"]
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 bs58 = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }
-solana-account-decoder = { workspace = true }
+solana-account-decoder = { path = "../account-decoder", features = ["agave-unstable-api"] }
 solana-bls-signatures = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-ledger = { path = ".", features = ["dev-context-only-utils", "agave-unstable-api"] }
-solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
-solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-perf = { path = "../perf", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-signature = { workspace = true, features = ["rand"] }
-solana-vote = { workspace = true, features = ["dev-context-only-utils"] }
+solana-vote = { path = "../vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
 spl-generic-token = { workspace = true }
 spl-pod = { workspace = true }
 test-case = { workspace = true }

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -88,9 +88,9 @@ assert_matches = { workspace = true }
 fs_extra = { workspace = true }
 gag = { workspace = true }
 serial_test = { workspace = true }
-solana-core = { workspace = true, features = ["dev-context-only-utils"] }
-solana-download-utils = { workspace = true }
-solana-genesis-utils = { workspace = true }
-solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
+solana-core = { path = "../core", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-download-utils = { path = "../download-utils", features = ["agave-unstable-api"] }
+solana-genesis-utils = { path = "../genesis-utils", features = ["agave-unstable-api"] }
+solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-local-cluster = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/rpc-client-nonce-utils/Cargo.toml
+++ b/rpc-client-nonce-utils/Cargo.toml
@@ -34,10 +34,10 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 futures = { workspace = true }
 serde_json = { workspace = true }
-solana-account-decoder = { workspace = true }
+solana-account-decoder = { path = "../account-decoder", features = ["agave-unstable-api"] }
 solana-fee-calculator = { workspace = true }
 solana-keypair = { workspace = true }
-solana-rpc-client-api = { workspace = true }
+solana-rpc-client-api = { path = "../rpc-client-api" }
 solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -59,7 +59,7 @@ crossbeam-channel = { workspace = true }
 futures = { workspace = true }
 jsonrpc-core = { workspace = true }
 jsonrpc-http-server = { workspace = true }
-solana-account-decoder = { workspace = true }
+solana-account-decoder = { path = "../account-decoder", features = ["agave-unstable-api"] }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -42,7 +42,7 @@ agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 solana-client = { path = "../client", features = ["dev-context-only-utils"] }
 solana-clock = { workspace = true }
 solana-commitment-config = { workspace = true }
-solana-connection-cache = { path = "../connection-cache", default-features = false, features = ["agave-unstable-api"] }
+solana-connection-cache = { path = "../connection-cache", features = ["agave-unstable-api"] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -38,11 +38,11 @@ solana-transaction-status = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
-solana-client = { workspace = true, features = ["dev-context-only-utils"] }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
+solana-client = { path = "../client", features = ["dev-context-only-utils"] }
 solana-clock = { workspace = true }
 solana-commitment-config = { workspace = true }
-solana-connection-cache = { workspace = true }
+solana-connection-cache = { path = "../connection-cache", default-features = false, features = ["agave-unstable-api"] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -101,7 +101,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, features = ["codec", "compat"] }
 
 [dev-dependencies]
-agave-reserved-account-keys = { workspace = true }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
 serial_test = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }
 solana-cluster-type = { workspace = true }
@@ -109,22 +109,20 @@ solana-compute-budget-interface = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-instruction = { workspace = true }
-solana-net-utils = { workspace = true }
+solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-nonce = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-program-option = { workspace = true }
-solana-program-runtime = { workspace = true }
+solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api"] }
 solana-rent = { workspace = true }
 solana-rpc = { path = ".", features = ["dev-context-only-utils"] }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-runtime-transaction = { workspace = true, features = [
-    "dev-context-only-utils",
-] }
+solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-sdk-ids = { workspace = true }
-solana-send-transaction-service = { workspace = true, features = ["dev-context-only-utils"] }
+solana-send-transaction-service = { path = "../send-transaction-service", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-sha256-hasher = { workspace = true }
 solana-stake-interface = { workspace = true }
-solana-svm-log-collector = { workspace = true }
+solana-svm-log-collector = { path = "../svm-log-collector", features = ["agave-unstable-api"] }
 solana-vote-interface = { workspace = true }
 spl-pod = { workspace = true }
 symlink = { workspace = true }

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -45,5 +45,5 @@ solana-version = { workspace = true }
 
 [dev-dependencies]
 solana-client-traits = { workspace = true }
-solana-program-binaries = { workspace = true }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
+solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -57,4 +57,4 @@ solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
-solana-transaction-context = { workspace = true }
+solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode"] }

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -58,8 +58,8 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { workspace = true }
+agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
-solana-test-validator = { workspace = true }
+solana-test-validator = { path = "../test-validator" }
 solana-transaction-error = { workspace = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -105,11 +105,11 @@ assert_cmd = { workspace = true }
 predicates = { workspace = true }
 pretty_assertions = { workspace = true }
 scopeguard = { workspace = true }
-solana-account-decoder = { workspace = true }
-solana-core = { workspace = true, features = ["dev-context-only-utils"] }
+solana-account-decoder = { path = "../account-decoder", features = ["agave-unstable-api"] }
+solana-core = { path = "../core", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
-solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-time-utils = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }


### PR DESCRIPTION
#### Problem

(split from https://github.com/anza-xyz/agave/pull/10874)

#### Summary of Changes

use path dependencies in dev-dependencies when possible