### PR TITLE
fix: improve publish-crate.sh logging and rate limit handling

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -69,26 +69,22 @@ for Cargo_toml in $Cargo_tomls; do
       echo "Attempt ${i} of ${numRetries}"
       # The rocksdb package does not build with the stock rust docker image so use
       # the solana rust docker image
-      output=$(mktemp)
-      if ci/docker-run-default-image.sh bash -exc "cd $crate; $cargoCommand" 2>&1 | tee "$output"; then
-        rm -f "$output"
+      if output=$(ci/docker-run-default-image.sh bash -exc "cd $crate; $cargoCommand" 2>&1 | tee /dev/fd/2); then
         break
       fi
 
       if [ "$i" -lt "$numRetries" ]; then
-        if grep -qiE "status 429|429 Too Many Requests" "$output"; then
-          backoff=$((60 * i))
-          echo "Rate limited by crates.io, backing off for ${backoff}s"
-          sleep "$backoff"
+        retry_after=$(sed -n 's/.*Please try again after \(.*\) or email.*/\1/p' <<< "$output")
+        if [[ -n "$retry_after" ]]; then
+          backoff=$(( $(date -d "$retry_after" +%s) - $(date +%s) ))
+          [[ $backoff -gt 0 ]] && sleep "$backoff"
         else
           sleep 3
         fi
       else
-        rm -f "$output"
         echo "couldn't publish '$crate_name'"
         exit 1
       fi
-      rm -f "$output"
     done
   )
 

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 cd "$(dirname "$0")/.."
 source ci/semver_bash/semver.sh
 source ci/rust-version.sh stable
@@ -61,8 +61,6 @@ for Cargo_toml in $Cargo_tomls; do
   fi
 
   (
-    set -euo pipefail
-
     crate=$(dirname "$Cargo_toml")
     cargoCommand="cargo publish --token $CRATES_IO_TOKEN"
 

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -38,7 +38,8 @@ done
 Cargo_tomls=$(ci/order-crates-for-publishing.py)
 
 for Cargo_toml in $Cargo_tomls; do
-  echo "--- $Cargo_toml"
+  crate_name=$(grep -m 1 '^name = ' "$Cargo_toml" | cut -f 3 -d ' ' | tr -d \")
+  echo "--- $crate_name"
 
   # check the version which doesn't inherit from worksapce
   if ! grep -q "^version = { workspace = true }$" "$Cargo_toml"; then
@@ -48,8 +49,6 @@ for Cargo_toml in $Cargo_tomls; do
       exit 1
     }
   fi
-
-  crate_name=$(grep -m 1 '^name = ' "$Cargo_toml" | cut -f 3 -d ' ' | tr -d \")
 
   if grep -q "^publish = false" "$Cargo_toml"; then
     echo "$crate_name is marked as unpublishable"
@@ -62,7 +61,7 @@ for Cargo_toml in $Cargo_tomls; do
   fi
 
   (
-    set -x
+    set -eo pipefail
 
     crate=$(dirname "$Cargo_toml")
     cargoCommand="cargo publish --token $CRATES_IO_TOKEN"
@@ -72,18 +71,32 @@ for Cargo_toml in $Cargo_tomls; do
       echo "Attempt ${i} of ${numRetries}"
       # The rocksdb package does not build with the stock rust docker image so use
       # the solana rust docker image
-      if ci/docker-run-default-image.sh bash -exc "cd $crate; $cargoCommand"; then
+      output=$(mktemp)
+      if ci/docker-run-default-image.sh bash -exc "cd $crate; $cargoCommand" 2>&1 | tee "$output"; then
+        rm -f "$output"
         break
       fi
 
       if [ "$i" -lt "$numRetries" ]; then
-        sleep 3
+        if grep -qiE "status 429|429 Too Many Requests" "$output"; then
+          backoff=$((60 * i))
+          echo "Rate limited by crates.io, backing off for ${backoff}s"
+          sleep "$backoff"
+        else
+          sleep 3
+        fi
       else
+        rm -f "$output"
         echo "couldn't publish '$crate_name'"
         exit 1
       fi
+      rm -f "$output"
     done
   )
+
+  # crates.io allows a burst of 30 new versions, then 1 per minute.
+  # Sleep between each crate to stay within the sustained rate limit.
+  sleep 60
 done
 
 exit 0

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -87,10 +87,6 @@ for Cargo_toml in $Cargo_tomls; do
       fi
     done
   )
-
-  # crates.io allows a burst of 30 new versions, then 1 per minute.
-  # Sleep between each crate to stay within the sustained rate limit.
-  sleep 60
 done
 
 exit 0

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -61,7 +61,7 @@ for Cargo_toml in $Cargo_tomls; do
   fi
 
   (
-    set -eo pipefail
+    set -euo pipefail
 
     crate=$(dirname "$Cargo_toml")
     cargoCommand="cargo publish --token $CRATES_IO_TOKEN"


### PR DESCRIPTION
#### Problem

Two issues with the `publish-crates` step on solana-secondary:

1. Buildkite section headers show the full `Cargo.toml` path rather than the crate name, making collapsed sections appear identical when truncated (#11087)
2. `set -x` floods the log with trace output, making it impossible to follow while running (#11087)
3. Retries use a flat 3s sleep with no awareness of crates.io rate limits. crates.io allows a burst of 30 new versions then 1 per minute; Agave publishes hundreds of crates per release so the burst is always exhausted (#11085)

#### Summary of Changes

- Use crate name instead of `Cargo.toml` path in Buildkite section headers
- Drop `set -x` from the publish subshell to reduce log noise
- Add a 60s inter-crate sleep to stay within the sustained rate limit
- Detect HTTP 429 responses via cargo's `Caused by: ... status 429` output and back off exponentially on retries instead of using a flat 3s delay
- Add `pipefail` so the `cargo publish | tee` pipeline correctly propagates failures

Fixes #11085
Fixes #11087