### PR TITLE
Ignore local-cluster bank_hash_details

### DIFF
--- a/local-cluster/.gitignore
+++ b/local-cluster/.gitignore
@@ -1,2 +1,3 @@
 /target/
 /farf/
+/bank_hash_details/


### PR DESCRIPTION
#### Problem
- Local cluster failures generate this directory/files.
- We do not ignore them in git so could accidently be added (reasonable reviewer would ofc reject). but it's still annoying

#### Summary of Changes
- Add /bank_hash_details/ to .gitignore in local-cluster

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
