### PR TITLE
Refactor - Remove program runtime v2 related code

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -807,7 +807,7 @@ macro_rules! with_mock_invoke_context_with_feature_set {
                 __private::{Hash, ReadableAccount, Rent, TransactionContext},
                 execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
                 invoke_context::{EnvironmentConfig, InvokeContext},
-                loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments},
+                loaded_programs::{ProgramCacheForTxBatch, get_mock_program_runtime_environments},
                 sysvar_cache::SysvarCache,
             },
         };
@@ -843,7 +843,7 @@ macro_rules! with_mock_invoke_context_with_feature_set {
                 }
             }
         });
-        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+        let program_runtime_environments = get_mock_program_runtime_environments();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1240,11 +1240,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     }
 
     /// Returns the list of entries which are verified and compiled.
-    pub fn get_flattened_entries(
-        &self,
-        include_program_runtime_v1: bool,
-        _include_program_runtime_v2: bool,
-    ) -> Vec<(Pubkey, Slot, Arc<ProgramCacheEntry>)> {
+    pub fn get_flattened_entries(&self) -> Vec<(Pubkey, Slot, Arc<ProgramCacheEntry>)> {
         match &self.index {
             IndexImplementation::V1 { entries, .. } => entries
                 .iter()
@@ -1252,13 +1248,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     second_level
                         .iter()
                         .filter_map(move |program| match program.program {
-                            ProgramCacheEntryType::Loaded(_) => {
-                                if include_program_runtime_v1 {
-                                    Some((*id, 0, program.clone()))
-                                } else {
-                                    None
-                                }
-                            }
+                            ProgramCacheEntryType::Loaded(_) => Some((*id, 0, program.clone())),
                             _ => None,
                         })
                 })
@@ -1290,7 +1280,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
 
     /// Unloads programs which were used infrequently
     pub fn sort_and_unload(&mut self, shrink_to: PercentageInteger) {
-        let mut sorted_candidates = self.get_flattened_entries(true, true);
+        let mut sorted_candidates = self.get_flattened_entries();
         sorted_candidates.sort_by_cached_key(|(_id, _last_modification_slot, program)| {
             program.tx_usage_counter.load(Ordering::Relaxed)
         });
@@ -1306,7 +1296,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     /// Evicts programs using 2's random selection, choosing the least used program out of the two entries.
     /// The eviction is performed enough number of times to reduce the cache usage to the given percentage.
     pub fn evict_using_2s_random_selection(&mut self, shrink_to: PercentageInteger, now: Slot) {
-        let mut candidates = self.get_flattened_entries(true, true);
+        let mut candidates = self.get_flattened_entries();
         self.stats
             .water_level
             .store(candidates.len() as u64, Ordering::Relaxed);

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -28,6 +28,22 @@ use {
 use {solana_svm_measure::measure::Measure, solana_svm_timings::ExecuteDetailsTimings};
 
 pub type ProgramRuntimeEnvironment = Arc<BuiltinProgram<InvokeContext<'static, 'static>>>;
+#[cfg(feature = "dev-context-only-utils")]
+pub fn get_mock_program_runtime_environment() -> ProgramRuntimeEnvironment {
+    static MOCK_ENVIRONMENT: std::sync::OnceLock<ProgramRuntimeEnvironment> =
+        std::sync::OnceLock::<ProgramRuntimeEnvironment>::new();
+    MOCK_ENVIRONMENT
+        .get_or_init(|| Arc::new(BuiltinProgram::new_mock()))
+        .clone()
+}
+#[cfg(feature = "dev-context-only-utils")]
+pub fn get_mock_program_runtime_environments() -> ProgramRuntimeEnvironments {
+    ProgramRuntimeEnvironments {
+        program_runtime_v1: get_mock_program_runtime_environment(),
+        program_runtime_v2: get_mock_program_runtime_environment(),
+    }
+}
+
 pub const MAX_LOADED_ENTRY_COUNT: usize = 512;
 pub const DELAY_VISIBILITY_SLOT_OFFSET: Slot = 1;
 
@@ -1413,7 +1429,8 @@ mod tests {
             BlockRelation, DELAY_VISIBILITY_SLOT_OFFSET, ForkGraph, ProgramCache,
             ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
             ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
-            ProgramRuntimeEnvironments,
+            ProgramRuntimeEnvironments, get_mock_program_runtime_environment,
+            get_mock_program_runtime_environments,
         },
         assert_matches::assert_matches,
         percentage::Percentage,
@@ -1431,22 +1448,6 @@ mod tests {
         },
         test_case::{test_case, test_matrix},
     };
-
-    static MOCK_ENVIRONMENT: std::sync::OnceLock<ProgramRuntimeEnvironment> =
-        std::sync::OnceLock::<ProgramRuntimeEnvironment>::new();
-
-    fn get_mock_env() -> ProgramRuntimeEnvironment {
-        MOCK_ENVIRONMENT
-            .get_or_init(|| Arc::new(BuiltinProgram::new_mock()))
-            .clone()
-    }
-
-    fn get_mock_envs() -> ProgramRuntimeEnvironments {
-        ProgramRuntimeEnvironments {
-            program_runtime_v1: get_mock_env(),
-            program_runtime_v2: get_mock_env(),
-        }
-    }
 
     fn new_test_entry(deployment_slot: Slot, effective_slot: Slot) -> Arc<ProgramCacheEntry> {
         new_test_entry_with_usage(deployment_slot, effective_slot, AtomicU64::default())
@@ -1468,7 +1469,7 @@ mod tests {
         usage_counter: AtomicU64,
     ) -> Arc<ProgramCacheEntry> {
         Arc::new(ProgramCacheEntry {
-            program: new_loaded_entry(get_mock_env()),
+            program: new_loaded_entry(get_mock_program_runtime_environment()),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
             account_size: 0,
             deployment_slot,
@@ -1499,7 +1500,7 @@ mod tests {
         current_slot: Slot,
         reason: ProgramCacheEntryType,
     ) -> Arc<ProgramCacheEntry> {
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
         let program = Arc::new(ProgramCacheEntry::new_tombstone(
             current_slot,
             ProgramCacheEntryOwner::LoaderV2,
@@ -1514,7 +1515,7 @@ mod tests {
         key: Pubkey,
         current_slot: Slot,
     ) -> Arc<ProgramCacheEntry> {
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
         let loaded = new_test_entry_with_usage(
             current_slot,
             current_slot.saturating_add(1),
@@ -1572,7 +1573,7 @@ mod tests {
         usage_counters: Vec<u64>,
         programs: &mut Vec<(Pubkey, Slot, u64)>,
     ) {
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
         // Add multiple entries for program
         deployment_slots
             .iter()
@@ -1812,7 +1813,7 @@ mod tests {
     #[test]
     fn test_usage_count_of_unloaded_program() {
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
 
         let program = Pubkey::new_unique();
         let evict_to_pct = 2;
@@ -1878,7 +1879,7 @@ mod tests {
             [(1, 2), (5, 5), (5, 6), (5, 10), (9, 10), (10, 10), (3, 12)];
         let mut rng = rand::rng();
         let program_id = Pubkey::new_unique();
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
         for _ in 0..1000 {
             let mut entries = EXPECTED_ENTRIES.to_vec();
             entries.shuffle(&mut rng);
@@ -1908,41 +1909,41 @@ mod tests {
     #[test_matrix(
         (
             ProgramCacheEntryType::Closed,
-            ProgramCacheEntryType::FailedVerification(get_mock_env()),
-            new_loaded_entry(get_mock_env()),
+            ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
+            new_loaded_entry(get_mock_program_runtime_environment()),
         ),
         (
-            ProgramCacheEntryType::FailedVerification(get_mock_env()),
+            ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Closed,
-            ProgramCacheEntryType::Unloaded(get_mock_env()),
-            new_loaded_entry(get_mock_env()),
+            ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
+            new_loaded_entry(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
         )
     )]
     #[test_matrix(
         (
-            ProgramCacheEntryType::Unloaded(get_mock_env()),
+            ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
         ),
         (
-            ProgramCacheEntryType::FailedVerification(get_mock_env()),
+            ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Closed,
-            ProgramCacheEntryType::Unloaded(get_mock_env()),
+            ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
         )
     )]
     #[test_matrix(
         (ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),),
         (
-            ProgramCacheEntryType::FailedVerification(get_mock_env()),
+            ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Closed,
-            ProgramCacheEntryType::Unloaded(get_mock_env()),
-            new_loaded_entry(get_mock_env()),
+            ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
+            new_loaded_entry(get_mock_program_runtime_environment()),
         )
     )]
     #[should_panic(expected = "Unexpected replacement of an entry")]
     fn test_assign_program_failure(old: ProgramCacheEntryType, new: ProgramCacheEntryType) {
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
         let program_id = Pubkey::new_unique();
         assert!(!cache.assign_program(
             &envs,
@@ -1976,7 +1977,7 @@ mod tests {
 
     #[test_case(
         ProgramCacheEntryType::Unloaded(Arc::new(BuiltinProgram::new_mock())),
-        new_loaded_entry(get_mock_env())
+        new_loaded_entry(get_mock_program_runtime_environment())
     )]
     #[test_case(
         ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
@@ -1984,7 +1985,7 @@ mod tests {
     )]
     fn test_assign_program_success(old: ProgramCacheEntryType, new: ProgramCacheEntryType) {
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
         let program_id = Pubkey::new_unique();
         assert!(!cache.assign_program(
             &envs,
@@ -2019,7 +2020,7 @@ mod tests {
     #[test]
     fn test_assign_program_removes_entries_in_same_slot() {
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
         let program_id = Pubkey::new_unique();
         let closed_other_slot = Arc::new(ProgramCacheEntry {
             program: ProgramCacheEntryType::Closed,
@@ -2040,7 +2041,7 @@ mod tests {
             latest_access_slot: AtomicU64::default(),
         });
         let loaded_entry_current_env = Arc::new(ProgramCacheEntry {
-            program: ProgramCacheEntryType::Unloaded(get_mock_env()),
+            program: ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
             account_size: 0,
             deployment_slot: 10,
@@ -2075,7 +2076,7 @@ mod tests {
     #[test]
     fn test_tombstone() {
         let env = Arc::new(BuiltinProgram::new_mock());
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
         let tombstone = ProgramCacheEntry::new_tombstone(
             0,
             ProgramCacheEntryOwner::LoaderV2,
@@ -2201,7 +2202,7 @@ mod tests {
     #[test]
     fn test_prune_different_env() {
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
 
         let fork_graph = Arc::new(RwLock::new(TestForkGraph {
             relation: BlockRelation::Ancestor,
@@ -2351,7 +2352,7 @@ mod tests {
     #[test]
     fn test_fork_extract_and_prune() {
         let mut cache = ProgramCache::<TestForkGraphSpecific>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
 
         // Fork graph created for the test
         //                   0
@@ -2551,7 +2552,7 @@ mod tests {
     #[test]
     fn test_extract_using_deployment_slot() {
         let mut cache = ProgramCache::<TestForkGraphSpecific>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
 
         // Fork graph created for the test
         //                   0
@@ -2609,7 +2610,7 @@ mod tests {
     #[test]
     fn test_extract_unloaded() {
         let mut cache = ProgramCache::<TestForkGraphSpecific>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
 
         // Fork graph created for the test
         //                   0
@@ -2688,7 +2689,7 @@ mod tests {
     #[test]
     fn test_extract_different_environment() {
         let mut cache = ProgramCache::<TestForkGraphSpecific>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
         let other_envs = ProgramRuntimeEnvironments {
             program_runtime_v1: Arc::new(BuiltinProgram::new_mock()),
             program_runtime_v2: Arc::new(BuiltinProgram::new_mock()),
@@ -2738,7 +2739,7 @@ mod tests {
     #[test]
     fn test_extract_nonexistent() {
         let mut cache = ProgramCache::<TestForkGraphSpecific>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
         let fork_graph = TestForkGraphSpecific::default();
         let fork_graph = Arc::new(RwLock::new(fork_graph));
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
@@ -2753,11 +2754,11 @@ mod tests {
     #[test]
     fn test_unloaded() {
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
         for program_cache_entry_type in [
-            ProgramCacheEntryType::FailedVerification(get_mock_env()),
+            ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Closed,
-            ProgramCacheEntryType::Unloaded(get_mock_env()),
+            ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
         ] {
             let entry = Arc::new(ProgramCacheEntry {
@@ -2796,7 +2797,7 @@ mod tests {
     #[test]
     fn test_fork_prune_find_first_ancestor() {
         let mut cache = ProgramCache::<TestForkGraphSpecific>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
 
         // Fork graph created for the test
         //                   0
@@ -2837,7 +2838,7 @@ mod tests {
     #[test]
     fn test_prune_by_deployment_slot() {
         let mut cache = ProgramCache::<TestForkGraphSpecific>::new(0);
-        let envs = get_mock_envs();
+        let envs = get_mock_program_runtime_environments();
 
         // Fork graph created for the test
         //                   0

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1593,14 +1593,18 @@ impl Bank {
             }
             epoch_boundary_preparation.upcoming_epoch = self.epoch.saturating_add(1);
             epoch_boundary_preparation.upcoming_environments = Some(upcoming_environments);
-            epoch_boundary_preparation.programs_to_recompile = program_cache
-                .get_flattened_entries(changed_program_runtime_v1, changed_program_runtime_v2)
-                .into_iter()
-                .map(|(id, _last_modification_slot, entry)| (id, entry))
-                .collect();
-            epoch_boundary_preparation
-                .programs_to_recompile
-                .sort_by_cached_key(|(_id, program)| program.decayed_usage_counter(self.slot));
+            if changed_program_runtime_v1 {
+                epoch_boundary_preparation.programs_to_recompile = program_cache
+                    .get_flattened_entries()
+                    .into_iter()
+                    .map(|(id, _last_modification_slot, entry)| (id, entry))
+                    .collect();
+                epoch_boundary_preparation
+                    .programs_to_recompile
+                    .sort_by_cached_key(|(_id, program)| program.decayed_usage_counter(self.slot));
+            } else {
+                epoch_boundary_preparation.programs_to_recompile.clear();
+            }
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -71,9 +71,7 @@ use {
     agave_precompiles::{get_precompile, get_precompiles, is_precompile},
     agave_reserved_account_keys::ReservedAccountKeys,
     agave_snapshots::snapshot_hash::SnapshotHash,
-    agave_syscalls::{
-        create_program_runtime_environment_v1, create_program_runtime_environment_v2,
-    },
+    agave_syscalls::create_program_runtime_environment_v1,
     agave_votor_messages::{
         consensus_message::Certificate, migration::GENESIS_CERTIFICATE_ACCOUNT,
     },
@@ -4441,20 +4439,18 @@ impl Bank {
             .as_ref()
             .unwrap_or(&ComputeBudget::new_with_defaults(simd_0268_active))
             .to_budget();
-        ProgramRuntimeEnvironments {
-            program_runtime_v1: Arc::new(
-                create_program_runtime_environment_v1(
-                    &feature_set.runtime_features(),
-                    &compute_budget,
-                    false, /* deployment */
-                    false, /* debugging_features */
-                )
-                .unwrap(),
-            ),
-            program_runtime_v2: Arc::new(create_program_runtime_environment_v2(
+        let program_runtime_environment = Arc::new(
+            create_program_runtime_environment_v1(
+                &feature_set.runtime_features(),
                 &compute_budget,
+                false, /* deployment */
                 false, /* debugging_features */
-            )),
+            )
+            .unwrap(),
+        );
+        ProgramRuntimeEnvironments {
+            program_runtime_v1: program_runtime_environment.clone(),
+            program_runtime_v2: program_runtime_environment,
         }
     }
 

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -730,7 +730,7 @@ pub(crate) mod tests {
                 .global_program_cache
                 .read()
                 .unwrap();
-            let entries = program_cache.get_flattened_entries(true, true);
+            let entries = program_cache.get_flattened_entries();
             let target_entry = entries
                 .iter()
                 .find(|(program_id, _last_modification_slot, _entry)| {

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -92,7 +92,7 @@ mod tests {
             execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
             invoke_context::EnvironmentConfig,
             loaded_programs::{
-                ProgramCacheEntry, ProgramCacheForTxBatch, ProgramRuntimeEnvironments,
+                ProgramCacheEntry, ProgramCacheForTxBatch, get_mock_program_runtime_environments,
             },
             sysvar_cache::SysvarCache,
         },
@@ -219,7 +219,7 @@ mod tests {
         ));
         let sysvar_cache = SysvarCache::default();
         let feature_set = SVMFeatureSet::all_enabled();
-        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+        let program_runtime_environments = get_mock_program_runtime_environments();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
@@ -276,7 +276,7 @@ mod tests {
                 ),
             ]),
         ));
-        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+        let program_runtime_environments = get_mock_program_runtime_environments();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
@@ -325,7 +325,7 @@ mod tests {
                 ),
             ]),
         ));
-        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+        let program_runtime_environments = get_mock_program_runtime_environments();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
@@ -463,7 +463,7 @@ mod tests {
         ));
         let sysvar_cache = SysvarCache::default();
         let feature_set = SVMFeatureSet::all_enabled();
-        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+        let program_runtime_environments = get_mock_program_runtime_environments();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
@@ -505,7 +505,7 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
-        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+        let program_runtime_environments = get_mock_program_runtime_environments();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
@@ -546,7 +546,7 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
-        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+        let program_runtime_environments = get_mock_program_runtime_environments();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
@@ -699,7 +699,7 @@ mod tests {
             }
         }
         let feature_set = SVMFeatureSet::all_enabled();
-        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+        let program_runtime_environments = get_mock_program_runtime_environments();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -237,7 +237,8 @@ mod tests {
         solana_account::WritableAccount,
         solana_program_runtime::{
             loaded_programs::{
-                BlockRelation, ForkGraph, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
+                BlockRelation, ForkGraph, ProgramRuntimeEnvironment,
+                get_mock_program_runtime_environments,
             },
             solana_sbpf::program::BuiltinProgram,
         },
@@ -573,7 +574,7 @@ mod tests {
             &mut ExecuteTimings::default(),
         );
 
-        let environments = ProgramRuntimeEnvironments::default();
+        let environments = get_mock_program_runtime_environments();
         let expected = ProgramCacheEntry::new(
             account_data.owner(),
             environments.program_runtime_v1.clone(),
@@ -667,7 +668,7 @@ mod tests {
         account_data
             .set_data(data[UpgradeableLoaderState::size_of_programdata_metadata()..].to_vec());
 
-        let environments = ProgramRuntimeEnvironments::default();
+        let environments = get_mock_program_runtime_environments();
         let expected = ProgramCacheEntry::new(
             account_data.owner(),
             environments.program_runtime_v1.clone(),
@@ -752,7 +753,7 @@ mod tests {
             .borrow_mut()
             .insert(key, (account_data.clone(), 0));
 
-        let environments = ProgramRuntimeEnvironments::default();
+        let environments = get_mock_program_runtime_environments();
         let expected = ProgramCacheEntry::new(
             account_data.owner(),
             environments.program_runtime_v1.clone(),
@@ -773,7 +774,7 @@ mod tests {
         let mut account_data = AccountSharedData::default();
         account_data.set_owner(bpf_loader::id());
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let upcoming_environments = ProgramRuntimeEnvironments::default();
+        let upcoming_environments = get_mock_program_runtime_environments();
         let current_environments = batch_processor.environments.clone();
         {
             let mut epoch_boundary_preparation =

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1245,7 +1245,9 @@ mod tests {
             execution_budget::{
                 SVMTransactionExecutionAndFeeBudgetLimits, SVMTransactionExecutionBudget,
             },
-            loaded_programs::{BlockRelation, ProgramCacheEntryType},
+            loaded_programs::{
+                BlockRelation, ProgramCacheEntryType, get_mock_program_runtime_environments,
+            },
         },
         solana_rent::Rent,
         solana_sdk_ids::{bpf_loader, loader_v4, system_program, sysvar},
@@ -1696,7 +1698,7 @@ mod tests {
         batch_processor.replenish_program_cache(
             &account_loader,
             &account_set,
-            &ProgramRuntimeEnvironments::default(),
+            &get_mock_program_runtime_environments(),
             &mut program_cache_for_tx_batch,
             &mut ExecuteTimings::default(),
             false,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -258,7 +258,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         epoch: Epoch,
         fork_graph: Weak<RwLock<FG>>,
         program_runtime_environment_v1: Option<ProgramRuntimeEnvironment>,
-        program_runtime_environment_v2: Option<ProgramRuntimeEnvironment>,
     ) -> Self {
         let mut processor = Self::new_uninitialized(slot, epoch);
         processor
@@ -279,8 +278,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .upcoming_epoch = processor.epoch;
         processor.environments.program_runtime_v1 =
             program_runtime_environment_v1.unwrap_or(empty_loader());
-        processor.environments.program_runtime_v2 =
-            program_runtime_environment_v2.unwrap_or(empty_loader());
+        processor.environments.program_runtime_v2 = empty_loader();
         processor
     }
 
@@ -1687,7 +1685,7 @@ mod tests {
         let account_loader = (&mock_bank).into();
         let fork_graph = Arc::new(RwLock::new(TestForkGraph {}));
         let batch_processor =
-            TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None, None);
+            TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None);
         let key = Pubkey::new_unique();
 
         let mut account_set = HashMap::new();
@@ -1712,7 +1710,7 @@ mod tests {
         let mock_bank = MockBankCallback::default();
         let fork_graph = Arc::new(RwLock::new(TestForkGraph {}));
         let batch_processor =
-            TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None, None);
+            TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None);
         let program_runtime_environments_for_execution =
             batch_processor.get_environments_for_epoch(0);
         let key = Pubkey::new_unique();
@@ -2088,7 +2086,7 @@ mod tests {
     fn test_add_builtin() {
         let fork_graph = Arc::new(RwLock::new(TestForkGraph {}));
         let batch_processor =
-            TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None, None);
+            TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None);
 
         let key = Pubkey::new_unique();
         let name = "a_builtin_name";

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -40,8 +40,7 @@ const MAX_ITERATIONS: usize = 10_000;
 fn program_cache_execution(threads: usize) {
     let mut mock_bank = MockBankCallback::default();
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
-    let batch_processor =
-        TransactionBatchProcessor::new(5, 5, Arc::downgrade(&fork_graph), None, None);
+    let batch_processor = TransactionBatchProcessor::new(5, 5, Arc::downgrade(&fork_graph), None);
 
     let programs = vec![
         deploy_program("hello-solana".to_string(), 0, &mut mock_bank),
@@ -146,7 +145,6 @@ fn svm_concurrent() {
         2,
         Arc::downgrade(&fork_graph),
         Some(Arc::new(create_custom_loader())),
-        None, // We are not using program runtime v2.
     ));
 
     mock_bank.configure_sysvars();

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -139,7 +139,6 @@ impl SvmTestEnvironment<'_> {
             EXECUTION_EPOCH,
             Arc::downgrade(&fork_graph),
             Some(Arc::new(create_custom_loader())),
-            None, // We are not using program runtime v2.
         );
 
         // The sysvars must be put in the cache

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -540,31 +540,6 @@ pub fn create_program_runtime_environment_v1<'a, 'ix_data>(
     Ok(result)
 }
 
-pub fn create_program_runtime_environment_v2<'a, 'ix_data>(
-    compute_budget: &SVMTransactionExecutionBudget,
-    debugging_features: bool,
-) -> BuiltinProgram<InvokeContext<'a, 'ix_data>> {
-    let config = Config {
-        max_call_depth: compute_budget.max_call_depth,
-        stack_frame_size: compute_budget.stack_frame_size,
-        enable_address_translation: true, // To be deactivated once we have BTF inference and verification
-        enable_stack_frame_gaps: false,
-        instruction_meter_checkpoint_distance: 10000,
-        enable_instruction_meter: true,
-        enable_register_tracing: debugging_features,
-        enable_symbol_and_section_labels: debugging_features,
-        reject_broken_elfs: true,
-        noop_instruction_rate: 256,
-        sanitize_user_provided_values: true,
-        enabled_sbpf_versions: SBPFVersion::Reserved..=SBPFVersion::Reserved,
-        optimize_rodata: true,
-        aligned_memory_mapping: true,
-        allow_memory_region_zero: true,
-        // Warning, do not use `Config::default()` so that configuration here is explicit.
-    };
-    BuiltinProgram::new_loader(config)
-}
-
 fn translate_type<T>(
     memory_mapping: &MemoryMapping,
     vm_addr: u64,

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -6052,7 +6052,7 @@ mod tests {
 
         with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
         let feature_set = SVMFeatureSet::default();
-        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+        let program_runtime_environments = get_mock_program_runtime_environments();
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
@@ -6118,7 +6118,7 @@ mod tests {
 
         with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
         let feature_set = SVMFeatureSet::default();
-        let program_runtime_environments = ProgramRuntimeEnvironments::default();
+        let program_runtime_environments = get_mock_program_runtime_environments();
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,


### PR DESCRIPTION
#### Problem

Split off from https://github.com/anza-xyz/agave/pull/11080.

#### Summary of Changes

- `Replaces ProgramRuntimeEnvironments::default()` with `get_mock_program_runtime_environments()` in tests.
- Removes `create_program_runtime_environment_v2()`.
- Removes parameter `program_runtime_environment_v2` of `TransactionBatchProcessor::new()`.
- Removes parameters `include_program_runtime_v1` and `_include_program_runtime_v2` of `get_flattened_entries()`.