### PR TITLE
Change accounts_index ancestor check

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1003,6 +1003,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             }
         }
 
+        // If we found an ancestor, then we can return early without checking the roots
+        // If there is a root that is newer than the newest ancestor but not an ancestor
+        // then the root is from a different fork and should not be returned
+        if let Some(rv) = rv {
+            return Some(slot_list.len() - 1 - rv);
+        }
+
         let max_root_inclusive = max_root_inclusive.unwrap_or(Slot::MAX);
         let mut tracker = None;
 
@@ -3130,13 +3137,13 @@ mod tests {
             3
         );
 
-        // Given ancestors that are *older* than the newest root, return the newest root
+        // Given ancestors that are *older* than the newest root, should still return ancestors
         let ancestors = Ancestors::from(vec![3]);
         assert_eq!(
             index
                 .latest_slot(Some(&ancestors), &slot_slice, None)
                 .unwrap(),
-            1
+            2
         );
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2585,10 +2585,7 @@ fn test_bank_get_account_in_parent_after_squash2() {
     );
     bank1.squash();
 
-    // This picks up the values from 1 which is the highest root:
-    // TODO: if we need to access rooted banks older than this,
-    // need to fix the lookup.
-    assert_eq!(bank0.get_balance(&key1.pubkey()), 4 * amount);
+    assert_eq!(bank0.get_balance(&key1.pubkey()), amount);
     assert_eq!(bank3.get_balance(&key1.pubkey()), 4 * amount);
     assert_eq!(bank2.get_balance(&key1.pubkey()), 3 * amount);
     bank3.squash();
@@ -2617,12 +2614,8 @@ fn test_bank_get_account_in_parent_after_squash2() {
         Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank5, &Pubkey::default(), 6);
     bank6.squash();
 
-    // This picks up the values from 4 which is the highest root:
-    // TODO: if we need to access rooted banks older than this,
-    // need to fix the lookup.
-    assert_eq!(bank3.get_balance(&key1.pubkey()), 8 * amount);
-    assert_eq!(bank2.get_balance(&key1.pubkey()), 8 * amount);
-
+    assert_eq!(bank3.get_balance(&key1.pubkey()), 4 * amount);
+    assert_eq!(bank2.get_balance(&key1.pubkey()), 3 * amount);
     assert_eq!(bank4.get_balance(&key1.pubkey()), 8 * amount);
 }
 


### PR DESCRIPTION
#### Problem
The accounts_index ancestor check will return newer roots over older ancestors. 

```
                          Bank0
               |                       |
       Bank1 (unrooted)            Bank2 (rooted)
               |
       Bank3 (replaying)
```
Currently, when replaying Bank3, Bank2 will be preferred over Bank1. However this is incorrect. While Bank3 is definitely going to be purged as the entire Bank1 fork must be purged, it is more correct (and less computationally expensive as it skips a rwlock) to return Bank1

#### Summary of Changes
- If an ancestor is found, ignore roots and return early. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
