### PR TITLE
runtime: Test partitioned epoch distribution with rent

### DIFF
--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -96,10 +96,8 @@ use {
 // These functions/fields are only usable from a dev context (i.e. tests and benches)
 #[cfg(feature = "dev-context-only-utils")]
 impl StakeReward {
-    pub fn new_random() -> Self {
+    pub fn new_random(rent: &Rent) -> Self {
         let mut rng = rand::rng();
-
-        let rent = Rent::free();
 
         let validator_pubkey = solana_pubkey::new_rand();
         let validator_stake_lamports = 20;
@@ -118,13 +116,14 @@ impl StakeReward {
             validator_stake_lamports,
         );
 
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let reward_lamports: i64 = rng.random_range(1..200);
         let validator_stake_account = create_stake_account(
             &validator_staking_keypair.pubkey(),
             &validator_voting_keypair.pubkey(),
             &validator_vote_account,
-            &rent,
-            validator_stake_lamports + reward_lamports as u64,
+            rent,
+            rent_exempt_reserve + validator_stake_lamports + reward_lamports as u64,
         );
 
         Self {

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -2147,7 +2147,7 @@ mod tests {
     ) {
         for _ in 0..count {
             let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
-                create_staked_node_accounts(stake_lamports);
+                create_staked_node_accounts(stake_lamports, &bank.rent_collector.rent);
             bank.store_account_and_update_capitalization(&vote_pubkey, &vote_account);
             bank.store_account_and_update_capitalization(&stake_pubkey, &stake_account);
             voters.insert(vote_pubkey);

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -214,7 +214,7 @@ impl Bank {
                 .delegation
                 .stake
                 .saturating_add(partitioned_stake_reward.stake_reward),
-            partitioned_stake_reward.stake.delegation.stake,
+            partitioned_stake_reward.stake.delegation.stake
         );
         account
             .set_state(&StakeStateV2::Stake(
@@ -326,7 +326,6 @@ mod tests {
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
         solana_native_token::LAMPORTS_PER_SOL,
-        solana_rent::Rent,
         solana_reward_info::RewardType,
         solana_stake_interface::{
             stake_flags::StakeFlags,
@@ -346,7 +345,11 @@ mod tests {
         let expected_num = 100;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .map(|_| {
+                Some(PartitionedStakeReward::new_random(
+                    &bank.rent_collector.rent,
+                ))
+            })
             .collect::<PartitionedStakeRewards>();
 
         let partition_indices =
@@ -370,7 +373,11 @@ mod tests {
         let expected_num = 1;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .map(|_| {
+                Some(PartitionedStakeReward::new_random(
+                    &bank.rent_collector.rent,
+                ))
+            })
             .collect::<PartitionedStakeRewards>();
 
         let partition_indices = hash_rewards_into_partitions(
@@ -403,7 +410,7 @@ mod tests {
     }
 
     fn populate_starting_stake_accounts_from_stake_rewards(bank: &Bank, rewards: &[StakeReward]) {
-        let rent = Rent::free();
+        let rent = &bank.rent_collector.rent;
         let validator_pubkey = Pubkey::new_unique();
         let validator_vote_pubkey = Pubkey::new_unique();
 
@@ -427,7 +434,7 @@ mod tests {
                 &stake_reward.stake_pubkey,
                 &validator_vote_pubkey,
                 &validator_vote_account,
-                &rent,
+                rent,
                 lamports,
             );
             bank.store_account(&stake_reward.stake_pubkey, &validator_stake_account);
@@ -464,7 +471,7 @@ mod tests {
         // Set up a partition of rewards to distribute
         let expected_num = 100;
         let stake_rewards = (0..expected_num)
-            .map(|_| StakeReward::new_random())
+            .map(|_| StakeReward::new_random(&bank.rent_collector.rent))
             .collect::<Vec<_>>();
         let rewards_to_distribute = stake_rewards
             .iter()
@@ -511,7 +518,7 @@ mod tests {
         let expected_num = 12345;
 
         let mut stake_rewards = (0..expected_num)
-            .map(|_| StakeReward::new_random())
+            .map(|_| StakeReward::new_random(&bank.rent_collector.rent))
             .collect::<Vec<_>>();
         populate_starting_stake_accounts_from_stake_rewards(&bank, &stake_rewards);
 
@@ -521,7 +528,7 @@ mod tests {
             .sum::<i64>() as u64;
 
         // Push extra StakeReward to simulate non-existent account
-        stake_rewards.push(StakeReward::new_random());
+        stake_rewards.push(StakeReward::new_random(&bank.rent_collector.rent));
 
         let stake_rewards = convert_rewards(stake_rewards);
 
@@ -574,7 +581,7 @@ mod tests {
             let mut expected_num = 100;
 
             let mut stake_rewards = (0..expected_num)
-                .map(|_| StakeReward::new_random())
+                .map(|_| StakeReward::new_random(&bank.rent_collector.rent))
                 .collect::<Vec<_>>();
 
             let mut rng = rand::rng();
@@ -638,7 +645,7 @@ mod tests {
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
         assert_eq!(
-            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward)
+            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward,)
                 .unwrap_err(),
             DistributionError::AccountNotFound
         );
@@ -669,7 +676,7 @@ mod tests {
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
         assert_eq!(
-            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward)
+            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward,)
                 .unwrap_err(),
             DistributionError::ArithmeticOverflow
         );
@@ -732,7 +739,7 @@ mod tests {
             },
         };
         assert_eq!(
-            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward)
+            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward,)
                 .unwrap(),
             expected_stake_reward
         );
@@ -759,7 +766,7 @@ mod tests {
         let expected_num = 100;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| StakeReward::new_random())
+            .map(|_| StakeReward::new_random(&bank.rent_collector.rent))
             .collect::<Vec<_>>();
         populate_starting_stake_accounts_from_stake_rewards(&bank, &stake_rewards);
         let converted_rewards = convert_rewards(stake_rewards);

--- a/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
@@ -34,6 +34,7 @@ mod tests {
         },
         solana_epoch_schedule::EpochSchedule,
         solana_native_token::LAMPORTS_PER_SOL,
+        solana_rent::Rent,
         std::sync::Arc,
     };
 
@@ -41,9 +42,10 @@ mod tests {
     fn test_hash_rewards_into_partitions() {
         // setup the expected number of stake rewards
         let expected_num = 12345;
+        let rent = Rent::default();
 
         let stake_rewards = (0..expected_num)
-            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .map(|_| Some(PartitionedStakeReward::new_random(&rent)))
             .collect::<PartitionedStakeRewards>();
 
         let partition_indices = hash_rewards_into_partitions(&stake_rewards, &Hash::default(), 5);
@@ -79,7 +81,11 @@ mod tests {
         // simulate 40K - 1 rewards, the expected num of credit blocks should be 10.
         let expected_num = 40959;
         let stake_rewards = (0..expected_num)
-            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .map(|_| {
+                Some(PartitionedStakeReward::new_random(
+                    &bank.rent_collector.rent,
+                ))
+            })
             .collect::<PartitionedStakeRewards>();
 
         let partition_indices =

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -438,6 +438,7 @@ mod tests {
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_native_token::LAMPORTS_PER_SOL,
+        solana_rent::Rent,
         solana_reward_info::RewardType,
         solana_signer::Signer,
         solana_stake_interface::state::StakeStateV2,
@@ -464,8 +465,8 @@ mod tests {
             }
         }
 
-        pub fn new_random() -> Self {
-            Self::maybe_from(&StakeReward::new_random()).unwrap()
+        pub fn new_random(rent: &Rent) -> Self {
+            Self::maybe_from(&StakeReward::new_random(rent)).unwrap()
         }
     }
 
@@ -679,7 +680,11 @@ mod tests {
         let expected_num = 100;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .map(|_| {
+                Some(PartitionedStakeReward::new_random(
+                    &bank.rent_collector.rent,
+                ))
+            })
             .collect::<PartitionedStakeRewards>();
 
         let partition_indices = vec![(0..expected_num).collect()];
@@ -729,7 +734,11 @@ mod tests {
             |num_stakes: u64, expected_num_reward_distribution_blocks: u64| {
                 // Given the short epoch, i.e. 32 slots, we should cap the number of reward distribution blocks to 32/10 = 3.
                 let stake_rewards = (0..num_stakes)
-                    .map(|_| Some(PartitionedStakeReward::new_random()))
+                    .map(|_| {
+                        Some(PartitionedStakeReward::new_random(
+                            &bank.rent_collector.rent,
+                        ))
+                    })
                     .collect::<PartitionedStakeRewards>();
 
                 assert_eq!(
@@ -767,7 +776,11 @@ mod tests {
         // Given 8k rewards, it will take 2 blocks to credit all the rewards
         let expected_num = 8192;
         let stake_rewards = (0..expected_num)
-            .map(|_| Some(PartitionedStakeReward::new_random()))
+            .map(|_| {
+                Some(PartitionedStakeReward::new_random(
+                    &bank.rent_collector.rent,
+                ))
+            })
             .collect::<PartitionedStakeRewards>();
 
         assert_eq!(bank.get_reward_distribution_num_blocks(&stake_rewards), 2);
@@ -793,20 +806,24 @@ mod tests {
     fn test_get_reward_distribution_num_blocks_none() {
         let rewards_all = 8192;
         let expected_rewards_some = 6144;
+
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let bank = Bank::new_for_tests(&genesis_config);
+
         let rewards = (0..rewards_all)
             .map(|i| {
                 if i % 4 == 0 {
                     None
                 } else {
-                    Some(PartitionedStakeReward::new_random())
+                    Some(PartitionedStakeReward::new_random(
+                        &bank.rent_collector.rent,
+                    ))
                 }
             })
             .collect::<PartitionedStakeRewards>();
         assert_eq!(rewards.rewards.len(), rewards_all);
         assert_eq!(rewards.num_rewards(), expected_rewards_some);
 
-        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
-        let bank = Bank::new_for_tests(&genesis_config);
         assert_eq!(bank.get_reward_distribution_num_blocks(&rewards), 1);
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -716,8 +716,13 @@ where
     );
 
     let ((vote_id, mut vote_account), (stake_id, stake_account)) =
-        crate::stakes::tests::create_staked_node_accounts(10_000);
-    let starting_vote_and_stake_balance = 10_000 + 1;
+        crate::stakes::tests::create_staked_node_accounts(10_000, &bank0.rent_collector.rent);
+    let starting_vote_and_stake_balance = 10_000
+        + 1
+        + bank0
+            .rent_collector
+            .rent
+            .minimum_balance(StakeStateV2::size_of());
 
     // set up accounts
     bank0.store_account_and_update_capitalization(&stake_id, &stake_account);
@@ -876,9 +881,19 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
         100,
     );
     let stake_id1 = solana_pubkey::new_rand();
-    let stake_account1 = crate::stakes::tests::create_stake_account(123, &vote_id, &stake_id1);
+    let stake_account1 = crate::stakes::tests::create_stake_account(
+        123,
+        &vote_id,
+        &stake_id1,
+        &bank.rent_collector.rent,
+    );
     let stake_id2 = solana_pubkey::new_rand();
-    let stake_account2 = crate::stakes::tests::create_stake_account(456, &vote_id, &stake_id2);
+    let stake_account2 = crate::stakes::tests::create_stake_account(
+        456,
+        &vote_id,
+        &stake_id2,
+        &bank.rent_collector.rent,
+    );
 
     // set up accounts
     bank.store_account_and_update_capitalization(&stake_id1, &stake_account1);
@@ -3723,7 +3738,7 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
         }
 
         let ((vote_id, vote_account), (stake_id, stake_account)) =
-            crate::stakes::tests::create_staked_node_accounts(1_0000);
+            crate::stakes::tests::create_staked_node_accounts(1_0000, &bank.rent_collector.rent);
         bank.capitalization
             .fetch_add(vote_account.lamports() + stake_account.lamports(), Relaxed);
         bank.store_account(&vote_id, &vote_account);

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -606,6 +606,7 @@ pub(crate) mod tests {
     //  set up some dummies for a staked node     ((     vote      )  (     stake     ))
     pub(crate) fn create_staked_node_accounts(
         stake: u64,
+        rent: &Rent,
     ) -> ((Pubkey, AccountSharedData), (Pubkey, AccountSharedData)) {
         let vote_pubkey = solana_pubkey::new_rand();
         let node_pubkey = solana_pubkey::new_rand();
@@ -625,7 +626,7 @@ pub(crate) mod tests {
             (vote_pubkey, vote_account),
             (
                 stake_pubkey,
-                create_stake_account(stake, &vote_pubkey, &stake_pubkey),
+                create_stake_account(stake, &vote_pubkey, &stake_pubkey, rent),
             ),
         )
     }
@@ -635,8 +636,10 @@ pub(crate) mod tests {
         stake: u64,
         vote_pubkey: &Pubkey,
         stake_pubkey: &Pubkey,
+        rent: &Rent,
     ) -> AccountSharedData {
         let node_pubkey = solana_pubkey::new_rand();
+        let lamports = rent.minimum_balance(StakeStateV2::size_of()) + stake;
         stake_utils::create_stake_account(
             stake_pubkey,
             vote_pubkey,
@@ -651,8 +654,8 @@ pub(crate) mod tests {
                 vote_pubkey,
                 1,
             ),
-            &Rent::free(),
-            stake,
+            rent,
+            lamports,
         )
     }
 
@@ -663,9 +666,10 @@ pub(crate) mod tests {
                 epoch: i,
                 ..Stakes::default()
             });
+            let rent = Rent::default();
 
             let ((vote_pubkey, vote_account), (stake_pubkey, mut stake_account)) =
-                create_staked_node_accounts(10);
+                create_staked_node_accounts(10, &rent);
 
             stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
             stakes_cache.check_and_store(&stake_pubkey, &stake_account, None);
@@ -698,7 +702,7 @@ pub(crate) mod tests {
 
             // activate more
             let mut stake_account =
-                create_stake_account(42, &vote_pubkey, &solana_pubkey::new_rand());
+                create_stake_account(42, &vote_pubkey, &solana_pubkey::new_rand(), &rent);
             stakes_cache.check_and_store(&stake_pubkey, &stake_account, None);
             let stake = stake_account
                 .deserialize_data::<StakeStateV2>()
@@ -729,17 +733,18 @@ pub(crate) mod tests {
     #[test]
     fn test_stakes_highest() {
         let stakes_cache = StakesCache::default();
+        let rent = Rent::default();
 
         assert_eq!(stakes_cache.stakes().highest_staked_node(), None);
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
-            create_staked_node_accounts(10);
+            create_staked_node_accounts(10, &rent);
 
         stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
         stakes_cache.check_and_store(&stake_pubkey, &stake_account, None);
 
         let ((vote11_pubkey, vote11_account), (stake11_pubkey, stake11_account)) =
-            create_staked_node_accounts(20);
+            create_staked_node_accounts(20, &rent);
 
         stakes_cache.check_and_store(&vote11_pubkey, &vote11_account, None);
         stakes_cache.check_and_store(&stake11_pubkey, &stake11_account, None);
@@ -758,9 +763,10 @@ pub(crate) mod tests {
             epoch: 4,
             ..Stakes::default()
         });
+        let rent = Rent::default();
 
         let ((vote_pubkey, mut vote_account), (stake_pubkey, stake_account)) =
-            create_staked_node_accounts(10);
+            create_staked_node_accounts(10, &rent);
 
         stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
         stakes_cache.check_and_store(&stake_pubkey, &stake_account, None);
@@ -834,12 +840,13 @@ pub(crate) mod tests {
             epoch: 4,
             ..Stakes::default()
         });
+        let rent = Rent::default();
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
-            create_staked_node_accounts(10);
+            create_staked_node_accounts(10, &rent);
 
         let ((vote_pubkey2, vote_account2), (_stake_pubkey2, stake_account2)) =
-            create_staked_node_accounts(10);
+            create_staked_node_accounts(10, &rent);
 
         stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
         stakes_cache.check_and_store(&vote_pubkey2, &vote_account2, None);
@@ -886,12 +893,13 @@ pub(crate) mod tests {
             epoch: 4,
             ..Stakes::default()
         });
+        let rent = Rent::default();
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
-            create_staked_node_accounts(10);
+            create_staked_node_accounts(10, &rent);
 
         let stake_pubkey2 = solana_pubkey::new_rand();
-        let stake_account2 = create_stake_account(10, &vote_pubkey, &stake_pubkey2);
+        let stake_account2 = create_stake_account(10, &vote_pubkey, &stake_pubkey2, &rent);
 
         stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
 
@@ -910,9 +918,10 @@ pub(crate) mod tests {
     #[test]
     fn test_activate_epoch() {
         let stakes_cache = StakesCache::default();
+        let rent = Rent::default();
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
-            create_staked_node_accounts(10);
+            create_staked_node_accounts(10, &rent);
 
         stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
         stakes_cache.check_and_store(&stake_pubkey, &stake_account, None);
@@ -954,9 +963,10 @@ pub(crate) mod tests {
             epoch: 4,
             ..Stakes::default()
         });
+        let rent = Rent::default();
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
-            create_staked_node_accounts(10);
+            create_staked_node_accounts(10, &rent);
 
         stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
         stakes_cache.check_and_store(&stake_pubkey, &stake_account, None);


### PR DESCRIPTION
#### Problem

As part of SIMD-0488, we want to take into account rent parameters during epoch rewards distribution. However, most distribution tests use zero rent currently.

#### Summary of changes

Parametrize functions with `Rent` to prepare for the future where Rent is used for calculation of epoch rewards, and use non-zero Rent in partitioned epoch reward tests.

NOTE: This PR contains no functional changes, but will be important to backport if we want to backport SIMD-0488.