### PR TITLE
clippy(connection-cache): use checked_div instead of manual >0

### DIFF
--- a/connection-cache/src/connection_cache_stats.rs
+++ b/connection-cache/src/connection_cache_stats.rs
@@ -88,20 +88,18 @@ impl ConnectionCacheStats {
             .successful_packets
             .swap(0, Ordering::Relaxed);
 
-        let (average_send_packet_us, average_prepare_connection_us) = if successful_packets > 0 {
-            (
-                self.total_client_stats
-                    .send_packets_us
-                    .swap(0, Ordering::Relaxed)
-                    / successful_packets,
-                self.total_client_stats
-                    .prepare_connection_us
-                    .swap(0, Ordering::Relaxed)
-                    / successful_packets,
-            )
-        } else {
-            (0, 0)
-        };
+        let average_send_packet_us = self
+            .total_client_stats
+            .send_packets_us
+            .swap(0, Ordering::Relaxed)
+            .checked_div(successful_packets)
+            .unwrap_or_default();
+        let average_prepare_connection_us = self
+            .total_client_stats
+            .prepare_connection_us
+            .swap(0, Ordering::Relaxed)
+            .checked_div(successful_packets)
+            .unwrap_or_default();
 
         datapoint_info!(
             name,


### PR DESCRIPTION
#### Problem

Rust 1.94's Clippy introduces a warning for the `if x > 0 { a / x } else { 0 }` pattern, flagging it in favour of `checked_div`.

#### Summary of Changes

Replace the combined `if successful_packets > 0` guard in `ConnectionCacheStats::report_stats` with two separate `checked_div(successful_packets).unwrap_or_default()` calls — one for `average_send_packet_us` and one for `average_prepare_connection_us`. Runtime behaviour is unchanged.
