### PR TITLE
vote-account: change VAT error log to info for tests

### DIFF
--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -215,7 +215,11 @@ impl VoteAccounts {
                 .map(|(pubkey, vote_account, stake)| (*pubkey, (stake, vote_account.clone()))),
         );
         if top_entries.is_empty() {
-            error!("no valid vote accounts found");
+            if cfg!(test) {
+                info!("No valid vote accounts found");
+            } else {
+                error!("No valid vote accounts found");
+            }
         }
         info!(
             "Out of {} vote accounts, {} are valid vote accounts after filtering, {} remain after \


### PR DESCRIPTION
#### Problem
We set up banks with no validators in many tests. This error log is noisy in output.

#### Summary of Changes
In tests change this to an info log.
