### PR TITLE
blockstore: refactor error handling / dead in shred insertion path

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -136,6 +136,18 @@ enum InsertDataShredError {
     BlockstoreError(#[from] BlockstoreError),
 }
 
+#[derive(Error, Debug)]
+enum InsertCodingShredError {
+    #[error("Coding shred already exists in Blockstore")]
+    Exists,
+    #[error("Invalid coding shred")]
+    InvalidShred,
+    #[error("Invalid coding shred erasure config")]
+    InvalidErasureConfig,
+    #[error(transparent)]
+    BlockstoreError(#[from] BlockstoreError),
+}
+
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum PossibleDuplicateShred {
     Exists(Shred), // Blockstore has another shred in its spot
@@ -1041,6 +1053,27 @@ impl Blockstore {
         self.perf_samples_cf.submit_rocksdb_cf_metrics();
     }
 
+    /// If the block is not full, mark the slot as dead
+    fn mark_slot_dead_if_not_full(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+        shred_insertion_tracker: &mut ShredInsertionTracker,
+    ) {
+        if shred_insertion_tracker
+            .slot_meta_working_set
+            .get(&(location, slot))
+            .is_none_or(|meta| !meta.new_slot_meta.borrow().is_full())
+        {
+            // If the slot is already full there is no reason to mark as dead
+            self.dead_slots_cf.put_bytes_in_batch(
+                &mut shred_insertion_tracker.write_batch,
+                slot,
+                &[true as u8],
+            );
+        }
+    }
+
     /// Attempts to insert shreds into blockstore and updates relevant metrics
     /// based on the results, split out by shred source (tubine vs. repair).
     fn attempt_shred_insertion<'a>(
@@ -1058,6 +1091,7 @@ impl Blockstore {
         metrics.num_shreds += shreds.len();
         let mut start = Measure::start("Shred insertion");
         for (shred, is_repaired, location) in shreds {
+            let slot = shred.slot();
             let shred_source = if is_repaired {
                 ShredSource::Repaired
             } else {
@@ -1081,6 +1115,11 @@ impl Blockstore {
                             }
                         }
                         Err(InsertDataShredError::InvalidShred) => {
+                            self.mark_slot_dead_if_not_full(
+                                slot,
+                                location,
+                                shred_insertion_tracker,
+                            );
                             metrics.num_data_shreds_invalid += 1
                         }
                         Err(InsertDataShredError::BlockstoreError(err)) => {
@@ -1099,13 +1138,40 @@ impl Blockstore {
                     // Block id based repair (the source for populating the Alternate column) cannot receive
                     // coding shreds. Thus if we receive a coding shred, it must be for `BlockLocation::Original`
                     debug_assert_matches!(location, BlockLocation::Original);
-                    self.check_insert_coding_shred(
+                    match self.check_insert_coding_shred(
                         shred,
                         shred_insertion_tracker,
                         is_trusted,
                         shred_source,
-                        metrics,
-                    );
+                    ) {
+                        Err(InsertCodingShredError::Exists) => {
+                            metrics.num_coding_shreds_exists += 1;
+                        }
+                        Err(InsertCodingShredError::InvalidShred) => {
+                            self.mark_slot_dead_if_not_full(
+                                slot,
+                                location,
+                                shred_insertion_tracker,
+                            );
+                            metrics.num_coding_shreds_invalid += 1;
+                        }
+                        Err(InsertCodingShredError::InvalidErasureConfig) => {
+                            self.mark_slot_dead_if_not_full(
+                                slot,
+                                location,
+                                shred_insertion_tracker,
+                            );
+                            metrics.num_coding_shreds_invalid_erasure_config += 1;
+                        }
+                        Err(InsertCodingShredError::BlockstoreError(err)) => {
+                            metrics.num_coding_shreds_blockstore_error += 1;
+                            error!("blockstore error during coding shred insertion: {err}");
+                        }
+                        Ok(()) => {
+                            metrics.num_coding_shreds_inserted += 1;
+                            metrics.num_inserted += 1;
+                        }
+                    }
                 }
             };
         }
@@ -1199,6 +1265,7 @@ impl Blockstore {
         }
         metrics.num_recovered += recovered_data_shreds.len();
         for shred in recovered_data_shreds {
+            let slot = shred.slot();
             *match self.check_insert_data_shred(
                 Cow::Owned(shred),
                 BlockLocation::Original,
@@ -1209,6 +1276,11 @@ impl Blockstore {
             ) {
                 Err(InsertDataShredError::Exists) => &mut metrics.num_recovered_exists,
                 Err(InsertDataShredError::InvalidShred) => {
+                    self.mark_slot_dead_if_not_full(
+                        slot,
+                        BlockLocation::Original,
+                        shred_insertion_tracker,
+                    );
                     &mut metrics.num_recovered_failed_invalid
                 }
                 Err(InsertDataShredError::BlockstoreError(err)) => {
@@ -1550,15 +1622,9 @@ impl Blockstore {
     /// and updates corresponding meta-data.
     ///
     /// This function updates the following column families:
-    ///   - [`cf::DeadSlots`]: mark a shred as "dead" if its meta-data indicates
-    ///     there is no need to replay this shred.  Specifically when both the
-    ///     following conditions satisfy,
-    ///     - We get a new shred N marked as the last shred in the slot S,
-    ///       but N.index() is less than the current slot_meta.received
-    ///       for slot S.
-    ///     - The slot is not currently full
-    ///       It means there's an alternate version of this slot. See
-    ///       `check_insert_data_shred` for more details.
+    ///   - [`cf::DeadSlots`]: mark a slot as "dead" for all shred insertion
+    ///     failures except [`InsertDataShredError::Exists`] and
+    ///     [`InsertCodingShredError::Exists`].
     ///   - [`cf::ShredData`]: stores data shreds (in check_insert_data_shreds).
     ///   - [`cf::ShredCode`]: stores coding shreds (in check_insert_coding_shreds).
     ///   - [`cf::SlotMeta`]: the SlotMeta of the input `shreds` and their related
@@ -1863,16 +1929,34 @@ impl Blockstore {
         insert_results.duplicate_shreds
     }
 
-    #[allow(clippy::too_many_arguments)]
-    /// Note: Coding shreds can only be inserted into the Original columns
+    /// Create an entry to the specified `write_batch` that performs coding shred
+    /// insertion and associated metadata update. The function also updates
+    /// in-memory copies of the associated metadata.
+    ///
+    /// Currently, this function must be invoked while holding
+    /// `insert_shreds_lock` as it performs read-modify-write operations
+    /// on multiple column families.
+    ///
+    /// On success, the resulting `write_batch` includes updates to
+    /// [`cf::ShredCode`], while in-memory `index_working_set`, `erasure_metas`,
+    /// and `merkle_root_metas` are updated so they can be committed later.
+    ///
+    /// On failure, this function returns [`InsertCodingShredError`]. Callers are
+    /// responsible for marking the slot as dead.
+    ///
+    /// Arguments:
+    /// - `shred`: the coding shred to insert.
+    /// - `shred_insertion_tracker`: collection of shred insertion tracking data.
+    /// - `is_trusted`: if false, duplicate and integrity checks are applied.
+    /// - `shred_source`: the source of the shred.
+    /// - `metrics`: insertion metrics to update.
     fn check_insert_coding_shred<'a>(
         &self,
         shred: Cow<'a, Shred>,
         shred_insertion_tracker: &mut ShredInsertionTracker<'a>,
         is_trusted: bool,
         shred_source: ShredSource,
-        metrics: &mut BlockstoreInsertionMetrics,
-    ) -> bool {
+    ) -> std::result::Result<(), InsertCodingShredError> {
         let slot = shred.slot();
         let shred_index = u64::from(shred.index());
 
@@ -1887,18 +1971,12 @@ impl Blockstore {
             ..
         } = shred_insertion_tracker;
 
-        let index_meta_working_set_entry = match self.get_index_meta_entry(
+        let index_meta_working_set_entry = self.get_index_meta_entry(
             slot,
             BlockLocation::Original,
             index_working_set,
             index_meta_time_us,
-        ) {
-            Ok(entry) => entry,
-            Err(err) => {
-                error!("blockstore error during coding shred insertion: {err}");
-                return false;
-            }
-        };
+        )?;
 
         let index_meta = &mut index_meta_working_set_entry.index;
         let erasure_set = shred.erasure_set();
@@ -1915,14 +1993,12 @@ impl Blockstore {
         // So, all coding shreds in a given FEC block will have the same set index
         if !is_trusted {
             if index_meta.coding().contains(shred_index) {
-                metrics.num_coding_shreds_exists += 1;
                 duplicate_shreds.push(PossibleDuplicateShred::Exists(shred.into_owned()));
-                return false;
+                return Err(InsertCodingShredError::Exists);
             }
 
             if !Blockstore::should_insert_coding_shred(&shred, self.max_root()) {
-                metrics.num_coding_shreds_invalid += 1;
-                return false;
+                return Err(InsertCodingShredError::InvalidShred);
             }
 
             if let Some(merkle_root_meta) =
@@ -1939,7 +2015,7 @@ impl Blockstore {
                     &shred,
                     duplicate_shreds,
                 ) {
-                    return false;
+                    return Err(InsertCodingShredError::InvalidShred);
                 }
             }
         }
@@ -1955,7 +2031,6 @@ impl Blockstore {
         let erasure_meta = erasure_meta_entry.as_ref();
 
         if !erasure_meta.check_coding_shred(&shred) {
-            metrics.num_coding_shreds_invalid_erasure_config += 1;
             if !self.has_duplicate_shreds_in_slot(slot) {
                 if let Some(conflicting_shred) = self
                     .find_conflicting_coding_shred(&shred, slot, erasure_meta, just_inserted_shreds)
@@ -1997,7 +2072,7 @@ impl Blockstore {
                 erasure_meta.config(),
                 shred,
             );
-            return false;
+            return Err(InsertCodingShredError::InvalidErasureConfig);
         }
 
         self.slots_stats.record_shred(
@@ -2009,27 +2084,21 @@ impl Blockstore {
         );
 
         // insert coding shred into rocks
-        let result = self
-            .insert_coding_shred(index_meta, &shred, write_batch)
-            .is_ok();
+        self.insert_coding_shred(index_meta, &shred, write_batch)?;
 
-        if result {
-            index_meta_working_set_entry.did_insert_occur = true;
-            metrics.num_inserted += 1;
+        index_meta_working_set_entry.did_insert_occur = true;
 
-            merkle_root_metas
-                .entry((BlockLocation::Original, erasure_set))
-                .or_insert(WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
-        }
+        merkle_root_metas
+            .entry((BlockLocation::Original, erasure_set))
+            .or_insert(WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
 
         if let HashMapEntry::Vacant(entry) =
             just_inserted_shreds.entry((BlockLocation::Original, shred.id()))
         {
-            metrics.num_coding_shreds_inserted += 1;
             entry.insert(shred);
         }
 
-        result
+        Ok(())
     }
 
     fn find_conflicting_coding_shred<'a>(
@@ -2083,11 +2152,14 @@ impl Blockstore {
     /// `insert_shreds_lock` as it performs read-modify-write operations
     /// on multiple column families.
     ///
-    /// The resulting `write_batch` may include updates to [`cf::DeadSlots`]
-    /// and [`cf::ShredData`].  Note that it will also update the in-memory copy
+    /// The resulting `write_batch` may include updates to [`cf::ShredData`].
+    /// Note that it will also update the in-memory copy
     /// of `erasure_metas`, `merkle_root_metas`, and `index_working_set`, which will
     /// later be used to update other column families such as [`cf::ErasureMeta`] and
     /// [`cf::Index`].
+    ///
+    /// On failure, this function returns [`InsertDataShredError`]. Callers are
+    /// responsible for marking the slot as dead.
     ///
     /// Arguments:
     /// - `shred`: the shred to be inserted
@@ -2162,16 +2234,13 @@ impl Blockstore {
                 // progress (for instance if a leader sends an additional detached "last index"
                 // shred with a very high index, but none of the intermediate shreds). Ideally, we would
                 // just purge all shreds > the new last index slot, but because replay may have already
-                // replayed entries past the newly detected "last" shred, then mark the slot as dead
-                // and wait for replay to dump and repair the correct version.
+                // replayed entries past the newly detected "last" shred, the caller marks the slot
+                // as dead and replay can dump and repair the correct version.
                 warn!(
                     "Received *last* shred index {} less than previous shred index {}, and slot \
-                     {} is not full, marking slot dead",
+                     {} is not full",
                     shred_index, slot_meta.received, slot
                 );
-                self.dead_slots_cf
-                    .put_in_batch(write_batch, slot, &true)
-                    .unwrap();
             }
 
             if !self.should_insert_data_shred(
@@ -2203,11 +2272,8 @@ impl Blockstore {
                     // Similar to the last index case above, we might never get all the
                     // shreds for our current version, never replay this slot, and make no
                     // progress. We cannot determine if we have the version that will eventually
-                    // be complete, so we take the conservative approach and mark the slot as dead
-                    // so that replay can dump and repair the correct version.
-                    self.dead_slots_cf
-                        .put_in_batch(write_batch, slot, &true)
-                        .unwrap();
+                    // be complete, so the caller marks the slot as dead and replay can dump
+                    // and repair the correct version.
                     return Err(InsertDataShredError::InvalidShred);
                 }
             }
@@ -3040,9 +3106,13 @@ impl Blockstore {
                         &reed_solomon_cache,
                         &mut ProcessShredsStats::default(),
                     );
+                let next_chained_merkle_root = coding_shreds
+                    .last()
+                    .and_then(|shred| shred.merkle_root().ok())
+                    .unwrap_or(chained_merkle_root);
                 all_shreds.append(&mut data_shreds);
                 all_shreds.append(&mut coding_shreds);
-                chained_merkle_root = coding_shreds.last().unwrap().merkle_root().unwrap();
+                chained_merkle_root = next_chained_merkle_root;
                 shredder = Shredder::new(
                     current_slot,
                     parent_slot,
@@ -3071,7 +3141,10 @@ impl Blockstore {
             ));
         }
         let num_data = all_shreds.iter().filter(|shred| shred.is_data()).count();
-        self.insert_shreds(all_shreds, None, false)?;
+        // `write_entries` is a test helper that synthesizes local shreds.
+        // Insert as trusted to avoid dead-slot marking from untrusted-path
+        // filters (for example slot-0 coding shred checks).
+        self.insert_shreds(all_shreds, None, true)?;
         Ok(num_data)
     }
 
@@ -7641,13 +7714,14 @@ pub mod tests {
 
         let mut shred_insertion_tracker =
             ShredInsertionTracker::new(coding_shreds.len(), blockstore.get_write_batch().unwrap());
-        assert!(blockstore.check_insert_coding_shred(
-            Cow::Borrowed(&coding_shred),
-            &mut shred_insertion_tracker,
-            false,
-            ShredSource::Turbine,
-            &mut BlockstoreInsertionMetrics::default(),
-        ));
+        blockstore
+            .check_insert_coding_shred(
+                Cow::Borrowed(&coding_shred),
+                &mut shred_insertion_tracker,
+                false,
+                ShredSource::Turbine,
+            )
+            .unwrap();
         let ShredInsertionTracker {
             merkle_root_metas,
             write_batch,
@@ -7696,13 +7770,16 @@ pub mod tests {
         let mut shred_insertion_tracker =
             ShredInsertionTracker::new(coding_shreds.len(), blockstore.get_write_batch().unwrap());
 
-        assert!(!blockstore.check_insert_coding_shred(
-            Cow::Owned(new_coding_shred),
-            &mut shred_insertion_tracker,
-            false,
-            ShredSource::Turbine,
-            &mut BlockstoreInsertionMetrics::default(),
+        assert!(matches!(
+            blockstore.check_insert_coding_shred(
+                Cow::Owned(new_coding_shred),
+                &mut shred_insertion_tracker,
+                false,
+                ShredSource::Turbine,
+            ),
+            Err(InsertCodingShredError::InvalidShred)
         ));
+
         let ShredInsertionTracker {
             ref merkle_root_metas,
             ref duplicate_shreds,
@@ -7759,13 +7836,15 @@ pub mod tests {
             setup_erasure_shreds_with_index(slot, parent_slot, 10, new_index);
         let new_coding_shred = coding_shreds[0].clone();
 
-        assert!(blockstore.check_insert_coding_shred(
-            Cow::Borrowed(&new_coding_shred),
-            &mut shred_insertion_tracker,
-            false,
-            ShredSource::Turbine,
-            &mut BlockstoreInsertionMetrics::default(),
-        ));
+        blockstore
+            .check_insert_coding_shred(
+                Cow::Borrowed(&new_coding_shred),
+                &mut shred_insertion_tracker,
+                false,
+                ShredSource::Turbine,
+            )
+            .unwrap();
+
         let ShredInsertionTracker {
             ref merkle_root_metas,
             ..
@@ -7881,18 +7960,22 @@ pub mod tests {
         let mut shred_insertion_tracker =
             ShredInsertionTracker::new(data_shreds.len(), blockstore.get_write_batch().unwrap());
 
-        assert!(
-            blockstore
-                .check_insert_data_shred(
-                    Cow::Owned(new_data_shred),
-                    BlockLocation::Original,
-                    &mut shred_insertion_tracker,
-                    false,
-                    None,
-                    ShredSource::Turbine,
-                )
-                .is_err()
+        let insert_result = blockstore.check_insert_data_shred(
+            Cow::Owned(new_data_shred),
+            BlockLocation::Original,
+            &mut shred_insertion_tracker,
+            false,
+            None,
+            ShredSource::Turbine,
         );
+        assert_matches!(
+            insert_result.unwrap_err(),
+            InsertDataShredError::InvalidShred
+        );
+        blockstore
+            .dead_slots_cf
+            .put_in_batch(&mut shred_insertion_tracker.write_batch, slot, &true)
+            .unwrap();
         let ShredInsertionTracker {
             merkle_root_metas,
             duplicate_shreds,
@@ -8045,21 +8128,24 @@ pub mod tests {
 
         let mut shred_insertion_tracker =
             ShredInsertionTracker::new(1, blockstore.get_write_batch().unwrap());
-        assert!(blockstore.check_insert_coding_shred(
-            Cow::Borrowed(&coding_shred),
-            &mut shred_insertion_tracker,
-            false,
-            ShredSource::Turbine,
-            &mut BlockstoreInsertionMetrics::default(),
-        ));
+        blockstore
+            .check_insert_coding_shred(
+                Cow::Borrowed(&coding_shred),
+                &mut shred_insertion_tracker,
+                false,
+                ShredSource::Turbine,
+            )
+            .unwrap();
 
         // insert again fails on dupe
-        assert!(!blockstore.check_insert_coding_shred(
-            Cow::Borrowed(&coding_shred),
-            &mut shred_insertion_tracker,
-            false,
-            ShredSource::Turbine,
-            &mut BlockstoreInsertionMetrics::default(),
+        assert!(matches!(
+            blockstore.check_insert_coding_shred(
+                Cow::Borrowed(&coding_shred),
+                &mut shred_insertion_tracker,
+                false,
+                ShredSource::Turbine,
+            ),
+            Err(InsertCodingShredError::Exists)
         ));
         assert_eq!(
             shred_insertion_tracker.duplicate_shreds,
@@ -11049,9 +11135,7 @@ pub mod tests {
         let shreds = setup_test_shreds(slot);
 
         // Case 1: Insert in the same batch. Since we're inserting the shreds in order,
-        // any shreds > smaller_last_shred_index will not be inserted. Slot is not marked
-        // as dead because no slots > the first "last" index shred are inserted before
-        // the "last" index shred itself is inserted.
+        // any shreds > smaller_last_shred_index will not be inserted.
         let (expected_slot_meta, expected_index) = get_expected_slot_meta_and_index_meta(
             &blockstore,
             shreds[..=smaller_last_shred_index].to_vec(),
@@ -11060,6 +11144,7 @@ pub mod tests {
             .insert_shreds(shreds.clone(), None, false)
             .unwrap();
         assert!(blockstore.get_duplicate_slot(slot).is_some());
+        // Block is already full not marked dead
         assert!(!blockstore.is_dead(slot));
         for i in 0..num_shreds {
             if i <= smaller_last_shred_index as u64 {

--- a/ledger/src/blockstore_metrics.rs
+++ b/ledger/src/blockstore_metrics.rs
@@ -39,6 +39,7 @@ pub struct BlockstoreInsertionMetrics {
     pub num_coding_shreds_exists: usize,
     pub num_coding_shreds_invalid: usize,
     pub num_coding_shreds_invalid_erasure_config: usize,
+    pub num_coding_shreds_blockstore_error: usize,
     pub num_coding_shreds_inserted: usize,
 }
 
@@ -126,6 +127,11 @@ impl BlockstoreInsertionMetrics {
             (
                 "num_coding_shreds_invalid_erasure_config",
                 self.num_coding_shreds_invalid_erasure_config,
+                i64
+            ),
+            (
+                "num_coding_shreds_blockstore_error",
+                self.num_coding_shreds_blockstore_error,
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem
We don't properly return errors in the insert coding shred pathway.
Additionally we individually mark the block as dead in the failure cases.

#### Summary of Changes
Refactor to add proper error bubbling and unify the mark dead logic
