### PR TITLE
Remove BlockProductionMethod::UnifiedScheduler

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -520,7 +520,6 @@ impl BankingStage {
                 BlockProductionMethod::CentralSchedulerGreedy => {
                     self.spawn_internal_central(true, num_workers, config)
                 }
-                BlockProductionMethod::UnifiedScheduler => self.spawn_internal_unified(),
             },
             #[cfg(unix)]
             BankingControlMsg::External { session } => self.spawn_external(session),
@@ -661,17 +660,6 @@ impl BankingStage {
         }
 
         Ok(threads)
-    }
-
-    fn spawn_internal_unified(&self) -> Result<Vec<JoinHandle<()>>, ()> {
-        info!("Spawning internal unified scheduler");
-        if self.toggle_internal_unified(true) {
-            // All unified scheduler threads are managed by itself. So, return none here.
-            Ok(vec![])
-        } else {
-            error!("Spawning unified scheduler failed");
-            Err(())
-        }
     }
 
     fn toggle_internal_unified(&self, enable: bool) -> bool {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -211,29 +211,10 @@ pub enum BlockProductionMethod {
     CentralScheduler,
     #[default]
     CentralSchedulerGreedy,
-    UnifiedScheduler,
 }
 
 impl BlockProductionMethod {
-    pub fn cli_names() -> &'static [&'static str] {
-        // Simply return Self::VARIANTS by removing this code block altogether once after
-        // UnifiedScheduler isn't experimental
-        {
-            use std::sync::LazyLock;
-            static VARIANTS_NO_EXPERIMENTAL: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
-                BlockProductionMethod::VARIANTS
-                    .iter()
-                    .filter_map(|&variant| (variant != "unified-scheduler").then_some(variant))
-                    .collect()
-            });
-
-            let disable_experimental =
-                std::env::var("SOLANA_ENABLE_EXPERIMENTAL_BLOCK_PRODUCTION_METHOD").is_err();
-            if disable_experimental {
-                return &VARIANTS_NO_EXPERIMENTAL[..];
-            }
-        }
-
+    pub const fn cli_names() -> &'static [&'static str] {
         Self::VARIANTS
     }
 
@@ -313,9 +294,6 @@ pub fn supported_scheduling_mode(
     (verification, production): (&BlockVerificationMethod, &BlockProductionMethod),
 ) -> SupportedSchedulingMode {
     match (verification, production) {
-        (BlockVerificationMethod::UnifiedScheduler, BlockProductionMethod::UnifiedScheduler) => {
-            SupportedSchedulingMode::Both
-        }
         (BlockVerificationMethod::UnifiedScheduler, _) => {
             SupportedSchedulingMode::Either(SchedulingMode::BlockVerification)
         }

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -385,15 +385,6 @@ pub fn load_and_process_ledger(
         "block_production_method",
         BlockProductionMethod
     )
-    .inspect(|method| {
-        if matches!(method, BlockProductionMethod::UnifiedScheduler) {
-            warn!(
-                "Currently, the unified-scheduler method is experimental for block-production. It \
-                 has known security issues and should be used only for developing and \
-                 benchmarking purposes"
-            );
-        }
-    })
     .unwrap_or_default();
     info!(
         "Using: block-verification-method: {block_verification_method}, block-production-method: \

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -904,17 +904,6 @@ pub fn execute(
     let maximum_snapshot_download_abort =
         value_t_or_exit!(matches, "maximum_snapshot_download_abort", u64);
 
-    if matches!(
-        validator_config.block_production_method,
-        BlockProductionMethod::UnifiedScheduler
-    ) {
-        warn!(
-            "Currently, the unified-scheduler method is experimental for block-production. It has \
-             known security issues and should be used only for developing and benchmarking \
-             purposes"
-        );
-    }
-
     let public_rpc_addr = matches
         .value_of("public_rpc_addr")
         .map(|addr| {


### PR DESCRIPTION
#### Problem
- Splitting this out of #11138 for backport. Since we do not have plans to maintain unified-scheduler

#### Summary of Changes
- Do not allow spawning of unified-scheduler for block-production

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
